### PR TITLE
Login to message creator

### DIFF
--- a/Kickstarter-iOS/Views/Controllers/ProjectCreatorViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/ProjectCreatorViewController.swift
@@ -38,6 +38,12 @@ internal final class ProjectCreatorViewController: WebViewController {
   internal override func bindViewModel() {
     super.bindViewModel()
 
+    self.viewModel.outputs.goToLoginTout
+      .observeForControllerAction()
+      .observeValues { [weak self] in
+        self?.goToLoginTout($0)
+    }
+
     self.viewModel.outputs.loadWebViewRequest
       .observeForControllerAction()
       .observeValues { [weak self] in _ = self?.webView.load($0) }
@@ -61,6 +67,14 @@ internal final class ProjectCreatorViewController: WebViewController {
         forNavigationAction: WKNavigationActionData(navigationAction: navigationAction)
       )
     )
+  }
+
+  fileprivate func goToLoginTout(_ loginIntent: LoginIntent) {
+    let vc = LoginToutViewController.configuredWith(loginIntent: loginIntent)
+    let nav = UINavigationController(rootViewController: vc)
+    nav.modalPresentationStyle = .formSheet
+
+    self.present(nav, animated: true, completion: nil)
   }
 
   fileprivate func goToMessageDialog(subject: MessageSubject, context: Koala.MessageDialogContext) {

--- a/Library/ViewModels/ProjectCreatorViewModel.swift
+++ b/Library/ViewModels/ProjectCreatorViewModel.swift
@@ -63,8 +63,8 @@ ProjectCreatorViewModelOutputs {
 
     self.goToMessageDialog = project
       .takeWhen(messageCreatorRequest)
-      .map { (MessageSubject.project($0), .projectPage) }
       .filter { _ in AppEnvironment.current.currentUser != nil }
+      .map { (MessageSubject.project($0), .projectPage) }
 
     self.goToSafariBrowser = navigationAction
       .filter { $0.navigationType == .linkActivated }

--- a/Library/ViewModels/ProjectCreatorViewModel.swift
+++ b/Library/ViewModels/ProjectCreatorViewModel.swift
@@ -17,6 +17,9 @@ public protocol ProjectCreatorViewModelInputs {
 }
 
 public protocol ProjectCreatorViewModelOutputs {
+  /// Emits when the LoginToutViewController should be presented.
+  var goToLoginTout: Signal<LoginIntent, NoError> { get }
+
   /// Emits when we should navigate to the message dialog.
   var goToMessageDialog: Signal<(MessageSubject, Koala.MessageDialogContext), NoError> { get }
 
@@ -54,9 +57,14 @@ ProjectCreatorViewModelOutputs {
     self.decidedPolicy <~ navigationAction
       .map { $0.navigationType == .other ? .allow : .cancel }
 
+    self.goToLoginTout = messageCreatorRequest.ignoreValues()
+      .filter { AppEnvironment.current.currentUser == nil }
+      .map { .messageCreator }
+
     self.goToMessageDialog = project
       .takeWhen(messageCreatorRequest)
       .map { (MessageSubject.project($0), .projectPage) }
+      .filter { _ in AppEnvironment.current.currentUser != nil }
 
     self.goToSafariBrowser = navigationAction
       .filter { $0.navigationType == .linkActivated }
@@ -88,6 +96,7 @@ ProjectCreatorViewModelOutputs {
     self.viewDidLoadProperty.value = ()
   }
 
+  public let goToLoginTout: Signal<LoginIntent, NoError>
   public let goToMessageDialog: Signal<(MessageSubject, Koala.MessageDialogContext), NoError>
   public let goToSafariBrowser: Signal<URL, NoError>
   public let loadWebViewRequest: Signal<URLRequest, NoError>

--- a/Library/ViewModels/ProjectCreatorViewModelTests.swift
+++ b/Library/ViewModels/ProjectCreatorViewModelTests.swift
@@ -76,7 +76,7 @@ final class ProjectCreatorViewModelTests: TestCase {
 
   func testGoToMessageDialog_LoggedIn() {
     AppEnvironment.login(AccessTokenEnvelope(accessToken: "deadbeef", user: User.template))
-    
+
     let project = Project.template
     self.vm.inputs.configureWith(project: project)
     self.vm.inputs.viewDidLoad()

--- a/Library/ViewModels/ProjectCreatorViewModelTests.swift
+++ b/Library/ViewModels/ProjectCreatorViewModelTests.swift
@@ -31,6 +31,8 @@ final class ProjectCreatorViewModelTests: TestCase {
     self.vm.inputs.configureWith(project: project)
     self.vm.inputs.viewDidLoad()
 
+    self.goToMessageDialogContext.assertValueCount(0)
+    self.goToMessageDialogSubject.assertValueCount(0)
     self.goToLoginTout.assertValueCount(0)
 
     let messagesRequest = URLRequest(
@@ -46,6 +48,8 @@ final class ProjectCreatorViewModelTests: TestCase {
     )
     XCTAssertEqual(.cancel, policy)
 
+    self.goToMessageDialogContext.assertValues([])
+    self.goToMessageDialogSubject.assertValues([])
     self.goToLoginTout.assertValues([.messageCreator])
   }
 
@@ -74,7 +78,7 @@ final class ProjectCreatorViewModelTests: TestCase {
     self.goToLoginTout.assertValueCount(0)
   }
 
-  func testGoToMessageDialog_LoggedIn() {
+  func testGoToMessageDialog() {
     AppEnvironment.login(AccessTokenEnvelope(accessToken: "deadbeef", user: User.template))
 
     let project = Project.template
@@ -115,47 +119,6 @@ final class ProjectCreatorViewModelTests: TestCase {
 
     self.goToMessageDialogContext.assertValues([.projectPage])
     self.goToMessageDialogSubject.assertValues([.project(project)])
-  }
-
-  func testGoToMessageDialog_LoggedOut() {
-    let project = Project.template
-    self.vm.inputs.configureWith(project: project)
-    self.vm.inputs.viewDidLoad()
-
-    self.goToMessageDialogContext.assertValues([])
-    self.goToMessageDialogSubject.assertValues([])
-
-    let creatorBioRequest = URLRequest(
-      url: URL(string: "https://www.kickstarter.com/projects/a/b/creator_bio")!
-    )
-    var policy = self.vm.inputs.decidePolicy(
-      forNavigationAction: WKNavigationActionData(
-        navigationType: .other,
-        request: creatorBioRequest,
-        sourceFrame: WKFrameInfoData(mainFrame: true, request: creatorBioRequest),
-        targetFrame: WKFrameInfoData(mainFrame: true, request: creatorBioRequest)
-      )
-    )
-    XCTAssertEqual(.allow, policy)
-
-    self.goToMessageDialogContext.assertValues([])
-    self.goToMessageDialogSubject.assertValues([])
-
-    let messagesRequest = URLRequest(
-      url: URL(string: "https://www.kickstarter.com/projects/a/b/messages/new")!
-    )
-    policy = self.vm.inputs.decidePolicy(
-      forNavigationAction: WKNavigationActionData(
-        navigationType: .linkActivated,
-        request: messagesRequest,
-        sourceFrame: WKFrameInfoData(mainFrame: true, request: messagesRequest),
-        targetFrame: WKFrameInfoData(mainFrame: true, request: messagesRequest)
-      )
-    )
-    XCTAssertEqual(.cancel, policy)
-
-    self.goToMessageDialogContext.assertValues([])
-    self.goToMessageDialogSubject.assertValues([])
   }
 
   func testGoToSafariBrowser() {


### PR DESCRIPTION
We have a small bug in that users can tap to message creators while they are logged out but then upon sending their message receive an error saying that they need to be logged in ([Trello](https://trello.com/c/nISUH4vr/1963-logged-out-ask-a-question-button-allows-user-to-start-drafting-message)).

This PR just adds the fix to present the `LoginToutViewController` when attempting to message the creator while logged out. It seems that there was a `.messageCreator` `LoginIntent` for this already so I just used that.