### PR TITLE
Move Facebook delegate methods to app target

### DIFF
--- a/Kickstarter-iOS/AppDelegate.swift
+++ b/Kickstarter-iOS/AppDelegate.swift
@@ -208,6 +208,11 @@ internal final class AppDelegate: UIResponder, UIApplicationDelegate {
 
     self.window?.tintColor = .ksr_green_700
 
+    self.viewModel.inputs.applicationDidFinishLaunching(
+      application: application,
+      launchOptions: launchOptions
+    )
+
     self.fbLoginViewModel.inputs.applicationDidFinishLaunching(
       application: application,
       launchOptions: launchOptions

--- a/Kickstarter-iOS/AppDelegate.swift
+++ b/Kickstarter-iOS/AppDelegate.swift
@@ -220,7 +220,7 @@ internal final class AppDelegate: UIResponder, UIApplicationDelegate {
 
     UNUserNotificationCenter.current().delegate = self
 
-    return self.fbLoginViewModel.outputs.applicationDidFinishLaunchingReturnValue
+    return self.viewModel.outputs.applicationDidFinishLaunchingReturnValue
   }
 
   func applicationWillEnterForeground(_: UIApplication) {

--- a/Kickstarter-iOS/AppDelegate.swift
+++ b/Kickstarter-iOS/AppDelegate.swift
@@ -21,6 +21,7 @@ import UserNotifications
 internal final class AppDelegate: UIResponder, UIApplicationDelegate {
   var window: UIWindow?
   fileprivate let viewModel: AppDelegateViewModelType = AppDelegateViewModel()
+  fileprivate let fbLoginViewModel: FacebookLoginViewModelType = FacebookLoginViewModel()
 
   internal var rootTabBarController: RootTabBarViewController? {
     return self.window?.rootViewController as? RootTabBarViewController
@@ -207,14 +208,14 @@ internal final class AppDelegate: UIResponder, UIApplicationDelegate {
 
     self.window?.tintColor = .ksr_green_700
 
-    self.viewModel.inputs.applicationDidFinishLaunching(
+    self.fbLoginViewModel.inputs.applicationDidFinishLaunching(
       application: application,
       launchOptions: launchOptions
     )
 
     UNUserNotificationCenter.current().delegate = self
 
-    return self.viewModel.outputs.applicationDidFinishLaunchingReturnValue
+    return self.fbLoginViewModel.outputs.applicationDidFinishLaunchingReturnValue
   }
 
   func applicationWillEnterForeground(_: UIApplication) {
@@ -238,7 +239,7 @@ internal final class AppDelegate: UIResponder, UIApplicationDelegate {
     open url: URL,
     options: [UIApplication.OpenURLOptionsKey: Any] = [:]
   ) -> Bool {
-    return self.viewModel.inputs.applicationOpenUrl(
+    return self.fbLoginViewModel.inputs.applicationOpenUrl(
       application: app,
       url: url,
       options: options

--- a/Kickstarter-iOS/AppDelegate.swift
+++ b/Kickstarter-iOS/AppDelegate.swift
@@ -239,11 +239,9 @@ internal final class AppDelegate: UIResponder, UIApplicationDelegate {
     open url: URL,
     options: [UIApplication.OpenURLOptionsKey: Any] = [:]
   ) -> Bool {
-    return self.fbLoginViewModel.inputs.applicationOpenUrl(
-      application: app,
-      url: url,
-      options: options
-    )
+    self.viewModel.inputs.applicationOpenUrl(application: app, url: url, options: options)
+
+    return self.fbLoginViewModel.inputs.applicationOpenUrl(application: app, url: url, options: options)
   }
 
   // MARK: - Remote notifications

--- a/Kickstarter-iOS/ViewModels/AppDelegateViewModel.swift
+++ b/Kickstarter-iOS/ViewModels/AppDelegateViewModel.swift
@@ -51,7 +51,7 @@ public protocol AppDelegateViewModelInputs {
     application: UIApplication?,
     url: URL,
     options: [UIApplication.OpenURLOptionsKey: Any]
-  ) -> Bool
+  )
 
   /// Call when the application receives a request to perform a shortcut action.
   func applicationPerformActionForShortcutItem(_ item: UIApplicationShortcutItem)
@@ -99,9 +99,6 @@ public protocol AppDelegateViewModelOutputs {
 
   /// Return this value in the delegate method.
   var continueUserActivityReturnValue: MutableProperty<Bool> { get }
-
-  /// Return this value in the delegate method.
-  var facebookOpenURLReturnValue: MutableProperty<Bool> { get }
 
   /// Emits when the view needs to figure out the redirect URL for the emitted URL.
   var findRedirectUrl: Signal<URL, Never> { get }
@@ -211,25 +208,7 @@ public final class AppDelegateViewModel: AppDelegateViewModelType, AppDelegateVi
     self.postNotification = self.currentUserUpdatedInEnvironmentProperty.signal
       .mapConst(Notification(name: .ksr_userUpdated, object: nil))
 
-    self.applicationLaunchOptionsProperty.signal.skipNil()
-      .take(first: 1)
-      .observeValues { appOptions in
-        _ = AppEnvironment.current.facebookAppDelegate.application(
-          appOptions.application ?? UIApplication.shared,
-          didFinishLaunchingWithOptions: appOptions.options
-        )
-      }
-
     let openUrl = self.applicationOpenUrlProperty.signal.skipNil()
-
-    self.facebookOpenURLReturnValue <~ openUrl
-      .map { options -> Bool in
-        AppEnvironment.current.facebookAppDelegate.application(
-          options.application ?? UIApplication.shared,
-          open: options.url,
-          options: options.options
-        )
-      }
 
     // iCloud
 
@@ -695,9 +674,8 @@ public final class AppDelegateViewModel: AppDelegateViewModelType, AppDelegateVi
     application: UIApplication?,
     url: URL,
     options: [UIApplication.OpenURLOptionsKey: Any]
-  ) -> Bool {
+  ) {
     self.applicationOpenUrlProperty.value = (application, url, options)
-    return self.facebookOpenURLReturnValue.value
   }
 
   fileprivate let showNotificationDialogProperty = MutableProperty<Notification?>(nil)
@@ -724,7 +702,6 @@ public final class AppDelegateViewModel: AppDelegateViewModelType, AppDelegateVi
   public let configureFabric: Signal<(), Never>
   public let configureHockey: Signal<HockeyConfigData, Never>
   public let continueUserActivityReturnValue = MutableProperty(false)
-  public let facebookOpenURLReturnValue = MutableProperty(false)
   public let findRedirectUrl: Signal<URL, Never>
   public let forceLogout: Signal<(), Never>
   public let goToActivity: Signal<(), Never>

--- a/Kickstarter-iOS/ViewModels/AppDelegateViewModelTests.swift
+++ b/Kickstarter-iOS/ViewModels/AppDelegateViewModelTests.swift
@@ -454,28 +454,6 @@ final class AppDelegateViewModelTests: TestCase {
     }
   }
 
-  func testFacebookAppDelegate() {
-    XCTAssertFalse(self.facebookAppDelegate.didFinishLaunching)
-    XCTAssertFalse(self.facebookAppDelegate.openedUrl)
-
-    self.vm.inputs.applicationDidFinishLaunching(
-      application: UIApplication.shared,
-      launchOptions: [:]
-    )
-
-    XCTAssertTrue(self.facebookAppDelegate.didFinishLaunching)
-    XCTAssertFalse(self.facebookAppDelegate.openedUrl)
-
-    let result = self.vm.inputs.applicationOpenUrl(
-      application: UIApplication.shared,
-      url: URL(string: "http://www.fb.com")!,
-      options: [:]
-    )
-    XCTAssertFalse(result)
-
-    XCTAssertTrue(self.facebookAppDelegate.openedUrl)
-  }
-
   func testOpenAppBanner() {
     self.vm.inputs.applicationDidFinishLaunching(
       application: UIApplication.shared,

--- a/Kickstarter-iOS/ViewModels/AppDelegateViewModelTests.swift
+++ b/Kickstarter-iOS/ViewModels/AppDelegateViewModelTests.swift
@@ -462,12 +462,11 @@ final class AppDelegateViewModelTests: TestCase {
 
     XCTAssertEqual(["App Open", "Opened App"], self.trackingClient.events)
 
-    let result = self.vm.inputs.applicationOpenUrl(
+    self.vm.inputs.applicationOpenUrl(
       application: UIApplication.shared,
       url: URL(string: "http://www.google.com/?app_banner=1&hello=world")!,
       options: [:]
     )
-    XCTAssertFalse(result)
 
     XCTAssertEqual(
       ["App Open", "Opened App", "Smart App Banner Opened", "Opened App Banner"],
@@ -513,52 +512,47 @@ final class AppDelegateViewModelTests: TestCase {
       self.presentViewController.assertValues([])
 
       let projectUrl = rootUrl + "projects/tequila/help-me-transform-this-pile-of-wood"
-      var result = self.vm.inputs.applicationOpenUrl(
+      self.vm.inputs.applicationOpenUrl(
         application: UIApplication.shared,
         url: URL(string: projectUrl)!,
         options: [:]
       )
-      XCTAssertFalse(result)
 
       self.presentViewController.assertValues([1])
 
       let commentsUrl = projectUrl + "/comments"
-      result = self.vm.inputs.applicationOpenUrl(
+      self.vm.inputs.applicationOpenUrl(
         application: UIApplication.shared,
         url: URL(string: commentsUrl)!,
         options: [:]
       )
-      XCTAssertFalse(result)
 
       self.presentViewController.assertValues([1, 2])
 
       let updatesUrl = projectUrl + "/posts"
-      result = self.vm.inputs.applicationOpenUrl(
+      self.vm.inputs.applicationOpenUrl(
         application: UIApplication.shared,
         url: URL(string: updatesUrl)!,
         options: [:]
       )
-      XCTAssertFalse(result)
 
       self.presentViewController.assertValues([1, 2, 2])
 
       let updateUrl = projectUrl + "/posts/1399396"
-      result = self.vm.inputs.applicationOpenUrl(
+      self.vm.inputs.applicationOpenUrl(
         application: UIApplication.shared,
         url: URL(string: updateUrl)!,
         options: [:]
       )
-      XCTAssertFalse(result)
 
       self.presentViewController.assertValues([1, 2, 2, 2])
 
       let updateCommentsUrl = updateUrl + "/comments"
-      result = self.vm.inputs.applicationOpenUrl(
+      self.vm.inputs.applicationOpenUrl(
         application: UIApplication.shared,
         url: URL(string: updateCommentsUrl)!,
         options: [:]
       )
-      XCTAssertFalse(result)
 
       self.presentViewController.assertValues([1, 2, 2, 2, 3])
     }
@@ -572,12 +566,11 @@ final class AppDelegateViewModelTests: TestCase {
 
     self.goToActivity.assertValueCount(0)
 
-    let result = self.vm.inputs.applicationOpenUrl(
+    self.vm.inputs.applicationOpenUrl(
       application: UIApplication.shared,
       url: URL(string: "https://www.kickstarter.com/activity")!,
       options: [:]
     )
-    XCTAssertFalse(result)
 
     self.goToActivity.assertValueCount(1)
   }
@@ -591,12 +584,11 @@ final class AppDelegateViewModelTests: TestCase {
     self.goToDashboard.assertValueCount(0)
 
     let url = "https://www.kickstarter.com/projects/tequila/help-me-transform-this-pile-of-wood/dashboard"
-    let result = self.vm.inputs.applicationOpenUrl(
+    self.vm.inputs.applicationOpenUrl(
       application: UIApplication.shared,
       url: URL(string: url)!,
       options: [:]
     )
-    XCTAssertFalse(result)
 
     self.goToDashboard.assertValueCount(1)
   }
@@ -609,12 +601,11 @@ final class AppDelegateViewModelTests: TestCase {
 
     self.goToDiscovery.assertValues([])
 
-    let result = self.vm.inputs.applicationOpenUrl(
+    self.vm.inputs.applicationOpenUrl(
       application: UIApplication.shared,
       url: URL(string: "https://www.kickstarter.com/discover?sort=newest")!,
       options: [:]
     )
-    XCTAssertFalse(result)
 
     let params = .defaults
       |> DiscoveryParams.lens.sort .~ .newest
@@ -629,12 +620,11 @@ final class AppDelegateViewModelTests: TestCase {
 
     self.goToDiscovery.assertValues([])
 
-    let result = self.vm.inputs.applicationOpenUrl(
+    self.vm.inputs.applicationOpenUrl(
       application: UIApplication.shared,
       url: URL(string: "https://www.kickstarter.com/discover")!,
       options: [:]
     )
-    XCTAssertFalse(result)
 
     self.goToDiscovery.assertValues([nil])
   }
@@ -648,12 +638,11 @@ final class AppDelegateViewModelTests: TestCase {
     self.goToDiscovery.assertValues([])
 
     let url = URL(string: "https://www.kickstarter.com/discover/categories/art")!
-    let result = self.vm.inputs.applicationOpenUrl(
+    self.vm.inputs.applicationOpenUrl(
       application: UIApplication.shared,
       url: url,
       options: [:]
     )
-    XCTAssertFalse(result)
 
     self.scheduler.advance()
 
@@ -669,12 +658,11 @@ final class AppDelegateViewModelTests: TestCase {
 
     self.goToLogin.assertValueCount(0)
 
-    let result = self.vm.inputs.applicationOpenUrl(
+    self.vm.inputs.applicationOpenUrl(
       application: UIApplication.shared,
       url: URL(string: "https://www.kickstarter.com/authorize")!,
       options: [:]
     )
-    XCTAssertFalse(result)
 
     self.goToLogin.assertValueCount(1)
   }
@@ -687,12 +675,11 @@ final class AppDelegateViewModelTests: TestCase {
 
     self.goToProfile.assertValueCount(0)
 
-    let result = self.vm.inputs.applicationOpenUrl(
+    self.vm.inputs.applicationOpenUrl(
       application: UIApplication.shared,
       url: URL(string: "https://www.kickstarter.com/profile/me")!,
       options: [:]
     )
-    XCTAssertFalse(result)
 
     self.goToProfile.assertValueCount(1)
   }
@@ -705,12 +692,11 @@ final class AppDelegateViewModelTests: TestCase {
 
     self.goToSearch.assertValueCount(0)
 
-    let result = self.vm.inputs.applicationOpenUrl(
+    self.vm.inputs.applicationOpenUrl(
       application: UIApplication.shared,
       url: URL(string: "https://www.kickstarter.com/search")!,
       options: [:]
     )
-    XCTAssertFalse(result)
 
     self.goToSearch.assertValueCount(1)
   }
@@ -1347,12 +1333,11 @@ final class AppDelegateViewModelTests: TestCase {
     // We deep-link to an email url.
     self.vm.inputs.applicationDidEnterBackground()
     self.vm.inputs.applicationWillEnterForeground()
-    let result = self.vm.inputs.applicationOpenUrl(
+    self.vm.inputs.applicationOpenUrl(
       application: UIApplication.shared,
       url: emailUrl,
       options: [:]
     )
-    XCTAssertFalse(result)
 
     self.findRedirectUrl.assertValues([emailUrl], "Ask to find the redirect after open the email url.")
     self.presentViewController.assertValues([], "No view controller is presented yet.")
@@ -1415,12 +1400,11 @@ final class AppDelegateViewModelTests: TestCase {
     // We deep-link to an email url.
     self.vm.inputs.applicationDidEnterBackground()
     self.vm.inputs.applicationWillEnterForeground()
-    let result = self.vm.inputs.applicationOpenUrl(
+    self.vm.inputs.applicationOpenUrl(
       application: UIApplication.shared,
       url: emailUrl,
       options: [:]
     )
-    XCTAssertFalse(result)
 
     self.findRedirectUrl.assertValues([emailUrl], "Ask to find the redirect after open the email url.")
     self.presentViewController.assertValues([], "No view controller is presented.")
@@ -1451,12 +1435,11 @@ final class AppDelegateViewModelTests: TestCase {
     // We deep-link to an email url.
     self.vm.inputs.applicationDidEnterBackground()
     self.vm.inputs.applicationWillEnterForeground()
-    let result = self.vm.inputs.applicationOpenUrl(
+    self.vm.inputs.applicationOpenUrl(
       application: UIApplication.shared,
       url: emailUrl,
       options: [:]
     )
-    XCTAssertFalse(result)
 
     self.findRedirectUrl.assertValues([emailUrl], "Ask to find the redirect after open the email url.")
     self.presentViewController.assertValues([], "No view controller is presented.")
@@ -1487,12 +1470,11 @@ final class AppDelegateViewModelTests: TestCase {
     // We deep-link to an email url.
     self.vm.inputs.applicationDidEnterBackground()
     self.vm.inputs.applicationWillEnterForeground()
-    let result = self.vm.inputs.applicationOpenUrl(
+    self.vm.inputs.applicationOpenUrl(
       application: UIApplication.shared,
       url: emailUrl,
       options: [:]
     )
-    XCTAssertFalse(result)
 
     self.findRedirectUrl.assertValues([emailUrl], "Ask to find the redirect after open the email url.")
     self.presentViewController.assertValues([], "No view controller is presented yet.")
@@ -1516,12 +1498,11 @@ final class AppDelegateViewModelTests: TestCase {
 
     let projectUrl = "https://www.kickstarter.com"
       + "/projects/tequila/help-me-transform-this-pile-of-wood/surveys/123"
-    let result = self.vm.inputs.applicationOpenUrl(
+    self.vm.inputs.applicationOpenUrl(
       application: UIApplication.shared,
       url: URL(string: projectUrl)!,
       options: [:]
     )
-    XCTAssertFalse(result)
 
     self.presentViewController.assertValues([1])
   }
@@ -1535,12 +1516,11 @@ final class AppDelegateViewModelTests: TestCase {
     self.presentViewController.assertValues([])
 
     let projectUrl = "https://www.kickstarter.com/users/tequila/surveys/123"
-    let result = self.vm.inputs.applicationOpenUrl(
+    self.vm.inputs.applicationOpenUrl(
       application: UIApplication.shared,
       url: URL(string: projectUrl)!,
       options: [:]
     )
-    XCTAssertFalse(result)
 
     self.presentViewController.assertValues([1])
   }

--- a/Kickstarter-iOS/ViewModels/FacebookLoginViewModel.swift
+++ b/Kickstarter-iOS/ViewModels/FacebookLoginViewModel.swift
@@ -21,7 +21,7 @@ public protocol FacebookLoginViewModelOutputs {
   var applicationDidFinishLaunchingReturnValue: Bool { get }
 
   /// Return this value in the delegate method.
-  var facebookOpenURLReturnValue: MutableProperty<Bool> { get }
+  var facebookOpenURLReturnValue: Bool { get }
 }
 
 public protocol FacebookLoginViewModelType {
@@ -43,7 +43,7 @@ public final class FacebookLoginViewModel: FacebookLoginViewModelType, FacebookL
 
     let openUrl = self.applicationOpenUrlProperty.signal.skipNil()
 
-    self.facebookOpenURLReturnValue <~ openUrl
+    self.facebookOpenURLReturnValueProperty <~ openUrl
       .map { options -> Bool in
         AppEnvironment.current.facebookAppDelegate.application(
           options.application ?? UIApplication.shared,
@@ -79,7 +79,7 @@ public final class FacebookLoginViewModel: FacebookLoginViewModelType, FacebookL
     options: [UIApplication.OpenURLOptionsKey: Any]
   ) -> Bool {
     self.applicationOpenUrlProperty.value = (application, url, options)
-    return self.facebookOpenURLReturnValue.value
+    return self.facebookOpenURLReturnValue
   }
 
   fileprivate let applicationDidFinishLaunchingReturnValueProperty = MutableProperty(true)
@@ -87,5 +87,8 @@ public final class FacebookLoginViewModel: FacebookLoginViewModelType, FacebookL
     return self.applicationDidFinishLaunchingReturnValueProperty.value
   }
 
-  public let facebookOpenURLReturnValue = MutableProperty(false)
+  fileprivate let facebookOpenURLReturnValueProperty = MutableProperty(false)
+  public var facebookOpenURLReturnValue: Bool {
+    return self.facebookOpenURLReturnValueProperty.value
+  }
 }

--- a/Kickstarter-iOS/ViewModels/FacebookLoginViewModel.swift
+++ b/Kickstarter-iOS/ViewModels/FacebookLoginViewModel.swift
@@ -1,5 +1,5 @@
 import Library
-import Prelude
+import UIKit
 import ReactiveSwift
 
 public protocol FacebookLoginViewModelInputs {

--- a/Kickstarter-iOS/ViewModels/FacebookLoginViewModel.swift
+++ b/Kickstarter-iOS/ViewModels/FacebookLoginViewModel.swift
@@ -1,6 +1,6 @@
 import Library
-import UIKit
 import ReactiveSwift
+import UIKit
 
 public protocol FacebookLoginViewModelInputs {
   /// Call when the application finishes launching.

--- a/Kickstarter-iOS/ViewModels/FacebookLoginViewModel.swift
+++ b/Kickstarter-iOS/ViewModels/FacebookLoginViewModel.swift
@@ -1,0 +1,91 @@
+import Library
+import Prelude
+import ReactiveSwift
+
+public protocol FacebookLoginViewModelInputs {
+  /// Call when the application finishes launching.
+  func applicationDidFinishLaunching(
+    application: UIApplication?, launchOptions: [UIApplication.LaunchOptionsKey: Any]?
+  )
+
+  /// Call to open a url that was sent to the app
+  func applicationOpenUrl(
+    application: UIApplication?,
+    url: URL,
+    options: [UIApplication.OpenURLOptionsKey: Any]
+  ) -> Bool
+}
+
+public protocol FacebookLoginViewModelOutputs {
+  /// The value to return from the delegate's `application:didFinishLaunchingWithOptions:` method.
+  var applicationDidFinishLaunchingReturnValue: Bool { get }
+
+  /// Return this value in the delegate method.
+  var facebookOpenURLReturnValue: MutableProperty<Bool> { get }
+}
+
+public protocol FacebookLoginViewModelType {
+  var inputs: FacebookLoginViewModelInputs { get }
+  var outputs: FacebookLoginViewModelOutputs { get }
+}
+
+public final class FacebookLoginViewModel: FacebookLoginViewModelType, FacebookLoginViewModelInputs,
+  FacebookLoginViewModelOutputs {
+  public init() {
+    self.applicationLaunchOptionsProperty.signal.skipNil()
+      .take(first: 1)
+      .observeValues { appOptions in
+        _ = AppEnvironment.current.facebookAppDelegate.application(
+          appOptions.application ?? UIApplication.shared,
+          didFinishLaunchingWithOptions: appOptions.options
+        )
+      }
+
+    let openUrl = self.applicationOpenUrlProperty.signal.skipNil()
+
+    self.facebookOpenURLReturnValue <~ openUrl
+      .map { options -> Bool in
+        AppEnvironment.current.facebookAppDelegate.application(
+          options.application ?? UIApplication.shared,
+          open: options.url,
+          options: options.options
+        )
+      }
+  }
+
+  public var inputs: FacebookLoginViewModelInputs { return self }
+  public var outputs: FacebookLoginViewModelOutputs { return self }
+
+  fileprivate typealias ApplicationWithOptions = (
+    application: UIApplication?, options: [UIApplication.LaunchOptionsKey: Any]?
+  )
+  fileprivate let applicationLaunchOptionsProperty = MutableProperty<ApplicationWithOptions?>(nil)
+  public func applicationDidFinishLaunching(
+    application: UIApplication?,
+    launchOptions: [UIApplication.LaunchOptionsKey: Any]?
+  ) {
+    self.applicationLaunchOptionsProperty.value = (application, launchOptions)
+  }
+
+  fileprivate typealias ApplicationOpenUrl = (
+    application: UIApplication?,
+    url: URL,
+    options: [UIApplication.OpenURLOptionsKey: Any]
+  )
+  fileprivate let applicationOpenUrlProperty = MutableProperty<ApplicationOpenUrl?>(nil)
+  public func applicationOpenUrl(
+    application: UIApplication?,
+    url: URL,
+    options: [UIApplication.OpenURLOptionsKey: Any]
+  ) -> Bool {
+    self.applicationOpenUrlProperty.value = (application, url, options)
+    return self.facebookOpenURLReturnValue.value
+  }
+
+  fileprivate let applicationDidFinishLaunchingReturnValueProperty = MutableProperty(true)
+  public var applicationDidFinishLaunchingReturnValue: Bool {
+    return self.applicationDidFinishLaunchingReturnValueProperty.value
+  }
+
+  public let facebookOpenURLReturnValue = MutableProperty(false)
+}

--- a/Kickstarter-iOS/ViewModels/FacebookLoginViewModelTests.swift
+++ b/Kickstarter-iOS/ViewModels/FacebookLoginViewModelTests.swift
@@ -1,5 +1,4 @@
 @testable import Kickstarter_Framework
-@testable import KsApi
 @testable import Library
 import ReactiveExtensions_TestHelpers
 import ReactiveSwift

--- a/Kickstarter-iOS/ViewModels/FacebookLoginViewModelTests.swift
+++ b/Kickstarter-iOS/ViewModels/FacebookLoginViewModelTests.swift
@@ -1,0 +1,32 @@
+@testable import Kickstarter_Framework
+@testable import KsApi
+@testable import Library
+import ReactiveExtensions_TestHelpers
+import ReactiveSwift
+import XCTest
+
+final class FacebookLoginViewModelTests: TestCase {
+  let vm: FacebookLoginViewModelType = FacebookLoginViewModel()
+
+  func testFacebookAppDelegate() {
+    XCTAssertFalse(self.facebookAppDelegate.didFinishLaunching)
+    XCTAssertFalse(self.facebookAppDelegate.openedUrl)
+
+    self.vm.inputs.applicationDidFinishLaunching(
+      application: UIApplication.shared,
+      launchOptions: [:]
+    )
+
+    XCTAssertTrue(self.facebookAppDelegate.didFinishLaunching)
+    XCTAssertFalse(self.facebookAppDelegate.openedUrl)
+
+    let result = self.vm.inputs.applicationOpenUrl(
+      application: UIApplication.shared,
+      url: URL(string: "http://www.fb.com")!,
+      options: [:]
+    )
+    XCTAssertFalse(result)
+
+    XCTAssertTrue(self.facebookAppDelegate.openedUrl)
+  }
+}

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -781,6 +781,9 @@
 		D0200A5621935F2900F5CC27 /* MessageBannerType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0200A5321935EDF00F5CC27 /* MessageBannerType.swift */; };
 		D0200A5721935F2D00F5CC27 /* GraphError+LocalizedDescription.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0200A5221935EDF00F5CC27 /* GraphError+LocalizedDescription.swift */; };
 		D0247A961DF9F29100D7A7C1 /* ProjectPamphletSubpageCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0247A911DF9F0EF00D7A7C1 /* ProjectPamphletSubpageCellViewModel.swift */; };
+		D02D15FD22B85338002C50F1 /* FacebookLoginViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D02D15FC22B85338002C50F1 /* FacebookLoginViewModel.swift */; };
+		D02D15FF22B85C91002C50F1 /* FacebookLoginViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D02D15FE22B85C91002C50F1 /* FacebookLoginViewModelTests.swift */; };
+		D02D160022B85C9A002C50F1 /* FacebookLoginViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D02D15FC22B85338002C50F1 /* FacebookLoginViewModel.swift */; };
 		D03BBA5C21A8E880005604A7 /* MockPushRegistration.swift in Sources */ = {isa = PBXBuildFile; fileRef = D093B4B721A8B0E000910962 /* MockPushRegistration.swift */; };
 		D04307A221853D530004FDC0 /* Crashlytics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 770E45ED2114E15D00396D46 /* Crashlytics.framework */; };
 		D04AABF7218BB2F700CF713E /* SettingsNotificationsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6B6F8DF20EE7C8700A295F7 /* SettingsNotificationsViewModelTests.swift */; };
@@ -2013,6 +2016,8 @@
 		D0200A5221935EDF00F5CC27 /* GraphError+LocalizedDescription.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "GraphError+LocalizedDescription.swift"; sourceTree = "<group>"; };
 		D0200A5321935EDF00F5CC27 /* MessageBannerType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MessageBannerType.swift; sourceTree = "<group>"; };
 		D0247A911DF9F0EF00D7A7C1 /* ProjectPamphletSubpageCellViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProjectPamphletSubpageCellViewModel.swift; sourceTree = "<group>"; };
+		D02D15FC22B85338002C50F1 /* FacebookLoginViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FacebookLoginViewModel.swift; sourceTree = "<group>"; };
+		D02D15FE22B85C91002C50F1 /* FacebookLoginViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FacebookLoginViewModelTests.swift; sourceTree = "<group>"; };
 		D04AAC08218BB70800CF713E /* SettingsNotificationCellViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsNotificationCellViewModel.swift; sourceTree = "<group>"; };
 		D04AAC09218BB70800CF713E /* SettingsViewModelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsViewModelTests.swift; sourceTree = "<group>"; };
 		D04AAC0A218BB70800CF713E /* ChangePasswordViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChangePasswordViewModel.swift; sourceTree = "<group>"; };
@@ -2468,6 +2473,8 @@
 			children = (
 				A75CBDE61C8A26F800758C55 /* AppDelegateViewModel.swift */,
 				A7ED205D1E83256700BFFA01 /* AppDelegateViewModelTests.swift */,
+				D02D15FC22B85338002C50F1 /* FacebookLoginViewModel.swift */,
+				D02D15FE22B85C91002C50F1 /* FacebookLoginViewModelTests.swift */,
 				01940B2A1D46814E0074FCE3 /* HelpWebViewModel.swift */,
 				A7ED205E1E83256700BFFA01 /* HelpWebViewModelTests.swift */,
 				A775B5451CA871D700BBB587 /* RootViewModel.swift */,
@@ -4581,6 +4588,7 @@
 				7754A0AE215A8361003AA36D /* ChangePasswordViewController.swift in Sources */,
 				A72C3AB71D00FB1F0075227E /* DiscoveryExpandedSelectableRow.swift in Sources */,
 				80EAEF071D243FC7008C2353 /* BackingViewController.swift in Sources */,
+				D02D160022B85C9A002C50F1 /* FacebookLoginViewModel.swift in Sources */,
 				A7B1EBB31D90496A00BEE8B3 /* NoRewardCell.swift in Sources */,
 				01940B291D467ECE0074FCE3 /* HelpWebViewController.swift in Sources */,
 				A73EF70A1DCC17DD008FDBE5 /* ProjectNavigatorPagesDataSource.swift in Sources */,
@@ -4681,6 +4689,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D02D15FD22B85338002C50F1 /* FacebookLoginViewModel.swift in Sources */,
 				A73924041D272404004524C3 /* AppDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -4751,6 +4760,7 @@
 				A7ED204F1E8323E900BFFA01 /* CommentsViewControllerTests.swift in Sources */,
 				A78356081E85BE6D0021DA5A /* BackerDashboardProjectsDataSourceTests.swift in Sources */,
 				D60C8BF321481BCC00D96152 /* SettingsAccountViewControllerTests.swift in Sources */,
+				D02D15FF22B85C91002C50F1 /* FacebookLoginViewModelTests.swift in Sources */,
 				D6B4F0032107B4760079159D /* SettingsNewslettersViewControllerTests.swift in Sources */,
 				A7ED205C1E83240D00BFFA01 /* FundingGraphViewTests.swift in Sources */,
 				D60C8CE12149A65000D96152 /* SettingsPrivacyDataSourceTests.swift in Sources */,


### PR DESCRIPTION
# 📲 What

Moves calls that we make to `FBSDKApplicationDelegate` so that they are made from within our main app target.

# 🤔 Why

We've recently found, in a very specific Facebook login scenario, that users upon returning to our app - after completing a login flow via the Facebook app - are caught in an infinite loop. I believe that this change addresses the issue.

**Note:** This does _not_ affect users logging in via a browser flow and authenticating Facebook in Safari, _only_ if they select 'login via the app'.

In trying to track down the cause I found that placing the call to the `FBSDKApplicationDelegate` directly in our own `AppDelegate` in `application(_:open:options:)` worked without getting caught in any loop. This is problematic for us because we use our view model to mock the response from `FBSDKApplicationDelegate` in our unit tests. I then found that simply by moving the call to `FBSDKApplicationDelegate` just one level, into our view model's input function, I could reproduce the infinite loop again. This suggested to me that something to do with the bundle identifier of the framework from which the call is made might be problematic for `FBSDK`. It's possible that they perform some check internally against the bundle and if the two differ then the call is considered to have not been handled and it is called again (I surmise).

# 🛠 How

- Moved all Facebook-related calls and tests from `AppDelegateViewModel` into `FacebookLoginViewModel`.
- Made `FacebookLoginViewModel` a direct member of the application target.
- Works 💯 .

# ✅ Acceptance criteria

- [x] Test that deep-linking is unaffected.
- [x] Test login through Facebook via the app, not the browser.
- [x] Test logging in via the browser too.