### PR TITLE
Live stream tracking updates

### DIFF
--- a/Library/Koala/Koala.swift
+++ b/Library/Koala/Koala.swift
@@ -1593,16 +1593,21 @@ public final class Koala {
 
   public func trackClosedLiveStream(project: Project,
                                     liveStream: Project.LiveStream,
+                                    startDate: Date,
+                                    endDate: Date,
                                     refTag: RefTag) {
+    let context = stateContext(forLiveStream: liveStream)
+
+    let duration = AppEnvironment.current.calendar
+      .dateComponents([.second], from: startDate, to: endDate).second ?? 0
+
     let props = properties(project: project, loggedInUser: self.loggedInUser)
       .withAllValuesFrom(properties(liveStream: liveStream))
       .withAllValuesFrom(["ref_tag": refTag.stringTag])
+      .withAllValuesFrom(["type": context.trackingString])
+      .withAllValuesFrom(["duration": duration])
 
-    if liveStream.isLiveNow {
-      self.track(event: "Closed Live Stream", properties: props)
-    } else {
-      self.track(event: "Closed Live Stream Replay", properties: props)
-    }
+    self.track(event: "Closed Live Stream", properties: props)
   }
 
   public func trackLiveStreamToggleSubscription(project: Project,
@@ -1620,16 +1625,6 @@ public final class Koala {
       event: subscribed ? "Confirmed KSR Live Subscribe Button" : "Confirmed KSR Live Unsubscribe Button",
       properties: props
     )
-  }
-
-  public func trackClosedLiveStreamCountdown(project: Project,
-                                             liveStream: Project.LiveStream,
-                                             refTag: RefTag) {
-    let props = properties(project: project, loggedInUser: self.loggedInUser)
-      .withAllValuesFrom(properties(liveStream: liveStream))
-      .withAllValuesFrom(["ref_tag": refTag.stringTag])
-
-    self.track(event: "Closed Live Stream Countdown", properties: props)
   }
 
   public func trackViewedLiveStreamCountdown(project: Project,

--- a/Library/Koala/Koala.swift
+++ b/Library/Koala/Koala.swift
@@ -1591,6 +1591,20 @@ public final class Koala {
     self.track(event: "Changed Live Stream Orientation", properties: props)
   }
 
+  public func trackClosedLiveStream(project: Project,
+                                    liveStream: Project.LiveStream,
+                                    refTag: RefTag) {
+    let props = properties(project: project, loggedInUser: self.loggedInUser)
+      .withAllValuesFrom(properties(liveStream: liveStream))
+      .withAllValuesFrom(["ref_tag": refTag.stringTag])
+
+    if liveStream.isLiveNow {
+      self.track(event: "Closed Live Stream", properties: props)
+    } else {
+      self.track(event: "Closed Live Stream Replay", properties: props)
+    }
+  }
+
   public func trackLiveStreamToggleSubscription(project: Project,
                                                 liveStream: Project.LiveStream,
                                                 subscribed: Bool) {
@@ -1606,6 +1620,16 @@ public final class Koala {
       event: subscribed ? "Confirmed KSR Live Subscribe Button" : "Confirmed KSR Live Unsubscribe Button",
       properties: props
     )
+  }
+
+  public func trackClosedLiveStreamCountdown(project: Project,
+                                             liveStream: Project.LiveStream,
+                                             refTag: RefTag) {
+    let props = properties(project: project, loggedInUser: self.loggedInUser)
+      .withAllValuesFrom(properties(liveStream: liveStream))
+      .withAllValuesFrom(["ref_tag": refTag.stringTag])
+
+    self.track(event: "Closed Live Stream Countdown", properties: props)
   }
 
   public func trackViewedLiveStreamCountdown(project: Project,

--- a/Library/Koala/Koala.swift
+++ b/Library/Koala/Koala.swift
@@ -1593,19 +1593,16 @@ public final class Koala {
 
   public func trackClosedLiveStream(project: Project,
                                     liveStream: Project.LiveStream,
-                                    startDate: Date,
-                                    endDate: Date,
+                                    startTime: TimeInterval,
+                                    endTime: TimeInterval,
                                     refTag: RefTag) {
-    let context = stateContext(forLiveStream: liveStream)
-
-    let duration = AppEnvironment.current.calendar
-      .dateComponents([.second], from: startDate, to: endDate).second ?? 0
-
     let props = properties(project: project, loggedInUser: self.loggedInUser)
       .withAllValuesFrom(properties(liveStream: liveStream))
-      .withAllValuesFrom(["ref_tag": refTag.stringTag])
-      .withAllValuesFrom(["type": context.trackingString])
-      .withAllValuesFrom(["duration": duration])
+      .withAllValuesFrom([
+        "ref_tag": refTag.stringTag,
+        "type": stateContext(forLiveStream: liveStream).trackingString,
+        "duration": max(0, endTime - startTime)
+      ])
 
     self.track(event: "Closed Live Stream", properties: props)
   }

--- a/Library/Tests/Koala/KoalaTests.swift
+++ b/Library/Tests/Koala/KoalaTests.swift
@@ -428,15 +428,15 @@ final class KoalaTests: TestCase {
     koala.trackClosedLiveStream(
       project: .template,
       liveStream: liveStream,
-      startDate: MockDate().date,
-      endDate: MockDate().addingTimeInterval(300).date,
+      startTime: MockDate().date.timeIntervalSince1970,
+      endTime: MockDate().addingTimeInterval(300).timeIntervalSince1970,
       refTag: .projectPage
     )
 
     XCTAssertEqual(["Closed Live Stream"], client.events)
     XCTAssertEqual(["project_page"], client.properties(forKey: "ref_tag", as: String.self))
     XCTAssertEqual(["live_stream_live"], client.properties(forKey: "type", as: String.self))
-    XCTAssertEqual([300], client.properties(forKey: "duration", as: Int.self))
+    XCTAssertEqual([300], client.properties(forKey: "duration", as: Double.self))
   }
 
   func testTrackClosedLiveStreamCountdown() {
@@ -450,15 +450,15 @@ final class KoalaTests: TestCase {
     koala.trackClosedLiveStream(
       project: .template,
       liveStream: liveStream,
-      startDate: MockDate().date,
-      endDate: MockDate().addingTimeInterval(300).date,
+      startTime: MockDate().date.timeIntervalSince1970,
+      endTime: MockDate().addingTimeInterval(300).timeIntervalSince1970,
       refTag: .projectPage
     )
 
     XCTAssertEqual(["Closed Live Stream"], client.events)
     XCTAssertEqual(["project_page"], client.properties(forKey: "ref_tag", as: String.self))
     XCTAssertEqual(["live_stream_countdown"], client.properties(forKey: "type", as: String.self))
-    XCTAssertEqual([300], client.properties(forKey: "duration", as: Int.self))
+    XCTAssertEqual([300], client.properties(forKey: "duration", as: Double.self))
   }
 
   func testTrackClosedLiveStreamReplay() {
@@ -472,15 +472,15 @@ final class KoalaTests: TestCase {
     koala.trackClosedLiveStream(
       project: .template,
       liveStream: liveStream,
-      startDate: MockDate().date,
-      endDate: MockDate().addingTimeInterval(300).date,
+      startTime: MockDate().date.timeIntervalSince1970,
+      endTime: MockDate().addingTimeInterval(300).timeIntervalSince1970,
       refTag: .projectPage
     )
 
     XCTAssertEqual(["Closed Live Stream"], client.events)
     XCTAssertEqual(["project_page"], client.properties(forKey: "ref_tag", as: String.self))
     XCTAssertEqual(["live_stream_replay"], client.properties(forKey: "type", as: String.self))
-    XCTAssertEqual([300], client.properties(forKey: "duration", as: Int.self))
+    XCTAssertEqual([300], client.properties(forKey: "duration", as: Double.self))
   }
 
   func testTrackViewedLiveStream() {

--- a/Library/Tests/Koala/KoalaTests.swift
+++ b/Library/Tests/Koala/KoalaTests.swift
@@ -418,6 +418,54 @@ final class KoalaTests: TestCase {
     XCTAssertEqual(["project_page"], client.properties(forKey: "ref_tag", as: String.self))
   }
 
+  func testTrackClosedLiveStream() {
+    let client = MockTrackingClient()
+    let koala = Koala(client: client)
+
+    let liveStream = .template
+      |> Project.LiveStream.lens.isLiveNow .~ true
+
+    koala.trackClosedLiveStream(
+      project: .template,
+      liveStream: liveStream,
+      refTag: .projectPage
+    )
+
+    XCTAssertEqual(["Closed Live Stream"], client.events)
+    XCTAssertEqual(["project_page"], client.properties(forKey: "ref_tag", as: String.self))
+  }
+
+  func testTrackClosedLiveStreamCountdown() {
+    let client = MockTrackingClient()
+    let koala = Koala(client: client)
+
+    koala.trackClosedLiveStreamCountdown(
+      project: .template,
+      liveStream: .template,
+      refTag: .projectPage
+    )
+
+    XCTAssertEqual(["Closed Live Stream Countdown"], client.events)
+    XCTAssertEqual(["project_page"], client.properties(forKey: "ref_tag", as: String.self))
+  }
+
+  func testTrackClosedLiveStreamReplay() {
+    let client = MockTrackingClient()
+    let koala = Koala(client: client)
+
+    let liveStream = .template
+      |> Project.LiveStream.lens.isLiveNow .~ false
+
+    koala.trackClosedLiveStream(
+      project: .template,
+      liveStream: liveStream,
+      refTag: .projectPage
+    )
+
+    XCTAssertEqual(["Closed Live Stream Replay"], client.events)
+    XCTAssertEqual(["project_page"], client.properties(forKey: "ref_tag", as: String.self))
+  }
+
   func testTrackViewedLiveStream() {
     let client = MockTrackingClient()
     let koala = Koala(client: client)
@@ -442,12 +490,12 @@ final class KoalaTests: TestCase {
       project: .template,
       liveStream: liveStream,
       refTag: .projectPage,
-      duration: 2
+      duration: 1
     )
 
     XCTAssertEqual(["Watched Live Stream"], client.events)
     XCTAssertEqual(["project_page"], client.properties(forKey: "ref_tag", as: String.self))
-    XCTAssertEqual([2], client.properties(forKey: "duration", as: Int.self))
+    XCTAssertEqual([1], client.properties(forKey: "duration", as: Int.self))
   }
 
   func testTrackWatchedLiveStream_Replay() {

--- a/Library/Tests/Koala/KoalaTests.swift
+++ b/Library/Tests/Koala/KoalaTests.swift
@@ -428,25 +428,37 @@ final class KoalaTests: TestCase {
     koala.trackClosedLiveStream(
       project: .template,
       liveStream: liveStream,
+      startDate: MockDate().date,
+      endDate: MockDate().addingTimeInterval(300).date,
       refTag: .projectPage
     )
 
     XCTAssertEqual(["Closed Live Stream"], client.events)
     XCTAssertEqual(["project_page"], client.properties(forKey: "ref_tag", as: String.self))
+    XCTAssertEqual(["live_stream_live"], client.properties(forKey: "type", as: String.self))
+    XCTAssertEqual([300], client.properties(forKey: "duration", as: Int.self))
   }
 
   func testTrackClosedLiveStreamCountdown() {
     let client = MockTrackingClient()
     let koala = Koala(client: client)
 
-    koala.trackClosedLiveStreamCountdown(
+    let liveStream = .template
+      |> Project.LiveStream.lens.isLiveNow .~ false
+      |> Project.LiveStream.lens.startDate .~ (MockDate().addingTimeInterval(60)).timeIntervalSince1970
+
+    koala.trackClosedLiveStream(
       project: .template,
-      liveStream: .template,
+      liveStream: liveStream,
+      startDate: MockDate().date,
+      endDate: MockDate().addingTimeInterval(300).date,
       refTag: .projectPage
     )
 
-    XCTAssertEqual(["Closed Live Stream Countdown"], client.events)
+    XCTAssertEqual(["Closed Live Stream"], client.events)
     XCTAssertEqual(["project_page"], client.properties(forKey: "ref_tag", as: String.self))
+    XCTAssertEqual(["live_stream_countdown"], client.properties(forKey: "type", as: String.self))
+    XCTAssertEqual([300], client.properties(forKey: "duration", as: Int.self))
   }
 
   func testTrackClosedLiveStreamReplay() {
@@ -455,15 +467,20 @@ final class KoalaTests: TestCase {
 
     let liveStream = .template
       |> Project.LiveStream.lens.isLiveNow .~ false
+      |> Project.LiveStream.lens.startDate .~ (MockDate().addingTimeInterval(-60)).timeIntervalSince1970
 
     koala.trackClosedLiveStream(
       project: .template,
       liveStream: liveStream,
+      startDate: MockDate().date,
+      endDate: MockDate().addingTimeInterval(300).date,
       refTag: .projectPage
     )
 
-    XCTAssertEqual(["Closed Live Stream Replay"], client.events)
+    XCTAssertEqual(["Closed Live Stream"], client.events)
     XCTAssertEqual(["project_page"], client.properties(forKey: "ref_tag", as: String.self))
+    XCTAssertEqual(["live_stream_replay"], client.properties(forKey: "type", as: String.self))
+    XCTAssertEqual([300], client.properties(forKey: "duration", as: Int.self))
   }
 
   func testTrackViewedLiveStream() {

--- a/Library/Tests/ViewModels/LiveStreamContainerViewModelTests.swift
+++ b/Library/Tests/ViewModels/LiveStreamContainerViewModelTests.swift
@@ -403,7 +403,7 @@ internal final class LiveStreamContainerViewModelTests: TestCase {
                                                                                     as: String.self))
     XCTAssertEqual([nil, "live_stream_live"], self.trackingClient.properties(forKey: "type",
                                                                                as: String.self))
-    XCTAssertEqual([nil, 50], self.trackingClient.properties(forKey: "duration", as: Int.self))
+    XCTAssertEqual([nil, 50], self.trackingClient.properties(forKey: "duration", as: Double.self))
   }
 
   func testTrackClosedLiveStreamReplay() {
@@ -435,7 +435,7 @@ internal final class LiveStreamContainerViewModelTests: TestCase {
                                                                                     as: String.self))
     XCTAssertEqual([nil, "live_stream_replay"], self.trackingClient.properties(forKey: "type",
                                                                                as: String.self))
-    XCTAssertEqual([nil, 50], self.trackingClient.properties(forKey: "duration", as: Int.self))
+    XCTAssertEqual([nil, 50], self.trackingClient.properties(forKey: "duration", as: Double.self))
   }
 
   func testTrackLiveStreamOrientationChanged() {

--- a/Library/Tests/ViewModels/LiveStreamContainerViewModelTests.swift
+++ b/Library/Tests/ViewModels/LiveStreamContainerViewModelTests.swift
@@ -504,7 +504,7 @@ internal final class LiveStreamContainerViewModelTests: TestCase {
                    self.trackingClient.events)
     XCTAssertEqual(["project_page", "project_page", "project_page"], self.trackingClient.properties(
       forKey: "ref_tag", as: String.self))
-    XCTAssertEqual([nil, 1, 2], self.trackingClient.properties(forKey: "duration", as: Int.self))
+    XCTAssertEqual([nil, 1, 1], self.trackingClient.properties(forKey: "duration", as: Int.self))
   }
 
   func testTrackWatchedLiveReplay() {
@@ -547,7 +547,7 @@ internal final class LiveStreamContainerViewModelTests: TestCase {
                    self.trackingClient.events)
     XCTAssertEqual(["project_page", "project_page", "project_page"], self.trackingClient.properties(
       forKey: "ref_tag", as: String.self))
-    XCTAssertEqual([nil, 1, 2], self.trackingClient.properties(forKey: "duration", as: Int.self))
+    XCTAssertEqual([nil, 1, 1], self.trackingClient.properties(forKey: "duration", as: Int.self))
   }
 
   func test_MakeSureSingleLiveStreamControllerIsCreated() {

--- a/Library/Tests/ViewModels/LiveStreamContainerViewModelTests.swift
+++ b/Library/Tests/ViewModels/LiveStreamContainerViewModelTests.swift
@@ -376,6 +376,56 @@ internal final class LiveStreamContainerViewModelTests: TestCase {
     XCTAssertEqual(["project_page"], self.trackingClient.properties(forKey: "ref_tag", as: String.self))
   }
 
+  func testTrackClosedLiveStream() {
+    let liveStream = Project.LiveStream.template
+      |> Project.LiveStream.lens.isLiveNow .~ true
+    let project = Project.template
+    let event = LiveStreamEvent.template
+      |> LiveStreamEvent.lens.stream.liveNow .~ true
+
+    XCTAssertEqual([], self.trackingClient.events)
+    XCTAssertEqual([], self.trackingClient.properties(forKey: "ref_tag", as: String.self))
+
+    self.vm.inputs.configureWith(
+      project: project, liveStream: liveStream, event: event, refTag: .projectPage
+    )
+    self.vm.inputs.viewDidLoad()
+
+    XCTAssertEqual(["Viewed Live Stream"], self.trackingClient.events)
+    XCTAssertEqual(["project_page"], self.trackingClient.properties(forKey: "ref_tag", as: String.self))
+
+    self.vm.inputs.closeButtonTapped()
+
+    XCTAssertEqual(["Viewed Live Stream", "Closed Live Stream"], self.trackingClient.events)
+    XCTAssertEqual(["project_page", "project_page"], self.trackingClient.properties(forKey: "ref_tag",
+                                                                                    as: String.self))
+  }
+
+  func testTrackClosedLiveStreamReplay() {
+    let liveStream = Project.LiveStream.template
+      |> Project.LiveStream.lens.isLiveNow .~ false
+    let project = Project.template
+    let event = LiveStreamEvent.template
+      |> LiveStreamEvent.lens.stream.liveNow .~ false
+
+    XCTAssertEqual([], self.trackingClient.events)
+    XCTAssertEqual([], self.trackingClient.properties(forKey: "ref_tag", as: String.self))
+
+    self.vm.inputs.configureWith(
+      project: project, liveStream: liveStream, event: event, refTag: .projectPage
+    )
+    self.vm.inputs.viewDidLoad()
+
+    XCTAssertEqual(["Viewed Live Stream"], self.trackingClient.events)
+    XCTAssertEqual(["project_page"], self.trackingClient.properties(forKey: "ref_tag", as: String.self))
+
+    self.vm.inputs.closeButtonTapped()
+
+    XCTAssertEqual(["Viewed Live Stream", "Closed Live Stream Replay"], self.trackingClient.events)
+    XCTAssertEqual(["project_page", "project_page"], self.trackingClient.properties(forKey: "ref_tag",
+                                                                                    as: String.self))
+  }
+
   func testTrackLiveStreamOrientationChanged() {
     let liveStream = Project.LiveStream.template
     let project = Project.template

--- a/Library/Tests/ViewModels/LiveStreamContainerViewModelTests.swift
+++ b/Library/Tests/ViewModels/LiveStreamContainerViewModelTests.swift
@@ -394,11 +394,16 @@ internal final class LiveStreamContainerViewModelTests: TestCase {
     XCTAssertEqual(["Viewed Live Stream"], self.trackingClient.events)
     XCTAssertEqual(["project_page"], self.trackingClient.properties(forKey: "ref_tag", as: String.self))
 
+    self.scheduler.advance(by: .seconds(50))
+
     self.vm.inputs.closeButtonTapped()
 
     XCTAssertEqual(["Viewed Live Stream", "Closed Live Stream"], self.trackingClient.events)
     XCTAssertEqual(["project_page", "project_page"], self.trackingClient.properties(forKey: "ref_tag",
                                                                                     as: String.self))
+    XCTAssertEqual([nil, "live_stream_live"], self.trackingClient.properties(forKey: "type",
+                                                                               as: String.self))
+    XCTAssertEqual([nil, 50], self.trackingClient.properties(forKey: "duration", as: Int.self))
   }
 
   func testTrackClosedLiveStreamReplay() {
@@ -418,12 +423,19 @@ internal final class LiveStreamContainerViewModelTests: TestCase {
 
     XCTAssertEqual(["Viewed Live Stream"], self.trackingClient.events)
     XCTAssertEqual(["project_page"], self.trackingClient.properties(forKey: "ref_tag", as: String.self))
+    XCTAssertEqual([nil], self.trackingClient.properties(forKey: "type", as: String.self))
+    XCTAssertEqual([nil], self.trackingClient.properties(forKey: "duration", as: Double.self))
+
+    self.scheduler.advance(by: .seconds(50))
 
     self.vm.inputs.closeButtonTapped()
 
-    XCTAssertEqual(["Viewed Live Stream", "Closed Live Stream Replay"], self.trackingClient.events)
+    XCTAssertEqual(["Viewed Live Stream", "Closed Live Stream"], self.trackingClient.events)
     XCTAssertEqual(["project_page", "project_page"], self.trackingClient.properties(forKey: "ref_tag",
                                                                                     as: String.self))
+    XCTAssertEqual([nil, "live_stream_replay"], self.trackingClient.properties(forKey: "type",
+                                                                               as: String.self))
+    XCTAssertEqual([nil, 50], self.trackingClient.properties(forKey: "duration", as: Int.self))
   }
 
   func testTrackLiveStreamOrientationChanged() {

--- a/Library/Tests/ViewModels/LiveStreamCountdownViewModelTests.swift
+++ b/Library/Tests/ViewModels/LiveStreamCountdownViewModelTests.swift
@@ -208,7 +208,7 @@ internal final class LiveStreamCountdownViewModelTests: TestCase {
                                                                                     as: String.self))
     XCTAssertEqual([nil, "live_stream_countdown"], self.trackingClient.properties(forKey: "type",
                                                                              as: String.self))
-    XCTAssertEqual([nil, 50], self.trackingClient.properties(forKey: "duration", as: Int.self))
+    XCTAssertEqual([nil, 50], self.trackingClient.properties(forKey: "duration", as: Double.self))
   }
 
   func testCategoryId() {

--- a/Library/ViewModels/LiveStreamContainerViewModel.swift
+++ b/Library/ViewModels/LiveStreamContainerViewModel.swift
@@ -253,6 +253,14 @@ LiveStreamContainerViewModelInputs, LiveStreamContainerViewModelOutputs {
     }
 
     configData
+      .takeWhen(self.closeButtonTappedProperty.signal)
+      .observeValues { (project, liveStream, _, refTag) in
+        AppEnvironment.current.koala.trackClosedLiveStream(project: project,
+                                                           liveStream: liveStream,
+                                                           refTag: refTag)
+    }
+
+    configData
       .map { project, liveStream, _, refTag in (project, liveStream, refTag) }
       .takePairWhen(numberOfMinutesWatched)
       .map { tuple, minute in (tuple.0, tuple.1, tuple.2, minute) }

--- a/Library/ViewModels/LiveStreamContainerViewModel.swift
+++ b/Library/ViewModels/LiveStreamContainerViewModel.swift
@@ -241,7 +241,7 @@ LiveStreamContainerViewModelInputs, LiveStreamContainerViewModelOutputs {
         }
       }
       .flatMap { _ in timer(interval: .seconds(60), on: AppEnvironment.current.scheduler) }
-      .scan(0) { accum, _ in accum + 1 }
+      .mapConst(1)
 
     configData
       .takePairWhen(self.deviceOrientationDidChangeProperty.signal.skipNil())

--- a/Library/ViewModels/LiveStreamCountdownViewModel.swift
+++ b/Library/ViewModels/LiveStreamCountdownViewModel.swift
@@ -152,6 +152,14 @@ LiveStreamCountdownViewModelInputs, LiveStreamCountdownViewModelOutputs {
                                                                     liveStream: liveStream,
                                                                     refTag: refTag)
     }
+
+    configData
+      .takeWhen(self.closeButtonTappedProperty.signal)
+      .observeValues { (project, liveStream, refTag) in
+        AppEnvironment.current.koala.trackClosedLiveStreamCountdown(project: project,
+                                                                    liveStream: liveStream,
+                                                                    refTag: refTag)
+    }
   }
 
   private let closeButtonTappedProperty = MutableProperty()

--- a/Library/ViewModels/LiveStreamCountdownViewModel.swift
+++ b/Library/ViewModels/LiveStreamCountdownViewModel.swift
@@ -153,22 +153,22 @@ LiveStreamCountdownViewModelInputs, LiveStreamCountdownViewModelOutputs {
                                                                     refTag: refTag)
     }
 
-    let startEndDates = Signal.zip(
-      configData.map { _ in AppEnvironment.current.scheduler.currentDate },
+    let startEndTimes = Signal.zip(
+      configData.map { _ in AppEnvironment.current.scheduler.currentDate.timeIntervalSince1970 },
       self.closeButtonTappedProperty.signal
-        .map { _ in AppEnvironment.current.scheduler.currentDate }
+        .map { _ in AppEnvironment.current.scheduler.currentDate.timeIntervalSince1970 }
     )
 
-    Signal.combineLatest(configData, startEndDates)
+    Signal.combineLatest(configData, startEndTimes)
       .takeWhen(self.closeButtonTappedProperty.signal)
-      .map(unpack)
-      .map { (configData, startDate, endDate) in
-        (configData.0, configData.1, configData.2, startDate, endDate) }
-      .observeValues { (project, liveStream, refTag, startDate, endDate) in
+      .observeValues { (configData, startEndTimes) in
+        let (project, liveStream, refTag) = configData
+        let (startTime, endTime) = startEndTimes
+
         AppEnvironment.current.koala.trackClosedLiveStream(project: project,
                                                            liveStream: liveStream,
-                                                           startDate: startDate,
-                                                           endDate: endDate,
+                                                           startTime: startTime,
+                                                           endTime: endTime,
                                                            refTag: refTag)
     }
   }

--- a/Library/ViewModels/LiveStreamCountdownViewModel.swift
+++ b/Library/ViewModels/LiveStreamCountdownViewModel.swift
@@ -153,12 +153,23 @@ LiveStreamCountdownViewModelInputs, LiveStreamCountdownViewModelOutputs {
                                                                     refTag: refTag)
     }
 
-    configData
+    let startEndDates = Signal.zip(
+      configData.map { _ in AppEnvironment.current.scheduler.currentDate },
+      self.closeButtonTappedProperty.signal
+        .map { _ in AppEnvironment.current.scheduler.currentDate }
+    )
+
+    Signal.combineLatest(configData, startEndDates)
       .takeWhen(self.closeButtonTappedProperty.signal)
-      .observeValues { (project, liveStream, refTag) in
-        AppEnvironment.current.koala.trackClosedLiveStreamCountdown(project: project,
-                                                                    liveStream: liveStream,
-                                                                    refTag: refTag)
+      .map(unpack)
+      .map { (configData, startDate, endDate) in
+        (configData.0, configData.1, configData.2, startDate, endDate) }
+      .observeValues { (project, liveStream, refTag, startDate, endDate) in
+        AppEnvironment.current.koala.trackClosedLiveStream(project: project,
+                                                           liveStream: liveStream,
+                                                           startDate: startDate,
+                                                           endDate: endDate,
+                                                           refTag: refTag)
     }
   }
 


### PR DESCRIPTION
This adds a few small updates to our live stream tracking:

- `duration` value for `Watch Live Stream` and `'Watch Live Stream Replay` events is now always a constant integer of 1.
- Added tracking for `Close Live Stream` event.
- Added tracking for `Close Live Stream Replay` event.
- Added tracking for `Close Live Stream Countdown` event.