### PR TITLE
Use team name instead of team ID for deliver

### DIFF
--- a/.fastlane/Fastfile
+++ b/.fastlane/Fastfile
@@ -128,7 +128,7 @@ platform :ios do
       app_identifier: ENV["ITUNES_APP_IDENTIFIER"],
       app: ENV["ITUNES_APP_ID"],
       ipa: "./output/gym/Kickstarter.ipa",
-      team_id: ENV["ITUNES_TEAM_ID"],
+      team_name: ENV["ITUNES_TEAM_NAME"],
       skip_screenshots: true,
       skip_metadata: true
     )


### PR DESCRIPTION
# 📲 What

Use `team_name` instead of `team_id` for `deliver`.

# 🤔 Why

We did this in #462 for uploading dSYMs and should have also made the change for `deliver`. It turns out the team IDs on iTunes Connect changed at some point and it's more future-proof to use team name for this.

# 🛠 How

Change `team_id` -> `team_name` for `deliver`.