### PR TITLE
Pin Swiftlint to version 0.29.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,8 @@ dependencies: submodules configs secrets opentok fabric stripe
 bootstrap: hooks dependencies
 	brew update || brew update
 	brew unlink swiftlint || true
-	brew install swiftlint
+	brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/686375d8bc672a439ca9fcf27794a394239b3ee6/Formula/swiftlint.rb
+	brew switch swiftlint 0.29.2
 	brew link --overwrite swiftlint
 
 submodules:


### PR DESCRIPTION
# 📲 What

Uses specific version of `Swiftlint` as part of our `make bootstrap` script.

# 🤔 Why

Pinning to a specific version helps us having predictable environment and prevents from breaking changes when new builds are released. This is quite easy in our situation because we're treating warnings as errors.

# 🛠 How

See DIFF