### PR TITLE
Increase timeout for tests to 20 minutes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,6 +140,7 @@ jobs:
       - run:
           name: Kickstarter tests
           command: PLATFORM=iOS make test
+          no_output_timeout: "20m" # 20 minutes
 
       - store_artifacts:
           path: /tmp/xcode_raw.log
@@ -193,6 +194,7 @@ jobs:
       - run:
           name: Library tests
           command: PLATFORM=iOS TARGET=Library make test
+          no_output_timeout: "20m" # 20 minutes
 
       - store_artifacts:
           path: /tmp/xcode_raw.log
@@ -244,6 +246,7 @@ jobs:
       - run:
           name: LiveStream tests
           command: SCHEME=LiveStream make test
+          no_output_timeout: "20m" # 20 minutes
 
       - store_artifacts:
           path: /tmp/xcode_raw.log
@@ -295,6 +298,7 @@ jobs:
       - run:
           name: KsApi tests
           command: SCHEME=KsApi make test
+          no_output_timeout: "20m" # 20 minutes
 
       - store_artifacts:
           path: /tmp/xcode_raw.log


### PR DESCRIPTION
# 📲 What

Increases the timeout for tests running on CircleCI to 20 minutes.

# 🤔 Why

We've been having some arbitrary timeouts while tests are running on some of our builds:

<img width="320" alt="screen shot 2019-02-26 at 4 45 59 pm" src="https://user-images.githubusercontent.com/3735375/53457134-03c4c800-39e6-11e9-86c4-be5b2518ac32.png">

In the past these were _mostly_ resolved by increasing the timeout limit.

# 🛠 How

Added `no_output_timeout` for test steps in test jobs.

# 👀 See

https://circleci.com/docs/2.0/configuration-reference/

# ✅ Acceptance criteria

- [ ] Tests all pass (validates config.yml and that test jobs ran)
