### PR TITLE
Ensure gym output path is consistent

### DIFF
--- a/.fastlane/Fastfile
+++ b/.fastlane/Fastfile
@@ -101,8 +101,8 @@ platform :ios do
     sh "./beta-changelog.rb"
 
     upload_s3(
-      ipa: "KickBeta.ipa",
-      dsym: "KickBeta.app.dSYM.zip"
+      ipa: "./output/gym/KickBeta.ipa",
+      dsym: "./output/gym/KickBeta.app.dSYM.zip"
     )
 
     sh "./beta-post-s3.rb"

--- a/.fastlane/Fastfile
+++ b/.fastlane/Fastfile
@@ -3,8 +3,6 @@ fastlane_version "2.28.3"
 default_platform :ios
 
 platform :ios do
-  gym_dir = ENV["GYM_OUTPUT_DIRECTORY"] || "."
-
   ### MATCH
   desc "Fastlane Match"
   lane :match_all do
@@ -293,6 +291,10 @@ platform :ios do
       path: "{CFBundleVersion}/",
       upload_metadata: true
     )
+  end
+
+  def gym_dir
+    ENV["GYM_OUTPUT_DIRECTORY"] || "."
   end
 
   def slack_message(type, version_number, build_number, platform)

--- a/.fastlane/Fastfile
+++ b/.fastlane/Fastfile
@@ -3,6 +3,8 @@ fastlane_version "2.28.3"
 default_platform :ios
 
 platform :ios do
+  gym_dir = ENV["GYM_OUTPUT_DIRECTORY"] || "."
+
   ### MATCH
   desc "Fastlane Match"
   lane :match_all do
@@ -77,11 +79,11 @@ platform :ios do
   desc "Upload Beta to HockeyApp"
   lane :beta_hockey do
     upload_hockey(
-      ipa: "./output/gym/KickBeta.ipa",
+      ipa: "#{gym_dir}/KickBeta.ipa",
       public_identifier: ENV["HOCKEY_BETA_APP_ID"]
     )
 
-    upload_dsyms(dsym: "./output/gym/KickBeta.app.dSYM.zip")
+    upload_dsyms(dsym: "#{gym_dir}/KickBeta.app.dSYM.zip")
 
     slack(
       slack_url: ENV["SLACK_WEBHOOK"],
@@ -101,8 +103,8 @@ platform :ios do
     sh "./beta-changelog.rb"
 
     upload_s3(
-      ipa: "./output/gym/KickBeta.ipa",
-      dsym: "./output/gym/KickBeta.app.dSYM.zip"
+      ipa: "#{gym_dir}/KickBeta.ipa",
+      dsym: "#{gym_dir}/KickBeta.app.dSYM.zip"
     )
 
     sh "./beta-post-s3.rb"
@@ -129,7 +131,7 @@ platform :ios do
   desc "Upload Production to HockeyApp"
   lane :itunes_hockey do
     upload_hockey(
-      ipa: "./output/gym/Kickstarter.ipa",
+      ipa: "#{gym_dir}/Kickstarter.ipa",
       public_identifier: ENV["HOCKEY_RELEASE_APP_ID"]
     )
   end
@@ -142,7 +144,7 @@ platform :ios do
       username: ENV["ITUNES_CONNECT_ACCOUNT"],
       app_identifier: ENV["ITUNES_APP_IDENTIFIER"],
       app: ENV["ITUNES_APP_ID"],
-      ipa: "./output/gym/Kickstarter.ipa",
+      ipa: "#{gym_dir}/Kickstarter.ipa",
       team_name: ENV["ITUNES_TEAM_NAME"],
       skip_screenshots: true,
       skip_metadata: true
@@ -158,7 +160,7 @@ platform :ios do
       )
     )
 
-    upload_dsyms(dsym: "./output/gym/Kickstarter.app.dSYM.zip")
+    upload_dsyms(dsym: "#{gym_dir}/Kickstarter.app.dSYM.zip")
   end
 
   ### ALPHA
@@ -180,11 +182,11 @@ platform :ios do
   desc "Upload Alpha to HockeyApp"
   lane :alpha_hockey do
     upload_hockey(
-      ipa: "./output/gym/KickAlpha.ipa",
+      ipa: "#{gym_dir}/KickAlpha.ipa",
       public_identifier: ENV["HOCKEY_ALPHA_APP_ID"]
     )
 
-    upload_dsyms(dsym: "./output/gym/KickAlpha.app.dSYM.zip")
+    upload_dsyms(dsym: "#{gym_dir}/KickAlpha.app.dSYM.zip")
 
     slack(
       slack_url: ENV["SLACK_WEBHOOK"],


### PR DESCRIPTION
# 📲 What

This ensures that the path that `fastlane gym` outputs to is always the same as the path that we try to read from.

# 🤔 Why

When we run `fastlane gym` on CircleCI, we have an environment variable called `FL_OUTPUT_DIR` which is set to `output`. This causes any output that `fastlane` actions generate to be put under that path. So for example, `fastlane gym` will output to `./output/gym`. However, when we run this locally that environment variable is not set and so, because I initially tested this locally, I set it to look for the `ipa` file at `.` and not `./output/gym`. This has happened a couple of times before so I decided to try and prevent it going forward.
# 🛠 How

If we look at our `setup_circle_ci` command in our `Fastfile` it [constructs an environment var](https://github.com/fastlane/fastlane/blob/master/fastlane/lib/fastlane/actions/setup_circle_ci.rb#L22) called `GYM_OUTPUT_DIRECTORY`. I've placed a line at the top of our `Fastfile` which uses the value of this env var if it's present and if not coalesces to the value `.`. We then use the `gym_dir` value in the places where we need to reference the `gym` output dir.

# ✅ Acceptance criteria

- [x] Running `fastlane beta_gym` both locally and on CircleCI should succeed.
- [x] Manipulating the `GYM_OUTPUT_DIRECTORY` locally and running `fastlane beta_gym` should show up in the console for that command (as in screenshot below).

| `GYM_OUTPUT_DIRECTORY` value set to `output`  | `GYM_OUTPUT_DIRECTORY` not set |
| ------------- | ------------- |
| <img width="934" alt="screen shot 2019-01-23 at 5 14 20 pm" src="https://user-images.githubusercontent.com/3735375/51647636-713a9000-1f32-11e9-97b6-3b6987b6b88e.png"> | <img width="931" alt="screen shot 2019-01-23 at 5 14 29 pm" src="https://user-images.githubusercontent.com/3735375/51647645-7bf52500-1f32-11e9-89d9-73f04ed7ea67.png"> |