### PR TITLE
Add before/after table to the PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,6 +16,10 @@ More in-depth discussion of the change or implementation.
 
 Trello, screenshots, external resources?
 
+| Before | After |
+| --- | --- |
+|  |  |
+
 # ♿️ Accessibility 
 
 - [ ] Tap targets use minimum of 44x44 pts dimensions

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,7 +16,7 @@ More in-depth discussion of the change or implementation.
 
 Trello, screenshots, external resources?
 
-| Before | After |
+| Before 🐛 | After 🦋 |
 | --- | --- |
 |  |  |
 


### PR DESCRIPTION
# 📲 What

Adds before/after table to the PR template under the `👀 See` section.

# 🤔 Why

This should make it easier to provide before/after screenshots side by side.

# 👀 See

| Before | After |
| --- | --- |
| <img width="375" alt="screen shot 2019-02-19 at 11 53 08 am" src="https://user-images.githubusercontent.com/387596/53043276-fa16ef80-343c-11e9-8d50-52e5337b5d73.png"> | <img width="376" alt="screen shot 2019-02-19 at 11 52 55 am" src="https://user-images.githubusercontent.com/387596/53043266-f2574b00-343c-11e9-9b14-d77e01f22af5.png"> |


![inception](https://i.kym-cdn.com/entries/icons/mobile/000/012/886/wntgd.jpg)