### PR TITLE
💲[Native Checkout] Pledge Summary Cell Handle Links

### DIFF
--- a/Kickstarter-iOS/ViewModels/HelpWebViewModel.swift
+++ b/Kickstarter-iOS/ViewModels/HelpWebViewModel.swift
@@ -24,7 +24,7 @@ internal final class HelpWebViewModel: HelpWebViewModelType, HelpWebViewModelInp
   internal init() {
     self.webViewLoadRequest = self.helpTypeProperty.signal.skipNil()
       .takeWhen(self.viewDidLoadProperty.signal)
-      .map { urlForHelpType($0, baseUrl: AppEnvironment.current.apiService.serverConfig.webBaseUrl) }
+      .map { $0.url(withBaseUrl: AppEnvironment.current.apiService.serverConfig.webBaseUrl) }
       .skipNil()
       .map { AppEnvironment.current.apiService.preparedRequest(forURL: $0) }
   }
@@ -42,24 +42,5 @@ internal final class HelpWebViewModel: HelpWebViewModelType, HelpWebViewModelInp
   fileprivate let viewDidLoadProperty = MutableProperty(())
   func viewDidLoad() {
     self.viewDidLoadProperty.value = ()
-  }
-}
-
-public func urlForHelpType(_ helpType: HelpType, baseUrl: URL) -> URL? {
-  switch helpType {
-  case .cookie:
-    return baseUrl.appendingPathComponent("cookies")
-  case .contact:
-    return nil
-  case .helpCenter:
-    return baseUrl.appendingPathComponent("help")
-  case .howItWorks:
-    return baseUrl.appendingPathComponent("about")
-  case .privacy:
-    return baseUrl.appendingPathComponent("privacy")
-  case .terms:
-    return baseUrl.appendingPathComponent("terms-of-use")
-  case .trust:
-    return baseUrl.appendingPathComponent("trust")
   }
 }

--- a/Kickstarter-iOS/Views/Cells/PledgeDescriptionCell.swift
+++ b/Kickstarter-iOS/Views/Cells/PledgeDescriptionCell.swift
@@ -215,7 +215,7 @@ private func attributedLearnMoreText() -> NSAttributedString? {
     key: "Kickstarter_is_not_a_store_Its_a_way_to_bring_creative_projects_to_life_Learn_more_about_accountability",
     defaultValue: "<p>Kickstarter is not a store. It's a way to bring creative projects to life.</br><a href=\"%{trust_link}\">Learn more about accountability</a><p>",
     substitutions: [
-      "trust_link": urlForHelpType(.trust, baseUrl: AppEnvironment.current.apiService.serverConfig.webBaseUrl)?.absoluteString
+      "trust_link": HelpType.trust.url(withBaseUrl: AppEnvironment.current.apiService.serverConfig.webBaseUrl)?.absoluteString
     ]
     .compactMapValues { $0.coalesceWith("") }
   )

--- a/Kickstarter-iOS/Views/Controllers/PledgeTableViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/PledgeTableViewController.swift
@@ -79,21 +79,25 @@ class PledgeTableViewController: UITableViewController {
       break
     }
   }
-}
 
-extension PledgeTableViewController: PledgeDescriptionCellDelegate {
-  internal func pledgeDescriptionCellDidPresentTrustAndSafety(_: PledgeDescriptionCell) {
-    let vc = HelpWebViewController.configuredWith(helpType: .trust)
+  // MARK: - Actions
+
+  private func presentHelpWebViewController(with helpType: HelpType) {
+    let vc = HelpWebViewController.configuredWith(helpType: helpType)
     let nav = UINavigationController(rootViewController: vc)
     self.present(nav, animated: true, completion: nil)
   }
 }
 
+extension PledgeTableViewController: PledgeDescriptionCellDelegate {
+  internal func pledgeDescriptionCellDidPresentTrustAndSafety(_: PledgeDescriptionCell) {
+    self.presentHelpWebViewController(with: .trust)
+  }
+}
+
 extension PledgeTableViewController: PledgeSummaryCellDelegate {
   internal func pledgeSummaryCell(_: PledgeSummaryCell, didOpen helpType: HelpType) {
-    let vc = HelpWebViewController.configuredWith(helpType: helpType)
-    let nav = UINavigationController(rootViewController: vc)
-    self.present(nav, animated: true, completion: nil)
+    self.presentHelpWebViewController(with: helpType)
   }
 }
 

--- a/Kickstarter-iOS/Views/Controllers/PledgeTableViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/PledgeTableViewController.swift
@@ -68,10 +68,15 @@ class PledgeTableViewController: UITableViewController {
   }
 
   internal override func tableView(_: UITableView, willDisplay cell: UITableViewCell, forRowAt _: IndexPath) {
-    if let descriptionCell = cell as? PledgeDescriptionCell {
-      descriptionCell.delegate = self
-    } else if let shippingLocationCell = cell as? PledgeShippingLocationCell {
-      self.shippingLocationCell = shippingLocationCell
+    switch cell {
+    case is PledgeDescriptionCell:
+      (cell as? PledgeDescriptionCell)?.delegate = self
+    case is PledgeSummaryCell:
+      (cell as? PledgeSummaryCell)?.delegate = self
+    case is PledgeShippingLocationCell:
+      self.shippingLocationCell = (cell as? PledgeShippingLocationCell)
+    default:
+      break
     }
   }
 }
@@ -79,6 +84,14 @@ class PledgeTableViewController: UITableViewController {
 extension PledgeTableViewController: PledgeDescriptionCellDelegate {
   internal func pledgeDescriptionCellDidPresentTrustAndSafety(_: PledgeDescriptionCell) {
     let vc = HelpWebViewController.configuredWith(helpType: .trust)
+    let nav = UINavigationController(rootViewController: vc)
+    self.present(nav, animated: true, completion: nil)
+  }
+}
+
+extension PledgeTableViewController: PledgeSummaryCellDelegate {
+  internal func pledgeSummaryCell(_: PledgeSummaryCell, didOpen helpType: HelpType) {
+    let vc = HelpWebViewController.configuredWith(helpType: helpType)
     let nav = UINavigationController(rootViewController: vc)
     self.present(nav, animated: true, completion: nil)
   }

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -829,6 +829,7 @@
 		D0200A5621935F2900F5CC27 /* MessageBannerType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0200A5321935EDF00F5CC27 /* MessageBannerType.swift */; };
 		D0200A5721935F2D00F5CC27 /* GraphError+LocalizedDescription.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0200A5221935EDF00F5CC27 /* GraphError+LocalizedDescription.swift */; };
 		D0237C1522BC2B640092C792 /* PledgeSummaryCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0237C1422BC2B640092C792 /* PledgeSummaryCell.swift */; };
+		D0237C2622BD7B540092C792 /* PledgeSummaryCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0237C2522BD7B540092C792 /* PledgeSummaryCellViewModel.swift */; };
 		D0247A961DF9F29100D7A7C1 /* ProjectPamphletSubpageCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0247A911DF9F0EF00D7A7C1 /* ProjectPamphletSubpageCellViewModel.swift */; };
 		D033E2C222A05B4800464E43 /* MockApplication.swift in Sources */ = {isa = PBXBuildFile; fileRef = D033E2C122A05B4800464E43 /* MockApplication.swift */; };
 		D033E2C322A05B7400464E43 /* MockApplication.swift in Sources */ = {isa = PBXBuildFile; fileRef = D033E2C122A05B4800464E43 /* MockApplication.swift */; };
@@ -2119,6 +2120,7 @@
 		D0200A5221935EDF00F5CC27 /* GraphError+LocalizedDescription.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "GraphError+LocalizedDescription.swift"; sourceTree = "<group>"; };
 		D0200A5321935EDF00F5CC27 /* MessageBannerType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MessageBannerType.swift; sourceTree = "<group>"; };
 		D0237C1422BC2B640092C792 /* PledgeSummaryCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PledgeSummaryCell.swift; sourceTree = "<group>"; };
+		D0237C2522BD7B540092C792 /* PledgeSummaryCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PledgeSummaryCellViewModel.swift; sourceTree = "<group>"; };
 		D0247A911DF9F0EF00D7A7C1 /* ProjectPamphletSubpageCellViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProjectPamphletSubpageCellViewModel.swift; sourceTree = "<group>"; };
 		D033E2C122A05B4800464E43 /* MockApplication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockApplication.swift; sourceTree = "<group>"; };
 		D04AAC08218BB70800CF713E /* SettingsNotificationCellViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsNotificationCellViewModel.swift; sourceTree = "<group>"; };
@@ -3243,6 +3245,8 @@
 				A7ED1F7F1E831C5C00BFFA01 /* DashboardViewModelTests.swift */,
 				9DDE1F731D5926D80092D9A5 /* DeprecatedCheckoutViewModel.swift */,
 				A7ED1F511E831C5C00BFFA01 /* DeprecatedCheckoutViewModelTests.swift */,
+				A747A8EA1D45896000AF199A /* DeprecatedRewardCellViewModel.swift */,
+				A7ED1FA21E831C5C00BFFA01 /* DeprecatedRewardCellViewModelTests.swift */,
 				A774684A1D6E400D007DCDFC /* DeprecatedRewardPledgeViewModel.swift */,
 				A7ED1F7E1E831C5C00BFFA01 /* DeprecatedRewardPledgeViewModelTests.swift */,
 				A78851901D6C900000617930 /* DeprecatedWebViewModel.swift */,
@@ -3311,6 +3315,7 @@
 				D775953B22725289005EE69B /* PledgeDescriptionCellViewModelTests.swift */,
 				3706408522A8A6D700889CBD /* PledgeShippingLocationCellViewModel.swift */,
 				3706408722A8A6F200889CBD /* PledgeShippingLocationCellViewModelTests.swift */,
+				D0237C2522BD7B540092C792 /* PledgeSummaryCellViewModel.swift */,
 				37DEC1E62257C9F30051EF9B /* PledgeViewModel.swift */,
 				37DEC21F2257CA0A0051EF9B /* PledgeViewModelTests.swift */,
 				A7F441A31D005A9400FE6FC5 /* ProfileViewModel.swift */,
@@ -3357,8 +3362,6 @@
 				77D8DBCC22A82C5C00454120 /* RewardCellViewModelTests.swift */,
 				77EFBAE12268D44D00DA5C3C /* RewardsCollectionViewModel.swift */,
 				77C7B653226E0E54001101AC /* RewardsCollectionViewModelTests.swift */,
-				A747A8EA1D45896000AF199A /* DeprecatedRewardCellViewModel.swift */,
-				A7ED1FA21E831C5C00BFFA01 /* DeprecatedRewardCellViewModelTests.swift */,
 				A75A9DBE1D6F3A3000603D1D /* RewardShippingPickerViewModel.swift */,
 				A7ED1FA31E831C5C00BFFA01 /* RewardShippingPickerViewModelTests.swift */,
 				D7A37CCE1E2FF93D00EA066D /* SearchEmptyStateCellViewModel.swift */,
@@ -4442,6 +4445,7 @@
 				D798A6AE21656D970053D097 /* Currency.swift in Sources */,
 				77F6E73521222E7C005A5C55 /* EmailFrequency.swift in Sources */,
 				A7EDEE571D83453F00780B34 /* PKPaymentAuthorizationViewController.swift in Sources */,
+				D0237C2622BD7B540092C792 /* PledgeSummaryCellViewModel.swift in Sources */,
 				01A7A4C01C9690220036E553 /* UITextField+LocalizedPlaceholderKey.swift in Sources */,
 				0176E13B1C9742FD009CA092 /* UIBarButtonItem.swift in Sources */,
 				D63BBD35217FAB85007E01F0 /* PaymentMethodsViewModel.swift in Sources */,

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -972,6 +972,7 @@
 		D0D10C201EEB4550005EBAD0 /* User.NewsletterSubscriptionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D01588211EEB2ED7006E7684 /* User.NewsletterSubscriptionsTests.swift */; };
 		D0D10C211EEB4550005EBAD0 /* User.NotificationsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D01588221EEB2ED7006E7684 /* User.NotificationsTests.swift */; };
 		D0D10C221EEB4550005EBAD0 /* UserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D01588241EEB2ED7006E7684 /* UserTests.swift */; };
+		D0D19BCA22BD886F0043A4E5 /* PledgeSummaryCellViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0D19BC922BD886F0043A4E5 /* PledgeSummaryCellViewModelTests.swift */; };
 		D0D2AB201E964485008D298A /* VideoGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0D2AB1A1E96444B008D298A /* VideoGridView.swift */; };
 		D0D58D862257FAE000532AC1 /* Prelude.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D0D58D792257FADE00532AC1 /* Prelude.framework */; };
 		D0D58D872257FAE000532AC1 /* Argo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D0D58D7A2257FADE00532AC1 /* Argo.framework */; };
@@ -2172,6 +2173,7 @@
 		D0B065E12281033100142B7A /* 1Password.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = 1Password.xcassets; path = "Carthage/Checkouts/onepassword-extension/1Password.xcassets"; sourceTree = SOURCE_ROOT; };
 		D0B7124522AEEDBC00317BAF /* FBSDKCoreKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = FBSDKCoreKit.framework; path = Carthage/Build/iOS/FBSDKCoreKit.framework; sourceTree = "<group>"; };
 		D0C9BAD521B1AB920098CABA /* Alpha.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Alpha.entitlements; sourceTree = "<group>"; };
+		D0D19BC922BD886F0043A4E5 /* PledgeSummaryCellViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PledgeSummaryCellViewModelTests.swift; sourceTree = "<group>"; };
 		D0D2AB1A1E96444B008D298A /* VideoGridView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VideoGridView.swift; sourceTree = "<group>"; };
 		D0D58D792257FADE00532AC1 /* Prelude.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Prelude.framework; path = Carthage/Build/iOS/Prelude.framework; sourceTree = "<group>"; };
 		D0D58D7A2257FADE00532AC1 /* Argo.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Argo.framework; path = Carthage/Build/iOS/Argo.framework; sourceTree = "<group>"; };
@@ -3316,6 +3318,7 @@
 				3706408522A8A6D700889CBD /* PledgeShippingLocationCellViewModel.swift */,
 				3706408722A8A6F200889CBD /* PledgeShippingLocationCellViewModelTests.swift */,
 				D0237C2522BD7B540092C792 /* PledgeSummaryCellViewModel.swift */,
+				D0D19BC922BD886F0043A4E5 /* PledgeSummaryCellViewModelTests.swift */,
 				37DEC1E62257C9F30051EF9B /* PledgeViewModel.swift */,
 				37DEC21F2257CA0A0051EF9B /* PledgeViewModelTests.swift */,
 				A7F441A31D005A9400FE6FC5 /* ProfileViewModel.swift */,
@@ -4542,6 +4545,7 @@
 				A7ED1FF41E831C5C00BFFA01 /* ProjectDescriptionViewModelTests.swift in Sources */,
 				D0A7880F2204EF93006AE4F4 /* SelectCurrencyViewModelTests.swift in Sources */,
 				D093B4F021A8B14100910962 /* MockPushRegistration.swift in Sources */,
+				D0D19BCA22BD886F0043A4E5 /* PledgeSummaryCellViewModelTests.swift in Sources */,
 				A7ED1FEA1E831C5C00BFFA01 /* HelpViewModelTests.swift in Sources */,
 				A7ED1F301E830FDC00BFFA01 /* NavigationTests.swift in Sources */,
 				37CBA64D221E10E100E6CAB6 /* HelpTypeTests.swift in Sources */,

--- a/Library/HelpType.swift
+++ b/Library/HelpType.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-public enum HelpType: SettingsCellTypeProtocol {
+public enum HelpType: SettingsCellTypeProtocol, CaseIterable {
   case helpCenter
   case contact
   case howItWorks
@@ -66,6 +66,25 @@ public enum HelpType: SettingsCellTypeProtocol {
       return "Terms"
     case .trust:
       return "Trust & Safety"
+    }
+  }
+
+  public func url(withBaseUrl baseUrl: URL) -> URL? {
+    switch self {
+    case .cookie:
+      return baseUrl.appendingPathComponent("cookies")
+    case .contact:
+      return nil
+    case .helpCenter:
+      return baseUrl.appendingPathComponent("help")
+    case .howItWorks:
+      return baseUrl.appendingPathComponent("about")
+    case .privacy:
+      return baseUrl.appendingPathComponent("privacy")
+    case .terms:
+      return baseUrl.appendingPathComponent("terms-of-use")
+    case .trust:
+      return baseUrl.appendingPathComponent("trust")
     }
   }
 }

--- a/Library/ViewModels/PledgeSummaryCellViewModel.swift
+++ b/Library/ViewModels/PledgeSummaryCellViewModel.swift
@@ -1,0 +1,42 @@
+import Foundation
+import Prelude
+import ReactiveSwift
+
+public protocol PledgeSummaryCellViewModelInputs {
+  func tapped(_ url: URL)
+}
+
+public protocol PledgeSummaryCellViewModelOutputs {
+  var notifyDelegateOpenHelpType: Signal<HelpType, Never> { get }
+}
+
+public protocol PledgeSummaryCellViewModelType {
+  var inputs: PledgeSummaryCellViewModelInputs { get }
+  var outputs: PledgeSummaryCellViewModelOutputs { get }
+}
+
+public class PledgeSummaryCellViewModel: PledgeSummaryCellViewModelType, PledgeSummaryCellViewModelInputs, PledgeSummaryCellViewModelOutputs {
+  public init() {
+    self.notifyDelegateOpenHelpType = self.tappedUrlSignal.map { url -> HelpType? in
+      let helpType = HelpType.allCases.filter { helpType in
+        url.absoluteString == helpType.url(
+          withBaseUrl: AppEnvironment.current.apiService.serverConfig.webBaseUrl
+        )?.absoluteString
+      }
+      .first
+
+      return helpType
+    }
+    .skipNil()
+  }
+
+  private let (tappedUrlSignal, tappedUrlObserver) = Signal<URL, Never>.pipe()
+  public func tapped(_ url: URL) {
+    self.tappedUrlObserver.send(value: url)
+  }
+
+  public let notifyDelegateOpenHelpType: Signal<HelpType, Never>
+
+  public var inputs: PledgeSummaryCellViewModelInputs { return self }
+  public var outputs: PledgeSummaryCellViewModelOutputs { return self }
+}

--- a/Library/ViewModels/PledgeSummaryCellViewModel.swift
+++ b/Library/ViewModels/PledgeSummaryCellViewModel.swift
@@ -16,7 +16,7 @@ public protocol PledgeSummaryCellViewModelType {
 }
 
 public class PledgeSummaryCellViewModel: PledgeSummaryCellViewModelType,
-PledgeSummaryCellViewModelInputs, PledgeSummaryCellViewModelOutputs {
+  PledgeSummaryCellViewModelInputs, PledgeSummaryCellViewModelOutputs {
   public init() {
     self.notifyDelegateOpenHelpType = self.tappedUrlSignal.map { url -> HelpType? in
       let helpType = HelpType.allCases.filter { helpType in

--- a/Library/ViewModels/PledgeSummaryCellViewModel.swift
+++ b/Library/ViewModels/PledgeSummaryCellViewModel.swift
@@ -15,7 +15,8 @@ public protocol PledgeSummaryCellViewModelType {
   var outputs: PledgeSummaryCellViewModelOutputs { get }
 }
 
-public class PledgeSummaryCellViewModel: PledgeSummaryCellViewModelType, PledgeSummaryCellViewModelInputs, PledgeSummaryCellViewModelOutputs {
+public class PledgeSummaryCellViewModel: PledgeSummaryCellViewModelType,
+PledgeSummaryCellViewModelInputs, PledgeSummaryCellViewModelOutputs {
   public init() {
     self.notifyDelegateOpenHelpType = self.tappedUrlSignal.map { url -> HelpType? in
       let helpType = HelpType.allCases.filter { helpType in

--- a/Library/ViewModels/PledgeSummaryCellViewModelTests.swift
+++ b/Library/ViewModels/PledgeSummaryCellViewModelTests.swift
@@ -1,0 +1,28 @@
+@testable import KsApi
+@testable import Library
+import Prelude
+import ReactiveExtensions_TestHelpers
+import XCTest
+
+internal final class PledgeSummaryCellViewModelTests: TestCase {
+  private let vm: PledgeSummaryCellViewModelType = PledgeSummaryCellViewModel()
+
+  private let notifyDelegateOpenHelpType = TestObserver<HelpType, Never>()
+
+  override func setUp() {
+    super.setUp()
+
+    self.vm.outputs.notifyDelegateOpenHelpType.observe(self.notifyDelegateOpenHelpType.observer)
+  }
+
+  func testNotifyDelegateOpenHelpType() {
+    let baseUrl = AppEnvironment.current.apiService.serverConfig.webBaseUrl
+    let allCases = HelpType.allCases.filter { $0 != .contact }
+
+    let allHelpTypeUrls = allCases.map { $0.url(withBaseUrl: baseUrl) }.compact()
+
+    allHelpTypeUrls.forEach { self.vm.inputs.tapped($0) }
+
+    self.notifyDelegateOpenHelpType.assertValues(allCases)
+  }
+}


### PR DESCRIPTION
# 📲 What

Adds functionality to open links that are tapped in the `PledgeSummaryCell`. This is one of the TODO items in #715.

# 🛠 How

When we construct the HTML to build the attributed string for the `UITextView` to display as tappable links, we derive these from the `HelpType`. The `UITextViewDelegate` passes us the `URL` that was tapped and we pass this to our view model for translation back to an `HelpType` which is the expected type for our `HelpWebViewController`.

# 👀 See

<img src="https://user-images.githubusercontent.com/3735375/59953728-43e90400-9436-11e9-92e2-5fc6d8143e24.gif" width="50%"/>

# ✅ Acceptance criteria

- [x] All links in the summary cell are tappable and open a web view modally.