### PR TITLE
Dismiss email frequency picker

### DIFF
--- a/Library/ViewModels/SettingsNotificationsViewModel.swift
+++ b/Library/ViewModels/SettingsNotificationsViewModel.swift
@@ -96,7 +96,7 @@ SettingsNotificationsViewModelInputs, SettingsNotificationsViewModelOutputs {
 
     let projectActivityEmailFrequencyDisabled = projectActivityNotificationChanged.signal
       .map { $0.1 }
-      .filter { $0 == false }
+      .filter(isFalse)
 
     self.pickerViewIsHidden = Signal.merge(
       emailFrequencyCellSelected.signal.mapConst(false),

--- a/Library/ViewModels/SettingsNotificationsViewModel.swift
+++ b/Library/ViewModels/SettingsNotificationsViewModel.swift
@@ -40,7 +40,7 @@ SettingsNotificationsViewModelInputs, SettingsNotificationsViewModelOutputs {
         .demoteErrors()
     }.skipNil()
 
-    let pledgeActivityNotificationChanged: Signal<(UserAttribute, Bool), NoError> =
+    let projectActivityNotificationChanged: Signal<(UserAttribute, Bool), NoError> =
       updatedUserProperty.signal.skipNil()
           .map { user in
             return  (UserAttribute.notification(.pledgeActivity), user.notifications.backings ?? false)
@@ -54,7 +54,7 @@ SettingsNotificationsViewModelInputs, SettingsNotificationsViewModelOutputs {
     }
 
     let userAttributeChanged = Signal.merge(
-      pledgeActivityNotificationChanged.signal,
+      projectActivityNotificationChanged.signal,
       creatorDigestNotificationChanged.signal
     )
 
@@ -94,10 +94,15 @@ SettingsNotificationsViewModelInputs, SettingsNotificationsViewModelOutputs {
       .skipNil()
       .filter { $0 == .emailFrequency }
 
+    let projectActivityEmailFrequencyDisabled = projectActivityNotificationChanged.signal
+      .map { $0.1 }
+      .filter { $0 == false }
+
     self.pickerViewIsHidden = Signal.merge(
-        emailFrequencyCellSelected.signal.mapConst(false),
-        emailFrequencyProperty.signal.mapConst(true),
-				dismissPickerTapProperty.signal.mapConst(true)
+      emailFrequencyCellSelected.signal.mapConst(false),
+      emailFrequencyProperty.signal.mapConst(true),
+      dismissPickerTapProperty.signal.mapConst(true),
+      projectActivityEmailFrequencyDisabled.signal.mapConst(true)
     ).skipRepeats()
 
     self.pickerViewSelectedRow = self.updateCurrentUser.signal

--- a/Library/ViewModels/SettingsNotificationsViewModel.swift
+++ b/Library/ViewModels/SettingsNotificationsViewModel.swift
@@ -95,7 +95,7 @@ SettingsNotificationsViewModelInputs, SettingsNotificationsViewModelOutputs {
       .filter { $0 == .emailFrequency }
 
     let projectActivityEmailFrequencyDisabled = projectActivityNotificationChanged.signal
-      .map { $0.1 }
+      .map(second)
       .filter(isFalse)
 
     self.pickerViewIsHidden = Signal.merge(

--- a/Library/ViewModels/SettingsNotificationsViewModelTests.swift
+++ b/Library/ViewModels/SettingsNotificationsViewModelTests.swift
@@ -149,4 +149,23 @@ internal final class SettingsNotificationsViewModelTests: TestCase {
 
     self.pickerViewIsHidden.assertValues([false, true], "Picker view should be hidden")
   }
+
+  func testShowHidePickerView_EmailFrequencyDisabled() {
+    let user = .template
+      |> UserAttribute.notification(.pledgeActivity).keyPath .~ false
+
+    self.pickerViewIsHidden.assertDidNotEmitValue()
+
+    self.vm.inputs.viewDidLoad()
+
+    self.pickerViewIsHidden.assertDidNotEmitValue()
+
+    self.vm.inputs.didSelectRow(cellType: .emailFrequency)
+
+    self.pickerViewIsHidden.assertValues([false], "Picker view is shown")
+
+    self.vm.inputs.updateUser(user: user)
+
+    self.pickerViewIsHidden.assertValues([false, true], "Picker view should be hidden")
+  }
 }


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

When the Email Frequency picker is opened and then Project Activity email notifications are disabled, the `Email Frequency` cell disappears, but the picker stays open. This PR makes sure the picker dismisses when the `Email Frequency` cell disappears after Project Activity email notifications are disabled.

# 🤔 Why

Better UX, user should not be able to set the email frequency if they disabled Project Activity email notifications.

# 🛠 How

We check if user disabled the project activity email frequency and dismiss if they did. 

# 👀 See
| Before | After |
| --- | --- |
| ![dismiss-picker-fix](https://user-images.githubusercontent.com/11362005/52727867-25ed2d80-2f84-11e9-9af7-bc5512bac8d7.gif) |![dismiss-picker-fix-after](https://user-images.githubusercontent.com/11362005/52727942-4ddc9100-2f84-11e9-9da5-a51154ac4470.gif) |

# ♿️ Accessibility 

- [ ] Tap targets use minimum of 44x44 pts dimensions
- [ ] Works with VoiceOver
- [ ] Supports Dynamic Type 

# ✅ Acceptance criteria

- [ ] Navigate to `Settings > Notifications` enable email notifications for `Project Activity`, `Email Frequency` cell should appear
- [ ] Tap on `Email Frequency` cell a picker should appear
- [ ] Disable email notifications for `Project Activity` picker to dismiss

