### PR TITLE
Possible fix for setViewController crash

### DIFF
--- a/Kickstarter-iOS/Views/Controllers/DiscoveryViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/DiscoveryViewController.swift
@@ -122,12 +122,15 @@ internal final class DiscoveryViewController: UIViewController {
     self.dataSource = DiscoveryPagesDataSource(sorts: sorts)
 
     self.pageViewController.dataSource = self.dataSource
-    self.pageViewController.setViewControllers(
-      [self.dataSource.controllerFor(index: 0)].compact(),
-      direction: .forward,
-      animated: false,
-      completion: nil
-    )
+
+    DispatchQueue.main.async {
+      self.pageViewController.setViewControllers(
+        [self.dataSource.controllerFor(index: 0)].compact(),
+        direction: .forward,
+        animated: false,
+        completion: nil
+      )
+    }
   }
 }
 


### PR DESCRIPTION
We've been seeing a number of crashes with the following message:

`*** Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'Invalid parameter not satisfying: [views count] == 3'`

Pretty much all searches for this type of crash suggest that the call to `UIPageViewController` `setViewControllers(_:direction:animated:completion:)` is not happening on the main thread.

Example: http://stackoverflow.com/questions/24000712/pageviewcontroller-setviewcontrollers-crashes-with-invalid-parameter-not-satisf

I've not been able to reproduce this but according to Hockey it seems to be happening frequently enough on app startup for it to be something we'd want to solve.

I added a symbolic breakpoint to trace the first call to `-[UIPageViewController setViewControllers:direction:animated:completion:]` at startup and it appears to be this one so suggestion is that we try wrapping it in `Dispatch.main.async` to see if it alleviates the issue on Hockey.

It's worth pointing out that we've had some strange successes with this [before](https://github.com/kickstarter/ios-oss/pull/53#pullrequestreview-17627932) 🤔 