### PR TITLE
Fix double paste bug

### DIFF
--- a/Library/SafariActivity.swift
+++ b/Library/SafariActivity.swift
@@ -3,14 +3,21 @@ import Foundation
 import UIKit
 
 public let SafariActivityType = UIActivityType("com.kickstarter.kickstarter.safari")
+public final class SafariURL {
+  public let url: URL
+
+  public init(_ url: URL) {
+    self.url = url
+  }
+}
 
 public final class SafariActivity: UIActivity {
   fileprivate var url: URL?
 
-  public convenience init(url: URL) {
+  public convenience init(url: SafariURL) {
     self.init()
 
-    self.url = url
+    self.url = url.url
   }
 
   public override var activityType: UIActivityType? {
@@ -26,7 +33,7 @@ public final class SafariActivity: UIActivity {
   }
 
   public override func canPerform(withActivityItems activityItems: [Any]) -> Bool {
-    let urls = activityItems.filter { $0 is URL && ($0 as? URL)?.host != nil }
+    let urls = activityItems.filter { $0 is SafariURL }
     return !urls.isEmpty
   }
 

--- a/Library/SafariActivity.swift
+++ b/Library/SafariActivity.swift
@@ -3,12 +3,8 @@ import Foundation
 import UIKit
 
 public let SafariActivityType = UIActivityType("com.kickstarter.kickstarter.safari")
-public final class SafariURL {
+public struct SafariURL {
   public let url: URL
-
-  public init(_ url: URL) {
-    self.url = url
-  }
 }
 
 public final class SafariActivity: UIActivity {

--- a/Library/ViewModels/ShareViewModel.swift
+++ b/Library/ViewModels/ShareViewModel.swift
@@ -237,7 +237,7 @@ private func activityController(forShareContext shareContext: ShareContext) -> U
   guard let url = shareUrl(forShareContext: shareContext) else { return nil }
 
   let provider = activityItemProvider(forShareContext: shareContext)
-  let safariUrl = SafariURL(url)
+  let safariUrl = SafariURL(url: url)
 
   let controller = UIActivityViewController(activityItems: [provider, safariUrl],
                                             applicationActivities: [SafariActivity(url: safariUrl)])

--- a/Library/ViewModels/ShareViewModel.swift
+++ b/Library/ViewModels/ShareViewModel.swift
@@ -235,11 +235,12 @@ private func excludedActivityTypes(forShareContext shareContext: ShareContext) -
 
 private func activityController(forShareContext shareContext: ShareContext) -> UIActivityViewController? {
   guard let url = shareUrl(forShareContext: shareContext) else { return nil }
-
+  
   let provider = activityItemProvider(forShareContext: shareContext)
+  let safariUrl = SafariURL(url)
 
-  let controller = UIActivityViewController(activityItems: [provider, url],
-                                            applicationActivities: [SafariActivity(url: url)])
+  let controller = UIActivityViewController(activityItems: [provider, safariUrl],
+                                            applicationActivities: [SafariActivity(url: safariUrl)])
 
   controller.excludedActivityTypes = excludedActivityTypes(forShareContext: shareContext)
 

--- a/Library/ViewModels/ShareViewModel.swift
+++ b/Library/ViewModels/ShareViewModel.swift
@@ -235,7 +235,7 @@ private func excludedActivityTypes(forShareContext shareContext: ShareContext) -
 
 private func activityController(forShareContext shareContext: ShareContext) -> UIActivityViewController? {
   guard let url = shareUrl(forShareContext: shareContext) else { return nil }
-  
+
   let provider = activityItemProvider(forShareContext: shareContext)
   let safariUrl = SafariURL(url)
 


### PR DESCRIPTION
# What

Fixed a bug that caused our shared links to copy twice to the paste board.

# Why

iOS 11 introduced a bug in that our shared links would be concatenated and therefore not share correctly.

This seems to be caused by putting a `URL` object directly into the `activityItems` array that we pass to instantiate a `UIActivityViewController`. iOS 11 appears to incorrectly interpret this in some way.

However we _do_ need to pass a URL to `activityItems` so that it is passed to our `SafariActivity` so that we can present the _Open in Safari_ item.

# How

Proposed solution here is to wrap the `URL` in a `SafariURL` so that iOS 11 does not try to internally interpret it but still passes it to our `SafariActivity` so that we might.

Not sure if this is the best way to go about it but it does seem to fix the issue, alternatives welcome!

cc @tiegz 