### PR TITLE
Go back to observeForControllerAction to fix deadlock

### DIFF
--- a/Kickstarter-iOS/Views/Controllers/SearchViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/SearchViewController.swift
@@ -120,7 +120,7 @@ internal final class SearchViewController: UITableViewController {
     self.searchTextField.rac.isFirstResponder = self.viewModel.outputs.resignFirstResponder.mapConst(false)
 
     self.viewModel.outputs.changeSearchFieldFocus
-      .observeForUI()
+      .observeForControllerAction() // NB: don't change this until we figure out the deadlock problem.
       .observeValues { [weak self] in
         self?.changeSearchFieldFocus(focus: $0, animated: $1)
     }


### PR DESCRIPTION
We just uncovered a subtle deadlock sitch in our search vm. Basically, there's some unfortunate ping-ponging between inputs/outputs where we tell the VM that we focused on something, and then the VM tells the view to focus, and then we tell the VM we focused on something, and then the VM ....

This happened due to our change of `observeForControllerAction` to `observeForUI` on a specific output. The latter is the correct one to use, but it runs the block immediately instead of on the next runloop, and that was causing the deadlock.

I'm going to do the naive/slightly-incorrect fix now, but in the future we could better delineate our inputs/outputs to avoid this.