### PR TITLE
Prevent currency picker interaction during requests

### DIFF
--- a/Kickstarter-iOS/DataSources/HelpDataSource.swift
+++ b/Kickstarter-iOS/DataSources/HelpDataSource.swift
@@ -4,7 +4,7 @@ import KsApi
 final class HelpDataSource: ValueCellDataSource {
   func configureRows() {
     _ = HelpSectionType.allCases.map { section -> Void in
-      let values = section.cellRowsForSection.map { SettingsCellValue(user: nil, cellType: $0) }
+      let values = section.cellRowsForSection.map { SettingsCellValue(cellType: $0) }
       self.set(values: values,
                cellClass: SettingsTableViewCell.self,
                inSection: section.rawValue)

--- a/Kickstarter-iOS/DataSources/SettingsAccountDataSource.swift
+++ b/Kickstarter-iOS/DataSources/SettingsAccountDataSource.swift
@@ -6,7 +6,7 @@ final class SettingsAccountDataSource: ValueCellDataSource {
     clearValues()
     SettingsAccountSectionType.allCases
       .forEach { section -> Void in
-      let values = section.cellRowsForSection.map { SettingsCellValue(user: nil, cellType: $0) }
+      let values = section.cellRowsForSection.map { SettingsCellValue(cellType: $0) }
 
       self.set(values: values,
                cellClass: SettingsTableViewCell.self,
@@ -34,8 +34,8 @@ final class SettingsAccountDataSource: ValueCellDataSource {
                           inSection: SettingsAccountSectionType.payment.rawValue)
   }
 
-  func insertCurrencyPickerRow() -> IndexPath {
-    let cellValue = SettingsCellValue(user: nil, cellType: SettingsAccountCellType.currencyPicker)
+  func insertCurrencyPickerRow(currency: Currency) -> IndexPath {
+    let cellValue = SettingsCellValue(cellType: SettingsAccountCellType.currencyPicker, currency: currency)
 
     return self.appendRow(value: cellValue,
                           cellClass: SettingsCurrencyPickerCell.self,
@@ -43,7 +43,7 @@ final class SettingsAccountDataSource: ValueCellDataSource {
   }
 
   func removeCurrencyPickerRow() -> IndexPath {
-    let cellValue = SettingsCellValue(user: nil, cellType: SettingsAccountCellType.currencyPicker)
+    let cellValue = SettingsCellValue(cellType: SettingsAccountCellType.currencyPicker)
 
     return self.deleteRow(value: cellValue,
                           cellClass: SettingsCurrencyPickerCell.self,

--- a/Kickstarter-iOS/DataSources/SettingsAccountDataSource.swift
+++ b/Kickstarter-iOS/DataSources/SettingsAccountDataSource.swift
@@ -15,7 +15,7 @@ final class SettingsAccountDataSource: ValueCellDataSource {
 
     self.insertChangeEmailCell(shouldHideEmailWarning)
 
-    _ = self.insertCurrencyCell(currency: currency)
+    _ = self.insertCurrencyCell(with: currency)
   }
 
   func insertChangeEmailCell(_ shouldHideEmailWarning: Bool) {
@@ -25,7 +25,7 @@ final class SettingsAccountDataSource: ValueCellDataSource {
                    inSection: SettingsAccountSectionType.emailPassword.rawValue)
   }
 
-  func insertCurrencyCell(currency: Currency?) -> IndexPath {
+  func insertCurrencyCell(with currency: Currency?) -> IndexPath {
     let cellValue = SettingsCurrencyCellValue(cellType: SettingsAccountCellType.currency, currency: currency )
 
     return self.insertRow(value: cellValue,
@@ -34,7 +34,7 @@ final class SettingsAccountDataSource: ValueCellDataSource {
                           inSection: SettingsAccountSectionType.payment.rawValue)
   }
 
-  func insertCurrencyPickerRow(currency: Currency) -> IndexPath {
+  func insertCurrencyPickerRow(with currency: Currency) -> IndexPath {
     let cellValue = SettingsCellValue(cellType: SettingsAccountCellType.currencyPicker, currency: currency)
 
     return self.appendRow(value: cellValue,

--- a/Kickstarter-iOS/DataSources/SettingsAccountDataSourceTests.swift
+++ b/Kickstarter-iOS/DataSources/SettingsAccountDataSourceTests.swift
@@ -18,9 +18,11 @@ final class SettingsAccountDataSourceTests: XCTestCase {
   }
 
   func testInsertRemoveCurrencyPickerRow() {
-    self.dataSource.configureRows(currency: Currency.USD, shouldHideEmailWarning: true)
+    let currency = Currency.USD
 
-    _ = self.dataSource.insertCurrencyPickerRow()
+    self.dataSource.configureRows(currency: currency, shouldHideEmailWarning: true)
+
+    _ = self.dataSource.insertCurrencyPickerRow(currency: currency)
 
     // swiftlint:disable line_length
     XCTAssertEqual(3, dataSource.tableView(tableView,

--- a/Kickstarter-iOS/DataSources/SettingsAccountDataSourceTests.swift
+++ b/Kickstarter-iOS/DataSources/SettingsAccountDataSourceTests.swift
@@ -22,7 +22,7 @@ final class SettingsAccountDataSourceTests: XCTestCase {
 
     self.dataSource.configureRows(currency: currency, shouldHideEmailWarning: true)
 
-    _ = self.dataSource.insertCurrencyPickerRow(currency: currency)
+    _ = self.dataSource.insertCurrencyPickerRow(with: currency)
 
     // swiftlint:disable line_length
     XCTAssertEqual(3, dataSource.tableView(tableView,

--- a/Kickstarter-iOS/DataSources/SettingsDataSource.swift
+++ b/Kickstarter-iOS/DataSources/SettingsDataSource.swift
@@ -5,7 +5,7 @@ final class SettingsDataSource: ValueCellDataSource {
   func configureRows(with user: User) {
 
     SettingsDataSource.sections.forEach { section -> Void in
-      let values = section.cellRowsForSection.map { SettingsCellValue(user: user, cellType: $0) }
+      let values = section.cellRowsForSection.map { SettingsCellValue(cellType: $0, user: user) }
 
       switch section {
       case .findFriends:

--- a/Kickstarter-iOS/Views/Cells/SettingsCurrencyPickerCell.swift
+++ b/Kickstarter-iOS/Views/Cells/SettingsCurrencyPickerCell.swift
@@ -20,7 +20,12 @@ final class SettingsCurrencyPickerCell: UITableViewCell, NibLoading, ValueCell {
     self.pickerView.dataSource = self
   }
 
-  func configureWith(value cellValue: SettingsCellValue) { }
+  func configureWith(value cellValue: SettingsCellValue) {
+    guard let currency = cellValue.currency else { return }
+    guard let row = Currency.allCases.firstIndex(of: currency) else { return }
+
+    self.pickerView.selectRow(row, inComponent: 0, animated: false)
+  }
 
   override func bindStyles() {
     super.bindStyles()
@@ -54,7 +59,7 @@ extension SettingsCurrencyPickerCell: UIPickerViewDataSource {
 
 extension SettingsCurrencyPickerCell: UIPickerViewDelegate {
   func pickerView(_ pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {
-    return Currency.allCases[row].descriptionText //Currency(rawValue: row)?.descriptionText
+    return Currency.allCases[row].descriptionText
   }
 
   func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {

--- a/Kickstarter-iOS/Views/Controllers/SettingsAccountViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/SettingsAccountViewController.swift
@@ -69,7 +69,7 @@ final class SettingsAccountViewController: UIViewController, MessageBannerViewCo
     self.viewModel.outputs.presentCurrencyPicker
       .observeForUI()
       .observeValues { [weak self] currency in
-        self?.showCurrencyPickerCell(currency: currency)
+        self?.showCurrencyPickerCell(with: currency)
     }
 
     self.viewModel.outputs.updateCurrencyFailure
@@ -109,14 +109,14 @@ final class SettingsAccountViewController: UIViewController, MessageBannerViewCo
       |> settingsTableViewStyle
   }
 
-  private func showCurrencyPickerCell(currency: Currency) {
+  private func showCurrencyPickerCell(with currency: Currency) {
     let tapRecognizer = UITapGestureRecognizer(
       target: self,
       action: #selector(tapGestureToDismissCurrencyPicker)
     )
 
     self.tableView.beginUpdates()
-    self.tableView.insertRows(at: [self.dataSource.insertCurrencyPickerRow(currency: currency)], with: .top)
+    self.tableView.insertRows(at: [self.dataSource.insertCurrencyPickerRow(with: currency)], with: .top)
     self.view.addGestureRecognizer(tapRecognizer)
     self.tableView.endUpdates()
   }

--- a/Kickstarter-iOS/Views/Controllers/SettingsAccountViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/SettingsAccountViewController.swift
@@ -32,6 +32,8 @@ final class SettingsAccountViewController: UIViewController, MessageBannerViewCo
     self.tableView.register(nib: .SettingsCurrencyCell)
     self.tableView.register(nib: .SettingsAccountWarningCell)
     self.tableView.registerHeaderFooter(nib: .SettingsHeaderView)
+
+    self.viewModel.inputs.viewDidLoad()
   }
 
   override func viewWillAppear(_ animated: Bool) {
@@ -108,10 +110,13 @@ final class SettingsAccountViewController: UIViewController, MessageBannerViewCo
   }
 
   private func showCurrencyPickerCell() {
+    let tapRecognizer = UITapGestureRecognizer(
+      target: self,
+      action: #selector(tapGestureToDismissCurrencyPicker)
+    )
+
     self.tableView.beginUpdates()
     self.tableView.insertRows(at: [self.dataSource.insertCurrencyPickerRow()], with: .top)
-    let tapRecognizer = UITapGestureRecognizer(target: self,
-                                               action: #selector(tapGestureToDismissCurrencyPicker))
     self.view.addGestureRecognizer(tapRecognizer)
     self.tableView.endUpdates()
   }
@@ -122,10 +127,10 @@ final class SettingsAccountViewController: UIViewController, MessageBannerViewCo
   }
 
   private func dismissCurrencyPickerCell() {
-    tableView.beginUpdates()
+    self.tableView.beginUpdates()
     self.tableView.deleteRows(at: [self.dataSource.removeCurrencyPickerRow()], with: .top)
-    tableView.endUpdates()
     self.view.gestureRecognizers?.removeAll()
+    self.tableView.endUpdates()
   }
 
   private func showChangeCurrencyAlert() {

--- a/Kickstarter-iOS/Views/Controllers/SettingsAccountViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/SettingsAccountViewController.swift
@@ -68,8 +68,8 @@ final class SettingsAccountViewController: UIViewController, MessageBannerViewCo
 
     self.viewModel.outputs.presentCurrencyPicker
       .observeForUI()
-      .observeValues { [weak self] in
-        self?.showCurrencyPickerCell()
+      .observeValues { [weak self] currency in
+        self?.showCurrencyPickerCell(currency: currency)
     }
 
     self.viewModel.outputs.updateCurrencyFailure
@@ -109,14 +109,14 @@ final class SettingsAccountViewController: UIViewController, MessageBannerViewCo
       |> settingsTableViewStyle
   }
 
-  private func showCurrencyPickerCell() {
+  private func showCurrencyPickerCell(currency: Currency) {
     let tapRecognizer = UITapGestureRecognizer(
       target: self,
       action: #selector(tapGestureToDismissCurrencyPicker)
     )
 
     self.tableView.beginUpdates()
-    self.tableView.insertRows(at: [self.dataSource.insertCurrencyPickerRow()], with: .top)
+    self.tableView.insertRows(at: [self.dataSource.insertCurrencyPickerRow(currency: currency)], with: .top)
     self.view.addGestureRecognizer(tapRecognizer)
     self.tableView.endUpdates()
   }

--- a/KsApi/MockService.swift
+++ b/KsApi/MockService.swift
@@ -12,6 +12,7 @@ internal struct MockService: ServiceType {
   internal let currency: String
   internal let buildVersion: String
 
+  fileprivate let changeCurrencyResponse: GraphMutationEmptyResponseEnvelope?
   fileprivate let changeCurrencyError: GraphError?
 
   fileprivate let changeEmailError: GraphError?
@@ -178,6 +179,7 @@ internal struct MockService: ServiceType {
                                                                        me: .template
                                                                      ),
                 changePasswordError: GraphError? = nil,
+                changeCurrencyResponse: GraphMutationEmptyResponseEnvelope? = nil,
                 changeCurrencyError: GraphError? = nil,
                 changePaymentMethodResult: Result<ChangePaymentMethodEnvelope, ErrorEnvelope>? = nil,
                 createPledgeResult: Result<CreatePledgeEnvelope, ErrorEnvelope>? = nil,
@@ -269,6 +271,7 @@ internal struct MockService: ServiceType {
     self.currency = currency
     self.buildVersion = buildVersion
 
+    self.changeCurrencyResponse = changeCurrencyResponse
     self.changeCurrencyError = changeCurrencyError
 
     self.changeEmailResponse = changeEmailResponse
@@ -498,11 +501,12 @@ internal struct MockService: ServiceType {
 
   internal func changeCurrency(input: ChangeCurrencyInput) ->
    SignalProducer<GraphMutationEmptyResponseEnvelope, GraphError> {
-      if let error = self.changeCurrencyError {
-        return SignalProducer(error: error)
-      } else {
-        return SignalProducer(value: GraphMutationEmptyResponseEnvelope())
-      }
+    if let response = self.changeCurrencyResponse {
+      return SignalProducer(value: response)
+    } else if let error = self.changeCurrencyError {
+      return SignalProducer(error: error)
+    }
+    return SignalProducer(value: GraphMutationEmptyResponseEnvelope())
   }
 
   internal func fetchCheckout(checkoutUrl url: String) -> SignalProducer<CheckoutEnvelope, ErrorEnvelope> {

--- a/Library/SettingsCellType.swift
+++ b/Library/SettingsCellType.swift
@@ -6,18 +6,20 @@ public struct SettingsCurrencyCellValue {
   public let currency: Currency?
 
   public init(cellType: SettingsCellTypeProtocol, currency: Currency?) {
-    self.currency = currency
     self.cellType = cellType
+    self.currency = currency
   }
 }
 
 public struct SettingsCellValue {
-  public let user: User?
   public let cellType: SettingsCellTypeProtocol
+  public let currency: Currency?
+  public let user: User?
 
-  public init(user: User?, cellType: SettingsCellTypeProtocol) {
-    self.user = user
+  public init(cellType: SettingsCellTypeProtocol, currency: Currency? = nil, user: User? = nil) {
     self.cellType = cellType
+    self.currency = currency
+    self.user = user
   }
 }
 

--- a/Library/ViewModels/SettingsAccountViewModel.swift
+++ b/Library/ViewModels/SettingsAccountViewModel.swift
@@ -87,9 +87,9 @@ SettingsAccountViewModelOutputs, SettingsAccountViewModelType {
 
     self.presentCurrencyPicker = Signal.combineLatest(currency, updateCurrencyInProgress)
       .takePairWhen(currencyCellSelected.signal)
-      .map { ($0.0, $0.1, $1) }
+      .map(unpack)
       .filter(second >>> isFalse)
-      .map { $0.0 }
+      .map(first)
 
     self.dismissCurrencyPicker = self.dismissPickerTapProperty.signal
 

--- a/Library/ViewModels/SettingsAccountViewModel.swift
+++ b/Library/ViewModels/SettingsAccountViewModel.swift
@@ -16,7 +16,7 @@ public protocol SettingsAccountViewModelInputs {
 public protocol SettingsAccountViewModelOutputs {
   var dismissCurrencyPicker: Signal<Void, NoError> { get }
   var fetchAccountFieldsError: Signal<Void, NoError> { get }
-  var presentCurrencyPicker: Signal<Void, NoError> { get }
+  var presentCurrencyPicker: Signal<Currency, NoError> { get }
   var reloadData: Signal<(Currency, Bool), NoError> { get }
   var showAlert: Signal<(), NoError> { get }
   var transitionToViewController: Signal<UIViewController, NoError> { get }
@@ -85,10 +85,11 @@ SettingsAccountViewModelOutputs, SettingsAccountViewModelType {
       updateCurrencyEvent.filter { $0.isTerminating }.mapConst(false)
     )
 
-    self.presentCurrencyPicker = updateCurrencyInProgress
-      .takePairWhen(currencyCellSelected.signal.mapConst(true))
-      .filter(first >>> isFalse)
-      .ignoreValues()
+    self.presentCurrencyPicker = Signal.combineLatest(currency, updateCurrencyInProgress)
+      .takePairWhen(currencyCellSelected.signal)
+      .map { ($0.0, $0.1, $1) }
+      .filter(second >>> isFalse)
+      .map { $0.0 }
 
     self.dismissCurrencyPicker = self.dismissPickerTapProperty.signal
 
@@ -140,7 +141,7 @@ SettingsAccountViewModelOutputs, SettingsAccountViewModelType {
   public let dismissCurrencyPicker: Signal<Void, NoError>
   public let fetchAccountFieldsError: Signal<Void, NoError>
   public let reloadData: Signal<(Currency, Bool), NoError>
-  public let presentCurrencyPicker: Signal<Void, NoError>
+  public let presentCurrencyPicker: Signal<Currency, NoError>
   public let showAlert: Signal<(), NoError>
   public let transitionToViewController: Signal<UIViewController, NoError>
   public let updateCurrencyFailure: Signal<String, NoError>

--- a/Library/ViewModels/SettingsAccountViewModelTests.swift
+++ b/Library/ViewModels/SettingsAccountViewModelTests.swift
@@ -13,7 +13,7 @@ internal final class SettingsAccountViewModelTests: TestCase {
 
   let dismissCurrencyPicker = TestObserver<Void, NoError>()
   let fetchAccountFieldsError = TestObserver<Void, NoError>()
-  let presentCurrencyPicker = TestObserver<Void, NoError>()
+  let presentCurrencyPicker = TestObserver<Currency, NoError>()
   let reloadDataShouldHideWarningIcon = TestObserver<Bool, NoError>()
   let reloadDataCurrency = TestObserver<Currency, NoError>()
   let showAlert = TestObserver<(), NoError>()
@@ -141,6 +141,33 @@ internal final class SettingsAccountViewModelTests: TestCase {
       self.vm.inputs.didConfirmChangeCurrency()
       self.scheduler.advance()
       self.updateCurrencyFailure.assertDidEmitValue()
+    }
+  }
+
+  func testPresentCurrencyPickerWithTheRightValueSelected() {
+    let graphResponse = GraphMutationEmptyResponseEnvelope()
+    let mockService = MockService(changeCurrencyResponse: graphResponse)
+
+    withEnvironment(apiService: mockService) {
+      self.vm.inputs.viewDidLoad()
+      self.vm.inputs.viewWillAppear()
+      self.vm.inputs.didSelectRow(cellType: .currency)
+
+      self.presentCurrencyPicker.assertValues([.USD])
+
+      self.vm.inputs.showChangeCurrencyAlert(for: .CAD)
+      self.vm.inputs.didConfirmChangeCurrency()
+      self.scheduler.advance()
+      self.vm.inputs.didSelectRow(cellType: .currency)
+
+      self.presentCurrencyPicker.assertValues([.USD, .CAD])
+
+      self.vm.inputs.showChangeCurrencyAlert(for: .GBP)
+      self.vm.inputs.didConfirmChangeCurrency()
+      self.scheduler.advance()
+      self.vm.inputs.didSelectRow(cellType: .currency)
+
+      self.presentCurrencyPicker.assertValues([.USD, .CAD, .GBP])
     }
   }
 

--- a/Library/ViewModels/SettingsAccountViewModelTests.swift
+++ b/Library/ViewModels/SettingsAccountViewModelTests.swift
@@ -42,6 +42,7 @@ internal final class SettingsAccountViewModelTests: TestCase {
   }
 
   func testPresentCurrencyPicker() {
+    self.vm.inputs.viewDidLoad()
     self.vm.inputs.viewWillAppear()
     self.reloadDataShouldHideWarningIcon.assertValueCount(1)
     self.reloadDataCurrency.assertValueCount(1)
@@ -50,6 +51,7 @@ internal final class SettingsAccountViewModelTests: TestCase {
   }
 
   func testDismissCurrencyPicker() {
+    self.vm.inputs.viewDidLoad()
     self.vm.inputs.viewWillAppear()
     self.reloadDataShouldHideWarningIcon.assertValueCount(1)
     self.reloadDataCurrency.assertValueCount(1)

--- a/Library/ViewModels/SettingsAccountViewModelTests.swift
+++ b/Library/ViewModels/SettingsAccountViewModelTests.swift
@@ -81,6 +81,55 @@ internal final class SettingsAccountViewModelTests: TestCase {
     }
   }
 
+  func testUpdateCurrencySuccess() {
+    let graphResponse = GraphMutationEmptyResponseEnvelope()
+    let mockService = MockService(changeCurrencyResponse: graphResponse)
+
+    withEnvironment(apiService: mockService) {
+      self.vm.inputs.viewDidLoad()
+      self.vm.inputs.viewWillAppear()
+      self.vm.inputs.didSelectRow(cellType: .currency)
+      self.vm.inputs.showChangeCurrencyAlert(for: .CAD)
+      self.vm.inputs.didConfirmChangeCurrency()
+
+      self.presentCurrencyPicker.assertValueCount(1)
+      self.reloadDataCurrency.assertValueCount(1)
+
+      self.scheduler.advance()
+
+      self.reloadDataCurrency.assertValueCount(2)
+    }
+  }
+
+  func testThatWeCanNotPresentCurrencyPickerWhileTheCurrencyChangeIsInProgress() {
+    let graphResponse = GraphMutationEmptyResponseEnvelope()
+    let mockService = MockService(changeCurrencyResponse: graphResponse)
+
+    withEnvironment(apiService: mockService) {
+      self.vm.inputs.viewDidLoad()
+      self.vm.inputs.viewWillAppear()
+      self.vm.inputs.didSelectRow(cellType: .currency)
+      self.vm.inputs.showChangeCurrencyAlert(for: .CAD)
+      self.vm.inputs.didConfirmChangeCurrency()
+
+      self.presentCurrencyPicker.assertValueCount(1)
+      self.reloadDataCurrency.assertValueCount(1)
+
+      self.vm.inputs.didSelectRow(cellType: .currency)
+      self.vm.inputs.didSelectRow(cellType: .currency)
+      self.vm.inputs.didSelectRow(cellType: .currency)
+
+      self.scheduler.advance()
+
+      self.presentCurrencyPicker.assertValueCount(1)
+      self.reloadDataCurrency.assertValueCount(2)
+
+      self.vm.inputs.didSelectRow(cellType: .currency)
+
+      self.presentCurrencyPicker.assertValueCount(2)
+    }
+  }
+
   func testUpdateCurrencyFailure() {
     let graphError = GraphError.emptyResponse(nil)
 


### PR DESCRIPTION
# 📲 What

Fixes the crash we were seeing related to the currency picker. This crash would happen if a user tried to show currency picker while the currency change was in progress causing the application to crash.

# 🤔 Why

We really, really, really should ship Settings.

# 🛠 How

This workaround waits till the currency change requests is done before allowing presenting the currency picker again. This solution would ideally show an activity indicator but since we're planning on completely changing this we should be good for now.

# 👀 See

| Before | After |
| --- | --- |
| ![before](https://user-images.githubusercontent.com/387596/49550837-ceef1c00-f8a1-11e8-930c-a1f6302e811a.gif) | ![after](https://user-images.githubusercontent.com/387596/49550843-d6aec080-f8a1-11e8-8625-f899bc6bf4db.gif) |


# ✅ Acceptance criteria

For easy testing, please download and install Network Link Conditioner (NLC) - https://developer.apple.com/downloads/ (Additional_Tools_for_Xcode_{YOUR_VERSION})

Enable NLC and use any option that slows down your Internet connection in order for you to being able to select the currency row while the progress is happening.

Go to `Account Settings`..

- [x] Tapping the currency picker opens the currency picker with proper currency selected (reflecting the last successfully updated currency)
- [x] Changing currency using the currency picker should work
- [x] Tapping the currency row will present the picker if no request (currency change) is happening
- [x] Tapping the currency row will NOt present the picker if a request (currency change) is happening

Don't forget to disable NLC in order to regain your Internet speedzzZZZzz