### PR TITLE
Put back a few of the swiftlint 0.16 rules

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,13 +1,10 @@
 disabled_rules:
-  - class_delegate_protocol
   - closure_parameter_position
   - function_parameter_count
-  - large_tuple
   - nesting
   - variable_name
   - weak_delegate
   - trailing_comma
-  - vertical_parameter_alignment
 opt_in_rules:
   - empty_count
   - force_unwrapping

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,6 +1,7 @@
 disabled_rules:
   - closure_parameter_position
   - function_parameter_count
+  - large_tuple
   - nesting
   - variable_name
   - weak_delegate

--- a/Kickstarter-iOS/AppDelegate.swift
+++ b/Kickstarter-iOS/AppDelegate.swift
@@ -216,7 +216,7 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
 
   internal func application(_ application: UIApplication,
                             performActionFor shortcutItem: UIApplicationShortcutItem,
-                                                         completionHandler: @escaping (Bool) -> Void) {
+                            completionHandler: @escaping (Bool) -> Void) {
 
     self.viewModel.inputs.applicationPerformActionForShortcutItem(shortcutItem)
     completionHandler(true)

--- a/Kickstarter-iOS/DataSources/DashboardDataSource.swift
+++ b/Kickstarter-iOS/DataSources/DashboardDataSource.swift
@@ -30,15 +30,15 @@ internal final class DashboardDataSource: ValueCellDataSource {
   }
 
   internal func load(cumulative: ProjectStatsEnvelope.CumulativeStats,
-                                project: Project,
-                                referrers: [ProjectStatsEnvelope.ReferrerStats]) {
+                     project: Project,
+                     referrers: [ProjectStatsEnvelope.ReferrerStats]) {
 
     self.set(values: [(cumulative, project, referrers)], cellClass: DashboardReferrersCell.self,
              inSection: Section.referrers.rawValue)
   }
 
   internal func load(rewardStats: [ProjectStatsEnvelope.RewardStats],
-                                 project: Project) {
+                     project: Project) {
 
     self.set(values: [(rewardStats: rewardStats, project: project)], cellClass: DashboardRewardsCell.self,
              inSection: Section.rewards.rawValue)

--- a/Kickstarter-iOS/Tests/.swiftlint.yml
+++ b/Kickstarter-iOS/Tests/.swiftlint.yml
@@ -4,6 +4,7 @@ disabled_rules:
   - force_unwrapping
   - function_body_length
   - function_parameter_count
+  - large_tuple
   - nesting
   - type_body_length
   - variable_name

--- a/Kickstarter-iOS/ViewModels/AppDelegateViewModel.swift
+++ b/Kickstarter-iOS/ViewModels/AppDelegateViewModel.swift
@@ -535,7 +535,7 @@ AppDelegateViewModelOutputs {
   fileprivate typealias ApplicationWithOptions = (application: UIApplication?, options: [AnyHashable: Any]?)
   fileprivate let applicationLaunchOptionsProperty = MutableProperty<ApplicationWithOptions?>(nil)
   public func applicationDidFinishLaunching(application: UIApplication?,
-                                                        launchOptions: [AnyHashable: Any]?) {
+                                            launchOptions: [AnyHashable: Any]?) {
     self.applicationLaunchOptionsProperty.value = (application, launchOptions)
   }
 
@@ -592,9 +592,9 @@ AppDelegateViewModelOutputs {
   )
   fileprivate let applicationOpenUrlProperty = MutableProperty<ApplicationOpenUrl?>(nil)
   public func applicationOpenUrl(application: UIApplication?,
-                                             url: URL,
-                                             sourceApplication: String?,
-                                             annotation: Any) -> Bool {
+                                 url: URL,
+                                 sourceApplication: String?,
+                                 annotation: Any) -> Bool {
     self.applicationOpenUrlProperty.value = (application, url, sourceApplication, annotation)
     return self.facebookOpenURLReturnValue.value
   }

--- a/Kickstarter-iOS/Views/Cells/ActivityUpdateCell.swift
+++ b/Kickstarter-iOS/Views/Cells/ActivityUpdateCell.swift
@@ -5,14 +5,14 @@ import ReactiveSwift
 import KsApi
 import UIKit
 
-internal protocol ActivityUpdateCellDelegate {
+internal protocol ActivityUpdateCellDelegate: class {
   /// Call with the activity value when navigating to the activity's project.
   func activityUpdateCellTappedProjectImage(activity: Activity)
 }
 
 internal final class ActivityUpdateCell: UITableViewCell, ValueCell {
   fileprivate var viewModel: ActivityUpdateViewModelType = ActivityUpdateViewModel()
-  internal var delegate: ActivityUpdateCellDelegate?
+  internal weak var delegate: ActivityUpdateCellDelegate?
 
   @IBOutlet fileprivate weak var bodyLabel: UILabel!
   @IBOutlet fileprivate weak var cardView: UIView!

--- a/Kickstarter-iOS/Views/Cells/DashboardRewardsCell.swift
+++ b/Kickstarter-iOS/Views/Cells/DashboardRewardsCell.swift
@@ -116,7 +116,7 @@ internal final class DashboardRewardsCell: UITableViewCell, ValueCell {
   }
 
   internal func configureWith(value: (rewardStats: [ProjectStatsEnvelope.RewardStats],
-                                            project: Project)) {
+                              project: Project)) {
     self.viewModel.inputs.configureWith(rewardStats: value.0, project: value.1)
   }
 

--- a/Kickstarter-iOS/Views/Controllers/BackingViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/BackingViewController.swift
@@ -162,7 +162,7 @@ internal final class BackingViewController: UIViewController {
   }
 
   fileprivate func goToMessageCreator(messageSubject: MessageSubject,
-                                                 context: Koala.MessageDialogContext) {
+                                      context: Koala.MessageDialogContext) {
     let vc = MessageDialogViewController.configuredWith(messageSubject: messageSubject, context: context)
     let nav = UINavigationController(rootViewController: vc)
     nav.modalPresentationStyle = .formSheet

--- a/Kickstarter-iOS/Views/Controllers/CheckoutViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/CheckoutViewController.swift
@@ -12,8 +12,8 @@ internal final class CheckoutViewController: DeprecatedWebViewController {
   fileprivate let viewModel: CheckoutViewModelType = CheckoutViewModel()
 
   internal static func configuredWith(initialRequest: URLRequest,
-                                                     project: Project,
-                                                     reward: Reward) -> CheckoutViewController {
+                                      project: Project,
+                                      reward: Reward) -> CheckoutViewController {
 
       let vc = Storyboard.Checkout.instantiate(CheckoutViewController.self)
       vc.viewModel.inputs.configureWith(
@@ -184,7 +184,7 @@ extension CheckoutViewController: PKPaymentAuthorizationViewControllerDelegate {
   internal func paymentAuthorizationViewController(
     _ controller: PKPaymentAuthorizationViewController,
     didAuthorizePayment payment: PKPayment,
-                        completion: @escaping (PKPaymentAuthorizationStatus) -> Void) {
+    completion: @escaping (PKPaymentAuthorizationStatus) -> Void) {
 
     self.viewModel.inputs.paymentAuthorization(didAuthorizePayment: .init(payment: payment))
 

--- a/Kickstarter-iOS/Views/Controllers/DiscoveryFiltersViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/DiscoveryFiltersViewController.swift
@@ -110,7 +110,7 @@ internal final class DiscoveryFiltersViewController: UIViewController, UITableVi
 
   internal func tableView(_ tableView: UITableView,
                           willDisplay cell: UITableViewCell,
-                                          forRowAt indexPath: IndexPath) {
+                          forRowAt indexPath: IndexPath) {
 
     if let cell = cell as? DiscoverySelectableRowCell {
       cell.willDisplay()

--- a/Kickstarter-iOS/Views/Controllers/FacebookConfirmationViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/FacebookConfirmationViewController.swift
@@ -183,7 +183,7 @@ internal final class FacebookConfirmationViewController: UIViewController,
 
   @objc internal func mailComposeController(_ controller: MFMailComposeViewController,
                                             didFinishWith result: MFMailComposeResult,
-                                                                error: Error?) {
+                                            error: Error?) {
     self.helpViewModel.inputs.mailComposeCompletion(result: result)
     self.dismiss(animated: true, completion: nil)
   }

--- a/Kickstarter-iOS/Views/Controllers/LiveStreamContainerViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/LiveStreamContainerViewController.swift
@@ -513,12 +513,12 @@ public final class LiveStreamContainerViewController: UIViewController {
 
 extension LiveStreamContainerViewController: LiveStreamViewControllerDelegate {
   public func liveStreamViewControllerNumberOfPeopleWatchingChanged(controller: LiveStreamViewController?,
-                                                                      numberOfPeople: Int) {
+                                                                    numberOfPeople: Int) {
     self.eventDetailsViewModel.inputs.setNumberOfPeopleWatching(numberOfPeople: numberOfPeople)
   }
 
   public func liveStreamViewControllerStateChanged(controller: LiveStreamViewController?,
-                                                     state: LiveStreamViewControllerState) {
+                                                   state: LiveStreamViewControllerState) {
     self.viewModel.inputs.liveStreamViewControllerStateChanged(state: state)
     self.eventDetailsViewModel.inputs.liveStreamViewControllerStateChanged(state: state)
   }

--- a/Kickstarter-iOS/Views/Controllers/LoginToutViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/LoginToutViewController.swift
@@ -154,7 +154,7 @@ internal final class LoginToutViewController: UIViewController, MFMailComposeVie
 
   @objc internal func mailComposeController(_ controller: MFMailComposeViewController,
                                             didFinishWith result: MFMailComposeResult,
-                                                                error: Error?) {
+                                            error: Error?) {
     self.helpViewModel.inputs.mailComposeCompletion(result: result)
     self.dismiss(animated: true, completion: nil)
   }
@@ -177,7 +177,7 @@ internal final class LoginToutViewController: UIViewController, MFMailComposeVie
   }
 
   fileprivate func pushFacebookConfirmationController(facebookUser user: ErrorEnvelope.FacebookUser?,
-                                                               facebookToken token: String) {
+                                                      facebookToken token: String) {
     let vc = FacebookConfirmationViewController
       .configuredWith(facebookUserEmail: user?.email ?? "", facebookAccessToken: token)
     self.navigationController?.pushViewController(vc, animated: true)

--- a/Kickstarter-iOS/Views/Controllers/MessageThreadsViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/MessageThreadsViewController.swift
@@ -70,7 +70,7 @@ internal final class MessageThreadsViewController: UITableViewController {
 
   internal override func tableView(_ tableView: UITableView,
                                    willDisplay cell: UITableViewCell,
-                                                   forRowAt indexPath: IndexPath) {
+                                   forRowAt indexPath: IndexPath) {
 
     self.viewModel.inputs.willDisplayRow(self.dataSource.itemIndexAt(indexPath),
                                          outOf: self.dataSource.numberOfItems())

--- a/Kickstarter-iOS/Views/Controllers/MessagesViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/MessagesViewController.swift
@@ -109,7 +109,7 @@ internal final class MessagesViewController: UITableViewController {
   }
 
   fileprivate func presentMessageDialog(messageThread: MessageThread,
-                                                  context: Koala.MessageDialogContext) {
+                                        context: Koala.MessageDialogContext) {
     let dialog = MessageDialogViewController
       .configuredWith(messageSubject: .messageThread(messageThread), context: context)
     dialog.modalPresentationStyle = .formSheet

--- a/Kickstarter-iOS/Views/Controllers/ProjectActivitiesViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/ProjectActivitiesViewController.swift
@@ -120,7 +120,7 @@ internal final class ProjectActivitiesViewController: UITableViewController {
   }
 
   internal func goToSendMessage(backing: Backing,
-                                        context: Koala.MessageDialogContext) {
+                                context: Koala.MessageDialogContext) {
     let vc = MessageDialogViewController.configuredWith(messageSubject: .backing(backing), context: context)
     vc.modalPresentationStyle = .formSheet
     vc.delegate = self

--- a/Kickstarter-iOS/Views/Controllers/ProjectCreatorViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/ProjectCreatorViewController.swift
@@ -55,7 +55,7 @@ internal final class ProjectCreatorViewController: WebViewController {
 
   internal func webView(_ webView: WKWebView,
                         decidePolicyForNavigationAction navigationAction: WKNavigationAction,
-                                                        decisionHandler: (WKNavigationActionPolicy) -> Void) {
+                        decisionHandler: (WKNavigationActionPolicy) -> Void) {
     decisionHandler(self.viewModel.inputs.decidePolicy(forNavigationAction: navigationAction))
   }
 

--- a/Kickstarter-iOS/Views/Controllers/ProjectNavigatorViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/ProjectNavigatorViewController.swift
@@ -24,9 +24,9 @@ internal final class ProjectNavigatorViewController: UIPageViewController {
 
   internal static func configuredWith(
     project: Project,
-            refTag: RefTag,
-            initialPlaylist: [Project]? = nil,
-            navigatorDelegate: ProjectNavigatorDelegate?) -> ProjectNavigatorViewController {
+    refTag: RefTag,
+    initialPlaylist: [Project]? = nil,
+    navigatorDelegate: ProjectNavigatorDelegate?) -> ProjectNavigatorViewController {
 
     let vc = ProjectNavigatorViewController(
       initialProject: project,
@@ -39,9 +39,9 @@ internal final class ProjectNavigatorViewController: UIPageViewController {
   }
 
   fileprivate init(initialProject: Project,
-               initialPlaylist: [Project]?,
-               refTag: RefTag,
-               navigatorDelegate: ProjectNavigatorDelegate?) {
+                   initialPlaylist: [Project]?,
+                   refTag: RefTag,
+                   navigatorDelegate: ProjectNavigatorDelegate?) {
 
     self.pageDataSource = ProjectNavigatorPagesDataSource(refTag: refTag,
                                                           initialPlaylist: initialPlaylist,
@@ -151,8 +151,8 @@ extension ProjectNavigatorViewController: UIGestureRecognizerDelegate {
 extension ProjectNavigatorViewController: UIPageViewControllerDelegate {
   internal func pageViewController(_ pageViewController: UIPageViewController,
                                    didFinishAnimating finished: Bool,
-                                                      previousViewControllers: [UIViewController],
-                                                      transitionCompleted completed: Bool) {
+                                   previousViewControllers: [UIViewController],
+                                   transitionCompleted completed: Bool) {
 
     self.viewModel.inputs.pageTransition(completed: completed)
   }

--- a/Kickstarter-iOS/Views/Controllers/ProjectPamphletContentViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/ProjectPamphletContentViewController.swift
@@ -114,8 +114,8 @@ public final class ProjectPamphletContentViewController: UITableViewController {
   }
 
   public override func tableView(_ tableView: UITableView,
-                                   willDisplay cell: UITableViewCell,
-                                   forRowAt indexPath: IndexPath) {
+                                 willDisplay cell: UITableViewCell,
+                                 forRowAt indexPath: IndexPath) {
 
     if let cell = cell as? ProjectPamphletMainCell {
       cell.delegate = self

--- a/Kickstarter-iOS/Views/Controllers/ProjectPamphletViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/ProjectPamphletViewController.swift
@@ -79,7 +79,7 @@ public final class ProjectPamphletViewController: UIViewController {
 
 extension ProjectPamphletViewController: ProjectPamphletContentViewControllerDelegate {
   public func projectPamphletContent(_ controller: ProjectPamphletContentViewController,
-                                       imageIsVisible: Bool) {
+                                     imageIsVisible: Bool) {
     self.navBarController.setProjectImageIsVisible(imageIsVisible)
   }
 

--- a/Kickstarter-iOS/Views/Controllers/RewardPledgeViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/RewardPledgeViewController.swift
@@ -68,8 +68,8 @@ internal final class RewardPledgeViewController: UIViewController {
 
   internal static func configuredWith(
     project: Project,
-            reward: Reward,
-            applePayCapable: Bool = PKPaymentAuthorizationViewController.applePayCapable())
+    reward: Reward,
+    applePayCapable: Bool = PKPaymentAuthorizationViewController.applePayCapable())
     -> RewardPledgeViewController {
 
       let vc = Storyboard.RewardPledge.instantiate(RewardPledgeViewController.self)
@@ -542,8 +542,8 @@ internal final class RewardPledgeViewController: UIViewController {
   // swiftlint:enable function_body_length
 
   fileprivate func goToCheckout(initialRequest: URLRequest,
-                                           project: Project,
-                                           reward: Reward) {
+                                project: Project,
+                                reward: Reward) {
 
     let vc = CheckoutViewController.configuredWith(initialRequest: initialRequest,
                                                    project: project,
@@ -572,8 +572,8 @@ internal final class RewardPledgeViewController: UIViewController {
   }
 
   fileprivate func goToShippingPicker(project: Project,
-                                          shippingRules: [ShippingRule],
-                                          selectedShippingRule: ShippingRule) {
+                                      shippingRules: [ShippingRule],
+                                      selectedShippingRule: ShippingRule) {
     let vc = RewardShippingPickerViewController.configuredWith(project: project,
                                                                shippingRules: shippingRules,
                                                                selectedShippingRule: selectedShippingRule,

--- a/Kickstarter-iOS/Views/Controllers/RewardShippingPickerViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/RewardShippingPickerViewController.swift
@@ -25,9 +25,9 @@ internal final class RewardShippingPickerViewController: UIViewController {
   @IBOutlet fileprivate weak var titleView: UIView!
 
   internal static func configuredWith(project: Project,
-                                              shippingRules: [ShippingRule],
-                                              selectedShippingRule: ShippingRule,
-                                              delegate: RewardShippingPickerViewControllerDelegate)
+                                      shippingRules: [ShippingRule],
+                                      selectedShippingRule: ShippingRule,
+                                      delegate: RewardShippingPickerViewControllerDelegate)
     -> RewardShippingPickerViewController {
 
       let vc = Storyboard.RewardPledge.instantiate(RewardShippingPickerViewController.self)

--- a/Kickstarter-iOS/Views/Controllers/RootTabBarViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/RootTabBarViewController.swift
@@ -203,9 +203,9 @@ private func tabbarAvatarImageFromData(_ data: Data) -> (defaultImage: UIImage?,
 }
 
 private func strokedRoundImage(fromImage image: UIImage?,
-                                         size: CGSize,
-                                         color: UIColor,
-                                         lineWidth: CGFloat = 1.0) -> UIImage? {
+                               size: CGSize,
+                               color: UIColor,
+                               lineWidth: CGFloat = 1.0) -> UIImage? {
 
   UIGraphicsBeginImageContextWithOptions(size, false, 0.0)
   defer { UIGraphicsEndImageContext() }

--- a/Kickstarter-iOS/Views/Controllers/SignupViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/SignupViewController.swift
@@ -189,7 +189,7 @@ internal final class SignupViewController: UIViewController, MFMailComposeViewCo
 
   @objc internal func mailComposeController(_ controller: MFMailComposeViewController,
                                             didFinishWith result: MFMailComposeResult,
-                                                                error: Error?) {
+                                            error: Error?) {
     self.helpViewModel.inputs.mailComposeCompletion(result: result)
     self.dismiss(animated: true, completion: nil)
   }

--- a/Kickstarter-iOS/Views/Controllers/SortPagerViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/SortPagerViewController.swift
@@ -116,7 +116,7 @@ internal final class SortPagerViewController: UIViewController {
   }
 
   override func willRotate(to toInterfaceOrientation: UIInterfaceOrientation,
-                                                 duration: TimeInterval) {
+                           duration: TimeInterval) {
     self.viewModel.inputs.willRotateToInterfaceOrientation()
   }
 

--- a/Kickstarter-iOS/Views/Controllers/SurveyResponseViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/SurveyResponseViewController.swift
@@ -86,8 +86,9 @@ internal final class SurveyResponseViewController: DeprecatedWebViewController {
     )
   }
 
-  internal func webView(_ webView: UIWebView, shouldStartLoadWithRequest request: URLRequest,
-               navigationType: UIWebViewNavigationType) -> Bool {
+  internal func webView(_ webView: UIWebView,
+                        shouldStartLoadWithRequest request: URLRequest,
+                        navigationType: UIWebViewNavigationType) -> Bool {
     let result = self.viewModel.inputs.shouldStartLoad(withRequest: request, navigationType: navigationType)
     return result
   }

--- a/Kickstarter-iOS/Views/Controllers/UpdatePreviewViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/UpdatePreviewViewController.swift
@@ -50,7 +50,7 @@ internal final class UpdatePreviewViewController: WebViewController {
 
   internal func webView(_ webView: WKWebView,
                         decidePolicyForNavigationAction navigationAction: WKNavigationAction,
-                                                        decisionHandler: (WKNavigationActionPolicy) -> Void) {
+                        decisionHandler: (WKNavigationActionPolicy) -> Void) {
 
     decisionHandler(
       self.viewModel.inputs.decidePolicyFor(navigationAction: .init(navigationAction: navigationAction))

--- a/Kickstarter-iOS/Views/Controllers/VideoViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/VideoViewController.swift
@@ -167,8 +167,8 @@ public final class VideoViewController: UIViewController {
   }
 
   public override func observeValue(forKeyPath keyPath: String?, of object: Any?,
-                                                change: [NSKeyValueChangeKey : Any]?,
-                                                context: UnsafeMutableRawPointer?) {
+                                    change: [NSKeyValueChangeKey : Any]?,
+                                    context: UnsafeMutableRawPointer?) {
 
     guard let player = self.playerController.player else { return }
 

--- a/Kickstarter-iOS/Views/Controllers/WebModalViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/WebModalViewController.swift
@@ -47,7 +47,7 @@ internal final class WebModalViewController: WebViewController {
 
   internal func webView(_ webView: WKWebView,
                         decidePolicyForNavigationAction navigationAction: WKNavigationAction,
-                                                        decisionHandler: (WKNavigationActionPolicy) -> Void) {
+                        decisionHandler: (WKNavigationActionPolicy) -> Void) {
     decisionHandler(self.viewModel.inputs.decidePolicyFor(navigationAction: navigationAction))
   }
 }

--- a/Kickstarter-iOS/Views/Transitions/ProjectNavigatorTransitionAnimator.swift
+++ b/Kickstarter-iOS/Views/Transitions/ProjectNavigatorTransitionAnimator.swift
@@ -73,9 +73,9 @@ UIViewControllerAnimatedTransitioning {
   }
 
   fileprivate func animateDismissal(fromViewController fromVC: UIViewController,
-                                                   toViewController toVC: UIViewController,
-                                                   containerView: UIView,
-                                                   transitionContext: UIViewControllerContextTransitioning) {
+                                    toViewController toVC: UIViewController,
+                                    containerView: UIView,
+                                    transitionContext: UIViewControllerContextTransitioning) {
 
     containerView.insertSubview(toVC.view, belowSubview: fromVC.view)
     containerView.insertSubview(self.darkOverlayView, belowSubview: fromVC.view)

--- a/Library/AppEnvironment.swift
+++ b/Library/AppEnvironment.swift
@@ -98,30 +98,28 @@ public struct AppEnvironment {
   // Pushes a new environment onto the stack that changes only a subset of the current global dependencies.
   public static func pushEnvironment(
     apiService: ServiceType = AppEnvironment.current.apiService,
-               apiDelayInterval: DispatchTimeInterval = AppEnvironment.current.apiDelayInterval,
-               // swiftlint:disable line_length
-               assetImageGeneratorType: AssetImageGeneratorType.Type = AppEnvironment.current.assetImageGeneratorType,
-               // swiftlint:enable line_length
-               cache: KSCache = KSCache(),
-               calendar: Calendar = AppEnvironment.current.calendar,
-               config: Config? = AppEnvironment.current.config,
-               cookieStorage: HTTPCookieStorageProtocol = AppEnvironment.current.cookieStorage,
-               countryCode: String = AppEnvironment.current.countryCode,
-               currentUser: User? = AppEnvironment.current.currentUser,
-               dateType: DateProtocol.Type = AppEnvironment.current.dateType,
-               debounceInterval: DispatchTimeInterval = AppEnvironment.current.debounceInterval,
-               facebookAppDelegate: FacebookAppDelegateProtocol = AppEnvironment.current.facebookAppDelegate,
-               isVoiceOverRunning: @escaping (() -> Bool) = AppEnvironment.current.isVoiceOverRunning,
-               koala: Koala = AppEnvironment.current.koala,
-               language: Language = AppEnvironment.current.language,
-               launchedCountries: LaunchedCountries = AppEnvironment.current.launchedCountries,
-               liveStreamService: LiveStreamServiceProtocol = AppEnvironment.current.liveStreamService,
-               locale: Locale = AppEnvironment.current.locale,
-               mainBundle: NSBundleType = AppEnvironment.current.mainBundle,
-               reachability: SignalProducer<Reachability, NoError> = AppEnvironment.current.reachability,
-               scheduler: DateSchedulerProtocol = AppEnvironment.current.scheduler,
-               ubiquitousStore: KeyValueStoreType = AppEnvironment.current.ubiquitousStore,
-               userDefaults: KeyValueStoreType = AppEnvironment.current.userDefaults) {
+    apiDelayInterval: DispatchTimeInterval = AppEnvironment.current.apiDelayInterval,
+    assetImageGeneratorType: AssetImageGeneratorType.Type = AppEnvironment.current.assetImageGeneratorType,
+    cache: KSCache = KSCache(),
+    calendar: Calendar = AppEnvironment.current.calendar,
+    config: Config? = AppEnvironment.current.config,
+    cookieStorage: HTTPCookieStorageProtocol = AppEnvironment.current.cookieStorage,
+    countryCode: String = AppEnvironment.current.countryCode,
+    currentUser: User? = AppEnvironment.current.currentUser,
+    dateType: DateProtocol.Type = AppEnvironment.current.dateType,
+    debounceInterval: DispatchTimeInterval = AppEnvironment.current.debounceInterval,
+    facebookAppDelegate: FacebookAppDelegateProtocol = AppEnvironment.current.facebookAppDelegate,
+    isVoiceOverRunning: @escaping (() -> Bool) = AppEnvironment.current.isVoiceOverRunning,
+    koala: Koala = AppEnvironment.current.koala,
+    language: Language = AppEnvironment.current.language,
+    launchedCountries: LaunchedCountries = AppEnvironment.current.launchedCountries,
+    liveStreamService: LiveStreamServiceProtocol = AppEnvironment.current.liveStreamService,
+    locale: Locale = AppEnvironment.current.locale,
+    mainBundle: NSBundleType = AppEnvironment.current.mainBundle,
+    reachability: SignalProducer<Reachability, NoError> = AppEnvironment.current.reachability,
+    scheduler: DateSchedulerProtocol = AppEnvironment.current.scheduler,
+    ubiquitousStore: KeyValueStoreType = AppEnvironment.current.ubiquitousStore,
+    userDefaults: KeyValueStoreType = AppEnvironment.current.userDefaults) {
 
     pushEnvironment(
       Environment(
@@ -156,29 +154,28 @@ public struct AppEnvironment {
   // of current global dependencies.
   public static func replaceCurrentEnvironment(
     apiService: ServiceType = AppEnvironment.current.apiService,
-               apiDelayInterval: DispatchTimeInterval = AppEnvironment.current.apiDelayInterval,
-               // swiftlint:disable:next line_length
-               assetImageGeneratorType: AssetImageGeneratorType.Type = AppEnvironment.current.assetImageGeneratorType,
-               cache: KSCache = KSCache(),
-               calendar: Calendar = AppEnvironment.current.calendar,
-               config: Config? = AppEnvironment.current.config,
-               cookieStorage: HTTPCookieStorageProtocol = AppEnvironment.current.cookieStorage,
-               countryCode: String = AppEnvironment.current.countryCode,
-               currentUser: User? = AppEnvironment.current.currentUser,
-               dateType: DateProtocol.Type = AppEnvironment.current.dateType,
-               debounceInterval: DispatchTimeInterval = AppEnvironment.current.debounceInterval,
-               facebookAppDelegate: FacebookAppDelegateProtocol = AppEnvironment.current.facebookAppDelegate,
-               isVoiceOverRunning: @escaping (() -> Bool) = AppEnvironment.current.isVoiceOverRunning,
-               koala: Koala = AppEnvironment.current.koala,
-               language: Language = AppEnvironment.current.language,
-               launchedCountries: LaunchedCountries = AppEnvironment.current.launchedCountries,
-               liveStreamService: LiveStreamServiceProtocol = AppEnvironment.current.liveStreamService,
-               locale: Locale = AppEnvironment.current.locale,
-               mainBundle: NSBundleType = AppEnvironment.current.mainBundle,
-               reachability: SignalProducer<Reachability, NoError> = AppEnvironment.current.reachability,
-               scheduler: DateSchedulerProtocol = AppEnvironment.current.scheduler,
-               ubiquitousStore: KeyValueStoreType = AppEnvironment.current.ubiquitousStore,
-               userDefaults: KeyValueStoreType = AppEnvironment.current.userDefaults) {
+    apiDelayInterval: DispatchTimeInterval = AppEnvironment.current.apiDelayInterval,
+    assetImageGeneratorType: AssetImageGeneratorType.Type = AppEnvironment.current.assetImageGeneratorType,
+    cache: KSCache = KSCache(),
+    calendar: Calendar = AppEnvironment.current.calendar,
+    config: Config? = AppEnvironment.current.config,
+    cookieStorage: HTTPCookieStorageProtocol = AppEnvironment.current.cookieStorage,
+    countryCode: String = AppEnvironment.current.countryCode,
+    currentUser: User? = AppEnvironment.current.currentUser,
+    dateType: DateProtocol.Type = AppEnvironment.current.dateType,
+    debounceInterval: DispatchTimeInterval = AppEnvironment.current.debounceInterval,
+    facebookAppDelegate: FacebookAppDelegateProtocol = AppEnvironment.current.facebookAppDelegate,
+    isVoiceOverRunning: @escaping (() -> Bool) = AppEnvironment.current.isVoiceOverRunning,
+    koala: Koala = AppEnvironment.current.koala,
+    language: Language = AppEnvironment.current.language,
+    launchedCountries: LaunchedCountries = AppEnvironment.current.launchedCountries,
+    liveStreamService: LiveStreamServiceProtocol = AppEnvironment.current.liveStreamService,
+    locale: Locale = AppEnvironment.current.locale,
+    mainBundle: NSBundleType = AppEnvironment.current.mainBundle,
+    reachability: SignalProducer<Reachability, NoError> = AppEnvironment.current.reachability,
+    scheduler: DateSchedulerProtocol = AppEnvironment.current.scheduler,
+    ubiquitousStore: KeyValueStoreType = AppEnvironment.current.ubiquitousStore,
+    userDefaults: KeyValueStoreType = AppEnvironment.current.userDefaults) {
 
     replaceCurrentEnvironment(
       Environment(
@@ -294,8 +291,8 @@ public struct AppEnvironment {
 
   // Saves some key data for the current environment
   internal static func saveEnvironment(environment env: Environment = AppEnvironment.current,
-                                                   ubiquitousStore: KeyValueStoreType,
-                                                   userDefaults: KeyValueStoreType) {
+                                       ubiquitousStore: KeyValueStoreType,
+                                       userDefaults: KeyValueStoreType) {
 
     var data: [String:Any] = [:]
 

--- a/Library/Format.swift
+++ b/Library/Format.swift
@@ -88,9 +88,9 @@ public enum Format {
    - returns: A formatted string.
    */
   public static func date(secondsInUTC seconds: TimeInterval,
-                                       dateStyle: DateFormatter.Style = .medium,
-                                       timeStyle: DateFormatter.Style = .medium,
-                                       env: Environment = AppEnvironment.current) -> String {
+                          dateStyle: DateFormatter.Style = .medium,
+                          timeStyle: DateFormatter.Style = .medium,
+                          env: Environment = AppEnvironment.current) -> String {
 
     let formatter = DateFormatterConfig.cachedFormatter(
       forConfig: .init(
@@ -114,7 +114,7 @@ public enum Format {
    - returns: A formatted string.
    */
   public static func date(secondsInUTC seconds: TimeInterval,
-                                       dateFormat: String) -> String {
+                          dateFormat: String) -> String {
 
     let formatter = DateFormatterConfig.cachedFormatter(
       forConfig: .init(dateFormat: dateFormat,
@@ -140,11 +140,10 @@ public enum Format {
    - returns: A pair of strings for the numeric time value and unit.
    */
   // swiftlint:disable valid_docs
-  public static func duration(
-    secondsInUTC seconds: TimeInterval,
-                 abbreviate: Bool = false,
-                 useToGo: Bool = false,
-                 env: Environment = AppEnvironment.current) -> (time: String, unit: String) {
+  public static func duration(secondsInUTC seconds: TimeInterval,
+                              abbreviate: Bool = false,
+                              useToGo: Bool = false,
+                              env: Environment = AppEnvironment.current) -> (time: String, unit: String) {
 
     let components = env.calendar.dateComponents([.day, .hour, .minute, .second],
                                                  from: env.dateType.init().date,
@@ -203,11 +202,10 @@ public enum Format {
 
    - returns: A formatted string.
    */
-  public static func relative(
-    secondsInUTC seconds: TimeInterval,
-                 abbreviate: Bool = false,
-                 threshold thresholdInDays: Int = defaultThresholdInDays,
-                 env: Environment = AppEnvironment.current) -> String {
+  public static func relative(secondsInUTC seconds: TimeInterval,
+                              abbreviate: Bool = false,
+                              threshold thresholdInDays: Int = defaultThresholdInDays,
+                              env: Environment = AppEnvironment.current) -> String {
 
     let components = env.calendar.dateComponents([.day, .hour, .minute, .second],
                                                  from: env.dateType.init(timeIntervalSince1970: seconds).date,

--- a/Library/Image.swift
+++ b/Library/Image.swift
@@ -1,15 +1,16 @@
 import UIKit
 
-public func image(named name: String, inBundle bundle: NSBundleType = AppEnvironment.current.mainBundle,
-                        compatibleWithTraitCollection traitCollection: UITraitCollection? = nil) -> UIImage? {
+public func image(named name: String,
+                  inBundle bundle: NSBundleType = AppEnvironment.current.mainBundle,
+                  compatibleWithTraitCollection traitCollection: UITraitCollection? = nil) -> UIImage? {
 
   return UIImage(named: name, in: Bundle(identifier: bundle.identifier), compatibleWith: traitCollection)
 }
 
 public func image(named name: String,
-                        tintColor: UIColor,
-                        inBundle bundle: NSBundleType = AppEnvironment.current.mainBundle,
-                        compatibleWithTraitCollection traitCollection: UITraitCollection? = nil) -> UIImage? {
+                  tintColor: UIColor,
+                  inBundle bundle: NSBundleType = AppEnvironment.current.mainBundle,
+                  compatibleWithTraitCollection traitCollection: UITraitCollection? = nil) -> UIImage? {
 
   guard let img = image(named: name, inBundle: bundle, compatibleWithTraitCollection: traitCollection)
     else {

--- a/Library/Koala/Koala.swift
+++ b/Library/Koala/Koala.swift
@@ -455,8 +455,8 @@ public final class Koala {
 
   // MARK: Checkout Events
   public func trackCheckoutCancel(project: Project,
-                                          reward: Reward,
-                                          pledgeContext: PledgeContext) {
+                                  reward: Reward,
+                                  pledgeContext: PledgeContext) {
 
     let props = properties(project: project, loggedInUser: self.loggedInUser)
       .withAllValuesFrom(properties(reward: reward))
@@ -467,10 +467,10 @@ public final class Koala {
   }
 
   public func trackClickedRewardPledgeButton(project: Project,
-                                                     reward: Reward,
-                                                     buttonType: ClickedRewardPledgeButtonType,
-                                                     pageContext: CheckoutPageContext,
-                                                     pledgeContext: PledgeContext) {
+                                             reward: Reward,
+                                             buttonType: ClickedRewardPledgeButtonType,
+                                             pageContext: CheckoutPageContext,
+                                             pledgeContext: PledgeContext) {
 
     let props = properties(project: project, loggedInUser: self.loggedInUser)
       .withAllValuesFrom(properties(reward: reward))
@@ -484,12 +484,12 @@ public final class Koala {
   }
 
   public func trackClickedRewardPledgeButton(project: Project,
-                                                     reward: Reward,
-                                                     errorText: String,
-                                                     errorType: ErroredRewardPledgeButtonClickType,
-                                                     paymentMethod: PaymentMethod?,
-                                                     pageContext: CheckoutPageContext,
-                                                     pledgeContext: PledgeContext) {
+                                             reward: Reward,
+                                             errorText: String,
+                                             errorType: ErroredRewardPledgeButtonClickType,
+                                             paymentMethod: PaymentMethod?,
+                                             pageContext: CheckoutPageContext,
+                                             pledgeContext: PledgeContext) {
 
     var extraProps = [
       "error_text": errorText,
@@ -675,9 +675,9 @@ public final class Koala {
   }
 
   public func trackLoadOlderComments(project: Project,
-                                             update: Update?,
-                                             page: Int,
-                                             context: CommentsContext) {
+                                     update: Update?,
+                                     page: Int,
+                                     context: CommentsContext) {
 
     let props = properties(project: project, loggedInUser: self.loggedInUser)
       .withAllValuesFrom(update.map { properties(update: $0) } ?? [:])
@@ -695,8 +695,8 @@ public final class Koala {
   }
 
   public func trackOpenedCommentEditor(project: Project,
-                                               update: Update?,
-                                               context: CommentDialogContext) {
+                                       update: Update?,
+                                       context: CommentDialogContext) {
 
     let props = properties(project: project, loggedInUser: self.loggedInUser)
       .withAllValuesFrom(update.map { properties(update: $0) } ?? [:])
@@ -712,8 +712,8 @@ public final class Koala {
   }
 
   public func trackCanceledCommentEditor(project: Project,
-                                                 update: Update?,
-                                                 context: CommentDialogContext) {
+                                         update: Update?,
+                                         context: CommentDialogContext) {
 
     let props = properties(project: project, loggedInUser: self.loggedInUser)
       .withAllValuesFrom(update.map { properties(update: $0) } ?? [:])
@@ -729,8 +729,8 @@ public final class Koala {
   }
 
   public func trackPostedComment(project: Project,
-                                         update: Update?,
-                                         context: CommentDialogContext) {
+                                 update: Update?,
+                                 context: CommentDialogContext) {
     let props = properties(project: project, loggedInUser: self.loggedInUser)
       .withAllValuesFrom(update.map { properties(update: $0) } ?? [:])
       .withAllValuesFrom(
@@ -825,8 +825,8 @@ public final class Koala {
    */
   public func trackShowedShare(shareContext: ShareContext, shareActivityType: UIActivityType?) {
     let props = properties(shareContext: shareContext,
-                                loggedInUser: self.loggedInUser,
-                                shareActivityType: shareActivityType)
+                           loggedInUser: self.loggedInUser,
+                           shareActivityType: shareActivityType)
     self.track(event: "Showed Share", properties: props)
 
     guard shareContext.isLiveStreamContext != true else { return }
@@ -1196,9 +1196,9 @@ public final class Koala {
    - parameter context: The context from which the newsletter preference is set.
    */
   public func trackChangeNewsletter(newsletterType newsletter: Newsletter,
-                                                   sendNewsletter: Bool,
-                                                   project: Project?,
-                                                   context: NewsletterContext) {
+                                    sendNewsletter: Bool,
+                                    project: Project?,
+                                    context: NewsletterContext) {
 
     let props = project.flatMap { properties(project: $0, loggedInUser: self.loggedInUser) } ?? [:]
       .withAllValuesFrom(["context": context.trackingString, "type": newsletter.trackingString])
@@ -1302,7 +1302,7 @@ public final class Koala {
   }
 
   public func trackCompletedAddUpdateDraftAttachment(forProject project: Project,
-                                                           attachedFrom source: AttachmentSource) {
+                                                     attachedFrom source: AttachmentSource) {
     var props = updateDraftProperties(project: project)
     props["type"] = source.rawValue
     self.track(event: "Completed Add Attachment", properties: props)
@@ -1452,8 +1452,8 @@ public final class Koala {
   // MARK: Apple Pay events
 
   public func trackShowApplePaySheet(project: Project,
-                                             reward: Reward,
-                                             pledgeContext: PledgeContext) {
+                                     reward: Reward,
+                                     pledgeContext: PledgeContext) {
 
     let props = properties(project: project, loggedInUser: self.loggedInUser)
       .withAllValuesFrom(properties(reward: reward))
@@ -1467,8 +1467,8 @@ public final class Koala {
   }
 
   public func trackApplePayAuthorizedPayment(project: Project,
-                                                     reward: Reward,
-                                                     pledgeContext: PledgeContext) {
+                                             reward: Reward,
+                                             pledgeContext: PledgeContext) {
 
     let props = properties(project: project, loggedInUser: self.loggedInUser)
       .withAllValuesFrom(properties(reward: reward))
@@ -1481,8 +1481,8 @@ public final class Koala {
   }
 
   public func trackStripeTokenCreatedForApplePay(project: Project,
-                                                         reward: Reward,
-                                                         pledgeContext: PledgeContext) {
+                                                 reward: Reward,
+                                                 pledgeContext: PledgeContext) {
 
     let props = properties(project: project, loggedInUser: self.loggedInUser)
       .withAllValuesFrom(properties(reward: reward))
@@ -1494,8 +1494,8 @@ public final class Koala {
   }
 
   public func trackStripeTokenErroredForApplePay(project: Project,
-                                                         reward: Reward,
-                                                         pledgeContext: PledgeContext) {
+                                                 reward: Reward,
+                                                 pledgeContext: PledgeContext) {
 
     let props = properties(project: project, loggedInUser: self.loggedInUser)
       .withAllValuesFrom(properties(reward: reward))
@@ -1507,8 +1507,8 @@ public final class Koala {
   }
 
   public func trackApplePayFinished(project: Project,
-                                            reward: Reward,
-                                            pledgeContext: PledgeContext) {
+                                    reward: Reward,
+                                    pledgeContext: PledgeContext) {
 
     let props = properties(project: project, loggedInUser: self.loggedInUser)
       .withAllValuesFrom(properties(reward: reward))
@@ -1518,8 +1518,8 @@ public final class Koala {
   }
 
   public func trackApplePaySheetCanceled(project: Project,
-                                                 reward: Reward,
-                                                 pledgeContext: PledgeContext) {
+                                         reward: Reward,
+                                         pledgeContext: PledgeContext) {
 
     let props = properties(project: project, loggedInUser: self.loggedInUser)
       .withAllValuesFrom(properties(reward: reward))
@@ -1619,8 +1619,8 @@ public final class Koala {
   }
 
   public func trackViewedLiveStream(project: Project,
-                                             liveStream: Project.LiveStream,
-                                             refTag: RefTag) {
+                                    liveStream: Project.LiveStream,
+                                    refTag: RefTag) {
     let props = properties(project: project, loggedInUser: self.loggedInUser)
       .withAllValuesFrom(properties(liveStream: liveStream))
       .withAllValuesFrom(["ref_tag": refTag.stringTag])
@@ -1629,9 +1629,9 @@ public final class Koala {
   }
 
   public func trackWatchedLiveStream(project: Project,
-                                    liveStream: Project.LiveStream,
-                                    refTag: RefTag,
-                                    duration: Int) {
+                                     liveStream: Project.LiveStream,
+                                     refTag: RefTag,
+                                     duration: Int) {
     let props = properties(project: project, loggedInUser: self.loggedInUser)
       .withAllValuesFrom(properties(liveStream: liveStream))
       .withAllValuesFrom(["ref_tag": refTag.stringTag, "duration": duration])
@@ -1737,8 +1737,8 @@ public final class Koala {
 }
 
 private func properties(project: Project,
-                                loggedInUser: User?,
-                                prefix: String = "project_") -> [String:Any] {
+                        loggedInUser: User?,
+                        prefix: String = "project_") -> [String:Any] {
 
   var props: [String:Any] = [:]
 

--- a/Library/NSBundleType.swift
+++ b/Library/NSBundleType.swift
@@ -73,8 +73,8 @@ public struct LanguageDoubler: NSBundleType {
 
 public final class DoublerBundle: Bundle {
   public override func localizedString(forKey key: String,
-                                             value: String?,
-                                             table tableName: String?) -> String {
+                                       value: String?,
+                                       table tableName: String?) -> String {
 
     let s = super.localizedString(forKey: key, value: value, table: tableName)
     return "\(s) \(s)"

--- a/Library/Storyboard.swift
+++ b/Library/Storyboard.swift
@@ -31,7 +31,7 @@ public enum Storyboard: String {
   case WebModal
 
   public func instantiate<VC: UIViewController>(_ viewController: VC.Type,
-                          inBundle bundle: Bundle = .framework) -> VC {
+                                                inBundle bundle: Bundle = .framework) -> VC {
     guard
       let vc = UIStoryboard(name: self.rawValue, bundle: Bundle(identifier: bundle.identifier))
         .instantiateViewController(withIdentifier: VC.storyboardIdentifier) as? VC

--- a/Library/Styles/BaseStyles.swift
+++ b/Library/Styles/BaseStyles.swift
@@ -71,9 +71,8 @@ public func cardStyle <V: UIViewProtocol> (cornerRadius radius: CGFloat = Styles
 public let containerViewBackgroundStyle =
   UIView.lens.backgroundColor .~ .ksr_grey_100
 
-public func dropShadowStyle <V: UIViewProtocol> (
-  radius: CGFloat = 2.0,
-         offset: CGSize = .init(width: 0, height: 1)) -> ((V) -> V) {
+public func dropShadowStyle <V: UIViewProtocol> (radius: CGFloat = 2.0,
+                                                 offset: CGSize = .init(width: 0, height: 1)) -> ((V) -> V) {
   return
     V.lens.layer.shadowColor .~ UIColor.ksr_dropShadow.cgColor
       <> V.lens.layer.shadowOpacity .~ 1

--- a/Library/Tests/.swiftlint.yml
+++ b/Library/Tests/.swiftlint.yml
@@ -1,6 +1,7 @@
 disabled_rules:
   - file_length
   - function_parameter_count
+  - large_tuple
   - nesting
   - variable_name
   - force_unwrapping

--- a/Library/Tests/.swiftlint.yml
+++ b/Library/Tests/.swiftlint.yml
@@ -1,8 +1,6 @@
 disabled_rules:
-  - class_delegate_protocol
   - file_length
   - function_parameter_count
-  - large_tuple
   - nesting
   - variable_name
   - force_unwrapping
@@ -11,7 +9,6 @@ disabled_rules:
   - function_body_length
   - weak_delegate
   - trailing_comma
-  - vertical_parameter_alignment
 opt_in_rules:
   - empty_count
 line_length: 110

--- a/Library/Tests/NavigationTests.swift
+++ b/Library/Tests/NavigationTests.swift
@@ -5,8 +5,8 @@ import XCTest
 
 private func KSRAssertMatch(_ expected: Navigation,
                             _ path: String,
-                              file: StaticString = #file,
-                              line: UInt = #line) {
+                            file: StaticString = #file,
+                            line: UInt = #line) {
 
   let baseUrl = AppEnvironment.current.apiService.serverConfig.webBaseUrl.absoluteString
   let match = URL(string: "\(baseUrl)\(path)")

--- a/Library/Tests/ViewModels/CheckoutViewModelTests.swift
+++ b/Library/Tests/ViewModels/CheckoutViewModelTests.swift
@@ -1036,9 +1036,9 @@ internal extension URLRequest {
 }
 
 private func applePayUrlRequest(project: Project,
-                                        amount: Int,
-                                        reward: Reward,
-                                        location: Location) -> URLRequest {
+                                amount: Int,
+                                reward: Reward,
+                                location: Location) -> URLRequest {
 
   let payload: [String:Any] = [
     "country_code": project.country.countryCode,

--- a/Library/ViewModels/ActivityProjectStatusViewModel.swift
+++ b/Library/ViewModels/ActivityProjectStatusViewModel.swift
@@ -109,7 +109,7 @@ private func metadataColor(forActivityCategory category: Activity.Category) -> U
 }
 
 private func metadataString(forActivityCategory category: Activity.Category,
-                                                isCreatorUser: Bool, friendName: String) -> String {
+                            isCreatorUser: Bool, friendName: String) -> String {
   switch category {
   case .cancellation:
     return Strings.Project_Cancelled()

--- a/Library/ViewModels/CheckoutViewModel.swift
+++ b/Library/ViewModels/CheckoutViewModel.swift
@@ -335,9 +335,9 @@ public final class CheckoutViewModel: CheckoutViewModelType {
 
   fileprivate let configDataProperty = MutableProperty<ConfigData?>(nil)
   public func configureWith(initialRequest: URLRequest,
-                                           project: Project,
-                                           reward: Reward,
-                                           applePayCapable: Bool) {
+                            project: Project,
+                            reward: Reward,
+                            applePayCapable: Bool) {
 
     self.configDataProperty.value = ConfigData(initialRequest: initialRequest,
                                                project: project,
@@ -366,7 +366,7 @@ public final class CheckoutViewModel: CheckoutViewModelType {
   fileprivate let shouldStartLoadProperty = MutableProperty<(URLRequest, UIWebViewNavigationType)?>(nil)
   fileprivate let shouldStartLoadResponseProperty = MutableProperty(false)
   public func shouldStartLoad(withRequest request: URLRequest,
-                                          navigationType: UIWebViewNavigationType) -> Bool {
+                              navigationType: UIWebViewNavigationType) -> Bool {
     self.shouldStartLoadProperty.value = (request, navigationType)
     return self.shouldStartLoadResponseProperty.value
   }

--- a/Library/ViewModels/CommentDialogViewModel.swift
+++ b/Library/ViewModels/CommentDialogViewModel.swift
@@ -18,8 +18,10 @@ public protocol CommentDialogViewModelInputs {
   func viewWillDisappear()
 
   /// Call with the project, update (optional), recipient (optional) and context given to the view.
-  func configureWith(project: Project, update: Update?, recipient: User?,
-                             context: Koala.CommentDialogContext)
+  func configureWith(project: Project,
+                     update: Update?,
+                     recipient: User?,
+                     context: Koala.CommentDialogContext)
 
   /// Call when the comment body text changes.
   func commentBodyChanged(_ text: String)

--- a/Library/ViewModels/DashboardFundingCellViewModel.swift
+++ b/Library/ViewModels/DashboardFundingCellViewModel.swift
@@ -21,7 +21,7 @@ public func == (lhs: FundingGraphData, rhs: FundingGraphData) -> Bool {
 public protocol DashboardFundingCellViewModelInputs {
   /// Call to configure cell with funding stats and project data.
   func configureWith(fundingDateStats stats: [ProjectStatsEnvelope.FundingDateStats],
-                                      project: Project)
+                     project: Project)
 }
 
 public protocol DashboardFundingCellViewModelOutputs {
@@ -146,7 +146,7 @@ public final class DashboardFundingCellViewModel: DashboardFundingCellViewModelI
 
   private let statsProjectProperty = MutableProperty<([ProjectStatsEnvelope.FundingDateStats], Project)?>(nil)
   public func configureWith(fundingDateStats stats: [ProjectStatsEnvelope.FundingDateStats],
-                                             project: Project) {
+                            project: Project) {
     self.statsProjectProperty.value = (stats, project)
   }
 

--- a/Library/ViewModels/DashboardReferrersCellViewModel.swift
+++ b/Library/ViewModels/DashboardReferrersCellViewModel.swift
@@ -20,8 +20,8 @@ public protocol DashboardReferrersCellViewModelInputs {
 
   /// Call to configure cell with cumulative and referral stats.
   func configureWith(cumulative: ProjectStatsEnvelope.CumulativeStats,
-                                project: Project,
-                                referrers: [ProjectStatsEnvelope.ReferrerStats])
+                     project: Project,
+                     referrers: [ProjectStatsEnvelope.ReferrerStats])
 
   /// Call when the Percent button is tapped.
   func percentButtonTapped()
@@ -201,13 +201,12 @@ public final class DashboardReferrersCellViewModel: DashboardReferrersCellViewMo
     self.backersButtonTappedProperty.value = ()
   }
 
-  fileprivate let cumulativeProjectStatsProperty = MutableProperty<(ProjectStatsEnvelope.CumulativeStats,
+  private let cumulativeProjectStatsProperty = MutableProperty<(ProjectStatsEnvelope.CumulativeStats,
                                                                 Project,
                                                                 [ProjectStatsEnvelope.ReferrerStats])?>(nil)
   public func configureWith(cumulative: ProjectStatsEnvelope.CumulativeStats,
-                                       project: Project,
-                                       referrers: [ProjectStatsEnvelope.ReferrerStats]) {
-
+                            project: Project,
+                            referrers: [ProjectStatsEnvelope.ReferrerStats]) {
     self.cumulativeProjectStatsProperty.value = (cumulative, project, referrers)
   }
 

--- a/Library/ViewModels/DashboardRewardRowStackViewViewModel.swift
+++ b/Library/ViewModels/DashboardRewardRowStackViewViewModel.swift
@@ -7,8 +7,8 @@ import Prelude
 public protocol DashboardRewardRowStackViewViewModelInputs {
   /// Call to configure view model with Country, RewardsStats, and total pledged.
   func configureWith(country: Project.Country,
-                             reward: ProjectStatsEnvelope.RewardStats,
-                             totalPledged: Int)
+                     reward: ProjectStatsEnvelope.RewardStats,
+                     totalPledged: Int)
 }
 
 public protocol DashboardRewardRowStackViewViewModelOutputs {
@@ -57,15 +57,15 @@ public final class DashboardRewardRowStackViewViewModel: DashboardRewardRowStack
   fileprivate let countryRewardPledgedProperty =
     MutableProperty<(Project.Country, ProjectStatsEnvelope.RewardStats, Int)?>(nil)
   public func configureWith(country: Project.Country,
-                                    reward: ProjectStatsEnvelope.RewardStats,
-                                    totalPledged: Int) {
+                            reward: ProjectStatsEnvelope.RewardStats,
+                            totalPledged: Int) {
     countryRewardPledgedProperty.value = (country, reward, totalPledged)
   }
 }
 
 private func pledgedWithPercentText(country: Project.Country,
-                                            reward: ProjectStatsEnvelope.RewardStats,
-                                            totalPledged: Int) -> String {
+                                    reward: ProjectStatsEnvelope.RewardStats,
+                                    totalPledged: Int) -> String {
     let percent = Double(reward.pledged) / Double(totalPledged)
     let percentText = (percent > 0.01 || percent == 0) ? Format.percentage(percent) : "<1%"
     return Format.currency(reward.pledged, country: country) + " (\(percentText))"

--- a/Library/ViewModels/DashboardRewardsCellViewModel.swift
+++ b/Library/ViewModels/DashboardRewardsCellViewModel.swift
@@ -23,8 +23,7 @@ public protocol DashboardRewardsCellViewModelInputs {
   func backersButtonTapped()
 
   /// Call when load cell with project.
-  func configureWith(rewardStats: [ProjectStatsEnvelope.RewardStats],
-                                 project: Project)
+  func configureWith(rewardStats: [ProjectStatsEnvelope.RewardStats], project: Project)
 
   /// Call when Pledged button is tapped.
   func pledgedButtonTapped()
@@ -132,8 +131,7 @@ public final class DashboardRewardsCellViewModel: DashboardRewardsCellViewModelT
   }
   fileprivate let statsProjectProperty =
     MutableProperty<([ProjectStatsEnvelope.RewardStats], Project)?>(nil)
-  public func configureWith(rewardStats: [ProjectStatsEnvelope.RewardStats],
-                                        project: Project) {
+  public func configureWith(rewardStats: [ProjectStatsEnvelope.RewardStats], project: Project) {
     self.statsProjectProperty.value = (rewardStats, project)
   }
   fileprivate let pledgedButtonTappedProperty = MutableProperty()
@@ -150,9 +148,8 @@ public final class DashboardRewardsCellViewModel: DashboardRewardsCellViewModelT
   }
 }
 
-private func allRewardsStats(rewards: [Reward],
-                                     stats: [ProjectStatsEnvelope.RewardStats]) ->
-  [ProjectStatsEnvelope.RewardStats] {
+private func allRewardsStats(rewards: [Reward], stats: [ProjectStatsEnvelope.RewardStats])
+  -> [ProjectStatsEnvelope.RewardStats] {
 
     let statsIds = stats.map { $0.rewardId }
 

--- a/Library/ViewModels/DiscoveryFiltersViewModel.swift
+++ b/Library/ViewModels/DiscoveryFiltersViewModel.swift
@@ -186,7 +186,7 @@ public final class DiscoveryFiltersViewModel: DiscoveryFiltersViewModelType,
  - returns: An array of expandable rows with one row expanded.
  */
 private func expandableRows(selectedRow: SelectableRow,
-                                        categories: [KsApi.Category]) -> [ExpandableRow] {
+                            categories: [KsApi.Category]) -> [ExpandableRow] {
 
   let expandableRows = categories
     .sorted { lhs, _ in !lhs.isRoot }
@@ -236,7 +236,7 @@ private func expandableRows(selectedRow: SelectableRow,
  - returns: A new array of expandable rows with the provided row's expansion toggled.
  */
 private func toggleExpansion(row rowToToggle: ExpandableRow,
-                                 in expandableRows: [ExpandableRow]) -> [ExpandableRow] {
+                             in expandableRows: [ExpandableRow]) -> [ExpandableRow] {
 
   return expandableRows
     .map { expandableRow in

--- a/Library/ViewModels/MessageDialogViewModel.swift
+++ b/Library/ViewModels/MessageDialogViewModel.swift
@@ -147,7 +147,7 @@ MessageDialogViewModelOutputs {
   fileprivate let messageSubjectProperty = MutableProperty<MessageSubject?>(nil)
   fileprivate let contextProperty = MutableProperty<Koala.MessageDialogContext?>(nil)
   public func configureWith(messageSubject: MessageSubject,
-                                           context: Koala.MessageDialogContext) {
+                            context: Koala.MessageDialogContext) {
     self.messageSubjectProperty.value = messageSubject
     self.contextProperty.value = context
   }

--- a/Library/ViewModels/ProjectActivitiesViewModel.swift
+++ b/Library/ViewModels/ProjectActivitiesViewModel.swift
@@ -201,8 +201,8 @@ public final class ProjectActivitiesViewModel: ProjectActivitiesViewModelType,
   private let projectActivityCommentCellGoToSendReplyProperty
     = MutableProperty<(Project, Update?, Comment)?>(nil)
   public func projectActivityCommentCellGoToSendReply(project: Project,
-                                                              update: Update?,
-                                                              comment: Comment) {
+                                                      update: Update?,
+                                                      comment: Comment) {
     self.projectActivityCommentCellGoToSendReplyProperty.value = (project, update, comment)
   }
 

--- a/Library/ViewModels/ProjectNavigatorViewModel.swift
+++ b/Library/ViewModels/ProjectNavigatorViewModel.swift
@@ -12,9 +12,9 @@ public protocol ProjectNavigatorViewModelInputs {
 
   /// Call with panning data.
   func panning(contentOffset: CGPoint,
-                             translation: CGPoint,
-                             velocity: CGPoint,
-                             isDragging: Bool)
+               translation: CGPoint,
+               velocity: CGPoint,
+               isDragging: Bool)
 
   /// Call when the view loads.
   func viewDidLoad()
@@ -161,9 +161,9 @@ ProjectNavigatorViewModelInputs, ProjectNavigatorViewModelOutputs {
 
   fileprivate let panningDataProperty = MutableProperty<PanningData?>(nil)
   public func panning(contentOffset: CGPoint,
-                                    translation: CGPoint,
-                                    velocity: CGPoint,
-                                    isDragging: Bool) {
+                      translation: CGPoint,
+                      velocity: CGPoint,
+                      isDragging: Bool) {
     self.panningDataProperty.value = PanningData(contentOffset: contentOffset,
                                                  isDragging: isDragging,
                                                  translation: translation,

--- a/Library/ViewModels/ProjectPamphletContentViewModel.swift
+++ b/Library/ViewModels/ProjectPamphletContentViewModel.swift
@@ -88,7 +88,7 @@ ProjectPamphletContentViewModelInputs, ProjectPamphletContentViewModelOutputs {
     self.goToLiveStreamCountdown = project
       .takePairWhen(
         self.tappedLiveStreamProperty.signal.skipNil()
-          .filter( { !shouldGoToLiveStream(withLiveStream:$0) })
+          .filter({ !shouldGoToLiveStream(withLiveStream:$0) })
     )
   }
 

--- a/Library/ViewModels/RewardPledgeViewModel.swift
+++ b/Library/ViewModels/RewardPledgeViewModel.swift
@@ -872,10 +872,10 @@ RewardPledgeViewModelOutputs {
 // swiftlint:enable type_body_length
 
 private func paymentRequest(forProject project: Project,
-                                       reward: Reward,
-                                       pledgeAmount: Int,
-                                       selectedShippingRule: ShippingRule?,
-                                       merchantIdentifier: String) -> PKPaymentRequest {
+                            reward: Reward,
+                            pledgeAmount: Int,
+                            selectedShippingRule: ShippingRule?,
+                            merchantIdentifier: String) -> PKPaymentRequest {
   let request = PKPaymentRequest()
   request.merchantIdentifier = merchantIdentifier
   request.supportedNetworks = PKPaymentAuthorizationViewController.supportedNetworks
@@ -893,9 +893,9 @@ private func paymentRequest(forProject project: Project,
 }
 
 private func paymentSummaryItems(forProject project: Project,
-                                            reward: Reward,
-                                            pledgeAmount: Int,
-                                            selectedShippingRule: ShippingRule?) -> [PKPaymentSummaryItem] {
+                                 reward: Reward,
+                                 pledgeAmount: Int,
+                                 selectedShippingRule: ShippingRule?) -> [PKPaymentSummaryItem] {
 
   var paymentSummaryItems: [PKPaymentSummaryItem] = []
 
@@ -979,11 +979,10 @@ private func backingError(forProject project: Project, amount: Int, reward: Rewa
   return nil
 }
 
-private func createPledge(
-  project: Project,
-          reward: Reward?,
-          amount: Int,
-          shipping: ShippingRule?) -> SignalProducer<URLRequest, PledgeError> {
+private func createPledge(project: Project,
+                          reward: Reward?,
+                          amount: Int,
+                          shipping: ShippingRule?) -> SignalProducer<URLRequest, PledgeError> {
 
   if let error = backingError(forProject: project, amount: amount, reward: reward) {
     return SignalProducer(error: error)
@@ -1010,11 +1009,10 @@ private func createPledge(
   }
 }
 
-private func updatePledge(
-  project: Project,
-          reward: Reward?,
-          amount: Int,
-          shipping: ShippingRule?) -> SignalProducer<URLRequest?, PledgeError> {
+private func updatePledge(project: Project,
+                          reward: Reward?,
+                          amount: Int,
+                          shipping: ShippingRule?) -> SignalProducer<URLRequest?, PledgeError> {
 
   if let error = backingError(forProject: project, amount: amount, reward: reward) {
     return SignalProducer(error: error)

--- a/Library/ViewModels/RewardShippingPickerViewModel.swift
+++ b/Library/ViewModels/RewardShippingPickerViewModel.swift
@@ -9,8 +9,8 @@ public protocol RewardShippingPickerViewModelInputs {
 
   /// Call with the project, shipping rules and selected shipping rule that is provided to the view.
   func configureWith(project: Project,
-                             shippingRules: [ShippingRule],
-                             selectedShippingRule: ShippingRule)
+                     shippingRules: [ShippingRule],
+                     selectedShippingRule: ShippingRule)
 
   /// Call when the done button is pressed.
   func doneButtonTapped()
@@ -104,8 +104,8 @@ RewardShippingPickerViewModelInputs, RewardShippingPickerViewModelOutputs {
   fileprivate let projectAndShippingRulesAndSelectedShippingRuleProperty
     = MutableProperty<(Project, [ShippingRule], ShippingRule)?>(nil)
   public func configureWith(project: Project,
-                                    shippingRules: [ShippingRule],
-                                    selectedShippingRule: ShippingRule) {
+                            shippingRules: [ShippingRule],
+                            selectedShippingRule: ShippingRule) {
     self.projectAndShippingRulesAndSelectedShippingRuleProperty.value
       = (project, shippingRules, selectedShippingRule)
   }

--- a/Library/ViewModels/SurveyResponseViewModel.swift
+++ b/Library/ViewModels/SurveyResponseViewModel.swift
@@ -112,7 +112,7 @@ public final class SurveyResponseViewModel: SurveyResponseViewModelType {
   fileprivate let shouldStartLoadProperty = MutableProperty<(URLRequest, UIWebViewNavigationType)?>(nil)
   fileprivate let shouldStartLoadResponseProperty = MutableProperty(false)
   public func shouldStartLoad(withRequest request: URLRequest,
-                                          navigationType: UIWebViewNavigationType) -> Bool {
+                              navigationType: UIWebViewNavigationType) -> Bool {
     self.shouldStartLoadProperty.value = (request, navigationType)
     return self.shouldStartLoadResponseProperty.value
   }

--- a/LiveStream/Views/Controllers/LiveStreamViewController.swift
+++ b/LiveStream/Views/Controllers/LiveStreamViewController.swift
@@ -183,7 +183,7 @@ public final class LiveStreamViewController: UIViewController {
   }
 
   private func createFirebaseScaleNumberOfPeopleWatchingObservers(ref: FIRDatabaseReference,
-                                                             refConfig: FirebaseRefConfig) {
+                                                                  refConfig: FirebaseRefConfig) {
     let query = ref.child(refConfig.ref).queryOrderedByKey()
 
     query.observe(.value, with: { [weak self] snapshot in
@@ -214,7 +214,7 @@ public final class LiveStreamViewController: UIViewController {
 
 extension LiveStreamViewController: LiveVideoViewControllerDelegate {
   public func liveVideoViewControllerPlaybackStateChanged(controller: LiveVideoViewController,
-                                            state: LiveVideoPlaybackState) {
+                                                          state: LiveVideoPlaybackState) {
     self.viewModel.inputs.videoPlaybackStateChanged(state: state)
   }
 }

--- a/LiveStream/Views/Controllers/LiveVideoViewController.swift
+++ b/LiveStream/Views/Controllers/LiveVideoViewController.swift
@@ -105,9 +105,9 @@ public final class LiveVideoViewController: UIViewController {
   }
 
   public override func observeValue(forKeyPath keyPath: String?,
-                                      of object: Any?,
-                                      change: [NSKeyValueChangeKey : Any]?,
-                                      context: UnsafeMutableRawPointer?) {
+                                    of object: Any?,
+                                    change: [NSKeyValueChangeKey : Any]?,
+                                    context: UnsafeMutableRawPointer?) {
     guard let status = self.playerController?.player?.currentItem?.status else { return }
 
     if keyPath == statusKeyPath {

--- a/LiveStream/Views/VideoGridView.swift
+++ b/LiveStream/Views/VideoGridView.swift
@@ -8,7 +8,7 @@ public final class VideoGridView: UIView {
 
     self.backgroundColor = .black
   }
-  
+
   public required init?(coder aDecoder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
   }


### PR DESCRIPTION
The most recently version of swiftlint had a lot of failures for our code so we  temporarily disabled, but two of those rules were p chill:

* `class_delegate_protocol`: when doing delegates we should always do them as `: class` so we can use them as `weak`
* `vertical_parameter_alignment`: when putting function args on multiple lines, the params should be aligned. we're good about this usually, but the swift 3 migration totally destroyed a lot of the alignment with so many API renames.

there's also a really cool swiftlint rule for forcing alphabetized imports, but we have so many errors that we can tackle that some other time.