### PR TITLE
Set stepper images using a lens

### DIFF
--- a/Kickstarter-iOS/Views/Cells/PledgeAmountCell.swift
+++ b/Kickstarter-iOS/Views/Cells/PledgeAmountCell.swift
@@ -1,5 +1,6 @@
 import Library
 import Prelude
+import Prelude_UIKit
 import UIKit
 
 final class PledgeAmountCell: UITableViewCell, ValueCell {
@@ -106,12 +107,12 @@ private let rootStackViewStyle: StackViewStyle = { (stackView: UIStackView) in
 }
 
 private func stepperStyle(_ stepper: UIStepper) -> UIStepper {
-  stepper.setDecrementImage(UIImage(named: "stepper-decrement-normal"), for: .normal)
-  stepper.setDecrementImage(UIImage(named: "stepper-decrement-disabled"), for: .disabled)
-  stepper.setDecrementImage(UIImage(named: "stepper-decrement-highlighted"), for: .highlighted)
-  stepper.setIncrementImage(UIImage(named: "stepper-increment-normal"), for: .normal)
-  stepper.setIncrementImage(UIImage(named: "stepper-increment-disabled"), for: .disabled)
-  stepper.setIncrementImage(UIImage(named: "stepper-increment-highlighted"), for: .highlighted)
   return stepper
     |> \.tintColor .~ UIColor.clear
+    <> UIStepper.lens.decrementImage(for: .normal) .~ image(named: "stepper-decrement-normal")
+    <> UIStepper.lens.decrementImage(for: .disabled) .~ image(named: "stepper-decrement-disabled")
+    <> UIStepper.lens.decrementImage(for: .highlighted) .~ image(named: "stepper-decrement-highlighted")
+    <> UIStepper.lens.incrementImage(for: .normal) .~ image(named: "stepper-increment-normal")
+    <> UIStepper.lens.incrementImage(for: .disabled) .~ image(named: "stepper-increment-disabled")
+    <> UIStepper.lens.incrementImage(for: .highlighted) .~ image(named: "stepper-increment-highlighted")
 }


### PR DESCRIPTION
# 📲 What

Sets `UIStepper` images using a lens. 

# 🤔 Why

In order to follow our patterns, we'd prefer to use a lens to set images on a `UIStepper` object.

# 🛠 How

Since we have previously not used `UIStepper` class in our project this PR is dependent on this work https://github.com/kickstarter/Kickstarter-Prelude/pull/93/files

# 📍Note

1. Update submodules
Please make sure to run `make bootstrap` in order to properly update `Prelude` submodule

2. Make screen accessible from user flow
Go to `` and replace `goToRewardPledge` function with the following

```
fileprivate func goToRewardPledge(project: Project, reward: Reward) {
  let vc = PledgeViewController.instantiate()
  vc.configureWith(project: project, reward: reward)
  let nc = UINavigationController(rootViewController: vc)
  self.present(nc, animated: true)
}
```

3. Login on staging as non-admin user

4. Go to project detail and tap on `Pledge without a reward` button

# ✅ Acceptance criteria

- [ ] Stepper uses correct images for `normal`, `selected` & `highlighted` state