### PR TITLE
[BUG] Regenerate tab VCs when user changes currency

### DIFF
--- a/Kickstarter-iOS/ViewModels/RootViewModel.swift
+++ b/Kickstarter-iOS/ViewModels/RootViewModel.swift
@@ -23,9 +23,6 @@ internal protocol RootViewModelInputs {
   /// Call when the controller has received a user updated notification.
   func currentUserUpdated()
 
-  /// Call when the language selection has changed
-  func currentLanguageChanged()
-
   /// Call before selected tab bar index changes.
   func shouldSelect(index: Int?)
 
@@ -49,6 +46,9 @@ internal protocol RootViewModelInputs {
 
   /// Call when we should switch to the search tab.
   func switchToSearch()
+
+  /// Call when the a user locale preference has changed
+  func userLocalePreferencesChanged()
 
   /// Call when the controller has received a user session ended notification.
   func userSessionEnded()
@@ -107,7 +107,7 @@ internal final class RootViewModel: RootViewModelType, RootViewModelInputs, Root
 
     let viewControllers = Signal.combineLatest(standardViewControllers, personalizedViewControllers).map(+)
 
-    let refreshedViewControllers = userState.takeWhen(self.currentLanguageProperty.signal)
+    let refreshedViewControllers = userState.takeWhen(self.userLocalePreferencesChangedProperty.signal)
       .map { userState -> [UIViewController?] in
         let standard = generateStandardViewControllers()
         let personalized = generatePersonalizedViewControllers(userState: userState)
@@ -192,7 +192,7 @@ internal final class RootViewModel: RootViewModelType, RootViewModelInputs, Root
 
     self.tabBarItemsData = Signal.combineLatest(currentUser, .merge(
       self.viewDidLoadProperty.signal,
-      self.currentLanguageProperty.signal.ignoreValues())
+      self.userLocalePreferencesChangedProperty.signal.ignoreValues())
       )
       .map(first)
       .map(tabData(forUser:))
@@ -201,11 +201,6 @@ internal final class RootViewModel: RootViewModelType, RootViewModelInputs, Root
   fileprivate let currentUserUpdatedProperty = MutableProperty(())
   internal func currentUserUpdated() {
     self.currentUserUpdatedProperty.value = ()
-  }
-
-  fileprivate let currentLanguageProperty = MutableProperty(())
-  internal func currentLanguageChanged() {
-    self.currentLanguageProperty.value = ()
   }
 
   fileprivate let shouldSelectIndexProperty = MutableProperty<Int?>(nil)
@@ -241,6 +236,12 @@ internal final class RootViewModel: RootViewModelType, RootViewModelInputs, Root
   internal func switchToSearch() {
     self.switchToSearchProperty.value = ()
   }
+
+  fileprivate let userLocalePreferencesChangedProperty = MutableProperty(())
+  internal func userLocalePreferencesChanged() {
+    self.userLocalePreferencesChangedProperty.value = ()
+  }
+
   fileprivate let userSessionStartedProperty = MutableProperty(())
   internal func userSessionStarted() {
     self.userSessionStartedProperty.value = ()

--- a/Kickstarter-iOS/ViewModels/RootViewModelTests.swift
+++ b/Kickstarter-iOS/ViewModels/RootViewModelTests.swift
@@ -132,7 +132,7 @@ final class RootViewModelTests: TestCase {
     self.viewControllerNames.assertValueCount(1)
   }
 
-  func testUpdateCurrentLanguage() {
+  func testUpdateUserLocalePreferences() {
     let viewControllerNames = TestObserver<[String], NoError>()
     vm.outputs.setViewControllers.map(extractRootNames)
       .observe(viewControllerNames.observer)
@@ -142,7 +142,7 @@ final class RootViewModelTests: TestCase {
     self.viewControllerNames.assertValueCount(1)
     self.tabBarItemsData.assertValueCount(1)
 
-    self.vm.inputs.currentLanguageChanged()
+    self.vm.inputs.userLocalePreferencesChanged()
 
     self.viewControllerNames.assertValueCount(2)
     self.tabBarItemsData.assertValueCount(2)

--- a/Kickstarter-iOS/Views/Controllers/BetaToolsViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/BetaToolsViewController.swift
@@ -155,7 +155,7 @@ internal final class BetaToolsViewController: UIViewController {
 
   private func languageDidChange(language: Language) {
     AppEnvironment.updateLanguage(language)
-    NotificationCenter.default.post(name: Notification.Name.ksr_languageChanged,
+    NotificationCenter.default.post(name: Notification.Name.ksr_userLocalePreferencesChanged,
                                     object: nil,
                                     userInfo: nil)
   }

--- a/Kickstarter-iOS/Views/Controllers/RootTabBarViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/RootTabBarViewController.swift
@@ -20,7 +20,7 @@ public final class RootTabBarViewController: UITabBarController {
   private var sessionEndedObserver: Any?
   private var sessionStartedObserver: Any?
   private var userUpdatedObserver: Any?
-  private var languageChangedObserver: Any?
+  private var userLocalePreferencesChanged: Any?
 
   fileprivate let viewModel: RootViewModelType = RootViewModel()
 
@@ -46,13 +46,13 @@ public final class RootTabBarViewController: UITabBarController {
         self?.viewModel.inputs.currentUserUpdated()
     }
 
-    self.languageChangedObserver = NotificationCenter
+    self.userLocalePreferencesChanged = NotificationCenter
       .default
-      .addObserver(forName: Notification.Name.ksr_languageChanged,
+      .addObserver(forName: Notification.Name.ksr_userLocalePreferencesChanged,
                    object: nil,
                    queue: nil,
                    using: { [weak self] _ in
-        self?.viewModel.inputs.currentLanguageChanged()
+        self?.viewModel.inputs.userLocalePreferencesChanged()
       })
 
     self.viewModel.inputs.viewDidLoad()

--- a/Kickstarter-iOS/Views/Controllers/SettingsAccountViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/SettingsAccountViewController.swift
@@ -52,7 +52,6 @@ final class SettingsAccountViewController: UIViewController, MessageBannerViewCo
     self.viewModel.outputs.currencyUpdated
       .observeForControllerAction()
       .observeValues { _ in
-        // Refresh the discovery screens
         NotificationCenter.default.post(.init(name: .ksr_userLocalePreferencesChanged))
     }
 

--- a/Kickstarter-iOS/Views/Controllers/SettingsAccountViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/SettingsAccountViewController.swift
@@ -49,6 +49,13 @@ final class SettingsAccountViewController: UIViewController, MessageBannerViewCo
   }
 
   override func bindViewModel() {
+    self.viewModel.outputs.currencyUpdated
+      .observeForControllerAction()
+      .observeValues { _ in
+        // Refresh the discovery screens
+        NotificationCenter.default.post(.init(name: .ksr_userLocalePreferencesChanged))
+    }
+
     self.viewModel.outputs.reloadData
       .observeForUI()
       .observeValues { [weak self] currency, shouldHideEmailWarning, shouldHideEmailPasswordSection in

--- a/Library/Notifications.swift
+++ b/Library/Notifications.swift
@@ -1,15 +1,15 @@
 import Foundation
 
 public enum CurrentUserNotifications {
-  public static let showNotificationsDialog = "CurrentUserNotifications.showNotificationsDialog"
-  public static let projectSaved = "CurrentUserNotifications.projectSaved"
   public static let dataRequested = "CurrentUserNotifications.dataRequested"
-  public static let savedProjectEmptyStateTapped = "CurrentUserNotifications.savedProjectEmptyStateTapped"
-  public static let sessionStarted = "CurrentUserNotifications.sessionStarted"
-  public static let sessionEnded = "CurrentUserNotifications.sessionEnded"
-  public static let userUpdated = "CurrentUserNotifications.userUpdated"
-  public static let languageChanged = "CurrentUserNotification.languageChanged"
   public static let environmentChanged = "CurrentUserNotification.environmentChanged"
+  public static let localePreferencesChanged = "CurrentUserNotification.localePreferencesChanged"
+  public static let projectSaved = "CurrentUserNotifications.projectSaved"
+  public static let savedProjectEmptyStateTapped = "CurrentUserNotifications.savedProjectEmptyStateTapped"
+  public static let sessionEnded = "CurrentUserNotifications.sessionEnded"
+  public static let sessionStarted = "CurrentUserNotifications.sessionStarted"
+  public static let showNotificationsDialog = "CurrentUserNotifications.showNotificationsDialog"
+  public static let userUpdated = "CurrentUserNotifications.userUpdated"
 }
 
 public enum UserInfoKeys {
@@ -18,19 +18,19 @@ public enum UserInfoKeys {
 }
 
 extension Notification.Name {
-  public static let ksr_sessionStarted = Notification.Name(rawValue: CurrentUserNotifications.sessionStarted)
-  public static let ksr_sessionEnded = Notification.Name(rawValue: CurrentUserNotifications.sessionEnded)
-  public static let ksr_userUpdated = Notification.Name(rawValue: CurrentUserNotifications.userUpdated)
-  public static let ksr_projectSaved = Notification.Name(rawValue: CurrentUserNotifications.projectSaved)
   public static let ksr_dataRequested = Notification.Name(rawValue: CurrentUserNotifications.dataRequested)
-  public static let ksr_savedProjectEmptyStateTapped =
-    Notification.Name(rawValue: CurrentUserNotifications.savedProjectEmptyStateTapped)
-  public static let ksr_showNotificationsDialog =
-    Notification.Name(rawValue: CurrentUserNotifications.showNotificationsDialog)
-  public static let ksr_languageChanged = Notification.Name(rawValue:
-    CurrentUserNotifications.languageChanged
-  )
   public static let ksr_environmentChanged = Notification.Name(rawValue:
     CurrentUserNotifications.environmentChanged
   )
+  public static let ksr_projectSaved = Notification.Name(rawValue: CurrentUserNotifications.projectSaved)
+  public static let ksr_savedProjectEmptyStateTapped =
+    Notification.Name(rawValue: CurrentUserNotifications.savedProjectEmptyStateTapped)
+  public static let ksr_sessionStarted = Notification.Name(rawValue: CurrentUserNotifications.sessionStarted)
+  public static let ksr_sessionEnded = Notification.Name(rawValue: CurrentUserNotifications.sessionEnded)
+  public static let ksr_showNotificationsDialog =
+    Notification.Name(rawValue: CurrentUserNotifications.showNotificationsDialog)
+  public static let ksr_userLocalePreferencesChanged = Notification.Name(rawValue:
+    CurrentUserNotifications.localePreferencesChanged
+  )
+  public static let ksr_userUpdated = Notification.Name(rawValue: CurrentUserNotifications.userUpdated)
 }

--- a/Library/ViewModels/SettingsAccountViewModel.swift
+++ b/Library/ViewModels/SettingsAccountViewModel.swift
@@ -14,6 +14,7 @@ public protocol SettingsAccountViewModelInputs {
 }
 
 public protocol SettingsAccountViewModelOutputs {
+  var currencyUpdated: Signal<Void, NoError> { get }
   var dismissCurrencyPicker: Signal<Void, NoError> { get }
   var fetchAccountFieldsError: Signal<Void, NoError> { get }
   var presentCurrencyPicker: Signal<Currency, NoError> { get }
@@ -77,6 +78,7 @@ SettingsAccountViewModelOutputs, SettingsAccountViewModelType {
 
     self.updateCurrencyFailure = updateCurrencyEvent.errors()
       .map { $0.localizedDescription }
+    self.currencyUpdated = updateCurrencyEvent.values().ignoreValues()
 
     let currency = Signal.merge(chosenCurrency, updateCurrency)
 
@@ -145,6 +147,7 @@ SettingsAccountViewModelOutputs, SettingsAccountViewModelType {
     self.viewDidLoadProperty.value = ()
   }
 
+  public let currencyUpdated: Signal<Void, NoError>
   public let dismissCurrencyPicker: Signal<Void, NoError>
   public let fetchAccountFieldsError: Signal<Void, NoError>
   public let reloadData: Signal<(Currency, Bool, Bool), NoError>


### PR DESCRIPTION
# 📲 What

When a user changes their currency, we reload all of the tabs so there is no lag in showing project pledge amounts in the user's selected currency.

# 🤔 Why

When we show a project, we first populate the pledge amount using the current `Project` object from the discovery feed. When a user changes their currency, unless we refresh the discovery feed, the `Project` object from discovery will have a "stale" currency until the "updated" currency is populated on the project page. This appears as a "lag" where the user will momentarily see pledge amounts in the old currency before seem them in their preferred currency.

Now, we refresh all the discovery feeds when users change their currency.

# 🛠 How

Combined the `languageChanged` notification into `userLocalePreferencesChanged`, which will now fire both when a user changes their currency, and when you change your language using the beta tools.

# 👀 See

**Before**
![wylse3umss](https://user-images.githubusercontent.com/3156796/50357777-1eca1600-0525-11e9-8cfe-2f2a29697062.gif)

**After**
![nfynecq0yu](https://user-images.githubusercontent.com/3156796/50357767-1a056200-0525-11e9-8ced-37f206b26477.gif)

# ✅ Acceptance criteria

- [x] navigate to change currency, change your currency, then navigate to any project (from profile, discovery, search, activity...) – there should be no lag in displaying pledge amounts in the correct currency
- [x] change language using the beta tools should work as before

