### PR TITLE
Use `value` parameter of `localizedStringForKey`

### DIFF
--- a/Library/LocalizedString.swift
+++ b/Library/LocalizedString.swift
@@ -27,14 +27,7 @@ public func localizedString(key key: String,
   let lprojName = lprojFileNameForLanguage(env.language)
   let localized = bundle.pathForResource(lprojName, ofType: "lproj")
     .flatMap(bundle.dynamicType.create(path:))
-    .flatMap { $0.localizedStringForKey(augmentedKey, value: nil, table: nil) }
-    .filter {
-      // NB: `localizedStringForKey` has the annoying habit of returning the key when the key doesn't exist.
-      // We filter those out and hope that we never use a value that is equal to its key.
-      $0.caseInsensitiveCompare(augmentedKey) != .OrderedSame
-    }
-    .filter { !$0.isEmpty }
-    .coalesceWith(defaultValue)
+    .flatMap { $0.localizedStringForKey(augmentedKey, value: defaultValue, table: nil) }
 
   return substitute(localized, with: substitutions)
 }


### PR DESCRIPTION
Hi! I was just taking a look at the project and saw this, and I wanted to give a bit of what you've given to the community 😃 

So, if you set the `value`parameter of `localizedString(forKey:value:table:)` it will return that value if `key` is `nil`, or a localized string for `key` can’t be found in the table (reference: https://developer.apple.com/reference/foundation/bundle/1417694-localizedstring).

Thank you for open sourcing the Kickstarter app!! It's super interesting to see the work behind it, you're amazing ❤️ 