### PR TITLE
🦡 [App Badges] Update badge value on push and lifecycle events

### DIFF
--- a/Kickstarter-iOS/AppDelegate.swift
+++ b/Kickstarter-iOS/AppDelegate.swift
@@ -362,9 +362,10 @@ extension AppDelegate: URLSessionTaskDelegate {
 extension AppDelegate: UNUserNotificationCenterDelegate {
   public func userNotificationCenter(
     _: UNUserNotificationCenter,
-    willPresent _: UNNotification,
+    willPresent notification: UNNotification,
     withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
   ) {
+    self.rootTabBarController?.didReceiveBadgeValue(notification.request.content.badge as? Int)
     completionHandler(.alert)
   }
 
@@ -374,6 +375,7 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
     withCompletionHandler completion: @escaping () -> Void
   ) {
     self.viewModel.inputs.didReceive(remoteNotification: response.notification.request.content.userInfo)
+    self.rootTabBarController?.didReceiveBadgeValue(response.notification.request.content.badge as? Int)
     completion()
   }
 }

--- a/Kickstarter-iOS/ViewModels/RootViewModel.swift
+++ b/Kickstarter-iOS/ViewModels/RootViewModel.swift
@@ -275,17 +275,17 @@ internal final class RootViewModel: RootViewModelType, RootViewModelInputs, Root
       )
       .map { _, index -> RootTabBarItemBadgeValueData in (nil, index) }
 
-    let badgeValueOnUserSessionStarted = self.userSessionStartedProperty.signal
+    let badgeValueOnUserUpdated = self.currentUserUpdatedProperty.signal
       .map { _ in AppEnvironment.current.currentUser?.unseenActivityCount }
 
     let updateBadgeValueFromNotification = selectedIndexAndActivityViewControllerIndex
       .takePairWhen(self.didReceiveBadgeValueSignal)
 
-    let updateBadgeValueOnUserSessionStarted = selectedIndexAndActivityViewControllerIndex
-      .takePairWhen(badgeValueOnUserSessionStarted)
+    let updateBadgeValueOnUserUpdated = selectedIndexAndActivityViewControllerIndex
+      .takePairWhen(badgeValueOnUserUpdated)
 
-    let updateBadgeValueOnUserSessionStartedOrFromNotification = Signal.merge(
-      updateBadgeValueOnUserSessionStarted,
+    let updateBadgeValueOnUserUpdatedOrFromNotification = Signal.merge(
+      updateBadgeValueOnUserUpdated,
       updateBadgeValueFromNotification
     )
     .map(unpack)
@@ -302,7 +302,7 @@ internal final class RootViewModel: RootViewModelType, RootViewModelInputs, Root
 
     self.setBadgeValueAtIndex = Signal.merge(
       updateBadgeValueOnLifecycleEvents,
-      updateBadgeValueOnUserSessionStartedOrFromNotification,
+      updateBadgeValueOnUserUpdatedOrFromNotification,
       clearBadgeValueOnUserSessionEnded,
       clearBadgeValueOnActivitiesTabSelected
     )

--- a/Kickstarter-iOS/ViewModels/RootViewModel.swift
+++ b/Kickstarter-iOS/ViewModels/RootViewModel.swift
@@ -294,7 +294,7 @@ internal final class RootViewModel: RootViewModelType, RootViewModelInputs, Root
     let currentBadgeValue = MutableProperty<String?>(nil)
 
     let clearBadgeValueOnActivitiesTabSelected = selectedIndexAndActivityViewControllerIndex.filter(==)
-      .flatMap { _, index in currentBadgeValue.producer.map { ($0, index) } }
+      .flatMap { _, index in currentBadgeValue.producer.map { ($0, index) }.take(first: 1) }
       .filter { value, _ in value != nil }
       .map { _, index -> RootTabBarItemBadgeValueData in (nil, index) }
 

--- a/Kickstarter-iOS/ViewModels/RootViewModel.swift
+++ b/Kickstarter-iOS/ViewModels/RootViewModel.swift
@@ -308,6 +308,7 @@ internal final class RootViewModel: RootViewModelType, RootViewModelInputs, Root
     currentBadgeValue <~ self.setBadgeValueAtIndex.map { $0.0 }
 
     self.updateUserInEnvironment = clearBadgeValueOnActivitiesTabSelected
+      .filter { _ in AppEnvironment.current.currentUser != nil }
       .switchMap { _ in
         updatedUserWithClearedActivityCountProducer()
           .ksr_delay(AppEnvironment.current.apiDelayInterval, on: AppEnvironment.current.scheduler)

--- a/Kickstarter-iOS/ViewModels/RootViewModelTests.swift
+++ b/Kickstarter-iOS/ViewModels/RootViewModelTests.swift
@@ -101,11 +101,9 @@ final class RootViewModelTests: TestCase {
 
       self.setBadgeValueAtIndexValue.assertValues(["99+"])
       self.setBadgeValueAtIndexIndex.assertValues([1])
-    }
 
-    mockApplication.applicationIconBadgeNumber = 50
+      mockApplication.applicationIconBadgeNumber = 50
 
-    withEnvironment(application: mockApplication) {
       self.vm.inputs.applicationWillEnterForeground()
 
       self.setBadgeValueAtIndexValue.assertValues(["99+", "50"])

--- a/Kickstarter-iOS/ViewModels/RootViewModelTests.swift
+++ b/Kickstarter-iOS/ViewModels/RootViewModelTests.swift
@@ -149,6 +149,41 @@ final class RootViewModelTests: TestCase {
     }
   }
 
+  func testClearBadgeValueOnActivitiesTabSelected_LoggedOut() {
+    let initialActivitiesCount = 100
+
+    let mockApplication = MockApplication()
+    mockApplication.applicationIconBadgeNumber = initialActivitiesCount
+
+    self.updateUserInEnvironment.assertValues([])
+    self.setBadgeValueAtIndexValue.assertValues([])
+    self.setBadgeValueAtIndexIndex.assertValues([])
+
+    let mockService = MockService(
+      clearUserUnseenActivityResult: Result(success: .init(activityIndicatorCount: 0))
+    )
+
+    withEnvironment(apiService: mockService, application: mockApplication) {
+      self.vm.inputs.viewDidLoad()
+
+      self.updateUserInEnvironment.assertValues([])
+      self.setBadgeValueAtIndexValue.assertValues(["99+"])
+      self.setBadgeValueAtIndexIndex.assertValues([1])
+
+      self.vm.inputs.didSelect(index: 1)
+
+      self.updateUserInEnvironment.assertValues([])
+      self.setBadgeValueAtIndexValue.assertValues(["99+", nil])
+      self.setBadgeValueAtIndexIndex.assertValues([1, 1])
+
+      self.scheduler.advance()
+
+      self.updateUserInEnvironment.assertValues([])
+      self.setBadgeValueAtIndexValue.assertValues(["99+", nil])
+      self.setBadgeValueAtIndexIndex.assertValues([1, 1])
+    }
+  }
+
   func testSetBadgeValueAtIndex_CurrentUserUpdated_SessionEnded() {
     let mockApplication = MockApplication()
     mockApplication.applicationIconBadgeNumber = 0

--- a/Kickstarter-iOS/ViewModels/RootViewModelTests.swift
+++ b/Kickstarter-iOS/ViewModels/RootViewModelTests.swift
@@ -131,7 +131,7 @@ final class RootViewModelTests: TestCase {
     }
   }
 
-  func testSetBadgeValueAtIndex_UserSessionStarted_Ended() {
+  func testSetBadgeValueAtIndex_CurrentUserUpdated_SessionEnded() {
     let mockApplication = MockApplication()
     mockApplication.applicationIconBadgeNumber = 0
 
@@ -150,7 +150,7 @@ final class RootViewModelTests: TestCase {
 
     withEnvironment(application: mockApplication) {
       AppEnvironment.login(.init(accessToken: "deadbeef", user: user))
-      self.vm.inputs.userSessionStarted()
+      self.vm.inputs.currentUserUpdated()
 
       self.setBadgeValueAtIndexValue.assertValues([nil, "50"])
       self.setBadgeValueAtIndexIndex.assertValues([1, 1])

--- a/Kickstarter-iOS/Views/Controllers/ActivitiesViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/ActivitiesViewController.swift
@@ -169,6 +169,12 @@ internal final class ActivitiesViewController: UITableViewController {
       .observeValues { [weak self] project, update in
         self?.goToUpdate(project: project, update: update)
       }
+
+    self.viewModel.outputs.clearBadgeValue
+      .observeForUI()
+      .observeValues { [weak self] in
+        self?.parent?.tabBarItem.badgeValue = nil
+      }
   }
 
   internal override func tableView(

--- a/Kickstarter-iOS/Views/Controllers/ActivitiesViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/ActivitiesViewController.swift
@@ -175,6 +175,12 @@ internal final class ActivitiesViewController: UITableViewController {
       .observeValues { [weak self] in
         self?.parent?.tabBarItem.badgeValue = nil
       }
+
+    self.viewModel.outputs.updateUserInEnvironment
+      .observeValues { [weak self] user in
+        AppEnvironment.updateCurrentUser(user)
+        NotificationCenter.default.post(.init(name: .ksr_userUpdated))
+      }
   }
 
   internal override func tableView(

--- a/Kickstarter-iOS/Views/Controllers/RootTabBarViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/RootTabBarViewController.swift
@@ -56,6 +56,12 @@ public final class RootTabBarViewController: UITabBarController {
         self?.viewModel.inputs.currentUserUpdated()
       }
 
+    self.viewModel.outputs.updateUserInEnvironment
+      .observeValues { [weak self] user in
+        AppEnvironment.updateCurrentUser(user)
+        NotificationCenter.default.post(.init(name: .ksr_userUpdated))
+      }
+
     self.userLocalePreferencesChanged = NotificationCenter
       .default
       .addObserver(

--- a/Kickstarter-iOS/Views/Controllers/RootTabBarViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/RootTabBarViewController.swift
@@ -17,6 +17,7 @@ extension TabBarControllerScrollable where Self: UIViewController {
 }
 
 public final class RootTabBarViewController: UITabBarController {
+  private var applicationWillEnterForegroundObserver: Any?
   private var sessionEndedObserver: Any?
   private var sessionStartedObserver: Any?
   private var userUpdatedObserver: Any?
@@ -27,6 +28,15 @@ public final class RootTabBarViewController: UITabBarController {
   public override func viewDidLoad() {
     super.viewDidLoad()
     self.delegate = self
+
+    self.applicationWillEnterForegroundObserver = NotificationCenter
+      .default
+      .addObserver(
+        forName: UIApplication.willEnterForegroundNotification,
+        object: nil, queue: nil
+      ) { [weak self] _ in
+        self?.viewModel.inputs.applicationWillEnterForeground()
+      }
 
     self.sessionStartedObserver = NotificationCenter
       .default
@@ -64,6 +74,7 @@ public final class RootTabBarViewController: UITabBarController {
     self.sessionEndedObserver.doIfSome(NotificationCenter.default.removeObserver)
     self.sessionStartedObserver.doIfSome(NotificationCenter.default.removeObserver)
     self.userUpdatedObserver.doIfSome(NotificationCenter.default.removeObserver)
+    self.applicationWillEnterForegroundObserver.doIfSome(NotificationCenter.default.removeObserver)
   }
 
   public override func bindStyles() {
@@ -260,6 +271,12 @@ public final class RootTabBarViewController: UITabBarController {
       }
     }
     return nil
+  }
+
+  // MARK: - Accessors
+
+  public func didReceiveBadgeValue(_ value: Int?) {
+    self.viewModel.inputs.didReceiveBadgeValue(value)
   }
 }
 

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -823,6 +823,7 @@
 		D05DFC4F227A5878006F3B68 /* MockPushRegistration.swift in Sources */ = {isa = PBXBuildFile; fileRef = D093B4B721A8B0E000910962 /* MockPushRegistration.swift */; };
 		D0851010219500F200BC418B /* PaymentSourceDeleteMutation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D085100F219500F200BC418B /* PaymentSourceDeleteMutation.swift */; };
 		D08510122195015F00BC418B /* PaymentSourceDeleteInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = D08510112195015F00BC418B /* PaymentSourceDeleteInput.swift */; };
+		D08C71DC22A71A0100A245B7 /* ClearUserUnseenActivityMutation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D08C71DB22A71A0100A245B7 /* ClearUserUnseenActivityMutation.swift */; };
 		D08CD1C021910C97009F89F0 /* GraphIDBridging.swift in Sources */ = {isa = PBXBuildFile; fileRef = D08CD1BF21910C97009F89F0 /* GraphIDBridging.swift */; };
 		D08CD1F921910DF5009F89F0 /* UnwatchProjectMutation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D08CD1F821910DF5009F89F0 /* UnwatchProjectMutation.swift */; };
 		D08CD1FF21913166009F89F0 /* WatchProjectViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D08CD1FE21913166009F89F0 /* WatchProjectViewModel.swift */; };
@@ -2034,6 +2035,7 @@
 		D05DFC45227A578C006F3B68 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		D085100F219500F200BC418B /* PaymentSourceDeleteMutation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentSourceDeleteMutation.swift; sourceTree = "<group>"; };
 		D08510112195015F00BC418B /* PaymentSourceDeleteInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentSourceDeleteInput.swift; sourceTree = "<group>"; };
+		D08C71DB22A71A0100A245B7 /* ClearUserUnseenActivityMutation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClearUserUnseenActivityMutation.swift; sourceTree = "<group>"; };
 		D08CD1BF21910C97009F89F0 /* GraphIDBridging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphIDBridging.swift; sourceTree = "<group>"; };
 		D08CD1F821910DF5009F89F0 /* UnwatchProjectMutation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnwatchProjectMutation.swift; sourceTree = "<group>"; };
 		D08CD1FE21913166009F89F0 /* WatchProjectViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchProjectViewModel.swift; sourceTree = "<group>"; };
@@ -2325,9 +2327,10 @@
 		775DFADB2162A56D00620CED /* mutations */ = {
 			isa = PBXGroup;
 			children = (
+				D08C71DB22A71A0100A245B7 /* ClearUserUnseenActivityMutation.swift */,
+				D79CF32B219CDEE100ECB73A /* CreatePaymentsSourceMutation.swift */,
 				D085100F219500F200BC418B /* PaymentSourceDeleteMutation.swift */,
 				D08CD1F821910DF5009F89F0 /* UnwatchProjectMutation.swift */,
-				D79CF32B219CDEE100ECB73A /* CreatePaymentsSourceMutation.swift */,
 				D6ED1B3D216D61E0007F7547 /* UpdateUserAccountMutation.swift */,
 				D77743E2217A2D67008D679F /* UpdateUserProfileMutation .swift */,
 				D6B686EA2191FEEE005F5DA7 /* UserSendEmailVerificationMutation.swift */,
@@ -4926,6 +4929,7 @@
 				D0158A271EEB30A2006E7684 /* ShippingRuleTemplates.swift in Sources */,
 				D6B9F90A22035840003282A5 /* Author.swift in Sources */,
 				77E44B7421823A56006446B8 /* ChangePasswordInput.swift in Sources */,
+				D08C71DC22A71A0100A245B7 /* ClearUserUnseenActivityMutation.swift in Sources */,
 				D01588891EEB2ED7006E7684 /* CheckoutEnvelopeLenses.swift in Sources */,
 				D0158A2E1EEB30A2006E7684 /* User.AvatarTemplates.swift in Sources */,
 				D01588571EEB2ED7006E7684 /* CheckoutEnvelope.swift in Sources */,

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -927,6 +927,8 @@
 		D0D58DC32257FCA900532AC1 /* Prelude_UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D0D58D812257FAE000532AC1 /* Prelude_UIKit.framework */; };
 		D0D58DC52257FD0200532AC1 /* Prelude_UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D0D58D812257FAE000532AC1 /* Prelude_UIKit.framework */; };
 		D0D58DC62257FD0200532AC1 /* Prelude.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D0D58D792257FADE00532AC1 /* Prelude.framework */; };
+		D0E78C3622A980A600AAB645 /* ClearUserUnseenActivityEnvelope.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0E78C3522A980A600AAB645 /* ClearUserUnseenActivityEnvelope.swift */; };
+		D0E78C3822A981EE00AAB645 /* ClearUserUnseenActivityEnvelopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0E78C3722A981EE00AAB645 /* ClearUserUnseenActivityEnvelopeTests.swift */; };
 		D6089E8F209106CD0032CC99 /* PushNotificationDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6089E572090D5B40032CC99 /* PushNotificationDialog.swift */; };
 		D60C8BE92142D61A00D96152 /* SettingsAccountCellType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D60C8BE72142D60800D96152 /* SettingsAccountCellType.swift */; };
 		D60C8BF12143167200D96152 /* SettingsAccountViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D60C8BAA2142CD0300D96152 /* SettingsAccountViewController.swift */; };
@@ -2065,6 +2067,8 @@
 		D0D58D822257FAE000532AC1 /* ReactiveExtensions_TestHelpers.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ReactiveExtensions_TestHelpers.framework; path = Carthage/Build/iOS/ReactiveExtensions_TestHelpers.framework; sourceTree = "<group>"; };
 		D0D58D832257FAE000532AC1 /* Curry.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Curry.framework; path = Carthage/Build/iOS/Curry.framework; sourceTree = "<group>"; };
 		D0D58D842257FAE000532AC1 /* Runes.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Runes.framework; path = Carthage/Build/iOS/Runes.framework; sourceTree = "<group>"; };
+		D0E78C3522A980A600AAB645 /* ClearUserUnseenActivityEnvelope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClearUserUnseenActivityEnvelope.swift; sourceTree = "<group>"; };
+		D0E78C3722A981EE00AAB645 /* ClearUserUnseenActivityEnvelopeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClearUserUnseenActivityEnvelopeTests.swift; sourceTree = "<group>"; };
 		D6089E572090D5B40032CC99 /* PushNotificationDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotificationDialog.swift; sourceTree = "<group>"; };
 		D60C8BAA2142CD0300D96152 /* SettingsAccountViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsAccountViewController.swift; sourceTree = "<group>"; };
 		D60C8BE52142D01E00D96152 /* SettingsAccountDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsAccountDataSource.swift; sourceTree = "<group>"; };
@@ -3312,19 +3316,23 @@
 				D6B9DF3E1F72E25A0064A4D8 /* Category.swift */,
 				D6AE52271FD1B4BA00BEC788 /* CategoryEnvelope.swift */,
 				D01587801EEB2ED6006E7684 /* CategoryTests.swift */,
-				D62B1476221216A000AC05C8 /* DeletePaymentMethodEnvelope.swift */,
 				D01587811EEB2ED6006E7684 /* ChangePaymentMethodEnvelope.swift */,
 				D01587821EEB2ED6006E7684 /* ChangePaymentMethodEnvelopeTests.swift */,
 				D01587831EEB2ED6006E7684 /* CheckoutEnvelope.swift */,
 				D01587841EEB2ED6006E7684 /* CheckoutEnvelopeTests.swift */,
+				D0E78C3522A980A600AAB645 /* ClearUserUnseenActivityEnvelope.swift */,
+				D0E78C3722A981EE00AAB645 /* ClearUserUnseenActivityEnvelopeTests.swift */,
 				D01587851EEB2ED6006E7684 /* Comment.swift */,
 				D01587861EEB2ED6006E7684 /* CommentsEnvelope.swift */,
 				D01587871EEB2ED6006E7684 /* CommentTests.swift */,
 				D01587881EEB2ED6006E7684 /* Config.swift */,
 				D67B6C9C221F458700B63A6B /* Config+Argo.swift */,
 				D01587891EEB2ED6006E7684 /* ConfigTests.swift */,
+				D79440562203A63300D0A747 /* CreatePaymentSourceEnvelope.swift */,
 				D015878A1EEB2ED6006E7684 /* CreatePledgeEnvelope.swift */,
 				D015878B1EEB2ED6006E7684 /* CreatePledgeEnvelopeTests.swift */,
+				D62B1476221216A000AC05C8 /* DeletePaymentMethodEnvelope.swift */,
+				D62B14AF2212184500AC05C8 /* DeletePaymentMethodEnvelopeTests.swift */,
 				D015878C1EEB2ED6006E7684 /* DiscoveryEnvelope.swift */,
 				D015878D1EEB2ED6006E7684 /* DiscoveryParams.swift */,
 				D015878E1EEB2ED6006E7684 /* DiscoveryParamsTests.swift */,
@@ -3336,7 +3344,8 @@
 				D01587931EEB2ED6006E7684 /* FriendStatsEnvelope.swift */,
 				D01587941EEB2ED6006E7684 /* FriendStatsEnvelopeTests.swift */,
 				D002CAE4218CF951009783F2 /* GraphMutationWatchProjectResponseEnvelope.swift */,
-				D79440562203A63300D0A747 /* CreatePaymentSourceEnvelope.swift */,
+				D63BBD30217F7212007E01F0 /* GraphUserCreditCard.swift */,
+				77DB53292215D0AA0078991C /* GraphUserCreditCardTests.swift */,
 				D01587951EEB2ED6006E7684 /* Item.swift */,
 				D01587961EEB2ED6006E7684 /* ItemTests.swift */,
 				D01587CB1EEB2ED7006E7684 /* Location.swift */,
@@ -3396,9 +3405,6 @@
 				D01587971EEB2ED6006E7684 /* lenses */,
 				D01587EE1EEB2ED7006E7684 /* templates */,
 				D6FB2A3C1FA27D0300B0D282 /* CategoryTests.swift */,
-				D63BBD30217F7212007E01F0 /* GraphUserCreditCard.swift */,
-				77DB53292215D0AA0078991C /* GraphUserCreditCardTests.swift */,
-				D62B14AF2212184500AC05C8 /* DeletePaymentMethodEnvelopeTests.swift */,
 			);
 			path = models;
 			sourceTree = "<group>";
@@ -4942,6 +4948,7 @@
 				D0158A2C1EEB30A2006E7684 /* UpdatePledgeEnvelopeTemplates.swift in Sources */,
 				D015889D1EEB2ED7006E7684 /* LocationLenses.swift in Sources */,
 				D01589011EEB2ED7006E7684 /* Project.Video.swift in Sources */,
+				D0E78C3622A980A600AAB645 /* ClearUserUnseenActivityEnvelope.swift in Sources */,
 				D0158A1A1EEB30A2006E7684 /* Project.PhotoTemplates.swift in Sources */,
 				D01588B51EEB2ED7006E7684 /* ProjectNotificationLenses.swift in Sources */,
 				D015882B1EEB2ED7006E7684 /* NSURLSession.swift in Sources */,
@@ -4972,6 +4979,7 @@
 				7798B56821750368008BC50D /* UserQueriesTests.swift in Sources */,
 				D0D10C201EEB4550005EBAD0 /* User.NewsletterSubscriptionsTests.swift in Sources */,
 				D0D10C051EEB4550005EBAD0 /* ChangePaymentMethodEnvelopeTests.swift in Sources */,
+				D0E78C3822A981EE00AAB645 /* ClearUserUnseenActivityEnvelopeTests.swift in Sources */,
 				D0D10C1E1EEB4550005EBAD0 /* UpdateTests.swift in Sources */,
 				D0D10C211EEB4550005EBAD0 /* User.NotificationsTests.swift in Sources */,
 				D0D10C1C1EEB4550005EBAD0 /* UpdateDraftTests.swift in Sources */,

--- a/KsApi/MockService.swift
+++ b/KsApi/MockService.swift
@@ -25,6 +25,8 @@
 
     fileprivate let changePaymentMethodResult: Result<ChangePaymentMethodEnvelope, ErrorEnvelope>?
 
+    fileprivate let clearUserUnseenActivityResult: Result<GraphMutationEmptyResponseEnvelope, GraphError>?
+
     fileprivate let deletePaymentMethodResult: Result<DeletePaymentMethodEnvelope, GraphError>?
 
     fileprivate let createPledgeResult: Result<CreatePledgeEnvelope, ErrorEnvelope>?
@@ -196,6 +198,7 @@
       changeCurrencyResponse: GraphMutationEmptyResponseEnvelope? = nil,
       changeCurrencyError: GraphError? = nil,
       changePaymentMethodResult: Result<ChangePaymentMethodEnvelope, ErrorEnvelope>? = nil,
+      clearUserUnseenActivityResult: Result<GraphMutationEmptyResponseEnvelope, GraphError>? = nil,
       deletePaymentMethodResult: Result<DeletePaymentMethodEnvelope, GraphError>? = nil,
       createPledgeResult: Result<CreatePledgeEnvelope, ErrorEnvelope>? = nil,
       facebookConnectResponse: User? = nil,
@@ -297,6 +300,8 @@
       self.changeEmailError = changeEmailError
 
       self.changePasswordError = changePasswordError
+
+      self.clearUserUnseenActivityResult = clearUserUnseenActivityResult
 
       self.createPasswordError = createPasswordError
 
@@ -546,6 +551,11 @@
         return SignalProducer(error: error)
       }
       return SignalProducer(value: GraphMutationEmptyResponseEnvelope())
+    }
+
+    internal func clearUserUnseenActivity(input _: EmptyInput)
+      -> SignalProducer<GraphMutationEmptyResponseEnvelope, GraphError> {
+      return producer(for: self.clearUserUnseenActivityResult)
     }
 
     internal func fetchCheckout(checkoutUrl _: String) -> SignalProducer<CheckoutEnvelope, ErrorEnvelope> {
@@ -1384,6 +1394,7 @@
             buildVersion: $1.buildVersion,
             addNewCreditCardResult: $1.addNewCreditCardResult,
             changePaymentMethodResult: $1.changePaymentMethodResult,
+            clearUserUnseenActivityResult: $1.clearUserUnseenActivityResult,
             deletePaymentMethodResult: $1.deletePaymentMethodResult,
             createPledgeResult: $1.createPledgeResult,
             facebookConnectResponse: $1.facebookConnectResponse,

--- a/KsApi/MockService.swift
+++ b/KsApi/MockService.swift
@@ -25,7 +25,7 @@
 
     fileprivate let changePaymentMethodResult: Result<ChangePaymentMethodEnvelope, ErrorEnvelope>?
 
-    fileprivate let clearUserUnseenActivityResult: Result<GraphMutationEmptyResponseEnvelope, GraphError>?
+    fileprivate let clearUserUnseenActivityResult: Result<ClearUserUnseenActivityEnvelope, GraphError>?
 
     fileprivate let deletePaymentMethodResult: Result<DeletePaymentMethodEnvelope, GraphError>?
 
@@ -198,7 +198,7 @@
       changeCurrencyResponse: GraphMutationEmptyResponseEnvelope? = nil,
       changeCurrencyError: GraphError? = nil,
       changePaymentMethodResult: Result<ChangePaymentMethodEnvelope, ErrorEnvelope>? = nil,
-      clearUserUnseenActivityResult: Result<GraphMutationEmptyResponseEnvelope, GraphError>? = nil,
+      clearUserUnseenActivityResult: Result<ClearUserUnseenActivityEnvelope, GraphError>? = nil,
       deletePaymentMethodResult: Result<DeletePaymentMethodEnvelope, GraphError>? = nil,
       createPledgeResult: Result<CreatePledgeEnvelope, ErrorEnvelope>? = nil,
       facebookConnectResponse: User? = nil,
@@ -554,7 +554,7 @@
     }
 
     internal func clearUserUnseenActivity(input _: EmptyInput)
-      -> SignalProducer<GraphMutationEmptyResponseEnvelope, GraphError> {
+      -> SignalProducer<ClearUserUnseenActivityEnvelope, GraphError> {
       return producer(for: self.clearUserUnseenActivityResult)
     }
 

--- a/KsApi/Service.swift
+++ b/KsApi/Service.swift
@@ -95,6 +95,11 @@ public struct Service: ServiceType {
     return request(.changePaymentMethod(project: project))
   }
 
+  public func clearUserUnseenActivity(input: EmptyInput)
+    -> SignalProducer<GraphMutationEmptyResponseEnvelope, GraphError> {
+    return applyMutation(mutation: ClearUserUnseenActivityMutation(input: input))
+  }
+
   public func deletePaymentMethod(input: PaymentSourceDeleteInput)
     -> SignalProducer<DeletePaymentMethodEnvelope, GraphError> {
     return applyMutation(mutation: PaymentSourceDeleteMutation(input: input))

--- a/KsApi/Service.swift
+++ b/KsApi/Service.swift
@@ -96,7 +96,7 @@ public struct Service: ServiceType {
   }
 
   public func clearUserUnseenActivity(input: EmptyInput)
-    -> SignalProducer<GraphMutationEmptyResponseEnvelope, GraphError> {
+    -> SignalProducer<ClearUserUnseenActivityEnvelope, GraphError> {
     return applyMutation(mutation: ClearUserUnseenActivityMutation(input: input))
   }
 

--- a/KsApi/ServiceType.swift
+++ b/KsApi/ServiceType.swift
@@ -53,6 +53,10 @@ public protocol ServiceType {
   func changeCurrency(input: ChangeCurrencyInput) ->
     SignalProducer<GraphMutationEmptyResponseEnvelope, GraphError>
 
+  /// Clears the user's unseen activity count.
+  func clearUserUnseenActivity(input: EmptyInput)
+    -> SignalProducer<GraphMutationEmptyResponseEnvelope, GraphError>
+
   func createPassword(input: CreatePasswordInput) ->
     SignalProducer<GraphMutationEmptyResponseEnvelope, GraphError>
 

--- a/KsApi/ServiceType.swift
+++ b/KsApi/ServiceType.swift
@@ -55,7 +55,7 @@ public protocol ServiceType {
 
   /// Clears the user's unseen activity count.
   func clearUserUnseenActivity(input: EmptyInput)
-    -> SignalProducer<GraphMutationEmptyResponseEnvelope, GraphError>
+    -> SignalProducer<ClearUserUnseenActivityEnvelope, GraphError>
 
   func createPassword(input: CreatePasswordInput) ->
     SignalProducer<GraphMutationEmptyResponseEnvelope, GraphError>

--- a/KsApi/models/ClearUserUnseenActivityEnvelope.swift
+++ b/KsApi/models/ClearUserUnseenActivityEnvelope.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+public struct ClearUserUnseenActivityEnvelope {
+  public var activityIndicatorCount: Int
+}
+
+extension ClearUserUnseenActivityEnvelope: Decodable {
+  enum CodingKeys: String, CodingKey {
+    case clearUserUnseenActivity
+    case activityIndicatorCount
+  }
+
+  public init(from decoder: Decoder) throws {
+    let values = try decoder.container(keyedBy: CodingKeys.self)
+    self.activityIndicatorCount = try values
+      .nestedContainer(keyedBy: CodingKeys.self, forKey: .clearUserUnseenActivity)
+      .decode(Int.self, forKey: .activityIndicatorCount)
+  }
+}

--- a/KsApi/models/ClearUserUnseenActivityEnvelopeTests.swift
+++ b/KsApi/models/ClearUserUnseenActivityEnvelopeTests.swift
@@ -1,0 +1,23 @@
+@testable import KsApi
+import XCTest
+
+class ClearUserUnseenActivityEnvelopeTests: XCTestCase {
+  func testDecoding() {
+    let jsonString = """
+    {
+      "clearUserUnseenActivity": {
+        "clientMutationId": null,
+        "activityIndicatorCount": 0
+      }
+    }
+    """
+    let data = Data(jsonString.utf8)
+
+    do {
+      let envelope = try JSONDecoder().decode(ClearUserUnseenActivityEnvelope.self, from: data)
+      XCTAssertEqual(envelope.activityIndicatorCount, 0)
+    } catch {
+      XCTFail("Decode failed.")
+    }
+  }
+}

--- a/KsApi/models/User.swift
+++ b/KsApi/models/User.swift
@@ -16,6 +16,7 @@ public struct User {
   public var showPublicProfile: Bool?
   public var social: Bool?
   public var stats: Stats
+  public var unseenActivityCount: Int?
 
   public struct Avatar {
     public var large: String?
@@ -115,6 +116,7 @@ extension User: Argo.Decodable {
       <*> json <|? "show_public_profile"
       <*> json <|? "social"
       <*> User.Stats.decode(json)
+      <*> json <|? "unseen_activity_count"
   }
 }
 

--- a/KsApi/models/lenses/UserLenses.swift
+++ b/KsApi/models/lenses/UserLenses.swift
@@ -17,7 +17,7 @@ extension User {
         optedOutOfRecommendations: $1.optedOutOfRecommendations,
         showPublicProfile: $1.showPublicProfile,
         social: $1.social,
-        stats: $1.stats
+        stats: $1.stats, unseenActivityCount: $1.unseenActivityCount
       ) }
     )
 
@@ -35,7 +35,7 @@ extension User {
         optedOutOfRecommendations: $1.optedOutOfRecommendations,
         showPublicProfile: $1.showPublicProfile,
         social: $1.social,
-        stats: $1.stats
+        stats: $1.stats, unseenActivityCount: $1.unseenActivityCount
       ) }
     )
 
@@ -53,7 +53,7 @@ extension User {
         notifications: $1.notifications,
         optedOutOfRecommendations: $1.optedOutOfRecommendations,
         showPublicProfile: $1.showPublicProfile,
-        social: $1.social, stats: $1.stats
+        social: $1.social, stats: $1.stats, unseenActivityCount: $1.unseenActivityCount
       ) }
     )
 
@@ -70,7 +70,7 @@ extension User {
         notifications: $1.notifications,
         optedOutOfRecommendations: $1.optedOutOfRecommendations,
         showPublicProfile: $1.showPublicProfile,
-        social: $1.social, stats: $1.stats
+        social: $1.social, stats: $1.stats, unseenActivityCount: $1.unseenActivityCount
       ) }
     )
 
@@ -88,7 +88,7 @@ extension User {
         notifications: $1.notifications,
         optedOutOfRecommendations: $1.optedOutOfRecommendations,
         showPublicProfile: $1.showPublicProfile,
-        social: $1.social, stats: $1.stats
+        social: $1.social, stats: $1.stats, unseenActivityCount: $1.unseenActivityCount
       ) }
     )
 
@@ -107,7 +107,7 @@ extension User {
         optedOutOfRecommendations: $1.optedOutOfRecommendations,
         showPublicProfile: $1.showPublicProfile,
         social: $1.social,
-        stats: $1.stats
+        stats: $1.stats, unseenActivityCount: $1.unseenActivityCount
       ) }
     )
 
@@ -126,7 +126,7 @@ extension User {
         optedOutOfRecommendations: $1.optedOutOfRecommendations,
         showPublicProfile: $1.showPublicProfile,
         social: $1.social,
-        stats: $1.stats
+        stats: $1.stats, unseenActivityCount: $1.unseenActivityCount
       ) }
     )
 
@@ -145,7 +145,7 @@ extension User {
         optedOutOfRecommendations: $1.optedOutOfRecommendations,
         showPublicProfile: $1.showPublicProfile,
         social: $1.social,
-        stats: $1.stats
+        stats: $1.stats, unseenActivityCount: $1.unseenActivityCount
       ) }
     )
 
@@ -164,7 +164,7 @@ extension User {
         optedOutOfRecommendations: $1.optedOutOfRecommendations,
         showPublicProfile: $1.showPublicProfile,
         social: $1.social,
-        stats: $1.stats
+        stats: $1.stats, unseenActivityCount: $1.unseenActivityCount
       ) }
     )
 
@@ -183,7 +183,7 @@ extension User {
         optedOutOfRecommendations: $0,
         showPublicProfile: $1.showPublicProfile,
         social: $1.social,
-        stats: $1.stats
+        stats: $1.stats, unseenActivityCount: $1.unseenActivityCount
       ) }
     )
 
@@ -202,7 +202,7 @@ extension User {
         optedOutOfRecommendations: $1.optedOutOfRecommendations,
         showPublicProfile: $0,
         social: $1.social,
-        stats: $1.stats
+        stats: $1.stats, unseenActivityCount: $1.unseenActivityCount
       ) }
     )
 
@@ -221,7 +221,7 @@ extension User {
         optedOutOfRecommendations: $1.optedOutOfRecommendations,
         showPublicProfile: $1.showPublicProfile,
         social: $0,
-        stats: $1.stats
+        stats: $1.stats, unseenActivityCount: $1.unseenActivityCount
       ) }
     )
 
@@ -240,7 +240,26 @@ extension User {
         optedOutOfRecommendations: $1.optedOutOfRecommendations,
         showPublicProfile: $1.showPublicProfile,
         social: $1.social,
-        stats: $0
+        stats: $0, unseenActivityCount: $1.unseenActivityCount
+      ) }
+    )
+
+    public static let unseenActivityCount = Lens<User, Int?>(
+      view: { $0.unseenActivityCount },
+      set: { User(
+        avatar: $1.avatar,
+        facebookConnected: $1.facebookConnected,
+        id: $1.id,
+        isFriend: $1.isFriend,
+        location: $1.location,
+        name: $1.name,
+        needsFreshFacebookToken: $1.needsFreshFacebookToken,
+        newsletters: $1.newsletters,
+        notifications: $1.notifications,
+        optedOutOfRecommendations: $1.optedOutOfRecommendations,
+        showPublicProfile: $1.showPublicProfile,
+        social: $1.social,
+        stats: $1.stats, unseenActivityCount: $0
       ) }
     )
   }

--- a/KsApi/models/templates/UserTemplates.swift
+++ b/KsApi/models/templates/UserTemplates.swift
@@ -14,7 +14,8 @@ extension User {
     optedOutOfRecommendations: false,
     showPublicProfile: false,
     social: nil,
-    stats: .template
+    stats: .template,
+    unseenActivityCount: nil
   )
 
   // swiftlint:disable line_length

--- a/KsApi/mutations/ClearUserUnseenActivityMutation.swift
+++ b/KsApi/mutations/ClearUserUnseenActivityMutation.swift
@@ -10,6 +10,7 @@ public struct ClearUserUnseenActivityMutation<T: GraphMutationInput>: GraphMutat
     mutation clearUserUnseenActivity($input: ClearUserUnseenActivityInput!) {
       clearUserUnseenActivity(input: $input) {
         clientMutationId
+        activityIndicatorCount
       }
     }
     """

--- a/KsApi/mutations/ClearUserUnseenActivityMutation.swift
+++ b/KsApi/mutations/ClearUserUnseenActivityMutation.swift
@@ -1,0 +1,17 @@
+public struct ClearUserUnseenActivityMutation<T: GraphMutationInput>: GraphMutation {
+  var input: T
+
+  public init(input: T) {
+    self.input = input
+  }
+
+  public var description: String {
+    return """
+    mutation clearUserUnseenActivity($input: ClearUserUnseenActivityInput!) {
+      clearUserUnseenActivity(input: $input) {
+        clientMutationId
+      }
+    }
+    """
+  }
+}

--- a/Library/SharedFunctions.swift
+++ b/Library/SharedFunctions.swift
@@ -169,3 +169,12 @@ public func ksr_isOSVersionAvailable(_ version: Double) -> Bool {
 
   return false
 }
+
+public func updatedUserWithClearedActivityCountProducer() -> SignalProducer<User, Never> {
+  return AppEnvironment.current.apiService.clearUserUnseenActivity(input: .init())
+    .filter { _ in AppEnvironment.current.currentUser != nil }
+    .map { $0.activityIndicatorCount }
+    .map { count in AppEnvironment.current.currentUser ?|> User.lens.unseenActivityCount .~ count }
+    .skipNil()
+    .demoteErrors()
+}

--- a/Library/SharedFunctionsTests.swift
+++ b/Library/SharedFunctionsTests.swift
@@ -182,7 +182,7 @@ final class SharedFunctionsTests: TestCase {
     XCTAssertTrue(ksr_isOSVersionAvailable(12.9))
   }
 
-  func testupdatedUserWithClearedActivityCountProducer_Success() {
+  func testUpdatedUserWithClearedActivityCountProducer_Success() {
     let initialActivitiesCount = 100
     let values = TestObserver<User, Never>()
 
@@ -209,7 +209,7 @@ final class SharedFunctionsTests: TestCase {
     }
   }
 
-  func testupdatedUserWithClearedActivityCountProducer_Failure() {
+  func testUpdatedUserWithClearedActivityCountProducer_Failure() {
     let initialActivitiesCount = 100
     let values = TestObserver<User, Never>()
 

--- a/Library/ViewModels/ActivitiesViewModel.swift
+++ b/Library/ViewModels/ActivitiesViewModel.swift
@@ -56,8 +56,11 @@ public protocol ActitiviesViewModelInputs {
 }
 
 public protocol ActivitiesViewModelOutputs {
-  /// Emits an array of activities that should be displayed
+  /// Emits an array of activities that should be displayed.
   var activities: Signal<[Activity], Never> { get }
+
+  /// Emits when the tab bar item's badge value should be cleared.
+  var clearBadgeValue: Signal<(), Never> { get }
 
   /// Emits when should remove Facebook Connect section
   var deleteFacebookConnectSection: Signal<(), Never> { get }
@@ -156,6 +159,16 @@ public final class ActivitiesViewModel: ActivitiesViewModelType, ActitiviesViewM
       }
 
     self.activities = Signal.merge(clearedActivitiesOnSessionEnd, updatedActivities)
+    self.clearBadgeValue = Signal.zip(
+      self.refreshProperty.signal,
+      updatedActivities
+    )
+    .on(
+      value: { _ in
+        _ = AppEnvironment.current.apiService.clearUserUnseenActivity(input: EmptyInput())
+      }
+    )
+    .ignoreValues()
 
     let currentUser = Signal
       .merge(
@@ -359,6 +372,7 @@ public final class ActivitiesViewModel: ActivitiesViewModelType, ActitiviesViewM
   }
 
   public let activities: Signal<[Activity], Never>
+  public let clearBadgeValue: Signal<(), Never>
   public let deleteFacebookConnectSection: Signal<(), Never>
   public let deleteFindFriendsSection: Signal<(), Never>
   public let hideEmptyState: Signal<(), Never>

--- a/Library/ViewModels/ActivitiesViewModel.swift
+++ b/Library/ViewModels/ActivitiesViewModel.swift
@@ -169,6 +169,7 @@ public final class ActivitiesViewModel: ActivitiesViewModelType, ActitiviesViewM
     .ignoreValues()
 
     self.updateUserInEnvironment = self.clearBadgeValue
+      .filter { _ in AppEnvironment.current.currentUser != nil }
       .switchMap { _ in
         updatedUserWithClearedActivityCountProducer()
           .ksr_delay(AppEnvironment.current.apiDelayInterval, on: AppEnvironment.current.scheduler)

--- a/Library/ViewModels/ActivitiesViewModel.swift
+++ b/Library/ViewModels/ActivitiesViewModel.swift
@@ -161,7 +161,7 @@ public final class ActivitiesViewModel: ActivitiesViewModelType, ActitiviesViewM
     self.activities = Signal.merge(clearedActivitiesOnSessionEnd, updatedActivities)
     self.clearBadgeValue = Signal.zip(
       self.refreshProperty.signal,
-      updatedActivities
+      updatedActivities.skip(first: 1)
     )
     .on(
       value: { _ in


### PR DESCRIPTION
# 📲 What

Adds the remaining functionality for badging in the app, in particular setting the badge value on the activities tab bar item when various events occur (see ACs below).

# 🤔 Why

We're now receiving badges via push notification payloads and via the `User` model, this adds the necessary functionality to update the UI to accurately reflect those.

# 🛠 How

- Added inputs to `RootViewModel` so that we can update it when `applicationWillEnterForeground` and when the app is launched from background after having been updated with a badge value and a push notification is tapped.
- Added `ClearUserUnseenActivityMutation` to clear the count on the back-end when the activities tab bar item is selected.
- Added a localized string for the clamped `99+` plus string so that translators can move the `+` around if necessary.

# 👀 See

| Push in app, clear on tap | Count from user refresh | Clear on activities refresh | Clear on logout |
| --- | --- | --- | --- |
| <img src="https://user-images.githubusercontent.com/3735375/58993095-65dd5800-87a1-11e9-9e66-6d3d3f7bc394.gif"/> | ![no-push-count-from-user-clear-on-tap](https://user-images.githubusercontent.com/3735375/58993135-7ab9eb80-87a1-11e9-9542-3c4c4641df24.gif) | ![clear-on-refresh](https://user-images.githubusercontent.com/3735375/58993321-10ee1180-87a2-11e9-930d-de671b3e7aec.gif) | ![clear-on-logout](https://user-images.githubusercontent.com/3735375/58993381-3713b180-87a2-11e9-9021-6f1d37510742.gif) |

# ✅ Acceptance criteria

**How to test:** Download [NWPusher](https://github.com/noodlewerk/NWPusher), run the build on device and grab the device push token from the console. Configure NWPusher with the `com.kickstarter.kickstarter.debug` APNS push certificate. Send yourself a payload like:

```json
{
  "aps": {
    "alert": "Push notification with badge value 80",
    "badge": 80,
    "sound": "default"
  }
}
```

**Note:** Messages do not affect the badge value, only activities.

- [ ] Push notification with badge in payload sets badge value on activities tab bar item clamped at `99`.
- [ ] `99+` is displayed for values greater than `99` and no value is shown for `0` or below.
- [ ] If push is received when app is open the tab bar item's badge value is updated.
- [ ] Select activities tab, background app, receive push with badge count, foreground app. Activities tab should now have a value and you should still be on that tab. Pull to refresh to clear it and refresh activities.
- [ ] If the current user is updated, the badge should be updated with that user's `unseenActivityCount` value (generate an activity to create this value).
- [ ] Navigating to the activities tab and pulling to refresh on activities should both clear the `unseenActivityCount` on the server (generate an activity to create this value).
- [ ] If the user logs out, the badge value is cleared.
- [ ] Tapping the activities tab clears the badge value immediately and fires off an asynchronous 'fire and forget' GraphQL call to reset the activity count on the back-end. Nothing happens if this fails but coming back to the app should show the original count from the refreshed `User` model.
- [ ] BONUS AC: Install an older version of the app and log in. Overwrite that version with this build. You should _still_ be logged in. This is worth testing since we've modified the `User` model.