### PR TITLE
Automatically refresh dSYMs and upload to Crashlytics

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -524,6 +524,8 @@ workflows:
             branches:
               only: fastlane-refresh-dsyms
               # only: /alpha-dist-.*/
+            requires:
+              - swiftlint-and-cache
       - deploy_alpha:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -326,6 +326,10 @@ jobs:
           no_output_timeout: "30m" # 30 minutes
 
       - run:
+          name: Download App Store dSYMs
+          command: bundle exec fastlane refresh_dsyms
+
+      - run:
           name: Cleanup Temp Branch
           command: make cleanup
 
@@ -390,6 +394,10 @@ jobs:
           command: bundle exec fastlane beta_match_gym_hockey --verbose
           no_output_timeout: "30m" # 30 minutes
 
+      - run:
+          name: Download App Store dSYMs
+          command: bundle exec fastlane refresh_dsyms
+
       - store_artifacts:
           path: /tmp/xcode_raw.log
 
@@ -450,6 +458,10 @@ jobs:
           name: Fastlane
           command: bundle exec fastlane itunes_match_gym_deliver_hockey --verbose
           no_output_timeout: "30m" # 30 minutes
+
+      - run:
+          name: Download App Store dSYMs
+          command: bundle exec fastlane refresh_dsyms
 
       - store_artifacts:
           path: /tmp/xcode_raw.log

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -326,10 +326,6 @@ jobs:
           no_output_timeout: "30m" # 30 minutes
 
       - run:
-          name: Download App Store dSYMs
-          command: bundle exec fastlane refresh_dsyms
-
-      - run:
           name: Cleanup Temp Branch
           command: make cleanup
 
@@ -394,10 +390,6 @@ jobs:
           command: bundle exec fastlane beta_match_gym_hockey --verbose
           no_output_timeout: "30m" # 30 minutes
 
-      - run:
-          name: Download App Store dSYMs
-          command: bundle exec fastlane refresh_dsyms
-
       - store_artifacts:
           path: /tmp/xcode_raw.log
 
@@ -414,6 +406,14 @@ jobs:
             - source-v1-
 
       - checkout
+
+      - run:
+          name: Store Fabric SDK Version
+          command: *store_fabric_sdk_version
+
+      - run:
+          name: Store OpenTok Version
+          command: *store_opentok_version
 
       - restore_cache:
           keys:
@@ -442,7 +442,7 @@ jobs:
             - vendor/bundle
       - run:
           name: Download dSYMs and upload to Crashlytics
-          command: bundle exec fastlane refresh_dsyms
+          command: bundle exec fastlane refresh_dsyms --verbose
 
   # iTunes
   itunes:
@@ -499,10 +499,6 @@ jobs:
           command: bundle exec fastlane itunes_match_gym_deliver_hockey --verbose
           no_output_timeout: "30m" # 30 minutes
 
-      - run:
-          name: Download App Store dSYMs
-          command: bundle exec fastlane refresh_dsyms
-
       - store_artifacts:
           path: /tmp/xcode_raw.log
 
@@ -524,8 +520,6 @@ workflows:
             branches:
               only: fastlane-refresh-dsyms
               # only: /alpha-dist-.*/
-          requires:
-            - swiftlint-and-cache
       - deploy_alpha:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -524,8 +524,8 @@ workflows:
             branches:
               only: fastlane-refresh-dsyms
               # only: /alpha-dist-.*/
-            requires:
-              - swiftlint-and-cache
+          requires:
+            - swiftlint-and-cache
       - deploy_alpha:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -396,7 +396,7 @@ jobs:
       - store_artifacts:
           path: output
 
-  test_refresh_dsyms:
+  refresh_app_store_dsyms:
     <<: *base_job
     steps:
       - restore_cache:
@@ -442,7 +442,7 @@ jobs:
             - vendor/bundle
       - run:
           name: Download dSYMs and upload to Crashlytics
-          command: bundle exec fastlane refresh_dsyms --verbose
+          command: bundle exec fastlane refresh_dsyms
 
   # iTunes
   itunes:
@@ -515,11 +515,10 @@ workflows:
       - library-tests
       - livestream-tests
       - ksapi-tests
-      - test_refresh_dsyms:
+      - refresh_app_store_dsyms:
           filters:
             branches:
-              only: fastlane-refresh-dsyms
-              # only: /alpha-dist-.*/
+              only: /alpha-dist-.*/
       - deploy_alpha:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -404,6 +404,46 @@ jobs:
       - store_artifacts:
           path: output
 
+  test_refresh_dsyms:
+    <<: *base_job
+    steps:
+      - restore_cache:
+          keys:
+            - source-v1-{{ .Branch }}-{{ .Revision }}
+            - source-v1-{{ .Branch }}-
+            - source-v1-
+
+      - checkout
+
+      - restore_cache:
+          keys:
+            - opentok-cache-{{ checksum "opentok_version.txt" }}
+
+      - restore_cache:
+          keys: 
+            - fabric-cache-{{ checksum "fabric_version.txt" }}
+
+      - run:
+          name: Make bootstrap
+          command: make bootstrap
+
+      - restore_cache:
+          keys:
+            - v1-gems-{{ checksum "Gemfile.lock" }}
+      - run:
+          name: Bundle install
+          command: bundle check || bundle install
+          environment:
+            BUNDLE_JOBS: 4
+            BUNDLE_RETRY: 3
+      - save_cache:
+          key: v1-gems-{{ checksum "Gemfile.lock" }}
+          paths:
+            - vendor/bundle
+      - run:
+          name: Download dSYMs and upload to Crashlytics
+          command: bundle exec fastlane refresh_dsyms
+
   # iTunes
   itunes:
     <<: *base_job
@@ -479,6 +519,11 @@ workflows:
       - library-tests
       - livestream-tests
       - ksapi-tests
+      - test_refresh_dsyms:
+          filters:
+            branches:
+              only: fastlane-refresh-dsyms
+              # only: /alpha-dist-.*/
       - deploy_alpha:
           filters:
             branches:

--- a/.fastlane/Fastfile
+++ b/.fastlane/Fastfile
@@ -236,7 +236,7 @@ platform :ios do
     upload_symbols_to_crashlytics(
       dsym_path: options[:dsym], 
       api_token: ENV["FABRIC_API_KEY"],
-      binary_path: "./Frameworks/Fabric/Fabric.framework/uploadDSYM"
+      binary_path: "./Frameworks/Fabric/Fabric.framework/Fabric"
     )
   end
 

--- a/.fastlane/Fastfile
+++ b/.fastlane/Fastfile
@@ -184,6 +184,18 @@ platform :ios do
 
   ### SHARED
 
+  desc "Download App Store dSYMs and upload to Crashlytics"
+  lane :refresh_dsyms do |options|
+    download_dsyms(
+      username: ENV["ITUNES_CONNECT_ACCOUNT"],
+      app_identifier: ENV["ITUNES_APP_IDENTIFIER"],
+      team_id: ENV["ITUNES_TEAM_ID"],
+    )
+
+    upload_dsyms # Paths are taken from lane_context[SharedValues::DSYM_PATHS] automatically
+    clean_build_artifacts
+  end
+
   private_lane :build_the_app do |options|
     export_options = {}
 

--- a/.fastlane/Fastfile
+++ b/.fastlane/Fastfile
@@ -236,7 +236,7 @@ platform :ios do
     upload_symbols_to_crashlytics(
       dsym_path: options[:dsym], 
       api_token: ENV["FABRIC_API_KEY"],
-      binary_path: "./Frameworks/Fabric/Fabric.framework/Fabric"
+      binary_path: "./bin/upload-symbols"
     )
   end
 

--- a/.fastlane/Fastfile
+++ b/.fastlane/Fastfile
@@ -195,6 +195,11 @@ platform :ios do
 
     upload_dsyms # Paths are taken from lane_context[SharedValues::DSYM_PATHS] automatically
     clean_build_artifacts
+
+    slack(
+      slack_url: ENV["SLACK_WEBHOOK"],
+      message: "Successfully refreshed dSYMs for the latest App Store version"
+    )
   end
 
   private_lane :build_the_app do |options|

--- a/.fastlane/Fastfile
+++ b/.fastlane/Fastfile
@@ -190,6 +190,7 @@ platform :ios do
       username: ENV["ITUNES_CONNECT_ACCOUNT"],
       app_identifier: ENV["ITUNES_APP_IDENTIFIER"],
       team_id: ENV["ITUNES_TEAM_ID"],
+      version: "latest"
     )
 
     upload_dsyms # Paths are taken from lane_context[SharedValues::DSYM_PATHS] automatically
@@ -235,7 +236,7 @@ platform :ios do
     upload_symbols_to_crashlytics(
       dsym_path: options[:dsym], 
       api_token: ENV["FABRIC_API_KEY"],
-      binary_path: "./Frameworks/Fabric/Fabric.framework"
+      binary_path: "./Frameworks/Fabric/Fabric.framework/uploadDSYM"
     )
   end
 

--- a/bin/fabric.sh
+++ b/bin/fabric.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-if [ ! -z "$CI" ] && [ ! -z "$FABRIC_API_KEY" ] && [ ! -z "$FABRIC_BUILD_SECRET"]; then
+if [ ! -z "$CI" ] && [ ! -z "$FABRIC_API_KEY" ] && [ ! -z "$FABRIC_BUILD_SECRET" ]; then
 	echo "Configuring Fabric..."
 	"${PROJECT_DIR}"/Frameworks/Fabric/Fabric.framework/run "$FABRIC_API_KEY" "$FABRIC_BUILD_SECRET"
 else

--- a/bin/fabric.sh
+++ b/bin/fabric.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 
-if [ ! -z "$CI" ] && [ ! -z "$FABRIC_API_KEY" ]; then
+if [ ! -z "$CI" ] && [ ! -z "$FABRIC_API_KEY" ] && [ ! -z "$FABRIC_BUILD_SECRET"]; then
 	echo "Configuring Fabric..."
-	"${PROJECT_DIR}"/Frameworks/Fabric/Fabric.framework/run "$FABRIC_API_KEY"
+	"${PROJECT_DIR}"/Frameworks/Fabric/Fabric.framework/run "$FABRIC_API_KEY" "$FABRIC_BUILD_SECRET"
 else
 	echo "Skipping Fabric configuration..."
 fi


### PR DESCRIPTION
# What

Adds a CircleCI job `refresh_app_store_dsyms` that runs on `alpha-dist-*` branches. This job runs the lane `refresh_dsyms`, which downloads the dSYMs from App Store Connect on the latest version, and uploads them to Crashlytics automatically.

# Why

We want Crashlytics to show symbolicated crashes so we can find and fix them more easily, and we want this to happen automatically.

# How

The `refresh_dsyms` lane downloads the dSYM files from the latest release from App Store Connect. Then, it uploads these dSYM files using the `upload_symbols_to_crashlytics` action to Crashlytics. This will happen automatically and in parallel with `alpha-dist-*` builds, which are triggered with every merge into master.

Also adds the `FABRIC_BUILD_SECRET` key to the `Fabric.framework/run` script. Although it seems like this wasn't required to upload crashes to Fabric, there's no reason not to add it.

# See

![image](https://user-images.githubusercontent.com/3156796/44745311-5b38b880-aad5-11e8-8c0e-929d5dff8aaf.png)
