### PR TITLE
Ensuring secrets bootstrapping works without access to native-secrets repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,9 +82,13 @@ strings:
 	cat Frameworks/ios-ksapi/Frameworks/native-secrets/ios/Secrets.swift bin/strings.swift | swift -
 
 secrets:
-	git clone https://github.com/kickstarter/native-secrets Frameworks/ios-ksapi/Frameworks/native-secrets \
-		|| mkdir -p Frameworks/ios-ksapi/Frameworks/native-secrets/ios \
+	-rm -rf Frameworks/ios-ksapi/Frameworks/native-secrets
+	-git clone https://github.com/kickstarter/native-secrets Frameworks/ios-ksapi/Frameworks/native-secrets
+	if [ ! -d Frameworks/ios-ksapi/Frameworks/native-secrets ]; \
+	then \
+		mkdir -p Frameworks/ios-ksapi/Frameworks/native-secrets/ios \
 		&& cp -n Configs/Secrets.swift.example Frameworks/ios-ksapi/Frameworks/native-secrets/ios/Secrets.swift \
-		|| true
+		|| true; \
+	fi
 
 .PHONY: test-all test clean dependencies submodules deploy lint secrets strings


### PR DESCRIPTION
The `secrets` make target didn’t work for me after #8 still, with failing git clone aborting the whole process and resulting in missing secrets on build stage.

Solution suggested here works as follows: (1) remove the secrets directory, (2) try cloning with git ignoring errors, and (3) if directory is nonexistent after that, create it and copy the example secrets.

I don’t like the initial forced removal too much, but it does offer an additional benefit in ensuring a simple `make bootstrap` would update secrets if they’re rotated. (A better solution could check if there’s a repo in native-secrets and do a force pull in such a case, but at a cost of increased complexity.)