### PR TITLE
💲 [Native Checkout] Plumbing

### DIFF
--- a/Kickstarter-iOS/DataSources/PledgeDataSource.swift
+++ b/Kickstarter-iOS/DataSources/PledgeDataSource.swift
@@ -1,0 +1,46 @@
+import Foundation
+import KsApi
+import Library
+
+final class PledgeDataSource: ValueCellDataSource {
+  enum Section: Int {
+    case project
+    case inputs
+    case summary
+  }
+
+  func load(reward: Reward) {
+    self.appendRow(
+      value: "Description",
+      cellClass: PledgeRowCell.self,
+      toSection: Section.project.rawValue
+    )
+
+    self.appendRow(
+      value: "Your pledge amount",
+      cellClass: PledgeRowCell.self,
+      toSection: Section.inputs.rawValue
+    )
+
+    self.appendRow(
+      value: "Your shipping location",
+      cellClass: PledgeRowCell.self,
+      toSection: Section.inputs.rawValue
+    )
+
+    self.appendRow(
+      value: "Total",
+      cellClass: PledgeRowCell.self,
+      toSection: Section.summary.rawValue
+    )
+  }
+
+  override func configureCell(tableCell cell: UITableViewCell, withValue value: Any) {
+    switch (cell, value) {
+    case let (cell as PledgeRowCell, value as String):
+      cell.configureWith(value: value)
+    default:
+      assertionFailure("Unrecognized (cell, viewModel) combo.")
+    }
+  }
+}

--- a/Kickstarter-iOS/DataSources/PledgeDataSourceTests.swift
+++ b/Kickstarter-iOS/DataSources/PledgeDataSourceTests.swift
@@ -1,0 +1,18 @@
+import XCTest
+@testable import Kickstarter_Framework
+@testable import Library
+@testable import KsApi
+
+final class PledgeDataSourceTests: XCTestCase {
+  let collectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewLayout())
+  let dataSource = PledgeDataSource()
+
+  func testLoadReward() {
+    dataSource.load(reward: Reward.template)
+
+    XCTAssertEqual(3, self.dataSource.numberOfSections(in: collectionView))
+    XCTAssertEqual(1, self.dataSource.collectionView(collectionView, numberOfItemsInSection: 0))
+    XCTAssertEqual(2, self.dataSource.collectionView(collectionView, numberOfItemsInSection: 1))
+    XCTAssertEqual(1, self.dataSource.collectionView(collectionView, numberOfItemsInSection: 2))
+  }
+}

--- a/Kickstarter-iOS/Views/Cells/PledgeRowCell.swift
+++ b/Kickstarter-iOS/Views/Cells/PledgeRowCell.swift
@@ -1,0 +1,8 @@
+import Library
+import UIKit
+
+final class PledgeRowCell: UITableViewCell, ValueCell {
+  func configureWith(value: String) {
+    self.textLabel?.text = value
+  }
+}

--- a/Kickstarter-iOS/Views/Controllers/PledgeTableViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/PledgeTableViewController.swift
@@ -3,54 +3,10 @@ import Library
 import Prelude
 import UIKit
 
-private enum PledgeSection: CaseIterable {
-  case project
-  case inputs
-  case summary
-}
-
-extension PledgeSection {
-  var rows: [PledgeRow] {
-    switch self {
-    case .project:
-      return [.description]
-    case .inputs:
-      return [.pledgeAmount, .shippingLocation]
-    case .summary:
-      return [.total]
-    }
-  }
-
-  var numberOfRows: Int {
-    return self.rows.count
-  }
-}
-
-private enum PledgeRow: CaseIterable {
-  case description
-  case pledgeAmount
-  case shippingLocation
-  case total
-}
-
-extension PledgeRow {
-  var title: String {
-    switch self {
-    case .description:
-      return "Description"
-    case .pledgeAmount:
-      return "Your pledge amount"
-    case .shippingLocation:
-      return "Your shipping location"
-    case .total:
-      return "Total"
-    }
-  }
-}
-
 class PledgeTableViewController: UITableViewController {
   // MARK: - Properties
 
+  private let dataSource: PledgeDataSource = PledgeDataSource()
   private let viewModel: PledgeViewModelType = PledgeViewModel()
 
   // MARK: - Lifecycle
@@ -59,8 +15,8 @@ class PledgeTableViewController: UITableViewController {
     return PledgeTableViewController(style: .grouped)
   }
 
-  func configure(with project: Project) {
-    self.viewModel.inputs.configure(with: project)
+  func configure(with reward: Reward) {
+    self.viewModel.inputs.configure(with: reward)
   }
 
   override func viewDidLoad() {
@@ -68,32 +24,31 @@ class PledgeTableViewController: UITableViewController {
 
     _ = self.tableView
       |> tableViewStyle
+      |> \.dataSource .~ self.dataSource
 
-    self.tableView.register(UITableViewCell.self, forCellReuseIdentifier: "Cell")
+    self.tableView.register(PledgeRowCell.self, forCellReuseIdentifier: "PledgeRowCell")
     self.tableView.register(UITableViewHeaderFooterView.self, forHeaderFooterViewReuseIdentifier: "Footer")
+
+    self.viewModel.inputs.viewDidLoad()
   }
 
-  // MARK: - UITableViewDataSource
+  // MARK: - Bindings
 
-  override func numberOfSections(in tableView: UITableView) -> Int {
-    return PledgeSection.allCases.count
-  }
+  override func bindViewModel() {
+    super.bindViewModel()
 
-  override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-    return PledgeSection.allCases[section].numberOfRows
-  }
-
-  override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-    let row = PledgeSection.allCases[indexPath.section].rows[indexPath.row]
-    let cell = tableView.dequeueReusableCell(withIdentifier: "Cell", for: indexPath)
-    cell.textLabel?.text = row.title
-    return cell
+    self.viewModel.outputs.reward
+      .observeForUI()
+      .observeValues { [weak self] reward in
+        self?.dataSource.load(reward: reward)
+        self?.tableView.reloadData()
+    }
   }
 
   // MARK: - UITableViewDelegate
 
   override func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
-    guard section < PledgeSection.allCases.count - 1 else { return nil }
+    guard section < self.dataSource.numberOfSections(in: self.tableView) - 1 else { return nil }
 
     let footerView = tableView.dequeueReusableHeaderFooterView(withIdentifier: "Footer")
     return footerView

--- a/Kickstarter-iOS/Views/Controllers/PledgeTableViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/PledgeTableViewController.swift
@@ -1,0 +1,111 @@
+import KsApi
+import Library
+import Prelude
+import UIKit
+
+private enum PledgeSection: CaseIterable {
+  case project
+  case inputs
+  case summary
+}
+
+extension PledgeSection {
+  var rows: [PledgeRow] {
+    switch self {
+    case .project:
+      return [.description]
+    case .inputs:
+      return [.pledgeAmount, .shippingLocation]
+    case .summary:
+      return [.total]
+    }
+  }
+
+  var numberOfRows: Int {
+    return self.rows.count
+  }
+}
+
+private enum PledgeRow: CaseIterable {
+  case description
+  case pledgeAmount
+  case shippingLocation
+  case total
+}
+
+extension PledgeRow {
+  var title: String {
+    switch self {
+    case .description:
+      return "Description"
+    case .pledgeAmount:
+      return "Your pledge amount"
+    case .shippingLocation:
+      return "Your shipping location"
+    case .total:
+      return "Total"
+    }
+  }
+}
+
+class PledgeTableViewController: UITableViewController {
+  // MARK: - Properties
+
+  private let viewModel: PledgeViewModelType = PledgeViewModel()
+
+  // MARK: - Lifecycle
+
+  static func instantiate() -> PledgeTableViewController {
+    return PledgeTableViewController(style: .grouped)
+  }
+
+  func configure(with project: Project) {
+    self.viewModel.inputs.configure(with: project)
+  }
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+
+    _ = self.tableView
+      |> tableViewStyle
+
+    self.tableView.register(UITableViewCell.self, forCellReuseIdentifier: "Cell")
+    self.tableView.register(UITableViewHeaderFooterView.self, forHeaderFooterViewReuseIdentifier: "Footer")
+  }
+
+  // MARK: - UITableViewDataSource
+
+  override func numberOfSections(in tableView: UITableView) -> Int {
+    return PledgeSection.allCases.count
+  }
+
+  override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+    return PledgeSection.allCases[section].numberOfRows
+  }
+
+  override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+    let row = PledgeSection.allCases[indexPath.section].rows[indexPath.row]
+    let cell = tableView.dequeueReusableCell(withIdentifier: "Cell", for: indexPath)
+    cell.textLabel?.text = row.title
+    return cell
+  }
+
+  // MARK: - UITableViewDelegate
+
+  override func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
+    guard section < PledgeSection.allCases.count - 1 else { return nil }
+
+    let footerView = tableView.dequeueReusableHeaderFooterView(withIdentifier: "Footer")
+    return footerView
+  }
+}
+
+// MARK: - Styles
+
+private let tableViewStyle: TableViewStyle = { (tableView: UITableView) in
+  tableView
+    |> \.contentInset .~ UIEdgeInsets(top: -35)
+    |> \.sectionFooterHeight .~ 10
+    |> \.sectionHeaderHeight .~ 0
+    |> \.separatorStyle .~ .none
+}

--- a/Kickstarter-iOS/Views/Controllers/PledgeTableViewControllerTests.swift
+++ b/Kickstarter-iOS/Views/Controllers/PledgeTableViewControllerTests.swift
@@ -1,0 +1,18 @@
+@testable import Kickstarter_Framework
+@testable import Library
+
+final class PledgeTableViewControllerTests: TestCase {
+  override func setUp() {
+    super.setUp()
+
+    AppEnvironment.pushEnvironment(mainBundle: Bundle.framework)
+    UIView.setAnimationsEnabled(false)
+  }
+
+  override func tearDown() {
+    AppEnvironment.popEnvironment()
+    UIView.setAnimationsEnabled(true)
+
+    super.tearDown()
+  }
+}

--- a/Kickstarter-iOS/Views/Controllers/PledgeViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/PledgeViewController.swift
@@ -1,0 +1,36 @@
+import KsApi
+import Prelude
+import UIKit
+
+final class PledgeViewController: UIViewController {
+  // MARK: - Properties
+
+  private lazy var pledgeTableViewController: PledgeTableViewController = {
+    PledgeTableViewController.instantiate()
+  }()
+
+  // MARK: - Lifecycle
+
+  static func instantiate() -> PledgeViewController {
+    return PledgeViewController()
+  }
+
+  func configure(with project: Project) {
+    self.pledgeTableViewController.configure(with: project)
+  }
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+
+    _ = self
+      |> \.title %~ { _ in "Back this project" }
+
+    if let childView = self.pledgeTableViewController.tableView {
+      self.addChild(self.pledgeTableViewController)
+      self.view.addSubview(childView)
+      self.pledgeTableViewController.didMove(toParent: self)
+
+      childView.constrainEdges(to: self.view)
+    }
+  }
+}

--- a/Kickstarter-iOS/Views/Controllers/PledgeViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/PledgeViewController.swift
@@ -15,8 +15,8 @@ final class PledgeViewController: UIViewController {
     return PledgeViewController()
   }
 
-  func configure(with project: Project) {
-    self.pledgeTableViewController.configure(with: project)
+  func configure(with reward: Reward) {
+    self.pledgeTableViewController.configure(with: reward)
   }
 
   override func viewDidLoad() {

--- a/Kickstarter-iOS/Views/Controllers/PledgeViewControllerTests.swift
+++ b/Kickstarter-iOS/Views/Controllers/PledgeViewControllerTests.swift
@@ -1,0 +1,11 @@
+@testable import Kickstarter_Framework
+import XCTest
+
+final class PledgeViewControllerTests: XCTestCase {
+  func testViewDidLoadAddsChildTableViewController() {
+    let vc = PledgeViewController.instantiate()
+    _ = vc.view
+
+    XCTAssertTrue(vc.children.first is PledgeTableViewController)
+  }
+}

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -99,6 +99,8 @@
 		37D6722F221E61D300B6D415 /* SettingsFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37D671F6221E61B600B6D415 /* SettingsFooterView.swift */; };
 		37D67231221E656500B6D415 /* SettingsFooterView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 37D67230221E656500B6D415 /* SettingsFooterView.xib */; };
 		37D99C5B22247F58008EF839 /* NSBundleType+Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37D99C2222247F4A008EF839 /* NSBundleType+Tests.swift */; };
+		37DEC1E72257C9F30051EF9B /* PledgeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37DEC1E62257C9F30051EF9B /* PledgeViewModel.swift */; };
+		37DEC2202257CA0A0051EF9B /* PledgeViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37DEC21F2257CA0A0051EF9B /* PledgeViewModelTests.swift */; };
 		37F39BB5221D05FA00E0FA65 /* UITraitCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37F39BB4221D05FA00E0FA65 /* UITraitCollection.swift */; };
 		37F39BEE221D062900E0FA65 /* UITraitCollectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37F39BED221D062900E0FA65 /* UITraitCollectionTests.swift */; };
 		37FEFBC8222F1E4F00FCA608 /* ProcessInfoType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37FEFBC7222F1E4F00FCA608 /* ProcessInfoType.swift */; };
@@ -1901,6 +1903,8 @@
 		37D671F6221E61B600B6D415 /* SettingsFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsFooterView.swift; sourceTree = "<group>"; };
 		37D67230221E656500B6D415 /* SettingsFooterView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SettingsFooterView.xib; sourceTree = "<group>"; };
 		37D99C2222247F4A008EF839 /* NSBundleType+Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSBundleType+Tests.swift"; sourceTree = "<group>"; };
+		37DEC1E62257C9F30051EF9B /* PledgeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PledgeViewModel.swift; sourceTree = "<group>"; };
+		37DEC21F2257CA0A0051EF9B /* PledgeViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PledgeViewModelTests.swift; sourceTree = "<group>"; };
 		37F39BB4221D05FA00E0FA65 /* UITraitCollection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITraitCollection.swift; sourceTree = "<group>"; };
 		37F39BED221D062900E0FA65 /* UITraitCollectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITraitCollectionTests.swift; sourceTree = "<group>"; };
 		37FEFBC7222F1E4F00FCA608 /* ProcessInfoType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessInfoType.swift; sourceTree = "<group>"; };
@@ -4192,6 +4196,8 @@
 				D7A86A3A1F324EB300C7DA53 /* MostPopularSearchProjectCellViewModelTests.swift */,
 				D63BBD34217FAB85007E01F0 /* PaymentMethodsViewModel.swift */,
 				D66FB347218212B700A27BCC /* PaymentMethodsViewModelTests.swift */,
+				37DEC1E62257C9F30051EF9B /* PledgeViewModel.swift */,
+				37DEC21F2257CA0A0051EF9B /* PledgeViewModelTests.swift */,
 				A7F441A11D005A9400FE6FC5 /* ProfileHeaderViewModel.swift */,
 				A7ED1F611E831C5C00BFFA01 /* ProfileHeaderViewModelTests.swift */,
 				015572701E79C426005FB8CC /* ProfileProjectCellViewModel.swift */,
@@ -5811,6 +5817,7 @@
 				A77D7B071CBAAF5D0077586B /* Paginate.swift in Sources */,
 				01F547ED1D53994B000A98EF /* TabBarItemStyles.swift in Sources */,
 				597073B41D07294500B00444 /* ProjectNotificationCellViewModel.swift in Sources */,
+				37DEC1E72257C9F30051EF9B /* PledgeViewModel.swift in Sources */,
 				015572711E79C427005FB8CC /* ProfileProjectCellViewModel.swift in Sources */,
 				A75CFB081CCE7FCF004CD5FA /* StaticTableViewCell.swift in Sources */,
 				A7F441D71D005A9400FE6FC5 /* ProfileViewModel.swift in Sources */,
@@ -6085,6 +6092,7 @@
 				D04AACAA218BB72100CF713E /* MessageBannerViewModelTests.swift in Sources */,
 				A7ED1FBC1E831C5C00BFFA01 /* FindFriendsFriendFollowCellViewModelTests.swift in Sources */,
 				A7ED1FDD1E831C5C00BFFA01 /* ShareViewModelTests.swift in Sources */,
+				37DEC2202257CA0A0051EF9B /* PledgeViewModelTests.swift in Sources */,
 				A7ED20001E831C5C00BFFA01 /* SearchViewModelTests.swift in Sources */,
 				D08CD201219216BA009F89F0 /* WatchProjectViewModelTests.swift in Sources */,
 				A7ED1F291E830FDC00BFFA01 /* EnvironmentTests.swift in Sources */,

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -105,6 +105,9 @@
 		37DEC2242257CB650051EF9B /* PledgeTableViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37DEC2232257CB650051EF9B /* PledgeTableViewControllerTests.swift */; };
 		37DEC2262257CC110051EF9B /* PledgeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37DEC2252257CC110051EF9B /* PledgeViewController.swift */; };
 		37DEC2282257CC270051EF9B /* PledgeViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37DEC2272257CC270051EF9B /* PledgeViewControllerTests.swift */; };
+		37DEC22A2257CD9F0051EF9B /* PledgeDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37DEC2292257CD9F0051EF9B /* PledgeDataSource.swift */; };
+		37DEC22C2257CDBA0051EF9B /* PledgeDataSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37DEC22B2257CDBA0051EF9B /* PledgeDataSourceTests.swift */; };
+		37DEC22E2257CDD50051EF9B /* PledgeRowCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37DEC22D2257CDD50051EF9B /* PledgeRowCell.swift */; };
 		37F39BB5221D05FA00E0FA65 /* UITraitCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37F39BB4221D05FA00E0FA65 /* UITraitCollection.swift */; };
 		37F39BEE221D062900E0FA65 /* UITraitCollectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37F39BED221D062900E0FA65 /* UITraitCollectionTests.swift */; };
 		37FEFBC8222F1E4F00FCA608 /* ProcessInfoType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37FEFBC7222F1E4F00FCA608 /* ProcessInfoType.swift */; };
@@ -1913,6 +1916,9 @@
 		37DEC2232257CB650051EF9B /* PledgeTableViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PledgeTableViewControllerTests.swift; sourceTree = "<group>"; };
 		37DEC2252257CC110051EF9B /* PledgeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PledgeViewController.swift; sourceTree = "<group>"; };
 		37DEC2272257CC270051EF9B /* PledgeViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PledgeViewControllerTests.swift; sourceTree = "<group>"; };
+		37DEC2292257CD9F0051EF9B /* PledgeDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PledgeDataSource.swift; sourceTree = "<group>"; };
+		37DEC22B2257CDBA0051EF9B /* PledgeDataSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PledgeDataSourceTests.swift; sourceTree = "<group>"; };
+		37DEC22D2257CDD50051EF9B /* PledgeRowCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PledgeRowCell.swift; sourceTree = "<group>"; };
 		37F39BB4221D05FA00E0FA65 /* UITraitCollection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITraitCollection.swift; sourceTree = "<group>"; };
 		37F39BED221D062900E0FA65 /* UITraitCollectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITraitCollectionTests.swift; sourceTree = "<group>"; };
 		37FEFBC7222F1E4F00FCA608 /* ProcessInfoType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessInfoType.swift; sourceTree = "<group>"; };
@@ -3419,6 +3425,7 @@
 				A773531E1D5E8AEF0017E239 /* MostPopularSearchProjectCell.swift */,
 				A7B1EBB21D90496A00BEE8B3 /* NoRewardCell.swift */,
 				A74382041D3458C900040A95 /* PaddingCell.swift */,
+				37DEC22D2257CDD50051EF9B /* PledgeRowCell.swift */,
 				A7FA38A31D9068940041FC9C /* PledgeTitleCell.swift */,
 				59B6B7091CCEBC1000953319 /* ProfileProjectCell.swift */,
 				9D9F57CB1D131AF200CE81DE /* ProjectActivityBackingCell.swift */,
@@ -4003,6 +4010,8 @@
 				015102741F1943D60006C0FC /* MessageThreadsDataSourceTests.swift */,
 				D63BBCF8217F666B007E01F0 /* PaymentMethodsDataSource.swift */,
 				D65E8F8821821EF500AB9412 /* PaymentMethodsDataSourceTests.swift */,
+				37DEC2292257CD9F0051EF9B /* PledgeDataSource.swift */,
+				37DEC22B2257CDBA0051EF9B /* PledgeDataSourceTests.swift */,
 				59322F051CD27B1000C90CC6 /* ProfileDataSource.swift */,
 				A7ED200E1E83229E00BFFA01 /* ProfileDataSourceTests.swift */,
 				9D9F58141D131D4A00CE81DE /* ProjectActivitiesDataSource.swift */,
@@ -6367,6 +6376,8 @@
 				A745D1411CAAB48F00C12802 /* LoginToutViewController.swift in Sources */,
 				77FD8B46216D6245000A95AC /* LoadingBarButtonItemView.swift in Sources */,
 				9D14FF8E1D133351005F4ABB /* ProjectActivityEmptyStateCell.swift in Sources */,
+				37DEC22E2257CDD50051EF9B /* PledgeRowCell.swift in Sources */,
+				37DEC22A2257CD9F0051EF9B /* PledgeDataSource.swift in Sources */,
 				017508161D67A4E300BB1863 /* DiscoveryNavigationHeaderViewController.swift in Sources */,
 				014D625B1E6E20BB0033D2BD /* BackerDashboardProjectsDataSource.swift in Sources */,
 				A78012651D2EEA620027396E /* ReferralChartView.swift in Sources */,
@@ -6425,6 +6436,7 @@
 				A7ED201D1E8322EC00BFFA01 /* TestCase.swift in Sources */,
 				A7ED201A1E83229E00BFFA01 /* ProfileDataSourceTests.swift in Sources */,
 				A7ED20111E83229E00BFFA01 /* ActivitiesDataSourceTests.swift in Sources */,
+				37DEC22C2257CDBA0051EF9B /* PledgeDataSourceTests.swift in Sources */,
 				A7ED20441E8323E900BFFA01 /* ResetPasswordViewControllerTests.swift in Sources */,
 				A7ED20491E8323E900BFFA01 /* DiscoveryPageViewControllerTests.swift in Sources */,
 				A7ED20151E83229E00BFFA01 /* DiscoveryFiltersDataSourceTests.swift in Sources */,

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -101,6 +101,10 @@
 		37D99C5B22247F58008EF839 /* NSBundleType+Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37D99C2222247F4A008EF839 /* NSBundleType+Tests.swift */; };
 		37DEC1E72257C9F30051EF9B /* PledgeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37DEC1E62257C9F30051EF9B /* PledgeViewModel.swift */; };
 		37DEC2202257CA0A0051EF9B /* PledgeViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37DEC21F2257CA0A0051EF9B /* PledgeViewModelTests.swift */; };
+		37DEC2222257CB470051EF9B /* PledgeTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37DEC2212257CB470051EF9B /* PledgeTableViewController.swift */; };
+		37DEC2242257CB650051EF9B /* PledgeTableViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37DEC2232257CB650051EF9B /* PledgeTableViewControllerTests.swift */; };
+		37DEC2262257CC110051EF9B /* PledgeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37DEC2252257CC110051EF9B /* PledgeViewController.swift */; };
+		37DEC2282257CC270051EF9B /* PledgeViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37DEC2272257CC270051EF9B /* PledgeViewControllerTests.swift */; };
 		37F39BB5221D05FA00E0FA65 /* UITraitCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37F39BB4221D05FA00E0FA65 /* UITraitCollection.swift */; };
 		37F39BEE221D062900E0FA65 /* UITraitCollectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37F39BED221D062900E0FA65 /* UITraitCollectionTests.swift */; };
 		37FEFBC8222F1E4F00FCA608 /* ProcessInfoType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37FEFBC7222F1E4F00FCA608 /* ProcessInfoType.swift */; };
@@ -1905,6 +1909,10 @@
 		37D99C2222247F4A008EF839 /* NSBundleType+Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSBundleType+Tests.swift"; sourceTree = "<group>"; };
 		37DEC1E62257C9F30051EF9B /* PledgeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PledgeViewModel.swift; sourceTree = "<group>"; };
 		37DEC21F2257CA0A0051EF9B /* PledgeViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PledgeViewModelTests.swift; sourceTree = "<group>"; };
+		37DEC2212257CB470051EF9B /* PledgeTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PledgeTableViewController.swift; sourceTree = "<group>"; };
+		37DEC2232257CB650051EF9B /* PledgeTableViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PledgeTableViewControllerTests.swift; sourceTree = "<group>"; };
+		37DEC2252257CC110051EF9B /* PledgeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PledgeViewController.swift; sourceTree = "<group>"; };
+		37DEC2272257CC270051EF9B /* PledgeViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PledgeViewControllerTests.swift; sourceTree = "<group>"; };
 		37F39BB4221D05FA00E0FA65 /* UITraitCollection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITraitCollection.swift; sourceTree = "<group>"; };
 		37F39BED221D062900E0FA65 /* UITraitCollectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITraitCollectionTests.swift; sourceTree = "<group>"; };
 		37FEFBC7222F1E4F00FCA608 /* ProcessInfoType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessInfoType.swift; sourceTree = "<group>"; };
@@ -3518,6 +3526,10 @@
 				A7ED203E1E8323E900BFFA01 /* MessageThreadsViewControllerTests.swift */,
 				D63BBCCF217E5460007E01F0 /* PaymentMethodsViewController.swift */,
 				D6F7416F21836C3D00C2DDA2 /* PaymentMethodsViewControllerTests.swift */,
+				37DEC2212257CB470051EF9B /* PledgeTableViewController.swift */,
+				37DEC2232257CB650051EF9B /* PledgeTableViewControllerTests.swift */,
+				37DEC2252257CC110051EF9B /* PledgeViewController.swift */,
+				37DEC2272257CC270051EF9B /* PledgeViewControllerTests.swift */,
 				9D9F580C1D131B1200CE81DE /* ProjectActivitiesViewController.swift */,
 				A7ED20331E8323E900BFFA01 /* ProjectActivityViewControllerTests.swift */,
 				A7808BBD1D6240B9001CF96A /* ProjectCreatorViewController.swift */,
@@ -6183,6 +6195,7 @@
 				7758A8372097BADF0018B96D /* DiscoveryProjectCategoryView.swift in Sources */,
 				59673CBD1D50ED380035AFD9 /* VideoViewController.swift in Sources */,
 				D796867E20FF910300E54C61 /* SettingsPrivacyDataSource.swift in Sources */,
+				37DEC2262257CC110051EF9B /* PledgeViewController.swift in Sources */,
 				77F9A9B02135FB760082A11E /* FindFriendsCell.swift in Sources */,
 				0146E3231CC0296900082C5B /* FacebookConfirmationViewController.swift in Sources */,
 				D79F0F712102973A00D3B32C /* SettingsPrivacyDeleteAccountCell.swift in Sources */,
@@ -6364,6 +6377,7 @@
 				A72C3AB51D00FB1F0075227E /* DiscoveryExpandableRowCell.swift in Sources */,
 				A7FA38D91D9068AD0041FC9C /* RewardsTitleCell.swift in Sources */,
 				A75AB1FA1C8A84B5002FC3E6 /* ActivitiesDataSource.swift in Sources */,
+				37DEC2222257CB470051EF9B /* PledgeTableViewController.swift in Sources */,
 				D60C8BF12143167200D96152 /* SettingsAccountViewController.swift in Sources */,
 				014D62991E6E22920033D2BD /* BackerDashboardEmptyStateCell.swift in Sources */,
 				D7237099211A3DA9001EA4CA /* SettingsFollowCell.swift in Sources */,
@@ -6406,6 +6420,7 @@
 				A7ED20661E83256700BFFA01 /* UpdateViewModelTests.swift in Sources */,
 				A7ED204E1E8323E900BFFA01 /* ProjectActivityViewControllerTests.swift in Sources */,
 				A7ED201B1E83229E00BFFA01 /* ProjectActivitiesDataSourceTests.swift in Sources */,
+				37DEC2242257CB650051EF9B /* PledgeTableViewControllerTests.swift in Sources */,
 				A7ED20161E83229E00BFFA01 /* DiscoveryPagesDataSourceTests.swift in Sources */,
 				A7ED201D1E8322EC00BFFA01 /* TestCase.swift in Sources */,
 				A7ED201A1E83229E00BFFA01 /* ProfileDataSourceTests.swift in Sources */,
@@ -6456,6 +6471,7 @@
 				A7ED20181E83229E00BFFA01 /* FindFriendsDataSourceTests.swift in Sources */,
 				A7ED20531E8323E900BFFA01 /* SearchViewControllerTests.swift in Sources */,
 				A7ED20121E83229E00BFFA01 /* CommentsDataSourceTests.swift in Sources */,
+				37DEC2282257CC270051EF9B /* PledgeViewControllerTests.swift in Sources */,
 				778215EB20F79FA300F3D09F /* HelpDataSourceTests.swift in Sources */,
 				A7ED20641E83256700BFFA01 /* RootViewModelTests.swift in Sources */,
 				A7ED204B1E8323E900BFFA01 /* DiscoveryNavigationHeaderViewControllerTests.swift in Sources */,

--- a/Library/ViewModels/PledgeViewModel.swift
+++ b/Library/ViewModels/PledgeViewModel.swift
@@ -5,11 +5,12 @@ import ReactiveSwift
 import Result
 
 public protocol PledgeViewModelInputs {
-  func configure(with project: Project)
+  func configure(with reward: Reward)
+  func viewDidLoad()
 }
 
 public protocol PledgeViewModelOutputs {
-
+  var reward: Signal<Reward, NoError> { get }
 }
 
 public protocol PledgeViewModelType {
@@ -17,22 +18,26 @@ public protocol PledgeViewModelType {
   var outputs: PledgeViewModelOutputs { get }
 }
 
-public class PledgeViewModel:
-  PledgeViewModelType,
-  PledgeViewModelInputs,
-PledgeViewModelOutputs {
+public class PledgeViewModel: PledgeViewModelType, PledgeViewModelInputs, PledgeViewModelOutputs {
   public init() {
-    self.configureProjectProperty.signal
+    let reward = self.configureRewardProperty.signal
       .skipNil()
-      .observeValues { project in
-        print("*** :\(project.name)")
-    }
+
+    self.reward = Signal.combineLatest(reward.signal, self.viewDidLoadProperty.signal)
+      .map(first)
   }
 
-  private let configureProjectProperty = MutableProperty<Project?>(nil)
-  public func configure(with project: Project) {
-    self.configureProjectProperty.value = project
+  private let configureRewardProperty = MutableProperty<Reward?>(nil)
+  public func configure(with reward: Reward) {
+    self.configureRewardProperty.value = reward
   }
+
+  private let viewDidLoadProperty = MutableProperty(())
+  public func viewDidLoad() {
+    self.viewDidLoadProperty.value = ()
+  }
+
+  public let reward: Signal<Reward, NoError>
 
   public var inputs: PledgeViewModelInputs { return self }
   public var outputs: PledgeViewModelOutputs { return self }

--- a/Library/ViewModels/PledgeViewModel.swift
+++ b/Library/ViewModels/PledgeViewModel.swift
@@ -1,0 +1,39 @@
+import KsApi
+import Foundation
+import Prelude
+import ReactiveSwift
+import Result
+
+public protocol PledgeViewModelInputs {
+  func configure(with project: Project)
+}
+
+public protocol PledgeViewModelOutputs {
+
+}
+
+public protocol PledgeViewModelType {
+  var inputs: PledgeViewModelInputs { get }
+  var outputs: PledgeViewModelOutputs { get }
+}
+
+public class PledgeViewModel:
+  PledgeViewModelType,
+  PledgeViewModelInputs,
+PledgeViewModelOutputs {
+  public init() {
+    self.configureProjectProperty.signal
+      .skipNil()
+      .observeValues { project in
+        print("*** :\(project.name)")
+    }
+  }
+
+  private let configureProjectProperty = MutableProperty<Project?>(nil)
+  public func configure(with project: Project) {
+    self.configureProjectProperty.value = project
+  }
+
+  public var inputs: PledgeViewModelInputs { return self }
+  public var outputs: PledgeViewModelOutputs { return self }
+}

--- a/Library/ViewModels/PledgeViewModelTests.swift
+++ b/Library/ViewModels/PledgeViewModelTests.swift
@@ -1,0 +1,14 @@
+import Foundation
+import Result
+import XCTest
+
+@testable import Library
+@testable import ReactiveExtensions_TestHelpers
+
+final class PledgeViewModelTests: TestCase {
+  private let vm: PledgeViewModelType = PledgeViewModel()
+
+  override func setUp() {
+    super.setUp()
+  }
+}

--- a/Library/ViewModels/PledgeViewModelTests.swift
+++ b/Library/ViewModels/PledgeViewModelTests.swift
@@ -1,14 +1,30 @@
 import Foundation
+import ReactiveSwift
+import ReactiveExtensions
 import Result
 import XCTest
 
+@testable import KsApi
 @testable import Library
 @testable import ReactiveExtensions_TestHelpers
 
 final class PledgeViewModelTests: TestCase {
   private let vm: PledgeViewModelType = PledgeViewModel()
 
+  private let reward = TestObserver<Reward, NoError>()
+
   override func setUp() {
     super.setUp()
+
+    self.vm.outputs.reward.observe(self.reward.observer)
+  }
+
+  func testRewardOnViewDidLoad() {
+    let reward = Reward.template
+
+    self.vm.inputs.configure(with: reward)
+    self.vm.inputs.viewDidLoad()
+
+    self.reward.assertValue(reward)
   }
 }


### PR DESCRIPTION
# 📲 What

Basic plumbing for the native checkout feature work

Includes:
- VC + Tests
- VM + Tests
- DataSource + Tests

# 🤔 Why

This should be a starting ground for the follow up work that should make it easy for us to work on different pieces in parallel.

# 🛠 How

`Simply` creates a `PledgeViewController` that manages its child `PledgeTableViewController` which displays content in form of a table. The reason for wrapping up `PledgeTableViewController` in `PledgeViewController` is so that we can present alert banners or other fancy things. The reason for using `PledgeTableViewController` being a subclass of `UITableViewController` is in order for getting all the keyboard handling functionality & layout resizing for free.

The architecture closely follows `ProjectPamphletContentViewController`.

# 📍 Note

In order to being able to see the screen you can navigate to `ProjectPamphletContentViewController` and change the behaviour of `goToRewardsPledge` signal observer to

```
// L:98
self.viewModel.outputs.goToRewardPledge
  .observeForControllerAction()
  .observeValues { [weak self] project, reward in
    let vc = PledgeViewController.instantiate()
    vc.configure(with: reward)
    vc.navigationItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(ProjectPamphletContentViewController.dismissRewardPledge(_:))) // Note: should not be handled by the controller itself but by its presenting controller (this controller)

    let nc = UINavigationController(rootViewController: vc)
    self?.present(nc, animated: true)
    }
  }
```

and also add the dismiss function to `ProjectPamphletContentViewController` like so
```
@objc private func dismissRewardPledge(_ button: UIBarButtonItem) {
  self.dismiss(animated: true, completion: nil)
}
```

# 👀 See

| iPhone SE | iPhone XS | iPad Pro 11 |
| --- | --- | --- |
| <img width="460" alt="Screen Shot 2019-03-29 at 2 53 49 PM" src="https://user-images.githubusercontent.com/387596/55265282-e6795880-5234-11e9-8209-d2d50e288251.png"> | <img width="545" alt="Screen Shot 2019-03-29 at 2 53 50 PM" src="https://user-images.githubusercontent.com/387596/55265287-ebd6a300-5234-11e9-9c2a-cce962bc128c.png"> | <img width="1002" alt="Screen Shot 2019-03-29 at 2 53 51 PM" src="https://user-images.githubusercontent.com/387596/55265295-f3964780-5234-11e9-9d55-b804c4dcc4a5.png"> |

# ✅ Acceptance criteria

- [ ] Presenting `PledgeVC` shows table with 5 rows and prints the name of selected project in the console
- [ ] Checkout using web still works