### PR TITLE
Ensure preferredContentSizeCategory is accessed on the main thread

### DIFF
--- a/Library/Environment.swift
+++ b/Library/Environment.swift
@@ -98,7 +98,7 @@ public struct Environment {
     debounceInterval: DispatchTimeInterval = .milliseconds(300),
     device: UIDeviceType = UIDevice.current,
     facebookAppDelegate: FacebookAppDelegateProtocol = FBSDKApplicationDelegate.sharedInstance(),
-    isVoiceOverRunning: @escaping () -> Bool = {UIAccessibility.isVoiceOverRunning },
+    isVoiceOverRunning: @escaping () -> Bool = { UIAccessibility.isVoiceOverRunning },
     koala: Koala = Koala(client: KoalaTrackingClient(endpoint: .production)),
     language: Language = Language(languageStrings: Locale.preferredLanguages) ?? Language.en,
     launchedCountries: LaunchedCountries = .init(),

--- a/Library/Koala/Koala.swift
+++ b/Library/Koala/Koala.swift
@@ -341,7 +341,9 @@ public final class Koala {
   }
 
   private func updateAndObservePreferredContentSizeCategory() {
-    let update = { self.preferredContentSizeCategory = UIApplication.shared.preferredContentSizeCategory }
+    let update = { [weak self] in
+      self?.preferredContentSizeCategory = UIApplication.shared.preferredContentSizeCategory
+    }
 
     self.preferredContentSizeCategoryObserver = NotificationCenter.default.addObserver(
       forName: UIContentSizeCategory.didChangeNotification,

--- a/Library/Koala/Koala.swift
+++ b/Library/Koala/Koala.swift
@@ -16,7 +16,7 @@ public final class Koala {
   fileprivate let device: UIDeviceType
   fileprivate let distinctId: String
   internal let loggedInUser: User?
-  private var preferredContentSizeCategory: UIContentSizeCategory
+  private var preferredContentSizeCategory: UIContentSizeCategory?
   private var preferredContentSizeCategoryObserver: Any?
   fileprivate let screen: UIScreenType
 
@@ -328,8 +328,7 @@ public final class Koala {
     device: UIDeviceType = UIDevice.current,
     loggedInUser: User? = nil,
     screen: UIScreenType = UIScreen.main,
-    distinctId: String = (UIDevice.current.identifierForVendor ?? UUID()).uuidString,
-    preferredContentSizeCategory: UIContentSizeCategory = UIApplication.shared.preferredContentSizeCategory) {
+    distinctId: String = (UIDevice.current.identifierForVendor ?? UUID()).uuidString) {
       self.bundle = bundle
       self.client = client
       self.config = config
@@ -337,17 +336,24 @@ public final class Koala {
       self.loggedInUser = loggedInUser
       self.screen = screen
       self.distinctId = distinctId
-      self.preferredContentSizeCategory = preferredContentSizeCategory
 
-      self.observePreferredContentSizeCategory()
+      self.updateAndObservePreferredContentSizeCategory()
   }
 
-  private func observePreferredContentSizeCategory() {
+  private func updateAndObservePreferredContentSizeCategory() {
+    let update = { self.preferredContentSizeCategory = UIApplication.shared.preferredContentSizeCategory }
+
     self.preferredContentSizeCategoryObserver = NotificationCenter.default.addObserver(
       forName: UIContentSizeCategory.didChangeNotification,
       object: nil,
-      queue: OperationQueue.main) { [weak self] _ in
-        self?.preferredContentSizeCategory = UIApplication.shared.preferredContentSizeCategory
+      queue: OperationQueue.main) { _ in update() }
+
+    if Thread.isMainThread {
+      update()
+    } else {
+      DispatchQueue.main.async {
+        update()
+      }
     }
   }
 


### PR DESCRIPTION
# What

Once again ensures that this property is only accessed on the main thread.

# Why

Turns out #456 didn't completely solve this property being accessed on background threads because `Koala` is sometimes instantiated from a background thread on environment changes. Xcode's main thread sanitizer has been flagging it occasionally.

# How

Implement the following logic:
1. If on main thread at instantiation, set this var.
2. Else on instantiation set it asynchronously on main thread.
3. Continue to observe any changes to it on main thread.
