### PR TITLE
Project image tap event bug

### DIFF
--- a/Kickstarter-iOS/Views/Controllers/ProjectCreatorViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/ProjectCreatorViewController.swift
@@ -48,6 +48,16 @@ internal final class ProjectCreatorViewController: WebViewController {
       .observeForControllerAction()
       .observeValues { [weak self] in _ = self?.webView.load($0) }
 
+    self.viewModel.outputs.goBackToProject
+      .observeForControllerAction()
+      .observeValues { [weak self] in
+        if self?.traitCollection.userInterfaceIdiom == .pad {
+          self?.dismiss(animated: true, completion: nil)
+        } else {
+          self?.navigationController?.popViewController(animated: true)
+        }
+    }
+
     self.viewModel.outputs.goToMessageDialog
       .observeForControllerAction()
       .observeValues { [weak self] in self?.goToMessageDialog(subject: $0, context: $1) }

--- a/Library/ViewModels/ProjectCreatorViewModel.swift
+++ b/Library/ViewModels/ProjectCreatorViewModel.swift
@@ -71,18 +71,16 @@ ProjectCreatorViewModelOutputs {
 
     self.goBackToProject = Signal.combineLatest(project, navigationAction)
       .filter { $1.navigationType == .linkActivated }
-      .filter { (arg: (Project, WKNavigationActionData)) -> Bool in
-        let (project, navigation) = arg
-        return project.urls.web.project == navigation.request.url?.absoluteString
+      .filter { project, navigation in
+         project.urls.web.project == navigation.request.url?.absoluteString
       }
       .ignoreValues()
 
     self.goToSafariBrowser = Signal.combineLatest(project, navigationAction)
       .filter { $1.navigationType == .linkActivated }
       .filter { !isMessageCreator(request: $1.request) }
-      .filter { (arg: (Project, WKNavigationActionData)) -> Bool in
-        let (project, navigation) = arg
-        return project.urls.web.project != navigation.request.url?.absoluteString
+      .filter { project, navigation in
+        project.urls.web.project != navigation.request.url?.absoluteString
       }
       .map { $1.request.url }
       .skipNil()

--- a/Library/ViewModels/ProjectCreatorViewModelTests.swift
+++ b/Library/ViewModels/ProjectCreatorViewModelTests.swift
@@ -10,6 +10,7 @@ import XCTest
 final class ProjectCreatorViewModelTests: TestCase {
   fileprivate let vm: ProjectCreatorViewModelType = ProjectCreatorViewModel()
 
+  fileprivate let goBackToProject = TestObserver<(), NoError>()
   fileprivate let goToLoginTout = TestObserver<LoginIntent, NoError>()
   fileprivate let goToMessageDialogContext = TestObserver<Koala.MessageDialogContext, NoError>()
   fileprivate let goToMessageDialogSubject = TestObserver<MessageSubject, NoError>()
@@ -19,6 +20,7 @@ final class ProjectCreatorViewModelTests: TestCase {
   override func setUp() {
     super.setUp()
 
+    self.vm.outputs.goBackToProject.observe(self.goBackToProject.observer)
     self.vm.outputs.goToLoginTout.observe(self.goToLoginTout.observer)
     self.vm.outputs.goToMessageDialog.map(second).observe(self.goToMessageDialogContext.observer)
     self.vm.outputs.goToMessageDialog.map(first).observe(self.goToMessageDialogSubject.observer)
@@ -119,6 +121,48 @@ final class ProjectCreatorViewModelTests: TestCase {
 
     self.goToMessageDialogContext.assertValues([.projectPage])
     self.goToMessageDialogSubject.assertValues([.project(project)])
+  }
+
+  func testGoBackToProjectDoesNotEmit_whenRequestURL_IsEqualToProjectURL() {
+    let project = Project.template
+    self.vm.inputs.configureWith(project: project)
+    self.vm.inputs.viewDidLoad()
+
+    self.goBackToProject.assertDidNotEmitValue()
+
+    let projectRequest = URLRequest(
+      url: URL(string: "https://www.kickstarter.com/projects/creator/a-fun-project")!
+    )
+    _ = self.vm.inputs.decidePolicy(
+      forNavigationAction: WKNavigationActionData(
+        navigationType: .linkActivated,
+        request: projectRequest,
+        sourceFrame: WKFrameInfoData(mainFrame: true, request: projectRequest),
+        targetFrame: WKFrameInfoData(mainFrame: true, request: projectRequest)
+      )
+    )
+    self.goBackToProject.assertDidEmitValue()
+  }
+
+  func testGoBackToProjectDoesNotEmit_whenRequestURL_IsNotEqualToProjectURL() {
+    let project = Project.template
+    self.vm.inputs.configureWith(project: project)
+    self.vm.inputs.viewDidLoad()
+
+    self.goBackToProject.assertDidNotEmitValue()
+
+    let projectRequest = URLRequest(
+      url: URL(string: "https://www.kickstarter.com/")!
+    )
+    _ = self.vm.inputs.decidePolicy(
+      forNavigationAction: WKNavigationActionData(
+        navigationType: .linkActivated,
+        request: projectRequest,
+        sourceFrame: WKFrameInfoData(mainFrame: true, request: projectRequest),
+        targetFrame: WKFrameInfoData(mainFrame: true, request: projectRequest)
+      )
+    )
+    self.goBackToProject.assertDidNotEmitValue()
   }
 
   func testGoToSafariBrowser() {

--- a/Library/ViewModels/ProjectCreatorViewModelTests.swift
+++ b/Library/ViewModels/ProjectCreatorViewModelTests.swift
@@ -151,15 +151,15 @@ final class ProjectCreatorViewModelTests: TestCase {
 
     self.goBackToProject.assertDidNotEmitValue()
 
-    let projectRequest = URLRequest(
-      url: URL(string: "https://www.kickstarter.com/")!
+    let linkRequest = URLRequest(
+      url: URL(string: "https://www.kickstarter.com/projects/creator/about")!
     )
     _ = self.vm.inputs.decidePolicy(
       forNavigationAction: WKNavigationActionData(
         navigationType: .linkActivated,
-        request: projectRequest,
-        sourceFrame: WKFrameInfoData(mainFrame: true, request: projectRequest),
-        targetFrame: WKFrameInfoData(mainFrame: true, request: projectRequest)
+        request: linkRequest,
+        sourceFrame: WKFrameInfoData(mainFrame: true, request: linkRequest),
+        targetFrame: WKFrameInfoData(mainFrame: true, request: linkRequest)
       )
     )
     self.goBackToProject.assertDidNotEmitValue()


### PR DESCRIPTION
# What
Inside a project: tapping on Creator's name > Project cover, a webView is presented instead of taking the user back to the project.

# Why
https://trello.com/c/AMqoLZxB/227-inside-a-project-tapping-on-creators-name-project-cover-thing-launch-of-web-view

# How
Adding a logic that compares the request URL(when tapping the WKWebView) and project URL. If they are the same, we should go back to the project page.
