### PR TITLE
Use correct function to log events in crash logs

### DIFF
--- a/Kickstarter-iOS/Info.plist
+++ b/Kickstarter-iOS/Info.plist
@@ -52,12 +52,14 @@
 		<key>APIKey</key>
 		<string>$(FABRIC_API_KEY)</string>
 		<key>Kits</key>
-		<array>
-			<dict>
-				<key>KitInfo</key>
-				<string>Crashlytics</string>
-			</dict>
-		</array>
+    <array>
+      <dict>
+        <key>KitInfo</key>
+        <dict/>
+        <key>KitName</key>
+        <string>Crashlytics</string>
+      </dict>
+    </array>
 	</dict>
 	<key>FacebookAppID</key>
 	<string>69103156693</string>

--- a/Kickstarter-iOS/Info.plist
+++ b/Kickstarter-iOS/Info.plist
@@ -52,14 +52,14 @@
 		<key>APIKey</key>
 		<string>$(FABRIC_API_KEY)</string>
 		<key>Kits</key>
-    <array>
-      <dict>
-        <key>KitInfo</key>
-        <dict/>
-        <key>KitName</key>
-        <string>Crashlytics</string>
-      </dict>
-    </array>
+		<array>
+			<dict>
+				<key>KitInfo</key>
+				<dict/>
+				<key>KitName</key>
+				<string>Crashlytics</string>
+			</dict>
+		</array>
 	</dict>
 	<key>FacebookAppID</key>
 	<string>69103156693</string>

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -5470,6 +5470,7 @@
 			files = (
 			);
 			inputPaths = (
+				"$(BUILT_PRODUCTS_DIR)/$(INFOPLIST_PATH)",
 			);
 			name = Fabric;
 			outputPaths = (

--- a/Library/Koala/KoalaTrackingClient.swift
+++ b/Library/Koala/KoalaTrackingClient.swift
@@ -57,7 +57,7 @@ public final class KoalaTrackingClient: TrackingClientType {
     print("🐨 [Koala Track]: \(event), properties: \(properties)")
 
     self.queue.async {
-      Answers.logCustomEvent(withName: event, customAttributes: nil)
+      CLSLogv("%@", getVaList([event]))
       self.buffer.append(["event": event, "properties": properties])
     }
   }


### PR DESCRIPTION
# What

Uses the correct Crashlytics function to log "bread crumb" events in crash logs.

# Why

We were trying to do this using Answers and determined that it wasn't working. When I dug into investigating why that was I also found that that's not actually what we wanted 😄. Crashlytics provides a logging function for this very purpose, described [here](https://docs.fabric.io/apple/crashlytics/enhanced-reports.html#custom-logs).

# How

Replaced the `Answers` line with the Crashlytics `CLSLogv` function.

# See 👀

Tested it by forcing a crash and it looks like this on Crashlytics:

<img width="453" alt="screen shot 2018-11-13 at 4 29 22 pm" src="https://user-images.githubusercontent.com/3735375/48452053-2f3ae400-e762-11e8-8dc8-418d2752c3b2.png">