### PR TITLE
Fix project of the day label visibility

### DIFF
--- a/Library/ViewModels/DiscoveryPostcardViewModel.swift
+++ b/Library/ViewModels/DiscoveryPostcardViewModel.swift
@@ -193,18 +193,11 @@ public final class DiscoveryPostcardViewModel: DiscoveryPostcardViewModelType,
     self.deadlineTitleLabelText = deadlineTitleAndSubtitle.map(first)
     self.deadlineSubtitleLabelText = deadlineTitleAndSubtitle.map(second)
 
-    self.metadataViewHidden = configuredProject
-      .map { p in
-        let today = AppEnvironment.current.dateType.init().date
-        let noMetadata = (p.personalization.isBacking == nil || p.personalization.isBacking == false) &&
-                         (p.personalization.isStarred == nil || p.personalization.isStarred == false) &&
-          !p.isPotdToday(today: today) && !p.isFeaturedToday(today: today)
+    let possibleMetadataData = configuredProject.map(postcardMetadata(forProject:))
 
-        return noMetadata
-      }
-      .skipRepeats()
+    self.metadataViewHidden = possibleMetadataData.map { $0 == nil }
 
-    let metadataData = configuredProject.map(postcardMetadata(forProject:)).skipNil()
+    let metadataData = possibleMetadataData.skipNil()
 
     self.metadataIcon = metadataData.map { $0.iconImage }
     self.metadataLabelText = metadataData.map { $0.labelText }

--- a/Library/ViewModels/DiscoveryPostcardViewModelTests.swift
+++ b/Library/ViewModels/DiscoveryPostcardViewModelTests.swift
@@ -258,6 +258,9 @@ internal final class DiscoveryPostcardViewModelTests: TestCase {
       |> Project.lens.category.parent .~ Category.art
       |> Project.lens.dates.featuredAt .~ featuredAt
 
+    let starred = .template
+      |> Project.lens.personalization.isStarred .~ true
+
     let starredAndPotdProject = .template
       |> Project.lens.dates.potdAt .~ potdAt
       |> Project.lens.personalization.isStarred .~ true
@@ -305,6 +308,7 @@ internal final class DiscoveryPostcardViewModelTests: TestCase {
           Strings.discovery_baseball_card_metadata_project_of_the_Day()
         ], "Starred metadata takes precedence.")
 
+      self.metadataViewHidden.assertValues([true, false, false])
       self.metadataIconHidden.assertValues([false, false, true], "No Icon shown for the potd")
       self.metadataIcon.assertValues([backedImage, starredImage])
       self.metadataTextColor.assertValues([backedColor, starredColor])
@@ -318,6 +322,7 @@ internal final class DiscoveryPostcardViewModelTests: TestCase {
           Strings.discovery_baseball_card_metadata_backer()
         ], "Backed metadata takes precedence.")
 
+      self.metadataViewHidden.assertValues([true, false, false, false])
       self.metadataIconHidden.assertValues([false, false, true, true], "No Icon shown for the potd")
       self.metadataIcon.assertValues([backedImage, starredImage, backedImage])
       self.metadataTextColor.assertValues([backedColor, starredColor, backedColor])
@@ -334,6 +339,7 @@ internal final class DiscoveryPostcardViewModelTests: TestCase {
           )
         ], "Featured metadata emits.")
 
+      self.metadataViewHidden.assertValues([true, false, false, false, false])
       self.metadataIconHidden.assertValues([false, false, true, true, false],
         "Icon shown for the featured project")
       self.metadataIcon.assertValues([backedImage, starredImage, backedImage, featuredImage])
@@ -352,8 +358,30 @@ internal final class DiscoveryPostcardViewModelTests: TestCase {
           Strings.discovery_baseball_card_metadata_project_of_the_Day()
         ], "Potd metadata takes precedence.")
 
+      self.metadataViewHidden.assertValues([true, false, false, false, false, false])
       self.metadataIconHidden.assertValues([false, false, true, true, false, true],
         "No Icon shown for the potd project")
+      self.metadataIcon.assertValues(
+        [backedImage, starredImage, backedImage, featuredImage, nil])
+      self.metadataTextColor.assertValues(
+        [backedColor, starredColor, backedColor, featuredColor, potdColor])
+      self.metadataIconTintColor.assertValues(
+        [backedColor, starredColor, backedColor, featuredColor, potdColor])
+
+      self.vm.inputs.configureWith(project: starred)
+      self.metadataLabelText.assertValues(
+        [
+          Strings.discovery_baseball_card_metadata_backer(),
+          Strings.discovery_baseball_card_metadata_project_of_the_Day(),
+          Strings.discovery_baseball_card_metadata_backer(),
+          Strings.discovery_baseball_card_metadata_featured_project(
+            category_name: featuredProject.category.name
+          ),
+          Strings.discovery_baseball_card_metadata_project_of_the_Day()
+        ], "Potd metadata takes precedence.")
+
+      self.metadataViewHidden.assertValues([true, false, false, false, false, false, true])
+      self.metadataIconHidden.assertValues([false, false, true, true, false, true, false])
       self.metadataIcon.assertValues(
         [backedImage, starredImage, backedImage, featuredImage, nil])
       self.metadataTextColor.assertValues(


### PR DESCRIPTION
# What

This just improves how we set the `hidden` attribute of the `metadataView` in `DiscoveryPostcardCell`.

# Why

@ktman noticed that we were incorrectly showing the project of the day label on saved projects:

<img src="https://user-images.githubusercontent.com/3735375/29145311-7b7d7dd0-7d11-11e7-9480-e8bf4cea0daf.PNG" width="50%"/>

# How

Previously we had two separate signals, one that emitted the metadata and another that set the `hidden` attribute based on whether or not there _should_ be metadata. The change here is just to base the latter on the former.

Also added more tests for the `metadataViewHidden` output.
