### PR TITLE
[Payment methods] A11y - Credit card name

### DIFF
--- a/Kickstarter-iOS/Views/Cells/CreditCardCell.swift
+++ b/Kickstarter-iOS/Views/Cells/CreditCardCell.swift
@@ -42,6 +42,7 @@ internal final class CreditCardCell: UITableViewCell, ValueCell {
   override func bindViewModel() {
     super.bindViewModel()
 
+    self.cardNumberLabel.rac.accessibilityLabel = self.viewModel.outputs.cardNumberAccessibilityLabel
     self.cardNumberLabel.rac.text = self.viewModel.outputs.cardNumberText
     self.expirationDateLabel.rac.text = self.viewModel.outputs.expirationDateText
 

--- a/KsApi/models/UserCreditCard.swift
+++ b/KsApi/models/UserCreditCard.swift
@@ -11,6 +11,15 @@ public struct GraphUserCreditCard: Swift.Decodable {
     public var formattedExpirationDate: String {
       return String(expirationDate.dropLast(3))
     }
+
+    public var imageName: String {
+      switch self.type {
+      case .generic:
+        return "icon--generic"
+      default:
+        return "icon--\(self.type.rawValue.lowercased())"
+      }
+    }
   }
 
   public enum CreditCardType: String, Decodable, CaseIterable {
@@ -21,6 +30,15 @@ public struct GraphUserCreditCard: Swift.Decodable {
     case visa = "VISA"
     case diners = "DINERS"
     case generic = "----"
+
+    public var description: String? {
+      switch self {
+      case .amex, .discover, .jcb, .mastercard, .visa, .diners:
+        return self.rawValue.capitalized
+      default:
+        return nil
+      }
+    }
   }
 
   public struct CreditCardConnection: Swift.Decodable {

--- a/Library/ViewModels/CreditCardCellViewModel.swift
+++ b/Library/ViewModels/CreditCardCellViewModel.swift
@@ -14,6 +14,9 @@ public protocol CreditCardCellViewModelOutputs {
   /// Emits the card's image.
   var cardImage: Signal<UIImage?, NoError> { get }
 
+  /// Emits
+  var cardNumberAccessibilityLabel: Signal<String, NoError> { get }
+
   /// Emits a formatted string containing the card's last four digits.
   var cardNumberText: Signal<String, NoError> { get }
 
@@ -30,9 +33,13 @@ public final class CreditCardCellViewModel: CreditCardCellViewModelInputs,
 CreditCardCellViewModelOutputs, CreditCardCellViewModelType {
 
   public init() {
-
     self.cardImage = self.cardProperty.signal.skipNil()
       .map(cardImage(with:))
+
+    self.cardNumberAccessibilityLabel = self.cardProperty.signal.skipNil()
+      .map { [$0.type.description, Strings.Card_ending_in_last_four(last_four: $0.lastFour)]
+        .compactMap{ $0 }.joined(separator: ", ")
+    }
 
     self.cardNumberText = self.cardProperty.signal.skipNil()
       .map { Strings.Card_ending_in_last_four(last_four: $0.lastFour) }
@@ -49,6 +56,7 @@ CreditCardCellViewModelOutputs, CreditCardCellViewModelType {
     self.cardProperty.value = creditCard
   }
 
+  public let cardNumberAccessibilityLabel: Signal<String, NoError>
   public let cardImage: Signal<UIImage?, NoError>
   public let expirationDateText: Signal<String, NoError>
   public let cardNumberText: Signal<String, NoError>
@@ -58,7 +66,7 @@ CreditCardCellViewModelOutputs, CreditCardCellViewModelType {
 }
 
 private func cardImage(with card: GraphUserCreditCard.CreditCard) -> UIImage? {
-  return image(named: "icon--" + card.type.rawValue.lowercased()) ?? image(named: "icon--generic")
+  return image(named: card.imageName)
 }
 
 private func formatted(dateString: String) -> String {

--- a/Library/ViewModels/CreditCardCellViewModel.swift
+++ b/Library/ViewModels/CreditCardCellViewModel.swift
@@ -14,7 +14,7 @@ public protocol CreditCardCellViewModelOutputs {
   /// Emits the card's image.
   var cardImage: Signal<UIImage?, NoError> { get }
 
-  /// Emits
+  /// Emits a formatted accessibility string containing the card type, number and last four digits
   var cardNumberAccessibilityLabel: Signal<String, NoError> { get }
 
   /// Emits a formatted string containing the card's last four digits.

--- a/Library/ViewModels/CreditCardCellViewModelTests.swift
+++ b/Library/ViewModels/CreditCardCellViewModelTests.swift
@@ -11,6 +11,7 @@ internal final class CreditCardCellViewModelTests: TestCase {
   internal let vm: CreditCardCellViewModelType = CreditCardCellViewModel()
 
   let cardImage = TestObserver<UIImage?, NoError>()
+  let cardNumberAccessibilityLabel = TestObserver<String, NoError>()
   let cardNumberText = TestObserver<String, NoError>()
   let expirationDateText = TestObserver<String, NoError>()
 
@@ -18,24 +19,61 @@ internal final class CreditCardCellViewModelTests: TestCase {
     super.setUp()
 
     self.vm.outputs.cardImage.observe(cardImage.observer)
+    self.vm.outputs.cardNumberAccessibilityLabel.observe(cardNumberAccessibilityLabel.observer)
     self.vm.outputs.cardNumberText.observe(cardNumberText.observer)
     self.vm.outputs.expirationDateText.observe(expirationDateText.observer)
-
   }
 
-  func testCardInfo() {
-
+  func testCardInfoForSupportedCards() {
     self.vm.inputs.configureWith(creditCard: GraphUserCreditCard.amex)
-    self.cardImage.assertValue(UIImage(named: "icon--amex"))
 
-    self.expirationDateText.assertValue("Expires 01/2024")
+    self.cardImage.assertLastValue(UIImage(named: "icon--amex"))
+    self.cardNumberAccessibilityLabel.assertLastValue("Amex, Card ending in 8882")
+    self.cardNumberText.assertLastValue("Card ending in 8882")
+    self.expirationDateText.assertLastValue("Expires 01/2024")
 
-    self.cardNumberText.assertValue("Card ending in 8882")
+    self.vm.inputs.configureWith(creditCard: GraphUserCreditCard.discover)
+
+    self.cardImage.assertLastValue(UIImage(named: "icon--discover"))
+    self.cardNumberAccessibilityLabel.assertLastValue("Discover, Card ending in 4242")
+    self.cardNumberText.assertLastValue("Card ending in 4242")
+    self.expirationDateText.assertLastValue("Expires 03/2022")
+
+    self.vm.inputs.configureWith(creditCard: GraphUserCreditCard.jcb)
+
+    self.cardImage.assertLastValue(UIImage(named: "icon--jcb"))
+    self.cardNumberAccessibilityLabel.assertLastValue("Jcb, Card ending in 2222")
+    self.cardNumberText.assertLastValue("Card ending in 2222")
+    self.expirationDateText.assertLastValue("Expires 01/2022")
+
+    self.vm.inputs.configureWith(creditCard: GraphUserCreditCard.masterCard)
+
+    self.cardImage.assertLastValue(UIImage(named: "icon--mastercard"))
+    self.cardNumberAccessibilityLabel.assertLastValue("Mastercard, Card ending in 0000")
+    self.cardNumberText.assertLastValue("Card ending in 0000")
+    self.expirationDateText.assertLastValue("Expires 10/2018")
+
+    self.vm.inputs.configureWith(creditCard: GraphUserCreditCard.visa)
+
+    self.cardImage.assertLastValue(UIImage(named: "icon--visa"))
+    self.cardNumberAccessibilityLabel.assertLastValue("Visa, Card ending in 1111")
+    self.cardNumberText.assertLastValue("Card ending in 1111")
+    self.expirationDateText.assertLastValue("Expires 09/2019")
+
+    self.vm.inputs.configureWith(creditCard: GraphUserCreditCard.diners)
+
+    self.cardImage.assertLastValue(UIImage(named: "icon--diners"))
+    self.cardNumberAccessibilityLabel.assertLastValue("Diners, Card ending in 1212")
+    self.cardNumberText.assertLastValue("Card ending in 1212")
+    self.expirationDateText.assertLastValue("Expires 09/2022")
   }
 
-  func testCardImage_ReturnsGenericImage_IfCardHasInvalidType() {
-
+  func testCardInfoForUnsupportedCards() {
     self.vm.inputs.configureWith(creditCard: GraphUserCreditCard.generic)
+
     self.cardImage.assertValue(UIImage(named: "icon--generic"))
+    self.cardNumberAccessibilityLabel.assertLastValue("Card ending in 1882")
+    self.cardNumberText.assertValue("Card ending in 1882")
+    self.expirationDateText.assertValue("Expires 01/2024")
   }
 }


### PR DESCRIPTION
# 📲 What

VoiceOver starts reading the credit card cell with the name of the card.

# 🤔 Why

Better VoiceOver experience

What is obvious to non-visually impaired users by seeing the credit card icon should be conveyed to visually impaired users using VoiceOver.

# 🛠 How

"Simply" concatenating the card name and card name information.

# ♿️ Accessibility 

with VoiceOver ON

- [x] VoiceOver reads the credit card cell as `Card name, Card ending in XXXX, Expires YYYY-MM` so for example `Amex, Card ending in 8431, Expires 2022-10` or `Visa, Card ending in 4242, Expires 2022-09`