### PR TITLE
Update config when the session starts and ends

### DIFF
--- a/Kickstarter-iOS/ViewModels/AppDelegateViewModel.swift
+++ b/Kickstarter-iOS/ViewModels/AppDelegateViewModel.swift
@@ -201,7 +201,9 @@ public final class AppDelegateViewModel: AppDelegateViewModelType, AppDelegateVi
 
     self.updateConfigInEnvironment = Signal.merge([
       self.applicationWillEnterForegroundProperty.signal,
-      self.applicationLaunchOptionsProperty.signal.ignoreValues()
+      self.applicationLaunchOptionsProperty.signal.ignoreValues(),
+      self.userSessionEndedProperty.signal,
+      self.userSessionStartedProperty.signal
     ])
       .switchMap { AppEnvironment.current.apiService.fetchConfig().demoteErrors() }
 

--- a/Kickstarter-iOS/ViewModels/AppDelegateViewModelTests.swift
+++ b/Kickstarter-iOS/ViewModels/AppDelegateViewModelTests.swift
@@ -498,6 +498,18 @@ final class AppDelegateViewModelTests: TestCase {
       self.vm.inputs.applicationWillEnterForeground()
       self.updateConfigInEnvironment.assertValues([config1, config2])
     }
+
+    let config3 = Config.template |> Config.lens.countryCode .~ "CZ"
+    withEnvironment(apiService: MockService(fetchConfigResponse: config3)) {
+      self.vm.inputs.userSessionEnded()
+      self.updateConfigInEnvironment.assertValues([config1, config2, config3])
+    }
+
+    let config4 = Config.template |> Config.lens.countryCode .~ "CA"
+    withEnvironment(apiService: MockService(fetchConfigResponse: config4)) {
+      self.vm.inputs.userSessionStarted()
+      self.updateConfigInEnvironment.assertValues([config1, config2, config3, config4])
+    }
   }
 
   func testPresentViewController() {


### PR DESCRIPTION
# 📲 What

Updates config every time a user logs in or logs out (in addition to launching the app or coming back to the app from background).

# 🤔 Why

We've noticed that the config would only refresh after the app has been backgrounded and brought back to foreground. This caused some confusion when logging in as a different user and logging out because the config wasn't properly updated unless the app was backgrounded and brought back to foreground again. This PR fixes that and should always make sure that the config is always up to date even without leaving the app.

# 🛠 How

Very straightforward, please see the code.

# ✅ Acceptance criteria

In order to properly test this you'll have to observe your device connection with `mitm` tool like `Charles proxy` or `mitmproxy` (there's a guru card with instructions on how to set this up).

- [ ] Launching the app from terminated state should fetch `config`
- [ ] Re-opening the app from background should fetch `config`
- [ ] Logging in should fetch `config`
- [ ] Logging out should fetch `config`