### PR TITLE
Prevent discovery filter crash on network error

### DIFF
--- a/Kickstarter-iOS/DataSources/DiscoveryFiltersDataSource.swift
+++ b/Kickstarter-iOS/DataSources/DiscoveryFiltersDataSource.swift
@@ -67,7 +67,7 @@ internal final class DiscoveryFiltersDataSource: ValueCellDataSource {
   }
 
   internal func deleteCategoriesLoaderRow() -> [IndexPath]? {
-    if self[section: Section.categoriesLoader.rawValue].count > 0 {
+    if !self[section: Section.categoriesLoader.rawValue].isEmpty {
       self.clearValues(section: Section.categoriesLoader.rawValue)
 
       return [IndexPath(row: 0, section: Section.categoriesLoader.rawValue)]

--- a/Kickstarter-iOS/DataSources/DiscoveryFiltersDataSource.swift
+++ b/Kickstarter-iOS/DataSources/DiscoveryFiltersDataSource.swift
@@ -66,8 +66,9 @@ internal final class DiscoveryFiltersDataSource: ValueCellDataSource {
              inSection: Section.categoriesLoader.rawValue)
   }
 
-  internal func deleteCategoriesLoaderRow() -> [IndexPath]? {
-    if !self[section: Section.categoriesLoader.rawValue].isEmpty {
+  internal func deleteCategoriesLoaderRow(_ tableView: UITableView) -> [IndexPath]? {
+    if self.numberOfSections(in: tableView) > Section.categoriesLoader.rawValue
+      && !self[section: Section.categoriesLoader.rawValue].isEmpty {
       self.clearValues(section: Section.categoriesLoader.rawValue)
 
       return [IndexPath(row: 0, section: Section.categoriesLoader.rawValue)]

--- a/Kickstarter-iOS/DataSources/DiscoveryFiltersDataSource.swift
+++ b/Kickstarter-iOS/DataSources/DiscoveryFiltersDataSource.swift
@@ -66,10 +66,14 @@ internal final class DiscoveryFiltersDataSource: ValueCellDataSource {
              inSection: Section.categoriesLoader.rawValue)
   }
 
-  internal func deleteCategoriesLoaderRow() -> [IndexPath] {
-    self.clearValues(section: Section.categoriesLoader.rawValue)
+  internal func deleteCategoriesLoaderRow() -> [IndexPath]? {
+    if self[section: Section.categoriesLoader.rawValue].count > 0 {
+      self.clearValues(section: Section.categoriesLoader.rawValue)
 
-    return [IndexPath(row: 0, section: Section.categoriesLoader.rawValue)]
+      return [IndexPath(row: 0, section: Section.categoriesLoader.rawValue)]
+    }
+
+    return nil
   }
 
   internal func selectableRow(indexPath: IndexPath) -> SelectableRow? {

--- a/Kickstarter-iOS/DataSources/DiscoveryFiltersDataSourceTests.swift
+++ b/Kickstarter-iOS/DataSources/DiscoveryFiltersDataSourceTests.swift
@@ -105,4 +105,18 @@ internal final class DiscoveryFiltersDataSourceTests: XCTestCase {
     XCTAssertEqual("DiscoveryExpandedSelectableRowCell",
                    self.dataSource.reusableId(item: 3, section: categories))
   }
+
+  func testLoadCategoriesLoaderRow() {
+    self.dataSource.loadCategoriesLoaderRow()
+
+    let row1 = self.dataSource.deleteCategoriesLoaderRow(self.tableView)
+
+    XCTAssertNotNil(row1)
+    XCTAssertEqual(row1?.first?.row, .some(0))
+    XCTAssertEqual(row1?.first?.section, .some(DiscoveryFiltersDataSource.Section.categoriesLoader.rawValue))
+
+    let row2 = self.dataSource.deleteCategoriesLoaderRow(self.tableView)
+
+    XCTAssertNil(row2)
+  }
 }

--- a/Kickstarter-iOS/Views/Controllers/DiscoveryFiltersViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/DiscoveryFiltersViewController.swift
@@ -201,7 +201,11 @@ internal final class DiscoveryFiltersViewController: UIViewController, UITableVi
   }
 
   private func deleteCategoriesLoaderRow() {
-    guard let deleteCategoriesLoaderRow = self.dataSource.deleteCategoriesLoaderRow() else { return }
+    guard let
+      deleteCategoriesLoaderRow = self.dataSource.deleteCategoriesLoaderRow(),
+      !deleteCategoriesLoaderRow.isEmpty else {
+        return
+    }
 
     self.filtersTableView.beginUpdates()
     defer { self.filtersTableView.endUpdates() }

--- a/Kickstarter-iOS/Views/Controllers/DiscoveryFiltersViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/DiscoveryFiltersViewController.swift
@@ -58,11 +58,12 @@ internal final class DiscoveryFiltersViewController: UIViewController, UITableVi
     self.viewModel.outputs.loadingIndicatorIsVisible
       .observeForUI()
       .observeValues { [weak self] isVisible in
+        guard let _self = self else { return }
         if isVisible {
-          self?.dataSource.loadCategoriesLoaderRow()
-          self?.filtersTableView.reloadData()
+          _self.dataSource.loadCategoriesLoaderRow()
+          _self.filtersTableView.reloadData()
         } else {
-          self?.deleteCategoriesLoaderRow()
+          _self.deleteCategoriesLoaderRow(_self.filtersTableView)
         }
     }
 
@@ -200,9 +201,9 @@ internal final class DiscoveryFiltersViewController: UIViewController, UITableVi
     }
   }
 
-  private func deleteCategoriesLoaderRow() {
+  private func deleteCategoriesLoaderRow(_ tableView: UITableView) {
     guard let
-      deleteCategoriesLoaderRow = self.dataSource.deleteCategoriesLoaderRow(),
+      deleteCategoriesLoaderRow = self.dataSource.deleteCategoriesLoaderRow(tableView),
       !deleteCategoriesLoaderRow.isEmpty else {
         return
     }

--- a/Kickstarter-iOS/Views/Controllers/DiscoveryFiltersViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/DiscoveryFiltersViewController.swift
@@ -60,6 +60,7 @@ internal final class DiscoveryFiltersViewController: UIViewController, UITableVi
       .observeValues { [weak self] isVisible in
         if isVisible {
           self?.dataSource.loadCategoriesLoaderRow()
+          self?.filtersTableView.reloadData()
         } else {
           self?.deleteCategoriesLoaderRow()
         }
@@ -200,10 +201,11 @@ internal final class DiscoveryFiltersViewController: UIViewController, UITableVi
   }
 
   private func deleteCategoriesLoaderRow() {
+    guard let deleteCategoriesLoaderRow = self.dataSource.deleteCategoriesLoaderRow() else { return }
+
     self.filtersTableView.beginUpdates()
+    defer { self.filtersTableView.endUpdates() }
 
-    self.filtersTableView.deleteRows(at: self.dataSource.deleteCategoriesLoaderRow(), with: .fade)
-
-    self.filtersTableView.endUpdates()
+    self.filtersTableView.deleteRows(at: deleteCategoriesLoaderRow, with: .fade)
   }
 }

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -3495,7 +3495,7 @@
 						CreatedOnToolsVersion = 7.2.1;
 						DevelopmentTeam = 48YBP49Y5N;
 						LastSwiftMigration = 0820;
-						ProvisioningStyle = Automatic;
+						ProvisioningStyle = Manual;
 						SystemCapabilities = {
 							com.apple.OMC = {
 								enabled = 1;
@@ -4996,9 +4996,9 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = "app-icon-beta";
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = "Kickstarter-iOS/Hockey.entitlements";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 5DAN4UM3NC;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Frameworks/HockeySDK/iOS/HockeySDK.embeddedframework",
@@ -5015,7 +5015,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.kickstarter.kickstarter.beta;
 				PRODUCT_MODULE_NAME = Kickstarter_iOS;
 				PRODUCT_NAME = KickBeta;
-				PROVISIONING_PROFILE_SPECIFIER = "";
+				PROVISIONING_PROFILE_SPECIFIER = circleci;
 				SDKROOT = iphoneos;
 				SWIFT_OBJC_BRIDGING_HEADER = "Kickstarter-iOS/Kickstarter-iOS-Bridging-Header.h";
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -5501,7 +5501,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 48YBP49Y5N;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Frameworks/HockeySDK/iOS/HockeySDK.embeddedframework",
@@ -5518,7 +5518,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.kickstarter.kickstarter.alpha;
 				PRODUCT_MODULE_NAME = Kickstarter_iOS;
 				PRODUCT_NAME = KickDebug;
-				PROVISIONING_PROFILE_SPECIFIER = "";
+				PROVISIONING_PROFILE_SPECIFIER = "Alpha Development";
 				SDKROOT = iphoneos;
 				SWIFT_OBJC_BRIDGING_HEADER = "Kickstarter-iOS/Kickstarter-iOS-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -5533,9 +5533,9 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = "app-icon";
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = "Kickstarter-iOS/Release.entitlements";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 48YBP49Y5N;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Frameworks/HockeySDK/iOS/HockeySDK.embeddedframework",
@@ -5550,7 +5550,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.kickstarter.kickstarter;
 				PRODUCT_MODULE_NAME = Kickstarter_iOS;
-				PROVISIONING_PROFILE_SPECIFIER = "";
+				PROVISIONING_PROFILE_SPECIFIER = AppStore;
 				SDKROOT = iphoneos;
 				SWIFT_OBJC_BRIDGING_HEADER = "Kickstarter-iOS/Kickstarter-iOS-Bridging-Header.h";
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -3495,7 +3495,7 @@
 						CreatedOnToolsVersion = 7.2.1;
 						DevelopmentTeam = 48YBP49Y5N;
 						LastSwiftMigration = 0820;
-						ProvisioningStyle = Manual;
+						ProvisioningStyle = Automatic;
 						SystemCapabilities = {
 							com.apple.OMC = {
 								enabled = 1;
@@ -4996,9 +4996,9 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = "app-icon-beta";
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = "Kickstarter-iOS/Hockey.entitlements";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = 5DAN4UM3NC;
+				DEVELOPMENT_TEAM = "";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Frameworks/HockeySDK/iOS/HockeySDK.embeddedframework",
@@ -5015,7 +5015,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.kickstarter.kickstarter.beta;
 				PRODUCT_MODULE_NAME = Kickstarter_iOS;
 				PRODUCT_NAME = KickBeta;
-				PROVISIONING_PROFILE_SPECIFIER = circleci;
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = iphoneos;
 				SWIFT_OBJC_BRIDGING_HEADER = "Kickstarter-iOS/Kickstarter-iOS-Bridging-Header.h";
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -5501,7 +5501,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = 48YBP49Y5N;
+				DEVELOPMENT_TEAM = "";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Frameworks/HockeySDK/iOS/HockeySDK.embeddedframework",
@@ -5518,7 +5518,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.kickstarter.kickstarter.alpha;
 				PRODUCT_MODULE_NAME = Kickstarter_iOS;
 				PRODUCT_NAME = KickDebug;
-				PROVISIONING_PROFILE_SPECIFIER = "Alpha Development";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = iphoneos;
 				SWIFT_OBJC_BRIDGING_HEADER = "Kickstarter-iOS/Kickstarter-iOS-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -5533,9 +5533,9 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = "app-icon";
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = "Kickstarter-iOS/Release.entitlements";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = 48YBP49Y5N;
+				DEVELOPMENT_TEAM = "";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Frameworks/HockeySDK/iOS/HockeySDK.embeddedframework",
@@ -5550,7 +5550,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.kickstarter.kickstarter;
 				PRODUCT_MODULE_NAME = Kickstarter_iOS;
-				PROVISIONING_PROFILE_SPECIFIER = AppStore;
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = iphoneos;
 				SWIFT_OBJC_BRIDGING_HEADER = "Kickstarter-iOS/Kickstarter-iOS-Bridging-Header.h";
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/Library/ViewModels/DiscoveryFiltersViewModel.swift
+++ b/Library/ViewModels/DiscoveryFiltersViewModel.swift
@@ -80,11 +80,11 @@ public final class DiscoveryFiltersViewModel: DiscoveryFiltersViewModelType,
     let categoryId = self.initialSelectedRowProperty.signal.skipNil()
       .map { $0.params.category?.rootId }
 
-    let cachedCats = self.viewDidLoadProperty.signal
-      .map(cachedCategories)
-
     let loaderIsVisible = MutableProperty(false)
     self.loadingIndicatorIsVisible = loaderIsVisible.signal
+
+    let cachedCats = self.viewDidLoadProperty.signal
+      .map(cachedCategories)
 
     let categoriesEvent = cachedCats
       .filter { $0?.isEmpty != .some(false) }

--- a/Library/ViewModels/DiscoveryFiltersViewModel.swift
+++ b/Library/ViewModels/DiscoveryFiltersViewModel.swift
@@ -90,7 +90,7 @@ public final class DiscoveryFiltersViewModel: DiscoveryFiltersViewModelType,
       .switchMap { _ in
         AppEnvironment.current.apiService.fetchCategories()
           .ksr_delay(AppEnvironment.current.apiDelayInterval, on: AppEnvironment.current.scheduler)
-          .on(starting: { loaderIsVisible.value = true } )
+          .on(starting: { loaderIsVisible.value = true })
           .map { $0.categories }
           .materialize()
       }

--- a/Library/ViewModels/DiscoveryFiltersViewModel.swift
+++ b/Library/ViewModels/DiscoveryFiltersViewModel.swift
@@ -81,7 +81,6 @@ public final class DiscoveryFiltersViewModel: DiscoveryFiltersViewModelType,
       .map { $0.params.category?.rootId }
 
     let loaderIsVisible = MutableProperty(false)
-    self.loadingIndicatorIsVisible = loaderIsVisible.signal
 
     let cachedCats = self.viewDidLoadProperty.signal
       .map(cachedCategories)
@@ -91,11 +90,15 @@ public final class DiscoveryFiltersViewModel: DiscoveryFiltersViewModelType,
       .switchMap { _ in
         AppEnvironment.current.apiService.fetchCategories()
           .ksr_delay(AppEnvironment.current.apiDelayInterval, on: AppEnvironment.current.scheduler)
-          .on(starting: { loaderIsVisible.value = true },
-              terminated: { loaderIsVisible.value = false })
+          .on(starting: { loaderIsVisible.value = true } )
           .map { $0.categories }
           .materialize()
       }
+
+    self.loadingIndicatorIsVisible = Signal.merge(
+      loaderIsVisible.signal,
+      categoriesEvent.values().mapConst(false)
+    )
 
     let cachedOrLoadedCategories = Signal.merge(
       cachedCats.skipNil(),

--- a/Library/ViewModels/DiscoveryFiltersViewModelTests.swift
+++ b/Library/ViewModels/DiscoveryFiltersViewModelTests.swift
@@ -44,7 +44,7 @@ private let filmExpandableRow = expandableRowTemplate
 private let categories = [ Category.art, .illustration, .filmAndVideo, .documentary ]
 
 internal final class DiscoveryFiltersViewModelTests: TestCase {
-  private var vm: DiscoveryFiltersViewModelType = DiscoveryFiltersViewModel()
+  private let vm: DiscoveryFiltersViewModelType = DiscoveryFiltersViewModel()
 
   private let animateInView = TestObserver<Int?, NoError>()
   private let loadCategoryRows = TestObserver<[ExpandableRow], NoError>()

--- a/Library/ViewModels/DiscoveryFiltersViewModelTests.swift
+++ b/Library/ViewModels/DiscoveryFiltersViewModelTests.swift
@@ -371,31 +371,26 @@ internal final class DiscoveryFiltersViewModelTests: TestCase {
           |> SelectableRow.lens.params.category .~ .illustration
     ]
 
-    withEnvironment(apiService: MockService(
-      fetchCategoriesResponse: categoriesResponse), apiDelayInterval: .seconds(3)) {
-      self.vm.inputs.configureWith(selectedRow: artSelectableRow)
+    self.vm.inputs.configureWith(selectedRow: artSelectableRow)
 
-      self.loadCategoryRows.assertValueCount(0)
+    self.loadCategoryRows.assertValueCount(0)
 
-      self.vm.inputs.viewDidLoad()
+    self.vm.inputs.viewDidLoad()
 
-      self.scheduler.advance()
+    self.loadingIndicatorisVisible.assertValues([true])
 
-      self.loadingIndicatorisVisible.assertValues([true])
+    self.scheduler.advance(by: AppEnvironment.current.apiDelayInterval)
 
-      self.scheduler.advance(by: AppEnvironment.current.apiDelayInterval)
+    self.loadingIndicatorisVisible.assertValues([true, false])
 
-      self.loadingIndicatorisVisible.assertValues([true, false])
-
-      self.loadCategoryRows.assertValues(
-        [
-          [artSelectedExpandedRow, filmExpandableRow]
-        ],
-        "The art category expands."
-      )
-      self.loadCategoryRowsInitialId.assertValues([1])
-      self.loadCategoryRowsSelectedId.assertValues([1])
-    }
+    self.loadCategoryRows.assertValues(
+      [
+        [artSelectedExpandedRow, filmExpandableRow]
+      ],
+      "The art category expands."
+    )
+    self.loadCategoryRowsInitialId.assertValues([1])
+    self.loadCategoryRowsSelectedId.assertValues([1])
   }
 
   func testTappingSelectableRow() {

--- a/Library/ViewModels/DiscoveryFiltersViewModelTests.swift
+++ b/Library/ViewModels/DiscoveryFiltersViewModelTests.swift
@@ -44,7 +44,7 @@ private let filmExpandableRow = expandableRowTemplate
 private let categories = [ Category.art, .illustration, .filmAndVideo, .documentary ]
 
 internal final class DiscoveryFiltersViewModelTests: TestCase {
-  private var vm: DiscoveryFiltersViewModelType!
+  private var vm: DiscoveryFiltersViewModelType = DiscoveryFiltersViewModel()
 
   private let animateInView = TestObserver<Int?, NoError>()
   private let loadCategoryRows = TestObserver<[ExpandableRow], NoError>()
@@ -61,8 +61,6 @@ internal final class DiscoveryFiltersViewModelTests: TestCase {
 
   override func setUp() {
     super.setUp()
-
-    self.vm = DiscoveryFiltersViewModel()
 
     self.vm.outputs.animateInView.observe(self.animateInView.observer)
     self.vm.outputs.loadingIndicatorIsVisible.observe(self.loadingIndicatorisVisible.observer)

--- a/Library/ViewModels/DiscoveryFiltersViewModelTests.swift
+++ b/Library/ViewModels/DiscoveryFiltersViewModelTests.swift
@@ -308,8 +308,6 @@ internal final class DiscoveryFiltersViewModelTests: TestCase {
 
       self.vm.inputs.viewDidLoad()
 
-      self.scheduler.advance()
-
       self.loadingIndicatorisVisible.assertValues([true])
 
       self.scheduler.advance(by: AppEnvironment.current.apiDelayInterval)


### PR DESCRIPTION
I found a bug while trying to fix other bugs that I was attempting to reproduce in airplane mode. This uncovered the fact that tapping the Discovery Filter without any network connection could crash the app as it attempts to remove the row for the loader indicator that was never added if the network request immediately failed.

Changes in this PR:
- Only return an `IndexPath` to delete if a row was really removed.
- Only animate the row deletion if there's a row to delete.
- Reload the table view after adding the loader indicator row to be sure.

I also noticed that in the corresponding test file the VM was being used directly and not via it's protocol type so just corrected that 👍 