### PR TITLE
Nil delegate when removing subscriber view

### DIFF
--- a/Kickstarter-iOS/Views/Controllers/LiveVideoViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/LiveVideoViewController.swift
@@ -198,6 +198,7 @@ public final class LiveVideoViewController: UIViewController {
   }
 
   private func removeSubscriber(subscriber: OTSubscriber) {
+    subscriber.delegate = nil
     subscriber.view.doIfSome { self.removeVideoView(view: $0) }
     self.session?.unsubscribe(subscriber, error: nil)
     self.subscribers.index(of: subscriber).doIfSome { self.subscribers.remove(at: $0) }


### PR DESCRIPTION
Quick fix for a bug that crept in with #145 - because we now do set the `delegate` on our `OTSubscriber` views we need to nil that delegate just before removing the subscribers.