### PR TITLE
Recognize other type of survey deep link

### DIFF
--- a/Kickstarter-iOS/ViewModels/AppDelegateViewModel.swift
+++ b/Kickstarter-iOS/ViewModels/AppDelegateViewModel.swift
@@ -420,8 +420,9 @@ AppDelegateViewModelOutputs {
 
     let surveyResponseLink = deepLink
       .map { link -> Int? in
-        guard case let .user(_, .survey(surveyResponseId)) = link else { return nil }
-        return surveyResponseId
+        if case let .user(_, .survey(surveyResponseId)) = link { return surveyResponseId }
+        if case let .project(_, .survey(surveyResponseId), _) = link { return surveyResponseId }
+        return nil
       }
       .skipNil()
       .switchMap { surveyResponseId in

--- a/Kickstarter-iOS/ViewModels/AppDelegateViewModelTests.swift
+++ b/Kickstarter-iOS/ViewModels/AppDelegateViewModelTests.swift
@@ -1370,8 +1370,7 @@ final class AppDelegateViewModelTests: TestCase {
 
     self.presentViewController.assertValues([])
 
-    let projectUrl = "https://www.kickstarter.com"
-      + "/users/tequila/surveys/123"
+    let projectUrl = "https://www.kickstarter.com/users/tequila/surveys/123"
     let result = self.vm.inputs.applicationOpenUrl(application: UIApplication.shared,
                                                    url: URL(string: projectUrl)!,
                                                    sourceApplication: nil,

--- a/Kickstarter-iOS/ViewModels/AppDelegateViewModelTests.swift
+++ b/Kickstarter-iOS/ViewModels/AppDelegateViewModelTests.swift
@@ -1346,6 +1346,40 @@ final class AppDelegateViewModelTests: TestCase {
     self.presentViewController.assertValueCount(1, "Present the project view controller.")
     self.goToMobileSafari.assertValues([])
   }
+
+  func testProjectSurveyDeepLink() {
+    self.vm.inputs.applicationDidFinishLaunching(application: UIApplication.shared,
+                                                 launchOptions: [:])
+
+    self.presentViewController.assertValues([])
+
+    let projectUrl = "https://www.kickstarter.com"
+      + "/projects/tequila/help-me-transform-this-pile-of-wood/surveys/123"
+    let result = self.vm.inputs.applicationOpenUrl(application: UIApplication.shared,
+                                                   url: URL(string: projectUrl)!,
+                                                   sourceApplication: nil,
+                                                   annotation: 1)
+    XCTAssertFalse(result)
+
+    self.presentViewController.assertValues([1])
+  }
+
+  func testUserSurveyDeepLink() {
+    self.vm.inputs.applicationDidFinishLaunching(application: UIApplication.shared,
+                                                 launchOptions: [:])
+
+    self.presentViewController.assertValues([])
+
+    let projectUrl = "https://www.kickstarter.com"
+      + "/users/tequila/surveys/123"
+    let result = self.vm.inputs.applicationOpenUrl(application: UIApplication.shared,
+                                                   url: URL(string: projectUrl)!,
+                                                   sourceApplication: nil,
+                                                   annotation: 1)
+    XCTAssertFalse(result)
+
+    self.presentViewController.assertValues([1])
+  }
 }
 
 private let backingForCreatorPushData: [String: Any] = [


### PR DESCRIPTION
Turns out there are two types of routes that can go to a survey, and we were only looking for one in our deep linking code. The unfortunate side effect of that is a user would tap a survey link in their email, it would deep link them to the app, and they would be just left there :(