### PR TITLE
Always observeForControllerAction when scrollToProjectRow

### DIFF
--- a/Kickstarter-iOS/Views/Controllers/SearchViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/SearchViewController.swift
@@ -161,16 +161,9 @@ internal final class SearchViewController: UITableViewController {
         self?.changeSearchFieldFocus(focus: $0, animated: $1)
     }
 
-    // NB: Currently running a feature on a subset of users to test out if `observeForUI` is still crashing.
-    if AppEnvironment.current.config?.features["ios_scroll_output_observe_for_ui"] == .some(true) {
-      self.viewModel.outputs.scrollToProjectRow
-        .observeForUI()
-        .observeValues { [weak self] in self?.scrollToProjectRow($0) }
-    } else {
-      self.viewModel.outputs.scrollToProjectRow
-        .observeForControllerAction()
-        .observeValues { [weak self] in self?.scrollToProjectRow($0) }
-    }
+    self.viewModel.outputs.scrollToProjectRow
+      .observeForControllerAction()
+      .observeValues { [weak self] in self?.scrollToProjectRow($0) }
   }
 
   private func scrollToProjectRow(_ row: Int) {


### PR DESCRIPTION
Related to https://github.com/kickstarter/kickstarter/pull/6769.

In the above PR we changed a feature flag which was enabling `observeForUI()` on 10 percent of users and internal admins.

This PR removes the check from our code in anticipation of the feature flag being removed from the web at a later stage.

`observeForUI` still crashes so we want to always `observeForControllerAction`.