### PR TITLE
Version OpenTok in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,14 +111,15 @@ ifeq ($(CURRENT_OPENTOK_VERSION),)
 	CURRENT_OPENTOK_VERSION = first
 endif
 opentok:
-	if [ $(OPENTOK_VERSION) != $(CURRENT_OPENTOK_VERSION) ]; \
+	@if [ $(OPENTOK_VERSION) != $(CURRENT_OPENTOK_VERSION) ]; \
 	then \
+		echo "Downloading OpenTok v$(OPENTOK_VERSION)"; \
 		mkdir -p Frameworks/OpenTok; \
 		curl -s -N -L https://tokbox.com/downloads/opentok-ios-sdk-$(OPENTOK_VERSION) \
 		| tar -xz --strip 1 --directory Frameworks/OpenTok OpenTok-iOS-$(OPENTOK_VERSION)/OpenTok.framework \
 		|| true; \
 	fi
-	if [ -e Frameworks/OpenTok/OpenTok.framework ]; \
+	@if [ -e Frameworks/OpenTok/OpenTok.framework ]; \
 	then \
 		echo "$(OPENTOK_VERSION)" > $(VERSION_FILE); \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -113,6 +113,7 @@ endif
 opentok:
 	if [ $(OPENTOK_VERSION) != $(CURRENT_OPENTOK_VERSION) ]; \
 	then \
+		mkdir -p Frameworks/OpenTok; \
 		curl -s -N -L https://tokbox.com/downloads/opentok-ios-sdk-$(OPENTOK_VERSION) \
 		| tar -xz --strip 1 --directory Frameworks/OpenTok OpenTok-iOS-$(OPENTOK_VERSION)/OpenTok.framework \
 		|| true; \

--- a/Makefile
+++ b/Makefile
@@ -104,9 +104,22 @@ secrets:
 		|| true; \
 	fi
 
+OPENTOK_VERSION = 2.10.0
+VERSION_FILE = Frameworks/OpenTok/version
+CURRENT_OPENTOK_VERSION = $(shell cat $(VERSION_FILE))
+ifeq ($(CURRENT_OPENTOK_VERSION),)
+	CURRENT_OPENTOK_VERSION = first
+endif
 opentok:
-	mkdir -p Frameworks/OpenTok
-	curl -s -N -L https://tokbox.com/downloads/opentok-ios-sdk-2.10.0 \
-		| tar -xz --strip 1 --directory Frameworks/OpenTok OpenTok-iOS-2.10.0/OpenTok.framework
+	if [ $(OPENTOK_VERSION) != $(CURRENT_OPENTOK_VERSION) ]; \
+	then \
+		curl -s -N -L https://tokbox.com/downloads/opentok-ios-sdk-$(OPENTOK_VERSION) \
+		| tar -xz --strip 1 --directory Frameworks/OpenTok OpenTok-iOS-$(OPENTOK_VERSION)/OpenTok.framework \
+		|| true; \
+	fi
+	if [ -e Frameworks/OpenTok/OpenTok.framework ]; \
+	then \
+		echo "$(OPENTOK_VERSION)" > $(VERSION_FILE); \
+	fi
 
 .PHONY: test-all test clean dependencies submodules deploy lint secrets strings opentok

--- a/circle.yml
+++ b/circle.yml
@@ -2,6 +2,8 @@ machine:
   xcode:
     version: 8.2
 dependencies:
+  cache_directories:
+    Frameworks/OpenTok
   pre:
     - make bootstrap
     - ls /Applications/ | grep "Xcode"

--- a/circle.yml
+++ b/circle.yml
@@ -3,7 +3,7 @@ machine:
     version: 8.2
 dependencies:
   cache_directories:
-    Frameworks/OpenTok
+    - "Frameworks/OpenTok"
   pre:
     - make bootstrap
     - ls /Applications/ | grep "Xcode"


### PR DESCRIPTION
Previously we were downloading the OpenTok binary on each Circle build. This change writes the current version to a file alongside `OpenTok.framework` (already gitignore'd) and does a comparison on the version number to check if it differs and requires downloading.

If we need to update OpenTok in the future we can just modify this version number in the Makefile.

@stephencelis does this look ok? I'm not super familiar with Makefile and shell scripts.