### PR TITLE
Remove shrug emoji

### DIFF
--- a/Library/ViewModels/SettingsCurrencyCellViewModel.swift
+++ b/Library/ViewModels/SettingsCurrencyCellViewModel.swift
@@ -21,7 +21,7 @@ SettingsCurrencyCellViewModelInputs, SettingsCurrencyCellViewModelOutputs {
 
   public init() {
     self.chosenCurrencyText = self.currencyProperty.signal
-      .map { $0?.descriptionText ?? "🤷🏽‍♀️" }
+      .map { $0?.descriptionText ?? "" }
   }
 
   fileprivate let currencyProperty = MutableProperty<Currency?>(nil)


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Removed "🤷🏾‍♀️" on currency cell where currency label should be present.
# 🤔 Why

This emoji was appearing whenever the chosen currency text was nil. Ex. no  wifi/ cellular data.

# 🛠 How

If the chosen currency text is nil then a blank string should emit.

# 👀 See


# ✅ Acceptance criteria

- [ ] Use your phone and turn off wifi/cellular data
- [ ] Navigate to  the Account screen and make sure "🤷🏾‍♀️" is no longer there.

