### PR TITLE
Put cancel button back on MessageDialogViewController

### DIFF
--- a/Kickstarter-iOS/Views/Controllers/MessageDialogViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/MessageDialogViewController.swift
@@ -32,10 +32,8 @@ internal final class MessageDialogViewController: UIViewController {
 
   internal override func viewDidLoad() {
     super.viewDidLoad()
+    
     self.viewModel.inputs.viewDidLoad()
-
-    _ = self.cancelButton
-      |> UIBarButtonItem.lens.title %~ { _ in Strings.general_navigation_buttons_cancel() }
   }
 
   internal override func bindViewModel() {
@@ -66,6 +64,9 @@ internal final class MessageDialogViewController: UIViewController {
 
   internal override func bindStyles() {
     super.bindStyles()
+    
+    _ = self.cancelButton
+      |> UIBarButtonItem.lens.title %~ { _ in Strings.general_navigation_buttons_cancel() }
 
     _ = self.nameLabel
       |> UILabel.lens.textColor .~ .ksr_text_dark_grey_900

--- a/Kickstarter-iOS/Views/Controllers/MessageDialogViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/MessageDialogViewController.swift
@@ -15,6 +15,7 @@ internal final class MessageDialogViewController: UIViewController {
 
   @IBOutlet private weak var bodyTextView: UITextView!
   @IBOutlet private weak var bottomConstraint: NSLayoutConstraint!
+  @IBOutlet private weak var cancelButton: UIBarButtonItem!
   @IBOutlet private weak var loadingView: UIView!
   @IBOutlet private weak var nameLabel: UILabel!
   @IBOutlet private weak var postButton: UIBarButtonItem!
@@ -32,6 +33,9 @@ internal final class MessageDialogViewController: UIViewController {
   internal override func viewDidLoad() {
     super.viewDidLoad()
     self.viewModel.inputs.viewDidLoad()
+
+    _ = self.cancelButton
+      |> UIBarButtonItem.lens.title %~ { _ in Strings.general_navigation_buttons_cancel() }
   }
 
   internal override func bindViewModel() {

--- a/Kickstarter-iOS/Views/Controllers/MessageDialogViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/MessageDialogViewController.swift
@@ -32,7 +32,7 @@ internal final class MessageDialogViewController: UIViewController {
 
   internal override func viewDidLoad() {
     super.viewDidLoad()
-    
+
     self.viewModel.inputs.viewDidLoad()
   }
 
@@ -64,7 +64,7 @@ internal final class MessageDialogViewController: UIViewController {
 
   internal override func bindStyles() {
     super.bindStyles()
-    
+
     _ = self.cancelButton
       |> UIBarButtonItem.lens.title %~ { _ in Strings.general_navigation_buttons_cancel() }
 

--- a/Kickstarter-iOS/Views/Storyboards/Messages.storyboard
+++ b/Kickstarter-iOS/Views/Storyboards/Messages.storyboard
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12121" systemVersion="16G29" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="yFB-aB-OIQ">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13196" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="yFB-aB-OIQ">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12089"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13173"/>
         <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -70,7 +71,7 @@
                                                                                     <nil key="highlightedColor"/>
                                                                                 </label>
                                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" text=" " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hgR-mz-tiu" userLabel="Participant">
-                                                                                    <rect key="frame" x="8.5" y="0.0" width="485" height="20.5"/>
+                                                                                    <rect key="frame" x="15" y="0.0" width="478.5" height="20.5"/>
                                                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                                     <nil key="highlightedColor"/>
@@ -200,21 +201,21 @@
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <subviews>
                                 <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="djz-c8-ji0">
-                                    <rect key="frame" x="224.5" y="0.0" width="30" height="33"/>
+                                    <rect key="frame" x="224" y="0.0" width="30" height="33"/>
                                     <subviews>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text=" " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Znl-pP-aP1" userLabel="Inbox">
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Znl-pP-aP1" userLabel="Inbox">
                                             <rect key="frame" x="0.0" y="6.5" width="15" height="20.5"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <nil key="highlightedColor"/>
                                         </label>
-                                        <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" image="arrow-down" translatesAutoresizingMaskIntoConstraints="NO" id="EW3-b0-MFq">
+                                        <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="arrow-down" translatesAutoresizingMaskIntoConstraints="NO" id="EW3-b0-MFq">
                                             <rect key="frame" x="19" y="13.5" width="11" height="6"/>
                                         </imageView>
                                     </subviews>
                                 </stackView>
                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="4DR-RI-47z" userLabel="Button overlay">
-                                    <rect key="frame" x="224.5" y="0.0" width="30" height="33"/>
+                                    <rect key="frame" x="224" y="0.0" width="30" height="33"/>
                                     <connections>
                                         <action selector="mailboxButtonPressed" destination="yFB-aB-OIQ" eventType="touchUpInside" id="ORI-4T-IEv"/>
                                     </connections>
@@ -340,7 +341,7 @@
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="751" text=" " textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="PSG-vO-xho">
-                                                    <rect key="frame" x="0.0" y="28" width="4.5" height="20.5"/>
+                                                    <rect key="frame" x="0.0" y="28" width="0.0" height="20.5"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
@@ -789,6 +790,7 @@
                     <connections>
                         <outlet property="bodyTextView" destination="vtp-r8-Uzf" id="Td2-ei-nNr"/>
                         <outlet property="bottomConstraint" destination="boJ-cf-Xi5" id="3a8-ro-1rH"/>
+                        <outlet property="cancelButton" destination="3hH-GL-W2n" id="L76-2v-2jc"/>
                         <outlet property="loadingView" destination="Lyc-i3-lJV" id="Q1P-Sw-nvn"/>
                         <outlet property="nameLabel" destination="mxd-lZ-Kbx" id="1vA-5n-SZw"/>
                         <outlet property="postButton" destination="9ac-Ox-Glu" id="PXV-cT-NC8"/>


### PR DESCRIPTION
# What

Quick fix to bring back the cancel button on `MessageDialogViewController`.

# Why

It's needed to dismiss the dialog if one does not want to send a message.

# How

I think it might have been removed during #224, so if "Cancel" was the default in the Storyboard then the button would have no text not not appear.

# See 👀

<img src="https://user-images.githubusercontent.com/3735375/30885723-46d69516-a2c9-11e7-85e7-74261e173232.gif" width="50%">