### PR TITLE
🐞[Bug] Force UserAgent value in AJAX requests

### DIFF
--- a/KsApi/Service.swift
+++ b/KsApi/Service.swift
@@ -36,7 +36,7 @@ public struct Service: ServiceType {
     self.buildVersion = buildVersion
 
     // Global override required for injecting custom User-Agent header in ajax requests
-    UserDefaults.standard.register(defaults: ["UserAgent" : "\(Service.userAgent)"])
+    UserDefaults.standard.register(defaults: ["UserAgent" : Service.userAgent])
   }
 
   public func login(_ oauthToken: OauthTokenAuthType) -> Service {

--- a/KsApi/Service.swift
+++ b/KsApi/Service.swift
@@ -36,7 +36,7 @@ public struct Service: ServiceType {
     self.buildVersion = buildVersion
 
     // Global override required for injecting custom User-Agent header in ajax requests
-    UserDefaults.standard.register(defaults: ["UserAgent" : Service.userAgent])
+    UserDefaults.standard.register(defaults: ["UserAgent": Service.userAgent])
   }
 
   public func login(_ oauthToken: OauthTokenAuthType) -> Service {

--- a/KsApi/Service.swift
+++ b/KsApi/Service.swift
@@ -34,6 +34,9 @@ public struct Service: ServiceType {
     self.language = language
     self.currency = currency
     self.buildVersion = buildVersion
+
+    // Global override required for injecting custom User-Agent header in ajax requests
+    UserDefaults.standard.register(defaults: ["UserAgent" : "\(Service.userAgent)"])
   }
 
   public func login(_ oauthToken: OauthTokenAuthType) -> Service {


### PR DESCRIPTION
# 📲 What

Forces the user agent for all requests to be our custom user agent which has the format:

`"\(app)/\(bundleVersion) (\(model); iOS \(systemVersion) Scale/\(scale))"`

As defined [here](https://github.com/kickstarter/ios-oss/blob/master/KsApi/ServiceType.swift#L515).

# 🤔 Why

Our `Completed Checkout` tracking event has been broken on iOS for some time due to that call being made in a webview via an AJAX request rather than a standard request which we could modify by intercepting the `NSURLRequest` object.

By injecting the custom user agent the back-end will track the request as being a native app request.

# 🛠 How

Added what appears to be a common workaround for this which is to set a value in `UserDefaults` for `UserAgent` (note: no hyphen).

# 👀 See

Charles Proxy screenshots testing on simulator:

| Before 🐛 | After 🦋 |
| --- | --- |
| <img width="816" alt="headers-before" src="https://user-images.githubusercontent.com/3735375/62417904-e76e2c80-b610-11e9-9fc3-25b82fdb7a1c.png"> | <img width="518" alt="headers-after" src="https://user-images.githubusercontent.com/3735375/62417910-eccb7700-b610-11e9-856c-894d4ce536ab.png"> |

# ✅ Acceptance criteria

- [x] Verify using Charles Proxy that the correct header is being sent.
- [x] Confirm with backend engineers that the request is being seen as native.