### PR TITLE
User agent fix

### DIFF
--- a/Kickstarter-iOS/Library/WebViewController.swift
+++ b/Kickstarter-iOS/Library/WebViewController.swift
@@ -1,4 +1,5 @@
 import Library
+import KsApi
 import Prelude
 import Prelude_UIKit
 import UIKit
@@ -12,7 +13,8 @@ internal class WebViewController: UIViewController {
     self.webView.configuration.suppressesIncrementalRendering = true
     self.webView.configuration.allowsInlineMediaPlayback = true
     self.webView.configuration.applicationNameForUserAgent = "Kickstarter-iOS"
-
+    self.webView.customUserAgent = Service.userAgent
+    
     self.view.addSubview(self.webView)
     NSLayoutConstraint.activate(
       [

--- a/Kickstarter-iOS/Library/WebViewController.swift
+++ b/Kickstarter-iOS/Library/WebViewController.swift
@@ -14,7 +14,7 @@ internal class WebViewController: UIViewController {
     self.webView.configuration.allowsInlineMediaPlayback = true
     self.webView.configuration.applicationNameForUserAgent = "Kickstarter-iOS"
     self.webView.customUserAgent = Service.userAgent
-    
+
     self.view.addSubview(self.webView)
     NSLayoutConstraint.activate(
       [

--- a/KsApi/ServiceType.swift
+++ b/KsApi/ServiceType.swift
@@ -407,6 +407,12 @@ extension ServiceType {
     headers["Authorization"] = self.authorizationHeader
     headers["Kickstarter-App-Id"] = self.appId
     headers["Kickstarter-iOS-App"] = self.buildVersion
+    headers["User-Agent"] = Self.userAgent
+
+    return headers
+  }
+
+  public static var userAgent: String {
 
     let executable = Bundle.main.infoDictionary?["CFBundleExecutable"] as? String
     let bundleIdentifier = Bundle.main.infoDictionary?["CFBundleIdentifier"] as? String
@@ -416,9 +422,7 @@ extension ServiceType {
     let systemVersion = UIDevice.current.systemVersion
     let scale = UIScreen.main.scale
 
-    headers["User-Agent"] = "\(app)/\(bundleVersion) (\(model); iOS \(systemVersion) Scale/\(scale))"
-
-    return headers
+    return "\(app)/\(bundleVersion) (\(model); iOS \(systemVersion) Scale/\(scale))"
   }
 
   fileprivate var authorizationHeader: String? {

--- a/KsApi/models/Config.swift
+++ b/KsApi/models/Config.swift
@@ -84,7 +84,7 @@ extension Config: EncodableType {
 // Turns out using `>>-` or `flatMap` on a `Decoded` fails to compile with optimizations on, so this
 // function does it manually.
 private func decodeDictionary<T: Argo.Decodable>(_ j: Decoded<JSON>)
-  -> Decoded<[String:T]> where T.DecodedType == T {
+  -> Decoded<[String: T]> where T.DecodedType == T {
   switch j {
   case let .success(json): return [String: T].decode(json)
   case let .failure(e): return .failure(e)


### PR DESCRIPTION
# What
Fixes an issue where user-agent header was being overwritten with a default value,  making some `Completed Checkout` events be shown  as `client_type = web`.

# Why
https://trello.com/c/pl9yHIQ0/543-native-clienttype-detection