### PR TITLE
Randomize test execution order

### DIFF
--- a/Kickstarter.xcodeproj/xcshareddata/xcschemes/Kickstarter-iOS.xcscheme
+++ b/Kickstarter.xcodeproj/xcshareddata/xcschemes/Kickstarter-iOS.xcscheme
@@ -45,7 +45,8 @@
       <Testables>
          <TestableReference
             skipped = "NO"
-            parallelizable = "YES">
+            parallelizable = "YES"
+            testExecutionOrdering = "random">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "A75511441C8642B3005355CF"
@@ -56,7 +57,8 @@
          </TestableReference>
          <TestableReference
             skipped = "NO"
-            parallelizable = "YES">
+            parallelizable = "YES"
+            testExecutionOrdering = "random">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "A7D1F9591C850B7C000D41D5"
@@ -67,7 +69,8 @@
          </TestableReference>
          <TestableReference
             skipped = "NO"
-            parallelizable = "YES">
+            parallelizable = "YES"
+            testExecutionOrdering = "random">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "A7BA54311E1E493600E54377"
@@ -78,7 +81,8 @@
          </TestableReference>
          <TestableReference
             skipped = "NO"
-            parallelizable = "YES">
+            parallelizable = "YES"
+            testExecutionOrdering = "random">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "D01587571EEB2DE4006E7684"


### PR DESCRIPTION
# 📲 What

Randomize test execution order

# 🤔 Why

Now that Xcode 10 has added the ability to make test execution order random we should use this option to prove that tests are independent of each other.

# 🛠 How

Simply enable this option in scheme editor
 
<img width="1148" alt="screen shot 2018-11-23 at 4 15 38 pm" src="https://user-images.githubusercontent.com/387596/48962858-7f246280-ef3b-11e8-9660-142d2bb77778.png">

# ✅ Acceptance criteria

- [x] All tests pass