### PR TITLE
Fix URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ playgrounds [here](https://github.com/kickstarter/ios-oss/tree/master/Kickstarte
 * [We use view models](https://www.youtube.com/watch?v=EpTlqx6NjYo) as
 a lightweight way to isolate side effects and embrace a functional core. We
 write [these](https://github.com/kickstarter/ios-oss/tree/master/Library/ViewModels)
-as a pure mapping of input signals to output signals, and [test](https://github.com/kickstarter/ios-oss/tree/master/Library/Tests/ViewModels)
+as a pure mapping of input signals to output signals, and [test](https://github.com/kickstarter/ios-oss/tree/master/Library/ViewModels)
 them heavily, including tests for localization, accessibility and event
 tracking.
 


### PR DESCRIPTION
- Since tests are now collocated with the ViewModels the correct folder
  for the tests is the same as the ViewModels