### PR TITLE
♿️ - Settings - Switch Toggle Rows 

### DIFF
--- a/Kickstarter-iOS/DataSources/SettingsPrivacyDataSource.swift
+++ b/Kickstarter-iOS/DataSources/SettingsPrivacyDataSource.swift
@@ -12,31 +12,40 @@ internal enum Section: Int {
   case deleteAccount
 }
 
-public struct SettingsPrivacyCellValue {
+public struct SettingsPrivacyStaticCellValue {
+  let cellType: SettingsStaticCellType
   let user: User
+}
+
+public struct SettingsPrivacySwitchCellValue {
   let cellType: SettingsSwitchCellType
+  let user: User
 }
 
 internal final class SettingsPrivacyDataSource: ValueCellDataSource {
   internal func load(user: User) {
-    self.set(values: [user],
+    let followingCellValue = SettingsPrivacyStaticCellValue(cellType: .following, user: user)
+
+    self.set(values: [followingCellValue],
              cellClass: SettingsFollowCell.self,
              inSection: Section.following.rawValue)
 
-    self.set(values: [Strings.When_following_is_on_you_can_follow_the_acticity_of_others()],
+    self.set(values: [followingCellValue.cellType.description],
              cellClass: SettingsPrivacyStaticCell.self,
              inSection: Section.followingFooter.rawValue)
 
-    self.set(values: [user],
+    let recommendationsCellValue = SettingsPrivacyStaticCellValue(cellType: .recommendations, user: user)
+
+    self.set(values: [recommendationsCellValue],
              cellClass: SettingsPrivacyRecommendationCell.self,
              inSection: Section.recommendations.rawValue)
 
-    self.set(values: [Strings.We_use_your_activity_internally_to_make_recommendations_for_you()],
+    self.set(values: [recommendationsCellValue.cellType.description],
              cellClass: SettingsPrivacyStaticCell.self,
              inSection: Section.recommendationsFooter.rawValue)
 
     if !user.isCreator {
-      let cellValue = SettingsPrivacyCellValue(user: user, cellType: .privacy)
+      let cellValue = SettingsPrivacySwitchCellValue(cellType: .privacy, user: user)
 
       self.set(values: [cellValue],
                cellClass: SettingsPrivacySwitchCell.self,
@@ -54,9 +63,9 @@ internal final class SettingsPrivacyDataSource: ValueCellDataSource {
 
   internal override func configureCell(tableCell cell: UITableViewCell, withValue value: Any) {
     switch (cell, value) {
-    case let (cell as SettingsFollowCell, value as User):
+    case let (cell as SettingsFollowCell, value as SettingsPrivacyStaticCellValue):
       cell.configureWith(value: value)
-    case let (cell as SettingsPrivacyRecommendationCell, value as User):
+    case let (cell as SettingsPrivacyRecommendationCell, value as SettingsPrivacyStaticCellValue):
       cell.configureWith(value: value)
     case let (cell as SettingsPrivacyRequestDataCell, value as User):
       cell.configureWith(value: value)
@@ -64,7 +73,7 @@ internal final class SettingsPrivacyDataSource: ValueCellDataSource {
       cell.configureWith(value: value)
     case let (cell as SettingsPrivacyStaticCell, value as String):
       cell.configureWith(value: value)
-    case let (cell as SettingsPrivacySwitchCell, value as SettingsPrivacyCellValue):
+    case let (cell as SettingsPrivacySwitchCell, value as SettingsPrivacySwitchCellValue):
       cell.configureWith(value: value)
     default:
       fatalError("Unrecognized combo (\(cell), \(value)).")

--- a/Kickstarter-iOS/Views/Cells/ProjectNotificationCell.swift
+++ b/Kickstarter-iOS/Views/Cells/ProjectNotificationCell.swift
@@ -17,14 +17,13 @@ internal final class ProjectNotificationCell: UITableViewCell, ValueCell {
   @IBOutlet fileprivate weak var notificationSwitch: UISwitch!
   @IBOutlet fileprivate weak var separatorView: UIView!
 
- internal override func awakeFromNib() {
+  internal override func awakeFromNib() {
     super.awakeFromNib()
 
-    self.notificationSwitch.addTarget(
-      self,
-      action: #selector(notificationTapped),
-      for: UIControl.Event.valueChanged
-    )
+    _ = self
+      |> \.accessibilityElements .~ [self.notificationSwitch]
+
+    self.notificationSwitch.addTarget(self, action: #selector(notificationTapped), for: .valueChanged)
   }
 
   internal override func bindStyles() {
@@ -46,6 +45,7 @@ internal final class ProjectNotificationCell: UITableViewCell, ValueCell {
     super.bindViewModel()
 
     self.nameLabel.rac.text = self.viewModel.outputs.name
+    self.notificationSwitch.rac.accessibilityLabel = self.viewModel.outputs.name
     self.notificationSwitch.rac.on = self.viewModel.outputs.notificationOn
 
     self.viewModel.outputs.notifyDelegateOfSaveError

--- a/Kickstarter-iOS/Views/Cells/SettingsFollowCell.swift
+++ b/Kickstarter-iOS/Views/Cells/SettingsFollowCell.swift
@@ -20,8 +20,21 @@ internal final class SettingsFollowCell: UITableViewCell, ValueCell {
   @IBOutlet fileprivate weak var followingSwitch: UISwitch!
   @IBOutlet fileprivate var separatorView: [UIView]!
 
-  internal func configureWith(value user: User) {
-    self.viewModel.inputs.configureWith(user: user)
+  override func awakeFromNib() {
+    super.awakeFromNib()
+
+    _ = self
+      |> \.accessibilityElements .~ [self.followingSwitch]
+
+    _ = self.followingSwitch
+      |> \.accessibilityLabel %~ { _ in Strings.Following() }
+  }
+
+  internal func configureWith(value: SettingsPrivacyStaticCellValue) {
+    self.viewModel.inputs.configureWith(user: value.user)
+
+    _ = self.followingSwitch
+      |> \.accessibilityHint %~ { _ in value.cellType.description }
   }
 
   internal override func bindStyles() {

--- a/Kickstarter-iOS/Views/Cells/SettingsFollowCell.swift
+++ b/Kickstarter-iOS/Views/Cells/SettingsFollowCell.swift
@@ -34,7 +34,7 @@ internal final class SettingsFollowCell: UITableViewCell, ValueCell {
     self.viewModel.inputs.configureWith(user: value.user)
 
     _ = self.followingSwitch
-      |> \.accessibilityHint %~ { _ in value.cellType.description }
+      |> \.accessibilityHint .~ value.cellType.description
   }
 
   internal override func bindStyles() {

--- a/Kickstarter-iOS/Views/Cells/SettingsFollowCell.swift
+++ b/Kickstarter-iOS/Views/Cells/SettingsFollowCell.swift
@@ -76,6 +76,10 @@ internal final class SettingsFollowCell: UITableViewCell, ValueCell {
     self.followingSwitch.rac.on = self.viewModel.outputs.followingPrivacyOn
   }
 
+  func toggleOn(animated: Bool = true) {
+    self.followingSwitch.setOn(true, animated: animated)
+  }
+
   @IBAction func followingPrivacySwitchTapped(_ followingPrivacySwitch: UISwitch) {
     self.viewModel.inputs.followTapped(on: followingPrivacySwitch.isOn)
   }

--- a/Kickstarter-iOS/Views/Cells/SettingsNewslettersCell.swift
+++ b/Kickstarter-iOS/Views/Cells/SettingsNewslettersCell.swift
@@ -20,19 +20,28 @@ internal final class SettingsNewslettersCell: UITableViewCell, ValueCell {
 
   public weak var delegate: SettingsNewslettersCellDelegate?
 
-  func configureWith(value: (newsletter: Newsletter, user: User)) {
+  override func awakeFromNib() {
+    super.awakeFromNib()
 
+    _ = self
+      |> \.accessibilityElements .~ [self.newslettersSwitch]
+  }
+
+  func configureWith(value: (newsletter: Newsletter, user: User)) {
     self.viewModel.inputs.configureWith(value: value)
 
+    _ = self.newslettersSwitch
+      |> \.accessibilityLabel %~ { _ in value.newsletter.displayableName }
+      |> \.accessibilityHint %~ { _ in value.newsletter.displayableDescription }
+
     _ = self.newslettersLabel
-      |> UILabel.lens.text %~ { _ in value.newsletter.displayableName }
+      |> \.text %~ { _ in value.newsletter.displayableName }
 
     _ = self.newslettersDescriptionLabel
-      |> UILabel.lens.text %~ { _ in value.newsletter.displayableDescription }
+      |> \.text %~ { _ in value.newsletter.displayableDescription }
   }
 
   override func bindStyles() {
-
     _ = self.separatorViews
       ||> separatorStyle
 

--- a/Kickstarter-iOS/Views/Cells/SettingsNewslettersCell.swift
+++ b/Kickstarter-iOS/Views/Cells/SettingsNewslettersCell.swift
@@ -31,14 +31,14 @@ internal final class SettingsNewslettersCell: UITableViewCell, ValueCell {
     self.viewModel.inputs.configureWith(value: value)
 
     _ = self.newslettersSwitch
-      |> \.accessibilityLabel %~ { _ in value.newsletter.displayableName }
-      |> \.accessibilityHint %~ { _ in value.newsletter.displayableDescription }
+      |> \.accessibilityLabel .~ value.newsletter.displayableName
+      |> \.accessibilityHint .~ value.newsletter.displayableDescription
 
     _ = self.newslettersLabel
-      |> \.text %~ { _ in value.newsletter.displayableName }
+      |> \.text .~ value.newsletter.displayableName
 
     _ = self.newslettersDescriptionLabel
-      |> \.text %~ { _ in value.newsletter.displayableDescription }
+      |> \.text .~ value.newsletter.displayableDescription
   }
 
   override func bindStyles() {

--- a/Kickstarter-iOS/Views/Cells/SettingsNewslettersTopCell.swift
+++ b/Kickstarter-iOS/Views/Cells/SettingsNewslettersTopCell.swift
@@ -20,6 +20,23 @@ final internal class SettingsNewslettersTopCell: UITableViewCell, ValueCell {
 
   public weak var delegate: SettingsNewslettersTopCellDelegate?
 
+  override func awakeFromNib() {
+    super.awakeFromNib()
+
+    _ = self
+      |> \.accessibilityElements .~ [self.newsletterSwitch]
+
+    _ = self.descriptionLabel
+      |> \.text %~ { _ in Strings.Stay_up_to_date_newsletter() }
+
+    _ = self.newsletterSwitch
+      |> \.accessibilityLabel %~ { _ in Strings.profile_settings_newsletter_subscribe_all() }
+      |> \.accessibilityHint %~ { _ in Strings.Stay_up_to_date_newsletter() }
+
+    _ = self.titleLabel
+      |> \.text %~ { _ in Strings.profile_settings_newsletter_subscribe_all() }
+  }
+
   func configureWith(value: User) {
     self.viewModel.inputs.configureWith(value: value)
   }
@@ -29,9 +46,6 @@ final internal class SettingsNewslettersTopCell: UITableViewCell, ValueCell {
 
     _ = self.descriptionLabel
       |> settingsDescriptionLabelStyle
-      |> UILabel.lens.text %~ { _ in
-        Strings.Stay_up_to_date_newsletter()
-    }
 
     _ = self.newsletterSwitch
       |> settingsSwitchStyle
@@ -41,7 +55,6 @@ final internal class SettingsNewslettersTopCell: UITableViewCell, ValueCell {
 
     _ = self.titleLabel
       |> settingsTitleLabelStyle
-      |> UILabel.lens.text %~ { _ in Strings.profile_settings_newsletter_subscribe_all() }
   }
 
   override func bindViewModel() {

--- a/Kickstarter-iOS/Views/Cells/SettingsPrivacyRecommendationCell.swift
+++ b/Kickstarter-iOS/Views/Cells/SettingsPrivacyRecommendationCell.swift
@@ -12,8 +12,21 @@ internal final class SettingsPrivacyRecommendationCell: UITableViewCell, ValueCe
   @IBOutlet fileprivate weak var recommendationsSwitch: UISwitch!
   @IBOutlet fileprivate var separatorView: [UIView]!
 
-  internal func configureWith(value user: User) {
-    self.viewModel.inputs.configureWith(user: user)
+  override func awakeFromNib() {
+    super.awakeFromNib()
+
+    _ = self
+      |> \.accessibilityElements .~ [self.recommendationsSwitch]
+
+    _ = self.recommendationsSwitch
+      |> \.accessibilityLabel %~ { _ in Strings.Recommendations() }
+  }
+
+  internal func configureWith(value: SettingsPrivacyStaticCellValue) {
+    self.viewModel.inputs.configureWith(user: value.user)
+
+    _ = self.recommendationsSwitch
+      |> \.accessibilityHint %~ { _ in value.cellType.description }
   }
 
   internal override func bindStyles() {

--- a/Kickstarter-iOS/Views/Cells/SettingsPrivacyRecommendationCell.swift
+++ b/Kickstarter-iOS/Views/Cells/SettingsPrivacyRecommendationCell.swift
@@ -26,7 +26,7 @@ internal final class SettingsPrivacyRecommendationCell: UITableViewCell, ValueCe
     self.viewModel.inputs.configureWith(user: value.user)
 
     _ = self.recommendationsSwitch
-      |> \.accessibilityHint %~ { _ in value.cellType.description }
+      |> \.accessibilityHint .~ value.cellType.description
   }
 
   internal override func bindStyles() {

--- a/Kickstarter-iOS/Views/Cells/SettingsPrivacyStaticCell.swift
+++ b/Kickstarter-iOS/Views/Cells/SettingsPrivacyStaticCell.swift
@@ -5,6 +5,13 @@ import UIKit
 internal final class SettingsPrivacyStaticCell: UITableViewCell, ValueCell {
   @IBOutlet fileprivate weak var privacyInfoLabel: UILabel!
 
+  override func awakeFromNib() {
+    super.awakeFromNib()
+
+    _ = self
+      |> \.accessibilityElementsHidden .~ true
+  }
+
   func configureWith(value: String) {
     _ = self.privacyInfoLabel
       |> UILabel.lens.text %~ { _ in value }

--- a/Kickstarter-iOS/Views/Cells/SettingsPrivacySwitchCell.swift
+++ b/Kickstarter-iOS/Views/Cells/SettingsPrivacySwitchCell.swift
@@ -18,17 +18,30 @@ final class SettingsPrivacySwitchCell: UITableViewCell, ValueCell, NibLoading {
 
   weak var delegate: SettingsPrivacySwitchCellDelegate?
 
-  func configureWith(value: SettingsPrivacyCellValue) {
+  override func awakeFromNib() {
+    super.awakeFromNib()
+
+    _ = self
+      |> \.accessibilityElements .~ [self.switchButton]
+  }
+
+  func configureWith(value: SettingsPrivacySwitchCellValue) {
     self.viewModel.configure(with: value.user)
 
     _ = self.titleLabel
-    |> UILabel.lens.text .~ value.cellType.titleString
+      |> \.text .~ value.cellType.title
 
     _ = self.primaryDescriptionLabel
-    |> UILabel.lens.text .~ value.cellType.primaryDescriptionString
+      |> \.text .~ value.cellType.primaryDescription
 
     _ = self.secondaryDescriptionLabel
-    |> UILabel.lens.text .~ value.cellType.secondaryDescriptionString
+      |> \.text .~ value.cellType.secondaryDescription
+
+    _ = self.switchButton
+      |> \.accessibilityLabel %~ { _ in value.cellType.title }
+      |> \.accessibilityHint %~ { _ in
+        "\(value.cellType.primaryDescription), \(value.cellType.secondaryDescription)"
+    }
   }
 
   override func bindStyles() {

--- a/Kickstarter-iOS/Views/Cells/SettingsPrivacySwitchCell.swift
+++ b/Kickstarter-iOS/Views/Cells/SettingsPrivacySwitchCell.swift
@@ -38,10 +38,8 @@ final class SettingsPrivacySwitchCell: UITableViewCell, ValueCell, NibLoading {
       |> \.text .~ value.cellType.secondaryDescription
 
     _ = self.switchButton
-      |> \.accessibilityLabel %~ { _ in value.cellType.title }
-      |> \.accessibilityHint %~ { _ in
-        "\(value.cellType.primaryDescription), \(value.cellType.secondaryDescription)"
-    }
+      |> \.accessibilityLabel .~ value.cellType.title
+      |> \.accessibilityHint .~ "\(value.cellType.primaryDescription), \(value.cellType.secondaryDescription)"
   }
 
   override func bindStyles() {

--- a/Kickstarter-iOS/Views/Controllers/MessageBannerViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/MessageBannerViewController.swift
@@ -124,7 +124,9 @@ final class MessageBannerViewController: UIViewController, NibLoading {
         if isHidden {
           // Tells Voice Over to resign focus of the message banner.
           // This causes the reader to focus on the previously selected element.
-          UIAccessibility.post(notification: UIAccessibility.Notification.layoutChanged, argument: nil)
+          if AppEnvironment.current.isVoiceOverRunning() {
+            UIAccessibility.post(notification: UIAccessibility.Notification.layoutChanged, argument: nil)
+          }
         }
 
         self.bottomConstraint?.constant = isHidden ? hiddenConstant : 0
@@ -138,10 +140,12 @@ final class MessageBannerViewController: UIViewController, NibLoading {
         if !isHidden {
           // Tells Voice Over to focus on the message banner.
           // This causes the reader to read the message and allows the user to dismiss the banner.
-          UIAccessibility.post(
-            notification: UIAccessibility.Notification.layoutChanged,
-            argument: self?.backgroundView
-          )
+          if AppEnvironment.current.isVoiceOverRunning() {
+            UIAccessibility.post(
+              notification: UIAccessibility.Notification.layoutChanged,
+              argument: self?.backgroundView
+            )
+          }
         }
     })
   }

--- a/Kickstarter-iOS/Views/Controllers/SettingsPrivacyViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/SettingsPrivacyViewController.swift
@@ -59,17 +59,18 @@ internal final class SettingsPrivacyViewController: UITableViewController {
         self?.present(UIAlertController.genericError(message), animated: true, completion: nil)
     }
 
-    self.viewModel.outputs.refreshFollowingSection
+    self.viewModel.outputs.resetFollowingSection
       .observeForUI()
       .observeValues { [weak self] _ in
-        let section = Section.following.rawValue
+        let indexPath = IndexPath(row: 0, section: Section.following.rawValue)
+        let cell = self?.tableView.cellForRow(at: indexPath) as? SettingsFollowCell
+        cell?.toggleOn()
+    }
 
-        self?.tableView.reloadSections(IndexSet(integer: section), with: .none)
-
-        if AppEnvironment.current.isVoiceOverRunning() {
-          let cell = self?.tableView.cellForRow(at: IndexPath(row: 0, section: section))
-          UIAccessibility.post(notification: UIAccessibility.Notification.layoutChanged, argument: cell)
-        }
+    self.viewModel.outputs.focusScreenReaderOnFollowingCell
+      .observeForUI()
+      .observeValues { [weak self] _ in
+        self?.accessibilityFocusOnFollowingCell()
     }
   }
 
@@ -84,6 +85,13 @@ internal final class SettingsPrivacyViewController: UITableViewController {
       deleteAccountCell.delegate = self
     } else if let privacySwitchCell = cell as? SettingsPrivacySwitchCell {
       privacySwitchCell.delegate = self
+    }
+  }
+
+  private func accessibilityFocusOnFollowingCell() {
+    let cell = self.tableView.visibleCells.filter { $0 is SettingsFollowCell }.first
+    if let cell = cell {
+      UIAccessibility.post(notification: UIAccessibility.Notification.screenChanged, argument: cell)
     }
   }
 }

--- a/Kickstarter-iOS/Views/Controllers/SettingsPrivacyViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/SettingsPrivacyViewController.swift
@@ -62,8 +62,14 @@ internal final class SettingsPrivacyViewController: UITableViewController {
     self.viewModel.outputs.refreshFollowingSection
       .observeForUI()
       .observeValues { [weak self] _ in
-        let followingSection = IndexSet(integer: Section.following.rawValue)
-        self?.tableView.reloadSections(followingSection, with: .none)
+        let section = Section.following.rawValue
+
+        self?.tableView.reloadSections(IndexSet(integer: section), with: .none)
+
+        if AppEnvironment.current.isVoiceOverRunning() {
+          let cell = self?.tableView.cellForRow(at: IndexPath(row: 0, section: section))
+          UIAccessibility.post(notification: UIAccessibility.Notification.layoutChanged, argument: cell)
+        }
     }
   }
 

--- a/Library/SettingsSwitchCellType.swift
+++ b/Library/SettingsSwitchCellType.swift
@@ -1,26 +1,31 @@
 import Foundation
 
+public enum SettingsStaticCellType {
+  case following
+  case recommendations
+
+  public var description: String {
+    switch self {
+    case .following:
+      return Strings.When_following_is_on_you_can_follow_the_acticity_of_others()
+    case .recommendations:
+      return Strings.We_use_your_activity_internally_to_make_recommendations_for_you()
+    }
+  }
+}
+
 public enum SettingsSwitchCellType {
   case privacy
 
-  public var titleString: String {
-    switch self {
-    case .privacy:
-      return Strings.Private_profile()
-    }
+  public var title: String {
+    return Strings.Private_profile()
   }
 
-  public var primaryDescriptionString: String {
-    switch self {
-    case .privacy:
-      return Strings.If_your_profile_is_private()
-    }
+  public var primaryDescription: String {
+    return Strings.If_your_profile_is_private()
   }
 
-  public var secondaryDescriptionString: String {
-    switch self {
-    case .privacy:
-      return Strings.If_your_profile_is_public()
-    }
+  public var secondaryDescription: String {
+    return Strings.If_your_profile_is_public()
   }
 }

--- a/Library/ViewModels/DashboardProjectsDrawerViewModel.swift
+++ b/Library/ViewModels/DashboardProjectsDrawerViewModel.swift
@@ -60,6 +60,7 @@ DashboardProjectsDrawerViewModelInputs, DashboardProjectsDrawerViewModelOutputs 
     self.notifyDelegateDidAnimateOut = self.animateOutCompletedProperty.signal
 
     self.focusScreenReaderOnFirstProject = self.animateInCompletedProperty.signal
+      .filter { AppEnvironment.current.isVoiceOverRunning() }
   }
 
   public var inputs: DashboardProjectsDrawerViewModelInputs { return self }

--- a/Library/ViewModels/DashboardProjectsDrawerViewModelTests.swift
+++ b/Library/ViewModels/DashboardProjectsDrawerViewModelTests.swift
@@ -87,13 +87,16 @@ internal final class DashboardProjectsDrawerViewModelTests: TestCase {
   }
 
   func testAnimateIn_FocusOnFirstProject() {
-    self.vm.inputs.configureWith(data: data1)
-    self.vm.inputs.viewDidLoad()
+    let isVoiceOverRunning = { true }
+    withEnvironment(isVoiceOverRunning: isVoiceOverRunning) {
+      self.vm.inputs.configureWith(data: data1)
+      self.vm.inputs.viewDidLoad()
 
-    self.focusScreenReaderOnFirstProject.assertValueCount(0)
+      self.focusScreenReaderOnFirstProject.assertValueCount(0)
 
-    self.vm.inputs.animateInCompleted()
+      self.vm.inputs.animateInCompleted()
 
-    self.focusScreenReaderOnFirstProject.assertValueCount(1)
+      self.focusScreenReaderOnFirstProject.assertValueCount(1)
+    }
   }
 }

--- a/Library/ViewModels/DashboardViewModel.swift
+++ b/Library/ViewModels/DashboardViewModel.swift
@@ -280,6 +280,7 @@ DashboardViewModelType {
       .takeWhen(self.messagesCellTappedProperty.signal)
 
     self.focusScreenReaderOnTitleView = self.viewWillAppearAnimatedProperty.signal.ignoreValues()
+      .filter { AppEnvironment.current.isVoiceOverRunning() }
 
     let projectForTrackingViews = Signal.merge(
       projects.map { $0.first }.skipNil().take(first: 1),

--- a/Library/ViewModels/DashboardViewModelTests.swift
+++ b/Library/ViewModels/DashboardViewModelTests.swift
@@ -195,16 +195,18 @@ internal final class DashboardViewModelTests: TestCase {
   func testScreenReaderFocus() {
     let projects = [Project.template]
 
-    withEnvironment(apiService: MockService(fetchProjectsResponse: projects)) {
-      self.focusScreenReaderOnTitleView.assertValueCount(0)
+    let mockApiService = MockService(fetchProjectsResponse: projects)
+    let isVoiceOverRunning = { true }
+    withEnvironment(apiService: mockApiService, isVoiceOverRunning: isVoiceOverRunning) {
+        self.focusScreenReaderOnTitleView.assertValueCount(0)
 
-      self.vm.inputs.viewWillAppear(animated: false)
+        self.vm.inputs.viewWillAppear(animated: false)
 
-      self.focusScreenReaderOnTitleView.assertValueCount(1)
+        self.focusScreenReaderOnTitleView.assertValueCount(1)
 
-      self.vm.inputs.viewWillAppear(animated: false)
+        self.vm.inputs.viewWillAppear(animated: false)
 
-      self.focusScreenReaderOnTitleView.assertValueCount(2)
+        self.focusScreenReaderOnTitleView.assertValueCount(2)
     }
   }
 

--- a/Library/ViewModels/SettingsPrivacyViewModel.swift
+++ b/Library/ViewModels/SettingsPrivacyViewModel.swift
@@ -15,8 +15,8 @@ public protocol SettingsPrivacyViewModelInputs {
 
 public protocol SettingsPrivacyViewModelOutputs {
   var focusScreenReaderOnFollowingCell: Signal<Void, NoError> { get }
-  var resetFollowingSection: Signal<Void, NoError> { get }
   var reloadData: Signal<User, NoError> { get }
+  var resetFollowingSection: Signal<Void, NoError> { get }
   var unableToSaveError: Signal<String, NoError> { get }
   var updateCurrentUser: Signal<User, NoError> { get }
 }
@@ -116,8 +116,8 @@ SettingsPrivacyViewModelInputs, SettingsPrivacyViewModelOutputs {
   }
 
   public let focusScreenReaderOnFollowingCell: Signal<Void, NoError>
-  public let resetFollowingSection: Signal<Void, NoError>
   public let reloadData: Signal<User, NoError>
+  public let resetFollowingSection: Signal<Void, NoError>
   public let unableToSaveError: Signal<String, NoError>
   public let updateCurrentUser: Signal<User, NoError>
 

--- a/Library/ViewModels/SettingsPrivacyViewModel.swift
+++ b/Library/ViewModels/SettingsPrivacyViewModel.swift
@@ -81,7 +81,10 @@ SettingsPrivacyViewModelInputs, SettingsPrivacyViewModelOutputs {
    self.updateCurrentUser = Signal.merge(updatedFetchedUser,
                                          previousUserOnError)
 
-   self.refreshFollowingSection = self.didCancelSocialOptOutProperty.signal
+    self.refreshFollowingSection = Signal.merge(
+      self.didCancelSocialOptOutProperty.signal,
+      self.didConfirmSocialOptOutProperty.signal
+    )
   }
 
   fileprivate let didCancelSocialOptOutProperty = MutableProperty(())

--- a/Library/ViewModels/SettingsPrivacyViewModel.swift
+++ b/Library/ViewModels/SettingsPrivacyViewModel.swift
@@ -14,7 +14,8 @@ public protocol SettingsPrivacyViewModelInputs {
 }
 
 public protocol SettingsPrivacyViewModelOutputs {
-  var refreshFollowingSection: Signal<Void, NoError> { get }
+  var focusScreenReaderOnFollowingCell: Signal<Void, NoError> { get }
+  var resetFollowingSection: Signal<Void, NoError> { get }
   var reloadData: Signal<User, NoError> { get }
   var unableToSaveError: Signal<String, NoError> { get }
   var updateCurrentUser: Signal<User, NoError> { get }
@@ -78,13 +79,15 @@ SettingsPrivacyViewModelInputs, SettingsPrivacyViewModelOutputs {
       .takeWhen(self.unableToSaveError)
       .map { previous, _ in previous }
 
-   self.updateCurrentUser = Signal.merge(updatedFetchedUser,
-                                         previousUserOnError)
+    self.updateCurrentUser = Signal.merge(updatedFetchedUser, previousUserOnError)
 
-    self.refreshFollowingSection = Signal.merge(
+    self.resetFollowingSection = self.didCancelSocialOptOutProperty.signal
+
+    self.focusScreenReaderOnFollowingCell = Signal.merge(
       self.didCancelSocialOptOutProperty.signal,
       self.didConfirmSocialOptOutProperty.signal
     )
+      .filter { _ in AppEnvironment.current.isVoiceOverRunning() }
   }
 
   fileprivate let didCancelSocialOptOutProperty = MutableProperty(())
@@ -112,7 +115,8 @@ SettingsPrivacyViewModelInputs, SettingsPrivacyViewModelOutputs {
     self.viewDidLoadProperty.value = ()
   }
 
-  public let refreshFollowingSection: Signal<Void, NoError>
+  public let focusScreenReaderOnFollowingCell: Signal<Void, NoError>
+  public let resetFollowingSection: Signal<Void, NoError>
   public let reloadData: Signal<User, NoError>
   public let unableToSaveError: Signal<String, NoError>
   public let updateCurrentUser: Signal<User, NoError>

--- a/Library/ViewModels/SettingsPrivacyViewModelTests.swift
+++ b/Library/ViewModels/SettingsPrivacyViewModelTests.swift
@@ -22,7 +22,24 @@ internal final class SettingsPrivacyViewModelTests: TestCase {
     self.vm.outputs.updateCurrentUser.observe(self.updateCurrentUser.observer)
   }
 
-  func testRefreshFollowingSection() {
+  func testRefreshFollowingSection_WhenConfirmingSocialOptOut() {
+    let user = User.template
+      |> \.social .~ true
+
+    let mockService = MockService(fetchUserSelfResponse: user)
+
+    withEnvironment(apiService: mockService, currentUser: user) {
+      self.vm.inputs.viewDidLoad()
+
+      self.vm.inputs.didConfirmSocialOptOut()
+
+      self.scheduler.advance()
+
+      self.refreshFollowingSection.assertValueCount(1)
+    }
+  }
+
+  func testRefreshFollowingSection_WhenCancelingSocialOptOut() {
     let user = User.template
     |> \.social .~ true
 

--- a/Library/ViewModels/SettingsPrivacyViewModelTests.swift
+++ b/Library/ViewModels/SettingsPrivacyViewModelTests.swift
@@ -9,37 +9,40 @@ import Prelude
 
 internal final class SettingsPrivacyViewModelTests: TestCase {
   let vm = SettingsPrivacyViewModel()
-  internal let refreshFollowingSection = TestObserver<Void, NoError>()
+  internal let focusScreenReaderOnFollowingCell = TestObserver<Void, NoError>()
+  internal let resetFollowingSection = TestObserver<Void, NoError>()
   internal let reloadData = TestObserver<User, NoError>()
   internal let unableToSaveError = TestObserver<String, NoError>()
   internal let updateCurrentUser = TestObserver<User, NoError>()
 
   internal override func setUp() {
     super.setUp()
-    self.vm.outputs.refreshFollowingSection.observe(self.refreshFollowingSection.observer)
+
+    self.vm.outputs.focusScreenReaderOnFollowingCell.observe(self.focusScreenReaderOnFollowingCell.observer)
+    self.vm.outputs.resetFollowingSection.observe(self.resetFollowingSection.observer)
     self.vm.outputs.reloadData.observe(self.reloadData.observer)
     self.vm.outputs.unableToSaveError.observe(self.unableToSaveError.observer)
     self.vm.outputs.updateCurrentUser.observe(self.updateCurrentUser.observer)
   }
 
-  func testRefreshFollowingSection_WhenConfirmingSocialOptOut() {
-    let user = User.template
-      |> \.social .~ true
+  func testFocusScreenReaderOnFollowingCel() {
+    let isVoiceOverRunning = { true }
+    withEnvironment(isVoiceOverRunning: isVoiceOverRunning) {
+      self.vm.inputs.didCancelSocialOptOut()
 
-    let mockService = MockService(fetchUserSelfResponse: user)
+      self.scheduler.advance()
 
-    withEnvironment(apiService: mockService, currentUser: user) {
-      self.vm.inputs.viewDidLoad()
+      self.focusScreenReaderOnFollowingCell.assertValueCount(1)
 
       self.vm.inputs.didConfirmSocialOptOut()
 
       self.scheduler.advance()
 
-      self.refreshFollowingSection.assertValueCount(1)
+      self.focusScreenReaderOnFollowingCell.assertValueCount(2)
     }
   }
 
-  func testRefreshFollowingSection_WhenCancelingSocialOptOut() {
+  func testResetFollowingSection_WhenCancelingSocialOptOut() {
     let user = User.template
     |> \.social .~ true
 
@@ -52,7 +55,7 @@ internal final class SettingsPrivacyViewModelTests: TestCase {
 
       self.scheduler.advance()
 
-      self.refreshFollowingSection.assertValueCount(1)
+      self.resetFollowingSection.assertValueCount(1)
     }
   }
 

--- a/Library/ViewModels/SettingsPrivacyViewModelTests.swift
+++ b/Library/ViewModels/SettingsPrivacyViewModelTests.swift
@@ -10,8 +10,8 @@ import Prelude
 internal final class SettingsPrivacyViewModelTests: TestCase {
   let vm = SettingsPrivacyViewModel()
   internal let focusScreenReaderOnFollowingCell = TestObserver<Void, NoError>()
-  internal let resetFollowingSection = TestObserver<Void, NoError>()
   internal let reloadData = TestObserver<User, NoError>()
+  internal let resetFollowingSection = TestObserver<Void, NoError>()
   internal let unableToSaveError = TestObserver<String, NoError>()
   internal let updateCurrentUser = TestObserver<User, NoError>()
 
@@ -19,8 +19,8 @@ internal final class SettingsPrivacyViewModelTests: TestCase {
     super.setUp()
 
     self.vm.outputs.focusScreenReaderOnFollowingCell.observe(self.focusScreenReaderOnFollowingCell.observer)
-    self.vm.outputs.resetFollowingSection.observe(self.resetFollowingSection.observer)
     self.vm.outputs.reloadData.observe(self.reloadData.observer)
+    self.vm.outputs.resetFollowingSection.observe(self.resetFollowingSection.observer)
     self.vm.outputs.unableToSaveError.observe(self.unableToSaveError.observer)
     self.vm.outputs.updateCurrentUser.observe(self.updateCurrentUser.observer)
   }


### PR DESCRIPTION
# 📲 What

Fixes the accessibility of our Settings cells with `UISwitch` control.

This includes:
* Settings > Account > Privacy
* Settings > Notifications > Project notifications
* Settings > Newsletters

# 🤔 Why

The intention is to simplify the amount of information we expose to VoiceOver reader. Our settings cells that have a `UISwitch` control currently expose multiple elements (label, switch control, header/footer). In order to make it easier for visually impaired users to navigate through settings we only want to expose the `UISwitch` control and provide enough context in form of a label or hint.

Since we're using custom cells we don't get the native behaviour for free. Normally (in order to support accessibility) a `UISwitch` control would be placed inside of a cell's `accessoryView`. This would result in the following key functionality (which we have to mitigate):

1. The cell would only expose the `UISwitch` control, making it instantly possible to toggle it
- go to Settings.app > Do Not Disturb to see this in action
- we are able to implement this by only exposing the `UISwitch` control to the VoiceOver reader like so `self.accessibilityElements = [self.mySwitchControl]`

2. The `UISwitch` control focus area would be the whole cell
- we are not able to achieve the above exactly reflecting native behaviour (visually)
- but what we get by exposing the `UISwitch` control is identical behaviour (tapping anywhere on the cell will focus on the `UISwitch` control except visually the focus area is only the `UISwitch` control frame) - this honestly is good enough since the functionality stays the same.

# 🛠 How

Tweaking bunch of accessibility thingies here and there 😄 

# 👀 See

**Settings > Account > Privacy**

| Before | Before | Before | After |
| --- | --- | --- | --- |
| Exposes content view which uses label's accessibility label .. | .. and switch control .. | .. and footer | Only exposes switch control with label & footer information |
| ![img_0050](https://user-images.githubusercontent.com/387596/50719551-8bc7ca80-1052-11e9-8611-4dfbd1b73c4e.jpg) | ![img_0051](https://user-images.githubusercontent.com/387596/50719555-9bdfaa00-1052-11e9-9eb3-9ffbacac8daf.jpg) | ![img_0052](https://user-images.githubusercontent.com/387596/50719558-a69a3f00-1052-11e9-9eeb-748abf8f3023.jpg) | ![img_0047](https://user-images.githubusercontent.com/387596/50719565-c6316780-1052-11e9-8aca-b69f3227b45a.jpg) |

**Settings > Notifications > Project notifications**

| Before | Before | After |
| --- | --- | --- |
| Exposes content view which uses label's accessibility label .. | .. and switch control | Only exposes switch control with label information |
| ![img_0053](https://user-images.githubusercontent.com/387596/50719615-dac22f80-1053-11e9-9dfe-1ca58f66d7ca.jpg) | ![img_0054](https://user-images.githubusercontent.com/387596/50719618-e0b81080-1053-11e9-9c70-85231f556ff3.jpg) | ![img_0048](https://user-images.githubusercontent.com/387596/50719622-f62d3a80-1053-11e9-9754-91bdb9ae84fc.jpg) |

**Settings > Newsletters**

| Before | Before | After |
| --- | --- | --- |
| Exposes content view which uses label's accessibility label .. | .. and switch control | Only exposes switch control with label information |
| ![img_0055](https://user-images.githubusercontent.com/387596/50719651-6fc52880-1054-11e9-9d3e-cb35a8a0701b.jpg) | ![img_0056](https://user-images.githubusercontent.com/387596/50719652-7784cd00-1054-11e9-9940-2c283c324590.jpg) | ![img_0049](https://user-images.githubusercontent.com/387596/50719655-81a6cb80-1054-11e9-9a32-8ef492172ab4.jpg) |

# ✅ Acceptance criteria

Test under the following conditions
👉 iOS 10, iOS 11 & iOS 12
👉Voice Over ON
👉 In order to test localization prefer to QA with one of the supported language set as the primary 📱 language

**Settings > Account > Privacy**

- [x] Swiping right/left navigates between switch controls
- [x] VoiceOver reads switch control as "title + switch button + state + footer + double tap to toggle setting" (all localized)
- [x] Tapping anywhere on the cell focuses on the switch control
- [x] Tapping anywhere on the footer (which does not belong to the cell) does nothing (unfortunately but based on our current implementation)
- [x] Toggling `Following` OFF and `Canceling` the alert re-focuses VoiceOver to the `Following` cell (which is now back to ON state and read by VoiceOver)
- [x] Toggling `Following` OFF and `Accepting` the alert re-focuses VoiceOver to the `Following` cell (which is now in OFF state and read by VoiceOver)

**Settings > Notifications > Project notifications**

- [x] Swiping right/left navigates between switch controls
- [x] VoiceOver reads switch control as "title + switch button + state + double tap to toggle setting" (all localized)
- [x] Tapping anywhere on the cell focuses on the switch control

**Settings > Newsletters**

- [x] Swiping right/left navigates between switch controls
- [x] VoiceOver reads switch control as "title + switch button + state + header or footer + double tap to toggle setting" (all localized)
- [x] Tapping anywhere on the cell focuses on the switch control
- [x] Tapping anywhere on the header/footer focuses on the switch control

Since some of this work has touched the following cell functionality the following is a regression testing:

👉Voice Over OFF
- [x] Toggle following cell OFF > alert will appear > cancel > toggle will switch back ON with animation
- [x] Toggle following cell OFF > alert will appear > confirm > toggle will stay OFF
- [x] Toggle following cell ON > no alert will appear > toggle will switch ON