### PR TITLE
Add permissions keys for access to camera/photos

### DIFF
--- a/Kickstarter-iOS/Info.plist
+++ b/Kickstarter-iOS/Info.plist
@@ -111,8 +111,8 @@
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>NSCameraUsageDescription</key>
-  <string>Add photos and video to your project updates.</string>
-  <key>NSPhotoLibraryUsageDescription</key>
-  <string>Add photos and video to your project updates.</string>
+	<string>Add photos and video to your project updates.</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>Add photos and video to your project updates.</string>
 </dict>
 </plist>

--- a/Kickstarter-iOS/Info.plist
+++ b/Kickstarter-iOS/Info.plist
@@ -110,5 +110,9 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>NSCameraUsageDescription</key>
+  <string>Add photos and video to your project updates.</string>
+  <key>NSPhotoLibraryUsageDescription</key>
+  <string>Add photos and video to your project updates.</string>
 </dict>
 </plist>

--- a/Kickstarter-iOS/Views/Controllers/UpdateDraftViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/UpdateDraftViewController.swift
@@ -303,11 +303,11 @@ extension UpdateDraftViewController: UIImagePickerControllerDelegate, UINavigati
     guard
       let image = info[UIImagePickerControllerOriginalImage] as? UIImage,
       let imageData = UIImageJPEGRepresentation(image, 0.9),
-      let caches = NSSearchPathForDirectoriesInDomains(.cachesDirectory, .userDomainMask, true).first,
-      let file = URL(string: caches)?.appendingPathComponent("\(image.hash).jpg")
+      let caches = NSSearchPathForDirectoriesInDomains(.cachesDirectory, .userDomainMask, true).first
       else { fatalError() }
 
-    _ = try? imageData.write(to: file, options: [.atomic])
+    let file = URL(fileURLWithPath: caches).appendingPathComponent("\(image.hash).jpg")
+    try? imageData.write(to: file, options: [.atomic])
 
     self.viewModel.inputs.imagePicked(url: file,
                                       fromSource: AttachmentSource(sourceType: picker.sourceType))

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -2061,7 +2061,7 @@
 				80762DF31D071BCF0074189D /* AlamofireImage.framework */,
 				80762DF51D071BCF0074189D /* AlamofireImage iOS Tests.xctest */,
 				80762DF71D071BCF0074189D /* AlamofireImage.framework */,
-				80762DF91D071BCF0074189D /* AlamofireImage macOS Tests.xctest */,
+				80762DF91D071BCF0074189D /* AlamofireImage OSX Tests.xctest */,
 				80762DFB1D071BCF0074189D /* AlamofireImage.framework */,
 				80762DFD1D071BCF0074189D /* AlamofireImage tvOS Tests.xctest */,
 				80762DFF1D071BCF0074189D /* AlamofireImage.framework */,
@@ -2075,7 +2075,7 @@
 				80762E311D071BFE0074189D /* Alamofire.framework */,
 				80762E331D071BFE0074189D /* Alamofire iOS Tests.xctest */,
 				80762E351D071BFE0074189D /* Alamofire.framework */,
-				80762E371D071BFE0074189D /* Alamofire macOS Tests.xctest */,
+				80762E371D071BFE0074189D /* Alamofire OSX Tests.xctest */,
 				80762E391D071BFE0074189D /* Alamofire.framework */,
 				80762E3B1D071BFE0074189D /* Alamofire tvOS Tests.xctest */,
 				80762E3D1D071BFE0074189D /* Alamofire.framework */,
@@ -3527,7 +3527,7 @@
 			remoteRef = 80762DF61D071BCF0074189D /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		80762DF91D071BCF0074189D /* AlamofireImage macOS Tests.xctest */ = {
+		80762DF91D071BCF0074189D /* AlamofireImage OSX Tests.xctest */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.cfbundle;
 			path = "AlamofireImage OSX Tests.xctest";
@@ -3576,7 +3576,7 @@
 			remoteRef = 80762E341D071BFE0074189D /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		80762E371D071BFE0074189D /* Alamofire macOS Tests.xctest */ = {
+		80762E371D071BFE0074189D /* Alamofire OSX Tests.xctest */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.cfbundle;
 			path = "Alamofire OSX Tests.xctest";


### PR DESCRIPTION
So far the only ios 10 crash we've seen from the swift 3 upgrade is when you try to attach images/video to a project update. This fixes that.

Info here: https://developer.apple.com/library/content/documentation/General/Reference/InfoPlistKeyReference/Articles/CocoaKeys.html