### PR TITLE
Fix save button constraints on iOS 10

### DIFF
--- a/Kickstarter-iOS/Views/LoadingBarButtonItemView.swift
+++ b/Kickstarter-iOS/Views/LoadingBarButtonItemView.swift
@@ -13,6 +13,8 @@ final class LoadingBarButtonItemView: UIView, NibLoading {
       fatalError("failed to load LoadingBarButtonItemView from Nib")
     }
 
+    saveButtonView.translatesAutoresizingMaskIntoConstraints = false
+
     return saveButtonView
   }
 


### PR DESCRIPTION
# 📲 What

Fixes autolayout issue on custom `UIBarButtonItem` on iOS 10.

# 👀 See

Screenshots taken from iPhone 6+ running iOS 10.3.2

![img_0107](https://user-images.githubusercontent.com/3156796/51939061-99b40580-23dc-11e9-9b77-8aff89c1880d.PNG)

![img_0108](https://user-images.githubusercontent.com/3156796/51939067-9c165f80-23dc-11e9-807f-b2f617933b43.PNG)

# ✅ Acceptance criteria

- [ ] run on iOS 10 simulator, change password `Save` button and change email `Save` button should be sized correctly and work as expected
