### PR TITLE
💲[Native Checkout] Re-enable the CTA button action

### DIFF
--- a/Kickstarter-iOS/Views/Controllers/ProjectPamphletViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/ProjectPamphletViewController.swift
@@ -93,6 +93,10 @@ public final class ProjectPamphletViewController: UIViewController {
     _ = (self.pledgeCTAContainerView, self.view)
       |> ksr_addSubviewToParent()
 
+    self.pledgeCTAContainerView.pledgeCTAButton.addTarget(
+      self, action: #selector(ProjectPamphletViewController.backThisProjectTapped), for: .touchUpInside
+    )
+
     // Configure constraints
     let pledgeCTAContainerViewConstraints = [
       self.pledgeCTAContainerView.leftAnchor.constraint(equalTo: self.view.leftAnchor),
@@ -189,7 +193,9 @@ public final class ProjectPamphletViewController: UIViewController {
   }
 
   private func updateContentInsets() {
-    let buttonSize = self.pledgeCTAButton.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize)
+    let buttonSize = self.pledgeCTAContainerView.pledgeCTAButton.systemLayoutSizeFitting(
+      UIView.layoutFittingCompressedSize
+    )
     let bottomInset = buttonSize.height + 2 * self.pledgeCTAContainerViewMargins
 
     self.contentController.additionalSafeAreaInsets = UIEdgeInsets(bottom: bottomInset)

--- a/Kickstarter-iOS/Views/Controllers/ProjectPamphletViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/ProjectPamphletViewController.swift
@@ -29,11 +29,6 @@ public final class ProjectPamphletViewController: UIViewController {
     PledgeCTAContainerView(frame: .zero) |> \.translatesAutoresizingMaskIntoConstraints .~ false
   }()
 
-  private let pledgeCTAButton: UIButton = {
-    MultiLineButton(type: .custom)
-      |> \.translatesAutoresizingMaskIntoConstraints .~ false
-  }()
-
   public static func configuredWith(
     projectOrParam: Either<Project, Param>,
     refTag: RefTag?

--- a/Kickstarter-iOS/Views/PledgeCTAContainerView.swift
+++ b/Kickstarter-iOS/Views/PledgeCTAContainerView.swift
@@ -14,7 +14,7 @@ final class PledgeCTAContainerView: UIView {
   }()
 
   private lazy var amountOrRewardLabel: UILabel = { UILabel(frame: .zero) }()
-  private lazy var pledgeCTAButton: UIButton = {
+  private(set) lazy var pledgeCTAButton: UIButton = {
     MultiLineButton(type: .custom)
       |> \.translatesAutoresizingMaskIntoConstraints .~ false
   }()


### PR DESCRIPTION
# 📲 What

Seems like we've mistakenly removed action from the CTA button so this PR re-adds it in order for us to navigate to the checkout workflow.

# 🛠 How

Please note this also cleans up (removes) now unused property that was previously left out.

# ✅ Acceptance criteria

- [ ] Tapping the `CTA` button in any state navigates to `Reward screen` as it previously used to