### PR TITLE
Dashboard data fix

### DIFF
--- a/KsApi/models/ProjectStatsEnvelope.swift
+++ b/KsApi/models/ProjectStatsEnvelope.swift
@@ -29,7 +29,7 @@ public struct ProjectStatsEnvelope {
     public let backersCount: Int
     public let code: String
     public let percentageOfDollars: Double
-    public let pledged: Int
+    public let pledged: Double
     public let referrerName: String
     public let referrerType: ReferrerType
 
@@ -113,7 +113,7 @@ extension ProjectStatsEnvelope.ReferrerStats: Argo.Decodable {
       <*> json <| "code"
       <*> (json <| "percentage_of_dollars" >>- stringToDouble)
     return tmp
-      <*> (json <| "pledged" >>- stringToIntOrZero)
+      <*> (json <| "pledged" >>- stringToDouble)
       <*> json <| "referrer_name"
       <*> json <| "referrer_type"
   }

--- a/KsApi/models/ProjectStatsEnvelopeTests.swift
+++ b/KsApi/models/ProjectStatsEnvelopeTests.swift
@@ -3,7 +3,7 @@ import XCTest
 @testable import Argo
 
 final class ProjectStatsEnvelopeTests: XCTestCase {
-    func testJSONDecoding() {
+  func testJSONDecoding() {
     let fundingStats: [[String:Any]] = [
       [
         "cumulative_backers_count": 7,
@@ -29,7 +29,7 @@ final class ProjectStatsEnvelopeTests: XCTestCase {
           "referrer_name": "My wonderful referrer name",
           "percentage_of_dollars": "0.250",
           "referrer_type": "External",
-          "pledged": "20.0",
+          "pledged": "20.5",
           "backers_count": 8
         ],
         [
@@ -96,11 +96,12 @@ final class ProjectStatsEnvelopeTests: XCTestCase {
 
     XCTAssertEqual("my_wonderful_referrer_code", referralDistribution[0].code)
     XCTAssertEqual(8, referralDistribution[0].backersCount)
+    XCTAssertEqual(20.5, referralDistribution[0].pledged)
     XCTAssertEqual(ProjectStatsEnvelope.ReferrerStats.ReferrerType.external,
                    referralDistribution[0].referrerType)
     XCTAssertEqual("my_okay_referrer_code", referralDistribution[1].code)
     XCTAssertEqual(1, referralDistribution[1].backersCount)
-    XCTAssertEqual(ProjectStatsEnvelope.ReferrerStats.ReferrerType.`internal`,
+    XCTAssertEqual(ProjectStatsEnvelope.ReferrerStats.ReferrerType.internal,
                    referralDistribution[1].referrerType)
 
     XCTAssertEqual(0, rewardDistribution[0].rewardId)

--- a/KsApi/models/lenses/ProjectStatsEnvelope.ReferrerStatsLenses.swift
+++ b/KsApi/models/lenses/ProjectStatsEnvelope.ReferrerStatsLenses.swift
@@ -23,7 +23,7 @@ extension ProjectStatsEnvelope.ReferrerStats {
         referrerType: $1.referrerType) }
     )
 
-    public static let pledged = Lens<ProjectStatsEnvelope.ReferrerStats, Int>(
+    public static let pledged = Lens<ProjectStatsEnvelope.ReferrerStats, Double>(
       view: { $0.pledged },
       set: { ProjectStatsEnvelope.ReferrerStats(backersCount: $1.backersCount, code: $1.code,
         percentageOfDollars: $1.percentageOfDollars, pledged: $0, referrerName: $1.referrerName,

--- a/Library/ViewModels/DashboardReferrerRowStackViewViewModel.swift
+++ b/Library/ViewModels/DashboardReferrerRowStackViewViewModel.swift
@@ -38,7 +38,7 @@ public final class DashboardReferrerRowStackViewViewModel: DashboardReferrerRowS
 
     self.pledgedText = countryReferrer
       .map { country, referrer in
-        Format.currency(referrer.pledged, country: country) + " ("
+        Format.currency(Int(referrer.pledged), country: country) + " ("
           + Format.percentage(referrer.percentageOfDollars) + ")"
     }
 
@@ -46,7 +46,7 @@ public final class DashboardReferrerRowStackViewViewModel: DashboardReferrerRowS
 
     self.textColor = countryReferrer.map { _, referrer in
       switch referrer.referrerType {
-      case .`internal`:
+      case .internal:
         return .ksr_green_700
       case .external:
         return .ksr_orange_400

--- a/Library/ViewModels/DashboardReferrersCellViewModel.swift
+++ b/Library/ViewModels/DashboardReferrersCellViewModel.swift
@@ -86,111 +86,111 @@ public final class DashboardReferrersCellViewModel: DashboardReferrersCellViewMo
   DashboardReferrersCellViewModelOutputs, DashboardReferrersCellViewModelType {
 
     public init() {
-    let cumulativeProjectStats = cumulativeProjectStatsProperty.signal.skipNil()
+      let cumulativeProjectStats = cumulativeProjectStatsProperty.signal.skipNil()
 
-    let country = cumulativeProjectStats.map { _, project, _ in project.country }
+      let country = cumulativeProjectStats.map { _, project, _ in project.country }
 
-    let referrers = cumulativeProjectStats.map { _, _, stats in stats }
+      let referrers = cumulativeProjectStats.map { _, _, stats in stats }
 
-    self.averagePledgeText = cumulativeProjectStats
-      .map { cumulative, project, _ in
-        Format.currency(cumulative.averagePledge, country: project.country)
-    }
+      self.averagePledgeText = cumulativeProjectStats
+        .map { cumulative, project, _ in
+          Format.currency(cumulative.averagePledge, country: project.country)
+      }
 
-    let customReferrers = referrers
-      .map { referrers in referrers.filter { $0.referrerType == .custom } }
+      let customReferrers = referrers
+        .map { referrers in referrers.filter { $0.referrerType == .custom } }
 
-    let customPledgedAmount = customReferrers
-      .map { $0.reduce(0) { accum, referrer in accum + referrer.pledged } }
+      let customPledgedAmount = customReferrers
+        .map { $0.reduce(0.0) { accum, referrer in accum + referrer.pledged } }
 
-    let externalReferrers = referrers
-      .map { referrers in referrers.filter { $0.referrerType == .external } }
+      let externalReferrers = referrers
+        .map { referrers in referrers.filter { $0.referrerType == .external } }
 
-    let externalPledgedAmount = externalReferrers
-      .map { $0.reduce(0) { accum, referrer in accum + referrer.pledged } }
+      let externalPledgedAmount = externalReferrers
+        .map { $0.reduce(0.0) { accum, referrer in accum + referrer.pledged } }
 
-    let internalReferrers = referrers
-      .map { referrers in referrers.filter { $0.referrerType == .`internal` } }
+      let internalReferrers = referrers
+        .map { referrers in referrers.filter { $0.referrerType == .internal } }
 
-    let internalPledgedAmount = internalReferrers
-      .map { $0.reduce(0) { accum, referrer in accum + referrer.pledged } }
+      let internalPledgedAmount = internalReferrers
+        .map { $0.reduce(0.0) { accum, referrer in accum + referrer.pledged } }
 
-    self.customPercentText = customReferrers
-      .map { $0.reduce(0.0) { accum, referrer in accum + referrer.percentageOfDollars } }
-      .map { Format.percentage($0) }
+      self.customPercentText = customReferrers
+        .map { $0.reduce(0.0) { accum, referrer in accum + referrer.percentageOfDollars } }
+        .map { Format.percentage($0) }
 
-    self.customPledgedText = Signal.combineLatest(customPledgedAmount, country)
-      .map { pledged, country in Format.currency(pledged, country: country) }
+      self.customPledgedText = Signal.combineLatest(customPledgedAmount, country)
+        .map { pledged, country in Format.currency(Int(pledged), country: country) }
 
-    self.customStackViewHidden = customReferrers.map { $0.isEmpty }
+      self.customStackViewHidden = customReferrers.map { $0.isEmpty }
 
-    self.externalPercentage = externalReferrers
-      .map { $0.reduce(0.0) { accum, referrer in accum + referrer.percentageOfDollars } }
+      self.externalPercentage = externalReferrers
+        .map { $0.reduce(0.0) { accum, referrer in accum + referrer.percentageOfDollars } }
 
-    self.externalPercentText = self.externalPercentage.map { Format.percentage($0) }
+      self.externalPercentText = self.externalPercentage.map { Format.percentage($0) }
 
-    self.externalPledgedText = Signal.combineLatest(externalPledgedAmount, country)
-      .map { pledged, country in Format.currency(pledged, country: country) }
+      self.externalPledgedText = Signal.combineLatest(externalPledgedAmount, country)
+        .map { pledged, country in Format.currency(Int(pledged), country: country) }
 
-    self.internalPercentage = internalReferrers
-      .map { $0.reduce(0.0) { accum, referrer in accum + referrer.percentageOfDollars } }
+      self.internalPercentage = internalReferrers
+        .map { $0.reduce(0.0) { accum, referrer in accum + referrer.percentageOfDollars } }
 
-    self.internalPercentText = self.internalPercentage.map { Format.percentage($0) }
+      self.internalPercentText = self.internalPercentage.map { Format.percentage($0) }
 
-    self.internalPledgedText = Signal.combineLatest(internalPledgedAmount, country)
-      .map { pledged, country in Format.currency(pledged, country: country) }
+      self.internalPledgedText = Signal.combineLatest(internalPledgedAmount, country)
+        .map { pledged, country in Format.currency(Int(pledged), country: country) }
 
-    let sortedByPledgedOrPercent = referrers.sort { $0.pledged > $1.pledged }
+      let sortedByPledgedOrPercent = referrers.sort { $0.pledged > $1.pledged }
 
-    let initialSort = sortedByPledgedOrPercent
+      let initialSort = sortedByPledgedOrPercent
 
-    let sortedByBackers = referrers
-      .takeWhen(self.backersButtonTappedProperty.signal)
-      .sort { $0.backersCount > $1.backersCount }
+      let sortedByBackers = referrers
+        .takeWhen(self.backersButtonTappedProperty.signal)
+        .sort { $0.backersCount > $1.backersCount }
 
-    let sortedByPercent = sortedByPledgedOrPercent
-      .takeWhen(self.percentButtonTappedProperty.signal)
+      let sortedByPercent = sortedByPledgedOrPercent
+        .takeWhen(self.percentButtonTappedProperty.signal)
 
-    let sortedByPledged = sortedByPledgedOrPercent
-      .takeWhen(self.pledgedButtonTappedProperty.signal)
+      let sortedByPledged = sortedByPledgedOrPercent
+        .takeWhen(self.pledgedButtonTappedProperty.signal)
 
-    let sortedBySource = referrers
-      .takeWhen(self.sourceButtonTappedProperty.signal)
-      .sort { $0.referrerName.lowercased() < $1.referrerName.lowercased() }
+      let sortedBySource = referrers
+        .takeWhen(self.sourceButtonTappedProperty.signal)
+        .sort { $0.referrerName.lowercased() < $1.referrerName.lowercased() }
 
-    let allReferrers = Signal.merge(
-      initialSort,
-      sortedByBackers,
-      sortedByPercent,
-      sortedByPledged,
-      sortedBySource
-    )
+      let allReferrers = Signal.merge(
+        initialSort,
+        sortedByBackers,
+        sortedByPercent,
+        sortedByPledged,
+        sortedBySource
+      )
 
-    let allReferrersRowData = Signal.combineLatest(country, allReferrers)
-      .map { ReferrersRowData(country: $0, referrers: $1) }
+      let allReferrersRowData = Signal.combineLatest(country, allReferrers)
+        .map { ReferrersRowData(country: $0, referrers: $1) }
 
-    let showMoreReferrersButtonIsHidden = Signal.merge(
-      referrers.map { $0.count < 6 },
-      showMoreReferrersTappedProperty.signal.mapConst(true)
-    )
+      let showMoreReferrersButtonIsHidden = Signal.merge(
+        referrers.map { $0.count < 6 },
+        showMoreReferrersTappedProperty.signal.mapConst(true)
+      )
 
-    self.showMoreReferrersButtonHidden = showMoreReferrersButtonIsHidden.skipRepeats()
+      self.showMoreReferrersButtonHidden = showMoreReferrersButtonIsHidden.skipRepeats()
 
-    self.referrersRowData = Signal.combineLatest(allReferrersRowData, showMoreReferrersButtonIsHidden)
-      .map { rowData, isHidden in
-        let refCount = rowData.referrers.count
-        let maxReferrers = isHidden ? rowData.referrers :
-          Array(rowData.referrers[0..<(min(3, refCount))])
-        return ReferrersRowData(country: rowData.country, referrers: maxReferrers)
-    }
-    .skipRepeats(==)
+      self.referrersRowData = Signal.combineLatest(allReferrersRowData, showMoreReferrersButtonIsHidden)
+        .map { rowData, isHidden in
+          let refCount = rowData.referrers.count
+          let maxReferrers = isHidden ? rowData.referrers :
+            Array(rowData.referrers[0..<(min(3, refCount))])
+          return ReferrersRowData(country: rowData.country, referrers: maxReferrers)
+      }
+      .skipRepeats(==)
 
-    self.notifyDelegateAddedReferrerRows = self.showMoreReferrersTappedProperty.signal
+      self.notifyDelegateAddedReferrerRows = self.showMoreReferrersTappedProperty.signal
 
-    cumulativeProjectStats
-      .takeWhen(self.showMoreReferrersTappedProperty.signal)
-      .observeValues { _, project, _ in
-        AppEnvironment.current.koala.trackDashboardSeeMoreReferrers(project: project)
+      cumulativeProjectStats
+        .takeWhen(self.showMoreReferrersTappedProperty.signal)
+        .observeValues { _, project, _ in
+          AppEnvironment.current.koala.trackDashboardSeeMoreReferrers(project: project)
     }
   }
   // swiftlint:enable function_body_length

--- a/Library/ViewModels/DashboardReferrersCellViewModelTests.swift
+++ b/Library/ViewModels/DashboardReferrersCellViewModelTests.swift
@@ -39,15 +39,15 @@ internal final class DashboardReferrersCellViewModelTests: TestCase {
     let referrers = [
       .template
         |> ProjectStatsEnvelope.ReferrerStats.lens.percentageOfDollars .~ 0.5
-        |> ProjectStatsEnvelope.ReferrerStats.lens.pledged .~ 500
+        |> ProjectStatsEnvelope.ReferrerStats.lens.pledged .~ 500.5
         |> ProjectStatsEnvelope.ReferrerStats.lens.referrerType .~ .`internal`,
       .template
         |> ProjectStatsEnvelope.ReferrerStats.lens.percentageOfDollars .~ 0.2
-        |> ProjectStatsEnvelope.ReferrerStats.lens.pledged .~ 200
+        |> ProjectStatsEnvelope.ReferrerStats.lens.pledged .~ 200.5
         |> ProjectStatsEnvelope.ReferrerStats.lens.referrerType .~ .`internal`,
       .template
         |> ProjectStatsEnvelope.ReferrerStats.lens.percentageOfDollars .~ 0.3
-        |> ProjectStatsEnvelope.ReferrerStats.lens.pledged .~ 300
+        |> ProjectStatsEnvelope.ReferrerStats.lens.pledged .~ 300.5
         |> ProjectStatsEnvelope.ReferrerStats.lens.referrerType .~ .external,
       ]
 
@@ -56,7 +56,7 @@ internal final class DashboardReferrersCellViewModelTests: TestCase {
     self.externalPercentText.assertValues(["30%"])
     self.externalPledgedText.assertValues(["$300"])
     self.internalPercentText.assertValues(["70%"])
-    self.internalPledgedText.assertValues(["$700"])
+    self.internalPledgedText.assertValues(["$701"])
   }
 
   func testCumulativeDataEmits() {


### PR DESCRIPTION
Referrer data comes back as a decimal, but we were converting to `Int`, losing precision along the way.