### PR TITLE
Remove iOS 11 Availability Checks From Native Checkout

### DIFF
--- a/Kickstarter-iOS/Views/Cells/PledgeDescriptionCell.swift
+++ b/Kickstarter-iOS/Views/Cells/PledgeDescriptionCell.swift
@@ -117,15 +117,8 @@ final class PledgeDescriptionCell: UITableViewCell, ValueCell {
    _ = (views, self.descriptionStackView)
     |> ksr_addArrangedSubviewsToStackView()
 
-    if #available(iOS 11.0, *) {
-      self.descriptionStackView.setCustomSpacing(10.0, after: self.dateLabel)
-    } else {
-      let view: UIView = {
-        return UIView(frame: .zero) |> \.translatesAutoresizingMaskIntoConstraints .~ false
-      }()
-      view.heightAnchor.constraint(equalToConstant: Layout.SpacerView.height).isActive = true
-      self.descriptionStackView.insertArrangedSubview(view, at: 3)
-    }
+    self.descriptionStackView.setCustomSpacing(10.0, after: self.dateLabel)
+
     _ = ([self.descriptionStackView], self.rootStackView)
       |> ksr_addArrangedSubviewsToStackView()
   }

--- a/Kickstarter-iOS/Views/Controllers/PledgeTableViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/PledgeTableViewController.swift
@@ -94,16 +94,5 @@ private func tableViewStyle(_ tableView: UITableView) -> UITableView {
     |> \.sectionFooterHeight .~ PledgeFooterView.defaultHeight
     |> \.sectionHeaderHeight .~ 0
 
-  if #available(iOS 11, *) { } else {
-    let estimatedHeight: CGFloat = 44
-
-    return style
-      |> \.contentInset .~ UIEdgeInsets(top: 30)
-      |> \.estimatedSectionFooterHeight .~ estimatedHeight
-      |> \.estimatedSectionHeaderHeight .~ estimatedHeight
-      |> \.estimatedRowHeight .~ estimatedHeight
-      |> \.rowHeight .~ UITableView.automaticDimension
-  }
-
   return style
 }

--- a/Kickstarter-iOS/Views/Controllers/ProjectPamphletViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/ProjectPamphletViewController.swift
@@ -99,11 +99,7 @@ public final class ProjectPamphletViewController: UIViewController {
       |> \.shadowOpacity .~ 0.12
       |> \.shadowOffset .~ CGSize(width: 0, height: -1.0)
       |> \.shadowRadius .~ 1.0
-
-    if #available(iOS 11.0, *) {
-      _ = self.backThisProjectContainerView.layer
-        |> \.maskedCorners .~ [.layerMaxXMinYCorner, .layerMinXMinYCorner]
-    }
+      |> \.maskedCorners .~ [.layerMaxXMinYCorner, .layerMinXMinYCorner]
 
     _ = self.backThisProjectButton
       |> checkoutGreenButtonStyle
@@ -210,16 +206,7 @@ public final class ProjectPamphletViewController: UIViewController {
     let buttonSize = self.backThisProjectButton.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize)
     let bottomInset = buttonSize.height + 2 * self.backThisProjectContainerViewMargins
 
-    if #available(iOS 11.0, *) {
-      self.contentController.additionalSafeAreaInsets = UIEdgeInsets(bottom: bottomInset)
-    } else {
-      let insets = self.contentController.tableView.contentInset
-
-      self.contentController.tableView.contentInset = UIEdgeInsets(top: insets.top,
-                                                                   left: insets.left,
-                                                                   bottom: bottomInset,
-                                                                   right: insets.right)
-    }
+    self.contentController.additionalSafeAreaInsets = UIEdgeInsets(bottom: bottomInset)
   }
 
   // MARK: - Selectors

--- a/Kickstarter-iOS/Views/Controllers/RewardsCollectionViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/RewardsCollectionViewController.swift
@@ -178,11 +178,7 @@ final class RewardsCollectionViewController: UICollectionViewController {
     let cardWidth = Layout.Card.width
 
     let sectionInsets = layout.sectionInset
-    var adjustedContentInset = UIEdgeInsets.zero
-
-    if #available(iOS 11.0, *) {
-      adjustedContentInset = collectionView.adjustedContentInset
-    }
+    let adjustedContentInset = collectionView.adjustedContentInset
 
     let topBottomSectionInsets = sectionInsets.top + sectionInsets.bottom
     let topBottomContentInsets = adjustedContentInset.top + adjustedContentInset.bottom

--- a/Kickstarter-iOS/Views/Controllers/SheetOverlayViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/SheetOverlayViewController.swift
@@ -45,12 +45,10 @@ final class SheetOverlayViewController: UIViewController {
     _ = view
       |> \.translatesAutoresizingMaskIntoConstraints .~ false
 
-    if #available(iOS 11.0, *) {
-      _ = view.layer
-        |> checkoutLayerCardStyleRounded
-        |> \.masksToBounds .~ true
-        |> \.maskedCorners .~ [.layerMaxXMinYCorner, .layerMinXMinYCorner]
-    }
+    _ = view.layer
+      |> checkoutLayerCardStyleRounded
+      |> \.masksToBounds .~ true
+      |> \.maskedCorners .~ [.layerMaxXMinYCorner, .layerMinXMinYCorner]
 
     let isRegular = UIScreen.main.traitCollection.isRegularRegular
     let portraitWidth = min(UIScreen.main.bounds.height, UIScreen.main.bounds.width)

--- a/Kickstarter-iOS/Views/Controllers/SheetOverlayViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/SheetOverlayViewController.swift
@@ -46,7 +46,7 @@ final class SheetOverlayViewController: UIViewController {
       |> \.translatesAutoresizingMaskIntoConstraints .~ false
 
     _ = view.layer
-      |> checkoutLayerCardStyleRounded
+      |> checkoutLayerCardRoundedStyle
       |> \.masksToBounds .~ true
       |> \.maskedCorners .~ [.layerMaxXMinYCorner, .layerMinXMinYCorner]
 


### PR DESCRIPTION
# 📲 What

Removes any iOS 11 availability checks from the `feature-native-checkout` work.

# 🤔 Why

We've deprecated iOS 10 🎉 
