### PR TITLE
Settings tracking vol 2

### DIFF
--- a/Kickstarter-iOS/Views/Controllers/ChangeEmailViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/ChangeEmailViewController.swift
@@ -57,6 +57,12 @@ internal final class ChangeEmailViewController: UIViewController {
     self.viewModel.inputs.viewDidLoad()
   }
 
+  override func viewDidAppear(_ animated: Bool) {
+    super.viewDidAppear(animated)
+
+    self.viewModel.inputs.viewDidAppear()
+  }
+
   override func bindStyles() {
     super.bindStyles()
 

--- a/Kickstarter-iOS/Views/Controllers/SettingsAccountViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/SettingsAccountViewController.swift
@@ -32,6 +32,12 @@ final class SettingsAccountViewController: UIViewController {
     self.viewModel.inputs.viewDidLoad()
   }
 
+  override func viewDidAppear(_ animated: Bool) {
+    super.viewDidAppear(animated)
+
+    self.viewModel.inputs.viewDidAppear()
+  }
+
   override func bindViewModel() {
     self.viewModel.outputs.reloadData
       .observeForUI()

--- a/Library/Koala/Koala.swift
+++ b/Library/Koala/Koala.swift
@@ -438,7 +438,7 @@ public final class Koala {
     self.track(event: "Triggered 1Password")
   }
 
-  // MARK: Discovery Events
+  // MARK: - Discovery Events
 
   /**
    Call when a discovery search is made, including pagination.
@@ -534,7 +534,7 @@ public final class Koala {
       ])
   }
 
-  // MARK: Checkout Events
+  // MARK: - Checkout Events
   public func trackCheckoutCancel(project: Project,
                                   reward: Reward,
                                   pledgeContext: PledgeContext) {
@@ -630,7 +630,7 @@ public final class Koala {
     self.track(event: "Closed Reward", properties: props)
   }
 
-  // MARK: Login Events
+  // MARK: - Login Events
   public func trackLoginTout(intent: LoginIntent) {
     // Deprecated event
     self.track(event: "Application Login or Signup",
@@ -712,7 +712,7 @@ public final class Koala {
     self.track(event: "Resent Two-Factor Code")
   }
 
-  // MARK: Signup
+  // MARK: - Signup
 
   // Call when an error is returned after attempting to signup.
   public func trackSignupError(authType: AuthType) {
@@ -738,7 +738,7 @@ public final class Koala {
     self.track(event: "Viewed Signup")
   }
 
-  // MARK: Comments Events
+  // MARK: - Comments Events
   public func trackLoadNewerComments(project: Project, update: Update?, context: CommentsContext) {
     let props = properties(project: project, loggedInUser: self.loggedInUser)
       .withAllValuesFrom(update.map { properties(update: $0) } ?? [:])
@@ -1007,7 +1007,7 @@ public final class Koala {
                properties: properties(project: project, loggedInUser: self.loggedInUser))
   }
 
-  // MARK: Dashboard
+  // MARK: - Dashboard
   public func trackDashboardClosedProjectSwitcher(onProject project: Project) {
     self.track(event: "Closed Project Switcher",
                properties: properties(project: project, loggedInUser: self.loggedInUser))
@@ -1048,7 +1048,7 @@ public final class Koala {
                properties: props.withAllValuesFrom(deprecatedProps))
   }
 
-  // MARK: Project activity
+  // MARK: - Project activity
   public func trackViewedProjectActivity(project: Project) {
     let props = properties(project: project, loggedInUser: self.loggedInUser)
 
@@ -1077,7 +1077,7 @@ public final class Koala {
                properties: props.withAllValuesFrom(deprecatedProps))
   }
 
-  // MARK: Messages
+  // MARK: - Messages
 
   public func trackMessageThreadsView(mailbox: Mailbox, project: Project?, refTag: RefTag) {
     let props = (project.flatMap { properties(project: $0, loggedInUser: self.loggedInUser) } ?? [:])
@@ -1154,7 +1154,7 @@ public final class Koala {
     self.track(event: "Sent Message", properties: props)
   }
 
-  // MARK: Search Events
+  // MARK: - Search Events
   /// Call once when the search view is initially shown.
   public func trackProjectSearchView() {
     self.track(event: "Discover Search", properties: deprecatedProps)
@@ -1184,7 +1184,7 @@ public final class Koala {
     self.track(event: "Cleared Search Term")
   }
 
-  // MARK: Project Events
+  // MARK: - Project Events
   /**
    Call when a project page is viewed.
 
@@ -1253,7 +1253,7 @@ public final class Koala {
     self.track(event: "Opened External Link", properties: props)
   }
 
-  // MARK: Profile Events
+  // MARK: - Profile Events
   public func trackProfileView() {
     // deprecated
     self.track(event: "Profile View My", properties: deprecatedProps)
@@ -1265,7 +1265,7 @@ public final class Koala {
     self.track(event: "Viewed Profile Tab", properties: ["type": projectsType.trackingString])
   }
 
-  // MARK: Settings Events
+  // MARK: - Settings Events
   public func trackAppStoreRatingOpen() {
     // deprecated
     self.track(event: "App Store Rating Open", properties: deprecatedProps)
@@ -1290,6 +1290,30 @@ public final class Koala {
   public func trackChangeEmailNotification(type: String, on: Bool) {
     self.track(event: on ? "Enabled Email Notifications" : "Disabled Email Notifications",
                properties: ["type": type])
+  }
+
+  public func trackAccountView() {
+    self.track(event: "Viewed Account")
+  }
+
+  public func trackChangeEmailView() {
+    self.track(event: "Viewed Change Email")
+  }
+
+  public func trackChangeEmail() {
+    self.track(event: "Changed Email")
+  }
+
+  public func trackChangePasswordView() {
+    self.track(event: "Viewed Change Password")
+  }
+
+  public func trackChangePassword() {
+    self.track(event: "Changed Password")
+  }
+
+  public func trackResentVerificationEmail() {
+    self.track(event: "Resent Verification Email")
   }
 
   /**
@@ -1355,7 +1379,7 @@ public final class Koala {
     self.track(event: "Viewed Settings")
   }
 
-  // MARK: Find Friends Events
+  // MARK: - Find Friends Events
   public func trackCloseFacebookConnect(source: FriendsSource) {
     self.track(event: "Close Facebook Connect", properties: ["source": source.trackingString])
   }
@@ -1433,7 +1457,7 @@ public final class Koala {
       properties: ["source": source.trackingString, "page_count": pageCount])
   }
 
-  // MARK: Update Draft Events
+  // MARK: - Update Draft Events
 
   public func trackViewedUpdateDraft(forProject project: Project) {
     self.track(event: "Viewed Draft", properties: updateDraftProperties(project: project))
@@ -1528,7 +1552,7 @@ public final class Koala {
     return props
   }
 
-  // MARK: Pledge screen events
+  // MARK: - Pledge screen events
   public func trackViewedPledge(forProject project: Project) {
     self.track(event: "Viewed Pledge Info",
                properties: properties(project: project, loggedInUser: self.loggedInUser))
@@ -1538,7 +1562,7 @@ public final class Koala {
                properties: ["modal_class": "backer_info", Koala.DeprecatedKey: true])
   }
 
-  // MARK: Help events
+  // MARK: - Help events
   public func trackCanceledContactEmail(context: HelpContext) {
     self.track(event: "Canceled Contact Email", properties: ["context": context.trackingString])
   }
@@ -1570,7 +1594,7 @@ public final class Koala {
     self.track(event: "Showed Help Menu", properties: ["context": context.trackingString])
   }
 
-  // MARK: Video events
+  // MARK: - Video events
   public func trackVideoCompleted(forProject project: Project) {
     // deprecated
     self.track(event: "Project Video Complete", properties: deprecatedProps)
@@ -1603,7 +1627,7 @@ public final class Koala {
                properties: properties(project: project, loggedInUser: self.loggedInUser))
   }
 
-  // MARK: Apple Pay events
+  // MARK: - Apple Pay events
 
   public func trackShowApplePaySheet(project: Project,
                                      reward: Reward,
@@ -1683,7 +1707,7 @@ public final class Koala {
     self.track(event: "Canceled Apple Pay", properties: props)
   }
 
-  // MARK: Empty State Events
+  // MARK: - Empty State Events
   public func trackEmptyStateViewed(type: EmptyState) {
     self.track(event: "Viewed Empty State",
                properties: ["type": type.rawValue])
@@ -1727,7 +1751,7 @@ public final class Koala {
     )
   }
 
-  // MARK: Live streams
+  // MARK: - Live streams
   public func trackChangedLiveStreamOrientation(project: Project,
                                                 liveStreamEvent: LiveStreamEvent,
                                                 toOrientation: UIInterfaceOrientation) {

--- a/Library/Koala/KoalaTests.swift
+++ b/Library/Koala/KoalaTests.swift
@@ -614,4 +614,49 @@ final class KoalaTests: TestCase {
     XCTAssertEqual("Apple", client.properties.last?["manufacturer"] as? String)
     XCTAssertEqual("Apple", callBackProperties?["manufacturer"] as? String)
   }
+
+  func testTrackViewedAccount() {
+    let client = MockTrackingClient()
+    let koala = Koala(client: client)
+
+    koala.trackAccountView()
+
+    XCTAssertEqual(["Viewed Account"], client.events)
+  }
+
+  func testTrackViewedChangeEmail() {
+    let client = MockTrackingClient()
+    let koala = Koala(client: client)
+
+    koala.trackChangeEmailView()
+
+    XCTAssertEqual(["Viewed Change Email"], client.events)
+  }
+
+  func testTrackChangeEmail() {
+    let client = MockTrackingClient()
+    let koala = Koala(client: client)
+
+    koala.trackChangeEmail()
+
+    XCTAssertEqual(["Changed Email"], client.events)
+  }
+
+  func testTrackViewedChangePassword() {
+    let client = MockTrackingClient()
+    let koala = Koala(client: client)
+
+    koala.trackChangePasswordView()
+
+    XCTAssertEqual(["Viewed Change Password"], client.events)
+  }
+
+  func testTrackChangePassword() {
+    let client = MockTrackingClient()
+    let koala = Koala(client: client)
+
+    koala.trackChangePassword()
+
+    XCTAssertEqual(["Changed Password"], client.events)
+  }
 }

--- a/Library/ViewModels/ChangeEmailViewModel.swift
+++ b/Library/ViewModels/ChangeEmailViewModel.swift
@@ -16,6 +16,7 @@ public protocol ChangeEmailViewModelInputs {
   func submitForm(newEmail: String?, password: String?)
   func textFieldShouldReturn(with returnKeyType: UIReturnKeyType)
   func viewDidLoad()
+  func viewDidAppear()
 }
 
 public protocol ChangeEmailViewModelOutputs {
@@ -161,6 +162,9 @@ ChangeEmailViewModelOutputs {
       self.didChangeEmail.mapConst(false),
       self.didFailToChangeEmail.mapConst(false)
     )
+
+    self.viewDidAppearProperty.signal
+      .observeValues { _ in AppEnvironment.current.koala.trackChangeEmailView() }
   }
 
   private let newEmailProperty = MutableProperty<String?>(nil)
@@ -205,6 +209,11 @@ ChangeEmailViewModelOutputs {
   private let viewDidLoadProperty = MutableProperty(())
   public func viewDidLoad() {
     self.viewDidLoadProperty.value = ()
+  }
+
+  private let viewDidAppearProperty = MutableProperty(())
+  public func viewDidAppear() {
+    self.viewDidAppearProperty.value = ()
   }
 
   private let changePasswordProperty = MutableProperty<(String, String)?>(nil)

--- a/Library/ViewModels/ChangeEmailViewModel.swift
+++ b/Library/ViewModels/ChangeEmailViewModel.swift
@@ -143,6 +143,9 @@ ChangeEmailViewModelOutputs {
     self.onePasswordFindLoginForURLString = self.onePasswordButtonTappedProperty.signal
       .map { AppEnvironment.current.apiService.serverConfig.webBaseUrl.absoluteString }
 
+    changeEmailEvent.values()
+      .observeValues { _ in AppEnvironment.current.koala.trackChangeEmail() }
+
     self.didChangeEmail = changeEmailEvent.values().ignoreValues()
 
     self.resetFields = changeEmailEvent.values()

--- a/Library/ViewModels/ChangeEmailViewModel.swift
+++ b/Library/ViewModels/ChangeEmailViewModel.swift
@@ -81,6 +81,9 @@ ChangeEmailViewModelOutputs {
           .materialize()
     }
 
+    resendEmailVerificationEvent.values()
+      .observeValues { _ in AppEnvironment.current.koala.trackResentVerificationEmail() }
+
     self.didSendVerificationEmail = resendEmailVerificationEvent.values().ignoreValues()
 
     self.didFailToSendVerificationEmail = resendEmailVerificationEvent.errors()

--- a/Library/ViewModels/ChangeEmailViewModelTests.swift
+++ b/Library/ViewModels/ChangeEmailViewModelTests.swift
@@ -401,4 +401,22 @@ final class ChangeEmailViewModelTests: TestCase {
       XCTAssertEqual(["Changed Email", "Changed Email"], client.events)
     }
   }
+
+  func testTrackResendVerificationEmail() {
+    let client = MockTrackingClient()
+
+    withEnvironment(koala: Koala(client: client)) {
+      XCTAssertEqual([], client.events)
+
+      self.vm.inputs.resendVerificationEmailButtonTapped()
+      self.scheduler.advance()
+
+      XCTAssertEqual(["Resent Verification Email"], client.events)
+
+      self.vm.inputs.resendVerificationEmailButtonTapped()
+      self.scheduler.advance()
+
+      XCTAssertEqual(["Resent Verification Email", "Resent Verification Email"], client.events)
+    }
+  }
 }

--- a/Library/ViewModels/ChangeEmailViewModelTests.swift
+++ b/Library/ViewModels/ChangeEmailViewModelTests.swift
@@ -383,4 +383,22 @@ final class ChangeEmailViewModelTests: TestCase {
       XCTAssertEqual(["Viewed Change Email", "Viewed Change Email"], client.events)
     }
   }
+
+  func testTrackChangeEmail() {
+    let client = MockTrackingClient()
+
+    withEnvironment(koala: Koala(client: client)) {
+      XCTAssertEqual([], client.events)
+
+      self.vm.inputs.submitForm(newEmail: "ksr@kickstarter.com", password: "123456")
+      self.scheduler.advance()
+
+      XCTAssertEqual(["Changed Email"], client.events)
+
+      self.vm.inputs.submitForm(newEmail: "ksr@kickstarter.com", password: "123456")
+      self.scheduler.advance()
+
+      XCTAssertEqual(["Changed Email", "Changed Email"], client.events)
+    }
+  }
 }

--- a/Library/ViewModels/ChangeEmailViewModelTests.swift
+++ b/Library/ViewModels/ChangeEmailViewModelTests.swift
@@ -367,4 +367,20 @@ final class ChangeEmailViewModelTests: TestCase {
     self.vm.inputs.saveButtonTapped(newEmail: "", password: "")
     self.shouldSubmitForm.assertValueCount(2)
   }
+
+  func testTrackViewedChangeEmail() {
+    let client = MockTrackingClient()
+
+    withEnvironment(koala: Koala(client: client)) {
+      XCTAssertEqual([], client.events)
+
+      self.vm.inputs.viewDidAppear()
+
+      XCTAssertEqual(["Viewed Change Email"], client.events)
+
+      self.vm.inputs.viewDidAppear()
+
+      XCTAssertEqual(["Viewed Change Email", "Viewed Change Email"], client.events)
+    }
+  }
 }

--- a/Library/ViewModels/ChangePasswordViewModel.swift
+++ b/Library/ViewModels/ChangePasswordViewModel.swift
@@ -92,6 +92,9 @@ ChangePasswordViewModelInputs, ChangePasswordViewModelOutputs {
           .materialize()
     }
 
+    passwordUpdateEvent.values()
+      .observeValues { _ in AppEnvironment.current.koala.trackChangePassword() }
+
     self.changePasswordSuccess = passwordUpdateEvent.values().ignoreValues()
     self.changePasswordFailure = passwordUpdateEvent.errors().map { $0.localizedDescription }
 

--- a/Library/ViewModels/ChangePasswordViewModel.swift
+++ b/Library/ViewModels/ChangePasswordViewModel.swift
@@ -126,6 +126,9 @@ ChangePasswordViewModelInputs, ChangePasswordViewModelOutputs {
         }
     }.skipNil()
     .skipRepeats()
+
+    self.viewDidAppearProperty.signal
+      .observeValues { _ in AppEnvironment.current.koala.trackChangePasswordView() }
   }
 
   private var currentPasswordDoneEditingProperty = MutableProperty(())

--- a/Library/ViewModels/ChangePasswordViewModelTests.swift
+++ b/Library/ViewModels/ChangePasswordViewModelTests.swift
@@ -152,4 +152,20 @@ final class ChangePasswordViewModelTests: TestCase {
       self.activityIndicatorShouldShowObserver.assertValues([true, false])
     }
   }
+
+  func testTrackViewedChangePassword() {
+    let client = MockTrackingClient()
+
+    withEnvironment(koala: Koala(client: client)) {
+      XCTAssertEqual([], client.events)
+
+      self.vm.inputs.viewDidAppear()
+
+      XCTAssertEqual(["Viewed Change Password"], client.events)
+
+      self.vm.inputs.viewDidAppear()
+
+      XCTAssertEqual(["Viewed Change Password", "Viewed Change Password"], client.events)
+    }
+  }
 }

--- a/Library/ViewModels/ChangePasswordViewModelTests.swift
+++ b/Library/ViewModels/ChangePasswordViewModelTests.swift
@@ -168,4 +168,19 @@ final class ChangePasswordViewModelTests: TestCase {
       XCTAssertEqual(["Viewed Change Password", "Viewed Change Password"], client.events)
     }
   }
+
+  func testTrackChangePassword() {
+    let service = MockService()
+    let client = MockTrackingClient()
+
+    withEnvironment(apiService: service, koala: Koala(client: client)) {
+      self.vm.inputs.currentPasswordFieldDidReturn(currentPassword: "password")
+      self.vm.inputs.newPasswordFieldDidReturn(newPassword: "123456")
+      self.vm.inputs.newPasswordConfirmationFieldDidReturn(newPasswordConfirmed: "123456")
+
+      self.scheduler.advance()
+
+      XCTAssertEqual(["Changed Password"], client.events)
+    }
+  }
 }

--- a/Library/ViewModels/SettingsAccountViewModel.swift
+++ b/Library/ViewModels/SettingsAccountViewModel.swift
@@ -9,6 +9,7 @@ public protocol SettingsAccountViewModelInputs {
   func didSelectRow(cellType: SettingsAccountCellType)
   func showChangeCurrencyAlert(for currency: Currency)
   func viewDidLoad()
+  func viewDidAppear()
 }
 
 public protocol SettingsAccountViewModelOutputs {
@@ -81,6 +82,9 @@ SettingsAccountViewModelOutputs, SettingsAccountViewModelType {
       .skipNil()
 
     self.showAlert = self.changeCurrencyAlertProperty.signal.skipNil().ignoreValues()
+
+    self.viewDidAppearProperty.signal
+      .observeValues { _ in AppEnvironment.current.koala.trackAccountView() }
   }
 
   fileprivate let selectedCellTypeProperty = MutableProperty<SettingsAccountCellType?>(nil)
@@ -106,6 +110,11 @@ SettingsAccountViewModelOutputs, SettingsAccountViewModelType {
   fileprivate let viewDidLoadProperty = MutableProperty(())
   public func viewDidLoad() {
     self.viewDidLoadProperty.value = ()
+  }
+
+  fileprivate let viewDidAppearProperty = MutableProperty(())
+  public func viewDidAppear() {
+    self.viewDidAppearProperty.value = ()
   }
 
   public let dismissCurrencyPicker: Signal<Void, NoError>

--- a/Library/ViewModels/SettingsAccountViewModelTests.swift
+++ b/Library/ViewModels/SettingsAccountViewModelTests.swift
@@ -78,4 +78,20 @@ internal final class SettingsAccountViewModelTests: TestCase {
       self.updateCurrencyFailure.assertDidEmitValue()
     }
   }
+
+  func testTrackViewedAccount() {
+    let client = MockTrackingClient()
+
+    withEnvironment(koala: Koala(client: client)) {
+      XCTAssertEqual([], client.events)
+
+      self.vm.inputs.viewDidAppear()
+
+      XCTAssertEqual(["Viewed Account"], client.events)
+
+      self.vm.inputs.viewDidAppear()
+
+      XCTAssertEqual(["Viewed Account", "Viewed Account"], client.events)
+    }
+  }
 }


### PR DESCRIPTION
# What

Adds tracking for the following events:
* Viewed Account
* Viewed Change Email
* Viewed Change Password
* Changed Email
* Changed Password
* Resent Verification Email 

# Why

Tracking the new settings screens #YOLO

# How

Viewed events are triggered on `viewDidAppear` in order for us to being able to observe navigating to the screen repeatedly on the navigation stack.
Action events are pretty straightforward

# Todo

- [ ] Double check events are being sent to `Looker`

# Acceptance criteria

- [x] Navigating to `Account` from Settings tracks `Viewed Account` in Looker
- [x] Navigating back to `Account` from `Change email` / `Change password` screens tracks `Viewed Account` in Looker
- [x] Navigating to `Change email` from `Account` tracks `Viewed Change Email` tracks `Viewed Change Email` in Looker
- [x] Navigating to `Change password` from `Account` tracks `Viewed Change Password` tracks `Viewed Change Password` in Looker
- [ ] Successfully changing email on the `Change email` screen tracks `Changed Email` in Looker
- [ ] Successfully changing password on the `Change password` screen tracks `Changed Password` in Looker
- [ ] Taping the re-send or send verification email button tracks `Resent Verification Email ` in Looker