### PR TITLE
📐 Allow tables to display content bellow the virtual home indicator

### DIFF
--- a/Kickstarter-iOS/Views/Storyboards/ProjectPamphlet.storyboard
+++ b/Kickstarter-iOS/Views/Storyboards/ProjectPamphlet.storyboard
@@ -1,14 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="GbK-FV-Iaj">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="GbK-FV-Iaj">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
-        <capability name="Alignment constraints with different attributes" minToolsVersion="5.1"/>
-        <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
-        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -41,7 +38,7 @@
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
                             <constraint firstItem="Bfz-Sg-Kdb" firstAttribute="trailing" secondItem="bdk-Xa-fm9" secondAttribute="trailing" id="3Dg-lk-oRa"/>
-                            <constraint firstItem="Bfz-Sg-Kdb" firstAttribute="bottom" secondItem="tIm-aj-d8Q" secondAttribute="bottom" id="8FY-Rt-Ar2"/>
+                            <constraint firstAttribute="bottom" secondItem="tIm-aj-d8Q" secondAttribute="bottom" id="8FY-Rt-Ar2"/>
                             <constraint firstItem="tIm-aj-d8Q" firstAttribute="leading" secondItem="Bfz-Sg-Kdb" secondAttribute="leading" id="HU6-02-QPk"/>
                             <constraint firstItem="tIm-aj-d8Q" firstAttribute="top" secondItem="bdk-Xa-fm9" secondAttribute="top" constant="52" id="Hk5-fJ-068"/>
                             <constraint firstItem="bdk-Xa-fm9" firstAttribute="leading" secondItem="Bfz-Sg-Kdb" secondAttribute="leading" id="eEt-q9-Snv"/>
@@ -94,7 +91,7 @@
                                         </state>
                                     </button>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="250" text=" " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="F7o-wQ-ufD">
-                                        <rect key="frame" x="198" y="14" width="4.5" height="21"/>
+                                        <rect key="frame" x="198" y="13.5" width="4.5" height="21"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
@@ -528,16 +525,16 @@
                                                 <imageView hidden="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="253" verticalHuggingPriority="251" image="live-indicator" translatesAutoresizingMaskIntoConstraints="NO" id="946-cU-6Dn">
                                                     <rect key="frame" x="0.0" y="11.5" width="0.0" height="11"/>
                                                 </imageView>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="BQJ-bs-AP3">
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text=" " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="BQJ-bs-AP3">
                                                     <rect key="frame" x="0.0" y="7" width="216" height="20.5"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <view contentMode="scaleToFill" horizontalHuggingPriority="253" translatesAutoresizingMaskIntoConstraints="NO" id="gk5-Oh-PZV">
+                                                <view contentMode="scaleToFill" horizontalHuggingPriority="253" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="gk5-Oh-PZV">
                                                     <rect key="frame" x="216" y="0.0" width="144" height="34"/>
                                                     <subviews>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iVO-lV-sJE">
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text=" " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iVO-lV-sJE">
                                                             <rect key="frame" x="8" y="8" width="128" height="18"/>
                                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                             <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/Kickstarter-iOS/Views/Storyboards/Settings.storyboard
+++ b/Kickstarter-iOS/Views/Storyboards/Settings.storyboard
@@ -56,7 +56,7 @@
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstItem="q38-TC-wFh" firstAttribute="trailing" secondItem="Xy4-mc-nWC" secondAttribute="trailing" id="DSv-1m-Iyv"/>
-                            <constraint firstItem="q38-TC-wFh" firstAttribute="bottom" secondItem="Xy4-mc-nWC" secondAttribute="bottom" id="NBc-HI-ls1"/>
+                            <constraint firstAttribute="bottom" secondItem="Xy4-mc-nWC" secondAttribute="bottom" id="NBc-HI-ls1"/>
                             <constraint firstItem="Xy4-mc-nWC" firstAttribute="leading" secondItem="q38-TC-wFh" secondAttribute="leading" id="Q5h-9D-kOU"/>
                             <constraint firstItem="Xy4-mc-nWC" firstAttribute="top" secondItem="q38-TC-wFh" secondAttribute="top" id="sms-yf-toC"/>
                         </constraints>
@@ -646,7 +646,7 @@
                         <constraints>
                             <constraint firstItem="cVt-VZ-hCL" firstAttribute="trailing" secondItem="W6g-6J-zfi" secondAttribute="trailing" id="FEF-jd-Tth"/>
                             <constraint firstItem="cVt-VZ-hCL" firstAttribute="leading" secondItem="W6g-6J-zfi" secondAttribute="leading" id="QbU-TT-1SW"/>
-                            <constraint firstItem="cVt-VZ-hCL" firstAttribute="bottom" secondItem="W6g-6J-zfi" secondAttribute="bottom" id="TQm-6g-n66"/>
+                            <constraint firstItem="cVt-VZ-hCL" firstAttribute="bottom" secondItem="gb9-7l-6YY" secondAttribute="bottom" id="TQm-6g-n66"/>
                             <constraint firstItem="cVt-VZ-hCL" firstAttribute="top" secondItem="gb9-7l-6YY" secondAttribute="top" id="fFh-dE-Hxh"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="W6g-6J-zfi"/>
@@ -678,7 +678,7 @@
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
-                            <constraint firstItem="JiT-6r-zd1" firstAttribute="bottom" secondItem="1CW-RA-xOi" secondAttribute="bottom" id="4Nh-0Z-prq"/>
+                            <constraint firstItem="JiT-6r-zd1" firstAttribute="bottom" secondItem="YT3-jR-gw6" secondAttribute="bottom" id="4Nh-0Z-prq"/>
                             <constraint firstItem="JiT-6r-zd1" firstAttribute="trailing" secondItem="1CW-RA-xOi" secondAttribute="trailing" id="Cik-RG-ixZ"/>
                             <constraint firstItem="JiT-6r-zd1" firstAttribute="leading" secondItem="1CW-RA-xOi" secondAttribute="leading" id="LAA-IF-JdQ"/>
                             <constraint firstItem="JiT-6r-zd1" firstAttribute="top" secondItem="1CW-RA-xOi" secondAttribute="top" id="PXS-SZ-UXU"/>
@@ -701,10 +701,10 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="WND-4C-aQn">
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="WND-4C-aQn">
                                 <rect key="frame" x="0.0" y="20" width="375" height="647"/>
                                 <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="lnb-P0-tav">
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="lnb-P0-tav">
                                         <rect key="frame" x="0.0" y="0.0" width="375" height="230"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="oRB-S8-IL5">
@@ -754,7 +754,7 @@
                                                     <constraint firstItem="lmn-J1-wDV" firstAttribute="leading" secondItem="CrV-4u-w6R" secondAttribute="leadingMargin" id="vMk-NW-Rck"/>
                                                 </constraints>
                                             </view>
-                                            <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="BMB-LZ-IRH" userLabel="Credit Card Section">
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BMB-LZ-IRH" userLabel="Credit Card Section">
                                                 <rect key="frame" x="0.0" y="86" width="375" height="50"/>
                                                 <subviews>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ygp-ig-bdL" userLabel="Separator">
@@ -764,11 +764,11 @@
                                                             <constraint firstAttribute="height" constant="0.5" id="7wL-Ak-ADg"/>
                                                         </constraints>
                                                     </view>
-                                                    <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="0rS-r2-TWS" customClass="STPPaymentCardTextField">
+                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0rS-r2-TWS" customClass="STPPaymentCardTextField">
                                                         <rect key="frame" x="0.0" y="0.5" width="375" height="49"/>
                                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     </view>
-                                                    <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="gOu-68-PJO" userLabel="Separator">
+                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gOu-68-PJO" userLabel="Separator">
                                                         <rect key="frame" x="12" y="49.5" width="363" height="0.5"/>
                                                         <color key="backgroundColor" red="0.86274509799999999" green="0.87058823529999996" blue="0.86666666670000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <constraints>
@@ -791,14 +791,14 @@
                                                     <constraint firstItem="ygp-ig-bdL" firstAttribute="leading" secondItem="BMB-LZ-IRH" secondAttribute="leading" constant="12" id="wE1-ah-iRT"/>
                                                 </constraints>
                                             </view>
-                                            <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="gef-dZ-cuA" customClass="SettingsFormFieldView" customModule="Kickstarter_Framework">
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gef-dZ-cuA" customClass="SettingsFormFieldView" customModule="Kickstarter_Framework">
                                                 <rect key="frame" x="0.0" y="136" width="375" height="44"/>
                                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" priority="750" constant="44" id="T6c-1g-LdI"/>
                                                 </constraints>
                                             </view>
-                                            <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="HyS-jM-HV4">
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="HyS-jM-HV4">
                                                 <rect key="frame" x="0.0" y="180" width="375" height="50"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="AWc-a8-i6h">


### PR DESCRIPTION
# 📲 What

Allows some of our table views to display content below the virtual home indicator on iPhone X/XS and the new iPad Pros.

# 🤔 Why

Following HIG

# 🛠 How

Simply updates bottom constraint to align to superview's bottom (instead of safe area's bottom).

This allows the content to be displayed below the virtual home indicator but also thanks to table view insets this will never lead to a state that would have content overlaid by the home indicator when the table view is scrolled all the way to the bottom.

# 👀 See

| Before 🐛 | After 🦋 |
| --- | --- |
| <img width="472" alt="Screen Shot 2019-03-18 at 10 28 14 AM" src="https://user-images.githubusercontent.com/387596/54550377-1f7a1900-4969-11e9-913a-3a1a5c91b41f.png"> |<img width="468" alt="Screen Shot 2019-03-18 at 10 28 07 AM" src="https://user-images.githubusercontent.com/387596/54550389-256ffa00-4969-11e9-9148-d0a8baba396f.png"> |

### Project detail

| Before 🐛 | After 🦋 | Resting state |
| --- | --- | --- |
| <img width="538" alt="Screen Shot 2019-03-18 at 10 17 50 AM" src="https://user-images.githubusercontent.com/387596/54550510-5819f280-4969-11e9-9367-5c0bcec3521c.png"> | <img width="538" alt="Screen Shot 2019-03-18 at 10 16 11 AM" src="https://user-images.githubusercontent.com/387596/54550519-5fd99700-4969-11e9-8cfa-d8454bd3104c.png"> | <img width="538" alt="Screen Shot 2019-03-18 at 10 16 14 AM" src="https://user-images.githubusercontent.com/387596/54550536-6831d200-4969-11e9-94ec-1a11ae12912f.png"> |

### Account

Please note that for visual demonstration the table view uses a red coloured border in order to demonstrate its bounds. The height of the header has also been adjusted to provide enough content size for the table. This code has not been committed.

| Before 🐛 | After 🦋 | Resting state |
| --- | --- | --- |
| <img width="538" alt="Screen Shot 2019-03-18 at 9 42 05 AM" src="https://user-images.githubusercontent.com/387596/54550904-29504c00-496a-11e9-9059-402c05e3dca4.png"> | <img width="538" alt="Screen Shot 2019-03-18 at 9 57 26 AM" src="https://user-images.githubusercontent.com/387596/54550928-30775a00-496a-11e9-8de1-53ff0691e336.png"> | <img width="538" alt="Screen Shot 2019-03-18 at 10 13 44 AM" src="https://user-images.githubusercontent.com/387596/54550940-3836fe80-496a-11e9-973d-67e3482b84ee.png"> |

### Payment methods

Please note that for visual demonstration the table view uses a red coloured border in order to demonstrate its bounds. This code has not been committed.

| Before 🐛 | After 🦋 | Resting state |
| --- | --- | --- |
| <img width="538" alt="Screen Shot 2019-03-18 at 10 04 28 AM" src="https://user-images.githubusercontent.com/387596/54550719-d1194a00-4969-11e9-82c2-c2c25ad00e8f.png"> | <img width="538" alt="Screen Shot 2019-03-18 at 10 05 27 AM" src="https://user-images.githubusercontent.com/387596/54550744-de363900-4969-11e9-9ed6-978422470fd8.png"> | <img width="538" alt="Screen Shot 2019-03-18 at 10 15 00 AM" src="https://user-images.githubusercontent.com/387596/54550766-e8f0ce00-4969-11e9-9504-786f2da9efe4.png"> |

### Help

Please note that for visual demonstration the table view uses a red coloured border in order to demonstrate its bounds. The height of the header has also been adjusted to provide enough content size for the table. This code has not been committed.

| Before 🐛 | After 🦋 | Resting state |
| --- | --- | --- |
| <img width="538" alt="Screen Shot 2019-03-18 at 10 08 42 AM" src="https://user-images.githubusercontent.com/387596/54551131-ac71a200-496a-11e9-866b-250d25431646.png"> | <img width="538" alt="Screen Shot 2019-03-18 at 10 10 13 AM" src="https://user-images.githubusercontent.com/387596/54551141-b2678300-496a-11e9-9f12-2af470880104.png"> | <img width="538" alt="Screen Shot 2019-03-18 at 10 10 16 AM" src="https://user-images.githubusercontent.com/387596/54551148-b98e9100-496a-11e9-9210-ab1caab76e5d.png"> |

# ✅ Acceptance criteria

The following should be tested on iPhone X/XS/XS Max or new iPad Pro (simulator will suffice)

Please note that specifically for Account & Help, you might need to simply verify by using the Visual Inspector in Xcode or tweak the size of the header on the specific VC to allow the table view to actually have a scrollable content.

- [x] `Project detail` screen displays content below the home indicator in both (portrait & landscape)
- [x] `Project detail` screen does NOT display content below the home indicator in a resting state (scrolled all the way to the bottom)
- [x] `Payment methods` screen displays content below the home indicator in both (portrait & landscape)
- [x] `Payment methods` screen does NOT display content bellow the home indicator in a resting state (scrolled all the way to the bottom)
- [x] `Settings > Account` screen displays content below the home indicator in both (portrait & 
landscape)
- [x] `Settings > Account` screen does NOT display content below the home indicator in a resting state (scrolled all the way to the bottom)
- [x] `Settings > Help` screen displays content below the home indicator in both (portrait & landscape)
- [x] `Settings > Help` screen does NOT display content bellow the home indicator in a resting state (scrolled all the way to the bottom)