### PR TITLE
[Payment methods] Refresh payment methods table view properly

### DIFF
--- a/Kickstarter-iOS/Views/Controllers/AddNewCardViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/AddNewCardViewController.swift
@@ -6,7 +6,8 @@ import Stripe
 import UIKit
 
 internal protocol AddNewCardViewControllerDelegate: class {
-  func presentAddCardSuccessfulBanner(_ message: String)
+  func addNewCardViewControllerSucceeded(with message: String)
+  func addNewCardViewControllerDismissed()
 }
 
 internal final class AddNewCardViewController: UIViewController,
@@ -212,7 +213,7 @@ STPPaymentCardTextFieldDelegate, MessageBannerViewControllerPresenting {
   }
 
   @objc fileprivate func cancelButtonTapped() {
-    self.dismiss(animated: true, completion: nil)
+    self.delegate?.addNewCardViewControllerDismissed()
   }
 
   @objc fileprivate func saveButtonTapped() {
@@ -251,9 +252,7 @@ STPPaymentCardTextFieldDelegate, MessageBannerViewControllerPresenting {
   }
 
   private func dismissAndPresentMessageBanner(with message: String) {
-    self.navigationController?.dismiss(animated: true, completion: { [weak self] in
-      self?.delegate?.presentAddCardSuccessfulBanner(message)
-    })
+    self.delegate?.addNewCardViewControllerSucceeded(with: message)
   }
 
   private func dismissKeyboard() {

--- a/Kickstarter-iOS/Views/Controllers/AddNewCardViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/AddNewCardViewController.swift
@@ -6,8 +6,9 @@ import Stripe
 import UIKit
 
 internal protocol AddNewCardViewControllerDelegate: class {
-  func addNewCardViewControllerSucceeded(with message: String)
-  func addNewCardViewControllerDismissed()
+  func addNewCardViewController(_ viewController: AddNewCardViewController,
+                                didSucceedWithMessage message: String)
+  func addNewCardViewControllerDismissed(_ viewController: AddNewCardViewController)
 }
 
 internal final class AddNewCardViewController: UIViewController,
@@ -213,7 +214,7 @@ STPPaymentCardTextFieldDelegate, MessageBannerViewControllerPresenting {
   }
 
   @objc fileprivate func cancelButtonTapped() {
-    self.delegate?.addNewCardViewControllerDismissed()
+    self.delegate?.addNewCardViewControllerDismissed(self)
   }
 
   @objc fileprivate func saveButtonTapped() {
@@ -252,7 +253,7 @@ STPPaymentCardTextFieldDelegate, MessageBannerViewControllerPresenting {
   }
 
   private func dismissAndPresentMessageBanner(with message: String) {
-    self.delegate?.addNewCardViewControllerSucceeded(with: message)
+    self.delegate?.addNewCardViewController(self, didSucceedWithMessage: message)
   }
 
   private func dismissKeyboard() {

--- a/Kickstarter-iOS/Views/Controllers/PaymentMethodsViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/PaymentMethodsViewController.swift
@@ -183,15 +183,13 @@ extension PaymentMethodsViewController: PaymentMethodsFooterViewDelegate {
 
 extension PaymentMethodsViewController: AddNewCardViewControllerDelegate {
   func addNewCardViewControllerSucceeded(with message: String) {
-    self.dismiss(animated: true) { [weak self] in
-      guard let self = self else { return }
+    self.dismiss(animated: true) {
       self.viewModel.inputs.cardAddedSuccessfully(message)
     }
   }
 
   func addNewCardViewControllerDismissed() {
-    self.dismiss(animated: true) { [weak self] in
-      guard let self = self else { return }
+    self.dismiss(animated: true) {
       self.viewModel.inputs.refresh()
     }
   }

--- a/Kickstarter-iOS/Views/Controllers/PaymentMethodsViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/PaymentMethodsViewController.swift
@@ -182,8 +182,18 @@ extension PaymentMethodsViewController: PaymentMethodsFooterViewDelegate {
 }
 
 extension PaymentMethodsViewController: AddNewCardViewControllerDelegate {
-  internal func presentAddCardSuccessfulBanner(_ message: String) {
-    self.viewModel.inputs.cardAddedSuccessfully(message)
+  func addNewCardViewControllerSucceeded(with message: String) {
+    self.dismiss(animated: true) { [weak self] in
+      guard let self = self else { return }
+      self.viewModel.inputs.cardAddedSuccessfully(message)
+    }
+  }
+
+  func addNewCardViewControllerDismissed() {
+    self.dismiss(animated: true) { [weak self] in
+      guard let self = self else { return }
+      self.viewModel.inputs.refresh()
+    }
   }
 }
 

--- a/Kickstarter-iOS/Views/Controllers/PaymentMethodsViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/PaymentMethodsViewController.swift
@@ -182,13 +182,14 @@ extension PaymentMethodsViewController: PaymentMethodsFooterViewDelegate {
 }
 
 extension PaymentMethodsViewController: AddNewCardViewControllerDelegate {
-  func addNewCardViewControllerSucceeded(with message: String) {
+  func addNewCardViewController(_ viewController: AddNewCardViewController,
+                                didSucceedWithMessage message: String) {
     self.dismiss(animated: true) {
       self.viewModel.inputs.cardAddedSuccessfully(message)
     }
   }
 
-  func addNewCardViewControllerDismissed() {
+  func addNewCardViewControllerDismissed(_ viewController: AddNewCardViewController) {
     self.dismiss(animated: true) {
       self.viewModel.inputs.refresh()
     }

--- a/Library/ViewModels/PaymentMethodsViewModelTests.swift
+++ b/Library/ViewModels/PaymentMethodsViewModelTests.swift
@@ -31,10 +31,9 @@ internal final class PaymentMethodsViewModelTests: TestCase {
   }
 
   func testPaymentMethodsFetch_OnViewDidLoad() {
-    let response = UserEnvelope<GraphUserCreditCard>(
-      me: GraphUserCreditCard.template
-    )
+    let response = UserEnvelope<GraphUserCreditCard>(me: GraphUserCreditCard.template)
     let apiService = MockService(fetchGraphCreditCardsResponse: response)
+
     withEnvironment(apiService: apiService) {
       self.vm.inputs.viewDidLoad()
 
@@ -44,6 +43,44 @@ internal final class PaymentMethodsViewModelTests: TestCase {
       self.scheduler.advance()
 
       self.paymentMethods.assertValues([GraphUserCreditCard.template.storedCards.nodes])
+    }
+  }
+
+  func testPaymentMethodsFetch_OnRefresh() {
+    let response = UserEnvelope<GraphUserCreditCard>(me: GraphUserCreditCard.template)
+    let apiService = MockService(fetchGraphCreditCardsResponse: response)
+
+    withEnvironment(apiService: apiService) {
+      self.paymentMethods.assertValues([])
+
+      self.vm.inputs.refresh()
+
+      self.scheduler.advance()
+
+      self.paymentMethods.assertValues([GraphUserCreditCard.template.storedCards.nodes])
+    }
+  }
+
+  func testPaymentMethodsFetch_OnCardAddedSuccessfully() {
+    let response = UserEnvelope<GraphUserCreditCard>(me: GraphUserCreditCard.template)
+    let apiService = MockService(fetchGraphCreditCardsResponse: response)
+
+    withEnvironment(apiService: apiService) {
+      self.paymentMethods.assertValues([])
+
+      self.vm.inputs.cardAddedSuccessfully("First card added successfully")
+
+      self.scheduler.advance()
+
+      self.paymentMethods.assertValueCount(1)
+
+      withEnvironment(apiService: apiService) {
+        self.vm.inputs.cardAddedSuccessfully("Second card added successfully")
+
+        self.scheduler.advance()
+
+        self.paymentMethods.assertValueCount(2)
+      }
     }
   }
 


### PR DESCRIPTION
# 📲 What

Refreshes payment methods properly

# 🤔 Why

Previously if you have added a new card on iPad, the payment methods table would not refresh due to the way we present the modal. It relies on `UIViewController` lifecycle methods that are called differently when we present things using `.formSheet` modal presentation style.

# 🛠 How

Causes the view model to re-fetch on "Add New Card" modal success or dismissal.

# ✅ Acceptance criteria

on iPad..

- [x] Payment methods screen properly refreshes when first navigating to the screen
- [x] Payment methods screen properly refreshes when dismissing the `Add New Card` modal (add or remove payment methods on the web after the modal has been presented and before dismissing)
- [x] Payment methods screen properly refreshes when submitting the `Add New Card` modal (no need to do anything as this will by itself add a new payment method)