### PR TITLE
Help link

### DIFF
--- a/Kickstarter-iOS/ViewModels/HelpWebViewModel.swift
+++ b/Kickstarter-iOS/ViewModels/HelpWebViewModel.swift
@@ -52,7 +52,7 @@ private func urlForHelpType(_ helpType: HelpType, baseUrl: URL) -> URL? {
   case .contact:
     return nil
   case .helpCenter:
-    return AppEnvironment.current.apiService.serverConfig.helpCenterUrl
+    return baseUrl.appendingPathComponent("help")
   case .howItWorks:
     return baseUrl.appendingPathComponent("about")
   case .privacy:

--- a/Kickstarter-iOS/ViewModels/HelpWebViewModelTests.swift
+++ b/Kickstarter-iOS/ViewModels/HelpWebViewModelTests.swift
@@ -15,7 +15,7 @@ internal final class HelpWebViewModelTests: TestCase {
   override func setUp() {
     super.setUp()
 
-    self.vm.outputs.webViewLoadRequest.map(urlFrom(request:))
+    self.vm.outputs.webViewLoadRequest.map { $0.url?.relativePath ?? "" }
       .observe(self.webViewLoadRequest.observer)
   }
 
@@ -32,32 +32,24 @@ internal final class HelpWebViewModelTests: TestCase {
     self.vm.inputs.configureWith(helpType: .helpCenter)
     self.vm.inputs.viewDidLoad()
 
-    self.webViewLoadRequest.assertValues(["/cookies", helpCenterUrl.absoluteString])
+    self.webViewLoadRequest.assertValues(["/cookies", "/help"])
 
     self.vm.inputs.configureWith(helpType: .howItWorks)
     self.vm.inputs.viewDidLoad()
 
-    self.webViewLoadRequest.assertValues(["/cookies", helpCenterUrl.absoluteString, "/about"])
+    self.webViewLoadRequest.assertValues(["/cookies", "/help", "/about"])
 
     self.vm.inputs.configureWith(helpType: .privacy)
     self.vm.inputs.viewDidLoad()
 
     self.webViewLoadRequest.assertValues(
-      ["/cookies", helpCenterUrl.absoluteString, "/about", "/privacy"]
+      ["/cookies", "/help", "/about", "/privacy"]
     )
 
     self.vm.inputs.configureWith(helpType: .terms)
     self.vm.inputs.viewDidLoad()
 
-    self.webViewLoadRequest.assertValues(["/cookies", helpCenterUrl.absoluteString, "/about", "/privacy",
+    self.webViewLoadRequest.assertValues(["/cookies", "/help", "/about", "/privacy",
       "/terms-of-use"])
-  }
-
-  private func urlFrom(request: URLRequest) -> String {
-
-    guard let url = request.url else { return "" }
-
-    let relativePath = request.url?.relativePath ?? ""
-    return url.absoluteString.contains("help") ? helpCenterUrl.absoluteString : relativePath
   }
 }

--- a/Kickstarter-iOS/ViewModels/HelpWebViewModelTests.swift
+++ b/Kickstarter-iOS/ViewModels/HelpWebViewModelTests.swift
@@ -10,8 +10,6 @@ import XCTest
 internal final class HelpWebViewModelTests: TestCase {
   fileprivate let vm: HelpWebViewModelType = HelpWebViewModel()
 
-  private let helpCenterUrl = AppEnvironment.current.apiService.serverConfig.helpCenterUrl
-
   fileprivate let webViewLoadRequest = TestObserver<String, NoError>()
 
   override func setUp() {

--- a/KsApi/ServerConfig.swift
+++ b/KsApi/ServerConfig.swift
@@ -10,7 +10,6 @@ public protocol ServerConfigType {
   var apiClientAuth: ClientAuthType { get }
   var basicHTTPAuth: BasicHTTPAuthType? { get }
   var graphQLEndpointUrl: URL { get }
-  var helpCenterUrl: URL { get }
   var environmentName: String { get }
 }
 
@@ -21,8 +20,7 @@ public func == (lhs: ServerConfigType, rhs: ServerConfigType) -> Bool {
     lhs.webBaseUrl == rhs.webBaseUrl &&
     lhs.apiClientAuth == rhs.apiClientAuth &&
     lhs.basicHTTPAuth == rhs.basicHTTPAuth &&
-    lhs.graphQLEndpointUrl == rhs.graphQLEndpointUrl &&
-    lhs.helpCenterUrl == rhs.helpCenterUrl
+    lhs.graphQLEndpointUrl == rhs.graphQLEndpointUrl
 }
 
 private let gqlPath = "graph"
@@ -34,7 +32,6 @@ public struct ServerConfig: ServerConfigType {
   public fileprivate(set) var apiClientAuth: ClientAuthType
   public fileprivate(set) var basicHTTPAuth: BasicHTTPAuthType?
   public fileprivate(set) var graphQLEndpointUrl: URL
-  public fileprivate(set) var helpCenterUrl: URL
   public fileprivate(set) var environmentName: String
 
   public static let production: ServerConfigType = ServerConfig(
@@ -44,7 +41,6 @@ public struct ServerConfig: ServerConfigType {
     basicHTTPAuth: nil,
     graphQLEndpointUrl: URL(string: "https://\(Secrets.WebEndpoint.production)")!
       .appendingPathComponent(gqlPath),
-    helpCenterUrl: URL(string: Secrets.HelpCenter.endpoint)!,
     environmentName: "Production"
   )
 
@@ -55,7 +51,6 @@ public struct ServerConfig: ServerConfigType {
     basicHTTPAuth: BasicHTTPAuth.development,
     graphQLEndpointUrl: URL(string: "https://\(Secrets.WebEndpoint.staging)")!
       .appendingPathComponent(gqlPath),
-    helpCenterUrl: URL(string: Secrets.HelpCenter.endpoint)!,
     environmentName: "Staging"
   )
 
@@ -65,7 +60,6 @@ public struct ServerConfig: ServerConfigType {
     apiClientAuth: ClientAuth.development,
     basicHTTPAuth: BasicHTTPAuth.development,
     graphQLEndpointUrl: URL(string: "http://ksr.dev")!.appendingPathComponent(gqlPath),
-    helpCenterUrl: URL(string: Secrets.HelpCenter.endpoint)!,
     environmentName: "Local"
   )
 
@@ -74,7 +68,6 @@ public struct ServerConfig: ServerConfigType {
               apiClientAuth: ClientAuthType,
               basicHTTPAuth: BasicHTTPAuthType?,
               graphQLEndpointUrl: URL,
-              helpCenterUrl: URL,
               environmentName: String = "") {
 
     self.apiBaseUrl = apiBaseUrl
@@ -82,7 +75,6 @@ public struct ServerConfig: ServerConfigType {
     self.apiClientAuth = apiClientAuth
     self.basicHTTPAuth = basicHTTPAuth
     self.graphQLEndpointUrl = graphQLEndpointUrl
-    self.helpCenterUrl = helpCenterUrl
     self.environmentName = environmentName
   }
 }

--- a/KsApi/ServiceTypeTests.swift
+++ b/KsApi/ServiceTypeTests.swift
@@ -15,8 +15,7 @@ final class ServiceTypeTests: XCTestCase {
         username: "username",
         password: "password"
       ),
-      graphQLEndpointUrl: URL(string: "http://www.ksr.com")!,
-      helpCenterUrl: URL(string: Secrets.HelpCenter.endpoint)!
+      graphQLEndpointUrl: URL(string: "http://www.ksr.com")!
     ),
     oauthToken: OauthToken(
       token: "cafebeef"
@@ -37,8 +36,7 @@ final class ServiceTypeTests: XCTestCase {
         username: "username",
         password: "password"
       ),
-      graphQLEndpointUrl: URL(string: "http://ksr.dev/graph")!,
-      helpCenterUrl: URL(string: Secrets.HelpCenter.endpoint)!
+      graphQLEndpointUrl: URL(string: "http://ksr.dev/graph")!
     )
   )
 
@@ -51,8 +49,7 @@ final class ServiceTypeTests: XCTestCase {
         clientId: "deadbeef"
       ),
       basicHTTPAuth: nil,
-      graphQLEndpointUrl: URL(string: "http://ksr.dev/graph")!,
-      helpCenterUrl: URL(string: Secrets.HelpCenter.endpoint)!
+      graphQLEndpointUrl: URL(string: "http://ksr.dev/graph")!
     )
   )
 
@@ -198,8 +195,7 @@ final class ServiceTypeTests: XCTestCase {
           username: "username",
           password: "password"
         ),
-        graphQLEndpointUrl: URL(string: "http://ksr.dev/graph")!,
-        helpCenterUrl: URL(string: Secrets.HelpCenter.endpoint)!
+        graphQLEndpointUrl: URL(string: "http://ksr.dev/graph")!
       )
     )
 

--- a/Library/AppEnvironment.swift
+++ b/Library/AppEnvironment.swift
@@ -247,8 +247,7 @@ public struct AppEnvironment {
           webBaseUrl: service.serverConfig.webBaseUrl,
           apiClientAuth: ClientAuth(clientId: clientId),
           basicHTTPAuth: service.serverConfig.basicHTTPAuth,
-          graphQLEndpointUrl: service.serverConfig.graphQLEndpointUrl,
-          helpCenterUrl: service.serverConfig.helpCenterUrl
+          graphQLEndpointUrl: service.serverConfig.graphQLEndpointUrl
         ),
         oauthToken: service.oauthToken,
         language: current.language.rawValue,
@@ -268,8 +267,7 @@ public struct AppEnvironment {
           webBaseUrl: webBaseUrl,
           apiClientAuth: service.serverConfig.apiClientAuth,
           basicHTTPAuth: service.serverConfig.basicHTTPAuth,
-          graphQLEndpointUrl: service.serverConfig.graphQLEndpointUrl,
-          helpCenterUrl: service.serverConfig.helpCenterUrl
+          graphQLEndpointUrl: service.serverConfig.graphQLEndpointUrl
         ),
         oauthToken: service.oauthToken,
         language: current.language.rawValue,
@@ -287,8 +285,7 @@ public struct AppEnvironment {
           webBaseUrl: service.serverConfig.webBaseUrl,
           apiClientAuth: service.serverConfig.apiClientAuth,
           basicHTTPAuth: BasicHTTPAuth(username: username, password: password),
-          graphQLEndpointUrl: service.serverConfig.graphQLEndpointUrl,
-          helpCenterUrl: service.serverConfig.helpCenterUrl
+          graphQLEndpointUrl: service.serverConfig.graphQLEndpointUrl
         ),
         oauthToken: service.oauthToken,
         language: current.language.rawValue,

--- a/Library/AppEnvironmentTests.swift
+++ b/Library/AppEnvironmentTests.swift
@@ -137,8 +137,7 @@ final class AppEnvironmentTests: XCTestCase {
         webBaseUrl: URL(string: "http://ksr.com")!,
         apiClientAuth: ClientAuth(clientId: "cafebeef"),
         basicHTTPAuth: nil,
-        graphQLEndpointUrl: URL(string: "http://ksr.dev/graph")!,
-        helpCenterUrl: URL(string: Secrets.HelpCenter.endpoint)!
+        graphQLEndpointUrl: URL(string: "http://ksr.dev/graph")!
       ),
       oauthToken: OauthToken(token: "deadbeef")
     )


### PR DESCRIPTION
# What
Reverted Help Center url.

# Why
Client shouldn't point directly to help center url. 

# See 👀

Updated:
Code (external/internal):

![test](https://github.com/favicon.ico)
Code (internal/external for sizing):

<img src="https://user-images.githubusercontent.com/3709676/40687134-9e23c096-6367-11e8-8491-111c4cb330d0.png" width="240" height="400">

![GIF](https://media.giphy.com/media/26FPpb2LTVLoDEJVe/giphy.gif)

