### PR TITLE
Ignore project preview deep-links

### DIFF
--- a/Kickstarter-iOS/ViewModels/AppDelegateViewModel.swift
+++ b/Kickstarter-iOS/ViewModels/AppDelegateViewModel.swift
@@ -404,11 +404,8 @@ AppDelegateViewModelOutputs {
       .filter { $0 == .tab(.me) }
       .ignoreValues()
 
-    self.goToMobileSafari = Signal.merge(
-      self.foundRedirectUrlProperty.signal.skipNil(),
-      deepLinkUrl
-    )
-    .filter { Navigation.deepLinkMatch($0) == nil }
+    self.goToMobileSafari = deepLinkUrl
+      .filter { Navigation.deepLinkMatch($0) == nil }
 
     let projectLink = deepLink
       .filter { link in

--- a/Kickstarter-iOS/ViewModels/AppDelegateViewModelTests.swift
+++ b/Kickstarter-iOS/ViewModels/AppDelegateViewModelTests.swift
@@ -1365,6 +1365,39 @@ final class AppDelegateViewModelTests: TestCase {
     self.goToMobileSafari.assertValues([unrecognizedUrl], "Go to mobile safari for the unrecognized url.")
   }
 
+  func testEmailDeepLinking_UnrecognizedUrl_ProjectPreview() {
+    let emailUrl = URL(string: "https://click.e.kickstarter.com/?qs=deadbeef")!
+
+    // The application launches.
+    self.vm.inputs.applicationDidFinishLaunching(application: UIApplication.shared,
+                                                 launchOptions: [:])
+
+    self.findRedirectUrl.assertValues([])
+    self.presentViewController.assertValueCount(0)
+    self.goToMobileSafari.assertValues([])
+
+    // We deep-link to an email url.
+    self.vm.inputs.applicationDidEnterBackground()
+    self.vm.inputs.applicationWillEnterForeground()
+    let result = self.vm.inputs.applicationOpenUrl(application: UIApplication.shared,
+                                                   url: emailUrl,
+                                                   sourceApplication: nil,
+                                                   annotation: 1)
+    XCTAssertFalse(result)
+
+    self.findRedirectUrl.assertValues([emailUrl], "Ask to find the redirect after open the email url.")
+    self.presentViewController.assertValues([], "No view controller is presented.")
+    self.goToMobileSafari.assertValues([], "Do not go to mobile safari")
+
+    // We find the redirect to be an unrecognized url (project preview).
+    let unrecognizedUrl = URL(string: "https://www.kickstarter.com/projects/creator/project?token=4")!
+    self.vm.inputs.foundRedirectUrl(unrecognizedUrl)
+
+    self.findRedirectUrl.assertValues([emailUrl], "Nothing new is emitted.")
+    self.presentViewController.assertValues([], "Do not present controller since the url was unrecognizable.")
+    self.goToMobileSafari.assertValues([unrecognizedUrl], "Go to mobile safari for the unrecognized url.")
+  }
+
   func testOtherEmailDeepLink() {
     let emailUrl = URL(string: "https://email.kickstarter.com/mpss/a/b/c/d/e/f/g")!
 

--- a/Library/Navigation.swift
+++ b/Library/Navigation.swift
@@ -14,6 +14,7 @@ public enum Navigation {
   case signup
   case tab(Tab)
   case project(Param, Navigation.Project, refTag: RefTag?)
+  case projectPreview(Param, Navigation.Project, refTag: RefTag?, token: String)
   case user(Param, Navigation.User)
 
   public enum Checkout {
@@ -91,6 +92,9 @@ public func == (lhs: Navigation, rhs: Navigation) -> Bool {
     return lhs == rhs
   case let (.project(lhsParam, lhsProject, lhsRefTag), .project(rhsParam, rhsProject, rhsRefTag)):
     return lhsParam == rhsParam && lhsProject == rhsProject && lhsRefTag == rhsRefTag
+  case let (.projectPreview(lhsParam, lhsProject, lhsRefTag, lhsToken),
+            .projectPreview(rhsParam, rhsProject, rhsRefTag, rhsToken)):
+    return lhsParam == rhsParam && lhsProject == rhsProject && lhsRefTag == rhsRefTag && lhsToken == rhsToken
   case let (.user(lhsParam, lhsUser), .user(rhsParam, rhsUser)):
     return lhsParam == rhsParam && lhsUser == rhsUser
   default:
@@ -401,10 +405,20 @@ private func signup(_: RouteParams) -> Decoded<Navigation> {
 }
 
 private func project(_ params: RouteParams) -> Decoded<Navigation> {
-  return curry(Navigation.project)
+  let projectPreview = curry(Navigation.projectPreview)
     <^> params <| "project_param"
     <*> .success(.root)
     <*> params <|? "ref"
+    <*> params <| "token"
+
+  if case .failure = projectPreview {
+    return curry(Navigation.project)
+      <^> params <| "project_param"
+      <*> .success(.root)
+      <*> params <|? "ref"
+  }
+
+  return projectPreview
 }
 
 private func thanks(_ params: RouteParams) -> Decoded<Navigation> {

--- a/Library/Navigation.swift
+++ b/Library/Navigation.swift
@@ -411,6 +411,7 @@ private func project(_ params: RouteParams) -> Decoded<Navigation> {
     <*> params <|? "ref"
     <*> params <| "token"
 
+  // If we're certain this is not a project preview link, try to decode it as a normal project link.
   if case .failure = projectPreview {
     return curry(Navigation.project)
       <^> params <| "project_param"
@@ -418,7 +419,8 @@ private func project(_ params: RouteParams) -> Decoded<Navigation> {
       <*> params <|? "ref"
   }
 
-  return projectPreview
+  // Fail here as we don't currently support project preview links.
+  return .failure(.custom("Project preview links are unsupported"))
 }
 
 private func thanks(_ params: RouteParams) -> Decoded<Navigation> {

--- a/Library/NavigationTests.swift
+++ b/Library/NavigationTests.swift
@@ -38,6 +38,9 @@ public final class NavigationTests: XCTestCase {
     KSRAssertMatch(.project(.slug("project"), .root, refTag: nil),
                    "/projects/creator/project")
 
+    KSRAssertMatch(.projectPreview(.slug("project"), .root, refTag: nil, token: "4"),
+                   "/projects/creator/project?token=4")
+
     KSRAssertMatch(.project(.slug("project"), .checkout(1, .thanks(racing: nil)), refTag: nil),
                    "/projects/creator/project/checkouts/1/thanks")
 

--- a/Library/NavigationTests.swift
+++ b/Library/NavigationTests.swift
@@ -4,7 +4,7 @@ import Prelude
 import XCTest
 @testable import Library
 
-private func KSRAssertMatch(_ expected: Navigation,
+private func KSRAssertMatch(_ expected: Navigation?,
                             _ path: String,
                             file: StaticString = #file,
                             line: UInt = #line) {
@@ -38,8 +38,7 @@ public final class NavigationTests: XCTestCase {
     KSRAssertMatch(.project(.slug("project"), .root, refTag: nil),
                    "/projects/creator/project")
 
-    KSRAssertMatch(.projectPreview(.slug("project"), .root, refTag: nil, token: "4"),
-                   "/projects/creator/project?token=4")
+    KSRAssertMatch(nil, "/projects/creator/project?token=4")
 
     KSRAssertMatch(.project(.slug("project"), .checkout(1, .thanks(racing: nil)), refTag: nil),
                    "/projects/creator/project/checkouts/1/thanks")

--- a/Library/NavigationTests.swift
+++ b/Library/NavigationTests.swift
@@ -40,6 +40,8 @@ public final class NavigationTests: XCTestCase {
 
     KSRAssertMatch(nil, "/projects/creator/project?token=4")
 
+    KSRAssertMatch(nil, "/projects/creator/project?ref=discovery&token=4")
+
     KSRAssertMatch(.project(.slug("project"), .checkout(1, .thanks(racing: nil)), refTag: nil),
                    "/projects/creator/project/checkouts/1/thanks")
 


### PR DESCRIPTION
# 📲 What

Ignores project preview links as these should be handled by mobile safari and not by the app itself.

# 🤔 Why

We don't currently support project preview links in the app but because their URL structure matches a route in our `Navigation` enum the app attempts to open them. This fails and the user is stuck in the app when they should be redirected back out to mobile safari.

# 🛠 How

- Added a `projectPreview` case to `Navigation` so that we can be sure that a given URL is in fact a preview URL.
- If a match is found, we ignore it by returning `.failure`, thereby using the existing functionality to ignore unrecognized URLs.

# 👀 See

https://trello.com/c/4GS7SNZ8

# ✅ Acceptance criteria

- [x] Project preview links should open the app but then redirect back to mobile safari (will need to be tested in Release mode).