### PR TITLE
Accessibility - Settings - Dismiss button

### DIFF
--- a/Kickstarter-iOS/Views/Controllers/SettingsViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/SettingsViewController.swift
@@ -28,12 +28,7 @@ final class SettingsViewController: UIViewController {
     self.tableView.registerHeaderFooter(nib: .SettingsHeaderView)
 
     if self.presentingViewController != nil {
-      let image = UIImage(named: "icon--cross")
-      self.navigationItem.leftBarButtonItem =
-        UIBarButtonItem(image: image,
-                        style: .plain,
-                        target: self,
-                        action: #selector(closeButtonPressed))
+      self.navigationItem.leftBarButtonItem = self.leftBarButtonItem()
     }
 
     self.userUpdatedObserver = NotificationCenter.default
@@ -87,6 +82,19 @@ final class SettingsViewController: UIViewController {
     self.viewModel.outputs.goToAppStoreRating
       .observeForControllerAction()
       .observeValues { [weak self] link in self?.goToAppStore(link: link) }
+  }
+
+  private func leftBarButtonItem() -> UIBarButtonItem {
+    let leftBarButtonItem = UIBarButtonItem(
+      image: UIImage(named: "icon--cross"),
+      style: .plain,
+      target: self,
+      action: #selector(closeButtonPressed)
+    )
+    leftBarButtonItem.accessibilityLabel = Strings.Dismiss()
+    leftBarButtonItem.width = 44
+
+    return leftBarButtonItem
   }
 
   @objc fileprivate func closeButtonPressed() {

--- a/Kickstarter-iOS/Views/Controllers/SettingsViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/SettingsViewController.swift
@@ -91,8 +91,10 @@ final class SettingsViewController: UIViewController {
       target: self,
       action: #selector(closeButtonPressed)
     )
-    leftBarButtonItem.accessibilityLabel = Strings.Dismiss()
-    leftBarButtonItem.width = 44
+
+    _ = leftBarButtonItem
+      |> \.accessibilityLabel %~ { _ in Strings.Dismiss() }
+      |> \.width .~ 44
 
     return leftBarButtonItem
   }


### PR DESCRIPTION
# 📲 What

Adds accessibility label to the dismiss button & fixes the minimum width of the button in order to follow HIG best practices for tappable elements (44x44 pts)

# 🤔 Why

Better accessibility

# 🛠 How

Simply adding accessibility label (this will prevent from using the image name)

# 👀 See

| Before | After |
| --- | --- |
| <img width="782" alt="screen shot 2018-12-19 at 2 32 17 pm" src="https://user-images.githubusercontent.com/387596/50252468-f236c280-039b-11e9-946c-7f6c6ffcfc76.png"> | <img width="782" alt="screen shot 2018-12-19 at 2 33 59 pm" src="https://user-images.githubusercontent.com/387596/50252475-f7940d00-039b-11e9-868d-2575b45dcb06.png"> |
| <img width="785" alt="screen shot 2018-12-19 at 2 32 26 pm" src="https://user-images.githubusercontent.com/387596/50252482-ffec4800-039b-11e9-9cae-f97d3dd43609.png"> | <img width="781" alt="screen shot 2018-12-19 at 2 34 58 pm" src="https://user-images.githubusercontent.com/387596/50252485-05499280-039c-11e9-89f6-76a572380b1f.png"> |

# ✅ Acceptance criteria

- [x] Voice Over reads the dismiss button as "Dismiss - Button" (please not that this is localized)
- [x] Accessibility Inspector doesn't show min-width warning when running the audit on Settings screen