### PR TITLE
Playground ViewController Sizes

### DIFF
--- a/Kickstarter-iOS.playground/Sources/playgroundController.swift
+++ b/Kickstarter-iOS.playground/Sources/playgroundController.swift
@@ -3,10 +3,12 @@ import UIKit
 // swiftlint:disable function_body_length
 
 public enum Device {
+  case phone4inchShorter
   case phone4inch
   case phone4_7inch
   case phone5_5inch
   case pad
+  case pad12_9inch
 }
 
 public enum Orientation {
@@ -41,6 +43,20 @@ public func playgroundControllers(device: Device = .phone4_7inch,
 
     let traits: UITraitCollection
     switch (device, orientation) {
+    case (.phone4inchShorter, .portrait):
+      parent.view.frame = .init(x: 0, y: 0, width: 320, height: 480)
+      traits = .init(traitsFrom: [
+        .init(horizontalSizeClass: .compact),
+        .init(verticalSizeClass: .regular),
+        .init(userInterfaceIdiom: .phone)
+        ])
+    case (.phone4inchShorter, .landscape):
+      parent.view.frame = .init(x: 0, y: 0, width: 480, height: 320)
+      traits = .init(traitsFrom: [
+        .init(horizontalSizeClass: .compact),
+        .init(verticalSizeClass: .compact),
+        .init(userInterfaceIdiom: .phone)
+        ])
     case (.phone4inch, .portrait):
       parent.view.frame = .init(x: 0, y: 0, width: 320, height: 575)
       traits = .init(traitsFrom: [
@@ -92,6 +108,20 @@ public func playgroundControllers(device: Device = .phone4_7inch,
         ])
     case (.pad, .landscape):
       parent.view.frame = .init(x: 0, y: 0, width: 1024, height: 768)
+      traits = .init(traitsFrom: [
+        .init(horizontalSizeClass: .regular),
+        .init(verticalSizeClass: .regular),
+        .init(userInterfaceIdiom: .pad)
+        ])
+    case (.pad12_9inch, .portrait):
+      parent.view.frame = .init(x: 0, y: 0, width: 1024, height: 1366)
+      traits = .init(traitsFrom: [
+        .init(horizontalSizeClass: .regular),
+        .init(verticalSizeClass: .regular),
+        .init(userInterfaceIdiom: .pad)
+        ])
+    case (.pad12_9inch, .landscape):
+      parent.view.frame = .init(x: 0, y: 0, width: 1366, height: 1024)
       traits = .init(traitsFrom: [
         .init(horizontalSizeClass: .regular),
         .init(verticalSizeClass: .regular),

--- a/Kickstarter-iOS.playground/Sources/playgroundController.swift
+++ b/Kickstarter-iOS.playground/Sources/playgroundController.swift
@@ -58,14 +58,14 @@ public func playgroundControllers(device: Device = .phone4_7inch,
         .init(userInterfaceIdiom: .phone)
         ])
     case (.phone4inch, .portrait):
-      parent.view.frame = .init(x: 0, y: 0, width: 320, height: 575)
+      parent.view.frame = .init(x: 0, y: 0, width: 320, height: 568)
       traits = .init(traitsFrom: [
         .init(horizontalSizeClass: .compact),
         .init(verticalSizeClass: .regular),
         .init(userInterfaceIdiom: .phone)
         ])
     case (.phone4inch, .landscape):
-      parent.view.frame = .init(x: 0, y: 0, width: 575, height: 320)
+      parent.view.frame = .init(x: 0, y: 0, width: 568, height: 320)
       traits = .init(traitsFrom: [
         .init(horizontalSizeClass: .compact),
         .init(verticalSizeClass: .compact),

--- a/Kickstarter-iOS.playground/Sources/playgroundController.swift
+++ b/Kickstarter-iOS.playground/Sources/playgroundController.swift
@@ -3,7 +3,7 @@ import UIKit
 // swiftlint:disable function_body_length
 
 public enum Device {
-  case phone4inchShorter
+  case phone3_5inch
   case phone4inch
   case phone4_7inch
   case phone5_5inch
@@ -43,14 +43,14 @@ public func playgroundControllers(device: Device = .phone4_7inch,
 
     let traits: UITraitCollection
     switch (device, orientation) {
-    case (.phone4inchShorter, .portrait):
+    case (.phone3_5inch, .portrait):
       parent.view.frame = .init(x: 0, y: 0, width: 320, height: 480)
       traits = .init(traitsFrom: [
         .init(horizontalSizeClass: .compact),
         .init(verticalSizeClass: .regular),
         .init(userInterfaceIdiom: .phone)
         ])
-    case (.phone4inchShorter, .landscape):
+    case (.phone3_5inch, .landscape):
       parent.view.frame = .init(x: 0, y: 0, width: 480, height: 320)
       traits = .init(traitsFrom: [
         .init(horizontalSizeClass: .compact),


### PR DESCRIPTION
Hi guys. As I was shamelessly copy/pasting your awesomely useful playgroundController.swift to our project ❤️ I noticed a couple of things. 

For us, it's useful to see the interface on 4/4S as well as iPad Pro 12 inch size, so I've added them to the `Device` enum. Though Apple want devs thinking in terms of traits rather than sizes, it's still useful to double check stuff on these sizes anyways, at least for us.

And a small fix for 5/5S/SE height as well.

And thanks again for this treasure trove of great code. I hope to contribute in a more substantial way sometime to give back!