### PR TITLE
Replace flatMap with compactMap in some places

### DIFF
--- a/Library/PKPaymentRequest.swift
+++ b/Library/PKPaymentRequest.swift
@@ -130,7 +130,7 @@ extension PKMerchantCapability: Argo.Decodable {
     case let .array(array):
       return .success(
         array
-          .flatMap { PKMerchantCapability.decode($0).value }
+          .compactMap { PKMerchantCapability.decode($0).value }
           .reduce([]) { $0.union($1) }
       )
 

--- a/Library/ViewModels/DiscoveryFiltersViewModel.swift
+++ b/Library/ViewModels/DiscoveryFiltersViewModel.swift
@@ -224,7 +224,7 @@ private func expandableRows(selectedRow: SelectableRow,
                            params: .defaults |> DiscoveryParams.lens.category .~ rootCategory,
                            selectableRows: ([rootCategory] + (rootCategory.subcategories?.nodes ?? []))
                             .sorted()
-                            .flatMap { node in
+                            .compactMap { node in
                               return SelectableRow(isSelected: node == selectedRow.params.category,
                                                    params: .defaults
                                                     |> DiscoveryParams.lens.category .~ node)
@@ -304,7 +304,7 @@ private func favorites(selectedRow: SelectableRow, categories: [KsApi.Category])
       .flatMap { category in ([category] + (category.subcategories?.nodes ?? [])) }
 
     let faves: [SelectableRow] = subcategories
-      .flatMap { subcategory in
+      .compactMap { subcategory in
         guard let id = subcategory.intID else {
           return nil
         }


### PR DESCRIPTION
# What

Replace `flatMap` with `compactMap` in some places

# Why

Lint was complaining during compilation so I felt like fixing it while waiting for the build

# How

Auto fixed it using xcode
