### PR TITLE
Delete payment methods

### DIFF
--- a/Kickstarter-iOS/DataSources/PaymentMethodsDataSource.swift
+++ b/Kickstarter-iOS/DataSources/PaymentMethodsDataSource.swift
@@ -4,6 +4,8 @@ import UIKit
 
 final class PaymentMethodsDataSource: ValueCellDataSource {
 
+  public var deletionHandler: ((GraphUserCreditCard.CreditCard) -> Void)?
+
   func load(creditCards: [GraphUserCreditCard.CreditCard]) {
 
     self.set(values: creditCards,
@@ -18,5 +20,16 @@ final class PaymentMethodsDataSource: ValueCellDataSource {
     default:
       assertionFailure("Unrecognized (cell, viewModel) combo.")
     }
+  }
+
+  func tableView(_ tableView: UITableView,
+                 commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
+    guard let creditCard = self[indexPath] as? GraphUserCreditCard.CreditCard else { return }
+
+    _ = self.deleteRow(value: creditCard, cellClass: CreditCardCell.self,
+                       atIndex: indexPath.row, inSection: indexPath.section)
+    tableView.deleteRows(at: [indexPath], with: .left)
+
+    self.deletionHandler?(creditCard)
   }
 }

--- a/Kickstarter-iOS/DataSources/PaymentMethodsDataSourceTests.swift
+++ b/Kickstarter-iOS/DataSources/PaymentMethodsDataSourceTests.swift
@@ -10,12 +10,35 @@ internal final class PaymentMethodsDataSourceTests: XCTestCase {
   let tableView = UITableView(frame: .zero)
 
   func testDataSource() {
-
     let cards = GraphUserCreditCard.template.storedCards.nodes
     self.dataSource.load(creditCards: cards)
 
     XCTAssertEqual(7, self.dataSource.tableView(self.tableView, numberOfRowsInSection: 0))
 
     XCTAssertEqual("CreditCardCell", self.dataSource.reusableId(item: 0, section: 0))
+  }
+
+  func testCardDeletion() {
+    let cards = GraphUserCreditCard.template.storedCards.nodes
+    self.dataSource.load(creditCards: cards)
+
+    XCTAssertEqual(7, self.dataSource.tableView(self.tableView, numberOfRowsInSection: 0))
+
+    XCTAssertEqual("CreditCardCell", self.dataSource.reusableId(item: 0, section: 0))
+
+    guard let card = cards.first else {
+      XCTFail("Card should exist")
+      return
+    }
+
+    var deletedCard: GraphUserCreditCard.CreditCard?
+    let deletionHandler = { card in
+      deletedCard = card
+    }
+
+    self.dataSource.deletionHandler = deletionHandler
+    self.dataSource.tableView(self.tableView, commit: .delete, forRowAt: .init(row: 0, section: 0))
+
+    XCTAssertEqual(deletedCard, card)
   }
 }

--- a/Kickstarter-iOS/DataSources/PaymentMethodsDataSourceTests.swift
+++ b/Kickstarter-iOS/DataSources/PaymentMethodsDataSourceTests.swift
@@ -22,10 +22,6 @@ internal final class PaymentMethodsDataSourceTests: XCTestCase {
     let cards = GraphUserCreditCard.template.storedCards.nodes
     self.dataSource.load(creditCards: cards)
 
-    XCTAssertEqual(7, self.dataSource.tableView(self.tableView, numberOfRowsInSection: 0))
-
-    XCTAssertEqual("CreditCardCell", self.dataSource.reusableId(item: 0, section: 0))
-
     guard let card = cards.first else {
       XCTFail("Card should exist")
       return

--- a/Kickstarter-iOS/Views/Controllers/PaymentMethodsViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/PaymentMethodsViewController.swift
@@ -77,7 +77,8 @@ internal final class PaymentMethodsViewController: UIViewController {
     self.viewModel.outputs.tableViewIsEditing
       .observeForUI()
       .observeValues { [weak self] isEditing in
-        self?.tableView.isEditing = isEditing
+        _ = self?.tableView
+          ?|> \.isEditing .~ isEditing
     }
 
     self.viewModel.outputs.showAlert

--- a/Kickstarter-iOS/Views/Controllers/PaymentMethodsViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/PaymentMethodsViewController.swift
@@ -28,8 +28,12 @@ internal final class PaymentMethodsViewController: UIViewController {
       title: Strings.discovery_favorite_categories_buttons_edit(),
       style: .plain,
       target: self,
-      action: nil
+      action: #selector(edit)
     )
+
+    self.dataSource.deletionHandler = { [weak self] creditCard in
+      self?.viewModel.inputs.didDelete(creditCard)
+    }
   }
 
   override func bindStyles() {
@@ -69,6 +73,24 @@ internal final class PaymentMethodsViewController: UIViewController {
       .observeValues { [weak self] in
         self?.goToAddCardScreen()
     }
+
+    self.viewModel.outputs.tableViewIsEditing
+      .observeForUI()
+      .observeValues { [weak self] isEditing in
+        self?.tableView.isEditing = isEditing
+    }
+
+    self.viewModel.outputs.showAlert
+      .observeForControllerAction()
+      .observeValues { [weak self] message in
+        self?.present(UIAlertController.genericError(message), animated: true)
+    }
+  }
+
+  // MARK: - Actions
+
+  @objc private func edit() {
+    self.viewModel.inputs.editButtonTapped()
   }
 
   private func goToAddCardScreen() {

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -156,7 +156,6 @@
 		77C5E252214182CA002E1670 /* SettingsPrivacySwitchCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77C5E251214182CA002E1670 /* SettingsPrivacySwitchCell.swift */; };
 		77CD894921791B05003066DA /* ProjectStatsTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77CD894821791B05003066DA /* ProjectStatsTemplate.swift */; };
 		77CD8981217FA01B003066DA /* ProjectPamphletContentViewControllerConversionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77CD8980217FA01B003066DA /* ProjectPamphletContentViewControllerConversionTests.swift */; };
-		77CD89F2218215CB003066DA /* GraphError+LocalizedDescription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 775DFAD621627D9C00620CED /* GraphError+LocalizedDescription.swift */; };
 		77D7A739214187A9003F258C /* SettingsSwitchCellType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77D7A738214187A9003F258C /* SettingsSwitchCellType.swift */; };
 		77E44B7421823A56006446B8 /* ChangePasswordInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77E44B7321823A56006446B8 /* ChangePasswordInput.swift */; };
 		77E6440120F64F0B005F6B38 /* HelpDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77E6440020F64F0B005F6B38 /* HelpDataSource.swift */; };
@@ -891,6 +890,8 @@
 		D080566B1E4DB25B008F67A7 /* LiveStreamChatMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D080566A1E4DB25B008F67A7 /* LiveStreamChatMessage.swift */; };
 		D08056A71E4DB427008F67A7 /* LiveStreamChatMessageTemplates.swift in Sources */ = {isa = PBXBuildFile; fileRef = D08056A61E4DB427008F67A7 /* LiveStreamChatMessageTemplates.swift */; };
 		D08056AA1E4DB808008F67A7 /* LiveStreamChatMessageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D08056A81E4DB4E8008F67A7 /* LiveStreamChatMessageTests.swift */; };
+		D0851010219500F200BC418B /* PaymentSourceDeleteMutation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D085100F219500F200BC418B /* PaymentSourceDeleteMutation.swift */; };
+		D08510122195015F00BC418B /* PaymentSourceDeleteInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = D08510112195015F00BC418B /* PaymentSourceDeleteInput.swift */; };
 		D08A81771DFAACD3000128DB /* ClearNavigationBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = D08A816F1DFAA7EF000128DB /* ClearNavigationBar.swift */; };
 		D08A81781DFAACF1000128DB /* LiveStreamContainerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0247A8E1DF9F0EF00D7A7C1 /* LiveStreamContainerViewModel.swift */; };
 		D08A81791DFAACF5000128DB /* LiveStreamCountdownViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0247A8F1DF9F0EF00D7A7C1 /* LiveStreamCountdownViewModel.swift */; };
@@ -1040,7 +1041,6 @@
 		D6ED386A1F796C26006CAAE9 /* GraphCategoriesEnvelopeLenses.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6ED38691F796C26006CAAE9 /* GraphCategoriesEnvelopeLenses.swift */; };
 		D6ED38A21F796FE5006CAAE9 /* GraphCategoriesEnvelopeTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6ED38A11F796FE5006CAAE9 /* GraphCategoriesEnvelopeTemplate.swift */; };
 		D6F741A821836E5700C2DDA2 /* PaymentMethodsViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6F7416F21836C3D00C2DDA2 /* PaymentMethodsViewControllerTests.swift */; };
-		D6FB2A3D1FA27D0300B0D282 /* CategoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6FB2A3C1FA27D0300B0D282 /* CategoryTests.swift */; };
 		D70347901DBAABC30099C668 /* DiscoveryExpandableRowCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D703478F1DBAABC30099C668 /* DiscoveryExpandableRowCellViewModel.swift */; };
 		D703FC3120F7E280004A272D /* SettingsPrivacy.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D703FC3020F7E280004A272D /* SettingsPrivacy.storyboard */; };
 		D703FC6920F7E2EC004A272D /* SettingsPrivacyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D703FC6820F7E2EC004A272D /* SettingsPrivacyViewController.swift */; };
@@ -1600,13 +1600,6 @@
 			remoteGlobalIDString = A7DB1D5A1C9F4FD7008244DA;
 			remoteInfo = "ReactiveExtensions-TestHelpers-tvOS";
 		};
-		D04AABCB218BB25E00CF713E /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 80762DE71D071BCF0074189D /* AlamofireImage.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 4C11830B2150517E007A8298;
-			remoteInfo = "iOS Example";
-		};
 		D0745AD61EEB09DE00FA53D3 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = D04277D01EEB08D800600E9C /* Argo.xcodeproj */;
@@ -1893,8 +1886,6 @@
 		7758A8352097A8180018B96D /* DiscoveryProjectCategoryView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = DiscoveryProjectCategoryView.xib; sourceTree = "<group>"; };
 		775DFA9C215E758400620CED /* GraphMutation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphMutation.swift; sourceTree = "<group>"; };
 		775DFAD4215EB2AB00620CED /* Service+RequestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Service+RequestHelpers.swift"; sourceTree = "<group>"; };
-		775DFAD82162A43F00620CED /* ChangePasswordInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangePasswordInput.swift; sourceTree = "<group>"; };
-		775DFAD621627D9C00620CED /* GraphError+LocalizedDescription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GraphError+LocalizedDescription.swift"; sourceTree = "<group>"; };
 		775DFB082162C08800620CED /* MessageBannerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageBannerViewController.swift; sourceTree = "<group>"; };
 		776B6F6F215183A400AB0652 /* ChangeEmailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeEmailViewController.swift; sourceTree = "<group>"; };
 		778215EA20F79FA300F3D09F /* HelpDataSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelpDataSourceTests.swift; sourceTree = "<group>"; };
@@ -2661,6 +2652,8 @@
 		D080566A1E4DB25B008F67A7 /* LiveStreamChatMessage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LiveStreamChatMessage.swift; sourceTree = "<group>"; };
 		D08056A61E4DB427008F67A7 /* LiveStreamChatMessageTemplates.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LiveStreamChatMessageTemplates.swift; sourceTree = "<group>"; };
 		D08056A81E4DB4E8008F67A7 /* LiveStreamChatMessageTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LiveStreamChatMessageTests.swift; sourceTree = "<group>"; };
+		D085100F219500F200BC418B /* PaymentSourceDeleteMutation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentSourceDeleteMutation.swift; sourceTree = "<group>"; };
+		D08510112195015F00BC418B /* PaymentSourceDeleteInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentSourceDeleteInput.swift; sourceTree = "<group>"; };
 		D08A816F1DFAA7EF000128DB /* ClearNavigationBar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClearNavigationBar.swift; sourceTree = "<group>"; };
 		D08A81711DFAA815000128DB /* LiveStreamContainerViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LiveStreamContainerViewController.swift; sourceTree = "<group>"; };
 		D08A81721DFAA815000128DB /* LiveStreamCountdownViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LiveStreamCountdownViewController.swift; sourceTree = "<group>"; };
@@ -2986,14 +2979,13 @@
 		775DFADB2162A56D00620CED /* mutations */ = {
 			isa = PBXGroup;
 			children = (
-				D6ED1B3C216D617E007F7547 /* inputs */,
+				D085100F219500F200BC418B /* PaymentSourceDeleteMutation.swift */,
 				D08CD1F821910DF5009F89F0 /* UnwatchProjectMutation.swift */,
 				D6ED1B3D216D61E0007F7547 /* UpdateUserAccountMutation.swift */,
 				D77743E2217A2D67008D679F /* UpdateUserProfileMutation .swift */,
 				D6B686EA2191FEEE005F5DA7 /* UserSendEmailVerificationMutation.swift */,
-				D0467DC0218A6F60004831E5 /* WatchProjectMutation.swift */,
-				D6ED1B3C216D617E007F7547 /* mutation inputs */,
 				D002CAE0218CF8F1009783F2 /* WatchProjectMutation.swift */,
+				D6ED1B3C216D617E007F7547 /* inputs */,
 			);
 			path = mutations;
 			sourceTree = "<group>";
@@ -3028,7 +3020,6 @@
 				80762DFD1D071BCF0074189D /* AlamofireImage tvOS Tests.xctest */,
 				80762DFF1D071BCF0074189D /* AlamofireImage.framework */,
 				D6B6872921923BA7005F5DA7 /* iOS Example.app */,
-				D04AABCC218BB25E00CF713E /* iOS Example.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -3393,12 +3384,10 @@
 				018F1F821C8E182200643DAA /* LoginViewController.swift */,
 				A7ED202D1E8323E900BFFA01 /* LoginViewControllerTests.swift */,
 				775DFB082162C08800620CED /* MessageBannerViewController.swift */,
-				77E84E0B2166A8C600DA8891 /* MessageBannerViewControllerTests.swift */,
 				A74FFDEE1CE3E33300C7BCB9 /* MessageDialogViewController.swift */,
 				A75A29231CE0AE5A00D35E5C /* MessagesViewController.swift */,
 				A71003D81CDCFA2500B4F4D7 /* MessageThreadsViewController.swift */,
 				A7ED203E1E8323E900BFFA01 /* MessageThreadsViewControllerTests.swift */,
-				77E84DD12166A45B00DA8891 /* MessageBannerViewController.swift */,
 				77E84E0B2166A8C600DA8891 /* MessageBannerViewControllerTests.swift */,
 				D63BBCCF217E5460007E01F0 /* PaymentMethodsViewController.swift */,
 				9D9F580C1D131B1200CE81DE /* ProjectActivitiesViewController.swift */,
@@ -4258,7 +4247,6 @@
 				D6ED1B38216D50BE007F7547 /* GraphUser.swift */,
 				D01587951EEB2ED6006E7684 /* Item.swift */,
 				D01587961EEB2ED6006E7684 /* ItemTests.swift */,
-				D01587971EEB2ED6006E7684 /* lenses */,
 				D01587CB1EEB2ED7006E7684 /* Location.swift */,
 				D01587CC1EEB2ED7006E7684 /* LocationTests.swift */,
 				D01587CD1EEB2ED7006E7684 /* Message.swift */,
@@ -4295,7 +4283,6 @@
 				D01587EB1EEB2ED7006E7684 /* SubmitApplePayEnvelopeTests.swift */,
 				D01587EC1EEB2ED7006E7684 /* SurveyResponse.swift */,
 				D01587ED1EEB2ED7006E7684 /* SurveyResponseTests.swift */,
-				D01587EE1EEB2ED7006E7684 /* templates */,
 				D015881A1EEB2ED7006E7684 /* Update.swift */,
 				D015881B1EEB2ED7006E7684 /* UpdateDraft.swift */,
 				D015881C1EEB2ED7006E7684 /* UpdateDraftTests.swift */,
@@ -4533,10 +4520,10 @@
 			isa = PBXGroup;
 			children = (
 				D777442E217A3382008D679F /* ChangeCurrencyInput.swift */,
-				D6B686E82191FE5E005F5DA7 /* EmptyInput.swift */,
-				D0467DFB218A709A004831E5 /* WatchProjectInput.swift */,
 				D6ED1B3A216D525B007F7547 /* ChangeEmailInput.swift */,
 				77E44B7321823A56006446B8 /* ChangePasswordInput.swift */,
+				D6B686E82191FE5E005F5DA7 /* EmptyInput.swift */,
+				D08510112195015F00BC418B /* PaymentSourceDeleteInput.swift */,
 				D002CAE2218CF91D009783F2 /* WatchProjectInput.swift */,
 			);
 			path = inputs;
@@ -5308,13 +5295,6 @@
 			fileType = wrapper.framework;
 			path = ReactiveExtensions_TestHelpers.framework;
 			remoteRef = D04278281EEB08F200600E9C /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		D04AABCC218BB25E00CF713E /* iOS Example.app */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.application;
-			path = "iOS Example.app";
-			remoteRef = D04AABCB218BB25E00CF713E /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 		D0745B3C1EEB0B5E00FA53D3 /* ReactiveSwift.framework */ = {
@@ -6386,6 +6366,7 @@
 				D0158A2F1EEB30A2006E7684 /* User.MemberDataTemplates.swift in Sources */,
 				D015883D1EEB2ED7006E7684 /* Route.swift in Sources */,
 				D0158A2B1EEB30A2006E7684 /* UpdateDraftTemplates.swift in Sources */,
+				D08510122195015F00BC418B /* PaymentSourceDeleteInput.swift in Sources */,
 				D015888F1EEB2ED7006E7684 /* CreatePledgeEnvelopeLenses.swift in Sources */,
 				D0158A531EEB3734006E7684 /* Secrets.swift in Sources */,
 				D01588A71EEB2ED7006E7684 /* Project.MemberDataLenses.swift in Sources */,
@@ -6448,6 +6429,7 @@
 				D01588F31EEB2ED7006E7684 /* MessageThreadsEnvelope.swift in Sources */,
 				D6C9A2561F75921500981E64 /* CategoryTemplates.swift in Sources */,
 				D015882D1EEB2ED7006E7684 /* BasicHTTPAuth.swift in Sources */,
+				D0851010219500F200BC418B /* PaymentSourceDeleteMutation.swift in Sources */,
 				D01589091EEB2ED7006E7684 /* ProjectsEnvelope.swift in Sources */,
 				D6C9A2541F758C7900981E64 /* GraphCategoryLenses.swift in Sources */,
 				D015883B1EEB2ED7006E7684 /* MimeType.swift in Sources */,

--- a/KsApi/MockService.swift
+++ b/KsApi/MockService.swift
@@ -21,6 +21,8 @@ internal struct MockService: ServiceType {
 
   fileprivate let changePaymentMethodResult: Result<ChangePaymentMethodEnvelope, ErrorEnvelope>?
 
+  fileprivate let deletePaymentMethodResult: Result<GraphMutationEmptyResponseEnvelope, GraphError>?
+
   fileprivate let createPledgeResult: Result<CreatePledgeEnvelope, ErrorEnvelope>?
 
   fileprivate let facebookConnectResponse: User?
@@ -181,6 +183,7 @@ internal struct MockService: ServiceType {
                 changePasswordError: GraphError? = nil,
                 changeCurrencyError: GraphError? = nil,
                 changePaymentMethodResult: Result<ChangePaymentMethodEnvelope, ErrorEnvelope>? = nil,
+                deletePaymentMethodResult: Result<GraphMutationEmptyResponseEnvelope, GraphError>? = nil,
                 createPledgeResult: Result<CreatePledgeEnvelope, ErrorEnvelope>? = nil,
                 facebookConnectResponse: User? = nil,
                 facebookConnectError: ErrorEnvelope? = nil,
@@ -279,6 +282,7 @@ internal struct MockService: ServiceType {
     self.changePasswordError = changePasswordError
 
     self.changePaymentMethodResult = changePaymentMethodResult
+    self.deletePaymentMethodResult = deletePaymentMethodResult
     self.createPledgeResult = createPledgeResult
 
     self.facebookConnectResponse = facebookConnectResponse
@@ -1310,6 +1314,11 @@ internal struct MockService: ServiceType {
       return SignalProducer(value: self.changePaymentMethodResult?.value ?? .template)
   }
 
+  internal func deletePaymentMethod(input: PaymentSourceDeleteInput) -> SignalProducer<
+    GraphMutationEmptyResponseEnvelope, GraphError> {
+    return producer(for: self.deletePaymentMethodResult)
+  }
+
   internal func delete(video: UpdateDraft.Video, fromDraft draft: UpdateDraft)
     -> SignalProducer<UpdateDraft.Video, ErrorEnvelope> {
 
@@ -1344,6 +1353,7 @@ private extension MockService {
           language: $1.language,
           buildVersion: $1.buildVersion,
           changePaymentMethodResult: $1.changePaymentMethodResult,
+          deletePaymentMethodResult: $1.deletePaymentMethodResult,
           createPledgeResult: $1.createPledgeResult,
           facebookConnectResponse: $1.facebookConnectResponse,
           facebookConnectError: $1.facebookConnectError,

--- a/KsApi/Service.swift
+++ b/KsApi/Service.swift
@@ -82,6 +82,11 @@ public struct Service: ServiceType {
       return request(.changePaymentMethod(project: project))
   }
 
+  public func deletePaymentMethod(input: PaymentSourceDeleteInput)
+    -> SignalProducer<GraphMutationEmptyResponseEnvelope, GraphError> {
+      return applyMutation(mutation: PaymentSourceDeleteMutation(input: input))
+  }
+
   public func changeCurrency(input: ChangeCurrencyInput) ->
     SignalProducer<GraphMutationEmptyResponseEnvelope, GraphError> {
       return applyMutation(mutation: UpdateUserProfileMutation(input: input))

--- a/KsApi/ServiceType.swift
+++ b/KsApi/ServiceType.swift
@@ -54,6 +54,10 @@ public protocol ServiceType {
   func changePaymentMethod(project: Project)
     -> SignalProducer<ChangePaymentMethodEnvelope, ErrorEnvelope>
 
+  /// Deletes a payment method
+  func deletePaymentMethod(input: PaymentSourceDeleteInput) ->
+    SignalProducer<GraphMutationEmptyResponseEnvelope, GraphError>
+
   /// Performs the first step of checkout by creating a pledge on the server.
   func createPledge(project: Project,
                     amount: Double,

--- a/KsApi/mutations/PaymentSourceDeleteMutation.swift
+++ b/KsApi/mutations/PaymentSourceDeleteMutation.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+public struct PaymentSourceDeleteMutation<T: GraphMutationInput>: GraphMutation {
+  var input: T
+
+  public init(input: T) {
+    self.input = input
+  }
+
+  public var description: String {
+    let desc = """
+    mutation paymentSourceDelete($input: PaymentSourceDeleteInput!) {
+      paymentSourceDelete(input: $input) {
+        clientMutationId
+      }
+    }
+    """
+
+    return desc
+  }
+}

--- a/KsApi/mutations/inputs/PaymentSourceDeleteInput.swift
+++ b/KsApi/mutations/inputs/PaymentSourceDeleteInput.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+public struct PaymentSourceDeleteInput: GraphMutationInput {
+  let paymentSourceId: String
+
+  public init(paymentSourceId: String) {
+    self.paymentSourceId = paymentSourceId
+  }
+
+  public func toInputDictionary() -> [String: Any] {
+    return ["paymentSourceId": self.paymentSourceId]
+  }
+}

--- a/Library/ViewModels/PaymentMethodsViewModel.swift
+++ b/Library/ViewModels/PaymentMethodsViewModel.swift
@@ -47,9 +47,9 @@ PaymentMethodsViewModelInputs, PaymentMethodsViewModelOutputs {
       .ignoreValues()
       .map {
         localizedString(
-          key: "Something_went_wrong_and_we_were_unable_to_remove_your_credit_card_please_try_again",
+          key: "Something_went_wrong_and_we_were_unable_to_remove_your_payment_method_please_try_again",
           //swiftlint:disable:next line_length
-          defaultValue: "Something went wrong and we were unable to remove your credit card, please try again."
+          defaultValue: "Something went wrong and we were unable to remove your payment method, please try again."
         )
     }
 

--- a/Library/ViewModels/PaymentMethodsViewModel.swift
+++ b/Library/ViewModels/PaymentMethodsViewModel.swift
@@ -5,14 +5,18 @@ import ReactiveSwift
 import Result
 
 public protocol PaymentMethodsViewModelInputs {
-  func viewDidLoad()
+  func didDelete(_ creditCard: GraphUserCreditCard.CreditCard)
+  func editButtonTapped()
   func paymentMethodsFooterViewDidTapAddNewCardButton()
+  func viewDidLoad()
 }
 
 public protocol PaymentMethodsViewModelOutputs {
   /// Emits the user's stored cards
-  var paymentMethods: Signal<[GraphUserCreditCard.CreditCard], NoError> { get }
   var goToAddCardScreen: Signal<Void, NoError> { get }
+  var paymentMethods: Signal<[GraphUserCreditCard.CreditCard], NoError> { get }
+  var showAlert: Signal<String, NoError> { get }
+  var tableViewIsEditing: Signal<Bool, NoError> { get }
 }
 
 public protocol PaymentMethodsViewModelType {
@@ -24,17 +28,52 @@ public final class PaymentMethodsViewModel: PaymentMethodsViewModelType,
 PaymentMethodsViewModelInputs, PaymentMethodsViewModelOutputs {
 
   public init() {
-
     let paymentMethodsEvent = self.viewDidLoadProperty.signal
       .switchMap { _ in
         AppEnvironment.current.apiService.fetchGraphCreditCards(query: UserQueries.storedCards.query)
           .ksr_delay(AppEnvironment.current.apiDelayInterval, on: AppEnvironment.current.scheduler)
           .materialize()
-      }
+    }
 
-    self.paymentMethods = paymentMethodsEvent.values().map { $0.me.storedCards.nodes }
+    let deletePaymentMethodEvents = self.didDeleteCreditCardSignal.switchMap { creditCard in
+      AppEnvironment.current.apiService.deletePaymentMethod(input: .init(paymentSourceId: creditCard.id))
+        .ksr_delay(AppEnvironment.current.apiDelayInterval, on: AppEnvironment.current.scheduler)
+        .materialize()
+    }
+
+    let deletePaymentMethodEventsErrors = deletePaymentMethodEvents.errors()
+
+    self.showAlert = deletePaymentMethodEventsErrors
+      .ignoreValues()
+      .map {
+        localizedString(
+          key: "Something_went_wrong_and_we_were_unable_to_remove_your_credit_card_please_try_again",
+          //swiftlint:disable:next line_length
+          defaultValue: "Something went wrong and we were unable to remove your credit card, please try again."
+        )
+    }
+
+    let paymentMethodsValues = paymentMethodsEvent.values().map { $0.me.storedCards.nodes }
+
+    self.paymentMethods = Signal.merge(
+      paymentMethodsValues,
+      paymentMethodsValues.takeWhen(deletePaymentMethodEventsErrors)
+    )
 
     self.goToAddCardScreen = self.didTapAddCardButtonProperty.signal
+
+    self.tableViewIsEditing = self.editButtonTappedSignal.scan(false) { current, _ in !current }
+  }
+
+  let (didDeleteCreditCardSignal, didDeleteCreditCardObserver) = Signal<GraphUserCreditCard.CreditCard,
+    NoError>.pipe()
+  public func didDelete(_ creditCard: GraphUserCreditCard.CreditCard) {
+    self.didDeleteCreditCardObserver.send(value: creditCard)
+  }
+
+  let (editButtonTappedSignal, editButtonTappedObserver) = Signal<(), NoError>.pipe()
+  public func editButtonTapped() {
+    self.editButtonTappedObserver.send(value: ())
   }
 
   fileprivate let viewDidLoadProperty = MutableProperty(())
@@ -47,8 +86,10 @@ PaymentMethodsViewModelInputs, PaymentMethodsViewModelOutputs {
     self.didTapAddCardButtonProperty.value = ()
   }
 
-  public let paymentMethods: Signal<[GraphUserCreditCard.CreditCard], NoError>
   public let goToAddCardScreen: Signal<Void, NoError>
+  public let paymentMethods: Signal<[GraphUserCreditCard.CreditCard], NoError>
+  public let showAlert: Signal<String, NoError>
+  public let tableViewIsEditing: Signal<Bool, NoError>
 
   public var inputs: PaymentMethodsViewModelInputs { return self }
   public var outputs: PaymentMethodsViewModelOutputs { return self }

--- a/Library/ViewModels/PaymentMethodsViewModelTests.swift
+++ b/Library/ViewModels/PaymentMethodsViewModelTests.swift
@@ -10,18 +10,21 @@ import Prelude
 internal final class PaymentMethodsViewModelTests: TestCase {
 
   let vm = PaymentMethodsViewModel()
-  let paymentMethods = TestObserver<[GraphUserCreditCard.CreditCard], NoError>()
   let goToAddCardScreen = TestObserver<Void, NoError>()
+  let paymentMethods = TestObserver<[GraphUserCreditCard.CreditCard], NoError>()
+  let showAlert = TestObserver<String, NoError>()
+  let tableViewIsEditing = TestObserver<Bool, NoError>()
 
   internal override func setUp() {
     super.setUp()
 
-    self.vm.outputs.paymentMethods.observe(paymentMethods.observer)
     self.vm.outputs.goToAddCardScreen.observe(goToAddCardScreen.observer)
+    self.vm.outputs.paymentMethods.observe(paymentMethods.observer)
+    self.vm.outputs.showAlert.observe(self.showAlert.observer)
+    self.vm.outputs.tableViewIsEditing.observe(self.tableViewIsEditing.observer)
   }
 
   func testPaymentMethodsFetch_OnViewDidLoad() {
-
     let response = UserEnvelope<GraphUserCreditCard>(
       me: GraphUserCreditCard.template
     )
@@ -42,5 +45,79 @@ internal final class PaymentMethodsViewModelTests: TestCase {
     self.vm.inputs.paymentMethodsFooterViewDidTapAddNewCardButton()
 
     self.goToAddCardScreen.assertValueCount(1, "Should emit after tapping button")
+  }
+
+  func testDeletePaymentMethod() {
+    guard let card = GraphUserCreditCard.template.storedCards.nodes.first else {
+      XCTFail("Card should exist")
+      return
+    }
+
+    let apiService = MockService(deletePaymentMethodResult: .success(GraphMutationEmptyResponseEnvelope()))
+    withEnvironment(apiService: apiService) {
+
+      self.vm.inputs.viewDidLoad()
+      self.scheduler.advance()
+
+      self.tableViewIsEditing.assertValues([])
+      self.showAlert.assertValues([])
+      self.paymentMethods.assertValues([GraphUserCreditCard.template.storedCards.nodes])
+
+      self.paymentMethods.assertValues([GraphUserCreditCard.template.storedCards.nodes])
+
+      self.vm.inputs.editButtonTapped()
+
+      self.tableViewIsEditing.assertValues([true], "Editing mode enabled")
+      self.showAlert.assertValues([])
+      self.paymentMethods.assertValues([GraphUserCreditCard.template.storedCards.nodes])
+
+      self.vm.inputs.didDelete(card)
+      self.scheduler.advance()
+
+      self.tableViewIsEditing.assertValues([true], "Editing mode remains enabled")
+      self.showAlert.assertValues([], "No errors emitted")
+      self.paymentMethods.assertValues(
+        [GraphUserCreditCard.template.storedCards.nodes],
+        "Emits once"
+      )
+    }
+  }
+
+  func testDeletePaymentMethod_Error() {
+    guard let card = GraphUserCreditCard.template.storedCards.nodes.first else {
+      XCTFail("Card should exist")
+      return
+    }
+
+    let apiService = MockService(deletePaymentMethodResult: .failure(.invalidInput))
+    withEnvironment(apiService: apiService) {
+
+      self.vm.inputs.viewDidLoad()
+      self.scheduler.advance()
+
+      self.tableViewIsEditing.assertValues([])
+      self.showAlert.assertValues([])
+      self.paymentMethods.assertValues([GraphUserCreditCard.template.storedCards.nodes])
+
+      self.paymentMethods.assertValues([GraphUserCreditCard.template.storedCards.nodes])
+
+      self.vm.inputs.editButtonTapped()
+
+      self.tableViewIsEditing.assertValues([true], "Editing mode enabled")
+      self.showAlert.assertValues([])
+      self.paymentMethods.assertValues([GraphUserCreditCard.template.storedCards.nodes])
+
+      self.vm.inputs.didDelete(card)
+      self.scheduler.advance()
+
+      self.tableViewIsEditing.assertValues([true], "Editing mode remains enabled")
+      self.showAlert.assertValues([
+        "Something went wrong and we were unable to remove your credit card, please try again."
+      ], "Error occurred")
+      self.paymentMethods.assertValues(
+        [GraphUserCreditCard.template.storedCards.nodes, GraphUserCreditCard.template.storedCards.nodes],
+        "Emits again to reload the tableview after an error occurred"
+      )
+    }
   }
 }

--- a/Library/ViewModels/PaymentMethodsViewModelTests.swift
+++ b/Library/ViewModels/PaymentMethodsViewModelTests.swift
@@ -108,8 +108,7 @@ internal final class PaymentMethodsViewModelTests: TestCase {
 
       self.tableViewIsEditing.assertValues([true], "Editing mode remains enabled")
       self.showAlert.assertValues([
-        "Something went wrong and we were unable to remove your credit card, please try again."
-      ], "Error occurred")
+        "Something went wrong and we were unable to remove your payment method, please try again."])
       self.paymentMethods.assertValues(
         [GraphUserCreditCard.template.storedCards.nodes, GraphUserCreditCard.template.storedCards.nodes],
         "Emits again to reload the tableview after an error occurred"

--- a/Library/ViewModels/PaymentMethodsViewModelTests.swift
+++ b/Library/ViewModels/PaymentMethodsViewModelTests.swift
@@ -18,8 +18,8 @@ internal final class PaymentMethodsViewModelTests: TestCase {
   internal override func setUp() {
     super.setUp()
 
-    self.vm.outputs.goToAddCardScreen.observe(goToAddCardScreen.observer)
-    self.vm.outputs.paymentMethods.observe(paymentMethods.observer)
+    self.vm.outputs.goToAddCardScreen.observe(self.goToAddCardScreen.observer)
+    self.vm.outputs.paymentMethods.observe(self.paymentMethods.observer)
     self.vm.outputs.showAlert.observe(self.showAlert.observer)
     self.vm.outputs.tableViewIsEditing.observe(self.tableViewIsEditing.observer)
   }
@@ -63,8 +63,6 @@ internal final class PaymentMethodsViewModelTests: TestCase {
       self.showAlert.assertValues([])
       self.paymentMethods.assertValues([GraphUserCreditCard.template.storedCards.nodes])
 
-      self.paymentMethods.assertValues([GraphUserCreditCard.template.storedCards.nodes])
-
       self.vm.inputs.editButtonTapped()
 
       self.tableViewIsEditing.assertValues([true], "Editing mode enabled")
@@ -97,8 +95,6 @@ internal final class PaymentMethodsViewModelTests: TestCase {
 
       self.tableViewIsEditing.assertValues([])
       self.showAlert.assertValues([])
-      self.paymentMethods.assertValues([GraphUserCreditCard.template.storedCards.nodes])
-
       self.paymentMethods.assertValues([GraphUserCreditCard.template.storedCards.nodes])
 
       self.vm.inputs.editButtonTapped()


### PR DESCRIPTION
# What

Adds the ability to delete payment methods using standard iOS deletion gestures.

# Why

This is a continuation of the work done in #457 to allow users to delete payment methods. This branch is also based off the `feature-payment-methods` branch.

# How

`UITableView` gives us most of this functionality for free so this was fairly straightforward to implement. I've also taken an optimistic UI approach here so the credit card will be removed immediately upon deletion and we will only show it again if an error occurs.

Some ways that we may want to iterate on this:

-  I think we might want to confirm deletion in some way, either through an alert _after_ swiping, but _before_ performing the deletion, or potentially displaying an undo button after animating it away but not committing the deletion.
- I've come up with some copy for an error alert (see below) which refers to the thing that failed to be removed as a _credit card_, do we want to stick to _payment method_ here?

cc @nnekab @dannyalright for the above.

# See 👀

| Tap to delete | Swipe to delete | Error case |
| ------------- | ------------- | ------------- |
| ![2018-11-08 16 41 31](https://user-images.githubusercontent.com/3735375/48237383-3be2c500-e37b-11e8-8e3f-334635eae45f.gif) | ![2018-11-08 16 42 37](https://user-images.githubusercontent.com/3735375/48237400-4604c380-e37b-11e8-9f1c-277c61826d3e.gif) | ![2018-11-08 17 31 38](https://user-images.githubusercontent.com/3735375/48237607-405bad80-e37c-11e8-9539-d82fc191a44b.gif) |