### PR TITLE
Hide private profile setting for creator

### DIFF
--- a/Kickstarter-iOS/DataSources/SettingsPrivacyDataSource.swift
+++ b/Kickstarter-iOS/DataSources/SettingsPrivacyDataSource.swift
@@ -35,11 +35,13 @@ internal final class SettingsPrivacyDataSource: ValueCellDataSource {
              cellClass: SettingsPrivacyStaticCell.self,
              inSection: Section.recommendationsFooter.rawValue)
 
-    let cellValue = SettingsPrivacyCellValue(user: user, cellType: .privacy)
+    if !user.isCreator {
+      let cellValue = SettingsPrivacyCellValue(user: user, cellType: .privacy)
 
-    self.set(values: [cellValue],
-             cellClass: SettingsPrivacySwitchCell.self,
-             inSection: Section.privateProfile.rawValue)
+      self.set(values: [cellValue],
+               cellClass: SettingsPrivacySwitchCell.self,
+               inSection: Section.privateProfile.rawValue)
+    }
 
     self.set(values: [user],
              cellClass: SettingsPrivacyRequestDataCell.self,

--- a/Kickstarter-iOS/DataSources/SettingsPrivacyDataSourceTests.swift
+++ b/Kickstarter-iOS/DataSources/SettingsPrivacyDataSourceTests.swift
@@ -1,0 +1,39 @@
+import XCTest
+@testable import Kickstarter_Framework
+@testable import KsApi
+@testable import Library
+import Prelude
+
+final class SettingsPrivacyDataSourceTests: XCTestCase {
+  private let dataSource = SettingsPrivacyDataSource()
+  private let tableView = UITableView(frame: .zero)
+
+  func testConfigureRows_NonCreator() {
+
+    let user = User.template
+
+    self.dataSource.load(user: user)
+
+    XCTAssertEqual(7, dataSource.numberOfSections(in: tableView))
+    XCTAssertEqual(1, dataSource.tableView(tableView, numberOfRowsInSection: 0))
+    XCTAssertEqual(1, dataSource.tableView(tableView, numberOfRowsInSection: 1))
+    XCTAssertEqual(1, dataSource.tableView(tableView, numberOfRowsInSection: 2))
+    XCTAssertEqual(1, dataSource.tableView(tableView, numberOfRowsInSection: 3))
+    XCTAssertEqual(1, dataSource.tableView(tableView, numberOfRowsInSection: 4))
+  }
+
+  func testConfigureRows_Creator() {
+
+    let user = User.template
+      |> User.lens.stats.createdProjectsCount .~ 1
+
+    self.dataSource.load(user: user)
+
+    XCTAssertEqual(7, dataSource.numberOfSections(in: tableView))
+    XCTAssertEqual(1, dataSource.tableView(tableView, numberOfRowsInSection: 0))
+    XCTAssertEqual(1, dataSource.tableView(tableView, numberOfRowsInSection: 1))
+    XCTAssertEqual(1, dataSource.tableView(tableView, numberOfRowsInSection: 2))
+    XCTAssertEqual(1, dataSource.tableView(tableView, numberOfRowsInSection: 3))
+    XCTAssertEqual(0, dataSource.tableView(tableView, numberOfRowsInSection: 4))
+  }
+}

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -935,6 +935,7 @@
 		D0D2ABA91E9677E8008D298A /* LiveStreamTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0D2ABA51E9677DD008D298A /* LiveStreamTypes.swift */; };
 		D0D2ABAA1E9677EC008D298A /* LiveStreamTypesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0D2ABA61E9677DD008D298A /* LiveStreamTypesTests.swift */; };
 		D6089E8F209106CD0032CC99 /* PushNotificationDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6089E572090D5B40032CC99 /* PushNotificationDialog.swift */; };
+		D60C8CE12149A65000D96152 /* SettingsPrivacyDataSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D60C8CE02149A65000D96152 /* SettingsPrivacyDataSourceTests.swift */; };
 		D64850551FD879AB00B6AB91 /* ProjectActivityItemProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D64850541FD879AB00B6AB91 /* ProjectActivityItemProviderTests.swift */; };
 		D6508F6C2049C83C002DCC01 /* UIStackView+BackgroundColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6508F342049C45D002DCC01 /* UIStackView+BackgroundColor.swift */; };
 		D67F29361F68333800E399A6 /* GraphSchema.swift in Sources */ = {isa = PBXBuildFile; fileRef = D67F29351F68333800E399A6 /* GraphSchema.swift */; };
@@ -2546,6 +2547,7 @@
 		D0FD4CC61E2642F200488660 /* libsqlite3.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libsqlite3.tbd; path = usr/lib/libsqlite3.tbd; sourceTree = SDKROOT; };
 		D0FD4CC81E26433C00488660 /* libz.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.tbd; path = usr/lib/libz.tbd; sourceTree = SDKROOT; };
 		D6089E572090D5B40032CC99 /* PushNotificationDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotificationDialog.swift; sourceTree = "<group>"; };
+		D60C8CE02149A65000D96152 /* SettingsPrivacyDataSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsPrivacyDataSourceTests.swift; sourceTree = "<group>"; };
 		D64850541FD879AB00B6AB91 /* ProjectActivityItemProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectActivityItemProviderTests.swift; sourceTree = "<group>"; };
 		D6508F342049C45D002DCC01 /* UIStackView+BackgroundColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIStackView+BackgroundColor.swift"; sourceTree = "<group>"; };
 		D6765B4C211091AB00AE3DB4 /* SettingsNewslettersDataSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsNewslettersDataSourceTests.swift; sourceTree = "<group>"; };
@@ -3615,13 +3617,14 @@
 				A7ED20101E83229E00BFFA01 /* ProjectPamphletContentDataSourceTests.swift */,
 				A75CFA4E1CCDB322004CD5FA /* SearchDataSource.swift */,
 				A74FFEC81CE4FB9900C7BCB9 /* SearchMessagesDataSource.swift */,
-				D796867D20FF910300E54C61 /* SettingsPrivacyDataSource.swift */,
+				77FA6C7020F3DD6C00809E31 /* SettingsDataSource.swift */,
+				77FA6CD120F53E5E00809E31 /* SettingsDataSourceTests.swift */,
 				D6B6766820FF8D850082717D /* SettingsNewslettersDataSource.swift */,
 				D6765B4C211091AB00AE3DB4 /* SettingsNewslettersDataSourceTests.swift */,
-				77FA6C7020F3DD6C00809E31 /* SettingsDataSource.swift */,
 				770DF3292106210900A6D0F1 /* SettingsNotificationsDataSource.swift */,
 				771669CF210B93BE007A64A4 /* SettingsNotificationsDataSourceTests.swift */,
-				77FA6CD120F53E5E00809E31 /* SettingsDataSourceTests.swift */,
+				D796867D20FF910300E54C61 /* SettingsPrivacyDataSource.swift */,
+				D60C8CE02149A65000D96152 /* SettingsPrivacyDataSourceTests.swift */,
 				014A8DE91CE3C350003BF51C /* ThanksProjectsDataSource.swift */,
 				77891BA720CEB6DB00B46D5D /* ThanksProjectsDataSourceTests.swift */,
 			);
@@ -5876,6 +5879,7 @@
 				A78356081E85BE6D0021DA5A /* BackerDashboardProjectsDataSourceTests.swift in Sources */,
 				D6B4F0032107B4760079159D /* SettingsNewslettersViewControllerTests.swift in Sources */,
 				A7ED205C1E83240D00BFFA01 /* FundingGraphViewTests.swift in Sources */,
+				D60C8CE12149A65000D96152 /* SettingsPrivacyDataSourceTests.swift in Sources */,
 				A7ED20131E83229E00BFFA01 /* DashboardDataSourceTests.swift in Sources */,
 				A7ED20481E8323E900BFFA01 /* LoginViewControllerTests.swift in Sources */,
 				A7A625B51E859FDB004C931A /* LiveStreamChatDataSourceTests.swift in Sources */,


### PR DESCRIPTION
# What
Hide `Private profile` setting from creators.

# Why
If the user is a creator, the option to make to profile private shouldn't appear.

# How
On the data source `load` function, we check if the user is a creator before configure the cells, hiding the Private Profile section if that's the case.

# See 👀
### Non-creator
<img src="https://user-images.githubusercontent.com/3709676/45450869-6b40c280-b6a7-11e8-9843-50aa4d26df86.png" width="220" height="400" /> 

### Creator
<img src="https://user-images.githubusercontent.com/3709676/45451057-f5892680-b6a7-11e8-8ec8-e16babb9a4be.png" width="220" height="400" />

![GIF](https://media.giphy.com/media/xUn3C9FDotHcQtJbuE/giphy.gif)
