### PR TITLE
Add ksr_userLocalePreferencesChanged notification on didUpdateCurrency

### DIFF
--- a/Kickstarter-iOS/Views/Controllers/SelectCurrencyViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/SelectCurrencyViewController.swift
@@ -126,14 +126,19 @@ final class SelectCurrencyViewController: UIViewController, MessageBannerViewCon
     self.viewModel.outputs.didUpdateCurrency
       .observeForControllerAction()
       .observeValues { [weak self] in
-        self?.messageBannerViewController?.showBanner(
-          with: .success,
-          message: Strings.Got_it_your_changes_have_been_saved()
-        )
+        self?.handleDidUpdateCurrency()
     }
   }
 
-  // MARK: Actions
+  // MARK: - Private Functions
+  private func handleDidUpdateCurrency() {
+    self.messageBannerViewController?.showBanner(with: .success,
+                                                 message: Strings.Got_it_your_changes_have_been_saved())
+
+    NotificationCenter.default.post(name: .ksr_userLocalePreferencesChanged, object: nil)
+  }
+
+  // MARK: - Actions
 
   @objc private func saveButtonTapped(_ sender: Any) {
     self.viewModel.inputs.saveButtonTapped()


### PR DESCRIPTION
# 📲 What

Fixes a regression from the currency preferences UI refactor which re-introduced a bug that caused latency in seeing project pledge amounts in your preferred currency.

# 🛠 How

Re-adds the `.ksr_userLocalePreferencesChanged` notification on the `didUpdateCurrency` signal in `SelectCurrencyViewController`. This notification causes all the view controllers in `RootViewModel` to be regenerated.

# 👀 See

Note both of these recordings were taken with the Network Link Conditioner set to "3G" to simulate slow connection.

| Before 🐛 | After 🦋 |
| --- | --- |
| ![mlhqmbp66b](https://user-images.githubusercontent.com/3156796/53766180-294b4900-3ea0-11e9-983c-706792ce5643.gif) | ![fhf09ynwrq](https://user-images.githubusercontent.com/3156796/53766243-5697f700-3ea0-11e9-9828-df1522a7c2aa.gif) |

# ✅ Acceptance criteria

- [x] Navigate to the Select Currency screen and change your currency. Then navigate back to your profile and tap on a backed project. You should *immediately* see the project pledge details in your preferred currency, with no latency.
