### PR TITLE
Fixed project layout when page opens from deeplink

### DIFF
--- a/Kickstarter-iOS/Views/Controllers/ProjectPamphletViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/ProjectPamphletViewController.swift
@@ -51,6 +51,10 @@ public final class ProjectPamphletViewController: UIViewController {
   public override func viewWillAppear(_ animated: Bool) {
     super.viewWillAppear(animated)
     self.viewModel.inputs.viewWillAppear(animated: animated)
+  }
+
+  public override func viewDidLayoutSubviews() {
+    super.viewDidLayoutSubviews()
     self.setInitial(constraints: [navBarTopConstraint, projectPamphletTopConstraint],
                     constant: initialTopConstraint)
   }


### PR DESCRIPTION
# What
Fixed layout of project page when the view is loaded due deeplink, notification interaction or after dismiss Reward page.

# Why
https://trello.com/c/ByhEfJkd/217-p2-project-page-header-is-misaligned-after-exiting-reward-view

# How
Updating constraints when `viewDidLayoutSubviews()` is called, instead of `viewDidAppear(animated:)`.

# See 👀
**Before :**

<img width="377" alt="screen shot 2017-10-25 at 15 41 20" src="https://user-images.githubusercontent.com/3709676/32019569-aa2f8dbe-b99b-11e7-9c38-96b6c5100aae.png">


**After :**

<img width="377" alt="screen shot 2017-10-25 at 15 47 09" src="https://user-images.githubusercontent.com/3709676/32019613-cf02b2f6-b99b-11e7-8f8d-7ef30c38ee4b.png">





![GIF](https://media.giphy.com/media/26ufq9mryvc5HI27m/giphy.gif)