### PR TITLE
Change Argo's url from http -> https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,7 +12,7 @@
 	url = https://github.com/kickstarter/Kickstarter-ReactiveExtensions.git
 [submodule "Frameworks/Argo"]
 	path = Frameworks/Argo
-	url = http://github.com/thoughtbot/Argo.git
+	url = https://github.com/thoughtbot/Argo.git
 [submodule "Frameworks/Curry"]
 	path = Frameworks/Curry
 	url = https://github.com/thoughtbot/Curry.git


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# What

Update the url for Argo to use https instead of http

# Why

While running `make bootstrap` on my machine (macOS Sierra with git 2.7.2), I got this error:

<img width="716" alt="screen shot 2017-11-16 at 7 38 16 pm" src="https://user-images.githubusercontent.com/1824298/32895384-e67f7952-cb05-11e7-85fc-3be2361a8499.png">

Apparently http is no longer supported by Github ¯\_(ツ)_/¯ So I thought maybe this will help someone who tries to set thing up locally.

# How

N/A

# See 👀

N/A

# TODO ⏰

N/A
