### PR TITLE
Bug fix - Recommended filter

### DIFF
--- a/Kickstarter-iOS/Views/Controllers/DiscoveryPageViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/DiscoveryPageViewController.swift
@@ -240,10 +240,10 @@ internal final class DiscoveryPageViewController: UITableViewController {
     self.navigationController?.pushViewController(vc, animated: true)
   }
 
-  fileprivate func showEmptyState(_ emptyState: EmptyState?) {
-    guard let emptyVC = self.emptyStatesController, let state = emptyState else { return }
+  fileprivate func showEmptyState(_ emptyState: EmptyState) {
+    guard let emptyVC = self.emptyStatesController else { return }
 
-    emptyVC.setEmptyState(state)
+    emptyVC.setEmptyState(emptyState)
     emptyVC.view.isHidden = false
     self.view.bringSubview(toFront: emptyVC.view)
     UIView.animate(withDuration: 0.3,

--- a/Kickstarter-iOS/Views/Controllers/DiscoveryPageViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/DiscoveryPageViewController.swift
@@ -240,15 +240,13 @@ internal final class DiscoveryPageViewController: UITableViewController {
     self.navigationController?.pushViewController(vc, animated: true)
   }
 
-  fileprivate func showEmptyState(_ emptyState: EmptyState) {
-    guard let emptyVC = self.emptyStatesController else { return }
+  fileprivate func showEmptyState(_ emptyState: EmptyState?) {
+    guard let emptyVC = self.emptyStatesController, let state = emptyState else { return }
 
-    emptyVC.setEmptyState(emptyState)
+    emptyVC.setEmptyState(state)
     emptyVC.view.isHidden = false
     self.view.bringSubview(toFront: emptyVC.view)
     UIView.animate(withDuration: 0.3,
-                   delay: 2,
-                   options: UIViewAnimationOptions(),
                    animations: {
       self.emptyStatesController?.view.alpha = 1.0
     }, completion: nil)

--- a/Kickstarter-iOS/Views/Controllers/DiscoveryPageViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/DiscoveryPageViewController.swift
@@ -246,10 +246,12 @@ internal final class DiscoveryPageViewController: UITableViewController {
     emptyVC.setEmptyState(emptyState)
     emptyVC.view.isHidden = false
     self.view.bringSubview(toFront: emptyVC.view)
-    UIView.animate(withDuration: 0.3, animations: {
+    UIView.animate(withDuration: 0.3,
+                   delay: 2,
+                   options: UIViewAnimationOptions(),
+                   animations: {
       self.emptyStatesController?.view.alpha = 1.0
-    })
-
+    }, completion: nil)
     if let discovery = self.parent?.parent as? DiscoveryViewController {
       discovery.setSortsEnabled(false)
     }

--- a/Kickstarter-iOS/Views/Controllers/DiscoveryViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/DiscoveryViewController.swift
@@ -107,7 +107,7 @@ internal final class DiscoveryViewController: UIViewController {
       .observeForUI()
       .observeValues { [weak self] in
         self?.sortPagerViewController.setSortPagerEnabled($0)
-        self?.pageViewController.isScrollEnabled($0)
+        self?.setPageViewControllerScrollEnabled($0)
     }
 
     self.viewModel.outputs.updateSortPagerStyle
@@ -136,6 +136,10 @@ internal final class DiscoveryViewController: UIViewController {
         completion: nil
       )
     }
+  }
+
+  private func setPageViewControllerScrollEnabled(_ enabled: Bool) {
+    self.pageViewController.dataSource = enabled == false ? nil : self.dataSource
   }
 }
 

--- a/Kickstarter-iOS/Views/Controllers/DiscoveryViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/DiscoveryViewController.swift
@@ -107,6 +107,7 @@ internal final class DiscoveryViewController: UIViewController {
       .observeForUI()
       .observeValues { [weak self] in
         self?.sortPagerViewController.setSortPagerEnabled($0)
+        self?.pageViewController.isScrollEnabled($0)
     }
 
     self.viewModel.outputs.updateSortPagerStyle

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -903,7 +903,6 @@
 		D6ED386A1F796C26006CAAE9 /* GraphCategoriesEnvelopeLenses.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6ED38691F796C26006CAAE9 /* GraphCategoriesEnvelopeLenses.swift */; };
 		D6ED38A21F796FE5006CAAE9 /* GraphCategoriesEnvelopeTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6ED38A11F796FE5006CAAE9 /* GraphCategoriesEnvelopeTemplate.swift */; };
 		D6FB2A3D1FA27D0300B0D282 /* GraphCategoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6FB2A3C1FA27D0300B0D282 /* GraphCategoryTests.swift */; };
-		D6B1A90F1FC3587900617A46 /* UIPageViewController+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6B1A8D81FC3587900617A46 /* UIPageViewController+Extensions.swift */; };
 		D70347901DBAABC30099C668 /* DiscoveryExpandableRowCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D703478F1DBAABC30099C668 /* DiscoveryExpandableRowCellViewModel.swift */; };
 		D70740541FAB9ABE004E2422 /* CreatorDigestSettingsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D70740531FAB9ABE004E2422 /* CreatorDigestSettingsViewModelTests.swift */; };
 		D764DAFC1F7194EA00DC32AE /* CreatorDigestSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D764DAFB1F7194EA00DC32AE /* CreatorDigestSettingsViewController.swift */; };
@@ -2427,7 +2426,6 @@
 		D6ED38691F796C26006CAAE9 /* GraphCategoriesEnvelopeLenses.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphCategoriesEnvelopeLenses.swift; sourceTree = "<group>"; };
 		D6ED38A11F796FE5006CAAE9 /* GraphCategoriesEnvelopeTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphCategoriesEnvelopeTemplate.swift; sourceTree = "<group>"; };
 		D6FB2A3C1FA27D0300B0D282 /* GraphCategoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphCategoryTests.swift; sourceTree = "<group>"; };
-		D6B1A8D81FC3587900617A46 /* UIPageViewController+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIPageViewController+Extensions.swift"; sourceTree = "<group>"; };
 		D703478F1DBAABC30099C668 /* DiscoveryExpandableRowCellViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DiscoveryExpandableRowCellViewModel.swift; sourceTree = "<group>"; };
 		D70740531FAB9ABE004E2422 /* CreatorDigestSettingsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreatorDigestSettingsViewModelTests.swift; sourceTree = "<group>"; };
 		D764DAFB1F7194EA00DC32AE /* CreatorDigestSettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreatorDigestSettingsViewController.swift; sourceTree = "<group>"; };
@@ -3205,7 +3203,6 @@
 				A7C725971C85D36D005A016B /* UILabel+LocalizedKey.swift */,
 				A7C725981C85D36D005A016B /* UILabel+SimpleHTML.swift */,
 				A7ED1F251E830FDC00BFFA01 /* UILabel+SimpleHTMLTests.swift */,
-				D6B1A8D81FC3587900617A46 /* UIPageViewController+Extensions.swift */,
 				A7C725991C85D36D005A016B /* UIPress-Extensions.swift */,
 				A78537E11CB5422100385B73 /* UIScreenType.swift */,
 				A7169BF51DDD064200480C0D /* UIScrollView+Extensions.swift */,
@@ -4876,7 +4873,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D6B1A90F1FC3587900617A46 /* UIPageViewController+Extensions.swift in Sources */,
 				013744F81D99A39B00E50C78 /* EmptyStatesViewModel.swift in Sources */,
 				D0247A961DF9F29100D7A7C1 /* ProjectPamphletSubpageCellViewModel.swift in Sources */,
 				0156B3751D0F7524000C4252 /* ActivityFriendFollowCellViewModel.swift in Sources */,

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -903,6 +903,7 @@
 		D6ED386A1F796C26006CAAE9 /* GraphCategoriesEnvelopeLenses.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6ED38691F796C26006CAAE9 /* GraphCategoriesEnvelopeLenses.swift */; };
 		D6ED38A21F796FE5006CAAE9 /* GraphCategoriesEnvelopeTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6ED38A11F796FE5006CAAE9 /* GraphCategoriesEnvelopeTemplate.swift */; };
 		D6FB2A3D1FA27D0300B0D282 /* GraphCategoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6FB2A3C1FA27D0300B0D282 /* GraphCategoryTests.swift */; };
+		D6B1A90F1FC3587900617A46 /* UIPageViewController+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6B1A8D81FC3587900617A46 /* UIPageViewController+Extensions.swift */; };
 		D70347901DBAABC30099C668 /* DiscoveryExpandableRowCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D703478F1DBAABC30099C668 /* DiscoveryExpandableRowCellViewModel.swift */; };
 		D70740541FAB9ABE004E2422 /* CreatorDigestSettingsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D70740531FAB9ABE004E2422 /* CreatorDigestSettingsViewModelTests.swift */; };
 		D764DAFC1F7194EA00DC32AE /* CreatorDigestSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D764DAFB1F7194EA00DC32AE /* CreatorDigestSettingsViewController.swift */; };
@@ -2426,6 +2427,7 @@
 		D6ED38691F796C26006CAAE9 /* GraphCategoriesEnvelopeLenses.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphCategoriesEnvelopeLenses.swift; sourceTree = "<group>"; };
 		D6ED38A11F796FE5006CAAE9 /* GraphCategoriesEnvelopeTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphCategoriesEnvelopeTemplate.swift; sourceTree = "<group>"; };
 		D6FB2A3C1FA27D0300B0D282 /* GraphCategoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphCategoryTests.swift; sourceTree = "<group>"; };
+		D6B1A8D81FC3587900617A46 /* UIPageViewController+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIPageViewController+Extensions.swift"; sourceTree = "<group>"; };
 		D703478F1DBAABC30099C668 /* DiscoveryExpandableRowCellViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DiscoveryExpandableRowCellViewModel.swift; sourceTree = "<group>"; };
 		D70740531FAB9ABE004E2422 /* CreatorDigestSettingsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreatorDigestSettingsViewModelTests.swift; sourceTree = "<group>"; };
 		D764DAFB1F7194EA00DC32AE /* CreatorDigestSettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreatorDigestSettingsViewController.swift; sourceTree = "<group>"; };
@@ -3203,6 +3205,7 @@
 				A7C725971C85D36D005A016B /* UILabel+LocalizedKey.swift */,
 				A7C725981C85D36D005A016B /* UILabel+SimpleHTML.swift */,
 				A7ED1F251E830FDC00BFFA01 /* UILabel+SimpleHTMLTests.swift */,
+				D6B1A8D81FC3587900617A46 /* UIPageViewController+Extensions.swift */,
 				A7C725991C85D36D005A016B /* UIPress-Extensions.swift */,
 				A78537E11CB5422100385B73 /* UIScreenType.swift */,
 				A7169BF51DDD064200480C0D /* UIScrollView+Extensions.swift */,
@@ -4873,6 +4876,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D6B1A90F1FC3587900617A46 /* UIPageViewController+Extensions.swift in Sources */,
 				013744F81D99A39B00E50C78 /* EmptyStatesViewModel.swift in Sources */,
 				D0247A961DF9F29100D7A7C1 /* ProjectPamphletSubpageCellViewModel.swift in Sources */,
 				0156B3751D0F7524000C4252 /* ActivityFriendFollowCellViewModel.swift in Sources */,

--- a/Library/UIPageViewController+Extensions.swift
+++ b/Library/UIPageViewController+Extensions.swift
@@ -1,0 +1,9 @@
+//
+//  UIPageViewController+Extensions.swift
+//  Kickstarter-iOS
+//
+//  Created by Saturnino Texeira on 17/11/2017.
+//  Copyright © 2017 Kickstarter. All rights reserved.
+//
+
+import Foundation

--- a/Library/UIPageViewController+Extensions.swift
+++ b/Library/UIPageViewController+Extensions.swift
@@ -1,9 +1,9 @@
-//
-//  UIPageViewController+Extensions.swift
-//  Kickstarter-iOS
-//
-//  Created by Saturnino Texeira on 17/11/2017.
-//  Copyright © 2017 Kickstarter. All rights reserved.
-//
+import UIKit
 
-import Foundation
+extension UIPageViewController {
+
+  public func isScrollEnabled(_ enabled: Bool) {
+    let scrollView = self.view.subviews.filter { $0 is UIScrollView }.first as? UIScrollView
+    scrollView?.isScrollEnabled = enabled
+  }
+}

--- a/Library/UIPageViewController+Extensions.swift
+++ b/Library/UIPageViewController+Extensions.swift
@@ -1,9 +1,0 @@
-import UIKit
-
-extension UIPageViewController {
-
-  public func isScrollEnabled(_ enabled: Bool) {
-    let scrollView = self.view.subviews.filter { $0 is UIScrollView }.first as? UIScrollView
-    scrollView?.isScrollEnabled = enabled
-  }
-}

--- a/Library/ViewModels/DiscoveryPageViewModel.swift
+++ b/Library/ViewModels/DiscoveryPageViewModel.swift
@@ -77,7 +77,7 @@ public protocol DiscoveryPageViewModelOutputs {
   var setScrollsToTop: Signal<Bool, NoError> { get }
 
   /// Emits to show the empty state controller.
-  var showEmptyState: Signal<EmptyState?, NoError> { get }
+  var showEmptyState: Signal<EmptyState, NoError> { get }
 
   /// Emits a boolean that determines of the onboarding should be shown.
   var showOnboarding: Signal<Bool, NoError> { get }
@@ -150,10 +150,12 @@ public final class DiscoveryPageViewModel: DiscoveryPageViewModelType, Discovery
     self.asyncReloadData = self.projects.take(first: 1).ignoreValues()
 
     self.showEmptyState = Signal.combineLatest(paramsChanged, self.projectsAreLoading, paginatedProjects)
+      .filter { _, projectsAreLoading, projects in projectsAreLoading == false && projects.isEmpty }
       .map { params, projectsAreLoading, projects in
-        emptyState(forParams: params, projectsAreLoading: projectsAreLoading, projects: projects)
+        emptyState(forParams: params)
       }
-      .skipRepeats(==)
+      .skipNil()
+      .skipRepeats()
 
     self.hideEmptyState = Signal.merge(
       self.viewWillAppearProperty.signal.take(first: 1),
@@ -295,7 +297,7 @@ public final class DiscoveryPageViewModel: DiscoveryPageViewModelType, Discovery
   public let projectsAreLoading: Signal<Bool, NoError>
   public let setScrollsToTop: Signal<Bool, NoError>
   public let scrollToProjectRow: Signal<Int, NoError>
-  public let showEmptyState: Signal<EmptyState?, NoError>
+  public let showEmptyState: Signal<EmptyState, NoError>
   public let showOnboarding: Signal<Bool, NoError>
 
   public var inputs: DiscoveryPageViewModelInputs { return self }
@@ -310,13 +312,6 @@ private func saveSeen(activities: [Activity]) {
   activities.forEach { activity in
     AppEnvironment.current.userDefaults.lastSeenActivitySampleId = activity.id
   }
-}
-
-private func emptyState(forParams params: DiscoveryParams,
-                        projectsAreLoading: Bool,
-                        projects: [Project]) -> EmptyState? {
-  guard projectsAreLoading == false, projects.isEmpty else { return nil }
-  return emptyState(forParams: params)
 }
 
 private func refTag(fromParams params: DiscoveryParams, project: Project) -> RefTag {

--- a/Library/ViewModels/DiscoveryPageViewModel.swift
+++ b/Library/ViewModels/DiscoveryPageViewModel.swift
@@ -153,6 +153,7 @@ public final class DiscoveryPageViewModel: DiscoveryPageViewModelType, Discovery
       .map { params, projectsAreLoading, projects in
         emptyState(forParams: params, projectsAreLoading: projectsAreLoading, projects: projects)
       }
+      .skipRepeats(==)
 
     self.hideEmptyState = Signal.merge(
       self.viewWillAppearProperty.signal.take(first: 1),
@@ -335,6 +336,7 @@ private func refTag(fromParams params: DiscoveryParams, project: Project) -> Ref
 }
 
 private func emptyState(forParams params: DiscoveryParams) -> EmptyState? {
+
   if params.starred == .some(true) {
     return .starred
   } else if params.recommended == .some(true) {

--- a/Library/ViewModels/DiscoveryPageViewModel.swift
+++ b/Library/ViewModels/DiscoveryPageViewModel.swift
@@ -151,7 +151,7 @@ public final class DiscoveryPageViewModel: DiscoveryPageViewModelType, Discovery
 
     self.showEmptyState = Signal.combineLatest(paramsChanged, self.projectsAreLoading, paginatedProjects)
       .filter { _, projectsAreLoading, projects in projectsAreLoading == false && projects.isEmpty }
-      .map { params, projectsAreLoading, projects in
+      .map { params, _, _ in
         emptyState(forParams: params)
       }
       .skipNil()

--- a/Library/ViewModels/DiscoveryPageViewModel.swift
+++ b/Library/ViewModels/DiscoveryPageViewModel.swift
@@ -150,13 +150,15 @@ public final class DiscoveryPageViewModel: DiscoveryPageViewModelType, Discovery
     self.asyncReloadData = self.projects.take(first: 1).ignoreValues()
 
     self.showEmptyState = paramsChanged
-      .takeWhen(paginatedProjects.filter { $0.isEmpty })
+      .takeWhen(Signal.merge(self.asyncReloadData, paginatedProjects.filter { $0.isEmpty }.ignoreValues()))
       .map(emptyState(forParams:))
       .skipNil()
       .skipRepeats()
 
     self.hideEmptyState = Signal.merge(
       self.viewWillAppearProperty.signal.take(first: 1),
+      self.asyncReloadData,
+      paginatedProjects.filter { !$0.isEmpty }.ignoreValues(),
       paramsChanged.skip(first: 1).ignoreValues()
     )
 

--- a/Library/ViewModels/DiscoveryPageViewModelTests.swift
+++ b/Library/ViewModels/DiscoveryPageViewModelTests.swift
@@ -527,7 +527,7 @@ internal final class DiscoveryPageViewModelTests: TestCase {
 
       self.scheduler.advance()
 
-      self.showEmptyState.assertValues([nil, .starred])
+      self.showEmptyState.assertValues([.starred])
       self.hideEmptyState.assertValueCount(0)
 
       // switch to another empty state
@@ -537,7 +537,7 @@ internal final class DiscoveryPageViewModelTests: TestCase {
 
       self.scheduler.advance()
 
-      self.showEmptyState.assertValues([nil, .starred, nil, .recommended])
+      self.showEmptyState.assertValues([.starred, .recommended])
 
       // switch to non-empty state
       withEnvironment(apiService: MockService(fetchDiscoveryResponse: projectEnvWithProjects)) {
@@ -548,7 +548,7 @@ internal final class DiscoveryPageViewModelTests: TestCase {
         self.scheduler.advance()
 
         self.showEmptyState.assertValues(
-          [nil, .starred, nil, .recommended, nil], "Show empty state does not emit.")
+          [.starred, .recommended], "Show empty state does not emit.")
 
         // switch back to empty state
         withEnvironment(apiService: MockService(fetchDiscoveryResponse: projectEnv)) {
@@ -558,7 +558,7 @@ internal final class DiscoveryPageViewModelTests: TestCase {
 
           self.scheduler.advance()
 
-          self.showEmptyState.assertValues([nil, .starred, nil, .recommended, nil])
+          self.showEmptyState.assertValues([.starred, .recommended, nil])
 
           self.vm.inputs.selectedFilter(.defaults |> DiscoveryParams.lens.social .~ true)
 
@@ -566,7 +566,7 @@ internal final class DiscoveryPageViewModelTests: TestCase {
 
           self.scheduler.advance()
 
-          self.showEmptyState.assertValues([nil, .starred, nil, .recommended, nil, .socialDisabled])
+          self.showEmptyState.assertValues([.starred, .recommended, nil, .socialDisabled])
         }
       }
     }
@@ -592,7 +592,7 @@ internal final class DiscoveryPageViewModelTests: TestCase {
 
       self.scheduler.advance()
 
-      self.showEmptyState.assertValues([nil, .socialDisabled], "Emits .socialDisabled for nil social.")
+      self.showEmptyState.assertValues([.socialDisabled], "Emits .socialDisabled for nil social.")
       self.hideEmptyState.assertValueCount(0)
 
       withEnvironment(currentUser: antisocialUser) {
@@ -604,7 +604,7 @@ internal final class DiscoveryPageViewModelTests: TestCase {
         self.vm.inputs.selectedFilter(.defaults |> DiscoveryParams.lens.social .~ true)
         self.scheduler.advance()
 
-        self.showEmptyState.assertValues([nil, .socialDisabled, nil, .recommended, nil, .socialDisabled],
+        self.showEmptyState.assertValues([.socialDisabled, .recommended, .socialDisabled],
                                          "Emits .socialDisabled for false social.")
         self.hideEmptyState.assertValueCount(2)
 
@@ -616,7 +616,7 @@ internal final class DiscoveryPageViewModelTests: TestCase {
           self.scheduler.advance()
 
           self.showEmptyState.assertValues(
-            [nil, .socialDisabled, nil, .recommended, nil, .socialDisabled, nil, .socialNoPledges],
+            [.socialDisabled, .recommended, .socialDisabled, .socialNoPledges],
                                            "Emits .socialNoPledges for true social.")
           self.hideEmptyState.assertValueCount(2)
         }

--- a/Library/ViewModels/DiscoveryPageViewModelTests.swift
+++ b/Library/ViewModels/DiscoveryPageViewModelTests.swift
@@ -24,7 +24,7 @@ internal final class DiscoveryPageViewModelTests: TestCase {
   fileprivate let projectsAreLoading = TestObserver<Bool, NoError>()
   fileprivate let setScrollsToTop = TestObserver<Bool, NoError>()
   private let scrollToProjectRow = TestObserver<Int, NoError>()
-  fileprivate let showEmptyState = TestObserver<EmptyState?, NoError>()
+  fileprivate let showEmptyState = TestObserver<EmptyState, NoError>()
   fileprivate let showOnboarding = TestObserver<Bool, NoError>()
 
   internal override func setUp() {
@@ -558,7 +558,7 @@ internal final class DiscoveryPageViewModelTests: TestCase {
 
           self.scheduler.advance()
 
-          self.showEmptyState.assertValues([.starred, .recommended, nil])
+          self.showEmptyState.assertValues([.starred, .recommended])
 
           self.vm.inputs.selectedFilter(.defaults |> DiscoveryParams.lens.social .~ true)
 
@@ -566,7 +566,7 @@ internal final class DiscoveryPageViewModelTests: TestCase {
 
           self.scheduler.advance()
 
-          self.showEmptyState.assertValues([.starred, .recommended, nil, .socialDisabled])
+          self.showEmptyState.assertValues([.starred, .recommended, .socialDisabled])
         }
       }
     }

--- a/Library/ViewModels/DiscoveryPageViewModelTests.swift
+++ b/Library/ViewModels/DiscoveryPageViewModelTests.swift
@@ -527,7 +527,7 @@ internal final class DiscoveryPageViewModelTests: TestCase {
 
       self.scheduler.advance()
 
-      self.showEmptyState.assertValues([.starred])
+      self.showEmptyState.assertValues([nil, .starred])
       self.hideEmptyState.assertValueCount(0)
 
       // switch to another empty state
@@ -537,7 +537,7 @@ internal final class DiscoveryPageViewModelTests: TestCase {
 
       self.scheduler.advance()
 
-      self.showEmptyState.assertValues([.starred, .recommended])
+      self.showEmptyState.assertValues([nil, .starred, nil, .recommended])
 
       // switch to non-empty state
       withEnvironment(apiService: MockService(fetchDiscoveryResponse: projectEnvWithProjects)) {
@@ -547,17 +547,27 @@ internal final class DiscoveryPageViewModelTests: TestCase {
 
         self.scheduler.advance()
 
-        self.showEmptyState.assertValues([.starred, .recommended], "Show empty state does not emit.")
+        self.showEmptyState.assertValues(
+          [nil, .starred, nil, .recommended, nil], "Show empty state does not emit.")
 
         // switch back to empty state
         withEnvironment(apiService: MockService(fetchDiscoveryResponse: projectEnv)) {
-          self.vm.inputs.selectedFilter(.defaults |> DiscoveryParams.lens.starred .~ true)
+          self.vm.inputs.selectedFilter(.defaults |> DiscoveryParams.lens.social .~ false)
 
-          self.hideEmptyState.assertValueCount(3)
+          self.hideEmptyState.assertValueCount(5)
 
           self.scheduler.advance()
 
-          self.showEmptyState.assertValues([.starred, .recommended, .socialDisabled, .starred])
+          self.showEmptyState.assertValues([nil, .starred, nil, .recommended, nil])
+
+
+          self.vm.inputs.selectedFilter(.defaults |> DiscoveryParams.lens.social .~ true)
+
+          self.hideEmptyState.assertValueCount(6)
+
+          self.scheduler.advance()
+
+          self.showEmptyState.assertValues([nil, .starred, nil, .recommended, nil, .socialDisabled])
         }
       }
     }
@@ -583,7 +593,7 @@ internal final class DiscoveryPageViewModelTests: TestCase {
 
       self.scheduler.advance()
 
-      self.showEmptyState.assertValues([.socialDisabled], "Emits .socialDisabled for nil social.")
+      self.showEmptyState.assertValues([nil, .socialDisabled], "Emits .socialDisabled for nil social.")
       self.hideEmptyState.assertValueCount(0)
 
       withEnvironment(currentUser: antisocialUser) {
@@ -595,7 +605,7 @@ internal final class DiscoveryPageViewModelTests: TestCase {
         self.vm.inputs.selectedFilter(.defaults |> DiscoveryParams.lens.social .~ true)
         self.scheduler.advance()
 
-        self.showEmptyState.assertValues([.socialDisabled, .recommended, .socialDisabled],
+        self.showEmptyState.assertValues([nil, .socialDisabled, nil, .recommended, nil, .socialDisabled],
                                          "Emits .socialDisabled for false social.")
         self.hideEmptyState.assertValueCount(2)
 
@@ -606,7 +616,8 @@ internal final class DiscoveryPageViewModelTests: TestCase {
           self.vm.inputs.viewDidAppear()
           self.scheduler.advance()
 
-          self.showEmptyState.assertValues([.socialDisabled, .recommended, .socialDisabled, .socialNoPledges],
+          self.showEmptyState.assertValues(
+            [nil, .socialDisabled, nil, .recommended, nil, .socialDisabled, nil, .socialNoPledges],
                                            "Emits .socialNoPledges for true social.")
           self.hideEmptyState.assertValueCount(2)
         }

--- a/Library/ViewModels/DiscoveryPageViewModelTests.swift
+++ b/Library/ViewModels/DiscoveryPageViewModelTests.swift
@@ -24,7 +24,7 @@ internal final class DiscoveryPageViewModelTests: TestCase {
   fileprivate let projectsAreLoading = TestObserver<Bool, NoError>()
   fileprivate let setScrollsToTop = TestObserver<Bool, NoError>()
   private let scrollToProjectRow = TestObserver<Int, NoError>()
-  fileprivate let showEmptyState = TestObserver<EmptyState, NoError>()
+  fileprivate let showEmptyState = TestObserver<EmptyState?, NoError>()
   fileprivate let showOnboarding = TestObserver<Bool, NoError>()
 
   internal override func setUp() {

--- a/Library/ViewModels/DiscoveryPageViewModelTests.swift
+++ b/Library/ViewModels/DiscoveryPageViewModelTests.swift
@@ -560,7 +560,6 @@ internal final class DiscoveryPageViewModelTests: TestCase {
 
           self.showEmptyState.assertValues([nil, .starred, nil, .recommended, nil])
 
-
           self.vm.inputs.selectedFilter(.defaults |> DiscoveryParams.lens.social .~ true)
 
           self.hideEmptyState.assertValueCount(6)


### PR DESCRIPTION
# What
Fixes a bug that shows the EmptyState screen when user selects any personal filter (Recommended, Saved...).

# Why
https://trello.com/c/cQlCKsYS/275-p2-empty-states-appearing-for-personalized-discovery-filters

# How
The `showEmptyState` signal was emitting because `paginatedProjects` sometimes sends false empty arrays (first sending an empty array and sending an array of Projects right after). This behaviour was making the app show the EmptyState screen when we actually had projects to be shown. 

# See
![simulator screen shot - iphone 8 - 2017-11-29 at 15 28 12](https://user-images.githubusercontent.com/3709676/33397560-f373dba8-d519-11e7-93fe-d05b264e06e1.png)


![GIF](https://media.giphy.com/media/6yRVg0HWzgS88/giphy.gif)