### PR TITLE
Add more disabled swiftlint rules 

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -7,10 +7,10 @@ disabled_rules:
   - identifier_name
   - large_tuple
   - nesting
-  - weak_delegate
   - type_body_length
   - type_name
   - trailing_comma
+  - weak_delegate
 opt_in_rules:
   - empty_count
   - force_unwrapping

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,11 +1,15 @@
 disabled_rules:
   - closure_parameter_position
   - discarded_notification_center_observer
+  - file_length
+  - function_body_length
   - function_parameter_count
   - identifier_name
   - large_tuple
   - nesting
   - weak_delegate
+  - type_body_length
+  - type_name
   - trailing_comma
 opt_in_rules:
   - empty_count

--- a/Kickstarter-iOS.playground/Sources/playgroundController.swift
+++ b/Kickstarter-iOS.playground/Sources/playgroundController.swift
@@ -1,6 +1,5 @@
 import UIKit
 
-// swiftlint:disable function_body_length
 
 public enum Device {
   case phone3_5inch

--- a/Kickstarter-iOS/AppDelegate.swift
+++ b/Kickstarter-iOS/AppDelegate.swift
@@ -25,8 +25,7 @@ internal final class AppDelegate: UIResponder, UIApplicationDelegate {
     return self.window?.rootViewController as? RootTabBarViewController
   }
 
-  // swiftlint:disable function_body_length
-  func application(
+    func application(
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
 

--- a/Kickstarter-iOS/DataSources/LiveStreamDiscoveryDataSourceTests.swift
+++ b/Kickstarter-iOS/DataSources/LiveStreamDiscoveryDataSourceTests.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable function_body_length
 import Prelude
 import XCTest
 @testable import Kickstarter_Framework

--- a/Kickstarter-iOS/DataSources/ProjectPamphletContentDataSourceTests.swift
+++ b/Kickstarter-iOS/DataSources/ProjectPamphletContentDataSourceTests.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable function_body_length
 import XCTest
 @testable import Kickstarter_Framework
 @testable import Library

--- a/Kickstarter-iOS/TestHelpers/TraitController.swift
+++ b/Kickstarter-iOS/TestHelpers/TraitController.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable function_body_length
 import UIKit
 
 internal enum Device {

--- a/Kickstarter-iOS/ViewModels/AppDelegateViewModel.swift
+++ b/Kickstarter-iOS/ViewModels/AppDelegateViewModel.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable file_length
 import Argo
 import KsApi
 import Library

--- a/Kickstarter-iOS/ViewModels/AppDelegateViewModel.swift
+++ b/Kickstarter-iOS/ViewModels/AppDelegateViewModel.swift
@@ -157,8 +157,7 @@ public protocol AppDelegateViewModelType {
 public final class AppDelegateViewModel: AppDelegateViewModelType, AppDelegateViewModelInputs,
 AppDelegateViewModelOutputs {
 
-  // swiftlint:disable function_body_length
-  // swiftlint:disable cyclomatic_complexity
+    // swiftlint:disable cyclomatic_complexity
   public init() {
     let currentUserEvent = Signal
       .merge(

--- a/Kickstarter-iOS/ViewModels/AppDelegateViewModelTests.swift
+++ b/Kickstarter-iOS/ViewModels/AppDelegateViewModelTests.swift
@@ -1,6 +1,5 @@
 // swiftlint:disable force_unwrapping
 // swiftlint:disable function_body_length
-// swiftlint:disable type_body_length
 // swiftlint:disable force_cast
 import Prelude
 import ReactiveExtensions

--- a/Kickstarter-iOS/ViewModels/AppDelegateViewModelTests.swift
+++ b/Kickstarter-iOS/ViewModels/AppDelegateViewModelTests.swift
@@ -1,5 +1,4 @@
 // swiftlint:disable force_unwrapping
-// swiftlint:disable function_body_length
 // swiftlint:disable force_cast
 import Prelude
 import ReactiveExtensions

--- a/Kickstarter-iOS/ViewModels/AppDelegateViewModelTests.swift
+++ b/Kickstarter-iOS/ViewModels/AppDelegateViewModelTests.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable file_length
 // swiftlint:disable force_unwrapping
 // swiftlint:disable function_body_length
 // swiftlint:disable type_body_length

--- a/Kickstarter-iOS/ViewModels/RootViewModel.swift
+++ b/Kickstarter-iOS/ViewModels/RootViewModel.swift
@@ -82,8 +82,7 @@ internal protocol RootViewModelType {
 
 internal final class RootViewModel: RootViewModelType, RootViewModelInputs, RootViewModelOutputs {
 
-  // swiftlint:disable function_body_length
-  internal init() {
+    internal init() {
     let currentUser = Signal.merge(
       self.viewDidLoadProperty.signal,
       self.userSessionStartedProperty.signal,

--- a/Kickstarter-iOS/ViewModels/UpdatePreviewViewModel.swift
+++ b/Kickstarter-iOS/ViewModels/UpdatePreviewViewModel.swift
@@ -46,8 +46,7 @@ internal protocol UpdatePreviewViewModelType {
 internal final class UpdatePreviewViewModel: UpdatePreviewViewModelInputs,
   UpdatePreviewViewModelOutputs, UpdatePreviewViewModelType {
 
-  // swiftlint:disable function_body_length
-  internal init() {
+    internal init() {
     let draft = self.draftProperty.signal.skipNil()
 
     let initialRequest = draft

--- a/Kickstarter-iOS/ViewModels/UpdateViewModel.swift
+++ b/Kickstarter-iOS/ViewModels/UpdateViewModel.swift
@@ -46,8 +46,7 @@ internal protocol UpdateViewModelType {
 
 internal final class UpdateViewModel: UpdateViewModelType, UpdateViewModelInputs, UpdateViewModelOutputs {
 
-  // swiftlint:disable function_body_length
-  internal init() {
+    internal init() {
     let configurationData = self.configurationDataProperty.signal.skipNil()
 
     let initialUpdate = configurationData.map { $0.update }

--- a/Kickstarter-iOS/Views/Cells/DashboardReferrersCell.swift
+++ b/Kickstarter-iOS/Views/Cells/DashboardReferrersCell.swift
@@ -68,8 +68,7 @@ internal final class DashboardReferrersCell: UITableViewCell, ValueCell {
     )
   }
 
-  // swiftlint:disable function_body_length
-  internal override func bindStyles() {
+    internal override func bindStyles() {
     _ = self |> baseTableViewCellStyle()
 
     _ = self.averagePledgeAmountSubtitleLabel

--- a/Kickstarter-iOS/Views/Cells/DiscoveryPostcardCell.swift
+++ b/Kickstarter-iOS/Views/Cells/DiscoveryPostcardCell.swift
@@ -43,8 +43,7 @@ internal final class DiscoveryPostcardCell: UITableViewCell, ValueCell {
   @IBOutlet fileprivate weak var socialStackView: UIStackView!
   @IBOutlet fileprivate weak var starButton: UIButton!
 
-  // swiftlint:disable function_body_length
-  internal override func awakeFromNib() {
+    internal override func awakeFromNib() {
     super.awakeFromNib()
 
     self.starButton.addTarget(self, action: #selector(starButtonTapped), for: .touchUpInside)
@@ -165,8 +164,7 @@ internal final class DiscoveryPostcardCell: UITableViewCell, ValueCell {
   }
   // swiftlint:enable function_body_length
 
-  // swiftlint:disable function_body_length
-  internal override func bindViewModel() {
+    internal override func bindViewModel() {
     super.bindViewModel()
 
     self.rac.accessibilityLabel = self.viewModel.outputs.cellAccessibilityLabel

--- a/Kickstarter-iOS/Views/Cells/FindFriendsFacebookConnectCell.swift
+++ b/Kickstarter-iOS/Views/Cells/FindFriendsFacebookConnectCell.swift
@@ -35,8 +35,7 @@ internal final class FindFriendsFacebookConnectCell: UITableViewCell, ValueCell 
     self.viewModel.inputs.configureWith(source: source)
   }
 
-  // swiftlint:disable function_body_length
-  internal override func bindViewModel() {
+    internal override func bindViewModel() {
     self.closeButton.rac.hidden = self.viewModel.outputs.hideCloseButton
 
     self.viewModel.outputs.attemptFacebookLogin

--- a/Kickstarter-iOS/Views/Cells/NoRewardCell.swift
+++ b/Kickstarter-iOS/Views/Cells/NoRewardCell.swift
@@ -16,8 +16,7 @@ internal final class NoRewardCell: UITableViewCell, ValueCell {
     self.contentView.backgroundColor = Library.backgroundColor(forCategoryId: project.category.rootId)
   }
 
-  // swiftlint:disable function_body_length
-  internal override func bindStyles() {
+    internal override func bindStyles() {
     super.bindStyles()
 
     _ = self

--- a/Kickstarter-iOS/Views/Cells/ProjectActivityBackingCell.swift
+++ b/Kickstarter-iOS/Views/Cells/ProjectActivityBackingCell.swift
@@ -47,8 +47,7 @@ internal final class ProjectActivityBackingCell: UITableViewCell, ValueCell {
                                         project: activityAndProject.1)
   }
 
-  // swiftlint:disable function_body_length
-  internal override func bindViewModel() {
+    internal override func bindViewModel() {
     super.bindViewModel()
 
     self.rac.accessibilityLabel = self.viewModel.outputs.cellAccessibilityLabel

--- a/Kickstarter-iOS/Views/Cells/ProjectActivityUpdateCell.swift
+++ b/Kickstarter-iOS/Views/Cells/ProjectActivityUpdateCell.swift
@@ -52,8 +52,7 @@ internal final class ProjectActivityUpdateCell: UITableViewCell, ValueCell {
     self.updateTitleLabel.rac.text = self.viewModel.outputs.updateTitle
   }
 
-  // swiftlint:disable function_body_length
-  internal override func bindStyles() {
+    internal override func bindStyles() {
     super.bindStyles()
 
     let statLabel =

--- a/Kickstarter-iOS/Views/Cells/ProjectPamphletMainCell.swift
+++ b/Kickstarter-iOS/Views/Cells/ProjectPamphletMainCell.swift
@@ -80,8 +80,7 @@ internal final class ProjectPamphletMainCell: UITableViewCell, ValueCell {
       tx: 0, ty: translation)
   }
 
-  // swiftlint:disable function_body_length
-  internal override func bindStyles() {
+    internal override func bindStyles() {
     super.bindStyles()
 
     _ = self
@@ -185,8 +184,7 @@ internal final class ProjectPamphletMainCell: UITableViewCell, ValueCell {
   }
   // swiftlint:enable function_body_length
 
-  // swiftlint:disable function_body_length
-  internal override func bindViewModel() {
+    internal override func bindViewModel() {
     super.bindViewModel()
 
     self.backersSubtitleLabel.rac.text = self.viewModel.outputs.backersSubtitleLabelText

--- a/Kickstarter-iOS/Views/Cells/RewardCell.swift
+++ b/Kickstarter-iOS/Views/Cells/RewardCell.swift
@@ -58,8 +58,7 @@ internal final class RewardCell: UITableViewCell, ValueCell {
     self.viewModel.inputs.configureWith(project: value.0, rewardOrBacking: value.1)
   }
 
-  // swiftlint:disable function_body_length
-  internal override func bindStyles() {
+    internal override func bindStyles() {
     super.bindStyles()
 
     _ = self
@@ -190,8 +189,7 @@ internal final class RewardCell: UITableViewCell, ValueCell {
   }
   // swiftlint:enable function_body_length
 
-  // swiftlint:disable function_body_length
-  internal override func bindViewModel() {
+    internal override func bindViewModel() {
     super.bindViewModel()
 
     self.allGoneContainerView.rac.hidden = self.viewModel.outputs.allGoneHidden

--- a/Kickstarter-iOS/Views/Controllers/ActivitiesViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/ActivitiesViewController.swift
@@ -67,8 +67,7 @@ internal final class ActivitiesViewController: UITableViewController {
       |> UINavigationItem.lens.title %~ { _ in Strings.activity_navigation_title_activity() }
   }
 
-  // swiftlint:disable function_body_length
-  internal override func bindViewModel() {
+    internal override func bindViewModel() {
     super.bindViewModel()
 
     self.viewModel.outputs.activities

--- a/Kickstarter-iOS/Views/Controllers/ActivitiesViewControllerTests.swift
+++ b/Kickstarter-iOS/Views/Controllers/ActivitiesViewControllerTests.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable function_body_length
 @testable import Kickstarter_Framework
 @testable import KsApi
 @testable import Library

--- a/Kickstarter-iOS/Views/Controllers/CheckoutViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/CheckoutViewController.swift
@@ -103,7 +103,7 @@ internal final class CheckoutViewController: DeprecatedWebViewController {
         self?.viewModel.inputs.userSessionStarted()
     }
   }
-  
+
   internal func webView(_ webView: UIWebView,
                         shouldStartLoadWithRequest request: URLRequest,
                         navigationType: UIWebViewNavigationType) -> Bool {

--- a/Kickstarter-iOS/Views/Controllers/CheckoutViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/CheckoutViewController.swift
@@ -37,8 +37,7 @@ internal final class CheckoutViewController: DeprecatedWebViewController {
     self.viewModel.inputs.viewDidLoad()
   }
 
-  // swiftlint:disable function_body_length
-  internal override func bindViewModel() {
+    internal override func bindViewModel() {
     super.bindViewModel()
 
     self.viewModel.outputs.closeLoginTout
@@ -104,8 +103,7 @@ internal final class CheckoutViewController: DeprecatedWebViewController {
         self?.viewModel.inputs.userSessionStarted()
     }
   }
-  // swiftlint:disable function_body_length
-
+  
   internal func webView(_ webView: UIWebView,
                         shouldStartLoadWithRequest request: URLRequest,
                         navigationType: UIWebViewNavigationType) -> Bool {

--- a/Kickstarter-iOS/Views/Controllers/CommentsViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/CommentsViewController.swift
@@ -59,8 +59,7 @@ internal final class CommentsViewController: UITableViewController {
     }
   }
 
-  // swiftlint:disable function_body_length
-  internal override func bindViewModel() {
+    internal override func bindViewModel() {
 
     self.viewModel.outputs.closeLoginTout
       .observeForControllerAction()

--- a/Kickstarter-iOS/Views/Controllers/DashboardViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/DashboardViewController.swift
@@ -46,8 +46,7 @@ internal final class DashboardViewController: UITableViewController {
       |> UITableViewController.lens.view.backgroundColor .~ .white
   }
 
-  // swiftlint:disable function_body_length
-  internal override func bindViewModel() {
+    internal override func bindViewModel() {
     super.bindViewModel()
 
     self.viewModel.outputs.fundingData

--- a/Kickstarter-iOS/Views/Controllers/DebugPushNotifictionsViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/DebugPushNotifictionsViewController.swift
@@ -8,8 +8,7 @@ internal final class DebugPushNotificationsViewController: UIViewController {
   @IBOutlet fileprivate weak var scrollView: UIScrollView!
   @IBOutlet fileprivate var separatorViews: [UIView]!
 
-  // swiftlint:disable function_body_length
-  internal override func bindStyles() {
+    internal override func bindStyles() {
     super.bindStyles()
 
     _ = self

--- a/Kickstarter-iOS/Views/Controllers/DiscoveryNavigationHeaderViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/DiscoveryNavigationHeaderViewController.swift
@@ -51,8 +51,7 @@ internal final class DiscoveryNavigationHeaderViewController: UIViewController {
     self.viewModel.inputs.viewDidLoad()
   }
 
-  // swiftlint:disable function_body_length
-  internal override func bindViewModel() {
+    internal override func bindViewModel() {
     super.bindViewModel()
 
     self.arrowImageView.rac.tintColor = self.viewModel.outputs.subviewColor
@@ -222,8 +221,7 @@ internal final class DiscoveryNavigationHeaderViewController: UIViewController {
      completion: nil)
   }
 
-  // swiftlint:disable function_body_length
-  fileprivate func updateFavoriteButton(selected: Bool, animated: Bool) {
+    fileprivate func updateFavoriteButton(selected: Bool, animated: Bool) {
     let duration = animated ? 0.4 : 0.0
 
     if selected {

--- a/Kickstarter-iOS/Views/Controllers/DiscoveryPageViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/DiscoveryPageViewController.swift
@@ -89,8 +89,7 @@ internal final class DiscoveryPageViewController: UITableViewController {
       |> UIActivityIndicatorView.lens.color .~ .ksr_navy_900
   }
 
-  // swiftlint:disable function_body_length
-  internal override func bindViewModel() {
+    internal override func bindViewModel() {
     super.bindViewModel()
 
     self.loadingIndicatorView.rac.animating = self.viewModel.outputs.projectsAreLoading

--- a/Kickstarter-iOS/Views/Controllers/EmptyStatesViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/EmptyStatesViewController.swift
@@ -46,8 +46,7 @@ internal final class EmptyStatesViewController: UIViewController {
     self.viewModel.inputs.viewWillAppear()
   }
 
-  // swiftlint:disable function_body_length
-  override func bindViewModel() {
+    override func bindViewModel() {
     super.bindViewModel()
 
     self.titleLabel.rac.text = self.viewModel.outputs.titleLabelText

--- a/Kickstarter-iOS/Views/Controllers/FacebookConfirmationViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/FacebookConfirmationViewController.swift
@@ -67,8 +67,7 @@ internal final class FacebookConfirmationViewController: UIViewController,
     _ = self.rootStackView |> loginRootStackViewStyle
   }
 
-  // swiftlint:disable function_body_length
-  override func bindViewModel() {
+    override func bindViewModel() {
     super.bindViewModel()
 
     self.viewModel.outputs.displayEmail

--- a/Kickstarter-iOS/Views/Controllers/LiveStreamContainerViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/LiveStreamContainerViewController.swift
@@ -1,4 +1,3 @@
-//swiftlint:disable file_length
 import KsApi
 import Library
 import LiveStream

--- a/Kickstarter-iOS/Views/Controllers/LiveStreamCountdownViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/LiveStreamCountdownViewController.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable file_length
 import KsApi
 import Library
 import LiveStream

--- a/Kickstarter-iOS/Views/Controllers/LoginToutViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/LoginToutViewController.swift
@@ -95,8 +95,7 @@ internal final class LoginToutViewController: UIViewController, MFMailComposeVie
       |> UIStackView.lens.layoutMarginsRelativeArrangement .~ true
     }
 
-  // swiftlint:disable function_body_length
-  override func bindViewModel() {
+    override func bindViewModel() {
     self.viewModel.outputs.startLogin
       .observeForControllerAction()
       .observeValues { [weak self] _ in

--- a/Kickstarter-iOS/Views/Controllers/ProjectNavBarViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/ProjectNavBarViewController.swift
@@ -63,8 +63,7 @@ public final class ProjectNavBarViewController: UIViewController {
     self.viewModel.inputs.viewDidLoad()
   }
 
-  // swiftlint:disable function_body_length
-  public override func bindStyles() {
+    public override func bindStyles() {
     super.bindStyles()
 
     self.backgroundGradientView.startPoint = .zero
@@ -115,8 +114,7 @@ public final class ProjectNavBarViewController: UIViewController {
   }
   // swiftlint:enable function_body_length
 
-  // swiftlint:disable function_body_length
-  public override func bindViewModel() {
+    public override func bindViewModel() {
     super.bindViewModel()
 
     self.categoryButton.rac.backgroundColor = self.viewModel.outputs.categoryButtonBackgroundColor

--- a/Kickstarter-iOS/Views/Controllers/ProjectPamphletContentViewControllerTests.swift
+++ b/Kickstarter-iOS/Views/Controllers/ProjectPamphletContentViewControllerTests.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable type_name
 // swiftlint:disable force_unwrapping
 import Prelude
 import Result

--- a/Kickstarter-iOS/Views/Controllers/RewardPledgeViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/RewardPledgeViewController.swift
@@ -4,7 +4,6 @@ import Prelude
 import Stripe
 import UIKit
 
-// swiftlint:disable type_body_length
 internal final class RewardPledgeViewController: UIViewController {
   internal let viewModel: RewardPledgeViewModelType = RewardPledgeViewModel()
 

--- a/Kickstarter-iOS/Views/Controllers/RewardPledgeViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/RewardPledgeViewController.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable file_length
 import KsApi
 import Library
 import Prelude

--- a/Kickstarter-iOS/Views/Controllers/RewardPledgeViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/RewardPledgeViewController.swift
@@ -146,8 +146,7 @@ internal final class RewardPledgeViewController: UIViewController {
     self.viewModel.inputs.viewDidLoad()
   }
 
-  // swiftlint:disable function_body_length
-  internal override func bindStyles() {
+    internal override func bindStyles() {
     super.bindStyles()
 
     _ = self
@@ -439,8 +438,7 @@ internal final class RewardPledgeViewController: UIViewController {
   }
   // swiftlint:enable function_body_length
 
-  // swiftlint:disable function_body_length
-  internal override func bindViewModel() {
+    internal override func bindViewModel() {
     super.bindViewModel()
 
     self.applePayButton.rac.hidden = self.viewModel.outputs.applePayButtonHidden

--- a/Kickstarter-iOS/Views/Controllers/RewardPledgeViewControllerTests.swift
+++ b/Kickstarter-iOS/Views/Controllers/RewardPledgeViewControllerTests.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable type_name
 // swiftlint:disable force_unwrapping
 import Library
 import Prelude

--- a/Kickstarter-iOS/Views/Controllers/SettingsViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/SettingsViewController.swift
@@ -5,7 +5,6 @@ import Prelude
 import SafariServices
 import UIKit
 
-// swiftlint:disable file_length
 // swiftlint:disable type_body_length
 internal final class SettingsViewController: UIViewController {
   fileprivate let viewModel: SettingsViewModelType = SettingsViewModel()

--- a/Kickstarter-iOS/Views/Controllers/SettingsViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/SettingsViewController.swift
@@ -5,7 +5,6 @@ import Prelude
 import SafariServices
 import UIKit
 
-// swiftlint:disable type_body_length
 internal final class SettingsViewController: UIViewController {
   fileprivate let viewModel: SettingsViewModelType = SettingsViewModel()
   fileprivate let helpViewModel: HelpViewModelType = HelpViewModel()

--- a/Kickstarter-iOS/Views/Controllers/SettingsViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/SettingsViewController.swift
@@ -128,8 +128,7 @@ internal final class SettingsViewController: UIViewController {
     self.viewModel.inputs.viewDidLoad()
   }
 
-  // swiftlint:disable function_body_length
-  internal override func bindStyles() {
+    internal override func bindStyles() {
     super.bindStyles()
 
     _ = self
@@ -310,8 +309,7 @@ internal final class SettingsViewController: UIViewController {
   }
   // swiftlint:enable function_body_length
 
-  // swiftlint:disable function_body_length
-  internal override func bindViewModel() {
+    internal override func bindViewModel() {
     super.bindViewModel()
 
     self.viewModel.outputs.goToAppStoreRating

--- a/Kickstarter-iOS/Views/Controllers/ThanksViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/ThanksViewController.swift
@@ -88,8 +88,7 @@ internal final class ThanksViewController: UIViewController, UICollectionViewDel
       |> UIBarButtonItem.lens.targetAction .~ (self, #selector(doneButtonTapped))
   }
 
-  // swiftlint:disable function_body_length
-  override func bindViewModel() {
+    override func bindViewModel() {
     super.bindViewModel()
 
     self.facebookButton.rac.hidden = self.viewModel.outputs.facebookButtonIsHidden

--- a/Kickstarter-iOS/Views/Controllers/UpdateDraftViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/UpdateDraftViewController.swift
@@ -58,8 +58,7 @@ internal final class UpdateDraftViewController: UIViewController {
     _ = self.separatorViews ||> separatorStyle
   }
 
-  // swiftlint:disable function_body_length
-  internal override func bindViewModel() {
+    internal override func bindViewModel() {
     super.bindViewModel()
 
     self.addAttachmentExpandedButton.rac.hidden =

--- a/Kickstarter-iOS/Views/Controllers/VideoViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/VideoViewController.swift
@@ -68,8 +68,7 @@ public final class VideoViewController: UIViewController {
       |> UIView.lens.backgroundColor .~ .black
   }
 
-  // swiftlint:disable function_body_length
-  public override func bindViewModel() {
+    public override func bindViewModel() {
     super.bindViewModel()
 
     self.playButton.rac.hidden = self.viewModel.outputs.playButtonHidden

--- a/Kickstarter-iOS/Views/FundingGraphView.swift
+++ b/Kickstarter-iOS/Views/FundingGraphView.swift
@@ -58,8 +58,7 @@ public final class FundingGraphView: UIView {
     }
   }
 
-  // swiftlint:disable function_body_length
-  public override func draw(_ rect: CGRect) {
+    public override func draw(_ rect: CGRect) {
     super.draw(rect)
 
     // Map the date and pledged amount to (dayNumber, pledgedAmount).

--- a/Kickstarter-iOS/Views/FundingGraphViewTests.swift
+++ b/Kickstarter-iOS/Views/FundingGraphViewTests.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable type_name
 // swiftlint:disable force_unwrapping
 import Library
 import Prelude

--- a/Kickstarter-iOS/Views/LiveStreamNavTitleViewTests.swift
+++ b/Kickstarter-iOS/Views/LiveStreamNavTitleViewTests.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable type_name
 // swiftlint:disable force_unwrapping
 import Prelude
 import Result

--- a/Kickstarter-iOS/Views/ReferralChartView.swift
+++ b/Kickstarter-iOS/Views/ReferralChartView.swift
@@ -24,8 +24,7 @@ public final class ReferralChartView: UIView {
     }
   }
 
-  // swiftlint:disable function_body_length
-  public override func draw(_ rect: CGRect) {
+    public override func draw(_ rect: CGRect) {
     super.draw(rect)
 
     guard let context = UIGraphicsGetCurrentContext() else { return }

--- a/Library/AppEnvironment.swift
+++ b/Library/AppEnvironment.swift
@@ -211,8 +211,7 @@ public struct AppEnvironment {
   }
 
   // Returns the last saved environment from user defaults.
-  // swiftlint:disable function_body_length
-  public static func fromStorage(ubiquitousStore: KeyValueStoreType,
+    public static func fromStorage(ubiquitousStore: KeyValueStoreType,
                                  userDefaults: KeyValueStoreType) -> Environment {
 
     let data = userDefaults.dictionary(forKey: environmentStorageKey) ?? [:]

--- a/Library/AppEnvironment.swift
+++ b/Library/AppEnvironment.swift
@@ -211,7 +211,7 @@ public struct AppEnvironment {
   }
 
   // Returns the last saved environment from user defaults.
-    public static func fromStorage(ubiquitousStore: KeyValueStoreType,
+  public static func fromStorage(ubiquitousStore: KeyValueStoreType,
                                  userDefaults: KeyValueStoreType) -> Environment {
 
     let data = userDefaults.dictionary(forKey: environmentStorageKey) ?? [:]

--- a/Library/ExpandableRow.swift
+++ b/Library/ExpandableRow.swift
@@ -6,8 +6,7 @@ public struct ExpandableRow {
   public let params: DiscoveryParams
   public let selectableRows: [SelectableRow]
 
-  // swiftlint:disable type_name
-  public enum lens {
+    public enum lens {
     public static let isExpanded = Lens<ExpandableRow, Bool>(
       view: { $0.isExpanded },
       set: { ExpandableRow(isExpanded: $0, params: $1.params, selectableRows: $1.selectableRows) }

--- a/Library/Format.swift
+++ b/Library/Format.swift
@@ -383,7 +383,6 @@ fileprivate func == (lhs: NumberFormatterConfig, rhs: NumberFormatterConfig) -> 
       && lhs.currencySymbol == rhs.currencySymbol
 }
 
-// swiftlint:disable type_name
 extension NumberFormatterConfig {
   fileprivate enum lens {
     fileprivate static let numberStyle = Lens<NumberFormatterConfig, NumberFormatter.Style>(

--- a/Library/Format.swift
+++ b/Library/Format.swift
@@ -1,4 +1,3 @@
-//swiftlint:disable file_length
 import Foundation
 import KsApi
 import Prelude

--- a/Library/FormatTests.swift
+++ b/Library/FormatTests.swift
@@ -1,5 +1,4 @@
 // swiftlint:disable force_unwrapping
-// swiftlint:disable file_length
 import XCTest
 import KsApi
 @testable import Library

--- a/Library/FormatTests.swift
+++ b/Library/FormatTests.swift
@@ -3,7 +3,6 @@ import XCTest
 import KsApi
 @testable import Library
 
-// swiftlint:disable function_body_length
 final class FormatTests: TestCase {
 
   func testWholeNumber() {

--- a/Library/Koala/Koala.swift
+++ b/Library/Koala/Koala.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable type_body_length
 import CoreTelephony
 import KsApi
 import LiveStream

--- a/Library/Koala/Koala.swift
+++ b/Library/Koala/Koala.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable file_length
 // swiftlint:disable type_body_length
 import CoreTelephony
 import KsApi

--- a/Library/Koala/Koala.swift
+++ b/Library/Koala/Koala.swift
@@ -2021,7 +2021,6 @@ private func shareTypeProperty(_ shareType: UIActivityType?) -> String? {
   #endif
 }
 
-// swiftlint:disable type_name
 extension Koala {
   public enum lens {
     public static let loggedInUser = Lens<Koala, User?>(

--- a/Library/Koala/KoalaTests.swift
+++ b/Library/Koala/KoalaTests.swift
@@ -1,7 +1,6 @@
 // swiftlint:disable force_cast
 // swiftlint:disable force_unwrapping
 // swiftlint:disable type_body_length
-// swiftlint:disable file_length
 import XCTest
 import Prelude
 @testable import KsApi

--- a/Library/Koala/KoalaTests.swift
+++ b/Library/Koala/KoalaTests.swift
@@ -1,6 +1,5 @@
 // swiftlint:disable force_cast
 // swiftlint:disable force_unwrapping
-// swiftlint:disable type_body_length
 import XCTest
 import Prelude
 @testable import KsApi

--- a/Library/Navigation.swift
+++ b/Library/Navigation.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable file_length
 import Argo
 import Runes
 import Curry

--- a/Library/NavigationTests.swift
+++ b/Library/NavigationTests.swift
@@ -1,5 +1,4 @@
 // swiftlint:disable force_unwrapping
-// swiftlint:disable function_body_length
 import KsApi
 import Prelude
 import XCTest

--- a/Library/PaginateTests.swift
+++ b/Library/PaginateTests.swift
@@ -1,6 +1,5 @@
 // swiftlint:disable force_unwrapping
 // swiftlint:disable function_body_length
-// swiftlint:disable type_body_length
 import XCTest
 @testable import Library
 import Prelude

--- a/Library/PaginateTests.swift
+++ b/Library/PaginateTests.swift
@@ -1,7 +1,6 @@
 // swiftlint:disable force_unwrapping
 // swiftlint:disable function_body_length
 // swiftlint:disable type_body_length
-// swiftlint:disable file_length
 import XCTest
 @testable import Library
 import Prelude

--- a/Library/PaginateTests.swift
+++ b/Library/PaginateTests.swift
@@ -1,5 +1,4 @@
 // swiftlint:disable force_unwrapping
-// swiftlint:disable function_body_length
 import XCTest
 @testable import Library
 import Prelude

--- a/Library/ProjectActivityData.swift
+++ b/Library/ProjectActivityData.swift
@@ -6,8 +6,7 @@ public struct ProjectActivityData {
   public let project: Project
   public let groupedDates: Bool
 
-  // swiftlint:disable type_name
-  public enum lens {
+    public enum lens {
     public static let activities = Lens<ProjectActivityData, [Activity]>(
       view: { $0.activities },
       set: { ProjectActivityData(activities: $0, project: $1.project, groupedDates: $1.groupedDates) }

--- a/Library/RefTag.swift
+++ b/Library/RefTag.swift
@@ -45,8 +45,7 @@ public enum RefTag {
 
    - returns: A ref tag.
    */
-  // swiftlint:disable function_body_length
-  // swiftlint:disable cyclomatic_complexity
+    // swiftlint:disable cyclomatic_complexity
   public init(code: String) {
     switch code {
     case "activity":                  self = .activity

--- a/Library/RefTagTests.swift
+++ b/Library/RefTagTests.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable function_body_length
 import XCTest
 @testable import Library
 

--- a/Library/SelectableRow.swift
+++ b/Library/SelectableRow.swift
@@ -5,8 +5,7 @@ public struct SelectableRow {
   public let isSelected: Bool
   public let params: DiscoveryParams
 
-  // swiftlint:disable type_name
-  public enum lens {
+    public enum lens {
     public static let isSelected = Lens<SelectableRow, Bool>(
       view: { $0.isSelected },
       set: { SelectableRow(isSelected: $0, params: $1.params) }

--- a/Library/SharedFunctionsTests.swift
+++ b/Library/SharedFunctionsTests.swift
@@ -1,5 +1,4 @@
 // swiftlint:disable force_unwrapping
-// swiftlint:disable function_body_length
 import Foundation
 import ReactiveSwift
 import Result

--- a/Library/Strings.swift
+++ b/Library/Strings.swift
@@ -6,7 +6,6 @@
 
 // swiftlint:disable valid_docs
 // swiftlint:disable line_length
-// swiftlint:disable type_body_length
 public enum Strings {
   /**
    "About %{reward_amount}"

--- a/Library/Strings.swift
+++ b/Library/Strings.swift
@@ -6,7 +6,6 @@
 
 // swiftlint:disable valid_docs
 // swiftlint:disable line_length
-// swiftlint:disable file_length
 // swiftlint:disable type_body_length
 public enum Strings {
   /**

--- a/Library/Styles/Colors.swift
+++ b/Library/Styles/Colors.swift
@@ -8,7 +8,6 @@ import UIKit
 
 // swiftlint:disable valid_docs
 // swiftlint:disable line_length
-// swiftlint:disable file_length
 // swiftlint:disable type_body_length
 extension UIColor {
   public static var ksr_allColors: [String: [Int: UIColor]] {

--- a/Library/Styles/Colors.swift
+++ b/Library/Styles/Colors.swift
@@ -8,7 +8,6 @@ import UIKit
 
 // swiftlint:disable valid_docs
 // swiftlint:disable line_length
-// swiftlint:disable type_body_length
 extension UIColor {
   public static var ksr_allColors: [String: [Int: UIColor]] {
     return [

--- a/Library/ViewModels/ActivitiesViewModel.swift
+++ b/Library/ViewModels/ActivitiesViewModel.swift
@@ -107,8 +107,7 @@ public protocol ActivitiesViewModelType {
 
 public final class ActivitiesViewModel: ActivitiesViewModelType, ActitiviesViewModelInputs,
 ActivitiesViewModelOutputs {
-  // swiftlint:disable function_body_length
-  public init() {
+    public init() {
     let isCloseToBottom = self.willDisplayRowProperty.signal.skipNil()
       .map { row, total in total > 3 && row >= total - 2 }
       .skipRepeats()

--- a/Library/ViewModels/ActivitiesViewModelTests.swift
+++ b/Library/ViewModels/ActivitiesViewModelTests.swift
@@ -1,5 +1,4 @@
 // swiftlint:disable force_unwrapping
-// swiftlint:disable file_length
 import XCTest
 @testable import Library
 @testable import KsApi

--- a/Library/ViewModels/ActivityFriendFollowCellViewModelTests.swift
+++ b/Library/ViewModels/ActivityFriendFollowCellViewModelTests.swift
@@ -8,7 +8,6 @@ import UIKit.UIActivity
 @testable import Library
 import Prelude
 
-// swiftlint:disable type_name
 final class ActivityFriendFollowCellViewModelTests: TestCase {
   // swiftlint:enable type_name
   let vm: ActivityFriendFollowCellViewModel = ActivityFriendFollowCellViewModel()

--- a/Library/ViewModels/BackingViewModel.swift
+++ b/Library/ViewModels/BackingViewModel.swift
@@ -96,8 +96,7 @@ public protocol BackingViewModelType {
 
 public final class BackingViewModel: BackingViewModelType, BackingViewModelInputs, BackingViewModelOutputs {
 
-  // swiftlint:disable function_body_length
-  public init() {
+    public init() {
     let projectAndBackerAndBackerIsCurrentUser = Signal.combineLatest(
       self.projectAndBackerProperty.signal.skipNil(),
       self.viewDidLoadProperty.signal

--- a/Library/ViewModels/BackingViewModelTests.swift
+++ b/Library/ViewModels/BackingViewModelTests.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable type_body_length
 // swiftlint:disable force_unwrapping
 import Prelude
 import ReactiveSwift

--- a/Library/ViewModels/BackingViewModelTests.swift
+++ b/Library/ViewModels/BackingViewModelTests.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable file_length
 // swiftlint:disable type_body_length
 // swiftlint:disable force_unwrapping
 import Prelude

--- a/Library/ViewModels/CheckoutViewModel.swift
+++ b/Library/ViewModels/CheckoutViewModel.swift
@@ -92,8 +92,7 @@ public final class CheckoutViewModel: CheckoutViewModelType {
 
   fileprivate let checkoutRacingViewModel: CheckoutRacingViewModelType = CheckoutRacingViewModel()
 
-  // swiftlint:disable function_body_length
-  // swiftlint:disable cyclomatic_complexity
+    // swiftlint:disable cyclomatic_complexity
   public init() {
     let configData = self.configDataProperty.signal.skipNil()
       .takeWhen(self.viewDidLoadProperty.signal)

--- a/Library/ViewModels/CheckoutViewModel.swift
+++ b/Library/ViewModels/CheckoutViewModel.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable file_length
 import Argo
 import Runes
 import KsApi

--- a/Library/ViewModels/CheckoutViewModelTests.swift
+++ b/Library/ViewModels/CheckoutViewModelTests.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable function_body_length
 // swiftlint:disable force_unwrapping
 import XCTest
 @testable import Library

--- a/Library/ViewModels/CheckoutViewModelTests.swift
+++ b/Library/ViewModels/CheckoutViewModelTests.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable type_body_length
 // swiftlint:disable function_body_length
 // swiftlint:disable force_unwrapping
 import XCTest

--- a/Library/ViewModels/CheckoutViewModelTests.swift
+++ b/Library/ViewModels/CheckoutViewModelTests.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable file_length
 // swiftlint:disable type_body_length
 // swiftlint:disable function_body_length
 // swiftlint:disable force_unwrapping

--- a/Library/ViewModels/CommentDialogViewModel.swift
+++ b/Library/ViewModels/CommentDialogViewModel.swift
@@ -118,8 +118,7 @@ CommentDialogViewModelOutputs, CommentDialogViewModelErrors {
   public var outputs: CommentDialogViewModelOutputs { return self }
   public var errors: CommentDialogViewModelErrors { return self }
 
-  // swiftlint:disable function_body_length
-  public init() {
+    public init() {
     let isLoading = MutableProperty(false)
 
     let configurationData = self.configurationDataProperty.signal.skipNil()

--- a/Library/ViewModels/CommentsViewModel.swift
+++ b/Library/ViewModels/CommentsViewModel.swift
@@ -59,8 +59,7 @@ public protocol CommentsViewModelType {
 public final class CommentsViewModel: CommentsViewModelType, CommentsViewModelInputs,
 CommentsViewModelOutputs {
 
-  // swiftlint:disable function_body_length
-  public init() {
+    public init() {
     let projectOrUpdate = Signal.combineLatest(
       self.projectAndUpdateProperty.signal.skipNil(),
       self.viewDidLoadProperty.signal

--- a/Library/ViewModels/CommentsViewModelTests.swift
+++ b/Library/ViewModels/CommentsViewModelTests.swift
@@ -1,5 +1,4 @@
 // swiftlint:disable force_unwrapping
-// swiftlint:disable file_length
 // swiftlint:disable type_body_length
 import XCTest
 import Result

--- a/Library/ViewModels/CommentsViewModelTests.swift
+++ b/Library/ViewModels/CommentsViewModelTests.swift
@@ -1,5 +1,4 @@
 // swiftlint:disable force_unwrapping
-// swiftlint:disable type_body_length
 import XCTest
 import Result
 import ReactiveSwift

--- a/Library/ViewModels/DashboardFundingCellViewModel.swift
+++ b/Library/ViewModels/DashboardFundingCellViewModel.swift
@@ -72,8 +72,7 @@ public final class DashboardFundingCellViewModel: DashboardFundingCellViewModelI
 
   public static let tickCount = 4
 
-  // swiftlint:disable function_body_length
-  public init() {
+    public init() {
     let statsProject = self.statsProjectProperty.signal.skipNil()
 
     self.backersText = statsProject.map { _, project in Format.wholeNumber(project.stats.backersCount) }

--- a/Library/ViewModels/DashboardProjectsDrawerCellViewModelTests.swift
+++ b/Library/ViewModels/DashboardProjectsDrawerCellViewModelTests.swift
@@ -6,8 +6,7 @@ import Prelude
 @testable import Library
 @testable import ReactiveExtensions_TestHelpers
 
-  // swiftlint:disable type_name
-internal final class DashboardProjectsDrawerCellViewModelTests: TestCase {
+  internal final class DashboardProjectsDrawerCellViewModelTests: TestCase {
   // swiftlint:enable type_name
   internal let vm: DashboardProjectsDrawerCellViewModelType = DashboardProjectsDrawerCellViewModel()
 

--- a/Library/ViewModels/DashboardReferrerRowStackViewViewModelTests.swift
+++ b/Library/ViewModels/DashboardReferrerRowStackViewViewModelTests.swift
@@ -7,7 +7,6 @@ import XCTest
 @testable import ReactiveExtensions
 @testable import ReactiveExtensions_TestHelpers
 
-// swiftlint:disable type_name
 internal final class DashboardReferrersRowStackViewViewModelTests: TestCase {
   // swiftlint:enable type_name
   internal let vm = DashboardReferrerRowStackViewViewModel()

--- a/Library/ViewModels/DashboardReferrersCellViewModel.swift
+++ b/Library/ViewModels/DashboardReferrersCellViewModel.swift
@@ -85,8 +85,7 @@ public protocol DashboardReferrersCellViewModelType {
 public final class DashboardReferrersCellViewModel: DashboardReferrersCellViewModelInputs,
   DashboardReferrersCellViewModelOutputs, DashboardReferrersCellViewModelType {
 
-  // swiftlint:disable function_body_length
-  public init() {
+    public init() {
     let cumulativeProjectStats = cumulativeProjectStatsProperty.signal.skipNil()
 
     let country = cumulativeProjectStats.map { _, project, _ in project.country }

--- a/Library/ViewModels/DashboardReferrersCellViewModelTests.swift
+++ b/Library/ViewModels/DashboardReferrersCellViewModelTests.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable function_body_length
 import Prelude
 import ReactiveSwift
 import Result

--- a/Library/ViewModels/DashboardRewardRowStackViewViewModelTests.swift
+++ b/Library/ViewModels/DashboardRewardRowStackViewViewModelTests.swift
@@ -7,8 +7,7 @@ import Prelude
 @testable import ReactiveExtensions
 @testable import ReactiveExtensions_TestHelpers
 
-  // swiftlint:disable type_name
-internal final class DashboardRewardRowStackViewViewModelTests: TestCase {
+  internal final class DashboardRewardRowStackViewViewModelTests: TestCase {
   // swiftlint:enable type_name
   let vm: DashboardRewardRowStackViewViewModelType = DashboardRewardRowStackViewViewModel()
 

--- a/Library/ViewModels/DashboardRewardsCellViewModel.swift
+++ b/Library/ViewModels/DashboardRewardsCellViewModel.swift
@@ -53,8 +53,7 @@ public protocol DashboardRewardsCellViewModelType {
 
 public final class DashboardRewardsCellViewModel: DashboardRewardsCellViewModelType,
   DashboardRewardsCellViewModelInputs, DashboardRewardsCellViewModelOutputs {
-  // swiftlint:disable function_body_length
-  public init() {
+    public init() {
     let statsProject = self.statsProjectProperty.signal.skipNil()
 
     let rewards = statsProject

--- a/Library/ViewModels/DashboardTitleViewViewModelTests.swift
+++ b/Library/ViewModels/DashboardTitleViewViewModelTests.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable function_body_length
 import XCTest
 import Result
 import ReactiveSwift

--- a/Library/ViewModels/DashboardViewModel.swift
+++ b/Library/ViewModels/DashboardViewModel.swift
@@ -87,8 +87,7 @@ public protocol DashboardViewModelType {
 public final class DashboardViewModel: DashboardViewModelInputs, DashboardViewModelOutputs,
   DashboardViewModelType {
 
-  // swiftlint:disable function_body_length
-  public init() {
+    public init() {
     let projects = self.viewWillAppearAnimatedProperty.signal.filter(isFalse).ignoreValues()
       .switchMap {
         AppEnvironment.current.apiService.fetchProjects(member: true)

--- a/Library/ViewModels/DashboardViewModelTests.swift
+++ b/Library/ViewModels/DashboardViewModelTests.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable function_body_length
 // swiftlint:disable force_unwrapping
 import Prelude
 import ReactiveSwift

--- a/Library/ViewModels/DashboardViewModelTests.swift
+++ b/Library/ViewModels/DashboardViewModelTests.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable file_length
 // swiftlint:disable function_body_length
 // swiftlint:disable force_unwrapping
 import Prelude

--- a/Library/ViewModels/DiscoveryFiltersViewModel.swift
+++ b/Library/ViewModels/DiscoveryFiltersViewModel.swift
@@ -55,8 +55,7 @@ public protocol DiscoveryFiltersViewModelType {
 public final class DiscoveryFiltersViewModel: DiscoveryFiltersViewModelType,
   DiscoveryFiltersViewModelInputs, DiscoveryFiltersViewModelOutputs {
 
-  // swiftlint:disable function_body_length
-  public init() {
+    public init() {
 
     let initialTopFilters = self.viewDidLoadProperty.signal
       .take(first: 1)

--- a/Library/ViewModels/DiscoveryFiltersViewModelTests.swift
+++ b/Library/ViewModels/DiscoveryFiltersViewModelTests.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable file_length
 @testable import ReactiveExtensions_TestHelpers
 @testable import KsApi
 @testable import Library

--- a/Library/ViewModels/DiscoveryNavigationHeaderViewModel.swift
+++ b/Library/ViewModels/DiscoveryNavigationHeaderViewModel.swift
@@ -91,8 +91,7 @@ public protocol DiscoveryNavigationHeaderViewModelType {
 public final class DiscoveryNavigationHeaderViewModel: DiscoveryNavigationHeaderViewModelType,
   DiscoveryNavigationHeaderViewModelInputs, DiscoveryNavigationHeaderViewModelOutputs {
 
-  // swiftlint:disable function_body_length
-  public init() {
+    public init() {
     let currentParams = Signal.merge(
       self.paramsProperty.signal.skipNil(),
       self.filtersSelectedRowProperty.signal.skipNil().map { $0.params }

--- a/Library/ViewModels/DiscoveryNavigationHeaderViewModelTests.swift
+++ b/Library/ViewModels/DiscoveryNavigationHeaderViewModelTests.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable type_body_length
 // swiftlint:disable function_body_length
 import Prelude
 import ReactiveSwift

--- a/Library/ViewModels/DiscoveryNavigationHeaderViewModelTests.swift
+++ b/Library/ViewModels/DiscoveryNavigationHeaderViewModelTests.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable file_length
 // swiftlint:disable type_body_length
 // swiftlint:disable function_body_length
 import Prelude

--- a/Library/ViewModels/DiscoveryNavigationHeaderViewModelTests.swift
+++ b/Library/ViewModels/DiscoveryNavigationHeaderViewModelTests.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable function_body_length
 import Prelude
 import ReactiveSwift
 import Result

--- a/Library/ViewModels/DiscoveryPageViewModel.swift
+++ b/Library/ViewModels/DiscoveryPageViewModel.swift
@@ -91,8 +91,7 @@ public protocol DiscoveryPageViewModelType {
 public final class DiscoveryPageViewModel: DiscoveryPageViewModelType, DiscoveryPageViewModelInputs,
   DiscoveryPageViewModelOutputs {
 
-  // swiftlint:disable function_body_length
-  public init() {
+    public init() {
     let currentUser = Signal.merge(
       self.userSessionStartedProperty.signal,
       self.userSessionEndedProperty.signal,

--- a/Library/ViewModels/DiscoveryPageViewModelTests.swift
+++ b/Library/ViewModels/DiscoveryPageViewModelTests.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable file_length
 // swiftlint:disable type_body_length
 // swiftlint:disable function_body_length
 @testable import KsApi

--- a/Library/ViewModels/DiscoveryPageViewModelTests.swift
+++ b/Library/ViewModels/DiscoveryPageViewModelTests.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable function_body_length
 @testable import KsApi
 @testable import Library
 @testable import ReactiveExtensions_TestHelpers

--- a/Library/ViewModels/DiscoveryPageViewModelTests.swift
+++ b/Library/ViewModels/DiscoveryPageViewModelTests.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable type_body_length
 // swiftlint:disable function_body_length
 @testable import KsApi
 @testable import Library

--- a/Library/ViewModels/DiscoveryPostcardViewModel.swift
+++ b/Library/ViewModels/DiscoveryPostcardViewModel.swift
@@ -133,8 +133,7 @@ public protocol DiscoveryPostcardViewModelType {
 public final class DiscoveryPostcardViewModel: DiscoveryPostcardViewModelType,
   DiscoveryPostcardViewModelInputs, DiscoveryPostcardViewModelOutputs {
 
-  // swiftlint:disable function_body_length
-  public init() {
+    public init() {
     let project = self.projectProperty.signal.skipNil()
 
     let backersTitleAndSubtitleText = project.map { project -> (String?, String?) in

--- a/Library/ViewModels/DiscoveryPostcardViewModelTests.swift
+++ b/Library/ViewModels/DiscoveryPostcardViewModelTests.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable function_body_length
 import Prelude
 import Result
 import XCTest

--- a/Library/ViewModels/EmptyStatesViewModel.swift
+++ b/Library/ViewModels/EmptyStatesViewModel.swift
@@ -77,8 +77,7 @@ public protocol EmptyStatesViewModelType {
 public final class EmptyStatesViewModel: EmptyStatesViewModelType, EmptyStatesViewModelInputs,
   EmptyStatesViewModelOutputs {
 
-  // swiftlint:disable function_body_length
-  public init() {
+    public init() {
     let emptyState = Signal.combineLatest(
       self.emptyStateProperty.signal.skipNil(),
       self.viewWillAppearProperty.signal.take(first: 1)

--- a/Library/ViewModels/FindFriendsFacebookConnectCellViewModel.swift
+++ b/Library/ViewModels/FindFriendsFacebookConnectCellViewModel.swift
@@ -58,8 +58,7 @@ public protocol FindFriendsFacebookConnectCellViewModelType {
 
 public final class FindFriendsFacebookConnectCellViewModel: FindFriendsFacebookConnectCellViewModelType,
   FindFriendsFacebookConnectCellViewModelInputs, FindFriendsFacebookConnectCellViewModelOutputs {
-  // swiftlint:disable function_body_length
-  public init() {
+    public init() {
     self.notifyDelegateToDismissHeader = self.closeButtonTappedProperty.signal
 
     let isLoading = MutableProperty(false)

--- a/Library/ViewModels/FindFriendsFaceookConnectCellViewModelTests.swift
+++ b/Library/ViewModels/FindFriendsFaceookConnectCellViewModelTests.swift
@@ -10,8 +10,7 @@ import UIKit.UIActivity
 @testable import Library
 @testable import FBSDKLoginKit
 
-  // swiftlint:disable type_name
-final class FindFriendsFacebookConnectCellViewModelTests: TestCase {
+  final class FindFriendsFacebookConnectCellViewModelTests: TestCase {
   // swiftlint: enable type_name
   let vm: FindFriendsFacebookConnectCellViewModelType = FindFriendsFacebookConnectCellViewModel()
 

--- a/Library/ViewModels/FindFriendsFriendFollowCellViewModel.swift
+++ b/Library/ViewModels/FindFriendsFriendFollowCellViewModel.swift
@@ -54,8 +54,7 @@ public protocol FindFriendsFriendFollowCellViewModelType {
 
 public final class FindFriendsFriendFollowCellViewModel: FindFriendsFriendFollowCellViewModelType,
   FindFriendsFriendFollowCellViewModelInputs, FindFriendsFriendFollowCellViewModelOutputs {
-  // swiftlint:disable function_body_length
-  public init() {
+    public init() {
     let friend = self.configureWithFriendProperty.signal.skipNil()
       .map(cached(friend:))
 

--- a/Library/ViewModels/FindFriendsFriendFollowCellViewModelTests.swift
+++ b/Library/ViewModels/FindFriendsFriendFollowCellViewModelTests.swift
@@ -10,7 +10,6 @@ import UIKit.UIActivity
 @testable import Library
 import Prelude
 
-// swiftlint:disable type_name
 final class FindFriendsFriendFollowCellViewModelTests: TestCase {
   // swiftlint:enable type_name
   let vm: FindFriendsFriendFollowCellViewModelType = FindFriendsFriendFollowCellViewModel()

--- a/Library/ViewModels/FindFriendsFriendFollowCellViewModelTests.swift
+++ b/Library/ViewModels/FindFriendsFriendFollowCellViewModelTests.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable function_body_length
 // swiftlint:disable force_cast
 import XCTest
 import ReactiveSwift

--- a/Library/ViewModels/FindFriendsViewModel.swift
+++ b/Library/ViewModels/FindFriendsViewModel.swift
@@ -70,8 +70,7 @@ public protocol FindFriendsViewModelType {
 public final class FindFriendsViewModel: FindFriendsViewModelType, FindFriendsViewModelInputs,
   FindFriendsViewModelOutputs {
 
-  // swiftlint:disable function_body_length
-  public init() {
+    public init() {
     let source = self.configureWithProperty.signal
 
     let followAll = self.confirmFollowAllFriendsProperty.signal

--- a/Library/ViewModels/HelpViewModel.swift
+++ b/Library/ViewModels/HelpViewModel.swift
@@ -64,8 +64,7 @@ public protocol HelpViewModelType {
 }
 
 public final class HelpViewModel: HelpViewModelType, HelpViewModelInputs, HelpViewModelOutputs {
-  // swiftlint:disable function_body_length
-  public init() {
+    public init() {
     let context = self.helpContextProperty.signal.skipNil()
     let canSendEmail = self.canSendEmailProperty.signal.skipNil()
     let helpTypeTapped = self.helpTypeButtonTappedProperty.signal.skipNil()

--- a/Library/ViewModels/HelpViewModelTests.swift
+++ b/Library/ViewModels/HelpViewModelTests.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable function_body_length
 // swiftlint:disable force_cast
 @testable import Library
 @testable import ReactiveExtensions_TestHelpers

--- a/Library/ViewModels/LiveStreamChatViewModelTests.swift
+++ b/Library/ViewModels/LiveStreamChatViewModelTests.swift
@@ -1,4 +1,3 @@
-//swiftlint:disable file_length
 import Prelude
 import ReactiveSwift
 import Result

--- a/Library/ViewModels/LiveStreamContainerViewModel.swift
+++ b/Library/ViewModels/LiveStreamContainerViewModel.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable file_length
 import KsApi
 import LiveStream
 import ReactiveSwift

--- a/Library/ViewModels/LiveStreamContainerViewModel.swift
+++ b/Library/ViewModels/LiveStreamContainerViewModel.swift
@@ -84,8 +84,7 @@ public protocol LiveStreamContainerViewModelOutputs {
 public final class LiveStreamContainerViewModel: LiveStreamContainerViewModelType,
 LiveStreamContainerViewModelInputs, LiveStreamContainerViewModelOutputs {
 
-  //swiftlint:disable function_body_length
-  //swiftlint:disable cyclomatic_complexity
+    //swiftlint:disable cyclomatic_complexity
   public init() {
     let configData = Signal.combineLatest(
       self.configData.signal.skipNil(),

--- a/Library/ViewModels/LiveStreamContainerViewModelTests.swift
+++ b/Library/ViewModels/LiveStreamContainerViewModelTests.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable file_length
 // swiftlint:disable type_body_length
 import Prelude
 import ReactiveSwift

--- a/Library/ViewModels/LiveStreamContainerViewModelTests.swift
+++ b/Library/ViewModels/LiveStreamContainerViewModelTests.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable type_body_length
 import Prelude
 import ReactiveSwift
 import Result

--- a/Library/ViewModels/LiveStreamDiscoveryLiveNowCellViewModelTests.swift
+++ b/Library/ViewModels/LiveStreamDiscoveryLiveNowCellViewModelTests.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable type_name
 import Prelude
 import ReactiveSwift
 import XCTest

--- a/Library/ViewModels/LiveStreamDiscoveryUpcomingAndReplayCellViewModel.swift
+++ b/Library/ViewModels/LiveStreamDiscoveryUpcomingAndReplayCellViewModel.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable type_name
 import LiveStream
 import Prelude
 import ReactiveSwift

--- a/Library/ViewModels/LiveStreamEventDetailsViewModelTests.swift
+++ b/Library/ViewModels/LiveStreamEventDetailsViewModelTests.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable function_body_length
 import Prelude
 import ReactiveSwift
 import Result

--- a/Library/ViewModels/LoginToutViewModel.swift
+++ b/Library/ViewModels/LoginToutViewModel.swift
@@ -83,8 +83,7 @@ public protocol LoginToutViewModelType {
 public final class LoginToutViewModel: LoginToutViewModelType, LoginToutViewModelInputs,
   LoginToutViewModelOutputs {
 
-  // swiftlint:disable function_body_length
-  public init() {
+    public init() {
 
     let intent = self.loginIntentProperty.signal.skipNil()
       .takeWhen(self.viewWillAppearProperty.signal)

--- a/Library/ViewModels/LoginToutViewModelTests.swift
+++ b/Library/ViewModels/LoginToutViewModelTests.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable file_length
 // swiftlint:disable force_unwrapping
 import XCTest
 @testable import KsApi

--- a/Library/ViewModels/LoginViewModel.swift
+++ b/Library/ViewModels/LoginViewModel.swift
@@ -91,8 +91,7 @@ public protocol LoginViewModelType {
 
 public final class LoginViewModel: LoginViewModelType, LoginViewModelInputs, LoginViewModelOutputs {
 
-  // swiftlint:disable function_body_length
-  public init() {
+    public init() {
     let emailAndPassword = Signal.combineLatest(
       .merge(self.emailChangedProperty.signal.skipNil(), self.prefillEmailProperty.signal.skipNil()),
       .merge(self.passwordChangedProperty.signal.skipNil(), self.prefillPasswordProperty.signal.skipNil())

--- a/Library/ViewModels/MessageDialogViewModel.swift
+++ b/Library/ViewModels/MessageDialogViewModel.swift
@@ -51,8 +51,7 @@ public protocol MessageDialogViewModelType {
 public final class MessageDialogViewModel: MessageDialogViewModelType, MessageDialogViewModelInputs,
 MessageDialogViewModelOutputs {
 
-  // swiftlint:disable function_body_length
-  public init() {
+    public init() {
     let messageSubject = self.messageSubjectProperty.signal.skipNil()
       .takeWhen(self.viewDidLoadProperty.signal)
 

--- a/Library/ViewModels/MessageThreadsViewModel.swift
+++ b/Library/ViewModels/MessageThreadsViewModel.swift
@@ -57,8 +57,7 @@ public protocol MessageThreadsViewModelType {
 public final class MessageThreadsViewModel: MessageThreadsViewModelType, MessageThreadsViewModelInputs,
 MessageThreadsViewModelOutputs {
 
-  // swiftlint:disable function_body_length
-  public init() {
+    public init() {
     let isCloseToBottom = self.willDisplayRowProperty.signal.skipNil()
       .filter { _, total in total > 1 }
       .map { row, total in row >= total - 3 }

--- a/Library/ViewModels/MessagesSearchViewModel.swift
+++ b/Library/ViewModels/MessagesSearchViewModel.swift
@@ -53,8 +53,7 @@ public protocol MessagesSearchViewModelType {
 public final class MessagesSearchViewModel: MessagesSearchViewModelType, MessagesSearchViewModelInputs,
 MessagesSearchViewModelOutputs {
 
-  // swiftlint:disable function_body_length
-  public init() {
+    public init() {
     let isLoading = MutableProperty(false)
 
     let project = self.projectProperty.producer

--- a/Library/ViewModels/MessagesSearchViewModelTests.swift
+++ b/Library/ViewModels/MessagesSearchViewModelTests.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable function_body_length
 // swiftlint:disable force_cast
 import XCTest
 @testable import Library

--- a/Library/ViewModels/MessagesViewModel.swift
+++ b/Library/ViewModels/MessagesViewModel.swift
@@ -54,8 +54,7 @@ public protocol MessagesViewModelType {
 public final class MessagesViewModel: MessagesViewModelType, MessagesViewModelInputs,
 MessagesViewModelOutputs {
 
-  // swiftlint:disable function_body_length
-  public init() {
+    public init() {
     let configData = self.configData.signal.skipNil()
       .takeWhen(self.viewDidLoadProperty.signal)
 

--- a/Library/ViewModels/MessagesViewModelTests.swift
+++ b/Library/ViewModels/MessagesViewModelTests.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable function_body_length
 // swiftlint:disable force_cast
 import XCTest
 @testable import Library

--- a/Library/ViewModels/ProjectActivitiesViewModel.swift
+++ b/Library/ViewModels/ProjectActivitiesViewModel.swift
@@ -69,8 +69,7 @@ public protocol ProjectActivitiesViewModelType {
 public final class ProjectActivitiesViewModel: ProjectActivitiesViewModelType,
   ProjectActivitiesViewModelInputs, ProjectActivitiesViewModelOutputs {
 
-  // swiftlint:disable function_body_length
-  public init() {
+    public init() {
     let project = self.projectProperty.signal.skipNil()
 
     let isCloseToBottom = self.willDisplayRowProperty.signal.skipNil()

--- a/Library/ViewModels/ProjectActivitiesViewModelTests.swift
+++ b/Library/ViewModels/ProjectActivitiesViewModelTests.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable function_body_length
 import XCTest
 @testable import Library
 @testable import KsApi

--- a/Library/ViewModels/ProjectActivityBackingCellViewModel.swift
+++ b/Library/ViewModels/ProjectActivityBackingCellViewModel.swift
@@ -70,8 +70,7 @@ public protocol ProjectActivityBackingCellViewModelType {
 public final class ProjectActivityBackingCellViewModel: ProjectActivityBackingCellViewModelType,
 ProjectActivityBackingCellViewModelInputs, ProjectActivityBackingCellViewModelOutputs {
 
-  // swiftlint:disable function_body_length
-  public init() {
+    public init() {
     let activityAndProject = self.activityAndProjectProperty.signal.skipNil()
     let activity = activityAndProject.map(first)
     let title = activity.map(title(activity:))

--- a/Library/ViewModels/ProjectActivityBackingCellViewModelTests.swift
+++ b/Library/ViewModels/ProjectActivityBackingCellViewModelTests.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable function_body_length
 // swiftlint:disable force_unwrapping
 import XCTest
 @testable import KsApi

--- a/Library/ViewModels/ProjectActivityBackingCellViewModelTests.swift
+++ b/Library/ViewModels/ProjectActivityBackingCellViewModelTests.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable type_body_length
 // swiftlint:disable function_body_length
 // swiftlint:disable force_unwrapping
 import XCTest

--- a/Library/ViewModels/ProjectActivityBackingCellViewModelTests.swift
+++ b/Library/ViewModels/ProjectActivityBackingCellViewModelTests.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable file_length
 // swiftlint:disable type_body_length
 // swiftlint:disable function_body_length
 // swiftlint:disable force_unwrapping

--- a/Library/ViewModels/ProjectActivityNegativeStateChangeCellViewModel.swift
+++ b/Library/ViewModels/ProjectActivityNegativeStateChangeCellViewModel.swift
@@ -19,7 +19,6 @@ public protocol ProjectActivityNegativeStateChangeCellViewModelType {
   var outputs: ProjectActivityNegativeStateChangeCellViewModelOutputs { get }
 }
 
-// swiftlint:disable type_name
 public final class ProjectActivityNegativeStateChangeCellViewModel:
 ProjectActivityNegativeStateChangeCellViewModelType, ProjectActivityNegativeStateChangeCellViewModelInputs,
 ProjectActivityNegativeStateChangeCellViewModelOutputs {

--- a/Library/ViewModels/ProjectActivityNegativeStateChangeCellViewModelTests.swift
+++ b/Library/ViewModels/ProjectActivityNegativeStateChangeCellViewModelTests.swift
@@ -5,7 +5,6 @@ import XCTest
 import Prelude
 import Result
 
-// swiftlint:disable type_name
 internal final class ProjectActivityNegativeStateChangeCellViewModelTests: TestCase {
   fileprivate let vm: ProjectActivityNegativeStateChangeCellViewModel =
     ProjectActivityNegativeStateChangeCellViewModel()
@@ -81,4 +80,3 @@ internal final class ProjectActivityNegativeStateChangeCellViewModelTests: TestC
     self.title.assertValues([expected], "Emits title indicating the project was suspended")
   }
 }
-// swiftlint:disable type_name

--- a/Library/ViewModels/ProjectNavBarViewModel.swift
+++ b/Library/ViewModels/ProjectNavBarViewModel.swift
@@ -63,8 +63,7 @@ public protocol ProjectNavBarViewModelType {
 public final class ProjectNavBarViewModel: ProjectNavBarViewModelType,
 ProjectNavBarViewModelInputs, ProjectNavBarViewModelOutputs {
 
-  // swiftlint:disable function_body_length
-  public init() {
+    public init() {
     let configuredProjectAndRefTag = Signal.combineLatest(
       self.projectAndRefTagProperty.signal.skipNil(),
       self.viewDidLoadProperty.signal

--- a/Library/ViewModels/ProjectNavigatorViewModelTests.swift
+++ b/Library/ViewModels/ProjectNavigatorViewModelTests.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable function_body_length
 // swiftlint:disable force_unwrapping
 @testable import KsApi
 @testable import Library

--- a/Library/ViewModels/ProjectNotificationCellViewModel.swift
+++ b/Library/ViewModels/ProjectNotificationCellViewModel.swift
@@ -31,8 +31,7 @@ public protocol ProjectNotificationCellViewModelType {
 public final class ProjectNotificationCellViewModel: ProjectNotificationCellViewModelType,
   ProjectNotificationCellViewModelInputs, ProjectNotificationCellViewModelOutputs {
 
-  // swiftlint:disable function_body_length
-  public init() {
+    public init() {
     let notification = self.notificationProperty.signal.skipNil()
       .map(cached(notification:))
 

--- a/Library/ViewModels/ProjectPamphletContentViewModelTests.swift
+++ b/Library/ViewModels/ProjectPamphletContentViewModelTests.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable file_length
 // swiftlint:disable type_body_length
 import Prelude
 import ReactiveSwift

--- a/Library/ViewModels/ProjectPamphletContentViewModelTests.swift
+++ b/Library/ViewModels/ProjectPamphletContentViewModelTests.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable type_body_length
 import Prelude
 import ReactiveSwift
 import Result

--- a/Library/ViewModels/ProjectPamphletMainCellViewModel.swift
+++ b/Library/ViewModels/ProjectPamphletMainCellViewModel.swift
@@ -111,8 +111,7 @@ public protocol ProjectPamphletMainCellViewModelType {
 public final class ProjectPamphletMainCellViewModel: ProjectPamphletMainCellViewModelType,
 ProjectPamphletMainCellViewModelInputs, ProjectPamphletMainCellViewModelOutputs {
 
-  // swiftlint:disable function_body_length
-  public init() {
+    public init() {
     let project = self.projectProperty.signal.skipNil()
 
     self.projectNameLabelText = project.map(Project.lens.name.view)

--- a/Library/ViewModels/ProjectPamphletViewModelTests.swift
+++ b/Library/ViewModels/ProjectPamphletViewModelTests.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable type_body_length
 // swiftlint:disable function_body_length
 import Prelude
 import ReactiveSwift

--- a/Library/ViewModels/ProjectPamphletViewModelTests.swift
+++ b/Library/ViewModels/ProjectPamphletViewModelTests.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable file_length
 // swiftlint:disable type_body_length
 // swiftlint:disable function_body_length
 import Prelude

--- a/Library/ViewModels/ProjectPamphletViewModelTests.swift
+++ b/Library/ViewModels/ProjectPamphletViewModelTests.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable function_body_length
 import Prelude
 import ReactiveSwift
 import Result

--- a/Library/ViewModels/RewardCellViewModel.swift
+++ b/Library/ViewModels/RewardCellViewModel.swift
@@ -46,8 +46,7 @@ public protocol RewardCellViewModelType {
 public final class RewardCellViewModel: RewardCellViewModelType, RewardCellViewModelInputs,
 RewardCellViewModelOutputs {
 
-  // swiftlint:disable function_body_length
-  public init() {
+    public init() {
     let projectAndRewardOrBacking = self.projectAndRewardOrBackingProperty.signal.skipNil()
     let project = projectAndRewardOrBacking.map(first)
     let reward = projectAndRewardOrBacking

--- a/Library/ViewModels/RewardCellViewModelTests.swift
+++ b/Library/ViewModels/RewardCellViewModelTests.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable file_length
 // swiftlint:disable type_body_length
 import Prelude
 import ReactiveSwift

--- a/Library/ViewModels/RewardCellViewModelTests.swift
+++ b/Library/ViewModels/RewardCellViewModelTests.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable type_body_length
 import Prelude
 import ReactiveSwift
 import ReactiveExtensions

--- a/Library/ViewModels/RewardPledgeViewModel.swift
+++ b/Library/ViewModels/RewardPledgeViewModel.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable file_length
 import KsApi
 import PassKit
 import Prelude

--- a/Library/ViewModels/RewardPledgeViewModel.swift
+++ b/Library/ViewModels/RewardPledgeViewModel.swift
@@ -206,7 +206,6 @@ public protocol RewardPledgeViewModelType {
   var outputs: RewardPledgeViewModelOutputs { get }
 }
 
-// swiftlint:disable type_body_length
 public final class RewardPledgeViewModel: RewardPledgeViewModelType, RewardPledgeViewModelInputs,
 RewardPledgeViewModelOutputs {
 

--- a/Library/ViewModels/RewardPledgeViewModel.swift
+++ b/Library/ViewModels/RewardPledgeViewModel.swift
@@ -211,8 +211,7 @@ RewardPledgeViewModelOutputs {
 
   fileprivate let rewardViewModel: RewardCellViewModelType = RewardCellViewModel()
 
-  // swiftlint:disable function_body_length
-  public init() {
+    public init() {
     let projectAndRewardAndApplePayCapable = Signal.combineLatest(
       self.projectAndRewardAndApplePayCapableProperty.signal.skipNil(),
       self.viewDidLoadProperty.signal

--- a/Library/ViewModels/RewardPledgeViewModelTests.swift
+++ b/Library/ViewModels/RewardPledgeViewModelTests.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable type_body_length
 // swiftlint:disable function_body_length
 // swiftlint:disable force_unwrapping
 import PassKit

--- a/Library/ViewModels/RewardPledgeViewModelTests.swift
+++ b/Library/ViewModels/RewardPledgeViewModelTests.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable function_body_length
 // swiftlint:disable force_unwrapping
 import PassKit
 import Prelude

--- a/Library/ViewModels/RewardPledgeViewModelTests.swift
+++ b/Library/ViewModels/RewardPledgeViewModelTests.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable file_length
 // swiftlint:disable type_body_length
 // swiftlint:disable function_body_length
 // swiftlint:disable force_unwrapping

--- a/Library/ViewModels/SearchViewModel.swift
+++ b/Library/ViewModels/SearchViewModel.swift
@@ -82,8 +82,7 @@ public protocol SearchViewModelType {
 
 public final class SearchViewModel: SearchViewModelType, SearchViewModelInputs, SearchViewModelOutputs {
 
-  // swiftlint:disable function_body_length
-  public init() {
+    public init() {
     let viewWillAppearNotAnimated = self.viewWillAppearAnimatedProperty.signal.filter(isFalse).ignoreValues()
 
     let query = Signal

--- a/Library/ViewModels/SearchViewModelTests.swift
+++ b/Library/ViewModels/SearchViewModelTests.swift
@@ -1,5 +1,4 @@
 // swiftlint:disable force_unwrapping
-// swiftlint:disable type_body_length
 import Foundation
 import XCTest
 @testable import KsApi

--- a/Library/ViewModels/SearchViewModelTests.swift
+++ b/Library/ViewModels/SearchViewModelTests.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable file_length
 // swiftlint:disable force_unwrapping
 // swiftlint:disable type_body_length
 import Foundation

--- a/Library/ViewModels/SearchViewModelTests.swift
+++ b/Library/ViewModels/SearchViewModelTests.swift
@@ -10,7 +10,6 @@ import Result
 @testable import Library
 import Prelude
 
-// swiftlint:disable function_body_length
 internal final class SearchViewModelTests: TestCase {
   fileprivate let vm: SearchViewModelType! = SearchViewModel()
 

--- a/Library/ViewModels/SettingsViewModel.swift
+++ b/Library/ViewModels/SettingsViewModel.swift
@@ -72,8 +72,7 @@ public protocol SettingsViewModelType {
 
 public final class SettingsViewModel: SettingsViewModelType, SettingsViewModelInputs,
   SettingsViewModelOutputs {
-  // swiftlint:disable function_body_length
-  // swiftlint:disable cyclomatic_complexity
+    // swiftlint:disable cyclomatic_complexity
   public init() {
     let initialUser = viewDidLoadProperty.signal
       .flatMap {

--- a/Library/ViewModels/SettingsViewModel.swift
+++ b/Library/ViewModels/SettingsViewModel.swift
@@ -5,7 +5,6 @@ import ReactiveSwift
 import ReactiveExtensions
 import Result
 
-// swiftlint:disable file_length
 public protocol SettingsViewModelInputs {
   func backingsTapped(selected: Bool)
   func betaFeedbackButtonTapped()

--- a/Library/ViewModels/SettingsViewModelTests.swift
+++ b/Library/ViewModels/SettingsViewModelTests.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable file_length
 import Foundation
 import XCTest
 import ReactiveSwift

--- a/Library/ViewModels/ShareViewModel.swift
+++ b/Library/ViewModels/ShareViewModel.swift
@@ -64,8 +64,7 @@ public protocol ShareViewModelType {
 
 public final class ShareViewModel: ShareViewModelType, ShareViewModelInputs, ShareViewModelOutputs {
 
-  // swiftlint:disable function_body_length
-  public init() {
+    public init() {
     let shareContextAndView = self.shareContextProperty.signal.skipNil()
     let shareContext = self.shareContextProperty.signal.skipNil().map(first)
 

--- a/Library/ViewModels/ShareViewModelTests.swift
+++ b/Library/ViewModels/ShareViewModelTests.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable file_length
 @testable import KsApi
 @testable import Library
 @testable import LiveStream

--- a/Library/ViewModels/SignupViewModel.swift
+++ b/Library/ViewModels/SignupViewModel.swift
@@ -69,8 +69,7 @@ public protocol SignupViewModelType {
 
 public final class SignupViewModel: SignupViewModelType, SignupViewModelInputs, SignupViewModelOutputs {
 
-  // swiftlint:disable function_body_length
-  public init() {
+    public init() {
     let initialText = self.viewDidLoadProperty.signal.mapConst("")
     let name = Signal.merge(
       self.nameChangedProperty.signal,

--- a/Library/ViewModels/SignupViewModelTests.swift
+++ b/Library/ViewModels/SignupViewModelTests.swift
@@ -1,5 +1,4 @@
 // swiftlint:disable force_unwrapping
-// swiftlint:disable function_body_length
 import XCTest
 @testable import KsApi
 @testable import Library

--- a/Library/ViewModels/SortPagerViewModel.swift
+++ b/Library/ViewModels/SortPagerViewModel.swift
@@ -58,8 +58,7 @@ public protocol SortPagerViewModelType {
 public final class SortPagerViewModel: SortPagerViewModelType, SortPagerViewModelInputs,
 SortPagerViewModelOutputs {
 
-  // swiftlint:disable function_body_length
-  public init() {
+    public init() {
     let sorts = self.sortsProperty.signal.skipNil()
       .takeWhen(self.viewWillAppearProperty.signal)
 

--- a/Library/ViewModels/SurveyResponseViewModel.swift
+++ b/Library/ViewModels/SurveyResponseViewModel.swift
@@ -44,8 +44,7 @@ public protocol SurveyResponseViewModelType: SurveyResponseViewModelInputs, Surv
 
 public final class SurveyResponseViewModel: SurveyResponseViewModelType {
 
-  // swiftlint:disable function_body_length
-  public init() {
+    public init() {
     let initialRequest = self.surveyResponseProperty.signal.skipNil()
       .takeWhen(self.viewDidLoadProperty.signal)
       .map { surveyResponse -> URLRequest? in

--- a/Library/ViewModels/ThanksViewModel.swift
+++ b/Library/ViewModels/ThanksViewModel.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable file_length
 import KsApi
 import Prelude
 import ReactiveSwift

--- a/Library/ViewModels/ThanksViewModel.swift
+++ b/Library/ViewModels/ThanksViewModel.swift
@@ -92,8 +92,7 @@ public protocol ThanksViewModelType {
 
 public final class ThanksViewModel: ThanksViewModelType, ThanksViewModelInputs, ThanksViewModelOutputs {
 
-  // swiftlint:disable function_body_length
-  public init() {
+    public init() {
     let project = self.projectProperty.signal.skipNil()
 
     self.backedProjectText = project.map {

--- a/Library/ViewModels/ThanksViewModelTests.swift
+++ b/Library/ViewModels/ThanksViewModelTests.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable file_length
 // swiftlint:disable type_body_length
 import XCTest
 import ReactiveSwift

--- a/Library/ViewModels/ThanksViewModelTests.swift
+++ b/Library/ViewModels/ThanksViewModelTests.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable type_body_length
 import XCTest
 import ReactiveSwift
 import UIKit

--- a/Library/ViewModels/TwoFactorViewModel.swift
+++ b/Library/ViewModels/TwoFactorViewModel.swift
@@ -77,8 +77,7 @@ public final class TwoFactorViewModel: TwoFactorViewModelType, TwoFactorViewMode
     // swiftlint:enable type_name
   }
 
-  // swiftlint:disable function_body_length
-  public init() {
+    public init() {
     let isLoading = MutableProperty(false)
 
     let loginData = SignalProducer.combineLatest(

--- a/Library/ViewModels/TwoFactorViewModel.swift
+++ b/Library/ViewModels/TwoFactorViewModel.swift
@@ -68,8 +68,7 @@ public final class TwoFactorViewModel: TwoFactorViewModelType, TwoFactorViewMode
     fileprivate let facebookToken: String?
     fileprivate let code: String?
 
-    // swiftlint:disable type_name
-    fileprivate enum lens {
+        fileprivate enum lens {
       fileprivate static let code = Lens<TfaData, String?>(
         view: { $0.code },
         set: { TfaData(email: $1.email, password: $1.password, facebookToken: $1.facebookToken, code: $0) }

--- a/Library/ViewModels/UpdateDraftViewModel.swift
+++ b/Library/ViewModels/UpdateDraftViewModel.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable file_length
 import KsApi
 import Prelude
 import ReactiveSwift

--- a/Library/ViewModels/UpdateDraftViewModel.swift
+++ b/Library/ViewModels/UpdateDraftViewModel.swift
@@ -132,8 +132,7 @@ public protocol UpdateDraftViewModelType {
 
 public final class UpdateDraftViewModel: UpdateDraftViewModelType, UpdateDraftViewModelInputs,
 UpdateDraftViewModelOutputs {
-  // swiftlint:disable function_body_length
-  public init() {
+    public init() {
     // MARK: Loading
 
     let project = self.projectProperty.signal.skipNil()

--- a/Library/ViewModels/UpdateDraftViewModelTests.swift
+++ b/Library/ViewModels/UpdateDraftViewModelTests.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable type_body_length
 // swiftlint:disable force_unwrapping
 import XCTest
 import UIKit

--- a/Library/ViewModels/UpdateDraftViewModelTests.swift
+++ b/Library/ViewModels/UpdateDraftViewModelTests.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable file_length
 // swiftlint:disable type_body_length
 // swiftlint:disable force_unwrapping
 import XCTest

--- a/Library/ViewModels/VideoViewModel.swift
+++ b/Library/ViewModels/VideoViewModel.swift
@@ -85,8 +85,7 @@ public protocol VideoViewModelType {
 
 public final class VideoViewModel: VideoViewModelInputs, VideoViewModelOutputs, VideoViewModelType {
 
-  // swiftlint:disable function_body_length
-  public init() {
+    public init() {
 
     let project = Signal.combineLatest(
       self.projectProperty.signal.skipNil(),

--- a/LiveStream/Models/LiveStreamChatMessage.swift
+++ b/LiveStream/Models/LiveStreamChatMessage.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable type_name
 import Argo
 import Curry
 import Prelude

--- a/LiveStream/Models/LiveStreamChatMessageTests.swift
+++ b/LiveStream/Models/LiveStreamChatMessageTests.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable function_body_length
 import XCTest
 import Argo
 @testable import LiveStream

--- a/LiveStream/Models/LiveStreamEvent.swift
+++ b/LiveStream/Models/LiveStreamEvent.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable type_name
 import Argo
 import Curry
 import Prelude

--- a/LiveStream/Models/LiveStreamEventTests.swift
+++ b/LiveStream/Models/LiveStreamEventTests.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable function_body_length
 import Argo
 import Prelude
 import XCTest

--- a/LiveStream/Models/LiveStreamEventsEnvelope.swift
+++ b/LiveStream/Models/LiveStreamEventsEnvelope.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable type_name
 import Argo
 import Curry
 import Prelude

--- a/LiveStream/Models/LiveStreamEventsEnvelopeTests.swift
+++ b/LiveStream/Models/LiveStreamEventsEnvelopeTests.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable function_body_length
 import XCTest
 import Argo
 @testable import LiveStream

--- a/LiveStream/Models/LiveStreamSubscribeEnvelope.swift
+++ b/LiveStream/Models/LiveStreamSubscribeEnvelope.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable type_name
 import Argo
 import Curry
 import Prelude

--- a/LiveStream/Models/LiveStreamSubscribeEnvelopeTests.swift
+++ b/LiveStream/Models/LiveStreamSubscribeEnvelopeTests.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable function_body_length
 import XCTest
 import Argo
 @testable import LiveStream

--- a/LiveStream/Models/lenses/LiveStreamEvent.BackgroundImageLenses.swift
+++ b/LiveStream/Models/lenses/LiveStreamEvent.BackgroundImageLenses.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable type_name
 import Prelude
 
 extension LiveStreamEvent.BackgroundImage {

--- a/LiveStream/Models/lenses/LiveStreamEvent.CreatorLenses.swift
+++ b/LiveStream/Models/lenses/LiveStreamEvent.CreatorLenses.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable type_name
 import Prelude
 
 extension LiveStreamEvent.Creator {

--- a/LiveStream/Models/lenses/LiveStreamEvent.OpenTokLenses.swift
+++ b/LiveStream/Models/lenses/LiveStreamEvent.OpenTokLenses.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable type_name
 import Prelude
 
 extension LiveStreamEvent.OpenTok {

--- a/LiveStream/Models/lenses/LiveStreamEvent.ProjectLenses.swift
+++ b/LiveStream/Models/lenses/LiveStreamEvent.ProjectLenses.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable type_name
 import Prelude
 
 extension LiveStreamEvent.Project {

--- a/LiveStream/Models/lenses/LiveStreamEvent.UserLenses.swift
+++ b/LiveStream/Models/lenses/LiveStreamEvent.UserLenses.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable type_name
 import Prelude
 
 extension LiveStreamEvent.User {

--- a/LiveStream/Service/LiveStreamService.swift
+++ b/LiveStream/Service/LiveStreamService.swift
@@ -1,4 +1,3 @@
-//swiftlint:disable file_length
 import Argo
 import FirebaseAnalytics
 import FirebaseAuth


### PR DESCRIPTION
There are a number of rules that we tend to disable whenever we encounter them and it seems to make sense to me that we just add these to the list of disabled rules as they're not really ones that we care about.

If we're in agreement then I will also go ahead and remove all of the places that we have done `//swiftlint:disable <redundant_rule_name>`.

Thoughts on keeping any of these or others we'd like to add? 🤔