### PR TITLE
Added current_variants to missing event

### DIFF
--- a/Library/Koala/Koala.swift
+++ b/Library/Koala/Koala.swift
@@ -418,7 +418,8 @@ public final class Koala {
    - parameter page: The number of pages that have been loaded.
    */
   public func trackDiscovery(params: DiscoveryParams, page: Int) {
-    let props = properties(params: params).withAllValuesFrom(["page": page])
+    var props = properties(params: params).withAllValuesFrom(["page": page])
+    props["current_variants"] = AppEnvironment.current.config?.abExperimentsArray
 
     self.track(event: "Loaded Discovery Results", properties: props)
 
@@ -1172,6 +1173,7 @@ public final class Koala {
     props["referrer_credit"] = cookieRefTag?.stringTag
     props["live_stream_type"] = prioritizedLiveStreamState(
       fromLiveStreamEvents: liveStreamEvents)?.trackingString
+    props["current_variants"] = AppEnvironment.current.config?.abExperimentsArray
 
     // Deprecated event
     self.track(event: "Project Page", properties: props.withAllValuesFrom(deprecatedProps))


### PR DESCRIPTION
# What
Added current_variants to missing event.

# Why
A Koala event wasn't sending current_variant of `default_rec_projects` experiment.