### PR TITLE
Push registration on app launch

### DIFF
--- a/Kickstarter-iOS/AppDelegate.swift
+++ b/Kickstarter-iOS/AppDelegate.swift
@@ -126,6 +126,7 @@ internal final class AppDelegate: UIResponder, UIApplicationDelegate {
     self.viewModel.outputs.registerForRemoteNotifications
       .observeForUI()
       .observeValues {
+        print("📲 [Push Registration] Registering for push notifications")
         if #available(iOS 10.0, *) {
           UIApplication.shared.registerForRemoteNotifications()
         } else {
@@ -136,6 +137,12 @@ internal final class AppDelegate: UIResponder, UIApplicationDelegate {
           UIApplication.shared.registerForRemoteNotifications()
         }
       }
+
+      self.viewModel.outputs.pushTokenSuccessfullyRegistered
+      .observeForUI()
+      .observeValues {
+        print("📲 [Push Registration] Push token successfully registered ✨")
+    }
 
       if #available(iOS 10.0, *) {
         self.viewModel.outputs.getNotificationAuthorizationStatus

--- a/Kickstarter-iOS/ViewModels/AppDelegateViewModel.swift
+++ b/Kickstarter-iOS/ViewModels/AppDelegateViewModel.swift
@@ -263,8 +263,16 @@ AppDelegateViewModelOutputs {
     if #available(iOS 10.0, *) {
       self.getNotificationAuthorizationStatus = applicationIsReadyForRegisteringNotifications
 
-      self.registerForRemoteNotifications = self.notificationAuthorizationCompletedProperty.signal
-        .filter(isTrue)
+      let userHasAuthorizedRemoteNotifications = self.notificationAuthorizationStatusProperty.signal
+        .filter { $0 == .authorized }
+        .take(first: 1)
+        .mapConst(true)
+      let authorizationCompletedAndGranted = self.notificationAuthorizationCompletedProperty
+        .signal.filter(isTrue)
+
+      self.registerForRemoteNotifications = Signal.merge(
+        authorizationCompletedAndGranted,
+        userHasAuthorizedRemoteNotifications)
         .ignoreValues()
     } else {
       //Never firing signal in ios 9

--- a/Kickstarter-iOS/ViewModels/AppDelegateViewModelTests.swift
+++ b/Kickstarter-iOS/ViewModels/AppDelegateViewModelTests.swift
@@ -662,13 +662,6 @@ final class AppDelegateViewModelTests: TestCase {
       self.registerForRemoteNotifications.assertValueCount(0)
       self.unregisterForRemoteNotifications.assertValueCount(0)
 
-      self.vm.inputs.notificationAuthorizationStatusReceived(UNAuthorizationStatus.authorized)
-
-      self.getNotificationAuthorizationStatus.assertValueCount(2)
-      self.authorizeForRemoteNotifications.assertValueCount(0)
-      self.registerForRemoteNotifications.assertValueCount(0)
-      self.unregisterForRemoteNotifications.assertValueCount(0)
-
       //Simulate initial notification authorization
       self.vm.inputs.notificationAuthorizationStatusReceived(UNAuthorizationStatus.notDetermined)
       self.vm.inputs.didAcceptReceivingRemoteNotifications()
@@ -689,14 +682,41 @@ final class AppDelegateViewModelTests: TestCase {
 
       self.getNotificationAuthorizationStatus.assertValueCount(2)
       self.authorizeForRemoteNotifications.assertValueCount(1)
-      self.registerForRemoteNotifications.assertValueCount(1)
+      self.registerForRemoteNotifications.assertValueCount(2)
       self.unregisterForRemoteNotifications.assertValueCount(0)
     }
 
     self.vm.inputs.userSessionEnded()
 
-    self.registerForRemoteNotifications.assertValueCount(1)
+    self.registerForRemoteNotifications.assertValueCount(2)
     self.unregisterForRemoteNotifications.assertValueCount(1)
+  }
+
+  @available(iOS 10.0, *)
+  func testSilentRegistration() {
+    withEnvironment(currentUser: User.template) {
+      self.vm.inputs.applicationDidFinishLaunching(application: UIApplication.shared,
+                                                   launchOptions: [:])
+
+      self.getNotificationAuthorizationStatus.assertValueCount(1)
+
+      self.vm.inputs.notificationAuthorizationStatusReceived(.authorized)
+
+      self.registerForRemoteNotifications.assertValueCount(1)
+      self.unregisterForRemoteNotifications.assertValueCount(0)
+      self.authorizeForRemoteNotifications.assertValueCount(0)
+
+      self.vm.inputs.applicationDidEnterBackground()
+      self.vm.inputs.applicationWillEnterForeground()
+
+      self.getNotificationAuthorizationStatus.assertValueCount(2)
+
+      self.vm.inputs.notificationAuthorizationStatusReceived(.authorized)
+
+      self.registerForRemoteNotifications.assertValueCount(1, "Registration only happens once per app launch")
+      self.unregisterForRemoteNotifications.assertValueCount(0)
+      self.authorizeForRemoteNotifications.assertValueCount(0)
+    }
   }
 
   @available(iOS 10.0, *)


### PR DESCRIPTION
# What

Ensures that we register for push notifications on app launch, so that we can have the most up-to-date push tokens.

# Why

Previously, we only registered for push notifications once: when the user first sees the push registration dialog and hits "Ok". This means that the push tokens stored on the server could be invalid, since APNs issues new tokens under certain conditions: https://developer.apple.com/library/archive/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/HandlingRemoteNotifications.html#//apple_ref/doc/uid/TP40008194-CH6-SW3

We are new fetching an updated push token on every app launch if the user has authorized the app for push notifications. 

Also added some additional logging so we can easily see when push registration is happening in the logs 🤓 