### PR TITLE
💲[Native Checkout] Disable non-numeric, non-decimal separator input for the amount

### DIFF
--- a/Kickstarter-iOS/Views/Cells/PledgeAmountCell.swift
+++ b/Kickstarter-iOS/Views/Cells/PledgeAmountCell.swift
@@ -141,7 +141,7 @@ extension PledgeAmountCell: UITextFieldDelegate {
     _ textField: UITextField, shouldChangeCharactersIn _: NSRange, replacementString string: String
   ) -> Bool {
     let decimalSeparatorCharacters = CharacterSet.ksr_decimalSeparators()
-    let existingCharacters = CharacterSet(charactersIn: textField.text ?? String.init())
+    let existingCharacters = CharacterSet(charactersIn: textField.text ?? "")
     let inputCharacters = CharacterSet(charactersIn: string)
     let numericCharacters = CharacterSet.ksr_numericCharacters()
 

--- a/Kickstarter-iOS/Views/Cells/PledgeAmountCell.swift
+++ b/Kickstarter-iOS/Views/Cells/PledgeAmountCell.swift
@@ -38,6 +38,8 @@ final class PledgeAmountCell: UITableViewCell, ValueCell {
     _ = ([self.stepper, self.spacer, self.amountInputView], self.adaptableStackView)
       |> ksr_addArrangedSubviewsToStackView()
 
+    self.amountInputView.textField.delegate = self
+
     self.spacer.widthAnchor.constraint(greaterThanOrEqualToConstant: Styles.grid(3)).isActive = true
 
     self.stepper.addTarget(
@@ -109,6 +111,25 @@ final class PledgeAmountCell: UITableViewCell, ValueCell {
 
   @objc func stepperValueChanged(_ stepper: UIStepper) {
     self.viewModel.inputs.stepperValueChanged(stepper.value)
+  }
+}
+
+extension PledgeAmountCell: UITextFieldDelegate {
+  func textField(
+    _ textField: UITextField, shouldChangeCharactersIn _: NSRange, replacementString string: String
+  ) -> Bool {
+    let decimalSeparatorCharacters = CharacterSet.ksr_decimalSeparators()
+    let existingCharacters = CharacterSet(charactersIn: textField.text ?? String.init())
+    let inputCharacters = CharacterSet(charactersIn: string)
+    let numericCharacters = CharacterSet.ksr_numericCharacters()
+
+    if numericCharacters.isSuperset(of: inputCharacters) {
+      return true
+    } else if decimalSeparatorCharacters.isSuperset(of: inputCharacters) {
+      return !decimalSeparatorCharacters.isSubset(of: existingCharacters)
+    } else {
+      return false
+    }
   }
 }
 

--- a/Kickstarter-iOS/Views/Cells/PledgeAmountCell.swift
+++ b/Kickstarter-iOS/Views/Cells/PledgeAmountCell.swift
@@ -141,7 +141,7 @@ extension PledgeAmountCell: UITextFieldDelegate {
     _ textField: UITextField, shouldChangeCharactersIn _: NSRange, replacementString string: String
   ) -> Bool {
     let decimalSeparatorCharacters = CharacterSet.ksr_decimalSeparators()
-    let existingCharacters = CharacterSet(charactersIn: textField.text ?? "")
+    let existingCharacters = CharacterSet(charactersIn: textField.text.coalesceWith(""))
     let inputCharacters = CharacterSet(charactersIn: string)
     let numericCharacters = CharacterSet.ksr_numericCharacters()
 

--- a/Kickstarter-iOS/Views/Cells/PledgeAmountCell.swift
+++ b/Kickstarter-iOS/Views/Cells/PledgeAmountCell.swift
@@ -101,7 +101,7 @@ final class PledgeAmountCell: UITableViewCell, ValueCell {
     self.amountInputView.doneButton.rac.enabled = self.viewModel.outputs.doneButtonIsEnabled
     self.amountInputView.label.rac.text = self.viewModel.outputs.currency
     self.amountInputView.textField.rac.isFirstResponder = self.viewModel.outputs.textFieldIsFirstResponder
-    self.amountInputView.textField.rac.text = self.viewModel.outputs.amount
+    self.amountInputView.textField.rac.text = self.viewModel.outputs.textFieldValue
     self.stepper.rac.maximumValue = self.viewModel.outputs.stepperMaxValue
     self.stepper.rac.minimumValue = self.viewModel.outputs.stepperMinValue
     self.stepper.rac.value = self.viewModel.outputs.stepperValue
@@ -152,6 +152,10 @@ extension PledgeAmountCell: UITextFieldDelegate {
     } else {
       return false
     }
+  }
+
+  func textFieldDidEndEditing(_ textField: UITextField, reason _: UITextField.DidEndEditingReason) {
+    self.viewModel.inputs.textFieldDidEndEditing(textField.text)
   }
 }
 

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -94,6 +94,8 @@
 		373AB25B222A063500769FC2 /* CreatePasswordViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 373AB25A222A063500769FC2 /* CreatePasswordViewModelTests.swift */; };
 		373AB25D222A0D8900769FC2 /* PasswordValidation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 373AB25C222A0D8900769FC2 /* PasswordValidation.swift */; };
 		373AB25F222A0DAC00769FC2 /* PasswordValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 373AB25E222A0DAC00769FC2 /* PasswordValidationTests.swift */; };
+		374CB94F22C17D4E00B84219 /* CharacterSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 374CB94E22C17D4E00B84219 /* CharacterSet.swift */; };
+		374CB95122C17D6700B84219 /* CharacterSetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 374CB95022C17D6700B84219 /* CharacterSetTests.swift */; };
 		374F507922614A1000DE6746 /* PledgeFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 374F507822614A1000DE6746 /* PledgeFooterView.swift */; };
 		3757D0CE228E51F800241AE6 /* UIFont.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3757D0CD228E51F800241AE6 /* UIFont.swift */; };
 		3757D107228E521600241AE6 /* UIFontTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3757D106228E521600241AE6 /* UIFontTests.swift */; };
@@ -1361,6 +1363,8 @@
 		373AB25A222A063500769FC2 /* CreatePasswordViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreatePasswordViewModelTests.swift; sourceTree = "<group>"; };
 		373AB25C222A0D8900769FC2 /* PasswordValidation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordValidation.swift; sourceTree = "<group>"; };
 		373AB25E222A0DAC00769FC2 /* PasswordValidationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordValidationTests.swift; sourceTree = "<group>"; };
+		374CB94E22C17D4E00B84219 /* CharacterSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CharacterSet.swift; sourceTree = "<group>"; };
+		374CB95022C17D6700B84219 /* CharacterSetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CharacterSetTests.swift; sourceTree = "<group>"; };
 		374F507822614A1000DE6746 /* PledgeFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PledgeFooterView.swift; sourceTree = "<group>"; };
 		3757D0CD228E51F800241AE6 /* UIFont.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIFont.swift; sourceTree = "<group>"; };
 		3757D106228E521600241AE6 /* UIFontTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIFontTests.swift; sourceTree = "<group>"; };
@@ -2853,6 +2857,8 @@
 				A7ED1F121E830FDC00BFFA01 /* AppEnvironmentTests.swift */,
 				D764373F22414FA900DAFC9E /* AppEnvironmentType.swift */,
 				A7C725791C85D36D005A016B /* AssetImageGeneratorType.swift */,
+				374CB94E22C17D4E00B84219 /* CharacterSet.swift */,
+				374CB95022C17D6700B84219 /* CharacterSetTests.swift */,
 				9DBF80DE1D666CAC007F2843 /* CheckoutModels.swift */,
 				A7FC8C051C8F1DEA00C3B49B /* CircleAvatarImageView.swift */,
 				A7ED1F131E830FDC00BFFA01 /* CircleAvatarImageViewTests.swift */,
@@ -4436,6 +4442,7 @@
 				598D96BA1D426FD8003F3F66 /* ActivitySampleBackingCellViewModel.swift in Sources */,
 				59E877381DC9419700BCD1F7 /* Newsletter.swift in Sources */,
 				D6B6F9C020F403F400A295F7 /* UserAttribute.swift in Sources */,
+				374CB94F22C17D4E00B84219 /* CharacterSet.swift in Sources */,
 				A755116C1C8642C3005355CF /* UIPress-Extensions.swift in Sources */,
 				D798A6AE21656D970053D097 /* Currency.swift in Sources */,
 				77F6E73521222E7C005A5C55 /* EmailFrequency.swift in Sources */,
@@ -4568,6 +4575,7 @@
 				D7237096211A1593001EA4CA /* SettingsFollowCellViewModelTests.swift in Sources */,
 				A7ED1FCF1E831C5C00BFFA01 /* CheckoutRacingViewModelTests.swift in Sources */,
 				37D99C5B22247F58008EF839 /* NSBundleType+Tests.swift in Sources */,
+				374CB95122C17D6700B84219 /* CharacterSetTests.swift in Sources */,
 				A7ED1FC51E831C5C00BFFA01 /* CommentsEmptyStateCellViewModelTests.swift in Sources */,
 				A7ED1F391E830FDC00BFFA01 /* UILabel+IBClearTests.swift in Sources */,
 				3706408422A8A68600889CBD /* PledgeAmountCellViewModelTests.swift in Sources */,

--- a/Library/CharacterSet.swift
+++ b/Library/CharacterSet.swift
@@ -2,10 +2,7 @@ import Foundation
 
 public extension CharacterSet {
   static func ksr_decimalSeparators() -> CharacterSet {
-    if let decimalSeparator = AppEnvironment.current.locale.decimalSeparator {
-      return CharacterSet(charactersIn: decimalSeparator)
-    }
-    return CharacterSet()
+    return CharacterSet(charactersIn: AppEnvironment.current.locale.decimalSeparator ?? "")
   }
 
   static func ksr_numericCharacters() -> CharacterSet {

--- a/Library/CharacterSet.swift
+++ b/Library/CharacterSet.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+public extension CharacterSet {
+  static func ksr_decimalSeparators() -> CharacterSet {
+    if let decimalSeparator = AppEnvironment.current.locale.decimalSeparator {
+      return CharacterSet(charactersIn: decimalSeparator)
+    }
+    return CharacterSet()
+  }
+
+  static func ksr_numericCharacters() -> CharacterSet {
+    return CharacterSet.decimalDigits
+  }
+}

--- a/Library/CharacterSetTests.swift
+++ b/Library/CharacterSetTests.swift
@@ -1,0 +1,39 @@
+@testable import Library
+import XCTest
+
+final class CharacterSetTests: TestCase {
+  func testDecimalSeparators() {
+    withEnvironment(locale: Locale(identifier: "en")) {
+      XCTAssertTrue(CharacterSet.ksr_decimalSeparators().contains("."))
+    }
+
+    withEnvironment(locale: Locale(identifier: "es")) {
+      XCTAssertTrue(CharacterSet.ksr_decimalSeparators().contains(","))
+    }
+
+    withEnvironment(locale: Locale(identifier: "fr")) {
+      XCTAssertTrue(CharacterSet.ksr_decimalSeparators().contains(","))
+    }
+
+    withEnvironment(locale: Locale(identifier: "de")) {
+      XCTAssertTrue(CharacterSet.ksr_decimalSeparators().contains(","))
+    }
+
+    withEnvironment(locale: Locale(identifier: "ja")) {
+      XCTAssertTrue(CharacterSet.ksr_decimalSeparators().contains("."))
+    }
+  }
+
+  func testNumericCharacters() {
+    XCTAssertTrue(CharacterSet.ksr_numericCharacters().contains("0"))
+    XCTAssertTrue(CharacterSet.ksr_numericCharacters().contains("1"))
+    XCTAssertTrue(CharacterSet.ksr_numericCharacters().contains("2"))
+    XCTAssertTrue(CharacterSet.ksr_numericCharacters().contains("3"))
+    XCTAssertTrue(CharacterSet.ksr_numericCharacters().contains("4"))
+    XCTAssertTrue(CharacterSet.ksr_numericCharacters().contains("5"))
+    XCTAssertTrue(CharacterSet.ksr_numericCharacters().contains("6"))
+    XCTAssertTrue(CharacterSet.ksr_numericCharacters().contains("7"))
+    XCTAssertTrue(CharacterSet.ksr_numericCharacters().contains("8"))
+    XCTAssertTrue(CharacterSet.ksr_numericCharacters().contains("9"))
+  }
+}

--- a/Library/ViewModels/PledgeAmountCellViewModel.swift
+++ b/Library/ViewModels/PledgeAmountCellViewModel.swift
@@ -8,11 +8,11 @@ public protocol PledgeAmountCellViewModelInputs {
   func configureWith(project: Project, reward: Reward)
   func doneButtonTapped()
   func stepperValueChanged(_ value: Double)
+  func textFieldDidEndEditing(_ value: String?)
   func textFieldValueChanged(_ value: String?)
 }
 
 public protocol PledgeAmountCellViewModelOutputs {
-  var amount: Signal<String, Never> { get }
   var currency: Signal<String, Never> { get }
   var doneButtonIsEnabled: Signal<Bool, Never> { get }
   var generateSelectionFeedback: Signal<Void, Never> { get }
@@ -21,6 +21,7 @@ public protocol PledgeAmountCellViewModelOutputs {
   var stepperMinValue: Signal<Double, Never> { get }
   var stepperValue: Signal<Double, Never> { get }
   var textFieldIsFirstResponder: Signal<Bool, Never> { get }
+  var textFieldValue: Signal<String, Never> { get }
 }
 
 public protocol PledgeAmountCellViewModelType {
@@ -39,22 +40,31 @@ public final class PledgeAmountCellViewModel: PledgeAmountCellViewModelType,
       .skipNil()
       .map(second)
 
+    let minAndMax = Signal.combineLatest(project, reward)
+      .map { _ in (10.0, 20.0) }
+
     let initialValue = Signal.combineLatest(project, reward)
       .map { _ in 15.0 }
 
+    let clampedTextFieldValue = Signal.combineLatest(
+      minAndMax.signal,
+      self.textFieldDidEndEditingProperty.signal
+        .skipNil()
+    )
+    .map(unpack)
+    .map(clampedValue)
+
     let stepperValue = Signal.merge(
       initialValue,
+      clampedTextFieldValue,
       self.stepperValueProperty.signal
     )
 
-    self.amount = stepperValue
+    self.textFieldValue = stepperValue
       .map { String(format: "%.0f", $0) }
 
     self.currency = project
       .map { currencySymbol(forCountry: $0.country).trimmed() }
-
-    let minAndMax = Signal.combineLatest(project, reward)
-      .map { _ in (10.0, 20.0) }
 
     self.stepperMinValue = minAndMax.signal
       .map(first)
@@ -94,9 +104,9 @@ public final class PledgeAmountCellViewModel: PledgeAmountCellViewModelType,
     let clampedStepperValue = Signal.combineLatest(
       self.stepperMinValue,
       self.stepperMaxValue,
-      textFieldValue.signal
+      self.textFieldValueProperty.signal.skipNil()
     )
-    .map { minValue, maxValue, value in min(max(minValue, value), maxValue) }
+    .map(clampedValue)
 
     self.stepperValue = Signal.merge(
       initialValue,
@@ -122,12 +132,16 @@ public final class PledgeAmountCellViewModel: PledgeAmountCellViewModelType,
     self.stepperValueProperty.value = value
   }
 
+  private let textFieldDidEndEditingProperty = MutableProperty<String?>(nil)
+  public func textFieldDidEndEditing(_ value: String?) {
+    self.textFieldDidEndEditingProperty.value = value
+  }
+
   private let textFieldValueProperty = MutableProperty<String?>(nil)
   public func textFieldValueChanged(_ value: String?) {
     self.textFieldValueProperty.value = value
   }
 
-  public let amount: Signal<String, Never>
   public let currency: Signal<String, Never>
   public let doneButtonIsEnabled: Signal<Bool, Never>
   public let generateSelectionFeedback: Signal<Void, Never>
@@ -136,7 +150,19 @@ public final class PledgeAmountCellViewModel: PledgeAmountCellViewModelType,
   public let stepperMinValue: Signal<Double, Never>
   public let stepperValue: Signal<Double, Never>
   public let textFieldIsFirstResponder: Signal<Bool, Never>
+  public let textFieldValue: Signal<String, Never>
 
   public var inputs: PledgeAmountCellViewModelInputs { return self }
   public var outputs: PledgeAmountCellViewModelOutputs { return self }
+}
+
+// MARK: - Functions
+
+private func clampedValue(_ min: Double, max: Double, value: String) -> Double {
+  switch (min, max, value) {
+  case let (min, _, v) where v.isEmpty: return min
+  case let (min, _, v as NSString) where v.doubleValue < min: return min
+  case let (_, max, v as NSString) where v.doubleValue > max: return max
+  case let (_, _, v as NSString): return v.doubleValue
+  }
 }

--- a/Library/ViewModels/PledgeAmountCellViewModelTests.swift
+++ b/Library/ViewModels/PledgeAmountCellViewModelTests.swift
@@ -203,6 +203,24 @@ internal final class PledgeAmountCellViewModelTests: TestCase {
     self.textFieldIsFirstResponder.assertValue(false)
   }
 
+  func testNilInputReturnsZero() {
+    self.vm.inputs.configureWith(project: .template, reward: .template)
+
+    self.amountPrimitive.assertValue(15)
+
+    self.vm.inputs.textFieldValueChanged("11")
+    self.amountPrimitive.assertValues([15, 11])
+
+    self.vm.inputs.textFieldValueChanged("")
+    self.amountPrimitive.assertValues([15, 11, 0])
+
+    self.vm.inputs.textFieldValueChanged("5")
+    self.amountPrimitive.assertValues([15, 11, 0, 5])
+
+    self.vm.inputs.textFieldValueChanged(nil)
+    self.amountPrimitive.assertValues([15, 11, 0, 5, 0])
+  }
+
   func testTextFieldDidEndEditing() {
     self.vm.inputs.configureWith(project: .template, reward: .template)
     self.amountPrimitive.assertValues([15])
@@ -231,6 +249,5 @@ internal final class PledgeAmountCellViewModelTests: TestCase {
     self.vm.inputs.textFieldDidEndEditing("")
     self.amountPrimitive.assertValues([15, 16, 20, 10, 17, 10])
     self.textFieldValue.assertValues(["15", "16", "20", "10", "17", "10"])
-
   }
 }

--- a/Library/ViewModels/PledgeAmountCellViewModelTests.swift
+++ b/Library/ViewModels/PledgeAmountCellViewModelTests.swift
@@ -7,7 +7,6 @@ import XCTest
 internal final class PledgeAmountCellViewModelTests: TestCase {
   private let vm: PledgeAmountCellViewModelType = PledgeAmountCellViewModel()
 
-  private let amount = TestObserver<String, Never>()
   private let currency = TestObserver<String, Never>()
   private let doneButtonIsEnabled = TestObserver<Bool, Never>()
   private let generateSelectionFeedback = TestObserver<Void, Never>()
@@ -16,11 +15,11 @@ internal final class PledgeAmountCellViewModelTests: TestCase {
   private let stepperMaxValue = TestObserver<Double, Never>()
   private let stepperValue = TestObserver<Double, Never>()
   private let textFieldIsFirstResponder = TestObserver<Bool, Never>()
+  private let textFieldValue = TestObserver<String, Never>()
 
   override func setUp() {
     super.setUp()
 
-    self.vm.outputs.amount.observe(self.amount.observer)
     self.vm.outputs.currency.observe(self.currency.observer)
     self.vm.outputs.doneButtonIsEnabled.observe(self.doneButtonIsEnabled.observer)
     self.vm.outputs.generateSelectionFeedback.observe(self.generateSelectionFeedback.observer)
@@ -31,12 +30,13 @@ internal final class PledgeAmountCellViewModelTests: TestCase {
     self.vm.outputs.stepperMinValue.observe(self.stepperMinValue.observer)
     self.vm.outputs.stepperMaxValue.observe(self.stepperMaxValue.observer)
     self.vm.outputs.textFieldIsFirstResponder.observe(self.textFieldIsFirstResponder.observer)
+    self.vm.outputs.textFieldValue.observe(self.textFieldValue.observer)
   }
 
-  func testAmountAndCurrency() {
+  func testTextFieldValueAndCurrency() {
     self.vm.inputs.configureWith(project: .template, reward: .template)
 
-    self.amount.assertValues(["15"])
+    self.textFieldValue.assertValues(["15"])
     self.currency.assertValues(["$"])
   }
 
@@ -186,5 +186,25 @@ internal final class PledgeAmountCellViewModelTests: TestCase {
     self.vm.inputs.doneButtonTapped()
 
     self.textFieldIsFirstResponder.assertValue(false)
+  }
+
+  func testTextFieldDidEndEditing() {
+    self.vm.inputs.configureWith(project: .template, reward: .template)
+    self.textFieldValue.assertValues(["15"])
+
+    self.vm.inputs.textFieldDidEndEditing(nil)
+    self.textFieldValue.assertValues(["15"])
+
+    self.vm.inputs.textFieldDidEndEditing("16")
+    self.textFieldValue.assertValues(["15", "16"])
+
+    self.vm.inputs.textFieldDidEndEditing("25")
+    self.textFieldValue.assertValues(["15", "16", "20"])
+
+    self.vm.inputs.textFieldDidEndEditing("8")
+    self.textFieldValue.assertValues(["15", "16", "20", "10"])
+
+    self.vm.inputs.textFieldDidEndEditing("")
+    self.textFieldValue.assertValues(["15", "16", "20", "10", "10"])
   }
 }


### PR DESCRIPTION
# 📲 What

Exactly what the title says

# 🤔 Why

We don't want users on iPads or with hardware keyboards to being able to input anything other than digits and decimal separator (localized)

# 🛠 How

Simply comparing input string to whether it's a numeric or decimal separator (based on `Locale`) and only allowing text field to proceed or not if it validates properly.

# ✅ Acceptance criteria

On iPad (with SW or HW keyboard connected) or on iPhone with HW keyboard connected (i.e. SIM) try the following input

- [ ] Entering any digit (`0123456789`) works
- [ ] Entering decimal number separator (i.e. `.` for `us` local or `,` for `jp` locale) works
- [ ] Entering multiple decimal number separators does not work
- [ ] Entering anything else does not work
- [ ] Dismissing the keyboard (by tapping anywhere on the screen) will keep the value untouched if it's within the `min`/`max` range (so currently `10-20`)
- [ ] Dismissing the keyboard (by tapping anywhere on the screen) while `text field` input is empty will set the value to `min` and dismiss keyboard
- [ ] Dismissing the keyboard (by tapping anywhere on the screen) while `text field` input is value 
smaller than 10 will set the text field value to `10` and dismiss keyboard
- [ ] Dismissing the keyboard (by tapping anywhere on the screen) while `text field` input is value greater than 20 will set the text field value to `20` and dismiss keyboard