### PR TITLE
Fix minor pledge screen issues

### DIFF
--- a/Kickstarter-iOS/Views/Controllers/DeprecatedRewardPledgeViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/DeprecatedRewardPledgeViewController.swift
@@ -352,6 +352,7 @@ internal final class DeprecatedRewardPledgeViewController: UIViewController {
       |> UIScrollView.lens.layoutMargins .~ .init(leftRight: Styles.grid(2))
       |> UIScrollView.lens.delaysContentTouches .~ false
       |> UIScrollView.lens.keyboardDismissMode .~ .interactive
+      |> \.alwaysBounceVertical .~ true
       |> \.contentInset .~ .init(topBottom: Styles.grid(2))
 
     _ = self.shippingActivityIndicatorView

--- a/Kickstarter-iOS/Views/Controllers/DeprecatedRewardPledgeViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/DeprecatedRewardPledgeViewController.swift
@@ -736,6 +736,14 @@ extension DeprecatedRewardPledgeViewController: DeprecatedRewardShippingPickerVi
     _ controller: DeprecatedRewardShippingPickerViewController
   ) {
     controller.dismiss(animated: true, completion: nil)
+
+    self.navigationController?.view.tintAdjustmentMode = .normal
+  }
+
+  func rewardShippingPickerViewControllerWillPresent(
+    _ controller: DeprecatedRewardShippingPickerViewController
+    ) {
+    self.navigationController?.view.tintAdjustmentMode = .dimmed
   }
 
   internal func rewardShippingPickerViewController(

--- a/Kickstarter-iOS/Views/Controllers/DeprecatedRewardShippingPickerViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/DeprecatedRewardShippingPickerViewController.swift
@@ -12,6 +12,11 @@ internal protocol DeprecatedRewardShippingPickerViewControllerDelegate: AnyObjec
 
   /// Called when the user wants to cancel the picker.
   func rewardShippingPickerViewControllerCancelled(_ controller: DeprecatedRewardShippingPickerViewController)
+
+  /// Called when the controller is presented.
+  func rewardShippingPickerViewControllerWillPresent(
+    _ controller: DeprecatedRewardShippingPickerViewController
+  )
 }
 
 internal final class DeprecatedRewardShippingPickerViewController: UIViewController {
@@ -55,6 +60,9 @@ internal final class DeprecatedRewardShippingPickerViewController: UIViewControl
 
   internal override func viewWillAppear(_ animated: Bool) {
     super.viewWillAppear(animated)
+
+    self.delegate.rewardShippingPickerViewControllerWillPresent(self)
+
     self.viewModel.inputs.viewWillAppear()
   }
 

--- a/Library/Styles/ButtonStyles.swift
+++ b/Library/Styles/ButtonStyles.swift
@@ -117,21 +117,15 @@ public let shareButtonStyle =
 
 // Remove when DeprecatedRewardShippingPickerViewController is removed.
 public let textOnlyButtonStyle = roundedStyle(cornerRadius: 0)
-  <> UIButton.lens.titleLabel.font %~~ { _, button in
-    button.traitCollection.verticalSizeClass == .compact
-      ? .ksr_callout(size: 12)
-      : .ksr_callout(size: 14)
-  }
-
+  <> UIButton.lens.titleLabel.font .~ UIFont.boldSystemFont(ofSize: 16)
   <> UIButton.lens.contentEdgeInsets %~~ { _, button in
     button.traitCollection.verticalSizeClass == .compact
       ? .init(topBottom: 10.0, leftRight: 12.0)
       : .init(topBottom: 13.0, leftRight: 16.0)
   }
-
   <> UIButton.lens.adjustsImageWhenDisabled .~ false
   <> UIButton.lens.adjustsImageWhenHighlighted .~ false
-  <> UIButton.lens.titleColor(for: .normal) .~ .ksr_soft_black
+  <> UIButton.lens.titleColor(for: .normal) .~ .ksr_green_500
   <> UIButton.lens.backgroundColor(for: .normal) .~ .clear
-  <> UIButton.lens.titleColor(for: .highlighted) .~ .ksr_green_400
-  <> UIButton.lens.titleColor(for: .disabled) .~ .ksr_dark_grey_400
+  <> UIButton.lens.titleColor(for: .highlighted) .~ UIColor.ksr_green_500.mixDarker(0.36)
+  <> UIButton.lens.titleColor(for: .disabled) .~ UIColor.ksr_green_500.mixDarker(0.36)


### PR DESCRIPTION
# 📲 What

Fixes
- Shipping location button styles
- Dims pledge screen's dismiss button when shipping location picker is presented
- Enables elasticity for when the card still fits the screen

# 🤔 Why

UI improvements

# 👀 See

| Before 🐛 | After 🦋 |
| --- | --- |
| <img width="535" alt="Screen Shot 2019-08-23 at 1 00 11 PM" src="https://user-images.githubusercontent.com/387596/63620393-f740b700-c5a5-11e9-8c70-af35a4d72309.png"> | <img width="535" alt="Screen Shot 2019-08-23 at 12 53 44 PM" src="https://user-images.githubusercontent.com/387596/63620143-5f42cd80-c5a5-11e9-831f-a801de7a81cd.png"> |

# ✅ Acceptance criteria

- [ ] UI changes are signed off by PM