### PR TITLE
Refreshing of the Live Stream Discovery view

### DIFF
--- a/Kickstarter-iOS/Views/Controllers/LiveStreamDiscoveryViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/LiveStreamDiscoveryViewController.swift
@@ -67,13 +67,7 @@ internal final class LiveStreamDiscoveryViewController: UITableViewController {
 
     self.viewModel.inputs.viewWillAppear()
   }
-
-  internal override func viewDidDisappear(_ animated: Bool) {
-    super.viewDidDisappear(animated)
-
-    self.viewModel.inputs.viewDidDisappear()
-  }
-
+  
   internal override func tableView(_ tableView: UITableView,
                                    didEndDisplaying cell: UITableViewCell,
                                    forRowAt indexPath: IndexPath) {

--- a/Kickstarter-iOS/Views/Controllers/LiveStreamDiscoveryViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/LiveStreamDiscoveryViewController.swift
@@ -30,12 +30,10 @@ internal final class LiveStreamDiscoveryViewController: UITableViewController {
   internal override func bindViewModel() {
     super.bindViewModel()
 
-    NotificationCenter.default.addObserver(
-      forName: NSNotification.Name.UIApplicationWillEnterForeground, object: nil,
-      queue: nil) { [weak self ]_ in
+    NotificationCenter.default
+      .addObserver(forName: .UIApplicationWillEnterForeground, object: nil, queue: nil) { [weak self ]_ in
         guard let _self = self else { return }
         _self.viewModel.inputs.appWillEnterForeground()
-
     }
 
     self.viewModel.outputs.loadDataSource

--- a/Kickstarter-iOS/Views/Controllers/LiveStreamDiscoveryViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/LiveStreamDiscoveryViewController.swift
@@ -30,6 +30,14 @@ internal final class LiveStreamDiscoveryViewController: UITableViewController {
   internal override func bindViewModel() {
     super.bindViewModel()
 
+    NotificationCenter.default.addObserver(
+      forName: NSNotification.Name.UIApplicationWillEnterForeground, object: nil,
+      queue: nil) { [weak self ]_ in
+        guard let _self = self else { return }
+        _self.viewModel.inputs.appWillEnterForeground()
+
+    }
+
     self.viewModel.outputs.loadDataSource
       .observeForUI()
       .observeValues { [weak self] in
@@ -52,6 +60,18 @@ internal final class LiveStreamDiscoveryViewController: UITableViewController {
     self.viewModel.outputs.showAlert
       .observeForUI()
       .observeValues { [weak self] in self?.showAlert(message: $0) }
+  }
+
+  internal override func viewWillAppear(_ animated: Bool) {
+    super.viewWillAppear(animated)
+
+    self.viewModel.inputs.viewWillAppear()
+  }
+
+  internal override func viewDidDisappear(_ animated: Bool) {
+    super.viewDidDisappear(animated)
+
+    self.viewModel.inputs.viewDidDisappear()
   }
 
   internal override func tableView(_ tableView: UITableView,

--- a/Library/Tests/ViewModels/LiveStreamDiscoveryViewModelTests.swift
+++ b/Library/Tests/ViewModels/LiveStreamDiscoveryViewModelTests.swift
@@ -156,7 +156,6 @@ final class LiveStreamDiscoveryViewModelTests: TestCase {
       self.loadDataSource.assertValueCount(1)
       XCTAssertTrue(self.loadDataSource.lastValue?.isEmpty == .some(false))
 
-      self.vm.inputs.viewDidDisappear()
       self.vm.inputs.viewWillAppear()
 
       self.scheduler.advance()
@@ -171,7 +170,6 @@ final class LiveStreamDiscoveryViewModelTests: TestCase {
       self.loadDataSource.assertValueCount(3)
       XCTAssertTrue(self.loadDataSource.lastValue?.isEmpty == .some(true))
 
-      self.vm.inputs.viewDidDisappear()
       self.vm.inputs.viewWillAppear()
 
       self.scheduler.advance()

--- a/Library/Tests/ViewModels/LiveStreamDiscoveryViewModelTests.swift
+++ b/Library/Tests/ViewModels/LiveStreamDiscoveryViewModelTests.swift
@@ -190,16 +190,6 @@ final class LiveStreamDiscoveryViewModelTests: TestCase {
 
       self.loadDataSource.assertValueCount(5)
       XCTAssertTrue(self.loadDataSource.lastValue?.isEmpty == .some(false))
-
-      self.scheduler.advance(by: .seconds(10))
-
-      self.loadDataSource.assertValueCount(5)
-      XCTAssertTrue(self.loadDataSource.lastValue?.isEmpty == .some(false))
-
-      self.scheduler.advance(by: .seconds(60*5))
-
-      self.loadDataSource.assertValueCount(6)
-      XCTAssertTrue(self.loadDataSource.lastValue?.isEmpty == .some(false))
     }
   }
 }

--- a/Library/Tests/ViewModels/LiveStreamDiscoveryViewModelTests.swift
+++ b/Library/Tests/ViewModels/LiveStreamDiscoveryViewModelTests.swift
@@ -135,4 +135,73 @@ final class LiveStreamDiscoveryViewModelTests: TestCase {
       self.showAlert.assertValues(["Couldn‘t open live stream. Try again later."])
     }
   }
+
+  func testLoadDataSource_Refreshes() {
+    let project = Project.template
+      |> Project.lens.id .~ 42
+    let liveStreamsEnvelope = .template
+      |> LiveStreamEventsEnvelope.lens.liveStreamEvents .~ (
+        (0...4).map { .template |> LiveStreamEvent.lens.id .~ $0 }
+    )
+
+    let apiService = MockService(fetchProjectResponse: project)
+    let liveStreamService = MockLiveStreamService(fetchEventsForProjectResult: .success(liveStreamsEnvelope))
+    withEnvironment(apiService: apiService, liveStreamService: liveStreamService) {
+      self.vm.inputs.viewDidLoad()
+      self.vm.inputs.viewWillAppear()
+      self.vm.inputs.isActive(true)
+
+      self.scheduler.advance()
+
+      self.loadDataSource.assertValueCount(1)
+      XCTAssertTrue(self.loadDataSource.lastValue?.isEmpty == .some(false))
+
+      self.vm.inputs.viewDidDisappear()
+      self.vm.inputs.viewWillAppear()
+
+      self.scheduler.advance()
+
+      self.loadDataSource.assertValueCount(2)
+      XCTAssertTrue(self.loadDataSource.lastValue?.isEmpty == .some(false))
+
+      self.vm.inputs.isActive(false)
+
+      self.scheduler.advance()
+
+      self.loadDataSource.assertValueCount(3)
+      XCTAssertTrue(self.loadDataSource.lastValue?.isEmpty == .some(true))
+
+      self.vm.inputs.viewDidDisappear()
+      self.vm.inputs.viewWillAppear()
+
+      self.scheduler.advance()
+      
+      self.loadDataSource.assertValueCount(3)
+      XCTAssertTrue(self.loadDataSource.lastValue?.isEmpty == .some(true))
+
+      self.vm.inputs.isActive(true)
+
+      self.scheduler.advance()
+
+      self.loadDataSource.assertValueCount(4)
+      XCTAssertTrue(self.loadDataSource.lastValue?.isEmpty == .some(false))
+
+      self.vm.inputs.appWillEnterForeground()
+
+      self.scheduler.advance()
+
+      self.loadDataSource.assertValueCount(5)
+      XCTAssertTrue(self.loadDataSource.lastValue?.isEmpty == .some(false))
+
+      self.scheduler.advance(by: .seconds(10))
+
+      self.loadDataSource.assertValueCount(5)
+      XCTAssertTrue(self.loadDataSource.lastValue?.isEmpty == .some(false))
+
+      self.scheduler.advance(by: .seconds(60*5))
+
+      self.loadDataSource.assertValueCount(6)
+      XCTAssertTrue(self.loadDataSource.lastValue?.isEmpty == .some(false))
+    }
+  }
 }

--- a/Library/ViewModels/LiveStreamDiscoveryViewModel.swift
+++ b/Library/ViewModels/LiveStreamDiscoveryViewModel.swift
@@ -14,9 +14,6 @@ public protocol LiveStreamDiscoveryViewModelInputs {
   /// Call when a live stream cell is tapped.
   func tapped(liveStreamEvent: LiveStreamEvent)
 
-  /// Call when the viewDidDisappear
-  func viewDidDisappear()
-
   /// Call when the view loads.
   func viewDidLoad()
 
@@ -66,10 +63,7 @@ LiveStreamDiscoveryViewModelInputs, LiveStreamDiscoveryViewModelOutputs {
       timer(interval: .seconds(60*5), on: AppEnvironment.current.scheduler)
     }
 
-    let didNavigateBack = Signal.zip(
-      self.viewDidDisappearProperty.signal,
-      self.viewWillAppearProperty.signal.skip(first: 1)
-    )
+    let didNavigateBack = self.viewWillAppearProperty.signal.skip(first: 1)
 
     let refreshes = Signal.merge(
       didNavigateBack.ignoreValues(),
@@ -108,11 +102,6 @@ LiveStreamDiscoveryViewModelInputs, LiveStreamDiscoveryViewModelOutputs {
   private let tappedLiveStreamEventProperty = MutableProperty<LiveStreamEvent?>(nil)
   public func tapped(liveStreamEvent: LiveStreamEvent) {
     self.tappedLiveStreamEventProperty.value = liveStreamEvent
-  }
-
-  private let viewDidDisappearProperty = MutableProperty()
-  public func viewDidDisappear() {
-    self.viewDidDisappearProperty.value = ()
   }
 
   private let viewDidLoadProperty = MutableProperty()

--- a/Library/ViewModels/LiveStreamDiscoveryViewModel.swift
+++ b/Library/ViewModels/LiveStreamDiscoveryViewModel.swift
@@ -59,17 +59,12 @@ LiveStreamDiscoveryViewModelInputs, LiveStreamDiscoveryViewModelOutputs {
     self.showAlert = projectAndTappedLiveStreamEvent.errors()
       .mapConst(Strings.Couldnt_open_live_stream_Try_again_later())
 
-    let periodicRefresh = self.viewDidLoadProperty.signal.switchMap {
-      timer(interval: .seconds(60*5), on: AppEnvironment.current.scheduler)
-    }
-
     let didNavigateBack = self.viewWillAppearProperty.signal.skip(first: 1)
 
     let refreshes = Signal.merge(
       didNavigateBack.ignoreValues(),
       appWillEnterForegroundProperty.signal,
-      self.viewDidLoadProperty.signal,
-      periodicRefresh.ignoreValues()
+      self.viewDidLoadProperty.signal
     )
 
     let freshLiveStreamEvents = Signal.combineLatest(


### PR DESCRIPTION
This adds a couple of different ways that the Live Stream Discovery view will be refreshed to avoid navigating back and seeing 'stale' cards that are perhaps no longer live and now in replay, or were upcoming and are now live, etc.

It will refresh the following ways:

- when `isActive` is set to `true` (causes a fetch as before)
- when `isActive` is set to `false` (clears data source as before)
- when the view disappears and reappears
- when the app returns from the background
- when 5 minutes has passed

All of these will only emit when `isActive` is `true`.

Having done all of this I'm now no longer sure if this is really what we want, it feels like there are just so many ways that this view can be refreshed, but it's done and seems to work fine so let me know what you think!