### PR TITLE
Added shipping metadata on page rewards

### DIFF
--- a/Kickstarter-iOS/Views/Cells/RewardCell.swift
+++ b/Kickstarter-iOS/Views/Cells/RewardCell.swift
@@ -32,6 +32,9 @@ internal final class RewardCell: UITableViewCell, ValueCell {
   @IBOutlet fileprivate weak var rewardTitleLabel: UILabel!
   @IBOutlet fileprivate weak var rootStackView: UIStackView!
   @IBOutlet fileprivate weak var selectRewardButton: UIButton!
+  @IBOutlet fileprivate weak var shippingLocationsLabel: UILabel!
+  @IBOutlet fileprivate weak var shippingLocationsStackView: UIStackView!
+  @IBOutlet fileprivate weak var shippingLocationsSummaryLabel: UILabel!
   @IBOutlet fileprivate var separatorViews: [UIView]!
   @IBOutlet fileprivate weak var titleDescriptionStackView: UIStackView!
   @IBOutlet fileprivate weak var viewYourPledgeButton: UIButton!
@@ -147,6 +150,15 @@ internal final class RewardCell: UITableViewCell, ValueCell {
         UIImage(named: "checkmark-icon", in: .framework, compatibleWith: nil)
     }
 
+    _ = self.shippingLocationsLabel
+      |> UILabel.lens.text %~ { _ in Strings.Ships_to() }
+      |> UILabel.lens.font .~ .ksr_caption1(size: 12)
+      |> UILabel.lens.textColor .~ .ksr_text_dark_grey_400
+
+    _ = self.shippingLocationsSummaryLabel
+      |> UILabel.lens.font .~ .ksr_caption1(size: 12)
+      |> UILabel.lens.textColor .~ .ksr_text_dark_grey_900
+
     _ = self.youreABackerContainerView
       |> roundedStyle(cornerRadius: 2)
       |> UIView.lens.backgroundColor .~ UIColor.ksr_green_500
@@ -211,6 +223,8 @@ internal final class RewardCell: UITableViewCell, ValueCell {
     self.rewardTitleLabel.rac.textColor = self.viewModel.outputs.titleLabelTextColor
     self.selectRewardButton.rac.hidden = self.viewModel.outputs.pledgeButtonHidden
     self.selectRewardButton.rac.title = self.viewModel.outputs.pledgeButtonTitleText
+    self.shippingLocationsStackView.rac.hidden = self.viewModel.outputs.shippingLocationsStackViewHidden
+    self.shippingLocationsSummaryLabel.rac.text = self.viewModel.outputs.shippingLocationsSummaryLabelText
     self.viewYourPledgeButton.rac.hidden = self.viewModel.outputs.viewPledgeButtonHidden
     self.youreABackerContainerView.rac.hidden = self.viewModel.outputs.youreABackerViewHidden
     self.youreABackerLabel.rac.text = self.viewModel.outputs.youreABackerLabelText

--- a/Kickstarter-iOS/Views/Cells/RewardCell.swift
+++ b/Kickstarter-iOS/Views/Cells/RewardCell.swift
@@ -90,8 +90,8 @@ internal final class RewardCell: UITableViewCell, ValueCell {
     _ = self.footerStackView
       |> UIStackView.lens.spacing .~ Styles.grid(1)
 
-    _ = self.estimatedDeliveryDateStackView
-      |> UIStackView.lens.spacing .~ Styles.gridHalf(1)
+    _ = [self.estimatedDeliveryDateStackView, self.shippingLocationsStackView]
+      ||> UIStackView.lens.spacing .~ Styles.gridHalf(1)
 
     _ = [self.itemsContainerStackView, self.itemsHeaderStackView, self.itemsStackView]
       ||> UIStackView.lens.spacing .~ Styles.grid(2)
@@ -144,12 +144,6 @@ internal final class RewardCell: UITableViewCell, ValueCell {
       |> UILabel.lens.textColor .~ .ksr_text_dark_grey_500
       |> UILabel.lens.text %~ { _ in Strings.rewards_info_includes() }
 
-    _ = self.youreABackerCheckmarkImageView
-      |> UIImageView.lens.tintColor .~ .ksr_text_dark_grey_500
-      |> UIImageView.lens.image %~ { _ in
-        UIImage(named: "checkmark-icon", in: .framework, compatibleWith: nil)
-    }
-
     _ = self.shippingLocationsLabel
       |> UILabel.lens.text %~ { _ in Strings.Ships_to() }
       |> UILabel.lens.font .~ .ksr_caption1(size: 12)
@@ -158,6 +152,12 @@ internal final class RewardCell: UITableViewCell, ValueCell {
     _ = self.shippingLocationsSummaryLabel
       |> UILabel.lens.font .~ .ksr_caption1(size: 12)
       |> UILabel.lens.textColor .~ .ksr_text_dark_grey_900
+
+    _ = self.youreABackerCheckmarkImageView
+      |> UIImageView.lens.tintColor .~ .ksr_text_dark_grey_500
+      |> UIImageView.lens.image %~ { _ in
+        UIImage(named: "checkmark-icon", in: .framework, compatibleWith: nil)
+    }
 
     _ = self.youreABackerContainerView
       |> roundedStyle(cornerRadius: 2)

--- a/Kickstarter-iOS/Views/Storyboards/RewardCell.xib
+++ b/Kickstarter-iOS/Views/Storyboards/RewardCell.xib
@@ -21,20 +21,20 @@
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="LtE-rB-s4X">
-                        <rect key="frame" x="8" y="8" width="384" height="360"/>
+                        <rect key="frame" x="0.0" y="8" width="0.0" height="360"/>
                         <color key="backgroundColor" red="0.89916485550000003" green="0.89916485550000003" blue="0.89916485550000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </view>
                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="ClI-KP-p62">
-                        <rect key="frame" x="8" y="8" width="384" height="360"/>
+                        <rect key="frame" x="0.0" y="8" width="0.0" height="360"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="SpG-Wk-xbI">
-                                <rect key="frame" x="0.0" y="0.0" width="384" height="91"/>
+                                <rect key="frame" x="0.0" y="0.0" width="0.0" height="91"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="HuL-8h-2yY">
-                                        <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="0.0" height="50"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ber-Jq-wpT">
-                                                <rect key="frame" x="8" y="8" width="34" height="34"/>
+                                                <rect key="frame" x="0.0" y="8" width="0.0" height="34"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleCaption1"/>
                                                 <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <nil key="highlightedColor"/>
@@ -63,16 +63,16 @@
                                 </subviews>
                             </stackView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="BVe-zh-Ug0">
-                                <rect key="frame" x="0.0" y="91" width="384" height="41"/>
+                                <rect key="frame" x="0.0" y="91" width="0.0" height="41"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" " textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iIC-hP-TM6">
-                                        <rect key="frame" x="0.0" y="0.0" width="384" height="20.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="0.0" height="20.5"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" " textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="B5h-K5-99V">
-                                        <rect key="frame" x="0.0" y="20.5" width="384" height="20.5"/>
+                                        <rect key="frame" x="0.0" y="20.5" width="0.0" height="20.5"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
@@ -80,19 +80,19 @@
                                 </subviews>
                             </stackView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="N9f-Hl-Cme">
-                                <rect key="frame" x="0.0" y="132" width="384" height="64.5"/>
+                                <rect key="frame" x="0.0" y="132" width="0.0" height="64.5"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="zOR-Fu-LpS">
-                                        <rect key="frame" x="0.0" y="0.0" width="384" height="21.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="0.0" height="21.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="syp-8Y-uEy">
-                                                <rect key="frame" x="0.0" y="0.0" width="384" height="20.5"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="0.0" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Quv-l1-g5N" userLabel="Separator">
-                                                <rect key="frame" x="0.0" y="20.5" width="384" height="1"/>
+                                                <rect key="frame" x="0.0" y="20.5" width="0.0" height="1"/>
                                                 <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="1" id="Gcy-ip-uDd"/>
@@ -101,29 +101,29 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="4J7-vD-mDv">
-                                        <rect key="frame" x="0.0" y="21.5" width="384" height="43"/>
+                                        <rect key="frame" x="0.0" y="21.5" width="0.0" height="43"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="efz-9c-5r4">
-                                                <rect key="frame" x="0.0" y="0.0" width="384" height="20.5"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="0.0" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ThU-qA-kix" userLabel="Separator">
-                                                <rect key="frame" x="0.0" y="20.5" width="384" height="1"/>
+                                                <rect key="frame" x="0.0" y="20.5" width="0.0" height="1"/>
                                                 <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="1" id="eiF-HV-NNG"/>
                                                 </constraints>
                                             </view>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="f1P-zD-bKm">
-                                                <rect key="frame" x="0.0" y="21.5" width="384" height="20.5"/>
+                                                <rect key="frame" x="0.0" y="21.5" width="0.0" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ouh-pf-8XJ" userLabel="Separator">
-                                                <rect key="frame" x="0.0" y="42" width="384" height="1"/>
+                                                <rect key="frame" x="0.0" y="42" width="0.0" height="1"/>
                                                 <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="1" id="a6R-5J-kfh"/>
@@ -134,7 +134,7 @@
                                 </subviews>
                             </stackView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="D07-wW-qgy">
-                                <rect key="frame" x="0.0" y="196.5" width="384" height="61.5"/>
+                                <rect key="frame" x="0.0" y="196.5" width="0.0" height="61.5"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aFx-bf-QvQ">
                                         <rect key="frame" x="0.0" y="0.0" width="4.5" height="20.5"/>
@@ -152,7 +152,7 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sdH-Qe-JqA">
-                                                <rect key="frame" x="4.5" y="0.0" width="4.5" height="20.5"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="4.5" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -169,7 +169,7 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6PZ-VQ-cOp">
-                                                <rect key="frame" x="4.5" y="0.0" width="4.5" height="20.5"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="4.5" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -179,19 +179,19 @@
                                 </subviews>
                             </stackView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="b6V-iQ-dJH">
-                                <rect key="frame" x="0.0" y="258" width="384" height="34"/>
+                                <rect key="frame" x="0.0" y="258" width="0.0" height="34"/>
                                 <state key="normal">
                                     <color key="titleColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 </state>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="EiA-FK-XIn">
-                                <rect key="frame" x="0.0" y="292" width="384" height="34"/>
+                                <rect key="frame" x="0.0" y="292" width="0.0" height="34"/>
                                 <state key="normal">
                                     <color key="titleColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 </state>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="OB6-C6-hXY">
-                                <rect key="frame" x="0.0" y="326" width="384" height="34"/>
+                                <rect key="frame" x="0.0" y="326" width="0.0" height="34"/>
                                 <state key="normal">
                                     <color key="titleColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 </state>
@@ -199,17 +199,17 @@
                         </subviews>
                     </stackView>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ERr-HV-ckO">
-                        <rect key="frame" x="8" y="-7.5" width="30.5" height="31"/>
+                        <rect key="frame" x="0.0" y="-7.5" width="30.5" height="31"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="0Od-kk-9HF">
-                                <rect key="frame" x="8" y="8.5" width="14.5" height="14.5"/>
+                                <rect key="frame" x="0.0" y="8.5" width="14.5" height="14.5"/>
                                 <subviews>
                                     <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="checkmark-icon" translatesAutoresizingMaskIntoConstraints="NO" id="Oej-Qu-s2x">
                                         <rect key="frame" x="0.0" y="2.5" width="11" height="9"/>
                                         <color key="tintColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     </imageView>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="u3J-kd-L3V">
-                                        <rect key="frame" x="11" y="0.0" width="3.5" height="14.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="3.5" height="14.5"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleCaption1"/>
                                         <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>

--- a/Kickstarter-iOS/Views/Storyboards/RewardCell.xib
+++ b/Kickstarter-iOS/Views/Storyboards/RewardCell.xib
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="12121" systemVersion="16G29" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13196" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12089"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13173"/>
         <capability name="Alignment constraints with different attributes" minToolsVersion="5.1"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -20,20 +21,20 @@
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="LtE-rB-s4X">
-                        <rect key="frame" x="8" y="8" width="384" height="339.5"/>
+                        <rect key="frame" x="8" y="8" width="384" height="360"/>
                         <color key="backgroundColor" red="0.89916485550000003" green="0.89916485550000003" blue="0.89916485550000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </view>
                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="ClI-KP-p62">
-                        <rect key="frame" x="8" y="8" width="384" height="339.5"/>
+                        <rect key="frame" x="8" y="8" width="384" height="360"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="SpG-Wk-xbI">
                                 <rect key="frame" x="0.0" y="0.0" width="384" height="91"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="HuL-8h-2yY">
-                                        <rect key="frame" x="0.0" y="0.0" width="62" height="50"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ber-Jq-wpT">
-                                                <rect key="frame" x="8" y="8" width="46" height="34"/>
+                                                <rect key="frame" x="8" y="8" width="34" height="34"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleCaption1"/>
                                                 <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <nil key="highlightedColor"/>
@@ -133,7 +134,7 @@
                                 </subviews>
                             </stackView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="D07-wW-qgy">
-                                <rect key="frame" x="0.0" y="196.5" width="384" height="41"/>
+                                <rect key="frame" x="0.0" y="196.5" width="384" height="61.5"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aFx-bf-QvQ">
                                         <rect key="frame" x="0.0" y="0.0" width="4.5" height="20.5"/>
@@ -141,8 +142,25 @@
                                         <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9Yt-QJ-18l">
+                                    <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hgQ-E0-GXa">
                                         <rect key="frame" x="0.0" y="20.5" width="9" height="20.5"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sCg-UF-tUm">
+                                                <rect key="frame" x="0.0" y="0.0" width="4.5" height="20.5"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sdH-Qe-JqA">
+                                                <rect key="frame" x="4.5" y="0.0" width="4.5" height="20.5"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                        </subviews>
+                                    </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9Yt-QJ-18l">
+                                        <rect key="frame" x="0.0" y="41" width="9" height="20.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xcw-kr-o9a">
                                                 <rect key="frame" x="0.0" y="0.0" width="4.5" height="20.5"/>
@@ -161,19 +179,19 @@
                                 </subviews>
                             </stackView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="b6V-iQ-dJH">
-                                <rect key="frame" x="0.0" y="237.5" width="384" height="34"/>
+                                <rect key="frame" x="0.0" y="258" width="384" height="34"/>
                                 <state key="normal">
                                     <color key="titleColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 </state>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="EiA-FK-XIn">
-                                <rect key="frame" x="0.0" y="271.5" width="384" height="34"/>
+                                <rect key="frame" x="0.0" y="292" width="384" height="34"/>
                                 <state key="normal">
                                     <color key="titleColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 </state>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="OB6-C6-hXY">
-                                <rect key="frame" x="0.0" y="305.5" width="384" height="34"/>
+                                <rect key="frame" x="0.0" y="326" width="384" height="34"/>
                                 <state key="normal">
                                     <color key="titleColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 </state>
@@ -187,7 +205,7 @@
                                 <rect key="frame" x="8" y="8.5" width="14.5" height="14.5"/>
                                 <subviews>
                                     <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="checkmark-icon" translatesAutoresizingMaskIntoConstraints="NO" id="Oej-Qu-s2x">
-                                        <rect key="frame" x="0.0" y="3" width="11" height="9"/>
+                                        <rect key="frame" x="0.0" y="2.5" width="11" height="9"/>
                                         <color key="tintColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     </imageView>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="u3J-kd-L3V">
@@ -243,6 +261,9 @@
                 <outlet property="rewardTitleLabel" destination="iIC-hP-TM6" id="te7-RQ-W4L"/>
                 <outlet property="rootStackView" destination="ClI-KP-p62" id="AHi-OE-SH9"/>
                 <outlet property="selectRewardButton" destination="b6V-iQ-dJH" id="oOm-dp-js4"/>
+                <outlet property="shippingLocationsLabel" destination="sCg-UF-tUm" id="A2Q-yj-eAe"/>
+                <outlet property="shippingLocationsStackView" destination="hgQ-E0-GXa" id="5Xb-1J-azz"/>
+                <outlet property="shippingLocationsSummaryLabel" destination="sdH-Qe-JqA" id="jGJ-Ak-Nhj"/>
                 <outlet property="titleDescriptionStackView" destination="BVe-zh-Ug0" id="aZw-SO-Apf"/>
                 <outlet property="viewYourPledgeButton" destination="OB6-C6-hXY" id="oFM-yb-lzN"/>
                 <outlet property="youreABackerCheckmarkImageView" destination="Oej-Qu-s2x" id="yt5-00-qpR"/>

--- a/Library/ViewModels/RewardCellViewModel.swift
+++ b/Library/ViewModels/RewardCellViewModel.swift
@@ -208,7 +208,7 @@ RewardCellViewModelOutputs {
     }
 
     self.shippingLocationsSummaryLabelText = reward.map {
-      " " + ($0.shipping.summary ?? "")
+      $0.shipping.summary ?? ""
     }
 
     let tappable = Signal.zip(project, reward, youreABacker)

--- a/Library/ViewModels/RewardCellViewModel.swift
+++ b/Library/ViewModels/RewardCellViewModel.swift
@@ -28,6 +28,8 @@ public protocol RewardCellViewModelOutputs {
   var notifyDelegateRewardCellWantsExpansion: Signal<(), NoError> { get }
   var pledgeButtonHidden: Signal<Bool, NoError> { get }
   var pledgeButtonTitleText: Signal<String, NoError> { get }
+  var shippingLocationsStackViewHidden: Signal<Bool, NoError> { get }
+  var shippingLocationsSummaryLabelText: Signal<String, NoError> { get }
   var titleLabelHidden: Signal<Bool, NoError> { get }
   var titleLabelText: Signal<String, NoError> { get }
   var titleLabelTextColor: Signal<UIColor, NoError> { get }
@@ -201,6 +203,14 @@ RewardCellViewModelOutputs {
         : Strings.Select_this_reward()
     }
 
+    self.shippingLocationsStackViewHidden = reward.map {
+      $0.shipping.summary == nil
+    }
+
+    self.shippingLocationsSummaryLabelText = reward.map {
+      " " + ($0.shipping.summary ?? "")
+    }
+
     let tappable = Signal.zip(project, reward, youreABacker)
       .map { project, reward, youreABacker in
         (project.state == .live && reward.remaining != 0)
@@ -270,6 +280,8 @@ RewardCellViewModelOutputs {
   public let notifyDelegateRewardCellWantsExpansion: Signal<(), NoError>
   public let pledgeButtonHidden: Signal<Bool, NoError>
   public let pledgeButtonTitleText: Signal<String, NoError>
+  public let shippingLocationsStackViewHidden: Signal<Bool, NoError>
+  public let shippingLocationsSummaryLabelText: Signal<String, NoError>
   public let titleLabelHidden: Signal<Bool, NoError>
   public let titleLabelText: Signal<String, NoError>
   public let titleLabelTextColor: Signal<UIColor, NoError>

--- a/Library/ViewModels/RewardCellViewModelTests.swift
+++ b/Library/ViewModels/RewardCellViewModelTests.swift
@@ -31,6 +31,8 @@ final class RewardCellViewModelTests: TestCase {
   fileprivate let titleLabelHidden = TestObserver<Bool, NoError>()
   fileprivate let titleLabelText = TestObserver<String, NoError>()
   fileprivate let titleLabelTextColor = TestObserver<UIColor, NoError>()
+  fileprivate let shippingLocationsStackViewHidden = TestObserver<Bool, NoError>()
+  fileprivate let shippingLocationsSummaryLabelText = TestObserver<String, NoError>()
   fileprivate let updateTopMarginsForIsBacking = TestObserver<Bool, NoError>() // todo
   fileprivate let viewPledgeButtonHidden = TestObserver<Bool, NoError>() // todo
   fileprivate let youreABackerViewHidden = TestObserver<Bool, NoError>() // todo
@@ -60,6 +62,8 @@ final class RewardCellViewModelTests: TestCase {
     self.vm.outputs.titleLabelHidden.observe(self.titleLabelHidden.observer)
     self.vm.outputs.titleLabelText.observe(self.titleLabelText.observer)
     self.vm.outputs.titleLabelTextColor.observe(self.titleLabelTextColor.observer)
+    self.vm.outputs.shippingLocationsStackViewHidden.observe(self.shippingLocationsStackViewHidden.observer)
+    self.vm.outputs.shippingLocationsSummaryLabelText.observe(self.shippingLocationsSummaryLabelText.observer)
     self.vm.outputs.updateTopMarginsForIsBacking.observe(self.updateTopMarginsForIsBacking.observer)
     self.vm.outputs.viewPledgeButtonHidden.observe(self.viewPledgeButtonHidden.observer)
     self.vm.outputs.youreABackerViewHidden.observe(self.youreABackerViewHidden.observer)
@@ -696,6 +700,32 @@ final class RewardCellViewModelTests: TestCase {
     )
 
     self.titleLabelTextColor.assertValues([.ksr_text_dark_grey_900])
+  }
+
+  func testShippingLocationsSummaryLabelText_WhenRewardDoesNotHaveShippingSummary() {
+    let reward = .template
+      |> Reward.lens.shipping.summary .~ nil
+
+    self.vm.inputs.configureWith(
+      project: .template,
+      rewardOrBacking: .left(reward)
+    )
+
+    self.shippingLocationsSummaryLabelText.assertValues([" "])
+    self.shippingLocationsStackViewHidden.assertValues([true])
+  }
+
+  func testShippingLocationsSummaryLabelText_WhenRewardHasShippingSummary() {
+    let reward = .template
+      |> Reward.lens.shipping.summary .~ "Anywhere in the world."
+
+    self.vm.inputs.configureWith(
+      project: .template,
+      rewardOrBacking: .left(reward)
+    )
+
+    self.shippingLocationsSummaryLabelText.assertValues([" " + "Anywhere in the world."])
+    self.shippingLocationsStackViewHidden.assertValues([false])
   }
 
   func testYoureABacker_WhenYoureABacker() {

--- a/Library/ViewModels/RewardCellViewModelTests.swift
+++ b/Library/ViewModels/RewardCellViewModelTests.swift
@@ -711,7 +711,7 @@ final class RewardCellViewModelTests: TestCase {
       rewardOrBacking: .left(reward)
     )
 
-    self.shippingLocationsSummaryLabelText.assertValues([" "])
+    self.shippingLocationsSummaryLabelText.assertValues([""])
     self.shippingLocationsStackViewHidden.assertValues([true])
   }
 
@@ -724,7 +724,7 @@ final class RewardCellViewModelTests: TestCase {
       rewardOrBacking: .left(reward)
     )
 
-    self.shippingLocationsSummaryLabelText.assertValues([" " + "Anywhere in the world."])
+    self.shippingLocationsSummaryLabelText.assertValues(["Anywhere in the world."])
     self.shippingLocationsStackViewHidden.assertValues([false])
   }
 


### PR DESCRIPTION
# What

Added Shipping summary on page rewards.

# Why

https://trello.com/c/sJ5bI434/95-display-shipping-metadata-on-project-page-rewards


# See 👀

<img width="376" alt="screen shot 2017-10-16 at 12 18 55" src="https://user-images.githubusercontent.com/3709676/31623145-88aa80a8-b26c-11e7-9f48-ae683676a43d.png">
