### PR TITLE
Pre-configure page view controllers to avoid potential race/crash

### DIFF
--- a/Kickstarter-iOS/Views/Controllers/BackerDashboardViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/BackerDashboardViewController.swift
@@ -41,6 +41,12 @@ internal final class BackerDashboardViewController: UIViewController {
 
     self.pageViewController = self.childViewControllers
       .flatMap { $0 as? UIPageViewController }.first
+    self.pageViewController.setViewControllers(
+      [.init()],
+      direction: .forward,
+      animated: false,
+      completion: nil
+    )
     self.pageViewController.delegate = self
 
     _ = self.backedMenuButton

--- a/Kickstarter-iOS/Views/Controllers/DiscoveryViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/DiscoveryViewController.swift
@@ -21,6 +21,12 @@ internal final class DiscoveryViewController: UIViewController {
 
     self.pageViewController = self.childViewControllers
       .flatMap { $0 as? UIPageViewController }.first
+    self.pageViewController.setViewControllers(
+      [.init()],
+      direction: .forward,
+      animated: false,
+      completion: nil
+    )
     self.pageViewController.delegate = self
 
     self.sortPagerViewController = self.childViewControllers

--- a/Kickstarter-iOS/Views/Controllers/LiveStreamContainerPageViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/LiveStreamContainerPageViewController.swift
@@ -37,7 +37,12 @@ internal final class LiveStreamContainerPageViewController: UIViewController {
     self.pageViewController = self.childViewControllers
       .flatMap { $0 as? UIPageViewController }
       .first
-
+    self.pageViewController?.setViewControllers(
+      [.init()],
+      direction: .forward,
+      animated: false,
+      completion: nil
+    )
     self.pageViewController?.dataSource = self.pagesDataSource
     self.pageViewController?.delegate = self
 

--- a/Kickstarter-iOS/Views/Controllers/ProjectNavigatorViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/ProjectNavigatorViewController.swift
@@ -36,6 +36,12 @@ internal final class ProjectNavigatorViewController: UIPageViewController {
       refTag: refTag,
       navigatorDelegate: navigatorDelegate
     )
+    vc.setViewControllers(
+      [.init()],
+      direction: .forward,
+      animated: true,
+      completion: nil
+    )
     vc.transitioningDelegate = vc
     return vc
   }


### PR DESCRIPTION
Page view controllers [need to have their child view controllers configured before rendering](https://developer.apple.com/library/content/documentation/WindowsViews/Conceptual/ViewControllerCatalog/Chapters/PageViewControllers.html#//apple_ref/doc/uid/TP40011313-CH4-SW10), so let's avoid any signal-based races.

We push all our logic into our signal chains, which means we've seen a few sporadic crashes around page view controllers rendering before they've been fully configured. This is a naive fix for these outlier crashes.