### PR TITLE
Add universal links URL

### DIFF
--- a/Kickstarter-iOS/Debug.entitlements
+++ b/Kickstarter-iOS/Debug.entitlements
@@ -8,6 +8,7 @@
 	<array>
 		<string>applinks:www.kickstarter.com</string>
 		<string>applinks:click.e.kickstarter.com</string>
+		<string>applinks:click.em.kickstarter.com</string>
 		<string>applinks:email.kickstarter.com</string>
 		<string>applinks:emails.kickstarter.com</string>
 		<string>applinks:e2.kickstarter.com</string>

--- a/Kickstarter-iOS/Release.entitlements
+++ b/Kickstarter-iOS/Release.entitlements
@@ -8,6 +8,7 @@
 	<array>
 		<string>applinks:www.kickstarter.com</string>
 		<string>applinks:click.e.kickstarter.com</string>
+		<string>applinks:click.em.kickstarter.com</string>
 		<string>applinks:email.kickstarter.com</string>
 		<string>applinks:emails.kickstarter.com</string>
 		<string>applinks:e2.kickstarter.com</string>


### PR DESCRIPTION
# What

Adds `click.em.kickstarter.com` as a URL that we support for universal links.

# Why

Some of our newsletter emails use links from `click.em.kickstarter.com`.

# How

Added to `Debug` and `Release` entitlements.
