### PR TITLE
Accessibility - Settings - Change email - Current email

### DIFF
--- a/Kickstarter-iOS/Views/Controllers/ChangeEmailViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/ChangeEmailViewController.swift
@@ -5,8 +5,9 @@ import ReactiveSwift
 import UIKit
 
 internal final class ChangeEmailViewController: UIViewController, MessageBannerViewControllerPresenting {
-  @IBOutlet fileprivate weak var currentEmailLabel: UILabel!
-  @IBOutlet fileprivate weak var currentEmail: UILabel!
+  @IBOutlet fileprivate weak var currentEmailContainer: UIView!
+  @IBOutlet fileprivate weak var currentEmailTitle: UILabel!
+  @IBOutlet fileprivate weak var currentEmailValue: UILabel!
   @IBOutlet fileprivate weak var messageLabelView: UIView!
   @IBOutlet fileprivate weak var newEmailLabel: UILabel!
   @IBOutlet fileprivate weak var newEmailTextField: UITextField!
@@ -86,13 +87,22 @@ internal final class ChangeEmailViewController: UIViewController, MessageBannerV
       |> \.textColor .~ .ksr_red_400
       |> \.text %~ { _ in Strings.We_ve_been_unable_to_send_email() }
 
-    _ = self.currentEmailLabel
+    _ = self.currentEmailContainer
+      |> \.isAccessibilityElement .~ true
+      |> \.accessibilityLabel %~ { _ in
+        guard let emailTitle = self.currentEmailTitle.text else { return nil }
+        return emailTitle
+    }
+
+    _ = self.currentEmailTitle
       |> settingsTitleLabelStyle
+      |> \.isAccessibilityElement .~ false
       |> \.text %~ { _ in Strings.Current_email() }
       |> \.textColor .~ .ksr_text_dark_grey_400
 
-    _ = self.currentEmail
+    _ = self.currentEmailValue
       |> settingsDetailLabelStyle
+      |> \.isAccessibilityElement .~ false
       |> \.textColor .~ .ksr_text_dark_grey_400
 
     _ = self.newEmailLabel
@@ -125,7 +135,8 @@ internal final class ChangeEmailViewController: UIViewController, MessageBannerV
   override func bindViewModel() {
     super.bindViewModel()
 
-    self.currentEmail.rac.text = self.viewModel.outputs.emailText
+    self.currentEmailContainer.rac.accessibilityValue = self.viewModel.outputs.emailText
+    self.currentEmailValue.rac.text = self.viewModel.outputs.emailText
     self.resendVerificationEmailView.rac.hidden = self.viewModel.outputs.resendVerificationEmailViewIsHidden
     self.resendVerificationEmailButton.rac.title = self.viewModel.outputs.verificationEmailButtonTitle
     self.onePasswordButton.rac.hidden = self.viewModel.outputs.onePasswordButtonIsHidden

--- a/Kickstarter-iOS/Views/Controllers/ChangeEmailViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/ChangeEmailViewController.swift
@@ -89,10 +89,7 @@ internal final class ChangeEmailViewController: UIViewController, MessageBannerV
 
     _ = self.currentEmailContainer
       |> \.isAccessibilityElement .~ true
-      |> \.accessibilityLabel %~ { _ in
-        guard let emailTitle = self.currentEmailTitle.text else { return nil }
-        return emailTitle
-    }
+      |> \.accessibilityLabel %~ { _ in self.currentEmailTitle.text }
 
     _ = self.currentEmailTitle
       |> settingsTitleLabelStyle

--- a/Kickstarter-iOS/Views/Storyboards/Settings.storyboard
+++ b/Kickstarter-iOS/Views/Storyboards/Settings.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14313.18" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14283.14"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -143,14 +143,14 @@
         <scene sceneID="sW7-08-TIc">
             <objects>
                 <viewController storyboardIdentifier="ChangeEmailViewController" title="Change Email" id="JTR-kW-WZp" customClass="ChangeEmailViewController" customModule="Kickstarter_Framework" sceneMemberID="viewController">
-                    <view key="view" contentMode="scaleToFill" id="Sro-rn-6F2">
+                    <view key="view" contentMode="scaleToFill" ambiguous="YES" id="Sro-rn-6F2">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="XfD-wg-Nx4" customClass="UIScrollView">
+                            <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="XfD-wg-Nx4" customClass="UIScrollView">
                                 <rect key="frame" x="0.0" y="20" width="375" height="647"/>
                                 <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="VyE-lE-aLQ">
+                                    <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="VyE-lE-aLQ">
                                         <rect key="frame" x="0.0" y="0.0" width="375" height="647"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="eOl-CY-t3g">
@@ -163,7 +163,7 @@
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gKy-91-KIN" userLabel="Change email">
                                                 <rect key="frame" x="0.0" y="36" width="375" height="52"/>
                                                 <subviews>
-                                                    <stackView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="255" verticalHuggingPriority="255" horizontalCompressionResistancePriority="755" verticalCompressionResistancePriority="755" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="44i-Jb-zGG" userLabel="Current Email View">
+                                                    <stackView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="255" verticalHuggingPriority="255" horizontalCompressionResistancePriority="755" verticalCompressionResistancePriority="755" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="44i-Jb-zGG" userLabel="Current Email Container">
                                                         <rect key="frame" x="12" y="6" width="351" height="40"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalCompressionResistancePriority="751" text="Current email" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hbC-wV-1kr">
@@ -305,7 +305,7 @@
                                                     <constraint firstItem="9eu-AW-ocS" firstAttribute="leading" secondItem="9Ny-Zh-npT" secondAttribute="leading" constant="12" id="mMW-w3-7Dw"/>
                                                 </constraints>
                                             </view>
-                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9uR-ng-0BU" userLabel="Password">
+                                            <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="9uR-ng-0BU" userLabel="Password">
                                                 <rect key="frame" x="0.0" y="222" width="375" height="425"/>
                                                 <subviews>
                                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="lrH-yX-xHX">
@@ -338,7 +338,7 @@
                                                             <constraint firstAttribute="height" constant="40" id="QpO-Lf-gR6"/>
                                                         </constraints>
                                                     </stackView>
-                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="PLh-cR-QEi" userLabel="Separator">
+                                                    <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="PLh-cR-QEi" userLabel="Separator">
                                                         <rect key="frame" x="0.0" y="424" width="375" height="1"/>
                                                         <color key="backgroundColor" red="0.86274509799999999" green="0.87058823529999996" blue="0.86666666670000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <constraints>
@@ -387,8 +387,9 @@
                         </barButtonItem>
                     </navigationItem>
                     <connections>
-                        <outlet property="currentEmail" destination="dhC-lf-MHP" id="W6i-3P-BKo"/>
-                        <outlet property="currentEmailLabel" destination="hbC-wV-1kr" id="hSG-qw-h93"/>
+                        <outlet property="currentEmailContainer" destination="44i-Jb-zGG" id="MKI-UJ-wHU"/>
+                        <outlet property="currentEmailTitle" destination="hbC-wV-1kr" id="0wv-ea-9E7"/>
+                        <outlet property="currentEmailValue" destination="dhC-lf-MHP" id="Qo9-DK-3VK"/>
                         <outlet property="messageLabelView" destination="Cdr-bL-P2W" id="gSf-t3-n3p"/>
                         <outlet property="newEmailLabel" destination="shM-z1-cjb" id="tnq-XP-h0n"/>
                         <outlet property="newEmailTextField" destination="uEZ-83-bce" id="IEP-yb-Kq6"/>


### PR DESCRIPTION
# 📲 What

Groups current email title and value label into one accessible element.

# 🤔 Why

This makes it easier for Voice Over to navigate and more human readable to digest.

# 🛠 How

Simply disabling accessibility on labels and using a container view as the accessible element.

Side note:
I've renamed some of the labels on the controller due to the lack of clarity they provided.

# 👀 See

| Before | After |
| --- | --- |
| <img width="494" alt="screen shot 2018-12-21 at 11 37 49 am" src="https://user-images.githubusercontent.com/387596/50360470-fc300100-0514-11e9-9ee8-bf4acb024edd.png"> | <img width="538" alt="screen shot 2018-12-21 at 11 36 57 am" src="https://user-images.githubusercontent.com/387596/50360625-811b1a80-0515-11e9-8e6f-1cfce66ee0b4.png"> |

# ✅ Acceptance criteria

on all the following: iOS 10, iOS 11 & iOS 12
with Voice Over turned ON

- [x] Current email row is one single focus element and is read by Voice Over like so: `Current email - whateveremailthereis@domain.com` (note: the title is localized)