### PR TITLE
Make swiftlint error in circle when there are warnings

### DIFF
--- a/Library/Tests/ViewModels/LiveStreamEventDetailsViewModelTests.swift
+++ b/Library/Tests/ViewModels/LiveStreamEventDetailsViewModelTests.swift
@@ -160,7 +160,7 @@ internal final class LiveStreamEventDetailsViewModelTests: TestCase {
       self.subscribeLabelHidden.assertValues([false, true, false])
       self.subscribeButtonText.assertValues(["Subscribe", "Subscribe"])
       self.subscribeButtonImage.assertValues([nil, nil])
-      
+
       self.vm.inputs.subscribeButtonTapped()
 
       self.scheduler.advance()
@@ -177,7 +177,8 @@ internal final class LiveStreamEventDetailsViewModelTests: TestCase {
 
       self.scheduler.advance()
 
-      self.animateSubscribeButtonActivityIndicator.assertValues([false, true, false, true, false, true, false])
+      self.animateSubscribeButtonActivityIndicator.assertValues([false, true, false, true, false, true,
+                                                                 false])
       self.subscribeLabelText.assertValues(["Keep up with future live streams"])
       self.subscribeLabelHidden.assertValues([false, true, false, true, false])
       self.subscribeButtonText.assertValues(["Subscribe", "Subscribe", "Subscribed", "Subscribe"])

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ deploy:
 	@echo "Deploy has been kicked off to CircleCI!"
 
 lint:
-	swiftlint lint --reporter json
+	swiftlint lint --reporter json --strict
 
 strings:
 	cat Frameworks/ios-ksapi/Frameworks/native-secrets/ios/Secrets.swift bin/strings.swift \


### PR DESCRIPTION
Not sure when we lost this, but we want any swiftlint warning to be treated as an error in circle.