### PR TITLE
Prefer private over fileprivate

### DIFF
--- a/Kickstarter-iOS/ViewModels/UpdateViewModel.swift
+++ b/Kickstarter-iOS/ViewModels/UpdateViewModel.swift
@@ -5,7 +5,7 @@ import Prelude
 import ReactiveSwift
 import Result
 
-fileprivate struct UpdateData {
+private struct UpdateData {
   fileprivate let project: Project
   fileprivate let update: Update
 }

--- a/Library/Format.swift
+++ b/Library/Format.swift
@@ -258,9 +258,9 @@ public enum Format {
   }
 }
 
-fileprivate let defaultThresholdInDays = 30 // days
+private let defaultThresholdInDays = 30 // days
 
-fileprivate struct DateFormatterConfig {
+private struct DateFormatterConfig {
   fileprivate let dateFormat: String?
   fileprivate let dateStyle: DateFormatter.Style?
   fileprivate let locale: Locale
@@ -303,7 +303,7 @@ extension DateFormatterConfig: Hashable {
   }
 }
 
-fileprivate func == (lhs: DateFormatterConfig, rhs: DateFormatterConfig) -> Bool {
+private func == (lhs: DateFormatterConfig, rhs: DateFormatterConfig) -> Bool {
   return
     lhs.dateFormat == rhs.dateFormat
       && lhs.dateStyle == rhs.dateStyle
@@ -312,7 +312,7 @@ fileprivate func == (lhs: DateFormatterConfig, rhs: DateFormatterConfig) -> Bool
       && lhs.timeZone == rhs.timeZone
 }
 
-fileprivate struct NumberFormatterConfig {
+private struct NumberFormatterConfig {
   fileprivate let numberStyle: NumberFormatter.Style
   fileprivate let roundingMode: NumberFormatter.RoundingMode
   fileprivate let maximumFractionDigits: Int
@@ -373,7 +373,7 @@ extension NumberFormatterConfig: Hashable {
   }
 }
 
-fileprivate func == (lhs: NumberFormatterConfig, rhs: NumberFormatterConfig) -> Bool {
+private func == (lhs: NumberFormatterConfig, rhs: NumberFormatterConfig) -> Bool {
   return
     lhs.numberStyle == rhs.numberStyle
       && lhs.roundingMode == rhs.roundingMode

--- a/Library/Koala/Koala.swift
+++ b/Library/Koala/Koala.swift
@@ -2120,7 +2120,7 @@ private func prioritizedLiveStreamState(fromLiveStreamEvents liveStreamEvents: [
 }
 
 // Simple enum to map states on LiveStreamEvent
-fileprivate enum LiveStreamStateContext: Comparable {
+private enum LiveStreamStateContext: Comparable {
   case countdown
   case live
   case replay

--- a/Library/ViewModels/RewardPledgeViewModel.swift
+++ b/Library/ViewModels/RewardPledgeViewModel.swift
@@ -1181,7 +1181,7 @@ private func navigationTitle(forProject project: Project, reward: Reward) -> Str
   )
 }
 
-fileprivate enum PledgeError: Error {
+private enum PledgeError: Error {
   case maximumAmount(ErrorEnvelope)
   case minimumAmount(ErrorEnvelope)
   case other(ErrorEnvelope)


### PR DESCRIPTION
# What

Real quick PR to satisfy a new swiftlint rule.

# Why

See swiftlint's [releases](https://github.com/realm/SwiftLint/releases) for more info but they said it best:

> Add private_over_fileprivate correctable rule to check for top-level usages
of fileprivate and recommend private instead. This is in line with
SE-0169's goal "for fileprivate to be used rarely". There is a also a new
strict_fileprivate opt-in rule that will mark every fileprivate
as a violation (especially useful with Swift 4).

# How

Literally just ran `swiftlint autocorrect` for this one.