### PR TITLE
[Payment methods] Refetch payment methods on viewDidLoad or explicitly (by delegate)

### DIFF
--- a/Kickstarter-iOS/Views/Controllers/PaymentMethodsViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/PaymentMethodsViewController.swift
@@ -185,13 +185,13 @@ extension PaymentMethodsViewController: AddNewCardViewControllerDelegate {
   func addNewCardViewController(_ viewController: AddNewCardViewController,
                                 didSucceedWithMessage message: String) {
     self.dismiss(animated: true) {
-      self.viewModel.inputs.cardAddedSuccessfully(message)
+      self.viewModel.inputs.addNewCardSucceeded(with: message)
     }
   }
 
   func addNewCardViewControllerDismissed(_ viewController: AddNewCardViewController) {
     self.dismiss(animated: true) {
-      self.viewModel.inputs.refresh()
+      self.viewModel.inputs.addNewCardDismissed()
     }
   }
 }

--- a/Library/ViewModels/PaymentMethodsViewModel.swift
+++ b/Library/ViewModels/PaymentMethodsViewModel.swift
@@ -86,7 +86,7 @@ PaymentMethodsViewModelInputs, PaymentMethodsViewModelOutputs {
 
     self.goToAddCardScreen = self.didTapAddCardButtonProperty.signal
 
-    self.presentBanner = self.addNewCardSucceededProperty.signal
+    self.presentBanner = self.addNewCardSucceededProperty.signal.skipNil()
 
     self.tableViewIsEditing = Signal.merge(
       self.editButtonTappedSignal.scan(false) { current, _ in !current },
@@ -132,7 +132,7 @@ PaymentMethodsViewModelInputs, PaymentMethodsViewModelOutputs {
     self.didTapAddCardButtonProperty.value = ()
   }
 
-  fileprivate let addNewCardSucceededProperty = MutableProperty("")
+  fileprivate let addNewCardSucceededProperty = MutableProperty<String?>(nil)
   public func addNewCardSucceeded(with message: String) {
     self.addNewCardSucceededProperty.value = message
   }

--- a/Library/ViewModels/PaymentMethodsViewModel.swift
+++ b/Library/ViewModels/PaymentMethodsViewModel.swift
@@ -5,11 +5,11 @@ import ReactiveSwift
 import Result
 
 public protocol PaymentMethodsViewModelInputs {
-  func cardAddedSuccessfully(_ message: String)
+  func addNewCardSucceeded(with message: String)
+  func addNewCardDismissed()
   func didDelete(_ creditCard: GraphUserCreditCard.CreditCard)
   func editButtonTapped()
   func paymentMethodsFooterViewDidTapAddNewCardButton()
-  func refresh()
   func viewDidLoad()
   func viewWillAppear()
 }
@@ -37,9 +37,9 @@ PaymentMethodsViewModelInputs, PaymentMethodsViewModelOutputs {
     self.reloadData = self.viewDidLoadProperty.signal
 
     let paymentMethodsEvent = Signal.merge(
-      self.viewWillAppearProperty.signal,
-      self.cardAddedSuccessfullyProperty.signal.ignoreValues(),
-      self.refreshProperty.signal
+      self.viewDidLoadProperty.signal,
+      self.addNewCardSucceededProperty.signal.ignoreValues(),
+      self.addNewCardDismissedProperty.signal
       )
       .switchMap { _ in
         AppEnvironment.current.apiService.fetchGraphCreditCards(query: UserQueries.storedCards.query)
@@ -86,7 +86,7 @@ PaymentMethodsViewModelInputs, PaymentMethodsViewModelOutputs {
 
     self.goToAddCardScreen = self.didTapAddCardButtonProperty.signal
 
-    self.presentBanner = self.cardAddedSuccessfullyProperty.signal
+    self.presentBanner = self.addNewCardSucceededProperty.signal
 
     self.tableViewIsEditing = Signal.merge(
       self.editButtonTappedSignal.scan(false) { current, _ in !current },
@@ -132,14 +132,14 @@ PaymentMethodsViewModelInputs, PaymentMethodsViewModelOutputs {
     self.didTapAddCardButtonProperty.value = ()
   }
 
-  fileprivate let cardAddedSuccessfullyProperty = MutableProperty("")
-  public func cardAddedSuccessfully(_ message: String) {
-    self.cardAddedSuccessfullyProperty.value = message
+  fileprivate let addNewCardSucceededProperty = MutableProperty("")
+  public func addNewCardSucceeded(with message: String) {
+    self.addNewCardSucceededProperty.value = message
   }
 
-  fileprivate let refreshProperty = MutableProperty(())
-  public func refresh() {
-    self.refreshProperty.value = ()
+  fileprivate let addNewCardDismissedProperty = MutableProperty(())
+  public func addNewCardDismissed() {
+    self.addNewCardDismissedProperty.value = ()
   }
 
   public let editButtonIsEnabled: Signal<Bool, NoError>

--- a/Library/ViewModels/PaymentMethodsViewModelTests.swift
+++ b/Library/ViewModels/PaymentMethodsViewModelTests.swift
@@ -221,6 +221,7 @@ internal final class PaymentMethodsViewModelTests: TestCase {
     withEnvironment(apiService: apiService) {
 
       self.vm.inputs.viewDidLoad()
+      self.vm.inputs.viewWillAppear()
 
       self.scheduler.advance()
 
@@ -256,6 +257,7 @@ internal final class PaymentMethodsViewModelTests: TestCase {
     withEnvironment(apiService: apiService) {
 
       self.vm.inputs.viewDidLoad()
+      self.vm.inputs.viewWillAppear()
 
       self.scheduler.advance()
 

--- a/Library/ViewModels/PaymentMethodsViewModelTests.swift
+++ b/Library/ViewModels/PaymentMethodsViewModelTests.swift
@@ -39,48 +39,47 @@ internal final class PaymentMethodsViewModelTests: TestCase {
 
       self.reloadData.assertDidEmitValue()
 
-      self.vm.inputs.viewWillAppear()
       self.scheduler.advance()
 
       self.paymentMethods.assertValues([GraphUserCreditCard.template.storedCards.nodes])
     }
   }
 
-  func testPaymentMethodsFetch_OnRefresh() {
+  func testPaymentMethodsFetch_OnAddNewCardSucceeded() {
     let response = UserEnvelope<GraphUserCreditCard>(me: GraphUserCreditCard.template)
     let apiService = MockService(fetchGraphCreditCardsResponse: response)
 
     withEnvironment(apiService: apiService) {
       self.paymentMethods.assertValues([])
 
-      self.vm.inputs.refresh()
-
-      self.scheduler.advance()
-
-      self.paymentMethods.assertValues([GraphUserCreditCard.template.storedCards.nodes])
-    }
-  }
-
-  func testPaymentMethodsFetch_OnCardAddedSuccessfully() {
-    let response = UserEnvelope<GraphUserCreditCard>(me: GraphUserCreditCard.template)
-    let apiService = MockService(fetchGraphCreditCardsResponse: response)
-
-    withEnvironment(apiService: apiService) {
-      self.paymentMethods.assertValues([])
-
-      self.vm.inputs.cardAddedSuccessfully("First card added successfully")
+      self.vm.inputs.addNewCardSucceeded(with: "First card added successfully")
 
       self.scheduler.advance()
 
       self.paymentMethods.assertValueCount(1)
 
       withEnvironment(apiService: apiService) {
-        self.vm.inputs.cardAddedSuccessfully("Second card added successfully")
+        self.vm.inputs.addNewCardSucceeded(with: "Second card added successfully")
 
         self.scheduler.advance()
 
         self.paymentMethods.assertValueCount(2)
       }
+    }
+  }
+
+  func testPaymentMethodsFetch_OnAddNewCardDismissed() {
+    let response = UserEnvelope<GraphUserCreditCard>(me: GraphUserCreditCard.template)
+    let apiService = MockService(fetchGraphCreditCardsResponse: response)
+
+    withEnvironment(apiService: apiService) {
+      self.paymentMethods.assertValues([])
+
+      self.vm.inputs.addNewCardDismissed()
+
+      self.scheduler.advance()
+
+      self.paymentMethods.assertValues([GraphUserCreditCard.template.storedCards.nodes])
     }
   }
 
@@ -138,14 +137,20 @@ internal final class PaymentMethodsViewModelTests: TestCase {
     let apiService = MockService(deletePaymentMethodResult: .success(.init(totalCount: 3)))
     withEnvironment(apiService: apiService) {
       self.editButtonIsEnabled.assertDidNotEmitValue()
+
       self.vm.inputs.viewDidLoad()
 
       self.editButtonIsEnabled.assertValues([false])
 
-      self.vm.inputs.didDelete(card)
       self.scheduler.advance()
 
       self.editButtonIsEnabled.assertValues([false, true])
+
+      self.vm.inputs.didDelete(card)
+
+      self.scheduler.advance()
+
+      self.editButtonIsEnabled.assertValues([false, true, true])
     }
   }
 
@@ -159,14 +164,20 @@ internal final class PaymentMethodsViewModelTests: TestCase {
     let apiService = MockService(deletePaymentMethodResult: .success(.init(totalCount: 0)))
     withEnvironment(apiService: apiService) {
       self.editButtonIsEnabled.assertDidNotEmitValue()
+
       self.vm.inputs.viewDidLoad()
 
       self.editButtonIsEnabled.assertValues([false])
 
-      self.vm.inputs.didDelete(card)
       self.scheduler.advance()
 
-      self.editButtonIsEnabled.assertValues([false, false])
+      self.editButtonIsEnabled.assertValues([false, true])
+
+      self.vm.inputs.didDelete(card)
+
+      self.scheduler.advance()
+
+      self.editButtonIsEnabled.assertValues([false, true, false])
     }
   }
 
@@ -193,7 +204,7 @@ internal final class PaymentMethodsViewModelTests: TestCase {
   func testPresentMessageBanner() {
     self.presentBanner.assertValues([])
 
-    self.vm.inputs.cardAddedSuccessfully(Strings.Got_it_your_changes_have_been_saved())
+    self.vm.inputs.addNewCardSucceeded(with: Strings.Got_it_your_changes_have_been_saved())
 
     self.vm.inputs.viewWillAppear()
 
@@ -209,7 +220,8 @@ internal final class PaymentMethodsViewModelTests: TestCase {
     let apiService = MockService(deletePaymentMethodResult: .success(.init(totalCount: 2)))
     withEnvironment(apiService: apiService) {
 
-      self.vm.inputs.viewWillAppear()
+      self.vm.inputs.viewDidLoad()
+
       self.scheduler.advance()
 
       self.tableViewIsEditing.assertValues([])
@@ -243,7 +255,8 @@ internal final class PaymentMethodsViewModelTests: TestCase {
     let apiService = MockService(deletePaymentMethodResult: .failure(.invalidInput))
     withEnvironment(apiService: apiService) {
 
-      self.vm.inputs.viewWillAppear()
+      self.vm.inputs.viewDidLoad()
+
       self.scheduler.advance()
 
       self.tableViewIsEditing.assertValues([])


### PR DESCRIPTION
# 📲 What

See the title

# 🤔 Why

Fixing iPad behaviour, caused duplicate calls on iPhone devices.

# 🛠 How

We've recently added the ability to re-fetch payment methods when the user returns from the `Add new payment method` modal (by submitting or dismissing). In order to consistently perform the fetch action we're using a delegate pattern (mostly because on iPad the view controller lifecycle events are called slightly different when presenting settings with `.pageSheet` presentation style). So where we previously relied on `viewWillAppear` these events worked on iPhones but not on iPads and in order to prevent from duplicate calls we now only cause fetching new data in `viewDidLoad` or explicitly by submitting & dismissing the `Add new payment method` modal or canceling the `Add new payment method` modal.

# ✅ Acceptance criteria

on iPhone & iPad

- [x] Navigate to payment methods and verify that your payment methods have been loaded
- [x] Verify that adding a new payment method (in the app) refreshes the list after modal is dismissed
- [x] Verify that removing or adding new payment method (on the web) while presenting the `Add new payment method` card refreshes the list when the modal is `canceled`