### PR TITLE
Checkout release events clean

### DIFF
--- a/Library/Koala/Koala.swift
+++ b/Library/Koala/Koala.swift
@@ -590,8 +590,7 @@ public final class Koala {
     reward: Reward?,
     backing: Backing?,
     screen: CheckoutContext
-    ) {
-
+  ) {
     let props = properties(project: project, reward: reward, backing: backing)
       .withAllValuesFrom(["screen": screen.trackingString])
 
@@ -2093,7 +2092,7 @@ private func properties(
   reward: Reward? = nil,
   backing: Backing? = nil,
   prefix: String = "project_"
-  ) -> [String: Any]  {
+) -> [String: Any] {
   var props: [String: Any] = [:]
 
   props["name"] = project.name

--- a/Library/Koala/Koala.swift
+++ b/Library/Koala/Koala.swift
@@ -589,13 +589,11 @@ public final class Koala {
     project: Project,
     reward: Reward?,
     backing: Backing?,
-    screen: CheckoutContext,
-    paymentMethod: PaymentMethod? = nil
+    screen: CheckoutContext
     ) {
 
     let props = properties(project: project, reward: reward, backing: backing)
       .withAllValuesFrom(["screen": screen.trackingString])
-      .withAllValuesFrom(["payment_method": paymentMethod?.trackingString ?? ""] )
 
     self.track(event: "Select Reward Button Clicked", properties: props)
   }

--- a/Library/Koala/Koala.swift
+++ b/Library/Koala/Koala.swift
@@ -2066,7 +2066,7 @@ private func properties(
   props["update_count"] = project.stats.updatesCount
   props["comments_count"] = project.stats.commentsCount
 
-  let now = MockDate().timeIntervalSince1970
+  let now = AppEnvironment.current.dateType.init().timeIntervalSince1970
   props["hours_remaining"] = Int(ceil(max(0.0, (project.dates.deadline - now) / 3_600.0)))
   props["duration"] = Int(round(project.dates.deadline - project.dates.launchedAt))
 
@@ -2102,7 +2102,7 @@ private func properties(
   props["location"] = project.location.name
   props["country"] = project.country.countryCode
 
-  let now = MockDate().timeIntervalSince1970
+  let now = AppEnvironment.current.dateType.init().timeIntervalSince1970
   props["hours_remaining"] = Int(ceil(max(0.0, (project.dates.deadline - now) / 3_600.0)))
 
   props["percent_raised"] = project.stats.fundingProgress

--- a/Library/Koala/Koala.swift
+++ b/Library/Koala/Koala.swift
@@ -265,7 +265,7 @@ public final class Koala {
    Describes the types of payment methods that can be used.
    */
   public enum PaymentMethod {
-    case applePay //USE FOR PAYMENT METHOD?
+    case applePay
 
     fileprivate var trackingString: String {
       switch self {
@@ -278,7 +278,7 @@ public final class Koala {
    Describes the pages where checkout events can occur.
    */
   public enum CheckoutPageContext {
-    case paymentsPage //USE FOR SCREEN?
+    case paymentsPage
     case projectPage
     case rewardSelection
 
@@ -287,6 +287,18 @@ public final class Koala {
       case .paymentsPage: return "Payments Page"
       case .projectPage: return "Project Page"
       case .rewardSelection: return "Reward Selection"
+      }
+    }
+  }
+
+  public enum CheckoutContext {
+    case backThisPage
+    case projectPage
+
+    var trackingString: String {
+      switch self {
+      case .backThisPage: return "Back this page"
+      case .projectPage: return "Project page"
       }
     }
   }
@@ -566,8 +578,10 @@ public final class Koala {
 
   // MARK: - Checkout Events
 
-  public func trackBackThisButtonClicked(project: Project) {
+  public func trackBackThisButtonClicked(project: Project, screen: CheckoutContext) {
     let props = properties(project: project)
+      .withAllValuesFrom(["screen": screen.trackingString])
+
     self.track(event: "Back this Project Button Clicked", properties: props)
   }
 
@@ -575,10 +589,12 @@ public final class Koala {
     project: Project,
     reward: Reward?,
     backing: Backing?,
+    screen: CheckoutContext,
     paymentMethod: PaymentMethod? = nil
     ) {
 
     let props = properties(project: project, reward: reward, backing: backing)
+      .withAllValuesFrom(["screen": screen.trackingString])
       .withAllValuesFrom(["payment_method": paymentMethod?.trackingString ?? ""] )
 
     self.track(event: "Select Reward Button Clicked", properties: props)

--- a/Library/Koala/KoalaTests.swift
+++ b/Library/Koala/KoalaTests.swift
@@ -494,7 +494,12 @@ final class KoalaTests: TestCase {
 
     let koala = Koala(client: client, loggedInUser: loggedInUser)
 
-    koala.trackSelectRewardButtonClicked(project: project, reward: reward, backing: backing, screen: .backThisPage)
+    koala.trackSelectRewardButtonClicked(
+      project: project,
+      reward: reward,
+      backing: backing,
+      screen: .backThisPage
+    )
 
     let properties = client.properties.last
 

--- a/Library/Koala/KoalaTests.swift
+++ b/Library/Koala/KoalaTests.swift
@@ -467,4 +467,29 @@ final class KoalaTests: TestCase {
     koala.trackDiscoveryPullToRefresh()
     XCTAssertEqual(["Triggered Refresh"], client.events)
   }
+
+  func testTrackBackThisButtonClicked() {
+    let client = MockTrackingClient()
+    let koala = Koala(client: client)
+
+    let project = Project.template
+
+    koala.trackBackThisButtonClicked(project: project)
+    XCTAssertEqual(["Back this Project Button Clicked"], client.events)
+  }
+
+  func testTrackSelectRewardButtonClicked() {
+    let client = MockTrackingClient()
+    let koala = Koala(client: client)
+
+    let reward = Reward.template
+    let backing = .template
+      |> Backing.lens.reward .~ reward
+    let project = .template
+      |> Project.lens.personalization.backing .~ backing
+
+    koala.trackSelectRewardButtonClicked(project: project, reward: reward, backing: backing)
+    XCTAssertEqual(["Select Reward Button Clicked"], client.events)
+
+  }
 }

--- a/Library/Koala/KoalaTests.swift
+++ b/Library/Koala/KoalaTests.swift
@@ -122,11 +122,11 @@ final class KoalaTests: TestCase {
     let project = Project.template
 
     koala.trackProjectShow(project, refTag: .discovery, cookieRefTag: .recommended)
-    XCTAssertEqual(2, client.properties.count)
+    XCTAssertEqual(3, client.properties.count)
 
     let properties = client.properties.last
 
-    XCTAssertEqual("Viewed Project Page", client.events.last)
+    XCTAssertEqual("Project Page Viewed", client.events.last)
     XCTAssertEqual(project.stats.backersCount, properties?["project_backers_count"] as? Int)
     XCTAssertEqual(project.country.countryCode, properties?["project_country"] as? String)
     XCTAssertEqual(project.country.currencyCode, properties?["project_currency"] as? String)
@@ -170,7 +170,7 @@ final class KoalaTests: TestCase {
     let koala = Koala(client: client, loggedInUser: loggedInUser)
 
     koala.trackProjectShow(project, refTag: nil, cookieRefTag: nil)
-    XCTAssertEqual(2, client.properties.count)
+    XCTAssertEqual(3, client.properties.count)
 
     let properties = client.properties.last
 
@@ -188,7 +188,7 @@ final class KoalaTests: TestCase {
     let koala = Koala(client: client, loggedInUser: loggedInUser)
 
     koala.trackProjectShow(project, refTag: nil, cookieRefTag: nil)
-    XCTAssertEqual(2, client.properties.count)
+    XCTAssertEqual(3, client.properties.count)
 
     let properties = client.properties.last
 
@@ -206,7 +206,7 @@ final class KoalaTests: TestCase {
     let koala = Koala(client: client, loggedInUser: loggedInUser)
 
     koala.trackProjectShow(project, refTag: nil, cookieRefTag: nil)
-    XCTAssertEqual(2, client.properties.count)
+    XCTAssertEqual(3, client.properties.count)
 
     let properties = client.properties.last
 
@@ -224,7 +224,7 @@ final class KoalaTests: TestCase {
     let koala = Koala(client: client, loggedInUser: loggedInUser)
 
     koala.trackProjectShow(project, refTag: nil, cookieRefTag: nil)
-    XCTAssertEqual(2, client.properties.count)
+    XCTAssertEqual(3, client.properties.count)
 
     let properties = client.properties.last
 
@@ -470,26 +470,35 @@ final class KoalaTests: TestCase {
 
   func testTrackBackThisButtonClicked() {
     let client = MockTrackingClient()
-    let koala = Koala(client: client)
-
     let project = Project.template
+    let loggedInUser = User.template |> \.id .~ 42
 
-    koala.trackBackThisButtonClicked(project: project)
+    let koala = Koala(client: client, loggedInUser: loggedInUser)
+
+    koala.trackBackThisButtonClicked(project: project, screen: .projectPage)
+
+    let properties = client.properties.last
+
     XCTAssertEqual(["Back this Project Button Clicked"], client.events)
+    XCTAssertEqual("Project page", properties?["screen"] as? String)
   }
 
   func testTrackSelectRewardButtonClicked() {
     let client = MockTrackingClient()
-    let koala = Koala(client: client)
-
     let reward = Reward.template
     let backing = .template
       |> Backing.lens.reward .~ reward
     let project = .template
       |> Project.lens.personalization.backing .~ backing
+    let loggedInUser = User.template |> \.id .~ 42
 
-    koala.trackSelectRewardButtonClicked(project: project, reward: reward, backing: backing)
+    let koala = Koala(client: client, loggedInUser: loggedInUser)
+
+    koala.trackSelectRewardButtonClicked(project: project, reward: reward, backing: backing, screen: .backThisPage)
+
+    let properties = client.properties.last
+
     XCTAssertEqual(["Select Reward Button Clicked"], client.events)
-
+    XCTAssertEqual("Back this page", properties?["screen"] as? String)
   }
 }

--- a/Library/ViewModels/ProjectPamphletViewModel.swift
+++ b/Library/ViewModels/ProjectPamphletViewModel.swift
@@ -137,6 +137,11 @@ public final class ProjectPamphletViewModel: ProjectPamphletViewModelType, Proje
       .map(cookieFrom(refTag:project:))
       .skipNil()
       .observeValues { AppEnvironment.current.cookieStorage.setCookie($0) }
+
+    // Tracking
+    project
+      .takeWhen(self.backThisProjectTappedProperty.signal)
+      .observeValues { AppEnvironment.current.koala.trackBackThisButtonClicked(project: $0) }
   }
 
   private let backThisProjectTappedProperty = MutableProperty(())

--- a/Library/ViewModels/ProjectPamphletViewModel.swift
+++ b/Library/ViewModels/ProjectPamphletViewModel.swift
@@ -141,7 +141,7 @@ public final class ProjectPamphletViewModel: ProjectPamphletViewModelType, Proje
     // Tracking
     project
       .takeWhen(self.backThisProjectTappedProperty.signal)
-      .observeValues { AppEnvironment.current.koala.trackBackThisButtonClicked(project: $0) }
+      .observeValues { AppEnvironment.current.koala.trackBackThisButtonClicked(project: $0, screen: .projectPage) }
   }
 
   private let backThisProjectTappedProperty = MutableProperty(())

--- a/Library/ViewModels/ProjectPamphletViewModel.swift
+++ b/Library/ViewModels/ProjectPamphletViewModel.swift
@@ -141,7 +141,9 @@ public final class ProjectPamphletViewModel: ProjectPamphletViewModelType, Proje
     // Tracking
     project
       .takeWhen(self.backThisProjectTappedProperty.signal)
-      .observeValues { AppEnvironment.current.koala.trackBackThisButtonClicked(project: $0, screen: .projectPage) }
+      .observeValues {
+        AppEnvironment.current.koala.trackBackThisButtonClicked(project: $0, screen: .projectPage)
+      }
   }
 
   private let backThisProjectTappedProperty = MutableProperty(())

--- a/Library/ViewModels/ProjectPamphletViewModelTests.swift
+++ b/Library/ViewModels/ProjectPamphletViewModelTests.swift
@@ -532,7 +532,7 @@ final class ProjectPamphletViewModelTests: TestCase {
 
       self.vm.inputs.backThisProjectTapped()
       XCTAssertEqual(
-        ["Project Page", "Viewed Project Page", "Project Page Viewed","Back this Project Button Clicked"],
+        ["Project Page", "Viewed Project Page", "Project Page Viewed", "Back this Project Button Clicked"],
         client.events
       )
     }

--- a/Library/ViewModels/ProjectPamphletViewModelTests.swift
+++ b/Library/ViewModels/ProjectPamphletViewModelTests.swift
@@ -131,16 +131,16 @@ final class ProjectPamphletViewModelTests: TestCase {
     self.scheduler.advance()
 
     XCTAssertEqual(
-      ["Project Page", "Viewed Project Page"],
+      ["Project Page", "Viewed Project Page", "Project Page Viewed"],
       self.trackingClient.events, "A project page koala event is tracked."
     )
     XCTAssertEqual(
-      [RefTag.category.stringTag, RefTag.category.stringTag],
+      [RefTag.category.stringTag, RefTag.category.stringTag, RefTag.category.stringTag ],
       self.trackingClient.properties.compactMap { $0["ref_tag"] as? String },
       "The ref tag is tracked in the koala event."
     )
     XCTAssertEqual(
-      [RefTag.category.stringTag, RefTag.category.stringTag],
+      [RefTag.category.stringTag, RefTag.category.stringTag, RefTag.category.stringTag,],
       self.trackingClient.properties.compactMap { $0["referrer_credit"] as? String },
       "The referral credit is tracked in the koala event."
     )
@@ -168,13 +168,13 @@ final class ProjectPamphletViewModelTests: TestCase {
     self.scheduler.advance()
 
     XCTAssertEqual(
-      ["Project Page", "Viewed Project Page", "Project Page", "Viewed Project Page"],
+      ["Project Page", "Viewed Project Page", "Project Page Viewed", "Project Page", "Viewed Project Page", "Project Page Viewed"],
       self.trackingClient.events, "A project page koala event is tracked."
     )
     XCTAssertEqual(
       [
-        RefTag.category.stringTag, RefTag.category.stringTag, RefTag.recommended.stringTag,
-        RefTag.recommended.stringTag
+        RefTag.category.stringTag, RefTag.category.stringTag, RefTag.category.stringTag,
+        RefTag.recommended.stringTag, RefTag.recommended.stringTag, RefTag.recommended.stringTag
       ],
       self.trackingClient.properties.compactMap { $0["ref_tag"] as? String },
       "The new ref tag is tracked in koala event."
@@ -182,7 +182,7 @@ final class ProjectPamphletViewModelTests: TestCase {
     XCTAssertEqual(
       [
         RefTag.category.stringTag, RefTag.category.stringTag, RefTag.category.stringTag,
-        RefTag.category.stringTag
+        RefTag.category.stringTag, RefTag.category.stringTag, RefTag.category.stringTag
       ],
       self.trackingClient.properties.compactMap { $0["referrer_credit"] as? String },
       "The referrer credit did not change, and is still category."
@@ -276,16 +276,16 @@ final class ProjectPamphletViewModelTests: TestCase {
     self.scheduler.advance()
 
     XCTAssertEqual(
-      ["Project Page", "Viewed Project Page"],
+      ["Project Page", "Viewed Project Page", "Project Page Viewed"],
       self.trackingClient.events, "A project page koala event is tracked."
     )
     XCTAssertEqual(
-      [RefTag.category.stringTag, RefTag.category.stringTag],
+      [RefTag.category.stringTag, RefTag.category.stringTag, RefTag.category.stringTag],
       self.trackingClient.properties.compactMap { $0["ref_tag"] as? String },
       "The ref tag is tracked in the koala event."
     )
     XCTAssertEqual(
-      [RefTag.category.stringTag, RefTag.category.stringTag],
+      [RefTag.category.stringTag, RefTag.category.stringTag, RefTag.category.stringTag],
       self.trackingClient.properties.compactMap { $0["referrer_credit"] as? String },
       "The referral credit is tracked in the koala event."
     )
@@ -313,13 +313,14 @@ final class ProjectPamphletViewModelTests: TestCase {
     self.scheduler.advance()
 
     XCTAssertEqual(
-      ["Project Page", "Viewed Project Page", "Project Page", "Viewed Project Page"],
+      ["Project Page", "Viewed Project Page", "Project Page Viewed", "Project Page",
+       "Viewed Project Page", "Project Page Viewed"],
       self.trackingClient.events, "A project page koala event is tracked."
     )
     XCTAssertEqual(
       [
-        RefTag.category.stringTag, RefTag.category.stringTag, RefTag.recommended.stringTag,
-        RefTag.recommended.stringTag
+        RefTag.category.stringTag, RefTag.category.stringTag, RefTag.category.stringTag,
+        RefTag.recommended.stringTag, RefTag.recommended.stringTag, RefTag.recommended.stringTag
       ],
       self.trackingClient.properties.compactMap { $0["ref_tag"] as? String },
       "The new ref tag is tracked in koala event."
@@ -327,7 +328,7 @@ final class ProjectPamphletViewModelTests: TestCase {
     XCTAssertEqual(
       [
         RefTag.category.stringTag, RefTag.category.stringTag, RefTag.category.stringTag,
-        RefTag.category.stringTag
+        RefTag.category.stringTag, RefTag.category.stringTag, RefTag.category.stringTag
       ],
       self.trackingClient.properties.compactMap { $0["referrer_credit"] as? String },
       "The referrer credit did not change, and is still category."

--- a/Library/ViewModels/ProjectPamphletViewModelTests.swift
+++ b/Library/ViewModels/ProjectPamphletViewModelTests.swift
@@ -517,7 +517,7 @@ final class ProjectPamphletViewModelTests: TestCase {
   }
 
   func testbackThisButton_eventTracking() {
-    let config = Config.template |> \.features .~ [Feature.checkout.rawValue: true]
+    let config = Config.template |> \.features .~ [Feature.nativeCheckout.rawValue: true]
     let client = MockTrackingClient()
     let project = Project.template
 

--- a/Library/ViewModels/ProjectPamphletViewModelTests.swift
+++ b/Library/ViewModels/ProjectPamphletViewModelTests.swift
@@ -509,4 +509,32 @@ final class ProjectPamphletViewModelTests: TestCase {
       self.configurePledgeCTAViewIsLoading.assertDidNotEmitValue()
     }
   }
+
+  func testbackThisButton_eventTracking() {
+    let config = Config.template |> \.features .~ [Feature.checkout.rawValue: true]
+    let client = MockTrackingClient()
+    let project = Project.template
+
+    withEnvironment(
+      apiService: MockService(),
+      config: config,
+      koala: Koala(client: client)
+    ) {
+      XCTAssertEqual([], client.events)
+
+      self.vm.inputs.configureWith(projectOrParam: .left(project), refTag: .discovery)
+      self.vm.inputs.viewDidLoad()
+      self.vm.inputs.viewWillAppear(animated: false)
+      self.vm.inputs.viewDidAppear(animated: false)
+
+      self.goToRewardsProject.assertDidNotEmitValue()
+      self.goToRewardsRefTag.assertDidNotEmitValue()
+
+      self.vm.inputs.backThisProjectTapped()
+      XCTAssertEqual(
+        ["Project Page", "Viewed Project Page", "Project Page Viewed","Back this Project Button Clicked"],
+        client.events
+      )
+    }
+  }
 }

--- a/Library/ViewModels/ProjectPamphletViewModelTests.swift
+++ b/Library/ViewModels/ProjectPamphletViewModelTests.swift
@@ -135,12 +135,12 @@ final class ProjectPamphletViewModelTests: TestCase {
       self.trackingClient.events, "A project page koala event is tracked."
     )
     XCTAssertEqual(
-      [RefTag.category.stringTag, RefTag.category.stringTag, RefTag.category.stringTag ],
+      [RefTag.category.stringTag, RefTag.category.stringTag, RefTag.category.stringTag],
       self.trackingClient.properties.compactMap { $0["ref_tag"] as? String },
       "The ref tag is tracked in the koala event."
     )
     XCTAssertEqual(
-      [RefTag.category.stringTag, RefTag.category.stringTag, RefTag.category.stringTag,],
+      [RefTag.category.stringTag, RefTag.category.stringTag, RefTag.category.stringTag],
       self.trackingClient.properties.compactMap { $0["referrer_credit"] as? String },
       "The referral credit is tracked in the koala event."
     )
@@ -168,7 +168,10 @@ final class ProjectPamphletViewModelTests: TestCase {
     self.scheduler.advance()
 
     XCTAssertEqual(
-      ["Project Page", "Viewed Project Page", "Project Page Viewed", "Project Page", "Viewed Project Page", "Project Page Viewed"],
+      [
+        "Project Page", "Viewed Project Page", "Project Page Viewed", "Project Page",
+        "Viewed Project Page", "Project Page Viewed"
+      ],
       self.trackingClient.events, "A project page koala event is tracked."
     )
     XCTAssertEqual(
@@ -313,8 +316,10 @@ final class ProjectPamphletViewModelTests: TestCase {
     self.scheduler.advance()
 
     XCTAssertEqual(
-      ["Project Page", "Viewed Project Page", "Project Page Viewed", "Project Page",
-       "Viewed Project Page", "Project Page Viewed"],
+      [
+        "Project Page", "Viewed Project Page", "Project Page Viewed", "Project Page",
+        "Viewed Project Page", "Project Page Viewed"
+      ],
       self.trackingClient.events, "A project page koala event is tracked."
     )
     XCTAssertEqual(

--- a/Library/ViewModels/RewardCardContainerViewModel.swift
+++ b/Library/ViewModels/RewardCardContainerViewModel.swift
@@ -58,7 +58,6 @@ public final class RewardCardContainerViewModel: RewardCardContainerViewModelTyp
       .takeWhen(self.pledgeButtonTappedProperty.signal)
       .map { $0.id }
 
-
     // Tracking
     projectAndRewardOrBacking
       .takeWhen(self.pledgeButtonTappedProperty.signal)
@@ -69,8 +68,8 @@ public final class RewardCardContainerViewModel: RewardCardContainerViewModelTyp
           reward: rewardOrBacking.left,
           backing: rewardOrBacking.right,
           screen: .backThisPage
-      )
-    }
+        )
+      }
   }
 
   private let projectAndRewardOrBackingProperty = MutableProperty<(Project, Either<Reward, Backing>)?>(nil)

--- a/Library/ViewModels/RewardCardContainerViewModel.swift
+++ b/Library/ViewModels/RewardCardContainerViewModel.swift
@@ -67,7 +67,8 @@ public final class RewardCardContainerViewModel: RewardCardContainerViewModelTyp
         AppEnvironment.current.koala.trackSelectRewardButtonClicked(
           project: project,
           reward: rewardOrBacking.left,
-          backing: rewardOrBacking.right
+          backing: rewardOrBacking.right,
+          screen: .backThisPage
       )
     }
   }

--- a/Library/ViewModels/RewardCardContainerViewModel.swift
+++ b/Library/ViewModels/RewardCardContainerViewModel.swift
@@ -57,6 +57,19 @@ public final class RewardCardContainerViewModel: RewardCardContainerViewModelTyp
     self.rewardSelected = reward
       .takeWhen(self.pledgeButtonTappedProperty.signal)
       .map { $0.id }
+
+
+    // Tracking
+    projectAndRewardOrBacking
+      .takeWhen(self.pledgeButtonTappedProperty.signal)
+      .observeValues { projectAndRewardOrBacking in
+        let (project, rewardOrBacking) = projectAndRewardOrBacking
+        AppEnvironment.current.koala.trackSelectRewardButtonClicked(
+          project: project,
+          reward: rewardOrBacking.left,
+          backing: rewardOrBacking.right
+      )
+    }
   }
 
   private let projectAndRewardOrBackingProperty = MutableProperty<(Project, Either<Reward, Backing>)?>(nil)

--- a/Library/ViewModels/RewardCardContainerViewModelTests.swift
+++ b/Library/ViewModels/RewardCardContainerViewModelTests.swift
@@ -475,4 +475,18 @@ final class RewardCardContainerViewModelTests: TestCase {
 
     self.rewardSelected.assertValues([Reward.template.id])
   }
+
+  func testPledgeButtonTapped_eventTracking() {
+    let client = MockTrackingClient()
+
+    withEnvironment(apiService: MockService(), koala: Koala(client: client)) {
+      XCTAssertEqual([], client.events)
+
+      self.vm.inputs.configureWith(project: .template, rewardOrBacking: .left(.template))
+
+      self.vm.inputs.pledgeButtonTapped()
+
+      XCTAssertEqual(["Select Reward Button Clicked"], client.events)
+    }
+  }
 }


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->
Please refer to PR https://github.com/kickstarter/ios-oss/pull/784 for the review.

# 📲 What

First release events that add tracking events and tests for checkout events in the project page and reward page.
# ✅ Acceptance criteria

- [x] Turn on the `KOALA_TRACKING` environment variable in the scheme. Then launch the app and navigate to a project. You should see the `Back this project` CTA, tap it. You should see an event `"Back this Project Button Clicked"` in the console.
- [x] Turn on the `KOALA_TRACKING` environment variable in the scheme. Then launch the app and navigate to a project. You should see the `Back this project` CTA, tap it. You should get to the reward screen. Tap on a reward to select it and an event, `"Select Reward Button Clicked"` should appear in the console.

