### PR TITLE
Implemented creators name A/B experiment

### DIFF
--- a/KsApi/models/Config.swift
+++ b/KsApi/models/Config.swift
@@ -5,7 +5,7 @@ import Runes
 public enum Experiment {
 
   public enum Name: String {
-    case iosTest = "ios_test_test"
+    case creatorsNameDiscovery = "show_created_by_discovery"
   }
 
   public enum Variant: String {

--- a/Library/ViewModels/DiscoveryPostcardViewModel.swift
+++ b/Library/ViewModels/DiscoveryPostcardViewModel.swift
@@ -150,8 +150,10 @@ public protocol DiscoveryPostcardViewModelType {
 }
 
 private func shouldHideCreatorLabel() -> Bool {
-// Since this is a A/A test, for now we will simply return true.
-  return true
+  let creatorExperiment = AppEnvironment.current.config?.abExperiments.filter {
+    $0.key == Experiment.Name.creatorsNameDiscovery.rawValue
+  }
+  return creatorExperiment?.first?.value != Experiment.Variant.experimental.rawValue
 }
 
 public final class DiscoveryPostcardViewModel: DiscoveryPostcardViewModelType,

--- a/Library/ViewModels/DiscoveryPostcardViewModelTests.swift
+++ b/Library/ViewModels/DiscoveryPostcardViewModelTests.swift
@@ -88,20 +88,26 @@ internal final class DiscoveryPostcardViewModelTests: TestCase {
 
   func testCreatorNameLabelHides_WhenExperimentDisabled() {
     let project = Project.template
-    _ = Config.template
+    let config = Config.template
       |> Config.lens.abExperiments .~
-      [Experiment.Name.iosTest.rawValue: Experiment.Variant.control.rawValue]
-    self.vm.inputs.configureWith(project: project)
-    self.creatorNameLabelHidden.assertValues([true])
+      [Experiment.Name.creatorsNameDiscovery.rawValue: Experiment.Variant.control.rawValue]
+
+    withEnvironment(config: config) {
+      self.vm.inputs.configureWith(project: project)
+      self.creatorNameLabelHidden.assertValues([true])
+    }
   }
 
   func testCreatorNameLabelShows_WhenExperimentEnabled() {
     let project = Project.template
-    _ = Config.template
+    let config = Config.template
       |> Config.lens.abExperiments .~
-      [Experiment.Name.iosTest.rawValue: Experiment.Variant.experimental.rawValue]
-    self.vm.inputs.configureWith(project: project)
-    self.creatorNameLabelHidden.assertValues([true])
+      [Experiment.Name.creatorsNameDiscovery.rawValue: Experiment.Variant.experimental.rawValue]
+
+    withEnvironment(config: config) {
+      self.vm.inputs.configureWith(project: project)
+      self.creatorNameLabelHidden.assertValues([false])
+    }
   }
 
   func testCreatorNameLabel_ShowsCorrectText() {


### PR DESCRIPTION
# What
Added A/B experiment to show/hide creators name on PostCardCell.

# How
The previous experiment called `ios_test_test` was renamed to `show_created_by_discovery` and now contains logic to show/hide creators name based on the bucket the user is in.