### PR TITLE
♿️ - Settings > Notifications - Manage project notifications + Email frequency

### DIFF
--- a/Kickstarter-iOS/Views/Cells/SettingsNotificationCell.swift
+++ b/Kickstarter-iOS/Views/Cells/SettingsNotificationCell.swift
@@ -100,8 +100,6 @@ final class SettingsNotificationCell: UITableViewCell, NibLoading, ValueCell {
     self.projectCountLabel.rac.text = viewModel.outputs.projectCountText
     self.pushNotificationsButton.rac.selected = viewModel.outputs.pushNotificationsEnabled
     self.pushNotificationsButton.rac.hidden = viewModel.outputs.pushNotificationButtonIsHidden
-    self.projectCountLabel.rac.accessibilityHint = viewModel.outputs
-      .manageProjectNotificationsButtonAccessibilityHint
 
     viewModel.outputs.enableButtonAnimation
     .observeForUI()

--- a/Kickstarter-iOS/Views/Cells/SettingsNotificationCell.swift
+++ b/Kickstarter-iOS/Views/Cells/SettingsNotificationCell.swift
@@ -34,6 +34,10 @@ final class SettingsNotificationCell: UITableViewCell, NibLoading, ValueCell {
 
     viewModel.inputs.configure(with: cellValue)
 
+    _ = self
+      |> \.accessibilityTraits .~ cellValue.cellType.accessibilityTraits
+      |> \.accessibilityLabel %~ { _ in cellValue.cellType.title }
+
     _ = titleLabel
       |> UILabel.lens.text .~ cellValue.cellType.title
 
@@ -90,6 +94,7 @@ final class SettingsNotificationCell: UITableViewCell, NibLoading, ValueCell {
   override func bindViewModel() {
     super.bindViewModel()
 
+    self.rac.accessibilityValue = viewModel.outputs.projectCountText
     self.emailNotificationsButton.rac.selected = viewModel.outputs.emailNotificationsEnabled
     self.emailNotificationsButton.rac.hidden = viewModel.outputs.emailNotificationButtonIsHidden
     self.projectCountLabel.rac.text = viewModel.outputs.projectCountText

--- a/Kickstarter-iOS/Views/Cells/SettingsNotificationCell.swift
+++ b/Kickstarter-iOS/Views/Cells/SettingsNotificationCell.swift
@@ -36,7 +36,6 @@ final class SettingsNotificationCell: UITableViewCell, NibLoading, ValueCell {
 
     _ = self
       |> \.accessibilityTraits .~ cellValue.cellType.accessibilityTraits
-      |> \.accessibilityLabel %~ { _ in cellValue.cellType.title }
 
     _ = titleLabel
       |> UILabel.lens.text .~ cellValue.cellType.title
@@ -94,7 +93,6 @@ final class SettingsNotificationCell: UITableViewCell, NibLoading, ValueCell {
   override func bindViewModel() {
     super.bindViewModel()
 
-    self.rac.accessibilityValue = viewModel.outputs.projectCountText
     self.emailNotificationsButton.rac.selected = viewModel.outputs.emailNotificationsEnabled
     self.emailNotificationsButton.rac.hidden = viewModel.outputs.emailNotificationButtonIsHidden
     self.projectCountLabel.rac.text = viewModel.outputs.projectCountText

--- a/Kickstarter-iOS/Views/Cells/SettingsNotificationPickerCell.swift
+++ b/Kickstarter-iOS/Views/Cells/SettingsNotificationPickerCell.swift
@@ -13,6 +13,9 @@ final class SettingsNotificationPickerCell: UITableViewCell, NibLoading, ValueCe
   func configureWith(value: SettingsNotificationCellValue) {
     self.viewModel.inputs.configure(with: value)
 
+    _ = self
+      |> \.accessibilityTraits .~ value.cellType.accessibilityTraits
+
     _ = titleLabel
       |> UILabel.lens.text .~ value.cellType.title
   }

--- a/Library/SettingsNotificationCellType.swift
+++ b/Library/SettingsNotificationCellType.swift
@@ -72,6 +72,15 @@ public enum SettingsNotificationCellType {
                                                                 .friendBacksProject,
                                                                 ]
 
+  public var accessibilityTraits: UIAccessibilityTraits {
+    switch self {
+    case .projectNotifications, .emailFrequency:
+      return .button
+    default:
+      return .none
+    }
+  }
+
   public var shouldShowEmailNotificationButton: Bool {
     switch self {
     case .projectNotifications, .emailFrequency:

--- a/Library/ViewModels/SettingsNotificationCellViewModel.swift
+++ b/Library/ViewModels/SettingsNotificationCellViewModel.swift
@@ -14,7 +14,6 @@ public protocol SettingsNotificationCellViewModelOutputs {
   var emailNotificationsEnabled: Signal<Bool, NoError> { get }
   var emailNotificationButtonIsHidden: Signal<Bool, NoError> { get }
   var pushNotificationButtonIsHidden: Signal<Bool, NoError> { get }
-  var manageProjectNotificationsButtonAccessibilityHint: Signal<String, NoError> { get }
   var projectCountText: Signal<String, NoError> { get }
   var pushNotificationsEnabled: Signal<Bool, NoError> { get }
   var unableToSaveError: Signal<String, NoError> { get }
@@ -130,9 +129,6 @@ SettingsNotificationCellViewModelType {
     self.enableButtonAnimation = self.emailNotificationButtonIsHidden
       .negate() // Only add animation if email notification button is shown
 
-    self.manageProjectNotificationsButtonAccessibilityHint = initialUser
-      .map { Strings.profile_project_count_projects_backed(project_count: $0.stats.backedProjectsCount ?? 0) }
-
     self.projectCountText = initialUser
       .map { Format.wholeNumber($0.stats.backedProjectsCount ?? 0) }
 
@@ -164,7 +160,6 @@ SettingsNotificationCellViewModelType {
   public let emailNotificationsEnabled: Signal<Bool, NoError>
   public let emailNotificationButtonIsHidden: Signal<Bool, NoError>
   public let pushNotificationButtonIsHidden: Signal<Bool, NoError>
-  public let manageProjectNotificationsButtonAccessibilityHint: Signal<String, NoError>
   public let projectCountText: Signal<String, NoError>
   public let pushNotificationsEnabled: Signal<Bool, NoError>
   public let unableToSaveError: Signal<String, NoError>

--- a/Library/ViewModels/SettingsNotificationCellViewModelTests.swift
+++ b/Library/ViewModels/SettingsNotificationCellViewModelTests.swift
@@ -26,8 +26,6 @@ final class SettingsNotificationCellViewModelTests: TestCase {
     self.vm.outputs.emailNotificationsEnabled.observe(emailNotificationsEnabled.observer)
     self.vm.outputs.emailNotificationButtonIsHidden.observe(emailNotificationButtonIsHidden.observer)
     self.vm.outputs.pushNotificationButtonIsHidden.observe(pushNotificationButtonIsHidden.observer)
-    self.vm.outputs.manageProjectNotificationsButtonAccessibilityHint
-      .observe(manageProjectNotificationsButtonAccessibilityHint.observer)
     self.vm.outputs.projectCountText.observe(projectCountText.observer)
     self.vm.pushNotificationsEnabled.observe(pushNotificationsEnabled.observer)
     self.vm.unableToSaveError.observe(unableToSaveError.observer)
@@ -196,8 +194,6 @@ final class SettingsNotificationCellViewModelTests: TestCase {
     let value = SettingsNotificationCellValue(cellType: .projectNotifications, user: user)
 
     self.vm.inputs.configure(with: value)
-
-    self.manageProjectNotificationsButtonAccessibilityHint.assertValue("5 projects backed")
   }
 
   func testProjectTextCount() {


### PR DESCRIPTION
# 📲 What

Improves the accessibility of the following rows
* Settings > Notifications > Manage project notifications
* Settings > Notifications > Email frequency

# 🤔 Why

Making a11y great again

# 🛠 How

Using `accessibilityTraits` and `accessibilityLabel` + `accessibilityValue`

# ✅ Acceptance criteria

Test under the following conditions
👉 iOS 10, iOS 11 & iOS 12
👉Voice Over ON
👉 In order to test localization prefer to QA with one of the supported language set as the primary 📱 language

- [x] Settings > Notifications > Manage project notifications row is read by VoiceOver as `Manage project notification, X, button` where X is the number of projects backed so (i.e. `Manage project notifications, twelve, button` (make sure this is localized)

- [x] Settings > Notifications > Email frequency row is read by VoiceOver as `Email frequency, Y, button` where X is the selected option of frequency so (i.e. `Email frequency, Individual emails, button`) (make sure to login as a creator to see this option)