### PR TITLE
Fixed bug that didn't show link while sharing project

### DIFF
--- a/Library/ProjectActivityItemProvider.swift
+++ b/Library/ProjectActivityItemProvider.swift
@@ -16,14 +16,23 @@ public final class ProjectActivityItemProvider: UIActivityItemProvider {
                                               itemForActivityType activityType: UIActivityType) -> Any? {
     if let project = self.project {
       if activityType == .mail || activityType == .message {
-        return project.name
+        return formattedString(for: project)
       } else if activityType == .postToTwitter {
-        return Strings.project_checkout_share_twitter_via_kickstarter(project_or_update_title: project.name)
+        return Strings.project_checkout_share_twitter_via_kickstarter(
+          project_or_update_title: formattedString(for: project)
+        )
       } else if activityType == .copyToPasteboard || activityType == .postToFacebook {
         return project.urls.web.project
       }
     }
     return self.activityViewControllerPlaceholderItem(activityViewController)
+  }
+
+  private func formattedString(for project: Project) -> String {
+    return """
+            \(project.name)\n
+            \(project.urls.web.project)
+           """
   }
 }
 #endif


### PR DESCRIPTION
# What

Fixed bug that didn't show link while sharing project.

# Why

https://trello.com/c/QzFxcdqA/218-p2-no-link-when-sharing-project.

# How

Appending the url to the project name.
#

![GIF](https://media.giphy.com/media/l1J3vV5lCmv8qx16M/giphy.gif)
