### PR TITLE
Crashlytics breadcrumbs final final

### DIFF
--- a/Kickstarter-iOS/AppDelegate.swift
+++ b/Kickstarter-iOS/AppDelegate.swift
@@ -198,6 +198,9 @@ internal final class AppDelegate: UIResponder, UIApplicationDelegate {
       .observeForUI()
       .observeValues {
         Fabric.with([Crashlytics.self])
+        AppEnvironment.current.koala.logEventCallback = { event, _ in
+          CLSLogv("%@", getVaList([event]))
+        }
     }
     #endif
 

--- a/Library/Koala/Koala.swift
+++ b/Library/Koala/Koala.swift
@@ -12,7 +12,7 @@ public final class Koala {
 
   fileprivate let bundle: NSBundleType
   fileprivate let client: TrackingClientType
-  fileprivate var config: Config?
+  internal private(set) var config: Config?
   fileprivate let device: UIDeviceType
   fileprivate let distinctId: String
   internal private(set) var loggedInUser: User?

--- a/Library/Koala/Koala.swift
+++ b/Library/Koala/Koala.swift
@@ -12,10 +12,11 @@ public final class Koala {
 
   fileprivate let bundle: NSBundleType
   fileprivate let client: TrackingClientType
-  fileprivate let config: Config?
+  fileprivate var config: Config?
   fileprivate let device: UIDeviceType
   fileprivate let distinctId: String
-  internal let loggedInUser: User?
+  internal private(set) var loggedInUser: User?
+  public var logEventCallback: ((String, [String: Any]) -> Void)?
   private var preferredContentSizeCategory: UIContentSizeCategory?
   private var preferredContentSizeCategoryObserver: Any?
   fileprivate let screen: UIScreenType
@@ -1826,9 +1827,13 @@ public final class Koala {
 
   // Private tracking method that merges in default properties.
   private func track(event: String, properties: [String: Any] = [:]) {
+    let props = self.defaultProperties().withAllValuesFrom(properties)
+
+    self.logEventCallback?(event, props)
+
     self.client.track(
       event: event,
-      properties: self.defaultProperties().withAllValuesFrom(properties)
+      properties: props
     )
   }
 
@@ -2130,14 +2135,12 @@ extension Koala {
   public enum lens {
     public static let loggedInUser = Lens<Koala, User?>(
       view: { $0.loggedInUser },
-      set: { Koala(bundle: $1.bundle, client: $1.client, config: $1.config, device: $1.device,
-        loggedInUser: $0, screen: $1.screen, distinctId: $1.distinctId) }
+      set: { $1.loggedInUser = $0; return $1 }
     )
 
     public static let config = Lens<Koala, Config?>(
       view: { $0.config },
-      set: { Koala(bundle: $1.bundle, client: $1.client, config: $0, device: $1.device,
-        loggedInUser: $1.loggedInUser, screen: $1.screen, distinctId: $1.distinctId) }
+      set: { $1.config = $0; return $1 }
     )
   }
 }

--- a/Library/Koala/KoalaTests.swift
+++ b/Library/Koala/KoalaTests.swift
@@ -590,4 +590,28 @@ final class KoalaTests: TestCase {
     XCTAssertEqual(["live_stream_live"], client.properties(forKey: "live_stream_state", as: String.self))
     XCTAssertEqual(["Cool Live Stream"], client.properties(forKey: "live_stream_name", as: String.self))
   }
+
+  func testLogEventsCallback() {
+    let bundle = MockBundle()
+    let client = MockTrackingClient()
+    let config = Config.template
+    let device = MockDevice(userInterfaceIdiom: .phone)
+    let screen = MockScreen()
+    let koala = Koala(bundle: bundle, client: client, config: config, device: device, loggedInUser: nil,
+                      screen: screen)
+
+    var callBackEvents = [String]()
+    var callBackProperties: [String: Any]?
+    koala.logEventCallback = { event, properties in
+      callBackEvents.append(event)
+      callBackProperties = properties
+    }
+
+    koala.trackAppOpen()
+    
+    XCTAssertEqual(["App Open", "Opened App"], client.events)
+    XCTAssertEqual(["App Open", "Opened App"], callBackEvents)
+    XCTAssertEqual("Apple", client.properties.last?["manufacturer"] as? String)
+    XCTAssertEqual("Apple", callBackProperties?["manufacturer"] as? String)
+  }
 }

--- a/Library/Koala/KoalaTests.swift
+++ b/Library/Koala/KoalaTests.swift
@@ -608,7 +608,7 @@ final class KoalaTests: TestCase {
     }
 
     koala.trackAppOpen()
-    
+
     XCTAssertEqual(["App Open", "Opened App"], client.events)
     XCTAssertEqual(["App Open", "Opened App"], callBackEvents)
     XCTAssertEqual("Apple", client.properties.last?["manufacturer"] as? String)

--- a/Library/Koala/KoalaTrackingClient.swift
+++ b/Library/Koala/KoalaTrackingClient.swift
@@ -1,4 +1,3 @@
-import Crashlytics
 import KsApi
 import Prelude
 import Result
@@ -57,7 +56,6 @@ public final class KoalaTrackingClient: TrackingClientType {
     print("🐨 [Koala Track]: \(event), properties: \(properties)")
 
     self.queue.async {
-      CLSLogv("%@", getVaList([event]))
       self.buffer.append(["event": event, "properties": properties])
     }
   }


### PR DESCRIPTION
# What

This once again tracks event breadcrumbs to Crashlytics.

# Why

- This was first attempted in #217 using Hockey. But that didn't work for unknown reasons (likely _this_ reason).
- It was then attempted again in #461 but that was incorrectly using Answers instead of Crashlytics as explained in #481.
- #481 however also failed because:
  - it appears that a race condition with the initialization of Crashlytics itself was causing it to not log any events and just print a warning to the console.
  - according to [this](https://stackoverflow.com/questions/48112623/issue-with-crashlytics-logging-when-using-crashlytics-in-a-dynamic-framework), using the logging function in a framework other than that in which Crashlytics was initialized, will cause it to fail.

# How

This (really) should solve it once and for all by:

- Calling back from Koala to the main app framework (where Crashlytics was initialized) so that it can call the logging function in that bundle.
- In order to achieve this I had to prevent Koala from being initialized multiple times, which required a modification to its lenses. Previously it was being re-initialized and passing back a new object but seeing as Koala is a class this shouldn't be necessary and instead I am setting the property on the instance.
- I forced a few crashes to test this. [This](https://www.fabric.io/kickstarter2/ios/apps/com.kickstarter.kickstarter/issues/5becb2c7f8b88c2963f5b9f3/sessions/latest) is one.

If this doesn't work:

![giphy](https://user-images.githubusercontent.com/3735375/48596640-ce044380-e90e-11e8-956c-2a814404f99d.gif)