### PR TITLE
Disable COMPILER_INDEX_STORE_ENABLE on CI

### DIFF
--- a/.fastlane/Fastfile
+++ b/.fastlane/Fastfile
@@ -233,7 +233,8 @@ platform :ios do
       export_method: options[:export_method],
       scheme: "Kickstarter-iOS",
       configuration: options[:configuration],
-      export_options: export_options
+      export_options: export_options,
+      xcconfig: "Configs/CircleCI.xcconfig"
     )
   end
 

--- a/Configs/CircleCI.xcconfig
+++ b/Configs/CircleCI.xcconfig
@@ -1,0 +1,3 @@
+#include "Base.xcconfig"
+
+COMPILER_INDEX_STORE_ENABLE=NO

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 XCODEBUILD := xcodebuild
-BUILD_FLAGS = -scheme $(SCHEME) -destination $(DESTINATION)
+BUILD_FLAGS = -scheme $(SCHEME) -destination $(DESTINATION) -xcconfig Configs/CircleCI.xcconfig
 
 SCHEME ?= $(TARGET)-$(PLATFORM)
 TARGET ?= Kickstarter-Framework


### PR DESCRIPTION
# 📲 What

Adds a `CircleCi.xcconfig` file which disables `COMPILER_INDEX_STORE_ENABLE` for a small performance gain on CI.

# 🤔 Why

@dusi mentioned a tweet that suggested this would offer a small performance gain so we figured we'd give it a try.

Results that I've seen on an initial run are:

| Test suite | [Before](https://circleci.com/workflow-run/fa2c6a79-ea07-453e-9693-cf7d23bf9054) 🐛 | [After](https://circleci.com/workflow-run/1e23e453-1a18-4282-8ba0-1a130c138d3e) 🦋 |
| --- | --- | --- |
| Library | 5:51 | 5:37 |
| Kickstarter-Framework | 9:20 | 8:31 |
| KsApi | 1:22 | 1:35 |
| LiveStream | 1:03 | 1:09 |

Curiously, on KsApi and LiveStream we saw a slight decline in speed, so it's hard to say whether the gain of nearly a minute for `Kickstarter-Framework` is worth it?

# 🛠 How

- Added a `CircleCI.xcconfig` file which inherits from `Base.xcconfig`.
- Implemented the use of `CircleCI.xcconfig` in our `Makefile` for tests and `Fastfile` for `gym`.

# 👀 See

https://twitter.com/steipete/status/1100404024224804871

# ✅ Acceptance criteria

- [ ] There is a tangible performance gain