### PR TITLE
Add CircleCI step to pre-load simulator before running tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,7 @@ stripe_sdk_version: &stripe_sdk_version 13.2.0
 store_fabric_sdk_version: &store_fabric_sdk_version echo "$FABRIC_SDK_VERSION" > fabric_version.txt
 store_opentok_version: &store_opentok_version echo "$OPENTOK_VERSION" > opentok_version.txt
 store_stripe_version: &store_stripe_version echo "$STRIPE_SDK_VERSION" > stripe_version.txt
+preload_simulator: &preload_simulator xcrun instruments -w "iPhone 8 (12.1) [" || true
 
 base_job: &base_job
   macos:
@@ -133,6 +134,10 @@ jobs:
           command: make bootstrap
 
       - run:
+          name: Pre-load simulator
+          command: *preload_simulator
+
+      - run:
           name: Kickstarter tests
           command: PLATFORM=iOS make test
 
@@ -182,6 +187,10 @@ jobs:
           command: make bootstrap
 
       - run:
+          name: Pre-load simulator
+          command: *preload_simulator
+
+      - run:
           name: Library tests
           command: PLATFORM=iOS TARGET=Library make test
 
@@ -229,6 +238,10 @@ jobs:
           command: make bootstrap
 
       - run:
+          name: Pre-load simulator
+          command: *preload_simulator
+
+      - run:
           name: LiveStream tests
           command: SCHEME=LiveStream make test
 
@@ -274,6 +287,10 @@ jobs:
       - run:
           name: Make bootstrap
           command: make bootstrap
+
+      - run:
+          name: Pre-load simulator
+          command: *preload_simulator
 
       - run:
           name: KsApi tests


### PR DESCRIPTION
# 📲 What

Adds a step to all of our jobs in `circle.yml` that run tests that will pre-load the iOS simulator before running those tests.

# 🤔 Why

We've had a bunch of jobs failing with an error that the simulator can't be found:

<img width="909" alt="screen shot 2019-02-06 at 2 57 52 pm" src="https://user-images.githubusercontent.com/3735375/52379538-9bef1300-2a1f-11e9-87f2-21788b34de99.png">

According to CircleCI it is sometimes useful to [pre-load](https://circleci.com/docs/2.0/testing-ios/#pre-starting-the-simulator) the simulator before running tests to avoid this.

# 🛠 How

- Added step to pre-load simulator in each job that runs tests.

# ✅ Acceptance criteria

- [ ] All test-running jobs complete successfully on CircleCI with this step in place.