### PR TITLE
[Payment methods] Minor bug fixes

### DIFF
--- a/Configs/Secrets.swift.example
+++ b/Configs/Secrets.swift.example
@@ -63,6 +63,11 @@ public enum Secrets {
     public static let endpoint = "https://api.com/stuff"
   }
 
+  public enum StripePublishableKey {
+  	public static let staging = "deadbeef"
+  	public static let production = "beefdead"
+  }
+
   public enum WebEndpoint {
     public static let production = "www.kickstarter.com"
     public static let staging = "staging.com"

--- a/Configs/Secrets.swift.example
+++ b/Configs/Secrets.swift.example
@@ -64,8 +64,8 @@ public enum Secrets {
   }
 
   public enum StripePublishableKey {
-  	public static let staging = "deadbeef"
-  	public static let production = "beefdead"
+    public static let staging = "deadbeef"
+    public static let production = "beefdead"
   }
 
   public enum WebEndpoint {

--- a/Kickstarter-iOS/Views/Controllers/AddNewCardViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/AddNewCardViewController.swift
@@ -189,8 +189,7 @@ STPPaymentCardTextFieldDelegate, MessageBannerViewControllerPresenting {
     self.viewModel.outputs.addNewCardSuccess
       .observeForControllerAction()
       .observeValues { [weak self] message in
-        self?.delegate?.presentAddCardSuccessfulBanner(message)
-        self?.navigationController?.dismiss(animated: true, completion: nil)
+        self?.dismissAndPresentMessageBanner(with: message)
     }
 
     self.viewModel.outputs.addNewCardFailure
@@ -249,6 +248,12 @@ STPPaymentCardTextFieldDelegate, MessageBannerViewControllerPresenting {
 
   private func cardBrandIsSupported(brand: STPCardBrand, supportedCardBrands: [STPCardBrand]) -> Bool {
     return self.supportedCardBrands.contains(brand)
+  }
+
+  private func dismissAndPresentMessageBanner(with message: String) {
+    self.navigationController?.dismiss(animated: true, completion: { [weak self] in
+      self?.delegate?.presentAddCardSuccessfulBanner(message)
+    })
   }
 
   private func dismissKeyboard() {

--- a/Library/Environment.swift
+++ b/Library/Environment.swift
@@ -46,6 +46,11 @@ public struct Environment {
   /// The current device running the app.
   public let device: UIDeviceType
 
+  /// Returns the current environment type
+  public var environmentType: EnvironmentType {
+    return self.apiService.serverConfig.environment
+  }
+
   /// A delegate to handle Facebook initialization and incoming url requests
   public let facebookAppDelegate: FacebookAppDelegateProtocol
 

--- a/Library/ViewModels/AddNewCardViewModel.swift
+++ b/Library/ViewModels/AddNewCardViewModel.swift
@@ -110,8 +110,7 @@ AddNewCardViewModelOutputs {
     self.dismissKeyboard = submitPaymentDetails.ignoreValues()
 
     self.setStripePublishableKey = self.viewDidLoadProperty.signal
-      .map { _ in AppEnvironment.current.config?.stripePublishableKey }
-      .skipNil()
+      .map { _ in AddNewCardViewModel.publishableKey(for: AppEnvironment.current.environmentType) }
 
     let addNewCardEvent = self.stripeTokenProperty.signal.skipNil()
       .map { CreatePaymentSourceInput(paymentType: PaymentType.creditCard,
@@ -241,4 +240,9 @@ AddNewCardViewModelOutputs {
 
   public var inputs: AddNewCardViewModelInputs { return self }
   public var outputs: AddNewCardViewModelOutputs { return self }
+
+  static func publishableKey(for environment: EnvironmentType) -> String {
+    return environment == .production ? Secrets.StripePublishableKey.production :
+      Secrets.StripePublishableKey.staging
+  }
 }

--- a/Library/ViewModels/AddNewCardViewModel.swift
+++ b/Library/ViewModels/AddNewCardViewModel.swift
@@ -110,7 +110,7 @@ AddNewCardViewModelOutputs {
     self.dismissKeyboard = submitPaymentDetails.ignoreValues()
 
     self.setStripePublishableKey = self.viewDidLoadProperty.signal
-      .map { _ in AddNewCardViewModel.publishableKey(for: AppEnvironment.current.environmentType) }
+      .map(value: publishableKey(for: AppEnvironment.current.environmentType))
 
     let addNewCardEvent = self.stripeTokenProperty.signal.skipNil()
       .map { CreatePaymentSourceInput(paymentType: PaymentType.creditCard,
@@ -240,9 +240,10 @@ AddNewCardViewModelOutputs {
 
   public var inputs: AddNewCardViewModelInputs { return self }
   public var outputs: AddNewCardViewModelOutputs { return self }
+}
 
-  static func publishableKey(for environment: EnvironmentType) -> String {
-    return environment == .production ? Secrets.StripePublishableKey.production :
-      Secrets.StripePublishableKey.staging
-  }
+// MARK: - View Model Helpers
+private func publishableKey(for environment: EnvironmentType) -> String {
+  return environment == .production ? Secrets.StripePublishableKey.production :
+    Secrets.StripePublishableKey.staging
 }

--- a/Library/ViewModels/AddNewCardViewModelTests.swift
+++ b/Library/ViewModels/AddNewCardViewModelTests.swift
@@ -215,13 +215,11 @@ internal final class AddNewCardViewModelTests: TestCase {
   }
 
   func testSetPublishableKey() {
-    withEnvironment(config: .template |> Config.lens.stripePublishableKey .~ "stripePublishableKey") {
-      self.setStripePublishableKey.assertDidNotEmitValue()
+    self.setStripePublishableKey.assertDidNotEmitValue()
 
-      self.vm.inputs.viewDidLoad()
+    self.vm.inputs.viewDidLoad()
 
-      self.setStripePublishableKey.assertValue("stripePublishableKey")
-    }
+    self.setStripePublishableKey.assertDidEmitValue()
   }
 
   func testDismissKeyboard() {

--- a/Library/ViewModels/PaymentMethodsViewModel.swift
+++ b/Library/ViewModels/PaymentMethodsViewModel.swift
@@ -84,7 +84,8 @@ PaymentMethodsViewModelInputs, PaymentMethodsViewModelOutputs {
       .observeValues { _ in AppEnvironment.current.koala.trackDeletePaymentMethodError() }
   }
 
-  fileprivate let (didDeleteCreditCardSignal, didDeleteCreditCardObserver) = Signal<GraphUserCreditCard.CreditCard,
+  fileprivate let (didDeleteCreditCardSignal, didDeleteCreditCardObserver) =
+    Signal<GraphUserCreditCard.CreditCard,
     NoError>.pipe()
   public func didDelete(_ creditCard: GraphUserCreditCard.CreditCard) {
     self.didDeleteCreditCardObserver.send(value: creditCard)

--- a/Library/ViewModels/PaymentMethodsViewModel.swift
+++ b/Library/ViewModels/PaymentMethodsViewModel.swift
@@ -67,7 +67,9 @@ PaymentMethodsViewModelInputs, PaymentMethodsViewModelOutputs {
 
     self.presentBanner = self.presentMessageBannerProperty.signal
 
-    self.tableViewIsEditing = self.editButtonTappedSignal.scan(false) { current, _ in !current }
+    self.tableViewIsEditing = Signal.merge(
+      self.editButtonTappedSignal.scan(false) { current, _ in !current },
+      self.didTapAddCardButtonProperty.signal.mapConst(false))
 
     // Koala:
     self.viewWillAppearProperty.signal
@@ -82,13 +84,13 @@ PaymentMethodsViewModelInputs, PaymentMethodsViewModelOutputs {
       .observeValues { _ in AppEnvironment.current.koala.trackDeletePaymentMethodError() }
   }
 
-  let (didDeleteCreditCardSignal, didDeleteCreditCardObserver) = Signal<GraphUserCreditCard.CreditCard,
+  fileprivate let (didDeleteCreditCardSignal, didDeleteCreditCardObserver) = Signal<GraphUserCreditCard.CreditCard,
     NoError>.pipe()
   public func didDelete(_ creditCard: GraphUserCreditCard.CreditCard) {
     self.didDeleteCreditCardObserver.send(value: creditCard)
   }
 
-  let (editButtonTappedSignal, editButtonTappedObserver) = Signal<(), NoError>.pipe()
+  fileprivate let (editButtonTappedSignal, editButtonTappedObserver) = Signal<(), NoError>.pipe()
   public func editButtonTapped() {
     self.editButtonTappedObserver.send(value: ())
   }

--- a/Library/ViewModels/PaymentMethodsViewModelTests.swift
+++ b/Library/ViewModels/PaymentMethodsViewModelTests.swift
@@ -48,6 +48,18 @@ internal final class PaymentMethodsViewModelTests: TestCase {
     self.goToAddCardScreen.assertValueCount(1, "Should emit after tapping button")
   }
 
+  func testTableViewIsEditing_isFalse_WhenAddNewCardIsTapped() {
+    self.tableViewIsEditing.assertValueCount(0)
+
+    self.vm.inputs.editButtonTapped()
+
+    self.tableViewIsEditing.assertValues([true])
+
+    self.vm.inputs.paymentMethodsFooterViewDidTapAddNewCardButton()
+
+    self.tableViewIsEditing.assertValues([true, false])
+  }
+
   func testPresentMessageBanner() {
     self.presentBanner.assertValues([])
 


### PR DESCRIPTION
# 📲 What

Fixes the following:
- table view should end editing when the user navigates to "Add New Card"
- success message banner should only display *after* the "Add New Card" screen has fully dismissed

🔴 NOTE: Also fixes a bug where switching from production -> staging didn't actually change the Stripe publishable key. This meant you sometimes couldn't add a test card in staging (because Stripe thought you were adding the card to production). Now the `StripePublishableKey` comes from the `Secrets` file. 

Tested on:
	- SIM iPhone 5s 10.3.1
	- SIM iPhone 7+ 11.4
	- SIM iPhone X 12.1
	- SIM iPad Pro 12.1

# 👀 See

![assetdcnfd](https://user-images.githubusercontent.com/3156796/52378729-7588a200-2a36-11e9-8d43-f04d6fe9e4b5.gif)
![5wkwkuplz2](https://user-images.githubusercontent.com/3156796/52378732-77eafc00-2a36-11e9-8893-c75b2e3f0bc5.gif)

# ♿️ Accessibility 

- [x] Tap targets use minimum of 44x44 pts dimensions
- [x] Works with VoiceOver
- [ ] Supports Dynamic Type 

# ✅ Acceptance criteria

- [x] Navigate to payment methods, then tap "Edit". Table view should show in editing mode. Then tap "Add New Card", then close the "Add New Card" screen. Table view should not be in editing mode.
- [x] Navigate to "Add New Card" screen and add a new card. On success, the message banner should only display after the "Add New Card" screen has dismissed
