### PR TITLE
Fastlane tweaks

### DIFF
--- a/.fastlane/Fastfile
+++ b/.fastlane/Fastfile
@@ -5,7 +5,7 @@ default_platform :ios
 platform :ios do
   before_all do
     setup_circle_ci
-    xcversion(version: ENV["XCODE_VERSION"])
+    xcversion(version: ENV["XCODE_VERSION"] || "9.3")
   end
 
   ### MATCH

--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,5 @@ Screenshots/FailureDiffs/*
 
 Frameworks/OpenTok/*
 Frameworks/native-secrets
+.fastlane/report.xml
+.fastlane/README.md


### PR DESCRIPTION
Two more quick fastlane-related changes.

1. nil-coalescing the xcode version number for when we run `match` locally.
2. Ignoring some fastlane docs artifacts that are created when we run `match`. As @Scollaco mentioned, we can also use `skip_docs` to do this but it will still create the `report.xml` so I think we should just ignore both in the .gitignore.