### PR TITLE
Discover card bug fix

### DIFF
--- a/Kickstarter-iOS/Views/Controllers/CheckoutViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/CheckoutViewController.swift
@@ -21,7 +21,7 @@ internal final class CheckoutViewController: DeprecatedWebViewController {
         initialRequest: initialRequest,
         project: project,
         reward: reward,
-        applePayCapable: PKPaymentAuthorizationViewController.applePayCapable()
+        applePayCapable: PKPaymentAuthorizationViewController.applePayCapable(for: project)
       )
       return vc
   }

--- a/Kickstarter-iOS/Views/Controllers/ProjectPamphletContentViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/ProjectPamphletContentViewController.swift
@@ -1,6 +1,7 @@
 import KsApi
 import LiveStream
 import Library
+import PassKit
 import Prelude
 import Prelude_UIKit
 
@@ -127,7 +128,12 @@ public final class ProjectPamphletContentViewController: UITableViewController {
   }
 
   fileprivate func goToRewardPledge(project: Project, reward: Reward) {
-    let vc = RewardPledgeViewController.configuredWith(project: project, reward: reward)
+
+    let applePayCapable = PKPaymentAuthorizationViewController.applePayCapable(for: project)
+
+    let vc = RewardPledgeViewController.configuredWith(project: project,
+                                                       reward: reward,
+                                                       applePayCapable: applePayCapable)
     let nav = UINavigationController(rootViewController: vc)
     nav.modalPresentationStyle = UIModalPresentationStyle.formSheet
     self.present(nav, animated: true, completion: nil)

--- a/Kickstarter-iOS/Views/Controllers/RewardPledgeViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/RewardPledgeViewController.swift
@@ -69,7 +69,7 @@ internal final class RewardPledgeViewController: UIViewController {
   internal static func configuredWith(
     project: Project,
     reward: Reward,
-    applePayCapable: Bool = true)
+    applePayCapable: Bool = PKPaymentAuthorizationViewController.applePayCapable())
     -> RewardPledgeViewController {
 
       let vc = Storyboard.RewardPledge.instantiate(RewardPledgeViewController.self)

--- a/Kickstarter-iOS/Views/Controllers/RewardPledgeViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/RewardPledgeViewController.swift
@@ -69,7 +69,7 @@ internal final class RewardPledgeViewController: UIViewController {
   internal static func configuredWith(
     project: Project,
     reward: Reward,
-    applePayCapable: Bool)
+    applePayCapable: Bool = true)
     -> RewardPledgeViewController {
 
       let vc = Storyboard.RewardPledge.instantiate(RewardPledgeViewController.self)

--- a/Kickstarter-iOS/Views/Controllers/RewardPledgeViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/RewardPledgeViewController.swift
@@ -69,7 +69,7 @@ internal final class RewardPledgeViewController: UIViewController {
   internal static func configuredWith(
     project: Project,
     reward: Reward,
-    applePayCapable: Bool = PKPaymentAuthorizationViewController.applePayCapable())
+    applePayCapable: Bool)
     -> RewardPledgeViewController {
 
       let vc = Storyboard.RewardPledge.instantiate(RewardPledgeViewController.self)

--- a/Library/PKPaymentAuthorizationViewController.swift
+++ b/Library/PKPaymentAuthorizationViewController.swift
@@ -27,7 +27,7 @@ extension PKPaymentAuthorizationViewController {
 
     if countryCode == "US" && project.country != Project.Country.us ||
       countryCode != "US" {
-      return PKPaymentAuthorizationViewController.supportedNetworks.filter { $0 != .masterCard }
+      return PKPaymentAuthorizationViewController.supportedNetworks.filter { $0 != .discover }
     }
 
     return PKPaymentAuthorizationViewController.supportedNetworks

--- a/Library/PKPaymentAuthorizationViewController.swift
+++ b/Library/PKPaymentAuthorizationViewController.swift
@@ -1,3 +1,4 @@
+import KsApi
 import PassKit
 
 extension PKPaymentAuthorizationViewController {
@@ -6,15 +7,33 @@ extension PKPaymentAuthorizationViewController {
     return "merchant.com.kickstarter"
   }
 
-  public static var supportedNetworks: [PKPaymentNetwork] {
-    return [.amex, .masterCard, .visa, .discover]
-  }
-
   public static func applePayCapable() -> Bool {
     return PKPaymentAuthorizationViewController.canMakePayments(usingNetworks: supportedNetworks)
   }
 
   public static func applePayDevice() -> Bool {
     return PKPaymentAuthorizationViewController.canMakePayments()
+  }
+
+  public static func applePayCapable(for project: Project) -> Bool {
+    return PKPaymentAuthorizationViewController.canMakePayments(
+      usingNetworks: PKPaymentAuthorizationViewController.supportedNetworks(for: project)
+    )
+  }
+
+  public static func supportedNetworks(for project: Project) -> [PKPaymentNetwork] {
+
+    let countryCode = AppEnvironment.current.countryCode
+
+    if countryCode == "US" && project.country != Project.Country.us ||
+      countryCode != "US" {
+      return PKPaymentAuthorizationViewController.supportedNetworks.filter { $0 != .masterCard }
+    }
+
+    return PKPaymentAuthorizationViewController.supportedNetworks
+  }
+
+  public static var supportedNetworks: [PKPaymentNetwork] {
+    return [.amex, .masterCard, .visa, .discover]
   }
 }

--- a/Library/ViewModels/RewardPledgeViewModel.swift
+++ b/Library/ViewModels/RewardPledgeViewModel.swift
@@ -947,7 +947,7 @@ private func paymentRequest(forProject project: Project,
                             merchantIdentifier: String) -> PKPaymentRequest {
   let request = PKPaymentRequest()
   request.merchantIdentifier = merchantIdentifier
-  request.supportedNetworks = PKPaymentAuthorizationViewController.supportedNetworks
+  request.supportedNetworks = PKPaymentAuthorizationViewController.supportedNetworks(for: project)
   request.merchantCapabilities = .capability3DS
   request.countryCode = project.country.countryCode
   request.currencyCode = project.country.currencyCode

--- a/Library/ViewModels/RewardPledgeViewModelTests.swift
+++ b/Library/ViewModels/RewardPledgeViewModelTests.swift
@@ -918,6 +918,41 @@ internal final class RewardPledgeViewModelTests: TestCase {
     self.loadingOverlayIsHidden.assertValues([true])
   }
 
+  func testDiscoverCard_NotAvailable_ProjectsOutsideUS() {
+
+    let project = Project.template
+      |> Project.lens.country .~ Project.Country.au
+    let user = User.template
+
+    withEnvironment(currentUser: user) {
+
+      XCTAssertFalse(PKPaymentAuthorizationViewController.supportedNetworks(for: project).contains(.discover))
+    }
+  }
+
+  func testDiscoverCard_NotAvailable_ProjectsInsideUS_UserOutsideUS() {
+
+    let env = Environment.init(countryCode: "AU")
+    let project = Project.template
+
+    withEnvironment(env) {
+
+      XCTAssertFalse(PKPaymentAuthorizationViewController.supportedNetworks(for: project).contains(.discover))
+    }
+  }
+
+  func testDiscoverCard_Available_ProjectsInsideUS_UserInUS() {
+
+    let project = Project.template
+    let user = User.template
+    let config = Config.template
+      |> Config.lens.countryCode .~ "AU"
+
+    withEnvironment(config: config, currentUser: user) {
+      XCTAssertTrue(PKPaymentAuthorizationViewController.supportedNetworks(for: project).contains(.discover))
+    }
+  }
+
   func testApplePay_LoggedOutFlow() {
     withEnvironment(currentUser: nil) {
       let project = Project.template


### PR DESCRIPTION
# What
Disable `Discover` card for rewards of projects outside US and non-US users.

# Why
We are having problems to complete transactions when projects were funded on these conditions, and to avoid the transactions to fail again, as it's happening now, we are disabling Discover cards for projects outside US and non-US users.

For more details: 
https://trello.com/c/4heDPDAs/274-spike-apple-pay-legacy-issues

![GIF](https://media.giphy.com/media/8L1LcULKtHqo4ZRySt/giphy.gif)