### PR TITLE
Fix local config graphQL endpoint

### DIFF
--- a/KsApi/ServerConfig.swift
+++ b/KsApi/ServerConfig.swift
@@ -67,7 +67,7 @@ public struct ServerConfig: ServerConfigType {
     webBaseUrl: URL(string: "http://ksr.test")!,
     apiClientAuth: ClientAuth.development,
     basicHTTPAuth: BasicHTTPAuth.development,
-    graphQLEndpointUrl: URL(string: "http://ksr.dev")!.appendingPathComponent(gqlPath),
+    graphQLEndpointUrl: URL(string: "http://ksr.test")!.appendingPathComponent(gqlPath),
     environment: EnvironmentType.local
   )
 


### PR DESCRIPTION
# 📲 What

Updates our `local` config graphQL endpoint, which was incorrect before.

# 🤔 Why

So we can run the app against the `local` environment and hit the graphQL endpoint successfully.

# 🛠 How

Just updated the endpoint.

# ✅ Acceptance criteria

*Test running the app against the `Local` environment*

Run the app after running `./bin/dev` on the `kickstarter` web repo;
Using the debug menu, change to the `Local` environment;
To test that graphQL requests are working, open the Categories menu;
*You should see the categories load successfully*.
