### PR TITLE
Send subscribe toggle as form data, not JSON

### DIFF
--- a/LiveStream/Service/LiveStreamService.swift
+++ b/LiveStream/Service/LiveStreamService.swift
@@ -143,7 +143,7 @@ public struct LiveStreamService: LiveStreamServiceProtocol {
 
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
-        request.httpBody = try? JSONSerialization.data(withJSONObject: params, options: [])
+        request.httpBody = formData(withDictionary: params).data(using: .utf8)
 
         let task = urlSession.dataTask(with: request) { data, _, _ in
           let result = data
@@ -196,4 +196,14 @@ public struct LiveStreamService: LiveStreamServiceProtocol {
   private static func getAppInstance() -> FIRApp? {
     return FIRApp(named: Secrets.Firebase.Huzza.Production.appName)
   }
+}
+
+fileprivate func formData(withDictionary dictionary: [String:String]) -> String {
+  let params = dictionary.flatMap { key, value -> String? in
+    guard let value = value.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) else { return nil }
+
+    return "\(key)=\(value)"
+  }
+
+  return params.joined(separator: "&")
 }


### PR DESCRIPTION
Whoops! I changed the live stream subscribe toggle api request to post `JSON` because it looked neater in the code but I didn't realise that the API was specifically expecting form data, and because we don't have any real error handling on this call it _appeared_ to work at the client but was in fact not. My bad!

This is a quick fix, I'm going to do more work to create an envelope struct for this response and do some proper error handling and tests for it.