### PR TITLE
Use team name instead of team ID to download dsyms

### DIFF
--- a/.fastlane/Fastfile
+++ b/.fastlane/Fastfile
@@ -189,7 +189,7 @@ platform :ios do
     download_dsyms(
       username: ENV["ITUNES_CONNECT_ACCOUNT"],
       app_identifier: ENV["ITUNES_APP_IDENTIFIER"],
-      team_id: ENV["ITUNES_TEAM_ID"],
+      team_name: ENV["ITUNES_TEAM_NAME"],
       version: "latest"
     )
 


### PR DESCRIPTION
# What

As the title says - using team name instead of team ID.

# Why

App Store Connect seems to be returning the team ID as an integer instead of a string. This could be a regression that they may fix but we can workaround it for now by using our team's name instead of ID. This might actually be a better way of doing this and potentially we should update the other commands too. I've left them alone for now given that they're still working correctly.

# How

- Use `team_name` argument instead of `team_id`.
- Add `ITUNES_TEAM_NAME` environment var to our CircleCI config.
