### PR TITLE
Manage pledge button fix

### DIFF
--- a/Kickstarter-iOS/Views/Cells/RewardCell.swift
+++ b/Kickstarter-iOS/Views/Cells/RewardCell.swift
@@ -212,7 +212,8 @@ internal final class RewardCell: UITableViewCell, ValueCell {
     self.descriptionLabel.rac.hidden = self.viewModel.outputs.descriptionLabelHidden
     self.descriptionLabel.rac.text = self.viewModel.outputs.descriptionLabelText
     self.estimatedDeliveryDateLabel.rac.text = self.viewModel.outputs.estimatedDeliveryDateLabelText
-    self.footerStackView.rac.hidden = self.viewModel.outputs.itemsContainerHidden
+    self.estimatedDeliveryDateStackView.rac.hidden = self.viewModel.outputs.estimatedDeliveryDateStackViewHidden
+    self.footerStackView.rac.hidden = self.viewModel.outputs.footerStackViewHidden
     self.footerLabel.rac.text = self.viewModel.outputs.footerLabelText
     self.itemsContainerStackView.rac.hidden = self.viewModel.outputs.itemsContainerHidden
     self.manageRewardButton.rac.hidden = self.viewModel.outputs.manageButtonHidden

--- a/Kickstarter-iOS/Views/Cells/RewardCell.swift
+++ b/Kickstarter-iOS/Views/Cells/RewardCell.swift
@@ -212,7 +212,7 @@ internal final class RewardCell: UITableViewCell, ValueCell {
     self.descriptionLabel.rac.hidden = self.viewModel.outputs.descriptionLabelHidden
     self.descriptionLabel.rac.text = self.viewModel.outputs.descriptionLabelText
     self.estimatedDeliveryDateLabel.rac.text = self.viewModel.outputs.estimatedDeliveryDateLabelText
-    self.footerStackView.rac.hidden = self.viewModel.outputs.footerStackViewHidden
+    self.footerStackView.rac.hidden = self.viewModel.outputs.itemsContainerHidden
     self.footerLabel.rac.text = self.viewModel.outputs.footerLabelText
     self.itemsContainerStackView.rac.hidden = self.viewModel.outputs.itemsContainerHidden
     self.manageRewardButton.rac.hidden = self.viewModel.outputs.manageButtonHidden

--- a/Kickstarter-iOS/Views/Cells/RewardCell.swift
+++ b/Kickstarter-iOS/Views/Cells/RewardCell.swift
@@ -61,7 +61,7 @@ internal final class RewardCell: UITableViewCell, ValueCell {
     self.viewModel.inputs.configureWith(project: value.0, rewardOrBacking: value.1)
   }
 
-    internal override func bindStyles() {
+  internal override func bindStyles() {
     super.bindStyles()
 
     _ = self
@@ -202,7 +202,7 @@ internal final class RewardCell: UITableViewCell, ValueCell {
     self.viewModel.inputs.boundStyles()
   }
 
-    internal override func bindViewModel() {
+  internal override func bindViewModel() {
     super.bindViewModel()
 
     self.allGoneContainerView.rac.hidden = self.viewModel.outputs.allGoneHidden
@@ -212,7 +212,6 @@ internal final class RewardCell: UITableViewCell, ValueCell {
     self.descriptionLabel.rac.hidden = self.viewModel.outputs.descriptionLabelHidden
     self.descriptionLabel.rac.text = self.viewModel.outputs.descriptionLabelText
     self.estimatedDeliveryDateLabel.rac.text = self.viewModel.outputs.estimatedDeliveryDateLabelText
-    self.estimatedDeliveryDateStackView.rac.hidden = self.viewModel.outputs.estimatedDeliveryDateStackViewHidden
     self.footerStackView.rac.hidden = self.viewModel.outputs.footerStackViewHidden
     self.footerLabel.rac.text = self.viewModel.outputs.footerLabelText
     self.itemsContainerStackView.rac.hidden = self.viewModel.outputs.itemsContainerHidden

--- a/Library/ViewModels/RewardCellViewModel.swift
+++ b/Library/ViewModels/RewardCellViewModel.swift
@@ -18,7 +18,6 @@ public protocol RewardCellViewModelOutputs {
   var descriptionLabelHidden: Signal<Bool, NoError> { get }
   var descriptionLabelText: Signal<String, NoError> { get }
   var estimatedDeliveryDateLabelText: Signal<String, NoError> { get }
-  var estimatedDeliveryDateStackViewHidden: Signal<Bool, NoError> { get }
   var footerLabelText: Signal<String, NoError> { get }
   var footerStackViewHidden: Signal<Bool, NoError> { get }
   var items: Signal<[String], NoError> { get }
@@ -169,30 +168,16 @@ RewardCellViewModelOutputs {
     let allGoneAndNotABacker = Signal.zip(reward, youreABacker)
       .map { reward, youreABacker in reward.remaining == 0 && !youreABacker }
 
-   self.footerStackViewHidden = Signal.merge(
-    projectAndReward.map { project, reward in
-    //  reward.estimatedDeliveryOn == nil ||
-        shouldCollapse(reward: reward, forProject: project)
-      },
-      self.tappedProperty.signal.mapConst(false)
-    )
+    let isNoReward = reward
+      .map { $0.isNoReward }
 
-    self.estimatedDeliveryDateStackViewHidden = reward.map {
-      $0.estimatedDeliveryOn == nil
-    }
-
-//    self.footerStackViewHidden = projectAndReward
-//      .map { project, reward in
-//        reward.remaining == 0 || reward.rewardsItems.isEmpty || project.state == .live
-//
-//      }
-//      .mergeWith(rewardItemsIsEmpty.takeWhen(self.tappedProperty.signal))
-//
-//    Signal.merge(
-//      reward.map { $0.remaining == 0 || $0.rewardsItems.isEmpty  },
-//      rewardItemsIsEmpty.takeWhen(self.tappedProperty.signal)
-//      )
-//      .skipRepeats()
+    self.footerStackViewHidden = Signal.merge(
+      projectAndReward
+      .map { project, reward in
+        reward.estimatedDeliveryOn == nil || shouldCollapse(reward: reward, forProject: project)
+        },
+        isNoReward.takeWhen(self.tappedProperty.signal)
+      )
 
     self.descriptionLabelHidden = Signal.merge(
       rewardIsCollapsed,
@@ -290,7 +275,6 @@ RewardCellViewModelOutputs {
   public let descriptionLabelHidden: Signal<Bool, NoError>
   public let descriptionLabelText: Signal<String, NoError>
   public let estimatedDeliveryDateLabelText: Signal<String, NoError>
-  public let estimatedDeliveryDateStackViewHidden: Signal<Bool, NoError>
   public let footerLabelText: Signal<String, NoError>
   public let footerStackViewHidden: Signal<Bool, NoError>
   public let items: Signal<[String], NoError>

--- a/Library/ViewModels/RewardCellViewModel.swift
+++ b/Library/ViewModels/RewardCellViewModel.swift
@@ -18,6 +18,7 @@ public protocol RewardCellViewModelOutputs {
   var descriptionLabelHidden: Signal<Bool, NoError> { get }
   var descriptionLabelText: Signal<String, NoError> { get }
   var estimatedDeliveryDateLabelText: Signal<String, NoError> { get }
+  var estimatedDeliveryDateStackViewHidden: Signal<Bool, NoError> { get }
   var footerLabelText: Signal<String, NoError> { get }
   var footerStackViewHidden: Signal<Bool, NoError> { get }
   var items: Signal<[String], NoError> { get }
@@ -168,18 +169,30 @@ RewardCellViewModelOutputs {
     let allGoneAndNotABacker = Signal.zip(reward, youreABacker)
       .map { reward, youreABacker in reward.remaining == 0 && !youreABacker }
 
-    self.footerStackViewHidden =
-    //projectAndReward
-//      .map { project, reward in
-//        reward.estimatedDeliveryOn == nil || shouldCollapse(reward: reward, forProject: project)
-//      }
-//      .mergeWith(self.tappedProperty.signal.mapConst(false))
+   self.footerStackViewHidden = Signal.merge(
+    projectAndReward.map { project, reward in
+    //  reward.estimatedDeliveryOn == nil ||
+        shouldCollapse(reward: reward, forProject: project)
+      },
+      self.tappedProperty.signal.mapConst(false)
+    )
 
-    Signal.merge(
-      reward.map { $0.remaining == 0 || $0.rewardsItems.isEmpty },
-      rewardItemsIsEmpty.takeWhen(self.tappedProperty.signal)
-      )
-      .skipRepeats()
+    self.estimatedDeliveryDateStackViewHidden = reward.map {
+      $0.estimatedDeliveryOn == nil
+    }
+
+//    self.footerStackViewHidden = projectAndReward
+//      .map { project, reward in
+//        reward.remaining == 0 || reward.rewardsItems.isEmpty || project.state == .live
+//
+//      }
+//      .mergeWith(rewardItemsIsEmpty.takeWhen(self.tappedProperty.signal))
+//
+//    Signal.merge(
+//      reward.map { $0.remaining == 0 || $0.rewardsItems.isEmpty  },
+//      rewardItemsIsEmpty.takeWhen(self.tappedProperty.signal)
+//      )
+//      .skipRepeats()
 
     self.descriptionLabelHidden = Signal.merge(
       rewardIsCollapsed,
@@ -277,6 +290,7 @@ RewardCellViewModelOutputs {
   public let descriptionLabelHidden: Signal<Bool, NoError>
   public let descriptionLabelText: Signal<String, NoError>
   public let estimatedDeliveryDateLabelText: Signal<String, NoError>
+  public let estimatedDeliveryDateStackViewHidden: Signal<Bool, NoError>
   public let footerLabelText: Signal<String, NoError>
   public let footerStackViewHidden: Signal<Bool, NoError>
   public let items: Signal<[String], NoError>

--- a/Library/ViewModels/RewardCellViewModel.swift
+++ b/Library/ViewModels/RewardCellViewModel.swift
@@ -170,7 +170,7 @@ RewardCellViewModelOutputs {
       .map { project, reward in
         reward.estimatedDeliveryOn == nil || shouldCollapse(reward: reward, forProject: project)
       }
-      .mergeWith(self.tappedProperty.signal.mapConst(false))
+     // .mergeWith(self.tappedProperty.signal.mapConst(false))
 
     self.descriptionLabelHidden = Signal.merge(
       rewardIsCollapsed,

--- a/Library/ViewModels/RewardCellViewModel.swift
+++ b/Library/ViewModels/RewardCellViewModel.swift
@@ -168,11 +168,18 @@ RewardCellViewModelOutputs {
     let allGoneAndNotABacker = Signal.zip(reward, youreABacker)
       .map { reward, youreABacker in reward.remaining == 0 && !youreABacker }
 
-    self.footerStackViewHidden = projectAndReward
-      .map { project, reward in
-        reward.estimatedDeliveryOn == nil || shouldCollapse(reward: reward, forProject: project)
-      }
-     // .mergeWith(self.tappedProperty.signal.mapConst(false))
+    self.footerStackViewHidden =
+    //projectAndReward
+//      .map { project, reward in
+//        reward.estimatedDeliveryOn == nil || shouldCollapse(reward: reward, forProject: project)
+//      }
+//      .mergeWith(self.tappedProperty.signal.mapConst(false))
+
+    Signal.merge(
+      reward.map { $0.remaining == 0 || $0.rewardsItems.isEmpty },
+      rewardItemsIsEmpty.takeWhen(self.tappedProperty.signal)
+      )
+      .skipRepeats()
 
     self.descriptionLabelHidden = Signal.merge(
       rewardIsCollapsed,

--- a/Library/ViewModels/RewardCellViewModelTests.swift
+++ b/Library/ViewModels/RewardCellViewModelTests.swift
@@ -473,24 +473,33 @@ final class RewardCellViewModelTests: TestCase {
     self.footerLabelText.assertValues(["42\u{00a0}backers"])
   }
 
-  func testFooterViewHidden_() {
+  func testFooterViewHidden_WithRewards() {
     self.vm.inputs.configureWith(project: .template, rewardOrBacking: .left(.template))
 
     self.footerStackViewHidden.assertValues([false])
+  }
 
-    self.vm.inputs.configureWith(project: .template,
-                                 rewardOrBacking: .left(.template |> Reward.lens.remaining .~ 0))
+  func testFooterViewHidden_SoldOut_WithRewards_OnTap() {
+    let reward = .template
+      |> Reward.lens.remaining .~ 0
 
-    self.footerStackViewHidden.assertValues([false, true])
+    self.vm.inputs.configureWith(project: .template, rewardOrBacking: .left(reward))
 
-    let reward = .template |> Reward.lens.remaining .~ 0
-    self.vm.inputs.configureWith(
-      project: .template
-        |> Project.lens.personalization.backing .~ (.template |> Backing.lens.reward .~ reward),
-      rewardOrBacking: .left(reward)
-    )
+    self.footerStackViewHidden.assertValues([true])
 
-    self.footerStackViewHidden.assertValues([false, true, false])
+    self.vm.inputs.tapped()
+
+    self.footerStackViewHidden.assertValues([true, false])
+  }
+
+  func testFooterViewHidden_WithNoRewards_OnTap() {
+    self.vm.inputs.configureWith(project: .template, rewardOrBacking: .left(.noReward))
+
+    self.footerStackViewHidden.assertValues([true])
+
+    self.vm.inputs.tapped()
+
+    self.footerStackViewHidden.assertValues([true, true])
   }
 
   func testItems() {

--- a/Library/ViewModels/RewardCellViewModelTests.swift
+++ b/Library/ViewModels/RewardCellViewModelTests.swift
@@ -473,7 +473,7 @@ final class RewardCellViewModelTests: TestCase {
     self.footerLabelText.assertValues(["42\u{00a0}backers"])
   }
 
-  func testFooterViewHidden() {
+  func testFooterViewHidden_() {
     self.vm.inputs.configureWith(project: .template, rewardOrBacking: .left(.template))
 
     self.footerStackViewHidden.assertValues([false])


### PR DESCRIPTION

# What

This is a bug fix for the manage pledge button resizing. 

# Why

Manage Pledge Button was compressing whenever it was tapped because the `footerStackView` was becoming visible on tap.

# See
### Before 
button compressed on tap
<img width="300" alt="compressed_button" src="https://user-images.githubusercontent.com/11362005/31745068-6e72b3d0-b42f-11e7-8283-96dd81928007.PNG">
### After
![managebuttonfix](https://user-images.githubusercontent.com/11362005/31745032-43c7ed94-b42f-11e7-8832-928fd0e61ebd.gif)
