### PR TITLE
Accessibility - Settings - Change email status

### DIFF
--- a/Kickstarter-iOS/Views/Cells/SettingsAccountWarningCell.swift
+++ b/Kickstarter-iOS/Views/Cells/SettingsAccountWarningCell.swift
@@ -14,6 +14,13 @@ final class SettingsAccountWarningCell: UITableViewCell, ValueCell, NibLoading {
 
     _ = self.warningIconImage
       |> \.isHidden .~ shouldHideAlertIcon
+
+    if !shouldHideAlertIcon {
+      _ = self
+        |> \.accessibilityHint %~ { _ in
+          Strings.Email_unverified()
+      }
+    }
   }
 
   override func bindStyles() {


### PR DESCRIPTION
# 📲 What

Adds accessibility hint to the `Change email` cell in case the email is unverified.

# 🤔 Why

Better reflects visual UI to Voice Over users

# 🛠 How

Simply adds `accessibilityHint`. This is so that the order of the reader is as follows: `Change email` - `Button` - `This email address is unverified`. This should be a suitable solution since the information is secondary.

# ✅ Acceptance criteria

on all the following: iOS 10, iOS 11 & iOS 12
with Voice Over turned ON

- [x] Focusing on Change email cell in `Settings > Account` reads as `Change email - Button - This email address is unverified`