### PR TITLE
Links to project update fix

### DIFF
--- a/Kickstarter-iOS/ViewModels/AppDelegateViewModel.swift
+++ b/Kickstarter-iOS/ViewModels/AppDelegateViewModel.swift
@@ -507,7 +507,6 @@ AppDelegateViewModelOutputs {
       .filter { _, subpage, _ in subpage == .updates }
       .map { project, _, vcs in vcs + [ProjectUpdatesViewController.configuredWith(project: project)] }
 
-
     let updateLink = projectLink
       .map { project, subpage, vcs -> (Project, Int, Navigation.Project.Update, [UIViewController])? in
         guard case let .update(id, updateSubpage) = subpage else { return nil }

--- a/Kickstarter-iOS/ViewModels/AppDelegateViewModel.swift
+++ b/Kickstarter-iOS/ViewModels/AppDelegateViewModel.swift
@@ -499,9 +499,14 @@ AppDelegateViewModelOutputs {
         }
     }
 
+    let campaignFaqLink = projectLink
+      .filter { _, subpage, _ in subpage == .faqs }
+      .map { project, _, vcs in vcs + [ProjectDescriptionViewController.configuredWith(project: project)] }
+
     let updatesLink = projectLink
       .filter { _, subpage, _ in subpage == .updates }
       .map { project, _, vcs in vcs + [ProjectUpdatesViewController.configuredWith(project: project)] }
+
 
     let updateLink = projectLink
       .map { project, subpage, vcs -> (Project, Int, Navigation.Project.Update, [UIViewController])? in
@@ -544,7 +549,8 @@ AppDelegateViewModelOutputs {
         surveyResponseLink,
         updatesLink,
         updateRootLink,
-        updateCommentsLink
+        updateCommentsLink,
+        campaignFaqLink
       )
       .map { UINavigationController() |> UINavigationController.lens.viewControllers .~ $0 }
 

--- a/Library/Navigation.swift
+++ b/Library/Navigation.swift
@@ -449,7 +449,6 @@ private func faqs(_ params: RouteParams) -> Decoded<Navigation> {
     <*> params <|? "ref"
 }
 
-
 private func friends(_ params: RouteParams) -> Decoded<Navigation> {
   return curry(Navigation.project)
     <^> params <| "project_param"
@@ -549,7 +548,6 @@ private func updates(_ params: RouteParams) -> Decoded<Navigation> {
     <*> .success(Navigation.Project.updates)
     <*> params <|? "ref"
 }
-
 
 private func userSurvey(_ params: RouteParams) -> Decoded<Navigation> {
   return curry(Navigation.user)

--- a/Library/Navigation.swift
+++ b/Library/Navigation.swift
@@ -41,6 +41,7 @@ public enum Navigation {
     case root
     case comments
     case creatorBio
+    case faqs
     case friends
     case messageCreator
     case liveStream(eventId: Int)
@@ -128,6 +129,8 @@ public func == (lhs: Navigation.Project, rhs: Navigation.Project) -> Bool {
   case (.comments, .comments):
     return true
   case (.creatorBio, .creatorBio):
+    return true
+  case (.faqs, .faqs):
     return true
   case (.friends, .friends):
     return true
@@ -253,6 +256,7 @@ private let allRoutes: [String: (RouteParams) -> Decoded<Navigation>] = [
   "/projects/:creator_param/:project_param/creator_bio": creatorBio,
   "/projects/:creator_param/:project_param/dashboard": dashboard,
   "/projects/:creator_param/:project_param/description": project,
+  "/projects/:creator_param/:project_param/faqs": faqs,
   "/projects/:creator_param/:project_param/friends": friends,
   "/projects/:creator_param/:project_param/messages/new": messageCreator,
   "/projects/:creator_param/:project_param/pledge": pledgeRoot,
@@ -263,6 +267,7 @@ private let allRoutes: [String: (RouteParams) -> Decoded<Navigation>] = [
   "/projects/:creator_param/:project_param/pledge/new": pledgeNew,
   "/projects/:creator_param/:project_param/posts": posts,
   "/projects/:creator_param/:project_param/posts/:update_param": update,
+  "/projects/:creator_param/:project_param/updates": updates,
   "/projects/:creator_param/:project_param/posts/:update_param/comments": updateComments,
   "/projects/:creator_param/:project_param/surveys/:survey_param": projectSurvey,
   "/users/:user_param/surveys/:survey_response_id": userSurvey
@@ -437,6 +442,14 @@ private func dashboard(_ params: RouteParams) -> Decoded<Navigation> {
   return .success(.tab(dashboard))
 }
 
+private func faqs(_ params: RouteParams) -> Decoded<Navigation> {
+  return curry(Navigation.project)
+    <^> params <| "project_param"
+    <*> .success(.faqs)
+    <*> params <|? "ref"
+}
+
+
 private func friends(_ params: RouteParams) -> Decoded<Navigation> {
   return curry(Navigation.project)
     <^> params <| "project_param"
@@ -527,6 +540,16 @@ private func updateComments(_ params: RouteParams) -> Decoded<Navigation> {
       <*> .success(.comments))
     <*> params <|? "ref"
 }
+
+private func updates(_ params: RouteParams) -> Decoded<Navigation> {
+  let createProject = curry(Navigation.project)
+
+  return createProject
+    <^> params <| "project_param"
+    <*> .success(Navigation.Project.updates)
+    <*> params <|? "ref"
+}
+
 
 private func userSurvey(_ params: RouteParams) -> Decoded<Navigation> {
   return curry(Navigation.user)

--- a/Library/NavigationTests.swift
+++ b/Library/NavigationTests.swift
@@ -56,6 +56,9 @@ public final class NavigationTests: XCTestCase {
     KSRAssertMatch(.project(.slug("project"), .root, refTag: nil),
                    "/projects/creator/project/description")
 
+    KSRAssertMatch(.project(.slug("project"), .faqs, refTag: nil),
+                   "/projects/creator/project/faqs")
+
     KSRAssertMatch(.project(.slug("project"), .friends, refTag: nil),
                    "/projects/creator/project/friends")
 


### PR DESCRIPTION
# What

Before deep linking into project campaign faqs and update would only take user to the homescreen. Links work properly now.


# See 👀

UPDATES:
![deeplink_updates](https://user-images.githubusercontent.com/11362005/35757140-da4c0380-083b-11e8-8d9c-5cd81c76ebbb.gif)

FAQ:
![faqdescription_faq](https://user-images.githubusercontent.com/11362005/35757157-e8d1b7ce-083b-11e8-9fcb-fe7631dfdca9.gif)

# TODO ⏰

For now, the faq links take the user to the campaign description and from there the user can see the faqs by tapping on the faq button. This is because we do not have a native view for faq. 
