### PR TITLE
♿️ - Settings - Request Personal Data

### DIFF
--- a/Kickstarter-iOS/Views/Cells/SettingsPrivacyRequestDataCell.swift
+++ b/Kickstarter-iOS/Views/Cells/SettingsPrivacyRequestDataCell.swift
@@ -29,6 +29,9 @@ internal final class SettingsPrivacyRequestDataCell: UITableViewCell, ValueCell 
   internal override func awakeFromNib() {
     super.awakeFromNib()
 
+    _ = self
+      |> \.accessibilityElements .~ [self.requestDataButton]
+
     self.requestDataButton.addTarget(self, action: #selector(exportButtonTapped), for: .touchUpInside)
 
     self.requestDataObserver = NotificationCenter.default.addObserver(
@@ -105,6 +108,7 @@ internal final class SettingsPrivacyRequestDataCell: UITableViewCell, ValueCell 
         self?.delegate?.settingsRequestDataCell(_self, requestedDataWith: url)
     }
 
+    self.requestDataButton.rac.accessibilityLabel = self.viewModel.outputs.requestDataText
     self.requestDataButton.rac.enabled = self.viewModel.outputs.requestDataButtonEnabled
     self.requestDataActivityIndicator.rac.animating = self.viewModel.outputs.requestDataLoadingIndicator
     self.requestDataLabel.rac.text = self.viewModel.outputs.requestDataText

--- a/Kickstarter-iOS/Views/Storyboards/SettingsPrivacy.storyboard
+++ b/Kickstarter-iOS/Views/Storyboards/SettingsPrivacy.storyboard
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
-        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -323,14 +322,14 @@
                                             <viewLayoutGuide key="safeArea" id="Ufg-5Z-5Nh"/>
                                         </view>
                                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Uag-cG-Z0v">
-                                            <rect key="frame" x="0.0" y="1" width="375" height="50.5"/>
+                                            <rect key="frame" x="4" y="0.5" width="367" height="50.5"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="50" id="0wO-eK-0N1"/>
                                             </constraints>
                                         </button>
                                     </subviews>
                                     <constraints>
-                                        <constraint firstItem="Uag-cG-Z0v" firstAttribute="trailing" secondItem="ihf-gP-uZh" secondAttribute="trailingMargin" constant="16" id="7Ol-wf-rlh"/>
+                                        <constraint firstItem="Uag-cG-Z0v" firstAttribute="trailing" secondItem="ihf-gP-uZh" secondAttribute="trailingMargin" constant="12" id="7Ol-wf-rlh"/>
                                         <constraint firstAttribute="trailing" secondItem="bMn-0H-yEC" secondAttribute="trailing" id="AJI-4c-pyJ"/>
                                         <constraint firstItem="Uag-cG-Z0v" firstAttribute="top" secondItem="w3T-mz-kcX" secondAttribute="bottom" id="JY6-6e-sLk"/>
                                         <constraint firstAttribute="trailing" secondItem="w3T-mz-kcX" secondAttribute="trailing" id="LVW-Uh-pDY"/>
@@ -340,7 +339,7 @@
                                         <constraint firstItem="bMn-0H-yEC" firstAttribute="top" secondItem="ihf-gP-uZh" secondAttribute="top" id="oJ9-Al-ZAu"/>
                                         <constraint firstItem="bMn-0H-yEC" firstAttribute="leading" secondItem="ihf-gP-uZh" secondAttribute="leading" id="vZR-r2-Oc1"/>
                                         <constraint firstItem="w3T-mz-kcX" firstAttribute="top" secondItem="ihf-gP-uZh" secondAttribute="top" id="w4F-id-x88"/>
-                                        <constraint firstItem="Uag-cG-Z0v" firstAttribute="leading" secondItem="ihf-gP-uZh" secondAttribute="leadingMargin" constant="-16" id="z03-kJ-y2z"/>
+                                        <constraint firstItem="Uag-cG-Z0v" firstAttribute="leading" secondItem="ihf-gP-uZh" secondAttribute="leadingMargin" constant="-12" id="z03-kJ-y2z"/>
                                     </constraints>
                                 </tableViewCellContentView>
                                 <connections>


### PR DESCRIPTION
# 📲 What

Fixes the accessibility of `Request my personal data` button

# 🤔 Why

There was a bug that wasn't properly exposing the `Request my personal data` button to VoiceOver as well as auto-layout issue that caused the focus area to be slightly thicker than the screen width causing a weird offset on selection.

# 🛠 How

Accessibility properties + auto layout fixes.

# 👀 See

**Clipped content**
<img width="490" alt="screen shot 2019-01-07 at 2 56 15 pm" src="https://user-images.githubusercontent.com/387596/50811494-71e0ee80-12c3-11e9-8617-38c0c656050e.png"> 

**VoiceOver Focus**
![request-my-personal-data](https://user-images.githubusercontent.com/387596/50811502-7b6a5680-12c3-11e9-83bf-9c3fdd1527fa.gif)

# ✅ Acceptance criteria

**Default state**
- [x] `Request my personal data`'s VoiceOver focus area is the size of the cell (excluding the footer)
- [x] The accessibility label is read as `Request my personal data, button`
- [x] The focus area doesn't cause additional offset due to previously clipped content

**Processing state**
- [ ] `Preparing your personal data`'s VoiceOver focus area is the size of the cell (excluding the footer)
- [ ] The accessibility label is read as `Preparing your personal data ellipsis, dimmed, button, Check back later for an update on your export progress.`
- [ ] The focus area doesn't cause additional offset due to previously clipped content
- [ ] The activity indicator is not accessible

**Completed state**
- [ ] `Download your personal data`'s VoiceOver focus area is the size of the cell (excluding the footer)
- [ ] The accessibility label is read as `Download your personal data, button, Expires Jan 14, 2019 at 9:42 AM`
- [ ] The focus area doesn't cause additional offset due to previously clipped content