### PR TITLE
Live chat fix view count and messages fix

### DIFF
--- a/Kickstarter-iOS/Views/LiveStreamNavTitleViewTests.swift
+++ b/Kickstarter-iOS/Views/LiveStreamNavTitleViewTests.swift
@@ -11,8 +11,6 @@ import XCTest
 
 internal final class LiveStreamNavTitleViewTests: TestCase {
 
-  fileprivate let vm: DashboardFundingCellViewModelType = DashboardFundingCellViewModel()
-
   override func setUp() {
     super.setUp()
     AppEnvironment.pushEnvironment(mainBundle: Bundle.framework)
@@ -84,6 +82,8 @@ internal final class LiveStreamNavTitleViewTests: TestCase {
     view.bindStyles()
     view.configureWith(liveStreamEvent: liveStreamEvent, delegate: nil)
     view.set(numberOfPeopleWatching: 2_500)
+
+    self.scheduler.run()
 
     let size = view.systemLayoutSizeFitting(UILayoutFittingCompressedSize)
     view.frame = CGRect(x: 0, y: 0, width: size.width, height: size.height)

--- a/Library/ViewModels/LiveStreamChatViewModel.swift
+++ b/Library/ViewModels/LiveStreamChatViewModel.swift
@@ -210,7 +210,6 @@ LiveStreamChatViewModelOutputs {
         case .snapshotDecodingFailed,
              .chatMessageDecodingFailed,
              .genericFailure,
-             .timedOut,
              .invalidJson,
              .invalidRequest:
           return Strings.Something_went_wrong_please_try_again()

--- a/Library/ViewModels/LiveStreamChatViewModel.swift
+++ b/Library/ViewModels/LiveStreamChatViewModel.swift
@@ -152,6 +152,7 @@ LiveStreamChatViewModelOutputs {
     let wantsToSendChat = self.textProperty.signal.skipNil()
       .filter { !isWhitespacesAndNewlines($0) }
       .takeWhen(self.sendButtonTappedProperty.signal)
+      .map { $0.trimmed() }
 
     let newChatMessage = firebase
       .takePairWhen(wantsToSendChat)

--- a/Library/ViewModels/LiveStreamContainerPageViewModelTests.swift
+++ b/Library/ViewModels/LiveStreamContainerPageViewModelTests.swift
@@ -92,25 +92,29 @@ internal final class LiveStreamContainerPageViewModelTests: TestCase {
                                                 refTag: .projectPage, presentedFromProject: true)
     let chatPage = LiveStreamContainerPage.chat(project: .template, liveStreamEvent: .template)
 
-    self.chatButtonTitleFontName.assertValues([".SFUIText"])
+    self.chatButtonTitleFontName.assertValues([UIFont.ksr_body().fontName])
     self.chatButtonTitleFontSize.assertValues([14])
-    self.infoButtonTitleFontName.assertValues([".SFUIText-Semibold"])
+    self.infoButtonTitleFontName.assertValues([UIFont.ksr_headline().fontName])
     self.infoButtonTitleFontSize.assertValues([14])
 
     self.vm.inputs.willTransition(toPage: chatPage)
     self.vm.inputs.pageTransition(completed: true)
 
-    self.chatButtonTitleFontName.assertValues([".SFUIText", ".SFUIText-Semibold"])
+    self.chatButtonTitleFontName.assertValues([UIFont.ksr_body().fontName, UIFont.ksr_headline().fontName])
     self.chatButtonTitleFontSize.assertValues([14, 14])
-    self.infoButtonTitleFontName.assertValues([".SFUIText-Semibold", ".SFUIText"])
+    self.infoButtonTitleFontName.assertValues([UIFont.ksr_headline().fontName, UIFont.ksr_body().fontName])
     self.infoButtonTitleFontSize.assertValues([14, 14])
 
     self.vm.inputs.willTransition(toPage: infoPage)
     self.vm.inputs.pageTransition(completed: true)
 
-    self.chatButtonTitleFontName.assertValues([".SFUIText", ".SFUIText-Semibold", ".SFUIText"])
+    self.chatButtonTitleFontName.assertValues([
+      UIFont.ksr_body().fontName, UIFont.ksr_headline().fontName, UIFont.ksr_body().fontName
+      ])
     self.chatButtonTitleFontSize.assertValues([14, 14, 14])
-    self.infoButtonTitleFontName.assertValues([".SFUIText-Semibold", ".SFUIText", ".SFUIText-Semibold"])
+    self.infoButtonTitleFontName.assertValues([
+      UIFont.ksr_headline().fontName, UIFont.ksr_body().fontName, UIFont.ksr_headline().fontName
+      ])
     self.infoButtonTitleFontSize.assertValues([14, 14, 14])
   }
 

--- a/Library/ViewModels/LiveStreamContainerViewModel.swift
+++ b/Library/ViewModels/LiveStreamContainerViewModel.swift
@@ -193,7 +193,7 @@ LiveStreamContainerViewModelInputs, LiveStreamContainerViewModelOutputs {
       .take(until: numberOfPeopleWatchingEvent.values().ignoreValues())
 
     self.numberOfPeopleWatching = Signal.merge(
-      numberOfPeopleWatchingEvent.values(),
+      numberOfPeopleWatchingEvent.values().throttle(5, on: AppEnvironment.current.scheduler),
       numberOfPeopleWatchingEvent.errors().mapConst(0)
     )
 

--- a/Library/ViewModels/LiveStreamContainerViewModel.swift
+++ b/Library/ViewModels/LiveStreamContainerViewModel.swift
@@ -175,23 +175,26 @@ LiveStreamContainerViewModelInputs, LiveStreamContainerViewModelOutputs {
 
     let greenRoomOffStatus = greenRoomStatusEvent.values()
 
-    let numberOfPeopleWatchingEvent = Signal.zip(
+    let startNumberOfPeopleWatchingProducer = Signal.zip(
       updatedEventFetch.values().map { $0.isScale }.skipNil(),
       firebase
-      )
+    )
+
+    let numberOfPeopleWatchingEvent = startNumberOfPeopleWatchingProducer
       .flatMap { isScale, firebase in
         numberOfPeopleWatchingProducer(withFirebase: firebase, isScale: isScale)
-          .timeout(after: 10, raising: .timedOut, on: AppEnvironment.current.scheduler)
           .materialize()
       }
 
-    let numberPeopleWatchingTimedOutError = numberOfPeopleWatchingEvent.errors().filter { $0 == .timedOut }
-    let numberPeopleWatchingErrorsExceptTimedOut = numberOfPeopleWatchingEvent.errors()
-      .filter { $0 != .timedOut }
+    let numberOfPeopleWatchingTimeOutSignal = startNumberOfPeopleWatchingProducer
+      .flatMap { _ in
+        timer(interval: .seconds(10), on: AppEnvironment.current.scheduler)
+      }
+      .take(until: numberOfPeopleWatchingEvent.values().ignoreValues())
 
     self.numberOfPeopleWatching = Signal.merge(
       numberOfPeopleWatchingEvent.values(),
-      numberPeopleWatchingErrorsExceptTimedOut.mapConst(0)
+      numberOfPeopleWatchingEvent.errors().mapConst(0)
     )
 
     let maxOpenTokViewers = updatedEventFetch.values()
@@ -227,7 +230,7 @@ LiveStreamContainerViewModelInputs, LiveStreamContainerViewModelOutputs {
       updatedEventFetch.values()
         .map { event in event.isRtmp == .some(true) || didEndNormally(event: event) }
         .filter(isTrue),
-      numberPeopleWatchingTimedOutError.mapConst(true)
+      numberOfPeopleWatchingTimeOutSignal.mapConst(true)
       )
       .take(first: 1)
 

--- a/Library/ViewModels/LiveStreamNavTitleViewModel.swift
+++ b/Library/ViewModels/LiveStreamNavTitleViewModel.swift
@@ -54,7 +54,8 @@ LiveStreamNavTitleViewModelInputs, LiveStreamNavTitleViewModelOutputs {
       .skipRepeats()
 
     self.numberOfPeopleWatchingLabelText = Signal.merge(
-      self.numberOfPeopleWatchingProperty.signal.skipNil(),
+      self.numberOfPeopleWatchingProperty.signal.skipNil()
+        .throttle(5, on: AppEnvironment.current.scheduler),
       self.liveStreamEventProperty.signal.mapConst(0)
       )
       .map { Format.wholeNumber($0) }

--- a/Library/ViewModels/LiveStreamNavTitleViewModelTests.swift
+++ b/Library/ViewModels/LiveStreamNavTitleViewModelTests.swift
@@ -8,7 +8,7 @@ import XCTest
 @testable import ReactiveExtensions_TestHelpers
 
 internal final class LiveStreamNavTitleViewModelTests: TestCase {
-  let vm: LiveStreamNavTitleViewModelType = LiveStreamNavTitleViewModel()
+  var vm: LiveStreamNavTitleViewModelType!
 
   private let playbackStateLabelText = TestObserver<String, NoError>()
   private let playbackStateContainerBackgroundColor = TestObserver<UIColor, NoError>()
@@ -17,6 +17,8 @@ internal final class LiveStreamNavTitleViewModelTests: TestCase {
 
   internal override func setUp() {
     super.setUp()
+
+    self.vm = LiveStreamNavTitleViewModel()
 
     self.vm.outputs.playbackStateLabelText.observe(self.playbackStateLabelText.observer)
     self.vm.outputs.playbackStateContainerBackgroundColor.observe(
@@ -105,9 +107,26 @@ internal final class LiveStreamNavTitleViewModelTests: TestCase {
       |> LiveStreamEvent.lens.liveNow .~ true
 
     self.vm.inputs.configureWith(liveStreamEvent: liveStreamEvent)
-    self.vm.inputs.setNumberOfPeopleWatching(numberOfPeople: 2500)
 
-    self.numberOfPeopleWatchingLabelText.assertValues(["0", "2,500"])
+    self.numberOfPeopleWatchingLabelText.assertValues(["0"])
+
+    self.vm.inputs.setNumberOfPeopleWatching(numberOfPeople: 2500)
+    self.vm.inputs.setNumberOfPeopleWatching(numberOfPeople: 2502)
+    self.vm.inputs.setNumberOfPeopleWatching(numberOfPeople: 2503)
+
+    self.scheduler.advance()
+
+    self.numberOfPeopleWatchingLabelText.assertValues(["0", "2,503"])
+
+    self.vm.inputs.setNumberOfPeopleWatching(numberOfPeople: 2504)
+
+    self.scheduler.advance(by: .seconds(4))
+
+    self.numberOfPeopleWatchingLabelText.assertValues(["0", "2,503"])
+
+    self.scheduler.advance(by: .seconds(1))
+
+    self.numberOfPeopleWatchingLabelText.assertValues(["0", "2,503", "2,504"])
   }
 
 }

--- a/LiveStream/Models/LiveApiError.swift
+++ b/LiveStream/Models/LiveApiError.swift
@@ -5,7 +5,6 @@ public enum LiveApiError: Error {
   case firebaseCustomTokenAuthFailed
   case sendChatMessageFailed
   case snapshotDecodingFailed(path: String)
-  case timedOut
   case genericFailure
   case invalidJson
   case invalidRequest
@@ -21,14 +20,13 @@ extension LiveApiError: Equatable {
          (sendChatMessageFailed, .sendChatMessageFailed),
          (genericFailure, .genericFailure),
          (invalidJson, .invalidJson),
-         (invalidRequest, .invalidRequest),
-         (timedOut, timedOut):
+         (invalidRequest, .invalidRequest):
       return true
     case let (snapshotDecodingFailed(lhs), .snapshotDecodingFailed(rhs)):
       return lhs == rhs
     case (chatMessageDecodingFailed, _), (failedToInitializeFirebase, _), (firebaseAnonymousAuthFailed, _),
          (firebaseCustomTokenAuthFailed, _), (sendChatMessageFailed, _), (snapshotDecodingFailed, _),
-         (genericFailure, _), (invalidJson, _), (invalidRequest, _), (timedOut, _):
+         (genericFailure, _), (invalidJson, _), (invalidRequest, _):
       return false
     }
   }

--- a/LiveStream/Models/LiveStreamChatMessage.swift
+++ b/LiveStream/Models/LiveStreamChatMessage.swift
@@ -25,7 +25,7 @@ public struct LiveStreamChatMessage {
   public fileprivate(set) var message: String
   public fileprivate(set) var name: String
   public fileprivate(set) var profilePictureUrl: String
-  public fileprivate(set) var userId: Int
+  public fileprivate(set) var userId: String
 
   static internal func decode(_ snapshot: FirebaseDataSnapshotType) -> Decoded<LiveStreamChatMessage> {
       return (snapshot.value as? [String:Any])
@@ -49,7 +49,7 @@ extension LiveStreamChatMessage: Decodable {
     let tmp2 = tmp1
       <*> json <| "name"
       <*> json <| "profilePic"
-      <*> ((json <| "userId") >>- convertId)
+      <*> json <| "userId"
 
     return tmp2
   }
@@ -58,22 +58,6 @@ extension LiveStreamChatMessage: Decodable {
 extension LiveStreamChatMessage: Equatable {
   static public func == (lhs: LiveStreamChatMessage, rhs: LiveStreamChatMessage) -> Bool {
     return lhs.id == rhs.id
-  }
-}
-
-// Currently chat user ID's are prefixed with "id_" and are strings, doing this until that changes
-private func convertId(fromJson json: JSON) -> Decoded<Int> {
-  switch json {
-  case .string(let string):
-
-    return (Int(string) ?? Int(string.replacingOccurrences(of: "id_", with: "")))
-      .map(Decoded.success)
-      .coalesceWith(.failure(.custom("Couldn't decoded \"\(string)\" into an Int.")))
-
-  case .number(let number):
-    return .success(number.intValue)
-  default:
-    return .failure(.custom("Couldn't decoded \(json) into an Int."))
   }
 }
 
@@ -103,7 +87,7 @@ extension LiveStreamChatMessage {
       view: { $0.date },
       set: { var new = $1; new.date = $0; return new }
     )
-    public static let userId = Lens<LiveStreamChatMessage, Int>(
+    public static let userId = Lens<LiveStreamChatMessage, String>(
       view: { $0.userId },
       set: { var new = $1; new.userId = $0; return new }
     )

--- a/LiveStream/Models/LiveStreamChatMessageTests.swift
+++ b/LiveStream/Models/LiveStreamChatMessageTests.swift
@@ -29,30 +29,7 @@ final class LiveStreamChatMessageTests: XCTestCase {
     XCTAssertEqual("Test Name", chatMessage.value?.name)
     XCTAssertEqual("http://www.kickstarter.com/picture.jpg", chatMessage.value?.profilePictureUrl)
     XCTAssertEqual(1234234123, chatMessage.value?.date)
-    XCTAssertEqual(1312341234321, chatMessage.value?.userId)
-  }
-
-  func testParseJson_AlternativeUserIdFormat() {
-    let json: [String:Any] = [
-      "id": "KDeCy9vvd7ZCRwHc8Ca",
-      "creator": false,
-      "message": "Test chat message",
-      "name": "Test Name",
-      "profilePic": "http://www.kickstarter.com/picture.jpg",
-      "timestamp": 1234234123,
-      "userId": "1312341234321"
-    ]
-
-    let chatMessage = LiveStreamChatMessage.decodeJSONDictionary(json)
-
-    XCTAssertNil(chatMessage.error)
-    XCTAssertEqual("KDeCy9vvd7ZCRwHc8Ca", chatMessage.value?.id)
-    XCTAssertEqual(false, chatMessage.value?.isCreator)
-    XCTAssertEqual("Test chat message", chatMessage.value?.message)
-    XCTAssertEqual("Test Name", chatMessage.value?.name)
-    XCTAssertEqual("http://www.kickstarter.com/picture.jpg", chatMessage.value?.profilePictureUrl)
-    XCTAssertEqual(1234234123, chatMessage.value?.date)
-    XCTAssertEqual(1312341234321, chatMessage.value?.userId)
+    XCTAssertEqual("id_1312341234321", chatMessage.value?.userId)
   }
 
   func testParseFirebaseDataSnapshot() {
@@ -76,30 +53,6 @@ final class LiveStreamChatMessageTests: XCTestCase {
     XCTAssertEqual("Test Name", chatMessage.value?.name)
     XCTAssertEqual("http://www.kickstarter.com/picture.jpg", chatMessage.value?.profilePictureUrl)
     XCTAssertEqual(1234234123, chatMessage.value?.date)
-    XCTAssertEqual(1312341234321, chatMessage.value?.userId)
-  }
-
-  func testParseFirebaseDataSnapshot_UserIdInt() {
-    let snapshot = TestFirebaseDataSnapshotType(
-      key: "KDeCy9vvd7ZCRwHc8Ca", value: [
-        "id": "KDeCy9vvd7ZCRwHc8Ca",
-        "creator": false,
-        "message": "Test chat message",
-        "name": "Test Name",
-        "profilePic": "http://www.kickstarter.com/picture.jpg",
-        "timestamp": 1234234123,
-        "userId": 1312341234321
-      ])
-
-    let chatMessage = LiveStreamChatMessage.decode(snapshot)
-
-    XCTAssertNil(chatMessage.error)
-    XCTAssertEqual("KDeCy9vvd7ZCRwHc8Ca", chatMessage.value?.id)
-    XCTAssertEqual(false, chatMessage.value?.isCreator)
-    XCTAssertEqual("Test chat message", chatMessage.value?.message)
-    XCTAssertEqual("Test Name", chatMessage.value?.name)
-    XCTAssertEqual("http://www.kickstarter.com/picture.jpg", chatMessage.value?.profilePictureUrl)
-    XCTAssertEqual(1234234123, chatMessage.value?.date)
-    XCTAssertEqual(1312341234321, chatMessage.value?.userId)
+    XCTAssertEqual("id_1312341234321", chatMessage.value?.userId)
   }
 }

--- a/LiveStream/Models/templates/LiveStreamChatMessageTemplates.swift
+++ b/LiveStream/Models/templates/LiveStreamChatMessageTemplates.swift
@@ -8,6 +8,6 @@ extension LiveStreamChatMessage {
     message: "Test message",
     name: "Test Name",
     profilePictureUrl: "http://www.kickstarter.com",
-    userId: 1324123434
+    userId: "id_12345"
   )
 }

--- a/LiveStream/Service/LiveStreamService.swift
+++ b/LiveStream/Service/LiveStreamService.swift
@@ -282,12 +282,13 @@ public struct LiveStreamService: LiveStreamServiceProtocol {
         )
 
         query.observe(.childAdded, with: { snapshot in
-          let chatMessage = (snapshot as FIRDataSnapshot?)
+          let tryChatMessage = (snapshot as FIRDataSnapshot?)
             .flatMap { $0 }
             .map(LiveStreamChatMessage.decode)
             .flatMap { $0.value }
             .map(Event<LiveStreamChatMessage, LiveApiError>.value)
-            .coalesceWith(.failed(.chatMessageDecodingFailed))
+
+          guard let chatMessage = tryChatMessage else { return }
 
           observer.action(chatMessage)
         })


### PR DESCRIPTION
### What

During our testing we picked up that the view count on the live stream stopped updating and that chat messages would also randomly stop feeding through.

### tl;dr
- Number of people watching timeout check is a one-time thing now.
- `LiveStreamChatMessage`s that fail to decode will simply be discarded.
- We don't care about the format of the `userId` anymore on these messages.

### For historical purposes:

We chatted about this on Slack but the reason number of people was failing after a little while is because I had a 10 second timeout which would basically check if there was no response from that firebase path within 10 seconds of loading the stream it should switch to HLS. I didn’t realize however that it would expect a value _every_ 10 seconds or it would consider it to have timed out. So I’ve now just moved things around so that the timeout is a one-time check which stops once a value is received.

Also the reason chat messages stopped coming through was because one failed to decode so it error’d out the `SignalProducer`. In any case the fix for now is to just discard messages that fail to decode and to ignore the format of the `userId`.

The reason that the decode failed though is someone chatted with an unexpected `userId` format, this is the failing message:

```
{
  "message" : "i can hear you just fine in this good place",
  "name" : "s-d--p",
  "profilePic" : "https://s3.amazonaws.com/huzza-web/users/avatars/000/192/920/medium/open-uri20161110-28-5z15ob?1478820199",
  "timestamp" : 1493236931735,
  "userId" : "tGcsBej5jAcq7lAGvqliguL6deC3"
}
```

We expect user IDs to be an integer prefixed with `id_` like `id_12345` so this was failing.

Trello: https://trello.com/c/JO0a24aY/1994-live-view-count-messages-bug