### PR TITLE
Make `pageViewController` optional

### DIFF
--- a/Kickstarter-iOS/Views/Controllers/BackerDashboardViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/BackerDashboardViewController.swift
@@ -24,7 +24,7 @@ internal final class BackerDashboardViewController: UIViewController {
   @IBOutlet private weak var sortBar: ProfileSortBarView!
   @IBOutlet private weak var topBackgroundView: UIView!
 
-  fileprivate weak var pageViewController: UIPageViewController!
+  fileprivate weak var pageViewController: UIPageViewController?
 
   fileprivate let viewModel: BackerDashboardViewModelType = BackerDashboardViewModel()
   fileprivate var pagesDataSource: BackerDashboardPagesDataSource!
@@ -40,13 +40,13 @@ internal final class BackerDashboardViewController: UIViewController {
 
     self.pageViewController = self.children
       .compactMap { $0 as? UIPageViewController }.first
-    self.pageViewController.setViewControllers(
+    self.pageViewController?.setViewControllers(
       [.init()],
       direction: .forward,
       animated: false,
       completion: nil
     )
-    self.pageViewController.delegate = self
+    self.pageViewController?.delegate = self
 
     _ = self.backedMenuButton
       |> UIButton.lens.targets .~ [(self, action: #selector(backedButtonTapped), .touchUpInside)]
@@ -66,7 +66,7 @@ internal final class BackerDashboardViewController: UIViewController {
 
     let tapRecognizer = UITapGestureRecognizer(target: self, action: #selector(tapGestureNotifier))
     tapRecognizer.cancelsTouchesInView = false
-    self.pageViewController.view.addGestureRecognizer(tapRecognizer)
+    self.pageViewController?.view.addGestureRecognizer(tapRecognizer)
 
     self.viewModel.inputs.viewDidLoad()
   }
@@ -126,7 +126,7 @@ internal final class BackerDashboardViewController: UIViewController {
         guard let _self = self, let controller = self?.pagesDataSource.controllerFor(tab: tab) else {
           fatalError("Controller not found for tab \(tab)")
         }
-        _self.pageViewController.setViewControllers(
+        _self.pageViewController?.setViewControllers(
           [controller],
           direction: .forward,
           animated: false,
@@ -192,8 +192,8 @@ internal final class BackerDashboardViewController: UIViewController {
   private func configurePagesDataSource(tab: BackerDashboardTab, sort: DiscoveryParams.Sort) {
     self.pagesDataSource = BackerDashboardPagesDataSource(delegate: self, sort: sort)
 
-    self.pageViewController.dataSource = self.pagesDataSource
-    self.pageViewController.setViewControllers(
+    self.pageViewController?.dataSource = self.pagesDataSource
+    self.pageViewController?.setViewControllers(
       [self.pagesDataSource.controllerFor(tab: tab)].compact(),
       direction: .forward,
       animated: false,
@@ -370,9 +370,7 @@ extension BackerDashboardViewController: UIGestureRecognizerDelegate {
 
 extension BackerDashboardViewController: TabBarControllerScrollable {
   func scrollToTop() {
-    //swiftlint:disable todo
-    //FIXME: crash because self.pageViewController is nil
-    if let scrollView = self.pageViewController.viewControllers?.first?.view as? UIScrollView {
+    if let scrollView = self.pageViewController?.viewControllers?.first?.view as? UIScrollView {
       scrollView.scrollToTop()
     }
   }


### PR DESCRIPTION
# 📲 What

Fixes the crash in `BackerDashboardViewController`'s `scrollToTop()`

# 🤔 Why

#crashFreeSince93

# 🛠 How

So this will be more of an elaborate rant of steps I've tried since it's very hard to reproduce this or find the real reason for this to happen.

We know why the crash happens, but we don't really know what's causing it (for now).

The crash is caused by `pageViewController` in `BackerDashboardViewController` being declared as `implicitly unwrapped optional` loaded from the NIB in `viewDidLoad`.

```
self.pageViewController = self.children
      .compactMap { $0 as? UIPageViewController }.first
```

This by itself should not cause any problems, except it actually does. The crash happens because `pageViewController` is set to `nil` at some point in time and that crashes the following line in `scrollToTop()` function:

```
if let scrollView = self.pageViewController.viewControllers?.first?.view as? UIScrollView {
                                           ^^^ crashes here while trying to access viewControllers on nil
```

So, let's try to find out what's wrong..

First, let's look at that `pageViewController`...

```
fileprivate weak var pageViewController: UIPageViewController!
```

Implicitly unwrapped optional but why not an `IBOutlet` 🤔 🤔 🤔 . That's cool...let's try removing `weak` since I've recently read it's not necessary for top level objects loaded from NIB files - https://stackoverflow.com/a/7729141

💥 Still crashes

Cool cool. Revert back to `weak` and let's try to make it optional and since we know this will workaround the crash let's still have a way of seeing if `pageViewController` is `nil` while `scrollToTop()` is called.

✅ ⚠️  Great, doesn't crash anymore. But we can eventually (after dreadful logging in and out between a backer user and a non-backer user >>> dreadful = 20+ times) see that `pageViewController` becomes `nil` (even though it shouldn't). 

I initially thought this is caused when logging in as a different type of a user (backer vs non-backer) but later on I was able to see the crash while trying to log in with Facebook login + 2FA. So the original assumption was wrong.

Let's try our old friend Instruments and get some allocation count help. Unfortunately Im not aware of an easy way to see `print` statements while running the app with Instruments so let's tweak this code a little.

```
// BackerDashboardViewController.swift

func scrollToTop() {
  if self.pageViewController == nil {
    NotificationCenter.default.post(name: Notification.Name(rawValue: "y_u_crash"), object: nil)
  }

  ...
}
```

and

```
// AppDelegate.swift

@objc func crash() {
  DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
      // Show alert that the crash happened so we can be notified while we don't have access to console output
    }
}

func application(
    _ application: UIApplication,
    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
    
    NotificationCenter.default.addObserver(self, selector: #selector(crash), name: Notification.Name(rawValue: "y_u_crash"), object: nil)
```

Great...so we have the app running with Instruments...logging in and out like a mad person trying to switch between backer and non-backer user. Eventually we see the alert happening. 🤔 

Let's see if we have leaked something. Let's see how many instances of `BackerDashboardViewController` are there? Weird, there's 1 persistent instance and couple transient...doesn't seem like something's wrong at this point.

That seems like a dead end.

I've actually didn't give up just there and tried to continue madly logging in and out to eventually see a leak in `BackerDashboardViewController` but since it didn't happen the first time we can assume it's not related (for now).

With all that above I'm not sure where does this leave us. We can implement this workaround of making `pageViewController` optional and investigate further into the crash later. We should also investigate why are we leaking `BackerDashboardViewController`. Hopefully these are 2 unrelated issues.

# ✅ Acceptance criteria

Since there are no easy steps to reproduce this will have to rely on our knowledge of Swift & `UIKit` to make the right call

# ⏰ TODO

- [ ] Open a card to address this crash properly. Find out what's actually happening ¯\_(ツ)_/¯
- [ ] Open a card to investigate `BackerDashboardViewController` leak