### PR TITLE
One pass availability reporting

### DIFF
--- a/Library/Koala/Koala.swift
+++ b/Library/Koala/Koala.swift
@@ -613,7 +613,7 @@ public final class Koala {
       ]
     )
     self.track(event: "Viewed Login",
-               properties: ["1password_extension_available": onePasswordIsAvailable])
+               properties: ["one_password_extension_available": onePasswordIsAvailable])
   }
 
   public func trackLoginSuccess(authType: AuthType) {

--- a/Library/ViewModels/LoginViewModelTests.swift
+++ b/Library/ViewModels/LoginViewModelTests.swift
@@ -53,16 +53,16 @@ final class LoginViewModelTests: TestCase {
       .assertValueCount(1, "Email field is first responder when view loads.")
 
     XCTAssertEqual(["User Login", "Viewed Login"], trackingClient.events, "Koala login is tracked")
-    
+
     XCTAssertEqual([false, nil],
                    self.trackingClient.properties(forKey: "1password_extension_available", as: Bool.self))
-    
+
     XCTAssertEqual([nil, false],
                    self.trackingClient.properties(forKey: "one_password_extension_available", as: Bool.self))
-    
+
     XCTAssertEqual([true, nil],
                    self.trackingClient.properties(forKey: Koala.DeprecatedKey, as: Bool.self))
-    
+
     self.isFormValid.assertValues([false], "Form is not valid")
 
     self.vm.inputs.emailChanged("Gina@rules.com")
@@ -193,10 +193,10 @@ final class LoginViewModelTests: TestCase {
 
     XCTAssertEqual([true, nil],
                    self.trackingClient.properties(forKey: "1password_extension_available", as: Bool.self))
-    
+
     XCTAssertEqual([nil, true],
                    self.trackingClient.properties(forKey: "one_password_extension_available", as: Bool.self))
-    
+
     self.onePasswordButtonHidden.assertValues([false])
 
     self.vm.inputs.onePasswordButtonTapped()

--- a/Library/ViewModels/LoginViewModelTests.swift
+++ b/Library/ViewModels/LoginViewModelTests.swift
@@ -53,10 +53,16 @@ final class LoginViewModelTests: TestCase {
       .assertValueCount(1, "Email field is first responder when view loads.")
 
     XCTAssertEqual(["User Login", "Viewed Login"], trackingClient.events, "Koala login is tracked")
-    XCTAssertEqual([false, false],
+    
+    XCTAssertEqual([false, nil],
                    self.trackingClient.properties(forKey: "1password_extension_available", as: Bool.self))
+    
+    XCTAssertEqual([nil, false],
+                   self.trackingClient.properties(forKey: "one_password_extension_available", as: Bool.self))
+    
     XCTAssertEqual([true, nil],
                    self.trackingClient.properties(forKey: Koala.DeprecatedKey, as: Bool.self))
+    
     self.isFormValid.assertValues([false], "Form is not valid")
 
     self.vm.inputs.emailChanged("Gina@rules.com")
@@ -185,8 +191,12 @@ final class LoginViewModelTests: TestCase {
     self.vm.inputs.viewWillAppear()
     self.vm.inputs.onePassword(isAvailable: true)
 
-    XCTAssertEqual([true, true],
+    XCTAssertEqual([true, nil],
                    self.trackingClient.properties(forKey: "1password_extension_available", as: Bool.self))
+    
+    XCTAssertEqual([nil, true],
+                   self.trackingClient.properties(forKey: "one_password_extension_available", as: Bool.self))
+    
     self.onePasswordButtonHidden.assertValues([false])
 
     self.vm.inputs.onePasswordButtonTapped()


### PR DESCRIPTION
replaced property _1password_extension_available_ with property _one_password_extension_available_ for _Viewed Login_ tracking event. Kept property _1password_extension_available_ for _User Login_ event intact because it is marked as deprecated and will be removed..  

Reference Trello card: Update 1password property