### PR TITLE
:shrimp: Filter backings in discovery filter tests :shrimp:

### DIFF
--- a/Library/SelectableRow.swift
+++ b/Library/SelectableRow.swift
@@ -39,6 +39,9 @@ public extension LensType where Whole == SelectableRow, Part == DiscoveryParams 
   public var recommended: Lens<SelectableRow, Bool?> {
     return SelectableRow.lens.params • DiscoveryParams.lens.recommended
   }
+  public var backed: Lens<SelectableRow, Bool?> {
+    return SelectableRow.lens.params • DiscoveryParams.lens.backed
+  }
 }
 
 extension SelectableRow: Equatable {}

--- a/Library/Tests/ViewModels/DiscoveryFiltersViewModelTests.swift
+++ b/Library/Tests/ViewModels/DiscoveryFiltersViewModelTests.swift
@@ -17,7 +17,10 @@ private let allProjectsRow = selectableRowTemplate |> SelectableRow.lens.params.
 private let staffPicksRow = selectableRowTemplate |> SelectableRow.lens.params.staffPicks .~ true
 private let starredRow = selectableRowTemplate |> SelectableRow.lens.params.starred .~ true
 private let socialRow = selectableRowTemplate |> SelectableRow.lens.params.social .~ true
-private let recommendedRow = selectableRowTemplate |> SelectableRow.lens.params.recommended .~ true
+private let recommendedRow = selectableRowTemplate 
+  |> SelectableRow.lens.params.recommended .~ true
+  |> SelectableRow.lens.params.backed .~ false
+
 private let artSelectableRow = selectableRowTemplate |> SelectableRow.lens.params.category .~ .art
 private let documentarySelectableRow = selectableRowTemplate
   |> SelectableRow.lens.params.category .~ .documentary


### PR DESCRIPTION
## what

Filters backed projects in the DiscoveryFilterViewModel tests in response to #74.

## why

🍤 