### PR TITLE
fix validation errors in .swiftlint.yml

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -26,7 +26,7 @@ reporter: "xcode"
 custom_rules:
   localized_lensing:
     name: "Localized Lensing"
-    regex: "\.~\s+Strings\s*\."
+    regex: '\.~\s+Strings\s*\.'
     message: "Capture calls to `Strings` functions using `%~ { _ in Strings... }`"
     severity: error
   record_mode_prohibited:


### PR DESCRIPTION
SwiftLint is migrating to a more robust YAML parser (libYAML, see https://github.com/realm/SwiftLint/pull/1411). The previous parser wasn't spec-compliant and actually accepted invalid YAML sequences as input.

This commit makes .swiftlint.yml pass validation at http://www.yamllint.com.