### PR TITLE
Disabling new linting rules

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,10 +1,13 @@
 disabled_rules:
+  - class_delegate_protocol
   - closure_parameter_position
   - function_parameter_count
+  - large_tuple
   - nesting
   - variable_name
   - weak_delegate
   - trailing_comma
+  - vertical_parameter_alignment
 opt_in_rules:
   - empty_count
   - force_unwrapping

--- a/Library/Tests/.swiftlint.yml
+++ b/Library/Tests/.swiftlint.yml
@@ -1,6 +1,8 @@
 disabled_rules:
+  - class_delegate_protocol
   - file_length
   - function_parameter_count
+  - large_tuple
   - nesting
   - variable_name
   - force_unwrapping
@@ -9,6 +11,7 @@ disabled_rules:
   - function_body_length
   - weak_delegate
   - trailing_comma
+  - vertical_parameter_alignment
 opt_in_rules:
   - empty_count
 line_length: 110


### PR DESCRIPTION
Hey, our CircleCI is running SwiftLint 0.16.1 since homebrew updated and it's introduced some new rules which are breaking our builds. @mbrandonw and I decided to disable them for now until we have time to implement some of them properly. The disabled rules are `class_delegate_protocol`, `large_tuple` and `vertical_parameter_alignment`.

More info in the SwitLint release notes: https://github.com/realm/SwiftLint/releases/tag/0.16.0.