### PR TITLE
👩‍🔬 [Investment Day] Swiftlint Cleanup

### DIFF
--- a/Kickstarter-iOS/AppDelegate.swift
+++ b/Kickstarter-iOS/AppDelegate.swift
@@ -191,7 +191,7 @@ internal final class AppDelegate: UIResponder, UIApplicationDelegate {
       .observeForUI()
       .observeValues { [weak self] in self?.findRedirectUrl($0) }
 
-    //swiftlint:disable discarded_notification_center_observer
+    // swiftlint:disable discarded_notification_center_observer
     NotificationCenter.default
       .addObserver(forName: Notification.Name.ksr_sessionStarted, object: nil, queue: nil) { [weak self] _ in
         self?.viewModel.inputs.userSessionStarted()
@@ -207,7 +207,7 @@ internal final class AppDelegate: UIResponder, UIApplicationDelegate {
       .addObserver(forName: Notification.Name.ksr_sessionEnded, object: nil, queue: nil) { [weak self] _ in
         self?.viewModel.inputs.userSessionEnded()
     }
-    //swiftlint:enable discarded_notification_center_observer
+    // swiftlint:enable discarded_notification_center_observer
 
     self.window?.tintColor = .ksr_green_700
 

--- a/Kickstarter-iOS/DataSources/ProjectActivitiesDataSourceTests.swift
+++ b/Kickstarter-iOS/DataSources/ProjectActivitiesDataSourceTests.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable force_unwrapping
 import XCTest
 @testable import Library
 @testable import Kickstarter_Framework
@@ -11,6 +10,7 @@ internal final class ProjectActivitiesDataSourceTests: XCTestCase {
   let tableView = UITableView()
 
   func testDataSource() {
+    // swiftlint:disable:next force_unwrapping
     let timeZone = TimeZone(abbreviation: "UTC")!
     var calendar = Calendar(identifier: .gregorian)
     calendar.timeZone = timeZone
@@ -53,6 +53,7 @@ internal final class ProjectActivitiesDataSourceTests: XCTestCase {
   }
 
   func testGroupedDatesIsFalse() {
+    // swiftlint:disable:next force_unwrapping
     let timeZone = TimeZone(abbreviation: "UTC")!
     var calendar = Calendar(identifier: .gregorian)
     calendar.timeZone = timeZone

--- a/Kickstarter-iOS/DataSources/SettingsAccountDataSource.swift
+++ b/Kickstarter-iOS/DataSources/SettingsAccountDataSource.swift
@@ -60,7 +60,7 @@ final class SettingsAccountDataSource: ValueCellDataSource {
       return value.cellType as? SettingsAccountCellType
     } else if let currencyValue = self[indexPath] as? SettingsCellValue {
       return currencyValue.cellType as? SettingsAccountCellType
-      //swiftlint:disable unused_optional_binding
+      // swiftlint:disable:next unused_optional_binding
     } else if let _ = self[indexPath] as? Bool {
       return SettingsAccountCellType.changeEmail
     } else {

--- a/Kickstarter-iOS/DataSources/SettingsAccountDataSourceTests.swift
+++ b/Kickstarter-iOS/DataSources/SettingsAccountDataSourceTests.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable line_length
 import Prelude
 import XCTest
 import Library
@@ -41,10 +40,18 @@ final class SettingsAccountDataSourceTests: XCTestCase {
                                   shouldHideEmailWarning: true,
                                   shouldHideEmailPasswordSection: false)
 
-    XCTAssertEqual(SettingsAccountCellType.changeEmail, self.dataSource.cellTypeForIndexPath(indexPath: indexPath1))
-    XCTAssertEqual(SettingsAccountCellType.changePassword, self.dataSource.cellTypeForIndexPath(indexPath: indexPath2))
-    XCTAssertEqual(SettingsAccountCellType.privacy, self.dataSource.cellTypeForIndexPath(indexPath: indexPath3))
-    XCTAssertEqual(SettingsAccountCellType.paymentMethods, self.dataSource.cellTypeForIndexPath(indexPath: indexPath4))
+    XCTAssertEqual(
+      SettingsAccountCellType.changeEmail, self.dataSource.cellTypeForIndexPath(indexPath: indexPath1)
+    )
+    XCTAssertEqual(
+      SettingsAccountCellType.changePassword, self.dataSource.cellTypeForIndexPath(indexPath: indexPath2)
+    )
+    XCTAssertEqual(
+      SettingsAccountCellType.privacy, self.dataSource.cellTypeForIndexPath(indexPath: indexPath3)
+    )
+    XCTAssertEqual(
+      SettingsAccountCellType.paymentMethods, self.dataSource.cellTypeForIndexPath(indexPath: indexPath4)
+    )
 
     let currencyCellType = SettingsAccountCellType.currency(.USD)
     XCTAssertEqual(currencyCellType, self.dataSource.cellTypeForIndexPath(indexPath: indexPath5))
@@ -59,8 +66,12 @@ final class SettingsAccountDataSourceTests: XCTestCase {
                                   shouldHideEmailWarning: true,
                                   shouldHideEmailPasswordSection: true)
 
-    XCTAssertEqual(SettingsAccountCellType.privacy, self.dataSource.cellTypeForIndexPath(indexPath: indexPath1))
-    XCTAssertEqual(SettingsAccountCellType.paymentMethods, self.dataSource.cellTypeForIndexPath(indexPath: indexPath2))
+    XCTAssertEqual(
+      SettingsAccountCellType.privacy, self.dataSource.cellTypeForIndexPath(indexPath: indexPath1)
+    )
+    XCTAssertEqual(
+      SettingsAccountCellType.paymentMethods, self.dataSource.cellTypeForIndexPath(indexPath: indexPath2)
+    )
 
     let currencyCellType = SettingsAccountCellType.currency(.USD)
     XCTAssertEqual(currencyCellType, self.dataSource.cellTypeForIndexPath(indexPath: indexPath3))

--- a/Kickstarter-iOS/TestHelpers/TraitController.swift
+++ b/Kickstarter-iOS/TestHelpers/TraitController.swift
@@ -13,7 +13,7 @@ internal enum Orientation {
   case landscape
 }
 
-//swiftlint:disable:next cyclomatic_complexity
+// swiftlint:disable:next cyclomatic_complexity
 internal func traitControllers(device: Device = .phone4_7inch,
                                orientation: Orientation = .portrait,
                                child: UIViewController = UIViewController(),

--- a/Kickstarter-iOS/ViewModels/UpdatePreviewViewModel.swift
+++ b/Kickstarter-iOS/ViewModels/UpdatePreviewViewModel.swift
@@ -82,10 +82,8 @@ internal final class UpdatePreviewViewModel: UpdatePreviewViewModelInputs,
 
     self.showPublishConfirmation = project
       .map {
-        // swiftlint:disable line_length
-        Strings
-          .dashboard_post_update_preview_confirmation_alert_this_will_notify_backers_that_a_new_update_is_available(backer_count: $0.stats.backersCount)
-        // swiftlint:enable line_length
+        // swiftlint:disable:next line_length
+        Strings.dashboard_post_update_preview_confirmation_alert_this_will_notify_backers_that_a_new_update_is_available(backer_count: $0.stats.backersCount)
       }
       .takeWhen(self.publishButtonTappedProperty.signal)
 

--- a/Kickstarter-iOS/ViewModels/UpdatePreviewViewModelTests.swift
+++ b/Kickstarter-iOS/ViewModels/UpdatePreviewViewModelTests.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable force_unwrapping
 @testable import Library
 @testable import Kickstarter_Framework
 @testable import KsApi
@@ -43,6 +42,7 @@ final class UpdatePreviewViewModelTests: TestCase {
     )
 
     let redirectUrl = "https://www.kickstarter.com/projects/smashmouth/somebody-once-told-me/posts/1"
+    // swiftlint:disable:next force_unwrapping
     let request = URLRequest(url: URL(string: redirectUrl)!)
     let navigationAction = WKNavigationActionData(
       navigationType: .other,

--- a/Kickstarter-iOS/Views/Controllers/DebugPushNotificationsViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/DebugPushNotificationsViewController.swift
@@ -3,7 +3,6 @@ import Prelude
 import UIKit
 import UserNotifications
 
-// swiftlint:disable line_length
 internal final class DebugPushNotificationsViewController: UIViewController {
 
   @IBOutlet fileprivate weak var rootStackView: UIStackView!
@@ -201,6 +200,7 @@ private let surveyPushData: [String: Any] = [
   ]
 ]
 
+// swiftlint:disable line_length
 private let reminderPushData: [String: Any] = [
   "aps": [
     "alert": "Reminder! This Pile of Wood is ending soon.",
@@ -210,6 +210,7 @@ private let reminderPushData: [String: Any] = [
     "id": 820501933,
   ]
 ]
+// swiftlint:enable line_length
 
 private let backingForCreatorPushData: [String: Any] = [
   "aps": [

--- a/Kickstarter-iOS/Views/Controllers/ProjectPamphletContentViewControllerConversionTests.swift
+++ b/Kickstarter-iOS/Views/Controllers/ProjectPamphletContentViewControllerConversionTests.swift
@@ -86,7 +86,7 @@ internal final class ProjectPamphletContentViewControllerConversionTests: TestCa
   func test_USProject_USUser_NonUSLocation_Backer() {
     let deadline = self.dateType.init().addingTimeInterval(-100).timeIntervalSince1970
     let backing = .template
-      // swiftlint:disable force_unwrapping
+      // swiftlint:disable:next force_unwrapping
       |> Backing.lens.amount .~ (self.cosmicSurgery.rewards.first!.minimum + 5.00)
       |> Backing.lens.rewardId .~ self.cosmicSurgery.rewards.first?.id
       |> Backing.lens.reward .~ self.cosmicSurgery.rewards.first

--- a/Kickstarter-iOS/Views/Controllers/RewardPledgeViewControllerTests.swift
+++ b/Kickstarter-iOS/Views/Controllers/RewardPledgeViewControllerTests.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable force_unwrapping
 import Library
 import Prelude
 import Result
@@ -11,6 +10,7 @@ private let tolerance: CGFloat = 0.0001
 internal final class RewardPledgeViewControllerTests: TestCase {
   fileprivate let cosmicSurgery = Project.cosmicSurgery
     |> Project.lens.state .~ .live
+  // swiftlint:disable:next force_unwrapping
   fileprivate let cosmicReward = Project.cosmicSurgery.rewards.last!
     |> Reward.lens.shipping.enabled .~ true
     |> Reward.lens.shipping.summary .~ "Wherever"

--- a/Kickstarter-iOS/Views/SettingsFormFieldView.swift
+++ b/Kickstarter-iOS/Views/SettingsFormFieldView.swift
@@ -3,9 +3,10 @@ import Library
 import Prelude
 
 final class SettingsFormFieldView: UIView, NibLoading {
-  //swiftlint:disable private_outlet
+  // swiftlint:disable private_outlet
   @IBOutlet weak var textField: UITextField!
   @IBOutlet weak var titleLabel: UILabel!
+  // swiftlint:enable private_outlets
   @IBOutlet fileprivate weak var separatorView: UIView!
   @IBOutlet fileprivate weak var stackView: UIStackView!
 

--- a/KsApi/MockService.swift
+++ b/KsApi/MockService.swift
@@ -1455,7 +1455,6 @@ private extension MockService {
       }
     )
   }
-  // swiftlint:enable type_name
 }
 
 private func producer<T, E>(for property: Result<T, E>?) -> SignalProducer<T, E> {

--- a/KsApi/models/AuthorTests.swift
+++ b/KsApi/models/AuthorTests.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable force_unwrapping
 import XCTest
 @testable import KsApi
 
@@ -64,6 +63,7 @@ final class CommentTests: XCTestCase {
     }
     """
 
+    // swiftlint:disable:next force_unwrapping
     let data = jsonString.data(using: .utf8)!
     let  author = try? JSONDecoder().decode(Author.self, from: data)
 

--- a/KsApi/models/DeletePaymentMethodEnvelopeTests.swift
+++ b/KsApi/models/DeletePaymentMethodEnvelopeTests.swift
@@ -32,7 +32,7 @@ class DeletePaymentMethodEnvelopeTests: XCTestCase {
     let data = jsonString.data(using: .utf8)
 
     do {
-      //swiftlint:disable force_unwrapping
+      // swiftlint:disable:next force_unwrapping
       let envelope = try JSONDecoder().decode(DeletePaymentMethodEnvelope.self, from: data!)
         XCTAssertEqual(envelope.storedCards.first?.expirationDate, "2055-11-01")
         XCTAssertEqual(envelope.storedCards.first?.id, "1057")

--- a/KsApi/models/GraphUserCreditCardTests.swift
+++ b/KsApi/models/GraphUserCreditCardTests.swift
@@ -15,7 +15,7 @@ final class GraphUserCreditCardTests: XCTestCase {
     let data = jsonString.data(using: .utf8)
 
     do {
-      //swiftlint:disable:next force_unwrapping
+      // swiftlint:disable:next force_unwrapping
       let cards = try JSONDecoder().decode(GraphUserCreditCard.self, from: data!)
 
       XCTAssertEqual(cards.storedCards.nodes.count, 0)
@@ -50,7 +50,7 @@ final class GraphUserCreditCardTests: XCTestCase {
     let data = jsonString.data(using: .utf8)
 
     do {
-      //swiftlint:disable:next force_unwrapping
+      // swiftlint:disable:next force_unwrapping
       let cards = try JSONDecoder().decode(GraphUserCreditCard.self, from: data!)
 
       XCTAssertEqual(cards.storedCards.nodes.count, 2)
@@ -88,7 +88,7 @@ final class GraphUserCreditCardTests: XCTestCase {
     let data = jsonString.data(using: .utf8)
 
     do {
-      //swiftlint:disable:next force_unwrapping
+      // swiftlint:disable:next force_unwrapping
       let cards = try JSONDecoder().decode(GraphUserCreditCard.self, from: data!)
 
       guard let card = cards.storedCards.nodes.first else {
@@ -125,7 +125,7 @@ final class GraphUserCreditCardTests: XCTestCase {
     let data = jsonString.data(using: .utf8)
 
     do {
-      //swiftlint:disable:next force_unwrapping
+      // swiftlint:disable:next force_unwrapping
       let cards = try JSONDecoder().decode(GraphUserCreditCard.self, from: data!)
 
       guard let card = cards.storedCards.nodes.first else {

--- a/KsApi/models/User.NewsletterSubscriptionsTests.swift
+++ b/KsApi/models/User.NewsletterSubscriptionsTests.swift
@@ -1,5 +1,3 @@
-// swiftlint:disable force_unwrapping
-
 import XCTest
 @testable import KsApi
 
@@ -15,6 +13,7 @@ final class NewsletterSubscriptionsTests: XCTestCase {
 
     let newsletter = User.NewsletterSubscriptions.decodeJSONDictionary(json)
 
+    // swiftlint:disable:next force_unwrapping
     let newsletterDescription = newsletter.value!.encode().description
 
     XCTAssertTrue(newsletterDescription.contains("games_newsletter\": false"))
@@ -38,6 +37,7 @@ final class NewsletterSubscriptionsTests: XCTestCase {
 
     let newsletter = User.NewsletterSubscriptions.decodeJSONDictionary(json)
 
+    // swiftlint:disable:next force_unwrapping
     let newsletterDescription = newsletter.value!.encode().description
 
     XCTAssertTrue(newsletterDescription.contains("games_newsletter\": true"))

--- a/KsApi/models/templates/UpdateTemplates.swift
+++ b/KsApi/models/templates/UpdateTemplates.swift
@@ -1,8 +1,8 @@
 import Foundation
 
-// swiftlint:disable line_length
 extension Update {
   internal static let template = Update(
+    // swiftlint:disable:next line_length
     body: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam id vulputate augue. Donec elementum est facilisis dolor accumsan feugiat. Nam et pellentesque massa. Sed sit amet commodo ligula. Sed viverra, est viverra pretium luctus, arcu ligula congue neque, sed bibendum neque quam vel elit. Nunc varius orci et tempus consequat. Nullam tempor velit vitae consectetur mattis. Proin dignissim id turpis ac fermentum.",
     commentsCount: 2,
     hasLiked: false,

--- a/KsApi/models/templates/UserTemplates.swift
+++ b/KsApi/models/templates/UserTemplates.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable line_length
 import Prelude
 
 extension User {
@@ -19,10 +18,12 @@ extension User {
     stats: .template
   )
 
+  // swiftlint:disable line_length
   internal static let brando = User.template
     |> \.avatar.large .~ "https://ksr-ugc.imgix.net/assets/006/258/518/b9033f46095b83119188cf9a66d19356_original.jpg?w=160&h=160&fit=crop&v=1461376829&auto=format&q=92&s=8d7666f01ab6765c3cf09149751ff077"
     |> \.avatar.medium .~ "https://ksr-ugc.imgix.net/assets/006/258/518/b9033f46095b83119188cf9a66d19356_original.jpg?w=40&h=40&fit=crop&v=1461376829&auto=format&q=92&s=0fcedf8888ca6990408ccde81888899b"
     |> \.avatar.small .~ "https://ksr-ugc.imgix.net/assets/006/258/518/b9033f46095b83119188cf9a66d19356_original.jpg?w=40&h=40&fit=crop&v=1461376829&auto=format&q=92&s=0fcedf8888ca6990408ccde81888899b"
     |> \.id .~ "brando".hash
     |> \.name .~ "Brandon Williams"
+  // swiftlint:enable line_length
 }

--- a/Library/AppEnvironmentTests.swift
+++ b/Library/AppEnvironmentTests.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable force_unwrapping 
 import XCTest
 import Foundation
 @testable import Library
@@ -131,6 +130,7 @@ final class AppEnvironmentTests: XCTestCase {
   }
 
   func testSaveEnvironment() {
+    // swiftlint:disable force_unwrapping
     let apiService = MockService(
       serverConfig: ServerConfig(
         apiBaseUrl: URL(string: "http://api.ksr.com")!,
@@ -141,6 +141,7 @@ final class AppEnvironmentTests: XCTestCase {
       ),
       oauthToken: OauthToken(token: "deadbeef")
     )
+    // swiftlint:enable force_unwrapping
     let currentUser = User.template
     let userDefaults = MockKeyValueStore()
     let ubiquitousStore = MockKeyValueStore()
@@ -149,6 +150,7 @@ final class AppEnvironmentTests: XCTestCase {
                                    ubiquitousStore: ubiquitousStore,
                                    userDefaults: userDefaults)
 
+    // swiftlint:disable:next force_unwrapping
     let result = userDefaults.dictionary(forKey: AppEnvironment.environmentStorageKey)!
 
     XCTAssertEqual("deadbeef", result["apiService.oauthToken.token"] as? String)

--- a/Library/Format.swift
+++ b/Library/Format.swift
@@ -490,4 +490,3 @@ extension NumberFormatterConfig {
     )
   }
 }
-// swiftlint:enable type_name

--- a/Library/FormatTests.swift
+++ b/Library/FormatTests.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable force_unwrapping
 import XCTest
 import KsApi
 @testable import Library
@@ -265,8 +264,10 @@ final class FormatTests: TestCase {
 
   func testDate() {
     let date = 434592000.0 // Oct 10 1983 in UTC
+    // swiftlint:disable force_unwrapping
     let UTC = TimeZone(abbreviation: "UTC")!
     let EST = TimeZone(abbreviation: "EST")!
+    // swiftlint:enable force_unwrapping
     var calUTC = Calendar.current
     calUTC.timeZone = UTC
     var calEST = Calendar.current
@@ -333,8 +334,10 @@ final class FormatTests: TestCase {
 
   func testDateWithDateFormat() {
     let date = 434592000.0 // Oct 10 1983 in UTC
+    // swiftlint:disable force_unwrapping
     let UTC = TimeZone(abbreviation: "UTC")!
     let EST = TimeZone(abbreviation: "EST")!
+    // swiftlint:enable force_unwrapping
     let format = "MMMyyyy"
     var calUTC = Calendar.current
     calUTC.timeZone = UTC
@@ -393,6 +396,7 @@ final class FormatTests: TestCase {
     let dateString = "2018-01"
     let timeZone = UTCTimeZone
     let PST = TimeZone(abbreviation: "PST")
+    // swiftlint:disable:next force_unwrapping
     let EST = TimeZone(abbreviation: "EST")!
     var calEST = Calendar.current
     calEST.timeZone = EST

--- a/Library/Navigation.swift
+++ b/Library/Navigation.swift
@@ -119,8 +119,8 @@ public func == (lhs: Navigation.Checkout.Payment, rhs: Navigation.Checkout.Payme
   }
 }
 
-// swiftlint:disable cyclomatic_complexity
 extension Navigation.Project: Equatable {}
+// swiftlint:disable:next cyclomatic_complexity
 public func == (lhs: Navigation.Project, rhs: Navigation.Project) -> Bool {
   switch (lhs, rhs) {
   case let (.checkout(lhsId, lhsCheckout), .checkout(rhsId, rhsCheckout)):
@@ -151,7 +151,6 @@ public func == (lhs: Navigation.Project, rhs: Navigation.Project) -> Bool {
     return false
   }
 }
-// swiftlint:enable cyclomatic_complexity
 
 extension Navigation.Project.Checkout: Equatable {}
 public func == (lhs: Navigation.Project.Checkout, rhs: Navigation.Project.Checkout) -> Bool {

--- a/Library/PKPaymentRequestTests.swift
+++ b/Library/PKPaymentRequestTests.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable force_unwrapping
 import Argo
 import Runes
 import PassKit
@@ -148,6 +147,7 @@ public final class PKPaymentRequestTests: XCTestCase {
     ]
     let decoded = PKPaymentRequest.decodeJSONDictionary(json)
 
+    // swiftlint:disable:next force_unwrapping
     XCTAssertEqual(json as NSDictionary, (decoded.value?.encode())! as NSDictionary)
   }
 }

--- a/Library/RefTag.swift
+++ b/Library/RefTag.swift
@@ -45,7 +45,7 @@ public enum RefTag {
 
    - returns: A ref tag.
    */
-    // swiftlint:disable cyclomatic_complexity
+  // swiftlint:disable:next cyclomatic_complexity
   public init(code: String) {
     switch code {
     case "activity":                  self = .activity
@@ -101,7 +101,6 @@ public enum RefTag {
     default:                          self = .unrecognized(code)
     }
   }
-  // swiftlint:enable cyclomatic_complexity
 
   /// A string representation of the ref tag that can be used in analytics tracking, cookies, etc...
   public var stringTag: String {

--- a/Library/RootCategory.swift
+++ b/Library/RootCategory.swift
@@ -27,8 +27,8 @@ public enum RootCategory: Int {
   }
 }
 
-// swiftlint:disable cyclomatic_complexity
 public extension RootCategory {
+  // swiftlint:disable:next cyclomatic_complexity
   public func allProjectsString() -> String {
     switch self {
     case .art:          return Strings.All_Art_Projects()
@@ -50,4 +50,3 @@ public extension RootCategory {
     }
   }
 }
-// swiftlint:enable cyclomatic_complexity

--- a/Library/Styles/Fonts.swift
+++ b/Library/Styles/Fonts.swift
@@ -106,9 +106,8 @@ extension UIFont {
     return UIFont(descriptor: monospacedDescriptor, size: 0.0)
   }
 
-  // swiftlint:disable cyclomatic_complexity
+  // swiftlint:disable:next cyclomatic_complexity
   fileprivate static func preferredFont(style: UIFont.TextStyle, size: CGFloat? = nil) -> UIFont {
-
     let defaultSize: CGFloat
     switch style {
     case UIFont.TextStyle.body:         defaultSize = 17
@@ -129,5 +128,4 @@ extension UIFont {
     return UIFont(descriptor: descriptor,
                   size: ceil(font.pointSize / defaultSize * (size ?? defaultSize)))
   }
-  // swiftlint:enable cyclomatic_complexity
 }

--- a/Library/TestHelpers/TestCase.swift
+++ b/Library/TestHelpers/TestCase.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable force_unwrapping
 import AVFoundation
 import FBSnapshotTestCase
 import Prelude
@@ -32,6 +31,7 @@ internal class TestCase: FBSnapshotTestCase {
     UIViewController.doBadSwizzleStuff()
 
     var calendar = Calendar(identifier: .gregorian)
+    // swiftlint:disable:next force_unwrapping
     calendar.timeZone = TimeZone(identifier: "GMT")!
 
     let isVoiceOverRunning = { false }

--- a/Library/ViewModels/ActivitiesViewModelTests.swift
+++ b/Library/ViewModels/ActivitiesViewModelTests.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable force_unwrapping
 import XCTest
 @testable import Library
 @testable import KsApi
@@ -222,6 +221,7 @@ final class ActivitiesViewModelTests: TestCase {
 
   func testGoToProject() {
     let activity = .template |> Activity.lens.category .~ .backing
+    // swiftlint:disable:next force_unwrapping
     let project = activity.project!
     let refTag = RefTag.activity
 

--- a/Library/ViewModels/ActivityFriendBackingViewModel.swift
+++ b/Library/ViewModels/ActivityFriendBackingViewModel.swift
@@ -117,7 +117,7 @@ private func progressBarColor(forActivityCategory category: Activity.Category) -
   }
 }
 
-// swiftlint:disable cyclomatic_complexity
+// swiftlint:disable:next cyclomatic_complexity
 private func string(forCategoryId id: String, friendName: String) -> String {
   let root = RootCategory(categoryId: Int(id) ?? -1)
   switch root {
@@ -139,7 +139,7 @@ private func string(forCategoryId id: String, friendName: String) -> String {
   case .unrecognized: return ""
   }
 }
-// swiftlint:enable cyclomatic_complexity
+
 private func percentFundedString(forActivity activity: Activity) -> NSAttributedString {
   guard let project = activity.project else { return NSAttributedString(string: "") }
 

--- a/Library/ViewModels/BackingCellViewModelTests.swift
+++ b/Library/ViewModels/BackingCellViewModelTests.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable force_unwrapping
 import Library
 import Prelude
 @testable import ReactiveExtensions_TestHelpers
@@ -25,6 +24,7 @@ internal final class BackingCellViewModelTests: TestCase {
     self.vm.outputs.rootStackViewAlignment.observe(self.rootStackViewAlignment.observer)
   }
 
+  // swiftlint:disable force_unwrapping
   func testOutputs() {
     let reward = .template |> Reward.lens.estimatedDeliveryOn .~ Date().timeIntervalSince1970
     let backing = .template |> Backing.lens.reward .~ reward
@@ -46,6 +46,7 @@ internal final class BackingCellViewModelTests: TestCase {
 
     self.rootStackViewAlignment.assertValues([UIStackView.Alignment.leading])
   }
+  // swiftlint:enable force_unwrapping
 
   func testRootStackViewAlignment() {
     let reward = .template |> Reward.lens.estimatedDeliveryOn .~ Date().timeIntervalSince1970

--- a/Library/ViewModels/BackingViewModelTests.swift
+++ b/Library/ViewModels/BackingViewModelTests.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable force_unwrapping
 import Prelude
 import ReactiveSwift
 import Result
@@ -182,6 +181,7 @@ internal final class BackingViewModelTests: TestCase {
 
   func testRewardInfo_BackerView() {
     let date = 1485907200.0 // Feb 01 2017 in UTC
+    // swiftlint:disable:next force_unwrapping
     let EST = TimeZone(abbreviation: "EST")!
     var calEST = Calendar.current
     calEST.timeZone = EST
@@ -224,6 +224,7 @@ internal final class BackingViewModelTests: TestCase {
 
   func testRewardInfo_CreatorView() {
     let date = 1485907200.0 // Feb 01 2017 in UTC
+    // swiftlint:disable:next force_unwrapping
     let EST = TimeZone(abbreviation: "EST")!
     var calEST = Calendar.current
     calEST.timeZone = EST

--- a/Library/ViewModels/CheckoutRacingViewModelTests.swift
+++ b/Library/ViewModels/CheckoutRacingViewModelTests.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable force_unwrapping
 import XCTest
 @testable import Library
 @testable import KsApi
@@ -114,5 +113,6 @@ final class CheckoutRacingViewModelTests: TestCase {
 }
 
 private func racingURL() -> URL {
+  // swiftlint:disable:next force_unwrapping
   return URL(string: "https://www.kickstarter.com/projects/creator/project/checkouts/1")!
 }

--- a/Library/ViewModels/DashboardViewModelTests.swift
+++ b/Library/ViewModels/DashboardViewModelTests.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable force_unwrapping
 import Prelude
 import ReactiveSwift
 import Result
@@ -243,6 +242,7 @@ internal final class DashboardViewModelTests: TestCase {
         self.scheduler.advance()
 
         self.project.assertValueCount(2)
+        // swiftlint:disable:next force_unwrapping
         XCTAssertEqual("\(projects[0].name) (updated)", self.project.values.last!.name)
 
         self.fundingStats.assertValueCount(2)
@@ -332,6 +332,7 @@ internal final class DashboardViewModelTests: TestCase {
     }
   }
 
+  // swiftlint:disable force_unwrapping
   func testDeepLink() {
     let projects = (0...4).map { .template |> Project.lens.id .~ $0 }
 
@@ -343,6 +344,7 @@ internal final class DashboardViewModelTests: TestCase {
       self.project.assertValues([projects.last!])
     }
   }
+  // swiftlint:enable force_unwrapping
 
   func testGoToThread() {
     let projects = (0...4).map { .template |> Project.lens.id .~ $0 }

--- a/Library/ViewModels/FindFriendsFaceookConnectCellViewModelTests.swift
+++ b/Library/ViewModels/FindFriendsFaceookConnectCellViewModelTests.swift
@@ -12,7 +12,6 @@ import Prelude
 @testable import FBSDKLoginKit
 
   final class FindFriendsFacebookConnectCellViewModelTests: TestCase {
-  // swiftlint: enable type_name
   let vm: FindFriendsFacebookConnectCellViewModelType = FindFriendsFacebookConnectCellViewModel()
 
   let attemptFacebookLogin = TestObserver<(), NoError>()

--- a/Library/ViewModels/FindFriendsHeaderCellViewModelTests.swift
+++ b/Library/ViewModels/FindFriendsHeaderCellViewModelTests.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable force_cast
 import XCTest
 @testable import Library
 @testable import KsApi
@@ -39,6 +38,7 @@ final class FindFriendsHeaderCellViewModelTests: TestCase {
 
     notifyPresenterToDismissHeader.assertValueCount(1)
     XCTAssertEqual(["Close Find Friends"], self.trackingClient.events)
+    // swiftlint:disable:next force_cast
     XCTAssertEqual(["activity"], self.trackingClient.properties.map { $0["source"] as! String? })
   }
 }

--- a/Library/ViewModels/LiveStreamContainerViewModel.swift
+++ b/Library/ViewModels/LiveStreamContainerViewModel.swift
@@ -83,7 +83,7 @@ public protocol LiveStreamContainerViewModelOutputs {
 public final class LiveStreamContainerViewModel: LiveStreamContainerViewModelType,
 LiveStreamContainerViewModelInputs, LiveStreamContainerViewModelOutputs {
 
-  // swiftlint:disable cyclomatic_complexity
+  // swiftlint:disable:next cyclomatic_complexity
   public init() {
     let configData = Signal.combineLatest(
       self.configData.signal.skipNil(),
@@ -476,8 +476,6 @@ LiveStreamContainerViewModelInputs, LiveStreamContainerViewModelOutputs {
                                                            refTag: refTag)
     }
   }
-  // swiftlint:enable function_body_length
-  // swiftlint:enable cyclomatic_complexity
 
   private typealias ConfigData = (Project, LiveStreamEvent, RefTag, Bool)
   private let configData = MutableProperty<ConfigData?>(nil)

--- a/Library/ViewModels/LiveStreamEventDetailsViewModel.swift
+++ b/Library/ViewModels/LiveStreamEventDetailsViewModel.swift
@@ -90,7 +90,6 @@ public protocol LiveStreamEventDetailsViewModelOutputs {
 public final class LiveStreamEventDetailsViewModel: LiveStreamEventDetailsViewModelType,
   LiveStreamEventDetailsViewModelInputs, LiveStreamEventDetailsViewModelOutputs {
 
-  // swiftlint:disable:next function_body_length
   public init () {
     let configData = Signal.combineLatest(
       self.configData.signal.skipNil(),

--- a/Library/ViewModels/LoginViewModelTests.swift
+++ b/Library/ViewModels/LoginViewModelTests.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable force_unwrapping
 import Prelude
 import XCTest
 @testable import Library
@@ -86,6 +85,7 @@ final class LoginViewModelTests: TestCase {
     self.logIntoEnvironment.assertValueCount(1, "Log into environment.")
     XCTAssertEqual(["User Login", "Viewed Login", "Login", "Logged In"], trackingClient.events,
                    "Koala login is tracked")
+    // swiftlint:disable:next force_unwrapping
     XCTAssertEqual("Email", trackingClient.properties.last!["auth_type"] as? String)
 
     self.vm.inputs.environmentLoggedIn()
@@ -130,6 +130,7 @@ final class LoginViewModelTests: TestCase {
       self.logIntoEnvironment.assertValueCount(0, "Did not log into environment.")
       XCTAssertEqual(["User Login", "Viewed Login", "Errored User Login", "Errored Login"],
                      trackingClient.events)
+      // swiftlint:disable:next force_unwrapping
       XCTAssertEqual("Email", trackingClient.properties.last!["auth_type"] as? String)
       self.showError.assertValues(["Unable to log in."], "Login errored")
       self.tfaChallenge.assertValueCount(0, "TFA challenge did not happen")
@@ -154,6 +155,7 @@ final class LoginViewModelTests: TestCase {
       self.logIntoEnvironment.assertValueCount(0, "Did not log into environment.")
       XCTAssertEqual(["User Login", "Viewed Login", "Errored User Login", "Errored Login"],
                      trackingClient.events)
+      // swiftlint:disable:next force_unwrapping
       XCTAssertEqual("Email", trackingClient.properties.last!["auth_type"] as? String)
       self.showError.assertValues([Strings.login_errors_unable_to_log_in()], "Login errored")
       self.tfaChallenge.assertValueCount(0, "TFA challenge did not happen")

--- a/Library/ViewModels/MessageThreadsViewModel.swift
+++ b/Library/ViewModels/MessageThreadsViewModel.swift
@@ -135,7 +135,6 @@ MessageThreadsViewModelOutputs {
 
       }
   }
-  // swiftlint:enable function_body_length
 
   fileprivate let mailboxButtonPressedProperty = MutableProperty(())
   public func mailboxButtonPressed() {

--- a/Library/ViewModels/MessageThreadsViewModelTests.swift
+++ b/Library/ViewModels/MessageThreadsViewModelTests.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable force_cast
 import XCTest
 @testable import Library
 @testable import ReactiveExtensions_TestHelpers
@@ -39,9 +38,11 @@ internal final class MessageThreadsViewModelTests: TestCase {
     XCTAssertEqual(["Viewed Message Inbox", "Message Threads View", "Message Inbox View"],
                    self.trackingClient.events,
                    "View event and its deprecated version are tracked.")
+    // swiftlint:disable force_cast
     XCTAssertEqual([nil, true, true],
                    self.trackingClient.properties.map { $0[Koala.DeprecatedKey] as! Bool? },
                    "Deprecated property is tracked in deprecated event.")
+    // swiftlint:enable force_cast
 
     // Wait enough time to get API response
     self.scheduler.advance()
@@ -131,9 +132,11 @@ internal final class MessageThreadsViewModelTests: TestCase {
     XCTAssertEqual(["Viewed Message Inbox", "Message Threads View", "Message Inbox View"],
                    self.trackingClient.events,
                    "View event and its deprecated version are tracked.")
+    // swiftlint:disable force_cast
     XCTAssertEqual([nil, true, true],
                    self.trackingClient.properties.map { $0[Koala.DeprecatedKey] as! Bool? },
                    "Deprecated property is tracked in deprecated event.")
+    // swiftlint:enable force_cast
 
     self.loadingFooterIsHidden.assertValues([false, true],
                                             "Loading footer is shown/hidden while loading threads.")
@@ -159,9 +162,11 @@ internal final class MessageThreadsViewModelTests: TestCase {
       ],
       self.trackingClient.events,
       "View event and its deprecated version are tracked.")
+    // swiftlint:disable force_cast
     XCTAssertEqual([nil, true, true, nil, true, true],
                    self.trackingClient.properties.map { $0[Koala.DeprecatedKey] as! Bool? },
                    "Deprecated property is tracked in deprecated event.")
+    // swiftlint:enable force_cast
 
     self.scheduler.advance()
 

--- a/Library/ViewModels/MessagesViewModel.swift
+++ b/Library/ViewModels/MessagesViewModel.swift
@@ -187,7 +187,6 @@ MessagesViewModelOutputs {
         AppEnvironment.current.koala.trackMessageThreadView(project: project)
     }
   }
-  // swiftlint:enable function_body_length
 
   private let backingInfoPressedProperty = MutableProperty(())
   public func backingInfoPressed() {

--- a/Library/ViewModels/PaymentMethodsViewModel.swift
+++ b/Library/ViewModels/PaymentMethodsViewModel.swift
@@ -62,11 +62,7 @@ PaymentMethodsViewModelInputs, PaymentMethodsViewModelOutputs {
     self.showAlert = deletePaymentMethodEventsErrors
       .ignoreValues()
       .map {
-        localizedString(
-          key: "Something_went_wrong_and_we_were_unable_to_remove_your_payment_method_please_try_again",
-          //swiftlint:disable:next line_length
-          defaultValue: "Something went wrong and we were unable to remove your payment method, please try again."
-        )
+        Strings.Something_went_wrong_and_we_were_unable_to_remove_your_payment_method_please_try_again()
     }
 
     let initialPaymentMethodsValues = paymentMethodsEvent

--- a/Library/ViewModels/ProjectActivityBackingCellViewModelTests.swift
+++ b/Library/ViewModels/ProjectActivityBackingCellViewModelTests.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable force_unwrapping
 import XCTest
 @testable import KsApi
 @testable import Library
@@ -307,6 +306,7 @@ internal final class ProjectActivityBackingCellViewModelTests: TestCase {
       |> Activity.lens.project .~ project
 
     self.vm.inputs.configureWith(activity: activity1, project: project)
+    // swiftlint:disable:next force_unwrapping
     let expected1 = Strings.dashboard_activity_reward_name(reward_name: reward1.title!)
     self.reward.assertValues([expected1], "Should emit reward title if present")
     self.rewardLabelIsHidden.assertValues([false])

--- a/Library/ViewModels/ProjectNavigatorViewModelTests.swift
+++ b/Library/ViewModels/ProjectNavigatorViewModelTests.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable force_unwrapping
 @testable import KsApi
 @testable import Library
 @testable import ReactiveExtensions_TestHelpers
@@ -310,6 +309,7 @@ internal final class ProjectNavigatorViewModelTests: TestCase {
 
   func testSetNeedsStatusBarAppearanceUpdate() {
     let playlist = (0...4).map { idx in .template |> Project.lens.id .~ (idx + 42) }
+    // swiftlint:disable:next force_unwrapping
     let project = playlist.first!
 
     self.vm.inputs.configureWith(project: project, refTag: .category)
@@ -338,6 +338,7 @@ internal final class ProjectNavigatorViewModelTests: TestCase {
 
   func testNotifyDelegateAfterSwipe() {
     let playlist = (0...4).map { idx in .template |> Project.lens.id .~ (idx + 42) }
+    // swiftlint:disable:next force_unwrapping
     let project = playlist.first!
 
     self.vm.inputs.configureWith(project: project, refTag: .category)

--- a/Library/ViewModels/RewardCellViewModel.swift
+++ b/Library/ViewModels/RewardCellViewModel.swift
@@ -246,7 +246,6 @@ RewardCellViewModelOutputs {
         )
     }
   }
-  // swiftlint:enable function_body_length
 
   private let boundStylesProperty = MutableProperty(())
   public func boundStyles() {

--- a/Library/ViewModels/RewardPledgeViewModel.swift
+++ b/Library/ViewModels/RewardPledgeViewModel.swift
@@ -765,7 +765,6 @@ RewardPledgeViewModelOutputs {
         )
     }
   }
-  // swiftlint:enable function_body_length
 
   fileprivate let applePayButtonTappedProperty = MutableProperty(())
   public func applePayButtonTapped() {

--- a/Library/ViewModels/SearchViewModelTests.swift
+++ b/Library/ViewModels/SearchViewModelTests.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable force_unwrapping
 import Foundation
 import XCTest
 @testable import KsApi
@@ -268,6 +267,7 @@ internal final class SearchViewModelTests: TestCase {
                    "A koala event is tracked for the search results.")
     XCTAssertEqual([true, nil, true, nil],
                    self.trackingClient.properties(forKey: Koala.DeprecatedKey, as: Bool.self))
+    // swiftlint:disable:next force_unwrapping
     XCTAssertEqual("skull graphic tee", self.trackingClient.properties.last!["search_term"] as? String)
 
     self.vm.inputs.willDisplayRow(7, outOf: 10)
@@ -282,6 +282,7 @@ internal final class SearchViewModelTests: TestCase {
       "A koala event is tracked for the search results.")
     XCTAssertEqual([true, nil, true, nil, true, nil],
                    self.trackingClient.properties(forKey: Koala.DeprecatedKey, as: Bool.self))
+    // swiftlint:disable:next force_unwrapping
     XCTAssertEqual("skull graphic tee", self.trackingClient.properties.last!["search_term"] as? String)
 
     self.vm.inputs.searchTextChanged("")
@@ -355,6 +356,7 @@ internal final class SearchViewModelTests: TestCase {
                      "A koala event is tracked for the search results.")
       XCTAssertEqual([true, nil, true, nil],
                      self.trackingClient.properties(forKey: Koala.DeprecatedKey, as: Bool.self))
+      // swiftlint:disable:next force_unwrapping
       XCTAssertEqual("skull graphic tee", self.trackingClient.properties.last!["search_term"] as? String)
 
       let searchResponse = .template |> DiscoveryEnvelope.lens.projects .~ []
@@ -406,6 +408,7 @@ internal final class SearchViewModelTests: TestCase {
       self.scheduler.advance(by: apiDelay)
 
       self.hasProjects.assertValues([true], "Popular projects emit immediately.")
+      // swiftlint:disable:next force_unwrapping
       let popularProjects = projects.values.last!
 
       self.vm.inputs.searchTextChanged("skull graphic tee")

--- a/Library/ViewModels/SignupViewModelTests.swift
+++ b/Library/ViewModels/SignupViewModelTests.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable force_unwrapping
 import XCTest
 @testable import KsApi
 @testable import Library
@@ -73,6 +72,7 @@ internal final class SignupViewModelTests: TestCase {
 
     self.scheduler.advance()
     XCTAssertEqual(["User Signup", "Viewed Signup", "New User", "Signed Up"], self.trackingClient.events)
+    // swiftlint:disable:next force_unwrapping
     XCTAssertEqual("Email", trackingClient.properties.last!["auth_type"] as? String)
     self.logIntoEnvironment.assertValueCount(1, "Login after scheduler advances.")
     self.postNotification.assertDidNotEmitValue("Does not emit until environment logged in.")
@@ -150,6 +150,7 @@ internal final class SignupViewModelTests: TestCase {
       self.showError.assertValues([error, error], "Signup error.")
       XCTAssertEqual(["User Signup", "Viewed Signup", "Errored User Signup", "Errored Signup",
         "Errored User Signup", "Errored Signup"], self.trackingClient.events)
+      // swiftlint:disable:next force_unwrapping
       XCTAssertEqual("Email", trackingClient.properties.last!["auth_type"] as? String)
     }
   }

--- a/Library/ViewModels/SurveyResponseViewModelTests.swift
+++ b/Library/ViewModels/SurveyResponseViewModelTests.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable force_unwrapping
 import XCTest
 @testable import Library
 @testable import KsApi
@@ -53,6 +52,7 @@ final class SurveyResponseViewModelTests: TestCase {
 
     XCTAssertFalse(
       self.vm.inputs.shouldStartLoad(
+        // swiftlint:disable:next force_unwrapping
         withRequest: URLRequest(url: URL(string: project.urls.web.project)!),
         navigationType: .linkClicked
       )
@@ -131,6 +131,7 @@ final class SurveyResponseViewModelTests: TestCase {
 
 private func surveyRequest(project: Project, prepared: Bool, method: KsApi.Method) -> URLRequest {
   let url = "\(project.urls.web.project)/surveys/1"
+  // swiftlint:disable:next force_unwrapping
   var request = URLRequest(url: URL(string: url)!)
   request.httpMethod = method.rawValue
   if prepared {

--- a/Library/ViewModels/TwoFactorViewModel.swift
+++ b/Library/ViewModels/TwoFactorViewModel.swift
@@ -74,7 +74,6 @@ public final class TwoFactorViewModel: TwoFactorViewModelType, TwoFactorViewMode
         set: { TfaData(email: $1.email, password: $1.password, facebookToken: $1.facebookToken, code: $0) }
       )
     }
-    // swiftlint:enable type_name
   }
 
     public init() {

--- a/Library/ViewModels/UpdateDraftViewModel.swift
+++ b/Library/ViewModels/UpdateDraftViewModel.swift
@@ -432,7 +432,6 @@ UpdateDraftViewModelOutputs {
         AppEnvironment.current.koala.trackFailedRemoveUpdateDraftAttachment(forProject: $0)
     }
   }
-  // swiftlint:enable function_body_length
 
   // INPUTS
   fileprivate let addAttachmentButtonTappedProperty = MutableProperty<[AttachmentSource]>([])

--- a/Library/ViewModels/UpdateDraftViewModelTests.swift
+++ b/Library/ViewModels/UpdateDraftViewModelTests.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable force_unwrapping
 import XCTest
 import UIKit
 @testable import ReactiveExtensions_TestHelpers
@@ -288,6 +287,7 @@ final class UpdateDraftViewModelTests: TestCase {
       self.vm.inputs.addAttachmentSheetButtonTapped(.camera)
       self.showImagePicker.assertValues([.cameraRoll, .camera])
 
+      // swiftlint:disable:next force_unwrapping
       self.vm.inputs.imagePicked(url: URL(string: "/tmp/photo.jpg")!, fromSource: .camera)
 
       self.attachmentAdded.assertValues([])
@@ -314,6 +314,7 @@ final class UpdateDraftViewModelTests: TestCase {
         self.vm.inputs.addAttachmentSheetButtonTapped(.cameraRoll)
         self.showImagePicker.assertValues([.cameraRoll])
 
+        // swiftlint:disable:next force_unwrapping
         self.vm.inputs.imagePicked(url: URL(string: "/tmp/photo.jpg")!, fromSource: .cameraRoll)
 
         self.showAddAttachmentFailure.assertValueCount(0)
@@ -402,6 +403,7 @@ final class UpdateDraftViewModelTests: TestCase {
 
       self.vm.inputs.addAttachmentButtonTapped(availableSources: [.camera, .cameraRoll])
       self.vm.inputs.addAttachmentSheetButtonTapped(.camera)
+      // swiftlint:disable:next force_unwrapping
       self.vm.inputs.imagePicked(url: URL(string: "/tmp/photo.jpg")!, fromSource: .camera)
 
       self.scheduler.advance()
@@ -437,6 +439,7 @@ final class UpdateDraftViewModelTests: TestCase {
 
       self.vm.inputs.addAttachmentButtonTapped(availableSources: [.camera, .cameraRoll])
       self.vm.inputs.addAttachmentSheetButtonTapped(.camera)
+      // swiftlint:disable:next force_unwrapping
       self.vm.inputs.imagePicked(url: URL(string: "/tmp/photo.jpg")!, fromSource: .camera)
 
       self.scheduler.advance()

--- a/Library/ViewModels/VideoViewModelTests.swift
+++ b/Library/ViewModels/VideoViewModelTests.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable force_unwrapping
 import AVFoundation
 import Library
 import Prelude
@@ -83,6 +82,7 @@ internal final class VideoViewModelTests: TestCase {
     self.vm.inputs.viewDidAppear()
     self.vm.inputs.playButtonTapped()
 
+    // swiftlint:disable:next force_unwrapping
     self.configurePlayerWithURL.assertValues([video.hls!], "Video url emitted.")
   }
 

--- a/Library/ViewModels/WebModalViewModelTests.swift
+++ b/Library/ViewModels/WebModalViewModelTests.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable force_unwrapping
 import Prelude
 import ReactiveSwift
 import Result
@@ -54,5 +53,6 @@ internal final class WebModalViewModelTests: TestCase {
     XCTAssertEqual(WKNavigationActionPolicy.allow.rawValue, decision.rawValue)
   }
 
+  // swiftlint:disable:next force_unwrapping
   fileprivate let request = URLRequest(url: URL(string: "https://www.kickstarter.com/projects/tfw/ijc")!)
 }


### PR DESCRIPTION
# 📲 What

* Removes unused rules
* Prefers to use `next` where possible

# 🔨 How

Where possible I've replaced `// swiftlint:disable` with `// swiftlint:disable:next` or disable block. If a specific file disabled a rule for the whole file (at the beginning of the file), I would have replaced this with `next` only if the rule wasn't broken more than 5 times. If it was broken more times it was an indicator that the file was assuming / working differently than we would like which is a work for some other time.

# 🤔 Why

Best practices

# 👀 See

| Before 🐛 | After 🦋 |
| --- | --- |
| 0 Swiftlint warnings after `Clean Build` | 0 Swiftlint warnings after `Clean Build`  |

# ✅ Acceptance criteria

- [x] All tests pass
- [ ] No `Swiftlint` warnings