### PR TITLE
Added supported localizations to CFBundleLocalizations

### DIFF
--- a/Kickstarter-iOS/Info.plist
+++ b/Kickstarter-iOS/Info.plist
@@ -2,6 +2,13 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleLocalizations</key>
+	<array>
+		<string>Spanish</string>
+		<string>ja</string>
+		<string>fr</string>
+		<string>de</string>
+	</array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleExecutable</key>


### PR DESCRIPTION
# What

Fix date localizations.

# Why

The app was showing American date format for all languages (iOS 11).

# How

Adding manually the supported localizations .

# See 👀

<img width="375" alt="screen shot 2017-10-12 at 12 40 39" src="https://user-images.githubusercontent.com/3709676/31508731-fc58cfbe-af4c-11e7-9c91-1fb5f7a5e513.png">
<img width="376" alt="screen shot 2017-10-12 at 12 42 38" src="https://user-images.githubusercontent.com/3709676/31508732-fc665dc8-af4c-11e7-94a2-e76dcf65a2c7.png">
<img width="376" alt="screen shot 2017-10-12 at 12 44 24" src="https://user-images.githubusercontent.com/3709676/31508733-fc709388-af4c-11e7-84af-103c481c7644.png">
<img width="376" alt="screen shot 2017-10-12 at 12 45 29" src="https://user-images.githubusercontent.com/3709676/31508734-fcf69028-af4c-11e7-969f-3940d4eed6c9.png">
<img width="376" alt="screen shot 2017-10-12 at 12 46 31" src="https://user-images.githubusercontent.com/3709676/31508735-fd09a532-af4c-11e7-8e83-340d1dae5b26.png">

