### PR TITLE
Deep link crash fix

### DIFF
--- a/Kickstarter-iOS/AppDelegate.swift
+++ b/Kickstarter-iOS/AppDelegate.swift
@@ -229,6 +229,15 @@ internal final class AppDelegate: UIResponder, UIApplicationDelegate {
     return self.viewModel.inputs.applicationContinueUserActivity(userActivity)
   }
 
+  func application(_ app: UIApplication, open url: URL, options: [UIApplicationOpenURLOptionsKey : Any] = [:]) -> Bool {
+    guard let sourceApplication = options[.sourceApplication] as? String else { return false }
+
+    return self.viewModel.inputs.applicationOpenUrl(application: app,
+                                                    url: url,
+                                                    sourceApplication: sourceApplication,
+                                                    annotation: options[.annotation] as Any)
+  }
+
   func application(_ application: UIApplication,
                    open url: URL,
                    sourceApplication: String?,

--- a/Kickstarter-iOS/AppDelegate.swift
+++ b/Kickstarter-iOS/AppDelegate.swift
@@ -230,7 +230,7 @@ internal final class AppDelegate: UIResponder, UIApplicationDelegate {
   }
 
   func application(_ app: UIApplication, open url: URL,
-                   options: [UIApplicationOpenURLOptionsKey : Any] = [:]) -> Bool {
+                   options: [UIApplicationOpenURLOptionsKey: Any] = [:]) -> Bool {
     guard let sourceApplication = options[.sourceApplication] as? String else { return false }
 
     return self.viewModel.inputs.applicationOpenUrl(application: app,

--- a/Kickstarter-iOS/AppDelegate.swift
+++ b/Kickstarter-iOS/AppDelegate.swift
@@ -229,7 +229,8 @@ internal final class AppDelegate: UIResponder, UIApplicationDelegate {
     return self.viewModel.inputs.applicationContinueUserActivity(userActivity)
   }
 
-  func application(_ app: UIApplication, open url: URL, options: [UIApplicationOpenURLOptionsKey : Any] = [:]) -> Bool {
+  func application(_ app: UIApplication, open url: URL,
+                   options: [UIApplicationOpenURLOptionsKey : Any] = [:]) -> Bool {
     guard let sourceApplication = options[.sourceApplication] as? String else { return false }
 
     return self.viewModel.inputs.applicationOpenUrl(application: app,


### PR DESCRIPTION
# What

Implement `UIApplicationDelegate`'s newer method for opening URL resources.

# Why

We've noticed a significant uptick in crashes on our last build. It appears that deep-links from Safari (FB logins or links from our known associations file) are calling [this](https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1623112-application) newer delegate method which we aren't yet implementing.

# How

Implement the delegate method.

# See

https://stackoverflow.com/questions/39069361/exc-bad-access-in-facebook-sdk-login-xcode-8-beta/39260549#39260549

![giphy-downsized-large](https://user-images.githubusercontent.com/3735375/39334217-aa178da2-4962-11e8-912a-6ead0b1c9bee.gif)