### PR TITLE
Changed global tint color from grey to green

### DIFF
--- a/Kickstarter-iOS/AppDelegate.swift
+++ b/Kickstarter-iOS/AppDelegate.swift
@@ -215,7 +215,7 @@ internal final class AppDelegate: UIResponder, UIApplicationDelegate {
     }
     //swiftlint:enable discarded_notification_center_observer
 
-    self.window?.tintColor = .ksr_dark_grey_500
+    self.window?.tintColor = .ksr_green_700
 
     self.viewModel.inputs.applicationDidFinishLaunching(application: application,
                                                         launchOptions: launchOptions)


### PR DESCRIPTION
# 📲 What

Changing our global `tintColor` from grey to green, as per [this Trello card](https://trello.com/c/Rpi5qqft), in service of having our alert and action sheet text being green.

This also makes the Beta Tools bug icon (see screenshots) green. I think that's fine though as we don't ship that to production. If anything, it makes it clearer that the user is on the debug build.

# 🤔 Why

- People have been [confused](https://trello.com/c/SMCUxucv) by the grey tint ("is it disabled?")
- Green is our 'brand' color to be used for primary actions

# 🛠 How

I paired with @dusi on this. We noticed we were already using `self.window?.tintColor` to serve the grey, so just modified to it the desired `ksr_green_700`.

# 👀 See

Before | After
--- | ---
![log out grey] | ![log out green]
![explore grey] | ![explore green]
![log out grey] | ![log out green]
![request grey] | ![request green]
![following grey] | ![following green]

Other, non-pictured changed areas:
- Changing Beta Tools environment
- Changing Beta Tools language
- Creator Inbox/Sent switcher
- Project share sheet 'Cancel' button



# ✅ Acceptance criteria

- [x] Ensure this global `tintColor` change does not manifest in other areas (especially if the green is confusing)

# ⏰ TODO

- [ ] Find out if the `SFSafariViewController` used in some places (_Delete my Kickstarter account_, for example) can also have its tint changed

[log out grey]: https://user-images.githubusercontent.com/3104761/49478371-9a218d00-f7ed-11e8-9225-eec31fa6f50d.PNG
[log out green]: https://user-images.githubusercontent.com/3104761/49478440-c3dab400-f7ed-11e8-9372-b0b576e18005.PNG
[explore grey]: https://user-images.githubusercontent.com/3104761/49478495-e8369080-f7ed-11e8-9249-ff6b5710dd6c.PNG
[explore green]: https://user-images.githubusercontent.com/3104761/49478500-ea98ea80-f7ed-11e8-8b6f-6d24fb506bb6.PNG
[request grey]: https://user-images.githubusercontent.com/3104761/49478554-11efb780-f7ee-11e8-8994-47d46bf28b14.PNG
[request green]: https://user-images.githubusercontent.com/3104761/49478559-14521180-f7ee-11e8-859d-6c74326e1e58.PNG
[following grey]: https://user-images.githubusercontent.com/3104761/49478611-42cfec80-f7ee-11e8-9e3d-2741003d3f6e.PNG
[following green]: https://user-images.githubusercontent.com/3104761/49478616-45324680-f7ee-11e8-999a-b0250ef95168.PNG







