### PR TITLE
Ensure tests are only run on iPhone 8

### DIFF
--- a/Library/TestHelpers/TestCase.swift
+++ b/Library/TestHelpers/TestCase.swift
@@ -26,10 +26,7 @@ internal class TestCase: FBSnapshotTestCase {
   override func setUp() {
     super.setUp()
 
-    let preferredDeviceName = "iPhone 8"
-    if !UIDevice.current.name.contains(preferredDeviceName) {
-      fatalError("Please only test and record screenshots on \(preferredDeviceName)")
-    }
+    preferredSimulatorCheck()
 
     UIView.doBadSwizzleStuff()
     UIViewController.doBadSwizzleStuff()
@@ -73,5 +70,16 @@ internal class TestCase: FBSnapshotTestCase {
   override func tearDown() {
     super.tearDown()
     AppEnvironment.popEnvironment()
+  }
+}
+
+internal func preferredSimulatorCheck() {
+  guard
+    let identifier = ProcessInfo().environment["SIMULATOR_MODEL_IDENTIFIER"],
+    ["iPhone10,1", "iPhone10,4"].contains(identifier),
+    AppEnvironment.current.isOSVersionAvailable(12)
+  else {
+    XCTFail("Please only test and record screenshots on an iPhone 8 simulator running iOS 12")
+    fatalError()
   }
 }

--- a/Library/TestHelpers/TestCase.swift
+++ b/Library/TestHelpers/TestCase.swift
@@ -79,7 +79,6 @@ internal func preferredSimulatorCheck() {
     ["iPhone10,1", "iPhone10,4"].contains(identifier),
     AppEnvironment.current.isOSVersionAvailable(12)
   else {
-    XCTFail("Please only test and record screenshots on an iPhone 8 simulator running iOS 12")
-    fatalError()
+    fatalError("Please only test and record screenshots on an iPhone 8 simulator running iOS 12")
   }
 }

--- a/Library/TestHelpers/TestCase.swift
+++ b/Library/TestHelpers/TestCase.swift
@@ -25,6 +25,12 @@ internal class TestCase: FBSnapshotTestCase {
 
   override func setUp() {
     super.setUp()
+
+    let preferredDeviceName = "iPhone 8"
+    if !UIDevice.current.name.contains(preferredDeviceName) {
+      fatalError("Please only test and record screenshots on \(preferredDeviceName)")
+    }
+
     UIView.doBadSwizzleStuff()
     UIViewController.doBadSwizzleStuff()
 


### PR DESCRIPTION
# 📲 What

Ensures that we only run tests and record screenshots on the iPhone 8 simulator.

If for whatever reason we need to run unit tests on a different device, we can just comment out this line.

# 🤔 Why

It's happened once or twice in the past that we accidentally record a bunch of screenshots on the wrong device which results in thousands of new screenshots being committed to the repo. This is just a safety catch to help us prevent that.

# 🛠 How

Put a check at the top of `TestCase` `setUp()` function which is called before all tests run.

# ✅ Acceptance criteria

- [ ] All tests pass as before.
- [ ] Running tests on any other device causes Xcode to fail and to not continue running tests.
