### PR TITLE
Back project button in comments fix

### DIFF
--- a/Kickstarter-iOS/Views/Controllers/CommentsViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/CommentsViewController.swift
@@ -157,7 +157,7 @@ extension CommentsViewController: CommentDialogDelegate {
 
 extension CommentsViewController: CommentsEmptyStateCellDelegate {
   internal func commentEmptyStateCellGoBackToProject() {
-    _ = self.navigationController?.popViewController(animated: true)
+    _ = self.navigationController?.popToRootViewController(animated: true)
   }
 
   internal func commentEmptyStateCellGoToCommentDialog() {


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# What

A description of the change.

# Why

Back this project button on empty comments returns you to update, not project page.

# How
Used `popToRootViewController` to present the the project page.  
