### PR TITLE
Improve error handling for past live streams without replays

### DIFF
--- a/Library/ViewModels/LiveStreamContainerViewModel.swift
+++ b/Library/ViewModels/LiveStreamContainerViewModel.swift
@@ -112,8 +112,14 @@ LiveStreamContainerViewModelInputs, LiveStreamContainerViewModelOutputs {
             AppEnvironment.current.liveStreamService
               .fetchEvent(eventId: initialEvent.id, uid: AppEnvironment.current.currentUser?.id)
               .ksr_delay(AppEnvironment.current.apiDelayInterval, on: AppEnvironment.current.scheduler)
-              .filter { !initialEvent.liveNow || $0.liveNow }
               .materialize()
+          }
+          .filter { event in
+            if initialEvent.liveNow && event.error == nil {
+              return event.value?.liveNow == .some(true)
+            }
+
+            return true
           }
           .take(first: 1)
     }

--- a/Library/ViewModels/LiveStreamContainerViewModel.swift
+++ b/Library/ViewModels/LiveStreamContainerViewModel.swift
@@ -115,7 +115,7 @@ LiveStreamContainerViewModelInputs, LiveStreamContainerViewModelOutputs {
               .materialize()
           }
           .filter { event in
-            if initialEvent.liveNow {
+            if initialEvent.liveNow && event.error == nil {
               return event.value?.liveNow == .some(true)
             }
 

--- a/Library/ViewModels/LiveStreamContainerViewModel.swift
+++ b/Library/ViewModels/LiveStreamContainerViewModel.swift
@@ -112,14 +112,8 @@ LiveStreamContainerViewModelInputs, LiveStreamContainerViewModelOutputs {
             AppEnvironment.current.liveStreamService
               .fetchEvent(eventId: initialEvent.id, uid: AppEnvironment.current.currentUser?.id)
               .ksr_delay(AppEnvironment.current.apiDelayInterval, on: AppEnvironment.current.scheduler)
+              .filter { !initialEvent.liveNow || $0.liveNow }
               .materialize()
-          }
-          .filter { event in
-            if initialEvent.liveNow && event.error == nil {
-              return event.value?.liveNow == .some(true)
-            }
-
-            return true
           }
           .take(first: 1)
     }


### PR DESCRIPTION
We recently had an issue where we'd receive a past `LiveStreamEvent` which was parsing successfully by Argo but met none of the filter criteria for it to pass through the signal that configures our `LiveStreamViewController`.

### tl;dr:
We allow pretty much all events through and our error handling which was always in place deals with them appropriately.

### The history behind this (lest we forget):
- Back in the days of `Project.LiveStream` we would always fetch the corresponding `LiveStreamEvent` when landing on the `LiveStreamContainerViewController`.
- We made more decisions about whether we were live or in replay etc based on playback states rather than values on the `LiveStreamEvent`. But this became confusing so we decided to mostly rely on the latter.

Now here's where it gets interesting 🍿:
- During the removal of `Project.LiveStream` we changed our view models to be immediately configured with a `LiveStreamEvent`.
- If we happened to be on the countdown view and the countdown reached zero, we would lens in and flip the `liveNow` boolean to `true` preemptively on our end. This would ensure that the live stream view is created in the 'live' state and doesn't switch back and forth confusingly as we refresh the event.
- However there are often times when the countdown reaches zero and the creator is not yet live meaning we'd flip live to `true`, refresh the event and receive a refreshed event in which live is `false` and then that would not change again.
- To fix this we changed our event refreshing to _poll_ for a new event and only let it through if a number of things were true, namely: it's live, it _definitely_ has a replay or an actual error occurred fetching the event.
- Our errors however relied on the event getting through so that the `LiveStreamViewController` could tell us by way of a a playback state that an event was what we call a `nonStarter`. An event that's over but has no replay.

The solution:
- We really only care about this one sitch in which we've flipped to live and we don't want it to incorrectly flip back. So I've simply change the filter to check whether the `initialEvent` was live, and if it was, continue to poll until we receive another live event (basically waiting for the creator to go live).
- All other scenarios will just play out as before (before we filtered) and errors will be displayed if necessary or replays etc will be played.