### PR TITLE
♿️ - Settings - Delete my Kickstarter account button

### DIFF
--- a/Kickstarter-iOS/Views/Cells/SettingsPrivacyDeleteAccountCell.swift
+++ b/Kickstarter-iOS/Views/Cells/SettingsPrivacyDeleteAccountCell.swift
@@ -20,6 +20,12 @@ internal final class SettingsPrivacyDeleteAccountCell: UITableViewCell, ValueCel
   internal override func awakeFromNib() {
     super.awakeFromNib()
 
+    _ = self
+      |> \.accessibilityElements .~ [self.deleteAccountButton]
+
+    _ = self.deleteAccountButton
+      |> \.accessibilityLabel %~ { _ in Strings.Delete_my_Kickstarter_Account() }
+
     self.deleteAccountButton.addTarget(self, action: #selector(deleteAccountTapped), for: .touchUpInside)
   }
 


### PR DESCRIPTION
# 📲 What

Updates a11y of the `Delete my Kickstarter account` button to properly say it's a button

# 🤔 Why

This tells users that they can perform an action on this element when focused.

# 🛠 How

Simply exposing the button instead of the label.

# ✅ Acceptance criteria

Test under the following conditions
👉 iOS 10, iOS 11 & iOS 12
👉Voice Over ON
👉 In order to test localization prefer to QA with one of the supported language set as the primary 📱 language

- [x] VoiceOver reads the `Settings > Account > Privacy > Delete my Kickstarter account` as `Delete my Kickstarter account, button` (this message is localized)