### PR TITLE
 Filter backings from recommended projects

### DIFF
--- a/Library/ViewModels/DiscoveryFiltersViewModel.swift
+++ b/Library/ViewModels/DiscoveryFiltersViewModel.swift
@@ -281,7 +281,9 @@ private func topFilters(forUser user: User?) -> [DiscoveryParams] {
 
   if user != nil {
     filters.append(.defaults |> DiscoveryParams.lens.starred .~ true)
-    filters.append(.defaults |> DiscoveryParams.lens.recommended .~ true)
+    filters.append(.defaults 
+                   |> DiscoveryParams.lens.recommended .~ true 
+                   <> DiscoveryParams.lens.backed .~ false)
     filters.append(.defaults |> DiscoveryParams.lens.social .~ true)
   }
 

--- a/Library/ViewModels/DiscoveryFiltersViewModel.swift
+++ b/Library/ViewModels/DiscoveryFiltersViewModel.swift
@@ -281,9 +281,11 @@ private func topFilters(forUser user: User?) -> [DiscoveryParams] {
 
   if user != nil {
     filters.append(.defaults |> DiscoveryParams.lens.starred .~ true)
-    filters.append(.defaults 
-                   |> DiscoveryParams.lens.recommended .~ true 
-                   <> DiscoveryParams.lens.backed .~ false)
+    filters.append(
+      .defaults
+        |> DiscoveryParams.lens.recommended .~ true
+        |> DiscoveryParams.lens.backed .~ false
+    )
     filters.append(.defaults |> DiscoveryParams.lens.social .~ true)
   }
 


### PR DESCRIPTION
hey it's me again, just filtering backings, don't mind me

in case you forgot:

> We filter user's backed projects from recommendations on web, and we also filter them in the native Thanks activity. Filtering them here will homogenize the backer experience across our platforms and stop people from asking jeff what's up with that rec engine.
> 
> The Thanks activity also filters backings from staff picks, so that's a possibility here.

cc. @kickstarter/native-squad