### PR TITLE
Chat keyboard dismiss fix

### DIFF
--- a/Library/ViewModels/LiveStreamChatViewModel.swift
+++ b/Library/ViewModels/LiveStreamChatViewModel.swift
@@ -141,7 +141,9 @@ LiveStreamChatViewModelOutputs {
     }
 
     self.collapseChatInputView = liveStreamEvent.map { !$0.liveNow }.skipRepeats()
-    self.dismissKeyboard = self.deviceOrientationDidChangeProperty.signal.ignoreValues()
+    self.dismissKeyboard = self.deviceOrientationDidChangeProperty.signal.skipNil()
+      .filter { $0.isLandscape }
+      .ignoreValues()
 
     let textIsEmpty = Signal.merge(
       self.textProperty.signal.filter { $0 == nil }.mapConst(true),

--- a/Library/ViewModels/LiveStreamChatViewModelTests.swift
+++ b/Library/ViewModels/LiveStreamChatViewModelTests.swift
@@ -160,15 +160,15 @@ internal final class LiveStreamChatViewModelTests: TestCase {
     self.vm.inputs.configureWith(project: .template, liveStreamEvent: liveStreamEvent)
     self.vm.inputs.deviceOrientationDidChange(orientation: .portrait)
 
-    self.dismissKeyboard.assertValueCount(1)
+    self.dismissKeyboard.assertValueCount(0)
 
     self.vm.inputs.deviceOrientationDidChange(orientation: .landscapeLeft)
 
-    self.dismissKeyboard.assertValueCount(2)
+    self.dismissKeyboard.assertValueCount(1)
 
     self.vm.inputs.deviceOrientationDidChange(orientation: .portrait)
 
-    self.dismissKeyboard.assertValueCount(3)
+    self.dismissKeyboard.assertValueCount(1)
   }
 
   func testConnectingToChat_LoggedIn() {


### PR DESCRIPTION
We found a bug that is causing the keyboard to be arbitrarily dismissed during chat. We observe `UIDeviceOrientationDidChange` to dismiss the keyboard when rotating to landscape and transitioning the video to full screen. However the code doesn't take into consideration the orientation changes between `faceUp` and `faceDown` causing it to dismiss on those changes while in `portrait`.

I've just added a `filter` to ensure that the orientation `isLandscape`.