### PR TITLE
Don't stream vid in discovery when not on wifi.

### DIFF
--- a/Library/Tests/TestHelpers/TestCase.swift
+++ b/Library/Tests/TestHelpers/TestCase.swift
@@ -18,6 +18,7 @@ internal class TestCase: FBSnapshotTestCase {
   internal let facebookAppDelegate = MockFacebookAppDelegate()
   internal let liveStreamService = MockLiveStreamService(fetchEventResult: nil)
   internal let mainBundle = MockBundle()
+  internal let reachability = MutableProperty(Reachability.wifi)
   internal let scheduler = TestScheduler(startDate: MockDate().date)
   internal let trackingClient = MockTrackingClient()
   internal let ubiquitousStore = MockKeyValueStore()
@@ -50,7 +51,7 @@ internal class TestCase: FBSnapshotTestCase {
       liveStreamService: self.liveStreamService,
       locale: .init(identifier: "en_US"),
       mainBundle: mainBundle,
-      reachability: .init(value: .wifi),
+      reachability: self.reachability.producer,
       scheduler: self.scheduler,
       ubiquitousStore: self.ubiquitousStore,
       userDefaults: self.userDefaults

--- a/Library/Tests/ViewModels/LiveStreamDiscoveryLiveNowCellViewModelTests.swift
+++ b/Library/Tests/ViewModels/LiveStreamDiscoveryLiveNowCellViewModelTests.swift
@@ -93,4 +93,24 @@ final class LiveStreamDiscoveryLiveNowCellViewModelTests: TestCase {
 
     self.stopVideo.assertValueCount(1)
   }
+
+  func testReachability() {
+    let liveStreamEvent = .template
+      |> LiveStreamEvent.lens.liveNow .~ true
+
+    self.vm.inputs.configureWith(liveStreamEvent: liveStreamEvent)
+
+    self.playVideoUrl.assertValueCount(1)
+    self.stopVideo.assertValueCount(0)
+
+    self.reachability.value = .wwan
+
+    self.playVideoUrl.assertValueCount(1)
+    self.stopVideo.assertValueCount(1)
+
+    self.reachability.value = .wifi
+
+    self.playVideoUrl.assertValueCount(2)
+    self.stopVideo.assertValueCount(1)
+  }
 }


### PR DESCRIPTION
### What

Let's not do the live streaming in discovery when the user isn't on wifi. This was a point brought up by @sarenji with regards to people with slow internet and people who need to conserve cellular data.

### How

We have a  `reachability` signal producer in the app environment that emits the current value immediately and then any new values as they come. We simply combine this into the signals that control playing/stopping the video and _BAM_. That easy.

### Demo

![wifi-3](https://cloud.githubusercontent.com/assets/135203/22797216/814834b4-eecb-11e6-83d4-ba156629854e.gif)