### PR TITLE
Adds ksr.dev support

### DIFF
--- a/Kickstarter-iOS/Info.plist
+++ b/Kickstarter-iOS/Info.plist
@@ -56,8 +56,6 @@
 	<dict>
 		<key>NSExceptionDomains</key>
 		<dict>
-<<<<<<< Updated upstream
-=======
 			<key>ksr.dev</key>
 			<dict>
 				<key>NSExceptionAllowsInsecureHTTPLoads</key>
@@ -65,7 +63,6 @@
 				<key>NSIncludesSubdomains</key>
 				<true/>
 			</dict>
->>>>>>> Stashed changes
 			<key>akamaihd.net</key>
 			<dict>
 				<key>NSIncludesSubdomains</key>

--- a/Kickstarter-iOS/Info.plist
+++ b/Kickstarter-iOS/Info.plist
@@ -56,6 +56,16 @@
 	<dict>
 		<key>NSExceptionDomains</key>
 		<dict>
+<<<<<<< Updated upstream
+=======
+			<key>ksr.dev</key>
+			<dict>
+				<key>NSExceptionAllowsInsecureHTTPLoads</key>
+				<true/>
+				<key>NSIncludesSubdomains</key>
+				<true/>
+			</dict>
+>>>>>>> Stashed changes
 			<key>akamaihd.net</key>
 			<dict>
 				<key>NSIncludesSubdomains</key>


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# What + Why

This pull request adds `ksr.dev` to the ExceptionDomains list, so that KSR devs can run the app in the simulator against APIs running locally.
