### PR TITLE
Wrap make path in quotes to handle spaces in path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,8 @@ build: dependencies
 	$(XCODEBUILD) $(BUILD_FLAGS) $(XCPRETTY)
 
 test-all:
-	PLATFORM=iOS $(MAKE) test
-	PLATFORM=iOS TARGET=Library $(MAKE) test
+	PLATFORM=iOS "$(MAKE)" test
+	PLATFORM=iOS TARGET=Library "$(MAKE)" test
 
 test: dependencies
 	$(XCODEBUILD) test $(BUILD_FLAGS) $(XCPRETTY)


### PR DESCRIPTION
I've got multiple versions of Xcode on my machine (for the sake of projects in various states), which causes problems when attempting to run tests:

```bash
$ make test-all
PLATFORM=iOS /Applications/Xcode 7.app/Contents/Developer/usr/bin/make test
/bin/sh: /Applications/Xcode: No such file or directory
make: *** [test-all] Error 127
```

This change just wraps `$(MAKE)` in quotes so that spaces don't break it.