### PR TITLE
♿️ [Voice Over] Settings > Help Accessibility Traits

### DIFF
--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -75,6 +75,7 @@
 		01F219561DC12BF7005DD2E4 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 01F219521DC12697005DD2E4 /* LaunchScreen.storyboard */; };
 		01F547ED1D53994B000A98EF /* TabBarItemStyles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F547EC1D53994B000A98EF /* TabBarItemStyles.swift */; };
 		01FD71EC1D3808E500070BAC /* BarButtonItemStyles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01FD71EB1D3808E500070BAC /* BarButtonItemStyles.swift */; };
+		37CBA64D221E10E100E6CAB6 /* HelpTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37CBA64C221E10E100E6CAB6 /* HelpTypeTests.swift */; };
 		59019FB61D21A47700EAEC9D /* DashboardReferrerRowStackViewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59019FB51D21A47700EAEC9D /* DashboardReferrerRowStackViewViewModel.swift */; };
 		59019FBA1D21ABD200EAEC9D /* DashboardReferrerRowStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59019FB81D21ABD200EAEC9D /* DashboardReferrerRowStackView.swift */; };
 		59322F071CD27B1000C90CC6 /* ProfileDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59322F051CD27B1000C90CC6 /* ProfileDataSource.swift */; };
@@ -1848,6 +1849,7 @@
 		01F219521DC12697005DD2E4 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
 		01F547EC1D53994B000A98EF /* TabBarItemStyles.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabBarItemStyles.swift; sourceTree = "<group>"; };
 		01FD71EB1D3808E500070BAC /* BarButtonItemStyles.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BarButtonItemStyles.swift; sourceTree = "<group>"; };
+		37CBA64C221E10E100E6CAB6 /* HelpTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelpTypeTests.swift; sourceTree = "<group>"; };
 		3D1363951F0191FB00B53420 /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/Localizable.strings; sourceTree = "<group>"; };
 		59019FB51D21A47700EAEC9D /* DashboardReferrerRowStackViewViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DashboardReferrerRowStackViewViewModel.swift; sourceTree = "<group>"; };
 		59019FB81D21ABD200EAEC9D /* DashboardReferrerRowStackView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DashboardReferrerRowStackView.swift; sourceTree = "<group>"; };
@@ -3675,6 +3677,7 @@
 				A7C725811C85D36D005A016B /* GradientView.swift */,
 				D0200A5221935EDF00F5CC27 /* GraphError+LocalizedDescription.swift */,
 				A707BAD31CFFAB9400653B2F /* HelpType.swift */,
+				37CBA64C221E10E100E6CAB6 /* HelpTypeTests.swift */,
 				80E8EAC71D3EC65A007BDA4B /* Image.swift */,
 				A76078091CAEE0A6001B39D0 /* IsValidEmail.swift */,
 				A7ED1F161E830FDC00BFFA01 /* IsValidEmailTests.swift */,
@@ -5898,6 +5901,7 @@
 				D093B4F021A8B14100910962 /* MockPushRegistration.swift in Sources */,
 				A7ED1FEA1E831C5C00BFFA01 /* HelpViewModelTests.swift in Sources */,
 				A7ED1F301E830FDC00BFFA01 /* NavigationTests.swift in Sources */,
+				37CBA64D221E10E100E6CAB6 /* HelpTypeTests.swift in Sources */,
 				A7ED1FB01E831C5C00BFFA01 /* ProjectPamphletViewModelTests.swift in Sources */,
 				A7ED1FA91E831C5C00BFFA01 /* ActivityProjectStatusViewModelTests.swift in Sources */,
 				A7ED1FB91E831C5C00BFFA01 /* LiveStreamDiscoveryLiveNowCellViewModelTests.swift in Sources */,

--- a/Library/HelpType.swift
+++ b/Library/HelpType.swift
@@ -10,7 +10,12 @@ public enum HelpType: SettingsCellTypeProtocol {
   case trust
 
   public var accessibilityTraits: UIAccessibilityTraits {
-    return .button
+    switch self {
+    case .contact:
+      return .button
+    default:
+      return .link
+    }
   }
 
   public var title: String {

--- a/Library/HelpTypeTests.swift
+++ b/Library/HelpTypeTests.swift
@@ -1,0 +1,14 @@
+import XCTest
+import Library
+
+final class HelpTypeTests: XCTestCase {
+  func testAccessibilityTraits() {
+    XCTAssertEqual(HelpType.helpCenter.accessibilityTraits, UIAccessibilityTraits.link)
+    XCTAssertEqual(HelpType.contact.accessibilityTraits, UIAccessibilityTraits.button)
+    XCTAssertEqual(HelpType.howItWorks.accessibilityTraits, UIAccessibilityTraits.link)
+    XCTAssertEqual(HelpType.terms.accessibilityTraits, UIAccessibilityTraits.link)
+    XCTAssertEqual(HelpType.privacy.accessibilityTraits, UIAccessibilityTraits.link)
+    XCTAssertEqual(HelpType.cookie.accessibilityTraits, UIAccessibilityTraits.link)
+    XCTAssertEqual(HelpType.trust.accessibilityTraits, UIAccessibilityTraits.link)
+  }
+}


### PR DESCRIPTION
# 📲 What

Uses link accessibility trait for each row that presents a website.

# 🤔 Why

This should give visually impaired users more context to where is this action going to take them.

# 🛠 How

Simply decide on the row type and return either `.link` for actions that navigate the user to a website or `.button` for presenting the mail composer to contact support.

# ♿️ Accessibility 

navigating to `Settings > Help`, VoiceOver reads the following cells like so

- [ ] `Help Center, link`, 
- [ ] `Contact, button`
- [ ] `Terms of Use, link`
- [ ] `Privacy Policy, link`
- [ ] `Cookie Policy, link`