### PR TITLE
Update conformance to Hashable protocol to make Swiftlint happy

### DIFF
--- a/KsApi/GraphSchema.swift
+++ b/KsApi/GraphSchema.swift
@@ -18,8 +18,8 @@ extension Never: CustomStringConvertible {
 public protocol QueryType: CustomStringConvertible, Hashable {}
 
 extension QueryType {
-  public var hashValue: Int {
-    return description.hashValue
+  public func hash(into hasher: inout Hasher) {
+    hasher.combine(self.description)
   }
 }
 

--- a/KsApi/models/Category.swift
+++ b/KsApi/models/Category.swift
@@ -99,9 +99,7 @@ extension Category {
 
 extension ParentCategory: Hashable {
   public func hash(into hasher: inout Hasher) {
-    let intID = self.categoryType.intID ?? unrecognizedCategoryId
-
-    hasher.combine(intID)
+    hasher.combine(self.categoryType.intID ?? unrecognizedCategoryId)
   }
 }
 
@@ -140,9 +138,7 @@ extension Category: Equatable {
 
 extension Category: Hashable {
   public func hash(into hasher: inout Hasher) {
-    let intID = self.intID ?? unrecognizedCategoryId
-
-    hasher.combine(intID)
+    hasher.combine(self.intID ?? unrecognizedCategoryId)
   }
 }
 

--- a/KsApi/models/Category.swift
+++ b/KsApi/models/Category.swift
@@ -98,8 +98,10 @@ extension Category {
 }
 
 extension ParentCategory: Hashable {
-  public var hashValue: Int {
-    return self.categoryType.intID ?? unrecognizedCategoryId
+  public func hash(into hasher: inout Hasher) {
+    let intID = self.categoryType.intID ?? unrecognizedCategoryId
+
+    hasher.combine(intID)
   }
 }
 
@@ -137,8 +139,10 @@ extension Category: Equatable {
 }
 
 extension Category: Hashable {
-  public var hashValue: Int {
-    return self.intID ?? unrecognizedCategoryId
+  public func hash(into hasher: inout Hasher) {
+    let intID = self.intID ?? unrecognizedCategoryId
+
+    hasher.combine(intID)
   }
 }
 

--- a/KsApi/models/DiscoveryParams.swift
+++ b/KsApi/models/DiscoveryParams.swift
@@ -74,8 +74,8 @@ public func == (a: DiscoveryParams, b: DiscoveryParams) -> Bool {
 }
 
 extension DiscoveryParams: Hashable {
-  public var hashValue: Int {
-    return self.description.hash
+  public func hash(into hasher: inout Hasher) {
+    hasher.combine(self.description)
   }
 }
 

--- a/Library/Format.swift
+++ b/Library/Format.swift
@@ -323,13 +323,22 @@ private struct DateFormatterConfig {
 }
 
 extension DateFormatterConfig: Hashable {
-  fileprivate var hashValue: Int {
-    return
-      (self.template?.hashValue ?? 0)
-        ^ (self.dateStyle?.hashValue ?? 0)
-        ^ self.locale.hashValue
-        ^ (self.timeStyle?.hashValue ?? 0)
-        ^ self.timeZone.hashValue
+  fileprivate func hash(into hasher: inout Hasher) {
+    if let template = self.template {
+      hasher.combine(template)
+    }
+
+    if let dateStyle = self.dateStyle {
+      hasher.combine(dateStyle)
+    }
+
+    hasher.combine(self.locale)
+
+    if let timeStyle = self.timeStyle {
+      hasher.combine(timeStyle)
+    }
+
+    hasher.combine(self.timeZone)
   }
 }
 
@@ -392,14 +401,13 @@ private struct NumberFormatterConfig {
 }
 
 extension NumberFormatterConfig: Hashable {
-  fileprivate var hashValue: Int {
-    return
-      self.numberStyle.hashValue
-        ^ self.roundingMode.hashValue
-        ^ self.maximumFractionDigits.hashValue
-        ^ self.generatesDecimalNumbers.hashValue
-        ^ self.locale.hashValue
-        ^ self.currencySymbol.hashValue
+  fileprivate func hash(into hasher: inout Hasher) {
+    hasher.combine(self.numberStyle)
+    hasher.combine(self.roundingMode)
+    hasher.combine(self.maximumFractionDigits)
+    hasher.combine(self.generatesDecimalNumbers)
+    hasher.combine(self.locale)
+    hasher.combine(self.currencySymbol)
   }
 }
 

--- a/Library/Format.swift
+++ b/Library/Format.swift
@@ -324,20 +324,10 @@ private struct DateFormatterConfig {
 
 extension DateFormatterConfig: Hashable {
   fileprivate func hash(into hasher: inout Hasher) {
-    if let template = self.template {
-      hasher.combine(template)
-    }
-
-    if let dateStyle = self.dateStyle {
-      hasher.combine(dateStyle)
-    }
-
+    hasher.combine(self.template)
+    hasher.combine(self.dateStyle)
     hasher.combine(self.locale)
-
-    if let timeStyle = self.timeStyle {
-      hasher.combine(timeStyle)
-    }
-
+    hasher.combine(self.timeStyle)
     hasher.combine(self.timeZone)
   }
 }

--- a/Library/RefTag.swift
+++ b/Library/RefTag.swift
@@ -216,8 +216,8 @@ extension RefTag: CustomStringConvertible {
 }
 
 extension RefTag: Hashable {
-  public var hashValue: Int {
-    return self.stringTag.hashValue
+  public func hash(into hasher: inout Hasher) {
+    hasher.combine(self.stringTag)
   }
 }
 


### PR DESCRIPTION
# 📲 What

Updates conformance to `Hashable` protocol.

# 🤔 Why

This is a required Swiftlint rule which is currently failing branches that are not up to date.

# 🛠 How

Replace `Hashable` conformance from `var hashValue: Int` to `func hash(into hasher: inout Hasher)`

# 👀 See

https://nshipster.com/hashable/
https://github.com/apple/swift-evolution/blob/master/proposals/0206-hashable-enhancements.md

# ✅ Acceptance criteria

- [x] All tests pass
