### PR TITLE
Remove Stripe SDK caching from .circleci/config.yml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,9 +3,7 @@ version: 2
 xcode_version: &xcode_version 10.1.0
 iphone_name: &iphone_name iPhone 8
 fabric_sdk_version: &fabric_sdk_version 3.10.5
-stripe_sdk_version: &stripe_sdk_version 13.2.0
 store_fabric_sdk_version: &store_fabric_sdk_version echo "$FABRIC_SDK_VERSION" > fabric_version.txt
-store_stripe_version: &store_stripe_version echo "$STRIPE_SDK_VERSION" > stripe_version.txt
 preload_simulator: &preload_simulator xcrun instruments -w "iPhone 8 (12.1) [" || true
 
 base_job: &base_job
@@ -19,7 +17,6 @@ base_job: &base_job
     LC_ALL: en_US.UTF-8
     LANG: en_US.UTF-8
     FABRIC_SDK_VERSION: *fabric_sdk_version
-    STRIPE_SDK_VERSION: *stripe_sdk_version
     IPHONE_NAME: *iphone_name
     XCODE_VERSION: *xcode_version
 
@@ -39,17 +36,9 @@ jobs:
           name: Store Fabric SDK Version
           command: *store_fabric_sdk_version
 
-      - run:
-          name: Store Stripe Version
-          command: *store_stripe_version
-
       - restore_cache:
           keys:
             - fabric-sdk-cache-{{ checksum "fabric_version.txt" }}
-
-      - restore_cache:
-          keys:
-            - stripe-sdk-cache-{{ checksum "stripe_version.txt" }}
 
       - run:
           name: Store Xcode Version
@@ -80,11 +69,6 @@ jobs:
           paths:
             - "Frameworks/Fabric"
 
-      - save_cache:
-          key: stripe-sdk-cache-{{ checksum "stripe_version.txt" }}
-          paths:
-            - "Frameworks/Stripe"
-
       - run:
           name: SwiftLint
           command: make lint
@@ -108,17 +92,9 @@ jobs:
           name: Store Fabric SDK Version
           command: *store_fabric_sdk_version
 
-      - run:
-          name: Store Stripe Version
-          command: *store_stripe_version
-
       - restore_cache:
           keys:
             - fabric-sdk-cache-{{ checksum "fabric_version.txt" }}
-
-      - restore_cache:
-          keys:
-            - stripe-sdk-cache-{{ checksum "stripe_version.txt" }}
 
       - run:
           name: Store Xcode Version
@@ -163,17 +139,9 @@ jobs:
           name: Store Fabric SDK Version
           command: *store_fabric_sdk_version
 
-      - run:
-          name: Store Stripe Version
-          command: *store_stripe_version
-
       - restore_cache:
           keys:
             - fabric-sdk-cache-{{ checksum "fabric_version.txt" }}
-
-      - restore_cache:
-          keys:
-            - stripe-sdk-cache-{{ checksum "stripe_version.txt" }}
 
       - run:
           name: Store Xcode Version
@@ -216,17 +184,9 @@ jobs:
           name: Store Fabric SDK Version
           command: *store_fabric_sdk_version
 
-      - run:
-          name: Store Stripe Version
-          command: *store_stripe_version
-
       - restore_cache:
           keys:
             - fabric-sdk-cache-{{ checksum "fabric_version.txt" }}
-
-      - restore_cache:
-          keys:
-            - stripe-sdk-cache-{{ checksum "stripe_version.txt" }}
 
       - run:
           name: Store Xcode Version
@@ -269,17 +229,9 @@ jobs:
           name: Store Fabric SDK Version
           command: *store_fabric_sdk_version
 
-      - run:
-          name: Store Stripe Version
-          command: *store_stripe_version
-
       - restore_cache:
           keys:
             - fabric-sdk-cache-{{ checksum "fabric_version.txt" }}
-
-      - restore_cache:
-          keys:
-            - stripe-sdk-cache-{{ checksum "stripe_version.txt" }}
 
       - run:
           name: Store Xcode Version
@@ -339,17 +291,9 @@ jobs:
           name: Store Fabric SDK Version
           command: *store_fabric_sdk_version
 
-      - run:
-          name: Store Stripe Version
-          command: *store_stripe_version
-
       - restore_cache:
           keys:
             - fabric-sdk-cache-{{ checksum "fabric_version.txt" }}
-
-      - restore_cache:
-          keys:
-            - stripe-sdk-cache-{{ checksum "stripe_version.txt" }}
 
       - run:
           name: Store Xcode Version
@@ -413,17 +357,9 @@ jobs:
           name: Store Fabric SDK Version
           command: *store_fabric_sdk_version
 
-      - run:
-          name: Store Stripe Version
-          command: *store_stripe_version
-
       - restore_cache:
           keys:
             - fabric-sdk-cache-{{ checksum "fabric_version.txt" }}
-
-      - restore_cache:
-          keys:
-            - stripe-sdk-cache-{{ checksum "stripe_version.txt" }}
 
       - run:
           name: Store Xcode Version
@@ -482,17 +418,9 @@ jobs:
           name: Store Fabric SDK Version
           command: *store_fabric_sdk_version
 
-      - run:
-          name: Store Stripe Version
-          command: *store_stripe_version
-
       - restore_cache:
           keys:
             - fabric-sdk-cache-{{ checksum "fabric_version.txt" }}
-
-      - restore_cache:
-          keys:
-            - stripe-sdk-cache-{{ checksum "stripe_version.txt" }}
 
       - run:
           name: Store Xcode Version
@@ -540,17 +468,9 @@ jobs:
           name: Store Fabric SDK Version
           command: *store_fabric_sdk_version
 
-      - run:
-          name: Store Stripe Version
-          command: *store_stripe_version
-
       - restore_cache:
           keys:
             - fabric-sdk-cache-{{ checksum "fabric_version.txt" }}
-
-      - restore_cache:
-          keys:
-            - stripe-sdk-cache-{{ checksum "stripe_version.txt" }}
 
       - run:
           name: Store Xcode Version


### PR DESCRIPTION
# 📲 What

Removes Stripe SDK caching from our CircleCI config

# 🤔 Why

This should have been removed in #658 as it is now downloaded by Carthage.