### PR TITLE
💲[Native Checkout] Shipping Location Cell 1/3 (UI)

### DIFF
--- a/Kickstarter-iOS/DataSources/PledgeDataSource.swift
+++ b/Kickstarter-iOS/DataSources/PledgeDataSource.swift
@@ -23,8 +23,8 @@ final class PledgeDataSource: ValueCellDataSource {
     )
 
     self.appendRow(
-      value: "Your shipping location",
-      cellClass: PledgeRowCell.self,
+      value: (location: "British Indian Ocean Territory", currency: "$", rate: 7.50),
+      cellClass: PledgeShippingLocationCell.self,
       toSection: Section.inputs.rawValue
     )
 
@@ -37,9 +37,11 @@ final class PledgeDataSource: ValueCellDataSource {
 
   override func configureCell(tableCell cell: UITableViewCell, withValue value: Any) {
     switch (cell, value) {
+    case let (cell as PledgeAmountCell, value as (Double, String)):
+      cell.configureWith(value: value)
     case let (cell as PledgeRowCell, value as String):
       cell.configureWith(value: value)
-    case let (cell as PledgeAmountCell, value as (Double, String)):
+    case let (cell as PledgeShippingLocationCell, value as (String, String, Double)):
       cell.configureWith(value: value)
     default:
       assertionFailure("Unrecognized (cell, viewModel) combo.")

--- a/Kickstarter-iOS/DataSources/PledgeDataSourceTests.swift
+++ b/Kickstarter-iOS/DataSources/PledgeDataSourceTests.swift
@@ -4,15 +4,15 @@ import XCTest
 @testable import KsApi
 
 final class PledgeDataSourceTests: XCTestCase {
-  let collectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewLayout())
   let dataSource = PledgeDataSource()
+  let tableView = UITableView(frame: .zero, style: .plain)
 
   func testLoad() {
     dataSource.load(amount: 100, currency: "USD")
 
-    XCTAssertEqual(3, self.dataSource.numberOfSections(in: collectionView))
-    XCTAssertEqual(1, self.dataSource.collectionView(collectionView, numberOfItemsInSection: 0))
-    XCTAssertEqual(2, self.dataSource.collectionView(collectionView, numberOfItemsInSection: 1))
-    XCTAssertEqual(1, self.dataSource.collectionView(collectionView, numberOfItemsInSection: 2))
+    XCTAssertEqual(3, self.dataSource.numberOfSections(in: self.tableView))
+    XCTAssertEqual(1, self.dataSource.tableView(self.tableView, numberOfRowsInSection: 0))
+    XCTAssertEqual(2, self.dataSource.tableView(self.tableView, numberOfRowsInSection: 1))
+    XCTAssertEqual(1, self.dataSource.tableView(self.tableView, numberOfRowsInSection: 2))
   }
 }

--- a/Kickstarter-iOS/DataSources/PledgeDataSourceTests.swift
+++ b/Kickstarter-iOS/DataSources/PledgeDataSourceTests.swift
@@ -7,12 +7,18 @@ final class PledgeDataSourceTests: XCTestCase {
   let dataSource = PledgeDataSource()
   let tableView = UITableView(frame: .zero, style: .plain)
 
+  // swiftlint:disable line_length
   func testLoad() {
-    dataSource.load(amount: 100, currency: "USD")
+    self.dataSource.load(amount: 100, currency: "USD")
 
     XCTAssertEqual(3, self.dataSource.numberOfSections(in: self.tableView))
     XCTAssertEqual(1, self.dataSource.tableView(self.tableView, numberOfRowsInSection: 0))
     XCTAssertEqual(2, self.dataSource.tableView(self.tableView, numberOfRowsInSection: 1))
     XCTAssertEqual(1, self.dataSource.tableView(self.tableView, numberOfRowsInSection: 2))
+    XCTAssertEqual(PledgeRowCell.defaultReusableId, self.dataSource.reusableId(item: 0, section: 0))
+    XCTAssertEqual(PledgeAmountCell.defaultReusableId, self.dataSource.reusableId(item: 0, section: 1))
+    XCTAssertEqual(PledgeShippingLocationCell.defaultReusableId, self.dataSource.reusableId(item: 1, section: 1))
+    XCTAssertEqual(PledgeRowCell.defaultReusableId, self.dataSource.reusableId(item: 0, section: 2))
   }
+  // swiftlint:enable line_length
 }

--- a/Kickstarter-iOS/Views/AmountInputView.swift
+++ b/Kickstarter-iOS/Views/AmountInputView.swift
@@ -15,12 +15,12 @@ class AmountInputView: UIView {
   override init(frame: CGRect) {
     super.init(frame: frame)
 
-    self.stackView.addArrangedSubview(self.label)
-    self.stackView.addArrangedSubview(self.textField)
-
     _ = (self.stackView, self)
       |> ksr_addSubviewToParent()
       |> ksr_constrainViewToEdgesInParent()
+
+    self.stackView.addArrangedSubview(self.label)
+    self.stackView.addArrangedSubview(self.textField)
   }
 
   required init?(coder aDecoder: NSCoder) {
@@ -33,7 +33,8 @@ class AmountInputView: UIView {
     super.bindStyles()
 
     _ = self
-      |> viewStyle
+      |> checkoutWhiteBackgroundStyle
+      |> checkoutRoundedCornersStyle
 
     _ = self.label
       |> labelStyle
@@ -84,12 +85,6 @@ private let stackViewStyle: StackViewStyle = { (stackView: UIStackView) in
   stackView
     |> \.alignment .~ UIStackView.Alignment.top
     |> \.isLayoutMarginsRelativeArrangement .~ true
-}
-
-private let viewStyle: ViewStyle = { (view: UIView) in
-  view
-    |> \.backgroundColor .~ UIColor.white
-    |> \.layer.cornerRadius .~ 6
 }
 
 // MARK: - Functions

--- a/Kickstarter-iOS/Views/AmountInputView.swift
+++ b/Kickstarter-iOS/Views/AmountInputView.swift
@@ -19,8 +19,8 @@ class AmountInputView: UIView {
       |> ksr_addSubviewToParent()
       |> ksr_constrainViewToEdgesInParent()
 
-    self.stackView.addArrangedSubview(self.label)
-    self.stackView.addArrangedSubview(self.textField)
+    _ = ([self.label, self.textField], self.stackView)
+      |> ksr_addArrangedSubviewsToStackView()
   }
 
   required init?(coder aDecoder: NSCoder) {

--- a/Kickstarter-iOS/Views/Cells/PledgeAmountCell.swift
+++ b/Kickstarter-iOS/Views/Cells/PledgeAmountCell.swift
@@ -28,12 +28,11 @@ final class PledgeAmountCell: UITableViewCell, ValueCell {
       |> ksr_addSubviewToParent()
       |> ksr_constrainViewToEdgesInParent()
 
-    self.rootStackView.addArrangedSubview(self.titleLabel)
-    self.rootStackView.addArrangedSubview(self.adaptableStackView)
+    _ = ([self.titleLabel, self.adaptableStackView], self.rootStackView)
+      |> ksr_addArrangedSubviewsToStackView()
 
-    self.adaptableStackView.addArrangedSubview(self.stepper)
-    self.adaptableStackView.addArrangedSubview(self.spacer)
-    self.adaptableStackView.addArrangedSubview(self.amountInputView)
+    _ = ([self.stepper, self.spacer, self.amountInputView], self.adaptableStackView)
+      |> ksr_addArrangedSubviewsToStackView()
 
     self.spacer.widthAnchor.constraint(greaterThanOrEqualToConstant: Styles.grid(3)).isActive = true
   }

--- a/Kickstarter-iOS/Views/Cells/PledgeAmountCell.swift
+++ b/Kickstarter-iOS/Views/Cells/PledgeAmountCell.swift
@@ -30,6 +30,7 @@ final class PledgeAmountCell: UITableViewCell, ValueCell {
 
     self.rootStackView.addArrangedSubview(self.titleLabel)
     self.rootStackView.addArrangedSubview(self.adaptableStackView)
+
     self.adaptableStackView.addArrangedSubview(self.stepper)
     self.adaptableStackView.addArrangedSubview(self.spacer)
     self.adaptableStackView.addArrangedSubview(self.amountInputView)

--- a/Kickstarter-iOS/Views/Cells/PledgeAmountCell.swift
+++ b/Kickstarter-iOS/Views/Cells/PledgeAmountCell.swift
@@ -6,14 +6,14 @@ import UIKit
 final class PledgeAmountCell: UITableViewCell, ValueCell {
   // MARK: - Properties
 
+  private lazy var adaptableStackView: UIStackView = { UIStackView(frame: .zero) }()
   private lazy var amountInputView: AmountInputView = { AmountInputView(frame: .zero) }()
-  private lazy var inputStackView: UIStackView = { UIStackView(frame: .zero) }()
-  private lazy var label: UILabel = { UILabel(frame: .zero) }()
+  private lazy var titleLabel: UILabel = { UILabel(frame: .zero) }()
   private lazy var rootStackView: UIStackView = { UIStackView(frame: .zero) }()
   private lazy var spacer: UIView = {
     UIView(frame: .zero)
       |> \.translatesAutoresizingMaskIntoConstraints .~ false
-  } ()
+  }()
   private lazy var stepper: UIStepper = { UIStepper(frame: .zero) }()
 
   // MARK: - Lifecycle
@@ -22,18 +22,17 @@ final class PledgeAmountCell: UITableViewCell, ValueCell {
     super.init(style: style, reuseIdentifier: reuseIdentifier)
 
     _ = self
-      |> \.accessibilityElements .~ [self.label, self.stepper, self.amountInputView]
-      |> \.backgroundColor .~ UIColor.ksr_grey_300
+      |> \.accessibilityElements .~ [self.titleLabel, self.stepper, self.amountInputView]
 
     _ = (self.rootStackView, self.contentView)
       |> ksr_addSubviewToParent()
       |> ksr_constrainViewToEdgesInParent()
 
-    self.rootStackView.addArrangedSubview(self.label)
-    self.rootStackView.addArrangedSubview(self.inputStackView)
-    self.inputStackView.addArrangedSubview(self.stepper)
-    self.inputStackView.addArrangedSubview(spacer)
-    self.inputStackView.addArrangedSubview(self.amountInputView)
+    self.rootStackView.addArrangedSubview(self.titleLabel)
+    self.rootStackView.addArrangedSubview(self.adaptableStackView)
+    self.adaptableStackView.addArrangedSubview(self.stepper)
+    self.adaptableStackView.addArrangedSubview(self.spacer)
+    self.adaptableStackView.addArrangedSubview(self.amountInputView)
 
     self.spacer.widthAnchor.constraint(greaterThanOrEqualToConstant: Styles.grid(3)).isActive = true
   }
@@ -47,14 +46,18 @@ final class PledgeAmountCell: UITableViewCell, ValueCell {
   override func bindStyles() {
     super.bindStyles()
 
-    _ = self.inputStackView
-      |> inputStackViewStyle(self.traitCollection.ksr_isAccessibilityCategory())
+    _ = self
+      |> checkoutBackgroundStyle
 
-    _ = self.label
-      |> labelStyle
+    _ = self.adaptableStackView
+      |> checkoutAdaptableStackViewStyle(self.traitCollection.ksr_isAccessibilityCategory())
+
+    _ = self.titleLabel
+      |> checkoutTitleLabelStyle
+      |> \.text %~ { _ in Strings.Your_pledge_amount() }
 
     _ = self.rootStackView
-      |> rootStackViewStyle
+      |> checkoutStackViewStyle
 
     _ = self.stepper
       |> stepperStyle
@@ -72,39 +75,6 @@ final class PledgeAmountCell: UITableViewCell, ValueCell {
 }
 
 // MARK: - Styles
-
-private func inputStackViewStyle(_ isAccessibilityCategory: Bool) -> ((UIStackView) -> UIStackView) {
-  return { (stackView: UIStackView) in
-    let alignment: UIStackView.Alignment = (isAccessibilityCategory ? .leading : .center)
-    let axis: NSLayoutConstraint.Axis = (isAccessibilityCategory ? .vertical : .horizontal)
-    let distribution: UIStackView.Distribution = (isAccessibilityCategory ? .equalSpacing : .fill)
-    let spacing: CGFloat = (isAccessibilityCategory ? Styles.grid(1) : 0)
-
-    return stackView
-      |> \.alignment .~ alignment
-      |> \.axis .~ axis
-      |> \.distribution .~ distribution
-      |> \.spacing .~ spacing
-  }
-}
-
-private let labelStyle: LabelStyle = { (label: UILabel) in
-  label
-    |> \.adjustsFontForContentSizeCategory .~ true
-    |> \.font .~ UIFont.ksr_headline()
-    |> \.numberOfLines .~ 0
-    |> \.text %~ { _ in Strings.Your_pledge_amount() }
-}
-
-private let rootStackViewStyle: StackViewStyle = { (stackView: UIStackView) in
-  stackView
-    |> \.axis .~ NSLayoutConstraint.Axis.vertical
-    |> \.isLayoutMarginsRelativeArrangement .~ true
-    |> \.layoutMargins .~ UIEdgeInsets(
-      top: Styles.grid(2), left: Styles.grid(4), bottom: Styles.grid(3), right: Styles.grid(4)
-    )
-    |> \.spacing .~ (Styles.grid(1) + Styles.gridHalf(1))
-}
 
 private func stepperStyle(_ stepper: UIStepper) -> UIStepper {
   return stepper

--- a/Kickstarter-iOS/Views/Cells/PledgeShippingLocationCell.swift
+++ b/Kickstarter-iOS/Views/Cells/PledgeShippingLocationCell.swift
@@ -27,12 +27,11 @@ final class PledgeShippingLocationCell: UITableViewCell, ValueCell {
       |> ksr_addSubviewToParent()
       |> ksr_constrainViewToEdgesInParent()
 
-    self.rootStackView.addArrangedSubview(self.titleLabel)
-    self.rootStackView.addArrangedSubview(self.adaptableStackView)
+    _ = ([self.titleLabel, self.adaptableStackView], self.rootStackView)
+      |> ksr_addArrangedSubviewsToStackView()
 
-    self.adaptableStackView.addArrangedSubview(self.countryButton)
-    self.adaptableStackView.addArrangedSubview(self.spacer)
-    self.adaptableStackView.addArrangedSubview(self.amountLabel)
+    _ = ([self.countryButton, self.spacer, self.amountLabel], self.adaptableStackView)
+      |> ksr_addArrangedSubviewsToStackView()
 
     self.spacer.widthAnchor.constraint(greaterThanOrEqualToConstant: Styles.grid(3)).isActive = true
 

--- a/Kickstarter-iOS/Views/Cells/PledgeShippingLocationCell.swift
+++ b/Kickstarter-iOS/Views/Cells/PledgeShippingLocationCell.swift
@@ -1,0 +1,103 @@
+import Library
+import Prelude
+import UIKit
+
+final class PledgeShippingLocationCell: UITableViewCell, ValueCell {
+  // MARK: - Properties
+
+  private lazy var adaptableStackView: UIStackView = { UIStackView(frame: .zero) }()
+  private lazy var amountLabel: UILabel = { UILabel(frame: .zero) }()
+  private lazy var countryButton: UIButton = { UIButton(frame: .zero) }()
+  private lazy var titleLabel: UILabel = { UILabel(frame: .zero) }()
+  private lazy var rootStackView: UIStackView = { UIStackView(frame: .zero) }()
+  private lazy var spacer: UIView = {
+    UIView(frame: .zero)
+      |> \.translatesAutoresizingMaskIntoConstraints .~ false
+  }()
+
+  // MARK: - Lifecycle
+
+  override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+    super.init(style: style, reuseIdentifier: reuseIdentifier)
+
+    _ = (self.rootStackView, self.contentView)
+      |> ksr_addSubviewToParent()
+      |> ksr_constrainViewToEdgesInParent()
+
+    self.rootStackView.addArrangedSubview(self.titleLabel)
+    self.rootStackView.addArrangedSubview(self.adaptableStackView)
+
+    self.adaptableStackView.addArrangedSubview(self.countryButton)
+    self.adaptableStackView.addArrangedSubview(self.spacer)
+    self.adaptableStackView.addArrangedSubview(self.amountLabel)
+
+    self.spacer.widthAnchor.constraint(greaterThanOrEqualToConstant: Styles.grid(3)).isActive = true
+
+    self.amountLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
+  }
+
+  required init?(coder aDecoder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  // MARK: - Styles
+
+  override func bindStyles() {
+    super.bindStyles()
+
+    _ = self
+      |> checkoutBackgroundStyle
+
+    _ = self.adaptableStackView
+      |> checkoutAdaptableStackViewStyle(self.traitCollection.ksr_isAccessibilityCategory())
+
+    _ = self.amountLabel
+      |> amountLabelStyle
+
+    _ = self.countryButton
+      |> countryButtonStyle
+      |> checkoutWhiteBackgroundStyle
+      |> checkoutRoundedCornersStyle
+
+    _ = self.countryButton.titleLabel
+      ?|> countryButtonTitleLabelStyle
+
+    _ = self.titleLabel
+      |> checkoutTitleLabelStyle
+      |> \.text %~ { _ in Strings.Your_shipping_location() }
+
+    _ = self.rootStackView
+      |> checkoutStackViewStyle
+  }
+
+  // MARK: - Configuration
+
+  func configureWith(value: (location: String, currency: String, rate: Double)) {
+    self.countryButton.setTitle(value.location, for: .normal)
+    self.amountLabel.text = "+\(value.currency)\(value.rate)"
+  }
+}
+
+// MARK: - Styles
+
+private let amountLabelStyle: LabelStyle = { (label: UILabel) in
+  label
+    |> \.adjustsFontForContentSizeCategory .~ true
+    |> \.font .~ UIFont.ksr_title1()
+    |> \.textColor .~ UIColor.ksr_text_dark_grey_500
+}
+
+private let countryButtonStyle: ButtonStyle = { (button: UIButton) in
+  button
+    |> \.contentEdgeInsets .~ UIEdgeInsets(
+      topBottom: Styles.grid(1) + Styles.gridHalf(1), leftRight: Styles.grid(2)
+    )
+    |> UIButton.lens.titleLabel.font .~ UIFont.ksr_body().bolded
+    |> UIButton.lens.titleColor(for: .normal) .~ UIColor.ksr_green_500
+    |> UIButton.lens.titleColor(for: .highlighted) .~ UIColor.ksr_green_700
+}
+
+private let countryButtonTitleLabelStyle: LabelStyle = { (label: UILabel) in
+  label
+    |> \.lineBreakMode .~ .byTruncatingTail
+}

--- a/Kickstarter-iOS/Views/Cells/PledgeShippingLocationCell.swift
+++ b/Kickstarter-iOS/Views/Cells/PledgeShippingLocationCell.swift
@@ -20,6 +20,9 @@ final class PledgeShippingLocationCell: UITableViewCell, ValueCell {
   override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
     super.init(style: style, reuseIdentifier: reuseIdentifier)
 
+    _ = self
+      |> \.accessibilityElements .~ [self.titleLabel, self.countryButton, self.amountLabel]
+
     _ = (self.rootStackView, self.contentView)
       |> ksr_addSubviewToParent()
       |> ksr_constrainViewToEdgesInParent()

--- a/Kickstarter-iOS/Views/Controllers/PledgeTableViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/PledgeTableViewController.swift
@@ -27,6 +27,7 @@ class PledgeTableViewController: UITableViewController {
 
     self.tableView.registerCellClass(PledgeAmountCell.self)
     self.tableView.registerCellClass(PledgeRowCell.self)
+    self.tableView.registerCellClass(PledgeShippingLocationCell.self)
     self.tableView.registerHeaderFooterClass(PledgeFooterView.self)
 
     self.viewModel.inputs.viewDidLoad()

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -81,6 +81,8 @@
 		370BE75022541CCE00B44DB2 /* UIViewController+URLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 370BE74E22541C8F00B44DB2 /* UIViewController+URLTests.swift */; };
 		370F527A2254267900F159B9 /* UIApplicationType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 370F52792254267900F159B9 /* UIApplicationType.swift */; };
 		370F52B3225426C700F159B9 /* UIApplication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 370F52B2225426C700F159B9 /* UIApplication.swift */; };
+		37280272226F880100E0ACBB /* CheckoutStyles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37280250226F878300E0ACBB /* CheckoutStyles.swift */; };
+		37280273226F880700E0ACBB /* CheckoutStylesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37280270226F879300E0ACBB /* CheckoutStylesTests.swift */; };
 		3732C25F224D3CE500155BE6 /* CreatePasswordViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3732C25E224D3CE500155BE6 /* CreatePasswordViewControllerTests.swift */; };
 		373AB222222A058600769FC2 /* CreatePasswordViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 373AB221222A058600769FC2 /* CreatePasswordViewModel.swift */; };
 		373AB25B222A063500769FC2 /* CreatePasswordViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 373AB25A222A063500769FC2 /* CreatePasswordViewModelTests.swift */; };
@@ -1893,6 +1895,8 @@
 		370BE74E22541C8F00B44DB2 /* UIViewController+URLTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+URLTests.swift"; sourceTree = "<group>"; };
 		370F52792254267900F159B9 /* UIApplicationType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIApplicationType.swift; sourceTree = "<group>"; };
 		370F52B2225426C700F159B9 /* UIApplication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIApplication.swift; sourceTree = "<group>"; };
+		37280250226F878300E0ACBB /* CheckoutStyles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckoutStyles.swift; sourceTree = "<group>"; };
+		37280270226F879300E0ACBB /* CheckoutStylesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckoutStylesTests.swift; sourceTree = "<group>"; };
 		3732C25E224D3CE500155BE6 /* CreatePasswordViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreatePasswordViewControllerTests.swift; sourceTree = "<group>"; };
 		373AB221222A058600769FC2 /* CreatePasswordViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreatePasswordViewModel.swift; sourceTree = "<group>"; };
 		373AB25A222A063500769FC2 /* CreatePasswordViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreatePasswordViewModelTests.swift; sourceTree = "<group>"; };
@@ -3186,18 +3190,20 @@
 				01FD71EB1D3808E500070BAC /* BarButtonItemStyles.swift */,
 				A73378FA1D0AE33B00C91445 /* BaseStyles.swift */,
 				A73379101D0E33A600C91445 /* ButtonStyles.swift */,
+				37280250226F878300E0ACBB /* CheckoutStyles.swift */,
+				37280270226F879300E0ACBB /* CheckoutStylesTests.swift */,
 				A73379441D0E36A600C91445 /* Colors.swift */,
 				5981BE0F1D7F4656002E49F1 /* CommentStyles.swift */,
 				59B0E07D1D147F340081D2DC /* DashboardStyles.swift */,
 				A757EB2A1D1AD89E00A5C978 /* DiscoveryStyles.swift */,
 				A73379471D0E36CA00C91445 /* Fonts.swift */,
+				A75313CA1E49363B002C4E7D /* LiveStreamStyles.swift */,
 				A73378FD1D0AE36400C91445 /* LoginStyles.swift */,
 				9DC572E41D36CA9800AE209C /* ProjectActivityStyles.swift */,
 				A796FF261D425A4500CD58AA /* ProjectStyles.swift */,
 				597582E21D5D12AE008765DE /* SettingsStyles.swift */,
 				01F547EC1D53994B000A98EF /* TabBarItemStyles.swift */,
 				8001D4971D41568C009E6667 /* UpdateDraftStyles.swift */,
-				A75313CA1E49363B002C4E7D /* LiveStreamStyles.swift */,
 			);
 			path = Styles;
 			sourceTree = "<group>";
@@ -5732,6 +5738,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D79F0F7521068DC800D3B32C /* SettingsDeleteAccountCellViewModel.swift in Sources */,
+				37280272226F880100E0ACBB /* CheckoutStyles.swift in Sources */,
 				013744F81D99A39B00E50C78 /* EmptyStatesViewModel.swift in Sources */,
 				D04AAC2E218BB70D00CF713E /* SettingsViewModel.swift in Sources */,
 				D0247A961DF9F29100D7A7C1 /* ProjectPamphletSubpageCellViewModel.swift in Sources */,
@@ -5999,6 +6006,7 @@
 				A7ED1F491E831BA200BFFA01 /* DispatchTimeInterval-Extensions.swift in Sources */,
 				A7ED1FBB1E831C5C00BFFA01 /* CommentsViewModelTests.swift in Sources */,
 				A7ED1FD91E831C5C00BFFA01 /* ProjectActivitiesViewModelTests.swift in Sources */,
+				37280273226F880700E0ACBB /* CheckoutStylesTests.swift in Sources */,
 				A7ED1FDB1E831C5C00BFFA01 /* DashboardViewModelTests.swift in Sources */,
 				A7ED1F2B1E830FDC00BFFA01 /* IsValidEmailTests.swift in Sources */,
 				A7ED1FEB1E831C5C00BFFA01 /* DashboardReferrersCellViewModelTests.swift in Sources */,

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -119,6 +119,8 @@
 		37E9E2A0225EABB000D29DD7 /* AmountInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E9E29F225EABB000D29DD7 /* AmountInputView.swift */; };
 		37F39BB5221D05FA00E0FA65 /* UITraitCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37F39BB4221D05FA00E0FA65 /* UITraitCollection.swift */; };
 		37F39BEE221D062900E0FA65 /* UITraitCollectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37F39BED221D062900E0FA65 /* UITraitCollectionTests.swift */; };
+		37FDAFAC2273BA4700662CC8 /* UIStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37FDAF702273B7FF00662CC8 /* UIStackView.swift */; };
+		37FDAFAD2273BA4B00662CC8 /* UIStackView+Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37FDAFAA2273B86800662CC8 /* UIStackView+Tests.swift */; };
 		37FEFBC8222F1E4F00FCA608 /* ProcessInfoType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37FEFBC7222F1E4F00FCA608 /* ProcessInfoType.swift */; };
 		59019FB61D21A47700EAEC9D /* DashboardReferrerRowStackViewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59019FB51D21A47700EAEC9D /* DashboardReferrerRowStackViewViewModel.swift */; };
 		59019FBA1D21ABD200EAEC9D /* DashboardReferrerRowStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59019FB81D21ABD200EAEC9D /* DashboardReferrerRowStackView.swift */; };
@@ -1934,6 +1936,8 @@
 		37E9E29F225EABB000D29DD7 /* AmountInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AmountInputView.swift; sourceTree = "<group>"; };
 		37F39BB4221D05FA00E0FA65 /* UITraitCollection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITraitCollection.swift; sourceTree = "<group>"; };
 		37F39BED221D062900E0FA65 /* UITraitCollectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITraitCollectionTests.swift; sourceTree = "<group>"; };
+		37FDAF702273B7FF00662CC8 /* UIStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIStackView.swift; sourceTree = "<group>"; };
+		37FDAFAA2273B86800662CC8 /* UIStackView+Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIStackView+Tests.swift"; sourceTree = "<group>"; };
 		37FEFBC7222F1E4F00FCA608 /* ProcessInfoType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessInfoType.swift; sourceTree = "<group>"; };
 		3D1363951F0191FB00B53420 /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/Localizable.strings; sourceTree = "<group>"; };
 		59019FB51D21A47700EAEC9D /* DashboardReferrerRowStackViewViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DashboardReferrerRowStackViewViewModel.swift; sourceTree = "<group>"; };
@@ -3369,7 +3373,6 @@
 				77FD8B45216D6245000A95AC /* LoadingBarButtonItemView.swift */,
 				D63BBD382180BE5D007E01F0 /* PaymentMethodsFooterView.swift */,
 				374F507822614A1000DE6746 /* PledgeFooterView.swift */,
-				5993DEBD1CE296F000925494 /* ProfileHeaderView.swift */,
 				015706BA1E68DE580087DD68 /* ProfileSortBarView.swift */,
 				A78012641D2EEA620027396E /* ReferralChartView.swift */,
 				D0A787BC2204D865006AE4F4 /* SelectCurrencyTableViewHeader.swift */,
@@ -3868,6 +3871,8 @@
 				A7C725991C85D36D005A016B /* UIPress-Extensions.swift */,
 				A78537E11CB5422100385B73 /* UIScreenType.swift */,
 				A7169BF51DDD064200480C0D /* UIScrollView+Extensions.swift */,
+				37FDAF702273B7FF00662CC8 /* UIStackView.swift */,
+				37FDAFAA2273B86800662CC8 /* UIStackView+Tests.swift */,
 				D6508F342049C45D002DCC01 /* UIStackView+BackgroundColor.swift */,
 				D0A787BE2204D975006AE4F4 /* UITableView+AutoLayoutHeaderView.swift */,
 				01A7A4BF1C9690220036E553 /* UITextField+LocalizedPlaceholderKey.swift */,
@@ -4031,8 +4036,6 @@
 				D65E8F8821821EF500AB9412 /* PaymentMethodsDataSourceTests.swift */,
 				37DEC2292257CD9F0051EF9B /* PledgeDataSource.swift */,
 				37DEC22B2257CDBA0051EF9B /* PledgeDataSourceTests.swift */,
-				59322F051CD27B1000C90CC6 /* ProfileDataSource.swift */,
-				A7ED200E1E83229E00BFFA01 /* ProfileDataSourceTests.swift */,
 				9D9F58141D131D4A00CE81DE /* ProjectActivitiesDataSource.swift */,
 				A7ED200F1E83229E00BFFA01 /* ProjectActivitiesDataSourceTests.swift */,
 				A73EF7091DCC17DD008FDBE5 /* ProjectNavigatorPagesDataSource.swift */,
@@ -4238,10 +4241,6 @@
 				D66FB347218212B700A27BCC /* PaymentMethodsViewModelTests.swift */,
 				37DEC1E62257C9F30051EF9B /* PledgeViewModel.swift */,
 				37DEC21F2257CA0A0051EF9B /* PledgeViewModelTests.swift */,
-				A7F441A11D005A9400FE6FC5 /* ProfileHeaderViewModel.swift */,
-				A7ED1F611E831C5C00BFFA01 /* ProfileHeaderViewModelTests.swift */,
-				015572701E79C426005FB8CC /* ProfileProjectCellViewModel.swift */,
-				A7ED1F771E831C5C00BFFA01 /* ProfileProjectCellViewModelTests.swift */,
 				A7F441A31D005A9400FE6FC5 /* ProfileViewModel.swift */,
 				A7ED1F671E831C5C00BFFA01 /* ProfileViewModelTests.swift */,
 				9D9F580F1D131B4000CE81DE /* ProjectActivitiesViewModel.swift */,
@@ -5861,7 +5860,6 @@
 				01F547ED1D53994B000A98EF /* TabBarItemStyles.swift in Sources */,
 				597073B41D07294500B00444 /* ProjectNotificationCellViewModel.swift in Sources */,
 				37DEC1E72257C9F30051EF9B /* PledgeViewModel.swift in Sources */,
-				015572711E79C427005FB8CC /* ProfileProjectCellViewModel.swift in Sources */,
 				A75CFB081CCE7FCF004CD5FA /* StaticTableViewCell.swift in Sources */,
 				A7F441D71D005A9400FE6FC5 /* ProfileViewModel.swift in Sources */,
 				597073521D05FE6B00B00444 /* ProjectNotificationsViewModel.swift in Sources */,
@@ -5909,6 +5907,7 @@
 				018422BB1D2C483000CA7566 /* DashboardTitleViewViewModel.swift in Sources */,
 				D04AAC1F218BB70D00CF713E /* SettingsNotificationCellViewModel.swift in Sources */,
 				A72AFFDA1CD7ED6B008F052B /* Keyboard.swift in Sources */,
+				37FDAFAC2273BA4700662CC8 /* UIStackView.swift in Sources */,
 				D04AAC2F218BB70D00CF713E /* LoadingBarButtonItemViewModel.swift in Sources */,
 				A718885D1DE0DDCE0094856D /* ShortcutItem.swift in Sources */,
 				D05C0CB01E02E3F100914393 /* LiveStreamActivityItemProvider.swift in Sources */,
@@ -6013,6 +6012,7 @@
 				A7ED1FDB1E831C5C00BFFA01 /* DashboardViewModelTests.swift in Sources */,
 				A7ED1F2B1E830FDC00BFFA01 /* IsValidEmailTests.swift in Sources */,
 				A7ED1FEB1E831C5C00BFFA01 /* DashboardReferrersCellViewModelTests.swift in Sources */,
+				37FDAFAD2273BA4B00662CC8 /* UIStackView+Tests.swift in Sources */,
 				D0D2AB2E1E9644B7008D298A /* LiveVideoViewModelTests.swift in Sources */,
 				D04AACA7218BB72100CF713E /* DiscoveryProjectCategoryViewModelTests.swift in Sources */,
 				A7ED1FD41E831C5C00BFFA01 /* DashboardRewardRowStackViewViewModelTests.swift in Sources */,

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -72,6 +72,7 @@
 		01F219561DC12BF7005DD2E4 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 01F219521DC12697005DD2E4 /* LaunchScreen.storyboard */; };
 		01F547ED1D53994B000A98EF /* TabBarItemStyles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F547EC1D53994B000A98EF /* TabBarItemStyles.swift */; };
 		01FD71EC1D3808E500070BAC /* BarButtonItemStyles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01FD71EB1D3808E500070BAC /* BarButtonItemStyles.swift */; };
+		37059843226F79A700BDA6E3 /* PledgeShippingLocationCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37059842226F79A700BDA6E3 /* PledgeShippingLocationCell.swift */; };
 		3705CF0F222EE7670025D37E /* EnvironmentVariables.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3705CF0E222EE7670025D37E /* EnvironmentVariables.swift */; };
 		3705CF48222EE77F0025D37E /* EnvironmentVariablesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3705CF47222EE77E0025D37E /* EnvironmentVariablesTests.swift */; };
 		3708DD43220A5A5700F8E569 /* SettingsGroupedFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3708DD42220A5A5700F8E569 /* SettingsGroupedFooterView.swift */; };
@@ -1886,6 +1887,7 @@
 		01F219521DC12697005DD2E4 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
 		01F547EC1D53994B000A98EF /* TabBarItemStyles.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabBarItemStyles.swift; sourceTree = "<group>"; };
 		01FD71EB1D3808E500070BAC /* BarButtonItemStyles.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BarButtonItemStyles.swift; sourceTree = "<group>"; };
+		37059842226F79A700BDA6E3 /* PledgeShippingLocationCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PledgeShippingLocationCell.swift; sourceTree = "<group>"; };
 		3705CF0E222EE7670025D37E /* EnvironmentVariables.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnvironmentVariables.swift; sourceTree = "<group>"; };
 		3705CF47222EE77E0025D37E /* EnvironmentVariablesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnvironmentVariablesTests.swift; sourceTree = "<group>"; };
 		3708DD42220A5A5700F8E569 /* SettingsGroupedFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsGroupedFooterView.swift; sourceTree = "<group>"; };
@@ -3438,6 +3440,7 @@
 				A74382041D3458C900040A95 /* PaddingCell.swift */,
 				37DEC22D2257CDD50051EF9B /* PledgeRowCell.swift */,
 				370ACAFF225D337900C8745F /* PledgeAmountCell.swift */,
+				37059842226F79A700BDA6E3 /* PledgeShippingLocationCell.swift */,
 				A7FA38A31D9068940041FC9C /* PledgeTitleCell.swift */,
 				9D9F57CB1D131AF200CE81DE /* ProjectActivityBackingCell.swift */,
 				9D2546F71D23101E0053844D /* ProjectActivityCommentCell.swift */,
@@ -6324,6 +6327,7 @@
 				A72C3AB71D00FB1F0075227E /* DiscoveryExpandedSelectableRow.swift in Sources */,
 				80EAEF071D243FC7008C2353 /* BackingViewController.swift in Sources */,
 				A7B1EBB31D90496A00BEE8B3 /* NoRewardCell.swift in Sources */,
+				37059843226F79A700BDA6E3 /* PledgeShippingLocationCell.swift in Sources */,
 				01940B291D467ECE0074FCE3 /* HelpWebViewController.swift in Sources */,
 				A73EF70A1DCC17DD008FDBE5 /* ProjectNavigatorPagesDataSource.swift in Sources */,
 				A7180BAA1CCED598001711CA /* CommentsViewController.swift in Sources */,

--- a/Library/Styles/CheckoutStyles.swift
+++ b/Library/Styles/CheckoutStyles.swift
@@ -40,7 +40,7 @@ public let checkoutTitleLabelStyle: LabelStyle = { (label: UILabel) in
   label
     |> \.accessibilityTraits .~ UIAccessibilityTraits.header
     |> \.adjustsFontForContentSizeCategory .~ true
-    |> \.font .~ UIFont.ksr_headline()
+    |> \.font .~ UIFont.ksr_headline(size: 15)
     |> \.numberOfLines .~ 0
 }
 

--- a/Library/Styles/CheckoutStyles.swift
+++ b/Library/Styles/CheckoutStyles.swift
@@ -1,0 +1,49 @@
+import Prelude
+import UIKit
+
+public func checkoutAdaptableStackViewStyle(_ isAccessibilityCategory: Bool) -> (StackViewStyle) {
+  return { (stackView: UIStackView) in
+    let alignment: UIStackView.Alignment = (isAccessibilityCategory ? .leading : .center)
+    let axis: NSLayoutConstraint.Axis = (isAccessibilityCategory ? .vertical : .horizontal)
+    let distribution: UIStackView.Distribution = (isAccessibilityCategory ? .equalSpacing : .fill)
+    let spacing: CGFloat = (isAccessibilityCategory ? Styles.grid(1) : 0)
+
+    return stackView
+      |> \.alignment .~ alignment
+      |> \.axis .~ axis
+      |> \.distribution .~ distribution
+      |> \.spacing .~ spacing
+  }
+}
+
+public let checkoutBackgroundStyle: ViewStyle = { (view: UIView) in
+  view
+    |> \.backgroundColor .~ UIColor.ksr_grey_300
+}
+
+public let checkoutRoundedCornersStyle: ViewStyle = { (view: UIView) in
+  view
+    |> \.layer.cornerRadius .~ 6
+}
+
+public let checkoutStackViewStyle: StackViewStyle = { (stackView: UIStackView) in
+  stackView
+    |> \.axis .~ NSLayoutConstraint.Axis.vertical
+    |> \.isLayoutMarginsRelativeArrangement .~ true
+    |> \.layoutMargins .~ UIEdgeInsets(
+      top: Styles.grid(2), left: Styles.grid(4), bottom: Styles.grid(3), right: Styles.grid(4)
+    )
+    |> \.spacing .~ (Styles.grid(1) + Styles.gridHalf(1))
+}
+
+public let checkoutTitleLabelStyle: LabelStyle = { (label: UILabel) in
+  label
+    |> \.adjustsFontForContentSizeCategory .~ true
+    |> \.font .~ UIFont.ksr_headline()
+    |> \.numberOfLines .~ 0
+}
+
+public let checkoutWhiteBackgroundStyle: ViewStyle = { (view: UIView) in
+  view
+    |> \.backgroundColor .~ UIColor.white
+}

--- a/Library/Styles/CheckoutStyles.swift
+++ b/Library/Styles/CheckoutStyles.swift
@@ -38,6 +38,7 @@ public let checkoutStackViewStyle: StackViewStyle = { (stackView: UIStackView) i
 
 public let checkoutTitleLabelStyle: LabelStyle = { (label: UILabel) in
   label
+    |> \.accessibilityTraits .~ UIAccessibilityTraits.header
     |> \.adjustsFontForContentSizeCategory .~ true
     |> \.font .~ UIFont.ksr_headline()
     |> \.numberOfLines .~ 0

--- a/Library/Styles/CheckoutStylesTests.swift
+++ b/Library/Styles/CheckoutStylesTests.swift
@@ -1,0 +1,53 @@
+@testable import Library
+import Prelude
+import UIKit
+import XCTest
+
+final class CheckoutStylesTests: XCTestCase {
+  func testCheckoutAdaptableStackViewStyle() {
+    let stackView = UIStackView(frame: .zero)
+
+    _ = stackView |> checkoutAdaptableStackViewStyle(false)
+
+    XCTAssertEqual(UIStackView.Alignment.center, stackView.alignment)
+    XCTAssertEqual(NSLayoutConstraint.Axis.horizontal, stackView.axis)
+    XCTAssertEqual(UIStackView.Distribution.fill, stackView.distribution)
+    XCTAssertEqual(0, stackView.spacing)
+
+    _ = stackView |> checkoutAdaptableStackViewStyle(true)
+
+    XCTAssertEqual(UIStackView.Alignment.leading, stackView.alignment)
+    XCTAssertEqual(NSLayoutConstraint.Axis.vertical, stackView.axis)
+    XCTAssertEqual(UIStackView.Distribution.equalSpacing, stackView.distribution)
+    XCTAssertEqual(6, stackView.spacing)
+  }
+
+  func testCheckoutBackgroundStyle() {
+    let view = UIView(frame: .zero)
+
+    _ = view |> checkoutBackgroundStyle
+
+    XCTAssertEqual(view.backgroundColor, UIColor.ksr_grey_300)
+  }
+
+  func testCheckoutStackViewStyle() {
+    let stackView = UIStackView(frame: .zero)
+
+    _ = stackView |> checkoutStackViewStyle
+
+    XCTAssertEqual(NSLayoutConstraint.Axis.vertical, stackView.axis)
+    XCTAssertEqual(true, stackView.isLayoutMarginsRelativeArrangement)
+    XCTAssertEqual(UIEdgeInsets(top: 12, left: 24, bottom: 18, right: 24), stackView.layoutMargins)
+    XCTAssertEqual(9, stackView.spacing)
+  }
+
+  func testCheckoutTitleLabelStyle() {
+    let label = UILabel(frame: .zero)
+
+    _ = label |> checkoutTitleLabelStyle
+
+    XCTAssertEqual(true, label.adjustsFontForContentSizeCategory)
+    XCTAssertEqual(UIFont.ksr_headline(), label.font)
+    XCTAssertEqual(0, label.numberOfLines)
+  }
+}

--- a/Library/Styles/CheckoutStylesTests.swift
+++ b/Library/Styles/CheckoutStylesTests.swift
@@ -47,7 +47,7 @@ final class CheckoutStylesTests: XCTestCase {
     _ = label |> checkoutTitleLabelStyle
 
     XCTAssertEqual(true, label.adjustsFontForContentSizeCategory)
-    XCTAssertEqual(UIFont.ksr_headline(), label.font)
+    XCTAssertEqual(UIFont.ksr_headline(size: 15), label.font)
     XCTAssertEqual(0, label.numberOfLines)
   }
 }

--- a/Library/UIStackView+Tests.swift
+++ b/Library/UIStackView+Tests.swift
@@ -13,7 +13,7 @@ final class UIStackViewTests: XCTestCase {
       |> ksr_addArrangedSubviewsToStackView()
 
     XCTAssertEqual(firstView, stackView.arrangedSubviews[0])
-    XCTAssertEqual(secondView, stackView.arrangedSubviews[0])
-    XCTAssertEqual(thirdView, stackView.arrangedSubviews[0])
+    XCTAssertEqual(secondView, stackView.arrangedSubviews[1])
+    XCTAssertEqual(thirdView, stackView.arrangedSubviews[2])
   }
 }

--- a/Library/UIStackView+Tests.swift
+++ b/Library/UIStackView+Tests.swift
@@ -1,0 +1,19 @@
+import Prelude
+import XCTest
+@testable import Library
+
+final class UIStackViewTests: XCTestCase {
+  func testAddArrangedSubviewsToStackView() {
+    let firstView = UIView(frame: .zero)
+    let secondView = UIView(frame: .zero)
+    let thirdView = UIView(frame: .zero)
+    let stackView = UIStackView(frame: .zero)
+
+    _ = ([firstView, secondView, thirdView], stackView)
+      |> ksr_addArrangedSubviewsToStackView()
+
+    XCTAssertEqual(firstView, stackView.arrangedSubviews[0])
+    XCTAssertEqual(secondView, stackView.arrangedSubviews[0])
+    XCTAssertEqual(thirdView, stackView.arrangedSubviews[0])
+  }
+}

--- a/Library/UIStackView.swift
+++ b/Library/UIStackView.swift
@@ -2,9 +2,7 @@ import UIKit.UIStackView
 
 public func ksr_addArrangedSubviewsToStackView() -> (([UIView], UIStackView) -> UIStackView) {
   return { (subviews, stackView) in
-    subviews.forEach { subview in
-      stackView.addArrangedSubview(subview)
-    }
+    subviews.forEach(stackView.addArrangedSubview)
 
     return stackView
   }

--- a/Library/UIStackView.swift
+++ b/Library/UIStackView.swift
@@ -1,0 +1,11 @@
+import UIKit.UIStackView
+
+public func ksr_addArrangedSubviewsToStackView() -> (([UIView], UIStackView) -> UIStackView) {
+  return { (subviews, stackView) in
+    subviews.forEach { subview in
+      stackView.addArrangedSubview(subview)
+    }
+
+    return stackView
+  }
+}


### PR DESCRIPTION
# 📲 What

Implements UI of the shipping location cell

# 🛠 How

In the same manner as we've added pledge amount cell we're continuing with shipping location cell.

Please note that this PR only considers visual appearance of the cell and that some values are hard coded + this work still misses user interaction.

This PR is the 1st out of 3 which will also address (passing correct data, formatting shipping amount correctly).

# 📍Note

In order to being able to see the screen you can navigate to `ProjectPamphletContentViewController` and change the behaviour of `goToRewardsPledge` function to the following

```
let vc = PledgeViewController.instantiate()
vc.configureWith(project: project, reward: reward)

let nc = UINavigationController(rootViewController: vc)
self.present(nc, animated: true)
```

# 👀 See

| Before 🐛 | After 🦋 |
| --- | --- |
| <img width="494" alt="Screen Shot 2019-04-11 at 4 25 23 PM" src="https://user-images.githubusercontent.com/387596/56002426-30236380-5c77-11e9-9f3d-2fa416655889.png">  | <img width="538" alt="Screen Shot 2019-04-23 at 5 20 01 PM" src="https://user-images.githubusercontent.com/387596/56624069-0b6eaa80-65ec-11e9-8cc5-e52001f6c598.png"> |

# ♿️ Accessibility 

**Dynamic Type**

Note how the country title truncates tail (there's an issue with multi-line labels/buttons in stack views) so currently we're simply using 1 line and might fix this in the future.

| Default | Large | Accessibility Large |
| --- | --- | --- |
| <img width="538" alt="Screen Shot 2019-04-23 at 4 37 25 PM" src="https://user-images.githubusercontent.com/387596/56623850-e2014f00-65ea-11e9-97e0-bf2700f8145f.png"> | <img width="494" alt="Screen Shot 2019-04-23 at 4 37 29 PM" src="https://user-images.githubusercontent.com/387596/56623854-e75e9980-65ea-11e9-959b-e185776bea40.png"> | <img width="494" alt="Screen Shot 2019-04-23 at 4 37 32 PM" src="https://user-images.githubusercontent.com/387596/56623858-e9c0f380-65ea-11e9-81cd-4d351352d427.png"> |
| <img width="538" alt="Screen Shot 2019-04-23 at 4 38 02 PM" src="https://user-images.githubusercontent.com/387596/56623862-f34a5b80-65ea-11e9-9883-5199e50007bb.png"> | <img width="494" alt="Screen Shot 2019-04-23 at 4 38 05 PM" src="https://user-images.githubusercontent.com/387596/56623868-f80f0f80-65ea-11e9-8fbe-b3586b5b534c.png"> | <img width="494" alt="Screen Shot 2019-04-23 at 4 38 07 PM" src="https://user-images.githubusercontent.com/387596/56623875-ff361d80-65ea-11e9-8385-d5d5915527ed.png"> |

**VoiceOver**

Shipping location cell exposes 3 accessible elements: title, button and label and reads them as follows

- [ ] Title is read by VO like: `Your shipping location, heading` and is localized
- [ ] Button is read by VO like: `{Country name}, button`
- [ ] Label is read by VO like: `+$7.5` (for now)

# ✅ Acceptance criteria

- [ ] Visual style matches design specs

(please note that the button doesn't use the small disclosure indicator, I'd suggest against this design approach due to it being mostly web pattern, not a mobile one)