### PR TITLE
💲[Native Checkout] Refactor cells to be backed by view model

### DIFF
--- a/Kickstarter-iOS/DataSources/PledgeDataSource.swift
+++ b/Kickstarter-iOS/DataSources/PledgeDataSource.swift
@@ -10,114 +10,29 @@ final class PledgeDataSource: ValueCellDataSource {
     case summary
   }
 
-  enum PledgeInputRow: Equatable {
-    case pledgeAmount(amount: Double, currencySymbol: String)
-    case shippingLocation(location: String, shippingCost: Double, project: Project)
-
-    var isShipping: Bool {
-      switch self {
-      case .shippingLocation: return true
-      default: return false
-      }
-    }
-
-    var isPledgeAmount: Bool {
-      switch self {
-      case .pledgeAmount: return true
-      default: return false
-      }
-    }
-  }
-
   // MARK: - Load
 
-  func load(data: PledgeTableViewData) {
-    self.loadProjectSection(delivery: data.estimatedDelivery)
-
-    self.loadInputsSection(
-      amount: data.amount,
-      currencySymbol: data.currencySymbol,
-      shippingLocation: data.shippingLocation,
-      shippingCost: data.shippingCost,
-      project: data.project,
-      requiresShippingRules: data.requiresShippingRules
-    )
-
-    self.loadSummarySection(isLoggedIn: data.isLoggedIn)
-  }
-
-  // MARK: - Update Shipping Location Cell
-
-  func loadSelectedShippingRule(data: SelectedShippingRuleData) {
-    guard let shippingCellIndex = shippingCellIndexPath(),
-      self.numberOfItems(in: PledgeDataSource.Section.inputs.rawValue) > shippingCellIndex.row else {
-      return
-    }
-
-    self.set(
-      value: PledgeInputRow.shippingLocation(
-        location: data.location,
-        shippingCost: data.shippingCost,
-        project: data.project
-      ),
-      cellClass: PledgeShippingLocationCell.self,
-      inSection: Section.inputs.rawValue,
-      row: shippingCellIndex.row
-    )
-  }
-
-  // MARK: - Index
-
-  func shippingCellIndexPath() -> IndexPath? {
-    let inputsRowCount = self.numberOfItems(in: PledgeDataSource.Section.inputs.rawValue)
-    let shippingIndexPath = IndexPath(
-      item: inputsRowCount - 1,
-      section: PledgeDataSource.Section.inputs.rawValue
-    )
-
-    guard self.indexPathIsShippingLocationCell(shippingIndexPath) else { return nil }
-
-    return shippingIndexPath
-  }
-
-  // MARK: - Private
-
-  private func loadProjectSection(delivery: String) {
+  func load(project: Project, reward: Reward, isLoggedIn: Bool) {
     self.appendRow(
-      value: delivery,
+      value: reward,
       cellClass: PledgeDescriptionCell.self,
       toSection: Section.project.rawValue
     )
-  }
 
-  private func loadInputsSection(
-    amount: Double,
-    currencySymbol: String,
-    shippingLocation: String,
-    shippingCost: Double,
-    project: Project,
-    requiresShippingRules: Bool
-  ) {
     self.appendRow(
-      value: PledgeInputRow.pledgeAmount(amount: amount, currencySymbol: currencySymbol),
+      value: (project, reward),
       cellClass: PledgeAmountCell.self,
       toSection: Section.inputs.rawValue
     )
 
-    if requiresShippingRules {
+    if reward.shipping.enabled {
       self.appendRow(
-        value: PledgeInputRow.shippingLocation(
-          location: shippingLocation,
-          shippingCost: shippingCost,
-          project: project
-        ),
+        value: (project, reward),
         cellClass: PledgeShippingLocationCell.self,
         toSection: Section.inputs.rawValue
       )
     }
-  }
 
-  private func loadSummarySection(isLoggedIn: Bool) {
     self.appendRow(
       value: Strings.Total(),
       cellClass: PledgeRowCell.self,
@@ -133,21 +48,17 @@ final class PledgeDataSource: ValueCellDataSource {
     }
   }
 
-  private func indexPathIsShippingLocationCell(_ indexPath: IndexPath) -> Bool {
-    return (self[indexPath] as? PledgeInputRow)?.isShipping == true
-  }
-
   override func configureCell(tableCell cell: UITableViewCell, withValue value: Any) {
     switch (cell, value) {
-    case let (cell as PledgeAmountCell, value as PledgeInputRow):
+    case let (cell as PledgeAmountCell, value as (Project, Reward)):
       cell.configureWith(value: value)
     case let (cell as PledgeContinueCell, value as ()):
       cell.configureWith(value: value)
-    case let (cell as PledgeDescriptionCell, value as String):
+    case let (cell as PledgeDescriptionCell, value as Reward):
       cell.configureWith(value: value)
     case let (cell as PledgeRowCell, value as String):
       cell.configureWith(value: value)
-    case let (cell as PledgeShippingLocationCell, value as PledgeInputRow):
+    case let (cell as PledgeShippingLocationCell, value as (Project, Reward)):
       cell.configureWith(value: value)
     case let (cell as PledgeContinueCell, value as ()):
       cell.configureWith(value: value)

--- a/Kickstarter-iOS/DataSources/PledgeDataSourceTests.swift
+++ b/Kickstarter-iOS/DataSources/PledgeDataSourceTests.swift
@@ -1,57 +1,42 @@
 @testable import Kickstarter_Framework
 @testable import KsApi
 @testable import Library
+import Prelude
 import XCTest
+
+// swiftlint:disable line_length
 
 final class PledgeDataSourceTests: XCTestCase {
   let dataSource = PledgeDataSource()
   let tableView = UITableView(frame: .zero, style: .plain)
 
-  // swiftlint:disable line_length
-  func testLoad_loggedIn() {
-    let data = PledgeTableViewData(
-      amount: 100, currencySymbol: "$", estimatedDelivery: "May 2020",
-      shippingLocation: "", shippingCost: 0.0, project: Project.template,
-      isLoggedIn: true, requiresShippingRules: true
-    )
-    self.dataSource.load(data: data)
+  func testLoad_LoggedIn() {
+    self.dataSource.load(project: .template, reward: .template, isLoggedIn: true)
 
     XCTAssertEqual(3, self.dataSource.numberOfSections(in: self.tableView))
     XCTAssertEqual(1, self.dataSource.tableView(self.tableView, numberOfRowsInSection: 0))
-    XCTAssertEqual(2, self.dataSource.tableView(self.tableView, numberOfRowsInSection: 1))
+    XCTAssertEqual(1, self.dataSource.tableView(self.tableView, numberOfRowsInSection: 1))
     XCTAssertEqual(1, self.dataSource.tableView(self.tableView, numberOfRowsInSection: 2))
     XCTAssertEqual(PledgeDescriptionCell.defaultReusableId, self.dataSource.reusableId(item: 0, section: 0))
     XCTAssertEqual(PledgeAmountCell.defaultReusableId, self.dataSource.reusableId(item: 0, section: 1))
-    XCTAssertEqual(PledgeShippingLocationCell.defaultReusableId, self.dataSource.reusableId(item: 1, section: 1))
     XCTAssertEqual(PledgeRowCell.defaultReusableId, self.dataSource.reusableId(item: 0, section: 2))
   }
 
-  func testLoad_loggedOut() {
-    let data = PledgeTableViewData(
-      amount: 100, currencySymbol: "$", estimatedDelivery: "May 2020",
-      shippingLocation: "", shippingCost: 0.0, project: Project.template,
-      isLoggedIn: false, requiresShippingRules: true
-    )
-    self.dataSource.load(data: data)
+  func testLoad_LoggedOut() {
+    self.dataSource.load(project: .template, reward: .template, isLoggedIn: false)
 
     XCTAssertEqual(3, self.dataSource.numberOfSections(in: self.tableView))
     XCTAssertEqual(1, self.dataSource.tableView(self.tableView, numberOfRowsInSection: 0))
-    XCTAssertEqual(2, self.dataSource.tableView(self.tableView, numberOfRowsInSection: 1))
+    XCTAssertEqual(1, self.dataSource.tableView(self.tableView, numberOfRowsInSection: 1))
     XCTAssertEqual(2, self.dataSource.tableView(self.tableView, numberOfRowsInSection: 2))
     XCTAssertEqual(PledgeDescriptionCell.defaultReusableId, self.dataSource.reusableId(item: 0, section: 0))
     XCTAssertEqual(PledgeAmountCell.defaultReusableId, self.dataSource.reusableId(item: 0, section: 1))
-    XCTAssertEqual(PledgeShippingLocationCell.defaultReusableId, self.dataSource.reusableId(item: 1, section: 1))
     XCTAssertEqual(PledgeRowCell.defaultReusableId, self.dataSource.reusableId(item: 0, section: 2))
     XCTAssertEqual(PledgeContinueCell.defaultReusableId, self.dataSource.reusableId(item: 1, section: 2))
   }
 
-  func testLoad_requiresShippingRules_isFalse() {
-    let data = PledgeTableViewData(
-      amount: 100, currencySymbol: "$", estimatedDelivery: "May 2020",
-      shippingLocation: "", shippingCost: 0.0, project: Project.template,
-      isLoggedIn: false, requiresShippingRules: false
-    )
-    self.dataSource.load(data: data)
+  func testLoad_Shipping_Disabled() {
+    self.dataSource.load(project: .template, reward: .template, isLoggedIn: false)
 
     XCTAssertEqual(3, self.dataSource.numberOfSections(in: self.tableView))
     XCTAssertEqual(1, self.dataSource.tableView(self.tableView, numberOfRowsInSection: PledgeDataSource.Section.project.rawValue))
@@ -63,84 +48,20 @@ final class PledgeDataSourceTests: XCTestCase {
     XCTAssertEqual(PledgeContinueCell.defaultReusableId, self.dataSource.reusableId(item: 1, section: PledgeDataSource.Section.summary.rawValue))
   }
 
-  func testLoadSelectedShippingRule_requiresShipping_isTrue() {
-    let data = PledgeTableViewData(
-      amount: 100, currencySymbol: "$", estimatedDelivery: "May 2020",
-      shippingLocation: "", shippingCost: 0.0, project: Project.template,
-      isLoggedIn: false, requiresShippingRules: true
-    )
-    let selectedShippingData = SelectedShippingRuleData(
-      location: "Brooklyn", shippingCost: 1.0,
-      project: Project.template
-    )
+  func testLoad_Shipping_Enabled() {
+    let shipping = Reward.Shipping.template |> Reward.Shipping.lens.enabled .~ true
+    let reward = Reward.template |> Reward.lens.shipping .~ shipping
 
-    let indexPath = IndexPath(item: 1, section: PledgeDataSource.Section.inputs.rawValue)
+    self.dataSource.load(project: .template, reward: reward, isLoggedIn: false)
 
-    let initialShippingCellData = PledgeDataSource.PledgeInputRow.shippingLocation(
-      location: "",
-      shippingCost: 0.0,
-      project: .template
-    )
-
-    self.dataSource.load(data: data)
-
-    XCTAssertEqual(initialShippingCellData, self.dataSource[indexPath] as? PledgeDataSource.PledgeInputRow)
-
-    self.dataSource.loadSelectedShippingRule(data: selectedShippingData)
-
-    let shippingCellData = PledgeDataSource.PledgeInputRow.shippingLocation(
-      location: "Brooklyn",
-      shippingCost: 1.0,
-      project: .template
-    )
-
-    XCTAssertEqual(shippingCellData, self.dataSource[indexPath] as? PledgeDataSource.PledgeInputRow)
+    XCTAssertEqual(3, self.dataSource.numberOfSections(in: self.tableView))
+    XCTAssertEqual(1, self.dataSource.tableView(self.tableView, numberOfRowsInSection: PledgeDataSource.Section.project.rawValue))
     XCTAssertEqual(2, self.dataSource.tableView(self.tableView, numberOfRowsInSection: PledgeDataSource.Section.inputs.rawValue))
+    XCTAssertEqual(2, self.dataSource.tableView(self.tableView, numberOfRowsInSection: PledgeDataSource.Section.summary.rawValue))
+    XCTAssertEqual(PledgeDescriptionCell.defaultReusableId, self.dataSource.reusableId(item: 0, section: PledgeDataSource.Section.project.rawValue))
+    XCTAssertEqual(PledgeAmountCell.defaultReusableId, self.dataSource.reusableId(item: 0, section: PledgeDataSource.Section.inputs.rawValue))
+    XCTAssertEqual(PledgeShippingLocationCell.defaultReusableId, self.dataSource.reusableId(item: 1, section: PledgeDataSource.Section.inputs.rawValue))
+    XCTAssertEqual(PledgeRowCell.defaultReusableId, self.dataSource.reusableId(item: 0, section: PledgeDataSource.Section.summary.rawValue))
+    XCTAssertEqual(PledgeContinueCell.defaultReusableId, self.dataSource.reusableId(item: 1, section: PledgeDataSource.Section.summary.rawValue))
   }
-
-  func testLoadSelectedShippingRule_requiresShipping_isFalse() {
-    let data = PledgeTableViewData(
-      amount: 100, currencySymbol: "$", estimatedDelivery: "May 2020",
-      shippingLocation: "", shippingCost: 0.0, project: Project.template,
-      isLoggedIn: false, requiresShippingRules: false
-    )
-    let selectedShippingData = SelectedShippingRuleData(
-      location: "Brooklyn", shippingCost: 1.0,
-      project: Project.template
-    )
-
-    self.dataSource.load(data: data)
-    self.dataSource.loadSelectedShippingRule(data: selectedShippingData)
-
-    XCTAssertEqual(1, self.dataSource.tableView(self.tableView, numberOfRowsInSection: PledgeDataSource.Section.inputs.rawValue))
-  }
-
-  func testShippingCellIndexPath_isNil() {
-    let data = PledgeTableViewData(
-      amount: 100, currencySymbol: "$", estimatedDelivery: "May 2020",
-      shippingLocation: "", shippingCost: 0.0, project: Project.template,
-      isLoggedIn: false, requiresShippingRules: false
-    )
-
-    self.dataSource.load(data: data)
-
-    XCTAssertNil(self.dataSource.shippingCellIndexPath())
-  }
-
-  func testShippingCellIndexPath_isNotNil() {
-    let data = PledgeTableViewData(
-      amount: 100, currencySymbol: "$", estimatedDelivery: "May 2020",
-      shippingLocation: "", shippingCost: 0.0, project: Project.template,
-      isLoggedIn: false, requiresShippingRules: true
-    )
-
-    self.dataSource.load(data: data)
-
-    let indexPath = self.dataSource.shippingCellIndexPath()
-
-    XCTAssertNotNil(indexPath)
-    XCTAssertEqual(indexPath, IndexPath(item: 1, section: PledgeDataSource.Section.inputs.rawValue))
-  }
-
-  // swiftlint:enable line_length
 }

--- a/Kickstarter-iOS/Views/AmountInputView.swift
+++ b/Kickstarter-iOS/Views/AmountInputView.swift
@@ -5,8 +5,8 @@ import UIKit
 class AmountInputView: UIView {
   // MARK: - Properties
 
-  private lazy var label: UILabel = { UILabel(frame: .zero) }()
-  private lazy var textField: UITextField = { UITextField(frame: .zero) }()
+  private(set) lazy var label: UILabel = { UILabel(frame: .zero) }()
+  private(set) lazy var textField: UITextField = { UITextField(frame: .zero) }()
   private lazy var stackView: UIStackView = { UIStackView(frame: .zero) }()
   private var labelCenterYAnchor: NSLayoutConstraint?
 

--- a/Kickstarter-iOS/Views/Cells/PledgeAmountCell.swift
+++ b/Kickstarter-iOS/Views/Cells/PledgeAmountCell.swift
@@ -1,3 +1,4 @@
+import KsApi
 import Library
 import Prelude
 import Prelude_UIKit
@@ -5,6 +6,8 @@ import UIKit
 
 final class PledgeAmountCell: UITableViewCell, ValueCell {
   // MARK: - Properties
+
+  private let viewModel = PledgeAmountCellViewModel()
 
   private lazy var adaptableStackView: UIStackView = { UIStackView(frame: .zero) }()
   private lazy var amountInputView: AmountInputView = { AmountInputView(frame: .zero) }()
@@ -36,6 +39,8 @@ final class PledgeAmountCell: UITableViewCell, ValueCell {
       |> ksr_addArrangedSubviewsToStackView()
 
     self.spacer.widthAnchor.constraint(greaterThanOrEqualToConstant: Styles.grid(3)).isActive = true
+
+    self.bindViewModel()
   }
 
   required init?(coder _: NSCoder) {
@@ -68,18 +73,19 @@ final class PledgeAmountCell: UITableViewCell, ValueCell {
       |> stepperStyle
   }
 
+  // MARK: - Binding
+
+  override func bindViewModel() {
+    super.bindViewModel()
+
+    self.amountInputView.label.rac.text = self.viewModel.outputs.currency
+    self.amountInputView.textField.rac.text = self.viewModel.outputs.amount
+  }
+
   // MARK: - Configuration
 
-  func configureWith(value: PledgeDataSource.PledgeInputRow) {
-    guard case let .pledgeAmount(amount, currencySymbol) = value else {
-      return
-    }
-
-    self.amountInputView.configureWith(
-      amount: String(format: "%i", amount),
-      placeholder: "\(0)",
-      currency: currencySymbol
-    )
+  func configureWith(value: (project: Project, reward: Reward)) {
+    self.viewModel.inputs.configureWith(project: value.project, reward: value.reward)
   }
 }
 

--- a/Kickstarter-iOS/Views/Cells/PledgeDescriptionCell.swift
+++ b/Kickstarter-iOS/Views/Cells/PledgeDescriptionCell.swift
@@ -1,3 +1,4 @@
+import KsApi
 import Library
 import Prelude
 import UIKit
@@ -44,6 +45,7 @@ final class PledgeDescriptionCell: UITableViewCell, ValueCell {
     super.init(style: style, reuseIdentifier: reuseIdentifier)
 
     self.configureSubviews()
+
     self.bindViewModel()
   }
 
@@ -144,8 +146,8 @@ final class PledgeDescriptionCell: UITableViewCell, ValueCell {
 
   // MARK: - Configuration
 
-  internal func configureWith(value: String) {
-    self.viewModel.inputs.configureWith(estimatedDeliveryDate: value)
+  internal func configureWith(value: Reward) {
+    self.viewModel.inputs.configureWith(reward: value)
   }
 }
 

--- a/Kickstarter-iOS/Views/Cells/PledgeShippingLocationCell.swift
+++ b/Kickstarter-iOS/Views/Cells/PledgeShippingLocationCell.swift
@@ -95,7 +95,7 @@ final class PledgeShippingLocationCell: UITableViewCell, ValueCell {
       .observeForUI()
       .observeValues { [weak self] isLoading in
         self?.animate(isLoading)
-    }
+      }
   }
 
   // MARK: - Configuration
@@ -106,7 +106,7 @@ final class PledgeShippingLocationCell: UITableViewCell, ValueCell {
 
   // MARK: - Public Functions
 
-  func animate(_: Bool) { }
+  func animate(_: Bool) {}
 }
 
 // MARK: - Styles

--- a/Kickstarter-iOS/Views/Cells/PledgeShippingLocationCell.swift
+++ b/Kickstarter-iOS/Views/Cells/PledgeShippingLocationCell.swift
@@ -6,6 +6,8 @@ import UIKit
 final class PledgeShippingLocationCell: UITableViewCell, ValueCell {
   // MARK: - Properties
 
+  private let viewModel = PledgeShippingLocationCellViewModel()
+
   private lazy var adaptableStackView: UIStackView = { UIStackView(frame: .zero) }()
   private lazy var amountLabel: UILabel = { UILabel(frame: .zero) }()
   private lazy var countryButton: UIButton = { UIButton(frame: .zero) }()
@@ -37,6 +39,8 @@ final class PledgeShippingLocationCell: UITableViewCell, ValueCell {
     self.spacer.widthAnchor.constraint(greaterThanOrEqualToConstant: Styles.grid(3)).isActive = true
 
     self.amountLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
+
+    self.bindViewModel()
   }
 
   required init?(coder _: NSCoder) {
@@ -79,20 +83,30 @@ final class PledgeShippingLocationCell: UITableViewCell, ValueCell {
       |> checkoutStackViewStyle
   }
 
+  // MARK: - Binding
+
+  override func bindViewModel() {
+    super.bindViewModel()
+
+    self.countryButton.rac.title = self.viewModel.location
+    self.amountLabel.rac.attributedText = self.viewModel.amount
+
+    self.viewModel.shippingIsLoading
+      .observeForUI()
+      .observeValues { [weak self] isLoading in
+        self?.animate(isLoading)
+    }
+  }
+
   // MARK: - Configuration
 
-  func configureWith(value: PledgeDataSource.PledgeInputRow) {
-    guard case let .shippingLocation(location, shippingCost, project) = value else {
-      return
-    }
-
-    self.countryButton.setTitle(location, for: .normal)
-    self.amountLabel.attributedText = shippingValue(for: shippingCost, project: project)
+  func configureWith(value: (project: Project, reward: Reward)) {
+    self.viewModel.inputs.configureWith(project: value.project, reward: value.reward)
   }
 
   // MARK: - Public Functions
 
-  func animate(_: Bool) {}
+  func animate(_: Bool) { }
 }
 
 // MARK: - Styles
@@ -115,23 +129,4 @@ private let countryButtonStyle: ButtonStyle = { (button: UIButton) in
 private let countryButtonTitleLabelStyle: LabelStyle = { (label: UILabel) in
   label
     |> \.lineBreakMode .~ .byTruncatingTail
-}
-
-// MARK: - Functions
-// TODO: Move this to the future `PledgeShippingLocationCellViewModel`
-private func shippingValue(for shippingCost: Double, project: Project) -> NSAttributedString? {
-  let defaultAttributes = checkoutCurrencyDefaultAttributes()
-  let superscriptAttributes = checkoutCurrencySuperscriptAttributes()
-  guard
-    let attributedCurrency = Format.attributedCurrency(
-      shippingCost,
-      country: project.country,
-      omitCurrencyCode: project.stats.omitUSCurrencyCode,
-      defaultAttributes: defaultAttributes,
-      superscriptAttributes: superscriptAttributes
-    ) else { return nil }
-
-  let combinedAttributes = defaultAttributes.merging(superscriptAttributes) { _, new in new }
-
-  return Format.attributedPlusSign(combinedAttributes) + attributedCurrency
 }

--- a/Kickstarter-iOS/Views/Controllers/CommentsViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/CommentsViewController.swift
@@ -105,11 +105,7 @@ internal final class CommentsViewController: UITableViewController {
       }
   }
 
-  override func tableView(
-    _: UITableView,
-    willDisplay cell: UITableViewCell,
-    forRowAt indexPath: IndexPath
-  ) {
+  override func tableView(_: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
     if let emptyCell = cell as? CommentsEmptyStateCell {
       emptyCell.delegate = self
     }

--- a/Kickstarter-iOS/Views/Controllers/DashboardViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/DashboardViewController.swift
@@ -188,11 +188,7 @@ internal final class DashboardViewController: UITableViewController {
       }
   }
 
-  internal override func tableView(
-    _: UITableView,
-    willDisplay cell: UITableViewCell,
-    forRowAt _: IndexPath
-  ) {
+  internal override func tableView(_: UITableView, willDisplay cell: UITableViewCell, forRowAt _: IndexPath) {
     if let actionCell = cell as? DashboardActionCell {
       actionCell.delegate = self
     } else if let referrersCell = cell as? DashboardReferrersCell {

--- a/Kickstarter-iOS/Views/Controllers/DiscoveryFiltersViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/DiscoveryFiltersViewController.swift
@@ -116,11 +116,7 @@ internal final class DiscoveryFiltersViewController: UIViewController, UITableVi
     }
   }
 
-  internal func tableView(
-    _: UITableView,
-    willDisplay cell: UITableViewCell,
-    forRowAt indexPath: IndexPath
-  ) {
+  internal func tableView(_: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
     if let cell = cell as? DiscoverySelectableRowCell {
       cell.willDisplay()
     } else if let cell = cell as? DiscoveryExpandableRowCell {

--- a/Kickstarter-iOS/Views/Controllers/FindFriendsViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/FindFriendsViewController.swift
@@ -97,10 +97,7 @@ internal final class FindFriendsViewController: UITableViewController {
       |> baseActivityIndicatorStyle
   }
 
-  override func tableView(
-    _: UITableView, willDisplay cell: UITableViewCell,
-    forRowAt indexPath: IndexPath
-  ) {
+  override func tableView(_: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
     if let statsCell = cell as? FindFriendsStatsCell, statsCell.delegate == nil {
       statsCell.delegate = self
     } else if let fbConnectCell = cell as? FindFriendsFacebookConnectCell, fbConnectCell.delegate == nil {

--- a/Kickstarter-iOS/Views/Controllers/MessagesViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/MessagesViewController.swift
@@ -102,10 +102,7 @@ internal final class MessagesViewController: UITableViewController {
     }
   }
 
-  internal override func tableView(
-    _: UITableView, willDisplay cell: UITableViewCell,
-    forRowAt _: IndexPath
-  ) {
+  internal override func tableView(_: UITableView, willDisplay cell: UITableViewCell, forRowAt _: IndexPath) {
     if let cell = cell as? BackingCell, cell.delegate == nil {
       cell.delegate = self
     }

--- a/Kickstarter-iOS/Views/Controllers/PledgeTableViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/PledgeTableViewController.swift
@@ -52,30 +52,9 @@ class PledgeTableViewController: UITableViewController {
 
     self.viewModel.outputs.reloadWithData
       .observeForUI()
-      .observeValues { [weak self] data in
-        self?.dataSource.load(data: data)
-
+      .observeValues { [weak self] project, reward, isLoggedIn in
+        self?.dataSource.load(project: project, reward: reward, isLoggedIn: isLoggedIn)
         self?.tableView.reloadData()
-
-        self?.viewModel.inputs.didReloadData()
-      }
-
-    self.viewModel.outputs.selectedShippingRuleData
-      .observeForUI()
-      .observeValues { [weak self] selectedShippingRuleData in
-        self?.dataSource.loadSelectedShippingRule(data: selectedShippingRuleData)
-
-        guard let shippingIndexPath = self?.dataSource.shippingCellIndexPath() else {
-          return
-        }
-
-        self?.tableView.reloadRows(at: [shippingIndexPath], with: .automatic)
-      }
-
-    self.viewModel.outputs.shippingIsLoading
-      .observeForUI()
-      .observeValues { [weak self] isLoading in
-        self?.shippingLocationCell?.animate(isLoading)
       }
   }
 
@@ -88,11 +67,7 @@ class PledgeTableViewController: UITableViewController {
     return footerView
   }
 
-  internal override func tableView(
-    _: UITableView,
-    willDisplay cell: UITableViewCell,
-    forRowAt _: IndexPath
-  ) {
+  internal override func tableView(_: UITableView, willDisplay cell: UITableViewCell, forRowAt _: IndexPath) {
     if let descriptionCell = cell as? PledgeDescriptionCell {
       descriptionCell.delegate = self
     } else if let shippingLocationCell = cell as? PledgeShippingLocationCell {

--- a/Kickstarter-iOS/Views/Controllers/ProjectNotificationsViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/ProjectNotificationsViewController.swift
@@ -46,11 +46,7 @@ internal final class ProjectNotificationsViewController: UITableViewController {
       }
   }
 
-  internal override func tableView(
-    _: UITableView,
-    willDisplay cell: UITableViewCell,
-    forRowAt _: IndexPath
-  ) {
+  internal override func tableView(_: UITableView, willDisplay cell: UITableViewCell, forRowAt _: IndexPath) {
     if let cell = cell as? ProjectNotificationCell {
       cell.delegate = self
     }

--- a/Kickstarter-iOS/Views/Controllers/ProjectPamphletContentViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/ProjectPamphletContentViewController.swift
@@ -104,11 +104,7 @@ public final class ProjectPamphletContentViewController: UITableViewController {
     }
   }
 
-  public override func tableView(
-    _: UITableView,
-    willDisplay cell: UITableViewCell,
-    forRowAt _: IndexPath
-  ) {
+  public override func tableView(_: UITableView, willDisplay cell: UITableViewCell, forRowAt _: IndexPath) {
     if let cell = cell as? ProjectPamphletMainCell {
       cell.delegate = self
     } else if let cell = cell as? DeprecatedRewardCell {

--- a/Kickstarter-iOS/Views/Controllers/SettingsNewslettersViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/SettingsNewslettersViewController.swift
@@ -51,11 +51,7 @@ internal final class SettingsNewslettersViewController: UIViewController {
 }
 
 extension SettingsNewslettersViewController: UITableViewDelegate {
-  internal func tableView(
-    _: UITableView,
-    willDisplay cell: UITableViewCell,
-    forRowAt _: IndexPath
-  ) {
+  internal func tableView(_: UITableView, willDisplay cell: UITableViewCell, forRowAt _: IndexPath) {
     if let cell = cell as? SettingsNewslettersTopCell, cell.delegate == nil {
       cell.delegate = self
     } else if let cell = cell as? SettingsNewslettersCell, cell.delegate == nil {

--- a/Kickstarter-iOS/Views/Controllers/SettingsPrivacyViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/SettingsPrivacyViewController.swift
@@ -73,11 +73,7 @@ internal final class SettingsPrivacyViewController: UITableViewController {
       }
   }
 
-  internal override func tableView(
-    _: UITableView,
-    willDisplay cell: UITableViewCell,
-    forRowAt _: IndexPath
-  ) {
+  internal override func tableView(_: UITableView, willDisplay cell: UITableViewCell, forRowAt _: IndexPath) {
     if let followCell = cell as? SettingsFollowCell {
       followCell.delegate = self
     } else if let requestDataCell = cell as? SettingsPrivacyRequestDataCell {

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -73,6 +73,11 @@
 		37059843226F79A700BDA6E3 /* PledgeShippingLocationCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37059842226F79A700BDA6E3 /* PledgeShippingLocationCell.swift */; };
 		3705CF0F222EE7670025D37E /* EnvironmentVariables.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3705CF0E222EE7670025D37E /* EnvironmentVariables.swift */; };
 		3705CF48222EE77F0025D37E /* EnvironmentVariablesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3705CF47222EE77E0025D37E /* EnvironmentVariablesTests.swift */; };
+		3706408222A8A66E00889CBD /* PledgeAmountCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3706408122A8A66E00889CBD /* PledgeAmountCellViewModel.swift */; };
+		3706408422A8A68600889CBD /* PledgeAmountCellViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3706408322A8A68600889CBD /* PledgeAmountCellViewModelTests.swift */; };
+		3706408622A8A6D700889CBD /* PledgeShippingLocationCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3706408522A8A6D700889CBD /* PledgeShippingLocationCellViewModel.swift */; };
+		3706408822A8A6F200889CBD /* PledgeShippingLocationCellViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3706408722A8A6F200889CBD /* PledgeShippingLocationCellViewModelTests.swift */; };
+		3706408A22A8B2B700889CBD /* ShippingTemplates.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3706408922A8B2B700889CBD /* ShippingTemplates.swift */; };
 		3708DD43220A5A5700F8E569 /* SettingsGroupedFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3708DD42220A5A5700F8E569 /* SettingsGroupedFooterView.swift */; };
 		3708DD45220A76FE00F8E569 /* CreatePasswordTableControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3708DD44220A76FD00F8E569 /* CreatePasswordTableControllerTests.swift */; };
 		370ACB00225D337900C8745F /* PledgeAmountCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 370ACAFF225D337900C8745F /* PledgeAmountCell.swift */; };
@@ -118,8 +123,6 @@
 		37E9E2A0225EABB000D29DD7 /* AmountInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E9E29F225EABB000D29DD7 /* AmountInputView.swift */; };
 		37EB3E4C228CF4A400076E4C /* NumberFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37EB3E4B228CF4A400076E4C /* NumberFormatter.swift */; };
 		37EB3E4E228CF4FB00076E4C /* NumberFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37EB3E4D228CF4FB00076E4C /* NumberFormatterTests.swift */; };
-		37F39BB5221D05FA00E0FA65 /* UITraitCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37F39BB4221D05FA00E0FA65 /* UITraitCollection.swift */; };
-		37F39BEE221D062900E0FA65 /* UITraitCollectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37F39BED221D062900E0FA65 /* UITraitCollectionTests.swift */; };
 		37FDAFAC2273BA4700662CC8 /* UIStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37FDAF702273B7FF00662CC8 /* UIStackView.swift */; };
 		37FDAFAD2273BA4B00662CC8 /* UIStackView+Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37FDAFAA2273B86800662CC8 /* UIStackView+Tests.swift */; };
 		37FEFBC8222F1E4F00FCA608 /* ProcessInfoType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37FEFBC7222F1E4F00FCA608 /* ProcessInfoType.swift */; };
@@ -1309,6 +1312,11 @@
 		37059842226F79A700BDA6E3 /* PledgeShippingLocationCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PledgeShippingLocationCell.swift; sourceTree = "<group>"; };
 		3705CF0E222EE7670025D37E /* EnvironmentVariables.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnvironmentVariables.swift; sourceTree = "<group>"; };
 		3705CF47222EE77E0025D37E /* EnvironmentVariablesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnvironmentVariablesTests.swift; sourceTree = "<group>"; };
+		3706408122A8A66E00889CBD /* PledgeAmountCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PledgeAmountCellViewModel.swift; sourceTree = "<group>"; };
+		3706408322A8A68600889CBD /* PledgeAmountCellViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PledgeAmountCellViewModelTests.swift; sourceTree = "<group>"; };
+		3706408522A8A6D700889CBD /* PledgeShippingLocationCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PledgeShippingLocationCellViewModel.swift; sourceTree = "<group>"; };
+		3706408722A8A6F200889CBD /* PledgeShippingLocationCellViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PledgeShippingLocationCellViewModelTests.swift; sourceTree = "<group>"; };
+		3706408922A8B2B700889CBD /* ShippingTemplates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingTemplates.swift; sourceTree = "<group>"; };
 		3708DD42220A5A5700F8E569 /* SettingsGroupedFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsGroupedFooterView.swift; sourceTree = "<group>"; };
 		3708DD44220A76FD00F8E569 /* CreatePasswordTableControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreatePasswordTableControllerTests.swift; sourceTree = "<group>"; };
 		370ACAFF225D337900C8745F /* PledgeAmountCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PledgeAmountCell.swift; sourceTree = "<group>"; };
@@ -1355,8 +1363,6 @@
 		37E9E29F225EABB000D29DD7 /* AmountInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AmountInputView.swift; sourceTree = "<group>"; };
 		37EB3E4B228CF4A400076E4C /* NumberFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumberFormatter.swift; sourceTree = "<group>"; };
 		37EB3E4D228CF4FB00076E4C /* NumberFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumberFormatterTests.swift; sourceTree = "<group>"; };
-		37F39BB4221D05FA00E0FA65 /* UITraitCollection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITraitCollection.swift; sourceTree = "<group>"; };
-		37F39BED221D062900E0FA65 /* UITraitCollectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITraitCollectionTests.swift; sourceTree = "<group>"; };
 		37FDAF702273B7FF00662CC8 /* UIStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIStackView.swift; sourceTree = "<group>"; };
 		37FDAFAA2273B86800662CC8 /* UIStackView+Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIStackView+Tests.swift"; sourceTree = "<group>"; };
 		37FEFBC7222F1E4F00FCA608 /* ProcessInfoType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessInfoType.swift; sourceTree = "<group>"; };
@@ -3247,8 +3253,12 @@
 				D7A86A3A1F324EB300C7DA53 /* MostPopularSearchProjectCellViewModelTests.swift */,
 				D63BBD34217FAB85007E01F0 /* PaymentMethodsViewModel.swift */,
 				D66FB347218212B700A27BCC /* PaymentMethodsViewModelTests.swift */,
+				3706408122A8A66E00889CBD /* PledgeAmountCellViewModel.swift */,
+				3706408322A8A68600889CBD /* PledgeAmountCellViewModelTests.swift */,
 				D77594DB226F9C9B005EE69B /* PledgeDescriptionCellViewModel.swift */,
 				D775953B22725289005EE69B /* PledgeDescriptionCellViewModelTests.swift */,
+				3706408522A8A6D700889CBD /* PledgeShippingLocationCellViewModel.swift */,
+				3706408722A8A6F200889CBD /* PledgeShippingLocationCellViewModelTests.swift */,
 				37DEC1E62257C9F30051EF9B /* PledgeViewModel.swift */,
 				37DEC21F2257CA0A0051EF9B /* PledgeViewModelTests.swift */,
 				A7F441A31D005A9400FE6FC5 /* ProfileViewModel.swift */,
@@ -3615,6 +3625,7 @@
 				D01588091EEB2ED7006E7684 /* ProjectTemplates.swift */,
 				D015880A1EEB2ED7006E7684 /* RewardsItemTemplates.swift */,
 				D015880B1EEB2ED7006E7684 /* RewardTemplates.swift */,
+				3706408922A8B2B700889CBD /* ShippingTemplates.swift */,
 				D015880C1EEB2ED7006E7684 /* ShippingRulesEnvelopeTemplates.swift */,
 				D015880D1EEB2ED7006E7684 /* ShippingRuleTemplates.swift */,
 				D015880E1EEB2ED7006E7684 /* StarEnvelopeTemplates.swift */,
@@ -4245,9 +4256,7 @@
 				3705CF0F222EE7670025D37E /* EnvironmentVariables.swift in Sources */,
 				A73379601D0EDFEE00C91445 /* UIViewController-Preparation.swift in Sources */,
 				A72C3A951D00F6C70075227E /* DiscoveryPageViewModel.swift in Sources */,
-				D0CC9D271E5733B500C2BC4A /* LiveStreamChatMessageCellViewModel.swift in Sources */,
 				37EB3E4C228CF4A400076E4C /* NumberFormatter.swift in Sources */,
-				A7792C3B1E30F9E1002BAD63 /* LiveStreamDiscoveryViewModel.swift in Sources */,
 				A7F441C71D005A9400FE6FC5 /* MessageCellViewModel.swift in Sources */,
 				59673CBF1D50EE9B0035AFD9 /* VideoViewModel.swift in Sources */,
 				9D10B91B1D35407C008B8045 /* String+Truncate.swift in Sources */,
@@ -4278,6 +4287,7 @@
 				A7F441CF1D005A9400FE6FC5 /* MessageThreadCellViewModel.swift in Sources */,
 				A7F441CB1D005A9400FE6FC5 /* MessagesSearchViewModel.swift in Sources */,
 				A7CC14651D00E81B00035C52 /* FriendsSource.swift in Sources */,
+				3706408622A8A6D700889CBD /* PledgeShippingLocationCellViewModel.swift in Sources */,
 				3757D0CE228E51F800241AE6 /* UIFont.swift in Sources */,
 				9D9F581B1D1324E200CE81DE /* DashboardViewModel.swift in Sources */,
 				D796867C20FE655300E54C61 /* SettingsFollowCellViewModel.swift in Sources */,
@@ -4393,6 +4403,7 @@
 				A76126BB1C90C94000EDCCB9 /* UITableView-Extensions.swift in Sources */,
 				9D9F58191D13243900CE81DE /* ProjectActivitiesViewModel.swift in Sources */,
 				A72C3A8E1D00F6A80075227E /* SelectableRow.swift in Sources */,
+				3706408222A8A66E00889CBD /* PledgeAmountCellViewModel.swift in Sources */,
 				A7F441C11D005A9400FE6FC5 /* DiscoveryViewModel.swift in Sources */,
 				A78537E21CB5422100385B73 /* UIScreenType.swift in Sources */,
 				A7208C3E1CCAC86800E3DAB3 /* FacebookAppDelegateProtocol.swift in Sources */,
@@ -4444,6 +4455,7 @@
 				A7ED1FD91E831C5C00BFFA01 /* ProjectActivitiesViewModelTests.swift in Sources */,
 				37280273226F880700E0ACBB /* CheckoutStylesTests.swift in Sources */,
 				A7ED1FDB1E831C5C00BFFA01 /* DashboardViewModelTests.swift in Sources */,
+				3706408822A8A6F200889CBD /* PledgeShippingLocationCellViewModelTests.swift in Sources */,
 				A7ED1F2B1E830FDC00BFFA01 /* IsValidEmailTests.swift in Sources */,
 				A7ED1FEB1E831C5C00BFFA01 /* DashboardReferrersCellViewModelTests.swift in Sources */,
 				37FDAFAD2273BA4B00662CC8 /* UIStackView+Tests.swift in Sources */,
@@ -4500,6 +4512,7 @@
 				37D99C5B22247F58008EF839 /* NSBundleType+Tests.swift in Sources */,
 				A7ED1FC51E831C5C00BFFA01 /* CommentsEmptyStateCellViewModelTests.swift in Sources */,
 				A7ED1F391E830FDC00BFFA01 /* UILabel+IBClearTests.swift in Sources */,
+				3706408422A8A68600889CBD /* PledgeAmountCellViewModelTests.swift in Sources */,
 				D79CF40521B0840E00ECB73A /* AddNewCardViewModelTests.swift in Sources */,
 				D7A86A3B1F324EB300C7DA53 /* MostPopularSearchProjectCellViewModelTests.swift in Sources */,
 				A7ED1FD61E831C5C00BFFA01 /* ActivityUpdateViewModelTests.swift in Sources */,
@@ -4941,6 +4954,7 @@
 				D7774466217A345D008D679F /* UpdateUserProfileMutation .swift in Sources */,
 				D67B6C9D221F458700B63A6B /* Config+Argo.swift in Sources */,
 				D01588391EEB2ED7006E7684 /* Method.swift in Sources */,
+				3706408A22A8B2B700889CBD /* ShippingTemplates.swift in Sources */,
 				D01588D91EEB2ED7006E7684 /* User.AvatarLenses.swift in Sources */,
 				D015882F1EEB2ED7006E7684 /* ClientAuth.swift in Sources */,
 				D01588371EEB2ED7006E7684 /* EncodableType.swift in Sources */,

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -78,6 +78,8 @@
 		3706408622A8A6D700889CBD /* PledgeShippingLocationCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3706408522A8A6D700889CBD /* PledgeShippingLocationCellViewModel.swift */; };
 		3706408822A8A6F200889CBD /* PledgeShippingLocationCellViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3706408722A8A6F200889CBD /* PledgeShippingLocationCellViewModelTests.swift */; };
 		3706408A22A8B2B700889CBD /* ShippingTemplates.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3706408922A8B2B700889CBD /* ShippingTemplates.swift */; };
+		3706408D22A9BE8100889CBD /* DateFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3706408C22A9BE8100889CBD /* DateFormatter.swift */; };
+		3706409022A9BE9400889CBD /* DateFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3706408F22A9BE9400889CBD /* DateFormatterTests.swift */; };
 		3708DD43220A5A5700F8E569 /* SettingsGroupedFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3708DD42220A5A5700F8E569 /* SettingsGroupedFooterView.swift */; };
 		3708DD45220A76FE00F8E569 /* CreatePasswordTableControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3708DD44220A76FD00F8E569 /* CreatePasswordTableControllerTests.swift */; };
 		370ACB00225D337900C8745F /* PledgeAmountCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 370ACAFF225D337900C8745F /* PledgeAmountCell.swift */; };
@@ -1317,6 +1319,8 @@
 		3706408522A8A6D700889CBD /* PledgeShippingLocationCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PledgeShippingLocationCellViewModel.swift; sourceTree = "<group>"; };
 		3706408722A8A6F200889CBD /* PledgeShippingLocationCellViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PledgeShippingLocationCellViewModelTests.swift; sourceTree = "<group>"; };
 		3706408922A8B2B700889CBD /* ShippingTemplates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingTemplates.swift; sourceTree = "<group>"; };
+		3706408C22A9BE8100889CBD /* DateFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateFormatter.swift; sourceTree = "<group>"; };
+		3706408F22A9BE9400889CBD /* DateFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateFormatterTests.swift; sourceTree = "<group>"; };
 		3708DD42220A5A5700F8E569 /* SettingsGroupedFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsGroupedFooterView.swift; sourceTree = "<group>"; };
 		3708DD44220A76FD00F8E569 /* CreatePasswordTableControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreatePasswordTableControllerTests.swift; sourceTree = "<group>"; };
 		370ACAFF225D337900C8745F /* PledgeAmountCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PledgeAmountCell.swift; sourceTree = "<group>"; };
@@ -2812,6 +2816,8 @@
 				77556F1C20A09993008CEA57 /* Config+Helpers.swift */,
 				A7D121081D15B08200F364FD /* CountBadgeView.swift */,
 				D798A6AD21656D970053D097 /* Currency.swift */,
+				3706408C22A9BE8100889CBD /* DateFormatter.swift */,
+				3706408F22A9BE9400889CBD /* DateFormatterTests.swift */,
 				A7F6F0C01DC7EBF7002C118C /* DateProtocol.swift */,
 				77F6E73421222E7C005A5C55 /* EmailFrequency.swift */,
 				A7C7257F1C85D36D005A016B /* Environment.swift */,
@@ -4417,6 +4423,7 @@
 				A72C3A8C1D00F6A80075227E /* ExpandableRow.swift in Sources */,
 				D04AAC25218BB70D00CF713E /* FindFriendsCellViewModel.swift in Sources */,
 				9DBF80DF1D666CAC007F2843 /* CheckoutModels.swift in Sources */,
+				3706408D22A9BE8100889CBD /* DateFormatter.swift in Sources */,
 				D04AABF8218BB2FD00CF713E /* SettingsNotificationsViewModel.swift in Sources */,
 				9DC204B71D1B46BD003C1636 /* ProjectActivityNegativeStateChangeCellViewModel.swift in Sources */,
 				A7698B2A1D00602800953FD3 /* LoginViewModel.swift in Sources */,
@@ -4506,6 +4513,7 @@
 				A7ED1FFF1E831C5C00BFFA01 /* RewardShippingPickerViewModelTests.swift in Sources */,
 				A7ED1FDF1E831C5C00BFFA01 /* DiscoveryFiltersViewModelTests.swift in Sources */,
 				A7ED1FDC1E831C5C00BFFA01 /* DashboardVideoCellViewModelTests.swift in Sources */,
+				3706409022A9BE9400889CBD /* DateFormatterTests.swift in Sources */,
 				A7ED1F2C1E830FDC00BFFA01 /* KSCacheTests.swift in Sources */,
 				D7237096211A1593001EA4CA /* SettingsFollowCellViewModelTests.swift in Sources */,
 				A7ED1FCF1E831C5C00BFFA01 /* CheckoutRacingViewModelTests.swift in Sources */,

--- a/KsApi/models/templates/ShippingTemplates.swift
+++ b/KsApi/models/templates/ShippingTemplates.swift
@@ -1,0 +1,3 @@
+extension Reward.Shipping {
+  internal static let template = Reward.Shipping(enabled: false, preference: nil, summary: nil)
+}

--- a/Library/DateFormatter.swift
+++ b/Library/DateFormatter.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+internal extension DateFormatter {
+  static let monthYear = "MMMMyyyy"
+}

--- a/Library/DateFormatterTests.swift
+++ b/Library/DateFormatterTests.swift
@@ -1,0 +1,8 @@
+@testable import Library
+import XCTest
+
+final class DateFormatterTests: XCTestCase {
+  func testMonthYear() {
+    XCTAssertEqual("MMMMyyyy", DateFormatter.monthYear)
+  }
+}

--- a/Library/SharedFunctions.swift
+++ b/Library/SharedFunctions.swift
@@ -169,3 +169,19 @@ public func ksr_isOSVersionAvailable(_ version: Double) -> Bool {
 
   return false
 }
+
+public func defaultShippingRule(fromShippingRules shippingRules: [ShippingRule]) -> ShippingRule? {
+  let shippingRuleFromCurrentLocation = shippingRules
+    .filter { shippingRule in shippingRule.location.country == AppEnvironment.current.config?.countryCode }
+    .first
+
+  if let shippingRuleFromCurrentLocation = shippingRuleFromCurrentLocation {
+    return shippingRuleFromCurrentLocation
+  }
+
+  let shippingRuleInUSA = shippingRules
+    .filter { shippingRule in shippingRule.location.country == "US" }
+    .first
+
+  return shippingRuleInUSA ?? shippingRules.first
+}

--- a/Library/SharedFunctionsTests.swift
+++ b/Library/SharedFunctionsTests.swift
@@ -198,10 +198,10 @@ final class SharedFunctionsTests: TestCase {
         Location.template |> Location.lens.country .~ "CZ",
         Location.template |> Location.lens.country .~ "CA"
       ]
-      let shippingRules = locations.map { ShippingRule.template |> ShippingRule.lens.location .~ $0
-      }
-      let shippingRule = defaultShippingRule(fromShippingRules: shippingRules)
-      XCTAssertEqual(shippingRules[0], shippingRule)
+      let shippingRule = defaultShippingRule(
+        fromShippingRules: locations.map { ShippingRule.template |> ShippingRule.lens.location .~ $0 }
+      )
+      XCTAssertEqual("DE", shippingRule?.location.country)
     }
   }
 
@@ -215,10 +215,10 @@ final class SharedFunctionsTests: TestCase {
         Location.template |> Location.lens.country .~ "CZ",
         Location.template |> Location.lens.country .~ "CA"
       ]
-      let shippingRules = locations.map { ShippingRule.template |> ShippingRule.lens.location .~ $0
-      }
-      let shippingRule = defaultShippingRule(fromShippingRules: shippingRules)
-      XCTAssertEqual(shippingRules[1], shippingRule)
+      let shippingRule = defaultShippingRule(
+        fromShippingRules: locations.map { ShippingRule.template |> ShippingRule.lens.location .~ $0 }
+      )
+      XCTAssertEqual("US", shippingRule?.location.country)
     }
   }
 
@@ -232,10 +232,10 @@ final class SharedFunctionsTests: TestCase {
         Location.template |> Location.lens.country .~ "CZ",
         Location.template |> Location.lens.country .~ "CA"
       ]
-      let shippingRules = locations.map { ShippingRule.template |> ShippingRule.lens.location .~ $0
-      }
-      let shippingRule = defaultShippingRule(fromShippingRules: shippingRules)
-      XCTAssertEqual(shippingRules[2], shippingRule)
+      let shippingRule = defaultShippingRule(
+        fromShippingRules: locations.map { ShippingRule.template |> ShippingRule.lens.location .~ $0 }
+      )
+      XCTAssertEqual("CZ", shippingRule?.location.country)
     }
   }
 }

--- a/Library/ViewModels/BackingCellViewModel.swift
+++ b/Library/ViewModels/BackingCellViewModel.swift
@@ -41,7 +41,11 @@ public final class BackingCellViewModel: BackingCellViewModelType, BackingCellVi
     self.delivery = backing.map { backing in
       backing.reward?.estimatedDeliveryOn.map {
         Strings.backing_info_estimated_delivery_date(
-          delivery_date: Format.date(secondsInUTC: $0, template: "MMMMyyyy", timeZone: UTCTimeZone)
+          delivery_date: Format.date(
+            secondsInUTC: $0,
+            template: DateFormatter.monthYear,
+            timeZone: UTCTimeZone
+          )
         )
       }
     }

--- a/Library/ViewModels/BackingCellViewModelTests.swift
+++ b/Library/ViewModels/BackingCellViewModelTests.swift
@@ -1,5 +1,5 @@
 @testable import KsApi
-import Library
+@testable import Library
 import Prelude
 import ReactiveExtensions_TestHelpers
 import ReactiveSwift
@@ -40,7 +40,7 @@ internal final class BackingCellViewModelTests: TestCase {
       Strings.backing_info_estimated_delivery_date(
         delivery_date:
         Format.date(
-          secondsInUTC: reward.estimatedDeliveryOn!, template: "MMMMyyyy", timeZone: UTCTimeZone
+          secondsInUTC: reward.estimatedDeliveryOn!, template: DateFormatter.monthYear, timeZone: UTCTimeZone
         )
       )
     ], "Emits the estimated delivery date")

--- a/Library/ViewModels/DeprecatedRewardCellViewModel.swift
+++ b/Library/ViewModels/DeprecatedRewardCellViewModel.swift
@@ -148,7 +148,7 @@ public final class DeprecatedRewardCellViewModel: RewardCellViewModelType, Rewar
     self.estimatedDeliveryDateLabelText = reward
       .map { reward in
         reward.estimatedDeliveryOn.map {
-          Format.date(secondsInUTC: $0, template: "MMMMyyyy", timeZone: UTCTimeZone)
+          Format.date(secondsInUTC: $0, template: DateFormatter.monthYear, timeZone: UTCTimeZone)
         }
       }
       .skipNil()

--- a/Library/ViewModels/DeprecatedRewardCellViewModelTests.swift
+++ b/Library/ViewModels/DeprecatedRewardCellViewModelTests.swift
@@ -329,7 +329,7 @@ final class DeprecatedRewardCellViewModelTests: TestCase {
     self.estimatedDeliveryDateLabelText.assertValues([
       Format.date(
         secondsInUTC: estimatedDelivery,
-        template: "MMMMyyyy",
+        template: DateFormatter.monthYear,
         timeZone: UTCTimeZone
       )
     ], "Emits the estimated delivery date")

--- a/Library/ViewModels/DeprecatedRewardPledgeViewModel.swift
+++ b/Library/ViewModels/DeprecatedRewardPledgeViewModel.swift
@@ -1016,22 +1016,6 @@ private func paymentSummaryItems(
   return paymentSummaryItems
 }
 
-internal func defaultShippingRule(fromShippingRules shippingRules: [ShippingRule]) -> ShippingRule? {
-  let shippingRuleFromCurrentLocation = shippingRules
-    .filter { shippingRule in shippingRule.location.country == AppEnvironment.current.config?.countryCode }
-    .first
-
-  if let shippingRuleFromCurrentLocation = shippingRuleFromCurrentLocation {
-    return shippingRuleFromCurrentLocation
-  }
-
-  let shippingRuleInUSA = shippingRules
-    .filter { shippingRule in shippingRule.location.country == "US" }
-    .first
-
-  return shippingRuleInUSA ?? shippingRules.first
-}
-
 private func backingError(forProject project: Project, amount: Double, reward: Reward?) -> PledgeError? {
   let (min, max) = minAndMaxPledgeAmount(forProject: project, reward: reward)
 

--- a/Library/ViewModels/PledgeAmountCellViewModel.swift
+++ b/Library/ViewModels/PledgeAmountCellViewModel.swift
@@ -19,7 +19,7 @@ public protocol PledgeAmountCellViewModelType {
 }
 
 public final class PledgeAmountCellViewModel: PledgeAmountCellViewModelType,
-PledgeAmountCellViewModelInputs, PledgeAmountCellViewModelOutputs {
+  PledgeAmountCellViewModelInputs, PledgeAmountCellViewModelOutputs {
   public init() {
     let project = self.projectAndRewardProperty.signal
       .skipNil()

--- a/Library/ViewModels/PledgeAmountCellViewModel.swift
+++ b/Library/ViewModels/PledgeAmountCellViewModel.swift
@@ -1,0 +1,49 @@
+import Foundation
+import KsApi
+import Prelude
+import ReactiveExtensions
+import ReactiveSwift
+
+public protocol PledgeAmountCellViewModelInputs {
+  func configureWith(project: Project, reward: Reward)
+}
+
+public protocol PledgeAmountCellViewModelOutputs {
+  var amount: Signal<String, Never> { get }
+  var currency: Signal<String, Never> { get }
+}
+
+public protocol PledgeAmountCellViewModelType {
+  var inputs: PledgeAmountCellViewModelInputs { get }
+  var outputs: PledgeAmountCellViewModelOutputs { get }
+}
+
+public final class PledgeAmountCellViewModel: PledgeAmountCellViewModelType,
+PledgeAmountCellViewModelInputs, PledgeAmountCellViewModelOutputs {
+  public init() {
+    let project = self.projectAndRewardProperty.signal
+      .skipNil()
+      .map(first)
+
+    let reward = self.projectAndRewardProperty.signal
+      .skipNil()
+      .map(second)
+
+    self.amount = reward
+      .map { String(format: "%.0f", $0.minimum) }
+
+    self.currency = project
+      .map { currencySymbol(forCountry: $0.country).trimmed() }
+  }
+
+  private let projectAndRewardProperty = MutableProperty<(Project, Reward)?>(nil)
+  public func configureWith(project: Project, reward: Reward) {
+    self.projectAndRewardProperty.value = (project, reward)
+  }
+
+  public let amount: Signal<String, Never>
+  public let currency: Signal<String, Never>
+
+  public var inputs: PledgeAmountCellViewModelInputs { return self }
+  public var outputs: PledgeAmountCellViewModelOutputs { return self }
+}

--- a/Library/ViewModels/PledgeAmountCellViewModelTests.swift
+++ b/Library/ViewModels/PledgeAmountCellViewModelTests.swift
@@ -1,0 +1,37 @@
+@testable import KsApi
+@testable import Library
+import Prelude
+import ReactiveExtensions_TestHelpers
+import XCTest
+
+internal final class PledgeAmountCellViewModelTests: TestCase {
+  private let vm: PledgeAmountCellViewModelType = PledgeAmountCellViewModel()
+
+  private let amount = TestObserver<String, Never>()
+  private let currency = TestObserver<String, Never>()
+
+  override func setUp() {
+    super.setUp()
+
+    self.vm.outputs.amount.observe(self.amount.observer)
+    self.vm.outputs.currency.observe(self.currency.observer)
+  }
+
+  func testAmountAndCurrency() {
+    self.vm.inputs.configureWith(project: .template, reward: .template)
+
+    self.amount.assertValues(["10"])
+    self.currency.assertValues(["$"])
+
+    let project = Project.template
+      |> Project.lens.country .~ .jp
+
+    let reward = Reward.template
+      |> Reward.lens.minimum .~ 200
+
+    self.vm.inputs.configureWith(project: project, reward: reward)
+
+    self.amount.assertValues(["10", "200"])
+    self.currency.assertValues(["$", "¥"])
+  }
+}

--- a/Library/ViewModels/PledgeDescriptionCellViewModel.swift
+++ b/Library/ViewModels/PledgeDescriptionCellViewModel.swift
@@ -3,8 +3,9 @@ import KsApi
 import Prelude
 import ReactiveExtensions
 import ReactiveSwift
+
 public protocol PledgeDescriptionCellViewModelInputs {
-  func configureWith(estimatedDeliveryDate: String)
+  func configureWith(reward: Reward)
   func learnMoreTapped()
 }
 
@@ -21,14 +22,18 @@ public protocol PledgeDescriptionCellViewModelType {
 public final class PledgeDescriptionCellViewModel: PledgeDescriptionCellViewModelType,
   PledgeDescriptionCellViewModelInputs, PledgeDescriptionCellViewModelOutputs {
   public init() {
-    self.estimatedDeliveryText = self.estimatedDeliveryDateProperty.signal
+    self.estimatedDeliveryText = self.rewardProperty.signal
+      .skipNil()
+      .map { $0.estimatedDeliveryOn }
+      .skipNil()
+      .map { Format.date(secondsInUTC: $0, template: "MMMMyyyy", timeZone: UTCTimeZone) }
 
     self.presentTrustAndSafety = self.learnMoreTappedProperty.signal
   }
 
-  private let estimatedDeliveryDateProperty = MutableProperty<String>("")
-  public func configureWith(estimatedDeliveryDate: String) {
-    self.estimatedDeliveryDateProperty.value = estimatedDeliveryDate
+  private let rewardProperty = MutableProperty<Reward?>(nil)
+  public func configureWith(reward: Reward) {
+    self.rewardProperty.value = reward
   }
 
   private let learnMoreTappedProperty = MutableProperty(())

--- a/Library/ViewModels/PledgeDescriptionCellViewModel.swift
+++ b/Library/ViewModels/PledgeDescriptionCellViewModel.swift
@@ -26,7 +26,7 @@ public final class PledgeDescriptionCellViewModel: PledgeDescriptionCellViewMode
       .skipNil()
       .map { $0.estimatedDeliveryOn }
       .skipNil()
-      .map { Format.date(secondsInUTC: $0, template: "MMMMyyyy", timeZone: UTCTimeZone) }
+      .map { Format.date(secondsInUTC: $0, template: DateFormatter.monthYear, timeZone: UTCTimeZone) }
 
     self.presentTrustAndSafety = self.learnMoreTappedProperty.signal
   }

--- a/Library/ViewModels/PledgeDescriptionCellViewModelTests.swift
+++ b/Library/ViewModels/PledgeDescriptionCellViewModelTests.swift
@@ -18,16 +18,17 @@ internal final class PledgeDescriptionCellViewModelTests: TestCase {
   }
 
   func testEstimatedDeliveryDate() {
-    let estimatedDelivery = 1_468_527_587.32843
+    let reward = Reward.template
+      |> Reward.lens.estimatedDeliveryOn .~ 1_468_527_587.32843
 
-    let date = Format.date(secondsInUTC: estimatedDelivery, template: "MMMMyyyy", timeZone: UTCTimeZone)
+    self.vm.inputs.configureWith(reward: reward)
 
-    self.vm.inputs.configureWith(estimatedDeliveryDate: date)
     self.estimatedDeliveryText.assertValues(["July 2016"], "Emits the estimated delivery date")
   }
 
   func testPresentTrustAndSafety() {
     self.vm.inputs.learnMoreTapped()
+
     self.presentTrustAndSafety.assertDidEmitValue()
   }
 }

--- a/Library/ViewModels/PledgeShippingLocationCellViewModel.swift
+++ b/Library/ViewModels/PledgeShippingLocationCellViewModel.swift
@@ -21,7 +21,7 @@ public protocol PledgeShippingLocationCellViewModelType {
 }
 
 public final class PledgeShippingLocationCellViewModel: PledgeShippingLocationCellViewModelType,
-PledgeShippingLocationCellViewModelInputs, PledgeShippingLocationCellViewModelOutputs {
+  PledgeShippingLocationCellViewModelInputs, PledgeShippingLocationCellViewModelOutputs {
   public init() {
     let project = self.projectAndRewardProperty.signal.skipNil().map(first)
     let reward = self.projectAndRewardProperty.signal.skipNil().map(second)
@@ -37,7 +37,7 @@ PledgeShippingLocationCellViewModelInputs, PledgeShippingLocationCellViewModelOu
           .map(ShippingRulesEnvelope.lens.shippingRules.view)
           .retry(upTo: 3)
           .materialize()
-    }
+      }
 
     let defaultSelectedShippingRule = shippingRulesEvent.values()
       .map(defaultShippingRule(fromShippingRules:))

--- a/Library/ViewModels/PledgeShippingLocationCellViewModel.swift
+++ b/Library/ViewModels/PledgeShippingLocationCellViewModel.swift
@@ -1,0 +1,97 @@
+import Foundation
+import KsApi
+import Prelude
+import ReactiveExtensions
+import ReactiveSwift
+
+public protocol PledgeShippingLocationCellViewModelInputs {
+  func configureWith(project: Project, reward: Reward)
+}
+
+public protocol PledgeShippingLocationCellViewModelOutputs {
+  var amount: Signal<NSAttributedString, Never> { get }
+  var location: Signal<String, Never> { get }
+  var shippingIsLoading: Signal<Bool, Never> { get }
+  var shippingRulesError: Signal<String, Never> { get }
+}
+
+public protocol PledgeShippingLocationCellViewModelType {
+  var inputs: PledgeShippingLocationCellViewModelInputs { get }
+  var outputs: PledgeShippingLocationCellViewModelOutputs { get }
+}
+
+public final class PledgeShippingLocationCellViewModel: PledgeShippingLocationCellViewModelType,
+PledgeShippingLocationCellViewModelInputs, PledgeShippingLocationCellViewModelOutputs {
+  public init() {
+    let project = self.projectAndRewardProperty.signal.skipNil().map(first)
+    let reward = self.projectAndRewardProperty.signal.skipNil().map(second)
+
+    let shouldLoadShippingRules = reward.map { $0.shipping.enabled }
+
+    let shippingRulesEvent = self.projectAndRewardProperty.signal
+      .skipNil()
+      .filter { _, reward in reward.shipping.enabled }
+      .switchMap { (project, reward) -> SignalProducer<Signal<[ShippingRule], ErrorEnvelope>.Event, Never> in
+        AppEnvironment.current.apiService.fetchRewardShippingRules(projectId: project.id, rewardId: reward.id)
+          .ksr_delay(AppEnvironment.current.apiDelayInterval, on: AppEnvironment.current.scheduler)
+          .map(ShippingRulesEnvelope.lens.shippingRules.view)
+          .retry(upTo: 3)
+          .materialize()
+    }
+
+    let defaultSelectedShippingRule = shippingRulesEvent.values()
+      .map(defaultShippingRule(fromShippingRules:))
+      .skipNil()
+
+    self.amount = Signal.combineLatest(project, defaultSelectedShippingRule)
+      .map { project, shippingRule in shippingValue(of: project, with: shippingRule.cost) }
+      .skipNil()
+
+    self.location = defaultSelectedShippingRule
+      .map { $0.location.localizedName }
+
+    let shippingShouldBeginLoading = shouldLoadShippingRules
+      .filter(isTrue)
+
+    self.shippingIsLoading = Signal.merge(
+      shippingShouldBeginLoading,
+      shippingRulesEvent.filter { $0.isTerminating }.mapConst(false)
+    )
+
+    self.shippingRulesError = shippingRulesEvent.errors().map { _ in
+      Strings.We_were_unable_to_load_the_shipping_destinations()
+    }
+  }
+
+  private let projectAndRewardProperty = MutableProperty<(Project, Reward)?>(nil)
+  public func configureWith(project: Project, reward: Reward) {
+    self.projectAndRewardProperty.value = (project, reward)
+  }
+
+  public let amount: Signal<NSAttributedString, Never>
+  public let location: Signal<String, Never>
+  public let shippingIsLoading: Signal<Bool, Never>
+  public let shippingRulesError: Signal<String, Never>
+
+  public var inputs: PledgeShippingLocationCellViewModelInputs { return self }
+  public var outputs: PledgeShippingLocationCellViewModelOutputs { return self }
+}
+
+// MARK: - Functions
+
+private func shippingValue(of project: Project, with shippingRuleCost: Double) -> NSAttributedString? {
+  let defaultAttributes = checkoutCurrencyDefaultAttributes()
+  let superscriptAttributes = checkoutCurrencySuperscriptAttributes()
+  guard
+    let attributedCurrency = Format.attributedCurrency(
+      shippingRuleCost,
+      country: project.country,
+      omitCurrencyCode: project.stats.omitUSCurrencyCode,
+      defaultAttributes: defaultAttributes,
+      superscriptAttributes: superscriptAttributes
+    ) else { return nil }
+
+  let combinedAttributes = defaultAttributes.merging(superscriptAttributes) { _, new in new }
+
+  return Format.attributedPlusSign(combinedAttributes) + attributedCurrency
+}

--- a/Library/ViewModels/PledgeShippingLocationCellViewModelTests.swift
+++ b/Library/ViewModels/PledgeShippingLocationCellViewModelTests.swift
@@ -1,11 +1,11 @@
 import Foundation
-import Prelude
-import ReactiveExtensions
-import ReactiveSwift
-import XCTest
 @testable import KsApi
 @testable import Library
+import Prelude
+import ReactiveExtensions
 import ReactiveExtensions_TestHelpers
+import ReactiveSwift
+import XCTest
 
 private let locations: [Location] = [
   .usa,

--- a/Library/ViewModels/PledgeShippingLocationCellViewModelTests.swift
+++ b/Library/ViewModels/PledgeShippingLocationCellViewModelTests.swift
@@ -1,0 +1,113 @@
+import Foundation
+import Prelude
+import ReactiveExtensions
+import ReactiveSwift
+import XCTest
+@testable import KsApi
+@testable import Library
+import ReactiveExtensions_TestHelpers
+
+private let locations: [Location] = [
+  .usa,
+  .canada,
+  .greatBritain,
+  .australia
+]
+
+private let shippingRules = locations
+  .enumerated()
+  .map { idx, location in
+    .template
+      |> ShippingRule.lens.location .~ location
+      |> ShippingRule.lens.cost .~ Double(idx + 1 * 10)
+  }
+
+final class PledgeShippingLocationCellViewModelTests: TestCase {
+  private let vm: PledgeShippingLocationCellViewModelType = PledgeShippingLocationCellViewModel()
+
+  private let amount = TestObserver<NSAttributedString, Never>()
+  private let location = TestObserver<String, Never>()
+  private let shippingIsLoading = TestObserver<Bool, Never>()
+  private let shippingRulesError = TestObserver<String, Never>()
+
+  override func setUp() {
+    super.setUp()
+
+    self.vm.outputs.amount.observe(self.amount.observer)
+    self.vm.outputs.location.observe(self.location.observer)
+    self.vm.outputs.shippingIsLoading.observe(self.shippingIsLoading.observer)
+    self.vm.outputs.shippingRulesError.observe(self.shippingRulesError.observer)
+  }
+
+  func testAmount() {
+    withEnvironment(apiService: MockService(fetchShippingRulesResult: .success(shippingRules))) {
+      let expectedAttributedString = NSMutableAttributedString(
+        string: "+$10.00", attributes: checkoutCurrencyDefaultAttributes()
+      )
+      expectedAttributedString.addAttributes(
+        checkoutCurrencySuperscriptAttributes(), range: NSRange(location: 0, length: 2)
+      )
+      expectedAttributedString.addAttributes(
+        checkoutCurrencySuperscriptAttributes(), range: NSRange(location: 4, length: 3)
+      )
+
+      let reward = Reward.template
+        |> Reward.lens.shipping.enabled .~ true
+
+      self.vm.inputs.configureWith(project: .template, reward: reward)
+
+      self.amount.assertValues([])
+
+      self.scheduler.run()
+
+      self.amount.assertValues([expectedAttributedString])
+    }
+  }
+
+  func testLocation() {
+    withEnvironment(apiService: MockService(fetchShippingRulesResult: .success(shippingRules))) {
+      let reward = Reward.template
+        |> Reward.lens.shipping.enabled .~ true
+
+      self.vm.inputs.configureWith(project: .template, reward: reward)
+
+      self.location.assertValues([])
+
+      self.scheduler.run()
+
+      self.location.assertValues(["United States"])
+    }
+  }
+
+  func testShippingIsLoading() {
+    withEnvironment(apiService: MockService(fetchShippingRulesResult: .success(shippingRules))) {
+      let reward = Reward.template
+        |> Reward.lens.shipping.enabled .~ true
+
+      self.vm.inputs.configureWith(project: .template, reward: reward)
+
+      self.shippingIsLoading.assertValues([true])
+
+      self.scheduler.run()
+
+      self.shippingIsLoading.assertValues([true, false])
+    }
+  }
+
+  func testShippingRulesError() {
+    let error = ErrorEnvelope(errorMessages: [], ksrCode: nil, httpCode: 404, exception: nil)
+
+    withEnvironment(apiService: MockService(fetchShippingRulesResult: .failure(error))) {
+      let reward = Reward.template
+        |> Reward.lens.shipping.enabled .~ true
+
+      self.vm.inputs.configureWith(project: .template, reward: reward)
+
+      self.shippingRulesError.assertValues([])
+
+      self.scheduler.run()
+
+      self.shippingRulesError.assertValues([Strings.We_were_unable_to_load_the_shipping_destinations()])
+    }
+  }
+}

--- a/Library/ViewModels/PledgeViewModel.swift
+++ b/Library/ViewModels/PledgeViewModel.swift
@@ -3,30 +3,13 @@ import KsApi
 import Prelude
 import ReactiveSwift
 
-public typealias PledgeTableViewData = (
-  amount: Double,
-  currencySymbol: String,
-  estimatedDelivery: String,
-  shippingLocation: String,
-  shippingCost: Double,
-  project: Project,
-  isLoggedIn: Bool,
-  requiresShippingRules: Bool
-)
-
-public typealias SelectedShippingRuleData = (location: String, shippingCost: Double, project: Project)
-
 public protocol PledgeViewModelInputs {
   func configureWith(project: Project, reward: Reward)
-  func didReloadData()
   func viewDidLoad()
 }
 
 public protocol PledgeViewModelOutputs {
-  var reloadWithData: Signal<PledgeTableViewData, Never> { get }
-  var selectedShippingRuleData: Signal<SelectedShippingRuleData, Never> { get }
-  var shippingIsLoading: Signal<Bool, Never> { get }
-  var shippingRulesError: Signal<String, Never> { get }
+  var reloadWithData: Signal<(Project, Reward, Bool), Never> { get }
 }
 
 public protocol PledgeViewModelType {
@@ -44,79 +27,11 @@ public class PledgeViewModel: PledgeViewModelType, PledgeViewModelInputs, Pledge
 
     let project = projectAndReward.map(first)
     let reward = projectAndReward.map(second)
-
-    let amountCurrencySymbolDeliveryShipping = projectAndReward.signal
-      .map { project, reward in
-        projectAndRewardData(project: project, reward: reward)
-      }
-
     let isLoggedIn = projectAndReward
       .map { _ in AppEnvironment.current.currentUser }
       .map(isNotNil)
 
-    let shouldLoadShippingRules = reward.map { $0.shipping.enabled }
-
-    let pledgeViewData: Signal<PledgeTableViewData, Never> = Signal
-      .combineLatest(project, amountCurrencySymbolDeliveryShipping, isLoggedIn, shouldLoadShippingRules)
-      .map { project, amountCurrencySymbolDeliveryShipping, isLoggedIn, requiresShippingRules in
-        let (amount, currencySymbol, estimatedDelivery, shippingLocation, shippingAmount)
-          = amountCurrencySymbolDeliveryShipping
-
-        return (
-          amount,
-          currencySymbol,
-          estimatedDelivery,
-          shippingLocation,
-          shippingAmount,
-          project,
-          isLoggedIn,
-          requiresShippingRules
-        )
-      }
-
-    self.reloadWithData = pledgeViewData
-
-    let shippingRulesEvent = projectAndReward
-      .filter { _, reward in reward.shipping.enabled }
-      .switchMap { (project, reward)
-        -> SignalProducer<Signal<[ShippingRule], ErrorEnvelope>.Event, Never> in
-        AppEnvironment.current.apiService.fetchRewardShippingRules(
-          projectId: project.id,
-          rewardId: reward.id
-        )
-        .ksr_delay(AppEnvironment.current.apiDelayInterval, on: AppEnvironment.current.scheduler)
-        .map(ShippingRulesEnvelope.lens.shippingRules.view)
-        .retry(upTo: 3)
-        .materialize()
-      }
-
-    let defaultSelectedShippingRule = shippingRulesEvent.values()
-      .map(defaultShippingRule(fromShippingRules:))
-
-    self.selectedShippingRuleData = Signal.combineLatest(
-      project,
-      defaultSelectedShippingRule.skipNil(),
-      self.didReloadDataProperty.signal
-    )
-    .map { project, shippingRule, _ -> SelectedShippingRuleData in
-      (shippingRule.location.localizedName, shippingRule.cost, project)
-    }
-
-    let shippingShouldBeginLoading = shouldLoadShippingRules
-      .filter(isTrue)
-
-    let shippingIsLoading = Signal.merge(
-      shippingShouldBeginLoading,
-      shippingRulesEvent.filter { $0.isTerminating }.mapConst(false)
-    )
-
-    // Ensure that table view's reloadData has completed at least once before triggering loading events
-    self.shippingIsLoading = Signal.combineLatest(self.didReloadDataProperty.signal, shippingIsLoading)
-      .map(second)
-
-    self.shippingRulesError = shippingRulesEvent.errors().map { _ in
-      Strings.We_were_unable_to_load_the_shipping_destinations()
-    }
+    self.reloadWithData = Signal.combineLatest(project, reward, isLoggedIn)
   }
 
   private let configureProjectAndRewardProperty = MutableProperty<(Project, Reward)?>(nil)
@@ -124,35 +39,13 @@ public class PledgeViewModel: PledgeViewModelType, PledgeViewModelInputs, Pledge
     self.configureProjectAndRewardProperty.value = (project, reward)
   }
 
-  private let didReloadDataProperty = MutableProperty<Void>(())
-  public func didReloadData() {
-    self.didReloadDataProperty.value = ()
-  }
-
   private let viewDidLoadProperty = MutableProperty(())
   public func viewDidLoad() {
     self.viewDidLoadProperty.value = ()
   }
 
-  public let reloadWithData: Signal<PledgeTableViewData, Never>
-  public let selectedShippingRuleData: Signal<SelectedShippingRuleData, Never>
-  public let shippingIsLoading: Signal<Bool, Never>
-  public let shippingRulesError: Signal<String, Never>
+  public let reloadWithData: Signal<(Project, Reward, Bool), Never>
 
   public var inputs: PledgeViewModelInputs { return self }
   public var outputs: PledgeViewModelOutputs { return self }
-}
-
-// MARK: - Functions
-
-private func projectAndRewardData(project: Project, reward: Reward)
-  -> (Double, String, String, String, Double) {
-  let amount = reward.minimum
-  let currency = currencySymbol(forCountry: project.country).trimmed()
-  let estimatedDelivery = reward.estimatedDeliveryOn
-    .map { Format.date(secondsInUTC: $0, template: "MMMMyyyy", timeZone: UTCTimeZone) } ?? ""
-  let shippingLocation = ""
-  let shippingAmount = 0.0
-
-  return (amount, currency, estimatedDelivery, shippingLocation, shippingAmount)
 }

--- a/Library/ViewModels/PledgeViewModelTests.swift
+++ b/Library/ViewModels/PledgeViewModelTests.swift
@@ -8,252 +8,47 @@ import XCTest
 @testable import Library
 import ReactiveExtensions_TestHelpers
 
-private let locations: [Location] = [
-  .usa,
-  .canada,
-  .greatBritain,
-  .australia
-]
-
-private let shippingRules = locations
-  .enumerated()
-  .map { idx, location in
-    .template
-      |> ShippingRule.lens.location .~ location
-      |> ShippingRule.lens.cost .~ Double(idx + 1)
-  } ||> ShippingRule.lens.location .. Location.lens.localizedName %~ { "Local " + $0 }
-
 final class PledgeViewModelTests: TestCase {
   private let vm: PledgeViewModelType = PledgeViewModel()
 
-  private let amount = TestObserver<Double, Never>()
-  private let currencySymbol = TestObserver<String, Never>()
-  private let estimatedDelivery = TestObserver<String, Never>()
-  private let isLoggedIn = TestObserver<Bool, Never>()
   private let project = TestObserver<Project, Never>()
-  private let requiresShippingRules = TestObserver<Bool, Never>()
-  private let selectedShippingRuleLocation = TestObserver<String, Never>()
-  private let selectedShippingCost = TestObserver<Double, Never>()
-  private let selectedShippingRuleProject = TestObserver<Project, Never>()
-  private let shippingCost = TestObserver<Double, Never>()
-  private let shippingIsLoading = TestObserver<Bool, Never>()
-  private let shippingLocation = TestObserver<String, Never>()
-  private let shippingRulesError = TestObserver<String, Never>()
+  private let reward = TestObserver<Reward, Never>()
+  private let isLoggedIn = TestObserver<Bool, Never>()
 
   override func setUp() {
     super.setUp()
 
-    self.vm.outputs.reloadWithData.map { $0.amount }.observe(self.amount.observer)
-    self.vm.outputs.reloadWithData.map { $0.currencySymbol }.observe(self.currencySymbol.observer)
-    self.vm.outputs.reloadWithData.map { $0.estimatedDelivery }.observe(self.estimatedDelivery.observer)
-    self.vm.outputs.reloadWithData.map { $0.shippingLocation }.observe(self.shippingLocation.observer)
-    self.vm.outputs.reloadWithData.map { $0.shippingCost }.observe(self.shippingCost.observer)
-    self.vm.outputs.reloadWithData.map { $0.project }.observe(self.project.observer)
-    self.vm.outputs.reloadWithData.map { $0.isLoggedIn }.observe(self.isLoggedIn.observer)
-    self.vm.outputs.reloadWithData.map { $0.requiresShippingRules }
-      .observe(self.requiresShippingRules.observer)
-    self.vm.outputs.selectedShippingRuleData.map { $0.location }
-      .observe(self.selectedShippingRuleLocation.observer)
-    self.vm.outputs.selectedShippingRuleData.map { $0.shippingCost }
-      .observe(self.selectedShippingCost.observer)
-    self.vm.outputs.selectedShippingRuleData.map { $0.project }
-      .observe(self.selectedShippingRuleProject.observer)
-    self.vm.outputs.shippingRulesError.observe(self.shippingRulesError.observer)
-
-    self.vm.outputs.shippingIsLoading.observe(self.shippingIsLoading.observer)
+    self.vm.outputs.reloadWithData.map { $0.0 }.observe(self.project.observer)
+    self.vm.outputs.reloadWithData.map { $0.1 }.observe(self.reward.observer)
+    self.vm.outputs.reloadWithData.map { $0.2 }.observe(self.isLoggedIn.observer)
   }
 
   func testReloadWithData_loggedOut() {
-    let estimatedDelivery = 1_468_527_587.32843
-    let project = Project.template
-    let reward = Reward.template |> Reward.lens.estimatedDeliveryOn .~ estimatedDelivery
-
     withEnvironment(currentUser: nil) {
+      let project = Project.template
+      let reward = Reward.template
+
       self.vm.inputs.configureWith(project: project, reward: reward)
       self.vm.inputs.viewDidLoad()
 
-      self.amount.assertValues([10])
-      self.currencySymbol.assertValues(["$"])
-      self.estimatedDelivery.assertValues(
-        [Format.date(secondsInUTC: estimatedDelivery, template: "MMMMyyyy", timeZone: UTCTimeZone)]
-      )
-      self.shippingLocation.assertValues([""])
-      self.shippingCost.assertValues([0.0], "Initial shipping cost value")
       self.project.assertValues([project])
+      self.reward.assertValues([reward])
       self.isLoggedIn.assertValues([false])
-      self.requiresShippingRules.assertValues([false])
     }
   }
 
   func testReloadWithData_loggedIn() {
-    let estimatedDelivery = 1_468_527_587.32843
     let project = Project.template
-    let reward = Reward.template |> Reward.lens.estimatedDeliveryOn .~ estimatedDelivery
+    let reward = Reward.template
     let user = User.template
 
     withEnvironment(currentUser: user) {
       self.vm.inputs.configureWith(project: project, reward: reward)
       self.vm.inputs.viewDidLoad()
 
-      self.amount.assertValues([10])
-      self.currencySymbol.assertValues(["$"])
-      self.estimatedDelivery.assertValues(
-        [Format.date(secondsInUTC: estimatedDelivery, template: "MMMMyyyy", timeZone: UTCTimeZone)]
-      )
-      self.shippingLocation.assertValues([""])
-      self.shippingCost.assertValues([0.0], "Initial shipping cost value")
       self.project.assertValues([project])
+      self.reward.assertValues([reward])
       self.isLoggedIn.assertValues([true])
-      self.requiresShippingRules.assertValues([false])
-    }
-  }
-
-  func testReloadData_requiresShippingRules() {
-    let estimatedDelivery = 1_468_527_587.32843
-    let project = Project.template
-    let reward = Reward.template
-      |> Reward.lens.estimatedDeliveryOn .~ estimatedDelivery
-      |> Reward.lens.shipping.enabled .~ true
-
-    let user = User.template
-
-    withEnvironment(currentUser: user) {
-      self.vm.inputs.configureWith(project: project, reward: reward)
-      self.vm.inputs.viewDidLoad()
-
-      self.amount.assertValues([10])
-      self.currencySymbol.assertValues(["$"])
-      self.estimatedDelivery.assertValues(
-        [Format.date(secondsInUTC: estimatedDelivery, template: "MMMMyyyy", timeZone: UTCTimeZone)]
-      )
-      self.shippingLocation.assertValues([""])
-      self.shippingCost.assertValues([0.0], "Initial shipping cost value")
-      self.project.assertValues([project])
-      self.isLoggedIn.assertValues([true])
-      self.requiresShippingRules.assertValues([true])
-    }
-  }
-
-  func testSelectedShippingInfo_shippingDisabled() {
-    let project = Project.template
-    let reward = Reward.template
-      |> Reward.lens.shipping.enabled .~ false
-
-    self.vm.inputs.configureWith(project: project, reward: reward)
-    self.vm.inputs.viewDidLoad()
-
-    self.requiresShippingRules.assertValues([false])
-
-    self.vm.inputs.didReloadData()
-
-    self.selectedShippingRuleLocation.assertDidNotEmitValue()
-    self.selectedShippingCost.assertDidNotEmitValue()
-    self.selectedShippingRuleProject.assertDidNotEmitValue()
-    self.shippingIsLoading.assertDidNotEmitValue()
-  }
-
-  func testSelectedShippingRule_shippingEnabled_recognizedCountry() {
-    let reward = Reward.template
-      |> Reward.lens.shipping.enabled .~ true
-    // swiftlint:disable:next force_unwrapping
-    let defaultShippingRule = shippingRules.first(where: { $0.location == .australia })!
-    let project = Project.template
-
-    withEnvironment(
-      apiService: MockService(fetchShippingRulesResult: .success(shippingRules)),
-      config: .template |> Config.lens.countryCode .~ "AU"
-    ) {
-      self.vm.inputs.configureWith(project: project, reward: reward)
-      self.vm.inputs.viewDidLoad()
-
-      self.selectedShippingRuleLocation.assertDidNotEmitValue()
-      self.selectedShippingCost.assertDidNotEmitValue()
-      self.selectedShippingRuleProject.assertDidNotEmitValue()
-      self.shippingIsLoading.assertDidNotEmitValue()
-
-      self.vm.inputs.didReloadData()
-
-      self.shippingIsLoading.assertValues([true])
-
-      self.scheduler.run()
-
-      self.selectedShippingRuleLocation.assertValues(["Local Australia"])
-      self.selectedShippingCost.assertValues([defaultShippingRule.cost])
-      self.selectedShippingRuleProject.assertValues([project])
-      self.shippingIsLoading.assertValues([true, false])
-    }
-  }
-
-  func testSelectedShippingRule_shippingEnabled_unrecognizedCountry() {
-    let reward = Reward.template
-      |> Reward.lens.shipping.enabled .~ true
-    // swiftlint:disable:next force_unwrapping
-    let defaultShippingRule = shippingRules.first(where: { $0.location == .usa })!
-    let project = Project.template
-
-    withEnvironment(
-      apiService: MockService(fetchShippingRulesResult: .success(shippingRules)),
-      config: .template |> Config.lens.countryCode .~ "XYZ"
-    ) {
-      self.vm.inputs.configureWith(project: project, reward: reward)
-      self.vm.inputs.viewDidLoad()
-
-      self.selectedShippingRuleLocation.assertDidNotEmitValue()
-      self.selectedShippingCost.assertDidNotEmitValue()
-      self.selectedShippingRuleProject.assertDidNotEmitValue()
-      self.shippingIsLoading.assertDidNotEmitValue()
-
-      self.vm.inputs.didReloadData()
-
-      self.shippingIsLoading.assertValues([true])
-
-      self.scheduler.run()
-
-      self.selectedShippingRuleLocation.assertValues(["Local United States"])
-      self.selectedShippingCost.assertValues([defaultShippingRule.cost])
-      self.selectedShippingRuleProject.assertValues([project])
-      self.shippingIsLoading.assertValues([true, false])
-    }
-  }
-
-  func testShippingRulesErrored() {
-    let reward = Reward.template
-      |> Reward.lens.shipping.enabled .~ true
-
-    let error = ErrorEnvelope(
-      errorMessages: ["Something went wrong."],
-      ksrCode: .UnknownCode,
-      httpCode: 500,
-      exception: nil
-    )
-
-    // swiftlint:disable:next force_unwrapping
-    let defaultShippingRule = shippingRules.last!
-
-    withEnvironment(
-      apiService: MockService(fetchShippingRulesResult: .failure(error)),
-      config: .template |> Config.lens.countryCode .~ defaultShippingRule.location.country
-    ) {
-      self.vm.inputs.configureWith(project: .template, reward: reward)
-      self.vm.inputs.viewDidLoad()
-
-      self.selectedShippingRuleLocation.assertDidNotEmitValue()
-      self.selectedShippingCost.assertDidNotEmitValue()
-      self.selectedShippingRuleProject.assertDidNotEmitValue()
-      self.shippingIsLoading.assertDidNotEmitValue()
-
-      self.vm.inputs.didReloadData()
-
-      self.shippingIsLoading.assertValues([true])
-
-      self.scheduler.run()
-
-      self.shippingIsLoading.assertValues([true, false])
-      self.shippingRulesError.assertValues([Strings.We_were_unable_to_load_the_shipping_destinations()])
-
-      self.selectedShippingRuleLocation.assertDidNotEmitValue()
-      self.selectedShippingCost.assertDidNotEmitValue()
-      self.selectedShippingRuleProject.assertDidNotEmitValue()
     }
   }
 }


### PR DESCRIPTION
# 📲 What

Refactors pledge screen architecture to back each cell with a view model (this should be consistent with the rest of the codebase and make updating UI slightly less frustrating)

# 🤔 Why

By passing values from VC's VM it was challenging to pass the right font size which broke Dynamic Support in the process.

# 🛠 How

Each cell now has a VM that's populated only with information that it needs for the cell to display values. In addition to that we now can bind `text` / `attributedText` props on specific UI components making it more consistent with the rest of the codebase.

# 👀 See

Notice how the shipping location amount didn't scale previously.

| Before 🐛 | After 🦋 |
| --- | --- |
| <img width="540" alt="Screen Shot 2019-05-30 at 11 01 58 AM" src="https://user-images.githubusercontent.com/387596/58653368-6752e000-82ca-11e9-8e83-a9ffbde985d1.png"> | <img width="540" alt="Screen Shot 2019-05-30 at 10 57 01 AM" src="https://user-images.githubusercontent.com/387596/58653089-d7ad3180-82c9-11e9-93d8-878febdfd084.png"> |

# 🏎 Performance

- [x] Optimized Blended Layers (screenshots)

# ✅ Acceptance criteria

- [ ] Shipping location supports Dynamic Type scaling properly
- [ ] Shipping amount supports Dynamic Type scaling properly