### PR TITLE
Privacy violation crash fix

### DIFF
--- a/Kickstarter-iOS/Info.plist
+++ b/Kickstarter-iOS/Info.plist
@@ -96,6 +96,8 @@
 	</dict>
 	<key>NSCameraUsageDescription</key>
 	<string>Add photos and video to your project updates.</string>
+	<key>NSPhotoLibraryAddUsageDescription</key>
+	<string>Add photos and video to your project updates.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>Add photos and video to your project updates.</string>
 	<key>UILaunchStoryboardName</key>

--- a/Library/UIPageViewController+Extensions.swift
+++ b/Library/UIPageViewController+Extensions.swift
@@ -1,0 +1,9 @@
+//
+//  UIPageViewController+Extensions.swift
+//  Kickstarter-iOS
+//
+//  Created by Saturnino Texeira on 17/11/2017.
+//  Copyright © 2017 Kickstarter. All rights reserved.
+//
+
+import Foundation

--- a/Library/UIPageViewController+Extensions.swift
+++ b/Library/UIPageViewController+Extensions.swift
@@ -1,9 +1,0 @@
-//
-//  UIPageViewController+Extensions.swift
-//  Kickstarter-iOS
-//
-//  Created by Saturnino Texeira on 17/11/2017.
-//  Copyright © 2017 Kickstarter. All rights reserved.
-//
-
-import Foundation


### PR DESCRIPTION
# What
Added new iOS 11 `NSPhotoLibraryAddUsageDescription` privacy key.

# Why
Some of our users are experiencing crashes (`__CRASHING_DUE_TO_PRIVACY_VIOLATION__`) and adding this key to the info.plist could solve this problem.

![GIF](https://media.giphy.com/media/xT77Y36ijyuwn58bja/giphy.gif)