### PR TITLE
Refresh live streams on project page appearing

### DIFF
--- a/Library/Tests/ViewModels/ProjectPamphletViewModelTests.swift
+++ b/Library/Tests/ViewModels/ProjectPamphletViewModelTests.swift
@@ -53,6 +53,15 @@ final class ProjectPamphletViewModelTests: TestCase {
     self.configureChildViewControllersWithProject.assertValues([project, project, project])
     self.configureChildViewControllersWithRefTag.assertValues([refTag, refTag, refTag])
     self.configureChildViewControllersWithLiveStreamEvents.assertValues([[], [.template], [.template]])
+
+    self.vm.inputs.viewWillAppear(animated: true)
+
+    self.scheduler.advance()
+
+    self.configureChildViewControllersWithProject.assertValues([project, project, project, project])
+    self.configureChildViewControllersWithRefTag.assertValues([refTag, refTag, refTag, refTag])
+    self.configureChildViewControllersWithLiveStreamEvents.assertValues([[], [.template], [.template],
+                                                                         [.template]])
   }
 
   func testConfigureChildViewControllersWithProject_ConfiguredWithParam() {

--- a/Library/Tests/ViewModels/ProjectPamphletViewModelTests.swift
+++ b/Library/Tests/ViewModels/ProjectPamphletViewModelTests.swift
@@ -72,6 +72,14 @@ final class ProjectPamphletViewModelTests: TestCase {
     self.configureChildViewControllersWithProject.assertValues([project, project])
     self.configureChildViewControllersWithRefTag.assertValues([nil, nil])
     self.configureChildViewControllersWithLiveStreamEvents.assertValues([[], [.template]])
+
+    self.vm.inputs.viewWillAppear(animated: true)
+
+    self.scheduler.advance()
+
+    self.configureChildViewControllersWithProject.assertValues([project, project, project])
+    self.configureChildViewControllersWithRefTag.assertValues([nil, nil, nil])
+    self.configureChildViewControllersWithLiveStreamEvents.assertValues([[], [.template], [.template]])
   }
 
   func testStatusBar() {

--- a/Library/ViewModels/ProjectPamphletViewModel.swift
+++ b/Library/ViewModels/ProjectPamphletViewModel.swift
@@ -70,11 +70,14 @@ ProjectPamphletViewModelOutputs {
     let refTag = self.refTagProperty.signal
       .map { $0.map(cleanUp(refTag:)) }
 
-    let liveStreamEventsFetch = Signal.combineLatest(
-      project,
+    let projectWhenViewAppears = project.takeWhen(
       self.viewWillAppearAnimated.signal
+    )
+
+    let liveStreamEventsFetch = Signal.merge(
+      project.take(first: 1),
+      projectWhenViewAppears
       )
-      .map(first)
       .switchMap { project -> SignalProducer<LiveStreamEventsEnvelope, NoError> in
         AppEnvironment.current.liveStreamService
           .fetchEvents(forProjectId: project.id, uid: AppEnvironment.current.currentUser?.id)

--- a/Library/ViewModels/ProjectPamphletViewModel.swift
+++ b/Library/ViewModels/ProjectPamphletViewModel.swift
@@ -70,8 +70,11 @@ ProjectPamphletViewModelOutputs {
     let refTag = self.refTagProperty.signal
       .map { $0.map(cleanUp(refTag:)) }
 
-    let liveStreamEventsFetch = project
-      .take(first: 1)
+    let liveStreamEventsFetch = Signal.combineLatest(
+      project,
+      self.viewWillAppearAnimated.signal
+      )
+      .map(first)
       .switchMap { project -> SignalProducer<LiveStreamEventsEnvelope, NoError> in
         AppEnvironment.current.liveStreamService
           .fetchEvents(forProjectId: project.id, uid: AppEnvironment.current.currentUser?.id)

--- a/Library/ViewModels/ProjectPamphletViewModel.swift
+++ b/Library/ViewModels/ProjectPamphletViewModel.swift
@@ -70,14 +70,11 @@ ProjectPamphletViewModelOutputs {
     let refTag = self.refTagProperty.signal
       .map { $0.map(cleanUp(refTag:)) }
 
-    let projectWhenViewAppears = project.takeWhen(
-      self.viewWillAppearAnimated.signal
-    )
-
-    let liveStreamEventsFetch = Signal.merge(
+    let liveStreamEventsFetch = Signal.combineLatest(
       project.take(first: 1),
-      projectWhenViewAppears
+      self.viewWillAppearAnimated.signal
       )
+      .map(first)
       .switchMap { project -> SignalProducer<LiveStreamEventsEnvelope, NoError> in
         AppEnvironment.current.liveStreamService
           .fetchEvents(forProjectId: project.id, uid: AppEnvironment.current.currentUser?.id)


### PR DESCRIPTION
This is a quick fix for refreshing a project's live streams when the project page appears.

Alternatively we could be more specific about only doing this when dismissing a live stream/replay but it would require more delegate calls etc due to the nested nature of the project page and the fact that live streams are launched on `ProjectPamphletContentViewController` and fetched in `ProjectPamphletViewModel`.

Perhaps worth doing that though?