### PR TITLE
Remove xcversion command from Fastfile

### DIFF
--- a/.fastlane/Fastfile
+++ b/.fastlane/Fastfile
@@ -3,15 +3,11 @@ fastlane_version "2.28.3"
 default_platform :ios
 
 platform :ios do
-  before_all do
-    setup_circle_ci
-    xcversion(version: ENV["XCODE_VERSION"] || "9.3")
-  end
-
   ### MATCH
 
   desc "Fastlane Match"
   lane :match_all do
+    setup_circle_ci
     match_appstore
     match_development
     match_enterprise


### PR DESCRIPTION
Our builds on CircleCI 2.0 have been breaking on the `xcversion` command. This is something we previously needed to run on CircleCI 1.0 because it sometimes had multiple versions of Xcode in the same container. It seems that it's no longer necessary on CI 2.0 and removing this should fix our builds.

Should have tried this sooner, but ¯\_(ツ)_/¯

I've also moved `setup_circle_ci` to the `match_all` lane because it is only needed there.

Related: https://github.com/kickstarter/drip-ios/pull/48