### PR TITLE
Reference scroll views properly per controller basis

### DIFF
--- a/Kickstarter-iOS/ViewModels/RootViewModel.swift
+++ b/Kickstarter-iOS/ViewModels/RootViewModel.swift
@@ -185,6 +185,7 @@ internal final class RootViewModel: RootViewModelType, RootViewModelInputs, Root
       self.setViewControllers,
       selectedTabAgain
       )
+      .filter { vcs, idx in idx < vcs.count }
       .map { vcs, idx in vcs[idx] }
       .map(extractViewController)
       .skipNil()

--- a/Kickstarter-iOS/Views/Controllers/ActivitiesViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/ActivitiesViewController.swift
@@ -296,3 +296,5 @@ extension ActivitiesViewController: SurveyResponseViewControllerDelegate {
     self.viewModel.inputs.surveyResponseViewControllerDismissed()
   }
 }
+
+extension ActivitiesViewController: TabBarControllerScrollable { }

--- a/Kickstarter-iOS/Views/Controllers/ActivitiesViewControllerTests.swift
+++ b/Kickstarter-iOS/Views/Controllers/ActivitiesViewControllerTests.swift
@@ -216,4 +216,10 @@ internal final class ActivitiesViewControllerTests: TestCase {
       }
     }
   }
+
+  func testScrollToTop() {
+    let controller = ActivitiesViewController.instantiate()
+
+    XCTAssertNotNil(controller.view as? UIScrollView)
+  }
 }

--- a/Kickstarter-iOS/Views/Controllers/BackerDashboardViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/BackerDashboardViewController.swift
@@ -367,3 +367,11 @@ extension BackerDashboardViewController: UIGestureRecognizerDelegate {
       return true
   }
 }
+
+extension BackerDashboardViewController: TabBarControllerScrollable {
+  func scrollToTop() {
+    if let scrollView = self.pageViewController.viewControllers?.first?.view as? UIScrollView {
+      scrollView.scrollToTop()
+    }
+  }
+}

--- a/Kickstarter-iOS/Views/Controllers/DashboardViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/DashboardViewController.swift
@@ -339,3 +339,5 @@ extension DashboardViewController: DashboardTitleViewDelegate {
     self.viewModel.inputs.showHideProjectsDrawer()
   }
 }
+
+extension DashboardViewController: TabBarControllerScrollable { }

--- a/Kickstarter-iOS/Views/Controllers/DashboardViewControllerTests.swift
+++ b/Kickstarter-iOS/Views/Controllers/DashboardViewControllerTests.swift
@@ -2,6 +2,7 @@ import Prelude
 @testable import Kickstarter_Framework
 @testable import KsApi
 @testable import Library
+import XCTest
 
 internal final class DashboardViewControllerTests: TestCase {
 
@@ -51,6 +52,12 @@ internal final class DashboardViewControllerTests: TestCase {
         FBSnapshotVerifyView(parent.view, identifier: "lang_\(language)_device_\(device)", tolerance: 0.004)
       }
     }
+  }
+
+  func testScrollToTop() {
+    let controller = ActivitiesViewController.instantiate()
+
+    XCTAssertNotNil(controller.view as? UIScrollView)
   }
 }
 

--- a/Kickstarter-iOS/Views/Controllers/DiscoveryViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/DiscoveryViewController.swift
@@ -175,3 +175,19 @@ extension DiscoveryViewController: DiscoveryNavigationHeaderViewDelegate {
     self.filter(with: params)
   }
 }
+
+extension DiscoveryViewController: TabBarControllerScrollable {
+  func scrollToTop() {
+    let view: UIView?
+
+    if let superview = self.liveStreamDiscoveryViewController.view.superview, superview.isHidden {
+      view = self.pageViewController.viewControllers?.first?.view
+    } else {
+      view = self.liveStreamDiscoveryViewController.view
+    }
+
+    if let scrollView = view as? UIScrollView {
+      scrollView.scrollToTop()
+    }
+  }
+}

--- a/Kickstarter-iOS/Views/Controllers/LoginToutViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/LoginToutViewController.swift
@@ -289,3 +289,11 @@ internal final class LoginToutViewController: UIViewController, MFMailComposeVie
     self.viewModel.inputs.signupButtonPressed()
   }
 }
+
+extension LoginToutViewController: TabBarControllerScrollable {
+  func scrollToTop() {
+    if let scrollView = self.view.subviews.first as? UIScrollView {
+      scrollView.scrollToTop()
+    }
+  }
+}

--- a/Kickstarter-iOS/Views/Controllers/LoginToutViewControllerTests.swift
+++ b/Kickstarter-iOS/Views/Controllers/LoginToutViewControllerTests.swift
@@ -1,5 +1,6 @@
 import Library
 @testable import Kickstarter_Framework
+import XCTest
 
 internal final class LoginToutViewControllerTests: TestCase {
 
@@ -28,5 +29,12 @@ internal final class LoginToutViewControllerTests: TestCase {
         FBSnapshotVerifyView(parent.view, identifier: "intent_\(intent)_lang_\(language)_device_\(device)")
       }
     }
+  }
+
+  func testScrollToTop() {
+    let intent = LoginIntent.generic
+    let controller = LoginToutViewController.configuredWith(loginIntent: intent)
+
+    XCTAssertNotNil(controller.view.subviews.first as? UIScrollView)
   }
 }

--- a/Kickstarter-iOS/Views/Controllers/RootTabBarViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/RootTabBarViewController.swift
@@ -4,6 +4,18 @@ import Library
 import Prelude
 import UIKit
 
+internal protocol TabBarControllerScrollable {
+  func scrollToTop()
+}
+
+extension TabBarControllerScrollable where Self: UIViewController {
+  func scrollToTop() {
+    if let scrollView = self.view as? UIScrollView {
+      scrollView.scrollToTop()
+    }
+  }
+}
+
 public final class RootTabBarViewController: UITabBarController {
   private var sessionEndedObserver: Any?
   private var sessionStartedObserver: Any?
@@ -220,8 +232,15 @@ public final class RootTabBarViewController: UITabBarController {
 
 extension RootTabBarViewController: UITabBarControllerDelegate {
   public func tabBarController(_ tabBarController: UITabBarController,
+                               shouldSelect viewController: UIViewController) -> Bool {
+    let index = tabBarController.viewControllers?.firstIndex(of: viewController)
+    self.viewModel.inputs.shouldSelect(index: index)
+    return true
+  }
+
+  public func tabBarController(_ tabBarController: UITabBarController,
                                didSelect viewController: UIViewController) {
-    self.viewModel.inputs.didSelectIndex(tabBarController.selectedIndex)
+    self.viewModel.inputs.didSelect(index: tabBarController.selectedIndex)
   }
 
   public func tabBarController(_ tabBarController: UITabBarController,
@@ -233,11 +252,8 @@ extension RootTabBarViewController: UITabBarControllerDelegate {
 }
 
 private func scrollToTop(_ viewController: UIViewController) {
-
-  if let scrollView = (viewController.view as? UIScrollView) ??
-    ((viewController as? UINavigationController)?.viewControllers.first?.view as? UIScrollView) {
-
-    scrollView.scrollToTop()
+  if let scrollable = viewController as? TabBarControllerScrollable {
+    scrollable.scrollToTop()
   }
 }
 

--- a/Kickstarter-iOS/Views/Controllers/SearchViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/SearchViewController.swift
@@ -264,3 +264,5 @@ extension SearchViewController: ProjectNavigatorDelegate {
     self.viewModel.inputs.transitionedToProject(at: index, outOf: self.dataSource.numberOfItems())
   }
 }
+
+extension SearchViewController: TabBarControllerScrollable { }

--- a/Kickstarter-iOS/Views/Controllers/SearchViewControllerTests.swift
+++ b/Kickstarter-iOS/Views/Controllers/SearchViewControllerTests.swift
@@ -99,4 +99,10 @@ internal final class SearchViewContollerTests: TestCase {
       }
     }
   }
+
+  func testScrollToTop() {
+    let controller = ActivitiesViewController.instantiate()
+
+    XCTAssertNotNil(controller.view as? UIScrollView)
+  }
 }


### PR DESCRIPTION
# What

Fixes tab bar's tap again gesture to properly scroll top root level controllers.

# Why

Due to the fact our main controllers got more complex this functionality got lost in the process.

# How

Explicitly conform to `TabBarScrollable` protocol and properly reference scroll view. The default protocol implementation works just fine for regular view controllers whose top view is `UIScrollView` and we're using custom override for more complex hierarchies.

# See 👀

| Before | After |
| --- | --- |
| ![before-logged-out](https://user-images.githubusercontent.com/387596/47815267-26cbbd80-dd0d-11e8-90f0-d637268f6ce7.gif) | ![after-logged-out](https://user-images.githubusercontent.com/387596/47747669-1a306200-dc46-11e8-921e-701c243ba90a.gif) |
| ![before-logged-in](https://user-images.githubusercontent.com/387596/47815280-32b77f80-dd0d-11e8-807a-6db61feac684.gif) | ![eee](https://user-images.githubusercontent.com/387596/47747820-72fffa80-dc46-11e8-8f38-646e725f43c7.gif) |
