### PR TITLE
Set koala's base url based on current environment

### DIFF
--- a/Library/Environment.swift
+++ b/Library/Environment.swift
@@ -114,7 +114,7 @@ public struct Environment {
     environmentVariables: EnvironmentVariables = EnvironmentVariables(),
     is1PasswordSupported: @escaping () -> Bool = { ksr_is1PasswordSupported() },
     isVoiceOverRunning: @escaping () -> Bool = { UIAccessibility.isVoiceOverRunning },
-    koala: Koala = Koala(client: KoalaTrackingClient(endpoint: .production)),
+    koala: Koala = Koala(client: KoalaTrackingClient()),
     language: Language = Language(languageStrings: Locale.preferredLanguages) ?? Language.en,
     launchedCountries: LaunchedCountries = .init(),
     locale: Locale = .current,

--- a/Library/Koala/KoalaTrackingClient.swift
+++ b/Library/Koala/KoalaTrackingClient.swift
@@ -5,29 +5,22 @@ private let flushInterval = 60.0
 private let chunkSize = 4
 
 public final class KoalaTrackingClient: TrackingClientType {
-  fileprivate let endpoint: Endpoint
   fileprivate let URLSession: URLSession
   fileprivate let queue = DispatchQueue(label: "com.kickstarter.KoalaTrackingClient")
   fileprivate var buffer: [[String: Any]] = []
   fileprivate var timer: Timer?
   fileprivate var taskId = UIBackgroundTaskIdentifier.invalid
 
-  public enum Endpoint {
-    case staging
-    case production
-
-    var base: String {
-      switch self {
-      case .staging:
-        return Secrets.KoalaEndpoint.staging
-      case .production:
-        return Secrets.KoalaEndpoint.production
-      }
+  fileprivate var base: String {
+    switch AppEnvironment.current.environmentType {
+    case .production:
+      return Secrets.KoalaEndpoint.production
+    default:
+      return Secrets.KoalaEndpoint.staging
     }
   }
 
-  public init(endpoint: Endpoint = .production, URLSession: URLSession = .shared) {
-    self.endpoint = endpoint
+  public init(URLSession: URLSession = .shared) {
     self.URLSession = URLSession
 
     let notifications = NotificationCenter.default
@@ -130,7 +123,7 @@ public final class KoalaTrackingClient: TrackingClientType {
     if dataString.count >= 10_000 {
       print("🐨 [Koala Error]: Base64 payload is longer than 10,000 characters.")
     }
-    return URL(string: "\(self.endpoint.base)?data=\(dataString)")
+    return URL(string: "\(self.base)?data=\(dataString)")
   }
 
   fileprivate static func koalaRequest(_ url: URL) -> URLRequest {


### PR DESCRIPTION
# 📲 What

Tracking events are send to the right Koala endpoint based on current environment.

# 🤔 Why

We ran into an issue where all tracking events were being sent to production environment. We would like to set the Koala endpoint based on current environment.

# 🛠 How

See the code change

# ✅ Acceptance criteria

## Release build

1. Proxy your device's network communication through your machine either by using `Charlesproxy` or `mitmproxy` (there are instructions in Guru how to do this)
2. Build and run in `Release` mode by following these instructions

<img width="800" alt="Screen Shot 2019-08-27 at 4 55 27 PM" src="https://user-images.githubusercontent.com/387596/63816075-a0134d00-c8eb-11e9-8b29-b24b88cfb39c.png">

- [x] Tracking events are being sent to `production` endpoint (this value is accessible in `Secrets.KoalaEndpoint.production`
- [x] Terminating the app and restarting it again does send Koala events to the right endpoint based on `Environment`

## Debug build (Alpha, Beta, Debug)

1. Proxy your device's network communication through your machine either by using `Charlesproxy` or `mitmproxy` (there are instructions in Guru how to do this)
2. Build and run in `Debug` mode
3. Make sure `KOALA_TRACKING` environment variable is turned `ON` by following these instructions

<img width="800" alt="Screen Shot 2019-08-27 at 4 52 26 PM" src="https://user-images.githubusercontent.com/387596/63816211-42333500-c8ec-11e9-9f4d-8aa36b162531.png">

- [x] By changing the `Environment` to `Staging` (in Beta tools) tracking events are being sent to 
`staging` endpoint (this value is accessible in `Secrets.KkoalaEndpoint.staging`)
- [x] By changing the `Environment` to `Production` (in Beta tools) tracking events are being sent to `production` endpoint (this value is accessible in `Secrets.KkoalaEndpoint.production`)
- [x] Logging in / out does send Koala events to the right endpoint based on `Environment`

Please note that if you're immediately not seeing any events you can background the app which should flush the queue.