### PR TITLE
👩‍🔬 [Investment Day] Clean up compiler warnings

### DIFF
--- a/Kickstarter-iOS/Views/Controllers/AddNewCardViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/AddNewCardViewController.swift
@@ -286,13 +286,13 @@ extension AddNewCardViewController {
 
 // MARK: - Styles
 
-private let cardholderNameLabelStyle: (UILabel) -> UILabel = { (label: UILabel) in
+private let cardholderNameLabelStyle: LabelStyle = { (label: UILabel) in
   label
     |> \.isAccessibilityElement .~ false
     |> \.text %~ { _ in Strings.Cardholder_name() }
 }
 
-private let cardholderNameTextFieldStyle: (UITextField) -> UITextField = { (textField: UITextField) in
+private let cardholderNameTextFieldStyle: TextFieldStyle = { (textField: UITextField) in
   textField
     |> \.autocapitalizationType .~ .words
     |> \.returnKeyType .~ .next
@@ -303,8 +303,9 @@ private let cardholderNameTextFieldStyle: (UITextField) -> UITextField = { (text
       attributes: [NSAttributedString.Key.foregroundColor: UIColor.ksr_text_dark_grey_400])
 }
 
-// swiftlint:disable line_length
-private let creditCardTextFieldStyle: (STPPaymentCardTextField) -> STPPaymentCardTextField = { (textField: STPPaymentCardTextField) in
+private typealias PaymentCardTextFieldStyle = (STPPaymentCardTextField) -> STPPaymentCardTextField
+
+private let creditCardTextFieldStyle: PaymentCardTextFieldStyle = { (textField: STPPaymentCardTextField) in
   textField
     |> \.borderColor .~ nil
     |> \.font .~ .ksr_body()

--- a/Kickstarter-iOS/Views/Controllers/AddNewCardViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/AddNewCardViewController.swift
@@ -88,29 +88,15 @@ STPPaymentCardTextFieldDelegate, MessageBannerViewControllerPresenting {
 
     _ = self.cardholderNameLabel
       |> settingsTitleLabelStyle
-      |> \.isAccessibilityElement .~ false
-      |> \.text %~ { _ in Strings.Cardholder_name() }
+      |> cardholderNameLabelStyle
 
     _ = self.cardholderNameTextField
       |> formFieldStyle
-      |> \.autocapitalizationType .~ .words
-      |> \.returnKeyType .~ .next
-      |> \.textAlignment .~ .right
-      |> \.textColor .~ .ksr_text_dark_grey_500
-
-    _ = self.cardholderNameTextField
+      |> cardholderNameTextFieldStyle
       |> \.accessibilityLabel .~ self.cardholderNameLabel.text
-      |> \.attributedPlaceholder .~ NSAttributedString(
-          string: Strings.Name(),
-          attributes: [NSAttributedString.Key.foregroundColor: UIColor.ksr_text_dark_grey_400])
 
     _ = self.creditCardTextField
-      |> \.borderColor .~ nil
-      |> \.font .~ .ksr_body()
-      |> \.textColor .~ .ksr_text_dark_grey_500
-      |> \.textErrorColor .~ .ksr_red_400
-      |> \.cursorColor .~ .ksr_green_700
-      |> \.placeholderColor .~ .ksr_text_dark_grey_400
+      |> creditCardTextFieldStyle
 
     _ = self.creditCardValidationErrorLabel
       |> settingsDescriptionLabelStyle
@@ -296,4 +282,34 @@ extension AddNewCardViewController {
   internal func paymentCardTextFieldDidEndEditing(_ textField: STPPaymentCardTextField) {
     self.viewModel.inputs.paymentCardTextFieldDidEndEditing()
   }
+}
+
+// MARK: - Styles
+
+private let cardholderNameLabelStyle: (UILabel) -> UILabel = { (label: UILabel) in
+  label
+    |> \.isAccessibilityElement .~ false
+    |> \.text %~ { _ in Strings.Cardholder_name() }
+}
+
+private let cardholderNameTextFieldStyle: (UITextField) -> UITextField = { (textField: UITextField) in
+  textField
+    |> \.autocapitalizationType .~ .words
+    |> \.returnKeyType .~ .next
+    |> \.textAlignment .~ .right
+    |> \.textColor .~ .ksr_text_dark_grey_500
+    |> \.attributedPlaceholder .~ NSAttributedString(
+      string: Strings.Name(),
+      attributes: [NSAttributedString.Key.foregroundColor: UIColor.ksr_text_dark_grey_400])
+}
+
+// swiftlint:disable line_length
+private let creditCardTextFieldStyle: (STPPaymentCardTextField) -> STPPaymentCardTextField = { (textField: STPPaymentCardTextField) in
+  textField
+    |> \.borderColor .~ nil
+    |> \.font .~ .ksr_body()
+    |> \.textColor .~ .ksr_text_dark_grey_500
+    |> \.textErrorColor .~ .ksr_red_400
+    |> \.cursorColor .~ .ksr_green_700
+    |> \.placeholderColor .~ .ksr_text_dark_grey_400
 }

--- a/Kickstarter-iOS/Views/Controllers/ChangeEmailViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/ChangeEmailViewController.swift
@@ -271,32 +271,32 @@ extension ChangeEmailViewController: UITextFieldDelegate {
 
 // MARK: - Styles
 
-private let warningMessageLabelStyle: (UILabel) -> UILabel = { (label: UILabel) in
+private let warningMessageLabelStyle: LabelStyle = { (label: UILabel) in
   label
     |> \.textColor .~ UIColor.ksr_red_400
     |> \.text %~ { _ in Strings.We_ve_been_unable_to_send_email() }
 }
 
-private let currentEmailTitleStyle: (UILabel) -> UILabel = { (label: UILabel) in
+private let currentEmailTitleStyle: LabelStyle = { (label: UILabel) in
   label
     |> \.isAccessibilityElement .~ false
     |> \.text %~ { _ in Strings.Current_email() }
     |> \.textColor .~ UIColor.ksr_text_dark_grey_400
 }
 
-private let currentEmailValueStyle: (UILabel) -> UILabel = { (label: UILabel) in
+private let currentEmailValueStyle: LabelStyle = { (label: UILabel) in
   label
     |> \.isAccessibilityElement .~ false
     |> \.textColor .~ UIColor.ksr_text_dark_grey_400
 }
 
-private let newEmailLabelStyle: (UILabel) -> UILabel = { (label: UILabel) in
+private let newEmailLabelStyle: LabelStyle = { (label: UILabel) in
   label
     |> \.text %~ { _ in Strings.New_email() }
     |> \.isAccessibilityElement .~ false
 }
 
-private let newEmailTextFieldStyle: (UITextField) -> UITextField = { (textField: UITextField) in
+private let newEmailTextFieldStyle: TextFieldStyle = { (textField: UITextField) in
   textField
     |> \.returnKeyType .~ UIReturnKeyType.next
     |> \.attributedPlaceholder %~ { _ in
@@ -304,13 +304,13 @@ private let newEmailTextFieldStyle: (UITextField) -> UITextField = { (textField:
   }
 }
 
-private let passwordLabelStyle: (UILabel) -> UILabel = { (label: UILabel) in
+private let passwordLabelStyle: LabelStyle = { (label: UILabel) in
   label
     |> \.text %~ { _ in Strings.Current_password() }
     |> \.isAccessibilityElement .~ false
 }
 
-private let passwordTextFieldStyle: (UITextField) -> UITextField = { (textField: UITextField) in
+private let passwordTextFieldStyle: TextFieldStyle = { (textField: UITextField) in
   textField
     |> \.returnKeyType .~ UIReturnKeyType.done
     |> \.attributedPlaceholder %~ { _ in
@@ -318,7 +318,7 @@ private let passwordTextFieldStyle: (UITextField) -> UITextField = { (textField:
   }
 }
 
-private let resendVerificationEmailButtonStyle: (UIButton) -> UIButton = { (button: UIButton) in
+private let resendVerificationEmailButtonStyle: ButtonStyle = { (button: UIButton) in
   button
     |> UIButton.lens.titleLabel.font .~ .ksr_body()
     |> UIButton.lens.titleColor(for: .normal) .~ .ksr_text_green_700

--- a/Kickstarter-iOS/Views/Controllers/ChangeEmailViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/ChangeEmailViewController.swift
@@ -84,8 +84,7 @@ internal final class ChangeEmailViewController: UIViewController, MessageBannerV
 
     _ = self.warningMessageLabel
       |> settingsDescriptionLabelStyle
-      |> \.textColor .~ .ksr_red_400
-      |> \.text %~ { _ in Strings.We_ve_been_unable_to_send_email() }
+      |> warningMessageLabelStyle
 
     _ = self.currentEmailContainer
       |> \.isAccessibilityElement .~ true
@@ -93,44 +92,32 @@ internal final class ChangeEmailViewController: UIViewController, MessageBannerV
 
     _ = self.currentEmailTitle
       |> settingsTitleLabelStyle
-      |> \.isAccessibilityElement .~ false
-      |> \.text %~ { _ in Strings.Current_email() }
-      |> \.textColor .~ .ksr_text_dark_grey_400
+      |> currentEmailTitleStyle
 
     _ = self.currentEmailValue
       |> settingsDetailLabelStyle
-      |> \.isAccessibilityElement .~ false
-      |> \.textColor .~ .ksr_text_dark_grey_400
+      |> currentEmailValueStyle
 
     _ = self.newEmailLabel
       |> settingsTitleLabelStyle
-      |> \.text %~ { _ in Strings.New_email() }
-      |> \.isAccessibilityElement .~ false
+      |> newEmailLabelStyle
 
     _ = self.newEmailTextField
       |> settingsEmailFieldAutoFillStyle
+      |> newEmailTextFieldStyle
       |> \.accessibilityLabel .~ self.newEmailLabel.text
-      |> \.returnKeyType .~ .next
-      |> \.attributedPlaceholder %~ { _ in
-        settingsAttributedPlaceholder(Strings.login_placeholder_email())
-    }
 
     _ = self.passwordLabel
       |> settingsTitleLabelStyle
-      |> \.text %~ { _ in Strings.Current_password() }
-      |> \.isAccessibilityElement .~ false
+      |> passwordLabelStyle
 
     _ = self.passwordTextField
       |> settingsPasswordFormFieldAutoFillStyle
+      |> passwordTextFieldStyle
       |> \.accessibilityLabel .~ self.passwordLabel.text
-      |> \.returnKeyType .~ .done
-      |> \.attributedPlaceholder %~ { _ in
-        settingsAttributedPlaceholder(Strings.login_placeholder_password())
-    }
 
     _ = self.resendVerificationEmailButton
-      |> UIButton.lens.titleLabel.font .~ .ksr_body()
-      |> UIButton.lens.titleColor(for: .normal) .~ .ksr_text_green_700
+      |> resendVerificationEmailButtonStyle
   }
 
   override func bindViewModel() {
@@ -280,4 +267,59 @@ extension ChangeEmailViewController: UITextFieldDelegate {
     self.viewModel.inputs.textFieldShouldReturn(with: textField.returnKeyType)
     return textField.resignFirstResponder()
   }
+}
+
+// MARK: - Styles
+
+private let warningMessageLabelStyle: (UILabel) -> UILabel = { (label: UILabel) in
+  label
+    |> \.textColor .~ UIColor.ksr_red_400
+    |> \.text %~ { _ in Strings.We_ve_been_unable_to_send_email() }
+}
+
+private let currentEmailTitleStyle: (UILabel) -> UILabel = { (label: UILabel) in
+  label
+    |> \.isAccessibilityElement .~ false
+    |> \.text %~ { _ in Strings.Current_email() }
+    |> \.textColor .~ UIColor.ksr_text_dark_grey_400
+}
+
+private let currentEmailValueStyle: (UILabel) -> UILabel = { (label: UILabel) in
+  label
+    |> \.isAccessibilityElement .~ false
+    |> \.textColor .~ UIColor.ksr_text_dark_grey_400
+}
+
+private let newEmailLabelStyle: (UILabel) -> UILabel = { (label: UILabel) in
+  label
+    |> \.text %~ { _ in Strings.New_email() }
+    |> \.isAccessibilityElement .~ false
+}
+
+private let newEmailTextFieldStyle: (UITextField) -> UITextField = { (textField: UITextField) in
+  textField
+    |> \.returnKeyType .~ UIReturnKeyType.next
+    |> \.attributedPlaceholder %~ { _ in
+      settingsAttributedPlaceholder(Strings.login_placeholder_email())
+  }
+}
+
+private let passwordLabelStyle: (UILabel) -> UILabel = { (label: UILabel) in
+  label
+    |> \.text %~ { _ in Strings.Current_password() }
+    |> \.isAccessibilityElement .~ false
+}
+
+private let passwordTextFieldStyle: (UITextField) -> UITextField = { (textField: UITextField) in
+  textField
+    |> \.returnKeyType .~ UIReturnKeyType.done
+    |> \.attributedPlaceholder %~ { _ in
+      settingsAttributedPlaceholder(Strings.login_placeholder_password())
+  }
+}
+
+private let resendVerificationEmailButtonStyle: (UIButton) -> UIButton = { (button: UIButton) in
+  button
+    |> UIButton.lens.titleLabel.font .~ .ksr_body()
+    |> UIButton.lens.titleColor(for: .normal) .~ .ksr_text_green_700
 }

--- a/Kickstarter-iOS/Views/Controllers/PaymentMethodsViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/PaymentMethodsViewController.swift
@@ -71,12 +71,8 @@ internal final class PaymentMethodsViewController: UIViewController, MessageBann
     }
 
     _ = self.tableView
-      |> \.backgroundColor .~ .clear
-      |> \.rowHeight .~ Styles.grid(11)
-      |> \.allowsSelection .~ false
-      |> \.separatorStyle .~ .singleLine
-      |> \.separatorColor .~ .ksr_grey_500
-      |> \.separatorInset .~ .init(left: Styles.grid(2))
+      |> tableViewStyle
+      |> tableViewSeparatorStyle
   }
 
   override func bindViewModel() {
@@ -214,4 +210,20 @@ extension PaymentMethodsViewController: AddNewCardViewControllerDelegate {
       self.viewModel.inputs.addNewCardDismissed()
     }
   }
+}
+
+// MARK: - Styles
+
+private let tableViewStyle: (UITableView) -> UITableView = { (tableView: UITableView) in
+  tableView
+    |> \.backgroundColor .~ UIColor.clear
+    |> \.rowHeight .~ Styles.grid(11)
+    |> \.allowsSelection .~ false
+}
+
+private let tableViewSeparatorStyle: (UITableView) -> UITableView = { tableView in
+  tableView
+    |> \.separatorStyle .~ .singleLine
+    |> \.separatorColor .~ .ksr_grey_500
+    |> \.separatorInset .~ .init(left: Styles.grid(2))
 }

--- a/Kickstarter-iOS/Views/Controllers/PaymentMethodsViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/PaymentMethodsViewController.swift
@@ -214,14 +214,14 @@ extension PaymentMethodsViewController: AddNewCardViewControllerDelegate {
 
 // MARK: - Styles
 
-private let tableViewStyle: (UITableView) -> UITableView = { (tableView: UITableView) in
+private let tableViewStyle: TableViewStyle = { (tableView: UITableView) in
   tableView
     |> \.backgroundColor .~ UIColor.clear
     |> \.rowHeight .~ Styles.grid(11)
     |> \.allowsSelection .~ false
 }
 
-private let tableViewSeparatorStyle: (UITableView) -> UITableView = { tableView in
+private let tableViewSeparatorStyle: TableViewStyle = { tableView in
   tableView
     |> \.separatorStyle .~ .singleLine
     |> \.separatorColor .~ .ksr_grey_500

--- a/Kickstarter-iOS/Views/Controllers/SelectCurrencyViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/SelectCurrencyViewController.swift
@@ -168,7 +168,7 @@ extension SelectCurrencyViewController: UITableViewDelegate {
 
 // MARK: - Styles
 
-private let tableViewStyle: (UITableView) -> UITableView = { (tableView: UITableView) in
+private let tableViewStyle: TableViewStyle = { (tableView: UITableView) in
   tableView
     |> \.translatesAutoresizingMaskIntoConstraints .~ false
     |> \.tableFooterView .~ UIView(frame: .zero)

--- a/Kickstarter-iOS/Views/Controllers/SelectCurrencyViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/SelectCurrencyViewController.swift
@@ -147,9 +147,8 @@ final class SelectCurrencyViewController: UIViewController, MessageBannerViewCon
   // MARK: - Subviews
 
   private lazy var tableView: UITableView = {
-    UITableView(frame: .zero, style: .plain)
-      |> \.translatesAutoresizingMaskIntoConstraints .~ false
-      |> \.tableFooterView .~ UIView(frame: .zero)
+    return UITableView(frame: .zero, style: .plain)
+      |> tableViewStyle
       |> \.dataSource .~ self.dataSource
       |> \.delegate .~ self
   }()
@@ -165,4 +164,12 @@ extension SelectCurrencyViewController: UITableViewDelegate {
 
     tableView.deselectRow(at: indexPath, animated: true)
   }
+}
+
+// MARK: - Styles
+
+private let tableViewStyle: (UITableView) -> UITableView = { (tableView: UITableView) in
+  tableView
+    |> \.translatesAutoresizingMaskIntoConstraints .~ false
+    |> \.tableFooterView .~ UIView(frame: .zero)
 }

--- a/Kickstarter-iOS/Views/Controllers/SettingsAccountViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/SettingsAccountViewController.swift
@@ -130,8 +130,6 @@ extension SettingsAccountViewController {
       let vc = SelectCurrencyViewController.instantiate()
       vc.configure(with: currency)
       return vc
-    default:
-      return nil
     }
   }
 }

--- a/Kickstarter-iOS/Views/SelectCurrencyTableViewHeader.swift
+++ b/Kickstarter-iOS/Views/SelectCurrencyTableViewHeader.swift
@@ -56,7 +56,7 @@ final class SelectCurrencyTableViewHeader: UIView {
 
 // MARK: - Styles
 
-private let headerStackViewStyle: (UIStackView) -> UIStackView = { (stackView: UIStackView) in
+private let headerStackViewStyle: StackViewStyle = { (stackView: UIStackView) in
   stackView
     |> \.axis .~ NSLayoutConstraint.Axis.vertical
     |> \.alignment .~ UIStackView.Alignment.center
@@ -67,7 +67,7 @@ private let headerStackViewStyle: (UIStackView) -> UIStackView = { (stackView: U
     |> \.isLayoutMarginsRelativeArrangement .~ true
 }
 
-private let headerLabelStyle: (UILabel) -> UILabel = { (label: UILabel) in
+private let headerLabelStyle: LabelStyle = { (label: UILabel) in
   label
     |> \.textColor .~ UIColor.ksr_text_dark_grey_500
     |> \.backgroundColor .~ UIColor.ksr_grey_200

--- a/Kickstarter-iOS/Views/SelectCurrencyTableViewHeader.swift
+++ b/Kickstarter-iOS/Views/SelectCurrencyTableViewHeader.swift
@@ -23,18 +23,11 @@ final class SelectCurrencyTableViewHeader: UIView {
       |> \.contentMode .~ .scaleAspectFill
 
     _ = self.headerStackView
-      |> \.axis .~ .vertical
-      |> \.alignment .~ .center
-      |> \.spacing .~ Styles.grid(2)
-      |> \.layoutMargins .~ .init(
-        top: Styles.grid(4), left: Styles.grid(2), bottom: Styles.grid(2), right: Styles.grid(2)
-      )
-      |> \.isLayoutMarginsRelativeArrangement .~ true
+      |> headerStackViewStyle
 
     _ = self.headerLabel
       |> settingsDescriptionLabelStyle
-      |> \.textColor .~ .ksr_text_dark_grey_500
-      |> \.backgroundColor .~ .ksr_grey_200
+      |> headerLabelStyle
   }
 
   // MARK: Accessors
@@ -59,4 +52,23 @@ final class SelectCurrencyTableViewHeader: UIView {
   }()
 
   private lazy var headerLabel: UILabel = { UILabel(frame: .zero) }()
+}
+
+// MARK: - Styles
+
+private let headerStackViewStyle: (UIStackView) -> UIStackView = { (stackView: UIStackView) in
+  stackView
+    |> \.axis .~ NSLayoutConstraint.Axis.vertical
+    |> \.alignment .~ UIStackView.Alignment.center
+    |> \.spacing .~ Styles.grid(2)
+    |> \.layoutMargins .~ UIEdgeInsets(
+      top: Styles.grid(4), left: Styles.grid(2), bottom: Styles.grid(2), right: Styles.grid(2)
+    )
+    |> \.isLayoutMarginsRelativeArrangement .~ true
+}
+
+private let headerLabelStyle: (UILabel) -> UILabel = { (label: UILabel) in
+  label
+    |> \.textColor .~ UIColor.ksr_text_dark_grey_500
+    |> \.backgroundColor .~ UIColor.ksr_grey_200
 }

--- a/Kickstarter-iOS/Views/SettingsFormFieldView.swift
+++ b/Kickstarter-iOS/Views/SettingsFormFieldView.swift
@@ -29,18 +29,30 @@ final class SettingsFormFieldView: UIView, NibLoading {
 
     _ = self.titleLabel
       |> settingsTitleLabelStyle
-      |> \.isAccessibilityElement .~ false
-      |> \.adjustsFontForContentSizeCategory .~ true
+      |> titleLabelStyle
 
     _ = self.textField
       |> formFieldStyle
+      |> textFieldStyle
       |> \.autocapitalizationType .~ self.autocapitalizationType
       |> \.returnKeyType .~ self.returnKeyType
-      |> \.textAlignment .~ .right
-      |> \.textColor .~ .ksr_text_dark_grey_500
       |> \.accessibilityLabel .~ self.titleLabel.text
 
     _ = self.separatorView
       |> separatorStyle
   }
+}
+
+// MARK: - Styles
+
+private let titleLabelStyle: (UILabel) -> UILabel = { (label: UILabel) in
+  label
+    |> \.isAccessibilityElement .~ false
+    |> \.adjustsFontForContentSizeCategory .~ true
+}
+
+private let textFieldStyle: (UITextField) -> UITextField = { (textField: UITextField) in
+  textField
+    |> \.textAlignment .~ NSTextAlignment.right
+    |> \.textColor .~ UIColor.ksr_text_dark_grey_500
 }

--- a/Kickstarter-iOS/Views/SettingsFormFieldView.swift
+++ b/Kickstarter-iOS/Views/SettingsFormFieldView.swift
@@ -45,13 +45,13 @@ final class SettingsFormFieldView: UIView, NibLoading {
 
 // MARK: - Styles
 
-private let titleLabelStyle: (UILabel) -> UILabel = { (label: UILabel) in
+private let titleLabelStyle: LabelStyle = { (label: UILabel) in
   label
     |> \.isAccessibilityElement .~ false
     |> \.adjustsFontForContentSizeCategory .~ true
 }
 
-private let textFieldStyle: (UITextField) -> UITextField = { (textField: UITextField) in
+private let textFieldStyle: TextFieldStyle = { (textField: UITextField) in
   textField
     |> \.textAlignment .~ NSTextAlignment.right
     |> \.textColor .~ UIColor.ksr_text_dark_grey_500

--- a/Library/Styles/BaseStyles.swift
+++ b/Library/Styles/BaseStyles.swift
@@ -111,19 +111,28 @@ public let feedTableViewCellStyle = baseTableViewCellStyle()
       : .init(topBottom: Styles.gridHalf(3), leftRight: Styles.grid(2))
 }
 
-public let formFieldStyle =
-  UITextField.lens.font .~ .ksr_body()
-    <> UITextField.lens.textColor .~ .ksr_soft_black
-    <> UITextField.lens.backgroundColor .~ .clear
-    <> UITextField.lens.borderStyle .~ .none
-    <> UITextField.lens.autocapitalizationType .~ .none
-    <> UITextField.lens.autocorrectionType .~ .no
-    <> UITextField.lens.spellCheckingType .~ .no
-    <> UITextField.lens.tintColor .~ .ksr_green_700
+public let formTextInputStyle: (UITextField) -> UITextField = { (textField: UITextField) in
+  textField
+    |> \.autocapitalizationType .~ UITextAutocapitalizationType.none
+    |> \.autocorrectionType .~ UITextAutocorrectionType.no
+    |> \.spellCheckingType .~ UITextSpellCheckingType.no
+}
 
-public let separatorStyle =
-  UIView.lens.backgroundColor .~ .ksr_grey_400
-    <> UIView.lens.accessibilityElementsHidden .~ true
+public let formFieldStyle: (UITextField) -> UITextField = { (textField: UITextField) in
+  textField
+    |> formTextInputStyle
+    |> \.backgroundColor .~ UIColor.clear
+    |> \.borderStyle .~ UITextField.BorderStyle.none
+    |> \.font .~ UIFont.ksr_body()
+    |> \.textColor .~ UIColor.ksr_soft_black
+    |> \.tintColor .~ UIColor.ksr_green_700
+}
+
+public let separatorStyle: (UIView) -> UIView = { (view: UIView) in
+  view
+    |> \.backgroundColor .~ UIColor.ksr_grey_400
+    |> \.accessibilityElementsHidden .~ true
+}
 
 /**
  - parameter r: The corner radius. This parameter is optional, and will use a default value if omitted.

--- a/Library/Styles/BaseStyles.swift
+++ b/Library/Styles/BaseStyles.swift
@@ -14,6 +14,13 @@ public enum Styles {
   }
 }
 
+public typealias ButtonStyle = (UIButton) -> UIButton
+public typealias LabelStyle = (UILabel) -> UILabel
+public typealias StackViewStyle = (UIStackView) -> UIStackView
+public typealias TableViewStyle = (UITableView) -> UITableView
+public typealias TextFieldStyle = (UITextField) -> UITextField
+public typealias ViewStyle = (UIView) -> UIView
+
 public func baseControllerStyle <VC: UIViewControllerProtocol> () -> ((VC) -> VC) {
   return VC.lens.view.backgroundColor .~ .white
     <> (VC.lens.navigationController..navBarLens) %~ { $0.map(baseNavigationBarStyle) }
@@ -111,14 +118,14 @@ public let feedTableViewCellStyle = baseTableViewCellStyle()
       : .init(topBottom: Styles.gridHalf(3), leftRight: Styles.grid(2))
 }
 
-public let formTextInputStyle: (UITextField) -> UITextField = { (textField: UITextField) in
+public let formTextInputStyle: TextFieldStyle = { (textField: UITextField) in
   textField
     |> \.autocapitalizationType .~ UITextAutocapitalizationType.none
     |> \.autocorrectionType .~ UITextAutocorrectionType.no
     |> \.spellCheckingType .~ UITextSpellCheckingType.no
 }
 
-public let formFieldStyle: (UITextField) -> UITextField = { (textField: UITextField) in
+public let formFieldStyle: TextFieldStyle = { (textField: UITextField) in
   textField
     |> formTextInputStyle
     |> \.backgroundColor .~ UIColor.clear
@@ -128,7 +135,7 @@ public let formFieldStyle: (UITextField) -> UITextField = { (textField: UITextFi
     |> \.tintColor .~ UIColor.ksr_green_700
 }
 
-public let separatorStyle: (UIView) -> UIView = { (view: UIView) in
+public let separatorStyle: ViewStyle = { (view: UIView) in
   view
     |> \.backgroundColor .~ UIColor.ksr_grey_400
     |> \.accessibilityElementsHidden .~ true

--- a/Library/Styles/SettingsStyles.swift
+++ b/Library/Styles/SettingsStyles.swift
@@ -15,7 +15,7 @@ public let settingsSectionLabelStyle = { (label: UILabel) in
     |> \.numberOfLines .~ 2
 }
 
-public let settingsTitleLabelStyle = { (label: UILabel) in
+public let settingsTitleLabelStyle: (UILabel) -> UILabel = { (label: UILabel) in
   label
     |> \.textColor .~ .ksr_soft_black
     |> \.font .~ .ksr_body()

--- a/Library/Styles/SettingsStyles.swift
+++ b/Library/Styles/SettingsStyles.swift
@@ -8,20 +8,20 @@ public let settingsSectionButtonStyle =
 
 public let settingsArrowViewStyle = UIImageView.lens.tintColor .~ .ksr_dark_grey_400
 
-public let settingsSectionLabelStyle = { (label: UILabel) in
+public let settingsSectionLabelStyle: LabelStyle = { (label: UILabel) in
   label
     |> \.textColor .~ .ksr_soft_black
     |> \.font .~ .ksr_subhead()
     |> \.numberOfLines .~ 2
 }
 
-public let settingsTitleLabelStyle: (UILabel) -> UILabel = { (label: UILabel) in
+public let settingsTitleLabelStyle: LabelStyle = { (label: UILabel) in
   label
     |> \.textColor .~ .ksr_soft_black
     |> \.font .~ .ksr_body()
 }
 
-public let settingsDetailLabelStyle = { (label: UILabel) in
+public let settingsDetailLabelStyle: LabelStyle = { (label: UILabel) in
   label
     |> \.font .~ .ksr_body()
     |> \.numberOfLines .~ 1
@@ -29,7 +29,7 @@ public let settingsDetailLabelStyle = { (label: UILabel) in
     |> \.lineBreakMode .~ .byTruncatingTail
 }
 
-public let settingsDescriptionLabelStyle = { (label: UILabel) in
+public let settingsDescriptionLabelStyle: LabelStyle = { (label: UILabel) in
   label
     |> \.font .~ .ksr_body(size: 13)
     |> \.numberOfLines .~ 0
@@ -37,13 +37,13 @@ public let settingsDescriptionLabelStyle = { (label: UILabel) in
     |> \.lineBreakMode .~ .byWordWrapping
 }
 
-public let settingsHeaderFooterLabelBaseStyle = { (label: UILabel) in
+public let settingsHeaderFooterLabelBaseStyle: LabelStyle = { (label: UILabel) in
   label
     |> \.font .~ .ksr_footnote()
     |> \.numberOfLines .~ 0
 }
 
-public let settingsHeaderFooterLabelStyle = { (label: UILabel) in
+public let settingsHeaderFooterLabelStyle: LabelStyle = { (label: UILabel) in
   label
     |> \.backgroundColor .~ .ksr_grey_200
     |> \.textColor .~ .ksr_text_dark_grey_500

--- a/Library/ViewModels/DiscoveryFiltersViewModel.swift
+++ b/Library/ViewModels/DiscoveryFiltersViewModel.swift
@@ -217,21 +217,21 @@ DiscoveryFiltersViewModelInputs, DiscoveryFiltersViewModelOutputs {
 private func expandableRows(selectedRow: SelectableRow,
                             categories: [KsApi.Category]) -> [ExpandableRow] {
 
-  let expandableRows = categories.filter { $0.isRoot }
-    .sorted { lhs, _ in lhs.isRoot }
-    .map { rootCategory in
+  let expandableRows = categories.filter { (category: KsApi.Category) in category.isRoot }
+    .sorted { (lhs: KsApi.Category, _) in lhs.isRoot }
+    .map { (rootCategory: KsApi.Category) in
       return ExpandableRow(isExpanded: false,
                            params: .defaults |> DiscoveryParams.lens.category .~ rootCategory,
                            selectableRows: ([rootCategory] + (rootCategory.subcategories?.nodes ?? []))
                             .sorted()
-                            .compactMap { node in
+                            .compactMap { (node: KsApi.Category) in
                               return SelectableRow(isSelected: node == selectedRow.params.category,
                                                    params: .defaults
                                                     |> DiscoveryParams.lens.category .~ node)
         }
       )
     }
-    .sorted { lhs, rhs in
+    .sorted { (lhs: ExpandableRow, rhs: ExpandableRow) in
       guard let lhsCategory = lhs.params.category, let rhsCategory = rhs.params.category else {
         return lhs.params.category == nil
       }


### PR DESCRIPTION
# 📲 What

Removes type check warnings by helping the compiler by explicitly setting types.

# 🤔 Why

It's considered best practice to keep warnings down to minimum in order to prevent from warnings bankruptcy which usually causes more warnings to slip into the codebase unnoticed.

# 🛠 How

Our project build settings uses experimental build flag `-warn-long-function-bodies=1000` (that's 1000ms) to set a type evaluation threshold for the compiler. Every time compiler tries to infer Swift types its evaluation time is considered against this threshold. If it takes the compiler longer than 1000ms, Xcode will show a warning. More about the topic [here](http://khanlou.com/2016/12/guarding-against-long-compiles).

<img width="687" alt="Screen Shot 2019-03-08 at 3 38 38 PM" src="https://user-images.githubusercontent.com/387596/54062145-337b8900-41b9-11e9-9d1e-7883d537b0c7.png">

In general this is a good practice. It helps us identify code that could take longer to infer. Unfortunately it appears that sometimes it's necessary to help the compiler a little. This is pretty simple and can be done by stating types explicitly.

It also appears that the most problematic area of our code base (that was causing the most warnings were the UI styles). As part of this PR I've tried to explicitly set types on these styles in order to help the compiler. This successfully suppressed compiler warnings.

I would like to propose that in the future we try to define our styles with using less of type inference and explicitly stating the types. This might add up to the code but ideally this would only happen in the styles sheet. In addition it might also help making it more readable.

I'd love to have a discussion around this topic and hear everyone's thoughts if possible before we decide what to do: @ifbarrera @Scollaco @cdolm92. This will affect the speed with which Xcode can infer types and therefore auto complete code (which is currently pretty slow).

# 👀 See

| Before 🐛 | After 🦋 |
| --- | --- |
| 13 warnings 😞  | 5 warnings 👍  |
| <img width="266" alt="Screen Shot 2019-03-08 at 3 40 15 PM" src="https://user-images.githubusercontent.com/387596/54062157-4a21e000-41b9-11e9-92d5-20ae91e081fd.png"> | <img width="268" alt="Screen Shot 2019-03-08 at 3 37 58 PM" src="https://user-images.githubusercontent.com/387596/54062160-4ee69400-41b9-11e9-9c5d-6d54a6bba878.png"> |

# ✅ Acceptance criteria

- [ ] All tests pass