### PR TITLE
Use MockDate when constructing HTTPCookie

### DIFF
--- a/Library/ViewModels/ProjectPamphletViewModel.swift
+++ b/Library/ViewModels/ProjectPamphletViewModel.swift
@@ -177,7 +177,7 @@ private func cleanUp(refTagString: String) -> String {
 // Constructs a cookie from a ref tag and project.
 private func cookieFrom(refTag: RefTag, project: Project) -> HTTPCookie? {
 
-  let timestamp = Int(Date().timeIntervalSince1970)
+  let timestamp = Int(AppEnvironment.current.dateType.init().timeIntervalSince1970)
 
   var properties: [HTTPCookiePropertyKey:Any] = [:]
   properties[.name]    = cookieName(project)
@@ -185,7 +185,8 @@ private func cookieFrom(refTag: RefTag, project: Project) -> HTTPCookie? {
   properties[.domain]  = URL(string: project.urls.web.project)?.host
   properties[.path]    = URL(string: project.urls.web.project)?.path
   properties[.version] = 0
-  properties[.expires] = Date(timeIntervalSince1970: project.dates.deadline)
+  properties[.expires] = AppEnvironment.current.dateType
+    .init(timeIntervalSince1970: project.dates.deadline).date
 
   return HTTPCookie(properties: properties)
 }

--- a/Library/ViewModels/ProjectPamphletViewModel.swift
+++ b/Library/ViewModels/ProjectPamphletViewModel.swift
@@ -177,7 +177,7 @@ private func cleanUp(refTagString: String) -> String {
 // Constructs a cookie from a ref tag and project.
 private func cookieFrom(refTag: RefTag, project: Project) -> HTTPCookie? {
 
-  let timestamp = Int(AppEnvironment.current.dateType.init().timeIntervalSince1970)
+  let timestamp = Int(AppEnvironment.current.scheduler.currentDate.timeIntervalSince1970)
 
   var properties: [HTTPCookiePropertyKey:Any] = [:]
   properties[.name]    = cookieName(project)

--- a/Library/ViewModels/ProjectPamphletViewModelTests.swift
+++ b/Library/ViewModels/ProjectPamphletViewModelTests.swift
@@ -186,6 +186,66 @@ final class ProjectPamphletViewModelTests: TestCase {
                    "A single cookie has been set.")
   }
 
+  func testMockCookieStorageSet_SeparateSchedulers() {
+    let project = Project.template
+    let scheduler1 = TestScheduler(startDate: MockDate().date)
+    let scheduler2 = TestScheduler(startDate: scheduler1.currentDate.addingTimeInterval(112345))
+
+    withEnvironment(scheduler: scheduler1) {
+      let newVm: ProjectPamphletViewModelType = ProjectPamphletViewModel()
+      newVm.inputs.configureWith(projectOrParam: .left(project), refTag: .category)
+      newVm.inputs.viewDidLoad()
+      newVm.inputs.viewWillAppear(animated: true)
+      newVm.inputs.viewDidAppear(animated: true)
+
+      scheduler1.advance()
+
+      XCTAssertEqual(1, self.cookieStorage.cookies?.count, "A single cookie has been set.")
+    }
+
+    withEnvironment(scheduler: scheduler2) {
+      let newVm: ProjectPamphletViewModelType = ProjectPamphletViewModel()
+      newVm.inputs.configureWith(projectOrParam: .left(project), refTag: .recommended)
+      newVm.inputs.viewDidLoad()
+      newVm.inputs.viewWillAppear(animated: true)
+      newVm.inputs.viewDidAppear(animated: true)
+
+      scheduler2.advance()
+
+      XCTAssertEqual(2, self.cookieStorage.cookies?.count, "Two cookies are set on separate schedulers.")
+    }
+  }
+
+  func testMockCookieStorageSet_SameScheduler() {
+    let project = Project.template
+    let scheduler1 = TestScheduler(startDate: MockDate().date)
+
+    withEnvironment(scheduler: scheduler1) {
+      let newVm: ProjectPamphletViewModelType = ProjectPamphletViewModel()
+      newVm.inputs.configureWith(projectOrParam: .left(project), refTag: .category)
+      newVm.inputs.viewDidLoad()
+      newVm.inputs.viewWillAppear(animated: true)
+      newVm.inputs.viewDidAppear(animated: true)
+
+      scheduler1.advance()
+
+      XCTAssertEqual(1, self.cookieStorage.cookies?.count, "A single cookie has been set.")
+    }
+
+    withEnvironment(scheduler: scheduler1) {
+      let newVm: ProjectPamphletViewModelType = ProjectPamphletViewModel()
+      newVm.inputs.configureWith(projectOrParam: .left(project), refTag: .recommended)
+      newVm.inputs.viewDidLoad()
+      newVm.inputs.viewWillAppear(animated: true)
+      newVm.inputs.viewDidAppear(animated: true)
+
+      scheduler1.advance()
+
+      XCTAssertEqual(1, self.cookieStorage.cookies?.count,
+                     "A single cookie has been set on the same scheduler.")
+    }
+  }
+
   func testTracksRefTag_WithBadData() {
     let project = Project.template
 

--- a/Library/ViewModels/ProjectPamphletViewModelTests.swift
+++ b/Library/ViewModels/ProjectPamphletViewModelTests.swift
@@ -189,7 +189,7 @@ final class ProjectPamphletViewModelTests: TestCase {
   func testMockCookieStorageSet_SeparateSchedulers() {
     let project = Project.template
     let scheduler1 = TestScheduler(startDate: MockDate().date)
-    let scheduler2 = TestScheduler(startDate: scheduler1.currentDate.addingTimeInterval(112345))
+    let scheduler2 = TestScheduler(startDate: scheduler1.currentDate.addingTimeInterval(1))
 
     withEnvironment(scheduler: scheduler1) {
       let newVm: ProjectPamphletViewModelType = ProjectPamphletViewModel()


### PR DESCRIPTION
# What

Updated code in `ProjectPamphletViewModel` that constructs an `HTTPCookie` to use our `DateProtocol` type on `AppEnvironment`.

# Why

`ProjectPamphletViewModelTests.testTracksRefTag()` keeps randomly failing on Circle and I think it has to do with equality of `HTTPCookie`s being set in the `Set<HTTPCookie>` on `MockCookieStorage`. Usually rebuilding on Circle fixes it but then it subsequently fails again.

# How

I noticed that the code which we were using to create `HTTPCookie`s was not using our `DateProtocol` type on our `AppEnvironment` and therefore in tests it would not be using `MockDate` so results in tests could be unpredictable. Perhaps the two `HTTPCookie`s that we are constructing in this test might have a different `created` date property and are seen as unique when they're added to the `Set<HTTPCookie>`? However, `HTTPCookie` is a class so equality should be on memory address, shouldn't it? 🤔 

Still, I'd like to merge this change to see if it resolves this test occasionally failing on Circle.

# See 👀

<img width="964" alt="screen shot 2017-07-16 at 12 45 22 pm" src="https://user-images.githubusercontent.com/3735375/28246876-d16a23f6-6a24-11e7-9dd2-72c201e0e96d.png">

