### PR TITLE
Update to Xcode 8.3.2

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   xcode:
-    version: 8.3
+    version: 8.3.2
 dependencies:
   cache_directories:
     - "Frameworks/OpenTok"


### PR DESCRIPTION
just caught this note on circleci about deprecating Xcode "8.3" in order to force using an 8.3.x and so thought I might as well bump us to the newest 8.3.2

https://discuss.circleci.com/t/we-are-deprecating-the-xcode-8-3-build-image/12115