### PR TITLE
Fix reuseIdentifier for empty message cells

### DIFF
--- a/Kickstarter-iOS/DataSources/MessageThreadsDataSource.swift
+++ b/Kickstarter-iOS/DataSources/MessageThreadsDataSource.swift
@@ -7,6 +7,8 @@ internal final class MessageThreadsDataSource: ValueCellDataSource {
     case messageThreads
   }
 
+  internal let emptyStateCellIdentifier = String(describing: MessageThreadEmptyStateCell.self)
+
   internal func load(messageThreads: [MessageThread]) {
     self.set(values: messageThreads,
              cellClass: MessageThreadCell.self,
@@ -14,7 +16,7 @@ internal final class MessageThreadsDataSource: ValueCellDataSource {
   }
 
   internal func emptyState(isVisible: Bool) {
-    self.set(cellIdentifiers: isVisible ? ["MessageThreadEmptyStateCell"] : [],
+    self.set(cellIdentifiers: isVisible ? [self.emptyStateCellIdentifier] : [],
              inSection: Section.emptyState.rawValue)
   }
 

--- a/Kickstarter-iOS/DataSources/MessageThreadsDataSource.swift
+++ b/Kickstarter-iOS/DataSources/MessageThreadsDataSource.swift
@@ -14,7 +14,7 @@ internal final class MessageThreadsDataSource: ValueCellDataSource {
   }
 
   internal func emptyState(isVisible: Bool) {
-    self.set(cellIdentifiers: isVisible ? ["MessageThreadsEmptyState"] : [],
+    self.set(cellIdentifiers: isVisible ? ["MessageThreadEmptyStateCell"] : [],
              inSection: Section.emptyState.rawValue)
   }
 

--- a/Kickstarter-iOS/DataSources/MessageThreadsDataSource.swift
+++ b/Kickstarter-iOS/DataSources/MessageThreadsDataSource.swift
@@ -7,7 +7,7 @@ internal final class MessageThreadsDataSource: ValueCellDataSource {
     case messageThreads
   }
 
-  internal let emptyStateCellIdentifier = String(describing: MessageThreadEmptyStateCell.self)
+  internal static let emptyStateCellIdentifier = String(describing: MessageThreadEmptyStateCell.self)
 
   internal func load(messageThreads: [MessageThread]) {
     self.set(values: messageThreads,
@@ -16,7 +16,7 @@ internal final class MessageThreadsDataSource: ValueCellDataSource {
   }
 
   internal func emptyState(isVisible: Bool) {
-    self.set(cellIdentifiers: isVisible ? [self.emptyStateCellIdentifier] : [],
+    self.set(cellIdentifiers: isVisible ? [MessageThreadsDataSource.emptyStateCellIdentifier] : [],
              inSection: Section.emptyState.rawValue)
   }
 

--- a/Kickstarter-iOS/DataSources/MessageThreadsDataSourceTests.swift
+++ b/Kickstarter-iOS/DataSources/MessageThreadsDataSourceTests.swift
@@ -1,0 +1,30 @@
+@testable import Kickstarter_Framework
+@testable import KsApi
+@testable import Library
+import XCTest
+
+final class MessageThreadsDataSourceTests: XCTestCase {
+  let dataSource = MessageThreadsDataSource()
+  let tableView = UITableView()
+
+  func testDataSource_WithMessages() {
+    self.dataSource.load(messageThreads: [.template])
+    self.dataSource.emptyState(isVisible: false)
+
+    XCTAssertEqual(2, self.dataSource.numberOfSections(in: tableView))
+
+    XCTAssertEqual(0, self.dataSource.tableView(tableView, numberOfRowsInSection: 0))
+    XCTAssertEqual(1, self.dataSource.tableView(tableView, numberOfRowsInSection: 1))
+    XCTAssertEqual(String(describing: MessageThreadCell.self),
+                   self.dataSource.reusableId(item: 0, section: 1))
+  }
+
+  func testDataSource_WithoutMessages() {
+    self.dataSource.emptyState(isVisible: true)
+
+    XCTAssertEqual(1, self.dataSource.numberOfSections(in: tableView))
+
+    XCTAssertEqual(1, self.dataSource.tableView(tableView, numberOfRowsInSection: 0))
+    XCTAssertEqual(self.dataSource.emptyStateCellIdentifier, self.dataSource.reusableId(item: 0, section: 0))
+  }
+}

--- a/Kickstarter-iOS/DataSources/MessageThreadsDataSourceTests.swift
+++ b/Kickstarter-iOS/DataSources/MessageThreadsDataSourceTests.swift
@@ -25,6 +25,7 @@ final class MessageThreadsDataSourceTests: XCTestCase {
     XCTAssertEqual(1, self.dataSource.numberOfSections(in: tableView))
 
     XCTAssertEqual(1, self.dataSource.tableView(tableView, numberOfRowsInSection: 0))
-    XCTAssertEqual(self.dataSource.emptyStateCellIdentifier, self.dataSource.reusableId(item: 0, section: 0))
+    XCTAssertEqual(MessageThreadsDataSource.emptyStateCellIdentifier,
+                   self.dataSource.reusableId(item: 0, section: 0))
   }
 }

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -24,6 +24,8 @@
 		014D629D1E6E5B070033D2BD /* BackerDashboardEmptyStateCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 014D629C1E6E5B070033D2BD /* BackerDashboardEmptyStateCell.xib */; };
 		014D62FF1E7211220033D2BD /* BackerDashboardProjectCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 014D62FE1E7211220033D2BD /* BackerDashboardProjectCell.xib */; };
 		014D63011E721D500033D2BD /* BackerDashboardProjectCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 014D63001E721D500033D2BD /* BackerDashboardProjectCell.swift */; };
+		015102AD1F1947C50006C0FC /* MessageThreadsDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = A71003DB1CDD068F00B4F4D7 /* MessageThreadsDataSource.swift */; };
+		015102AE1F1947CB0006C0FC /* MessageThreadsDataSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 015102741F1943D60006C0FC /* MessageThreadsDataSourceTests.swift */; };
 		01515F8C1E1D6E0C00FDECB6 /* MessageThreadEmptyStateCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01515F8A1E1D6E0C00FDECB6 /* MessageThreadEmptyStateCell.swift */; };
 		0154A93B1CA1A17800DB9BA4 /* UIColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0151AE871C8F60370067F1BE /* UIColor.swift */; };
 		015572711E79C427005FB8CC /* ProfileProjectCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 015572701E79C426005FB8CC /* ProfileProjectCellViewModel.swift */; };
@@ -181,7 +183,6 @@
 		A70E9EE61E859C96009E67F2 /* LiveStreamNavTitleViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A70E9EE01E859C96009E67F2 /* LiveStreamNavTitleViewModelTests.swift */; };
 		A70F1F321D8A3E85007DA8E9 /* ProjectPamphletViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A70F1F311D8A3E85007DA8E9 /* ProjectPamphletViewController.swift */; };
 		A71003DA1CDCFA2500B4F4D7 /* MessageThreadsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A71003D81CDCFA2500B4F4D7 /* MessageThreadsViewController.swift */; };
-		A71003DD1CDD068F00B4F4D7 /* MessageThreadsDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = A71003DB1CDD068F00B4F4D7 /* MessageThreadsDataSource.swift */; };
 		A71003E01CDD06E600B4F4D7 /* MessageThreadCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A71003DE1CDD06E600B4F4D7 /* MessageThreadCell.swift */; };
 		A71003E31CDD077200B4F4D7 /* MessageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A71003E11CDD077200B4F4D7 /* MessageCell.swift */; };
 		A710573B1DC2B2DF00A69552 /* SharedFunctions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A710573A1DC2B2DF00A69552 /* SharedFunctions.swift */; };
@@ -1548,6 +1549,7 @@
 		014D629C1E6E5B070033D2BD /* BackerDashboardEmptyStateCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = BackerDashboardEmptyStateCell.xib; sourceTree = "<group>"; };
 		014D62FE1E7211220033D2BD /* BackerDashboardProjectCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = BackerDashboardProjectCell.xib; sourceTree = "<group>"; };
 		014D63001E721D500033D2BD /* BackerDashboardProjectCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BackerDashboardProjectCell.swift; sourceTree = "<group>"; };
+		015102741F1943D60006C0FC /* MessageThreadsDataSourceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MessageThreadsDataSourceTests.swift; sourceTree = "<group>"; };
 		01515F8A1E1D6E0C00FDECB6 /* MessageThreadEmptyStateCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MessageThreadEmptyStateCell.swift; sourceTree = "<group>"; };
 		0151AE871C8F60370067F1BE /* UIColor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIColor.swift; sourceTree = "<group>"; };
 		015572701E79C426005FB8CC /* ProfileProjectCellViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProfileProjectCellViewModel.swift; sourceTree = "<group>"; };
@@ -3316,6 +3318,7 @@
 				A7ED200D1E83229E00BFFA01 /* LiveStreamDiscoveryDataSourceTests.swift */,
 				A75A292C1CE0B95300D35E5C /* MessagesDataSource.swift */,
 				A71003DB1CDD068F00B4F4D7 /* MessageThreadsDataSource.swift */,
+				015102741F1943D60006C0FC /* MessageThreadsDataSourceTests.swift */,
 				59322F051CD27B1000C90CC6 /* ProfileDataSource.swift */,
 				A7ED200E1E83229E00BFFA01 /* ProfileDataSourceTests.swift */,
 				9D9F58141D131D4A00CE81DE /* ProjectActivitiesDataSource.swift */,
@@ -5231,6 +5234,7 @@
 				0157067D1E65F0420087DD68 /* BackerDashboardProjectsViewController.swift in Sources */,
 				A762EFF31C8CC663005581A4 /* ActivityFriendFollowCell.swift in Sources */,
 				59019FBA1D21ABD200EAEC9D /* DashboardReferrerRowStackView.swift in Sources */,
+				015102AD1F1947C50006C0FC /* MessageThreadsDataSource.swift in Sources */,
 				A742CC7D1E43B3A00029D256 /* LiveStreamDiscoveryLiveNowCell.swift in Sources */,
 				A71C7FAE1E2FA65F0051E5E3 /* LiveStreamDiscoveryDataSource.swift in Sources */,
 				59AE35E21D67643100A310E6 /* DiscoveryPostcardCell.swift in Sources */,
@@ -5260,7 +5264,6 @@
 				9DDE1F721D5925A90092D9A5 /* CheckoutViewController.swift in Sources */,
 				01940B2B1D46814E0074FCE3 /* HelpWebViewModel.swift in Sources */,
 				D08A817B1DFAAD04000128DB /* LiveStreamContainerViewController.swift in Sources */,
-				A71003DD1CDD068F00B4F4D7 /* MessageThreadsDataSource.swift in Sources */,
 				598D96B61D426D80003F3F66 /* ActivitySampleFollowCell.swift in Sources */,
 				A72C3AB91D00FB1F0075227E /* DiscoverySelectableRowCell.swift in Sources */,
 				A745D04B1CA8986E00C12802 /* ProfileViewController.swift in Sources */,
@@ -5400,6 +5403,7 @@
 				A7ED204A1E8323E900BFFA01 /* RewardPledgeViewControllerTests.swift in Sources */,
 				A7ED20401E8323E900BFFA01 /* DiscoveryFiltersViewControllerTests.swift in Sources */,
 				A7ED204D1E8323E900BFFA01 /* FindFriendsViewControllerTests.swift in Sources */,
+				015102AE1F1947CB0006C0FC /* MessageThreadsDataSourceTests.swift in Sources */,
 				A7ED20541E8323E900BFFA01 /* ProjectPamphletContentViewControllerTests.swift in Sources */,
 				A7ED20471E8323E900BFFA01 /* LiveStreamContainerViewControllerTests.swift in Sources */,
 				A7ED201E1E83231C00BFFA01 /* MockBundle.swift in Sources */,


### PR DESCRIPTION
# What

Was testing something for @tiegz  and found a bug where we didn't have the correct reuse identifier for empty Messages cells! Woops. This fixes that as well as points us to `master` on `ReactiveExtensions` with @stephencelis's  latest update.

<img width="374" alt="screen shot 2017-07-12 at 5 37 03 pm" src="https://user-images.githubusercontent.com/988998/28141389-5ad12fca-672a-11e7-9f75-936aa56bc4e3.png">



