### PR TITLE
Fix "back this project" when deep-linking

### DIFF
--- a/Kickstarter-iOS/Views/Controllers/ProjectNavigatorViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/ProjectNavigatorViewController.swift
@@ -178,45 +178,6 @@ extension ProjectNavigatorViewController: ProjectPamphletViewControllerDelegate 
       isDragging: scrollView.isTracking
     )
   }
-
-  func projectPamphletViewController(
-    _: ProjectPamphletViewController,
-    didTapBackThisProject project: Project,
-    refTag: RefTag?
-  ) {
-    let vc = self.rewardsCollectionViewController(project: project, refTag: refTag)
-
-    self.present(vc, animated: true)
-  }
-
-  func deprecatedProjectPamphletViewController(
-    _: ProjectPamphletViewController,
-    didTapBackThisProject project: Project,
-    refTag: RefTag?
-  ) {
-    let vc = self.rewardsCollectionViewController(project: project, refTag: refTag)
-
-    self.present(vc, animated: true)
-  }
-
-  private func rewardsCollectionViewController(
-    project: Project,
-    refTag: RefTag?
-  ) -> UINavigationController {
-    let rewardsCollectionViewController = RewardsCollectionViewController
-      .instantiate(with: project, refTag: refTag)
-
-    let navigationController = RewardPledgeNavigationController(
-      rootViewController: rewardsCollectionViewController
-    )
-
-    if AppEnvironment.current.device.userInterfaceIdiom == .pad {
-      _ = navigationController
-        |> \.modalPresentationStyle .~ .pageSheet
-    }
-
-    return navigationController
-  }
 }
 
 // MARK: - UIGestureRecognizerDelegate

--- a/Kickstarter-iOS/Views/Controllers/ProjectPamphletViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/ProjectPamphletViewController.swift
@@ -8,16 +8,6 @@ public protocol ProjectPamphletViewControllerDelegate: AnyObject {
     _ controller: ProjectPamphletViewController,
     panGestureRecognizerDidChange recognizer: UIPanGestureRecognizer
   )
-  func projectPamphletViewController(
-    _ projectPamphletViewController: ProjectPamphletViewController,
-    didTapBackThisProject project: Project,
-    refTag: RefTag?
-  )
-  func deprecatedProjectPamphletViewController(
-    _ projectPamphletViewController: ProjectPamphletViewController,
-    didTapBackThisProject project: Project,
-    refTag: RefTag?
-  )
 }
 
 public final class ProjectPamphletViewController: UIViewController {
@@ -137,14 +127,6 @@ public final class ProjectPamphletViewController: UIViewController {
         self?.goToRewards(project: project, refTag: refTag)
       }
 
-    self.viewModel.outputs.goToDeprecatedRewards
-      .observeForControllerAction()
-      .observeValues { [weak self] params in
-        let (project, refTag) = params
-
-        self?.goToDeprecatedRewards(project: project, refTag: refTag)
-      }
-
     self.viewModel.outputs.configureChildViewControllersWithProject
       .observeForUI()
       .observeValues { [weak self] project, refTag in
@@ -190,20 +172,10 @@ public final class ProjectPamphletViewController: UIViewController {
     }
   }
 
-  private func goToDeprecatedRewards(project: Project, refTag: RefTag?) {
-    self.delegate?.deprecatedProjectPamphletViewController(
-      self,
-      didTapBackThisProject: project,
-      refTag: refTag
-    )
-  }
-
   private func goToRewards(project: Project, refTag: RefTag?) {
-    self.delegate?.projectPamphletViewController(
-      self,
-      didTapBackThisProject: project,
-      refTag: refTag
-    )
+    let vc = rewardsCollectionViewController(project: project, refTag: refTag)
+
+    self.present(vc, animated: true)
   }
 
   private func updateContentInsets() {
@@ -259,4 +231,23 @@ extension ProjectPamphletViewController: ProjectNavBarViewControllerDelegate {
   public func projectNavBarControllerDidTapTitle(_: ProjectNavBarViewController) {
     self.contentController.tableView.scrollToTop()
   }
+}
+
+private func rewardsCollectionViewController(
+  project: Project,
+  refTag: RefTag?
+) -> UINavigationController {
+  let rewardsCollectionViewController = RewardsCollectionViewController
+    .instantiate(with: project, refTag: refTag)
+
+  let navigationController = RewardPledgeNavigationController(
+    rootViewController: rewardsCollectionViewController
+  )
+
+  if AppEnvironment.current.device.userInterfaceIdiom == .pad {
+    _ = navigationController
+      |> \.modalPresentationStyle .~ .pageSheet
+  }
+
+  return navigationController
 }

--- a/Library/ViewModels/ProjectPamphletViewModel.swift
+++ b/Library/ViewModels/ProjectPamphletViewModel.swift
@@ -77,7 +77,7 @@ public final class ProjectPamphletViewModel: ProjectPamphletViewModelType, Proje
       }
 
     self.goToRewards = goToRewards
-      .filter { _ in featureNativeCheckoutPledgeViewEnabled() }
+      .filter { _ in featureNativeCheckoutEnabled() }
 
     let project = freshProjectAndRefTag
       .map(first)

--- a/Library/ViewModels/ProjectPamphletViewModel.swift
+++ b/Library/ViewModels/ProjectPamphletViewModel.swift
@@ -33,9 +33,6 @@ public protocol ProjectPamphletViewModelOutputs {
   /// Emits a project and refTag to be used to navigate to the reward selection screen.
   var goToRewards: Signal<(Project, RefTag?), Never> { get }
 
-  /// Emits a project and refTag to be used to navigate to the deprecated reward selection screen.
-  var goToDeprecatedRewards: Signal<(Project, RefTag?), Never> { get }
-
   /// Emits two booleans that determine if the navigation bar should be hidden, and if it should be animated.
   var setNavigationBarHiddenAnimated: Signal<(Bool, Bool), Never> { get }
 
@@ -81,9 +78,6 @@ public final class ProjectPamphletViewModel: ProjectPamphletViewModelType, Proje
 
     self.goToRewards = goToRewards
       .filter { _ in featureNativeCheckoutPledgeViewEnabled() }
-
-    self.goToDeprecatedRewards = goToRewards
-      .filter { _ in !featureNativeCheckoutPledgeViewEnabled() }
 
     let project = freshProjectAndRefTag
       .map(first)
@@ -184,7 +178,6 @@ public final class ProjectPamphletViewModel: ProjectPamphletViewModelType, Proje
 
   public let configureChildViewControllersWithProject: Signal<(Project, RefTag?), Never>
   public let configurePledgeCTAView: Signal<(Project, Bool), Never>
-  public let goToDeprecatedRewards: Signal<(Project, RefTag?), Never>
   public let goToRewards: Signal<(Project, RefTag?), Never>
   public let setNavigationBarHiddenAnimated: Signal<(Bool, Bool), Never>
   public let setNeedsStatusBarAppearanceUpdate: Signal<(), Never>

--- a/Library/ViewModels/ProjectPamphletViewModelTests.swift
+++ b/Library/ViewModels/ProjectPamphletViewModelTests.swift
@@ -355,7 +355,7 @@ final class ProjectPamphletViewModelTests: TestCase {
 
   func testGoToRewards() {
     let config = Config.template
-      |> \.features .~ [Feature.nativeCheckoutPledgeView.rawValue: true]
+      |> \.features .~ [Feature.nativeCheckout.rawValue: true]
 
     withEnvironment(config: config) {
       let project = Project.template

--- a/Library/ViewModels/ProjectPamphletViewModelTests.swift
+++ b/Library/ViewModels/ProjectPamphletViewModelTests.swift
@@ -12,8 +12,6 @@ final class ProjectPamphletViewModelTests: TestCase {
   private let configureChildViewControllersWithRefTag = TestObserver<RefTag?, Never>()
   private let configurePledgeCTAViewProject = TestObserver<Project, Never>()
   private let configurePledgeCTAViewIsLoading = TestObserver<Bool, Never>()
-  private let goToDeprecatedRewardsProject = TestObserver<Project, Never>()
-  private let goToDeprecatedRewardsRefTag = TestObserver<RefTag?, Never>()
   private let goToRewardsProject = TestObserver<Project, Never>()
   private let goToRewardsRefTag = TestObserver<RefTag?, Never>()
   private let setNavigationBarHidden = TestObserver<Bool, Never>()
@@ -31,8 +29,6 @@ final class ProjectPamphletViewModelTests: TestCase {
       .observe(self.configureChildViewControllersWithRefTag.observer)
     self.vm.outputs.configurePledgeCTAView.map(first).observe(self.configurePledgeCTAViewProject.observer)
     self.vm.outputs.configurePledgeCTAView.map(second).observe(self.configurePledgeCTAViewIsLoading.observer)
-    self.vm.outputs.goToDeprecatedRewards.map(first).observe(self.goToDeprecatedRewardsProject.observer)
-    self.vm.outputs.goToDeprecatedRewards.map(second).observe(self.goToDeprecatedRewardsRefTag.observer)
     self.vm.outputs.goToRewards.map(first).observe(self.goToRewardsProject.observer)
     self.vm.outputs.goToRewards.map(second).observe(self.goToRewardsRefTag.observer)
     self.vm.outputs.setNavigationBarHiddenAnimated.map(first)
@@ -369,39 +365,14 @@ final class ProjectPamphletViewModelTests: TestCase {
       self.vm.inputs.viewWillAppear(animated: false)
       self.vm.inputs.viewDidAppear(animated: false)
 
-      self.goToDeprecatedRewardsProject.assertDidNotEmitValue()
-      self.goToDeprecatedRewardsRefTag.assertDidNotEmitValue()
       self.goToRewardsProject.assertDidNotEmitValue()
       self.goToRewardsRefTag.assertDidNotEmitValue()
 
       self.vm.inputs.backThisProjectTapped()
 
-      self.goToDeprecatedRewardsProject.assertDidNotEmitValue()
-      self.goToDeprecatedRewardsRefTag.assertDidNotEmitValue()
       self.goToRewardsProject.assertValues([project], "Tapping 'Back this project' emits the project")
       self.goToRewardsRefTag.assertValues([.discovery], "Tapping 'Back this project' emits the refTag")
     }
-  }
-
-  func testGoToDeprecatedRewards() {
-    let project = Project.template
-
-    self.vm.inputs.configureWith(projectOrParam: .left(project), refTag: .discovery)
-    self.vm.inputs.viewDidLoad()
-    self.vm.inputs.viewWillAppear(animated: false)
-    self.vm.inputs.viewDidAppear(animated: false)
-
-    self.goToDeprecatedRewardsProject.assertDidNotEmitValue()
-    self.goToDeprecatedRewardsRefTag.assertDidNotEmitValue()
-    self.goToRewardsProject.assertDidNotEmitValue()
-    self.goToRewardsRefTag.assertDidNotEmitValue()
-
-    self.vm.inputs.backThisProjectTapped()
-
-    self.goToDeprecatedRewardsProject
-      .assertValues([project], "Tapping 'Back this project' emits the project")
-    self.goToDeprecatedRewardsRefTag
-      .assertValues([.discovery], "Tapping 'Back this project' emits the refTag")
   }
 
   func testConfigurePledgeCTAView_fetchProjectSuccess_featureEnabled() {


### PR DESCRIPTION
# 📲 What

Fixes the `Back this project` button not doing anything when deep-linking with the native checkout feature flag enabled.

# 🤔 Why

In a moment of confusion when I did this work before I used the `delegate` to present the `RewardsCollectionViewController`. This was unnecessary.

# 🛠 How

- Moved the presentation to the `ProjectPamphletViewController`.
- Removed `goToDeprecatedRewards` as it serves no purpose 🤦‍♂ 

# ✅ Acceptance criteria

Easiest way to test this is to make the following changes to these two files:

<img width="1001" alt="image" src="https://user-images.githubusercontent.com/3735375/63124836-0948a700-bf61-11e9-81ed-6bc3a8b9ace8.png">

This will make it easy to test that the view model is deep-linking that URL structure correctly.

- [x] Test deep-linking as above with the native checkout feature flag OFF (should see old project pamphlet with no CTA).
- [x] Test deep-linking as above with the native checkout feature flag ON (should see new CTA button and the button should do something).