### PR TITLE
Kick off Testflight builds for release branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -669,7 +669,9 @@ workflows:
       - itunes:
           filters:
             branches:
-              only: itunes-dist
+              only: 
+                - itunes-dist
+                - /release-.*/
           requires:
             - build-and-cache
             - kickstarter-tests


### PR DESCRIPTION
# 📲 What

This will extend automated Testflight build deployment from just the `itunes-dist` branch to all release branches.

# 🤔 Why

So we don't have to manually push up to the `itunes-dist` branch on the `private` remote when deploying from a release branch.

# 🛠 How

Include `only: /release-.*/` in the list of branches that execute the `itunes` job on CircleCI. This means that the following branches would get deployed to App Store Connect:

- `release-3.6.0`

but *not* 

- `release3.6.0`

# ✅ Acceptance criteria

- [ ] Create a release branch and push it up to the `private` remote! It should kick off an `itunes` job which will upload to App Store Connect

