### PR TITLE
Minor optimization to Optional zip

### DIFF
--- a/Library/Navigation.swift
+++ b/Library/Navigation.swift
@@ -551,8 +551,8 @@ private func stringToInt(_ string: String) -> Decoded<Int> {
 
  - returns: An optional tuple.
  */
-private func zip <A, B> (_ a: A?, _ b: B?) -> (A, B)? {
-  if let a = a, let b = b {
+private func zip <A, B> (_ a: A?, _ b: @autoclosure () -> B?) -> (A, B)? {
+  if let a = a, let b = b() {
     return (a, b)
   }
   return nil

--- a/Library/Navigation.swift
+++ b/Library/Navigation.swift
@@ -551,9 +551,6 @@ private func stringToInt(_ string: String) -> Decoded<Int> {
 
  - returns: An optional tuple.
  */
-private func zip <A, B> (_ a: A?, _ b: @autoclosure () -> B?) -> (A, B)? {
-  if let a = a, let b = b() {
-    return (a, b)
-  }
-  return nil
+private func zip <A, B> (_ x: A?, _ y: @autoclosure () -> B?) -> (A, B)? {
+  return x.flatMap { x_ in y().map { y_ in (x_, y_) } }
 }


### PR DESCRIPTION
Fun little optimization: we can use `@autoclosure` to approach the laziness we get using `if`–`let` more traditionally.

Might be nice to extract this (and a few more overloads for 3-argument zip, 4-, etc.) to Prelude!