### PR TITLE
Fix an over-tracking issue.

### DIFF
--- a/Library/Koala/KoalaTrackingClient.swift
+++ b/Library/Koala/KoalaTrackingClient.swift
@@ -78,7 +78,7 @@ public final class KoalaTrackingClient: TrackingClientType {
 
       while !self.buffer.isEmpty {
         guard
-          nil == KoalaTrackingClient.base64Payload(Array(self.buffer.prefix(chunkSize)))
+          nil != KoalaTrackingClient.base64Payload(Array(self.buffer.prefix(chunkSize)))
             .flatMap(self.koalaURL)
             .flatMap(KoalaTrackingClient.koalaRequest)
             .flatMap(self.synchronousKoalaResult)


### PR DESCRIPTION
This is a p bad one :(

The over tracking issues we are having comes from a small logical typo from our Swift 3 #26 conversion. It's unfortunately on some untested code, but @stephencelis and I will fix that soon.

The issue is that we never remove successfully tracked events from the event queue, and so we keep on re-tracking those events as the user continues using the app more.