### PR TITLE
Uses specific XCTest matchers over XCTAssertEqual

### DIFF
--- a/KsApi/models/CategoryTests.swift
+++ b/KsApi/models/CategoryTests.swift
@@ -63,7 +63,7 @@ class CategoryTests: XCTestCase {
 
   func testParent() {
     XCTAssertEqual(Category.illustration.parent, Category.art)
-    XCTAssertEqual(Category.art.parent, nil)
+    XCTAssertNil(Category.art.parent)
   }
 
   func testParentCategoryType() {

--- a/KsApi/models/CategoryTests.swift
+++ b/KsApi/models/CategoryTests.swift
@@ -79,9 +79,9 @@ class CategoryTests: XCTestCase {
 
   func testRoot() {
     XCTAssertEqual(Category.illustration.root, Category.art)
-    XCTAssertEqual(Category.illustration.isRoot, false)
+    XCTAssertFalse(Category.illustration.isRoot)
     XCTAssertEqual(Category.art.root, Category.art)
-    XCTAssertEqual(Category.art.isRoot, true)
+    XCTAssertTrue(Category.art.isRoot)
     XCTAssertNil((Category.illustration
                   |> Category.lens.parent .~ nil).root,
       "A subcategory with no parent category present does not have a root."

--- a/KsApi/models/ProjectStatsEnvelopeTests.swift
+++ b/KsApi/models/ProjectStatsEnvelopeTests.swift
@@ -110,7 +110,7 @@ final class ProjectStatsEnvelopeTests: XCTestCase {
     XCTAssertEqual(25, rewardDistribution[1].pledged)
     XCTAssertEqual(5, rewardDistribution[0].backersCount)
     XCTAssertEqual(10, rewardDistribution[1].backersCount)
-    XCTAssertEqual(nil, rewardDistribution[0].minimum)
+    XCTAssertNil(rewardDistribution[0].minimum)
     XCTAssertEqual(5, rewardDistribution[1].minimum)
     XCTAssertEqual(25, rewardDistribution[2].minimum)
   }

--- a/KsApi/models/ProjectTests.swift
+++ b/KsApi/models/ProjectTests.swift
@@ -24,7 +24,7 @@ final class ProjectTests: XCTestCase {
     let justLaunched = Project.template
       |> Project.lens.dates.launchedAt .~ Date(timeIntervalSince1970: 1475361315).timeIntervalSince1970
 
-    XCTAssertEqual(false, justLaunched.endsIn48Hours(today: Date(timeIntervalSince1970: 1475361315)))
+    XCTAssertFalse(justLaunched.endsIn48Hours(today: Date(timeIntervalSince1970: 1475361315)))
   }
 
   func testEndsIn48Hours_WithEndingSoonProject() {
@@ -32,7 +32,7 @@ final class ProjectTests: XCTestCase {
       |> Project.lens.dates.deadline .~ (Date(timeIntervalSince1970: 1475361315)
         .timeIntervalSince1970 - 60.0 * 60.0)
 
-    XCTAssertEqual(true, endingSoon.endsIn48Hours(today: Date(timeIntervalSince1970: 1475361315)))
+    XCTAssertTrue(endingSoon.endsIn48Hours(today: Date(timeIntervalSince1970: 1475361315)))
   }
 
   func testEndsIn48Hours_WithTimeZoneEdgeCaseProject() {
@@ -40,7 +40,7 @@ final class ProjectTests: XCTestCase {
       |> Project.lens.dates.deadline .~ (Date(timeIntervalSince1970: 1475361315)
         .timeIntervalSince1970 - 60.0 * 60.0 * 47.0)
 
-    XCTAssertEqual(true, edgeCase.endsIn48Hours(today: Date(timeIntervalSince1970: 1475361315)))
+    XCTAssertTrue(edgeCase.endsIn48Hours(today: Date(timeIntervalSince1970: 1475361315)))
   }
 
   func testEquatable() {

--- a/KsApi/models/RewardTests.swift
+++ b/KsApi/models/RewardTests.swift
@@ -5,8 +5,8 @@ import Prelude
 final class RewardTests: XCTestCase {
 
   func testIsNoReward() {
-    XCTAssertEqual(Reward.noReward.isNoReward, true)
-    XCTAssertEqual(Reward.template.isNoReward, false)
+    XCTAssertTrue(Reward.noReward.isNoReward)
+    XCTAssertFalse(Reward.template.isNoReward)
   }
 
   func testEquatable() {

--- a/Library/AppEnvironmentTests.swift
+++ b/Library/AppEnvironmentTests.swift
@@ -82,7 +82,7 @@ final class AppEnvironmentTests: XCTestCase {
     let env = AppEnvironment.fromStorage(ubiquitousStore: ubiquitousStore, userDefaults: userDefaults)
 
     XCTAssertNil(env.apiService.oauthToken?.token)
-    XCTAssertEqual(nil, env.currentUser)
+    XCTAssertNil(env.currentUser)
   }
 
   func testFromStorage_WithFullDataStored() {
@@ -117,7 +117,7 @@ final class AppEnvironmentTests: XCTestCase {
     let differentEnv = AppEnvironment.fromStorage(ubiquitousStore: MockKeyValueStore(),
                                                   userDefaults: MockKeyValueStore())
     XCTAssertNil(differentEnv.apiService.oauthToken?.token)
-    XCTAssertEqual(nil, differentEnv.currentUser)
+    XCTAssertNil(differentEnv.currentUser)
   }
 
   func testFromStorage_LegacyUserDefaults() {
@@ -158,8 +158,8 @@ final class AppEnvironmentTests: XCTestCase {
     XCTAssertEqual("en", result["apiService.language"] as? String)
     XCTAssertEqual(User.template.id, (result["currentUser"] as? [String: AnyObject])?["id"] as? Int)
 
-    XCTAssertEqual(nil, ubiquitousStore.string(forKey: AppEnvironment.oauthTokenStorageKey),
-                   "No token stored.")
+    XCTAssertNil(ubiquitousStore.string(forKey: AppEnvironment.oauthTokenStorageKey),
+                 "No token stored.")
   }
 
   func testPushPopSave() {
@@ -180,7 +180,7 @@ final class AppEnvironmentTests: XCTestCase {
       .dictionary(forKey: AppEnvironment.environmentStorageKey)
       .flatMap { $0["currentUser"] as? [String: AnyObject] }
       .flatMap { $0["id"] as? Int }
-    XCTAssertEqual(nil, currentUserId, "Current user is cleared.")
+    XCTAssertNil(currentUserId, "Current user is cleared.")
 
     AppEnvironment.popEnvironment()
   }

--- a/Library/CircleAvatarImageViewTests.swift
+++ b/Library/CircleAvatarImageViewTests.swift
@@ -9,12 +9,12 @@ final class CircleAvatarImageViewTests: XCTestCase {
     imageView.layoutSubviews()
 
     XCTAssertEqual(50.0, imageView.layer.cornerRadius)
-    XCTAssertEqual(true, imageView.layer.masksToBounds)
+    XCTAssertTrue(imageView.layer.masksToBounds)
 
     imageView.frame.size = CGSize(width: 200.0, height: 200.0)
     imageView.layoutSubviews()
 
     XCTAssertEqual(100.0, imageView.layer.cornerRadius)
-    XCTAssertEqual(true, imageView.layer.masksToBounds)
+    XCTAssertTrue(imageView.layer.masksToBounds)
   }
 }

--- a/Library/LanguageTests.swift
+++ b/Library/LanguageTests.swift
@@ -4,12 +4,10 @@ import XCTest
 final class LanguageTests: XCTestCase {
 
   func testEquality() {
-
     XCTAssertEqual(Language.en, Language.en)
     XCTAssertEqual(Language.de, Language.de)
     XCTAssertEqual(Language.fr, Language.fr)
     XCTAssertEqual(Language.es, Language.es)
-
     XCTAssertNotEqual(Language.en, Language.es)
   }
 
@@ -18,12 +16,12 @@ final class LanguageTests: XCTestCase {
     XCTAssertEqual(Language.en, Language(languageString: "En"))
     XCTAssertEqual(Language.es, Language(languageString: "Es"))
     XCTAssertEqual(Language.fr, Language(languageString: "Fr"))
-    XCTAssertEqual(nil, Language(languageString: "AB"))
+    XCTAssertNil(Language(languageString: "AB"))
   }
 
   func testLanguageFromLanguageStrings() {
     XCTAssertEqual(Language.en, Language(languageStrings: ["AB", "EN", "FR"]))
     XCTAssertEqual(Language.es, Language(languageStrings: ["AB", "BC", "ES"]))
-    XCTAssertEqual(nil, Language(languageStrings: ["AB", "BC", "CD"]))
+    XCTAssertNil(Language(languageStrings: ["AB", "BC", "CD"]))
   }
 }

--- a/Library/UILabel+IBClearTests.swift
+++ b/Library/UILabel+IBClearTests.swift
@@ -13,6 +13,6 @@ final class UILabelIBClearTests: XCTestCase {
     label.text = "howdy"
     label.clearIBValue = false
     XCTAssertEqual(label.text, "howdy")
-    XCTAssertEqual(label.clearIBValue, false)
+    XCTAssertFalse(label.clearIBValue)
   }
 }

--- a/Library/ViewModels/ThanksViewModelTests.swift
+++ b/Library/ViewModels/ThanksViewModelTests.swift
@@ -212,7 +212,7 @@ final class ThanksViewModelTests: TestCase {
 
       vm.inputs.rateNowButtonTapped()
 
-      XCTAssertEqual(true, AppEnvironment.current.userDefaults.hasSeenAppRating, "Rating pref saved")
+      XCTAssertTrue(AppEnvironment.current.userDefaults.hasSeenAppRating, "Rating pref saved")
       XCTAssertEqual(
         ["Triggered App Store Rating Dialog", "Accepted App Store Rating Dialog",
          "Checkout Finished Alert App Store Rating Rate Now"],
@@ -232,7 +232,7 @@ final class ThanksViewModelTests: TestCase {
 
       vm.inputs.rateRemindLaterButtonTapped()
 
-      XCTAssertEqual(false, AppEnvironment.current.userDefaults.hasSeenAppRating, "Rating pref saved")
+      XCTAssertFalse(AppEnvironment.current.userDefaults.hasSeenAppRating, "Rating pref saved")
       XCTAssertEqual(
         ["Triggered App Store Rating Dialog", "Delayed App Store Rating Dialog",
          "Checkout Finished Alert App Store Rating Remind Later"],
@@ -251,7 +251,7 @@ final class ThanksViewModelTests: TestCase {
 
       vm.inputs.rateNoThanksButtonTapped()
 
-      XCTAssertEqual(true, AppEnvironment.current.userDefaults.hasSeenAppRating, "Rating pref saved")
+      XCTAssertTrue(AppEnvironment.current.userDefaults.hasSeenAppRating, "Rating pref saved")
       XCTAssertEqual(
         ["Triggered App Store Rating Dialog", "Dismissed App Store Rating Dialog",
          "Checkout Finished Alert App Store Rating No Thanks"],
@@ -262,7 +262,7 @@ final class ThanksViewModelTests: TestCase {
 
   func testGamesAlert_ShowsOnce() {
     withEnvironment(currentUser: .template) {
-      XCTAssertEqual(false, AppEnvironment.current.userDefaults.hasSeenGamesNewsletterPrompt,
+      XCTAssertFalse(AppEnvironment.current.userDefaults.hasSeenGamesNewsletterPrompt,
                      "Newsletter pref is not set")
 
       vm.inputs.project(.template |> Project.lens.category .~ .games)
@@ -270,8 +270,8 @@ final class ThanksViewModelTests: TestCase {
 
       showRatingAlert.assertValueCount(0, "Rating alert does not show on games project")
       showGamesNewsletterAlert.assertValueCount(1, "Games alert shows on games project")
-      XCTAssertEqual(true, AppEnvironment.current.userDefaults.hasSeenGamesNewsletterPrompt,
-                     "Newsletter pref saved")
+      XCTAssertTrue(AppEnvironment.current.userDefaults.hasSeenGamesNewsletterPrompt,
+                    "Newsletter pref saved")
 
       let secondVM: ThanksViewModelType = ThanksViewModel()
       let secondShowRatingAlert = TestObserver<(), NoError>()


### PR DESCRIPTION
# What

Hi there! I'm working on a [SwiftLint](https://github.com/realm/SwiftLint) rule which enforces specific matchers over `XCTAssertEqual` and `XCTAssertNotEqual`. For instance,  `XCTAssertEqual(true, foo)` throws a violations and suggests `XCTAssertTrue` instead.

SwiftLint's build system runs against popular open source software - which includes this one - and some violations were detected.

# Why

This pull request is just a suggestion. Feel free to reject it if it's relevant for the project.
