### PR TITLE
Bind project to no reward cell

### DIFF
--- a/Kickstarter-iOS/DataSources/ProjectPamphletContentDataSource.swift
+++ b/Kickstarter-iOS/DataSources/ProjectPamphletContentDataSource.swift
@@ -64,7 +64,7 @@ internal final class ProjectPamphletContentDataSource: ValueCellDataSource {
   private func setRewardTitleArea(project: Project) {
     if project.personalization.isBacking != true && project.state == .live {
       self.set(values: [project], cellClass: PledgeTitleCell.self, inSection: Section.pledgeTitle.rawValue)
-      self.set(values: [()], cellClass: NoRewardCell.self, inSection: Section.calloutReward.rawValue)
+      self.set(values: [project], cellClass: NoRewardCell.self, inSection: Section.calloutReward.rawValue)
     } else if let backing = project.personalization.backing {
 
       self.set(values: [project], cellClass: PledgeTitleCell.self, inSection: Section.pledgeTitle.rawValue)
@@ -133,8 +133,8 @@ internal final class ProjectPamphletContentDataSource: ValueCellDataSource {
       cell.configureWith(value: value)
     case let (cell as PledgeTitleCell, value as Project):
       cell.configureWith(value: value)
-    case let (cell as NoRewardCell, _):
-      cell.configureWith(value: ())
+    case let (cell as NoRewardCell, value as Project):
+      cell.configureWith(value: value)
     case let (cell as RewardsTitleCell, value as Project):
       cell.configureWith(value: value)
     default:

--- a/Kickstarter-iOS/DataSources/ProjectPamphletContentDataSourceTests.swift
+++ b/Kickstarter-iOS/DataSources/ProjectPamphletContentDataSourceTests.swift
@@ -9,6 +9,14 @@ final class ProjectPamphletContentDataSourceTests: TestCase {
   let dataSource = ProjectPamphletContentDataSource()
   let tableView = UITableView()
 
+  func testIndexPathIsPledgeAnyAmountCell() {
+    let project = Project.template
+    dataSource.load(project: project, liveStreamEvents: [])
+
+    let section = ProjectPamphletContentDataSource.Section.calloutReward.rawValue
+    XCTAssertTrue(dataSource.indexPathIsPledgeAnyAmountCell(.init(row: 0, section: section)))
+  }
+
   func testSubpages_NoLiveStreams() {
     let section = ProjectPamphletContentDataSource.Section.subpages.rawValue
 

--- a/Kickstarter-iOS/Views/Cells/NoRewardCell.swift
+++ b/Kickstarter-iOS/Views/Cells/NoRewardCell.swift
@@ -12,9 +12,10 @@ internal final class NoRewardCell: UITableViewCell, ValueCell {
   @IBOutlet fileprivate weak var rootStackView: UIStackView!
   @IBOutlet fileprivate weak var copyStackView: UIStackView!
 
-  internal func configureWith(value: Void) {}
+  // value required to bind value to data source
+  internal func configureWith(value: Project) {}
 
-    internal override func bindStyles() {
+  internal override func bindStyles() {
     super.bindStyles()
 
     _ = self


### PR DESCRIPTION
TIL a bit more about what our `ValueCell`s do behind the scenes! Namely: their associated data type is bound directly to the data source's index paths. We recently removed the project type from our "No Reward" cell configuration (we weren't using it in the function directly), but this broke the connection for no-reward pledging! Here's a quick lil fix and quick lil test.