### PR TITLE
Pause live video on disappear/reappear

### DIFF
--- a/LiveStream/ViewModels/LiveVideoViewModel.swift
+++ b/LiveStream/ViewModels/LiveVideoViewModel.swift
@@ -53,7 +53,7 @@ internal protocol LiveVideoViewModelOutputs {
   var resubscribeAllSubscribersToSession: Signal<(), NoError> { get }
 
   /// Emits to toggle play/pause when the view disappears/reappears.
-  var toggleHlsPause: Signal<Bool, NoError> { get }
+  var setHlsToPlaybackState: Signal<Bool, NoError> { get }
 
   /// Emits when all subscribers should be unsubscribed when the view disappears.
   var unsubscribeAllSubscribersFromSession: Signal<(), NoError> { get }
@@ -101,15 +101,12 @@ internal final class LiveVideoViewModel: LiveVideoViewModelType, LiveVideoViewMo
         .mapConst(.error(error: .sessionInterrupted))
     )
 
-    let viewReappeared = Signal.zip(
-      self.viewDidDisappearProperty.signal,
-      self.viewWillAppearProperty.signal.skip(first: 1)
-    )
+    let viewReappeared = self.viewWillAppearProperty.signal.skip(first: 1)
 
-    self.toggleHlsPause = Signal.combineLatest(
+    self.setHlsToPlaybackState = Signal.combineLatest(
       Signal.merge(
-        self.viewDidDisappearProperty.signal.mapConst(true),
-        viewReappeared.mapConst(false)
+        self.viewDidDisappearProperty.signal.mapConst(false),
+        viewReappeared.mapConst(true)
       ),
       self.addAndConfigureHLSPlayerWithStreamUrl.signal
     ).map(first)
@@ -176,7 +173,7 @@ internal final class LiveVideoViewModel: LiveVideoViewModelType, LiveVideoViewMo
   internal let notifyDelegateOfPlaybackStateChange: Signal<LiveVideoPlaybackState, NoError>
   internal let removeSubscriber: Signal<OTStreamType, NoError>
   internal let resubscribeAllSubscribersToSession: Signal<(), NoError>
-  internal let toggleHlsPause: Signal<Bool, NoError>
+  internal let setHlsToPlaybackState: Signal<Bool, NoError>
   internal let unsubscribeAllSubscribersFromSession: Signal<(), NoError>
 
   internal var inputs: LiveVideoViewModelInputs { return self }

--- a/LiveStream/ViewModels/LiveVideoViewModel.swift
+++ b/LiveStream/ViewModels/LiveVideoViewModel.swift
@@ -23,8 +23,14 @@ internal protocol LiveVideoViewModelInputs {
   /// Call when the OpenTok session is destroy.
   func sessionStreamDestroyed(stream: OTStreamType)
 
+  /// Call when the view disappears.
+  func viewDidDisappear()
+
   /// Call when the view loads.
   func viewDidLoad()
+
+  /// Call when the view will appear.
+  func viewWillAppear()
 }
 
 internal protocol LiveVideoViewModelOutputs {
@@ -42,6 +48,15 @@ internal protocol LiveVideoViewModelOutputs {
 
   /// Emits a stream when the subscriber of that stream should be removed.
   var removeSubscriber: Signal<OTStreamType, NoError> { get }
+
+  /// Emits when all subscribers should be re-subscribed when the view reappears.
+  var resubscribeAllSubscribersToSession: Signal<(), NoError> { get }
+
+  /// Emits to toggle play/pause when the view disappears/reappears.
+  var toggleHlsPause: Signal<Bool, NoError> { get }
+
+  /// Emits when all subscribers should be unsubscribed when the view disappears.
+  var unsubscribeAllSubscribersFromSession: Signal<(), NoError> { get }
 }
 
 internal protocol LiveVideoViewModelType {
@@ -85,6 +100,29 @@ internal final class LiveVideoViewModel: LiveVideoViewModelType, LiveVideoViewMo
       self.sessionDidFailWithErrorProperty.signal.skipNil()
         .mapConst(.error(error: .sessionInterrupted))
     )
+
+    let viewReappeared = Signal.zip(
+      self.viewDidDisappearProperty.signal,
+      self.viewWillAppearProperty.signal.skip(first: 1)
+    )
+
+    self.toggleHlsPause = Signal.combineLatest(
+      Signal.merge(
+        self.viewDidDisappearProperty.signal.mapConst(true),
+        viewReappeared.mapConst(false)
+      ),
+      self.addAndConfigureHLSPlayerWithStreamUrl.signal
+    ).map(first)
+
+    self.unsubscribeAllSubscribersFromSession = Signal.combineLatest(
+      self.viewDidDisappearProperty.signal,
+      createAndConfigureSessionWithConfig
+    ).ignoreValues()
+
+    self.resubscribeAllSubscribersToSession = Signal.combineLatest(
+      viewReappeared,
+      createAndConfigureSessionWithConfig
+    ).ignoreValues()
   }
 
   private let liveStreamTypeProperty = MutableProperty<LiveStreamType?>(nil)
@@ -117,9 +155,19 @@ internal final class LiveVideoViewModel: LiveVideoViewModelType, LiveVideoViewMo
     self.sessionStreamDestroyedProperty.value = stream
   }
 
+  private let viewDidDisappearProperty = MutableProperty()
+  internal func viewDidDisappear() {
+    self.viewDidDisappearProperty.value = ()
+  }
+
   private let viewDidLoadProperty = MutableProperty()
   internal func viewDidLoad() {
     self.viewDidLoadProperty.value = ()
+  }
+
+  private let viewWillAppearProperty = MutableProperty()
+  internal func viewWillAppear() {
+    self.viewWillAppearProperty.value = ()
   }
 
   internal let addAndConfigureHLSPlayerWithStreamUrl: Signal<String, NoError>
@@ -127,6 +175,9 @@ internal final class LiveVideoViewModel: LiveVideoViewModelType, LiveVideoViewMo
   internal let createAndConfigureSessionWithConfig: Signal<OpenTokSessionConfig, NoError>
   internal let notifyDelegateOfPlaybackStateChange: Signal<LiveVideoPlaybackState, NoError>
   internal let removeSubscriber: Signal<OTStreamType, NoError>
+  internal let resubscribeAllSubscribersToSession: Signal<(), NoError>
+  internal let toggleHlsPause: Signal<Bool, NoError>
+  internal let unsubscribeAllSubscribersFromSession: Signal<(), NoError>
 
   internal var inputs: LiveVideoViewModelInputs { return self }
   internal var outputs: LiveVideoViewModelOutputs { return self }

--- a/LiveStream/ViewModels/LiveVideoViewModel.swift
+++ b/LiveStream/ViewModels/LiveVideoViewModel.swift
@@ -53,7 +53,7 @@ internal protocol LiveVideoViewModelOutputs {
   var resubscribeAllSubscribersToSession: Signal<(), NoError> { get }
 
   /// Emits to toggle play/pause when the view disappears/reappears.
-  var setHlsToPlaybackState: Signal<Bool, NoError> { get }
+  var shouldPauseHlsPlayer: Signal<Bool, NoError> { get }
 
   /// Emits when all subscribers should be unsubscribed when the view disappears.
   var unsubscribeAllSubscribersFromSession: Signal<(), NoError> { get }
@@ -103,10 +103,10 @@ internal final class LiveVideoViewModel: LiveVideoViewModelType, LiveVideoViewMo
 
     let viewReappeared = self.viewWillAppearProperty.signal.skip(first: 1)
 
-    self.setHlsToPlaybackState = Signal.combineLatest(
+    self.shouldPauseHlsPlayer = Signal.combineLatest(
       Signal.merge(
-        self.viewDidDisappearProperty.signal.mapConst(false),
-        viewReappeared.mapConst(true)
+        self.viewDidDisappearProperty.signal.mapConst(true),
+        viewReappeared.mapConst(false)
       ),
       self.addAndConfigureHLSPlayerWithStreamUrl.signal
     ).map(first)
@@ -173,7 +173,7 @@ internal final class LiveVideoViewModel: LiveVideoViewModelType, LiveVideoViewMo
   internal let notifyDelegateOfPlaybackStateChange: Signal<LiveVideoPlaybackState, NoError>
   internal let removeSubscriber: Signal<OTStreamType, NoError>
   internal let resubscribeAllSubscribersToSession: Signal<(), NoError>
-  internal let setHlsToPlaybackState: Signal<Bool, NoError>
+  internal let shouldPauseHlsPlayer: Signal<Bool, NoError>
   internal let unsubscribeAllSubscribersFromSession: Signal<(), NoError>
 
   internal var inputs: LiveVideoViewModelInputs { return self }

--- a/LiveStream/ViewModels/LiveVideoViewModelTests.swift
+++ b/LiveStream/ViewModels/LiveVideoViewModelTests.swift
@@ -19,7 +19,7 @@ internal final class LiveVideoViewModelTests: XCTestCase {
   private let notifyDelegateOfPlaybackStateChange = TestObserver<LiveVideoPlaybackState, NoError>()
   private let removeSubscriberStreamId = TestObserver<String, NoError>()
   private let resubscribeAllSubscribersToSession = TestObserver<(), NoError>()
-  private let setHlsToPlaybackState = TestObserver<Bool, NoError>()
+  private let shouldPauseHlsPlayer = TestObserver<Bool, NoError>()
   private let unsubscribeAllSubscribersFromSession = TestObserver<(), NoError>()
 
   override func setUp() {
@@ -35,7 +35,7 @@ internal final class LiveVideoViewModelTests: XCTestCase {
     self.vm.outputs.removeSubscriber.map { $0.streamId }.observe(self.removeSubscriberStreamId.observer)
     self.vm.outputs.resubscribeAllSubscribersToSession.observe(
       self.resubscribeAllSubscribersToSession.observer)
-    self.vm.outputs.setHlsToPlaybackState.observe(self.setHlsToPlaybackState.observer)
+    self.vm.outputs.shouldPauseHlsPlayer.observe(self.shouldPauseHlsPlayer.observer)
     self.vm.outputs.unsubscribeAllSubscribersFromSession.observe(
       self.unsubscribeAllSubscribersFromSession.observer)
   }
@@ -112,7 +112,7 @@ internal final class LiveVideoViewModelTests: XCTestCase {
 
     self.createAndConfigureSessionWithConfig.assertValueCount(0)
     self.resubscribeAllSubscribersToSession.assertValueCount(0)
-    self.setHlsToPlaybackState.assertValueCount(0)
+    self.shouldPauseHlsPlayer.assertValueCount(0)
     self.unsubscribeAllSubscribersFromSession.assertValueCount(0)
 
     self.vm.inputs.configureWith(liveStreamType: .openTok(sessionConfig: sessionConfig))
@@ -121,19 +121,19 @@ internal final class LiveVideoViewModelTests: XCTestCase {
 
     self.createAndConfigureSessionWithConfig.assertValue(sessionConfig)
     self.resubscribeAllSubscribersToSession.assertValueCount(0)
-    self.setHlsToPlaybackState.assertValueCount(0)
+    self.shouldPauseHlsPlayer.assertValueCount(0)
     self.unsubscribeAllSubscribersFromSession.assertValueCount(0)
 
     self.vm.inputs.viewDidDisappear()
 
     self.resubscribeAllSubscribersToSession.assertValueCount(0)
-    self.setHlsToPlaybackState.assertValueCount(0)
+    self.shouldPauseHlsPlayer.assertValueCount(0)
     self.unsubscribeAllSubscribersFromSession.assertValueCount(1)
 
     self.vm.inputs.viewWillAppear()
 
     self.resubscribeAllSubscribersToSession.assertValueCount(1)
-    self.setHlsToPlaybackState.assertValueCount(0)
+    self.shouldPauseHlsPlayer.assertValueCount(0)
     self.unsubscribeAllSubscribersFromSession.assertValueCount(1)
   }
 
@@ -142,7 +142,7 @@ internal final class LiveVideoViewModelTests: XCTestCase {
 
     self.addAndConfigureHLSPlayerWithStreamUrl.assertValueCount(0)
     self.resubscribeAllSubscribersToSession.assertValueCount(0)
-    self.setHlsToPlaybackState.assertValueCount(0)
+    self.shouldPauseHlsPlayer.assertValueCount(0)
     self.unsubscribeAllSubscribersFromSession.assertValueCount(0)
 
     self.vm.inputs.configureWith(liveStreamType: .hlsStream(hlsStreamUrl: streamUrl))
@@ -151,19 +151,19 @@ internal final class LiveVideoViewModelTests: XCTestCase {
 
     self.addAndConfigureHLSPlayerWithStreamUrl.assertValue(streamUrl)
     self.resubscribeAllSubscribersToSession.assertValueCount(0)
-    self.setHlsToPlaybackState.assertValueCount(0)
+    self.shouldPauseHlsPlayer.assertValueCount(0)
     self.unsubscribeAllSubscribersFromSession.assertValueCount(0)
 
     self.vm.inputs.viewDidDisappear()
 
     self.resubscribeAllSubscribersToSession.assertValueCount(0)
-    self.setHlsToPlaybackState.assertValues([false])
+    self.shouldPauseHlsPlayer.assertValues([true])
     self.unsubscribeAllSubscribersFromSession.assertValueCount(0)
 
     self.vm.inputs.viewWillAppear()
 
     self.resubscribeAllSubscribersToSession.assertValueCount(0)
-    self.setHlsToPlaybackState.assertValues([false, true])
+    self.shouldPauseHlsPlayer.assertValues([true, false])
     self.unsubscribeAllSubscribersFromSession.assertValueCount(0)
   }
 }

--- a/LiveStream/ViewModels/LiveVideoViewModelTests.swift
+++ b/LiveStream/ViewModels/LiveVideoViewModelTests.swift
@@ -33,9 +33,11 @@ internal final class LiveVideoViewModelTests: XCTestCase {
     self.vm.outputs.notifyDelegateOfPlaybackStateChange
       .observe(self.notifyDelegateOfPlaybackStateChange.observer)
     self.vm.outputs.removeSubscriber.map { $0.streamId }.observe(self.removeSubscriberStreamId.observer)
-    self.vm.outputs.resubscribeAllSubscribersToSession.observe(self.resubscribeAllSubscribersToSession.observer)
+    self.vm.outputs.resubscribeAllSubscribersToSession.observe(
+      self.resubscribeAllSubscribersToSession.observer)
     self.vm.outputs.toggleHlsPause.observe(self.toggleHlsPause.observer)
-    self.vm.outputs.unsubscribeAllSubscribersFromSession.observe(self.unsubscribeAllSubscribersFromSession.observer)
+    self.vm.outputs.unsubscribeAllSubscribersFromSession.observe(
+      self.unsubscribeAllSubscribersFromSession.observer)
   }
 
   override func tearDown() {

--- a/LiveStream/ViewModels/LiveVideoViewModelTests.swift
+++ b/LiveStream/ViewModels/LiveVideoViewModelTests.swift
@@ -19,7 +19,7 @@ internal final class LiveVideoViewModelTests: XCTestCase {
   private let notifyDelegateOfPlaybackStateChange = TestObserver<LiveVideoPlaybackState, NoError>()
   private let removeSubscriberStreamId = TestObserver<String, NoError>()
   private let resubscribeAllSubscribersToSession = TestObserver<(), NoError>()
-  private let toggleHlsPause = TestObserver<Bool, NoError>()
+  private let setHlsToPlaybackState = TestObserver<Bool, NoError>()
   private let unsubscribeAllSubscribersFromSession = TestObserver<(), NoError>()
 
   override func setUp() {
@@ -35,7 +35,7 @@ internal final class LiveVideoViewModelTests: XCTestCase {
     self.vm.outputs.removeSubscriber.map { $0.streamId }.observe(self.removeSubscriberStreamId.observer)
     self.vm.outputs.resubscribeAllSubscribersToSession.observe(
       self.resubscribeAllSubscribersToSession.observer)
-    self.vm.outputs.toggleHlsPause.observe(self.toggleHlsPause.observer)
+    self.vm.outputs.setHlsToPlaybackState.observe(self.setHlsToPlaybackState.observer)
     self.vm.outputs.unsubscribeAllSubscribersFromSession.observe(
       self.unsubscribeAllSubscribersFromSession.observer)
   }
@@ -112,7 +112,7 @@ internal final class LiveVideoViewModelTests: XCTestCase {
 
     self.createAndConfigureSessionWithConfig.assertValueCount(0)
     self.resubscribeAllSubscribersToSession.assertValueCount(0)
-    self.toggleHlsPause.assertValueCount(0)
+    self.setHlsToPlaybackState.assertValueCount(0)
     self.unsubscribeAllSubscribersFromSession.assertValueCount(0)
 
     self.vm.inputs.configureWith(liveStreamType: .openTok(sessionConfig: sessionConfig))
@@ -121,19 +121,19 @@ internal final class LiveVideoViewModelTests: XCTestCase {
 
     self.createAndConfigureSessionWithConfig.assertValue(sessionConfig)
     self.resubscribeAllSubscribersToSession.assertValueCount(0)
-    self.toggleHlsPause.assertValueCount(0)
+    self.setHlsToPlaybackState.assertValueCount(0)
     self.unsubscribeAllSubscribersFromSession.assertValueCount(0)
 
     self.vm.inputs.viewDidDisappear()
 
     self.resubscribeAllSubscribersToSession.assertValueCount(0)
-    self.toggleHlsPause.assertValueCount(0)
+    self.setHlsToPlaybackState.assertValueCount(0)
     self.unsubscribeAllSubscribersFromSession.assertValueCount(1)
 
     self.vm.inputs.viewWillAppear()
 
     self.resubscribeAllSubscribersToSession.assertValueCount(1)
-    self.toggleHlsPause.assertValueCount(0)
+    self.setHlsToPlaybackState.assertValueCount(0)
     self.unsubscribeAllSubscribersFromSession.assertValueCount(1)
   }
 
@@ -142,7 +142,7 @@ internal final class LiveVideoViewModelTests: XCTestCase {
 
     self.addAndConfigureHLSPlayerWithStreamUrl.assertValueCount(0)
     self.resubscribeAllSubscribersToSession.assertValueCount(0)
-    self.toggleHlsPause.assertValueCount(0)
+    self.setHlsToPlaybackState.assertValueCount(0)
     self.unsubscribeAllSubscribersFromSession.assertValueCount(0)
 
     self.vm.inputs.configureWith(liveStreamType: .hlsStream(hlsStreamUrl: streamUrl))
@@ -151,19 +151,19 @@ internal final class LiveVideoViewModelTests: XCTestCase {
 
     self.addAndConfigureHLSPlayerWithStreamUrl.assertValue(streamUrl)
     self.resubscribeAllSubscribersToSession.assertValueCount(0)
-    self.toggleHlsPause.assertValueCount(0)
+    self.setHlsToPlaybackState.assertValueCount(0)
     self.unsubscribeAllSubscribersFromSession.assertValueCount(0)
 
     self.vm.inputs.viewDidDisappear()
 
     self.resubscribeAllSubscribersToSession.assertValueCount(0)
-    self.toggleHlsPause.assertValues([true])
+    self.setHlsToPlaybackState.assertValues([false])
     self.unsubscribeAllSubscribersFromSession.assertValueCount(0)
 
     self.vm.inputs.viewWillAppear()
 
     self.resubscribeAllSubscribersToSession.assertValueCount(0)
-    self.toggleHlsPause.assertValues([true, false])
+    self.setHlsToPlaybackState.assertValues([false, true])
     self.unsubscribeAllSubscribersFromSession.assertValueCount(0)
   }
 }

--- a/LiveStream/ViewModels/LiveVideoViewModelTests.swift
+++ b/LiveStream/ViewModels/LiveVideoViewModelTests.swift
@@ -18,6 +18,9 @@ internal final class LiveVideoViewModelTests: XCTestCase {
   private let createAndConfigureSessionWithConfig = TestObserver<OpenTokSessionConfig, NoError>()
   private let notifyDelegateOfPlaybackStateChange = TestObserver<LiveVideoPlaybackState, NoError>()
   private let removeSubscriberStreamId = TestObserver<String, NoError>()
+  private let resubscribeAllSubscribersToSession = TestObserver<(), NoError>()
+  private let toggleHlsPause = TestObserver<Bool, NoError>()
+  private let unsubscribeAllSubscribersFromSession = TestObserver<(), NoError>()
 
   override func setUp() {
     super.setUp()
@@ -30,6 +33,9 @@ internal final class LiveVideoViewModelTests: XCTestCase {
     self.vm.outputs.notifyDelegateOfPlaybackStateChange
       .observe(self.notifyDelegateOfPlaybackStateChange.observer)
     self.vm.outputs.removeSubscriber.map { $0.streamId }.observe(self.removeSubscriberStreamId.observer)
+    self.vm.outputs.resubscribeAllSubscribersToSession.observe(self.resubscribeAllSubscribersToSession.observer)
+    self.vm.outputs.toggleHlsPause.observe(self.toggleHlsPause.observer)
+    self.vm.outputs.unsubscribeAllSubscribersFromSession.observe(self.unsubscribeAllSubscribersFromSession.observer)
   }
 
   override func tearDown() {
@@ -57,7 +63,7 @@ internal final class LiveVideoViewModelTests: XCTestCase {
     ])
   }
 
-  func testOpentokSessionConfig() {
+  func testOpenTokSessionConfig() {
     let sessionConfig = OpenTokSessionConfig(apiKey: "123", sessionId: "123", token: "123")
 
     // Step 1: Configure the OpenTok session, playback state should become loading
@@ -97,5 +103,65 @@ internal final class LiveVideoViewModelTests: XCTestCase {
 
     self.addAndConfigureSubscriberStreamId.assertValues(["1", "2"])
     self.removeSubscriberStreamId.assertValues(["1", "2"])
+  }
+
+  func testOpenTok_Unsubscribe_Resubscribe() {
+    let sessionConfig = OpenTokSessionConfig(apiKey: "123", sessionId: "123", token: "123")
+
+    self.createAndConfigureSessionWithConfig.assertValueCount(0)
+    self.resubscribeAllSubscribersToSession.assertValueCount(0)
+    self.toggleHlsPause.assertValueCount(0)
+    self.unsubscribeAllSubscribersFromSession.assertValueCount(0)
+
+    self.vm.inputs.configureWith(liveStreamType: .openTok(sessionConfig: sessionConfig))
+    self.vm.inputs.viewDidLoad()
+    self.vm.inputs.viewWillAppear()
+
+    self.createAndConfigureSessionWithConfig.assertValue(sessionConfig)
+    self.resubscribeAllSubscribersToSession.assertValueCount(0)
+    self.toggleHlsPause.assertValueCount(0)
+    self.unsubscribeAllSubscribersFromSession.assertValueCount(0)
+
+    self.vm.inputs.viewDidDisappear()
+
+    self.resubscribeAllSubscribersToSession.assertValueCount(0)
+    self.toggleHlsPause.assertValueCount(0)
+    self.unsubscribeAllSubscribersFromSession.assertValueCount(1)
+
+    self.vm.inputs.viewWillAppear()
+
+    self.resubscribeAllSubscribersToSession.assertValueCount(1)
+    self.toggleHlsPause.assertValueCount(0)
+    self.unsubscribeAllSubscribersFromSession.assertValueCount(1)
+  }
+
+  func testHls_TogglePause() {
+    let streamUrl = "http://www.kickstarter.com"
+
+    self.addAndConfigureHLSPlayerWithStreamUrl.assertValueCount(0)
+    self.resubscribeAllSubscribersToSession.assertValueCount(0)
+    self.toggleHlsPause.assertValueCount(0)
+    self.unsubscribeAllSubscribersFromSession.assertValueCount(0)
+
+    self.vm.inputs.configureWith(liveStreamType: .hlsStream(hlsStreamUrl: streamUrl))
+    self.vm.inputs.viewDidLoad()
+    self.vm.inputs.viewWillAppear()
+
+    self.addAndConfigureHLSPlayerWithStreamUrl.assertValue(streamUrl)
+    self.resubscribeAllSubscribersToSession.assertValueCount(0)
+    self.toggleHlsPause.assertValueCount(0)
+    self.unsubscribeAllSubscribersFromSession.assertValueCount(0)
+
+    self.vm.inputs.viewDidDisappear()
+
+    self.resubscribeAllSubscribersToSession.assertValueCount(0)
+    self.toggleHlsPause.assertValues([true])
+    self.unsubscribeAllSubscribersFromSession.assertValueCount(0)
+
+    self.vm.inputs.viewWillAppear()
+
+    self.resubscribeAllSubscribersToSession.assertValueCount(0)
+    self.toggleHlsPause.assertValues([true, false])
+    self.unsubscribeAllSubscribersFromSession.assertValueCount(0)
   }
 }

--- a/LiveStream/Views/Controllers/LiveVideoViewController.swift
+++ b/LiveStream/Views/Controllers/LiveVideoViewController.swift
@@ -124,7 +124,6 @@ public final class LiveVideoViewController: UIViewController {
     }
   }
 
-
   private func configureHLSPlayer(streamUrl: String) {
     guard let url = URL(string: streamUrl) else { return }
 

--- a/LiveStream/Views/Controllers/LiveVideoViewController.swift
+++ b/LiveStream/Views/Controllers/LiveVideoViewController.swift
@@ -46,6 +46,7 @@ public final class LiveVideoViewController: UIViewController {
     self.viewModel.inputs.viewDidLoad()
   }
 
+  //swiftlint:disable:next function_body_length
   public func bindVM() {
     self.viewModel.outputs.addAndConfigureHLSPlayerWithStreamUrl
       .observeForUI()

--- a/LiveStream/Views/Controllers/LiveVideoViewController.swift
+++ b/LiveStream/Views/Controllers/LiveVideoViewController.swift
@@ -78,6 +78,47 @@ public final class LiveVideoViewController: UIViewController {
         guard let _self = self else { return }
         self?.delegate?.liveVideoViewControllerPlaybackStateChanged(controller: _self, state: $0)
     }
+
+    self.viewModel.outputs.unsubscribeAllSubscribersFromSession
+      .observeForUI()
+      .observeValues { [weak self] in
+        guard let _self = self else { return }
+        _self.subscribers.forEach { subscriber in
+          _self.session?.unsubscribe(subscriber, error: nil)
+        }
+    }
+
+    self.viewModel.outputs.resubscribeAllSubscribersToSession
+      .observeForUI()
+      .observeValues { [weak self] in
+        guard let _self = self else { return }
+        _self.subscribers.forEach { subscriber in
+          _self.session?.subscribe(subscriber, error: nil)
+        }
+    }
+
+    self.viewModel.outputs.toggleHlsPause
+      .observeForUI()
+      .observeValues { [weak self] pause in
+        guard let _self = self else { return }
+        if pause {
+          _self.playerController?.player?.pause()
+        } else {
+          _self.playerController?.player?.play()
+        }
+    }
+  }
+
+  public override func viewDidDisappear(_ animated: Bool) {
+    super.viewDidDisappear(animated)
+
+    self.viewModel.inputs.viewDidDisappear()
+  }
+
+  public override func viewWillAppear(_ animated: Bool) {
+    super.viewWillAppear(animated)
+
+    self.viewModel.inputs.viewWillAppear()
   }
 
   private func configureHLSPlayer(streamUrl: String) {

--- a/LiveStream/Views/Controllers/LiveVideoViewController.swift
+++ b/LiveStream/Views/Controllers/LiveVideoViewController.swift
@@ -113,7 +113,7 @@ public final class LiveVideoViewController: UIViewController {
         }
     }
 
-    self.viewModel.outputs.setHlsToPlaybackState
+    self.viewModel.outputs.shouldPauseHlsPlayer
       .observeForUI()
       .observeValues { [weak self] pause in
         if pause {

--- a/LiveStream/Views/Controllers/LiveVideoViewController.swift
+++ b/LiveStream/Views/Controllers/LiveVideoViewController.swift
@@ -83,29 +83,26 @@ public final class LiveVideoViewController: UIViewController {
     self.viewModel.outputs.unsubscribeAllSubscribersFromSession
       .observeForUI()
       .observeValues { [weak self] in
-        guard let _self = self else { return }
-        _self.subscribers.forEach { subscriber in
-          _self.session?.unsubscribe(subscriber, error: nil)
+        self?.subscribers.forEach { subscriber in
+          self?.session?.unsubscribe(subscriber, error: nil)
         }
     }
 
     self.viewModel.outputs.resubscribeAllSubscribersToSession
       .observeForUI()
       .observeValues { [weak self] in
-        guard let _self = self else { return }
-        _self.subscribers.forEach { subscriber in
-          _self.session?.subscribe(subscriber, error: nil)
+        self?.subscribers.forEach { subscriber in
+          self?.session?.subscribe(subscriber, error: nil)
         }
     }
 
-    self.viewModel.outputs.toggleHlsPause
+    self.viewModel.outputs.setHlsToPlaybackState
       .observeForUI()
       .observeValues { [weak self] pause in
-        guard let _self = self else { return }
         if pause {
-          _self.playerController?.player?.pause()
+          self?.playerController?.player?.pause()
         } else {
-          _self.playerController?.player?.play()
+          self?.playerController?.player?.play()
         }
     }
   }

--- a/LiveStream/Views/Controllers/LiveVideoViewController.swift
+++ b/LiveStream/Views/Controllers/LiveVideoViewController.swift
@@ -46,6 +46,23 @@ public final class LiveVideoViewController: UIViewController {
     self.viewModel.inputs.viewDidLoad()
   }
 
+  public override func viewDidDisappear(_ animated: Bool) {
+    super.viewDidDisappear(animated)
+
+    self.viewModel.inputs.viewDidDisappear()
+  }
+
+  public override func viewWillAppear(_ animated: Bool) {
+    super.viewWillAppear(animated)
+
+    self.viewModel.inputs.viewWillAppear()
+  }
+
+  public override func viewDidLayoutSubviews() {
+    super.viewDidLayoutSubviews()
+    self.videoGridView.frame = self.view.bounds
+  }
+
   //swiftlint:disable:next function_body_length
   public func bindVM() {
     self.viewModel.outputs.addAndConfigureHLSPlayerWithStreamUrl
@@ -107,17 +124,6 @@ public final class LiveVideoViewController: UIViewController {
     }
   }
 
-  public override func viewDidDisappear(_ animated: Bool) {
-    super.viewDidDisappear(animated)
-
-    self.viewModel.inputs.viewDidDisappear()
-  }
-
-  public override func viewWillAppear(_ animated: Bool) {
-    super.viewWillAppear(animated)
-
-    self.viewModel.inputs.viewWillAppear()
-  }
 
   private func configureHLSPlayer(streamUrl: String) {
     guard let url = URL(string: streamUrl) else { return }
@@ -191,13 +197,6 @@ public final class LiveVideoViewController: UIViewController {
     self.removeVideoView(view: subscriber.view)
     self.session?.unsubscribe(subscriber, error: nil)
     self.subscribers.index(of: subscriber).doIfSome { self.subscribers.remove(at: $0) }
-  }
-
-  // MARK: Actions
-
-  public override func viewDidLayoutSubviews() {
-    super.viewDidLayoutSubviews()
-    self.videoGridView.frame = self.view.bounds
   }
 
   private lazy var videoGridView: VideoGridView = {


### PR DESCRIPTION
@theginbin picked up a tasty bug which caused two live streams to play over one another when navigating to the live stream from discovery, tapping 'go to project page' and then once again navigating to the live stream. The video would continue in the background and the new one would start over it.

I initially thought this was going to be a doozy and that we'd have to trash the OpenTok session and recreate it etc causing a weird experience, but it turns out that all we need to do is unsubscribe and resubscribe the subscribers from and to the session.

In the case of HLS it's a simply `pause()` and `play()` on the `AVPlayer`.