### PR TITLE
FunSwift2018: Reactive view models, simplified

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,3 +22,6 @@
 [submodule "Frameworks/Runes"]
 	path = Frameworks/Runes
 	url = https://github.com/thoughtbot/Runes.git
+[submodule "Frameworks/ReactiveCocoa"]
+	path = Frameworks/ReactiveCocoa
+	url = https://github.com/ReactiveCocoa/ReactiveCocoa.git

--- a/Kickstarter-iOS/Views/Controllers/SignupViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/SignupViewController.swift
@@ -2,6 +2,8 @@ import Library
 import MessageUI
 import Prelude
 import Prelude_UIKit
+import ReactiveCocoa
+import ReactiveSwift
 import UIKit
 
 internal final class SignupViewController: UIViewController, MFMailComposeViewControllerDelegate {

--- a/Kickstarter-iOS/Views/Storyboards/Login.storyboard
+++ b/Kickstarter-iOS/Views/Storyboards/Login.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14313.18" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14283.14"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -298,9 +298,6 @@
                                                                                     <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="1000" verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="vep-Pb-kEj">
                                                                                         <rect key="frame" x="299" y="12" width="51" height="31"/>
                                                                                         <color key="onTintColor" red="0.01176470588" green="0.45098039220000002" blue="0.38431372549999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                                                        <connections>
-                                                                                            <action selector="weeklyNewsletterChanged:" destination="NFm-bM-Ukr" eventType="valueChanged" id="fbw-oz-WLe"/>
-                                                                                        </connections>
                                                                                     </switch>
                                                                                 </subviews>
                                                                                 <edgeInsets key="layoutMargins" top="12" left="12" bottom="12" right="12"/>

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -1078,6 +1078,104 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		800134C521B2552D001EB680 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 8001349421B2552D001EB680 /* ReactiveCocoa.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = D04725EA19E49ED7006002AA;
+			remoteInfo = "ReactiveCocoa-macOS";
+		};
+		800134C721B2552D001EB680 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 8001349421B2552D001EB680 /* ReactiveCocoa.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = D04725F519E49ED7006002AA;
+			remoteInfo = "ReactiveCocoa-macOSTests";
+		};
+		800134C921B2552D001EB680 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 8001349421B2552D001EB680 /* ReactiveCocoa.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = D047260C19E49F82006002AA;
+			remoteInfo = "ReactiveCocoa-iOS";
+		};
+		800134CB21B2552D001EB680 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 8001349421B2552D001EB680 /* ReactiveCocoa.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = D047261619E49F82006002AA;
+			remoteInfo = "ReactiveCocoa-iOSTests";
+		};
+		800134CD21B2552D001EB680 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 8001349421B2552D001EB680 /* ReactiveCocoa.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = A9B315541B3940610001CB9C;
+			remoteInfo = "ReactiveCocoa-watchOS";
+		};
+		800134CF21B2552D001EB680 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 8001349421B2552D001EB680 /* ReactiveCocoa.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 57A4D2411BA13D7A00F7D4B1;
+			remoteInfo = "ReactiveCocoa-tvOS";
+		};
+		800134D121B2552D001EB680 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 8001349421B2552D001EB680 /* ReactiveCocoa.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 7DFBED031CDB8C9500EE435B;
+			remoteInfo = "ReactiveCocoa-tvOSTests";
+		};
+		800134D321B2552D001EB680 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 8001349421B2552D001EB680 /* ReactiveCocoa.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 9AC03A571F7CC3BF00EC33C1;
+			remoteInfo = "ReactiveMapKit-macOS";
+		};
+		800134D521B2552D001EB680 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 8001349421B2552D001EB680 /* ReactiveCocoa.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 9A73DFF8216D3CEB0069AD76;
+			remoteInfo = "ReactiveMapKitTests-macOS";
+		};
+		800134D721B2552D001EB680 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 8001349421B2552D001EB680 /* ReactiveCocoa.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 9A73DFBB216D3C550069AD76;
+			remoteInfo = "ReactiveMapKit-iOS";
+		};
+		800134D921B2552D001EB680 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 8001349421B2552D001EB680 /* ReactiveCocoa.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 9A16753D1F80C35100B63650;
+			remoteInfo = "ReactiveMapKitTests-iOS";
+		};
+		800134DB21B2552D001EB680 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 8001349421B2552D001EB680 /* ReactiveCocoa.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 9A73DFCC216D3C570069AD76;
+			remoteInfo = "ReactiveMapKit-tvOS";
+		};
+		800134DD21B2552D001EB680 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 8001349421B2552D001EB680 /* ReactiveCocoa.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 9A73E013216D3CEE0069AD76;
+			remoteInfo = "ReactiveMapKitTests-tvOS";
+		};
+		800134F521B25534001EB680 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 8001349421B2552D001EB680 /* ReactiveCocoa.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = D047260B19E49F82006002AA;
+			remoteInfo = "ReactiveCocoa-iOS";
+		};
 		80388E201F21429100B2EE88 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = A7E06C711C5A6EB300EBDCC2 /* Project object */;
@@ -1915,6 +2013,7 @@
 		77FD8B43216D6167000A95AC /* LoadingBarButtonItemView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = LoadingBarButtonItemView.xib; sourceTree = "<group>"; };
 		77FD8B45216D6245000A95AC /* LoadingBarButtonItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingBarButtonItemView.swift; sourceTree = "<group>"; };
 		7DD8EE231F02DBED0070B63D /* Bolts.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Bolts.framework; path = Frameworks/FBSDK/iOS/Bolts.framework; sourceTree = "<group>"; };
+		8001349421B2552D001EB680 /* ReactiveCocoa.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = ReactiveCocoa.xcodeproj; path = Frameworks/ReactiveCocoa/ReactiveCocoa.xcodeproj; sourceTree = "<group>"; };
 		8001D4971D41568C009E6667 /* UpdateDraftStyles.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UpdateDraftStyles.swift; sourceTree = "<group>"; };
 		8016BFE71D0F582D00067956 /* String+Whitespace.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+Whitespace.swift"; sourceTree = "<group>"; };
 		802800571C88F64D00141235 /* Base.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Base.xcconfig; path = Configs/Base.xcconfig; sourceTree = "<group>"; };
@@ -2975,6 +3074,26 @@
 			path = queries;
 			sourceTree = "<group>";
 		};
+		8001349521B2552D001EB680 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				800134C621B2552D001EB680 /* ReactiveCocoa.framework */,
+				800134C821B2552D001EB680 /* ReactiveCocoaTests.xctest */,
+				800134CA21B2552D001EB680 /* ReactiveCocoa.framework */,
+				800134CC21B2552D001EB680 /* ReactiveCocoaTests.xctest */,
+				800134CE21B2552D001EB680 /* ReactiveCocoa.framework */,
+				800134D021B2552D001EB680 /* ReactiveCocoa.framework */,
+				800134D221B2552D001EB680 /* ReactiveCocoaTests.xctest */,
+				800134D421B2552D001EB680 /* ReactiveMapKit.framework */,
+				800134D621B2552D001EB680 /* ReactiveMapKitTests.xctest */,
+				800134D821B2552D001EB680 /* ReactiveMapKit.framework */,
+				800134DA21B2552D001EB680 /* ReactiveMapKitTests.xctest */,
+				800134DC21B2552D001EB680 /* ReactiveMapKit.framework */,
+				800134DE21B2552D001EB680 /* ReactiveMapKitTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
 		802800561C88F62500141235 /* Configs */ = {
 			isa = PBXGroup;
 			children = (
@@ -3766,6 +3885,7 @@
 				D04277E81EEB08E100600E9C /* Curry.xcodeproj */,
 				A73778921D819736004C2A9B /* FBSnapshotTestCase.xcodeproj */,
 				D04277F71EEB08E900600E9C /* Prelude.xcodeproj */,
+				8001349421B2552D001EB680 /* ReactiveCocoa.xcodeproj */,
 				D04278131EEB08F100600E9C /* ReactiveExtensions.xcodeproj */,
 				D0745B311EEB0B5D00FA53D3 /* ReactiveSwift.xcodeproj */,
 				D01BE9D81F02598A0064C1D9 /* Result.xcodeproj */,
@@ -4615,6 +4735,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				800134F621B25534001EB680 /* PBXTargetDependency */,
 				A709698B1D14685C00DB39D3 /* PBXTargetDependency */,
 				A70969891D14685600DB39D3 /* PBXTargetDependency */,
 				A76E0A4C1D00C00500EC525A /* PBXTargetDependency */,
@@ -4829,6 +4950,10 @@
 					ProjectRef = D04277F71EEB08E900600E9C /* Prelude.xcodeproj */;
 				},
 				{
+					ProductGroup = 8001349521B2552D001EB680 /* Products */;
+					ProjectRef = 8001349421B2552D001EB680 /* ReactiveCocoa.xcodeproj */;
+				},
+				{
 					ProductGroup = D04278141EEB08F100600E9C /* Products */;
 					ProjectRef = D04278131EEB08F100600E9C /* ReactiveExtensions.xcodeproj */;
 				},
@@ -4861,6 +4986,97 @@
 /* End PBXProject section */
 
 /* Begin PBXReferenceProxy section */
+		800134C621B2552D001EB680 /* ReactiveCocoa.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = ReactiveCocoa.framework;
+			remoteRef = 800134C521B2552D001EB680 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		800134C821B2552D001EB680 /* ReactiveCocoaTests.xctest */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.cfbundle;
+			path = ReactiveCocoaTests.xctest;
+			remoteRef = 800134C721B2552D001EB680 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		800134CA21B2552D001EB680 /* ReactiveCocoa.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = ReactiveCocoa.framework;
+			remoteRef = 800134C921B2552D001EB680 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		800134CC21B2552D001EB680 /* ReactiveCocoaTests.xctest */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.cfbundle;
+			path = ReactiveCocoaTests.xctest;
+			remoteRef = 800134CB21B2552D001EB680 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		800134CE21B2552D001EB680 /* ReactiveCocoa.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = ReactiveCocoa.framework;
+			remoteRef = 800134CD21B2552D001EB680 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		800134D021B2552D001EB680 /* ReactiveCocoa.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = ReactiveCocoa.framework;
+			remoteRef = 800134CF21B2552D001EB680 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		800134D221B2552D001EB680 /* ReactiveCocoaTests.xctest */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.cfbundle;
+			path = ReactiveCocoaTests.xctest;
+			remoteRef = 800134D121B2552D001EB680 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		800134D421B2552D001EB680 /* ReactiveMapKit.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = ReactiveMapKit.framework;
+			remoteRef = 800134D321B2552D001EB680 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		800134D621B2552D001EB680 /* ReactiveMapKitTests.xctest */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.cfbundle;
+			path = ReactiveMapKitTests.xctest;
+			remoteRef = 800134D521B2552D001EB680 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		800134D821B2552D001EB680 /* ReactiveMapKit.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = ReactiveMapKit.framework;
+			remoteRef = 800134D721B2552D001EB680 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		800134DA21B2552D001EB680 /* ReactiveMapKitTests.xctest */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.cfbundle;
+			path = ReactiveMapKitTests.xctest;
+			remoteRef = 800134D921B2552D001EB680 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		800134DC21B2552D001EB680 /* ReactiveMapKit.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = ReactiveMapKit.framework;
+			remoteRef = 800134DB21B2552D001EB680 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		800134DE21B2552D001EB680 /* ReactiveMapKitTests.xctest */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.cfbundle;
+			path = ReactiveMapKitTests.xctest;
+			remoteRef = 800134DD21B2552D001EB680 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
 		80762DF31D071BCF0074189D /* AlamofireImage.framework */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.framework;
@@ -6467,6 +6683,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		800134F621B25534001EB680 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "ReactiveCocoa-iOS";
+			targetProxy = 800134F521B25534001EB680 /* PBXContainerItemProxy */;
+		};
 		80388E211F21429100B2EE88 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = A7BA54281E1E493500E54377 /* LiveStream */;

--- a/Library/ViewModels/SignupViewModel.swift
+++ b/Library/ViewModels/SignupViewModel.swift
@@ -5,60 +5,26 @@ import ReactiveSwift
 import Result
 
 public protocol SignupViewModelInputs {
-  /// Call when the user enters a new email address.
   func emailChanged(_ email: String)
-
-  /// Call when the user returns from email text field.
   func emailTextFieldReturn()
-
-  /// Call when the environment has been logged into
   func environmentLoggedIn()
-
-  /// Call when the user enters a new name.
   func nameChanged(_ name: String)
-
-  /// Call when the user returns from the name text field.
   func nameTextFieldReturn()
-
-  /// Call when the user enters a new password.
   func passwordChanged(_ password: String)
-
-  /// Call when the user returns from the password text field.
   func passwordTextFieldReturn()
-
-  /// Call when the user taps signup.
   func signupButtonPressed()
-
-  /// Call when the view did load.
   func viewDidLoad()
-
-  /// Call when the user toggles weekly newsletter.
   func weeklyNewsletterChanged(_ weeklyNewsletter: Bool)
 }
 
 public protocol SignupViewModelOutputs {
-  /// Sets whether the email text field is the first responder.
   var emailTextFieldBecomeFirstResponder: Signal<(), NoError> { get }
-
-  /// Emits true when the signup button should be enabled, false otherwise.
   var isSignupButtonEnabled: Signal<Bool, NoError> { get }
-
-  /// Emits an access token envelope that can be used to update the environment.
   var logIntoEnvironment: Signal<AccessTokenEnvelope, NoError> { get }
-
-  /// Sets whether the password text field is the first responder.
   var passwordTextFieldBecomeFirstResponder: Signal<(), NoError> { get }
-
-  /// Emits when a notification should be posted.
   var postNotification: Signal<Notification, NoError> { get }
-
-  /// Sets whether the name text field is the first responder.
   var nameTextFieldBecomeFirstResponder: Signal<(), NoError> { get }
-
-  /// Emits the value for the weekly newsletter.
   var setWeeklyNewsletterState: Signal<Bool, NoError> { get }
-
-  /// Emits when a signup error has occurred and a message should be displayed.
   var showError: Signal<String, NoError> { get }
 }
 
@@ -69,7 +35,10 @@ public protocol SignupViewModelType {
 
 public final class SignupViewModel: SignupViewModelType, SignupViewModelInputs, SignupViewModelOutputs {
 
-    public init() {
+  public var inputs: SignupViewModelInputs { return self }
+  public var outputs: SignupViewModelOutputs { return self }
+
+  public init() {
     let initialText = self.viewDidLoadProperty.signal.mapConst("")
     let name = Signal.merge(
       self.nameChangedProperty.signal,
@@ -212,7 +181,4 @@ public final class SignupViewModel: SignupViewModelType, SignupViewModelInputs, 
   public let postNotification: Signal<Notification, NoError>
   public let setWeeklyNewsletterState: Signal<Bool, NoError>
   public let showError: Signal<String, NoError>
-
-  public var inputs: SignupViewModelInputs { return self }
-  public var outputs: SignupViewModelOutputs { return self }
 }


### PR DESCRIPTION
:wave: Hey squad!

I gave a talk yesterday at Functional Swift Conference in which I live-refactored a Kickstarter view model and controller. @ifbarrera attended and suggested that I open a PR with the result. We've been tweaking the reactive view model approach a bit the past coupla years and have been wanting to share.

Here's what the end result looks like:

https://github.com/stephencelis/ios-oss/blob/40cfb4da8afd23ea4d4cea637fbab161c238839d/Library/ViewModels/SignupViewModel.swift

Main benefits we've seen:

- Addresses the big boilerplate problem. Instead of containing view model logic using a bunch of different constructs (including multiple protocols, a class/struct, an initializer, a bunch of properties, a bunch of input functions that delegate directly to private properties), we can use a single construct: a single function. Half of the implementation boilerplate goes away and things become a bit easier to digest as a result

- Another benefit of this style is that we get unused warnings for outputs not used in the view controller (one of which I found during the refactor).

Note that this PR adds ReactiveCocoa as a dependency for less verbose binding in the view controller (avoids the extra target-action boilerplate). This isn't necessary, so take it or leave it, but after using RxSwift+RxCocoa on a project, it's been pretty nice to avoid the extra work and it made my talk go by a bit quicker.

Not in this PR: updated tests! Some (but definitely not all) of the boilerplate lost in the main view model reappears in the tests since you need to manually create mutable properties in the test case, but it seems like a nicer trade-off to hide this boilerplate away in tests. For example:

``` diff
 internal final class SignupViewModelTests: TestCase {
-  fileprivate let vm: SignupViewModelType = SignupViewModel()
+  fileprivate let emailChangedProperty = MutableProperty("")
+  fileprivate let emailTextFieldReturnProperty = MutableProperty(())
+  fileprivate let environmentLoggedInProperty = MutableProperty(())
+  fileprivate let nameChangedProperty = MutableProperty("")
+  fileprivate let nameTextFieldReturnProperty = MutableProperty(())
+  fileprivate let passwordChangedProperty = MutableProperty("")
+  fileprivate let passwordTextFieldReturnProperty = MutableProperty(())
+  fileprivate let signupButtonPressedProperty = MutableProperty(())
+  fileprivate let viewDidLoadProperty = MutableProperty(())
+  fileprivate let weeklyNewsletterChangedProperty = MutableProperty<Bool>(nil)
+
   fileprivate let emailTextFieldBecomeFirstResponder = TestObserver<(), NoError>()
   fileprivate let isSignupButtonEnabled = TestObserver<Bool, NoError>()
   fileprivate let logIntoEnvironment = TestObserver<AccessTokenEnvelope, NoError>()
   fileprivate let nameTextFieldBecomeFirstResponder = TestObserver<(), NoError>()
   fileprivate let passwordTextFieldBecomeFirstResponder = TestObserver<(), NoError>()
   fileprivate let postNotification = TestObserver<Notification.Name, NoError>()
   fileprivate let setWeeklyNewsletterState = TestObserver<Bool, NoError>()
   fileprivate let showError = TestObserver<String, NoError>()

   override func setUp() {
     super.setUp()

+    let (
+      emailTextFieldBecomeFirstResponder,
+      isSignupButtonEnabled,
+      logIntoEnvironment,
+      passwordTextFieldBecomeFirstResponder,
+      postNotification,
+      nameTextFieldBecomeFirstResponder,
+      setWeeklyNewsletterState,
+      showError
+    ) = signupViewModel(
+      emailChanged: self.emailChangedProperty.signal,
+      emailTextFieldReturn: self.emailTextFieldChangedProperty.signal,
+      environmentLoggedIn: environmentLoggedInProperty.signal,
+      nameChanged: self.nameTextFieldChangedProperty.signal,
+      nameTextFieldReturn: self.nameTextFieldReturnProperty.signal,
+      passwordChanged: self.passwordTextFieldChangedProperty.signal,
+      passwordTextFieldReturn: self.passwordTextFieldReturnPropety.signal,
+      signupButtonPressed: self.signupButtonPressedProperty.signal,
+      viewDidLoad: viewDidLoadProperty.signal,
+      weeklyNewsletterChanged: weeklyNewsletterChangedProperty.signal
+    )
-    self.vm.outputs.emailTextFieldBecomeFirstResponder
+    emailTextFieldBecomeFirstResponder
-      .observe(self.emailTextFieldBecomeFirstResponder.observer)
-    self.vm.outputs.isSignupButtonEnabled.observe(self.isSignupButtonEnabled.observer)
+    isSignupButtonEnabled.observe(self.isSignupButtonEnabled.observer)
-    self.vm.outputs.logIntoEnvironment.observe(self.logIntoEnvironment.observer)
+    logIntoEnvironment.observe(self.logIntoEnvironment.observer)
-    self.vm.outputs.nameTextFieldBecomeFirstResponder.observe(self.nameTextFieldBecomeFirstResponder.observer)
+    nameTextFieldBecomeFirstResponder.observe(self.nameTextFieldBecomeFirstResponder.observer)
-    self.vm.outputs.passwordTextFieldBecomeFirstResponder
+    passwordTextFieldBecomeFirstResponder
-      .observe(self.passwordTextFieldBecomeFirstResponder.observer)
-    self.vm.outputs.postNotification.map { $0.name }.observe(self.postNotification.observer)
+    postNotification.map { $0.name }.observe(self.postNotification.observer)
-    self.vm.outputs.setWeeklyNewsletterState.observe(self.setWeeklyNewsletterState.observer)
+    setWeeklyNewsletterState.observe(self.setWeeklyNewsletterState.observer)
-    self.vm.outputs.showError.observe(self.showError.observer)
+    showError.observe(self.showError.observer)
   }
```

It's possible to get rid of some additional boilerplate by avoiding the destructuring (_e.g._, `let outputs = signupViewModel(…)`), but then the compiler won't warn you when you forget to use an output, so in this case the trade-off seems worth it.

We've really enjoyed this approach, so we hope you do too!