### PR TITLE
Friend avatar corrected in Explorer

### DIFF
--- a/Kickstarter-iOS/Library/UIImageView+URL.swift
+++ b/Kickstarter-iOS/Library/UIImageView+URL.swift
@@ -17,6 +17,17 @@ extension UIImageView {
                      runImageTransitionIfCached: false,
                      completion: nil)
   }
+
+  public func ksr_roundedImageWith(_ url: URL, rounded: Bool = false)  {
+    self.af_setImage(withURL: url,
+                     placeholderImage: nil,
+                     filter: CircleFilter(),
+                     progress: nil,
+                     progressQueue: DispatchQueue.main,
+                     imageTransition: .crossDissolve(0.3),
+                     runImageTransitionIfCached: false,
+                     completion: nil)
+  }
 }
 
 private enum Associations {

--- a/Kickstarter-iOS/Library/UIImageView+URL.swift
+++ b/Kickstarter-iOS/Library/UIImageView+URL.swift
@@ -18,7 +18,7 @@ extension UIImageView {
                      completion: nil)
   }
 
-  public func ksr_roundedImageWith(_ url: URL) {
+  public func ksr_setRoundedImageWith(_ url: URL) {
     self.af_setImage(withURL: url,
                      placeholderImage: nil,
                      filter: CircleFilter(),

--- a/Kickstarter-iOS/Library/UIImageView+URL.swift
+++ b/Kickstarter-iOS/Library/UIImageView+URL.swift
@@ -18,7 +18,7 @@ extension UIImageView {
                      completion: nil)
   }
 
-  public func ksr_roundedImageWith(_ url: URL, rounded: Bool = false)  {
+  public func ksr_roundedImageWith(_ url: URL, rounded: Bool = false) {
     self.af_setImage(withURL: url,
                      placeholderImage: nil,
                      filter: CircleFilter(),

--- a/Kickstarter-iOS/Library/UIImageView+URL.swift
+++ b/Kickstarter-iOS/Library/UIImageView+URL.swift
@@ -18,7 +18,7 @@ extension UIImageView {
                      completion: nil)
   }
 
-  public func ksr_roundedImageWith(_ url: URL, rounded: Bool = false) {
+  public func ksr_roundedImageWith(_ url: URL) {
     self.af_setImage(withURL: url,
                      placeholderImage: nil,
                      filter: CircleFilter(),

--- a/Kickstarter-iOS/Views/Cells/DiscoveryPostcardCell.swift
+++ b/Kickstarter-iOS/Views/Cells/DiscoveryPostcardCell.swift
@@ -307,7 +307,7 @@ internal final class DiscoveryPostcardCell: UITableViewCell, ValueCell {
         })
       .skipNil()
       .observeValues { [weak self] url in
-        self?.socialAvatarImageView.image = self?.roundedImage(for: url)
+        self?.socialAvatarImageView.ksr_roundedImageWith(url, rounded: true)
     }
 
     self.watchProjectViewModel.outputs.showProjectSavedAlert
@@ -348,13 +348,5 @@ internal final class DiscoveryPostcardCell: UITableViewCell, ValueCell {
 
   @objc fileprivate func saveButtonTapped(_ button: UIButton) {
     self.watchProjectViewModel.inputs.saveButtonTapped(selected: button.isSelected)
-  }
-
-  private func roundedImage(for url: URL) -> UIImage? {
-    guard let imageData = try? Data(contentsOf: url) else { return nil }
-
-    let avatar = UIImage(data: imageData, scale: UIScreen.main.scale)?
-      .af_imageRoundedIntoCircle()
-    return avatar
   }
 }

--- a/Kickstarter-iOS/Views/Cells/DiscoveryPostcardCell.swift
+++ b/Kickstarter-iOS/Views/Cells/DiscoveryPostcardCell.swift
@@ -202,7 +202,7 @@ internal final class DiscoveryPostcardCell: UITableViewCell, ValueCell {
       |> UIStackView.lens.alignment .~ .center
       |> UIStackView.lens.spacing .~ Styles.grid(1)
       |> UIStackView.lens.layoutMargins
-        .~ .init(top: Styles.gridHalf(2), left: Styles.grid(2),
+         .~ .init(top: 0.0, left: Styles.grid(4),
                  bottom:  Styles.grid(2), right: Styles.grid(2))
       |> UIStackView.lens.isLayoutMarginsRelativeArrangement .~ true
   }

--- a/Kickstarter-iOS/Views/Cells/DiscoveryPostcardCell.swift
+++ b/Kickstarter-iOS/Views/Cells/DiscoveryPostcardCell.swift
@@ -307,7 +307,7 @@ internal final class DiscoveryPostcardCell: UITableViewCell, ValueCell {
         })
       .skipNil()
       .observeValues { [weak self] url in
-        self?.socialAvatarImageView.image = self?.roundImage(url)
+        self?.socialAvatarImageView.image = self?.roundedImage(for: url)
     }
 
     self.watchProjectViewModel.outputs.showProjectSavedAlert

--- a/Kickstarter-iOS/Views/Cells/DiscoveryPostcardCell.swift
+++ b/Kickstarter-iOS/Views/Cells/DiscoveryPostcardCell.swift
@@ -307,7 +307,7 @@ internal final class DiscoveryPostcardCell: UITableViewCell, ValueCell {
         })
       .skipNil()
       .observeValues { [weak self] url in
-        self?.socialAvatarImageView.ksr_roundedImageWith(url)
+        self?.socialAvatarImageView.ksr_setRoundedImageWith(url)
     }
 
     self.watchProjectViewModel.outputs.showProjectSavedAlert

--- a/Kickstarter-iOS/Views/Cells/DiscoveryPostcardCell.swift
+++ b/Kickstarter-iOS/Views/Cells/DiscoveryPostcardCell.swift
@@ -42,7 +42,7 @@ internal final class DiscoveryPostcardCell: UITableViewCell, ValueCell {
   @IBOutlet fileprivate weak var projectStateStackView: UIStackView!
   @IBOutlet fileprivate weak var projectStatsStackView: UIStackView!
   @IBOutlet fileprivate weak var saveButton: UIButton!
-  @IBOutlet fileprivate weak var socialAvatarImageView: UIImageView!
+  @IBOutlet fileprivate weak var socialAvatarImageView: CircleAvatarImageView!
   @IBOutlet fileprivate weak var socialLabel: UILabel!
   @IBOutlet fileprivate weak var socialStackView: UIStackView!
 
@@ -193,9 +193,6 @@ internal final class DiscoveryPostcardCell: UITableViewCell, ValueCell {
     _ = self.saveButton
       |> discoverySaveButtonStyle
 
-    _ = self.socialAvatarImageView
-      |> UIImageView.lens.layer.shouldRasterize .~ true
-
     _ = self.socialLabel
       |> UILabel.lens.numberOfLines .~ 2
       |> UILabel.lens.textColor .~ .ksr_text_navy_600
@@ -205,7 +202,8 @@ internal final class DiscoveryPostcardCell: UITableViewCell, ValueCell {
       |> UIStackView.lens.alignment .~ .center
       |> UIStackView.lens.spacing .~ Styles.grid(1)
       |> UIStackView.lens.layoutMargins
-        .~ .init(top: Styles.grid(2), left: Styles.grid(2), bottom: 0.0, right: Styles.grid(2))
+        .~ .init(top: Styles.gridHalf(2), left: Styles.grid(2),
+                 bottom:  Styles.grid(2), right: Styles.grid(2))
       |> UIStackView.lens.isLayoutMarginsRelativeArrangement .~ true
   }
 

--- a/Kickstarter-iOS/Views/Cells/DiscoveryPostcardCell.swift
+++ b/Kickstarter-iOS/Views/Cells/DiscoveryPostcardCell.swift
@@ -350,7 +350,7 @@ internal final class DiscoveryPostcardCell: UITableViewCell, ValueCell {
     self.watchProjectViewModel.inputs.saveButtonTapped(selected: button.isSelected)
   }
 
-  func roundImage(_ url: URL) -> UIImage? {
+  private func roundedImage(_ url: URL) -> UIImage? {
     guard let imageData = try? Data(contentsOf: url) else { return nil }
 
     let avatar = UIImage(data: imageData, scale: UIScreen.main.scale)?

--- a/Kickstarter-iOS/Views/Cells/DiscoveryPostcardCell.swift
+++ b/Kickstarter-iOS/Views/Cells/DiscoveryPostcardCell.swift
@@ -307,7 +307,7 @@ internal final class DiscoveryPostcardCell: UITableViewCell, ValueCell {
         })
       .skipNil()
       .observeValues { [weak self] url in
-        self?.socialAvatarImageView.ksr_roundedImageWith(url, rounded: true)
+        self?.socialAvatarImageView.ksr_roundedImageWith(url)
     }
 
     self.watchProjectViewModel.outputs.showProjectSavedAlert

--- a/Kickstarter-iOS/Views/Cells/DiscoveryPostcardCell.swift
+++ b/Kickstarter-iOS/Views/Cells/DiscoveryPostcardCell.swift
@@ -42,7 +42,7 @@ internal final class DiscoveryPostcardCell: UITableViewCell, ValueCell {
   @IBOutlet fileprivate weak var projectStateStackView: UIStackView!
   @IBOutlet fileprivate weak var projectStatsStackView: UIStackView!
   @IBOutlet fileprivate weak var saveButton: UIButton!
-  @IBOutlet fileprivate weak var socialAvatarImageView: CircleAvatarImageView!
+  @IBOutlet fileprivate weak var socialAvatarImageView: UIImageView!
   @IBOutlet fileprivate weak var socialLabel: UILabel!
   @IBOutlet fileprivate weak var socialStackView: UIStackView!
 

--- a/Kickstarter-iOS/Views/Cells/DiscoveryPostcardCell.swift
+++ b/Kickstarter-iOS/Views/Cells/DiscoveryPostcardCell.swift
@@ -350,7 +350,7 @@ internal final class DiscoveryPostcardCell: UITableViewCell, ValueCell {
     self.watchProjectViewModel.inputs.saveButtonTapped(selected: button.isSelected)
   }
 
-  private func roundedImage(_ url: URL) -> UIImage? {
+  private func roundedImage(for url: URL) -> UIImage? {
     guard let imageData = try? Data(contentsOf: url) else { return nil }
 
     let avatar = UIImage(data: imageData, scale: UIScreen.main.scale)?

--- a/Kickstarter-iOS/Views/Cells/DiscoveryPostcardCell.swift
+++ b/Kickstarter-iOS/Views/Cells/DiscoveryPostcardCell.swift
@@ -193,6 +193,9 @@ internal final class DiscoveryPostcardCell: UITableViewCell, ValueCell {
     _ = self.saveButton
       |> discoverySaveButtonStyle
 
+    _ = self.socialAvatarImageView
+      |> UIImageView.lens.layer.shouldRasterize .~ true
+
     _ = self.socialLabel
       |> UILabel.lens.numberOfLines .~ 2
       |> UILabel.lens.textColor .~ .ksr_text_navy_600
@@ -304,7 +307,7 @@ internal final class DiscoveryPostcardCell: UITableViewCell, ValueCell {
         })
       .skipNil()
       .observeValues { [weak self] url in
-        self?.socialAvatarImageView.ksr_setImageWithURL(url)
+        self?.socialAvatarImageView.image = self?.roundImage(url)
     }
 
     self.watchProjectViewModel.outputs.showProjectSavedAlert
@@ -345,5 +348,13 @@ internal final class DiscoveryPostcardCell: UITableViewCell, ValueCell {
 
   @objc fileprivate func saveButtonTapped(_ button: UIButton) {
     self.watchProjectViewModel.inputs.saveButtonTapped(selected: button.isSelected)
+  }
+
+  func roundImage(_ url: URL) -> UIImage? {
+    guard let imageData = try? Data(contentsOf: url) else { return nil }
+
+    let avatar = UIImage(data: imageData, scale: UIScreen.main.scale)?
+      .af_imageRoundedIntoCircle()
+    return avatar
   }
 }

--- a/Kickstarter-iOS/Views/Storyboards/DiscoveryPostcardCell.xib
+++ b/Kickstarter-iOS/Views/Storyboards/DiscoveryPostcardCell.xib
@@ -144,7 +144,7 @@
                             <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="1" translatesAutoresizingMaskIntoConstraints="NO" id="PUL-Kg-8AR" userLabel="Social Stack View">
                                 <rect key="frame" x="0.0" y="523" width="352" height="30"/>
                                 <subviews>
-                                    <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="3kE-Jg-fp9" userLabel="Social Avatar Image View" customClass="CircleAvatarImageView" customModule="Library">
+                                    <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="3kE-Jg-fp9" userLabel="Social Avatar Image View">
                                         <rect key="frame" x="0.0" y="0.0" width="30" height="30"/>
                                         <constraints>
                                             <constraint firstAttribute="width" secondItem="3kE-Jg-fp9" secondAttribute="height" multiplier="1:1" id="02a-Uq-adj"/>

--- a/Kickstarter-iOS/Views/Storyboards/DiscoveryPostcardCell.xib
+++ b/Kickstarter-iOS/Views/Storyboards/DiscoveryPostcardCell.xib
@@ -144,7 +144,7 @@
                             <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="1" translatesAutoresizingMaskIntoConstraints="NO" id="PUL-Kg-8AR" userLabel="Social Stack View">
                                 <rect key="frame" x="0.0" y="523" width="352" height="30"/>
                                 <subviews>
-                                    <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="3kE-Jg-fp9" userLabel="Social Avatar Image View">
+                                    <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="3kE-Jg-fp9" userLabel="Social Avatar Image View" customClass="CircleAvatarImageView" customModule="Library">
                                         <rect key="frame" x="0.0" y="0.0" width="30" height="30"/>
                                         <constraints>
                                             <constraint firstAttribute="width" secondItem="3kE-Jg-fp9" secondAttribute="height" multiplier="1:1" id="02a-Uq-adj"/>
@@ -273,7 +273,7 @@
                 <outlet property="projectStateTitleLabel" destination="p3B-Nb-GBg" id="Hmn-Pf-dgZ"/>
                 <outlet property="projectStatsStackView" destination="qYw-F3-aZl" id="fjZ-Du-FyC"/>
                 <outlet property="saveButton" destination="eIL-Rt-9Tk" id="VuL-1D-4h5"/>
-                <outlet property="socialAvatarImageView" destination="3kE-Jg-fp9" id="hEo-df-C32"/>
+                <outlet property="socialAvatarImageView" destination="3kE-Jg-fp9" id="xB3-xW-gQK"/>
                 <outlet property="socialLabel" destination="1Pi-Hj-7EO" id="908-7l-lXO"/>
                 <outlet property="socialStackView" destination="PUL-Kg-8AR" id="npn-Vt-G4G"/>
             </connections>

--- a/Kickstarter-iOS/Views/Storyboards/DiscoveryPostcardCell.xib
+++ b/Kickstarter-iOS/Views/Storyboards/DiscoveryPostcardCell.xib
@@ -273,7 +273,7 @@
                 <outlet property="projectStateTitleLabel" destination="p3B-Nb-GBg" id="Hmn-Pf-dgZ"/>
                 <outlet property="projectStatsStackView" destination="qYw-F3-aZl" id="fjZ-Du-FyC"/>
                 <outlet property="saveButton" destination="eIL-Rt-9Tk" id="VuL-1D-4h5"/>
-                <outlet property="socialAvatarImageView" destination="3kE-Jg-fp9" id="xB3-xW-gQK"/>
+                <outlet property="socialAvatarImageView" destination="3kE-Jg-fp9" id="vXc-ng-fLi"/>
                 <outlet property="socialLabel" destination="1Pi-Hj-7EO" id="908-7l-lXO"/>
                 <outlet property="socialStackView" destination="PUL-Kg-8AR" id="npn-Vt-G4G"/>
             </connections>


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Friend avatar was showing up as a rectangle. This PR corrects that and shows it as a circle.

# 🛠 How

Changed class to `CircleAvatarImageView` which makes the image circular.

# 👀 See


| Before 🐛 | After 🦋 |
| --- | --- |
|![img_ffb507d530d2-1 jpeg](https://user-images.githubusercontent.com/11362005/53820430-c6a68b80-3f39-11e9-9523-0f169ff6baa8.jpg)|![simulator screen shot - iphone 8 - 2019-03-05 at 19 30 38](https://user-images.githubusercontent.com/11362005/53847102-79e4a400-3f7d-11e9-8553-08d725c2ba94.png)|

# ✅ Acceptance criteria

- [ ] Scroll through `Explorer` screen and check if friend avatar image appears as a circle and not a rectangle

# ⏰ TODO

- [x] Design feedback

