### PR TITLE
👩‍🔬 [Investment Day] - Project detail - modal presentation

### DIFF
--- a/Kickstarter-iOS/Views/Controllers/ProjectPamphletViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/ProjectPamphletViewController.swift
@@ -28,10 +28,6 @@ public final class ProjectPamphletViewController: UIViewController {
     return vc
   }
 
-  public override var prefersStatusBarHidden: Bool {
-    return UIApplication.shared.statusBarOrientation.isLandscape
-  }
-
   public override func viewDidLoad() {
     super.viewDidLoad()
 

--- a/Kickstarter-iOS/Views/Storyboards/ProjectPamphlet.storyboard
+++ b/Kickstarter-iOS/Views/Storyboards/ProjectPamphlet.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="GbK-FV-Iaj">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="GbK-FV-Iaj">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -37,11 +37,11 @@
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
-                            <constraint firstItem="Bfz-Sg-Kdb" firstAttribute="trailing" secondItem="bdk-Xa-fm9" secondAttribute="trailing" id="3Dg-lk-oRa"/>
+                            <constraint firstAttribute="trailing" secondItem="bdk-Xa-fm9" secondAttribute="trailing" id="3Dg-lk-oRa"/>
                             <constraint firstAttribute="bottom" secondItem="tIm-aj-d8Q" secondAttribute="bottom" id="8FY-Rt-Ar2"/>
                             <constraint firstItem="tIm-aj-d8Q" firstAttribute="leading" secondItem="Bfz-Sg-Kdb" secondAttribute="leading" id="HU6-02-QPk"/>
                             <constraint firstItem="tIm-aj-d8Q" firstAttribute="top" secondItem="bdk-Xa-fm9" secondAttribute="top" constant="52" id="Hk5-fJ-068"/>
-                            <constraint firstItem="bdk-Xa-fm9" firstAttribute="leading" secondItem="Bfz-Sg-Kdb" secondAttribute="leading" id="eEt-q9-Snv"/>
+                            <constraint firstItem="bdk-Xa-fm9" firstAttribute="leading" secondItem="Y4L-8W-arN" secondAttribute="leading" id="eEt-q9-Snv"/>
                             <constraint firstItem="Bfz-Sg-Kdb" firstAttribute="trailing" secondItem="tIm-aj-d8Q" secondAttribute="trailing" id="qTt-pv-zBK"/>
                             <constraint firstItem="bdk-Xa-fm9" firstAttribute="top" secondItem="Y4L-8W-arN" secondAttribute="top" id="qnD-sd-f2N"/>
                         </constraints>
@@ -130,8 +130,8 @@
                             <constraint firstItem="826-Wi-ToO" firstAttribute="bottom" secondItem="9W6-oq-vUw" secondAttribute="bottom" id="0um-l2-woZ"/>
                             <constraint firstItem="9W6-oq-vUw" firstAttribute="top" secondItem="826-Wi-ToO" secondAttribute="top" id="6w6-Ed-Vk7"/>
                             <constraint firstItem="826-Wi-ToO" firstAttribute="trailing" secondItem="jxM-Ay-art" secondAttribute="trailing" id="KQT-o1-UDj"/>
-                            <constraint firstItem="9W6-oq-vUw" firstAttribute="leading" secondItem="826-Wi-ToO" secondAttribute="leading" id="N1c-Da-BYS"/>
-                            <constraint firstItem="826-Wi-ToO" firstAttribute="trailing" secondItem="9W6-oq-vUw" secondAttribute="trailing" id="OVE-At-q1s"/>
+                            <constraint firstItem="9W6-oq-vUw" firstAttribute="leading" secondItem="ed4-VA-c6v" secondAttribute="leading" id="N1c-Da-BYS"/>
+                            <constraint firstAttribute="trailing" secondItem="9W6-oq-vUw" secondAttribute="trailing" id="OVE-At-q1s"/>
                             <constraint firstItem="jxM-Ay-art" firstAttribute="leading" secondItem="826-Wi-ToO" secondAttribute="leading" id="PFE-sj-SVP"/>
                             <constraint firstItem="jxM-Ay-art" firstAttribute="top" secondItem="ed4-VA-c6v" secondAttribute="top" constant="3" id="p5j-Im-MUi"/>
                         </constraints>

--- a/Library/ViewModels/ProjectPamphletViewModel.swift
+++ b/Library/ViewModels/ProjectPamphletViewModel.swift
@@ -25,9 +25,6 @@ public protocol ProjectPamphletViewModelOutputs {
   /// Emits a project that should be used to configure all children view controllers.
   var configureChildViewControllersWithProject: Signal<(Project, RefTag?), Never> { get }
 
-  /// Return this value from the view's `prefersStatusBarHidden` method.
-  var prefersStatusBarHidden: Bool { get }
-
   /// Emits two booleans that determine if the navigation bar should be hidden, and if it should be animated.
   var setNavigationBarHiddenAnimated: Signal<(Bool, Bool), Never> { get }
 
@@ -61,8 +58,6 @@ public final class ProjectPamphletViewModel: ProjectPamphletViewModelType, Proje
 
     self.configureChildViewControllersWithProject = freshProjectAndRefTag
       .map { project, refTag in (project, refTag) }
-
-    self.prefersStatusBarHiddenProperty <~ self.viewWillAppearAnimated.signal.mapConst(true)
 
     self.setNeedsStatusBarAppearanceUpdate = Signal.merge(
       self.viewWillAppearAnimated.signal.ignoreValues(),
@@ -138,10 +133,6 @@ public final class ProjectPamphletViewModel: ProjectPamphletViewModelType, Proje
   }
 
   public let configureChildViewControllersWithProject: Signal<(Project, RefTag?), Never>
-  fileprivate let prefersStatusBarHiddenProperty = MutableProperty(false)
-  public var prefersStatusBarHidden: Bool {
-    return self.prefersStatusBarHiddenProperty.value
-  }
 
   public let setNavigationBarHiddenAnimated: Signal<(Bool, Bool), Never>
   public let setNeedsStatusBarAppearanceUpdate: Signal<(), Never>

--- a/Library/ViewModels/ProjectPamphletViewModelTests.swift
+++ b/Library/ViewModels/ProjectPamphletViewModelTests.swift
@@ -81,20 +81,6 @@ final class ProjectPamphletViewModelTests: TestCase {
     self.configureChildViewControllersWithRefTag.assertValues([nil, nil])
   }
 
-  func testStatusBar() {
-    self.vm.inputs.configureWith(projectOrParam: .left(.template), refTag: nil)
-    self.vm.inputs.viewDidLoad()
-
-    self.setNeedsStatusBarAppearanceUpdate.assertValueCount(0)
-    XCTAssertFalse(self.vm.outputs.prefersStatusBarHidden)
-
-    self.vm.inputs.viewWillAppear(animated: true)
-    self.vm.inputs.viewDidAppear(animated: true)
-
-    self.setNeedsStatusBarAppearanceUpdate.assertValueCount(1)
-    XCTAssertTrue(self.vm.outputs.prefersStatusBarHidden)
-  }
-
   func testNavigationBar() {
     self.vm.inputs.configureWith(projectOrParam: .left(.template), refTag: nil)
     self.vm.inputs.viewDidLoad()


### PR DESCRIPTION
# 📲 What

Fixes the jaggy animation when showing project screen modally.

# 🤔 Why

Hiding the status bar in landscape mode on iPad causes the modal presentation to cause a weird jump. This happens because we're hiding the status bar in landscape even though it's the default thing on iPhone.

# 👀 See

Trello, screenshots, external resources?

| Before 🐛 | After 🦋 |
| --- | --- |
| <img width="535" alt="Screen Shot 2019-07-12 at 9 34 38 PM" src="https://user-images.githubusercontent.com/387596/61167244-e86bdc80-a4f0-11e9-8ce4-18945ba60ce0.png"> | <img width="535" alt="Screen Shot 2019-07-12 at 9 55 07 PM" src="https://user-images.githubusercontent.com/387596/61167251-f7528f00-a4f0-11e9-8306-cf46001432cf.png"> |
| (there should be no change) | (there should be no change) |
| <img width="535" alt="Screen Shot 2019-07-12 at 9 34 45 PM" src="https://user-images.githubusercontent.com/387596/61167265-28cb5a80-a4f1-11e9-8d86-cb819ad64ac7.png"> | <img width="535" alt="Screen Shot 2019-07-12 at 9 55 10 PM" src="https://user-images.githubusercontent.com/387596/61167273-397bd080-a4f1-11e9-87d7-f01714dd62cb.png"> |
| (there should be no change) | (there should be no change) |
| <img width="950" alt="Screen Shot 2019-07-12 at 9 34 59 PM" src="https://user-images.githubusercontent.com/387596/61167301-b018ce00-a4f1-11e9-83e1-26762a4fd773.png"> |<img width="950" alt="Screen Shot 2019-07-12 at 9 55 15 PM" src="https://user-images.githubusercontent.com/387596/61167303-b9099f80-a4f1-11e9-935f-ac85ec7e9da1.png"> |
| (there should be no change) | (there should be no change) |
| <img width="950" alt="Screen Shot 2019-07-12 at 9 55 22 PM" src="https://user-images.githubusercontent.com/387596/61167314-e5252080-a4f1-11e9-88dc-3fb8b8fc7e69.png"> | <img width="950" alt="Screen Shot 2019-07-12 at 9 35 20 PM" src="https://user-images.githubusercontent.com/387596/61167311-db9bb880-a4f1-11e9-9ddb-1b9957dce874.png"> |
| the shadow cuts off | the shadow goes edge to edge |
| <img width="544" alt="Screen Shot 2019-07-12 at 9 38 06 PM" src="https://user-images.githubusercontent.com/387596/61167334-26b5cb80-a4f2-11e9-8e43-317908f58ae3.png"> | <img width="544" alt="Screen Shot 2019-07-12 at 9 53 08 PM" src="https://user-images.githubusercontent.com/387596/61167337-333a2400-a4f2-11e9-809c-42b9919b80eb.png"> |
| (there should be no change) | (there should be no change) |
| <img width="544" alt="Screen Shot 2019-07-12 at 9 38 11 PM" src="https://user-images.githubusercontent.com/387596/61167341-451bc700-a4f2-11e9-8be2-098c7beee088.png"> | <img width="544" alt="Screen Shot 2019-07-12 at 9 53 16 PM" src="https://user-images.githubusercontent.com/387596/61167343-51a01f80-a4f2-11e9-9a2b-4aeea4e32c08.png"> |
| (there should be no change) | (there should be no change) |
| <img width="950" alt="Screen Shot 2019-07-12 at 9 38 41 PM" src="https://user-images.githubusercontent.com/387596/61167350-70061b00-a4f2-11e9-9c98-cad159ecf950.png"> | <img width="950" alt="Screen Shot 2019-07-12 at 9 54 17 PM" src="https://user-images.githubusercontent.com/387596/61167353-78f6ec80-a4f2-11e9-8cb2-f5a338306551.png"> |
| (there should be no change) | (there should be no change) |
| <img width="950" alt="Screen Shot 2019-07-12 at 9 38 48 PM" src="https://user-images.githubusercontent.com/387596/61167354-81e7be00-a4f2-11e9-86d3-c145f8c6bbeb.png"> | <img width="950" alt="Screen Shot 2019-07-12 at 9 54 24 PM" src="https://user-images.githubusercontent.com/387596/61167357-8c09bc80-a4f2-11e9-8102-eb5391400efb.png"> |
| (there should be no change) | (there should be no change) |
| <img width="725" alt="Screen Shot 2019-07-12 at 9 40 09 PM" src="https://user-images.githubusercontent.com/387596/61167362-a5ab0400-a4f2-11e9-92b1-483ac8bfec84.png"> | <img width="725" alt="Screen Shot 2019-07-12 at 9 56 38 PM" src="https://user-images.githubusercontent.com/387596/61167364-afcd0280-a4f2-11e9-9106-97d94334692a.png"> |
| (there should be no change) | (there should be no change) |
| <img width="959" alt="Screen Shot 2019-07-12 at 9 40 21 PM" src="https://user-images.githubusercontent.com/387596/61167367-bd828800-a4f2-11e9-9d63-c2148fd9135d.png"> | <img width="959" alt="Screen Shot 2019-07-12 at 9 57 12 PM" src="https://user-images.githubusercontent.com/387596/61167369-c7a48680-a4f2-11e9-9854-0d3142bb8eab.png"> |
| (hides status bar) | (does not hide the status bar) |

| Before | After |
| --- | --- |
| ![status-bar-bug-480](https://user-images.githubusercontent.com/387596/61167403-7ea10200-a4f3-11e9-824b-9de878dab6fa.gif) | ![status-bar-fixed-480](https://user-images.githubusercontent.com/387596/61167407-83fe4c80-a4f3-11e9-8d7a-e80e890222b3.gif) |
| (jumps the navigation bar) | (fixed) |

# ✅ Acceptance criteria

- [ ] Modal presentation works as previously
- [ ] Modal presentation doesn't affect any push / modal from the project page