### PR TITLE
[NT-164] Consume Rewards converted minimum from v1

### DIFF
--- a/Kickstarter-iOS/Views/Controllers/DeprecatedRewardPledgeViewControllerTests.swift
+++ b/Kickstarter-iOS/Views/Controllers/DeprecatedRewardPledgeViewControllerTests.swift
@@ -215,6 +215,7 @@ internal final class DeprecatedRewardPledgeViewControllerTests: TestCase {
 
   func testManagePledge() {
     let reward = Reward.noReward
+      |> Reward.lens.convertedMinimum .~ 1
     let project = self.cosmicSurgery
       |> Project.lens.personalization.isBacking .~ true
       |> Project.lens.personalization.backing .~ (
@@ -239,6 +240,7 @@ internal final class DeprecatedRewardPledgeViewControllerTests: TestCase {
 
   func testManagePledge_ApplePayCapable() {
     let reward = Reward.noReward
+      |> Reward.lens.convertedMinimum .~ 1
     let project = self.cosmicSurgery
       |> Project.lens.personalization.isBacking .~ true
       |> Project.lens.personalization.backing .~ (
@@ -261,6 +263,7 @@ internal final class DeprecatedRewardPledgeViewControllerTests: TestCase {
     let newReward = self.cosmicReward
       |> Reward.lens.id .~ 42
       |> Reward.lens.minimum .~ 42
+      |> Reward.lens.convertedMinimum .~ 55
       |> Reward.lens.rewardsItems .~ []
     let oldReward = self.cosmicReward
       |> Reward.lens.rewardsItems .~ []
@@ -294,6 +297,7 @@ internal final class DeprecatedRewardPledgeViewControllerTests: TestCase {
     let newReward = self.cosmicReward
       |> Reward.lens.id .~ 42
       |> Reward.lens.minimum .~ 42
+      |> Reward.lens.convertedMinimum .~ 55
       |> Reward.lens.rewardsItems .~ []
     let oldReward = self.cosmicReward
       |> Reward.lens.rewardsItems .~ []
@@ -321,6 +325,7 @@ internal final class DeprecatedRewardPledgeViewControllerTests: TestCase {
     let project = self.cosmicSurgery
       |> Project.lens.stats.currentCurrencyRate .~ 1.2
     let reward = self.cosmicReward
+      |> Reward.lens.convertedMinimum .~ 780
       |> Reward.lens.rewardsItems .~ []
 
     let launchedCountries = AppEnvironment.current.launchedCountries.countries

--- a/Kickstarter-iOS/Views/Controllers/ProjectPamphletContentViewControllerConversionTests.swift
+++ b/Kickstarter-iOS/Views/Controllers/ProjectPamphletContentViewControllerConversionTests.swift
@@ -110,7 +110,11 @@ internal final class ProjectPamphletContentViewControllerConversionTests: TestCa
   }
 
   func test_USProject_NonUSUser_NonUSLocation() {
+    let rewards = self.cosmicSurgery.rewards
+      .map { $0 |> Reward.lens.convertedMinimum .~ ($0.minimum * 3.0) }
+
     self.cosmicSurgery = self.cosmicSurgery
+      |> Project.lens.rewards .~ rewards
       |> Project.lens.country .~ .us
       |> Project.lens.stats.currency .~ "USD"
       |> Project.lens.stats.currentCurrency .~ "SEK"

--- a/Kickstarter-iOS/Views/RewardCardContainerViewTests.swift
+++ b/Kickstarter-iOS/Views/RewardCardContainerViewTests.swift
@@ -295,22 +295,27 @@ let allRewards: [(String, Reward)] = {
   let availableLimitedReward = Reward.postcards
     |> Reward.lens.limit .~ 100
     |> Reward.lens.remaining .~ 25
+    |> Reward.lens.convertedMinimum .~ 7
   let availableTimebasedReward = Reward.postcards
     |> Reward.lens.limit .~ nil
     |> Reward.lens.remaining .~ nil
+    |> Reward.lens.convertedMinimum .~ 7
     |> Reward.lens.endsAt .~ (MockDate().timeIntervalSince1970 + 60.0 * 60.0 * 24.0)
   let availableLimitedTimebasedReward = Reward.postcards
     |> Reward.lens.limit .~ 100
     |> Reward.lens.remaining .~ 25
+    |> Reward.lens.convertedMinimum .~ 7
     |> Reward.lens.endsAt .~ (MockDate().timeIntervalSince1970 + 60.0 * 60.0 * 24.0)
   let availableNonLimitedReward = Reward.postcards
     |> Reward.lens.limit .~ nil
     |> Reward.lens.remaining .~ nil
     |> Reward.lens.endsAt .~ nil
+    |> Reward.lens.convertedMinimum .~ 7
   let availableShippingEnabledReward = Reward.postcards
     |> Reward.lens.limit .~ 100
     |> Reward.lens.remaining .~ 25
     |> Reward.lens.endsAt .~ (MockDate().timeIntervalSince1970 + 60.0 * 60.0 * 24.0)
+    |> Reward.lens.convertedMinimum .~ 7
     |> Reward.lens.shipping .~ (
       .template
         |> Reward.Shipping.lens.enabled .~ true
@@ -321,17 +326,22 @@ let allRewards: [(String, Reward)] = {
   let unavailableLimitedReward = Reward.postcards
     |> Reward.lens.limit .~ 100
     |> Reward.lens.remaining .~ 0
+    |> Reward.lens.convertedMinimum .~ 7
   let unavailableTimebasedReward = Reward.postcards
     |> Reward.lens.limit .~ nil
     |> Reward.lens.remaining .~ nil
     |> Reward.lens.endsAt .~ (MockDate().date.timeIntervalSince1970 - 1)
+    |> Reward.lens.convertedMinimum .~ 7
   let unavailableLimitedTimebasedReward = Reward.postcards
     |> Reward.lens.limit .~ 100
     |> Reward.lens.remaining .~ 0
+    |> Reward.lens.convertedMinimum .~ 7
     |> Reward.lens.endsAt .~ (MockDate().date.timeIntervalSince1970 - 1)
   let unavailableShippingEnabledReward = Reward.postcards
     |> Reward.lens.limit .~ 100
     |> Reward.lens.remaining .~ 0
+    |> Reward.lens.convertedMinimum .~ 7
+
     |> Reward.lens.endsAt .~ (MockDate().date.timeIntervalSince1970 - 1)
     |> Reward.lens.shipping .~ (
       .template
@@ -339,6 +349,8 @@ let allRewards: [(String, Reward)] = {
         |> Reward.Shipping.lens.preference .~ .restricted
         |> Reward.Shipping.lens.summary .~ "Anywhere in the world"
     )
+  let noReward = Reward.noReward
+    |> Reward.lens.convertedMinimum .~ 1
 
   return [
     ("AvailableLimitedReward", availableLimitedReward),
@@ -350,6 +362,6 @@ let allRewards: [(String, Reward)] = {
     ("UnavailableTimebasedReward", unavailableTimebasedReward),
     ("UnavailableLimitedTimebasedReward", unavailableLimitedTimebasedReward),
     ("UnavailableShippingEnabledReward", unavailableShippingEnabledReward),
-    ("NoReward", Reward.noReward)
+    ("NoReward", noReward)
   ]
 }()

--- a/KsApi/models/Reward.swift
+++ b/KsApi/models/Reward.swift
@@ -5,7 +5,7 @@ import Runes
 
 public struct Reward {
   public let backersCount: Int?
-  public let convertedMinimum: Double?
+  public let convertedMinimum: Double
   public let description: String
   public let endsAt: TimeInterval?
   public let estimatedDeliveryOn: TimeInterval?
@@ -52,7 +52,7 @@ extension Reward: Argo.Decodable {
   public static func decode(_ json: JSON) -> Decoded<Reward> {
     let tmp1 = curry(Reward.init)
       <^> json <|? "backers_count"
-      <*> json <|? "converted_minimum"
+      <*> json <| "converted_minimum"
       <*> (json <| "description" <|> json <| "reward")
       <*> json <|? "ends_at"
       <*> json <|? "estimated_delivery_on"

--- a/KsApi/models/Reward.swift
+++ b/KsApi/models/Reward.swift
@@ -5,6 +5,7 @@ import Runes
 
 public struct Reward {
   public let backersCount: Int?
+  public let convertedMinimum: Double?
   public let description: String
   public let endsAt: TimeInterval?
   public let estimatedDeliveryOn: TimeInterval?
@@ -51,6 +52,7 @@ extension Reward: Argo.Decodable {
   public static func decode(_ json: JSON) -> Decoded<Reward> {
     let tmp1 = curry(Reward.init)
       <^> json <|? "backers_count"
+      <*> json <|? "converted_minimum"
       <*> (json <| "description" <|> json <| "reward")
       <*> json <|? "ends_at"
       <*> json <|? "estimated_delivery_on"

--- a/KsApi/models/RewardTests.swift
+++ b/KsApi/models/RewardTests.swift
@@ -30,11 +30,14 @@ final class RewardTests: XCTestCase {
     let reward = Reward.decodeJSONDictionary([
       "id": 1,
       "minimum": 10,
+      "converted_minimum": 12,
       "description": "cool stuff"
     ])
 
     XCTAssertNil(reward.error)
     XCTAssertEqual(reward.value?.id, 1)
+    XCTAssertEqual(reward.value?.minimum, 10)
+    XCTAssertEqual(reward.value?.convertedMinimum, 12)
     XCTAssertEqual(reward.value?.description, "cool stuff")
     XCTAssertNotNil(reward.value?.shipping)
     XCTAssertEqual(false, reward.value?.shipping.enabled)
@@ -44,12 +47,14 @@ final class RewardTests: XCTestCase {
     let reward = Reward.decodeJSONDictionary([
       "id": 1,
       "minimum": 10,
+      "converted_minimum": 12,
       "reward": "cool stuff"
     ])
 
     XCTAssertNil(reward.error)
     XCTAssertEqual(reward.value?.id, 1)
     XCTAssertEqual(reward.value?.minimum, 10)
+    XCTAssertEqual(reward.value?.convertedMinimum, 12)
     XCTAssertEqual(reward.value?.description, "cool stuff")
   }
 
@@ -58,6 +63,7 @@ final class RewardTests: XCTestCase {
       "id": 1,
       "description": "Some reward",
       "minimum": 10,
+      "converted_minimum": 12,
       "backers_count": 10
     ])
 
@@ -65,6 +71,7 @@ final class RewardTests: XCTestCase {
     XCTAssertEqual(reward.value?.id, 1)
     XCTAssertEqual(reward.value?.description, "Some reward")
     XCTAssertEqual(reward.value?.minimum, 10)
+    XCTAssertEqual(reward.value?.convertedMinimum, 12)
     XCTAssertEqual(reward.value?.backersCount, 10)
   }
 
@@ -73,6 +80,7 @@ final class RewardTests: XCTestCase {
       "id": 1,
       "description": "Some reward",
       "minimum": 10,
+      "converted_minimum": 12,
       "backers_count": 10,
       "shipping_enabled": true,
       "shipping_preference": "unrestricted",
@@ -83,6 +91,7 @@ final class RewardTests: XCTestCase {
     XCTAssertEqual(reward.value?.id, 1)
     XCTAssertEqual(reward.value?.description, "Some reward")
     XCTAssertEqual(reward.value?.minimum, 10)
+    XCTAssertEqual(reward.value?.convertedMinimum, 12)
     XCTAssertEqual(reward.value?.backersCount, 10)
     XCTAssertEqual(true, reward.value?.shipping.enabled)
     XCTAssertEqual(.unrestricted, reward.value?.shipping.preference)

--- a/KsApi/models/lenses/RewardLenses.swift
+++ b/KsApi/models/lenses/RewardLenses.swift
@@ -37,7 +37,7 @@ extension Reward {
         shipping: $1.shipping,
         startsAt: $1.startsAt,
         title: $1.title
-        ) }
+      ) }
     )
 
     public static let description = Lens<Reward, String>(

--- a/KsApi/models/lenses/RewardLenses.swift
+++ b/KsApi/models/lenses/RewardLenses.swift
@@ -21,7 +21,7 @@ extension Reward {
       ) }
     )
 
-    public static let convertedMinimum = Lens<Reward, Double?>(
+    public static let convertedMinimum = Lens<Reward, Double>(
       view: { $0.convertedMinimum },
       set: { Reward(
         backersCount: $1.backersCount,

--- a/KsApi/models/lenses/RewardLenses.swift
+++ b/KsApi/models/lenses/RewardLenses.swift
@@ -5,19 +5,56 @@ extension Reward {
     public static let backersCount = Lens<Reward, Int?>(
       view: { $0.backersCount },
       set: { Reward(
-        backersCount: $0, description: $1.description, endsAt: $1.endsAt,
-        estimatedDeliveryOn: $1.estimatedDeliveryOn, id: $1.id, limit: $1.limit, minimum: $1.minimum,
-        remaining: $1.remaining, rewardsItems: $1.rewardsItems, shipping: $1.shipping, startsAt: $1.startsAt,
+        backersCount: $0,
+        convertedMinimum: $1.convertedMinimum,
+        description: $1.description,
+        endsAt: $1.endsAt,
+        estimatedDeliveryOn: $1.estimatedDeliveryOn,
+        id: $1.id,
+        limit: $1.limit,
+        minimum: $1.minimum,
+        remaining: $1.remaining,
+        rewardsItems: $1.rewardsItems,
+        shipping: $1.shipping,
+        startsAt: $1.startsAt,
         title: $1.title
       ) }
+    )
+
+    public static let convertedMinimum = Lens<Reward, Double?>(
+      view: { $0.convertedMinimum },
+      set: { Reward(
+        backersCount: $1.backersCount,
+        convertedMinimum: $0,
+        description: $1.description,
+        endsAt: $1.endsAt,
+        estimatedDeliveryOn: $1.estimatedDeliveryOn,
+        id: $1.id,
+        limit: $1.limit,
+        minimum: $1.minimum,
+        remaining: $1.remaining,
+        rewardsItems: $1.rewardsItems,
+        shipping: $1.shipping,
+        startsAt: $1.startsAt,
+        title: $1.title
+        ) }
     )
 
     public static let description = Lens<Reward, String>(
       view: { $0.description },
       set: { Reward(
-        backersCount: $1.backersCount, description: $0, endsAt: $1.endsAt,
-        estimatedDeliveryOn: $1.estimatedDeliveryOn, id: $1.id, limit: $1.limit, minimum: $1.minimum,
-        remaining: $1.remaining, rewardsItems: $1.rewardsItems, shipping: $1.shipping, startsAt: $1.startsAt,
+        backersCount: $1.backersCount,
+        convertedMinimum: $1.convertedMinimum,
+        description: $0,
+        endsAt: $1.endsAt,
+        estimatedDeliveryOn: $1.estimatedDeliveryOn,
+        id: $1.id,
+        limit: $1.limit,
+        minimum: $1.minimum,
+        remaining: $1.remaining,
+        rewardsItems: $1.rewardsItems,
+        shipping: $1.shipping,
+        startsAt: $1.startsAt,
         title: $1.title
       ) }
     )
@@ -25,9 +62,18 @@ extension Reward {
     public static let endsAt = Lens<Reward, TimeInterval?>(
       view: { $0.endsAt },
       set: { Reward(
-        backersCount: $1.backersCount, description: $1.description, endsAt: $0,
-        estimatedDeliveryOn: $1.estimatedDeliveryOn, id: $1.id, limit: $1.limit, minimum: $1.minimum,
-        remaining: $1.remaining, rewardsItems: $1.rewardsItems, shipping: $1.shipping, startsAt: $1.startsAt,
+        backersCount: $1.backersCount,
+        convertedMinimum: $1.convertedMinimum,
+        description: $1.description,
+        endsAt: $0,
+        estimatedDeliveryOn: $1.estimatedDeliveryOn,
+        id: $1.id,
+        limit: $1.limit,
+        minimum: $1.minimum,
+        remaining: $1.remaining,
+        rewardsItems: $1.rewardsItems,
+        shipping: $1.shipping,
+        startsAt: $1.startsAt,
         title: $1.title
       ) }
     )
@@ -35,9 +81,18 @@ extension Reward {
     public static let estimatedDeliveryOn = Lens<Reward, TimeInterval?>(
       view: { $0.estimatedDeliveryOn },
       set: { Reward(
-        backersCount: $1.backersCount, description: $1.description, endsAt: $1.endsAt,
-        estimatedDeliveryOn: $0, id: $1.id, limit: $1.limit, minimum: $1.minimum,
-        remaining: $1.remaining, rewardsItems: $1.rewardsItems, shipping: $1.shipping, startsAt: $1.startsAt,
+        backersCount: $1.backersCount,
+        convertedMinimum: $1.convertedMinimum,
+        description: $1.description,
+        endsAt: $1.endsAt,
+        estimatedDeliveryOn: $0,
+        id: $1.id,
+        limit: $1.limit,
+        minimum: $1.minimum,
+        remaining: $1.remaining,
+        rewardsItems: $1.rewardsItems,
+        shipping: $1.shipping,
+        startsAt: $1.startsAt,
         title: $1.title
       ) }
     )
@@ -45,9 +100,18 @@ extension Reward {
     public static let id = Lens<Reward, Int>(
       view: { $0.id },
       set: { Reward(
-        backersCount: $1.backersCount, description: $1.description, endsAt: $1.endsAt,
-        estimatedDeliveryOn: $1.estimatedDeliveryOn, id: $0, limit: $1.limit, minimum: $1.minimum,
-        remaining: $1.remaining, rewardsItems: $1.rewardsItems, shipping: $1.shipping, startsAt: $1.startsAt,
+        backersCount: $1.backersCount,
+        convertedMinimum: $1.convertedMinimum,
+        description: $1.description,
+        endsAt: $1.endsAt,
+        estimatedDeliveryOn: $1.estimatedDeliveryOn,
+        id: $0,
+        limit: $1.limit,
+        minimum: $1.minimum,
+        remaining: $1.remaining,
+        rewardsItems: $1.rewardsItems,
+        shipping: $1.shipping,
+        startsAt: $1.startsAt,
         title: $1.title
       ) }
     )
@@ -55,9 +119,18 @@ extension Reward {
     public static let limit = Lens<Reward, Int?>(
       view: { $0.limit },
       set: { Reward(
-        backersCount: $1.backersCount, description: $1.description, endsAt: $1.endsAt,
-        estimatedDeliveryOn: $1.estimatedDeliveryOn, id: $1.id, limit: $0, minimum: $1.minimum,
-        remaining: $1.remaining, rewardsItems: $1.rewardsItems, shipping: $1.shipping, startsAt: $1.startsAt,
+        backersCount: $1.backersCount,
+        convertedMinimum: $1.convertedMinimum,
+        description: $1.description,
+        endsAt: $1.endsAt,
+        estimatedDeliveryOn: $1.estimatedDeliveryOn,
+        id: $1.id,
+        limit: $0,
+        minimum: $1.minimum,
+        remaining: $1.remaining,
+        rewardsItems: $1.rewardsItems,
+        shipping: $1.shipping,
+        startsAt: $1.startsAt,
         title: $1.title
       ) }
     )
@@ -65,9 +138,18 @@ extension Reward {
     public static let minimum = Lens<Reward, Double>(
       view: { $0.minimum },
       set: { Reward(
-        backersCount: $1.backersCount, description: $1.description, endsAt: $1.endsAt,
-        estimatedDeliveryOn: $1.estimatedDeliveryOn, id: $1.id, limit: $1.limit, minimum: $0,
-        remaining: $1.remaining, rewardsItems: $1.rewardsItems, shipping: $1.shipping, startsAt: $1.startsAt,
+        backersCount: $1.backersCount,
+        convertedMinimum: $1.convertedMinimum,
+        description: $1.description,
+        endsAt: $1.endsAt,
+        estimatedDeliveryOn: $1.estimatedDeliveryOn,
+        id: $1.id,
+        limit: $1.limit,
+        minimum: $0,
+        remaining: $1.remaining,
+        rewardsItems: $1.rewardsItems,
+        shipping: $1.shipping,
+        startsAt: $1.startsAt,
         title: $1.title
       ) }
     )
@@ -75,9 +157,18 @@ extension Reward {
     public static let remaining = Lens<Reward, Int?>(
       view: { $0.remaining },
       set: { Reward(
-        backersCount: $1.backersCount, description: $1.description, endsAt: $1.endsAt,
-        estimatedDeliveryOn: $1.estimatedDeliveryOn, id: $1.id, limit: $1.limit, minimum: $1.minimum,
-        remaining: $0, rewardsItems: $1.rewardsItems, shipping: $1.shipping, startsAt: $1.startsAt,
+        backersCount: $1.backersCount,
+        convertedMinimum: $1.convertedMinimum,
+        description: $1.description,
+        endsAt: $1.endsAt,
+        estimatedDeliveryOn: $1.estimatedDeliveryOn,
+        id: $1.id,
+        limit: $1.limit,
+        minimum: $1.minimum,
+        remaining: $0,
+        rewardsItems: $1.rewardsItems,
+        shipping: $1.shipping,
+        startsAt: $1.startsAt,
         title: $1.title
       ) }
     )
@@ -85,9 +176,18 @@ extension Reward {
     public static let rewardsItems = Lens<Reward, [RewardsItem]>(
       view: { $0.rewardsItems },
       set: { Reward(
-        backersCount: $1.backersCount, description: $1.description, endsAt: $1.endsAt,
-        estimatedDeliveryOn: $1.estimatedDeliveryOn, id: $1.id, limit: $1.limit, minimum: $1.minimum,
-        remaining: $1.remaining, rewardsItems: $0, shipping: $1.shipping, startsAt: $1.startsAt,
+        backersCount: $1.backersCount,
+        convertedMinimum: $1.convertedMinimum,
+        description: $1.description,
+        endsAt: $1.endsAt,
+        estimatedDeliveryOn: $1.estimatedDeliveryOn,
+        id: $1.id,
+        limit: $1.limit,
+        minimum: $1.minimum,
+        remaining: $1.remaining,
+        rewardsItems: $0,
+        shipping: $1.shipping,
+        startsAt: $1.startsAt,
         title: $1.title
       ) }
     )
@@ -95,9 +195,18 @@ extension Reward {
     public static let shipping = Lens<Reward, Reward.Shipping>(
       view: { $0.shipping },
       set: { Reward(
-        backersCount: $1.backersCount, description: $1.description, endsAt: $1.endsAt,
-        estimatedDeliveryOn: $1.estimatedDeliveryOn, id: $1.id, limit: $1.limit, minimum: $1.minimum,
-        remaining: $1.remaining, rewardsItems: $1.rewardsItems, shipping: $0, startsAt: $1.startsAt,
+        backersCount: $1.backersCount,
+        convertedMinimum: $1.convertedMinimum,
+        description: $1.description,
+        endsAt: $1.endsAt,
+        estimatedDeliveryOn: $1.estimatedDeliveryOn,
+        id: $1.id,
+        limit: $1.limit,
+        minimum: $1.minimum,
+        remaining: $1.remaining,
+        rewardsItems: $1.rewardsItems,
+        shipping: $0,
+        startsAt: $1.startsAt,
         title: $1.title
       ) }
     )
@@ -105,9 +214,18 @@ extension Reward {
     public static let startsAt = Lens<Reward, TimeInterval?>(
       view: { $0.startsAt },
       set: { Reward(
-        backersCount: $1.backersCount, description: $1.description, endsAt: $1.endsAt,
-        estimatedDeliveryOn: $1.estimatedDeliveryOn, id: $1.id, limit: $1.limit, minimum: $1.minimum,
-        remaining: $1.remaining, rewardsItems: $1.rewardsItems, shipping: $1.shipping, startsAt: $0,
+        backersCount: $1.backersCount,
+        convertedMinimum: $1.convertedMinimum,
+        description: $1.description,
+        endsAt: $1.endsAt,
+        estimatedDeliveryOn: $1.estimatedDeliveryOn,
+        id: $1.id,
+        limit: $1.limit,
+        minimum: $1.minimum,
+        remaining: $1.remaining,
+        rewardsItems: $1.rewardsItems,
+        shipping: $1.shipping,
+        startsAt: $0,
         title: $1.title
       ) }
     )
@@ -115,9 +233,18 @@ extension Reward {
     public static let title = Lens<Reward, String?>(
       view: { $0.title },
       set: { Reward(
-        backersCount: $1.backersCount, description: $1.description, endsAt: $1.endsAt,
-        estimatedDeliveryOn: $1.estimatedDeliveryOn, id: $1.id, limit: $1.limit, minimum: $1.minimum,
-        remaining: $1.remaining, rewardsItems: $1.rewardsItems, shipping: $1.shipping, startsAt: $1.startsAt,
+        backersCount: $1.backersCount,
+        convertedMinimum: $1.convertedMinimum,
+        description: $1.description,
+        endsAt: $1.endsAt,
+        estimatedDeliveryOn: $1.estimatedDeliveryOn,
+        id: $1.id,
+        limit: $1.limit,
+        minimum: $1.minimum,
+        remaining: $1.remaining,
+        rewardsItems: $1.rewardsItems,
+        shipping: $1.shipping,
+        startsAt: $1.startsAt,
         title: $0
       ) }
     )

--- a/KsApi/models/templates/ProjectTemplates.swift
+++ b/KsApi/models/templates/ProjectTemplates.swift
@@ -85,6 +85,7 @@ extension Project {
       .template
         |> Reward.lens.id .~ 20
         |> Reward.lens.minimum .~ 6
+        |> Reward.lens.convertedMinimum .~ 7
         |> Reward.lens.limit .~ nil
         |> Reward.lens.backersCount .~ 23
         |> Reward.lens.title .~ "Postcards"
@@ -93,6 +94,7 @@ extension Project {
       .template
         |> Reward.lens.id .~ 1
         |> Reward.lens.minimum .~ 25
+        |> Reward.lens.convertedMinimum .~ 32
         |> Reward.lens.limit .~ 100
         |> Reward.lens.backersCount .~ 100
         |> Reward.lens.remaining .~ 0
@@ -102,6 +104,7 @@ extension Project {
       .template
         |> Reward.lens.id .~ 2
         |> Reward.lens.minimum .~ 30
+        |> Reward.lens.convertedMinimum .~ 39
         |> Reward.lens.backersCount .~ 83
         |> Reward.lens.title .~ "COSMIC SURGERY BOOK"
         |> Reward.lens.description .~ "You will be the first to receive a copy of the book at the special price of £30. The book will be sold for £35 in shops when released in July.",
@@ -109,6 +112,7 @@ extension Project {
       .template
         |> Reward.lens.id .~ 3
         |> Reward.lens.minimum .~ 650
+        |> Reward.lens.convertedMinimum .~ 851
         |> Reward.lens.limit .~ 10
         |> Reward.lens.backersCount .~ 3
         |> Reward.lens.title .~ "‘PATIENT NO. 16’ PRINT"

--- a/KsApi/models/templates/RewardTemplates.swift
+++ b/KsApi/models/templates/RewardTemplates.swift
@@ -3,6 +3,7 @@ import Prelude
 extension Reward {
   internal static let template = Reward(
     backersCount: 50,
+    convertedMinimum: nil,
     description: "A cool thing",
     endsAt: nil,
     estimatedDeliveryOn: Date(
@@ -24,6 +25,7 @@ extension Reward {
 
   public static let noReward = Reward(
     backersCount: nil,
+    convertedMinimum: nil,
     description: "",
     endsAt: nil,
     estimatedDeliveryOn: nil,
@@ -41,6 +43,7 @@ extension Reward {
 
   public static let otherReward = Reward(
     backersCount: nil,
+    convertedMinimum: nil,
     description: "",
     endsAt: nil,
     estimatedDeliveryOn: nil,

--- a/KsApi/models/templates/RewardTemplates.swift
+++ b/KsApi/models/templates/RewardTemplates.swift
@@ -3,7 +3,7 @@ import Prelude
 extension Reward {
   internal static let template = Reward(
     backersCount: 50,
-    convertedMinimum: nil,
+    convertedMinimum: 10.00,
     description: "A cool thing",
     endsAt: nil,
     estimatedDeliveryOn: Date(
@@ -25,7 +25,7 @@ extension Reward {
 
   public static let noReward = Reward(
     backersCount: nil,
-    convertedMinimum: nil,
+    convertedMinimum: 0,
     description: "",
     endsAt: nil,
     estimatedDeliveryOn: nil,
@@ -43,7 +43,7 @@ extension Reward {
 
   public static let otherReward = Reward(
     backersCount: nil,
-    convertedMinimum: nil,
+    convertedMinimum: 0,
     description: "",
     endsAt: nil,
     estimatedDeliveryOn: nil,

--- a/Library/ViewModels/DeprecatedRewardCellViewModel.swift
+++ b/Library/ViewModels/DeprecatedRewardCellViewModel.swift
@@ -69,9 +69,9 @@ public final class DeprecatedRewardCellViewModel: DeprecatedRewardCellViewModelT
         ) ?? (.us, project.stats.staticUsdRate)
         switch rewardOrBacking {
         case let .left(reward):
-          let min = minPledgeAmount(forProject: project, reward: reward)
+          let amount = reward.convertedMinimum ?? max(1, reward.minimum * Double(rate))
           return Format.currency(
-            max(1, Int(Float(min) * rate)),
+            amount,
             country: country,
             omitCurrencyCode: project.stats.omitUSCurrencyCode
           )

--- a/Library/ViewModels/DeprecatedRewardCellViewModel.swift
+++ b/Library/ViewModels/DeprecatedRewardCellViewModel.swift
@@ -69,9 +69,8 @@ public final class DeprecatedRewardCellViewModel: DeprecatedRewardCellViewModelT
         ) ?? (.us, project.stats.staticUsdRate)
         switch rewardOrBacking {
         case let .left(reward):
-          let amount = reward.convertedMinimum ?? max(1, reward.minimum * Double(rate))
           return Format.currency(
-            amount,
+            reward.convertedMinimum,
             country: country,
             omitCurrencyCode: project.stats.omitUSCurrencyCode
           )

--- a/Library/ViewModels/DeprecatedRewardCellViewModelTests.swift
+++ b/Library/ViewModels/DeprecatedRewardCellViewModelTests.swift
@@ -168,10 +168,11 @@ final class DeprecatedRewardCellViewModelTests: TestCase {
   func testConversionLabel_US_User_NonUS_Project_ConfiguredWithReward() {
     let project = .template
       |> Project.lens.country .~ .ca
-      |> Project.lens.stats.staticUsdRate .~ 0.76
       |> Project.lens.stats.currentCurrency .~ "MXN"
-      |> Project.lens.stats.currentCurrencyRate .~ 2.0
-    let reward = .template |> Reward.lens.minimum .~ 1
+
+    let reward = .template
+      |> Reward.lens.minimum .~ 1
+      |> Reward.lens.convertedMinimum .~ 2
 
     withEnvironment(
       apiService: MockService(currency: "MXN"),
@@ -183,7 +184,7 @@ final class DeprecatedRewardCellViewModelTests: TestCase {
         [false],
         "Mexican user viewing non-Mexican project sees conversion."
       )
-      self.conversionLabelText.assertValues(["About MX$ 2"], "Conversion label rounds up.")
+      self.conversionLabelText.assertValues(["About MX$ 2"], "Conversion shows the convertedMinimum value.")
     }
   }
 
@@ -191,15 +192,15 @@ final class DeprecatedRewardCellViewModelTests: TestCase {
     let project = .template
       |> Project.lens.country .~ .ca
       |> Project.lens.stats.currency .~ Project.Country.ca.currencyCode
-      |> Project.lens.stats.staticUsdRate .~ 0.76
-      |> Project.lens.stats.currentCurrencyRate .~ nil
-    let reward = .template |> Reward.lens.minimum .~ 1
+    let reward = .template
+      |> Reward.lens.minimum .~ 1
+      |> Reward.lens.convertedMinimum .~ 2
 
     withEnvironment(countryCode: "US") {
       self.vm.inputs.configureWith(project: project, rewardOrBacking: .left(reward))
 
       self.conversionLabelHidden.assertValues([false], "US user viewing non-US project sees conversion.")
-      self.conversionLabelText.assertValues(["About $1"], "Conversion label rounds up.")
+      self.conversionLabelText.assertValues(["About $2"], "Conversion shows the convertedMinimum value.")
     }
   }
 

--- a/Library/ViewModels/DeprecatedRewardPledgeViewModelTests.swift
+++ b/Library/ViewModels/DeprecatedRewardPledgeViewModelTests.swift
@@ -212,11 +212,9 @@ internal final class DeprecatedRewardPledgeViewModelTests: TestCase {
     let project = .template
       |> Project.lens.country .~ .gb
       |> Project.lens.stats.currency .~ Project.Country.gb.currencyCode
-      |> Project.lens.stats.staticUsdRate .~ 2
       |> Project.lens.stats.currentCurrency .~ "USD"
-      |> Project.lens.stats.currentCurrencyRate .~ 2
     let reward = .template
-      |> Reward.lens.minimum .~ 1_000
+      |> Reward.lens.convertedMinimum .~ 2_000
 
     withEnvironment(config: .template |> Config.lens.countryCode .~ "US") {
       self.vm.inputs.configureWith(project: project, reward: reward, applePayCapable: false)
@@ -231,10 +229,8 @@ internal final class DeprecatedRewardPledgeViewModelTests: TestCase {
     let project = .template
       |> Project.lens.country .~ .gb
       |> Project.lens.stats.currency .~ Project.Country.gb.currencyCode
-      |> Project.lens.stats.staticUsdRate .~ 2
-      |> Project.lens.stats.currentCurrencyRate .~ nil
     let reward = .template
-      |> Reward.lens.minimum .~ 1_000
+      |> Reward.lens.convertedMinimum .~ 2_000
 
     withEnvironment(config: .template |> Config.lens.countryCode .~ "US") {
       self.vm.inputs.configureWith(project: project, reward: reward, applePayCapable: false)
@@ -250,10 +246,8 @@ internal final class DeprecatedRewardPledgeViewModelTests: TestCase {
       |> Project.lens.country .~ .us
       |> Project.lens.stats.currency .~ Project.Country.us.currencyCode
       |> Project.lens.stats.currentCurrency .~ Project.Country.ca.currencyCode
-      |> Project.lens.stats.staticUsdRate .~ 2
-      |> Project.lens.stats.currentCurrencyRate .~ 1.2
     let reward = .template
-      |> Reward.lens.minimum .~ 1_000
+      |> Reward.lens.convertedMinimum .~ 1_200
 
     withEnvironment(countryCode: "CA") {
       self.vm.inputs.configureWith(project: project, reward: reward, applePayCapable: false)
@@ -268,10 +262,8 @@ internal final class DeprecatedRewardPledgeViewModelTests: TestCase {
     let project = .template
       |> Project.lens.country .~ .gb
       |> Project.lens.stats.currency .~ Project.Country.gb.currencyCode
-      |> Project.lens.stats.staticUsdRate .~ 2
-      |> Project.lens.stats.currentCurrencyRate .~ nil
     let reward = .template
-      |> Reward.lens.minimum .~ 1_000
+      |> Reward.lens.convertedMinimum .~ 2_000
 
     withEnvironment(countryCode: "CA") {
       self.vm.inputs.configureWith(project: project, reward: reward, applePayCapable: false)

--- a/Library/ViewModels/RewardCardViewModel.swift
+++ b/Library/ViewModels/RewardCardViewModel.swift
@@ -64,9 +64,9 @@ public final class RewardCardViewModel: RewardCardViewModelType, RewardCardViewM
         ) ?? (.us, project.stats.staticUsdRate)
         switch rewardOrBacking {
         case let .left(reward):
-          let min = minPledgeAmount(forProject: project, reward: reward)
+          let amount = reward.convertedMinimum ?? max(1, reward.minimum * Double(rate))
           return Format.currency(
-            max(1, Int(Float(min) * rate)),
+            amount,
             country: country,
             omitCurrencyCode: project.stats.omitUSCurrencyCode
           )

--- a/Library/ViewModels/RewardCardViewModel.swift
+++ b/Library/ViewModels/RewardCardViewModel.swift
@@ -64,9 +64,8 @@ public final class RewardCardViewModel: RewardCardViewModelType, RewardCardViewM
         ) ?? (.us, project.stats.staticUsdRate)
         switch rewardOrBacking {
         case let .left(reward):
-          let amount = reward.convertedMinimum ?? max(1, reward.minimum * Double(rate))
           return Format.currency(
-            amount,
+            reward.convertedMinimum,
             country: country,
             omitCurrencyCode: project.stats.omitUSCurrencyCode
           )

--- a/Library/ViewModels/RewardCardViewModelTests.swift
+++ b/Library/ViewModels/RewardCardViewModelTests.swift
@@ -313,7 +313,7 @@ final class RewardCardViewModelTests: TestCase {
       |> Project.lens.country .~ .us
       |> Project.lens.stats.currency .~ "USD"
       |> Project.lens.stats.currentCurrency .~ "USD"
-    let reward = .template |> Reward.lens.minimum .~ 1_000
+    let reward = .template |> Reward.lens.convertedMinimum .~ 1_000
 
     withEnvironment(countryCode: "US") {
       self.vm.inputs.configureWith(project: project, rewardOrBacking: .left(reward))
@@ -352,8 +352,7 @@ final class RewardCardViewModelTests: TestCase {
       |> Project.lens.country .~ .ca
       |> Project.lens.stats.currency .~ Project.Country.ca.currencyCode
       |> Project.lens.stats.currentCurrency .~ Project.Country.us.currencyCode
-      |> Project.lens.stats.currentCurrencyRate .~ 2.0
-    let reward = .template |> Reward.lens.minimum .~ 1
+    let reward = .template |> Reward.lens.convertedMinimum .~ 2
 
     withEnvironment(countryCode: "US") {
       self.vm.inputs.configureWith(project: project, rewardOrBacking: .left(reward))
@@ -399,8 +398,7 @@ final class RewardCardViewModelTests: TestCase {
       |> Project.lens.country .~ .ca
       |> Project.lens.stats.currency .~ Project.Country.ca.currencyCode
       |> Project.lens.stats.currentCurrency .~ Project.Country.us.currencyCode
-      |> Project.lens.stats.currentCurrencyRate .~ 2.0
-    let reward = .template |> Reward.lens.minimum .~ 1
+    let reward = .template |> Reward.lens.convertedMinimum .~ 2
 
     withEnvironment(countryCode: "MX") {
       self.vm.inputs.configureWith(project: project, rewardOrBacking: .left(reward))
@@ -445,7 +443,7 @@ final class RewardCardViewModelTests: TestCase {
       |> Project.lens.stats.currency .~ Project.Country.us.currencyCode
       |> Project.lens.stats.currentCurrency .~ nil
       |> Project.lens.stats.currentCurrencyRate .~ nil
-    let reward = .template |> Reward.lens.minimum .~ 1
+    let reward = .template |> Reward.lens.convertedMinimum .~ 1
 
     withEnvironment(countryCode: "XX") {
       self.vm.inputs.configureWith(project: project, rewardOrBacking: .left(reward))
@@ -463,7 +461,7 @@ final class RewardCardViewModelTests: TestCase {
       |> Project.lens.stats.currency .~ Project.Country.us.currencyCode
       |> Project.lens.stats.currentCurrency .~ nil
       |> Project.lens.stats.currentCurrencyRate .~ nil
-    let reward = .template |> Reward.lens.minimum .~ 1
+    let reward = .template |> Reward.lens.convertedMinimum .~ 1
     let backing = .template
       |> Backing.lens.amount .~ 2
       |> Backing.lens.reward .~ reward
@@ -482,10 +480,9 @@ final class RewardCardViewModelTests: TestCase {
     let project = .template
       |> Project.lens.country .~ .ca
       |> Project.lens.stats.currency .~ Project.Country.ca.currencyCode
-      |> Project.lens.stats.staticUsdRate .~ 0.76
       |> Project.lens.stats.currentCurrency .~ nil
       |> Project.lens.stats.currentCurrencyRate .~ nil
-    let reward = .template |> Reward.lens.minimum .~ 1
+    let reward = .template |> Reward.lens.convertedMinimum .~ 2
 
     withEnvironment(countryCode: "XX") {
       self.vm.inputs.configureWith(project: project, rewardOrBacking: .left(reward))
@@ -494,7 +491,7 @@ final class RewardCardViewModelTests: TestCase {
         [false],
         "Unknown-location, unknown-currency user viewing non-US project sees conversion to USD."
       )
-      self.conversionLabelText.assertValues(["About US$ 1"], "Conversion label rounds up.")
+      self.conversionLabelText.assertValues(["About US$ 2"], "Conversion label shows convertedMinimum value.")
     }
   }
 
@@ -526,8 +523,7 @@ final class RewardCardViewModelTests: TestCase {
       |> Project.lens.country .~ .us
       |> Project.lens.stats.currency .~ Project.Country.us.currencyCode
       |> Project.lens.stats.currentCurrency .~ Project.Country.mx.currencyCode
-      |> Project.lens.stats.currentCurrencyRate .~ 2.0
-    let reward = .template |> Reward.lens.minimum .~ 1
+    let reward = .template |> Reward.lens.convertedMinimum .~ 2
 
     withEnvironment(
       apiService: MockService(currency: "MXN"), countryCode: "MX"
@@ -538,7 +534,7 @@ final class RewardCardViewModelTests: TestCase {
         [false],
         "Mexican user viewing US project sees conversion."
       )
-      self.conversionLabelText.assertValues(["About MX$ 2"], "Conversion label rounds up.")
+      self.conversionLabelText.assertValues(["About MX$ 2"], "Conversion label shows convertedMinimum value.")
     }
   }
 
@@ -569,8 +565,7 @@ final class RewardCardViewModelTests: TestCase {
       |> Project.lens.country .~ .us
       |> Project.lens.stats.currency .~ Project.Country.us.currencyCode
       |> Project.lens.stats.currentCurrency .~ Project.Country.us.currencyCode
-      |> Project.lens.stats.currentCurrencyRate .~ 1.0
-    let reward = .template |> Reward.lens.minimum .~ 1_000
+    let reward = .template |> Reward.lens.convertedMinimum .~ 1_000
 
     withEnvironment(countryCode: "GB") {
       self.vm.inputs.configureWith(project: project, rewardOrBacking: .left(reward))


### PR DESCRIPTION
# 📲 What 
- Shows Rewards converted minimum based on the value of `convertedMinimum` returned by the API.

# 🤔 Why
- This allows us to have one source of truth and avoids the calculation of conversions to be done on the client side.

# 🛠 How
- Added a new property `convertedMinimum` to our Reward model.
- Changed logic to present the value of that property instead of calculating conversion value based on project conversion rate.
- Updated tests.

# ✅ Acceptance criteria

- [ ] iOS and web should show the same values for conversion minimum on Reward cells.