### PR TITLE
Pause/resume video on backgrounding

### DIFF
--- a/Kickstarter-iOS/Views/Controllers/LiveVideoViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/LiveVideoViewController.swift
@@ -44,6 +44,16 @@ public final class LiveVideoViewController: UIViewController {
     self.view.backgroundColor = .black
     self.view.addSubview(self.videoGridView)
 
+    NotificationCenter.default.addObserver(forName: .UIApplicationDidEnterBackground,
+                                           object: nil, queue: nil) { [weak self] _ in
+      self?.viewModel.inputs.didEnterBackground()
+    }
+
+    NotificationCenter.default.addObserver(forName: .UIApplicationWillEnterForeground,
+                                           object: nil, queue: nil) { [weak self] _ in
+      self?.viewModel.inputs.willEnterForeground()
+    }
+
     self.viewModel.inputs.viewDidLoad()
   }
 

--- a/Library/ViewModels/LiveVideoViewModelTests.swift
+++ b/Library/ViewModels/LiveVideoViewModelTests.swift
@@ -143,6 +143,18 @@ internal final class LiveVideoViewModelTests: TestCase {
     self.resubscribeAllSubscribersToSession.assertValueCount(1)
     self.shouldPauseHlsPlayer.assertValueCount(0)
     self.unsubscribeAllSubscribersFromSession.assertValueCount(1)
+
+    self.vm.inputs.didEnterBackground()
+
+    self.resubscribeAllSubscribersToSession.assertValueCount(1)
+    self.shouldPauseHlsPlayer.assertValueCount(0)
+    self.unsubscribeAllSubscribersFromSession.assertValueCount(2)
+
+    self.vm.inputs.willEnterForeground()
+
+    self.resubscribeAllSubscribersToSession.assertValueCount(2)
+    self.shouldPauseHlsPlayer.assertValueCount(0)
+    self.unsubscribeAllSubscribersFromSession.assertValueCount(2)
   }
 
   func testHls_TogglePause() {
@@ -172,6 +184,18 @@ internal final class LiveVideoViewModelTests: TestCase {
 
     self.resubscribeAllSubscribersToSession.assertValueCount(0)
     self.shouldPauseHlsPlayer.assertValues([true, false])
+    self.unsubscribeAllSubscribersFromSession.assertValueCount(0)
+
+    self.vm.inputs.didEnterBackground()
+
+    self.resubscribeAllSubscribersToSession.assertValueCount(0)
+    self.shouldPauseHlsPlayer.assertValues([true, false, true])
+    self.unsubscribeAllSubscribersFromSession.assertValueCount(0)
+
+    self.vm.inputs.willEnterForeground()
+
+    self.resubscribeAllSubscribersToSession.assertValueCount(0)
+    self.shouldPauseHlsPlayer.assertValues([true, false, true, false])
     self.unsubscribeAllSubscribersFromSession.assertValueCount(0)
   }
 


### PR DESCRIPTION
Quick fix for some [audio weirdness](https://trello.com/c/QHpfxQoa/159-p3-audio-continues-after-closing-app-from-live-stream) when one backgrounds the app during a live stream. Although this is kind've standard behaviour in iOS and how its audio codec works during backgrounding, it's a better experience to pause and resume when the app enters the foreground again.