### PR TITLE
Fix MessageBannerViewController nib warning

### DIFF
--- a/Kickstarter-iOS/Views/Controllers/MessageBannerViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/MessageBannerViewController.swift
@@ -156,11 +156,11 @@ final class MessageBannerViewController: UIViewController, NibLoading {
 extension MessageBannerViewControllerPresenting where Self: UIViewController {
   func configureMessageBannerViewController(on parentViewController: UIViewController)
     -> MessageBannerViewController? {
-    guard let messageBannerViewController = MessageBannerViewController
-      .fromNib(nib: Nib.MessageBannerViewController),
-          let messageBannerView = messageBannerViewController.view else {
-      return nil
-    }
+    let messageBannerViewController = MessageBannerViewController(
+      nibName: Nib.MessageBannerViewController.rawValue, bundle: .framework
+    )
+
+    guard let messageBannerView = messageBannerViewController.view else { return nil }
 
     parentViewController.addChild(messageBannerViewController)
     parentViewController.view.addSubview(messageBannerView)

--- a/Kickstarter-iOS/Views/Storyboards/MessageBannerViewController.xib
+++ b/Kickstarter-iOS/Views/Storyboards/MessageBannerViewController.xib
@@ -10,93 +10,80 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
-        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="MessageBannerViewController" customModule="Kickstarter_Framework" customModuleProvider="target">
+            <connections>
+                <outlet property="backgroundView" destination="mNP-H4-3lQ" id="4fL-c8-5D1"/>
+                <outlet property="containerView" destination="Kow-9t-EMe" id="bqC-xB-2uL"/>
+                <outlet property="iconImageView" destination="OeT-cr-9Co" id="vVP-AN-etd"/>
+                <outlet property="messageLabel" destination="5A6-3y-w5z" id="zP2-Zu-Z5F"/>
+                <outlet property="view" destination="VuK-HK-hlJ" id="i4x-9Q-bdq"/>
+            </connections>
+        </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <viewController restorationIdentifier="MessageBannerViewController" nibName="MessageBannerViewController" id="h7y-fG-v9O" customClass="MessageBannerViewController" customModule="Kickstarter_Framework">
-            <view key="view" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" id="Zcf-a3-qgT">
-                <rect key="frame" x="0.0" y="0.0" width="375" height="93"/>
-                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                <subviews>
-                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="yW0-Ud-aSE" userLabel="Container View">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="93"/>
-                        <subviews>
-                            <view contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" translatesAutoresizingMaskIntoConstraints="NO" id="uBb-R8-koc" userLabel="Background View" customClass="MessageBanner">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="93"/>
-                                <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="gUR-Ad-xmQ">
-                                        <rect key="frame" x="12" y="12" width="351" height="69"/>
-                                        <subviews>
-                                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="nK4-zs-uiJ">
-                                                <rect key="frame" x="0.0" y="22" width="25" height="25"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="height" constant="25" id="2R8-5T-wya"/>
-                                                    <constraint firstAttribute="width" constant="25" id="E9B-4d-r0T"/>
-                                                </constraints>
-                                            </imageView>
-                                            <label opaque="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0Wv-n2-rdf">
-                                                <rect key="frame" x="37" y="24.5" width="314" height="20.5"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                <color key="textColor" red="0.98431372549999996" green="0.98431372549999996" blue="0.98039215690000003" alpha="1" colorSpace="calibratedRGB"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                        </subviews>
-                                    </stackView>
-                                </subviews>
-                                <color key="backgroundColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                <gestureRecognizers/>
-                                <constraints>
-                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="78" id="8FV-IZ-Hd5"/>
-                                    <constraint firstAttribute="bottom" secondItem="gUR-Ad-xmQ" secondAttribute="bottom" constant="12" id="L3J-RQ-XRO"/>
-                                    <constraint firstAttribute="trailing" secondItem="gUR-Ad-xmQ" secondAttribute="trailing" constant="12" id="QQx-ZE-F5s"/>
-                                    <constraint firstAttribute="height" relation="lessThanOrEqual" constant="140" id="XN0-Jw-pJL"/>
-                                    <constraint firstItem="gUR-Ad-xmQ" firstAttribute="top" secondItem="uBb-R8-koc" secondAttribute="top" constant="12" id="ZdC-Pd-0kQ"/>
-                                    <constraint firstItem="gUR-Ad-xmQ" firstAttribute="leading" secondItem="uBb-R8-koc" secondAttribute="leading" constant="12" id="amX-DZ-fBN"/>
-                                </constraints>
-                                <viewLayoutGuide key="safeArea" id="Q7b-eV-mTR"/>
-                            </view>
-                        </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                        <constraints>
-                            <constraint firstItem="uBb-R8-koc" firstAttribute="top" secondItem="yW0-Ud-aSE" secondAttribute="topMargin" id="3Tp-KV-zsL"/>
-                            <constraint firstItem="uBb-R8-koc" firstAttribute="leading" secondItem="yW0-Ud-aSE" secondAttribute="leadingMargin" id="P1Y-Xa-jbZ"/>
-                            <constraint firstItem="uBb-R8-koc" firstAttribute="trailing" secondItem="yW0-Ud-aSE" secondAttribute="trailingMargin" id="UIf-dw-zRI"/>
-                            <constraint firstItem="uBb-R8-koc" firstAttribute="bottom" secondItem="yW0-Ud-aSE" secondAttribute="bottomMargin" id="puR-yd-TsB"/>
-                        </constraints>
-                        <edgeInsets key="layoutMargins" top="0.0" left="0.0" bottom="0.0" right="0.0"/>
-                    </view>
-                </subviews>
-                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                <gestureRecognizers/>
-                <constraints>
-                    <constraint firstItem="yW0-Ud-aSE" firstAttribute="top" secondItem="Zcf-a3-qgT" secondAttribute="top" id="5BX-Vy-XLP"/>
-                    <constraint firstItem="yW0-Ud-aSE" firstAttribute="trailing" secondItem="Zcf-a3-qgT" secondAttribute="trailing" id="EMp-ZB-mHA"/>
-                    <constraint firstItem="yW0-Ud-aSE" firstAttribute="leading" secondItem="Zcf-a3-qgT" secondAttribute="leading" id="Ur9-rj-0oA"/>
-                    <constraint firstItem="yW0-Ud-aSE" firstAttribute="bottom" secondItem="Zcf-a3-qgT" secondAttribute="bottom" id="kAv-yc-xjE"/>
-                </constraints>
-                <viewLayoutGuide key="safeArea" id="pJh-sj-ENH"/>
-                <connections>
-                    <outletCollection property="gestureRecognizers" destination="SrO-tc-rR8" appends="YES" id="APU-tn-hy3"/>
-                    <outletCollection property="gestureRecognizers" destination="W3s-gZ-kOg" appends="YES" id="Rgm-Nb-pfk"/>
-                </connections>
-            </view>
-            <size key="freeformSize" width="375" height="93"/>
-            <connections>
-                <outlet property="backgroundView" destination="uBb-R8-koc" id="koE-AU-5xA"/>
-                <outlet property="containerView" destination="yW0-Ud-aSE" id="4B5-tU-OpD"/>
-                <outlet property="iconImageView" destination="nK4-zs-uiJ" id="QGa-mg-y9M"/>
-                <outlet property="messageLabel" destination="0Wv-n2-rdf" id="6yf-Ru-AAr"/>
-            </connections>
-            <point key="canvasLocation" x="53.600000000000001" y="47.226386806596707"/>
-        </viewController>
-        <panGestureRecognizer minimumNumberOfTouches="1" id="SrO-tc-rR8">
-            <connections>
-                <action selector="bannerViewPanned:" destination="h7y-fG-v9O" id="vAu-mx-0FK"/>
-            </connections>
-        </panGestureRecognizer>
-        <tapGestureRecognizer id="W3s-gZ-kOg">
-            <connections>
-                <action selector="bannerViewTapped:" destination="h7y-fG-v9O" id="prc-8y-Z3X"/>
-            </connections>
-        </tapGestureRecognizer>
+        <view contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" id="VuK-HK-hlJ">
+            <rect key="frame" x="0.0" y="0.0" width="375" height="115"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Kow-9t-EMe" userLabel="Container View">
+                    <rect key="frame" x="0.0" y="0.0" width="375" height="115"/>
+                    <subviews>
+                        <view contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" translatesAutoresizingMaskIntoConstraints="NO" id="mNP-H4-3lQ" userLabel="Background View" customClass="MessageBanner">
+                            <rect key="frame" x="0.0" y="0.0" width="375" height="115"/>
+                            <subviews>
+                                <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="Nwc-0E-75G">
+                                    <rect key="frame" x="12" y="12" width="351" height="91"/>
+                                    <subviews>
+                                        <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="OeT-cr-9Co">
+                                            <rect key="frame" x="0.0" y="33" width="25" height="25"/>
+                                            <constraints>
+                                                <constraint firstAttribute="width" constant="25" id="3ag-9C-Clq"/>
+                                                <constraint firstAttribute="height" constant="25" id="wyS-O3-h7k"/>
+                                            </constraints>
+                                        </imageView>
+                                        <label opaque="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5A6-3y-w5z">
+                                            <rect key="frame" x="37" y="35.5" width="314" height="20.5"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                            <color key="textColor" red="0.98431372549999996" green="0.98431372549999996" blue="0.98039215690000003" alpha="1" colorSpace="calibratedRGB"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                    </subviews>
+                                </stackView>
+                            </subviews>
+                            <color key="backgroundColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                            <gestureRecognizers/>
+                            <constraints>
+                                <constraint firstAttribute="bottom" secondItem="Nwc-0E-75G" secondAttribute="bottom" constant="12" id="0fN-k8-Apy"/>
+                                <constraint firstAttribute="height" relation="lessThanOrEqual" constant="140" id="4Jd-zg-qCz"/>
+                                <constraint firstItem="Nwc-0E-75G" firstAttribute="top" secondItem="mNP-H4-3lQ" secondAttribute="top" constant="12" id="aMh-Dg-ENr"/>
+                                <constraint firstItem="Nwc-0E-75G" firstAttribute="leading" secondItem="mNP-H4-3lQ" secondAttribute="leading" constant="12" id="aPa-Pe-qG5"/>
+                                <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="78" id="hfE-C8-iye"/>
+                                <constraint firstAttribute="trailing" secondItem="Nwc-0E-75G" secondAttribute="trailing" constant="12" id="lsL-34-PHM"/>
+                            </constraints>
+                            <viewLayoutGuide key="safeArea" id="EQH-dG-Lc3"/>
+                        </view>
+                    </subviews>
+                    <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    <constraints>
+                        <constraint firstItem="mNP-H4-3lQ" firstAttribute="top" secondItem="Kow-9t-EMe" secondAttribute="topMargin" id="6wf-ds-tQ8"/>
+                        <constraint firstItem="mNP-H4-3lQ" firstAttribute="trailing" secondItem="Kow-9t-EMe" secondAttribute="trailingMargin" id="EiW-1C-WwB"/>
+                        <constraint firstItem="mNP-H4-3lQ" firstAttribute="bottom" secondItem="Kow-9t-EMe" secondAttribute="bottomMargin" id="mS1-Hb-GQx"/>
+                        <constraint firstItem="mNP-H4-3lQ" firstAttribute="leading" secondItem="Kow-9t-EMe" secondAttribute="leadingMargin" id="qqd-Vn-Sfm"/>
+                    </constraints>
+                    <edgeInsets key="layoutMargins" top="0.0" left="0.0" bottom="0.0" right="0.0"/>
+                </view>
+            </subviews>
+            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+            <gestureRecognizers/>
+            <constraints>
+                <constraint firstItem="Kow-9t-EMe" firstAttribute="trailing" secondItem="VuK-HK-hlJ" secondAttribute="trailing" id="0nn-yN-nOM"/>
+                <constraint firstItem="Kow-9t-EMe" firstAttribute="top" secondItem="VuK-HK-hlJ" secondAttribute="top" id="JGb-ZC-crt"/>
+                <constraint firstItem="Kow-9t-EMe" firstAttribute="bottom" secondItem="VuK-HK-hlJ" secondAttribute="bottom" id="Yvc-PU-UWZ"/>
+                <constraint firstItem="Kow-9t-EMe" firstAttribute="leading" secondItem="VuK-HK-hlJ" secondAttribute="leading" id="c60-vh-BkK"/>
+            </constraints>
+            <nil key="simulatedTopBarMetrics"/>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <viewLayoutGuide key="safeArea" id="9yc-G5-kBM"/>
+            <point key="canvasLocation" x="84" y="-91.304347826086968"/>
+        </view>
     </objects>
 </document>

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -126,7 +126,6 @@
 		77216CE220EFE7F70061BE82 /* FacebookConnectionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77216CAB20EFE7F70061BE82 /* FacebookConnectionType.swift */; };
 		77216D6020F3D27C0061BE82 /* Settings.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 77216D5F20F3D27C0061BE82 /* Settings.storyboard */; };
 		77216D9820F3D2E40061BE82 /* SettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77216D9720F3D2E40061BE82 /* SettingsViewController.swift */; };
-		774527DE21B1E0480072E590 /* MessageBannerViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 774527DD21B1E0480072E590 /* MessageBannerViewController.xib */; };
 		774A76E920D841110012A71F /* BetaToolsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 774A76E820D841110012A71F /* BetaToolsViewController.swift */; };
 		774A76EE20D863EF0012A71F /* BetaTools.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 774A76AF20D83F6B0012A71F /* BetaTools.storyboard */; };
 		774A76F520D98EEF0012A71F /* BetaToolsViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 774A76F420D98EEF0012A71F /* BetaToolsViewControllerTests.swift */; };
@@ -876,6 +875,7 @@
 		D04AACBF218BC9FE00CF713E /* SettingsCurrencyPickerCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D04AACBE218BC9FE00CF713E /* SettingsCurrencyPickerCell.swift */; };
 		D04F48D41E0313FB00EDC98A /* ActivityProjectStatusCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A762F01B1C8CD2B3005581A4 /* ActivityProjectStatusCell.swift */; };
 		D05C0CB01E02E3F100914393 /* LiveStreamActivityItemProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = D05C0CAF1E02E3F100914393 /* LiveStreamActivityItemProvider.swift */; };
+		D05F4C5C21BA0C1900B9C4B0 /* MessageBannerViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = D05F4C5B21BA0C1900B9C4B0 /* MessageBannerViewController.xib */; };
 		D07226E91E66E9C500C2E537 /* LiveStreamContainerPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D07226E81E66E9C500C2E537 /* LiveStreamContainerPageViewController.swift */; };
 		D07226EB1E66EA1600C2E537 /* LiveStreamEventDetailsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D07226EA1E66EA1600C2E537 /* LiveStreamEventDetailsViewController.swift */; };
 		D07227001E66FA3200C2E537 /* LiveStreamContainerPagesDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = D07226FF1E66FA3200C2E537 /* LiveStreamContainerPagesDataSource.swift */; };
@@ -1865,7 +1865,6 @@
 		77216CAB20EFE7F70061BE82 /* FacebookConnectionType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FacebookConnectionType.swift; sourceTree = "<group>"; };
 		77216D5F20F3D27C0061BE82 /* Settings.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Settings.storyboard; sourceTree = "<group>"; };
 		77216D9720F3D2E40061BE82 /* SettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewController.swift; sourceTree = "<group>"; };
-		774527DD21B1E0480072E590 /* MessageBannerViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = MessageBannerViewController.xib; sourceTree = "<group>"; };
 		774A76AF20D83F6B0012A71F /* BetaTools.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = BetaTools.storyboard; sourceTree = "<group>"; };
 		774A76E820D841110012A71F /* BetaToolsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BetaToolsViewController.swift; sourceTree = "<group>"; };
 		774A76F420D98EEF0012A71F /* BetaToolsViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BetaToolsViewControllerTests.swift; sourceTree = "<group>"; };
@@ -2635,6 +2634,7 @@
 		D04AAC1E218BB70C00CF713E /* SettingsCurrencyPickerCellViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsCurrencyPickerCellViewModel.swift; sourceTree = "<group>"; };
 		D04AACBE218BC9FE00CF713E /* SettingsCurrencyPickerCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsCurrencyPickerCell.swift; sourceTree = "<group>"; };
 		D05C0CAF1E02E3F100914393 /* LiveStreamActivityItemProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LiveStreamActivityItemProvider.swift; sourceTree = "<group>"; };
+		D05F4C5B21BA0C1900B9C4B0 /* MessageBannerViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = MessageBannerViewController.xib; sourceTree = "<group>"; };
 		D07226E81E66E9C500C2E537 /* LiveStreamContainerPageViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LiveStreamContainerPageViewController.swift; sourceTree = "<group>"; };
 		D07226EA1E66EA1600C2E537 /* LiveStreamEventDetailsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LiveStreamEventDetailsViewController.swift; sourceTree = "<group>"; };
 		D07226FF1E66FA3200C2E537 /* LiveStreamContainerPagesDataSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LiveStreamContainerPagesDataSource.swift; sourceTree = "<group>"; };
@@ -3067,8 +3067,6 @@
 			children = (
 				A73923AB1D272242004524C3 /* Activity.storyboard */,
 				015706511E64A6C70087DD68 /* BackerDashboard.storyboard */,
-				014D629C1E6E5B070033D2BD /* BackerDashboardEmptyStateCell.xib */,
-				014D62FE1E7211220033D2BD /* BackerDashboardProjectCell.xib */,
 				80EAEF031D243C4E008C2353 /* Backing.storyboard */,
 				774A76AF20D83F6B0012A71F /* BetaTools.storyboard */,
 				9DDE1F6F1D5924AC0092D9A5 /* Checkout.storyboard */,
@@ -3078,47 +3076,49 @@
 				A75798C21D6A24CD0063CEEC /* DebugPushNotifications.storyboard */,
 				A73923AF1D272242004524C3 /* Discovery.storyboard */,
 				59AE35AF1D67631B00A310E6 /* DiscoveryPage.storyboard */,
-				D6A7AB371FD9EDFD007B20AE /* DiscoveryPostcardCell.xib */,
-				7758A8352097A8180018B96D /* DiscoveryProjectCategoryView.xib */,
 				013744C01D999BE200E50C78 /* EmptyStates.storyboard */,
 				A73923B01D272242004524C3 /* Friends.storyboard */,
-				77F9A9B12135FC9B0082A11E /* FindFriendsCell.xib */,
 				01940B2D1D46A9AD0074FCE3 /* Help.storyboard */,
 				01F219521DC12697005DD2E4 /* LaunchScreen.storyboard */,
 				A787E6951E28A84B0017B186 /* LiveStream.storyboard */,
-				D0CC9D2C1E5B304200C2BC4A /* LiveStreamChatInputView.xib */,
 				A71C7F6D1E2FA03B0051E5E3 /* LiveStreamDiscovery.storyboard */,
-				D0CDA8A01E7434E400AA3450 /* LiveStreamNavTitleView.xib */,
-				77FD8B43216D6167000A95AC /* LoadingBarButtonItemView.xib */,
 				A73923B21D272242004524C3 /* Login.storyboard */,
 				A73923B31D272242004524C3 /* Main.storyboard */,
-				774527DD21B1E0480072E590 /* MessageBannerViewController.xib */,
 				A73923B41D272242004524C3 /* Messages.storyboard */,
 				A73923B71D272242004524C3 /* ProjectActivity.storyboard */,
 				A78838731D8A2EFF0081E94D /* ProjectPamphlet.storyboard */,
-				A77DA9231E4D13F000DB3A66 /* RewardCell.xib */,
 				A78852381D6CC5DE00617930 /* RewardPledge.storyboard */,
 				A73923B81D272242004524C3 /* Search.storyboard */,
 				77216D5F20F3D27C0061BE82 /* Settings.storyboard */,
-				77FB8BF620F6586500F91EEB /* SettingsHeaderView.xib */,
 				D6B6766120FE849F0082717D /* SettingsNewsletters.storyboard */,
+				D6AE3F5920EA973500DB212F /* SettingsNotifications.storyboard */,
+				D703FC3020F7E280004A272D /* SettingsPrivacy.storyboard */,
+				A73923AC1D272242004524C3 /* Thanks.storyboard */,
+				A73923BA1D272242004524C3 /* Update.storyboard */,
+				A73923BB1D272242004524C3 /* UpdateDraft.storyboard */,
+				59673C8A1D50EC920035AFD9 /* Video.storyboard */,
+				9D89B7E71D6BA71F0021F6FF /* WebModal.storyboard */,
+				014D629C1E6E5B070033D2BD /* BackerDashboardEmptyStateCell.xib */,
+				014D62FE1E7211220033D2BD /* BackerDashboardProjectCell.xib */,
+				D6A7AB371FD9EDFD007B20AE /* DiscoveryPostcardCell.xib */,
+				7758A8352097A8180018B96D /* DiscoveryProjectCategoryView.xib */,
+				77F9A9B12135FC9B0082A11E /* FindFriendsCell.xib */,
+				D0CC9D2C1E5B304200C2BC4A /* LiveStreamChatInputView.xib */,
+				D0CDA8A01E7434E400AA3450 /* LiveStreamNavTitleView.xib */,
+				77FD8B43216D6167000A95AC /* LoadingBarButtonItemView.xib */,
+				D05F4C5B21BA0C1900B9C4B0 /* MessageBannerViewController.xib */,
+				A77DA9231E4D13F000DB3A66 /* RewardCell.xib */,
 				77752F96219B3D7300E7DA7D /* SettingsAccountWarningCell.xib */,
+				D7C9F10721711954006F412F /* SettingsCurrencyCell.xib */,
+				D798A647215BE9B10053D097 /* SettingsCurrencyPickerCell.xib */,
+				77FB8BF620F6586500F91EEB /* SettingsHeaderView.xib */,
 				D6B6762A20FE849B0082717D /* SettingsNewslettersCell.xib */,
 				D6C3845A210B9AC400ADB671 /* SettingsNewslettersTopCell.xib */,
 				77A7B64221026CAE008D12C1 /* SettingsNotificationCell.xib */,
 				770E441421137F3700396D46 /* SettingsNotificationPickerCell.xib */,
 				77C5E219214182A2002E1670 /* SettingsPrivacySwitchCell.xib */,
-				D798A647215BE9B10053D097 /* SettingsCurrencyPickerCell.xib */,
-				D7C9F10721711954006F412F /* SettingsCurrencyCell.xib */,
-				D6AE3F5920EA973500DB212F /* SettingsNotifications.storyboard */,
-				D703FC3020F7E280004A272D /* SettingsPrivacy.storyboard */,
 				77FA6CAA20F3E3C200809E31 /* SettingsTableViewCell.xib */,
-				A73923AC1D272242004524C3 /* Thanks.storyboard */,
 				D6A7AB3E1FDAF3EC007B20AE /* ThanksCategoryCell.xib */,
-				A73923BA1D272242004524C3 /* Update.storyboard */,
-				A73923BB1D272242004524C3 /* UpdateDraft.storyboard */,
-				59673C8A1D50EC920035AFD9 /* Video.storyboard */,
-				9D89B7E71D6BA71F0021F6FF /* WebModal.storyboard */,
 			);
 			path = Storyboards;
 			sourceTree = "<group>";
@@ -3395,7 +3395,6 @@
 				D703FC6820F7E2EC004A272D /* SettingsPrivacyViewController.swift */,
 				D72370932119139D001EA4CA /* SettingsPrivacyViewControllerTests.swift */,
 				77216D9720F3D2E40061BE82 /* SettingsViewController.swift */,
-				D74E66AF212B7AB500C61708 /* SettingsViewControllerTests.swift */,
 				77E84DD12166A45B00DA8891 /* MessageBannerViewController.swift */,
 				A749001D1D00E27100BC3BE7 /* SignupViewController.swift */,
 				A7ED203D1E8323E900BFFA01 /* SignupViewControllerTests.swift */,
@@ -3740,6 +3739,7 @@
 				A7C725771C85D36D005A016B /* Library */,
 				A7BA542A1E1E493600E54377 /* LiveStream */,
 				A7E06C7A1C5A6EB300EBDCC2 /* Products */,
+				D0A2EB8521BA0DEE0006BB81 /* Recovered References */,
 			);
 			indentWidth = 2;
 			sourceTree = "<group>";
@@ -4483,6 +4483,14 @@
 				D0745B481EEB0B5E00FA53D3 /* ReactiveSwiftTests.xctest */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		D0A2EB8521BA0DEE0006BB81 /* Recovered References */ = {
+			isa = PBXGroup;
+			children = (
+				D74E66AF212B7AB500C61708 /* SettingsViewControllerTests.swift */,
+			);
+			name = "Recovered References";
 			sourceTree = "<group>";
 		};
 		D6ED1B3C216D617E007F7547 /* inputs */ = {
@@ -5377,6 +5385,7 @@
 				80EAEF051D243C4E008C2353 /* Backing.storyboard in Resources */,
 				A75798C31D6A24CD0063CEEC /* DebugPushNotifications.storyboard in Resources */,
 				A73923C31D272242004524C3 /* Login.storyboard in Resources */,
+				D05F4C5C21BA0C1900B9C4B0 /* MessageBannerViewController.xib in Resources */,
 				770E441521137F3700396D46 /* SettingsNotificationPickerCell.xib in Resources */,
 				A73923C91D272242004524C3 /* Search.storyboard in Resources */,
 				D6AE3F9120EA975300DB212F /* SettingsNotifications.storyboard in Resources */,
@@ -5404,7 +5413,6 @@
 				A73923BF1D272242004524C3 /* Dashboard.storyboard in Resources */,
 				9DDE1F701D5924AC0092D9A5 /* Checkout.storyboard in Resources */,
 				77A7B64321026CAE008D12C1 /* SettingsNotificationCell.xib in Resources */,
-				774527DE21B1E0480072E590 /* MessageBannerViewController.xib in Resources */,
 				A73923C01D272242004524C3 /* Discovery.storyboard in Resources */,
 				A73923C11D272242004524C3 /* Friends.storyboard in Resources */,
 				01940B2E1D46A9AD0074FCE3 /* Help.storyboard in Resources */,


### PR DESCRIPTION
# 📲 What

Fixes an Xcode warning due to our nib file not being set up correctly.

# 🤔 Why

Noticed a peculiar warning in Xcode:

<img width="307" alt="screen shot 2018-12-06 at 6 25 43 pm" src="https://user-images.githubusercontent.com/3735375/49624034-d1767200-f984-11e8-84bb-91d7e1119da4.png">

Started investigating and realized we probably aren't instantiating the `MessageBannerViewController` correctly now that it has its own `nib`.

# 🛠 How

- recreated the `xib` file 
- reconnected outlets
- updated vc instantiation

# 👀 See

| IB before  | IB after |
| ------------- | ------------- |
| <img width="320" alt="screen shot 2018-12-06 at 6 32 03 pm" src="https://user-images.githubusercontent.com/3735375/49624171-45187f00-f985-11e8-9ad2-497a31d8884f.png"> | <img width="319" alt="screen shot 2018-12-06 at 6 31 37 pm" src="https://user-images.githubusercontent.com/3735375/49624178-4d70ba00-f985-11e8-95d2-b178d9ee15c1.png"> |

# ✅ Acceptance criteria

- [ ] Message banner works exactly as before!