### PR TITLE
🦡 [App Badges] Improve voice-over support for badge value

### DIFF
--- a/Kickstarter-iOS/Locales/Base.lproj/Localizable.strings
+++ b/Kickstarter-iOS/Locales/Base.lproj/Localizable.strings
@@ -532,6 +532,7 @@
 "accessibility.projects.buttons.star" = "Star";
 "accessibility.projects.buttons.star_hint_favorites_this_project" = "Favorites this project.";
 "accessibility.projects.buttons.star_hint_reminds_you" = "Reminds you 48 hours before this project ends.";
+"activities_badge_value_plus" = "%{activities_badge_value}+";
 "activity.by_creator" = "by %{creator_name}";
 "activity.creator.actions.user_name_adjusted_their_pledge" = "%{user_name} adjusted their pledge:";
 "activity.creator.actions.user_name_canceled_their_pledge" = "%{user_name} canceled their pledge:";

--- a/Kickstarter-iOS/Locales/de.lproj/Localizable.strings
+++ b/Kickstarter-iOS/Locales/de.lproj/Localizable.strings
@@ -532,6 +532,7 @@
 "accessibility.projects.buttons.star" = "Favoriten";
 "accessibility.projects.buttons.star_hint_favorites_this_project" = "Fügt Projekt zu Favoriten hinzu.";
 "accessibility.projects.buttons.star_hint_reminds_you" = "Sendet dir eine Benachrichtigung 48 Stunden vor Ablauf des Projekts.";
+"activities_badge_value_plus" = "%{activities_badge_value}+";
 "activity.by_creator" = "von %{creator_name}";
 "activity.creator.actions.user_name_adjusted_their_pledge" = "Beitrag von %{user_name} wurde geändert:";
 "activity.creator.actions.user_name_canceled_their_pledge" = "Beitrag von %{user_name} wurde storniert:";

--- a/Kickstarter-iOS/Locales/es.lproj/Localizable.strings
+++ b/Kickstarter-iOS/Locales/es.lproj/Localizable.strings
@@ -532,6 +532,7 @@
 "accessibility.projects.buttons.star" = "Favoritos";
 "accessibility.projects.buttons.star_hint_favorites_this_project" = "Añade este proyecto a tus favoritos.";
 "accessibility.projects.buttons.star_hint_reminds_you" = "Recibirás una notificación 48 horas antes de que finalice el proyecto.";
+"activities_badge_value_plus" = "%{activities_badge_value}+";
 "activity.by_creator" = "por %{creator_name}";
 "activity.creator.actions.user_name_adjusted_their_pledge" = "%{user_name} ajustó su contribución:";
 "activity.creator.actions.user_name_canceled_their_pledge" = "%{user_name} canceló su contribución:";

--- a/Kickstarter-iOS/Locales/fr.lproj/Localizable.strings
+++ b/Kickstarter-iOS/Locales/fr.lproj/Localizable.strings
@@ -532,6 +532,7 @@
 "accessibility.projects.buttons.star" = "Projets préférés";
 "accessibility.projects.buttons.star_hint_favorites_this_project" = "Ce projet sera ajouté à ma liste de projets préférés.";
 "accessibility.projects.buttons.star_hint_reminds_you" = "Vous recevrez un rappel 48 heures avant la fin de cette campagne.";
+"activities_badge_value_plus" = "%{activities_badge_value}+";
 "activity.by_creator" = "par %{creator_name}";
 "activity.creator.actions.user_name_adjusted_their_pledge" = "%{user_name} a ajusté son engagement";
 "activity.creator.actions.user_name_canceled_their_pledge" = "%{user_name} a annulé son engagement";

--- a/Kickstarter-iOS/Locales/ja.lproj/Localizable.strings
+++ b/Kickstarter-iOS/Locales/ja.lproj/Localizable.strings
@@ -532,6 +532,7 @@
 "accessibility.projects.buttons.star" = "お気に入り";
 "accessibility.projects.buttons.star_hint_favorites_this_project" = "このプロジェクトをお気に入り";
 "accessibility.projects.buttons.star_hint_reminds_you" = "プロジェクトが終了する48時間前に知らせる";
+"activities_badge_value_plus" = "%{activities_badge_value}+";
 "activity.by_creator" = "by %{creator_name}";
 "activity.creator.actions.user_name_adjusted_their_pledge" = "%{user_name} はプレッジを変更済：";
 "activity.creator.actions.user_name_canceled_their_pledge" = "%{user_name} がプレッジをキャンセル：";

--- a/Kickstarter-iOS/ViewModels/RootViewModel.swift
+++ b/Kickstarter-iOS/ViewModels/RootViewModel.swift
@@ -483,13 +483,7 @@ private func activitiesBadgeValue(with value: Int?) -> String? {
 
   guard clampedBadgeValue > 0 else { return nil }
 
-  guard badgeValue > maxBadgeValue else {
-    return "\(clampedBadgeValue)"
-  }
-
-  return localizedString(
-    key: "activities_badge_value_plus",
-    defaultValue: "%{activities_badge_value}+",
-    substitutions: ["activities_badge_value": "\(clampedBadgeValue)"]
-  )
+  return badgeValue > maxBadgeValue
+    ? Strings.activities_badge_value_plus(activities_badge_value: "\(clampedBadgeValue)")
+    : "\(clampedBadgeValue)"
 }

--- a/Kickstarter-iOS/ViewModels/RootViewModelTests.swift
+++ b/Kickstarter-iOS/ViewModels/RootViewModelTests.swift
@@ -89,6 +89,35 @@ final class RootViewModelTests: TestCase {
     }
   }
 
+  func testSetBadgeValueAtIndex_MaxValueSet_ToggleVoiceOver() {
+    let mockApplication = MockApplication()
+    mockApplication.applicationIconBadgeNumber = 100
+
+    self.setBadgeValueAtIndexValue.assertValues([])
+    self.setBadgeValueAtIndexIndex.assertValues([])
+
+    withEnvironment(application: mockApplication, isVoiceOverRunning: { false }) {
+      self.vm.inputs.viewDidLoad()
+
+      self.setBadgeValueAtIndexValue.assertValues(["99+"])
+      self.setBadgeValueAtIndexIndex.assertValues([1])
+    }
+
+    withEnvironment(application: mockApplication, isVoiceOverRunning: { true }) {
+      self.vm.inputs.voiceOverStatusDidChange()
+
+      self.setBadgeValueAtIndexValue.assertValues(["99+", "100"])
+      self.setBadgeValueAtIndexIndex.assertValues([1, 1])
+    }
+
+    withEnvironment(application: mockApplication, isVoiceOverRunning: { false }) {
+      self.vm.inputs.voiceOverStatusDidChange()
+
+      self.setBadgeValueAtIndexValue.assertValues(["99+", "100", "99+"])
+      self.setBadgeValueAtIndexIndex.assertValues([1, 1, 1])
+    }
+  }
+
   func testSetBadgeValueAtIndex_AppWillEnterForeground() {
     let mockApplication = MockApplication()
     mockApplication.applicationIconBadgeNumber = 100

--- a/Library/Strings.swift
+++ b/Library/Strings.swift
@@ -8701,6 +8701,23 @@ Veuillez réessayer ultérieurement."
     )
   }
   /**
+   "%{activities_badge_value}+"
+
+   - **en**: "%{activities_badge_value}+"
+   - **de**: "%{activities_badge_value}+"
+   - **es**: "%{activities_badge_value}+"
+   - **fr**: "%{activities_badge_value}+"
+   - **ja**: "%{activities_badge_value}+"
+  */
+  public static func activities_badge_value_plus(activities_badge_value: String) -> String {
+    return localizedString(
+      key: "activities_badge_value_plus",
+      defaultValue: "%{activities_badge_value}+",
+      count: nil,
+      substitutions: ["activities_badge_value": activities_badge_value]
+    )
+  }
+  /**
    "by %{creator_name}"
 
    - **en**: "by %{creator_name}"


### PR DESCRIPTION
# 📲 What

- Adds the localized string for `99+` so that the `+` can be moved around/modified by translators.
- Displays the uncapped badge value when voice over is enabled.

# 🤔 Why

iOS voice over natively reads badge value as "1 item", "2 items", "100 items", etc. This functionality was lost when we displayed the badge value as `99+` when it exceeded `99`, the screen reader would just read "ninety-nine plus". `UITabBarItem` does not provide access to its badge value view and digging through the view hierarchy for `_UIBadgeView` to add an accessibility hint seemed like the wrong approach.

# 🛠 How

Added an input to `RootViewModel` so that when voice over is enabled or disabled we can display the uncapped or capped badge value respectively.

# 👀 See

Enabling and disabling voice-over - note the screen reader focus appearing at the top and the badge value updating accordingly:

<img src="https://user-images.githubusercontent.com/3735375/59541255-49ce6a80-8eb5-11e9-82b2-f2418b76bb4a.gif" width="50%"/>

# ♿️ Accessibility

- [ ] Works with VoiceOver

# ✅ Acceptance criteria

- [ ] Run on device, send yourself a badge value greater than 99, enable and disable voice over.
