### PR TITLE
💲[Native Checkout] Reward->Pledge Transition Plumbing

### DIFF
--- a/Kickstarter-iOS/Views/Controllers/CheckoutNavigationController.swift
+++ b/Kickstarter-iOS/Views/Controllers/CheckoutNavigationController.swift
@@ -1,6 +1,8 @@
 import UIKit
 
 final class CheckoutNavigationController: UINavigationController {
+  // MARK: - Lifecycle
+  
   override func viewDidLoad() {
     super.viewDidLoad()
     self.delegate = self

--- a/Kickstarter-iOS/Views/Controllers/CheckoutNavigationController.swift
+++ b/Kickstarter-iOS/Views/Controllers/CheckoutNavigationController.swift
@@ -1,0 +1,26 @@
+import UIKit
+
+final class CheckoutNavigationController: UINavigationController {
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    self.delegate = self
+  }
+}
+
+extension CheckoutNavigationController: UINavigationControllerDelegate {
+  func navigationController(
+    _: UINavigationController,
+    animationControllerFor operation: UINavigationController.Operation,
+    from fromVC: UIViewController,
+    to toVC: UIViewController
+  ) -> UIViewControllerAnimatedTransitioning? {
+    switch (operation, fromVC, toVC) {
+    case (.push, is RewardPledgeTransitionAnimatorDelegate, is PledgeViewController):
+      return RewardPledgePushTransitionAnimator()
+    case (.pop, is PledgeViewController, is RewardPledgeTransitionAnimatorDelegate):
+      return RewardPledgePopTransitionAnimator()
+    default:
+      return nil
+    }
+  }
+}

--- a/Kickstarter-iOS/Views/Controllers/CheckoutNavigationController.swift
+++ b/Kickstarter-iOS/Views/Controllers/CheckoutNavigationController.swift
@@ -5,6 +5,7 @@ final class CheckoutNavigationController: UINavigationController {
   
   override func viewDidLoad() {
     super.viewDidLoad()
+
     self.delegate = self
   }
 }

--- a/Kickstarter-iOS/Views/Controllers/CheckoutNavigationController.swift
+++ b/Kickstarter-iOS/Views/Controllers/CheckoutNavigationController.swift
@@ -2,7 +2,7 @@ import UIKit
 
 final class CheckoutNavigationController: UINavigationController {
   // MARK: - Lifecycle
-  
+
   override func viewDidLoad() {
     super.viewDidLoad()
 

--- a/Kickstarter-iOS/Views/Controllers/PledgeViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/PledgeViewController.swift
@@ -35,3 +35,7 @@ final class PledgeViewController: UIViewController {
     }
   }
 }
+
+// MARK: - RewardPledgeTransitionAnimatorDelegate
+
+extension PledgeViewController: RewardPledgeTransitionAnimatorDelegate {}

--- a/Kickstarter-iOS/Views/Controllers/ProjectNavigatorViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/ProjectNavigatorViewController.swift
@@ -186,7 +186,7 @@ extension ProjectNavigatorViewController: ProjectPamphletViewControllerDelegate 
   ) {
     let rewardsViewController = RewardsCollectionViewController.instantiate(with: project, refTag: refTag)
 
-    let navigationController = UINavigationController(rootViewController: rewardsViewController)
+    let navigationController = CheckoutNavigationController(rootViewController: rewardsViewController)
       |> \.modalPresentationStyle .~ .formSheet
 
     self.present(navigationController, animated: true)

--- a/Kickstarter-iOS/Views/Controllers/RewardsCollectionViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/RewardsCollectionViewController.swift
@@ -266,11 +266,17 @@ extension RewardsCollectionViewController: UICollectionViewDelegateFlowLayout {
   }
 }
 
+// MARK: - RewardCellDelegate
+
 extension RewardsCollectionViewController: RewardCellDelegate {
   func rewardCellDidTapPledgeButton(_: RewardCell, rewardId: Int) {
     self.viewModel.inputs.rewardSelected(with: rewardId)
   }
 }
+
+// MARK: - RewardPledgeTransitionAnimatorDelegate
+
+extension RewardsCollectionViewController: RewardPledgeTransitionAnimatorDelegate {}
 
 // MARK: Styles
 

--- a/Kickstarter-iOS/Views/Transitions/RewardPledgePopTransitionAnimator.swift
+++ b/Kickstarter-iOS/Views/Transitions/RewardPledgePopTransitionAnimator.swift
@@ -1,0 +1,16 @@
+import UIKit
+
+public class RewardPledgePopTransitionAnimator: NSObject, UIViewControllerAnimatedTransitioning {
+  public func transitionDuration(
+    using _: UIViewControllerContextTransitioning?
+  ) -> TimeInterval {
+    return 0.3
+  }
+
+  public func animateTransition(using transitionContext: UIViewControllerContextTransitioning) {
+    guard let toView = transitionContext.view(forKey: .to) else { return }
+
+    transitionContext.containerView.addSubview(toView)
+    transitionContext.completeTransition(!transitionContext.transitionWasCancelled)
+  }
+}

--- a/Kickstarter-iOS/Views/Transitions/RewardPledgePopTransitionAnimator.swift
+++ b/Kickstarter-iOS/Views/Transitions/RewardPledgePopTransitionAnimator.swift
@@ -1,9 +1,7 @@
 import UIKit
 
 public class RewardPledgePopTransitionAnimator: NSObject, UIViewControllerAnimatedTransitioning {
-  public func transitionDuration(
-    using _: UIViewControllerContextTransitioning?
-  ) -> TimeInterval {
+  public func transitionDuration(using _: UIViewControllerContextTransitioning?) -> TimeInterval {
     return 0.3
   }
 

--- a/Kickstarter-iOS/Views/Transitions/RewardPledgePushTransitionAnimator.swift
+++ b/Kickstarter-iOS/Views/Transitions/RewardPledgePushTransitionAnimator.swift
@@ -3,9 +3,7 @@ import UIKit
 public protocol RewardPledgeTransitionAnimatorDelegate: AnyObject {}
 
 public class RewardPledgePushTransitionAnimator: NSObject, UIViewControllerAnimatedTransitioning {
-  public func transitionDuration(
-    using _: UIViewControllerContextTransitioning?
-  ) -> TimeInterval {
+  public func transitionDuration(using _: UIViewControllerContextTransitioning?) -> TimeInterval {
     return 0.3
   }
 

--- a/Kickstarter-iOS/Views/Transitions/RewardPledgePushTransitionAnimator.swift
+++ b/Kickstarter-iOS/Views/Transitions/RewardPledgePushTransitionAnimator.swift
@@ -1,0 +1,18 @@
+import UIKit
+
+public protocol RewardPledgeTransitionAnimatorDelegate: AnyObject {}
+
+public class RewardPledgePushTransitionAnimator: NSObject, UIViewControllerAnimatedTransitioning {
+  public func transitionDuration(
+    using _: UIViewControllerContextTransitioning?
+  ) -> TimeInterval {
+    return 0.3
+  }
+
+  public func animateTransition(using transitionContext: UIViewControllerContextTransitioning) {
+    guard let toView = transitionContext.view(forKey: .to) else { return }
+
+    transitionContext.containerView.addSubview(toView)
+    transitionContext.completeTransition(!transitionContext.transitionWasCancelled)
+  }
+}

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -873,6 +873,9 @@
 		D05DFC4D227A5842006F3B68 /* TestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7ED1F461E831BA200BFFA01 /* TestCase.swift */; };
 		D05DFC4E227A5861006F3B68 /* MockBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7ED1F451E831BA200BFFA01 /* MockBundle.swift */; };
 		D05DFC4F227A5878006F3B68 /* MockPushRegistration.swift in Sources */ = {isa = PBXBuildFile; fileRef = D093B4B721A8B0E000910962 /* MockPushRegistration.swift */; };
+		D06FCC6922CC0A10003363DC /* CheckoutNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D06FCC6822CC0A10003363DC /* CheckoutNavigationController.swift */; };
+		D06FCC6B22CC0B05003363DC /* RewardPledgePushTransitionAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D06FCC6A22CC0B05003363DC /* RewardPledgePushTransitionAnimator.swift */; };
+		D06FCC6D22CC0B1E003363DC /* RewardPledgePopTransitionAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D06FCC6C22CC0B1E003363DC /* RewardPledgePopTransitionAnimator.swift */; };
 		D0851010219500F200BC418B /* PaymentSourceDeleteMutation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D085100F219500F200BC418B /* PaymentSourceDeleteMutation.swift */; };
 		D08510122195015F00BC418B /* PaymentSourceDeleteInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = D08510112195015F00BC418B /* PaymentSourceDeleteInput.swift */; };
 		D08C68A822AF104B001ED5E8 /* FBSDKLoginKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D08C68A722AF104B001ED5E8 /* FBSDKLoginKit.framework */; };
@@ -1096,8 +1099,6 @@
 		D7774466217A345D008D679F /* UpdateUserProfileMutation .swift in Sources */ = {isa = PBXBuildFile; fileRef = D77743E2217A2D67008D679F /* UpdateUserProfileMutation .swift */; };
 		D78E038E229305E90043E92F /* PledgeStateCTAType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D78E0355229305E20043E92F /* PledgeStateCTAType.swift */; };
 		D78E039022930DF80043E92F /* PledgeCTAContainerViewViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D78E038F22930DF80043E92F /* PledgeCTAContainerViewViewModelTests.swift */; };
-		D78E4E482188CB4300E99295 /* UIButton+HapticFeedback.swift in Sources */ = {isa = PBXBuildFile; fileRef = D78E4E472188CB4300E99295 /* UIButton+HapticFeedback.swift */; };
-		D78E4EE3218909DC00E99295 /* UIFeedbackGenerator+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D78E4EE2218909DC00E99295 /* UIFeedbackGenerator+Extensions.swift */; };
 		D79440572203A63300D0A747 /* CreatePaymentSourceEnvelope.swift in Sources */ = {isa = PBXBuildFile; fileRef = D79440562203A63300D0A747 /* CreatePaymentSourceEnvelope.swift */; };
 		D79440902208970E00D0A747 /* CreatePaymentSourceTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D794408F2208970E00D0A747 /* CreatePaymentSourceTemplate.swift */; };
 		D796867C20FE655300E54C61 /* SettingsFollowCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D796867B20FE655300E54C61 /* SettingsFollowCellViewModel.swift */; };
@@ -2166,6 +2167,9 @@
 		D05DFC41227A578B006F3B68 /* KickstarterUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = KickstarterUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D05DFC43227A578C006F3B68 /* KickstarterUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KickstarterUITests.swift; sourceTree = "<group>"; };
 		D05DFC45227A578C006F3B68 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		D06FCC6822CC0A10003363DC /* CheckoutNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckoutNavigationController.swift; sourceTree = "<group>"; };
+		D06FCC6A22CC0B05003363DC /* RewardPledgePushTransitionAnimator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RewardPledgePushTransitionAnimator.swift; sourceTree = "<group>"; };
+		D06FCC6C22CC0B1E003363DC /* RewardPledgePopTransitionAnimator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RewardPledgePopTransitionAnimator.swift; sourceTree = "<group>"; };
 		D085100F219500F200BC418B /* PaymentSourceDeleteMutation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentSourceDeleteMutation.swift; sourceTree = "<group>"; };
 		D08510112195015F00BC418B /* PaymentSourceDeleteInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentSourceDeleteInput.swift; sourceTree = "<group>"; };
 		D08C68A722AF104B001ED5E8 /* FBSDKLoginKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = FBSDKLoginKit.framework; path = Carthage/Build/iOS/FBSDKLoginKit.framework; sourceTree = "<group>"; };
@@ -2314,8 +2318,6 @@
 		D777442E217A3382008D679F /* ChangeCurrencyInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeCurrencyInput.swift; sourceTree = "<group>"; };
 		D78E0355229305E20043E92F /* PledgeStateCTAType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PledgeStateCTAType.swift; sourceTree = "<group>"; };
 		D78E038F22930DF80043E92F /* PledgeCTAContainerViewViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PledgeCTAContainerViewViewModelTests.swift; sourceTree = "<group>"; };
-		D78E4E472188CB4300E99295 /* UIButton+HapticFeedback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIButton+HapticFeedback.swift"; sourceTree = "<group>"; };
-		D78E4EE2218909DC00E99295 /* UIFeedbackGenerator+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFeedbackGenerator+Extensions.swift"; sourceTree = "<group>"; };
 		D79076F8207BC161008014EC /* CrossDissolveTransitionAnimator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrossDissolveTransitionAnimator.swift; sourceTree = "<group>"; };
 		D79440562203A63300D0A747 /* CreatePaymentSourceEnvelope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreatePaymentSourceEnvelope.swift; sourceTree = "<group>"; };
 		D794408F2208970E00D0A747 /* CreatePaymentSourceTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreatePaymentSourceTemplate.swift; sourceTree = "<group>"; };
@@ -2705,7 +2707,6 @@
 				77FD60A022735AED0084B84C /* PledgeContinueCell.swift */,
 				D79A054A225E9B6B004BC6A8 /* PledgeDescriptionCell.swift */,
 				D6D4425C22C276DF0070C3AF /* PledgePaymentMethodsCell.swift */,
-				37DEC22D2257CDD50051EF9B /* PledgeRowCell.swift */,
 				37059842226F79A700BDA6E3 /* PledgeShippingLocationCell.swift */,
 				D0237C1422BC2B640092C792 /* PledgeSummaryCell.swift */,
 				A7FA38A31D9068940041FC9C /* PledgeTitleCell.swift */,
@@ -2762,6 +2763,7 @@
 				D6B6871721923BA6005F5DA7 /* ChangeEmailViewControllerTests.swift */,
 				7754A0AD215A8361003AA36D /* ChangePasswordViewController.swift */,
 				77941D2D216FCB0100398B89 /* ChangePasswordViewControllerTests.swift */,
+				D06FCC6822CC0A10003363DC /* CheckoutNavigationController.swift */,
 				A7A0534C1CD19C68005AF5E2 /* CommentDialogViewController.swift */,
 				A7180BA81CCED598001711CA /* CommentsViewController.swift */,
 				A7ED20341E8323E900BFFA01 /* CommentsViewControllerTests.swift */,
@@ -2842,11 +2844,11 @@
 				D6B4F0012107B3D00079159D /* SettingsNewslettersViewControllerTests.swift */,
 				D6AD9A7F20EA720F0015A18B /* SettingsNotificationsViewController.swift */,
 				D6B6F91720EE955B00A295F7 /* SettingsNotificationsViewControllerTests.swift */,
-				771E3C622289DBA8003E7CF1 /* SheetOverlayViewController.swift */,
 				D703FC6820F7E2EC004A272D /* SettingsPrivacyViewController.swift */,
 				D72370932119139D001EA4CA /* SettingsPrivacyViewControllerTests.swift */,
 				77216D9720F3D2E40061BE82 /* SettingsViewController.swift */,
 				D6E7DAFB22089F9800689BD6 /* SettingsViewControllerTests.swift */,
+				771E3C622289DBA8003E7CF1 /* SheetOverlayViewController.swift */,
 				A749001D1D00E27100BC3BE7 /* SignupViewController.swift */,
 				A7ED203D1E8323E900BFFA01 /* SignupViewControllerTests.swift */,
 				A72C3AA51D00F7A30075227E /* SortPagerViewController.swift */,
@@ -3054,8 +3056,10 @@
 		A7D8B67F1DCCD4B9009BF854 /* Transitions */ = {
 			isa = PBXGroup;
 			children = (
-				A7D8B6B51DCCD4DE009BF854 /* ProjectNavigatorTransitionAnimator.swift */,
 				D79076F8207BC161008014EC /* CrossDissolveTransitionAnimator.swift */,
+				A7D8B6B51DCCD4DE009BF854 /* ProjectNavigatorTransitionAnimator.swift */,
+				D06FCC6C22CC0B1E003363DC /* RewardPledgePopTransitionAnimator.swift */,
+				D06FCC6A22CC0B05003363DC /* RewardPledgePushTransitionAnimator.swift */,
 				778CCC5122822B5D00FB8D35 /* SheetOverlayTransitionAnimator.swift */,
 			);
 			path = Transitions;
@@ -4770,6 +4774,7 @@
 				015102AD1F1947C50006C0FC /* MessageThreadsDataSource.swift in Sources */,
 				379CFFFF2242DAF900F6F0C2 /* UIImageView+URL.swift in Sources */,
 				59AE35E21D67643100A310E6 /* DiscoveryPostcardCell.swift in Sources */,
+				D06FCC6D22CC0B1E003363DC /* RewardPledgePopTransitionAnimator.swift in Sources */,
 				A7FA38A41D9068940041FC9C /* PledgeTitleCell.swift in Sources */,
 				37096C3422BC24DD003D1F40 /* UIFeedbackGeneratorType.swift in Sources */,
 				59B0DFC51D11AC850081D2DC /* DashboardDataSource.swift in Sources */,
@@ -4889,6 +4894,7 @@
 				770DF32A2106210900A6D0F1 /* SettingsNotificationsDataSource.swift in Sources */,
 				018F1F841C8E182200643DAA /* LoginViewController.swift in Sources */,
 				77752F5E219B39EA00E7DA7D /* SettingsAccountWarningCell.swift in Sources */,
+				D06FCC6922CC0A10003363DC /* CheckoutNavigationController.swift in Sources */,
 				3780C8622208F8C8002117D1 /* SettingsTextInputCell.swift in Sources */,
 				597073A01D07277100B00444 /* ProjectNotificationsDataSource.swift in Sources */,
 				A757E9EF1D19C37F00A5C978 /* ActivitySurveyResponseCell.swift in Sources */,
@@ -4899,6 +4905,7 @@
 				D6508F6C2049C83C002DCC01 /* UIStackView+BackgroundColor.swift in Sources */,
 				A745D1411CAAB48F00C12802 /* LoginToutViewController.swift in Sources */,
 				77EFBAE52268E01400DA5C3C /* RewardCell.swift in Sources */,
+				D06FCC6B22CC0B05003363DC /* RewardPledgePushTransitionAnimator.swift in Sources */,
 				77FD8B46216D6245000A95AC /* LoadingBarButtonItemView.swift in Sources */,
 				9D14FF8E1D133351005F4ABB /* ProjectActivityEmptyStateCell.swift in Sources */,
 				37DEC22A2257CD9F0051EF9B /* PledgeDataSource.swift in Sources */,


### PR DESCRIPTION
# 📲 What

The initial plumbing for the transition from `RewardCollectionViewController` to `PledgeViewController`.

# 🤔 Why

Decided to break this up into its own PR to make reviewing easier.

# 🛠 How

- Added `CheckoutNavigationController` which will be the `UINavigationController` subclass for Checkout and can be extended to perform additional animations if necessary.
- Added `RewardPledgePushTransitionAnimator` and `RewardPledgePopTransitionAnimator`. I believe it makes sense to split these into their own animators but am open to refactoring down the line.

This approach is largely inspired by this great series of blog posts: https://devsign.co/notes/navigation-transitions-iii

**Note:** Currently there are no animations and to prove that the correct code paths are being called the push and pop animations will complete instantly.

# ✅ Acceptance criteria

- [ ] Tapping on a reward causes it to appear immediately (no animation).
- [ ] Tapping back on the navigation bar causes it to pop immediately (no animation).