### PR TITLE
🔑 [Create Password] Extend ServiceType

### DIFF
--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -1074,6 +1074,7 @@
 		D7237099211A3DA9001EA4CA /* SettingsFollowCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7237097211A3925001EA4CA /* SettingsFollowCell.swift */; };
 		D7417CD620BF12F4004DABA6 /* ExportDataEnvelope.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7417CD520BF12F4004DABA6 /* ExportDataEnvelope.swift */; };
 		D7417D0E20BF4833004DABA6 /* ExportStateEnvelopeTemplates.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7417D0D20BF4833004DABA6 /* ExportStateEnvelopeTemplates.swift */; };
+		D75DACA8221DC4340027F478 /* CreatePasswordInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = D75DACA7221DC4340027F478 /* CreatePasswordInput.swift */; };
 		D770DDE8217D729300B5319A /* UserCurrencyTemplates.swift in Sources */ = {isa = PBXBuildFile; fileRef = D770DDE7217D729300B5319A /* UserCurrencyTemplates.swift */; };
 		D770DE75217E598C00B5319A /* AddNewCardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D770DE3D217E339500B5319A /* AddNewCardViewController.swift */; };
 		D770DE78217E876000B5319A /* AddNewCardViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D770DE76217E874F00B5319A /* AddNewCardViewControllerTests.swift */; };
@@ -2821,6 +2822,7 @@
 		D7417D0D20BF4833004DABA6 /* ExportStateEnvelopeTemplates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExportStateEnvelopeTemplates.swift; sourceTree = "<group>"; };
 		D74E66AF212B7AB500C61708 /* SettingsViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewControllerTests.swift; sourceTree = "<group>"; };
 		D74E6757212CB5A400C61708 /* SettingsViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewControllerTests.swift; sourceTree = "<group>"; };
+		D75DACA7221DC4340027F478 /* CreatePasswordInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreatePasswordInput.swift; sourceTree = "<group>"; };
 		D76E9BEE2174EF580049F64E /* SettingsCurrencyCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsCurrencyCellViewModel.swift; sourceTree = "<group>"; };
 		D770DDE7217D729300B5319A /* UserCurrencyTemplates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserCurrencyTemplates.swift; sourceTree = "<group>"; };
 		D770DE3D217E339500B5319A /* AddNewCardViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddNewCardViewController.swift; sourceTree = "<group>"; };
@@ -4597,6 +4599,7 @@
 				D79CF32D219CE51A00ECB73A /* CreatePaymentSourceInput.swift */,
 				D6ED1B3A216D525B007F7547 /* ChangeEmailInput.swift */,
 				77E44B7321823A56006446B8 /* ChangePasswordInput.swift */,
+				D75DACA7221DC4340027F478 /* CreatePasswordInput.swift */,
 				D6B686E82191FE5E005F5DA7 /* EmptyInput.swift */,
 				D08510112195015F00BC418B /* PaymentSourceDeleteInput.swift */,
 				D002CAE2218CF91D009783F2 /* WatchProjectInput.swift */,
@@ -6504,6 +6507,7 @@
 				D0158A221EEB30A2006E7684 /* ProjectStatsEnvelopeTemplates.swift in Sources */,
 				D01588B71EEB2ED7006E7684 /* ProjectStatsEnvelope.CumulativeStatsLenses.swift in Sources */,
 				D01589271EEB2ED7006E7684 /* SurveyResponse.swift in Sources */,
+				D75DACA8221DC4340027F478 /* CreatePasswordInput.swift in Sources */,
 				D0158A0D1EEB30A2006E7684 /* ChangePaymentMethodEnvelopeTemplates.swift in Sources */,
 				D0158A201EEB30A2006E7684 /* ProjectStatsEnvelope.RewardDistributionTemplates.swift in Sources */,
 				D01588C11EEB2ED7006E7684 /* ProjectStatsEnvelopeLenses.swift in Sources */,

--- a/KsApi/MockService.swift
+++ b/KsApi/MockService.swift
@@ -22,6 +22,8 @@ internal struct MockService: ServiceType {
 
   fileprivate let changePasswordError: GraphError?
 
+  fileprivate let createPasswordError: GraphError?
+
   fileprivate let changePaymentMethodResult: Result<ChangePaymentMethodEnvelope, ErrorEnvelope>?
 
   fileprivate let deletePaymentMethodResult: Result<DeletePaymentMethodEnvelope, GraphError>?
@@ -187,6 +189,7 @@ internal struct MockService: ServiceType {
                                                                        me: .template
                                                                      ),
                 changePasswordError: GraphError? = nil,
+                createPasswordError: GraphError? = nil,
                 changeCurrencyResponse: GraphMutationEmptyResponseEnvelope? = nil,
                 changeCurrencyError: GraphError? = nil,
                 changePaymentMethodResult: Result<ChangePaymentMethodEnvelope, ErrorEnvelope>? = nil,
@@ -291,6 +294,8 @@ internal struct MockService: ServiceType {
     self.changeEmailError = changeEmailError
 
     self.changePasswordError = changePasswordError
+
+    self.createPasswordError = createPasswordError
 
     self.changePaymentMethodResult = changePaymentMethodResult
     self.deletePaymentMethodResult = deletePaymentMethodResult
@@ -516,6 +521,15 @@ internal struct MockService: ServiceType {
   internal func changePassword(input: ChangePasswordInput) ->
     SignalProducer<GraphMutationEmptyResponseEnvelope, GraphError> {
       if let error = self.changePasswordError {
+        return SignalProducer(error: error)
+      } else {
+        return SignalProducer(value: GraphMutationEmptyResponseEnvelope())
+      }
+  }
+
+  internal func createPassword(input: CreatePasswordInput) ->
+    SignalProducer<GraphMutationEmptyResponseEnvelope, GraphError> {
+      if let error = self.createPasswordError {
         return SignalProducer(error: error)
       } else {
         return SignalProducer(value: GraphMutationEmptyResponseEnvelope())

--- a/KsApi/Service.swift
+++ b/KsApi/Service.swift
@@ -82,6 +82,11 @@ public struct Service: ServiceType {
       return applyMutation(mutation: UpdateUserAccountMutation(input: input))
   }
 
+  public func createPassword(input: CreatePasswordInput) ->
+    SignalProducer<GraphMutationEmptyResponseEnvelope, GraphError> {
+      return applyMutation(mutation: UpdateUserAccountMutation(input: input))
+  }
+
   public func changePaymentMethod(project: Project)
     -> SignalProducer<ChangePaymentMethodEnvelope, ErrorEnvelope> {
 

--- a/KsApi/ServiceType.swift
+++ b/KsApi/ServiceType.swift
@@ -51,6 +51,9 @@ public protocol ServiceType {
   func changeCurrency(input: ChangeCurrencyInput) ->
     SignalProducer<GraphMutationEmptyResponseEnvelope, GraphError>
 
+  func createPassword(input: CreatePasswordInput) ->
+    SignalProducer<GraphMutationEmptyResponseEnvelope, GraphError>
+
   func addNewCreditCard(input: CreatePaymentSourceInput) ->
     SignalProducer<CreatePaymentSourceEnvelope, GraphError>
 

--- a/KsApi/mutations/inputs/CreatePasswordInput.swift
+++ b/KsApi/mutations/inputs/CreatePasswordInput.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+public struct CreatePasswordInput: GraphMutationInput {
+  let password: String
+  let passwordConfirmation: String
+
+  public init(password: String, passwordConfirmation: String) {
+    self.password = password
+    self.passwordConfirmation = passwordConfirmation
+  }
+
+  public func toInputDictionary() -> [String : Any] {
+    return ["password": password,
+            "passwordConfirmation": passwordConfirmation
+    ]
+  }
+}


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Extend ServiceType (Service, MockService) with the mutation graph call that allows users to create a new password.

# 🤔 Why

Needed for create password feature for Facebook users w/o a password.

# ▶️▶️▶️ Note

**Testing Procedures to trigger call:**

- [x] The first step to test the API is to delete your Kickstarter password on staging, please refer to this [Trello card ](https://trello.com/c/hKd7MmSy/1186-%F0%9F%94%91-create-password-graph-call) to delete your kickstarter password on staging. 
- [x] After you delete your password make sure you are logged in to your Kickstarter account on staging
Navigate to `Settings > Account` if you deleted your password successfully you should not see the `Change email` or `Change password` cells.
- [x] Add the following code to:

```
// SettingsAccountViewModel.swift

// SettingsAccountViewModelOutputs
// L: 25
var createPasswordSuccess: Signal<Void, NoError> { get }
var createPasswordFailure: Signal<String, NoError> { get }

// L: 177
public let createPasswordSuccess: Signal<Void, NoError>
public let createPasswordFailure: Signal<String, NoError>

//public init
// L: 79
 
let createPasswordOnLoad = self.viewDidLoadProperty.signal
      .map { CreatePasswordInput(password: "YourPassword123", passwordConfirmation: "YourPassword123") }
      .switchMap {
        AppEnvironment.current.apiService.createPassword(input: $0)
          .ksr_delay(AppEnvironment.current.apiDelayInterval, on: AppEnvironment.current.scheduler)
          .materialize()
    }

    self.createPasswordFailure = createPasswordOnLoad.errors()
      .map { $0.localizedDescription }
    self.createPasswordSuccess = createPasswordOnLoad.values().ignoreValues()
```

```
// SettingsAccountViewController.swift
// bindViewModel()
// L: 90

self.viewModel.outputs.createPasswordFailure
      .observeForControllerAction()
      .observeValues { [weak self] errorMessage in
        self?.present(UIAlertController.genericError(errorMessage),
                      animated: true, completion: nil)
    }

    self.viewModel.outputs.createPasswordSuccess
      .observeForUI()
      .observeValues { [weak self] _ in
        print("PASSWORD Success!!!")
    }

```
- [x] Run the app. Navigate to `Settings > Account` you should still not see the `Change email` or `Change password` cells. The graph call should have happened so search the console for "PASSWORD Success!!!". Navigate away from the `Account` screen and then navigate again. You should see the `Change email` or `Change password` cells now because you have a password to change.

- [x] To test further logout of the account and then you should be able to log back in w/ the new password







