### PR TITLE
Prevent login filtering Discovery

### DIFF
--- a/Kickstarter-iOS/ViewModels/RootViewModel.swift
+++ b/Kickstarter-iOS/ViewModels/RootViewModel.swift
@@ -138,8 +138,8 @@ internal final class RootViewModel: RootViewModelType, RootViewModelInputs, Root
       .map(first(DiscoveryViewController.self))
       .skipNil()
 
-    self.filterDiscovery =
-      Signal.combineLatest(discovery, self.switchToDiscoveryProperty.signal.skipNil())
+    self.filterDiscovery = discovery
+      .takePairWhen(self.switchToDiscoveryProperty.signal.skipNil())
 
     let dashboard = viewControllers
       .map(first(DashboardViewController.self))

--- a/Kickstarter-iOS/ViewModels/RootViewModelTests.swift
+++ b/Kickstarter-iOS/ViewModels/RootViewModelTests.swift
@@ -290,6 +290,10 @@ final class RootViewModelTests: TestCase {
 
     vm.inputs.viewDidLoad()
 
+    let params = DiscoveryParams.defaults
+    self.vm.inputs.switchToDiscovery(params: params)
+    self.filterDiscovery.assertValues([params])
+
     AppEnvironment.login(AccessTokenEnvelope(accessToken: "deadbeef", user: .template))
     vm.inputs.userSessionStarted()
 
@@ -300,7 +304,7 @@ final class RootViewModelTests: TestCase {
     vm.inputs.userSessionEnded()
 
     self.viewControllerNames.assertValueCount(4)
-    self.filterDiscovery.assertValueCount(0)
+    self.filterDiscovery.assertValues([params])
   }
 }
 


### PR DESCRIPTION
During #107 I picked up that logging in while a modal view controller was presented on `LiveStreamDiscoveryViewController` caused it to disappear. This was due to a `combineLatest` in `RootViewModel`'s `filterDiscovery` output.

Changing this to a `takePairWhen` solves the problem.

This will affect logging in to subscribe in the current live build when presented from live discovery.