### PR TITLE
Live streaming fixes

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,10 +1,13 @@
 disabled_rules:
+  - class_delegate_protocol
   - closure_parameter_position
   - function_parameter_count
+  - large_tuple
   - nesting
   - variable_name
   - weak_delegate
   - trailing_comma
+  - vertical_parameter_alignment
 opt_in_rules:
   - empty_count
   - force_unwrapping

--- a/Kickstarter-iOS/Views/Controllers/LiveStreamContainerViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/LiveStreamContainerViewController.swift
@@ -414,7 +414,7 @@ public final class LiveStreamContainerViewController: UIViewController {
 
   private func layoutNavBarTitle() {
     let stackViewSize = self.navBarTitleStackView.systemLayoutSizeFitting(
-      CGSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude))
+      CGSize(width: self.view.frame.size.width, height: self.view.frame.size.height))
 
     let newOrigin = CGPoint(x: (self.view.frame.size.width / 2) - (stackViewSize.width / 2),
                          y: self.navBarTitleStackViewBackgroundView.frame.origin.y)

--- a/Kickstarter-iOS/Views/Controllers/ProjectPamphletContentViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/ProjectPamphletContentViewController.swift
@@ -151,7 +151,7 @@ public final class ProjectPamphletContentViewController: UITableViewController {
 
   private func goToLiveStream(project: Project, liveStream: Project.LiveStream) {
     let vc: UIViewController
-    if liveStream.isLiveNow {
+    if liveStream.isLiveNow || liveStream.startDate < Date().timeIntervalSince1970 {
       vc = LiveStreamContainerViewController.configuredWith(project: project,
                                                             liveStream: liveStream,
                                                             event: nil)

--- a/Kickstarter-iOS/Views/Controllers/ProjectPamphletContentViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/ProjectPamphletContentViewController.swift
@@ -151,7 +151,7 @@ public final class ProjectPamphletContentViewController: UITableViewController {
 
   private func goToLiveStream(project: Project, liveStream: Project.LiveStream) {
     let vc: UIViewController
-    if liveStream.startDate < Date().timeIntervalSince1970 {
+    if liveStream.isLiveNow {
       vc = LiveStreamContainerViewController.configuredWith(project: project,
                                                             liveStream: liveStream,
                                                             event: nil)

--- a/Kickstarter-iOS/Views/Controllers/ProjectPamphletContentViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/ProjectPamphletContentViewController.swift
@@ -82,6 +82,12 @@ public final class ProjectPamphletContentViewController: UITableViewController {
         self?.goToLiveStream(project: project, liveStream: liveStream)
     }
 
+    self.viewModel.outputs.goToLiveStreamCountdown
+      .observeForControllerAction()
+      .observeValues { [weak self] project, liveStream in
+        self?.goToLiveStreamCountdown(project: project, liveStream: liveStream)
+    }
+
     self.viewModel.outputs.goToUpdates
       .observeForControllerAction()
       .observeValues { [weak self] in self?.goToUpdates(project: $0) }
@@ -150,19 +156,24 @@ public final class ProjectPamphletContentViewController: UITableViewController {
   }
 
   private func goToLiveStream(project: Project, liveStream: Project.LiveStream) {
-    let vc: UIViewController
-    if liveStream.isLiveNow || liveStream.startDate < Date().timeIntervalSince1970 {
-      vc = LiveStreamContainerViewController.configuredWith(project: project,
-                                                            liveStream: liveStream,
-                                                            event: nil)
-    } else {
-      vc = LiveStreamCountdownViewController.configuredWith(project: project, liveStream: liveStream)
-    }
-
+    let vc = LiveStreamContainerViewController.configuredWith(project: project, liveStream: liveStream,
+                                                              event: nil)
     let nav = UINavigationController(navigationBarClass: ClearNavigationBar.self, toolbarClass: nil)
     nav.viewControllers = [vc]
 
-    self.present(nav, animated: true, completion: nil)
+    DispatchQueue.main.async {
+      self.present(nav, animated: true, completion: nil)
+    }
+  }
+
+  private func goToLiveStreamCountdown(project: Project, liveStream: Project.LiveStream) {
+    let vc = LiveStreamCountdownViewController.configuredWith(project: project, liveStream: liveStream)
+    let nav = UINavigationController(navigationBarClass: ClearNavigationBar.self, toolbarClass: nil)
+    nav.viewControllers = [vc]
+
+    DispatchQueue.main.async {
+      self.present(nav, animated: true, completion: nil)
+    }
   }
 
   fileprivate func goToUpdates(project: Project) {

--- a/Library/Tests/.swiftlint.yml
+++ b/Library/Tests/.swiftlint.yml
@@ -1,6 +1,8 @@
 disabled_rules:
+  - class_delegate_protocol
   - file_length
   - function_parameter_count
+  - large_tuple
   - nesting
   - variable_name
   - force_unwrapping
@@ -9,6 +11,7 @@ disabled_rules:
   - function_body_length
   - weak_delegate
   - trailing_comma
+  - vertical_parameter_alignment
 opt_in_rules:
   - empty_count
 line_length: 110

--- a/Library/Tests/ViewModels/LiveStreamContainerViewModelTests.swift
+++ b/Library/Tests/ViewModels/LiveStreamContainerViewModelTests.swift
@@ -277,6 +277,12 @@ internal final class LiveStreamContainerViewModelTests: TestCase {
     )
 
     self.loaderStackViewHidden.assertValues([false, true])
+
+    self.vm.inputs.liveStreamViewControllerStateChanged(
+      state: .greenRoom
+    )
+
+    self.loaderStackViewHidden.assertValues([false, true])
   }
 
   func testLoaderText() {

--- a/Library/Tests/ViewModels/LiveStreamContainerViewModelTests.swift
+++ b/Library/Tests/ViewModels/LiveStreamContainerViewModelTests.swift
@@ -272,6 +272,10 @@ internal final class LiveStreamContainerViewModelTests: TestCase {
       state: .replay(playbackState: .playing, duration: 123)
     )
 
+    self.vm.inputs.liveStreamViewControllerStateChanged(
+      state: .replay(playbackState: .loading, duration: 123)
+    )
+
     self.loaderStackViewHidden.assertValues([false, true])
   }
 

--- a/Library/ViewModels/LiveStreamContainerViewModel.swift
+++ b/Library/ViewModels/LiveStreamContainerViewModel.swift
@@ -160,8 +160,8 @@ LiveStreamContainerViewModelInputs, LiveStreamContainerViewModelOutputs {
       self.showErrorAlert
     )
 
-    self.loaderStackViewHidden = self.liveStreamState
-      .map { state in
+    let singleState = self.liveStreamState
+      .map { state -> Bool in
         switch state {
         case .live(playbackState: .playing, _):
           return true
@@ -172,6 +172,11 @@ LiveStreamContainerViewModelInputs, LiveStreamContainerViewModelOutputs {
         }
       }
       .skipRepeats()
+
+    self.loaderStackViewHidden = Signal.merge(
+      self.viewDidLoadProperty.signal.mapConst(false).take(first: 1),
+      singleState.filter { $0 }.take(first: 1)
+    )
 
     self.projectImageUrl = project
       .map { URL(string: $0.photo.full) }

--- a/Library/ViewModels/LiveStreamContainerViewModel.swift
+++ b/Library/ViewModels/LiveStreamContainerViewModel.swift
@@ -161,7 +161,7 @@ LiveStreamContainerViewModelInputs, LiveStreamContainerViewModelOutputs {
     )
 
     self.loaderStackViewHidden = Signal.merge(
-      self.viewDidLoadProperty.signal.mapConst(false).take(first: 1),
+      self.viewDidLoadProperty.signal.mapConst(false),
       self.liveStreamState
         .map { state -> Bool in
           switch state {
@@ -173,7 +173,7 @@ LiveStreamContainerViewModelInputs, LiveStreamContainerViewModelOutputs {
             return false
           }
         }
-        .filter { $0 }
+        .filter(isTrue)
         .take(first: 1)
     )
 

--- a/Library/ViewModels/LiveStreamContainerViewModel.swift
+++ b/Library/ViewModels/LiveStreamContainerViewModel.swift
@@ -160,22 +160,21 @@ LiveStreamContainerViewModelInputs, LiveStreamContainerViewModelOutputs {
       self.showErrorAlert
     )
 
-    let singleState = self.liveStreamState
-      .map { state -> Bool in
-        switch state {
-        case .live(playbackState: .playing, _):
-          return true
-        case .replay(playbackState: .playing, _):
-          return true
-        default:
-          return false
-        }
-      }
-      .skipRepeats()
-
     self.loaderStackViewHidden = Signal.merge(
       self.viewDidLoadProperty.signal.mapConst(false).take(first: 1),
-      singleState.filter { $0 }.take(first: 1)
+      self.liveStreamState
+        .map { state -> Bool in
+          switch state {
+          case .live(playbackState: .playing, _):
+            return true
+          case .replay(playbackState: .playing, _):
+            return true
+          default:
+            return false
+          }
+        }
+        .filter { $0 }
+        .take(first: 1)
     )
 
     self.projectImageUrl = project

--- a/Library/ViewModels/ProjectPamphletContentViewModel.swift
+++ b/Library/ViewModels/ProjectPamphletContentViewModel.swift
@@ -19,6 +19,7 @@ public protocol ProjectPamphletContentViewModelOutputs {
   var goToBacking: Signal<Project, NoError> { get }
   var goToComments: Signal<Project, NoError> { get }
   var goToLiveStream: Signal<(Project, Project.LiveStream), NoError> { get }
+  var goToLiveStreamCountdown: Signal<(Project, Project.LiveStream), NoError> { get }
   var goToRewardPledge: Signal<(Project, Reward), NoError> { get }
   var goToUpdates: Signal<Project, NoError> { get }
   var loadMinimalProjectIntoDataSource: Signal<Project, NoError> { get }
@@ -79,7 +80,16 @@ ProjectPamphletContentViewModelInputs, ProjectPamphletContentViewModelOutputs {
       .takeWhen(self.tappedUpdatesProperty.signal)
 
     self.goToLiveStream = project
-      .takePairWhen(self.tappedLiveStreamProperty.signal.skipNil())
+      .takePairWhen(
+        self.tappedLiveStreamProperty.signal.skipNil()
+          .filter(shouldGoToLiveStream(withLiveStream:))
+    )
+
+    self.goToLiveStreamCountdown = project
+      .takePairWhen(
+        self.tappedLiveStreamProperty.signal.skipNil()
+          .filter( { !shouldGoToLiveStream(withLiveStream:$0) })
+    )
   }
 
   fileprivate let projectProperty = MutableProperty<Project?>(nil)
@@ -130,6 +140,7 @@ ProjectPamphletContentViewModelInputs, ProjectPamphletContentViewModelOutputs {
   public let goToBacking: Signal<Project, NoError>
   public let goToComments: Signal<Project, NoError>
   public let goToLiveStream: Signal<(Project, Project.LiveStream), NoError>
+  public let goToLiveStreamCountdown: Signal<(Project, Project.LiveStream), NoError>
   public let goToRewardPledge: Signal<(Project, Reward), NoError>
   public let goToUpdates: Signal<Project, NoError>
   public let loadMinimalProjectIntoDataSource: Signal<Project, NoError>
@@ -144,6 +155,11 @@ private func reward(forBacking backing: Backing, inProject project: Project) -> 
   return backing.reward
     ?? project.rewards.filter { $0.id == backing.rewardId }.first
     ?? Reward.noReward
+}
+
+private func shouldGoToLiveStream(withLiveStream liveStream: Project.LiveStream) -> Bool {
+  return liveStream.isLiveNow || liveStream.startDate <
+    AppEnvironment.current.dateType.init().timeIntervalSince1970
 }
 
 private func goToRewardPledgeData(forProject project: Project, rewardOrBacking: Either<Reward, Backing>)

--- a/LiveStream/Views/Controllers/LiveVideoViewController.swift
+++ b/LiveStream/Views/Controllers/LiveVideoViewController.swift
@@ -116,8 +116,11 @@ public final class LiveVideoViewController: UIViewController {
   }
 
   private func createAndConfigureSession(sessionConfig: OpenTokSessionConfig) {
+    let settings = OTSessionSettings()
+    settings.connectionEventsSuppressed = true
+
     self.session = OTSession(
-      apiKey: sessionConfig.apiKey, sessionId: sessionConfig.sessionId, delegate: self
+      apiKey: sessionConfig.apiKey, sessionId: sessionConfig.sessionId, delegate: self, settings: settings
     )
     self.session?.connect(withToken: sessionConfig.token, error: nil)
   }

--- a/LiveStream/Views/VideoGridView.swift
+++ b/LiveStream/Views/VideoGridView.swift
@@ -3,6 +3,16 @@ import ReactiveSwift
 
 public final class VideoGridView: UIView {
 
+  public init() {
+    super.init(frame: CGRect())
+
+    self.backgroundColor = .black
+  }
+  
+  public required init?(coder aDecoder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
   public func addVideoView(view: UIView) {
     self.insertSubview(view, at: 0)
     self.setNeedsLayout()


### PR DESCRIPTION
Just some fixes that we need for live streaming:

- Fix a `systemLayoutSizeFitting` sizing issue with the nav bar title view which was causing a layout warning.
- Allow live streams to be played if the creator goes live early.
- A fix so that the loader view isn't shown again when the creator goes off air.
- Added a setting for OpenTok to support a beta feature of theirs which should allow viewers up to ~1000 before we need to scale to HLS. The setting suppresses connection messages to reduce traffic overhead while the client is connected to a live stream.