### PR TITLE
Fix koala crash on oss builds

### DIFF
--- a/Library/Koala/KoalaTrackingClient.swift
+++ b/Library/Koala/KoalaTrackingClient.swift
@@ -148,11 +148,11 @@ public final class KoalaTrackingClient: TrackingClientType {
 
     }.resume()
     _ = semaphore.wait(timeout: .distantFuture)
-    
+
     if result == nil {
       NSLog("[Koala Request] response/error result unexpectedly nil")
     }
-    
+
     return result
   }
 

--- a/Library/Koala/KoalaTrackingClient.swift
+++ b/Library/Koala/KoalaTrackingClient.swift
@@ -148,7 +148,11 @@ public final class KoalaTrackingClient: TrackingClientType {
 
     }.resume()
     _ = semaphore.wait(timeout: .distantFuture)
-
+    
+    if result == nil {
+      NSLog("[Koala Request] response/error result unexpectedly nil")
+    }
+    
     return result
   }
 

--- a/Library/Koala/KoalaTrackingClient.swift
+++ b/Library/Koala/KoalaTrackingClient.swift
@@ -149,11 +149,6 @@ public final class KoalaTrackingClient: TrackingClientType {
     }.resume()
     _ = semaphore.wait(timeout: .distantFuture)
 
-    if result == nil {
-      NSLog("[Koala Request] response/error result unexpectedly nil")
-      assertionFailure()
-    }
-
     return result
   }
 


### PR DESCRIPTION
I just realized that we have a crash in the oss builds of the app once events are attempted to be sent. The reason is that we have stubbed secrets in the oss build, and so those requests fail in a bad way (we don't even get an `HTTPURLResponse ` value back), and that leads to an assertion failure.

Seems like we should just not assert?