### PR TITLE
Specify target in get_version_number

### DIFF
--- a/.fastlane/Fastfile
+++ b/.fastlane/Fastfile
@@ -133,7 +133,7 @@ platform :ios do
     slack(
       slack_url: ENV["SLACK_WEBHOOK"],
       message: "Successfully uploaded" +
-        " v" + get_version_number(xcodeproj: "Kickstarter.xcodeproj") +
+        " v" + get_version_number(xcodeproj: "Kickstarter.xcodeproj", target: "Kickstarter-iOS") +
         " (" + get_build_number(xcodeproj: "Kickstarter.xcodeproj") + ")" +
         " of the Kickstarter iOS app to iTunes Connect 🚀"
     )


### PR DESCRIPTION
It seems that we now need to specify the target in `get_version_number` since switching to CircleCI 2.0, this might be due to a newer version of Fastlane being used.

https://docs.fastlane.tools/actions/get_version_number/