### PR TITLE
Discovery Gradient fix

### DIFF
--- a/Kickstarter-iOS/Views/Storyboards/DiscoveryPage.storyboard
+++ b/Kickstarter-iOS/Views/Storyboards/DiscoveryPage.storyboard
@@ -494,23 +494,23 @@
                                     </subviews>
                                     <constraints>
                                         <constraint firstAttribute="trailingMargin" secondItem="OqX-qg-UeE" secondAttribute="trailing" constant="10" id="5RF-E2-1AF"/>
-                                        <constraint firstItem="ylR-Sv-CeG" firstAttribute="top" secondItem="f91-JL-fui" secondAttribute="topMargin" id="9Z7-uI-sIf"/>
-                                        <constraint firstItem="ylR-Sv-CeG" firstAttribute="leading" secondItem="eC3-Kj-zPc" secondAttribute="leading" id="9jo-Jv-MO3"/>
+                                        <constraint firstItem="eC3-Kj-zPc" firstAttribute="top" secondItem="f91-JL-fui" secondAttribute="topMargin" id="6by-7F-gOy"/>
                                         <constraint firstAttribute="leadingMargin" secondItem="hnN-BJ-FXy" secondAttribute="leading" id="Axh-gN-jM9"/>
                                         <constraint firstItem="R0g-tb-Pfo" firstAttribute="bottom" secondItem="x7P-p0-T4F" secondAttribute="bottom" constant="-1.5" id="Bx7-Iz-HSU"/>
+                                        <constraint firstItem="ylR-Sv-CeG" firstAttribute="height" secondItem="eC3-Kj-zPc" secondAttribute="height" multiplier="1:4" id="Ief-cj-080"/>
                                         <constraint firstItem="R0g-tb-Pfo" firstAttribute="top" secondItem="x7P-p0-T4F" secondAttribute="top" id="JdS-7h-Iwd"/>
-                                        <constraint firstItem="ylR-Sv-CeG" firstAttribute="width" secondItem="eC3-Kj-zPc" secondAttribute="width" id="OMQ-iT-mrQ"/>
                                         <constraint firstAttribute="bottomMargin" secondItem="hnN-BJ-FXy" secondAttribute="bottom" id="P0n-Bg-KYh"/>
-                                        <constraint firstItem="eC3-Kj-zPc" firstAttribute="leading" secondItem="R0g-tb-Pfo" secondAttribute="leading" id="Wbj-Gu-dY2"/>
-                                        <constraint firstItem="eC3-Kj-zPc" firstAttribute="width" secondItem="vUL-dU-47D" secondAttribute="width" id="bMV-Xm-m82"/>
+                                        <constraint firstItem="eC3-Kj-zPc" firstAttribute="trailing" secondItem="f91-JL-fui" secondAttribute="trailingMargin" id="RYY-JC-VCM"/>
                                         <constraint firstItem="KNM-IW-eI1" firstAttribute="centerY" secondItem="R0g-tb-Pfo" secondAttribute="top" id="buC-U9-470"/>
-                                        <constraint firstItem="eC3-Kj-zPc" firstAttribute="top" secondItem="f91-JL-fui" secondAttribute="topMargin" id="eBK-eh-s0w"/>
                                         <constraint firstItem="R0g-tb-Pfo" firstAttribute="trailing" secondItem="x7P-p0-T4F" secondAttribute="trailing" id="ePj-Ey-Kun"/>
                                         <constraint firstItem="KNM-IW-eI1" firstAttribute="leading" secondItem="R0g-tb-Pfo" secondAttribute="leading" constant="12" id="fFf-79-3QU"/>
+                                        <constraint firstItem="eC3-Kj-zPc" firstAttribute="leading" secondItem="f91-JL-fui" secondAttribute="leadingMargin" id="fq1-hp-7sp"/>
+                                        <constraint firstItem="ylR-Sv-CeG" firstAttribute="top" secondItem="eC3-Kj-zPc" secondAttribute="top" id="hiE-fV-Nln"/>
                                         <constraint firstItem="R0g-tb-Pfo" firstAttribute="leading" secondItem="x7P-p0-T4F" secondAttribute="leading" id="lVJ-hm-ql7"/>
-                                        <constraint firstItem="eC3-Kj-zPc" firstAttribute="bottom" secondItem="vUL-dU-47D" secondAttribute="bottom" id="lvQ-4Z-DH8"/>
                                         <constraint firstAttribute="topMargin" secondItem="hnN-BJ-FXy" secondAttribute="top" id="mFo-CL-QQM"/>
-                                        <constraint firstItem="ylR-Sv-CeG" firstAttribute="height" secondItem="eC3-Kj-zPc" secondAttribute="height" multiplier="1:4" id="v1R-gP-ASB"/>
+                                        <constraint firstItem="ylR-Sv-CeG" firstAttribute="trailing" secondItem="eC3-Kj-zPc" secondAttribute="trailing" id="orw-wt-Z8i"/>
+                                        <constraint firstItem="ylR-Sv-CeG" firstAttribute="leading" secondItem="eC3-Kj-zPc" secondAttribute="leading" id="t99-VQ-h31"/>
+                                        <constraint firstItem="eC3-Kj-zPc" firstAttribute="bottom" secondItem="vUL-dU-47D" secondAttribute="bottom" id="uvx-MK-lL7"/>
                                         <constraint firstAttribute="trailingMargin" secondItem="hnN-BJ-FXy" secondAttribute="trailing" id="wwI-U6-fYG"/>
                                         <constraint firstItem="OqX-qg-UeE" firstAttribute="top" secondItem="vUL-dU-47D" secondAttribute="top" constant="10" id="zJl-7S-Kub"/>
                                     </constraints>

--- a/Kickstarter-iOS/Views/Storyboards/DiscoveryPage.storyboard
+++ b/Kickstarter-iOS/Views/Storyboards/DiscoveryPage.storyboard
@@ -431,7 +431,7 @@
                                                 </stackView>
                                             </subviews>
                                         </stackView>
-                                        <view alpha="0.14999999999999999" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="eC3-Kj-zPc">
+                                        <view alpha="0.14999999999999999" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="eC3-Kj-zPc" userLabel="Project image overlay">
                                             <rect key="frame" x="18" y="18" width="364" height="205"/>
                                             <color key="backgroundColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
                                         </view>
@@ -493,18 +493,18 @@
                                         </stackView>
                                     </subviews>
                                     <constraints>
+                                        <constraint firstItem="eC3-Kj-zPc" firstAttribute="top" secondItem="vUL-dU-47D" secondAttribute="top" id="2wC-OD-Vco"/>
                                         <constraint firstAttribute="trailingMargin" secondItem="OqX-qg-UeE" secondAttribute="trailing" constant="10" id="5RF-E2-1AF"/>
-                                        <constraint firstItem="eC3-Kj-zPc" firstAttribute="top" secondItem="f91-JL-fui" secondAttribute="topMargin" id="6by-7F-gOy"/>
                                         <constraint firstAttribute="leadingMargin" secondItem="hnN-BJ-FXy" secondAttribute="leading" id="Axh-gN-jM9"/>
                                         <constraint firstItem="R0g-tb-Pfo" firstAttribute="bottom" secondItem="x7P-p0-T4F" secondAttribute="bottom" constant="-1.5" id="Bx7-Iz-HSU"/>
                                         <constraint firstItem="ylR-Sv-CeG" firstAttribute="height" secondItem="eC3-Kj-zPc" secondAttribute="height" multiplier="1:4" id="Ief-cj-080"/>
                                         <constraint firstItem="R0g-tb-Pfo" firstAttribute="top" secondItem="x7P-p0-T4F" secondAttribute="top" id="JdS-7h-Iwd"/>
                                         <constraint firstAttribute="bottomMargin" secondItem="hnN-BJ-FXy" secondAttribute="bottom" id="P0n-Bg-KYh"/>
-                                        <constraint firstItem="eC3-Kj-zPc" firstAttribute="trailing" secondItem="f91-JL-fui" secondAttribute="trailingMargin" id="RYY-JC-VCM"/>
+                                        <constraint firstItem="eC3-Kj-zPc" firstAttribute="trailing" secondItem="vUL-dU-47D" secondAttribute="trailing" id="b9M-PY-nW0"/>
                                         <constraint firstItem="KNM-IW-eI1" firstAttribute="centerY" secondItem="R0g-tb-Pfo" secondAttribute="top" id="buC-U9-470"/>
                                         <constraint firstItem="R0g-tb-Pfo" firstAttribute="trailing" secondItem="x7P-p0-T4F" secondAttribute="trailing" id="ePj-Ey-Kun"/>
                                         <constraint firstItem="KNM-IW-eI1" firstAttribute="leading" secondItem="R0g-tb-Pfo" secondAttribute="leading" constant="12" id="fFf-79-3QU"/>
-                                        <constraint firstItem="eC3-Kj-zPc" firstAttribute="leading" secondItem="f91-JL-fui" secondAttribute="leadingMargin" id="fq1-hp-7sp"/>
+                                        <constraint firstItem="eC3-Kj-zPc" firstAttribute="leading" secondItem="vUL-dU-47D" secondAttribute="leading" id="fpo-c0-uL0"/>
                                         <constraint firstItem="ylR-Sv-CeG" firstAttribute="top" secondItem="eC3-Kj-zPc" secondAttribute="top" id="hiE-fV-Nln"/>
                                         <constraint firstItem="R0g-tb-Pfo" firstAttribute="leading" secondItem="x7P-p0-T4F" secondAttribute="leading" id="lVJ-hm-ql7"/>
                                         <constraint firstAttribute="topMargin" secondItem="hnN-BJ-FXy" secondAttribute="top" id="mFo-CL-QQM"/>


### PR DESCRIPTION
## WHAT

Gradient position in project card were shifting on reuse because of conflicting storyboard constraints. Before the project view overlay's leading, trailing and top space was constrained to the superview, now it is constrained to the leading, trailing, and top space of the project image.  


<img width="300" alt="simulator screen shot may 17 2017 11 05 00 am" src="https://cloud.githubusercontent.com/assets/11362005/26210620/316dbd66-3bbe-11e7-9fae-45a4fdc55e8c.png">

 