### PR TITLE
💲[Native Checkout] Activity Indicator for the Pledge View

### DIFF
--- a/Kickstarter-iOS/Views/Controllers/ProjectPamphletViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/ProjectPamphletViewController.swift
@@ -157,8 +157,8 @@ public final class ProjectPamphletViewController: UIViewController {
 
     self.viewModel.outputs.configurePledgeCTAView
       .observeForUI()
-      .observeValues { [weak self] project in
-        self?.pledgeCTAContainerView.configureWith(project: project)
+      .observeValues { [weak self] value in
+        self?.pledgeCTAContainerView.configureWith(value: value)
       }
   }
 

--- a/Kickstarter-iOS/Views/PledgeCTAContainerView.swift
+++ b/Kickstarter-iOS/Views/PledgeCTAContainerView.swift
@@ -108,6 +108,16 @@ final class PledgeCTAContainerView: UIView {
         self?.pledgeCTAButton.setTitleColor(textColor, for: .normal)
       }
 
+    self.viewModel.outputs.rootStackViewAnimateIsHidden
+      .observeValues { [weak self] isHidden in
+        let duration = isHidden ? 0.0 : 0.3
+        let alpha: CGFloat = isHidden ? 0.0 : 1.0
+        UIView.animate(withDuration: duration, animations: {
+          _ = self?.rootStackView
+            ?|> \.alpha .~ alpha
+        })
+    }
+
     self.activityIndicator.rac.animating = self.viewModel.outputs.activityIndicatorIsAnimating
     self.titleAndSubtitleStackView.rac.hidden = self.viewModel.outputs.stackViewIsHidden
     self.titleLabel.rac.text = self.viewModel.outputs.titleText

--- a/Kickstarter-iOS/Views/PledgeCTAContainerView.swift
+++ b/Kickstarter-iOS/Views/PledgeCTAContainerView.swift
@@ -93,7 +93,8 @@ final class PledgeCTAContainerView: UIView {
       |> \.numberOfLines .~ 0
 
     _ = self.activityIndicator
-      |> \.color .~ UIColor.ksr_grey_500
+      |> \.color .~ UIColor.ksr_dark_grey_500
+      |> \.hidesWhenStopped .~ true
   }
 
   // MARK: - View model
@@ -118,7 +119,7 @@ final class PledgeCTAContainerView: UIView {
 
   // MARK: - Configuration
 
-  func configureWith(value: (project: Project?, isLoading: Bool)) {
+  func configureWith(value: (project: Project, isLoading: Bool)) {
     self.viewModel.inputs.configureWith(value: value)
   }
 

--- a/Kickstarter-iOS/Views/PledgeCTAContainerView.swift
+++ b/Kickstarter-iOS/Views/PledgeCTAContainerView.swift
@@ -8,6 +8,10 @@ private enum Layout {
     static let minHeight: CGFloat = 48.0
     static let minWidth: CGFloat = 98.0
   }
+
+  enum ActivityIndicator {
+    static let height: CGFloat = 30
+  }
 }
 
 final class PledgeCTAContainerView: UIView {
@@ -116,13 +120,6 @@ final class PledgeCTAContainerView: UIView {
         })
       }
 
-    self.viewModel.outputs.activityIndicatorIsAnimating
-      .observeValues { isAnimating in
-        let announcementMessage = isAnimating ? "Loading project state" : "Loading project state complete"
-
-        UIAccessibility.post(notification: .announcement, argument: announcementMessage)
-      }
-
     self.activityIndicator.rac.animating = self.viewModel.outputs.activityIndicatorIsAnimating
     self.titleAndSubtitleStackView.rac.hidden = self.viewModel.outputs.stackViewIsHidden
     self.titleLabel.rac.text = self.viewModel.outputs.titleText
@@ -147,7 +144,6 @@ final class PledgeCTAContainerView: UIView {
 
     _ = (self.activityIndicator, self)
       |> ksr_addSubviewToParent()
-      |> ksr_constrainViewToCenterInParent()
 
     _ = ([self.titleLabel, self.subtitleLabel], self.titleAndSubtitleStackView)
       |> ksr_addArrangedSubviewsToStackView()
@@ -158,8 +154,10 @@ final class PledgeCTAContainerView: UIView {
 
   private func setupConstraints() {
     NSLayoutConstraint.activate([
-      self.activityIndicator.heightAnchor.constraint(equalToConstant: 30),
-      self.activityIndicator.widthAnchor.constraint(equalToConstant: 30),
+      self.activityIndicator.heightAnchor.constraint(equalToConstant: Layout.ActivityIndicator.height),
+      self.activityIndicator.widthAnchor.constraint(equalTo: self.activityIndicator.heightAnchor),
+      self.activityIndicator.centerXAnchor.constraint(equalTo: self.layoutMarginsGuide.centerXAnchor),
+      self.activityIndicator.centerYAnchor.constraint(equalTo: self.layoutMarginsGuide.centerYAnchor),
       self.pledgeCTAButton.heightAnchor.constraint(greaterThanOrEqualToConstant: Layout.Button.minHeight),
       self.pledgeCTAButton.widthAnchor.constraint(greaterThanOrEqualToConstant: Layout.Button.minWidth),
       self.rootStackView.topAnchor.constraint(equalTo: self.layoutMarginsGuide.topAnchor)

--- a/Kickstarter-iOS/Views/PledgeCTAContainerView.swift
+++ b/Kickstarter-iOS/Views/PledgeCTAContainerView.swift
@@ -116,7 +116,7 @@ final class PledgeCTAContainerView: UIView {
           _ = self?.rootStackView
             ?|> \.alpha .~ alpha
         })
-    }
+      }
 
     self.activityIndicator.rac.animating = self.viewModel.outputs.activityIndicatorIsAnimating
     self.titleAndSubtitleStackView.rac.hidden = self.viewModel.outputs.stackViewIsHidden
@@ -134,6 +134,7 @@ final class PledgeCTAContainerView: UIView {
   }
 
   // MARK: Functions
+
   private func configureSubviews() {
     _ = (self.rootStackView, self)
       |> ksr_addSubviewToParent()
@@ -148,7 +149,6 @@ final class PledgeCTAContainerView: UIView {
 
     _ = ([self.titleAndSubtitleStackView, self.spacer, self.pledgeCTAButton], self.rootStackView)
       |> ksr_addArrangedSubviewsToStackView()
-
   }
 
   private func setupConstraints() {
@@ -158,7 +158,7 @@ final class PledgeCTAContainerView: UIView {
       self.pledgeCTAButton.heightAnchor.constraint(greaterThanOrEqualToConstant: Layout.Button.minHeight),
       self.pledgeCTAButton.widthAnchor.constraint(greaterThanOrEqualToConstant: Layout.Button.minWidth),
       self.rootStackView.topAnchor.constraint(equalTo: self.layoutMarginsGuide.topAnchor)
-      ])
+    ])
   }
 }
 

--- a/Kickstarter-iOS/Views/PledgeCTAContainerView.swift
+++ b/Kickstarter-iOS/Views/PledgeCTAContainerView.swift
@@ -110,7 +110,7 @@ final class PledgeCTAContainerView: UIView {
 
     self.viewModel.outputs.rootStackViewAnimateIsHidden
       .observeValues { [weak self] isHidden in
-        let duration = isHidden ? 0.0 : 0.3
+        let duration = isHidden ? 0.0 : 0.18
         let alpha: CGFloat = isHidden ? 0.0 : 1.0
         UIView.animate(withDuration: duration, animations: {
           _ = self?.rootStackView

--- a/Kickstarter-iOS/Views/PledgeCTAContainerView.swift
+++ b/Kickstarter-iOS/Views/PledgeCTAContainerView.swift
@@ -13,7 +13,10 @@ private enum Layout {
 final class PledgeCTAContainerView: UIView {
   // MARK: - Properties
 
-  private let vm: PledgeCTAContainerViewViewModelType = PledgeCTAContainerViewViewModel()
+  private lazy var activityIndicator: UIActivityIndicatorView = {
+    UIActivityIndicatorView(frame: .zero)
+      |> \.translatesAutoresizingMaskIntoConstraints .~ false
+  }()
 
   private lazy var titleAndSubtitleStackView: UIStackView = {
     UIStackView(frame: .zero)
@@ -22,7 +25,7 @@ final class PledgeCTAContainerView: UIView {
 
   private lazy var subtitleLabel: UILabel = { UILabel(frame: .zero) }()
   private(set) lazy var pledgeCTAButton: UIButton = {
-    MultiLineButton(type: .custom)
+    UIButton(type: .custom)
       |> \.translatesAutoresizingMaskIntoConstraints .~ false
   }()
 
@@ -38,28 +41,18 @@ final class PledgeCTAContainerView: UIView {
 
   private lazy var titleLabel: UILabel = { UILabel(frame: .zero) }()
 
+  private let viewModel: PledgeCTAContainerViewViewModelType = PledgeCTAContainerViewViewModel()
+
   // MARK: - Lifecycle
 
   override init(frame: CGRect) {
     super.init(frame: frame)
 
-    _ = (self.rootStackView, self)
-      |> ksr_addSubviewToParent()
-      |> ksr_constrainViewToEdgesInParent()
-
-    _ = ([self.titleLabel, self.subtitleLabel], self.titleAndSubtitleStackView)
-      |> ksr_addArrangedSubviewsToStackView()
-
-    _ = ([self.titleAndSubtitleStackView, self.spacer, self.pledgeCTAButton], self.rootStackView)
-      |> ksr_addArrangedSubviewsToStackView()
-
-    NSLayoutConstraint.activate([
-      self.pledgeCTAButton.heightAnchor.constraint(greaterThanOrEqualToConstant: Layout.Button.minHeight),
-      self.pledgeCTAButton.widthAnchor.constraint(greaterThanOrEqualToConstant: Layout.Button.minWidth),
-      self.rootStackView.topAnchor.constraint(equalTo: self.layoutMarginsGuide.topAnchor)
-    ])
-
+    self.configureSubviews()
+    self.setupConstraints()
     self.bindViewModel()
+
+    self.activityIndicator.startAnimating()
   }
 
   required init?(coder _: NSCoder) {
@@ -98,6 +91,9 @@ final class PledgeCTAContainerView: UIView {
       |> \.font .~ UIFont.ksr_caption1().bolded
       |> \.textColor .~ UIColor.ksr_dark_grey_500
       |> \.numberOfLines .~ 0
+
+    _ = self.activityIndicator
+      |> \.color .~ UIColor.ksr_grey_500
   }
 
   // MARK: - View model
@@ -105,24 +101,53 @@ final class PledgeCTAContainerView: UIView {
   override func bindViewModel() {
     super.bindViewModel()
 
-    self.vm.outputs.buttonTitleTextColor
+    self.viewModel.outputs.buttonTitleTextColor
       .observeForUI()
       .observeValues { [weak self] textColor in
         self?.pledgeCTAButton.setTitleColor(textColor, for: .normal)
       }
 
-    self.titleAndSubtitleStackView.rac.hidden = self.vm.outputs.stackViewIsHidden
-    self.titleLabel.rac.text = self.vm.outputs.titleText
-    self.subtitleLabel.rac.text = self.vm.outputs.subtitleText
-    self.pledgeCTAButton.rac.backgroundColor = self.vm.outputs.buttonBackgroundColor
-    self.pledgeCTAButton.rac.title = self.vm.outputs.buttonTitleText
-    self.spacer.rac.hidden = self.vm.outputs.spacerIsHidden
+    self.activityIndicator.rac.animating = self.viewModel.outputs.activityIndicatorIsAnimating
+    self.titleAndSubtitleStackView.rac.hidden = self.viewModel.outputs.stackViewIsHidden
+    self.titleLabel.rac.text = self.viewModel.outputs.titleText
+    self.subtitleLabel.rac.text = self.viewModel.outputs.subtitleText
+    self.pledgeCTAButton.rac.backgroundColor = self.viewModel.outputs.buttonBackgroundColor
+    self.pledgeCTAButton.rac.title = self.viewModel.outputs.buttonTitleText
+    self.spacer.rac.hidden = self.viewModel.outputs.spacerIsHidden
   }
 
   // MARK: - Configuration
 
-  func configureWith(project: Project) {
-    self.vm.inputs.configureWith(project: project)
+  func configureWith(value: (project: Project?, isLoading: Bool)) {
+    self.viewModel.inputs.configureWith(value: value)
+  }
+
+  // MARK: Functions
+  private func configureSubviews() {
+    _ = (self.rootStackView, self)
+      |> ksr_addSubviewToParent()
+      |> ksr_constrainViewToEdgesInParent()
+
+    _ = (self.activityIndicator, self)
+      |> ksr_addSubviewToParent()
+      |> ksr_constrainViewToCenterInParent()
+
+    _ = ([self.titleLabel, self.subtitleLabel], self.titleAndSubtitleStackView)
+      |> ksr_addArrangedSubviewsToStackView()
+
+    _ = ([self.titleAndSubtitleStackView, self.spacer, self.pledgeCTAButton], self.rootStackView)
+      |> ksr_addArrangedSubviewsToStackView()
+
+  }
+
+  private func setupConstraints() {
+    NSLayoutConstraint.activate([
+      self.activityIndicator.heightAnchor.constraint(equalToConstant: 30),
+      self.activityIndicator.widthAnchor.constraint(equalToConstant: 30),
+      self.pledgeCTAButton.heightAnchor.constraint(greaterThanOrEqualToConstant: Layout.Button.minHeight),
+      self.pledgeCTAButton.widthAnchor.constraint(greaterThanOrEqualToConstant: Layout.Button.minWidth),
+      self.rootStackView.topAnchor.constraint(equalTo: self.layoutMarginsGuide.topAnchor)
+      ])
   }
 }
 

--- a/Kickstarter-iOS/Views/PledgeCTAContainerView.swift
+++ b/Kickstarter-iOS/Views/PledgeCTAContainerView.swift
@@ -121,7 +121,7 @@ final class PledgeCTAContainerView: UIView {
         let announcementMessage = isAnimating ? "Loading project state" : "Loading project state complete"
 
         UIAccessibility.post(notification: .announcement, argument: announcementMessage)
-    }
+      }
 
     self.activityIndicator.rac.animating = self.viewModel.outputs.activityIndicatorIsAnimating
     self.titleAndSubtitleStackView.rac.hidden = self.viewModel.outputs.stackViewIsHidden

--- a/Kickstarter-iOS/Views/PledgeCTAContainerView.swift
+++ b/Kickstarter-iOS/Views/PledgeCTAContainerView.swift
@@ -51,8 +51,6 @@ final class PledgeCTAContainerView: UIView {
     self.configureSubviews()
     self.setupConstraints()
     self.bindViewModel()
-
-    self.activityIndicator.startAnimating()
   }
 
   required init?(coder _: NSCoder) {
@@ -117,6 +115,13 @@ final class PledgeCTAContainerView: UIView {
             ?|> \.alpha .~ alpha
         })
       }
+
+    self.viewModel.outputs.activityIndicatorIsAnimating
+      .observeValues { isAnimating in
+        let announcementMessage = isAnimating ? "Loading project state" : "Loading project state complete"
+
+        UIAccessibility.post(notification: .announcement, argument: announcementMessage)
+    }
 
     self.activityIndicator.rac.animating = self.viewModel.outputs.activityIndicatorIsAnimating
     self.titleAndSubtitleStackView.rac.hidden = self.viewModel.outputs.stackViewIsHidden

--- a/Library/ViewModels/PledgeCTAContainerViewViewModel.swift
+++ b/Library/ViewModels/PledgeCTAContainerViewViewModel.swift
@@ -28,8 +28,8 @@ public final class PledgeCTAContainerViewViewModel: PledgeCTAContainerViewViewMo
   public init() {
     let project = self.configureWithValueProperty.signal
       .skipNil()
+      .filter(second >>> isFalse)
       .map(first)
-      .skipNil()
 
     self.activityIndicatorIsAnimating = self.configureWithValueProperty.signal
       .skipNil()
@@ -51,8 +51,8 @@ public final class PledgeCTAContainerViewViewModel: PledgeCTAContainerViewViewMo
       .map(subtitle(project:pledgeState:))
   }
 
-  fileprivate let configureWithValueProperty = MutableProperty<(project: Project?, isLoading: Bool)?>(nil)
-  public func configureWith(value: (project: Project?, isLoading: Bool)) {
+  fileprivate let configureWithValueProperty = MutableProperty<(project: Project, isLoading: Bool)?>(nil)
+  public func configureWith(value: (project: Project, isLoading: Bool)) {
     self.configureWithValueProperty.value = value
   }
 

--- a/Library/ViewModels/PledgeCTAContainerViewViewModel.swift
+++ b/Library/ViewModels/PledgeCTAContainerViewViewModel.swift
@@ -4,7 +4,7 @@ import ReactiveExtensions
 import ReactiveSwift
 
 public protocol PledgeCTAContainerViewViewModelInputs {
-  func configureWith(value: (project: Project?, isLoading: Bool))
+  func configureWith(value: (project: Project, isLoading: Bool))
 }
 
 public protocol PledgeCTAContainerViewViewModelOutputs {
@@ -12,6 +12,7 @@ public protocol PledgeCTAContainerViewViewModelOutputs {
   var buttonBackgroundColor: Signal<UIColor, Never> { get }
   var buttonTitleText: Signal<String, Never> { get }
   var buttonTitleTextColor: Signal<UIColor, Never> { get }
+  var rootStackViewAnimateIsHidden: Signal<Bool, Never> { get }
   var spacerIsHidden: Signal<Bool, Never> { get }
   var stackViewIsHidden: Signal<Bool, Never> { get }
   var subtitleText: Signal<String, Never> { get }
@@ -35,10 +36,11 @@ public final class PledgeCTAContainerViewViewModel: PledgeCTAContainerViewViewMo
       .skipNil()
       .map(second)
 
+    self.rootStackViewAnimateIsHidden = self.activityIndicatorIsAnimating
+
     let backing = project.map { $0.personalization.backing }
     let pledgeState = Signal.combineLatest(project, backing)
       .map(pledgeCTA(project:backing:))
-
 
     self.buttonTitleText = pledgeState.map { $0.buttonTitle }
     self.buttonTitleTextColor = pledgeState.map { $0.buttonTitleTextColor }
@@ -63,6 +65,7 @@ public final class PledgeCTAContainerViewViewModel: PledgeCTAContainerViewViewMo
   public let buttonBackgroundColor: Signal<UIColor, Never>
   public let buttonTitleText: Signal<String, Never>
   public let buttonTitleTextColor: Signal<UIColor, Never>
+  public let rootStackViewAnimateIsHidden: Signal<Bool, Never>
   public let spacerIsHidden: Signal<Bool, Never>
   public let stackViewIsHidden: Signal<Bool, Never>
   public let subtitleText: Signal<String, Never>

--- a/Library/ViewModels/PledgeCTAContainerViewViewModelTests.swift
+++ b/Library/ViewModels/PledgeCTAContainerViewViewModelTests.swift
@@ -9,9 +9,11 @@ import XCTest
 internal final class PledgeCTAContainerViewViewModelTests: TestCase {
   let vm: PledgeCTAContainerViewViewModelType = PledgeCTAContainerViewViewModel()
 
+  let activityIndicatorIsAnimating = TestObserver<Bool, Never>()
   let buttonBackgroundColor = TestObserver<UIColor, Never>()
   let buttonTitleText = TestObserver<String, Never>()
   let buttonTitleTextColor = TestObserver<UIColor, Never>()
+  let rootStackViewAnimateIsHidden = TestObserver<Bool, Never>()
   let spacerIsHidden = TestObserver<Bool, Never>()
   let stackViewIsHidden = TestObserver<Bool, Never>()
   let subtitleText = TestObserver<String, Never>()
@@ -19,9 +21,11 @@ internal final class PledgeCTAContainerViewViewModelTests: TestCase {
 
   internal override func setUp() {
     super.setUp()
+    self.vm.outputs.activityIndicatorIsAnimating.observe(self.activityIndicatorIsAnimating.observer)
     self.vm.outputs.buttonBackgroundColor.observe(self.buttonBackgroundColor.observer)
     self.vm.outputs.buttonTitleText.observe(self.buttonTitleText.observer)
     self.vm.outputs.buttonTitleTextColor.observe(self.buttonTitleTextColor.observer)
+    self.vm.outputs.rootStackViewAnimateIsHidden.observe(self.rootStackViewAnimateIsHidden.observer)
     self.vm.outputs.spacerIsHidden.observe(self.spacerIsHidden.observer)
     self.vm.outputs.stackViewIsHidden.observe(self.stackViewIsHidden.observer)
     self.vm.outputs.subtitleText.observe(self.subtitleText.observer)
@@ -39,7 +43,7 @@ internal final class PledgeCTAContainerViewViewModelTests: TestCase {
       |> Project.lens.personalization.backing .~ backing
       |> Project.lens.stats.currentCurrency .~ "USD"
 
-    self.vm.inputs.configureWith(project: project)
+    self.vm.inputs.configureWith(value: (project, false))
     self.buttonBackgroundColor.assertValues([manageCTAColor])
     self.buttonTitleText.assertValues([Strings.Manage()])
     self.titleText.assertValues([Strings.Youre_a_backer()])
@@ -55,7 +59,7 @@ internal final class PledgeCTAContainerViewViewModelTests: TestCase {
       |> Project.lens.personalization.backing .~ Backing.template
       |> Project.lens.state .~ .successful
 
-    self.vm.inputs.configureWith(project: project)
+    self.vm.inputs.configureWith(value: (project, false))
     self.buttonBackgroundColor.assertValues([viewPledgeCTAColor])
     self.buttonTitleText.assertValues([Strings.View_your_pledge()])
     self.spacerIsHidden.assertValues([true])
@@ -68,7 +72,7 @@ internal final class PledgeCTAContainerViewViewModelTests: TestCase {
       |> Project.lens.personalization.isBacking .~ nil
       |> Project.lens.state .~ .live
 
-    self.vm.inputs.configureWith(project: project)
+    self.vm.inputs.configureWith(value: (project, false))
     self.buttonBackgroundColor.assertValues([pledgeCTAColor])
     self.buttonTitleText.assertValues([Strings.Back_this_project()])
     self.spacerIsHidden.assertValues([true])
@@ -81,7 +85,7 @@ internal final class PledgeCTAContainerViewViewModelTests: TestCase {
       |> Project.lens.personalization.isBacking .~ nil
       |> Project.lens.state .~ .successful
 
-    self.vm.inputs.configureWith(project: project)
+    self.vm.inputs.configureWith(value: (project, false))
     self.buttonBackgroundColor.assertValues([viewRewardsCTAColor])
     self.buttonTitleText.assertValues([Strings.View_rewards()])
     self.spacerIsHidden.assertValues([true])
@@ -97,7 +101,7 @@ internal final class PledgeCTAContainerViewViewModelTests: TestCase {
       |> Project.lens.state .~ .live
       |> Project.lens.personalization.backing .~ backing
 
-    self.vm.inputs.configureWith(project: project)
+    self.vm.inputs.configureWith(value: (project, false))
     self.buttonBackgroundColor.assertValues([viewPledgeCTAColor])
     self.buttonTitleText.assertValues([Strings.Fix()])
     self.titleText.assertValues([Strings.Check_your_payment_details()])
@@ -112,7 +116,7 @@ internal final class PledgeCTAContainerViewViewModelTests: TestCase {
       |> Project.lens.personalization.backing .~ nil
       |> Project.lens.personalization.isBacking .~ false
 
-    self.vm.inputs.configureWith(project: project)
+    self.vm.inputs.configureWith(value: (project, false))
     self.buttonBackgroundColor.assertValues([pledgeCTAColor])
     self.buttonTitleText.assertValues([Strings.Back_this_project()])
     self.spacerIsHidden.assertValues([true])
@@ -125,10 +129,33 @@ internal final class PledgeCTAContainerViewViewModelTests: TestCase {
       |> Project.lens.state .~ .successful
       |> Project.lens.personalization.isBacking .~ false
 
-    self.vm.inputs.configureWith(project: project)
+    self.vm.inputs.configureWith(value: (project, false))
     self.buttonBackgroundColor.assertValues([viewRewardsCTAColor])
     self.buttonTitleText.assertValues([Strings.View_rewards()])
     self.spacerIsHidden.assertValues([true])
     self.stackViewIsHidden.assertValues([true])
+  }
+
+  func testPledgeCTA_activityIndicator() {
+    let project = Project.template
+      |> Project.lens.state .~ .live
+
+    self.vm.inputs.configureWith(value: (project, true))
+    self.activityIndicatorIsAnimating.assertValues([true])
+    self.rootStackViewAnimateIsHidden.assertValues([true])
+
+    self.buttonTitleText.assertDidNotEmitValue()
+    self.buttonBackgroundColor.assertDidNotEmitValue()
+    self.spacerIsHidden.assertDidNotEmitValue()
+    self.stackViewIsHidden.assertDidNotEmitValue()
+
+    self.vm.inputs.configureWith(value: (project, false))
+    self.activityIndicatorIsAnimating.assertValues([true, false])
+    self.rootStackViewAnimateIsHidden.assertValues([true, false])
+
+    self.buttonTitleText.assertDidEmitValue()
+    self.buttonBackgroundColor.assertDidEmitValue()
+    self.spacerIsHidden.assertDidEmitValue()
+    self.stackViewIsHidden.assertDidEmitValue()
   }
 }

--- a/Library/ViewModels/ProjectPamphletViewModel.swift
+++ b/Library/ViewModels/ProjectPamphletViewModel.swift
@@ -53,13 +53,11 @@ public final class ProjectPamphletViewModel: ProjectPamphletViewModelType, Proje
   public init() {
     let isLoading = MutableProperty(false)
 
-    let beginFetchProjectShouldPrefix = self.configDataProperty.signal.skipNil()
+    let freshProjectAndRefTag = self.configDataProperty.signal.skipNil()
       .takePairWhen(Signal.merge(
         self.viewDidLoadProperty.signal.mapConst(true),
         self.viewDidAppearAnimated.signal.filter(isTrue).mapConst(false)
       ))
-
-    let freshProjectAndRefTag = beginFetchProjectShouldPrefix
       .map(unpack)
       .switchMap { projectOrParam, refTag, shouldPrefix in
         fetchProject(projectOrParam: projectOrParam, shouldPrefix: shouldPrefix)

--- a/Library/ViewModels/ProjectPamphletViewModel.swift
+++ b/Library/ViewModels/ProjectPamphletViewModel.swift
@@ -81,7 +81,7 @@ public final class ProjectPamphletViewModel: ProjectPamphletViewModelType, Proje
     let project = freshProjectAndRefTag
       .map(first)
 
-    self.configurePledgeCTAView = Signal.combineLatest(project.wrapInOptional(),
+    self.configurePledgeCTAView = Signal.combineLatest(project,
                                                        isLoading.signal)
     .filter { _ in featureNativeCheckoutEnabled() }
 

--- a/Library/ViewModels/ProjectPamphletViewModel.swift
+++ b/Library/ViewModels/ProjectPamphletViewModel.swift
@@ -53,13 +53,13 @@ public final class ProjectPamphletViewModel: ProjectPamphletViewModelType, Proje
   public init() {
     let isLoading = MutableProperty(false)
 
-    let beginFetchProject = self.configDataProperty.signal.skipNil()
+    let beginFetchProjectShouldPrefix = self.configDataProperty.signal.skipNil()
       .takePairWhen(Signal.merge(
         self.viewDidLoadProperty.signal.mapConst(true),
         self.viewDidAppearAnimated.signal.filter(isTrue).mapConst(false)
       ))
 
-    let freshProjectAndRefTag = beginFetchProject
+    let freshProjectAndRefTag = beginFetchProjectShouldPrefix
       .map(unpack)
       .switchMap { projectOrParam, refTag, shouldPrefix in
         fetchProject(projectOrParam: projectOrParam, shouldPrefix: shouldPrefix)

--- a/Library/ViewModels/ProjectPamphletViewModel.swift
+++ b/Library/ViewModels/ProjectPamphletViewModel.swift
@@ -63,13 +63,13 @@ public final class ProjectPamphletViewModel: ProjectPamphletViewModelType, Proje
       .map(unpack)
       .switchMap { projectOrParam, refTag, shouldPrefix in
         fetchProject(projectOrParam: projectOrParam, shouldPrefix: shouldPrefix)
-        .on(
-          starting: { isLoading.value = true },
-          terminated: { isLoading.value = false }
-        )
-        .map { project in
-          (project, refTag.map(cleanUp(refTag:)))
-        }
+          .on(
+            starting: { isLoading.value = true },
+            terminated: { isLoading.value = false }
+          )
+          .map { project in
+            (project, refTag.map(cleanUp(refTag:)))
+          }
       }
 
     self.goToRewards = freshProjectAndRefTag
@@ -81,8 +81,10 @@ public final class ProjectPamphletViewModel: ProjectPamphletViewModelType, Proje
     let project = freshProjectAndRefTag
       .map(first)
 
-    self.configurePledgeCTAView = Signal.combineLatest(project,
-                                                       isLoading.signal)
+    self.configurePledgeCTAView = Signal.combineLatest(
+      project,
+      isLoading.signal
+    )
     .filter { _ in featureNativeCheckoutEnabled() }
 
     self.configureChildViewControllersWithProject = freshProjectAndRefTag

--- a/Library/ViewModels/ProjectPamphletViewModelTests.swift
+++ b/Library/ViewModels/ProjectPamphletViewModelTests.swift
@@ -472,6 +472,7 @@ final class ProjectPamphletViewModelTests: TestCase {
       self.vm.inputs.viewDidAppear(animated: false)
 
       self.configurePledgeCTAViewProject.assertDidNotEmitValue()
+      self.configurePledgeCTAViewIsLoading.assertDidNotEmitValue()
     }
   }
 }

--- a/Library/ViewModels/ProjectPamphletViewModelTests.swift
+++ b/Library/ViewModels/ProjectPamphletViewModelTests.swift
@@ -10,7 +10,8 @@ final class ProjectPamphletViewModelTests: TestCase {
 
   private let configureChildViewControllersWithProject = TestObserver<Project, Never>()
   private let configureChildViewControllersWithRefTag = TestObserver<RefTag?, Never>()
-  private let configurePledgeCTAView = TestObserver<Project, Never>()
+  private let configurePledgeCTAViewProject = TestObserver<Project, Never>()
+  private let configurePledgeCTAViewIsLoading = TestObserver<Bool, Never>()
   private let goToRewardsProject = TestObserver<Project, Never>()
   private let goToRewardsRefTag = TestObserver<RefTag?, Never>()
   private let setNavigationBarHidden = TestObserver<Bool, Never>()
@@ -26,7 +27,8 @@ final class ProjectPamphletViewModelTests: TestCase {
       .observe(self.configureChildViewControllersWithProject.observer)
     self.vm.outputs.configureChildViewControllersWithProject.map(second)
       .observe(self.configureChildViewControllersWithRefTag.observer)
-    self.vm.outputs.configurePledgeCTAView.observe(self.configurePledgeCTAView.observer)
+    self.vm.outputs.configurePledgeCTAView.map(first).observe(self.configurePledgeCTAViewProject.observer)
+    self.vm.outputs.configurePledgeCTAView.map(second).observe(self.configurePledgeCTAViewIsLoading.observer)
     self.vm.outputs.goToRewards.map(first).observe(self.goToRewardsProject.observer)
     self.vm.outputs.goToRewards.map(second).observe(self.goToRewardsRefTag.observer)
     self.vm.outputs.setNavigationBarHiddenAnimated.map(first)
@@ -362,21 +364,98 @@ final class ProjectPamphletViewModelTests: TestCase {
     self.goToRewardsRefTag.assertValues([.discovery], "Tapping 'Back this project' emits the refTag")
   }
 
-  func testConfigurePledgeCTAView_featureEnabled() {
+  func testConfigurePledgeCTAView_fetchProjectSuccess_featureEnabled() {
     let config = Config.template |> \.features .~ [Feature.checkout.rawValue: true]
     let project = Project.template
+    let projectFull = Project.template
+      |> \.id .~ 2
+      |> Project.lens.personalization.isBacking .~ true
 
-    withEnvironment(config: config) {
-      self.configurePledgeCTAView.assertDidNotEmitValue()
+    let mockService = MockService(fetchProjectResponse: projectFull)
+
+    withEnvironment(apiService: mockService, apiDelayInterval: .seconds(1), config: config) {
+      self.configurePledgeCTAViewProject.assertDidNotEmitValue()
+      self.configurePledgeCTAViewIsLoading.assertDidNotEmitValue()
 
       self.vm.inputs.configureWith(projectOrParam: .left(project), refTag: .discovery)
       self.vm.inputs.viewDidLoad()
       self.vm.inputs.viewWillAppear(animated: false)
       self.vm.inputs.viewDidAppear(animated: false)
 
+      self.configurePledgeCTAViewProject.assertValues([project])
+      self.configurePledgeCTAViewIsLoading.assertValues([true])
+
+      self.scheduler.run()
+
+      self.configurePledgeCTAViewProject.assertValues([project, projectFull, projectFull])
+      self.configurePledgeCTAViewIsLoading.assertValues([true, true, false])
+    }
+  }
+
+  func testConfigurePledgeCTAView_fetchProjectFailure_featureEnabled() {
+    let config = Config.template |> \.features .~ [Feature.checkout.rawValue: true]
+    let project = Project.template
+    let mockService = MockService(fetchProjectError: .couldNotParseJSON)
+
+    withEnvironment(apiService: mockService, apiDelayInterval: .seconds(1), config: config) {
+      self.configurePledgeCTAViewProject.assertDidNotEmitValue()
+      self.configurePledgeCTAViewIsLoading.assertDidNotEmitValue()
+
+      self.vm.inputs.configureWith(projectOrParam: .left(project), refTag: .discovery)
+      self.vm.inputs.viewDidLoad()
+      self.vm.inputs.viewWillAppear(animated: false)
+      self.vm.inputs.viewDidAppear(animated: false)
+
+      self.configurePledgeCTAViewProject.assertValues([project])
+      self.configurePledgeCTAViewIsLoading.assertValues([true])
+
+      self.scheduler.run()
+
+      self.configurePledgeCTAViewProject.assertValues([project, project])
+      self.configurePledgeCTAViewIsLoading.assertValues([true, false])
+    }
+  }
+
+  func testConfigurePledgeCTAView_reloadsUponReturnToView_featureEnabled() {
+    let config = Config.template |> \.features .~ [Feature.checkout.rawValue: true]
+    let project = Project.template
+    let projectFull = Project.template
+      |> \.id .~ 2
+      |> Project.lens.personalization.isBacking .~ true
+    let projectFull2 = Project.template
+      |> \.id .~ 3
+
+    let mockService = MockService(fetchProjectResponse: projectFull)
+
+    withEnvironment(apiService: mockService, config: config) {
+      self.configurePledgeCTAViewProject.assertDidNotEmitValue()
+      self.configurePledgeCTAViewIsLoading.assertDidNotEmitValue()
+
+      self.vm.inputs.configureWith(projectOrParam: .left(project), refTag: .discovery)
+      self.vm.inputs.viewDidLoad()
+
+      self.configurePledgeCTAViewProject.assertValues([project])
+      self.configurePledgeCTAViewIsLoading.assertValues([true])
+
       self.scheduler.advance()
 
-      self.configurePledgeCTAView.assertValues([project])
+      self.configurePledgeCTAViewProject.assertValues([project, projectFull, projectFull])
+      self.configurePledgeCTAViewIsLoading.assertValues([true, true, false])
+    }
+
+    withEnvironment(apiService: MockService(fetchProjectResponse: projectFull2),
+                    config: config) {
+      self.vm.inputs.viewWillAppear(animated: true)
+      self.vm.inputs.viewDidAppear(animated: true)
+
+      self.configurePledgeCTAViewProject.assertValues([project, projectFull, projectFull, projectFull])
+      self.configurePledgeCTAViewIsLoading.assertValues([true, true, false, true])
+
+      self.scheduler.advance()
+
+      self.configurePledgeCTAViewProject.assertValues(
+        [project, projectFull, projectFull, projectFull, projectFull2, projectFull2])
+      self.configurePledgeCTAViewIsLoading.assertValues([true, true, false, true, true, false])
     }
   }
 
@@ -390,7 +469,7 @@ final class ProjectPamphletViewModelTests: TestCase {
       self.vm.inputs.viewWillAppear(animated: false)
       self.vm.inputs.viewDidAppear(animated: false)
 
-      self.configurePledgeCTAView.assertDidNotEmitValue()
+      self.configurePledgeCTAViewProject.assertDidNotEmitValue()
     }
   }
 }

--- a/Library/ViewModels/ProjectPamphletViewModelTests.swift
+++ b/Library/ViewModels/ProjectPamphletViewModelTests.swift
@@ -443,8 +443,10 @@ final class ProjectPamphletViewModelTests: TestCase {
       self.configurePledgeCTAViewIsLoading.assertValues([true, true, false])
     }
 
-    withEnvironment(apiService: MockService(fetchProjectResponse: projectFull2),
-                    config: config) {
+    withEnvironment(
+      apiService: MockService(fetchProjectResponse: projectFull2),
+      config: config
+    ) {
       self.vm.inputs.viewWillAppear(animated: true)
       self.vm.inputs.viewDidAppear(animated: true)
 


### PR DESCRIPTION
# 📲 What

Adds an activity indicator to indicate a loading state to the user while the full project is being fetched from the server.

# 🤔 Why

We can't determine the pledge CTA view's state until we have the full project, so instead of showing a blank view we show an activity indicator commonly used to signify content that is being loaded. Once the full project has fetched from the server, we hide the activity indicator and fade in the pledge CTA view with its correct state.

# 🛠 How

Since the project is fetched from the `ProjectPamphletViewModel`, we need to pass the loading info to the `PledgeCTAView` through it's configuration function. This PR extends the configuration `value` passed into the `PledgeCTAView` into a tuple containing a `Project` object and an `isLoading` `Bool` to communicate the loading state of the project.

The `PledgeCTAView` uses this `isLoading` property to hide/show the activity indicator and the `rootStackView` which contains all the subviews of the `PledgeCTAView`. Only once the project is fully loaded (`isLoading == false`) does the `PledgeCTAView` calculate the state of it's subviews and display them.

Note that if the `fetchProject` endpoint fails (due to server error or poor network access), the default `Project` value is used - this means that the default state of the `PledgeCTAView` in case of an error will be the green `Back this Project` button.

# 👀 See

![PFikwcYzfJ](https://user-images.githubusercontent.com/3156796/62079079-f6716b00-b21b-11e9-9e32-d0630d901df2.gif)


# ✅ Acceptance criteria

Use the Network Link Conditioner or Charles Proxy to simulate slower connections. Then do the following:

As a user with the `Native Checkout` feature flag turned **ON**;
Navigate to any project on the discovery screen;
You should see the activity indicator animating before seeing the `Back this project` button fade in.
Tap `Back this project`;
Navigate back to the project screen;
You should see the activity indicator animating before seeing the `Back this project` button fade in again.

As a user with the `Native Checkout` feature flag turned **ON**;
Navigate to any backed project in the backer dashboard;
Tap a backed project;
You should see the activity indicator animating before seeing the `Manage` button fade in.
Tap `Manage`;
Navigate back to the project screen;
You should see the activity indicator animating before seeing the `Manage` button fade in again.

# ⏰ TODO

- [ ] loading announcement copy for Voice Over
