### PR TITLE
Ios11 compatibility tweaks

### DIFF
--- a/Kickstarter-iOS/Views/Controllers/DiscoveryViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/DiscoveryViewController.swift
@@ -4,8 +4,6 @@ import Prelude
 import UIKit
 
 internal final class DiscoveryViewController: UIViewController {
-  @IBOutlet private weak var navigationHeaderHeightLayoutConstraint: NSLayoutConstraint!
-
   fileprivate let viewModel: DiscoveryViewModelType = DiscoveryViewModel()
   fileprivate var dataSource: DiscoveryPagesDataSource!
 
@@ -50,11 +48,6 @@ internal final class DiscoveryViewController: UIViewController {
     self.viewModel.inputs.viewWillAppear(animated: animated)
 
     self.navigationController?.setNavigationBarHidden(true, animated: animated)
-  }
-
-  @available(iOS 11, *)
-  override func viewSafeAreaInsetsDidChange() {
-    self.viewModel.inputs.viewSafeAreaInsetsDidChange()
   }
 
   override func bindViewModel() {
@@ -104,12 +97,6 @@ internal final class DiscoveryViewController: UIViewController {
         self?.pageViewController.setViewControllers(
           [controller], direction: direction, animated: true, completion: nil
         )
-    }
-
-    self.viewModel.outputs.navigationHeaderTopInset
-      .observeForUI()
-      .observeValues { [weak self] value in
-        self?.navigationHeaderHeightLayoutConstraint.constant -= value
     }
 
     self.viewModel.outputs.selectSortPage

--- a/Kickstarter-iOS/Views/Controllers/DiscoveryViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/DiscoveryViewController.swift
@@ -106,10 +106,10 @@ internal final class DiscoveryViewController: UIViewController {
         )
     }
 
-    self.viewModel.outputs.navigationHeaderHeightLayoutConstant
+    self.viewModel.outputs.navigationHeaderTopInset
       .observeForUI()
-      .observeValues { [weak self] constant in
-        self?.navigationHeaderHeightLayoutConstraint.constant -= constant
+      .observeValues { [weak self] value in
+        self?.navigationHeaderHeightLayoutConstraint.constant -= value
     }
 
     self.viewModel.outputs.selectSortPage

--- a/Kickstarter-iOS/Views/Controllers/DiscoveryViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/DiscoveryViewController.swift
@@ -11,7 +11,8 @@ internal final class DiscoveryViewController: UIViewController {
   private weak var navigationHeaderViewController: DiscoveryNavigationHeaderViewController!
   private weak var pageViewController: UIPageViewController!
   private weak var sortPagerViewController: SortPagerViewController!
-
+  @IBOutlet weak var navigationHeaderHeightLayoutConstraint: NSLayoutConstraint!
+  
   internal static func instantiate() -> DiscoveryViewController {
     return Storyboard.Discovery.instantiate(DiscoveryViewController.self)
   }
@@ -51,6 +52,11 @@ internal final class DiscoveryViewController: UIViewController {
     self.navigationController?.setNavigationBarHidden(true, animated: animated)
   }
 
+  @available(iOS 11, *)
+  override func viewSafeAreaInsetsDidChange() {
+    self.viewModel.inputs.viewSafeAreaInsetsDidChange()
+  }
+
   override func bindViewModel() {
     super.bindViewModel()
 
@@ -88,14 +94,6 @@ internal final class DiscoveryViewController: UIViewController {
       .observeForControllerAction()
       .observeValues { [weak self] in self?.dataSource.load(filter: $0) }
 
-    self.viewModel.outputs.selectSortPage
-      .observeForControllerAction()
-      .observeValues { [weak self] in self?.sortPagerViewController.select(sort: $0) }
-
-    self.viewModel.outputs.updateSortPagerStyle
-      .observeForControllerAction()
-      .observeValues { [weak self] in self?.sortPagerViewController.updateStyle(categoryId: $0) }
-
     self.viewModel.outputs.navigateToSort
       .observeForControllerAction()
       .observeValues { [weak self] sort, direction in
@@ -108,11 +106,25 @@ internal final class DiscoveryViewController: UIViewController {
         )
     }
 
+    self.viewModel.outputs.navigationHeaderHeightLayoutConstant
+      .observeForUI()
+      .observeValues { [weak self] constant in
+        self?.navigationHeaderHeightLayoutConstraint.constant -= constant
+    }
+
+    self.viewModel.outputs.selectSortPage
+      .observeForControllerAction()
+      .observeValues { [weak self] in self?.sortPagerViewController.select(sort: $0) }
+
     self.viewModel.outputs.sortsAreEnabled
       .observeForUI()
       .observeValues { [weak self] in
         self?.sortPagerViewController.setSortPagerEnabled($0)
     }
+
+    self.viewModel.outputs.updateSortPagerStyle
+      .observeForControllerAction()
+      .observeValues { [weak self] in self?.sortPagerViewController.updateStyle(categoryId: $0) }
   }
 
   internal func filter(with params: DiscoveryParams) {

--- a/Kickstarter-iOS/Views/Controllers/DiscoveryViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/DiscoveryViewController.swift
@@ -4,6 +4,8 @@ import Prelude
 import UIKit
 
 internal final class DiscoveryViewController: UIViewController {
+  @IBOutlet private weak var navigationHeaderHeightLayoutConstraint: NSLayoutConstraint!
+
   fileprivate let viewModel: DiscoveryViewModelType = DiscoveryViewModel()
   fileprivate var dataSource: DiscoveryPagesDataSource!
 
@@ -11,8 +13,6 @@ internal final class DiscoveryViewController: UIViewController {
   private weak var navigationHeaderViewController: DiscoveryNavigationHeaderViewController!
   private weak var pageViewController: UIPageViewController!
   private weak var sortPagerViewController: SortPagerViewController!
-  @IBOutlet weak var navigationHeaderHeightLayoutConstraint: NSLayoutConstraint!
-  
   internal static func instantiate() -> DiscoveryViewController {
     return Storyboard.Discovery.instantiate(DiscoveryViewController.self)
   }

--- a/Kickstarter-iOS/Views/Controllers/ProjectPamphletViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/ProjectPamphletViewController.swift
@@ -30,10 +30,6 @@ public final class ProjectPamphletViewController: UIViewController {
     return UIApplication.shared.statusBarOrientation.isLandscape
   }
 
-  public override var preferredStatusBarStyle: UIStatusBarStyle {
-    return .lightContent
-  }
-
   public override func viewDidLoad() {
     super.viewDidLoad()
 

--- a/Kickstarter-iOS/Views/Controllers/ProjectPamphletViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/ProjectPamphletViewController.swift
@@ -33,6 +33,8 @@ public final class ProjectPamphletViewController: UIViewController {
   public override func viewDidLoad() {
     super.viewDidLoad()
 
+    self.edgesForExtendedLayout = [.left, .bottom, .right]
+
     self.navBarController = self.childViewControllers
       .flatMap { $0 as? ProjectNavBarViewController }.first
     self.navBarController.delegate = self

--- a/Kickstarter-iOS/Views/Storyboards/Discovery.storyboard
+++ b/Kickstarter-iOS/Views/Storyboards/Discovery.storyboard
@@ -20,19 +20,19 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="FAX-pt-y2u" userLabel="Pages container">
-                                <rect key="frame" x="0.0" y="135" width="400" height="465"/>
+                                <rect key="frame" x="0.0" y="116" width="400" height="484"/>
                                 <connections>
                                     <segue destination="ynw-dc-pxD" kind="embed" id="5LZ-9P-sMI"/>
                                 </connections>
                             </containerView>
                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="FbJ-Sz-gTi" userLabel="Live stream container">
-                                <rect key="frame" x="0.0" y="85" width="400" height="515"/>
+                                <rect key="frame" x="0.0" y="64" width="400" height="536"/>
                                 <connections>
                                     <segue destination="UAu-DY-esz" kind="embed" id="kVE-io-dOw"/>
                                 </connections>
                             </containerView>
                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Doj-qA-CRz" userLabel="Sorts container">
-                                <rect key="frame" x="0.0" y="85" width="400" height="50"/>
+                                <rect key="frame" x="0.0" y="65" width="400" height="50"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="50" id="HnD-3P-4LC"/>
                                 </constraints>
@@ -41,9 +41,9 @@
                                 </connections>
                             </containerView>
                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dUb-ni-s34" userLabel="Navigation Header container">
-                                <rect key="frame" x="0.0" y="20" width="400" height="65"/>
+                                <rect key="frame" x="0.0" y="20" width="400" height="45"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="65" id="WoQ-4r-ybI"/>
+                                    <constraint firstAttribute="height" constant="45" id="WoQ-4r-ybI"/>
                                 </constraints>
                                 <connections>
                                     <segue destination="RCd-Hu-FaN" kind="embed" id="LIY-S4-2G6"/>
@@ -52,14 +52,14 @@
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
-                            <constraint firstItem="dUb-ni-s34" firstAttribute="top" secondItem="Kuh-85-Y4E" secondAttribute="topMargin" id="5jZ-Uk-gLE"/>
+                            <constraint firstItem="dUb-ni-s34" firstAttribute="top" secondItem="bgp-rK-1DR" secondAttribute="top" id="5jZ-Uk-gLE"/>
                             <constraint firstItem="FbJ-Sz-gTi" firstAttribute="leading" secondItem="dUb-ni-s34" secondAttribute="leading" id="6rH-us-STJ"/>
-                            <constraint firstItem="FAX-pt-y2u" firstAttribute="top" secondItem="Doj-qA-CRz" secondAttribute="bottom" id="9Dr-uo-nMZ"/>
+                            <constraint firstItem="FAX-pt-y2u" firstAttribute="top" secondItem="Doj-qA-CRz" secondAttribute="bottom" constant="1" id="9Dr-uo-nMZ"/>
                             <constraint firstItem="dUb-ni-s34" firstAttribute="leading" secondItem="bgp-rK-1DR" secondAttribute="leading" id="Ato-za-9z9"/>
                             <constraint firstItem="bgp-rK-1DR" firstAttribute="bottom" secondItem="FbJ-Sz-gTi" secondAttribute="bottom" id="Ggf-9q-yZh"/>
                             <constraint firstItem="bgp-rK-1DR" firstAttribute="trailing" secondItem="FAX-pt-y2u" secondAttribute="trailing" id="Haf-Tu-zCG"/>
                             <constraint firstItem="Doj-qA-CRz" firstAttribute="leading" secondItem="bgp-rK-1DR" secondAttribute="leading" id="JuW-Ce-Bj2"/>
-                            <constraint firstItem="FbJ-Sz-gTi" firstAttribute="top" secondItem="dUb-ni-s34" secondAttribute="bottom" id="QAs-lR-vmg"/>
+                            <constraint firstItem="FbJ-Sz-gTi" firstAttribute="top" secondItem="dUb-ni-s34" secondAttribute="bottom" constant="-1" id="QAs-lR-vmg"/>
                             <constraint firstItem="bgp-rK-1DR" firstAttribute="trailing" secondItem="Doj-qA-CRz" secondAttribute="trailing" id="ZjO-cl-xir"/>
                             <constraint firstItem="bgp-rK-1DR" firstAttribute="trailing" secondItem="dUb-ni-s34" secondAttribute="trailing" id="gmC-ma-ITZ"/>
                             <constraint firstItem="bgp-rK-1DR" firstAttribute="bottom" secondItem="FAX-pt-y2u" secondAttribute="bottom" id="hJB-FS-xfb"/>
@@ -75,13 +75,10 @@
                     <nil key="simulatedTopBarMetrics"/>
                     <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
                     <size key="freeformSize" width="400" height="600"/>
-                    <connections>
-                        <outlet property="navigationHeaderHeightLayoutConstraint" destination="WoQ-4r-ybI" id="yef-rN-R8D"/>
-                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="fHV-lA-AM8" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1321" y="-767"/>
+            <point key="canvasLocation" x="1320" y="-767.31634182908556"/>
         </scene>
         <!--Page View Controller-->
         <scene sceneID="fhy-HW-TM2">
@@ -429,22 +426,22 @@
             <objects>
                 <viewController storyboardIdentifier="DiscoveryNavigationHeaderViewController" id="RCd-Hu-FaN" customClass="DiscoveryNavigationHeaderViewController" customModule="Kickstarter_Framework" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="189-Qu-20l">
-                        <rect key="frame" x="0.0" y="0.0" width="400" height="65"/>
+                        <rect key="frame" x="0.0" y="0.0" width="400" height="45"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="H2g-DT-JXM" customClass="GradientView" customModule="Library">
-                                <rect key="frame" x="0.0" y="0.0" width="400" height="65"/>
+                                <rect key="frame" x="0.0" y="0.0" width="400" height="45"/>
                                 <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95294117649999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Uqu-6W-LIK">
-                                <rect key="frame" x="0.0" y="64" width="400" height="1"/>
+                                <rect key="frame" x="0.0" y="44" width="400" height="1"/>
                                 <color key="backgroundColor" red="0.023529411764705882" green="0.13725490196078433" blue="0.25098039215686274" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="1" id="JXf-q8-Fkc"/>
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="CTG-N8-oCA" userLabel="Favorite Container View">
-                                <rect key="frame" x="0.0" y="11" width="44" height="44"/>
+                                <rect key="frame" x="0.0" y="1" width="44" height="44"/>
                                 <subviews>
                                     <imageView userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="heart-outline" translatesAutoresizingMaskIntoConstraints="NO" id="Ij6-dc-OpY">
                                         <rect key="frame" x="8" y="13" width="20" height="18"/>
@@ -478,10 +475,10 @@
                                 </variation>
                             </view>
                             <stackView opaque="NO" contentMode="scaleToFill" misplaced="YES" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="AvP-Jg-11Z" userLabel="Outer Stack View">
-                                <rect key="frame" x="104" y="0.0" width="41.5" height="65"/>
+                                <rect key="frame" x="104" y="0.0" width="41.5" height="45"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="RUu-Jy-Y4V">
-                                        <rect key="frame" x="0.0" y="22.5" width="22.5" height="20.5"/>
+                                        <rect key="frame" x="0.0" y="12.5" width="22.5" height="20.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Xzf-ev-nrc">
                                                 <rect key="frame" x="0.0" y="0.0" width="4.5" height="20.5"/>
@@ -504,7 +501,7 @@
                                         </subviews>
                                     </stackView>
                                     <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" image="arrow-down" translatesAutoresizingMaskIntoConstraints="NO" id="0Gr-Vv-egm">
-                                        <rect key="frame" x="30.5" y="29.5" width="11" height="6"/>
+                                        <rect key="frame" x="30.5" y="19.5" width="11" height="6"/>
                                         <color key="tintColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     </imageView>
                                 </subviews>
@@ -513,7 +510,7 @@
                                 </constraints>
                             </stackView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="9CN-EK-zBj">
-                                <rect key="frame" x="179.5" y="0.0" width="41.5" height="65"/>
+                                <rect key="frame" x="179.5" y="0.0" width="41.5" height="45"/>
                                 <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                             </button>
                         </subviews>

--- a/Kickstarter-iOS/Views/Storyboards/Discovery.storyboard
+++ b/Kickstarter-iOS/Views/Storyboards/Discovery.storyboard
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13196" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
@@ -76,6 +75,9 @@
                     <nil key="simulatedTopBarMetrics"/>
                     <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
                     <size key="freeformSize" width="400" height="600"/>
+                    <connections>
+                        <outlet property="navigationHeaderHeightLayoutConstraint" destination="WoQ-4r-ybI" id="yef-rN-R8D"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="fHV-lA-AM8" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>

--- a/Kickstarter-iOS/Views/Storyboards/ProjectPamphlet.storyboard
+++ b/Kickstarter-iOS/Views/Storyboards/ProjectPamphlet.storyboard
@@ -23,6 +23,8 @@
                         <subviews>
                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="tIm-aj-d8Q">
                                 <rect key="frame" x="0.0" y="0.0" width="400" height="1400"/>
+                                <edgeInsets key="layoutMargins" top="8" left="8" bottom="8" right="8"/>
+                                <viewLayoutGuide key="safeArea" id="G2d-Ze-vJe"/>
                                 <connections>
                                     <segue destination="8BT-Sh-bBd" kind="embed" id="C2u-Fy-leY"/>
                                 </connections>
@@ -32,6 +34,7 @@
                                 <constraints>
                                     <constraint firstAttribute="height" constant="55" id="Mpa-HP-9KU"/>
                                 </constraints>
+                                <viewLayoutGuide key="safeArea" id="HMF-Sm-Wkm"/>
                                 <connections>
                                     <segue destination="Tne-VL-OCU" kind="embed" id="Zw0-Ot-rWA"/>
                                 </connections>
@@ -49,6 +52,7 @@
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="6CV-SZ-InC"/>
                     </view>
+                    <extendedEdge key="edgesForExtendedLayout" bottom="YES"/>
                     <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
                     <size key="freeformSize" width="400" height="1400"/>
                     <connections>
@@ -170,7 +174,7 @@
         <scene sceneID="Rey-uy-gd3">
             <objects>
                 <tableViewController storyboardIdentifier="ProjectPamphletContentViewController" id="8BT-Sh-bBd" customClass="ProjectPamphletContentViewController" customModule="Kickstarter_Framework" customModuleProvider="target" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="381" sectionHeaderHeight="28" sectionFooterHeight="28" id="lny-Ga-DTZ">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="381" sectionHeaderHeight="28" sectionFooterHeight="28" contentViewInsetsToSafeArea="NO" id="lny-Ga-DTZ">
                         <rect key="frame" x="0.0" y="0.0" width="400" height="1800"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/Kickstarter-iOS/Views/Storyboards/ProjectPamphlet.storyboard
+++ b/Kickstarter-iOS/Views/Storyboards/ProjectPamphlet.storyboard
@@ -52,7 +52,6 @@
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="6CV-SZ-InC"/>
                     </view>
-                    <extendedEdge key="edgesForExtendedLayout" bottom="YES"/>
                     <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
                     <size key="freeformSize" width="400" height="1400"/>
                     <connections>
@@ -174,7 +173,7 @@
         <scene sceneID="Rey-uy-gd3">
             <objects>
                 <tableViewController storyboardIdentifier="ProjectPamphletContentViewController" id="8BT-Sh-bBd" customClass="ProjectPamphletContentViewController" customModule="Kickstarter_Framework" customModuleProvider="target" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="381" sectionHeaderHeight="28" sectionFooterHeight="28" contentViewInsetsToSafeArea="NO" id="lny-Ga-DTZ">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="381" sectionHeaderHeight="28" sectionFooterHeight="28" id="lny-Ga-DTZ">
                         <rect key="frame" x="0.0" y="0.0" width="400" height="1800"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/Kickstarter-iOS/Views/Storyboards/ProjectPamphlet.storyboard
+++ b/Kickstarter-iOS/Views/Storyboards/ProjectPamphlet.storyboard
@@ -37,7 +37,7 @@
                                 </connections>
                             </containerView>
                         </subviews>
-                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
                             <constraint firstItem="6CV-SZ-InC" firstAttribute="trailing" secondItem="bdk-Xa-fm9" secondAttribute="trailing" id="3Dg-lk-oRa"/>
                             <constraint firstItem="6CV-SZ-InC" firstAttribute="bottom" secondItem="tIm-aj-d8Q" secondAttribute="bottom" id="8FY-Rt-Ar2"/>

--- a/Kickstarter-iOS/Views/Storyboards/Search.storyboard
+++ b/Kickstarter-iOS/Views/Storyboards/Search.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13196" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="zb8-de-x1Y">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13196" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="zb8-de-x1Y">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
@@ -8,6 +8,7 @@
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13173"/>
         <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -17,9 +18,10 @@
                 <navigationController id="zb8-de-x1Y" sceneMemberID="viewController">
                     <tabBarItem key="tabBarItem" title="" id="mIh-15-JtZ"/>
                     <simulatedTabBarMetrics key="simulatedBottomBarMetrics"/>
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="25t-aa-IxE">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" id="25t-aa-IxE">
                         <rect key="frame" x="0.0" y="20" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
+                        <viewLayoutGuide key="safeArea" id="oa1-PM-8fv"/>
                     </navigationBar>
                     <connections>
                         <segue destination="GNf-h9-HSf" kind="relationship" relationship="rootViewController" id="X7l-R6-Qfb"/>
@@ -27,7 +29,7 @@
                 </navigationController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="z8h-35-Quf" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-593" y="361"/>
+            <point key="canvasLocation" x="-591" y="357"/>
         </scene>
         <!--Search View Controller-->
         <scene sceneID="4Kj-Ef-uD0">

--- a/Kickstarter-iOS/Views/Transitions/ProjectNavigatorTransitionAnimator.swift
+++ b/Kickstarter-iOS/Views/Transitions/ProjectNavigatorTransitionAnimator.swift
@@ -1,7 +1,7 @@
 import UIKit
 
-private let dismissedOverlayColor = UIColor(white: 0, alpha: 0)
-private let presentedOverlayColor = UIColor(white: 0, alpha: 0.7)
+private let dismissedOverlayColor = UIColor(white: 1, alpha: 0)
+private let presentedOverlayColor = UIColor(white: 1, alpha: 1)
 
 internal final class ProjectNavigatorTransitionAnimator: UIPercentDrivenInteractiveTransition,
 UIViewControllerAnimatedTransitioning {

--- a/Library/ViewModels/DiscoveryViewModel.swift
+++ b/Library/ViewModels/DiscoveryViewModel.swift
@@ -22,6 +22,9 @@ public protocol DiscoveryViewModelInputs {
   /// Call from the controller's viewDidLoad.
   func viewDidLoad()
 
+  /// Call from the controller's viewSafeAreaInsetsDidChange.
+  func viewSafeAreaInsetsDidChange()
+
   /// Call from the controller's viewWillAppear.
   func viewWillAppear(animated: Bool)
 
@@ -50,6 +53,9 @@ public protocol DiscoveryViewModelOutputs {
 
   /// Emits when we should manually navigate to a sort's page.
   var navigateToSort: Signal<(DiscoveryParams.Sort, UIPageViewControllerNavigationDirection), NoError> { get }
+
+  /// Emits a CGFloat that should be used to configure the NavigationHeaderViewController height
+  var navigationHeaderHeightLayoutConstant: Signal<CGFloat, NoError> { get }
 
   /// Emits a sort that should be passed on to the sort pager view controller.
   var selectSortPage: Signal<DiscoveryParams.Sort, NoError> { get }
@@ -117,6 +123,10 @@ DiscoveryViewModelOutputs {
         return (next.sort, lhs < rhs ? .reverse : .forward)
     }
 
+    self.navigationHeaderHeightLayoutConstant = self.navigationHeightProperty.signal.skipNil()
+      .map { $0 }
+      .skipRepeats()
+
     self.updateSortPagerStyle = self.filterWithParamsProperty.signal.skipNil()
       .map { $0.category?.root?.id }
       .skipRepeats(==)
@@ -170,6 +180,12 @@ DiscoveryViewModelOutputs {
   public func viewDidLoad() {
     self.viewDidLoadProperty.value = ()
   }
+
+  private let navigationHeightProperty = MutableProperty<CGFloat?>(nil)
+  public func viewSafeAreaInsetsDidChange() {
+    self.navigationHeightProperty.value = 20
+  }
+
   fileprivate let viewWillAppearProperty = MutableProperty<Bool?>(nil)
   public func viewWillAppear(animated: Bool) {
     self.viewWillAppearProperty.value = animated
@@ -182,6 +198,7 @@ DiscoveryViewModelOutputs {
   public let liveStreamDiscoveryViewHidden: Signal<Bool, NoError>
   public let loadFilterIntoDataSource: Signal<DiscoveryParams, NoError>
   public let navigateToSort: Signal<(DiscoveryParams.Sort, UIPageViewControllerNavigationDirection), NoError>
+  public let navigationHeaderHeightLayoutConstant: Signal<CGFloat, NoError>
   public let selectSortPage: Signal<DiscoveryParams.Sort, NoError>
   public let sortsAreEnabled: Signal<Bool, NoError>
   public let sortViewHidden: Signal<Bool, NoError>

--- a/Library/ViewModels/DiscoveryViewModel.swift
+++ b/Library/ViewModels/DiscoveryViewModel.swift
@@ -22,9 +22,6 @@ public protocol DiscoveryViewModelInputs {
   /// Call from the controller's viewDidLoad.
   func viewDidLoad()
 
-  /// Call from the controller's viewSafeAreaInsetsDidChange.
-  func viewSafeAreaInsetsDidChange()
-
   /// Call from the controller's viewWillAppear.
   func viewWillAppear(animated: Bool)
 
@@ -53,9 +50,6 @@ public protocol DiscoveryViewModelOutputs {
 
   /// Emits when we should manually navigate to a sort's page.
   var navigateToSort: Signal<(DiscoveryParams.Sort, UIPageViewControllerNavigationDirection), NoError> { get }
-
-  /// Emits a CGFloat that should be used to configure the NavigationHeaderViewController height
-  var navigationHeaderTopInset: Signal<CGFloat, NoError> { get }
 
   /// Emits a sort that should be passed on to the sort pager view controller.
   var selectSortPage: Signal<DiscoveryParams.Sort, NoError> { get }
@@ -123,10 +117,6 @@ DiscoveryViewModelOutputs {
         return (next.sort, lhs < rhs ? .reverse : .forward)
     }
 
-    self.navigationHeaderTopInset = self.navigationHeaderTopInsetProperty.signal.skipNil()
-      .map { $0 }
-      .skipRepeats()
-
     self.updateSortPagerStyle = self.filterWithParamsProperty.signal.skipNil()
       .map { $0.category?.root?.id }
       .skipRepeats(==)
@@ -181,11 +171,6 @@ DiscoveryViewModelOutputs {
     self.viewDidLoadProperty.value = ()
   }
 
-  private let navigationHeaderTopInsetProperty = MutableProperty<CGFloat?>(nil)
-  public func viewSafeAreaInsetsDidChange() {
-    self.navigationHeaderTopInsetProperty.value = 20
-  }
-
   fileprivate let viewWillAppearProperty = MutableProperty<Bool?>(nil)
   public func viewWillAppear(animated: Bool) {
     self.viewWillAppearProperty.value = animated
@@ -198,7 +183,6 @@ DiscoveryViewModelOutputs {
   public let liveStreamDiscoveryViewHidden: Signal<Bool, NoError>
   public let loadFilterIntoDataSource: Signal<DiscoveryParams, NoError>
   public let navigateToSort: Signal<(DiscoveryParams.Sort, UIPageViewControllerNavigationDirection), NoError>
-  public let navigationHeaderTopInset: Signal<CGFloat, NoError>
   public let selectSortPage: Signal<DiscoveryParams.Sort, NoError>
   public let sortsAreEnabled: Signal<Bool, NoError>
   public let sortViewHidden: Signal<Bool, NoError>

--- a/Library/ViewModels/DiscoveryViewModel.swift
+++ b/Library/ViewModels/DiscoveryViewModel.swift
@@ -55,7 +55,7 @@ public protocol DiscoveryViewModelOutputs {
   var navigateToSort: Signal<(DiscoveryParams.Sort, UIPageViewControllerNavigationDirection), NoError> { get }
 
   /// Emits a CGFloat that should be used to configure the NavigationHeaderViewController height
-  var navigationHeaderHeightLayoutConstant: Signal<CGFloat, NoError> { get }
+  var navigationHeaderTopInset: Signal<CGFloat, NoError> { get }
 
   /// Emits a sort that should be passed on to the sort pager view controller.
   var selectSortPage: Signal<DiscoveryParams.Sort, NoError> { get }
@@ -123,7 +123,7 @@ DiscoveryViewModelOutputs {
         return (next.sort, lhs < rhs ? .reverse : .forward)
     }
 
-    self.navigationHeaderHeightLayoutConstant = self.navigationHeightProperty.signal.skipNil()
+    self.navigationHeaderTopInset = self.navigationHeaderTopInsetProperty.signal.skipNil()
       .map { $0 }
       .skipRepeats()
 
@@ -181,9 +181,9 @@ DiscoveryViewModelOutputs {
     self.viewDidLoadProperty.value = ()
   }
 
-  private let navigationHeightProperty = MutableProperty<CGFloat?>(nil)
+  private let navigationHeaderTopInsetProperty = MutableProperty<CGFloat?>(nil)
   public func viewSafeAreaInsetsDidChange() {
-    self.navigationHeightProperty.value = 20
+    self.navigationHeaderTopInsetProperty.value = 20
   }
 
   fileprivate let viewWillAppearProperty = MutableProperty<Bool?>(nil)
@@ -198,7 +198,7 @@ DiscoveryViewModelOutputs {
   public let liveStreamDiscoveryViewHidden: Signal<Bool, NoError>
   public let loadFilterIntoDataSource: Signal<DiscoveryParams, NoError>
   public let navigateToSort: Signal<(DiscoveryParams.Sort, UIPageViewControllerNavigationDirection), NoError>
-  public let navigationHeaderHeightLayoutConstant: Signal<CGFloat, NoError>
+  public let navigationHeaderTopInset: Signal<CGFloat, NoError>
   public let selectSortPage: Signal<DiscoveryParams.Sort, NoError>
   public let sortsAreEnabled: Signal<Bool, NoError>
   public let sortViewHidden: Signal<Bool, NoError>

--- a/Library/ViewModels/ProjectPamphletViewModel.swift
+++ b/Library/ViewModels/ProjectPamphletViewModel.swift
@@ -161,10 +161,10 @@ private let escapedCookieSeparator = "%3F"
 
 private func topLayoutConstraintConstant(initialTopConstraint: CGFloat,
                                          traitCollection: UITraitCollection) -> CGFloat {
-  if #available(iOS 11.0, *), !traitCollection.isRegularRegular {
-    return traitCollection.isVerticallyCompact ? 0.0 : initialTopConstraint
+  guard !traitCollection.isRegularRegular else {
+    return 0.0
   }
-  return !traitCollection.isVerticallyCompact ? initialTopConstraint : 0.0
+   return traitCollection.isVerticallyCompact ? 0.0 : initialTopConstraint
 }
 
 // Extracts the ref tag stored in cookies for a particular project. Returns `nil` if no such cookie has


### PR DESCRIPTION
# What

Fixes Discovery header height discrepancy.

# Why

https://trello.com/c/lXSjlfPa/195-discovery-header-height-discrepancy
This discrepancy occurred due the new safeArea on XCode 9. So while with iOS 10 the layout would look normal (header keeping the same height as Search, Activity, etc), with iOS 11 an extra space(safeArea) is added to the top, making the Discovery header look taller than the other tabs.

# See 👀

# Before:
<img width="376" alt="screen shot 2017-10-17 at 15 50 14" src="https://user-images.githubusercontent.com/3709676/31686617-a5574b9e-b354-11e7-92bd-963fefb7de98.png">


# After:
<img width="376" alt="screen shot 2017-10-17 at 15 50 45" src="https://user-images.githubusercontent.com/3709676/31686626-b0650116-b354-11e7-9ab9-8b1d68045688.png">

