### PR TITLE
💲[Native Checkout] Reward Selection (no animation)

### DIFF
--- a/Kickstarter-iOS/Views/Controllers/RewardsCollectionViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/RewardsCollectionViewController.swift
@@ -13,7 +13,7 @@ final class RewardsCollectionViewController: UICollectionViewController {
   // MARK: - Properties
 
   private let dataSource = RewardsCollectionViewDataSource()
-  private let viewModel = RewardsCollectionViewModel()
+  fileprivate let viewModel = RewardsCollectionViewModel()
 
   private let hiddenPagingScrollView: UIScrollView = {
     UIScrollView()
@@ -111,6 +111,12 @@ final class RewardsCollectionViewController: UICollectionViewController {
         self?.dataSource.load(rewards: rewards)
         self?.collectionView.reloadData()
     }
+
+    self.viewModel.outputs.goToPledge
+      .observeForControllerAction()
+      .observeValues { [weak self] project, reward, refTag in
+        self?.goToPledge(project: project, reward: reward, refTag: refTag)
+    }
   }
 
   // MARK: - Private Helpers
@@ -190,10 +196,25 @@ final class RewardsCollectionViewController: UICollectionViewController {
     return CGSize(width: itemWidth, height: itemHeight)
   }
 
+  private func goToPledge(project: Project, reward: Reward, refTag: RefTag?) {
+    let pledgeViewController = PledgeViewController.instantiate()
+    pledgeViewController.configureWith(project: project, reward: reward)
+
+    self.navigationController?.pushViewController(pledgeViewController, animated: true)
+  }
+
   // MARK: - Public Functions
 
   @objc func closeButtonTapped() {
     self.navigationController?.dismiss(animated: true)
+  }
+}
+
+// MARK: - UICollectionViewDelegate
+
+extension RewardsCollectionViewController {
+  override func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+    self.viewModel.inputs.rewardSelected(at: indexPath.row)
   }
 }
 

--- a/Library/ViewModels/RewardsCollectionViewModel.swift
+++ b/Library/ViewModels/RewardsCollectionViewModel.swift
@@ -4,10 +4,10 @@ import Result
 import KsApi
 import Prelude
 
-public typealias GoToPledgeData = (project: Project, reward: Reward, refTag: RefTag?)
+public typealias PledgeData = (project: Project, reward: Reward, refTag: RefTag?)
 
 public protocol RewardsCollectionViewModelOutputs {
-  var goToPledge: Signal<GoToPledgeData, NoError> { get }
+  var goToPledge: Signal<PledgeData, NoError> { get }
   var reloadDataWithRewards: Signal<[Reward], NoError> { get }
 }
 
@@ -40,7 +40,7 @@ RewardsCollectionViewModelInputs, RewardsCollectionViewModelOutputs {
       selectedReward,
       self.configureWithRefTagProperty.signal)
       .map { project, reward, refTag in
-        return GoToPledgeData(project: project, reward: reward, refTag: refTag)
+        return PledgeData(project: project, reward: reward, refTag: refTag)
     }
   }
 
@@ -61,7 +61,7 @@ RewardsCollectionViewModelInputs, RewardsCollectionViewModelOutputs {
     self.viewDidLoadProperty.value = ()
   }
 
-  public let goToPledge: Signal<GoToPledgeData, NoError>
+  public let goToPledge: Signal<PledgeData, NoError>
   public let reloadDataWithRewards: Signal<[Reward], NoError>
 
   public var inputs: RewardsCollectionViewModelInputs { return self }

--- a/Library/ViewModels/RewardsCollectionViewModelTests.swift
+++ b/Library/ViewModels/RewardsCollectionViewModelTests.swift
@@ -10,8 +10,8 @@ final class RewardsCollectionViewModelTests: TestCase {
   private let vm: RewardsCollectionViewModelType = RewardsCollectionViewModel()
 
   private let goToPledgeProject = TestObserver<Project, NoError>()
-  private let goToPledgeReward = TestObserver<Reward, NoError>()
   private let goToPledgeRefTag = TestObserver<RefTag?, NoError>()
+  private let goToPledgeReward = TestObserver<Reward, NoError>()
   private let reloadDataWithRewards = TestObserver<[Reward], NoError>()
 
   override func setUp() {
@@ -53,15 +53,15 @@ final class RewardsCollectionViewModelTests: TestCase {
     self.vm.inputs.rewardSelected(at: 0)
 
     self.goToPledgeProject.assertValues([project])
-    //swiftlint:disable:next force_unwrapping
-    self.goToPledgeReward.assertValues([project.rewards.first!])
+    self.goToPledgeReward.assertValues([project.rewards[0]])
     self.goToPledgeRefTag.assertValues([.activity])
 
-    self.vm.inputs.rewardSelected(at: project.rewards.endIndex - 1)
+    let endIndex = project.rewards.endIndex
+
+    self.vm.inputs.rewardSelected(at: endIndex - 1)
 
     self.goToPledgeProject.assertValues([project, project])
-    //swiftlint:disable:next force_unwrapping
-    self.goToPledgeReward.assertValues([project.rewards.first!, project.rewards.last!])
+    self.goToPledgeReward.assertValues([project.rewards[0], project.rewards[endIndex - 1]])
     self.goToPledgeRefTag.assertValues([.activity, .activity])
   }
 }

--- a/Library/ViewModels/RewardsCollectionViewModelTests.swift
+++ b/Library/ViewModels/RewardsCollectionViewModelTests.swift
@@ -56,5 +56,12 @@ final class RewardsCollectionViewModelTests: TestCase {
     //swiftlint:disable:next force_unwrapping
     self.goToPledgeReward.assertValues([project.rewards.first!])
     self.goToPledgeRefTag.assertValues([.activity])
+
+    self.vm.inputs.rewardSelected(at: project.rewards.endIndex - 1)
+
+    self.goToPledgeProject.assertValues([project, project])
+    //swiftlint:disable:next force_unwrapping
+    self.goToPledgeReward.assertValues([project.rewards.first!, project.rewards.last!])
+    self.goToPledgeRefTag.assertValues([.activity, .activity])
   }
 }

--- a/Library/ViewModels/RewardsCollectionViewModelTests.swift
+++ b/Library/ViewModels/RewardsCollectionViewModelTests.swift
@@ -9,11 +9,17 @@ import ReactiveExtensions_TestHelpers
 final class RewardsCollectionViewModelTests: TestCase {
   private let vm: RewardsCollectionViewModelType = RewardsCollectionViewModel()
 
+  private let goToPledgeProject = TestObserver<Project, NoError>()
+  private let goToPledgeReward = TestObserver<Reward, NoError>()
+  private let goToPledgeRefTag = TestObserver<RefTag?, NoError>()
   private let reloadDataWithRewards = TestObserver<[Reward], NoError>()
 
   override func setUp() {
     super.setUp()
 
+    self.vm.outputs.goToPledge.map { $0.project }.observe(self.goToPledgeProject.observer)
+    self.vm.outputs.goToPledge.map { $0.reward }.observe(self.goToPledgeReward.observer)
+    self.vm.outputs.goToPledge.map { $0.refTag }.observe(self.goToPledgeRefTag.observer)
     self.vm.outputs.reloadDataWithRewards.observe(self.reloadDataWithRewards.observer)
   }
 
@@ -32,5 +38,23 @@ final class RewardsCollectionViewModelTests: TestCase {
     let value = self.reloadDataWithRewards.values.last
 
     XCTAssertTrue(value?.count == rewardsCount)
+  }
+
+  func testGoToPledge() {
+    let project = Project.cosmicSurgery
+
+    self.vm.inputs.configure(with: project, refTag: .activity)
+    self.vm.inputs.viewDidLoad()
+
+    self.goToPledgeProject.assertDidNotEmitValue()
+    self.goToPledgeReward.assertDidNotEmitValue()
+    self.goToPledgeRefTag.assertDidNotEmitValue()
+
+    self.vm.inputs.rewardSelected(at: 0)
+
+    self.goToPledgeProject.assertValues([project])
+    //swiftlint:disable:next force_unwrapping
+    self.goToPledgeReward.assertValues([project.rewards.first!])
+    self.goToPledgeRefTag.assertValues([.activity])
   }
 }


### PR DESCRIPTION
# 📲 What

Adds functionality for navigating to the `Pledge` screen when a reward is tapped from the `RewardsCollectionViewController`. Note that right now it's a simple `push` navigation, since we plan on implementing the custom transition in a separate item of work.

# 🤔 Why

So we can finally have an end-to-end flow for the new native checkout experience ❇️ 

# 🛠 How

Overrides the reward collection view's `collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath)` function, and passes the selected index to the view model as an input. The view model then grabs the reward selected at the given index, and combines it with the project object and the optional `refTag` to pass as an output. The `goToPledge` output is observed and subsequently creates and pushes the `PledgeViewController`.

# 👀 See

![BMklK0dMkq](https://user-images.githubusercontent.com/3156796/58194653-687e7e80-7cc6-11e9-9401-ff625f3cf717.gif)


# ♿️ Accessibility 

☝️ Note that right now the reward cells don't have an accessibility value, because it will be set as the title of the reward once we actually populate the reward cells with content.

- [x] Tap targets use minimum of 44x44 pts dimensions
- [x] Works with VoiceOver
- [x] Supports Dynamic Type 

# 🏎 Performance

- [x] Optimized Blended Layers (screenshots)

# ✅ Acceptance criteria

- [ ] Log in on an *admin* account to staging. Background the app, then open it again. Navigate to any project. Tap "Back this Project". Tap on any reward "card" and you should then be navigated to the pledge screen.
