### PR TITLE
Crash on email link fix

### DIFF
--- a/Kickstarter-iOS/Views/Controllers/ProjectUpdatesViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/ProjectUpdatesViewController.swift
@@ -1,4 +1,5 @@
 import KsApi
+import MessageUI
 import Library
 import Prelude
 import SafariServices
@@ -14,6 +15,7 @@ internal final class ProjectUpdatesViewController: WebViewController {
 
   internal override func viewDidLoad() {
     super.viewDidLoad()
+    self.viewModel.inputs.canSendEmail(MFMailComposeViewController.canSendMail())
     self.activityIndicator.translatesAutoresizingMaskIntoConstraints = false
     self.view.addSubview(self.activityIndicator)
     NSLayoutConstraint.activate([
@@ -44,7 +46,15 @@ internal final class ProjectUpdatesViewController: WebViewController {
 
     self.viewModel.outputs.goToSafariBrowser
       .observeForControllerAction()
-      .observeValues { [weak self] in self?.goToSafariBrowser(url: $0) }
+      .observeValues { [weak self] in
+        self?.goToSafariBrowser(url: $0)
+    }
+
+    self.viewModel.outputs.showMailCompose
+      .observeForUI()
+      .observeValues { [weak self] recipient in
+        self?.openMailComposer(recipient: recipient)
+    }
 
     self.viewModel.outputs.goToUpdate
       .observeForControllerAction()
@@ -83,6 +93,23 @@ internal final class ProjectUpdatesViewController: WebViewController {
     self.navigationController?.pushViewController(vc, animated: true)
   }
 
+  fileprivate func openMailComposer(recipient: String) {
+    guard MFMailComposeViewController.canSendMail() else { return }
+
+    let userName = AppEnvironment.current.currentUser?.name ?? "Logged out user"
+    let userId = AppEnvironment.current.currentUser?.id ?? 0
+
+    let controller = MFMailComposeViewController()
+    controller.setToRecipients([recipient])
+    controller.setMessageBody(
+      "\(userName) | \(userId)\n\n",
+      isHTML: false
+    )
+
+    controller.mailComposeDelegate = self
+    self.present(controller, animated: true, completion: nil)
+  }
+
   internal func webView(_ webView: WKWebView,
                         decidePolicyFor navigationAction: WKNavigationAction,
                         decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
@@ -97,5 +124,14 @@ internal final class ProjectUpdatesViewController: WebViewController {
 
   func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
     self.viewModel.inputs.webViewDidFinishNavigation()
+  }
+}
+
+extension ProjectUpdatesViewController: MFMailComposeViewControllerDelegate {
+  internal func mailComposeController(_ controller: MFMailComposeViewController,
+                                      didFinishWith result: MFMailComposeResult,
+                                      error: Error?) {
+    self.viewModel.inputs.mailComposeCompletion(result: result)
+    controller.dismiss(animated: true, completion: nil)
   }
 }

--- a/Kickstarter-iOS/Views/Controllers/ProjectUpdatesViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/ProjectUpdatesViewController.swift
@@ -50,6 +50,12 @@ internal final class ProjectUpdatesViewController: WebViewController {
         self?.goToSafariBrowser(url: $0)
     }
 
+    self.viewModel.outputs.makePhoneCall
+      .observeForUI()
+      .observeValues { [weak self] number in
+        self?.call(number: number)
+      }
+
     self.viewModel.outputs.showMailCompose
       .observeForUI()
       .observeValues { [weak self] recipient in
@@ -108,6 +114,14 @@ internal final class ProjectUpdatesViewController: WebViewController {
 
     controller.mailComposeDelegate = self
     self.present(controller, animated: true, completion: nil)
+  }
+
+  fileprivate func call(number url: URL) {
+    if #available(iOS 10, *) {
+      UIApplication.shared.open(url)
+    } else {
+      UIApplication.shared.openURL(url)
+    }
   }
 
   internal func webView(_ webView: WKWebView,

--- a/Kickstarter-iOS/Views/Controllers/ProjectUpdatesViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/ProjectUpdatesViewController.swift
@@ -62,6 +62,12 @@ internal final class ProjectUpdatesViewController: WebViewController {
         self?.openMailComposer(recipient: recipient)
     }
 
+    self.viewModel.outputs.showNoEmailError
+      .observeForUI()
+      .observeValues { [weak self] alertController in
+        self?.present(alertController, animated: true)
+      }
+
     self.viewModel.outputs.goToUpdate
       .observeForControllerAction()
       .observeValues { [weak self] in self?.goToUpdate(forProject: $0, update: $1) }

--- a/Kickstarter-iOS/Views/Controllers/ProjectUpdatesViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/ProjectUpdatesViewController.swift
@@ -108,15 +108,8 @@ internal final class ProjectUpdatesViewController: WebViewController {
   fileprivate func openMailComposer(recipient: String) {
     guard MFMailComposeViewController.canSendMail() else { return }
 
-    let userName = AppEnvironment.current.currentUser?.name ?? "Logged out user"
-
     let controller = MFMailComposeViewController()
     controller.setToRecipients([recipient])
-    controller.setMessageBody(
-      "\(userName)\n\n",
-      isHTML: false
-    )
-
     controller.mailComposeDelegate = self
     self.present(controller, animated: true, completion: nil)
   }

--- a/Kickstarter-iOS/Views/Controllers/ProjectUpdatesViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/ProjectUpdatesViewController.swift
@@ -54,7 +54,7 @@ internal final class ProjectUpdatesViewController: WebViewController {
       .observeForUI()
       .observeValues { [weak self] number in
         self?.call(number: number)
-      }
+    }
 
     self.viewModel.outputs.showMailCompose
       .observeForUI()
@@ -66,7 +66,7 @@ internal final class ProjectUpdatesViewController: WebViewController {
       .observeForUI()
       .observeValues { [weak self] alertController in
         self?.present(alertController, animated: true)
-      }
+    }
 
     self.viewModel.outputs.goToUpdate
       .observeForControllerAction()

--- a/Kickstarter-iOS/Views/Controllers/ProjectUpdatesViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/ProjectUpdatesViewController.swift
@@ -109,12 +109,11 @@ internal final class ProjectUpdatesViewController: WebViewController {
     guard MFMailComposeViewController.canSendMail() else { return }
 
     let userName = AppEnvironment.current.currentUser?.name ?? "Logged out user"
-    let userId = AppEnvironment.current.currentUser?.id ?? 0
 
     let controller = MFMailComposeViewController()
     controller.setToRecipients([recipient])
     controller.setMessageBody(
-      "\(userName) | \(userId)\n\n",
+      "\(userName)\n\n",
       isHTML: false
     )
 

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -6457,8 +6457,8 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.kickstarter.kickstarter.alpha;
 				PRODUCT_MODULE_NAME = Kickstarter_iOS;
 				PRODUCT_NAME = KickDebug;
-				PROVISIONING_PROFILE = "";
-				PROVISIONING_PROFILE_SPECIFIER = "Alpha Development";
+				PROVISIONING_PROFILE = "504dc70b-18c4-4d5e-8a63-cb130f04ce34";
+				PROVISIONING_PROFILE_SPECIFIER = "Nino Development";
 				SDKROOT = iphoneos;
 				SWIFT_OBJC_BRIDGING_HEADER = "Kickstarter-iOS/Kickstarter-iOS-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -6457,8 +6457,8 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.kickstarter.kickstarter.alpha;
 				PRODUCT_MODULE_NAME = Kickstarter_iOS;
 				PRODUCT_NAME = KickDebug;
-				PROVISIONING_PROFILE = "504dc70b-18c4-4d5e-8a63-cb130f04ce34";
-				PROVISIONING_PROFILE_SPECIFIER = "Nino Development";
+				PROVISIONING_PROFILE = "";
+				PROVISIONING_PROFILE_SPECIFIER = "Alpha Development";
 				SDKROOT = iphoneos;
 				SWIFT_OBJC_BRIDGING_HEADER = "Kickstarter-iOS/Kickstarter-iOS-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";

--- a/KsApi/models/Config.swift
+++ b/KsApi/models/Config.swift
@@ -84,7 +84,7 @@ extension Config: EncodableType {
 // Turns out using `>>-` or `flatMap` on a `Decoded` fails to compile with optimizations on, so this
 // function does it manually.
 private func decodeDictionary<T: Argo.Decodable>(_ j: Decoded<JSON>)
-  -> Decoded<[String:T]> where T.DecodedType == T {
+  -> Decoded<[String: T]> where T.DecodedType == T {
   switch j {
   case let .success(json): return [String: T].decode(json)
   case let .failure(e): return .failure(e)

--- a/Library/DataSource/ValueCellDataSource.swift
+++ b/Library/DataSource/ValueCellDataSource.swift
@@ -281,7 +281,7 @@ open class ValueCellDataSource: NSObject, UICollectionViewDataSource, UITableVie
    - parameter item:    An item index.
    - parameter section: A section index.
 
-   - returns: The resuableId associated with an (item, section) pair. Marked as internal as it's
+   - returns: The reusableId associated with an (item, section) pair. Marked as internal as it's
               only useful for testing.
    */
   internal final func reusableId(item: Int, section: Int) -> String? {

--- a/Library/ViewModels/ProjectUpdatesViewModel.swift
+++ b/Library/ViewModels/ProjectUpdatesViewModel.swift
@@ -49,6 +49,9 @@ public protocol ProjectUpdatesViewModelOutputs {
   /// Emits when to show a MFMailComposeViewController to contact support.
   var showMailCompose: Signal<String, NoError> { get }
 
+  /// Emits to show an alert when Mail is not available.
+  var showNoEmailError: Signal<UIAlertController, NoError> { get }
+
   /// Emits a request that should be loaded into the web view.
   var webViewLoadRequest: Signal<URLRequest, NoError> { get }
 }
@@ -127,7 +130,6 @@ ProjectUpdatesViewModelOutputs {
           !isGoToCommentsRequest(request: action.request) &&
           !isGoToUpdateRequest(request: action.request) &&
           !isUpdatesRequest(request: action.request) &&
-          !isEmailLink(action: action) &&
           isPhoneLink(action: action)
       }
       .map { $0.request.url }

--- a/Library/ViewModels/ProjectUpdatesViewModel.swift
+++ b/Library/ViewModels/ProjectUpdatesViewModel.swift
@@ -248,7 +248,7 @@ private func formattedEmailAddress(_ action: WKNavigationActionData) -> String {
 }
 
 private func isEmailLink(action: WKNavigationActionData) -> Bool {
-  return action.request.url?.scheme == "mailto:"
+  return action.request.url?.scheme == "mailto"
 }
 
 private func isGoToCommentsRequest(request: URLRequest) -> Bool {
@@ -262,7 +262,7 @@ private func isGoToUpdateRequest(request: URLRequest) -> Bool {
 }
 
 private func isPhoneLink(action: WKNavigationActionData) -> Bool {
-  return action.request.url?.scheme == "tel:" ? true : false
+  return action.request.url?.scheme == "tel" ? true : false
 }
 
 private func isUpdatesRequest(request: URLRequest) -> Bool {

--- a/Library/ViewModels/ProjectUpdatesViewModel.swift
+++ b/Library/ViewModels/ProjectUpdatesViewModel.swift
@@ -46,10 +46,10 @@ public protocol ProjectUpdatesViewModelOutputs {
   /// Emits when app should make phone call.
   var makePhoneCall: Signal<URL, NoError> { get }
 
-  /// Emits when to show a MFMailComposeViewController to contact support.
+  /// Emits to show a MFMailComposeViewController.
   var showMailCompose: Signal<String, NoError> { get }
 
-  /// Emits to show an alert when Mail is not available.
+  /// Emits to show an alert when device can not send emails.
   var showNoEmailError: Signal<UIAlertController, NoError> { get }
 
   /// Emits a request that should be loaded into the web view.

--- a/Library/ViewModels/ProjectUpdatesViewModelTests.swift
+++ b/Library/ViewModels/ProjectUpdatesViewModelTests.swift
@@ -17,6 +17,7 @@ final class ProjectUpdatesViewModelTests: TestCase {
   fileprivate let isActivityIndicatorHidden = TestObserver<Bool, NoError>()
   fileprivate let makePhoneCall = TestObserver<URL, NoError>()
   fileprivate let showMailCompose = TestObserver<String, NoError>()
+  fileprivate let showNoMailError = TestObserver<UIAlertController, NoError>()
   fileprivate let webViewLoadRequest = TestObserver<URLRequest, NoError>()
 
   internal override func setUp() {
@@ -27,6 +28,7 @@ final class ProjectUpdatesViewModelTests: TestCase {
     self.vm.outputs.isActivityIndicatorHidden.observe(self.isActivityIndicatorHidden.observer)
     self.vm.outputs.makePhoneCall.observe(self.makePhoneCall.observer)
     self.vm.outputs.showMailCompose.observe(self.showMailCompose.observer)
+    self.vm.outputs.showNoError
     self.vm.outputs.webViewLoadRequest.observe(self.webViewLoadRequest.observer)
   }
 
@@ -119,8 +121,9 @@ final class ProjectUpdatesViewModelTests: TestCase {
     targetFrame: WKFrameInfoData.init(mainFrame: false, request: updateRequest)
     )
 
-    self.vm.inputs.viewDidLoad()
-    _ = self.vm.inputs.decidePolicy(forNavigationAction: .init(navigationAction: navigationActionData.navigationAction))
+    self.vm.inputs.canSendEmail(true)
+    
+    _ = self.vm.inputs.decidePolicy(forNavigationAction: navigationActionData)
     self.showMailCompose.assertValues(["dead@beef.com"])
   }
 
@@ -128,6 +131,7 @@ final class ProjectUpdatesViewModelTests: TestCase {
 
     let phoneUrl = URL(string: "tel://5551234567")!
     let updateRequest = URLRequest(url: phoneUrl)
+
     let navigationActionData = WKNavigationActionData(
       navigationType: .linkActivated,
       request: updateRequest,
@@ -136,7 +140,7 @@ final class ProjectUpdatesViewModelTests: TestCase {
     )
 
     self.vm.inputs.viewDidLoad()
-    _ = self.vm.inputs.decidePolicy(forNavigationAction: .init(navigationAction: navigationActionData.navigationAction))
+    _ = self.vm.inputs.decidePolicy(forNavigationAction: navigationActionData)
     self.makePhoneCall.assertValues([phoneUrl])
   }
 

--- a/Library/ViewModels/ProjectUpdatesViewModelTests.swift
+++ b/Library/ViewModels/ProjectUpdatesViewModelTests.swift
@@ -102,7 +102,7 @@ final class ProjectUpdatesViewModelTests: TestCase {
     let navigationAction = self.navigationAction(with: URL(string: "mailto:dead@beef.com")!)
 
     self.vm.inputs.canSendEmail(true)
-    
+
     _ = self.vm.inputs.decidePolicy(forNavigationAction: navigationAction)
     self.showMailCompose.assertValues(["dead@beef.com"])
   }


### PR DESCRIPTION
# What
Fixed crash caused when user tapped email link on Project Updates.

# How
The app was treating links with url scheme `mailto:` as a safari link, instead of email. Because the WebView couldn't handle this kind of url, the app crashed.

![GIF](https://media.giphy.com/media/ypHEH8VjThGPS/giphy.gif)