### PR TITLE
CircleCI Xcode 9 updates

### DIFF
--- a/.fastlane/Fastfile
+++ b/.fastlane/Fastfile
@@ -4,7 +4,7 @@ default_platform :ios
 
 platform :ios do
   before_all do
-    xcversion(version: "8.3.3")
+    xcversion(version: "9.0")
   end
 
   ### BETA

--- a/circle.yml
+++ b/circle.yml
@@ -37,20 +37,20 @@ deployment:
     commands:
       - agvtool new-version -all $(($(date +%s)/100))
       - fastlane alpha_gym --verbose:
-        timeout: 1800
+          timeout: 1800
       - fastlane alpha_hockey --verbose
   ios_beta:
     branch: beta-dist
     commands:
       - agvtool new-version -all $(($(date +%s)/100))
       - fastlane beta_gym --verbose:
-        timeout: 1800
+          timeout: 1800
       - fastlane beta_hockey --verbose
   ios_itc:
     branch: itunes-dist
     commands:
       - agvtool new-version -all $(($(date +%s)/100))
       - fastlane itunes_gym --verbose:
-        timeout: 1800
+          timeout: 1800
       - fastlane itunes_hockey --verbose
       - fastlane itunes_deliver --verbose

--- a/circle.yml
+++ b/circle.yml
@@ -12,7 +12,6 @@ dependencies:
     - security find-identity -p codesigning
     - instruments -s devices
     - xcodebuild -showsdks
-    - gem install fastlane -NVv 2.37.0
 test:
   pre:
     - xcrun instruments -w 'iPhone 7 (10.3.1)' || true

--- a/circle.yml
+++ b/circle.yml
@@ -36,18 +36,21 @@ deployment:
     branch: alpha-dist
     commands:
       - agvtool new-version -all $(($(date +%s)/100))
-      - fastlane alpha_gym --verbose
+      - fastlane alpha_gym --verbose:
+        timeout: 1800
       - fastlane alpha_hockey --verbose
   ios_beta:
     branch: beta-dist
     commands:
       - agvtool new-version -all $(($(date +%s)/100))
-      - fastlane beta_gym --verbose
+      - fastlane beta_gym --verbose:
+        timeout: 1800
       - fastlane beta_hockey --verbose
   ios_itc:
     branch: itunes-dist
     commands:
       - agvtool new-version -all $(($(date +%s)/100))
-      - fastlane itunes_gym --verbose
+      - fastlane itunes_gym --verbose:
+        timeout: 1800
       - fastlane itunes_hockey --verbose
       - fastlane itunes_deliver --verbose


### PR DESCRIPTION
# What

Some changes needed to build our app using Xcode 9 on CircleCI.

Changes are:

- Set CircleCI to use Xcode 9
- Allow fastlane's `gym` command to timeout after 30 mins

`gym` seems to take nearly 20 mins to successfully compile our app now and this was failing with the default 10 min timeout option. Increasing this to 30 mins gets us successful deployments. I would suggest that we keep an eye on this and if we see these times dropping in the future we can try removing this option.