### PR TITLE
[WIP]changed keyboard pad

### DIFF
--- a/Kickstarter-iOS/Views/Controllers/RewardPledgeViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/RewardPledgeViewController.swift
@@ -356,7 +356,7 @@ internal final class RewardPledgeViewController: UIViewController {
       |> UITextField.lens.borderStyle .~ .none
       |> UITextField.lens.textColor .~ UIColor.ksr_green_700
       |> UITextField.lens.font .~ UIFont.ksr_headline(size: 14)
-      |> UITextField.lens.keyboardType .~ .numberPad
+      |> UITextField.lens.keyboardType .~ .decimalPad
 
     _ = self.rootStackView
       |> UIStackView.lens.layoutMargins .~ .init(topBottom: Styles.grid(4) + Styles.grid(2),


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# What

changed `pledgeTextField` keyboard type from `numberPad` to `decimalPad`
# Why

Users were not able to pledge decimal values on the app but on web they were because `.` is missing from the `numberPad`

# See 👀

The Bug:
![image from ios 1](https://user-images.githubusercontent.com/11362005/45371022-787e8400-b5b7-11e8-9685-ae980a89e874.png)


The Fix:
![img_0021](https://user-images.githubusercontent.com/11362005/45371031-803e2880-b5b7-11e8-87b6-74e28bb1b229.PNG)


# TODO ⏰

- [ ] Fixing alert view. Apparently decimal values are treated as invalid.

