### PR TITLE
Add ITSAppUsesNonExemptEncryption to Info.plist

### DIFF
--- a/Kickstarter-iOS/Info.plist
+++ b/Kickstarter-iOS/Info.plist
@@ -67,6 +67,8 @@
 	<string>Kickstarter</string>
 	<key>FirebaseAppDelegateProxyEnabled</key>
 	<false/>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
 		<string>fbauth2</string>


### PR DESCRIPTION
# 📲 What

This adds `ITSAppUsesNonExemptEncryption` to our `Info.plist` with the value of `false`.

# 🤔 Why

Each time that we submit apps to the store we need to confirm that we do not use non-exempt encryption in our app. We only use TLS and make calls over HTTPS which are exempted forms of encryption and we will always answer _no_ to this question on App Store Connect. Adding this flag should mean that when we submit builds to the app store they will automatically be available for internal testing without having to log in and answer this question about encryption.

# 🛠 How

Edited the `.plist` and added the flag.

# 👀 See

https://stackoverflow.com/a/43924708/2271759
https://help.apple.com/app-store-connect/#/devc3f64248f

# ✅ Acceptance criteria

- [ ] The app will automatically be available for internal testing via TestFlight the next time that we submit to the app store.
