### PR TITLE
revise push handling

### DIFF
--- a/Kickstarter-iOS/AppDelegate.swift
+++ b/Kickstarter-iOS/AppDelegate.swift
@@ -135,10 +135,11 @@ internal final class AppDelegate: UIResponder, UIApplicationDelegate {
         self.viewModel.outputs.authorizeForRemoteNotifications
           .observeForUI()
           .observeValues { [weak self] in
-            UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge]) { _ in
-              self?.viewModel.inputs.notificationAuthorizationCompleted()
+            UNUserNotificationCenter.current().requestAuthorization(options: [.alert]) {
+              (isGranted, _) in
+              self?.viewModel.inputs.notificationAuthorizationCompleted(isGranted: isGranted)
+              }
             }
-          }
       }
 
     self.viewModel.outputs.unregisterForRemoteNotifications

--- a/Kickstarter-iOS/ViewModels/AppDelegateViewModel.swift
+++ b/Kickstarter-iOS/ViewModels/AppDelegateViewModel.swift
@@ -22,7 +22,7 @@ public func == (lhs: HockeyConfigData, rhs: HockeyConfigData) -> Bool {
     && lhs.userName == rhs.userName
 }
 
-public enum NotificationAuthorizationStatusType {
+public enum NotificationAuthorizationStatus {
   case authorized
   case denied
   case notDetermined
@@ -562,7 +562,7 @@ AppDelegateViewModelOutputs {
           AppEnvironment.current.koala.trackPushPermissionOptIn()
         case .denied:
           AppEnvironment.current.koala.trackPushPermissionOptOut()
-        default: ()
+        case .notDetermined: ()
         }
       }
 
@@ -723,7 +723,7 @@ AppDelegateViewModelOutputs {
   }
 
   fileprivate let notificationAuthorizationStatusProperty =
-    MutableProperty<NotificationAuthorizationStatusType?>(nil)
+    MutableProperty<NotificationAuthorizationStatus?>(nil)
   @available(iOS 10.0, *)
   public func notificationAuthorizationStatusReceived(_ authorizationStatus: UNAuthorizationStatus) {
     return self.notificationAuthorizationStatusProperty.value = authStatusType(for: authorizationStatus)
@@ -1021,7 +1021,7 @@ private func visitorCookies() -> [HTTPCookie] {
 }
 
 @available(iOS 10.0, *)
-private func authStatusType(for status: UNAuthorizationStatus) -> NotificationAuthorizationStatusType {
+private func authStatusType(for status: UNAuthorizationStatus) -> NotificationAuthorizationStatus {
   switch status {
     case .authorized: return .authorized
     case .denied: return .denied

--- a/Kickstarter-iOS/ViewModels/AppDelegateViewModelTests.swift
+++ b/Kickstarter-iOS/ViewModels/AppDelegateViewModelTests.swift
@@ -577,7 +577,7 @@ final class AppDelegateViewModelTests: TestCase {
       self.vm.inputs.userSessionStarted()
 
       self.getNotificationAuthorizationStatus.assertValueCount(1)
-      self.authorizeForRemoteNotifications.assertValueCount(0)
+      self.authorizeForRemoteNotifications.assertValueCount(1)
       self.registerForRemoteNotifications.assertValueCount(0)
       self.unregisterForRemoteNotifications.assertValueCount(0)
 
@@ -585,50 +585,50 @@ final class AppDelegateViewModelTests: TestCase {
       self.vm.inputs.applicationWillEnterForeground()
 
       self.getNotificationAuthorizationStatus.assertValueCount(2)
-      self.authorizeForRemoteNotifications.assertValueCount(0)
+      self.authorizeForRemoteNotifications.assertValueCount(2)
       self.registerForRemoteNotifications.assertValueCount(0)
       self.unregisterForRemoteNotifications.assertValueCount(0)
 
       self.vm.inputs.notificationAuthorizationStatusReceived(UNAuthorizationStatus.denied)
 
       self.getNotificationAuthorizationStatus.assertValueCount(2)
-      self.authorizeForRemoteNotifications.assertValueCount(0)
+      self.authorizeForRemoteNotifications.assertValueCount(2)
       self.registerForRemoteNotifications.assertValueCount(0)
       self.unregisterForRemoteNotifications.assertValueCount(0)
 
       self.vm.inputs.notificationAuthorizationStatusReceived(UNAuthorizationStatus.authorized)
 
       self.getNotificationAuthorizationStatus.assertValueCount(2)
-      self.authorizeForRemoteNotifications.assertValueCount(0)
-      self.registerForRemoteNotifications.assertValueCount(1)
+      self.authorizeForRemoteNotifications.assertValueCount(2)
+      self.registerForRemoteNotifications.assertValueCount(0)
       self.unregisterForRemoteNotifications.assertValueCount(0)
 
       //Simulate initial notification authorization
       self.vm.inputs.notificationAuthorizationStatusReceived(UNAuthorizationStatus.notDetermined)
 
       self.getNotificationAuthorizationStatus.assertValueCount(2)
-      self.authorizeForRemoteNotifications.assertValueCount(1)
-      self.registerForRemoteNotifications.assertValueCount(1)
+      self.authorizeForRemoteNotifications.assertValueCount(3)
+      self.registerForRemoteNotifications.assertValueCount(0)
       self.unregisterForRemoteNotifications.assertValueCount(0)
 
-      self.vm.inputs.notificationAuthorizationCompleted()
+      self.vm.inputs.notificationAuthorizationCompleted(isGranted: true)
 
-      self.getNotificationAuthorizationStatus.assertValueCount(3)
-      self.authorizeForRemoteNotifications.assertValueCount(1)
+      self.getNotificationAuthorizationStatus.assertValueCount(2)
+      self.authorizeForRemoteNotifications.assertValueCount(3)
       self.registerForRemoteNotifications.assertValueCount(1)
       self.unregisterForRemoteNotifications.assertValueCount(0)
 
       self.vm.inputs.notificationAuthorizationStatusReceived(UNAuthorizationStatus.authorized)
 
-      self.getNotificationAuthorizationStatus.assertValueCount(3)
-      self.authorizeForRemoteNotifications.assertValueCount(1)
-      self.registerForRemoteNotifications.assertValueCount(2)
+      self.getNotificationAuthorizationStatus.assertValueCount(2)
+      self.authorizeForRemoteNotifications.assertValueCount(3)
+      self.registerForRemoteNotifications.assertValueCount(1)
       self.unregisterForRemoteNotifications.assertValueCount(0)
     }
 
     self.vm.inputs.userSessionEnded()
 
-    self.registerForRemoteNotifications.assertValueCount(2)
+    self.registerForRemoteNotifications.assertValueCount(1)
     self.unregisterForRemoteNotifications.assertValueCount(1)
   }
 
@@ -650,7 +650,7 @@ final class AppDelegateViewModelTests: TestCase {
 
       XCTAssertEqual(["App Close", "Closed App", "App Open", "Opened App"], client.events)
 
-      self.vm.inputs.notificationAuthorizationCompleted()
+      self.vm.inputs.notificationAuthorizationCompleted(isGranted: true)
       self.vm.inputs.notificationAuthorizationStatusReceived(UNAuthorizationStatus.authorized)
 
       XCTAssertEqual(["App Close", "Closed App", "App Open", "Opened App", "Confirmed Push Opt-In"],
@@ -676,7 +676,7 @@ final class AppDelegateViewModelTests: TestCase {
 
       XCTAssertEqual(["App Close", "Closed App", "App Open", "Opened App"], client.events)
 
-      self.vm.inputs.notificationAuthorizationCompleted()
+      self.vm.inputs.notificationAuthorizationCompleted(isGranted: true)
       self.vm.inputs.notificationAuthorizationStatusReceived(UNAuthorizationStatus.denied)
 
       XCTAssertEqual(["App Close", "Closed App", "App Open", "Opened App", "Dismissed Push Opt-In"],


### PR DESCRIPTION
# What 

This is a PR on top of @bormind's PR for push notification opt-in and out. I thought this would be the easiest way to explain a refactor. I will make comments inline to explain the changes, which are mainly to clean up the flow of input/outputs based on the [Apple dev guide](https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/index.html#//apple_ref/doc/uid/TP40008194-CH3-SW1) and avoid the use of the protocol/enum wrapper for `UNAuthorizationStatus`.  Let me know what you think @bormind @justinswart @stephencelis!

**The revised flow:**
_For iOS 10:_

On app launch, we should call `requestAuthorization(options: UNAuthorizationOptions, completionHandler:)` for new users or users with undetermined notification authorization status. When the completion handler is called, we should check if the authorization has been granted and only then register for remote notifications.

On app launch, we should also be calling `UNUserNotificationCenter.current().getNotificationSettings` for returning users who have set or updated notification settings. In addition to tracking the setting, we should call `requestAuthorization(options: UNAuthorizationOptions, completionHandler:)` again if the setting is `.notDetermined`.

### todo
Should add tests for iOS9, for authorization not granted, and for denied and authorized status.

