### PR TITLE
Persist Debug Feature Flags

### DIFF
--- a/Kickstarter-iOS/Views/Controllers/FeatureFlagToolsViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/FeatureFlagToolsViewController.swift
@@ -58,6 +58,7 @@ final class FeatureFlagToolsViewController: UITableViewController {
 
     let updatedConfig = config |> \.features .~ features
 
+    AppEnvironment.updateDebugData(DebugData(config: updatedConfig))
     AppEnvironment.updateConfig(updatedConfig)
 
     self.viewModel.inputs.didUpdateConfig()

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -189,6 +189,7 @@
 		77556F5720A0B41E008CEA57 /* ThanksViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77556F5520A0B408008CEA57 /* ThanksViewControllerTests.swift */; };
 		7758A8372097BADF0018B96D /* DiscoveryProjectCategoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7758A83120979BE50018B96D /* DiscoveryProjectCategoryView.swift */; };
 		7758A8382097BB090018B96D /* DiscoveryProjectCategoryView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 7758A8352097A8180018B96D /* DiscoveryProjectCategoryView.xib */; };
+		775D922922BD7CFD00442301 /* DebugData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 775D922822BD7CFD00442301 /* DebugData.swift */; };
 		776B6F70215183A400AB0652 /* ChangeEmailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 776B6F6F215183A400AB0652 /* ChangeEmailViewController.swift */; };
 		77752F5E219B39EA00E7DA7D /* SettingsAccountWarningCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77752F5D219B39EA00E7DA7D /* SettingsAccountWarningCell.swift */; };
 		77752F97219B3D7300E7DA7D /* SettingsAccountWarningCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 77752F96219B3D7300E7DA7D /* SettingsAccountWarningCell.xib */; };
@@ -1456,6 +1457,7 @@
 		77556F5520A0B408008CEA57 /* ThanksViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThanksViewControllerTests.swift; sourceTree = "<group>"; };
 		7758A83120979BE50018B96D /* DiscoveryProjectCategoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoveryProjectCategoryView.swift; sourceTree = "<group>"; };
 		7758A8352097A8180018B96D /* DiscoveryProjectCategoryView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = DiscoveryProjectCategoryView.xib; sourceTree = "<group>"; };
+		775D922822BD7CFD00442301 /* DebugData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugData.swift; sourceTree = "<group>"; };
 		775DFA9C215E758400620CED /* GraphMutation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphMutation.swift; sourceTree = "<group>"; };
 		775DFAD4215EB2AB00620CED /* Service+RequestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Service+RequestHelpers.swift"; sourceTree = "<group>"; };
 		776B6F6F215183A400AB0652 /* ChangeEmailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeEmailViewController.swift; sourceTree = "<group>"; };
@@ -3483,8 +3485,8 @@
 				D015877C1EEB2ED6006E7684 /* Backing.swift */,
 				D015877D1EEB2ED6006E7684 /* BackingTests.swift */,
 				D6B9DF3E1F72E25A0064A4D8 /* Category.swift */,
+				D6FB2A3C1FA27D0300B0D282 /* CategoryTests.swift */,
 				D6AE52271FD1B4BA00BEC788 /* CategoryEnvelope.swift */,
-				D01587801EEB2ED6006E7684 /* CategoryTests.swift */,
 				D01587811EEB2ED6006E7684 /* ChangePaymentMethodEnvelope.swift */,
 				D01587821EEB2ED6006E7684 /* ChangePaymentMethodEnvelopeTests.swift */,
 				D01587831EEB2ED6006E7684 /* CheckoutEnvelope.swift */,
@@ -3500,6 +3502,7 @@
 				D79440562203A63300D0A747 /* CreatePaymentSourceEnvelope.swift */,
 				D015878A1EEB2ED6006E7684 /* CreatePledgeEnvelope.swift */,
 				D015878B1EEB2ED6006E7684 /* CreatePledgeEnvelopeTests.swift */,
+				775D922822BD7CFD00442301 /* DebugData.swift */,
 				D62B1476221216A000AC05C8 /* DeletePaymentMethodEnvelope.swift */,
 				D62B14AF2212184500AC05C8 /* DeletePaymentMethodEnvelopeTests.swift */,
 				D015878C1EEB2ED6006E7684 /* DiscoveryEnvelope.swift */,
@@ -5076,6 +5079,7 @@
 				D015891F1EEB2ED7006E7684 /* ShippingRulesEnvelope.swift in Sources */,
 				D01588831EEB2ED7006E7684 /* BackingLenses.swift in Sources */,
 				D01588C51EEB2ED7006E7684 /* Reward.ShippingLenses.swift in Sources */,
+				775D922922BD7CFD00442301 /* DebugData.swift in Sources */,
 				D01588D51EEB2ED7006E7684 /* UpdateDraftLenses.swift in Sources */,
 				D01589211EEB2ED7006E7684 /* StarEnvelope.swift in Sources */,
 				D01588EF1EEB2ED7006E7684 /* MessageThread.swift in Sources */,

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -193,6 +193,7 @@
 		776B6F70215183A400AB0652 /* ChangeEmailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 776B6F6F215183A400AB0652 /* ChangeEmailViewController.swift */; };
 		77752F5E219B39EA00E7DA7D /* SettingsAccountWarningCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77752F5D219B39EA00E7DA7D /* SettingsAccountWarningCell.swift */; };
 		77752F97219B3D7300E7DA7D /* SettingsAccountWarningCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 77752F96219B3D7300E7DA7D /* SettingsAccountWarningCell.xib */; };
+		777B88E522BD911F0027640F /* CategoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6FB2A3C1FA27D0300B0D282 /* CategoryTests.swift */; };
 		777C67BB220A0FA5009F8D42 /* SettingsTableViewHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 777C67BA220A0FA5009F8D42 /* SettingsTableViewHeader.swift */; };
 		777C67F4220A22FD009F8D42 /* SettingsTableViewHeader.xib in Resources */ = {isa = PBXBuildFile; fileRef = 777C67F3220A22FD009F8D42 /* SettingsTableViewHeader.xib */; };
 		778215E820F6922100F3D09F /* HelpType.swift in Sources */ = {isa = PBXBuildFile; fileRef = A707BAD31CFFAB9400653B2F /* HelpType.swift */; };
@@ -649,7 +650,6 @@
 		A7FA38A41D9068940041FC9C /* PledgeTitleCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7FA38A31D9068940041FC9C /* PledgeTitleCell.swift */; };
 		A7FA38D91D9068AD0041FC9C /* RewardsTitleCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7FA38D81D9068AD0041FC9C /* RewardsTitleCell.swift */; };
 		A7FC8C061C8F1DEA00C3B49B /* CircleAvatarImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7FC8C051C8F1DEA00C3B49B /* CircleAvatarImageView.swift */; };
-		D002CADF218CF8B7009783F2 /* CategoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D01587801EEB2ED6006E7684 /* CategoryTests.swift */; };
 		D002CAE1218CF8F1009783F2 /* WatchProjectMutation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D002CAE0218CF8F1009783F2 /* WatchProjectMutation.swift */; };
 		D002CAE3218CF91D009783F2 /* WatchProjectInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = D002CAE2218CF91D009783F2 /* WatchProjectInput.swift */; };
 		D002CAE5218CF951009783F2 /* GraphMutationWatchProjectResponseEnvelope.swift in Sources */ = {isa = PBXBuildFile; fileRef = D002CAE4218CF951009783F2 /* GraphMutationWatchProjectResponseEnvelope.swift */; };
@@ -2465,6 +2465,14 @@
 			path = mutations;
 			sourceTree = "<group>";
 		};
+		777B88E322BD8E620027640F /* Recovered References */ = {
+			isa = PBXGroup;
+			children = (
+				D01587801EEB2ED6006E7684 /* CategoryTests.swift */,
+			);
+			name = "Recovered References";
+			sourceTree = "<group>";
+		};
 		7798B5292174F3BC008BC50D /* queries */ = {
 			isa = PBXGroup;
 			children = (
@@ -3041,6 +3049,7 @@
 				D01587511EEB2DE4006E7684 /* KsApi */,
 				A7C725771C85D36D005A016B /* Library */,
 				A7E06C7A1C5A6EB300EBDCC2 /* Products */,
+				777B88E322BD8E620027640F /* Recovered References */,
 			);
 			indentWidth = 2;
 			sourceTree = "<group>";
@@ -3577,7 +3586,6 @@
 				D01588251EEB2ED7006E7684 /* VoidEnvelope.swift */,
 				D01587971EEB2ED6006E7684 /* lenses */,
 				D01587EE1EEB2ED7006E7684 /* templates */,
-				D6FB2A3C1FA27D0300B0D282 /* CategoryTests.swift */,
 			);
 			path = models;
 			sourceTree = "<group>";
@@ -5228,7 +5236,6 @@
 				D0D10C101EEB4550005EBAD0 /* MessageTests.swift in Sources */,
 				D0D10C151EEB4550005EBAD0 /* ProjectStatsEnvelopeTests.swift in Sources */,
 				D0D10C221EEB4550005EBAD0 /* UserTests.swift in Sources */,
-				D002CADF218CF8B7009783F2 /* CategoryTests.swift in Sources */,
 				D0D10C171EEB4550005EBAD0 /* PushEnvelopeTests.swift in Sources */,
 				D0D10C1D1EEB4550005EBAD0 /* UpdatePledgeEnvelopeTests.swift in Sources */,
 				D0D10C0E1EEB4550005EBAD0 /* ItemTests.swift in Sources */,
@@ -5240,6 +5247,7 @@
 				D0D10C111EEB4550005EBAD0 /* MessageThreadTests.swift in Sources */,
 				D0D10C161EEB4550005EBAD0 /* ProjectTests.swift in Sources */,
 				D0D10C1A1EEB4550005EBAD0 /* SubmitApplePayEnvelopeTests.swift in Sources */,
+				777B88E522BD911F0027640F /* CategoryTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -1953,7 +1953,6 @@
 		D015877B1EEB2ED6006E7684 /* ActivityTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActivityTests.swift; sourceTree = "<group>"; };
 		D015877C1EEB2ED6006E7684 /* Backing.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Backing.swift; sourceTree = "<group>"; };
 		D015877D1EEB2ED6006E7684 /* BackingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BackingTests.swift; sourceTree = "<group>"; };
-		D01587801EEB2ED6006E7684 /* CategoryTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CategoryTests.swift; sourceTree = "<group>"; };
 		D01587811EEB2ED6006E7684 /* ChangePaymentMethodEnvelope.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChangePaymentMethodEnvelope.swift; sourceTree = "<group>"; };
 		D01587821EEB2ED6006E7684 /* ChangePaymentMethodEnvelopeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChangePaymentMethodEnvelopeTests.swift; sourceTree = "<group>"; };
 		D01587831EEB2ED6006E7684 /* CheckoutEnvelope.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CheckoutEnvelope.swift; sourceTree = "<group>"; };
@@ -2463,14 +2462,6 @@
 				D6ED1B3C216D617E007F7547 /* inputs */,
 			);
 			path = mutations;
-			sourceTree = "<group>";
-		};
-		777B88E322BD8E620027640F /* Recovered References */ = {
-			isa = PBXGroup;
-			children = (
-				D01587801EEB2ED6006E7684 /* CategoryTests.swift */,
-			);
-			name = "Recovered References";
 			sourceTree = "<group>";
 		};
 		7798B5292174F3BC008BC50D /* queries */ = {
@@ -3049,7 +3040,6 @@
 				D01587511EEB2DE4006E7684 /* KsApi */,
 				A7C725771C85D36D005A016B /* Library */,
 				A7E06C7A1C5A6EB300EBDCC2 /* Products */,
-				777B88E322BD8E620027640F /* Recovered References */,
 			);
 			indentWidth = 2;
 			sourceTree = "<group>";

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -189,7 +189,6 @@
 		77556F5720A0B41E008CEA57 /* ThanksViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77556F5520A0B408008CEA57 /* ThanksViewControllerTests.swift */; };
 		7758A8372097BADF0018B96D /* DiscoveryProjectCategoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7758A83120979BE50018B96D /* DiscoveryProjectCategoryView.swift */; };
 		7758A8382097BB090018B96D /* DiscoveryProjectCategoryView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 7758A8352097A8180018B96D /* DiscoveryProjectCategoryView.xib */; };
-		775D922922BD7CFD00442301 /* DebugData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 775D922822BD7CFD00442301 /* DebugData.swift */; };
 		776B6F70215183A400AB0652 /* ChangeEmailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 776B6F6F215183A400AB0652 /* ChangeEmailViewController.swift */; };
 		77752F5E219B39EA00E7DA7D /* SettingsAccountWarningCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77752F5D219B39EA00E7DA7D /* SettingsAccountWarningCell.swift */; };
 		77752F97219B3D7300E7DA7D /* SettingsAccountWarningCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 77752F96219B3D7300E7DA7D /* SettingsAccountWarningCell.xib */; };
@@ -222,6 +221,7 @@
 		77C5E21A214182A2002E1670 /* SettingsPrivacySwitchCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 77C5E219214182A2002E1670 /* SettingsPrivacySwitchCell.xib */; };
 		77C5E252214182CA002E1670 /* SettingsPrivacySwitchCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77C5E251214182CA002E1670 /* SettingsPrivacySwitchCell.swift */; };
 		77C7B654226E0E54001101AC /* RewardsCollectionViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77C7B653226E0E54001101AC /* RewardsCollectionViewModelTests.swift */; };
+		77C93C2522C27443005D3195 /* DebugData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 775D922822BD7CFD00442301 /* DebugData.swift */; };
 		77CD894921791B05003066DA /* ProjectStatsTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77CD894821791B05003066DA /* ProjectStatsTemplate.swift */; };
 		77CD8981217FA01B003066DA /* ProjectPamphletContentViewControllerConversionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77CD8980217FA01B003066DA /* ProjectPamphletContentViewControllerConversionTests.swift */; };
 		77D7A739214187A9003F258C /* SettingsSwitchCellType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77D7A738214187A9003F258C /* SettingsSwitchCellType.swift */; };
@@ -2860,6 +2860,7 @@
 				3706408C22A9BE8100889CBD /* DateFormatter.swift */,
 				3706408F22A9BE9400889CBD /* DateFormatterTests.swift */,
 				A7F6F0C01DC7EBF7002C118C /* DateProtocol.swift */,
+				775D922822BD7CFD00442301 /* DebugData.swift */,
 				77F6E73421222E7C005A5C55 /* EmailFrequency.swift */,
 				A7C7257F1C85D36D005A016B /* Environment.swift */,
 				A7ED1F141E830FDC00BFFA01 /* EnvironmentTests.swift */,
@@ -3501,7 +3502,6 @@
 				D79440562203A63300D0A747 /* CreatePaymentSourceEnvelope.swift */,
 				D015878A1EEB2ED6006E7684 /* CreatePledgeEnvelope.swift */,
 				D015878B1EEB2ED6006E7684 /* CreatePledgeEnvelopeTests.swift */,
-				775D922822BD7CFD00442301 /* DebugData.swift */,
 				D62B1476221216A000AC05C8 /* DeletePaymentMethodEnvelope.swift */,
 				D62B14AF2212184500AC05C8 /* DeletePaymentMethodEnvelopeTests.swift */,
 				D015878C1EEB2ED6006E7684 /* DiscoveryEnvelope.swift */,
@@ -4279,6 +4279,7 @@
 				A755115B1C8642C3005355CF /* AppEnvironment.swift in Sources */,
 				A7F441AD1D005A9400FE6FC5 /* ActivitiesViewModel.swift in Sources */,
 				A75A9DBF1D6F3A3000603D1D /* RewardShippingPickerViewModel.swift in Sources */,
+				77C93C2522C27443005D3195 /* DebugData.swift in Sources */,
 				D7A37D7A1E367E5A00EA066D /* MostPopularSearchProjectCellViewModel.swift in Sources */,
 				A73379111D0E33A600C91445 /* ButtonStyles.swift in Sources */,
 				A73378FB1D0AE33B00C91445 /* BaseStyles.swift in Sources */,
@@ -5077,7 +5078,6 @@
 				D015891F1EEB2ED7006E7684 /* ShippingRulesEnvelope.swift in Sources */,
 				D01588831EEB2ED7006E7684 /* BackingLenses.swift in Sources */,
 				D01588C51EEB2ED7006E7684 /* Reward.ShippingLenses.swift in Sources */,
-				775D922922BD7CFD00442301 /* DebugData.swift in Sources */,
 				D01588D51EEB2ED7006E7684 /* UpdateDraftLenses.swift in Sources */,
 				D01589211EEB2ED7006E7684 /* StarEnvelope.swift in Sources */,
 				D01588EF1EEB2ED7006E7684 /* MessageThread.swift in Sources */,

--- a/KsApi/models/DebugData.swift
+++ b/KsApi/models/DebugData.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public struct DebugData {
+  public let config: Config?
+
+  public init(config: Config?) {
+    self.config = config
+  }
+}

--- a/Library/AppEnvironment.swift
+++ b/Library/AppEnvironment.swift
@@ -60,12 +60,12 @@ public struct AppEnvironment: AppEnvironmentType {
   }
 
   public static func updateConfig(_ config: Config) {
-    let debugConfig = self.current.debugData?.config
+    let debugConfigOrConfig = self.current.debugData?.config ?? config
 
     self.replaceCurrentEnvironment(
-      config: debugConfig ?? config,
-      countryCode: debugConfig?.countryCode ?? config.countryCode,
-      koala: AppEnvironment.current.koala |> Koala.lens.config .~ (debugConfig ?? config)
+      config: debugConfigOrConfig,
+      countryCode: debugConfigOrConfig.countryCode,
+      koala: AppEnvironment.current.koala |> Koala.lens.config .~ debugConfigOrConfig
     )
   }
 

--- a/Library/AppEnvironment.swift
+++ b/Library/AppEnvironment.swift
@@ -45,6 +45,12 @@ public struct AppEnvironment: AppEnvironmentType {
     )
   }
 
+  public static func updateDebugData(_ debugData: DebugData) {
+    self.replaceCurrentEnvironment(
+      debugData: debugData
+    )
+  }
+
   public static func updateServerConfig(_ config: ServerConfigType) {
     let service = Service(serverConfig: config)
 
@@ -54,10 +60,12 @@ public struct AppEnvironment: AppEnvironmentType {
   }
 
   public static func updateConfig(_ config: Config) {
+    let debugConfig = self.current.debugData?.config
+
     self.replaceCurrentEnvironment(
-      config: config,
-      countryCode: config.countryCode,
-      koala: AppEnvironment.current.koala |> Koala.lens.config .~ config
+      config: debugConfig ?? config,
+      countryCode: debugConfig?.countryCode ?? config.countryCode,
+      koala: AppEnvironment.current.koala |> Koala.lens.config .~ (debugConfig ?? config)
     )
   }
 
@@ -124,6 +132,7 @@ public struct AppEnvironment: AppEnvironmentType {
     currentUser: User? = AppEnvironment.current.currentUser,
     dateType: DateProtocol.Type = AppEnvironment.current.dateType,
     debounceInterval: DispatchTimeInterval = AppEnvironment.current.debounceInterval,
+    debugData: DebugData? = AppEnvironment.current.debugData,
     device: UIDeviceType = AppEnvironment.current.device,
     isOSVersionAvailable: @escaping ((Double) -> Bool) = AppEnvironment.current.isOSVersionAvailable,
     isVoiceOverRunning: @escaping (() -> Bool) = AppEnvironment.current.isVoiceOverRunning,
@@ -152,6 +161,7 @@ public struct AppEnvironment: AppEnvironmentType {
         currentUser: currentUser,
         dateType: dateType,
         debounceInterval: debounceInterval,
+        debugData: debugData,
         device: device,
         isOSVersionAvailable: isOSVersionAvailable,
         isVoiceOverRunning: isVoiceOverRunning,
@@ -184,6 +194,7 @@ public struct AppEnvironment: AppEnvironmentType {
     currentUser: User? = AppEnvironment.current.currentUser,
     dateType: DateProtocol.Type = AppEnvironment.current.dateType,
     debounceInterval: DispatchTimeInterval = AppEnvironment.current.debounceInterval,
+    debugData: DebugData? = AppEnvironment.current.debugData,
     device: UIDeviceType = AppEnvironment.current.device,
     isOSVersionAvailable: @escaping ((Double) -> Bool) = AppEnvironment.current.isOSVersionAvailable,
     isVoiceOverRunning: @escaping (() -> Bool) = AppEnvironment.current.isVoiceOverRunning,
@@ -212,6 +223,7 @@ public struct AppEnvironment: AppEnvironmentType {
         currentUser: currentUser,
         dateType: dateType,
         debounceInterval: debounceInterval,
+        debugData: debugData,
         device: device,
         isOSVersionAvailable: isOSVersionAvailable,
         isVoiceOverRunning: isVoiceOverRunning,

--- a/Library/AppEnvironmentTests.swift
+++ b/Library/AppEnvironmentTests.swift
@@ -240,15 +240,23 @@ final class AppEnvironmentTests: XCTestCase {
 
     // Starts out as production environment
     XCTAssertEqual(AppEnvironment.current.apiService.serverConfig.environment, .production)
-    XCTAssertEqual(AppEnvironment.current.apiService.serverConfig.apiBaseUrl,
-                   ServerConfig.production.apiBaseUrl)
-    XCTAssertEqual(AppEnvironment.current.apiService.serverConfig.webBaseUrl,
-                   ServerConfig.production.webBaseUrl)
-    XCTAssertEqual(AppEnvironment.current.apiService.serverConfig.apiClientAuth.clientId,
-                   ClientAuth.production.clientId)
+    XCTAssertEqual(
+      AppEnvironment.current.apiService.serverConfig.apiBaseUrl,
+      ServerConfig.production.apiBaseUrl
+    )
+    XCTAssertEqual(
+      AppEnvironment.current.apiService.serverConfig.webBaseUrl,
+      ServerConfig.production.webBaseUrl
+    )
+    XCTAssertEqual(
+      AppEnvironment.current.apiService.serverConfig.apiClientAuth.clientId,
+      ClientAuth.production.clientId
+    )
     XCTAssertNil(AppEnvironment.current.apiService.serverConfig.basicHTTPAuth)
-    XCTAssertEqual(AppEnvironment.current.apiService.serverConfig.graphQLEndpointUrl,
-                   ServerConfig.production.graphQLEndpointUrl)
+    XCTAssertEqual(
+      AppEnvironment.current.apiService.serverConfig.graphQLEndpointUrl,
+      ServerConfig.production.graphQLEndpointUrl
+    )
 
     let serverConfig = ServerConfig.staging
 
@@ -258,14 +266,22 @@ final class AppEnvironmentTests: XCTestCase {
     XCTAssertEqual(AppEnvironment.current.apiService.serverConfig.environment, .staging)
     XCTAssertEqual(AppEnvironment.current.apiService.serverConfig.apiBaseUrl, ServerConfig.staging.apiBaseUrl)
     XCTAssertEqual(AppEnvironment.current.apiService.serverConfig.webBaseUrl, ServerConfig.staging.webBaseUrl)
-    XCTAssertEqual(AppEnvironment.current.apiService.serverConfig.apiClientAuth.clientId,
-                   ClientAuth.development.clientId)
-    XCTAssertEqual(AppEnvironment.current.apiService.serverConfig.basicHTTPAuth?.username,
-                   BasicHTTPAuth.development.username)
-    XCTAssertEqual(AppEnvironment.current.apiService.serverConfig.basicHTTPAuth?.password,
-                   BasicHTTPAuth.development.password)
-    XCTAssertEqual(AppEnvironment.current.apiService.serverConfig.graphQLEndpointUrl,
-                   ServerConfig.staging.graphQLEndpointUrl)
+    XCTAssertEqual(
+      AppEnvironment.current.apiService.serverConfig.apiClientAuth.clientId,
+      ClientAuth.development.clientId
+    )
+    XCTAssertEqual(
+      AppEnvironment.current.apiService.serverConfig.basicHTTPAuth?.username,
+      BasicHTTPAuth.development.username
+    )
+    XCTAssertEqual(
+      AppEnvironment.current.apiService.serverConfig.basicHTTPAuth?.password,
+      BasicHTTPAuth.development.password
+    )
+    XCTAssertEqual(
+      AppEnvironment.current.apiService.serverConfig.graphQLEndpointUrl,
+      ServerConfig.staging.graphQLEndpointUrl
+    )
 
     AppEnvironment.popEnvironment()
   }

--- a/Library/AppEnvironmentTests.swift
+++ b/Library/AppEnvironmentTests.swift
@@ -238,13 +238,34 @@ final class AppEnvironmentTests: XCTestCase {
   func testUpdateServerConfig() {
     AppEnvironment.pushEnvironment()
 
+    // Starts out as production environment
     XCTAssertEqual(AppEnvironment.current.apiService.serverConfig.environment, .production)
+    XCTAssertEqual(AppEnvironment.current.apiService.serverConfig.apiBaseUrl,
+                   ServerConfig.production.apiBaseUrl)
+    XCTAssertEqual(AppEnvironment.current.apiService.serverConfig.webBaseUrl,
+                   ServerConfig.production.webBaseUrl)
+    XCTAssertEqual(AppEnvironment.current.apiService.serverConfig.apiClientAuth.clientId,
+                   ClientAuth.production.clientId)
+    XCTAssertNil(AppEnvironment.current.apiService.serverConfig.basicHTTPAuth)
+    XCTAssertEqual(AppEnvironment.current.apiService.serverConfig.graphQLEndpointUrl,
+                   ServerConfig.production.graphQLEndpointUrl)
 
     let serverConfig = ServerConfig.staging
 
     AppEnvironment.updateServerConfig(serverConfig)
 
+    // Updates all properties to staging environment
     XCTAssertEqual(AppEnvironment.current.apiService.serverConfig.environment, .staging)
+    XCTAssertEqual(AppEnvironment.current.apiService.serverConfig.apiBaseUrl, ServerConfig.staging.apiBaseUrl)
+    XCTAssertEqual(AppEnvironment.current.apiService.serverConfig.webBaseUrl, ServerConfig.staging.webBaseUrl)
+    XCTAssertEqual(AppEnvironment.current.apiService.serverConfig.apiClientAuth.clientId,
+                   ClientAuth.development.clientId)
+    XCTAssertEqual(AppEnvironment.current.apiService.serverConfig.basicHTTPAuth?.username,
+                   BasicHTTPAuth.development.username)
+    XCTAssertEqual(AppEnvironment.current.apiService.serverConfig.basicHTTPAuth?.password,
+                   BasicHTTPAuth.development.password)
+    XCTAssertEqual(AppEnvironment.current.apiService.serverConfig.graphQLEndpointUrl,
+                   ServerConfig.staging.graphQLEndpointUrl)
 
     AppEnvironment.popEnvironment()
   }

--- a/Library/DebugData.swift
+++ b/Library/DebugData.swift
@@ -1,4 +1,5 @@
 import Foundation
+import KsApi
 
 public struct DebugData {
   public let config: Config?

--- a/Library/Environment.swift
+++ b/Library/Environment.swift
@@ -44,6 +44,9 @@ public struct Environment {
   /// The amount of time to debounce signals by. Default value is `0.3`.
   public let debounceInterval: DispatchTimeInterval
 
+  /// Stored data used for debugging tools
+  public let debugData: DebugData?
+
   /// The current device running the app.
   public let device: UIDeviceType
 
@@ -106,6 +109,7 @@ public struct Environment {
     currentUser: User? = nil,
     dateType: DateProtocol.Type = Date.self,
     debounceInterval: DispatchTimeInterval = .milliseconds(300),
+    debugData: DebugData? = nil,
     device: UIDeviceType = UIDevice.current,
     environmentVariables: EnvironmentVariables = EnvironmentVariables(),
     isOSVersionAvailable: @escaping (Double) -> Bool = ksr_isOSVersionAvailable,
@@ -133,6 +137,7 @@ public struct Environment {
     self.currentUser = currentUser
     self.dateType = dateType
     self.debounceInterval = debounceInterval
+    self.debugData = debugData
     self.device = device
     self.environmentVariables = environmentVariables
     self.isOSVersionAvailable = isOSVersionAvailable


### PR DESCRIPTION
# 📲 What

[This PR](https://github.com/kickstarter/ios-oss/pull/705) added support for toggling local feature flags to make it easier to test feature flagged... features 😄. One issue with that PR was that because feature flags are stored in the `Config` object, and the object is refreshed on `ApplicationWillEnterForeground`, our feature flag settings would get reset if you background the app. This could lead to a confusing debugging experience - this PR fixes that issue by "caching" the debug feature flag settings.

# 🤔 Why

See "What".

# 🛠 How

Store debug settings in `AppEnvironment` and always prefer to take the debug settings, when updating the config.

# 👀 See

Notice how backgrounding the app doesn't reset our feature flag setting:

![hMkWBSgR43](https://user-images.githubusercontent.com/3156796/60029003-52b9fb80-966e-11e9-9d92-ce7bd3765263.gif)

# ✅ Acceptance criteria

- [ ] Navigate to feature flag tools, toggle the native checkout feature flag. Navigate to a project and check that the feature is actually togged. Background the app. Navigate again to the feature flags tool and check that the flag is still toggled to whatever the previous value was. Navigate back to the project page and check that the feature is actually toggled still.
