### PR TITLE
[Payment methods] Disable edit button if no payment methods

### DIFF
--- a/Kickstarter-iOS/Views/Controllers/ChangePasswordViewControllerTests.swift
+++ b/Kickstarter-iOS/Views/Controllers/ChangePasswordViewControllerTests.swift
@@ -9,6 +9,7 @@ final class ChangePasswordViewControllerTests: TestCase {
     super.setUp()
     AppEnvironment.pushEnvironment(mainBundle: Bundle.framework)
     UIView.setAnimationsEnabled(false)
+    self.recordMode = true
   }
 
   override func tearDown() {

--- a/Kickstarter-iOS/Views/Controllers/ChangePasswordViewControllerTests.swift
+++ b/Kickstarter-iOS/Views/Controllers/ChangePasswordViewControllerTests.swift
@@ -9,7 +9,6 @@ final class ChangePasswordViewControllerTests: TestCase {
     super.setUp()
     AppEnvironment.pushEnvironment(mainBundle: Bundle.framework)
     UIView.setAnimationsEnabled(false)
-    self.recordMode = true
   }
 
   override func tearDown() {

--- a/Kickstarter-iOS/Views/Controllers/PaymentMethodsViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/PaymentMethodsViewController.swift
@@ -11,6 +11,15 @@ internal final class PaymentMethodsViewController: UIViewController, MessageBann
   @IBOutlet private weak var headerLabel: UILabel!
   @IBOutlet private weak var tableView: UITableView!
 
+  fileprivate lazy var editButton: UIBarButtonItem = {
+    return UIBarButtonItem(
+      title: Strings.discovery_favorite_categories_buttons_edit(),
+      style: .plain,
+      target: self,
+      action: #selector(edit)
+    )
+  }()
+
   internal var messageBannerViewController: MessageBannerViewController?
 
   public static func instantiate() -> PaymentMethodsViewController {
@@ -28,12 +37,7 @@ internal final class PaymentMethodsViewController: UIViewController, MessageBann
     self.tableView.registerHeaderFooter(nib: .PaymentMethodsFooterView)
 
     self.viewModel.inputs.viewDidLoad()
-    self.navigationItem.rightBarButtonItem = UIBarButtonItem(
-      title: Strings.discovery_favorite_categories_buttons_edit(),
-      style: .plain,
-      target: self,
-      action: #selector(edit)
-    )
+    self.navigationItem.rightBarButtonItem = self.editButton
 
     self.dataSource.deletionHandler = { [weak self] creditCard in
       self?.viewModel.inputs.didDelete(creditCard)
@@ -70,6 +74,8 @@ internal final class PaymentMethodsViewController: UIViewController, MessageBann
 
   override func bindViewModel() {
     super.bindViewModel()
+
+    self.editButton.rac.enabled = self.viewModel.outputs.editButtonIsEnabled
 
     self.viewModel.outputs.paymentMethods
       .observeForUI()

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -994,6 +994,8 @@
 		D60C8BF12143167200D96152 /* SettingsAccountViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D60C8BAA2142CD0300D96152 /* SettingsAccountViewController.swift */; };
 		D60C8BF321481BCC00D96152 /* SettingsAccountViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D60C8BF221481BCC00D96152 /* SettingsAccountViewControllerTests.swift */; };
 		D60C8CE12149A65000D96152 /* SettingsPrivacyDataSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D60C8CE02149A65000D96152 /* SettingsPrivacyDataSourceTests.swift */; };
+		D62B1477221216A000AC05C8 /* DeletePaymentMethodEnvelope.swift in Sources */ = {isa = PBXBuildFile; fileRef = D62B1476221216A000AC05C8 /* DeletePaymentMethodEnvelope.swift */; };
+		D62B14B02212184500AC05C8 /* DeletePaymentMethodEnvelopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D62B14AF2212184500AC05C8 /* DeletePaymentMethodEnvelopeTests.swift */; };
 		D63BBCD0217E5460007E01F0 /* PaymentMethodsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D63BBCCF217E5460007E01F0 /* PaymentMethodsViewController.swift */; };
 		D63BBCDA217E7802007E01F0 /* CreditCardCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D63BBCD8217E7802007E01F0 /* CreditCardCell.swift */; };
 		D63BBCDB217E7802007E01F0 /* CreditCardCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = D63BBCD9217E7802007E01F0 /* CreditCardCell.xib */; };
@@ -2731,6 +2733,8 @@
 		D60C8BEA21430BC200D96152 /* SettingsAccountViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsAccountViewModel.swift; sourceTree = "<group>"; };
 		D60C8BF221481BCC00D96152 /* SettingsAccountViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsAccountViewControllerTests.swift; sourceTree = "<group>"; };
 		D60C8CE02149A65000D96152 /* SettingsPrivacyDataSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsPrivacyDataSourceTests.swift; sourceTree = "<group>"; };
+		D62B1476221216A000AC05C8 /* DeletePaymentMethodEnvelope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeletePaymentMethodEnvelope.swift; sourceTree = "<group>"; };
+		D62B14AF2212184500AC05C8 /* DeletePaymentMethodEnvelopeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeletePaymentMethodEnvelopeTests.swift; sourceTree = "<group>"; };
 		D63BBCCF217E5460007E01F0 /* PaymentMethodsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentMethodsViewController.swift; sourceTree = "<group>"; };
 		D63BBCD8217E7802007E01F0 /* CreditCardCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreditCardCell.swift; sourceTree = "<group>"; };
 		D63BBCD9217E7802007E01F0 /* CreditCardCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CreditCardCell.xib; sourceTree = "<group>"; };
@@ -4277,6 +4281,7 @@
 				D6B9DF3E1F72E25A0064A4D8 /* Category.swift */,
 				D6AE52271FD1B4BA00BEC788 /* CategoryEnvelope.swift */,
 				D01587801EEB2ED6006E7684 /* CategoryTests.swift */,
+				D62B1476221216A000AC05C8 /* DeletePaymentMethodEnvelope.swift */,
 				D01587811EEB2ED6006E7684 /* ChangePaymentMethodEnvelope.swift */,
 				D01587821EEB2ED6006E7684 /* ChangePaymentMethodEnvelopeTests.swift */,
 				D01587831EEB2ED6006E7684 /* CheckoutEnvelope.swift */,
@@ -4358,6 +4363,7 @@
 				D01587EE1EEB2ED7006E7684 /* templates */,
 				D6FB2A3C1FA27D0300B0D282 /* CategoryTests.swift */,
 				D63BBD30217F7212007E01F0 /* UserCreditCard.swift */,
+				D62B14AF2212184500AC05C8 /* DeletePaymentMethodEnvelopeTests.swift */,
 			);
 			path = models;
 			sourceTree = "<group>";
@@ -5939,6 +5945,7 @@
 				A7ED1F381E830FDC00BFFA01 /* UIColorTests.swift in Sources */,
 				A7ED1FBA1E831C5C00BFFA01 /* ProjectActivityCommentCellViewModelTests.swift in Sources */,
 				A7ED1FE91E831C5C00BFFA01 /* DeprecatedWebViewModelTests.swift in Sources */,
+				D62B14B02212184500AC05C8 /* DeletePaymentMethodEnvelopeTests.swift in Sources */,
 				D66FB348218212B700A27BCC /* PaymentMethodsViewModelTests.swift in Sources */,
 				A7ED1FD01E831C5C00BFFA01 /* DashboardActionCellViewModelTests.swift in Sources */,
 				A7ED1FE21E831C5C00BFFA01 /* DiscoveryViewModelTests.swift in Sources */,
@@ -6504,6 +6511,7 @@
 				D0158A1C1EEB30A2006E7684 /* ProjectNotificationTemplates.swift in Sources */,
 				D01588F91EEB2ED7006E7684 /* Project.Country.swift in Sources */,
 				D01588311EEB2ED7006E7684 /* OauthToken.swift in Sources */,
+				D62B1477221216A000AC05C8 /* DeletePaymentMethodEnvelope.swift in Sources */,
 				D0158A261EEB30A2006E7684 /* ShippingRulesEnvelopeTemplates.swift in Sources */,
 				D01588F31EEB2ED7006E7684 /* MessageThreadsEnvelope.swift in Sources */,
 				D6C9A2561F75921500981E64 /* CategoryTemplates.swift in Sources */,

--- a/KsApi/MockService.swift
+++ b/KsApi/MockService.swift
@@ -24,7 +24,7 @@ internal struct MockService: ServiceType {
 
   fileprivate let changePaymentMethodResult: Result<ChangePaymentMethodEnvelope, ErrorEnvelope>?
 
-  fileprivate let deletePaymentMethodResult: Result<GraphMutationEmptyResponseEnvelope, GraphError>?
+  fileprivate let deletePaymentMethodResult: Result<DeletePaymentMethodEnvelope, GraphError>?
 
   fileprivate let createPledgeResult: Result<CreatePledgeEnvelope, ErrorEnvelope>?
 
@@ -190,7 +190,7 @@ internal struct MockService: ServiceType {
                 changeCurrencyResponse: GraphMutationEmptyResponseEnvelope? = nil,
                 changeCurrencyError: GraphError? = nil,
                 changePaymentMethodResult: Result<ChangePaymentMethodEnvelope, ErrorEnvelope>? = nil,
-                deletePaymentMethodResult: Result<GraphMutationEmptyResponseEnvelope, GraphError>? = nil,
+                deletePaymentMethodResult: Result<DeletePaymentMethodEnvelope, GraphError>? = nil,
                 createPledgeResult: Result<CreatePledgeEnvelope, ErrorEnvelope>? = nil,
                 facebookConnectResponse: User? = nil,
                 facebookConnectError: ErrorEnvelope? = nil,
@@ -1341,7 +1341,7 @@ internal struct MockService: ServiceType {
   }
 
   internal func deletePaymentMethod(input: PaymentSourceDeleteInput) -> SignalProducer<
-    GraphMutationEmptyResponseEnvelope, GraphError> {
+    DeletePaymentMethodEnvelope, GraphError> {
     return producer(for: self.deletePaymentMethodResult)
   }
 

--- a/KsApi/Service.swift
+++ b/KsApi/Service.swift
@@ -89,7 +89,7 @@ public struct Service: ServiceType {
   }
 
   public func deletePaymentMethod(input: PaymentSourceDeleteInput)
-    -> SignalProducer<GraphMutationEmptyResponseEnvelope, GraphError> {
+    -> SignalProducer<DeletePaymentMethodEnvelope, GraphError> {
       return applyMutation(mutation: PaymentSourceDeleteMutation(input: input))
   }
 

--- a/KsApi/ServiceType.swift
+++ b/KsApi/ServiceType.swift
@@ -59,7 +59,7 @@ public protocol ServiceType {
 
   /// Deletes a payment method
   func deletePaymentMethod(input: PaymentSourceDeleteInput) ->
-    SignalProducer<GraphMutationEmptyResponseEnvelope, GraphError>
+    SignalProducer<DeletePaymentMethodEnvelope, GraphError>
 
   /// Performs the first step of checkout by creating a pledge on the server.
   func createPledge(project: Project,

--- a/KsApi/models/DeletePaymentMethodEnvelope.swift
+++ b/KsApi/models/DeletePaymentMethodEnvelope.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+public struct DeletePaymentMethodEnvelope {
+  public let totalCount: Int
+}
+
+extension DeletePaymentMethodEnvelope: Swift.Decodable {
+  enum CodingKeys: String, CodingKey {
+    case data
+    case user
+    case storedCards
+    case totalCount
+    case paymentSourceDelete
+  }
+
+  public init(from decoder: Decoder) throws {
+    let values = try decoder.container(keyedBy: CodingKeys.self)
+    self.totalCount = try values.nestedContainer(keyedBy: CodingKeys.self, forKey: .paymentSourceDelete)
+      .nestedContainer(keyedBy: CodingKeys.self, forKey: .user)
+      .nestedContainer(keyedBy: CodingKeys.self, forKey: .storedCards)
+      .decode(Int.self, forKey: .totalCount)
+  }
+}

--- a/KsApi/models/DeletePaymentMethodEnvelopeTests.swift
+++ b/KsApi/models/DeletePaymentMethodEnvelopeTests.swift
@@ -1,0 +1,28 @@
+import XCTest
+@testable import KsApi
+
+class DeletePaymentMethodEnvelopeTests: XCTestCase {
+
+  func testDeletePaymentMethodEnvelopeDecoding() {
+
+    let jsonString = """
+        {
+          "paymentSourceDelete": {
+              "user": {
+                "storedCards": {
+                  "totalCount": 0
+                }
+              }
+          }
+        }
+        """
+    let data = jsonString.data(using: .utf8)
+
+    do {
+      let envelope = try JSONDecoder().decode(DeletePaymentMethodEnvelope.self, from: data!)
+        XCTAssertEqual(envelope.totalCount, 0)
+    } catch {
+      XCTFail("DeletePaymentMethodEnvelope should be decoded!")
+    }
+  }
+}

--- a/KsApi/mutations/PaymentSourceDeleteMutation.swift
+++ b/KsApi/mutations/PaymentSourceDeleteMutation.swift
@@ -12,6 +12,11 @@ public struct PaymentSourceDeleteMutation<T: GraphMutationInput>: GraphMutation 
     mutation paymentSourceDelete($input: PaymentSourceDeleteInput!) {
       paymentSourceDelete(input: $input) {
         clientMutationId
+        user {
+          storedCards {
+            totalCount
+          }
+        }
       }
     }
     """

--- a/Library/ViewModels/PaymentMethodsViewModel.swift
+++ b/Library/ViewModels/PaymentMethodsViewModel.swift
@@ -15,6 +15,7 @@ public protocol PaymentMethodsViewModelInputs {
 
 public protocol PaymentMethodsViewModelOutputs {
   /// Emits the user's stored cards
+  var editButtonIsEnabled: Signal<Bool, NoError> { get }
   var goToAddCardScreen: Signal<Void, NoError> { get }
   var paymentMethods: Signal<[GraphUserCreditCard.CreditCard], NoError> { get }
   var presentBanner: Signal<String, NoError> { get }
@@ -61,6 +62,11 @@ PaymentMethodsViewModelInputs, PaymentMethodsViewModelOutputs {
     self.paymentMethods = Signal.merge(
       paymentMethodsValues,
       paymentMethodsValues.takeWhen(deletePaymentMethodEventsErrors)
+    )
+
+    self.editButtonIsEnabled = Signal.merge(
+      self.viewDidLoadProperty.signal.mapConst(false),
+      paymentMethodsValues.map { $0.isEmpty }.mapConst(true)
     )
 
     self.goToAddCardScreen = self.didTapAddCardButtonProperty.signal
@@ -116,6 +122,7 @@ PaymentMethodsViewModelInputs, PaymentMethodsViewModelOutputs {
     self.presentMessageBannerProperty.value = message
   }
 
+  public let editButtonIsEnabled: Signal<Bool, NoError>
   public let goToAddCardScreen: Signal<Void, NoError>
   public let paymentMethods: Signal<[GraphUserCreditCard.CreditCard], NoError>
   public let presentBanner: Signal<String, NoError>

--- a/Library/ViewModels/PaymentMethodsViewModel.swift
+++ b/Library/ViewModels/PaymentMethodsViewModel.swift
@@ -9,6 +9,7 @@ public protocol PaymentMethodsViewModelInputs {
   func didDelete(_ creditCard: GraphUserCreditCard.CreditCard)
   func editButtonTapped()
   func paymentMethodsFooterViewDidTapAddNewCardButton()
+  func reloadedData(with cards: [GraphUserCreditCard.CreditCard])
   func viewDidLoad()
   func viewWillAppear()
 }
@@ -127,6 +128,12 @@ PaymentMethodsViewModelInputs, PaymentMethodsViewModelOutputs {
   fileprivate let presentMessageBannerProperty = MutableProperty("")
   public func cardAddedSuccessfully(_ message: String) {
     self.presentMessageBannerProperty.value = message
+  }
+
+  fileprivate let (reloadedDataSignal, reloadedDataObserver) =
+    Signal<[GraphUserCreditCard.CreditCard], NoError>.pipe()
+  public func reloadedData(with cards: [GraphUserCreditCard.CreditCard]) {
+    self.reloadedDataObserver.send(value: cards)
   }
 
   public let editButtonIsEnabled: Signal<Bool, NoError>

--- a/Library/ViewModels/PaymentMethodsViewModel.swift
+++ b/Library/ViewModels/PaymentMethodsViewModel.swift
@@ -9,7 +9,6 @@ public protocol PaymentMethodsViewModelInputs {
   func didDelete(_ creditCard: GraphUserCreditCard.CreditCard)
   func editButtonTapped()
   func paymentMethodsFooterViewDidTapAddNewCardButton()
-  func reloadedData(with cards: [GraphUserCreditCard.CreditCard])
   func viewDidLoad()
   func viewWillAppear()
 }
@@ -128,12 +127,6 @@ PaymentMethodsViewModelInputs, PaymentMethodsViewModelOutputs {
   fileprivate let presentMessageBannerProperty = MutableProperty("")
   public func cardAddedSuccessfully(_ message: String) {
     self.presentMessageBannerProperty.value = message
-  }
-
-  fileprivate let (reloadedDataSignal, reloadedDataObserver) =
-    Signal<[GraphUserCreditCard.CreditCard], NoError>.pipe()
-  public func reloadedData(with cards: [GraphUserCreditCard.CreditCard]) {
-    self.reloadedDataObserver.send(value: cards)
   }
 
   public let editButtonIsEnabled: Signal<Bool, NoError>

--- a/Library/ViewModels/PaymentMethodsViewModelTests.swift
+++ b/Library/ViewModels/PaymentMethodsViewModelTests.swift
@@ -10,6 +10,7 @@ import Prelude
 internal final class PaymentMethodsViewModelTests: TestCase {
 
   let vm = PaymentMethodsViewModel()
+  let editButtonIsEnabled = TestObserver<Bool, NoError>()
   let goToAddCardScreen = TestObserver<Void, NoError>()
   let paymentMethods = TestObserver<[GraphUserCreditCard.CreditCard], NoError>()
   let presentBanner = TestObserver<String, NoError>()
@@ -19,6 +20,7 @@ internal final class PaymentMethodsViewModelTests: TestCase {
   internal override func setUp() {
     super.setUp()
 
+    self.vm.outputs.editButtonIsEnabled.observe(self.editButtonIsEnabled.observer)
     self.vm.outputs.goToAddCardScreen.observe(self.goToAddCardScreen.observer)
     self.vm.outputs.paymentMethods.observe(self.paymentMethods.observer)
     self.vm.outputs.presentBanner.observe(self.presentBanner.observer)
@@ -37,6 +39,29 @@ internal final class PaymentMethodsViewModelTests: TestCase {
       self.scheduler.advance()
 
       self.paymentMethods.assertValues([GraphUserCreditCard.template.storedCards.nodes])
+    }
+  }
+
+  func testEditButtonIsNotEnabled_OnViewDidLoad() {
+    self.editButtonIsEnabled.assertDidNotEmitValue()
+    self.vm.viewDidLoad()
+    self.editButtonIsEnabled.assertValue(false)
+  }
+
+  func testEditButtonIsNotEnabled_NoPaymentMethods() {
+    let response = UserEnvelope<GraphUserCreditCard>(
+      me: GraphUserCreditCard.emptyTemplate
+    )
+    let apiService = MockService(fetchGraphCreditCardsResponse: response)
+    withEnvironment(apiService: apiService) {
+
+      self.editButtonIsEnabled.assertDidNotEmitValue()
+      self.vm.inputs.viewDidLoad()
+      self.editButtonIsEnabled.assertValues([false])
+
+      self.scheduler.advance()
+
+      self.editButtonIsEnabled.assertValues([false, true])
     }
   }
 

--- a/Library/ViewModels/PaymentMethodsViewModelTests.swift
+++ b/Library/ViewModels/PaymentMethodsViewModelTests.swift
@@ -87,26 +87,6 @@ internal final class PaymentMethodsViewModelTests: TestCase {
     }
   }
 
-  func testEditButtonNotEnabled_AfterDeleteLastPaymentMethod() {
-
-    guard let card = GraphUserCreditCard.template.storedCards.nodes.first else {
-      XCTFail("Card should exist")
-      return
-    }
-
-    let apiService = MockService(deletePaymentMethodResult: .success(.init(totalCount: 0)))
-    withEnvironment(apiService: apiService) {
-      self.editButtonIsEnabled.assertDidNotEmitValue()
-      self.vm.inputs.viewDidLoad()
-      self.editButtonIsEnabled.assertValues([false])
-
-      self.vm.inputs.didDelete(card)
-      self.scheduler.advance()
-
-      self.editButtonIsEnabled.assertValues([false, false])
-    }
-  }
-
   func testEditButtonEnabled_AfterDeletePaymentMethod() {
 
     guard let card = GraphUserCreditCard.template.storedCards.nodes.first else {
@@ -124,6 +104,26 @@ internal final class PaymentMethodsViewModelTests: TestCase {
       self.scheduler.advance()
 
       self.editButtonIsEnabled.assertValues([false, true])
+    }
+  }
+
+  func testEditButtonNotEnabled_AfterDeleteLastPaymentMethod() {
+
+    guard let card = GraphUserCreditCard.template.storedCards.nodes.first else {
+      XCTFail("Card should exist")
+      return
+    }
+
+    let apiService = MockService(deletePaymentMethodResult: .success(.init(totalCount: 0)))
+    withEnvironment(apiService: apiService) {
+      self.editButtonIsEnabled.assertDidNotEmitValue()
+      self.vm.inputs.viewDidLoad()
+      self.editButtonIsEnabled.assertValues([false])
+
+      self.vm.inputs.didDelete(card)
+      self.scheduler.advance()
+
+      self.editButtonIsEnabled.assertValues([false, false])
     }
   }
 

--- a/Library/ViewModels/PaymentMethodsViewModelTests.swift
+++ b/Library/ViewModels/PaymentMethodsViewModelTests.swift
@@ -59,11 +59,9 @@ internal final class PaymentMethodsViewModelTests: TestCase {
       self.editButtonIsEnabled.assertDidNotEmitValue()
 
       self.vm.inputs.viewDidLoad()
-
       self.editButtonIsEnabled.assertValues([false])
 
       self.vm.inputs.viewWillAppear()
-
       self.scheduler.advance()
 
       self.editButtonIsEnabled.assertValues([false, true])
@@ -78,7 +76,6 @@ internal final class PaymentMethodsViewModelTests: TestCase {
     withEnvironment(apiService: apiService) {
 
       self.editButtonIsEnabled.assertDidNotEmitValue()
-
       self.vm.inputs.viewDidLoad()
 
       self.editButtonIsEnabled.assertValues([false])
@@ -104,10 +101,9 @@ internal final class PaymentMethodsViewModelTests: TestCase {
       self.editButtonIsEnabled.assertValues([false])
 
       self.vm.inputs.didDelete(card)
-
       self.scheduler.advance()
 
-      self.editButtonIsEnabled.assertValues([false, false])
+      self.editButtonIsEnabled.assertValues([false, true])
     }
   }
 

--- a/Library/ViewModels/PaymentMethodsViewModelTests.swift
+++ b/Library/ViewModels/PaymentMethodsViewModelTests.swift
@@ -43,6 +43,7 @@ internal final class PaymentMethodsViewModelTests: TestCase {
   }
 
   func testEditButtonIsNotEnabled_OnViewDidLoad() {
+
     self.editButtonIsEnabled.assertDidNotEmitValue()
     self.vm.viewDidLoad()
     self.editButtonIsEnabled.assertValue(false)
@@ -58,9 +59,11 @@ internal final class PaymentMethodsViewModelTests: TestCase {
       self.editButtonIsEnabled.assertDidNotEmitValue()
 
       self.vm.inputs.viewDidLoad()
+
       self.editButtonIsEnabled.assertValues([false])
 
       self.vm.inputs.viewWillAppear()
+
       self.scheduler.advance()
 
       self.editButtonIsEnabled.assertValues([false, true])
@@ -75,6 +78,7 @@ internal final class PaymentMethodsViewModelTests: TestCase {
     withEnvironment(apiService: apiService) {
 
       self.editButtonIsEnabled.assertDidNotEmitValue()
+
       self.vm.inputs.viewDidLoad()
 
       self.editButtonIsEnabled.assertValues([false])
@@ -103,9 +107,11 @@ internal final class PaymentMethodsViewModelTests: TestCase {
 
       self.editButtonIsEnabled.assertValues([false])
 
+      self.vm.inputs.viewWillAppear()
+
       self.scheduler.advance()
 
-      self.editButtonIsEnabled.assertValues([false, true])
+      self.editButtonIsEnabled.assertValues([false, false])
     }
   }
 

--- a/Library/ViewModels/PaymentMethodsViewModelTests.swift
+++ b/Library/ViewModels/PaymentMethodsViewModelTests.swift
@@ -59,9 +59,11 @@ internal final class PaymentMethodsViewModelTests: TestCase {
       self.editButtonIsEnabled.assertDidNotEmitValue()
 
       self.vm.inputs.viewDidLoad()
+
       self.editButtonIsEnabled.assertValues([false])
 
       self.vm.inputs.viewWillAppear()
+
       self.scheduler.advance()
 
       self.editButtonIsEnabled.assertValues([false, true])
@@ -76,6 +78,7 @@ internal final class PaymentMethodsViewModelTests: TestCase {
     withEnvironment(apiService: apiService) {
 
       self.editButtonIsEnabled.assertDidNotEmitValue()
+
       self.vm.inputs.viewDidLoad()
 
       self.editButtonIsEnabled.assertValues([false])
@@ -101,9 +104,10 @@ internal final class PaymentMethodsViewModelTests: TestCase {
       self.editButtonIsEnabled.assertValues([false])
 
       self.vm.inputs.didDelete(card)
+
       self.scheduler.advance()
 
-      self.editButtonIsEnabled.assertValues([false, true])
+      self.editButtonIsEnabled.assertValues([false, false])
     }
   }
 

--- a/Library/ViewModels/PaymentMethodsViewModelTests.swift
+++ b/Library/ViewModels/PaymentMethodsViewModelTests.swift
@@ -92,6 +92,7 @@ internal final class PaymentMethodsViewModelTests: TestCase {
       XCTFail("Card should exist")
       return
     }
+    
     let apiService = MockService(deletePaymentMethodResult: .success(.init(totalCount: 3)))
     withEnvironment(apiService: apiService) {
       self.editButtonIsEnabled.assertDidNotEmitValue()

--- a/Library/ViewModels/PaymentMethodsViewModelTests.swift
+++ b/Library/ViewModels/PaymentMethodsViewModelTests.swift
@@ -59,9 +59,11 @@ internal final class PaymentMethodsViewModelTests: TestCase {
       self.editButtonIsEnabled.assertDidNotEmitValue()
 
       self.vm.inputs.viewDidLoad()
+
       self.editButtonIsEnabled.assertValues([false])
 
       self.vm.inputs.viewWillAppear()
+
       self.scheduler.advance()
 
       self.editButtonIsEnabled.assertValues([false, true])
@@ -76,11 +78,13 @@ internal final class PaymentMethodsViewModelTests: TestCase {
     withEnvironment(apiService: apiService) {
 
       self.editButtonIsEnabled.assertDidNotEmitValue()
+
       self.vm.inputs.viewDidLoad()
 
       self.editButtonIsEnabled.assertValues([false])
 
       self.vm.inputs.viewWillAppear()
+
       self.scheduler.advance()
 
       self.editButtonIsEnabled.assertValues([false, false])

--- a/Library/ViewModels/PaymentMethodsViewModelTests.swift
+++ b/Library/ViewModels/PaymentMethodsViewModelTests.swift
@@ -101,6 +101,7 @@ internal final class PaymentMethodsViewModelTests: TestCase {
       self.editButtonIsEnabled.assertValues([false])
 
       self.vm.inputs.didDelete(card)
+
       self.scheduler.advance()
 
       self.editButtonIsEnabled.assertValues([false, true])

--- a/Library/ViewModels/PaymentMethodsViewModelTests.swift
+++ b/Library/ViewModels/PaymentMethodsViewModelTests.swift
@@ -43,7 +43,6 @@ internal final class PaymentMethodsViewModelTests: TestCase {
   }
 
   func testEditButtonIsNotEnabled_OnViewDidLoad() {
-
     self.editButtonIsEnabled.assertDidNotEmitValue()
     self.vm.viewDidLoad()
     self.editButtonIsEnabled.assertValue(false)
@@ -101,6 +100,9 @@ internal final class PaymentMethodsViewModelTests: TestCase {
       self.editButtonIsEnabled.assertValues([false])
 
       self.vm.inputs.didDelete(card)
+
+      self.editButtonIsEnabled.assertValues([false])
+
       self.scheduler.advance()
 
       self.editButtonIsEnabled.assertValues([false, true])

--- a/Library/ViewModels/PaymentMethodsViewModelTests.swift
+++ b/Library/ViewModels/PaymentMethodsViewModelTests.swift
@@ -101,7 +101,6 @@ internal final class PaymentMethodsViewModelTests: TestCase {
       self.editButtonIsEnabled.assertValues([false])
 
       self.vm.inputs.didDelete(card)
-
       self.scheduler.advance()
 
       self.editButtonIsEnabled.assertValues([false, true])

--- a/Library/ViewModels/PaymentMethodsViewModelTests.swift
+++ b/Library/ViewModels/PaymentMethodsViewModelTests.swift
@@ -43,9 +43,31 @@ internal final class PaymentMethodsViewModelTests: TestCase {
   }
 
   func testEditButtonIsNotEnabled_OnViewDidLoad() {
+
     self.editButtonIsEnabled.assertDidNotEmitValue()
     self.vm.viewDidLoad()
     self.editButtonIsEnabled.assertValue(false)
+  }
+
+  func testEditButtonIsEnabled_HasPaymentMethods() {
+    let response = UserEnvelope<GraphUserCreditCard>(
+      me: GraphUserCreditCard.template
+    )
+    let apiService = MockService(fetchGraphCreditCardsResponse: response)
+    withEnvironment(apiService: apiService) {
+
+      self.editButtonIsEnabled.assertDidNotEmitValue()
+
+      self.vm.inputs.viewDidLoad()
+
+      self.editButtonIsEnabled.assertValues([false])
+
+      self.vm.inputs.viewWillAppear()
+
+      self.scheduler.advance()
+
+      self.editButtonIsEnabled.assertValues([false, true])
+    }
   }
 
   func testEditButtonIsNotEnabled_NoPaymentMethods() {
@@ -56,12 +78,16 @@ internal final class PaymentMethodsViewModelTests: TestCase {
     withEnvironment(apiService: apiService) {
 
       self.editButtonIsEnabled.assertDidNotEmitValue()
+
       self.vm.inputs.viewDidLoad()
+
       self.editButtonIsEnabled.assertValues([false])
+
+      self.vm.inputs.viewWillAppear()
 
       self.scheduler.advance()
 
-      self.editButtonIsEnabled.assertValues([false, true])
+      self.editButtonIsEnabled.assertValues([false, false])
     }
   }
 
@@ -101,7 +127,7 @@ internal final class PaymentMethodsViewModelTests: TestCase {
       return
     }
 
-    let apiService = MockService(deletePaymentMethodResult: .success(GraphMutationEmptyResponseEnvelope()))
+    let apiService = MockService(deletePaymentMethodResult: .success(.init(totalCount: 2)))
     withEnvironment(apiService: apiService) {
 
       self.vm.inputs.viewWillAppear()
@@ -175,7 +201,7 @@ internal final class PaymentMethodsViewModelTests: TestCase {
       XCTFail("Card should exist")
       return
     }
-    let apiService = MockService(deletePaymentMethodResult: .success(GraphMutationEmptyResponseEnvelope()))
+    let apiService = MockService(deletePaymentMethodResult: .success(.init(totalCount: 2)))
     withEnvironment(apiService: apiService) {
 
       self.vm.inputs.viewDidLoad()

--- a/Library/ViewModels/PaymentMethodsViewModelTests.swift
+++ b/Library/ViewModels/PaymentMethodsViewModelTests.swift
@@ -59,11 +59,9 @@ internal final class PaymentMethodsViewModelTests: TestCase {
       self.editButtonIsEnabled.assertDidNotEmitValue()
 
       self.vm.inputs.viewDidLoad()
-
       self.editButtonIsEnabled.assertValues([false])
 
       self.vm.inputs.viewWillAppear()
-
       self.scheduler.advance()
 
       self.editButtonIsEnabled.assertValues([false, true])
@@ -78,16 +76,54 @@ internal final class PaymentMethodsViewModelTests: TestCase {
     withEnvironment(apiService: apiService) {
 
       self.editButtonIsEnabled.assertDidNotEmitValue()
-
       self.vm.inputs.viewDidLoad()
 
       self.editButtonIsEnabled.assertValues([false])
 
       self.vm.inputs.viewWillAppear()
-
       self.scheduler.advance()
 
       self.editButtonIsEnabled.assertValues([false, false])
+    }
+  }
+
+  func testEditButtonNotEnabled_AfterDeleteLastPaymentMethod() {
+
+    guard let card = GraphUserCreditCard.template.storedCards.nodes.first else {
+      XCTFail("Card should exist")
+      return
+    }
+
+    let apiService = MockService(deletePaymentMethodResult: .success(.init(totalCount: 0)))
+    withEnvironment(apiService: apiService) {
+      self.editButtonIsEnabled.assertDidNotEmitValue()
+      self.vm.inputs.viewDidLoad()
+      self.editButtonIsEnabled.assertValues([false])
+
+      self.vm.inputs.didDelete(card)
+      self.scheduler.advance()
+
+      self.editButtonIsEnabled.assertValues([false, false])
+    }
+  }
+
+  func testEditButtonEnabled_AfterDeletePaymentMethod() {
+
+    guard let card = GraphUserCreditCard.template.storedCards.nodes.first else {
+      XCTFail("Card should exist")
+      return
+    }
+
+    let apiService = MockService(deletePaymentMethodResult: .success(.init(totalCount: 3)))
+    withEnvironment(apiService: apiService) {
+      self.editButtonIsEnabled.assertDidNotEmitValue()
+      self.vm.inputs.viewDidLoad()
+      self.editButtonIsEnabled.assertValues([false])
+
+      self.vm.inputs.didDelete(card)
+      self.scheduler.advance()
+
+      self.editButtonIsEnabled.assertValues([false, true])
     }
   }
 

--- a/Library/ViewModels/PaymentMethodsViewModelTests.swift
+++ b/Library/ViewModels/PaymentMethodsViewModelTests.swift
@@ -59,11 +59,9 @@ internal final class PaymentMethodsViewModelTests: TestCase {
       self.editButtonIsEnabled.assertDidNotEmitValue()
 
       self.vm.inputs.viewDidLoad()
-
       self.editButtonIsEnabled.assertValues([false])
 
       self.vm.inputs.viewWillAppear()
-
       self.scheduler.advance()
 
       self.editButtonIsEnabled.assertValues([false, true])
@@ -78,13 +76,11 @@ internal final class PaymentMethodsViewModelTests: TestCase {
     withEnvironment(apiService: apiService) {
 
       self.editButtonIsEnabled.assertDidNotEmitValue()
-
       self.vm.inputs.viewDidLoad()
 
       self.editButtonIsEnabled.assertValues([false])
 
       self.vm.inputs.viewWillAppear()
-
       self.scheduler.advance()
 
       self.editButtonIsEnabled.assertValues([false, false])

--- a/Library/ViewModels/PaymentMethodsViewModelTests.swift
+++ b/Library/ViewModels/PaymentMethodsViewModelTests.swift
@@ -59,11 +59,9 @@ internal final class PaymentMethodsViewModelTests: TestCase {
       self.editButtonIsEnabled.assertDidNotEmitValue()
 
       self.vm.inputs.viewDidLoad()
-
       self.editButtonIsEnabled.assertValues([false])
 
       self.vm.inputs.viewWillAppear()
-
       self.scheduler.advance()
 
       self.editButtonIsEnabled.assertValues([false, true])
@@ -78,7 +76,6 @@ internal final class PaymentMethodsViewModelTests: TestCase {
     withEnvironment(apiService: apiService) {
 
       self.editButtonIsEnabled.assertDidNotEmitValue()
-
       self.vm.inputs.viewDidLoad()
 
       self.editButtonIsEnabled.assertValues([false])
@@ -91,27 +88,21 @@ internal final class PaymentMethodsViewModelTests: TestCase {
   }
 
   func testEditButtonEnabled_AfterDeletePaymentMethod() {
-
     guard let card = GraphUserCreditCard.template.storedCards.nodes.first else {
       XCTFail("Card should exist")
       return
     }
-
     let apiService = MockService(deletePaymentMethodResult: .success(.init(totalCount: 3)))
     withEnvironment(apiService: apiService) {
       self.editButtonIsEnabled.assertDidNotEmitValue()
       self.vm.inputs.viewDidLoad()
+
       self.editButtonIsEnabled.assertValues([false])
 
       self.vm.inputs.didDelete(card)
-
-      self.editButtonIsEnabled.assertValues([false])
-
-      self.vm.inputs.viewWillAppear()
-
       self.scheduler.advance()
 
-      self.editButtonIsEnabled.assertValues([false, false])
+      self.editButtonIsEnabled.assertValues([false, true])
     }
   }
 
@@ -126,6 +117,7 @@ internal final class PaymentMethodsViewModelTests: TestCase {
     withEnvironment(apiService: apiService) {
       self.editButtonIsEnabled.assertDidNotEmitValue()
       self.vm.inputs.viewDidLoad()
+
       self.editButtonIsEnabled.assertValues([false])
 
       self.vm.inputs.didDelete(card)


### PR DESCRIPTION
# 📲 What
- Disables `Edit` button on `PaymentMethodsViewController` if there's no payment method on the list.

# 🤔 Why
- To improve UX, we should disable the button, since it can't be used if there's no payment method to be edited.

# 🛠 How
- In order to make this happen, I had to change the `PaymentSourceDeleteMutation` to return the number of remaining cards and created a `DeletePaymentMethodEnvelope` model.

# 👀 See
| With Payment Method | No Payment Method |
| --- | --- |
| <img width="300" alt="screen shot 2018-11-27 at 1 50 48 pm" src="https://user-images.githubusercontent.com/3709676/52646831-819ab680-2eb1-11e9-87b2-0f1e5e6bfcb2.png"> | <img width="300" alt="screen shot 2018-11-27 at 1 49 08 pm" src="https://user-images.githubusercontent.com/3709676/52646822-7e072f80-2eb1-11e9-98ea-af29c8bc27cd.png"> |

# ✅ Acceptance criteria
## With payment methods
- [ ] I go to `Account > Payment methods`
- [ ] I should see a list of payment methods and the `Edit` button should be `enabled`
- [ ] I delete my payment methods and, after delete the last card from the list, the `Edit` button should be `disabled` (greyed out).

## With no payment methods
- [ ] I go to `Account > Payment methods`
- [ ] I only see the `Add new card` button on the list. The `Edit` button should be `disabled` (greyed out)
- [ ] I add a card. The `Edit` button should be `enabled`