### PR TITLE
Third party sharing bug

### DIFF
--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -888,6 +888,7 @@
 		D0D2ABA31E964852008D298A /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = D0FD4CC81E26433C00488660 /* libz.tbd */; };
 		D0D2ABA91E9677E8008D298A /* LiveStreamTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0D2ABA51E9677DD008D298A /* LiveStreamTypes.swift */; };
 		D0D2ABAA1E9677EC008D298A /* LiveStreamTypesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0D2ABA61E9677DD008D298A /* LiveStreamTypesTests.swift */; };
+		D64850551FD879AB00B6AB91 /* ProjectActivityItemProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D64850541FD879AB00B6AB91 /* ProjectActivityItemProviderTests.swift */; };
 		D67F29361F68333800E399A6 /* GraphSchema.swift in Sources */ = {isa = PBXBuildFile; fileRef = D67F29351F68333800E399A6 /* GraphSchema.swift */; };
 		D6AE52251FD1B3F600BEC788 /* RootCategoriesEnvelope.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6AE52241FD1B3F600BEC788 /* RootCategoriesEnvelope.swift */; };
 		D6AE52281FD1B4BA00BEC788 /* CategoryEnvelope.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6AE52271FD1B4BA00BEC788 /* CategoryEnvelope.swift */; };
@@ -2409,6 +2410,7 @@
 		D0FD4CC41E2642EB00488660 /* libicucore.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libicucore.tbd; path = usr/lib/libicucore.tbd; sourceTree = SDKROOT; };
 		D0FD4CC61E2642F200488660 /* libsqlite3.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libsqlite3.tbd; path = usr/lib/libsqlite3.tbd; sourceTree = SDKROOT; };
 		D0FD4CC81E26433C00488660 /* libz.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.tbd; path = usr/lib/libz.tbd; sourceTree = SDKROOT; };
+		D64850541FD879AB00B6AB91 /* ProjectActivityItemProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectActivityItemProviderTests.swift; sourceTree = "<group>"; };
 		D67F29351F68333800E399A6 /* GraphSchema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GraphSchema.swift; sourceTree = "<group>"; };
 		D6AE52241FD1B3F600BEC788 /* RootCategoriesEnvelope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootCategoriesEnvelope.swift; sourceTree = "<group>"; };
 		D6AE52261FD1B41200BEC788 /* RootCategoriesEnvelope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = RootCategoriesEnvelope.swift; path = lenses/RootCategoriesEnvelope.swift; sourceTree = "<group>"; };
@@ -3168,6 +3170,7 @@
 				A7ED1F1D1E830FDC00BFFA01 /* PKPaymentRequestTests.swift */,
 				9DD1E3871D50035E00D4829E /* ProjectActivityData.swift */,
 				A75C811A1D210C4700B5AD03 /* ProjectActivityItemProvider.swift */,
+				D64850541FD879AB00B6AB91 /* ProjectActivityItemProviderTests.swift */,
 				8053D3101D3848A3007B85DB /* Reachability.swift */,
 				A7DC83951C9DBBE700BB2B44 /* RefTag.swift */,
 				A7ED1F1E1E830FDC00BFFA01 /* RefTagTests.swift */,
@@ -5205,6 +5208,7 @@
 				A7ED1F4A1E831BA200BFFA01 /* MockBundle.swift in Sources */,
 				A7ED1FB71E831C5C00BFFA01 /* LiveStreamEventDetailsViewModelTests.swift in Sources */,
 				A7ED1FD81E831C5C00BFFA01 /* DashboardRewardsCellViewModelTests.swift in Sources */,
+				D64850551FD879AB00B6AB91 /* ProjectActivityItemProviderTests.swift in Sources */,
 				A7ED1FC71E831C5C00BFFA01 /* DashboardFundingCellViewModelTests.swift in Sources */,
 				A7ED1FD51E831C5C00BFFA01 /* FindFriendsStatsCellViewModelTests.swift in Sources */,
 			);

--- a/Library/ProjectActivityItemProvider.swift
+++ b/Library/ProjectActivityItemProvider.swift
@@ -23,6 +23,8 @@ public final class ProjectActivityItemProvider: UIActivityItemProvider {
         )
       } else if activityType == .copyToPasteboard || activityType == .postToFacebook {
         return project.urls.web.project
+      } else {
+        return formattedString(for: project)
       }
     }
     return self.activityViewControllerPlaceholderItem(activityViewController)

--- a/Library/ProjectActivityItemProviderTests.swift
+++ b/Library/ProjectActivityItemProviderTests.swift
@@ -34,6 +34,9 @@ class ProjectActivityItemProviderTests: XCTestCase {
     let facebookType = provider.activityViewController(activityVC, itemForActivityType: .postToFacebook)
     XCTAssertEqual(facebookType as? String, project.urls.web.project)
 
+    let pasteboardType = provider.activityViewController(activityVC, itemForActivityType: .copyToPasteboard)
+    XCTAssertEqual(pasteboardType as? String, project.urls.web.project)
+
     let otherTypes =  provider.activityViewController(activityVC, itemForActivityType: UIActivityType(""))
     XCTAssertEqual(otherTypes as? String, formattedString)
   }

--- a/Library/ProjectActivityItemProviderTests.swift
+++ b/Library/ProjectActivityItemProviderTests.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable force_unwrapping
 import XCTest
 @testable import KsApi
 @testable import Prelude
@@ -19,7 +18,7 @@ class ProjectActivityItemProviderTests: XCTestCase {
 
   func testProviderInitReturnsCorrectPlaceholderItem() {
     let provider: ProjectActivityItemProvider = ProjectActivityItemProvider(project: project)
-    XCTAssertEqual(project.name, provider.placeholderItem as! String)
+    XCTAssertEqual(project.name, provider.placeholderItem as? String)
   }
 
   func testItemForActivityTypeReturnsCorrectValue() {
@@ -27,16 +26,16 @@ class ProjectActivityItemProviderTests: XCTestCase {
     let activityVC = UIActivityViewController.init(activityItems: [], applicationActivities: [])
 
     let mailType =  provider.activityViewController(activityVC, itemForActivityType: .mail)
-    XCTAssertEqual(mailType as! String, formattedString)
+    XCTAssertEqual(mailType as? String, formattedString)
 
     let messageType =  provider.activityViewController(activityVC, itemForActivityType: .message)
-    XCTAssertEqual(messageType as! String, formattedString)
+    XCTAssertEqual(messageType as? String, formattedString)
 
     let facebookType = provider.activityViewController(activityVC, itemForActivityType: .postToFacebook)
-    XCTAssertEqual(facebookType as! String, project.urls.web.project)
+    XCTAssertEqual(facebookType as? String, project.urls.web.project)
 
     let otherTypes =  provider.activityViewController(activityVC, itemForActivityType: UIActivityType(""))
-    XCTAssertEqual(otherTypes as! String, formattedString)
+    XCTAssertEqual(otherTypes as? String, formattedString)
   }
 
   func testItemForTwitterTypeReturnsCorrectValue() {
@@ -46,6 +45,6 @@ class ProjectActivityItemProviderTests: XCTestCase {
       project_or_update_title: formattedString)
 
     let twitterType =  provider.activityViewController(activityVC, itemForActivityType: .postToTwitter)
-    XCTAssertEqual(twitterType as! String, twitterOutput)
+    XCTAssertEqual(twitterType as? String, twitterOutput)
   }
 }

--- a/Library/ProjectActivityItemProviderTests.swift
+++ b/Library/ProjectActivityItemProviderTests.swift
@@ -1,0 +1,51 @@
+// swiftlint:disable force_unwrapping
+import XCTest
+@testable import KsApi
+@testable import Prelude
+@testable import Library
+
+class ProjectActivityItemProviderTests: XCTestCase {
+
+  private let project = .template
+    |> Project.lens.name .~ "Awesome project"
+    |> Project.lens.urls.web.project .~ "https://kickstarter.com/awesome-project"
+
+  private var formattedString: String {
+    return """
+            \(project.name)\n
+            \(project.urls.web.project)
+           """
+  }
+
+  func testProviderInitReturnsCorrectPlaceholderItem() {
+    let provider: ProjectActivityItemProvider = ProjectActivityItemProvider(project: project)
+    XCTAssertEqual(project.name, provider.placeholderItem as! String)
+  }
+
+  func testItemForActivityTypeReturnsCorrectValue() {
+    let provider: ProjectActivityItemProvider = ProjectActivityItemProvider(project: project)
+    let activityVC = UIActivityViewController.init(activityItems: [], applicationActivities: [])
+
+    let mailType =  provider.activityViewController(activityVC, itemForActivityType: .mail)
+    XCTAssertEqual(mailType as! String, formattedString)
+
+    let messageType =  provider.activityViewController(activityVC, itemForActivityType: .message)
+    XCTAssertEqual(messageType as! String, formattedString)
+
+    let facebookType = provider.activityViewController(activityVC, itemForActivityType: .postToFacebook)
+    XCTAssertEqual(facebookType as! String, project.urls.web.project)
+
+    let otherTypes =  provider.activityViewController(activityVC, itemForActivityType: UIActivityType(""))
+    XCTAssertEqual(otherTypes as! String, formattedString)
+  }
+
+  func testItemForTwitterTypeReturnsCorrectValue() {
+    let provider: ProjectActivityItemProvider = ProjectActivityItemProvider(project: project)
+    let activityVC = UIActivityViewController.init(activityItems: [], applicationActivities: [])
+    let twitterOutput = Strings.project_checkout_share_twitter_via_kickstarter(
+      project_or_update_title: formattedString)
+
+    let twitterType =  provider.activityViewController(activityVC, itemForActivityType: .postToTwitter)
+    XCTAssertEqual(twitterType as! String, twitterOutput)
+  }
+}


### PR DESCRIPTION
# What
A fix for a bug on which didn't allow users to share projects with 3rd-party social networks.

# Why
https://trello.com/c/UPQLLZdj/323-p2-sharing-still-not-working-for-some-contexts

# How
Our code were return Project name as default for 3rd-party social networks. Now the default is name + url.
