### PR TITLE
Make an allow list of deep linkable routes

### DIFF
--- a/Kickstarter-iOS/ViewModels/AppDelegateViewModel.swift
+++ b/Kickstarter-iOS/ViewModels/AppDelegateViewModel.swift
@@ -277,7 +277,7 @@ AppDelegateViewModelOutputs {
 
     let continueUserActivityWithNavigation = continueUserActivity
       .filter { $0.activityType == NSUserActivityTypeBrowsingWeb }
-      .map { activity in (activity, activity.webpageURL.flatMap(Navigation.deepLinkMatch)) }
+      .map { activity in (activity, activity.webpageURL.flatMap(Navigation.match)) }
       .filter(second >>> isNotNil)
 
     self.continueUserActivityReturnValue <~ continueUserActivityWithNavigation.mapConst(true)
@@ -294,7 +294,7 @@ AppDelegateViewModelOutputs {
           .skipNil()
     )
 
-    let deepLinkFromUrl = deepLinkUrl.map(Navigation.deepLinkMatch)
+    let deepLinkFromUrl = deepLinkUrl.map(Navigation.match)
 
     let performShortcutItem = Signal.merge(
       self.performActionForShortcutItemProperty.signal.skipNil(),
@@ -318,7 +318,7 @@ AppDelegateViewModelOutputs {
 
     self.findRedirectUrl = deepLinkUrl
       .filter {
-        switch Navigation.deepLinkMatch($0) {
+        switch Navigation.match($0) {
         case .some(.emailClick(_)), .some(.emailLink):  return true
         default:                                        return false
         }

--- a/Kickstarter-iOS/ViewModels/AppDelegateViewModel.swift
+++ b/Kickstarter-iOS/ViewModels/AppDelegateViewModel.swift
@@ -277,7 +277,7 @@ AppDelegateViewModelOutputs {
 
     let continueUserActivityWithNavigation = continueUserActivity
       .filter { $0.activityType == NSUserActivityTypeBrowsingWeb }
-      .map { activity in (activity, activity.webpageURL.flatMap(Navigation.match)) }
+      .map { activity in (activity, activity.webpageURL.flatMap(Navigation.deepLinkMatch)) }
       .filter(second >>> isNotNil)
 
     self.continueUserActivityReturnValue <~ continueUserActivityWithNavigation.mapConst(true)
@@ -294,7 +294,7 @@ AppDelegateViewModelOutputs {
           .skipNil()
     )
 
-    let deepLinkFromUrl = deepLinkUrl.map(Navigation.match)
+    let deepLinkFromUrl = deepLinkUrl.map(Navigation.deepLinkMatch)
 
     let performShortcutItem = Signal.merge(
       self.performActionForShortcutItemProperty.signal.skipNil(),
@@ -318,7 +318,7 @@ AppDelegateViewModelOutputs {
 
     self.findRedirectUrl = deepLinkUrl
       .filter {
-        switch Navigation.match($0) {
+        switch Navigation.deepLinkMatch($0) {
         case .some(.emailClick(_)), .some(.emailLink):  return true
         default:                                        return false
         }
@@ -379,7 +379,7 @@ AppDelegateViewModelOutputs {
       .ignoreValues()
 
     self.goToMobileSafari = self.foundRedirectUrlProperty.signal.skipNil()
-      .filter { Navigation.match($0) == nil }
+      .filter { Navigation.deepLinkMatch($0) == nil }
 
     let projectLink = deepLink
       .filter { link in

--- a/Kickstarter-iOS/ViewModels/AppDelegateViewModelTests.swift
+++ b/Kickstarter-iOS/ViewModels/AppDelegateViewModelTests.swift
@@ -515,6 +515,21 @@ final class AppDelegateViewModelTests: TestCase {
     self.goToDiscovery.assertValues([params])
   }
 
+  func testGoToLogin() {
+    self.vm.inputs.applicationDidFinishLaunching(application: UIApplication.shared,
+                                                 launchOptions: [:])
+
+    self.goToLogin.assertValueCount(0)
+
+    let result = self.vm.inputs.applicationOpenUrl(application: UIApplication.shared,
+                                                   url: URL(string: "https://www.kickstarter.com/authorize")!,
+                                                   sourceApplication: nil,
+                                                   annotation: 1)
+    XCTAssertFalse(result)
+
+    self.goToLogin.assertValueCount(1)
+  }
+
   func testGoToProfile() {
     self.vm.inputs.applicationDidFinishLaunching(application: UIApplication.shared,
                                                  launchOptions: [:])

--- a/Kickstarter-iOS/ViewModels/AppDelegateViewModelTests.swift
+++ b/Kickstarter-iOS/ViewModels/AppDelegateViewModelTests.swift
@@ -515,21 +515,6 @@ final class AppDelegateViewModelTests: TestCase {
     self.goToDiscovery.assertValues([params])
   }
 
-  func testGoToLogin() {
-    self.vm.inputs.applicationDidFinishLaunching(application: UIApplication.shared,
-                                                 launchOptions: [:])
-
-    self.goToLogin.assertValueCount(0)
-
-    let result = self.vm.inputs.applicationOpenUrl(application: UIApplication.shared,
-                                      url: URL(string: "https://www.kickstarter.com/authorize")!,
-                                      sourceApplication: nil,
-                                      annotation: 1)
-    XCTAssertFalse(result)
-
-    self.goToLogin.assertValueCount(1)
-  }
-
   func testGoToProfile() {
     self.vm.inputs.applicationDidFinishLaunching(application: UIApplication.shared,
                                                  launchOptions: [:])

--- a/Library/Navigation.swift
+++ b/Library/Navigation.swift
@@ -211,7 +211,14 @@ public func == (lhs: Navigation.User, rhs: Navigation.User) -> Bool {
 
 extension Navigation {
   public static func match(_ url: URL) -> Navigation? {
-    return routes.reduce(nil) { accum, templateAndRoute in
+    return allRoutes.reduce(nil) { accum, templateAndRoute in
+      let (template, route) = templateAndRoute
+      return accum ?? parsedParams(url: url, fromTemplate: template).flatMap(route)?.value
+    }
+  }
+
+  public static func deepLinkMatch(_ url: URL) -> Navigation? {
+    return deepLinkRoutes.reduce(nil) { accum, templateAndRoute in
       let (template, route) = templateAndRoute
       return accum ?? parsedParams(url: url, fromTemplate: template).flatMap(route)?.value
     }
@@ -222,7 +229,7 @@ extension Navigation {
   }
 }
 
-private let routes: [String:(RouteParams) -> Decoded<Navigation>] = [
+private let allRoutes: [String:(RouteParams) -> Decoded<Navigation>] = [
   "/": emailClick,
   "/mpss/:a/:b/:c/:d/:e/:f/:g": emailLink,
   "/activity": activity,
@@ -259,6 +266,33 @@ private let routes: [String:(RouteParams) -> Decoded<Navigation>] = [
   "/projects/:creator_param/:project_param/surveys/:survey_param": projectSurvey,
   "/users/:user_param/surveys/:survey_response_id": userSurvey
 ]
+
+private let deepLinkRoutes: [String:(RouteParams) -> Decoded<Navigation>] = allRoutes.allValues(
+  from: [
+    "/",
+    "/mpss/:a/:b/:c/:d/:e/:f/:g",
+    "/activity",
+    "/discover",
+    "/discover/advanced",
+    "/discover/categories/:category_id",
+    "/discover/categories/:parent_category_id/:category_id",
+    "/messages/:message_thread_id",
+    "/profile/:user_param",
+    "/search",
+    "/projects/:creator_param/:project_param",
+    "/projects/:creator_param/:project_param/checkouts/:checkout_param/thanks",
+    "/projects/:creator_param/:project_param/comments",
+    "/projects/:creator_param/:project_param/creator_bio",
+    "/projects/:creator_param/:project_param/dashboard",
+    "/projects/:creator_param/:project_param/description",
+    "/projects/:creator_param/:project_param/friends",
+    "/projects/:creator_param/:project_param/posts",
+    "/projects/:creator_param/:project_param/posts/:update_param",
+    "/projects/:creator_param/:project_param/posts/:update_param/comments",
+    "/projects/:creator_param/:project_param/surveys/:survey_param",
+    "/users/:user_param/surveys/:survey_response_id"
+  ]
+)
 
 extension Navigation.Project {
   // swiftlint:disable conditional_binding_cascade
@@ -569,4 +603,16 @@ private func oneToBool(_ string: String?) -> Decoded<Bool?> {
 
 private func stringToInt(_ string: String) -> Decoded<Int> {
   return Int(string).map(Decoded.success) ?? .failure(.custom("Could not parse string into int."))
+}
+
+extension Dictionary {
+  fileprivate func allValues(from keys: [Key]) -> Dictionary {
+    var result = Dictionary()
+    self.forEach { key, value in
+      if keys.contains(key) {
+        result[key] = value
+      }
+    }
+    return result
+  }
 }

--- a/Library/Navigation.swift
+++ b/Library/Navigation.swift
@@ -267,8 +267,8 @@ private let allRoutes: [String:(RouteParams) -> Decoded<Navigation>] = [
   "/users/:user_param/surveys/:survey_response_id": userSurvey
 ]
 
-private let deepLinkRoutes: [String:(RouteParams) -> Decoded<Navigation>] = allRoutes.allValues(
-  from: [
+private let deepLinkRoutes: [String:(RouteParams) -> Decoded<Navigation>] = allRoutes.restrict(
+  keys: [
     "/",
     "/mpss/:a/:b/:c/:d/:e/:f/:g",
     "/activity",
@@ -606,7 +606,7 @@ private func stringToInt(_ string: String) -> Decoded<Int> {
 }
 
 extension Dictionary {
-  fileprivate func allValues(from keys: [Key]) -> Dictionary {
+  fileprivate func restrict(keys: Set<Key>) -> Dictionary {
     var result = Dictionary()
     self.forEach { key, value in
       if keys.contains(key) {


### PR DESCRIPTION
Right now our routing systems has a big ole list of URLs on Kickstarter that we want to recognize in a variety of situations, e.g. when inspecting requests in a web view, and when deep linking into the app.

Sometimes we want to use a different set of recognizable routes depending on the situation we are routing. In particular, when deep linking there is a smaller set of routes we want to recognize, and then anything we don't recognize can bump the user back to mobile safari.

That's what this PR does...

There are smarter ways to do this, and would love to try it out soon, but this will do the job and is well tested!