### PR TITLE
Backer Saved projects cell bug fix

### DIFF
--- a/Kickstarter-iOS/Views/Controllers/BackerDashboardViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/BackerDashboardViewController.swift
@@ -65,6 +65,7 @@ internal final class BackerDashboardViewController: UIViewController {
     self.view.addGestureRecognizer(panGesture)
 
     let tapRecognizer = UITapGestureRecognizer(target: self, action: #selector(tapGestureNotifier))
+    tapRecognizer.cancelsTouchesInView = false
     self.pageViewController.view.addGestureRecognizer(tapRecognizer)
 
     self.viewModel.inputs.viewDidLoad()


### PR DESCRIPTION
# What
This PR fixes a bug on which the user were not able to see saved projects from `BackerDashboardProjectsViewController`.

# Why
There is a `gestureRecognizer` on the view controller that was cancelling user interaction with the cell. UIGestureRecognizer has a property `cancelsTouchesInView`. This property causes `touchesCancelled:withEvent:` or `pressesCancelled:withEvent:` to the view. The default value of this property is `true`, and by setting it to `false`, we reenable the user interactions on the cell.

# How
By setting `cancelsTouchesInView` to false.