### PR TITLE
Fix ApplePay crash

### DIFF
--- a/Kickstarter-iOS/Views/Controllers/CheckoutViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/CheckoutViewController.swift
@@ -134,12 +134,7 @@ internal final class CheckoutViewController: DeprecatedWebViewController {
 
   fileprivate func goToThanks(project: Project) {
     let thanksVC = ThanksViewController.configuredWith(project: project)
-    let stack = self.navigationController?.viewControllers
-    guard let root = stack?.first else {
-      assertionFailure("Unable to find root view controller!")
-      return
-    }
-    self.navigationController?.setViewControllers([root, thanksVC], animated: true)
+    self.navigationController?.pushViewController(thanksVC, animated: true)
   }
 
   fileprivate func goToWebModal(request: URLRequest) {

--- a/Kickstarter-iOS/Views/Controllers/RewardPledgeViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/RewardPledgeViewController.swift
@@ -607,11 +607,7 @@ internal final class RewardPledgeViewController: UIViewController {
 
   fileprivate func goToThanks(project: Project) {
     let thanksVC = ThanksViewController.configuredWith(project: project)
-    let stack = self.navigationController?.viewControllers
-    guard let root = stack?.first else {
-      fatalError("Unable to find root view controller!")
-    }
-    self.navigationController?.setViewControllers([root, thanksVC], animated: true)
+    self.navigationController?.pushViewController(thanksVC, animated: true)
   }
 
   fileprivate func load(items: [String]) {


### PR DESCRIPTION
There is a crash that is affecting a small number of users where if you first choose not to do Apple Pay in the reward pledge screen, but then later decide to use Apple Pay from the credit card page, you will get a crash once you drill down to the thanks screen. This is happening because the checkout view is removed from the navigation stack, and that is where the pay sheet had been presented from, and something deep in the bowels of UIKit doesn't like that :/

Turns out though, we totally don't need to be messing with the nav stack during this flow. Let's just push the thanks screen onto the stack. We already hide the back button on that screen anyway...