### PR TITLE
♿️ [Dynamic Type] Navigation bar title

### DIFF
--- a/Library/Styles/BaseStyles.swift
+++ b/Library/Styles/BaseStyles.swift
@@ -144,8 +144,7 @@ private let navBarLens: Lens<UINavigationController?, UINavigationBar?> = Lens(
 
 private let baseNavigationBarStyle =
   UINavigationBar.lens.titleTextAttributes .~ [
-    NSAttributedString.Key.foregroundColor: UIColor.black,
-    NSAttributedString.Key.font: UIFont.ksr_headline()
+    NSAttributedString.Key.foregroundColor: UIColor.black
     ]
     <> UINavigationBar.lens.isTranslucent .~ false
     <> UINavigationBar.lens.barTintColor .~ .white
@@ -153,8 +152,7 @@ private let baseNavigationBarStyle =
 
 private let clearNavigationBarStyle =
   UINavigationBar.lens.titleTextAttributes .~ [
-    NSAttributedString.Key.foregroundColor: UIColor.white,
-    NSAttributedString.Key.font: UIFont.ksr_headline()
+    NSAttributedString.Key.foregroundColor: UIColor.white
     ]
     <> UINavigationBar.lens.isTranslucent .~ true
     <> UINavigationBar.lens.shadowImage .~ UIImage()


### PR DESCRIPTION
# 📲 What

Uses default (system) font for the navigation bar title in order to prevent from allowing resizing when the font size changes.

# 🤔 Why

More native behaviour.

# 👀 See

| Before 🐛 | After 🦋 |
| --- | --- |
| <img width="504" alt="screen shot 2019-02-19 at 9 00 55 pm" src="https://user-images.githubusercontent.com/387596/53067547-7f27f600-3489-11e9-99df-c6a5641b878e.png"> | <img width="504" alt="screen shot 2019-02-19 at 8 59 09 pm" src="https://user-images.githubusercontent.com/387596/53067509-4daf2a80-3489-11e9-82c3-36fd5a0b62aa.png"> |

# ♿️ Accessibility 

- [ ] Changing font size does not affect navigation bar title anywhere on the primary navigation stack (anything under tab bar or presented modally)
- [ ] Changing font size does not affect navigation bar title on KSR Live