### PR TITLE
💲[Native Checkout] Use HTML string with anchor tags

### DIFF
--- a/Kickstarter-iOS/Views/Cells/PledgeDescriptionCell.swift
+++ b/Kickstarter-iOS/Views/Cells/PledgeDescriptionCell.swift
@@ -216,24 +216,29 @@ private let learnMoreTextViewStyle: TextViewStyle = { (textView: UITextView) -> 
   return textView
 }
 
-private func attributedLearnMoreText() -> NSAttributedString {
-  let string = """
-  \(Strings.Kickstarter_is_not_a_store_Its_a_way_to_bring_creative_projects_to_life())
-  \(Strings.Learn_more_about_accountability())
-  """ as NSString
-
-  let linkRange = string.range(of: Strings.Learn_more_about_accountability())
-  let stringRange = string.range(of: string as String)
-
-  let attributedString = NSMutableAttributedString(string: string as String)
-
-  let url = urlForHelpType(
-    HelpType.trust, baseUrl: AppEnvironment.current.apiService.serverConfig.webBaseUrl
+private func attributedLearnMoreText() -> NSAttributedString? {
+  // swiftlint:disable line_length
+  let string = localizedString(
+    key: "Kickstarter_is_not_a_store_Its_a_way_to_bring_creative_projects_to_life_Learn_more_about_accountability",
+    defaultValue: "<p>Kickstarter is not a store. It's a way to bring creative projects to life.</br><a href=\"https://www.kickstarter.com/trust\">Learn more about accountability</a><p>"
   )
+  // swiftlint:enable line_length
 
-  attributedString.addAttribute(.font, value: UIFont.ksr_caption1(), range: stringRange)
-  attributedString.addAttribute(.foregroundColor, value: UIColor.ksr_text_dark_grey_500, range: stringRange)
-  attributedString.addAttribute(.link, value: url as Any, range: linkRange)
+  guard let attributedString = try? NSMutableAttributedString(
+    data: Data(bytes: string.utf8),
+    options: [.documentType: NSAttributedString.DocumentType.html],
+    documentAttributes: nil
+  ) else { return nil }
+
+  let attributes: [NSAttributedString.Key: Any] = [
+    .font: UIFont.ksr_caption1(),
+    .foregroundColor: UIColor.ksr_text_dark_grey_500,
+    .underlineStyle: 0
+  ]
+
+  let fullRange = (attributedString.string as NSString).range(of: attributedString.string)
+
+  attributedString.addAttributes(attributes, range: fullRange)
 
   return attributedString
 }


### PR DESCRIPTION
# 📲 What

Updates our way of inserting tappable links in `UITextView` by generating the `NSAttributedString` directly from HTML.

# 🤔 Why

In #672 and #668 we explored a way to add links to `NSAttributedString` using `UITextView` by searching for specific phrases in that string and applying link attributes to those ranges.

While this is fine in and of itself, it may be problematic when we start to work with translations and try to search for phrases in translated strings. A safer route would be for the entire string to be translated at once and wrap the phrases we care about in anchor tags in good old fashioned HTML.

# 🛠 How

- Added a hard-coded `String` for now which I'll submit for translation if we're happy with this approach.
- Generated our `NSAttributedString` from that.

# 👀 See

Still seems legit:

<img width="50%" alt="Screen Shot 2019-05-08 at 3 14 57 PM" src="https://user-images.githubusercontent.com/3735375/57412186-afd41d80-71a4-11e9-9b38-bb9dc1c41e99.png">

# ♿️ Accessibility 

- [ ] Tap targets use minimum of 44x44 pts dimensions
- [ ] Works with VoiceOver
- [ ] Supports Dynamic Type 

# 🏎 Performance

😕 This appears to be quite [challenging](https://stackoverflow.com/questions/18281525/uitextview-with-white-background-showing-as-color-blended-layer-in-instruments-a) with `UITextView`
- ❌ Optimized Blended Layers (screenshots)

# ✅ Acceptance criteria

- [ ] Comfortable with this approach

# ⏰ TODO

- [ ] Add string for translation
