### PR TITLE
Reduce AVPlayerViewController memory leak overhead

### DIFF
--- a/Kickstarter-iOS/Views/Controllers/VideoViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/VideoViewController.swift
@@ -193,5 +193,6 @@ public final class VideoViewController: UIViewController {
     }
     self.playerController.player?.removeObserver(self, forKeyPath: durationKeyPath)
     self.playerController.player?.removeObserver(self, forKeyPath: rateKeyPath)
+    self.playerController?.player?.replaceCurrentItem(with: nil)
   }
 }

--- a/LiveStream/Views/Controllers/LiveVideoViewController.swift
+++ b/LiveStream/Views/Controllers/LiveVideoViewController.swift
@@ -32,8 +32,8 @@ public final class LiveVideoViewController: UIViewController {
     self.session?.disconnect(nil)
     self.session = nil
     self.subscribers.forEach(self.removeSubscriber(subscriber:))
-    self.playerController?.player?.pause()
     self.playerController?.player?.currentItem?.removeObserver(self, forKeyPath: statusKeyPath)
+    self.playerController?.player?.replaceCurrentItem(with: nil)
   }
 
   public override func viewDidLoad() {


### PR DESCRIPTION
So as @mbrandonw and I recently discovered, `AVPlayerViewController` leaks when it's used as an embedded child view controller and the user taps to go full-screen. In our testing we could only reproduce this when going full-screen, it appeared to release correctly if only watching it as an embedded video.

I played around with Xcode 8's memory debugger a bit and found these sorts of things after dismissing the video view so it seems as if internal KVO observers may be the cause?:
<img width="878" alt="screen shot 2017-02-02 at 2 37 45 pm" src="https://cloud.githubusercontent.com/assets/3735375/22552793/0605afe2-e963-11e6-85a6-c7636a6d8f29.png">
<img width="641" alt="screen shot 2017-02-02 at 3 53 29 pm" src="https://cloud.githubusercontent.com/assets/3735375/22552797/08c6a542-e963-11e6-8eef-c65a70a854bc.png">

Our temporary solution was to just pause the video on dismiss so that we didn't continue to hear the audio after the modal was gone, however this would only reduce the memory footprint from around **145MB** (while playing) to around **130MB** after dismissal.

I found that adding the two lines in this PR, which go a step further to replace the player's current `AVPlayerItem` with `nil`, helped to further reduce the footprint after dismissal to around **98MB**.

In both instances the footprint before displaying the `AVPlayerViewController` is around **91MB**. So whilst it doesn't entirely solve the problem and we may still have to replace this with a custom `AVPlayer` with controls at some point, it mitigates the issue somewhat for now.

Oh and lastly it's worth noting that this leak does _not_ happen if we straight up modal the `AVPlayerViewController` but then we would lose the embedded view functionality which wouldn't work at least in the case of live streaming.