### PR TITLE
Settings Dynamic Type Fixes

### DIFF
--- a/Kickstarter-iOS/Views/LoadingBarButtonItemView.swift
+++ b/Kickstarter-iOS/Views/LoadingBarButtonItemView.swift
@@ -26,7 +26,7 @@ final class LoadingBarButtonItemView: UIView, NibLoading {
     super.bindStyles()
 
     _ = self.titleButton
-      |> UIButton.lens.titleLabel.font .~ .ksr_body()
+      |> UIButton.lens.titleLabel.font .~ UIFont.systemFont(ofSize: 17)
       |> UIButton.lens.titleColor(for: .normal) .~ .ksr_green_700
       |> UIButton.lens.titleColor(for: .disabled) .~ .ksr_grey_500
 

--- a/Library/Styles/SettingsStyles.swift
+++ b/Library/Styles/SettingsStyles.swift
@@ -8,24 +8,46 @@ public let settingsSectionButtonStyle =
 
 public let settingsArrowViewStyle = UIImageView.lens.tintColor .~ .ksr_dark_grey_400
 
-public let settingsSectionLabelStyle =
-  UILabel.lens.textColor .~ .ksr_soft_black
-    <> UILabel.lens.font .~ .ksr_subhead()
-    <> UILabel.lens.numberOfLines .~ 2
+public let settingsSectionLabelStyle = { (label: UILabel) in
+  label
+    |> \.textColor .~ .ksr_soft_black
+    |> \.font .~ .ksr_subhead()
+    |> \.numberOfLines .~ 2
+}
 
-public let settingsTitleLabelStyle =
-  UILabel.lens.textColor .~ .ksr_soft_black
-    <> UILabel.lens.font .~ .ksr_body()
+public let settingsTitleLabelStyle = { (label: UILabel) in
+  label
+    |> \.textColor .~ .ksr_soft_black
+    |> \.font .~ .ksr_body()
+}
 
-public let settingsDetailLabelStyle = UILabel.lens.font .~ .ksr_body()
-  <> UILabel.lens.numberOfLines .~ 1
-  <> UILabel.lens.textColor .~ .ksr_text_dark_grey_500
-  <> UILabel.lens.lineBreakMode .~ .byTruncatingTail
+public let settingsDetailLabelStyle = { (label: UILabel) in
+  label
+    |> \.font .~ .ksr_body()
+    |> \.numberOfLines .~ 1
+    |> \.textColor .~ .ksr_text_dark_grey_500
+    |> \.lineBreakMode .~ .byTruncatingTail
+}
 
-public let settingsDescriptionLabelStyle = UILabel.lens.font .~ .ksr_body(size: 13)
-    <> UILabel.lens.numberOfLines .~ 0
-    <> UILabel.lens.textColor .~ .ksr_dark_grey_400
-    <> UILabel.lens.lineBreakMode .~ .byWordWrapping
+public let settingsDescriptionLabelStyle = { (label: UILabel) in
+  label
+    |> \.font .~ .ksr_body(size: 13)
+    |> \.numberOfLines .~ 0
+    |> \.textColor .~ .ksr_dark_grey_400
+    |> \.lineBreakMode .~ .byWordWrapping
+}
+
+public let settingsHeaderFooterLabelBaseStyle = { (label: UILabel) in
+  label
+    |> \.font .~ .ksr_footnote()
+    |> \.numberOfLines .~ 0
+}
+
+public let settingsHeaderFooterLabelStyle = { (label: UILabel) in
+  label
+    |> \.backgroundColor .~ .ksr_grey_200
+    |> \.textColor .~ .ksr_text_dark_grey_500
+}
 
 public let settingsFormFieldStyle =
   UITextField.lens.textColor .~ .ksr_text_dark_grey_500
@@ -43,10 +65,6 @@ public let settingsPasswordFormFieldAutoFillStyle = passwordFieldAutoFillStyle
 
 public let settingsNewPasswordFormFieldAutoFillStyle = newPasswordFieldAutoFillStyle
   <> settingsPasswordFormFieldStyle
-
-public let settingsLogoutButtonStyle = borderButtonStyle
-  <> UIButton.lens.titleLabel.font .~ .ksr_headline(size: 15)
-  <> UIButton.lens.title(for: .normal) %~ { _ in Strings.profile_settings_log_out_button() }
 
 public let settingsSeparatorStyle = UIView.lens.backgroundColor .~ .ksr_grey_500
   <> UIView.lens.accessibilityElementsHidden .~ true
@@ -84,16 +102,4 @@ public func settingsAttributedPlaceholder(_ string: String) -> NSAttributedStrin
     string: string,
     attributes: [NSAttributedString.Key.foregroundColor: UIColor.ksr_text_dark_grey_400]
   )
-}
-
-public func settingsHeaderFooterLabelBaseStyle(_ label: UILabel) -> UILabel {
-  return label
-    |> \.font %~ { _ in .ksr_footnote() }
-    |> \.numberOfLines .~ 0
-}
-
-public func settingsHeaderFooterLabelStyle(_ label: UILabel) -> UILabel {
-  return label
-    |> \.backgroundColor .~ .ksr_grey_200
-    |> \.textColor .~ .ksr_text_dark_grey_500
 }


### PR DESCRIPTION
# 📲 What

Fixes a bug that prevented fonts in settings from resizing correctly with dynamic type. Also turns off font resizing on the `LoadingBarButtonItemView` since it's a navigation item.

# 🛠 How

A deep-dive done by @dusi into dynamic type within Settings identified a bug where several labels whose fonts were set using our custom `.ksr_()` functions were not resizing correctly when the font size was changed using the accessibility inspector. An investigation showed that this was due to the helper styling functions in `SettingsStyles.swift` capturing the current context which essentially cached the initial `preferredFont` instead of re-evaluating it every time `bindStyles` was called.

The solution was to convert the `SettingsStyles` helpers that are setting a font into a closure that takes a label and applies the styles within the closure.

# 👀 See

Before:
 - notice that although the section footers resize, the title labels for the settings cells do not
 - notice that the "Save" button resizes even though it shouldn't

After:
 - notice that all cell titles now resize
 - notice that the "Save" button no longer resizes

| Before 🐛 | After 🦋 |
| --- | --- |
| ![y4xlkmeme4](https://user-images.githubusercontent.com/3156796/53760419-ce5e2580-3e90-11e9-86b0-b5b949a6789c.gif) | ![mhnrvh6nhy](https://user-images.githubusercontent.com/3156796/53760412-c9997180-3e90-11e9-8123-89994c1b3669.gif) |


# ♿️ Accessibility 

- [x] Works with VoiceOver
- [x] Supports Dynamic Type 

# ✅ Acceptance criteria

- [x] Run the app with the accessibility inspector. Then use the accessibility inspector to increase the font size. Navigate to Settings. Cell titles in all settings cells should now resize.
- [x] Run the app with the accessibility inspector. Then use the accessibility inspector to increase the font size. Navigate to Settings -> Account -> Change Password. The Save button on the top right *should not* resize.
- [x] Run the app with the accessibility inspector. Then use the accessibility inspector to increase the font size. Navigate to Settings -> Account -> Change Email. The Save button on the top right *should not* resize.