### PR TITLE
Removed discover category experiment

### DIFF
--- a/Kickstarter-iOS/Views/Cells/DiscoveryPostcardCell.swift
+++ b/Kickstarter-iOS/Views/Cells/DiscoveryPostcardCell.swift
@@ -296,11 +296,6 @@ internal final class DiscoveryPostcardCell: UITableViewCell, ValueCell {
         guard let _self = self else { return }
         _self.delegate?.discoveryPostcardCellGoToLoginTout()
     }
-
-    let showCategoriesExperiment =
-      Experiment.Name.showProjectCardCategory.isEnabled(in: AppEnvironment.current)
-
-    self.viewModel.inputs.enableProjectCategoryExperiment(showCategoriesExperiment)
   }
 
   internal func configureWith(value: DiscoveryProjectCellRowValue) {

--- a/Kickstarter-iOS/Views/Controllers/DiscoveryPageViewControllerTests.swift
+++ b/Kickstarter-iOS/Views/Controllers/DiscoveryPageViewControllerTests.swift
@@ -51,8 +51,6 @@ internal final class DiscoveryPageViewControllerTests: TestCase {
     let discoveryResponse = .template
       |> DiscoveryEnvelope.lens.projects .~ [project]
     let config = Config.template
-      |> Config.lens.abExperiments
-        .~ [Experiment.Name.showProjectCardCategory.rawValue: Experiment.Variant.experimental.rawValue]
 
     combos(Language.allLanguages, [Device.phone4_7inch, Device.phone5_8inch, Device.pad])
       .forEach { language, device in
@@ -84,8 +82,6 @@ internal final class DiscoveryPageViewControllerTests: TestCase {
 
     let devices = [Device.phone4_7inch, Device.phone5_8inch, Device.pad]
     let config = Config.template
-      |> Config.lens.abExperiments
-      .~ [Experiment.Name.showProjectCardCategory.rawValue: Experiment.Variant.experimental.rawValue]
 
     combos(Language.allLanguages, devices, [("featured", featuredProj)])
       .forEach { language, device, labeledProj in
@@ -123,8 +119,6 @@ internal final class DiscoveryPageViewControllerTests: TestCase {
     let states = [Project.State.successful, .canceled, .failed, .suspended]
     let devices = [Device.phone4_7inch, Device.phone5_8inch, Device.pad]
     let config = Config.template
-      |> Config.lens.abExperiments
-      .~ [Experiment.Name.showProjectCardCategory.rawValue: Experiment.Variant.experimental.rawValue]
 
     combos(Language.allLanguages, devices, states )
       .forEach { language, device, state in

--- a/Kickstarter-iOS/Views/Controllers/ThanksViewControllerTests.swift
+++ b/Kickstarter-iOS/Views/Controllers/ThanksViewControllerTests.swift
@@ -44,31 +44,4 @@ class ThanksViewControllerTests: TestCase {
         }
       }
     }
-
-  func testThanksViewController_CategoriesExperimentEnabled() {
-    let discoveryEnvelope = DiscoveryEnvelope.template
-    let rootCategories = RootCategoriesEnvelope(rootCategories: [Category.tabletopGames])
-    let mockService = MockService(fetchGraphCategoriesResponse: rootCategories,
-                                  fetchDiscoveryResponse: discoveryEnvelope)
-    let config = AppEnvironment.current.config ?? Config.template
-      |> Config.lens.abExperiments
-      .~ [Experiment.Name.showProjectCardCategory.rawValue: Experiment.Variant.experimental.rawValue]
-
-    combos(Language.allLanguages, [Device.phone4_7inch, Device.phone5_8inch, Device.pad]).forEach {
-      language, device in
-      withEnvironment(apiService: mockService, config: config, language: language) {
-        let project = Project.cosmicSurgery
-          |> Project.lens.id .~ 3
-
-        let controller = ThanksViewController.configuredWith(project: project)
-
-        let (parent, _) = traitControllers(device: device, orientation: .portrait, child: controller)
-        parent.view.frame.size.height = 1000
-
-        self.scheduler.run()
-
-        FBSnapshotVerifyView(parent.view, identifier: "lang_\(language)_device_\(device)")
-      }
-    }
-  }
 }

--- a/KsApi/models/Config.swift
+++ b/KsApi/models/Config.swift
@@ -6,7 +6,6 @@ public enum Experiment {
 
   public enum Name: String {
     case creatorsNameDiscovery = "show_created_by_discovery"
-    case showProjectCardCategory = "native_show_project_card_category"
   }
 
   public enum Variant: String {

--- a/Library/ViewModels/DiscoveryPostcardViewModel.swift
+++ b/Library/ViewModels/DiscoveryPostcardViewModel.swift
@@ -36,9 +36,6 @@ public protocol DiscoveryPostcardViewModelInputs {
   /// Call when the cell has received a project notification.
   func projectFromNotification(project: Project?)
 
-  /// Call to set the project category experiment variable
-  func enableProjectCategoryExperiment(_ shouldEnable: Bool)
-
   /// Call when save button is tapped.
   func saveButtonTapped()
 
@@ -266,15 +263,9 @@ public final class DiscoveryPostcardViewModel: DiscoveryPostcardViewModelType,
       self.projectCategoryViewHidden.signal,
       self.projectIsStaffPickLabelHidden.signal)
 
-    self.projectCategoryStackViewHidden = Signal.combineLatest(
-      projectCategoryViewsHidden,
-      self.enableProjectCategoryExperimentProperty.signal)
-      .map { projectCategoryViews, experimentEnabled in
-        if experimentEnabled {
+    self.projectCategoryStackViewHidden = projectCategoryViewsHidden
+      .map { projectCategoryViews in
           return projectCategoryViews.0 && projectCategoryViews.1
-        }
-
-        return true
       }
 
     self.projectStatsStackViewHidden = self.projectStateStackViewHidden.map(negate)
@@ -421,11 +412,6 @@ public final class DiscoveryPostcardViewModel: DiscoveryPostcardViewModelType,
   fileprivate let userSessionEndedProperty = MutableProperty(())
   public func userSessionEnded() {
     self.userSessionEndedProperty.value = ()
-  }
-
-  fileprivate let enableProjectCategoryExperimentProperty = MutableProperty<Bool>(false)
-  public func enableProjectCategoryExperiment(_ shouldEnable: Bool) {
-    self.enableProjectCategoryExperimentProperty.value = shouldEnable
   }
 
   public let backersTitleLabelText: Signal<String, NoError>

--- a/Library/ViewModels/DiscoveryPostcardViewModelTests.swift
+++ b/Library/ViewModels/DiscoveryPostcardViewModelTests.swift
@@ -497,13 +497,12 @@ internal final class DiscoveryPostcardViewModelTests: TestCase {
   }
 
   // MARK: Project Category View
-  func testShowsCategoryLabelsExperimental() {
+  func testShowsCategoryLabels_ParentCategorySelected() {
     let staffPickProject = Project.template
       |> Project.lens.staffPick .~ true
       |> Project.lens.category .~ .illustration
 
     self.vm.inputs.configureWith(project: staffPickProject, category: .art)
-    self.vm.inputs.enableProjectCategoryExperiment(true)
 
     self.projectIsStaffPickViewHidden.assertValue(false)
     self.projectCategoryStackViewHidden.assertValue(false)
@@ -511,14 +510,13 @@ internal final class DiscoveryPostcardViewModelTests: TestCase {
     self.projectCategoryViewHidden.assertValue(false)
   }
 
-  func testShowsCategoryLabelsExperimental_AlwaysIfFilterCategoryIsNil() {
+  func testShowsCategoryLabels_AlwaysIfFilterCategoryIsNil() {
     self.vm.inputs.configureWith(project: Project.template, category: nil)
-    self.vm.inputs.enableProjectCategoryExperiment(true)
 
     self.projectCategoryStackViewHidden.assertValue(false)
   }
 
-  func testHidesCategoryLabelExperimental_IfFilterCategoryIsEqualToProjectCategory() {
+  func testHidesCategoryLabel_IfFilterCategoryIsEqualToProjectCategory() {
     // Workaround for discrepancy between category ids from graphQL and category ids from the legacy API
     let categoryId = KsApi.Category.illustration.intID
     let illustrationCategory = KsApi.Category.illustration
@@ -528,33 +526,11 @@ internal final class DiscoveryPostcardViewModelTests: TestCase {
       |> Project.lens.category .~ illustrationCategory
 
     self.vm.inputs.configureWith(project: illustrationProject, category: .illustration)
-    self.vm.inputs.enableProjectCategoryExperiment(true)
 
     self.projectIsStaffPickViewHidden.assertValue(true)
     self.projectCategoryStackViewHidden.assertValue(true)
     self.projectCategoryName.assertValue(KsApi.Category.illustration.name)
     self.projectCategoryViewHidden.assertValue(true)
-  }
-
-  /* Experiment control should hide stack
-    view regardless of whether category/staff pick labels should be shown
- */
-  func testHidesCategoryLabelControl() {
-    let staffPickProject = Project.template
-      |> Project.lens.staffPick .~ true
-      |> Project.lens.category .~ .illustration
-
-    self.vm.inputs.configureWith(project: staffPickProject, category: .art)
-    self.vm.inputs.enableProjectCategoryExperiment(false)
-
-    self.projectCategoryStackViewHidden.assertValue(true)
-  }
-
-  func testHidesCategoryLabelControl_IfFilterCategoryIsNil() {
-    self.vm.inputs.configureWith(project: Project.template, category: nil)
-    self.vm.inputs.enableProjectCategoryExperiment(false)
-
-    self.projectCategoryStackViewHidden.assertValue(true)
   }
 
   // MARK: Notification Dialog


### PR DESCRIPTION
# What
Removed the `showProjectCardCategory` experiment (And show category name on `DiscoveryCardCell` to all users).

# Why
The experiment didn't show any relevant change.

# See 👀
<img src="https://user-images.githubusercontent.com/3709676/47749733-23c8c280-dc64-11e8-8672-70f4c22ed824.png" width="230" height="400" />
