### PR TITLE
[Create Password] Event tracking & tests

### DIFF
--- a/Library/Koala/Koala.swift
+++ b/Library/Koala/Koala.swift
@@ -1240,6 +1240,7 @@ public final class Koala {
   }
 
   // MARK: - Settings Events
+
   public func trackAppStoreRatingOpen() {
     // deprecated
     self.track(event: "App Store Rating Open", properties: deprecatedProps)
@@ -1270,6 +1271,19 @@ public final class Koala {
     self.track(event: "Viewed Account")
   }
 
+  // MARK: - Create Password Tracking
+
+  public enum CreatePasswordTrackingEvent: String {
+    case passwordCreated = "Created password"
+    case viewed = "Viewed create password"
+  }
+
+  public func trackCreatePassword(event: CreatePasswordTrackingEvent) {
+    self.track(event: event.rawValue)
+  }
+
+  // MARK: - Change Email Tracking
+
   public func trackChangeEmailView() {
     self.track(event: "Viewed Change Email")
   }
@@ -1277,6 +1291,8 @@ public final class Koala {
   public func trackChangeEmail() {
     self.track(event: "Changed Email")
   }
+
+  // MARK: - Change Password Tracking
 
   public func trackChangePasswordView() {
     self.track(event: "Viewed Change Password")

--- a/Library/Koala/KoalaTests.swift
+++ b/Library/Koala/KoalaTests.swift
@@ -694,6 +694,24 @@ final class KoalaTests: TestCase {
     XCTAssertEqual(["Viewed Account"], client.events)
   }
 
+  func testTrackCreatePassword_viewed() {
+    let client = MockTrackingClient()
+    let koala = Koala(client: client)
+
+    koala.trackCreatePassword(event: .viewed)
+
+    XCTAssertEqual([Koala.CreatePasswordTrackingEvent.viewed.rawValue], client.events)
+  }
+
+  func testTrackCreatePassword_passwordCreated() {
+    let client = MockTrackingClient()
+    let koala = Koala(client: client)
+
+    koala.trackCreatePassword(event: .passwordCreated)
+
+    XCTAssertEqual([Koala.CreatePasswordTrackingEvent.passwordCreated.rawValue], client.events)
+  }
+
   func testTrackViewedChangeEmail() {
     let client = MockTrackingClient()
     let koala = Koala(client: client)

--- a/Library/ViewModels/CreatePasswordViewModel.swift
+++ b/Library/ViewModels/CreatePasswordViewModel.swift
@@ -121,6 +121,13 @@ CreatePasswordViewModelInputs, CreatePasswordViewModelOutputs {
     ).map { $0.1 }
 
     self.validationLabelIsHidden = validationLabelTextIsNil
+
+    // Tracking
+    self.viewDidAppearProperty.signal
+      .observeValues { _ in AppEnvironment.current.koala.trackCreatePassword(event: .viewed) }
+
+    createPasswordEvent.values()
+      .observeValues { _ in AppEnvironment.current.koala.trackCreatePassword(event: .passwordCreated) }
   }
 
   private var newPasswordChangedProperty = MutableProperty<String?>(nil)

--- a/Library/ViewModels/CreatePasswordViewModelTests.swift
+++ b/Library/ViewModels/CreatePasswordViewModelTests.swift
@@ -316,4 +316,29 @@ final class CreatePasswordViewModelTests: TestCase {
       )
     }
   }
+
+  func testCreatePassword_eventTracking() {
+    let client = MockTrackingClient()
+
+    withEnvironment(apiService: MockService(), koala: Koala(client: client)) {
+      XCTAssertEqual([], client.events)
+
+      self.vm.inputs.viewDidAppear()
+
+      XCTAssertEqual(["Viewed create password"], client.events)
+
+      self.vm.inputs.newPasswordTextFieldChanged(text: "password")
+      self.vm.inputs.newPasswordConfirmationTextFieldChanged(text: "password")
+
+      self.saveButtonIsEnabled.assertValues([true])
+
+      self.vm.inputs.saveButtonTapped()
+
+      self.scheduler.advance()
+
+      self.createPasswordSuccess.assertValueCount(1)
+
+      XCTAssertEqual(["Viewed create password", "Created password"], client.events)
+    }
+  }
 }


### PR DESCRIPTION
# 📲 What

Adds tracking events and tests for the Create Password feature.

# ✅ Acceptance criteria

- [x] turn on the`KOALA_TRACKING` environment variable in the scheme. Then navigate to `Create Password` screen. You should see an event `"Viewed create password"` in the console.
- [x] turn on the`KOALA_TRACKING` environment variable in the scheme. Then navigate to `Create Password` screen. Fill in a new password and tap "Save". You should see an event `"Created password"` in the console.
