### PR TITLE
Renaming Create Password event

### DIFF
--- a/Library/Koala/Koala.swift
+++ b/Library/Koala/Koala.swift
@@ -1281,8 +1281,8 @@ public final class Koala {
   // MARK: - Create Password Tracking
 
   public enum CreatePasswordTrackingEvent: String {
-    case passwordCreated = "Created password"
-    case viewed = "Viewed create password"
+    case passwordCreated = "Created Password"
+    case viewed = "Viewed Create Password"
   }
 
   public func trackCreatePassword(event: CreatePasswordTrackingEvent) {

--- a/Library/ViewModels/CreatePasswordViewModelTests.swift
+++ b/Library/ViewModels/CreatePasswordViewModelTests.swift
@@ -354,7 +354,7 @@ final class CreatePasswordViewModelTests: TestCase {
 
       self.vm.inputs.viewDidAppear()
 
-      XCTAssertEqual(["Viewed create password"], client.events)
+      XCTAssertEqual([Koala.CreatePasswordTrackingEvent.viewed.rawValue], client.events)
 
       self.vm.inputs.newPasswordTextFieldChanged(text: "password")
       self.vm.inputs.newPasswordConfirmationTextFieldChanged(text: "password")
@@ -367,7 +367,8 @@ final class CreatePasswordViewModelTests: TestCase {
 
       self.createPasswordSuccess.assertValueCount(1)
 
-      XCTAssertEqual(["Viewed create password", "Created password"], client.events)
+      XCTAssertEqual([Koala.CreatePasswordTrackingEvent.viewed.rawValue,
+                      Koala.CreatePasswordTrackingEvent.passwordCreated.rawValue], client.events)
     }
   }
 }


### PR DESCRIPTION
# 📲 What

Renames the create password events.

# ✅ Acceptance criteria

- [ ] This feature has already been thoroughly tested in a previous PR, so this shouldn't need any additional AC testing
