### PR TITLE
Match email links based on host rather than paths

### DIFF
--- a/Kickstarter-iOS/ViewModels/AppDelegateViewModel.swift
+++ b/Kickstarter-iOS/ViewModels/AppDelegateViewModel.swift
@@ -324,10 +324,8 @@ AppDelegateViewModelOutputs {
 
     self.findRedirectUrl = deepLinkUrl
       .filter {
-        switch Navigation.match($0) {
-        case .some(.emailClick), .some(.emailLink): return true
-        default:                                    return false
-        }
+        guard case .some(.emailClick) = Navigation.match($0) else { return true }
+        return false
     }
 
     self.goToDiscovery = deepLink

--- a/Library/Navigation.swift
+++ b/Library/Navigation.swift
@@ -594,9 +594,9 @@ private func parsedParams(url: URL, fromTemplate template: String) -> RouteParam
 
   // if we're parsing against the '/' emailClick template and this is a recognized email host
   // return the expected params for that route to be resolved
-//  if templateComponents.isEmpty && isRecognizedEmailHost {
-//    return .object(["qs": .string("deadbeef")])
-//  }
+  if templateComponents.isEmpty && isRecognizedEmailHost {
+    return .object(["qs": .string("deadbeef")])
+  }
 
   guard templateComponents.count == urlComponents.count else { return nil }
 

--- a/Library/Navigation.swift
+++ b/Library/Navigation.swift
@@ -8,7 +8,7 @@ public enum Navigation {
   case checkout(Int, Navigation.Checkout)
   case creatorMessages(Param, messageThreadId: Int)
   case projectActivity(Param)
-  case emailClick(qs: String)
+  case emailClick
   case messages(messageThreadId: Int)
   case signup
   case tab(Tab)
@@ -79,8 +79,8 @@ public func == (lhs: Navigation, rhs: Navigation) -> Bool {
   switch (lhs, rhs) {
   case let (.checkout(lhsId, lhsCheckout), .checkout(rhsId, rhsCheckout)):
     return lhsId == rhsId && lhsCheckout == rhsCheckout
-  case let (.emailClick(lhs), .emailClick(rhs)):
-    return lhs == rhs
+  case (.emailClick, .emailClick):
+    return true
   case let (.messages(lhs), .messages(rhs)):
     return lhs == rhs
   case (.signup, .signup):
@@ -321,8 +321,7 @@ extension Navigation.Project {
 public typealias RouteParams = JSON
 
 private func emailClick(_ params: RouteParams) -> Decoded<Navigation> {
-  return curry(Navigation.emailClick)
-   <^> params <| "qs"
+  return .success(Navigation.emailClick)
 }
 
 private func activity(_: RouteParams) -> Decoded<Navigation> {
@@ -595,7 +594,7 @@ private func parsedParams(url: URL, fromTemplate template: String) -> RouteParam
   // if we're parsing against the '/' emailClick template and this is a recognized email host
   // return the expected params for that route to be resolved
   if templateComponents.isEmpty && isRecognizedEmailHost {
-    return .object(["qs": .string("deadbeef")])
+    return .object([:])
   }
 
   guard templateComponents.count == urlComponents.count else { return nil }

--- a/Library/NavigationTests.swift
+++ b/Library/NavigationTests.swift
@@ -132,18 +132,18 @@ public final class NavigationTests: XCTestCase {
   }
 
   func testRecognizesEmailClickUrls() {
-    XCTAssertEqual(.emailClick(qs: "deadbeef"),
+    XCTAssertEqual(.emailClick,
                    Navigation.match(URL(string: "https://click.e.kickstarter.com/?qs=deadbeef")!))
   }
 
   func testOtherEmailClickUrls() {
-    XCTAssertEqual(.emailClick(qs: "deadbeef"),
+    XCTAssertEqual(.emailClick,
                    Navigation.match(URL(string: "https://click.em.kickstarter.com/wf/click?upn=deadbeef")!))
   }
 
   func testOtherEmailLinks() {
     let url = URL(string: "https://email.kickstarter.com/mpss/c/2gA/Oiw/t.25j/deadbeef/h1/dead-beef")!
-    XCTAssertEqual(.emailClick(qs: "deadbeef"), Navigation.match(url))
+    XCTAssertEqual(.emailClick, Navigation.match(url))
   }
 
   func testRecognizesKsrUrlScheme() {

--- a/Library/NavigationTests.swift
+++ b/Library/NavigationTests.swift
@@ -136,9 +136,14 @@ public final class NavigationTests: XCTestCase {
                    Navigation.match(URL(string: "https://click.e.kickstarter.com/?qs=deadbeef")!))
   }
 
+  func testOtherEmailClickUrls() {
+    XCTAssertEqual(.emailClick(qs: "deadbeef"),
+                   Navigation.match(URL(string: "https://click.em.kickstarter.com/wf/click?upn=deadbeef")!))
+  }
+
   func testOtherEmailLinks() {
     let url = URL(string: "https://email.kickstarter.com/mpss/c/2gA/Oiw/t.25j/deadbeef/h1/dead-beef")!
-    XCTAssertEqual(.emailLink, Navigation.match(url))
+    XCTAssertEqual(.emailClick(qs: "deadbeef"), Navigation.match(url))
   }
 
   func testRecognizesKsrUrlScheme() {


### PR DESCRIPTION
# 📲 What

This ignores the paths of email links for deep-linking and instead bases it on the host portion of these URLs.

# 🤔 Why

We found that some of our newsletter email links weren't deep-linking correctly. Upon investigating, this appeared to be because they have a different format to the links we've expected in the past, for example:

### Currently recognized links
`https://click.e.kickstarter.com/?qs=deadbeef`
`https://email.kickstarter.com/mpss/c/2gA/Oiw/t.25j/deadbeef/h1/dead-beef`
### New (unrecognized) recognized link
`https://click.em.kickstarter.com/wf/click?upn=deadbeef`

Our parser handles the detection of these URLs as email links by way of parsing their paths and query params. We don't actually make use of any of these params other than to recognize the URLs and to then attempt to resolve redirects for them which we then again test against the route parser and deep-link if we find a supported route.

# 🛠 How

The solution I'm proposing is that we instead base the recognition on the `HOST` portion of the URL. So if a URL matches any of the _known_ email hosts that we support, we return some empty params so that it matches on the `/` route and returns `Navigation.emailClick` which we then handle as before and find a redirect URL for.

Chatting to @pcreux about this he mentioned that we don't have any control over the construction of these URLs so we might be playing a game of whack-a-mole if we keep adding different paths in order to parse these URLs. Instead we can better-predict that host portions of these URLs and match on that, ignoring the paths and query strings.

# 👀 See

https://trello.com/c/Y033E5v2

# ✅ Acceptance criteria

- [ ] Newsletter email links deep-link correctly
- [ ] Push notifications deep-link correctly
- [ ] Project preview links are ignored correctly (as per #538)