### PR TITLE
Koala event fix

### DIFF
--- a/KsApi/models/Config.swift
+++ b/KsApi/models/Config.swift
@@ -24,7 +24,7 @@ public struct Config {
   public private(set) var launchedCountries: [Project.Country]
   public private(set) var locale: String
   public private(set) var stripePublishableKey: String
-  
+
   public var abExperimentsArray: [String] {
     let stringsArray = self.abExperiments.map { (key, value) in
       key + "[\(value)]"

--- a/KsApi/models/Config.swift
+++ b/KsApi/models/Config.swift
@@ -24,6 +24,13 @@ public struct Config {
   public private(set) var launchedCountries: [Project.Country]
   public private(set) var locale: String
   public private(set) var stripePublishableKey: String
+  
+  public var abExperimentsArray: [String] {
+    let stringsArray = self.abExperiments.map { (key, value) in
+      key + "[\(value)]"
+    }
+    return stringsArray
+  }
 }
 
 extension Config: Argo.Decodable {

--- a/KsApi/models/ConfigTests.swift
+++ b/KsApi/models/ConfigTests.swift
@@ -55,7 +55,7 @@ final class ConfigTests: XCTestCase {
     XCTAssertEqual([.es, .fr], config.launchedCountries)
     XCTAssertEqual("en", config.locale)
     XCTAssertEqual("pk", config.stripePublishableKey)
-
+    XCTAssertEqual(["2001_space_odyssey[control]", "dr_strangelove[experiment]"], config.abExperimentsArray)
     // Confirm that encoding and decoding again results in the same config.
     XCTAssertEqual(config, Config.decodeJSONDictionary(config.encode()).value)
   }

--- a/Library/Koala/Koala.swift
+++ b/Library/Koala/Koala.swift
@@ -1797,6 +1797,7 @@ public final class Koala {
     props["manufacturer"] = "Apple"
     props["app_version"] = self.bundle.infoDictionary?["CFBundleVersion"]
     props["app_release"] = self.bundle.infoDictionary?["CFBundleShortVersionString"]
+    props["current_variants"] = AppEnvironment.current.config?.abExperimentsArray
     props["model"] = Koala.deviceModel
     props["distinct_id"] = self.distinctId
     props["device_fingerprint"] = self.distinctId
@@ -1960,18 +1961,10 @@ private func properties(userActivity: NSUserActivity) -> [String: Any] {
   return props
 }
 
-private func dictionaryToArray(_ dictionary: [String: String]?) -> [String]? {
-  let stringsArray = dictionary?.map { (key, value) in
-    key + "[\(value)]"
-  }
-  return stringsArray
-}
-
 private func properties(params: DiscoveryParams, prefix: String = "discover_") -> [String: Any] {
   var result: [String: Any] = [:]
 
   // NB: All filters should be added here since `result["everything"]` is derived from this.
-  result["current_variants"] = dictionaryToArray(AppEnvironment.current.config?.abExperiments)
   result["recommended"] = params.recommended
   result["social"] = params.social
   result["staff_picks"] = params.staffPicks

--- a/Library/Koala/KoalaTests.swift
+++ b/Library/Koala/KoalaTests.swift
@@ -356,7 +356,7 @@ final class KoalaTests: TestCase {
     XCTAssertNil(properties["discover_staff_picks"])
     XCTAssertNil(properties["discover_starred"])
     XCTAssertNil(properties["discover_term"])
-    XCTAssertEqual(false, properties["discover_everything"] as? Bool)
+    XCTAssertEqual(true, properties["discover_everything"] as? Bool)
     XCTAssertEqual("magic", properties["discover_sort"] as? String)
     XCTAssertEqual(1, properties["page"] as? Int)
   }


### PR DESCRIPTION
# What
Change the place where we send `current_variants` property with Koala events.

# Why
Because we were sending `current_variants` with `Viewed Discovery` Koala event, the property was being renamed to `discover_current_variants`, what doesn't exist on the backend.