### PR TITLE
Hide message banner superview properly

### DIFF
--- a/Kickstarter-iOS/Views/Controllers/ChangeEmailViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/ChangeEmailViewController.swift
@@ -7,6 +7,7 @@ import UIKit
 internal final class ChangeEmailViewController: UIViewController {
   @IBOutlet fileprivate weak var currentEmailLabel: UILabel!
   @IBOutlet fileprivate weak var currentEmail: UILabel!
+  @IBOutlet fileprivate weak var messageBannerContainer: UIView!
   @IBOutlet fileprivate weak var messageLabelView: UIView!
   @IBOutlet fileprivate weak var newEmailLabel: UILabel!
   @IBOutlet fileprivate weak var newEmailTextField: UITextField!
@@ -35,6 +36,7 @@ internal final class ChangeEmailViewController: UIViewController {
       fatalError("Couldn't instantiate MessageBannerViewController")
     }
     self.messageBannerViewController = messageBannerViewController
+    self.messageBannerViewController.delegate = self
 
     self.saveButtonView = LoadingBarButtonItemView.instantiate()
     self.saveButtonView.setTitle(title: Strings.Save())
@@ -264,5 +266,11 @@ extension ChangeEmailViewController: UITextFieldDelegate {
 
     self.viewModel.inputs.textFieldShouldReturn(with: textField.returnKeyType)
     return textField.resignFirstResponder()
+  }
+}
+
+extension ChangeEmailViewController: MessageBannerViewControllerDelegate {
+  func messageBannerViewControllerIsHidden(_ isHidden: Bool) {
+    self.messageBannerContainer.isHidden = isHidden
   }
 }

--- a/Kickstarter-iOS/Views/Controllers/ChangeEmailViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/ChangeEmailViewController.swift
@@ -20,7 +20,7 @@ internal final class ChangeEmailViewController: UIViewController {
   @IBOutlet fileprivate weak var warningMessageLabel: UILabel!
 
   private let viewModel: ChangeEmailViewModelType = ChangeEmailViewModel()
-  private var messageBannerView: MessageBannerViewController!
+  private var messageBannerViewController: MessageBannerViewController!
 
   private weak var saveButtonView: LoadingBarButtonItemView!
 
@@ -31,11 +31,10 @@ internal final class ChangeEmailViewController: UIViewController {
   override func viewDidLoad() {
     super.viewDidLoad()
 
-    guard let messageBannerView = self.children.first as? MessageBannerViewController else {
+    guard let messageBannerViewController = self.children.first as? MessageBannerViewController else {
       fatalError("Couldn't instantiate MessageBannerViewController")
     }
-
-    self.messageBannerView = messageBannerView
+    self.messageBannerViewController = messageBannerViewController
 
     self.saveButtonView = LoadingBarButtonItemView.instantiate()
     self.saveButtonView.setTitle(title: Strings.Save())
@@ -153,27 +152,27 @@ internal final class ChangeEmailViewController: UIViewController {
     self.viewModel.outputs.didFailToChangeEmail
       .observeForUI()
       .observeValues { [weak self] error in
-        self?.messageBannerView.showBanner(with: .error, message: error)
+        self?.messageBannerViewController.showBanner(with: .error, message: error)
     }
 
     self.viewModel.outputs.didChangeEmail
       .observeForUI()
       .observeValues { [weak self] in
-        self?.messageBannerView.showBanner(with: .success,
+        self?.messageBannerViewController.showBanner(with: .success,
                                            message: Strings.Got_it_your_changes_have_been_saved())
     }
 
     self.viewModel.outputs.didSendVerificationEmail
       .observeForUI()
       .observeValues { [weak self] in
-        self?.messageBannerView.showBanner(with: .success,
+        self?.messageBannerViewController.showBanner(with: .success,
                                            message: Strings.Verification_email_sent())
     }
 
     self.viewModel.outputs.didFailToSendVerificationEmail
       .observeForUI()
       .observeValues { [weak self] error in
-        self?.messageBannerView.showBanner(with: .error, message: error)
+        self?.messageBannerViewController.showBanner(with: .error, message: error)
     }
 
     self.viewModel.outputs.shouldSubmitForm

--- a/Kickstarter-iOS/Views/Controllers/ChangeEmailViewControllerTests.swift
+++ b/Kickstarter-iOS/Views/Controllers/ChangeEmailViewControllerTests.swift
@@ -2,6 +2,7 @@ import Prelude
 @testable import Kickstarter_Framework
 @testable import KsApi
 @testable import Library
+import XCTest
 
 final class ChangeEmailViewControllerTests: TestCase {
   override func setUp() {
@@ -79,5 +80,39 @@ final class ChangeEmailViewControllerTests: TestCase {
         FBSnapshotVerifyView(parent.view, identifier: "lang_\(language)_device_\(device)")
       }
     }
+  }
+
+  func testMessageBannerContainerIsHiddenByDefault() {
+    let controller = ChangeEmailViewController.instantiate()
+    _ = controller.view
+    let messageBannerViewController = controller.children
+      .compactMap { $0 as? MessageBannerViewController }.first
+
+    guard let containerView = messageBannerViewController?.view.superview else {
+        XCTFail("View should be created")
+        return
+    }
+
+    XCTAssertTrue(containerView.isHidden)
+  }
+
+  func testMessageBannerContainerIsHiddenIsSetProperly() {
+    let controller = ChangeEmailViewController.instantiate()
+    _ = controller.view
+    let messageBannerViewController = controller.children
+      .compactMap { $0 as? MessageBannerViewController }.first
+
+    guard let containerView = messageBannerViewController?.view.superview else {
+      XCTFail("View should be created")
+      return
+    }
+
+    controller.messageBannerViewControllerIsHidden(true)
+
+    XCTAssertTrue(containerView.isHidden)
+
+    controller.messageBannerViewControllerIsHidden(false)
+
+    XCTAssertFalse(containerView.isHidden)
   }
 }

--- a/Kickstarter-iOS/Views/Controllers/ChangePasswordViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/ChangePasswordViewController.swift
@@ -16,7 +16,7 @@ final class ChangePasswordViewController: UIViewController {
   @IBOutlet fileprivate weak var scrollView: UIScrollView!
 
   private var saveButtonView: LoadingBarButtonItemView!
-  private var messageBannerView: MessageBannerViewController!
+  private var messageBannerViewController: MessageBannerViewController!
 
   private let viewModel: ChangePasswordViewModelType = ChangePasswordViewModel()
 
@@ -27,11 +27,10 @@ final class ChangePasswordViewController: UIViewController {
   override func viewDidLoad() {
     super.viewDidLoad()
 
-    guard let messageViewController = self.children.first as? MessageBannerViewController else {
+    guard let messageBannerViewController = self.children.first as? MessageBannerViewController else {
       fatalError("Missing message View Controller")
     }
-
-    self.messageBannerView = messageViewController
+    self.messageBannerViewController = messageBannerViewController
 
     self.saveButtonView = LoadingBarButtonItemView.instantiate()
     self.saveButtonView.setTitle(title: Strings.Save())
@@ -166,7 +165,7 @@ final class ChangePasswordViewController: UIViewController {
     self.viewModel.outputs.changePasswordFailure
       .observeForControllerAction()
       .observeValues { [weak self] errorMessage in
-        self?.messageBannerView.showBanner(with: .error, message: errorMessage)
+        self?.messageBannerViewController.showBanner(with: .error, message: errorMessage)
     }
 
     self.viewModel.outputs.changePasswordSuccess

--- a/Kickstarter-iOS/Views/Controllers/ChangePasswordViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/ChangePasswordViewController.swift
@@ -10,6 +10,7 @@ final class ChangePasswordViewController: UIViewController {
   @IBOutlet fileprivate weak var currentPasswordLabel: UILabel!
   @IBOutlet fileprivate weak var currentPasswordTextField: UITextField!
   @IBOutlet fileprivate weak var validationErrorMessageLabel: UILabel!
+  @IBOutlet fileprivate weak var messageBannerContainer: UIView!
   @IBOutlet fileprivate weak var newPasswordLabel: UILabel!
   @IBOutlet fileprivate weak var newPasswordTextField: UITextField!
   @IBOutlet fileprivate weak var onePasswordButton: UIButton!
@@ -31,6 +32,7 @@ final class ChangePasswordViewController: UIViewController {
       fatalError("Missing message View Controller")
     }
     self.messageBannerViewController = messageBannerViewController
+    self.messageBannerViewController.delegate = self
 
     self.saveButtonView = LoadingBarButtonItemView.instantiate()
     self.saveButtonView.setTitle(title: Strings.Save())
@@ -292,5 +294,11 @@ final class ChangePasswordViewController: UIViewController {
 
   @IBAction func onePasswordButtonTapped(_ sender: Any) {
     self.viewModel.inputs.onePasswordButtonTapped()
+  }
+}
+
+extension ChangePasswordViewController: MessageBannerViewControllerDelegate {
+  func messageBannerViewControllerIsHidden(_ isHidden: Bool) {
+    self.messageBannerContainer.isHidden = isHidden
   }
 }

--- a/Kickstarter-iOS/Views/Controllers/ChangePasswordViewControllerTests.swift
+++ b/Kickstarter-iOS/Views/Controllers/ChangePasswordViewControllerTests.swift
@@ -2,6 +2,7 @@ import Prelude
 @testable import Kickstarter_Framework
 @testable import KsApi
 @testable import Library
+import XCTest
 
 final class ChangePasswordViewControllerTests: TestCase {
   override func setUp() {
@@ -27,5 +28,39 @@ final class ChangePasswordViewControllerTests: TestCase {
         FBSnapshotVerifyView(parent.view, identifier: "lang_\(language)_device_\(device)")
       }
     }
+  }
+
+  func testMessageBannerContainerIsHiddenByDefault() {
+    let controller = ChangePasswordViewController.instantiate()
+    _ = controller.view
+    let messageBannerViewController = controller.children
+      .compactMap { $0 as? MessageBannerViewController }.first
+
+    guard let containerView = messageBannerViewController?.view.superview else {
+      XCTFail("View should be created")
+      return
+    }
+
+    XCTAssertTrue(containerView.isHidden)
+  }
+
+  func testMessageBannerContainerIsHiddenIsSetProperly() {
+    let controller = ChangePasswordViewController.instantiate()
+    _ = controller.view
+    let messageBannerViewController = controller.children
+      .compactMap { $0 as? MessageBannerViewController }.first
+
+    guard let containerView = messageBannerViewController?.view.superview else {
+      XCTFail("View should be created")
+      return
+    }
+
+    controller.messageBannerViewControllerIsHidden(true)
+
+    XCTAssertTrue(containerView.isHidden)
+
+    controller.messageBannerViewControllerIsHidden(false)
+
+    XCTAssertFalse(containerView.isHidden)
   }
 }

--- a/Kickstarter-iOS/Views/Controllers/MessageBannerViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/MessageBannerViewController.swift
@@ -2,11 +2,17 @@ import Foundation
 import Library
 import Prelude
 
+internal protocol MessageBannerViewControllerDelegate: class {
+  func messageBannerViewControllerIsHidden(_ isHidden: Bool)
+}
+
 final class MessageBannerViewController: UIViewController {
   @IBOutlet fileprivate weak var backgroundView: UIView!
   @IBOutlet fileprivate weak var backgroundViewBottomConstraint: NSLayoutConstraint!
   @IBOutlet fileprivate weak var iconImageView: UIImageView!
   @IBOutlet fileprivate weak var messageLabel: UILabel!
+
+  internal weak var delegate: MessageBannerViewControllerDelegate?
 
   private var bottomMarginConstraintConstant: CGFloat = -Styles.grid(1)
 
@@ -71,6 +77,7 @@ final class MessageBannerViewController: UIViewController {
 
     if !isHidden {
       self.view.isHidden = isHidden
+      self.delegate?.messageBannerViewControllerIsHidden(isHidden)
     }
 
     UIView.animate(withDuration: duration, delay: 0.0,
@@ -82,9 +89,13 @@ final class MessageBannerViewController: UIViewController {
                       ? frameHeight : self.bottomMarginConstraintConstant
                     self.view.layoutIfNeeded()
     }, completion: { [weak self] _ in
-        self?.view.isHidden = isHidden
+      self?.view.isHidden = isHidden
 
-        self?.viewModel.inputs.bannerViewAnimationFinished(isHidden: isHidden)
+      if isHidden {
+        self?.delegate?.messageBannerViewControllerIsHidden(isHidden)
+      }
+
+      self?.viewModel.inputs.bannerViewAnimationFinished(isHidden: isHidden)
     })
   }
 

--- a/Kickstarter-iOS/Views/Storyboards/Settings.storyboard
+++ b/Kickstarter-iOS/Views/Storyboards/Settings.storyboard
@@ -370,7 +370,7 @@
                                     <constraint firstItem="VyE-lE-aLQ" firstAttribute="leading" secondItem="XfD-wg-Nx4" secondAttribute="leading" id="pUW-P0-AFT"/>
                                 </constraints>
                             </view>
-                            <containerView opaque="NO" contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Z5v-98-lpx">
+                            <containerView hidden="YES" opaque="NO" contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Z5v-98-lpx">
                                 <rect key="frame" x="6" y="533" width="363" height="128"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="128" id="KQp-mG-igY"/>
@@ -403,6 +403,7 @@
                     <connections>
                         <outlet property="currentEmail" destination="dhC-lf-MHP" id="W6i-3P-BKo"/>
                         <outlet property="currentEmailLabel" destination="hbC-wV-1kr" id="hSG-qw-h93"/>
+                        <outlet property="messageBannerContainer" destination="Z5v-98-lpx" id="liD-fX-zGL"/>
                         <outlet property="messageLabelView" destination="Cdr-bL-P2W" id="gSf-t3-n3p"/>
                         <outlet property="newEmailLabel" destination="shM-z1-cjb" id="tnq-XP-h0n"/>
                         <outlet property="newEmailTextField" destination="uEZ-83-bce" id="IEP-yb-Kq6"/>
@@ -621,7 +622,7 @@
                                     <constraint firstAttribute="trailing" secondItem="Jfc-kg-fPd" secondAttribute="trailing" id="ydu-rL-nNN"/>
                                 </constraints>
                             </scrollView>
-                            <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Orx-BR-Kot">
+                            <containerView hidden="YES" opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Orx-BR-Kot">
                                 <rect key="frame" x="6" y="533" width="363" height="128"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="128" id="czY-l0-0k9"/>
@@ -650,6 +651,7 @@
                         <outlet property="confirmNewPasswordTextField" destination="nrx-gx-3DV" id="7ne-sN-e2c"/>
                         <outlet property="currentPasswordLabel" destination="RKC-vo-zm6" id="aSc-hB-eXt"/>
                         <outlet property="currentPasswordTextField" destination="l9b-mM-SUG" id="efL-Fe-Rqn"/>
+                        <outlet property="messageBannerContainer" destination="Orx-BR-Kot" id="9bc-mG-Asv"/>
                         <outlet property="newPasswordLabel" destination="K1u-LI-jmm" id="RP0-n7-kMJ"/>
                         <outlet property="newPasswordTextField" destination="tPP-5U-zGh" id="ejC-0t-96q"/>
                         <outlet property="onePasswordButton" destination="Ml8-qx-02m" id="OXX-ho-87N"/>
@@ -757,6 +759,6 @@
         <image name="onepassword-button" width="27" height="27"/>
     </resources>
     <inferredMetricsTieBreakers>
-        <segue reference="npK-7h-4nS"/>
+        <segue reference="S9b-Nx-mWW"/>
     </inferredMetricsTieBreakers>
 </document>


### PR DESCRIPTION
# What

Addresses a small issue with the message banner's container view preventing it from scrolling (or any user interaction) on the `change email` & `change password` screens.

# Why

#484 has properly added elasticity to both `change email` & `change password` screens. Unfortunately due to the fact that the banner container view is presented above the scroll view it can intercept touches and prevent the scroll view to scroll.

This can be very easily reproduced by trying to swipe in the bottom area (where the container is overlaying the scroll view). Since the container is invisible it might appear like nothing should block the touch events, but it actually is.

# How

In order to fix this we can simply set the `isHidden` property on the container. To follow iOS standards this can be done using a `delegate` call from it's child. We can simply do this in the child controller (`MessageBannerViewController`) but to be a good citizen and follow best practices we need to do this in the parent `ChangeEmailViewController` & `ChangePasswordViewController` that has a control of the container view.

# See 👀

| Before | After |
| --- | --- |
| ![before](https://user-images.githubusercontent.com/387596/48808420-9d892480-ecd5-11e8-8594-a4da0a03dfb7.gif) | ![after](https://user-images.githubusercontent.com/387596/48808426-a4b03280-ecd5-11e8-8343-44b08bee760f.gif) |
