### PR TITLE
Reusable download framework script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,11 +44,11 @@ jobs:
 
       - restore_cache:
           keys:
-            - opentok-cache-{{ checksum "opentok_version.txt" }}
+            - opentok-sdk-cache-{{ checksum "opentok_version.txt" }}
 
       - restore_cache:
           keys:
-            - fabric-cache-{{ checksum "fabric_version.txt" }}
+            - fabric-sdk-cache-{{ checksum "fabric_version.txt" }}
 
       - run:
           name: Make bootstrap
@@ -60,12 +60,12 @@ jobs:
             - ".git"
 
       - save_cache:
-          key: opentok-cache-{{ checksum "opentok_version.txt" }}
+          key: opentok-sdk-cache-{{ checksum "opentok_version.txt" }}
           paths:
             - "Frameworks/OpenTok"
 
       - save_cache:
-          key: fabric-cache-{{ checksum "fabric_version.txt" }}
+          key: fabric-sdk-cache-{{ checksum "fabric_version.txt" }}
           paths:
             - "Frameworks/Fabric"
 
@@ -98,11 +98,11 @@ jobs:
 
       - restore_cache:
           keys:
-            - opentok-cache-{{ checksum "opentok_version.txt" }}
+            - opentok-sdk-cache-{{ checksum "opentok_version.txt" }}
 
       - restore_cache:
           keys:
-            - fabric-cache-{{ checksum "fabric_version.txt" }}
+            - fabric-sdk-cache-{{ checksum "fabric_version.txt" }}
 
       - run:
           name: Make bootstrap
@@ -139,11 +139,11 @@ jobs:
 
       - restore_cache:
           keys:
-            - opentok-cache-{{ checksum "opentok_version.txt" }}
+            - opentok-sdk-cache-{{ checksum "opentok_version.txt" }}
 
       - restore_cache:
           keys:
-            - fabric-cache-{{ checksum "fabric_version.txt" }}
+            - fabric-sdk-cache-{{ checksum "fabric_version.txt" }}
 
       - run:
           name: Make bootstrap
@@ -178,11 +178,11 @@ jobs:
 
       - restore_cache:
           keys:
-            - opentok-cache-{{ checksum "opentok_version.txt" }}
+            - opentok-sdk-cache-{{ checksum "opentok_version.txt" }}
 
       - restore_cache:
           keys:
-            - fabric-cache-{{ checksum "fabric_version.txt" }}
+            - fabric-sdk-cache-{{ checksum "fabric_version.txt" }}
 
       - run:
           name: Make bootstrap
@@ -217,11 +217,11 @@ jobs:
 
       - restore_cache:
           keys:
-            - opentok-cache-{{ checksum "opentok_version.txt" }}
+            - opentok-sdk-cache-{{ checksum "opentok_version.txt" }}
 
       - restore_cache:
           keys:
-            - fabric-cache-{{ checksum "fabric_version.txt" }}
+            - fabric-sdk-cache-{{ checksum "fabric_version.txt" }}
 
       - run:
           name: Make bootstrap
@@ -273,11 +273,11 @@ jobs:
 
       - restore_cache:
           keys:
-            - opentok-cache-{{ checksum "opentok_version.txt" }}
+            - opentok-sdk-cache-{{ checksum "opentok_version.txt" }}
 
       - restore_cache:
           keys:
-            - fabric-cache-{{ checksum "fabric_version.txt" }}
+            - fabric-sdk-cache-{{ checksum "fabric_version.txt" }}
 
       - run:
           name: Make bootstrap
@@ -338,11 +338,11 @@ jobs:
 
       - restore_cache:
           keys:
-            - opentok-cache-{{ checksum "opentok_version.txt" }}
+            - opentok-sdk-cache-{{ checksum "opentok_version.txt" }}
 
       - restore_cache:
           keys:
-            - fabric-cache-{{ checksum "fabric_version.txt" }}
+            - fabric-sdk-cache-{{ checksum "fabric_version.txt" }}
 
       - run:
           name: Make bootstrap
@@ -398,11 +398,11 @@ jobs:
 
       - restore_cache:
           keys:
-            - opentok-cache-{{ checksum "opentok_version.txt" }}
+            - opentok-sdk-cache-{{ checksum "opentok_version.txt" }}
 
       - restore_cache:
           keys:
-            - fabric-cache-{{ checksum "fabric_version.txt" }}
+            - fabric-sdk-cache-{{ checksum "fabric_version.txt" }}
 
       - run:
           name: Make bootstrap
@@ -447,11 +447,11 @@ jobs:
 
       - restore_cache:
           keys:
-            - opentok-cache-{{ checksum "opentok_version.txt" }}
+            - opentok-sdk-cache-{{ checksum "opentok_version.txt" }}
 
       - restore_cache:
           keys:
-            - fabric-cache-{{ checksum "fabric_version.txt" }}
+            - fabric-sdk-cache-{{ checksum "fabric_version.txt" }}
 
       - run:
           name: Make bootstrap

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,10 +124,8 @@ jobs:
           keys:
             - fabric-sdk-cache-{{ checksum "fabric_version.txt" }}
 
-      - save_cache:
+      - restore_cache:
           key: stripe-sdk-cache-{{ checksum "stripe_version.txt" }}
-          paths:
-            - "Frameworks/Stripe"
 
       - run:
           name: Make bootstrap

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,6 +112,10 @@ jobs:
           name: Store OpenTok Version
           command: *store_opentok_version
 
+      - run:
+          name: Store Stripe Version
+          command: *store_stripe_version
+
       - restore_cache:
           keys:
             - opentok-sdk-cache-{{ checksum "opentok_version.txt" }}
@@ -119,6 +123,11 @@ jobs:
       - restore_cache:
           keys:
             - fabric-sdk-cache-{{ checksum "fabric_version.txt" }}
+
+      - save_cache:
+          key: stripe-sdk-cache-{{ checksum "stripe_version.txt" }}
+          paths:
+            - "Frameworks/Stripe"
 
       - run:
           name: Make bootstrap
@@ -152,6 +161,10 @@ jobs:
       - run:
           name: Store OpenTok Version
           command: *store_opentok_version
+
+      - run:
+          name: Store Stripe Version
+          command: *store_stripe_version
 
       - restore_cache:
           keys:
@@ -196,6 +209,10 @@ jobs:
           name: Store OpenTok Version
           command: *store_opentok_version
 
+      - run:
+          name: Store Stripe Version
+          command: *store_stripe_version
+
       - restore_cache:
           keys:
             - opentok-sdk-cache-{{ checksum "opentok_version.txt" }}
@@ -238,6 +255,10 @@ jobs:
       - run:
           name: Store OpenTok Version
           command: *store_opentok_version
+
+      - run:
+          name: Store Stripe Version
+          command: *store_stripe_version
 
       - restore_cache:
           keys:
@@ -298,6 +319,10 @@ jobs:
       - run:
           name: Store OpenTok Version
           command: *store_opentok_version
+
+      - run:
+          name: Store Stripe Version
+          command: *store_stripe_version
 
       - restore_cache:
           keys:
@@ -368,6 +393,10 @@ jobs:
           name: Store OpenTok Version
           command: *store_opentok_version
 
+      - run:
+          name: Store Stripe Version
+          command: *store_stripe_version
+
       - restore_cache:
           keys:
             - opentok-sdk-cache-{{ checksum "opentok_version.txt" }}
@@ -432,6 +461,10 @@ jobs:
           name: Store OpenTok Version
           command: *store_opentok_version
 
+      - run:
+          name: Store Stripe Version
+          command: *store_stripe_version
+
       - restore_cache:
           keys:
             - opentok-sdk-cache-{{ checksum "opentok_version.txt" }}
@@ -484,6 +517,10 @@ jobs:
       - run:
           name: Store OpenTok Version
           command: *store_opentok_version
+
+      - run:
+          name: Store Stripe Version
+          command: *store_stripe_version
 
       - restore_cache:
           keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,7 +125,8 @@ jobs:
             - fabric-sdk-cache-{{ checksum "fabric_version.txt" }}
 
       - restore_cache:
-          key: stripe-sdk-cache-{{ checksum "stripe_version.txt" }}
+          keys:
+            - stripe-sdk-cache-{{ checksum "stripe_version.txt" }}
 
       - run:
           name: Make bootstrap

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,8 +4,10 @@ xcode_version: &xcode_version 10.0
 iphone_name: &iphone_name iPhone 8
 opentok_version: &opentok_version 2.10.2
 fabric_sdk_version: &fabric_sdk_version 3.10.5
+stripe_sdk_version: &stripe_sdk_version 13.2.0
 store_fabric_sdk_version: &store_fabric_sdk_version echo "$FABRIC_SDK_VERSION" > fabric_version.txt
 store_opentok_version: &store_opentok_version echo "$OPENTOK_VERSION" > opentok_version.txt
+store_stripe_version: &store_stripe_version echo "$STRIPE_SDK_VERSION" > stripe_version.txt
 
 base_job: &base_job
   macos:
@@ -18,6 +20,7 @@ base_job: &base_job
     LC_ALL: en_US.UTF-8
     LANG: en_US.UTF-8
     FABRIC_SDK_VERSION: *fabric_sdk_version
+    STRIPE_SDK_VERSION: *stripe_sdk_version
     OPENTOK_VERSION: *opentok_version
     IPHONE_NAME: *iphone_name
     XCODE_VERSION: *xcode_version
@@ -42,6 +45,10 @@ jobs:
           name: Store OpenTok Version
           command: *store_opentok_version
 
+      - run:
+          name: Store Stripe Version
+          command: *store_stripe_version
+
       - restore_cache:
           keys:
             - opentok-sdk-cache-{{ checksum "opentok_version.txt" }}
@@ -49,6 +56,10 @@ jobs:
       - restore_cache:
           keys:
             - fabric-sdk-cache-{{ checksum "fabric_version.txt" }}
+
+      - restore_cache:
+          keys:
+            - stripe-sdk-cache-{{ checksum "stripe_version.txt" }}
 
       - run:
           name: Make bootstrap
@@ -68,6 +79,11 @@ jobs:
           key: fabric-sdk-cache-{{ checksum "fabric_version.txt" }}
           paths:
             - "Frameworks/Fabric"
+
+      - save_cache:
+          key: stripe-sdk-cache-{{ checksum "stripe_version.txt" }}
+          paths:
+            - "Frameworks/Stripe"
 
       - run:
           name: SwiftLint
@@ -145,6 +161,10 @@ jobs:
           keys:
             - fabric-sdk-cache-{{ checksum "fabric_version.txt" }}
 
+      - restore_cache:
+          keys:
+            - stripe-sdk-cache-{{ checksum "stripe_version.txt" }}
+
       - run:
           name: Make bootstrap
           command: make bootstrap
@@ -184,6 +204,10 @@ jobs:
           keys:
             - fabric-sdk-cache-{{ checksum "fabric_version.txt" }}
 
+      - restore_cache:
+          keys:
+            - stripe-sdk-cache-{{ checksum "stripe_version.txt" }}
+
       - run:
           name: Make bootstrap
           command: make bootstrap
@@ -222,6 +246,10 @@ jobs:
       - restore_cache:
           keys:
             - fabric-sdk-cache-{{ checksum "fabric_version.txt" }}
+
+      - restore_cache:
+          keys:
+            - stripe-sdk-cache-{{ checksum "stripe_version.txt" }}
 
       - run:
           name: Make bootstrap
@@ -278,6 +306,10 @@ jobs:
       - restore_cache:
           keys:
             - fabric-sdk-cache-{{ checksum "fabric_version.txt" }}
+
+      - restore_cache:
+          keys:
+            - stripe-sdk-cache-{{ checksum "stripe_version.txt" }}
 
       - run:
           name: Make bootstrap
@@ -344,6 +376,10 @@ jobs:
           keys:
             - fabric-sdk-cache-{{ checksum "fabric_version.txt" }}
 
+      - restore_cache:
+          keys:
+            - stripe-sdk-cache-{{ checksum "stripe_version.txt" }}
+
       - run:
           name: Make bootstrap
           command: make bootstrap
@@ -404,6 +440,10 @@ jobs:
           keys:
             - fabric-sdk-cache-{{ checksum "fabric_version.txt" }}
 
+      - restore_cache:
+          keys:
+            - stripe-sdk-cache-{{ checksum "stripe_version.txt" }}
+
       - run:
           name: Make bootstrap
           command: make bootstrap
@@ -452,6 +492,10 @@ jobs:
       - restore_cache:
           keys:
             - fabric-sdk-cache-{{ checksum "fabric_version.txt" }}
+
+      - restore_cache:
+          keys:
+            - stripe-sdk-cache-{{ checksum "stripe_version.txt" }}
 
       - run:
           name: Make bootstrap

--- a/Makefile
+++ b/Makefile
@@ -161,34 +161,9 @@ opentok:
 	fi
 
 fabric:
-	@if [ ! -d Frameworks/Fabric ]; then \
-		echo "Downloading Fabric v$(FABRIC_SDK_VERSION)"; \
-		mkdir -p Frameworks/Fabric; \
-		curl -N -L -o fabric.zip https://s3.amazonaws.com/kits-crashlytics-com/ios/com.twitter.crashlytics.ios/$(FABRIC_SDK_VERSION)/com.crashlytics.ios-manual.zip; \
-		unzip fabric.zip -d Frameworks/Fabric || true; \
-		rm fabric.zip; \
-	fi
-	@if [ -e Frameworks/Fabric/Fabric.framework ]; then \
-		echo "Fabric v$(FABRIC_SDK_VERSION) downloaded"; \
-	else \
-		echo "Failed to download Fabric SDK"; \
-		rm -rf Frameworks/Fabric; \
-	fi
+	bin/download_framework.sh Fabric $(FABRIC_SDK_VERSION) https://s3.amazonaws.com/kits-crashlytics-com/ios/com.twitter.crashlytics.ios/INSERT_SDK_VERSION/com.crashlytics.ios-manual.zip; \
 
 stripe:
-	@if [ ! -d Frameworks/Stripe ]; then \
-		echo "Downloading Stripe SDK v$(STRIPE_SDK_VERSION)"; \
-		mkdir -p Frameworks/Stripe; \
-		curl -N -L -o stripe.zip https://github.com/stripe/stripe-ios/releases/download/v$(STRIPE_SDK_VERSION)/Stripe.framework.zip; \
-		unzip stripe.zip -d Frameworks/Stripe || true; \
-		rm stripe.zip; \
-	fi
-	@if [ -e Frameworks/Stripe/Stripe.framework ]; then \
-		echo "Stripe SDK v$(STRIPE_SDK_VERSION) downloaded"; \
-	else \
-		echo "Failed to download Stripe SDK"; \
-		rm -rf Frameworks/Stripe; \
-	fi
-
+	bin/download_framework.sh Stripe $(STRIPE_SDK_VERSION) https://github.com/stripe/stripe-ios/releases/download/vINSERT_SDK_VERSION/Stripe.framework.zip; \
 
 .PHONY: test-all test clean dependencies submodules deploy lint secrets strings opentok fabric

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,9 @@ BRANCH ?= master
 DIST_BRANCH = $(RELEASE)-dist
 OPENTOK_VERSION ?= 2.10.2
 FABRIC_SDK_VERSION ?= 3.10.5
+FABRIC_SDK_URL ?= https://s3.amazonaws.com/kits-crashlytics-com/ios/com.twitter.crashlytics.ios/INSERT_SDK_VERSION/com.crashlytics.ios-manual.zip
 STRIPE_SDK_VERSION ?= 13.2.0
+STRIPE_SDK_URL ?= https://github.com/stripe/stripe-ios/releases/download/vINSERT_SDK_VERSION/Stripe.framework.zip
 COMMIT ?= $(CIRCLE_SHA1)
 
 ifeq ($(PLATFORM),iOS)
@@ -161,9 +163,9 @@ opentok:
 	fi
 
 fabric:
-	bin/download_framework.sh Fabric $(FABRIC_SDK_VERSION) https://s3.amazonaws.com/kits-crashlytics-com/ios/com.twitter.crashlytics.ios/INSERT_SDK_VERSION/com.crashlytics.ios-manual.zip; \
+	bin/download_framework.sh Fabric $(FABRIC_SDK_VERSION) $(FABRIC_SDK_URL); \
 
 stripe:
-	bin/download_framework.sh Stripe $(STRIPE_SDK_VERSION) https://github.com/stripe/stripe-ios/releases/download/vINSERT_SDK_VERSION/Stripe.framework.zip; \
+	bin/download_framework.sh Stripe $(STRIPE_SDK_VERSION) $(STRIPE_SDK_URL); \
 
 .PHONY: test-all test clean dependencies submodules deploy lint secrets strings opentok fabric

--- a/bin/download_framework.sh
+++ b/bin/download_framework.sh
@@ -16,12 +16,12 @@ fi
 URL=${URL//INSERT_SDK_VERSION/"$SDK_VERSION"}
 
 if [ "$SDK_VERSION" != "$CURRENT_SDK_VERSION" ]; then \
-	echo "Downloading $SDK_NAME v$SDK_VERSION"; \
-	mkdir -p Frameworks/$SDK_NAME; \
+  echo "Downloading $SDK_NAME v$SDK_VERSION"; \
+  mkdir -p Frameworks/$SDK_NAME; \
   curl -N -L -o framework.zip $URL; \
   unzip -o framework.zip -d Frameworks/$SDK_NAME; \
   rm framework.zip; \
 fi
 if [ -e Frameworks/$SDK_NAME/$SDK_NAME.framework ]; then \
-	echo "$SDK_VERSION" > $VERSION_FILE; \
+  echo "$SDK_VERSION" > $VERSION_FILE; \
 fi

--- a/bin/download_framework.sh
+++ b/bin/download_framework.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+SDK_NAME=$1
+SDK_VERSION=$2
+URL=$3
+FRAMEWORK_DIR=Frameworks/$SDK_NAME
+VERSION_FILE=$FRAMEWORK_DIR/version
+CURRENT_SDK_VERSION=first
+
+if [ -e $VERSION_FILE ]; then \
+  while read value; do
+    CURRENT_SDK_VERSION=$value
+  done < $VERSION_FILE
+fi
+
+URL=${URL//INSERT_SDK_VERSION/"$SDK_VERSION"}
+
+if [ "$SDK_VERSION" != "$CURRENT_SDK_VERSION" ]; then \
+	echo "Downloading $SDK_NAME v$SDK_VERSION"; \
+	mkdir -p Frameworks/$SDK_NAME; \
+  curl -N -L -o framework.zip $URL; \
+  unzip -o framework.zip -d Frameworks/$SDK_NAME; \
+  rm framework.zip; \
+fi
+if [ -e Frameworks/$SDK_NAME/$SDK_NAME.framework ]; then \
+	echo "$SDK_VERSION" > $VERSION_FILE; \
+fi


### PR DESCRIPTION
# 📲 What

Improves our `Makefile` a wee bit by moving duplicated logic for downloading our Stripe and Fabric SDKs into a shared bash script.

# 🤔 Why

We like to keep things DRY and this wasn't being very DRY at all. In the event that we download more frameworks this way during `make bootstrap` this will hopefully make that cleaner.

# 🛠 How

Extracted the logic that we were using into a shared bash script that receives arguments.

Note that I didn't do this for OpenTok, reasons being that we're likely to remove it soon and the additional complexity of it being a bzip'd tar ball made for a pretty gnarly script to handle that.

# ✅ Acceptance criteria

- [x] Scripts download as before
- [ ] Everything works on CircleCI

<img src="https://media.giphy.com/media/roIRm9blot1UQ/giphy.gif"/>
