### PR TITLE
LiveStreamViewController dismiss crash fix

### DIFF
--- a/LiveStream/Views/Controllers/LiveStreamViewController.swift
+++ b/LiveStream/Views/Controllers/LiveStreamViewController.swift
@@ -20,7 +20,7 @@ public final class LiveStreamViewController: UIViewController {
   private var firebaseRef: FIRDatabaseReference?
   private var videoViewController: LiveVideoViewController?
   private weak var delegate: LiveStreamViewControllerDelegate?
-  private var liveStreamService: LiveStreamServiceProtocol!
+  private var liveStreamService: LiveStreamServiceProtocol?
 
   public func configureWith(event: LiveStreamEvent,
                             userId: Int?,
@@ -129,14 +129,13 @@ public final class LiveStreamViewController: UIViewController {
   deinit {
     self.firebaseRef?.removeAllObservers()
     self.firebaseRef?.database.goOffline()
-    self.liveStreamService.deleteDatabase()
+    self.liveStreamService?.deleteDatabase()
   }
 
   // MARK: Firebase
 
   private func initializeFirebase(withEvent event: LiveStreamEvent, userId: Int?) {
-
-    self.liveStreamService.initializeDatabase(
+    self.liveStreamService?.initializeDatabase(
       userId: userId,
       failed: {
         self.viewModel.inputs.firebaseAppFailedToInitialize()
@@ -145,7 +144,7 @@ public final class LiveStreamViewController: UIViewController {
         self.firebaseRef = ref
         self.viewModel.inputs.createdDatabaseRef(ref: ref)
 
-        self.liveStreamService.signInAnonymously { id in
+        self.liveStreamService?.signInAnonymously { id in
           self.viewModel.inputs.setFirebaseUserId(userId: id)
         }
     })


### PR DESCRIPTION
`LiveStreamViewController` was crashing on dismiss.

@mbrandonw this seems to be since the refactor of the container view, a `LiveStreamViewController` instance is automatically created by the story board instantiation before our `createAndConfigureLiveStreamViewController` signal in `LiveStreamContainerViewModel` even emits.

On dismiss `LiveStreamViewController` is trying to call `deleteDatabase()` on its implicitly unwrapped `liveStreamService` property. Quick fix is to make this optional, this problem will be resolved once my other refactor of removing `Project.LiveStream` is completed as we will then no longer have this asynchronous fetching of the `LiveStreamEvent` after the `LiveStreamContainerViewController` is created.