### PR TITLE
Add HD video support

### DIFF
--- a/KsApi/models/Project.Video.swift
+++ b/KsApi/models/Project.Video.swift
@@ -7,5 +7,6 @@ extension Project.Video: Argo.Decodable {
     return curry(Project.Video.init)
       <^> json <| "id"
       <*> json <| "high"
+      <*> json <|? "hls"
   }
 }

--- a/KsApi/models/Project.swift
+++ b/KsApi/models/Project.swift
@@ -35,6 +35,7 @@ public struct Project {
   public struct Video {
     public let id: Int
     public let high: String
+    public let hls: String?
   }
 
   public enum State: String, Argo.Decodable {

--- a/KsApi/models/Project.swift
+++ b/KsApi/models/Project.swift
@@ -158,8 +158,6 @@ extension Project: CustomDebugStringConvertible {
 
 extension Project: Argo.Decodable {
   static public func decode(_ json: JSON) -> Decoded<Project> {
-
-    print(json)
     let create = curry(Project.init)
     let tmp1 = create
       <^> json <| "blurb"

--- a/KsApi/models/Project.swift
+++ b/KsApi/models/Project.swift
@@ -158,6 +158,8 @@ extension Project: CustomDebugStringConvertible {
 
 extension Project: Argo.Decodable {
   static public func decode(_ json: JSON) -> Decoded<Project> {
+
+    print(json)
     let create = curry(Project.init)
     let tmp1 = create
       <^> json <| "blurb"

--- a/KsApi/models/lenses/Project.VideoLenses.swift
+++ b/KsApi/models/lenses/Project.VideoLenses.swift
@@ -4,12 +4,17 @@ extension Project.Video {
   public enum lens {
     public static let id = Lens<Project.Video, Int>(
       view: { $0.id },
-      set: { .init(id: $0, high: $1.high) }
+      set: { .init(id: $0, high: $1.high, hls: $1.hls) }
     )
 
     public static let high = Lens<Project.Video, String>(
       view: { $0.high },
-      set: { .init(id: $1.id, high: $0) }
+      set: { .init(id: $1.id, high: $0, hls: $1.hls) }
+    )
+
+    public static let hls = Lens<Project.Video, String?>(
+      view: { $0.hls },
+      set: { .init(id: $1.id, high: $1.high, hls: $0) }
     )
   }
 }

--- a/KsApi/models/templates/Project.VideoTemplates.swift
+++ b/KsApi/models/templates/Project.VideoTemplates.swift
@@ -1,6 +1,7 @@
 extension Project.Video {
   internal static let template = Project.Video(
     id: 1,
-    high: "http://www.kickstarter.com/video.mp4"
+    high: "http://www.kickstarter.com/video.mp4",
+    hls: "http://www.kickstarter.com/video.m3u8"
   )
 }

--- a/Library/ViewModels/VideoViewModel.swift
+++ b/Library/ViewModels/VideoViewModel.swift
@@ -134,7 +134,7 @@ public final class VideoViewModel: VideoViewModelInputs, VideoViewModelOutputs, 
     self.configurePlayerWithURL = project
       .filter { $0.video != nil }
       .takeWhen(self.playButtonTappedProperty.signal)
-      .map { URL(string: $0.video?.high ?? "") }
+      .map { URL(string: $0.video?.hls ?? $0.video?.high ?? "") }
       .skipNil()
       .skipRepeats()
 

--- a/Library/ViewModels/VideoViewModelTests.swift
+++ b/Library/ViewModels/VideoViewModelTests.swift
@@ -1,3 +1,4 @@
+// swiftlint:disable force_unwrapping
 import AVFoundation
 import Library
 import Prelude
@@ -57,8 +58,10 @@ internal final class VideoViewModelTests: TestCase {
     self.addCompletionObserver.assertValues([completedThreshold], "Observer added to completion threshold.")
   }
 
-  func testConfigureVideoWithURL() {
-    let video = .template |> Project.Video.lens.high .~ "https://sickskatevid.mp4"
+  func testConfigureVideoWithURL_setsHighURL_WhenHlsIsNil() {
+    let video = .template
+      |> Project.Video.lens.hls .~ nil
+      |> Project.Video.lens.high .~ "https://sickskatevid.mp4"
     let project = .template |> Project.lens.video .~ video
 
     self.vm.inputs.configureWith(project: project)
@@ -67,6 +70,20 @@ internal final class VideoViewModelTests: TestCase {
     self.vm.inputs.playButtonTapped()
 
     self.configurePlayerWithURL.assertValues([video.high], "Video url emitted.")
+  }
+
+  func testConfigureVideoWithURL_setsHlsURL_WhenHlsIsNotNil() {
+    let video = .template
+      |> Project.Video.lens.hls .~ "https://sickskatevid.m3u8"
+      |> Project.Video.lens.high .~ "https://sickskatevid.mp4"
+    let project = .template |> Project.lens.video .~ video
+
+    self.vm.inputs.configureWith(project: project)
+    self.vm.inputs.viewDidLoad()
+    self.vm.inputs.viewDidAppear()
+    self.vm.inputs.playButtonTapped()
+
+    self.configurePlayerWithURL.assertValues([video.hls!], "Video url emitted.")
   }
 
   func testIncrementVideoStats() {


### PR DESCRIPTION
# What
Adds support for hls streaming on iOS.

# Why
Creators now can create HD videos, and by adding HLS support, we allow users to watch these videos on iOS.

![GIF](https://media.giphy.com/media/BbIBCTZOOsF2w/giphy.gif)