### PR TITLE
Disable Facebook event and advertiser ID collection flags

### DIFF
--- a/Kickstarter-iOS/AppDelegate.swift
+++ b/Kickstarter-iOS/AppDelegate.swift
@@ -30,7 +30,9 @@ internal final class AppDelegate: UIResponder, UIApplicationDelegate {
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
+    // FBSDK initialization
     ApplicationDelegate.shared.application(application, didFinishLaunchingWithOptions: launchOptions)
+    Settings.shouldLimitEventAndDataUsage = true
 
     UIView.doBadSwizzleStuff()
     UIViewController.doBadSwizzleStuff()
@@ -236,7 +238,7 @@ internal final class AppDelegate: UIResponder, UIApplicationDelegate {
     open url: URL,
     options: [UIApplication.OpenURLOptionsKey: Any] = [:]
   ) -> Bool {
-    // if this is not a Facebook login call, handle the potential deep-link
+    // If this is not a Facebook login call, handle the potential deep-link
     guard !ApplicationDelegate.shared.application(app, open: url, options: options) else {
       return true
     }

--- a/Kickstarter-iOS/Info.plist
+++ b/Kickstarter-iOS/Info.plist
@@ -61,8 +61,12 @@
 			</dict>
 		</array>
 	</dict>
+	<key>FacebookAdvertiserIDCollectionEnabled</key>
+	<false/>
 	<key>FacebookAppID</key>
 	<string>69103156693</string>
+	<key>FacebookAutoLogAppEventsEnabled</key>
+	<false/>
 	<key>FacebookDisplayName</key>
 	<string>Kickstarter</string>
 	<key>ITSAppUsesNonExemptEncryption</key>


### PR DESCRIPTION
# 📲 What

Sets `FacebookAutoLogAppEventsEnabled` and `FacebookAdvertiserIDCollectionEnabled` to `false` in our `Info.plist`.

# 🤔 Why

We want Facebook's SDK doing as little as possible in our app, currently we _only_ use it as a convenience for people to sign in and we do not want it logging anything or trying to use our app's advertising identifier.

# 🛠 How

Set the flags in the plist.

# 👀 See

https://developers.facebook.com/docs/app-events/getting-started-app-events-ios/#auto-events
