### PR TITLE
[Apple Pay] Part 1 - Create Apple Pay Backing Mutation

### DIFF
--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -227,6 +227,9 @@
 		7790DF892200D3BD005DBB11 /* SettingsFormFieldView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 7790DF882200D3BD005DBB11 /* SettingsFormFieldView.xib */; };
 		7793B16D21077AEB007857C0 /* SettingsHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7793B16C21077AEB007857C0 /* SettingsHeaderView.swift */; };
 		77941D2E216FCB0100398B89 /* ChangePasswordViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77941D2D216FCB0100398B89 /* ChangePasswordViewControllerTests.swift */; };
+		77950F0A231EB8C300308331 /* CreateApplePayBackingMutation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77950F09231EB8C300308331 /* CreateApplePayBackingMutation.swift */; };
+		77950F0C231EBC4200308331 /* CreateApplePayBackingInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77950F0B231EBC4200308331 /* CreateApplePayBackingInput.swift */; };
+		77950F0E231EC12700308331 /* CreateApplePayBackingInputTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77950F0D231EC12700308331 /* CreateApplePayBackingInputTests.swift */; };
 		7798B5612174F3CD008BC50D /* UserQueries.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7798B5602174F3CD008BC50D /* UserQueries.swift */; };
 		7798B5632174F494008BC50D /* UserEnvelope.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7798B5622174F494008BC50D /* UserEnvelope.swift */; };
 		7798B56521750041008BC50D /* UserCurrency.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7798B56421750041008BC50D /* UserCurrency.swift */; };
@@ -1548,6 +1551,9 @@
 		7790DF882200D3BD005DBB11 /* SettingsFormFieldView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SettingsFormFieldView.xib; sourceTree = "<group>"; };
 		7793B16C21077AEB007857C0 /* SettingsHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsHeaderView.swift; sourceTree = "<group>"; };
 		77941D2D216FCB0100398B89 /* ChangePasswordViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangePasswordViewControllerTests.swift; sourceTree = "<group>"; };
+		77950F09231EB8C300308331 /* CreateApplePayBackingMutation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateApplePayBackingMutation.swift; sourceTree = "<group>"; };
+		77950F0B231EBC4200308331 /* CreateApplePayBackingInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateApplePayBackingInput.swift; sourceTree = "<group>"; };
+		77950F0D231EC12700308331 /* CreateApplePayBackingInputTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateApplePayBackingInputTests.swift; sourceTree = "<group>"; };
 		7798B5602174F3CD008BC50D /* UserQueries.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserQueries.swift; sourceTree = "<group>"; };
 		7798B5622174F494008BC50D /* UserEnvelope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserEnvelope.swift; sourceTree = "<group>"; };
 		7798B56421750041008BC50D /* UserCurrency.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserCurrency.swift; sourceTree = "<group>"; };
@@ -2566,6 +2572,7 @@
 		775DFADB2162A56D00620CED /* mutations */ = {
 			isa = PBXGroup;
 			children = (
+				77950F09231EB8C300308331 /* CreateApplePayBackingMutation.swift */,
 				D08C71DB22A71A0100A245B7 /* ClearUserUnseenActivityMutation.swift */,
 				D79CF32B219CDEE100ECB73A /* CreatePaymentsSourceMutation.swift */,
 				D085100F219500F200BC418B /* PaymentSourceDeleteMutation.swift */,
@@ -2734,7 +2741,6 @@
 				D63BBD382180BE5D007E01F0 /* PaymentMethodsFooterView.swift */,
 				D741577A2284849000C0B907 /* PledgeCTAContainerView.swift */,
 				770D86C522F0D47000CDC6A1 /* PledgeAddNewCardView.swift */,
-				D66511A522F8750100232841 /* PledgeCTAErrorView.swift */,
 				374F507822614A1000DE6746 /* PledgeFooterView.swift */,
 				015706BA1E68DE580087DD68 /* ProfileSortBarView.swift */,
 				A78012641D2EEA620027396E /* ReferralChartView.swift */,
@@ -3895,6 +3901,8 @@
 			isa = PBXGroup;
 			children = (
 				D777442E217A3382008D679F /* ChangeCurrencyInput.swift */,
+				77950F0B231EBC4200308331 /* CreateApplePayBackingInput.swift */,
+				77950F0D231EC12700308331 /* CreateApplePayBackingInputTests.swift */,
 				D79CF32D219CE51A00ECB73A /* CreatePaymentSourceInput.swift */,
 				D6ED1B3A216D525B007F7547 /* ChangeEmailInput.swift */,
 				77E44B7321823A56006446B8 /* ChangePasswordInput.swift */,
@@ -5333,6 +5341,7 @@
 				D01588EB1EEB2ED7006E7684 /* MessageSubject.swift in Sources */,
 				D770DDE8217D729300B5319A /* UserCurrencyTemplates.swift in Sources */,
 				D01589171EEB2ED7006E7684 /* RewardsItem.swift in Sources */,
+				77950F0A231EB8C300308331 /* CreateApplePayBackingMutation.swift in Sources */,
 				D0158A1B1EEB30A2006E7684 /* Project.VideoTemplates.swift in Sources */,
 				D0158A311EEB30A2006E7684 /* User.NotificationsTemplates.swift in Sources */,
 				D6ED1B3E216D61E0007F7547 /* UpdateUserAccountMutation.swift in Sources */,
@@ -5389,6 +5398,7 @@
 				D01588891EEB2ED7006E7684 /* CheckoutEnvelopeLenses.swift in Sources */,
 				D0158A2E1EEB30A2006E7684 /* User.AvatarTemplates.swift in Sources */,
 				D01588571EEB2ED7006E7684 /* CheckoutEnvelope.swift in Sources */,
+				77950F0C231EBC4200308331 /* CreateApplePayBackingInput.swift in Sources */,
 				D01588771EEB2ED7006E7684 /* FriendStatsEnvelope.swift in Sources */,
 				D015891D1EEB2ED7006E7684 /* ShippingRule.swift in Sources */,
 				D67B6CD6221F468100B63A6B /* Location+Argo.swift in Sources */,
@@ -5435,6 +5445,7 @@
 				D0D10C1C1EEB4550005EBAD0 /* UpdateDraftTests.swift in Sources */,
 				D0D10C0D1EEB4550005EBAD0 /* FriendStatsEnvelopeTests.swift in Sources */,
 				77DB532A2215D0AA0078991C /* GraphUserCreditCardTests.swift in Sources */,
+				77950F0E231EC12700308331 /* CreateApplePayBackingInputTests.swift in Sources */,
 				D01589A21EEB2ED7006E7684 /* ServiceTypeTests.swift in Sources */,
 				D0D10C0F1EEB4550005EBAD0 /* LocationTests.swift in Sources */,
 				D0D10C121EEB4550005EBAD0 /* Project.CountryTests.swift in Sources */,

--- a/KsApi/GraphSchema.swift
+++ b/KsApi/GraphSchema.swift
@@ -108,7 +108,6 @@ public enum GraphError: Error {
   case emptyResponse(URLResponse?)
   case decodeError(GraphResponseError)
   case jsonDecodingError(responseString: String?, error: Error?)
-  case jsonEncodingError
 }
 
 public enum Query {

--- a/KsApi/GraphSchema.swift
+++ b/KsApi/GraphSchema.swift
@@ -108,6 +108,7 @@ public enum GraphError: Error {
   case emptyResponse(URLResponse?)
   case decodeError(GraphResponseError)
   case jsonDecodingError(responseString: String?, error: Error?)
+  case jsonEncodingError
 }
 
 public enum Query {

--- a/KsApi/MockService.swift
+++ b/KsApi/MockService.swift
@@ -21,6 +21,8 @@
 
     fileprivate let changePasswordError: GraphError?
 
+    fileprivate let createApplePayBackingError: GraphError?
+
     fileprivate let createPasswordError: GraphError?
 
     fileprivate let changePaymentMethodResult: Result<ChangePaymentMethodEnvelope, ErrorEnvelope>?
@@ -194,6 +196,7 @@
         me: .template
       ),
       changePasswordError: GraphError? = nil,
+      createApplePayBackingError: GraphError? = nil,
       createPasswordError: GraphError? = nil,
       changeCurrencyResponse: GraphMutationEmptyResponseEnvelope? = nil,
       changeCurrencyError: GraphError? = nil,
@@ -302,6 +305,8 @@
       self.changePasswordError = changePasswordError
 
       self.clearUserUnseenActivityResult = clearUserUnseenActivityResult
+
+      self.createApplePayBackingError = createApplePayBackingError
 
       self.createPasswordError = createPasswordError
 
@@ -528,6 +533,15 @@
     internal func changePassword(input _: ChangePasswordInput) ->
       SignalProducer<GraphMutationEmptyResponseEnvelope, GraphError> {
       if let error = self.changePasswordError {
+        return SignalProducer(error: error)
+      } else {
+        return SignalProducer(value: GraphMutationEmptyResponseEnvelope())
+      }
+    }
+
+    internal func createApplePayBacking(input: CreateApplePayBackingInput)
+      -> SignalProducer<GraphMutationEmptyResponseEnvelope, GraphError> {
+      if let error = self.createApplePayBackingError {
         return SignalProducer(error: error)
       } else {
         return SignalProducer(value: GraphMutationEmptyResponseEnvelope())

--- a/KsApi/MockService.swift
+++ b/KsApi/MockService.swift
@@ -539,7 +539,7 @@
       }
     }
 
-    internal func createApplePayBacking(input: CreateApplePayBackingInput)
+    internal func createApplePayBacking(input _: CreateApplePayBackingInput)
       -> SignalProducer<GraphMutationEmptyResponseEnvelope, GraphError> {
       if let error = self.createApplePayBackingError {
         return SignalProducer(error: error)

--- a/KsApi/Service.swift
+++ b/KsApi/Service.swift
@@ -88,6 +88,11 @@ public struct Service: ServiceType {
     return applyMutation(mutation: UpdateUserAccountMutation(input: input))
   }
 
+  public func createApplePayBacking(input: CreateApplePayBackingInput)
+    -> SignalProducer<GraphMutationEmptyResponseEnvelope, GraphError> {
+    return applyMutation(mutation: CreateApplePayBackingMutation(input: input))
+  }
+
   public func createPassword(input: CreatePasswordInput) ->
     SignalProducer<GraphMutationEmptyResponseEnvelope, GraphError> {
     return applyMutation(mutation: UpdateUserAccountMutation(input: input))

--- a/KsApi/ServiceType.swift
+++ b/KsApi/ServiceType.swift
@@ -57,6 +57,9 @@ public protocol ServiceType {
   func clearUserUnseenActivity(input: EmptyInput)
     -> SignalProducer<ClearUserUnseenActivityEnvelope, GraphError>
 
+  func createApplePayBacking(input: CreateApplePayBackingInput)
+    -> SignalProducer<GraphMutationEmptyResponseEnvelope, GraphError>
+
   func createPassword(input: CreatePasswordInput) ->
     SignalProducer<GraphMutationEmptyResponseEnvelope, GraphError>
 

--- a/KsApi/mutations/CreateApplePayBackingMutation.swift
+++ b/KsApi/mutations/CreateApplePayBackingMutation.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+public struct CreateApplePayBackingMutation<T: GraphMutationInput>: GraphMutation {
+  var input: T
+
+  public init(input: T) {
+    self.input = input
+  }
+
+  public var description: String {
+    return """
+    mutation createApplePayBacking($input: CreateApplePayBackingInput!) {
+      createApplePayBacking(input: $input) {
+        clientMutationId
+      }
+    }
+    """
+  }
+}

--- a/KsApi/mutations/inputs/CreateApplePayBackingInput.swift
+++ b/KsApi/mutations/inputs/CreateApplePayBackingInput.swift
@@ -10,17 +10,6 @@ public struct CreateApplePayBackingInput: GraphMutationInput {
   let stripeToken: String
   let transactionIdentifier: String
 
-  private enum CodingKeys: String, CodingKey {
-    case amount
-    case locationId
-    case paymentInstrumentName
-    case paymentNetwork
-    case projectId
-    case rewardId
-    case stripeToken = "token"
-    case transactionIdentifier
-  }
-
   public init(amount: String, locationId: Int?, paymentInstrumentName: String, paymentNetwork: String,
               projectId: Int, rewardId: Int?, stripeToken: String, transactionIdentifier: String) {
     self.amount = amount
@@ -34,37 +23,23 @@ public struct CreateApplePayBackingInput: GraphMutationInput {
   }
 
   public func toInputDictionary() -> [String : Any] {
-    do {
-      let JSONObject = try JSONSerialization.jsonObject(with: JSONEncoder().encode(self), options: [])
-
-      guard let jsonDictionary = JSONObject as? [String: Any] else {
-        throw GraphError.jsonEncodingError
-      }
-
-      return jsonDictionary
-    } catch {
-      return [:]
-    }
-  }
-}
-
-extension CreateApplePayBackingInput: Encodable {
-  public func encode(to encoder: Encoder) throws {
-    var container = encoder.container(keyedBy: CodingKeys.self)
-
-    try container.encode(self.amount, forKey: .amount)
-    try container.encode(self.paymentInstrumentName, forKey: .paymentInstrumentName)
-    try container.encode(self.paymentNetwork, forKey: .paymentNetwork)
-    try container.encode(String(self.projectId), forKey: .projectId)
-    try container.encode(self.stripeToken, forKey: .stripeToken)
-    try container.encode(self.transactionIdentifier, forKey: .transactionIdentifier)
+    var inputDictionary = [
+      "amount": self.amount,
+      "paymentInstrumentName": self.paymentInstrumentName,
+      "paymentNetwork": self.paymentNetwork,
+      "projectId": String(self.projectId),
+      "token": self.stripeToken,
+      "transactionIdentifier": self.transactionIdentifier
+    ]
 
     if let locationId = self.locationId {
-      try container.encode("\(locationId)", forKey: .locationId)
+      inputDictionary["locationId"] = String(locationId)
     }
 
     if let rewardId = self.rewardId {
-      try container.encode("\(rewardId)", forKey: .rewardId)
+      inputDictionary["rewardId"] = String(rewardId)
     }
+
+    return inputDictionary
   }
 }

--- a/KsApi/mutations/inputs/CreateApplePayBackingInput.swift
+++ b/KsApi/mutations/inputs/CreateApplePayBackingInput.swift
@@ -1,0 +1,70 @@
+import Foundation
+
+public struct CreateApplePayBackingInput: GraphMutationInput {
+  let amount: String
+  let locationId: Int?
+  let paymentInstrumentName: String
+  let paymentNetwork: String
+  let projectId: Int
+  let rewardId: Int?
+  let stripeToken: String
+  let transactionIdentifier: String
+
+  private enum CodingKeys: String, CodingKey {
+    case amount
+    case locationId
+    case paymentInstrumentName
+    case paymentNetwork
+    case projectId
+    case rewardId
+    case stripeToken = "token"
+    case transactionIdentifier
+  }
+
+  public init(amount: String, locationId: Int?, paymentInstrumentName: String, paymentNetwork: String,
+              projectId: Int, rewardId: Int?, stripeToken: String, transactionIdentifier: String) {
+    self.amount = amount
+    self.locationId = locationId
+    self.paymentInstrumentName = paymentInstrumentName
+    self.paymentNetwork = paymentNetwork
+    self.projectId = projectId
+    self.rewardId = rewardId
+    self.stripeToken = stripeToken
+    self.transactionIdentifier = transactionIdentifier
+  }
+
+  public func toInputDictionary() -> [String : Any] {
+    do {
+      let JSONObject = try JSONSerialization.jsonObject(with: JSONEncoder().encode(self), options: [])
+
+      guard let jsonDictionary = JSONObject as? [String: Any] else {
+        throw GraphError.jsonEncodingError
+      }
+
+      return jsonDictionary
+    } catch {
+      return [:]
+    }
+  }
+}
+
+extension CreateApplePayBackingInput: Encodable {
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+
+    try container.encode(self.amount, forKey: .amount)
+    try container.encode(self.paymentInstrumentName, forKey: .paymentInstrumentName)
+    try container.encode(self.paymentNetwork, forKey: .paymentNetwork)
+    try container.encode(String(self.projectId), forKey: .projectId)
+    try container.encode(self.stripeToken, forKey: .stripeToken)
+    try container.encode(self.transactionIdentifier, forKey: .transactionIdentifier)
+
+    if let locationId = self.locationId {
+      try container.encode("\(locationId)", forKey: .locationId)
+    }
+
+    if let rewardId = self.rewardId {
+      try container.encode("\(rewardId)", forKey: .rewardId)
+    }
+  }
+}

--- a/KsApi/mutations/inputs/CreateApplePayBackingInput.swift
+++ b/KsApi/mutations/inputs/CreateApplePayBackingInput.swift
@@ -10,8 +10,10 @@ public struct CreateApplePayBackingInput: GraphMutationInput {
   let stripeToken: String
   let transactionIdentifier: String
 
-  public init(amount: String, locationId: Int?, paymentInstrumentName: String, paymentNetwork: String,
-              projectId: Int, rewardId: Int?, stripeToken: String, transactionIdentifier: String) {
+  public init(
+    amount: String, locationId: Int?, paymentInstrumentName: String, paymentNetwork: String,
+    projectId: Int, rewardId: Int?, stripeToken: String, transactionIdentifier: String
+  ) {
     self.amount = amount
     self.locationId = locationId
     self.paymentInstrumentName = paymentInstrumentName
@@ -22,7 +24,7 @@ public struct CreateApplePayBackingInput: GraphMutationInput {
     self.transactionIdentifier = transactionIdentifier
   }
 
-  public func toInputDictionary() -> [String : Any] {
+  public func toInputDictionary() -> [String: Any] {
     var inputDictionary = [
       "amount": self.amount,
       "paymentInstrumentName": self.paymentInstrumentName,

--- a/KsApi/mutations/inputs/CreateApplePayBackingInput.swift
+++ b/KsApi/mutations/inputs/CreateApplePayBackingInput.swift
@@ -2,17 +2,17 @@ import Foundation
 
 public struct CreateApplePayBackingInput: GraphMutationInput {
   let amount: String
-  let locationId: Int?
+  let locationId: String?
   let paymentInstrumentName: String
   let paymentNetwork: String
-  let projectId: Int
-  let rewardId: Int?
+  let projectId: String
+  let rewardId: String?
   let stripeToken: String
   let transactionIdentifier: String
 
   public init(
-    amount: String, locationId: Int?, paymentInstrumentName: String, paymentNetwork: String,
-    projectId: Int, rewardId: Int?, stripeToken: String, transactionIdentifier: String
+    amount: String, locationId: String?, paymentInstrumentName: String, paymentNetwork: String,
+    projectId: String, rewardId: String?, stripeToken: String, transactionIdentifier: String
   ) {
     self.amount = amount
     self.locationId = locationId
@@ -29,17 +29,17 @@ public struct CreateApplePayBackingInput: GraphMutationInput {
       "amount": self.amount,
       "paymentInstrumentName": self.paymentInstrumentName,
       "paymentNetwork": self.paymentNetwork,
-      "projectId": String(self.projectId),
+      "projectId": self.projectId,
       "token": self.stripeToken,
       "transactionIdentifier": self.transactionIdentifier
     ]
 
     if let locationId = self.locationId {
-      inputDictionary["locationId"] = String(locationId)
+      inputDictionary["locationId"] = locationId
     }
 
     if let rewardId = self.rewardId {
-      inputDictionary["rewardId"] = String(rewardId)
+      inputDictionary["rewardId"] = rewardId
     }
 
     return inputDictionary

--- a/KsApi/mutations/inputs/CreateApplePayBackingInputTests.swift
+++ b/KsApi/mutations/inputs/CreateApplePayBackingInputTests.swift
@@ -6,25 +6,25 @@ final class CreateApplePayBackingInputTests: XCTestCase {
   func testCreateApplePayBacking_toInputDictionary_noNilValues() {
     let input = CreateApplePayBackingInput(
       amount: "10.00",
-      locationId: 123,
+      locationId: "123",
       paymentInstrumentName: "instrumentName",
       paymentNetwork: "paymentNetwork",
-      projectId: 12_345,
-      rewardId: 321,
+      projectId: "12345",
+      rewardId: "321",
       stripeToken: "stripeTokenXYZ",
       transactionIdentifier: "transactionId"
     )
 
     let inputDictionary = input.toInputDictionary()
 
-    XCTAssertEqual(inputDictionary["amount"] as! String, "10.00")
-    XCTAssertEqual(inputDictionary["locationId"] as! String, "123")
-    XCTAssertEqual(inputDictionary["paymentInstrumentName"] as! String, "instrumentName")
-    XCTAssertEqual(inputDictionary["paymentNetwork"] as! String, "paymentNetwork")
-    XCTAssertEqual(inputDictionary["projectId"] as! String, "12345")
-    XCTAssertEqual(inputDictionary["rewardId"] as! String, "321")
-    XCTAssertEqual(inputDictionary["token"] as! String, "stripeTokenXYZ")
-    XCTAssertEqual(inputDictionary["transactionIdentifier"] as! String, "transactionId")
+    XCTAssertEqual(inputDictionary["amount"] as? String, "10.00")
+    XCTAssertEqual(inputDictionary["locationId"] as? String, "123")
+    XCTAssertEqual(inputDictionary["paymentInstrumentName"] as? String, "instrumentName")
+    XCTAssertEqual(inputDictionary["paymentNetwork"] as? String, "paymentNetwork")
+    XCTAssertEqual(inputDictionary["projectId"] as? String, "12345")
+    XCTAssertEqual(inputDictionary["rewardId"] as? String, "321")
+    XCTAssertEqual(inputDictionary["token"] as? String, "stripeTokenXYZ")
+    XCTAssertEqual(inputDictionary["transactionIdentifier"] as? String, "transactionId")
   }
 
   func testCreateApplePayBacking_toInputDictionary_withNilValues() {
@@ -33,7 +33,7 @@ final class CreateApplePayBackingInputTests: XCTestCase {
       locationId: nil,
       paymentInstrumentName: "instrumentName",
       paymentNetwork: "paymentNetwork",
-      projectId: 12_345,
+      projectId: "12345",
       rewardId: nil,
       stripeToken: "stripeTokenXYZ",
       transactionIdentifier: "transactionId"
@@ -41,12 +41,12 @@ final class CreateApplePayBackingInputTests: XCTestCase {
 
     let inputDictionary = input.toInputDictionary()
 
-    XCTAssertEqual(inputDictionary["amount"] as! String, "10.50")
-    XCTAssertEqual(inputDictionary["paymentInstrumentName"] as! String, "instrumentName")
-    XCTAssertEqual(inputDictionary["paymentNetwork"] as! String, "paymentNetwork")
-    XCTAssertEqual(inputDictionary["projectId"] as! String, "12345")
-    XCTAssertEqual(inputDictionary["token"] as! String, "stripeTokenXYZ")
-    XCTAssertEqual(inputDictionary["transactionIdentifier"] as! String, "transactionId")
+    XCTAssertEqual(inputDictionary["amount"] as? String, "10.50")
+    XCTAssertEqual(inputDictionary["paymentInstrumentName"] as? String, "instrumentName")
+    XCTAssertEqual(inputDictionary["paymentNetwork"] as? String, "paymentNetwork")
+    XCTAssertEqual(inputDictionary["projectId"] as? String, "12345")
+    XCTAssertEqual(inputDictionary["token"] as? String, "stripeTokenXYZ")
+    XCTAssertEqual(inputDictionary["transactionIdentifier"] as? String, "transactionId")
     XCTAssertNil(inputDictionary["locationId"])
     XCTAssertNil(inputDictionary["rewardId"])
   }

--- a/KsApi/mutations/inputs/CreateApplePayBackingInputTests.swift
+++ b/KsApi/mutations/inputs/CreateApplePayBackingInputTests.swift
@@ -1,17 +1,19 @@
 import Foundation
-import XCTest
 @testable import KsApi
+import XCTest
 
 final class CreateApplePayBackingInputTests: XCTestCase {
   func testCreateApplePayBacking_toInputDictionary_noNilValues() {
-    let input = CreateApplePayBackingInput(amount: "10.00",
-                                           locationId: 123,
-                                           paymentInstrumentName: "instrumentName",
-                                           paymentNetwork: "paymentNetwork",
-                                           projectId: 12345,
-                                           rewardId: 321,
-                                           stripeToken: "stripeTokenXYZ",
-                                           transactionIdentifier: "transactionId")
+    let input = CreateApplePayBackingInput(
+      amount: "10.00",
+      locationId: 123,
+      paymentInstrumentName: "instrumentName",
+      paymentNetwork: "paymentNetwork",
+      projectId: 12_345,
+      rewardId: 321,
+      stripeToken: "stripeTokenXYZ",
+      transactionIdentifier: "transactionId"
+    )
 
     let inputDictionary = input.toInputDictionary()
 
@@ -26,14 +28,16 @@ final class CreateApplePayBackingInputTests: XCTestCase {
   }
 
   func testCreateApplePayBacking_toInputDictionary_withNilValues() {
-    let input = CreateApplePayBackingInput(amount: "10.50",
-                                            locationId: nil,
-                                            paymentInstrumentName: "instrumentName",
-                                            paymentNetwork: "paymentNetwork",
-                                            projectId: 12345,
-                                            rewardId: nil,
-                                            stripeToken: "stripeTokenXYZ",
-                                            transactionIdentifier: "transactionId")
+    let input = CreateApplePayBackingInput(
+      amount: "10.50",
+      locationId: nil,
+      paymentInstrumentName: "instrumentName",
+      paymentNetwork: "paymentNetwork",
+      projectId: 12_345,
+      rewardId: nil,
+      stripeToken: "stripeTokenXYZ",
+      transactionIdentifier: "transactionId"
+    )
 
     let inputDictionary = input.toInputDictionary()
 

--- a/KsApi/mutations/inputs/CreateApplePayBackingInputTests.swift
+++ b/KsApi/mutations/inputs/CreateApplePayBackingInputTests.swift
@@ -1,0 +1,49 @@
+import Foundation
+import XCTest
+@testable import KsApi
+
+final class CreateApplePayBackingInputTests: XCTestCase {
+  func testCreateApplePayBacking_toInputDictionary_noNilValues() {
+    let input = CreateApplePayBackingInput(amount: "10.00",
+                                           locationId: 123,
+                                           paymentInstrumentName: "instrumentName",
+                                           paymentNetwork: "paymentNetwork",
+                                           projectId: 12345,
+                                           rewardId: 321,
+                                           stripeToken: "stripeTokenXYZ",
+                                           transactionIdentifier: "transactionId")
+
+    let inputDictionary = input.toInputDictionary()
+
+    XCTAssertEqual(inputDictionary["amount"] as! String, "10.00")
+    XCTAssertEqual(inputDictionary["locationId"] as! String, "123")
+    XCTAssertEqual(inputDictionary["paymentInstrumentName"] as! String, "instrumentName")
+    XCTAssertEqual(inputDictionary["paymentNetwork"] as! String, "paymentNetwork")
+    XCTAssertEqual(inputDictionary["projectId"] as! String, "12345")
+    XCTAssertEqual(inputDictionary["rewardId"] as! String, "321")
+    XCTAssertEqual(inputDictionary["token"] as! String, "stripeTokenXYZ")
+    XCTAssertEqual(inputDictionary["transactionIdentifier"] as! String, "transactionId")
+  }
+
+  func testCreateApplePayBacking_toInputDictionary_withNilValues() {
+    let input = CreateApplePayBackingInput(amount: "10.50",
+                                            locationId: nil,
+                                            paymentInstrumentName: "instrumentName",
+                                            paymentNetwork: "paymentNetwork",
+                                            projectId: 12345,
+                                            rewardId: nil,
+                                            stripeToken: "stripeTokenXYZ",
+                                            transactionIdentifier: "transactionId")
+
+    let inputDictionary = input.toInputDictionary()
+
+    XCTAssertEqual(inputDictionary["amount"] as! String, "10.50")
+    XCTAssertEqual(inputDictionary["paymentInstrumentName"] as! String, "instrumentName")
+    XCTAssertEqual(inputDictionary["paymentNetwork"] as! String, "paymentNetwork")
+    XCTAssertEqual(inputDictionary["projectId"] as! String, "12345")
+    XCTAssertEqual(inputDictionary["token"] as! String, "stripeTokenXYZ")
+    XCTAssertEqual(inputDictionary["transactionIdentifier"] as! String, "transactionId")
+    XCTAssertNil(inputDictionary["locationId"])
+    XCTAssertNil(inputDictionary["rewardId"])
+  }
+}

--- a/Library/Format.swift
+++ b/Library/Format.swift
@@ -51,6 +51,14 @@ public enum Format {
     return formatter.string(for: percentage) ?? (String(percentage) + "%")
   }
 
+  public static func decimalCurrency(for amount: Double) -> String {
+    let formatter = NumberFormatterConfig.cachedFormatter(
+      forConfig: .defaultDecimalCurrencyConfig
+    )
+
+    return formatter.string(for: amount) ?? String(format: "%.2f", amount)
+  }
+
   /**
    Formats an int with currency symbol into a string.
 
@@ -435,6 +443,7 @@ private struct NumberFormatterConfig {
   fileprivate let numberStyle: NumberFormatter.Style
   fileprivate let roundingMode: NumberFormatter.RoundingMode
   fileprivate let maximumFractionDigits: Int
+  fileprivate let minimumFractionDigits: Int
   fileprivate let generatesDecimalNumbers: Bool
   fileprivate let locale: Locale
   fileprivate let currencySymbol: String
@@ -444,6 +453,7 @@ private struct NumberFormatterConfig {
     formatter.numberStyle = self.numberStyle
     formatter.roundingMode = self.roundingMode
     formatter.maximumFractionDigits = self.maximumFractionDigits
+    formatter.minimumFractionDigits = self.minimumFractionDigits
     formatter.generatesDecimalNumbers = self.generatesDecimalNumbers
     formatter.locale = self.locale
     formatter.currencySymbol = self.currencySymbol
@@ -456,8 +466,19 @@ private struct NumberFormatterConfig {
     numberStyle: .decimal,
     roundingMode: .down,
     maximumFractionDigits: 0,
+    minimumFractionDigits: 0,
     generatesDecimalNumbers: false,
     locale: .current,
+    currencySymbol: "$"
+  )
+
+  fileprivate static let defaultDecimalCurrencyConfig = NumberFormatterConfig(
+    numberStyle: .decimal,
+    roundingMode: .down,
+    maximumFractionDigits: 2,
+    minimumFractionDigits: 2,
+    generatesDecimalNumbers: false,
+    locale: Locale(identifier: "en"), //Always format decimal currency amounts using En locale
     currencySymbol: "$"
   )
 
@@ -465,6 +486,7 @@ private struct NumberFormatterConfig {
     numberStyle: .percent,
     roundingMode: .down,
     maximumFractionDigits: 0,
+    minimumFractionDigits: 0,
     generatesDecimalNumbers: false,
     locale: .current,
     currencySymbol: "$"
@@ -474,6 +496,7 @@ private struct NumberFormatterConfig {
     numberStyle: .currency,
     roundingMode: .down,
     maximumFractionDigits: 0,
+    minimumFractionDigits: 0,
     generatesDecimalNumbers: false,
     locale: .current,
     currencySymbol: "$"
@@ -513,7 +536,9 @@ extension NumberFormatterConfig {
       view: { $0.numberStyle },
       set: { .init(
         numberStyle: $0, roundingMode: $1.roundingMode,
-        maximumFractionDigits: $1.maximumFractionDigits, generatesDecimalNumbers: $1.generatesDecimalNumbers,
+        maximumFractionDigits: $1.maximumFractionDigits,
+        minimumFractionDigits: $1.minimumFractionDigits,
+        generatesDecimalNumbers: $1.generatesDecimalNumbers,
         locale: $1.locale, currencySymbol: $1.currencySymbol
       ) }
     )
@@ -522,7 +547,9 @@ extension NumberFormatterConfig {
       view: { $0.roundingMode },
       set: { .init(
         numberStyle: $1.numberStyle, roundingMode: $0,
-        maximumFractionDigits: $1.maximumFractionDigits, generatesDecimalNumbers: $1.generatesDecimalNumbers,
+        maximumFractionDigits: $1.maximumFractionDigits,
+        minimumFractionDigits: $1.minimumFractionDigits,
+        generatesDecimalNumbers: $1.generatesDecimalNumbers,
         locale: $1.locale, currencySymbol: $1.currencySymbol
       ) }
     )
@@ -531,16 +558,30 @@ extension NumberFormatterConfig {
       view: { $0.maximumFractionDigits },
       set: { .init(
         numberStyle: $1.numberStyle, roundingMode: $1.roundingMode, maximumFractionDigits: $0,
+        minimumFractionDigits: $1.minimumFractionDigits,
         generatesDecimalNumbers: $1.generatesDecimalNumbers, locale: $1.locale,
         currencySymbol: $1.currencySymbol
       ) }
+    )
+
+    fileprivate static let minimumFractionDigits = Lens<NumberFormatterConfig, Int>(
+      view: { $0.minimumFractionDigits },
+      set: { .init(
+        numberStyle: $1.numberStyle, roundingMode: $1.roundingMode,
+        maximumFractionDigits: $1.maximumFractionDigits,
+        minimumFractionDigits: $0,
+        generatesDecimalNumbers: $1.generatesDecimalNumbers, locale: $1.locale,
+        currencySymbol: $1.currencySymbol
+        ) }
     )
 
     fileprivate static let generatesDecimalNumbers = Lens<NumberFormatterConfig, Bool>(
       view: { $0.generatesDecimalNumbers },
       set: { .init(
         numberStyle: $1.numberStyle, roundingMode: $1.roundingMode,
-        maximumFractionDigits: $1.maximumFractionDigits, generatesDecimalNumbers: $0, locale: $1.locale,
+        maximumFractionDigits: $1.maximumFractionDigits,
+        minimumFractionDigits: $1.minimumFractionDigits,
+        generatesDecimalNumbers: $0, locale: $1.locale,
         currencySymbol: $1.currencySymbol
       ) }
     )
@@ -549,7 +590,9 @@ extension NumberFormatterConfig {
       view: { $0.locale },
       set: { .init(
         numberStyle: $1.numberStyle, roundingMode: $1.roundingMode,
-        maximumFractionDigits: $1.maximumFractionDigits, generatesDecimalNumbers: $1.generatesDecimalNumbers,
+        maximumFractionDigits: $1.maximumFractionDigits,
+        minimumFractionDigits: $1.minimumFractionDigits,
+        generatesDecimalNumbers: $1.generatesDecimalNumbers,
         locale: $0, currencySymbol: $1.currencySymbol
       ) }
     )
@@ -558,7 +601,9 @@ extension NumberFormatterConfig {
       view: { $0.currencySymbol },
       set: { .init(
         numberStyle: $1.numberStyle, roundingMode: $1.roundingMode,
-        maximumFractionDigits: $1.maximumFractionDigits, generatesDecimalNumbers: $1.generatesDecimalNumbers,
+        maximumFractionDigits: $1.maximumFractionDigits,
+        minimumFractionDigits: $1.minimumFractionDigits,
+        generatesDecimalNumbers: $1.generatesDecimalNumbers,
         locale: $1.locale, currencySymbol: $0
       ) }
     )

--- a/Library/Format.swift
+++ b/Library/Format.swift
@@ -51,6 +51,14 @@ public enum Format {
     return formatter.string(for: percentage) ?? (String(percentage) + "%")
   }
 
+  /**
+    Formats a Double currency amount into a string.
+
+   - parameter amount: A Double associated with a currency amount
+
+   - returns: A formatted string with 2 fraction digits
+   */
+
   public static func decimalCurrency(for amount: Double) -> String {
     let formatter = NumberFormatterConfig.cachedFormatter(
       forConfig: .defaultDecimalCurrencyConfig

--- a/Library/Format.swift
+++ b/Library/Format.swift
@@ -481,16 +481,6 @@ private struct NumberFormatterConfig {
     currencySymbol: "$"
   )
 
-  fileprivate static let defaultDecimalCurrencyConfig = NumberFormatterConfig(
-    numberStyle: .decimal,
-    roundingMode: .down,
-    maximumFractionDigits: 2,
-    minimumFractionDigits: 2,
-    generatesDecimalNumbers: false,
-    locale: Locale(identifier: "en"), // Always format decimal currency amounts using En locale
-    currencySymbol: "$"
-  )
-
   fileprivate static let defaultPercentageConfig = NumberFormatterConfig(
     numberStyle: .percent,
     roundingMode: .down,
@@ -508,6 +498,16 @@ private struct NumberFormatterConfig {
     minimumFractionDigits: 0,
     generatesDecimalNumbers: false,
     locale: .current,
+    currencySymbol: "$"
+  )
+
+  fileprivate static let defaultDecimalCurrencyConfig = NumberFormatterConfig(
+    numberStyle: .decimal,
+    roundingMode: .down,
+    maximumFractionDigits: 2,
+    minimumFractionDigits: 2,
+    generatesDecimalNumbers: false,
+    locale: Locale(identifier: "en"), // Always format decimal currency amounts using En locale
     currencySymbol: "$"
   )
 

--- a/Library/Format.swift
+++ b/Library/Format.swift
@@ -507,7 +507,8 @@ private struct NumberFormatterConfig {
     maximumFractionDigits: 2,
     minimumFractionDigits: 2,
     generatesDecimalNumbers: false,
-    locale: Locale(identifier: "en"), // Always format decimal currency amounts using En locale
+    // Decimal currency amounts are always formatted using En locale for compatibility with the API
+    locale: Locale(identifier: "en"),
     currencySymbol: "$"
   )
 

--- a/Library/Format.swift
+++ b/Library/Format.swift
@@ -478,7 +478,7 @@ private struct NumberFormatterConfig {
     maximumFractionDigits: 2,
     minimumFractionDigits: 2,
     generatesDecimalNumbers: false,
-    locale: Locale(identifier: "en"), //Always format decimal currency amounts using En locale
+    locale: Locale(identifier: "en"), // Always format decimal currency amounts using En locale
     currencySymbol: "$"
   )
 
@@ -572,7 +572,7 @@ extension NumberFormatterConfig {
         minimumFractionDigits: $0,
         generatesDecimalNumbers: $1.generatesDecimalNumbers, locale: $1.locale,
         currencySymbol: $1.currencySymbol
-        ) }
+      ) }
     )
 
     fileprivate static let generatesDecimalNumbers = Lens<NumberFormatterConfig, Bool>(

--- a/Library/Format.swift
+++ b/Library/Format.swift
@@ -125,7 +125,7 @@ public enum Format {
   public static func attributedCurrency(
     _ amount: Double,
     country: Project.Country,
-    omitCurrencyCode: Bool = false,
+    omitCurrencyCode: Bool = true,
     defaultAttributes: String.Attributes = [:],
     superscriptAttributes: String.Attributes = [:],
     env: Environment = AppEnvironment.current
@@ -134,6 +134,7 @@ public enum Format {
     let config = NumberFormatterConfig.defaultCurrencyConfig
       |> NumberFormatterConfig.lens.locale .~ env.locale
       |> NumberFormatterConfig.lens.currencySymbol .~ symbol
+      |> NumberFormatterConfig.lens.minimumFractionDigits .~ 2
       |> NumberFormatterConfig.lens.maximumFractionDigits .~ 2
 
     guard let formatter = NumberFormatterConfig.cachedFormatter(forConfig: config)

--- a/Library/FormatTests.swift
+++ b/Library/FormatTests.swift
@@ -112,22 +112,18 @@ final class FormatTests: TestCase {
         XCTAssertEqual(Format.attributedCurrency(1_000, country: .de)?.string, "€1,000.00")
         XCTAssertEqual(Format.attributedCurrency(1_000, country: .jp)?.string, "¥1,000.00")
 
-        XCTAssertEqual(Format.attributedCurrency(
-          1_000, country: .ca,
-          omitCurrencyCode: true
-        )?.string, " CA$ 1,000.00")
-        XCTAssertEqual(Format.attributedCurrency(
-          1_000, country: .ca,
-          omitCurrencyCode: false
-        )?.string, " CA$ 1,000.00")
-        XCTAssertEqual(Format.attributedCurrency(
-          1_000, country: .us,
-          omitCurrencyCode: true
-        )?.string, "$1,000.00")
-        XCTAssertEqual(Format.attributedCurrency(
-          1_000, country: .us,
-          omitCurrencyCode: false
-        )?.string, " US$ 1,000.00")
+        XCTAssertEqual(
+          Format.attributedCurrency(1_000, country: .ca, omitCurrencyCode: true)?.string, " CA$ 1,000.00"
+        )
+        XCTAssertEqual(
+          Format.attributedCurrency(1_000, country: .ca, omitCurrencyCode: false)?.string, " CA$ 1,000.00"
+        )
+        XCTAssertEqual(
+          Format.attributedCurrency(1_000, country: .us, omitCurrencyCode: true)?.string, "$1,000.00"
+        )
+        XCTAssertEqual(
+          Format.attributedCurrency(1_000, country: .us, omitCurrencyCode: false)?.string, " US$ 1,000.00"
+        )
       }
     }
   }

--- a/Library/FormatTests.swift
+++ b/Library/FormatTests.swift
@@ -112,14 +112,22 @@ final class FormatTests: TestCase {
         XCTAssertEqual(Format.attributedCurrency(1_000, country: .de)!.string, "€1,000.00")
         XCTAssertEqual(Format.attributedCurrency(1_000, country: .jp)!.string, "¥1,000.00")
 
-        XCTAssertEqual(Format.attributedCurrency(1_000, country: .ca,
-                                                 omitCurrencyCode: true)!.string, " CA$ 1,000.00")
-        XCTAssertEqual(Format.attributedCurrency(1_000, country: .ca,
-                                                 omitCurrencyCode: false)!.string, " CA$ 1,000.00")
-        XCTAssertEqual(Format.attributedCurrency(1_000, country: .us,
-                                                 omitCurrencyCode: true)!.string, "$1,000.00")
-        XCTAssertEqual(Format.attributedCurrency(1_000, country: .us,
-                                                 omitCurrencyCode: false)!.string, " US$ 1,000.00")
+        XCTAssertEqual(Format.attributedCurrency(
+          1_000, country: .ca,
+          omitCurrencyCode: true
+        )!.string, " CA$ 1,000.00")
+        XCTAssertEqual(Format.attributedCurrency(
+          1_000, country: .ca,
+          omitCurrencyCode: false
+        )!.string, " CA$ 1,000.00")
+        XCTAssertEqual(Format.attributedCurrency(
+          1_000, country: .us,
+          omitCurrencyCode: true
+        )!.string, "$1,000.00")
+        XCTAssertEqual(Format.attributedCurrency(
+          1_000, country: .us,
+          omitCurrencyCode: false
+        )!.string, " US$ 1,000.00")
       }
     }
   }

--- a/Library/FormatTests.swift
+++ b/Library/FormatTests.swift
@@ -102,6 +102,28 @@ final class FormatTests: TestCase {
     XCTAssertEqual(Format.decimalCurrency(for: 10.511), "10.51", "Rounds down to 2 fraction digits")
   }
 
+  func testAttributedCurrency() {
+    withEnvironment(locale: Locale(identifier: "en")) {
+      withEnvironment(countryCode: "US") {
+        XCTAssertEqual(Format.attributedCurrency(1_000, country: .us)!.string, "$1,000.00")
+        XCTAssertEqual(Format.attributedCurrency(1_000, country: .ca)!.string, " CA$ 1,000.00")
+        XCTAssertEqual(Format.attributedCurrency(1_000, country: .gb)!.string, "£1,000.00")
+        XCTAssertEqual(Format.attributedCurrency(1_000, country: .dk)!.string, " DKK 1,000.00")
+        XCTAssertEqual(Format.attributedCurrency(1_000, country: .de)!.string, "€1,000.00")
+        XCTAssertEqual(Format.attributedCurrency(1_000, country: .jp)!.string, "¥1,000.00")
+
+        XCTAssertEqual(Format.attributedCurrency(1_000, country: .ca,
+                                                 omitCurrencyCode: true)!.string, " CA$ 1,000.00")
+        XCTAssertEqual(Format.attributedCurrency(1_000, country: .ca,
+                                                 omitCurrencyCode: false)!.string, " CA$ 1,000.00")
+        XCTAssertEqual(Format.attributedCurrency(1_000, country: .us,
+                                                 omitCurrencyCode: true)!.string, "$1,000.00")
+        XCTAssertEqual(Format.attributedCurrency(1_000, country: .us,
+                                                 omitCurrencyCode: false)!.string, " US$ 1,000.00")
+      }
+    }
+  }
+
   func testCurrency() {
     withEnvironment(locale: Locale(identifier: "en")) {
       withEnvironment(countryCode: "US") {

--- a/Library/FormatTests.swift
+++ b/Library/FormatTests.swift
@@ -94,6 +94,14 @@ final class FormatTests: TestCase {
     }
   }
 
+  func testDecimalCurrency() {
+    XCTAssertEqual(Format.decimalCurrency(for: 10), "10.00")
+    XCTAssertEqual(Format.decimalCurrency(for: 10.00), "10.00")
+    XCTAssertEqual(Format.decimalCurrency(for: 10.50), "10.50")
+    XCTAssertEqual(Format.decimalCurrency(for: 10.5555), "10.55", "Rounds down to 2 fraction digits")
+    XCTAssertEqual(Format.decimalCurrency(for: 10.511), "10.51", "Rounds down to 2 fraction digits")
+  }
+
   func testCurrency() {
     withEnvironment(locale: Locale(identifier: "en")) {
       withEnvironment(countryCode: "US") {

--- a/Library/FormatTests.swift
+++ b/Library/FormatTests.swift
@@ -105,29 +105,29 @@ final class FormatTests: TestCase {
   func testAttributedCurrency() {
     withEnvironment(locale: Locale(identifier: "en")) {
       withEnvironment(countryCode: "US") {
-        XCTAssertEqual(Format.attributedCurrency(1_000, country: .us)!.string, "$1,000.00")
-        XCTAssertEqual(Format.attributedCurrency(1_000, country: .ca)!.string, " CA$ 1,000.00")
-        XCTAssertEqual(Format.attributedCurrency(1_000, country: .gb)!.string, "£1,000.00")
-        XCTAssertEqual(Format.attributedCurrency(1_000, country: .dk)!.string, " DKK 1,000.00")
-        XCTAssertEqual(Format.attributedCurrency(1_000, country: .de)!.string, "€1,000.00")
-        XCTAssertEqual(Format.attributedCurrency(1_000, country: .jp)!.string, "¥1,000.00")
+        XCTAssertEqual(Format.attributedCurrency(1_000, country: .us)?.string, "$1,000.00")
+        XCTAssertEqual(Format.attributedCurrency(1_000, country: .ca)?.string, " CA$ 1,000.00")
+        XCTAssertEqual(Format.attributedCurrency(1_000, country: .gb)?.string, "£1,000.00")
+        XCTAssertEqual(Format.attributedCurrency(1_000, country: .dk)?.string, " DKK 1,000.00")
+        XCTAssertEqual(Format.attributedCurrency(1_000, country: .de)?.string, "€1,000.00")
+        XCTAssertEqual(Format.attributedCurrency(1_000, country: .jp)?.string, "¥1,000.00")
 
         XCTAssertEqual(Format.attributedCurrency(
           1_000, country: .ca,
           omitCurrencyCode: true
-        )!.string, " CA$ 1,000.00")
+        )?.string, " CA$ 1,000.00")
         XCTAssertEqual(Format.attributedCurrency(
           1_000, country: .ca,
           omitCurrencyCode: false
-        )!.string, " CA$ 1,000.00")
+        )?.string, " CA$ 1,000.00")
         XCTAssertEqual(Format.attributedCurrency(
           1_000, country: .us,
           omitCurrencyCode: true
-        )!.string, "$1,000.00")
+        )?.string, "$1,000.00")
         XCTAssertEqual(Format.attributedCurrency(
           1_000, country: .us,
           omitCurrencyCode: false
-        )!.string, " US$ 1,000.00")
+        )?.string, " US$ 1,000.00")
       }
     }
   }


### PR DESCRIPTION
# 📲 What

Adds the `createApplePayBacking` mutation and mutation input object, with tests. Also, in preparation for sending formatted amounts to the mutation, I've added a new currency formatter that formats currency amounts into doubles with the correct number of fraction digits. This formatting function isn't in use in this PR, but will be used in Part II of this work.

# 🤔 Why

To allow users to pledge using  Apple Pay without going through the legacy API routes.

# 🛠 How

Adds `CreateApplePayBackingMutation` and `CreateApplePayBackingInput`. Also adds `decimalCurrency(for amount:)` that formats `Double`s into currency strings that can be sent to the API as an input parameter.

# ✅ Acceptance criteria

Note: this mutation cannot be tested with the existing code. It will be tested in a follow up PR once we integrate the Apple Pay button with the mutation.

# ⏰ TODO

- [ ] waiting on a refactor of the Graph mutation for consistent naming
