### PR TITLE
Revert 1Password button hiding logic

### DIFF
--- a/Library/SharedFunctions.swift
+++ b/Library/SharedFunctions.swift
@@ -152,11 +152,8 @@ public func countdownProducer(to date: Date)
 }
 
 internal func is1PasswordButtonHidden(_ isHidden: Bool) -> Bool {
-  if AppEnvironment.current.is1PasswordSupported() {
-    return true
-  } else {
-    return isHidden
-  }
+  guard AppEnvironment.current.is1PasswordSupported() else { return true }
+  return isHidden
 }
 
 public func ksr_is1PasswordSupported() -> Bool {

--- a/Library/SharedFunctionsTests.swift
+++ b/Library/SharedFunctionsTests.swift
@@ -164,12 +164,12 @@ final class SharedFunctionsTests: TestCase {
   func testOnePasswordButtonIsHidden() {
     withEnvironment(is1PasswordSupported: { true }) {
       XCTAssertTrue(is1PasswordButtonHidden(true))
-      XCTAssertTrue(is1PasswordButtonHidden(false))
+      XCTAssertFalse(is1PasswordButtonHidden(false))
     }
 
     withEnvironment(is1PasswordSupported: { false }) {
       XCTAssertTrue(is1PasswordButtonHidden(true))
-      XCTAssertFalse(is1PasswordButtonHidden(false))
+      XCTAssertTrue(is1PasswordButtonHidden(false))
     }
   }
 

--- a/Library/ViewModels/ChangeEmailViewModelTests.swift
+++ b/Library/ViewModels/ChangeEmailViewModelTests.swift
@@ -114,7 +114,7 @@ final class ChangeEmailViewModelTests: TestCase {
   func testOnePasswordButtonHidesProperly_OnIOS11AndEarlier() {
     self.vm.inputs.viewDidLoad()
 
-    withEnvironment(is1PasswordSupported: { false }) {
+    withEnvironment(is1PasswordSupported: { true }) {
       self.vm.inputs.onePassword(isAvailable: true)
 
       self.onePasswordButtonIsHidden.assertValues([false])
@@ -128,7 +128,7 @@ final class ChangeEmailViewModelTests: TestCase {
   func testOnePasswordButtonHidesProperly_OnIOS12AndLater() {
     self.vm.inputs.viewDidLoad()
 
-    withEnvironment(is1PasswordSupported: { true }) {
+    withEnvironment(is1PasswordSupported: { false }) {
       self.vm.inputs.onePassword(isAvailable: true)
 
       self.onePasswordButtonIsHidden.assertValues([true])

--- a/Library/ViewModels/ChangePasswordViewModelTests.swift
+++ b/Library/ViewModels/ChangePasswordViewModelTests.swift
@@ -94,7 +94,7 @@ final class ChangePasswordViewModelTests: TestCase {
   }
 
   func testOnePasswordButtonHidesProperly_OnIOS11AndEarlier() {
-    withEnvironment(is1PasswordSupported: { false }) {
+    withEnvironment(is1PasswordSupported: { true }) {
       self.vm.inputs.onePassword(isAvailable: true)
 
       self.onePasswordButtonIsHidden.assertValues([false])
@@ -106,7 +106,7 @@ final class ChangePasswordViewModelTests: TestCase {
   }
 
   func testOnePasswordButtonHidesProperly_OnIOS12AndLater() {
-    withEnvironment(is1PasswordSupported: { true }) {
+    withEnvironment(is1PasswordSupported: { false }) {
       self.vm.inputs.onePassword(isAvailable: true)
 
       self.onePasswordButtonIsHidden.assertValues([true])
@@ -120,7 +120,7 @@ final class ChangePasswordViewModelTests: TestCase {
   func testOnePasswordAutofill() {
     let mockService = MockService(serverConfig: ServerConfig.local)
 
-    withEnvironment(apiService: mockService, is1PasswordSupported: { false }) {
+    withEnvironment(apiService: mockService, is1PasswordSupported: { true }) {
       self.vm.inputs.onePassword(isAvailable: true)
       self.vm.inputs.viewDidAppear()
 

--- a/Library/ViewModels/LoginViewModelTests.swift
+++ b/Library/ViewModels/LoginViewModelTests.swift
@@ -214,7 +214,7 @@ final class LoginViewModelTests: TestCase {
   }
 
   func testOnePasswordButtonHidesProperly_OnIOS11AndEarlier() {
-    withEnvironment(is1PasswordSupported: { false }) {
+    withEnvironment(is1PasswordSupported: { true }) {
       self.vm.inputs.onePassword(isAvailable: true)
 
       self.onePasswordButtonIsHidden.assertValues([false])
@@ -226,7 +226,7 @@ final class LoginViewModelTests: TestCase {
   }
 
   func testOnePasswordButtonHidesProperly_OnIOS12AndLater() {
-    withEnvironment(is1PasswordSupported: { true }) {
+    withEnvironment(is1PasswordSupported: { false }) {
       self.vm.inputs.onePassword(isAvailable: true)
 
       self.onePasswordButtonIsHidden.assertValues([true])
@@ -238,7 +238,7 @@ final class LoginViewModelTests: TestCase {
   }
 
   func testOnePasswordFlow() {
-    withEnvironment(is1PasswordSupported: { false }) {
+    withEnvironment(is1PasswordSupported: { true }) {
       self.vm.inputs.viewWillAppear()
       self.vm.inputs.onePassword(isAvailable: true)
 


### PR DESCRIPTION
# 📲 What

Last week, we've done some refactoring and broke `1Password` extension functionality in progress. This PR should revert that to the fixed state.

# 🤔 Why

We've introduced semantic changes to our APIs in #731 from `ksr_isOSVersionAvailable` to `ksr_is1PasswordSupported`. We used this API to decide whether to show or hide `1Password` button on screens that provide credentials input. The semantical changes were unfortunately not identical and resulted in negated output 🤦‍♂ So in order for us to properly hide/show the `1Password` button we had to fix the call site.

(Remember, we only want to show `1Password` button on iOS 11 devices with `1Password` app installed)

**Example**

What previously was this
```swift
if ksr_isOSVersionAvailable(12) { /* hides the button */ }
else { /* shows the button depending on whether there is 1Password app installed or not */ }
```

has to now be this
```swift
if ksr_is1PasswordSupported() { /* shows the button depending on whether there is 1Password app installed or not */ }
else { /* hides the button */ }
```

# ✅ Acceptance criteria

On iOS 12 device with `1Password.app` installed

- [x] `1Password` button does `NOT` show on `Login screen`
- [x] `1Password` button does `NOT` show on `Change email screen` (Settings > Account > Change email)
- [x] `1Password` button does `NOT` show on `Change password screen` (Settings > Account > Change password)

On iOS 12 device without `1Password.app` installed

- [x] `1Password` button does `NOT` show on `Login screen`
- [x] `1Password` button does `NOT` show on `Change email screen` (Settings > Account > Change email)
- [x] `1Password` button does `NOT` show on `Change password screen` (Settings > Account > Change password)

On iOS 11 device without `1Password.app` installed

- [ ] `1Password` button does `NOT` show on `Login screen`
- [ ] `1Password` button does `NOT` show on `Change email screen` (Settings > Account > Change email)
- [ ] `1Password` button does `NOT` show on `Change password screen` (Settings > Account > Change password)

On iOS 11 device with `1Password.app` installed

- [ ] `1Password` button `DOES` show on `Login screen`
- [ ] `1Password` button `DOES` show on `Change email screen` (Settings > Account > Change email)
- [ ] `1Password` button `DOES` show on `Change password screen` (Settings > Account > Change password)
- [ ] `1Password` extension works on the above screens as an input mechanism for username / password credentials