### PR TITLE
[don't merge] why function vs underlying property for ViewModelInput?

### DIFF
--- a/Library/ViewModels/ActivitiesViewModel.swift
+++ b/Library/ViewModels/ActivitiesViewModel.swift
@@ -6,7 +6,7 @@ import Result
 
 public protocol ActitiviesViewModelInputs {
   /// Called when the project image in an update activity cell is tapped.
-  func activityUpdateCellTappedProjectImage(activity: Activity)
+  var tappedActivityProjectImageSink: MutableProperty<Activity?> { get }
 
   /// Call when the Find Friends section is dismissed.
   func findFriendsHeaderCellDismissHeader()
@@ -310,10 +310,9 @@ ActivitiesViewModelOutputs {
   public func surveyResponseViewControllerDismissed() {
     self.surveyResponseViewControllerDismissedProperty.value = ()
   }
-  fileprivate let tappedActivityProjectImage = MutableProperty<Activity?>(nil)
-  public func activityUpdateCellTappedProjectImage(activity: Activity) {
-    self.tappedActivityProjectImage.value = activity
-  }
+
+  public let tappedActivityProjectImageSink = MutableProperty<Activity?>(nil)
+
   fileprivate let tappedSurveyResponseProperty = MutableProperty<SurveyResponse?>(nil)
   public func tappedRespondNow(forSurveyResponse surveyResponse: SurveyResponse) {
     self.tappedSurveyResponseProperty.value = surveyResponse


### PR DESCRIPTION
I was wondering why you used a function that just wraps a `MutableProperty` in a number of your view models, it seems like totally unnecessary boilerplate.

Is it there just to keep the view controller _simple_, and not leak your Reactive abstraction into the view?

I made an example diff of what the alternative I see could be, and the diff pretty much just removes 3 lines of code. 3 x the number of input functions you have would be a massive negative diff 😉 