### PR TITLE
Fixed crash when trying to change environment/language

### DIFF
--- a/Kickstarter-iOS/Views/Controllers/BetaToolsViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/BetaToolsViewController.swift
@@ -131,6 +131,11 @@ internal final class BetaToolsViewController: UIViewController {
       UIAlertAction.init(title: "Cancel", style: .cancel)
     )
 
+    if UIDevice.current.userInterfaceIdiom == .pad {
+      alert.modalPresentationStyle = .popover
+      alert.popoverPresentationController?.sourceView = self.languageSwitcher
+    }
+
     self.present(alert, animated: true, completion: nil)
   }
 
@@ -148,6 +153,11 @@ internal final class BetaToolsViewController: UIViewController {
     alert.addAction(
       UIAlertAction.init(title: "Cancel", style: .cancel)
     )
+
+    if UIDevice.current.userInterfaceIdiom == .pad {
+      alert.modalPresentationStyle = .popover
+      alert.popoverPresentationController?.sourceView = self.environmentSwitcher
+    }
 
     self.present(alert, animated: true, completion: nil)
   }


### PR DESCRIPTION
# 📲 What
Fixed a crash that was happening on `BetaToolsViewController` when trying to change environment or language.

# 🤔 Why
The app was crashing because we were not setting the modalPresentation style to `.popover`, what's  required for iPad if we are trying to present an ActionSheet.

# 🛠 How
By setting if the device is iPad and setting the presentation style to popover.

# 👀 See
<img width="400" src="https://user-images.githubusercontent.com/3709676/49884857-dcf1ef00-fe03-11e8-9e50-2ee8f918af8b.png"/>

# ✅ Acceptance criteria

- [ ] Using an iPad, go to `Beta Tools` and tap the environment button. A popover should appear with the environment options.
- [ ] Using an iPad, go to `Beta Tools` and tap the language button. A popover should appear with the language options.

![GIF](https://media.giphy.com/media/6mGzvKGJGsYH6/giphy.gif)
