### PR TITLE
[NT-280] Manage pledge screen from CTA container

### DIFF
--- a/Kickstarter-iOS/Views/Controllers/ProjectPamphletViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/ProjectPamphletViewController.swift
@@ -135,7 +135,7 @@ public final class ProjectPamphletViewController: UIViewController {
         self?.goToRewards(project: project, refTag: refTag)
       }
 
-    self.viewModel.outputs.goToManagePledge
+    self.viewModel.outputs.goToManageViewPledge
       .observeForControllerAction()
       .observeValues { [weak self] (params) in
         let (project, reward, refTag) = params
@@ -210,7 +210,12 @@ public final class ProjectPamphletViewController: UIViewController {
     let managePledgeViewController = ManagePledgeViewController.instantiate()
     managePledgeViewController.configureWith(project: project, reward: reward)
 
-    self.navigationController?.pushViewController(managePledgeViewController, animated: true)
+    let nav = UINavigationController(rootViewController: managePledgeViewController)
+    if AppEnvironment.current.device.userInterfaceIdiom == .pad {
+      _ = nav
+        |> \.modalPresentationStyle .~ .formSheet
+    }
+    self.present(nav, animated: true)
   }
 
   private func goToDeprecatedPledge(project: Project, reward: Reward, refTag _: RefTag?) {
@@ -218,14 +223,31 @@ public final class ProjectPamphletViewController: UIViewController {
       .configuredWith(
         project: project, reward: reward
     )
+    pledgeViewController.navigationItem.leftBarButtonItem = UIBarButtonItem(
+      image: image(named: "icon--cross", tintColor: .ksr_navy_600),
+      style: .plain,
+      target: pledgeViewController,
+      action: #selector(DeprecatedRewardPledgeViewController.closeButtonTapped)
+    )
 
-    self.navigationController?.pushViewController(pledgeViewController, animated: true)
+    let nav = UINavigationController(rootViewController: pledgeViewController)
+    if AppEnvironment.current.device.userInterfaceIdiom == .pad {
+      _ = nav
+        |> \.modalPresentationStyle .~ .formSheet
+    }
+    self.present(nav, animated: true, completion: nil)
   }
 
   private func goToViewBacking(project: Project, user: User?) {
-    let backingViewController = BackingViewController.configuredWith(project: project, backer: user)
+    let backingViewController = BackingViewController.configuredWith(project: project, backer: nil)
 
-    self.navigationController?.pushViewController(backingViewController, animated: true)
+    if AppEnvironment.current.device.userInterfaceIdiom == .pad {
+      let nav = UINavigationController(rootViewController: backingViewController)
+        |> \.modalPresentationStyle .~ .formSheet
+      self.present(nav, animated: true, completion: nil)
+    } else {
+      self.navigationController?.pushViewController(backingViewController, animated: true)
+    }
   }
 
   private func updateContentInsets() {

--- a/Kickstarter-iOS/Views/Controllers/ProjectPamphletViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/ProjectPamphletViewController.swift
@@ -135,6 +135,14 @@ public final class ProjectPamphletViewController: UIViewController {
         self?.goToRewards(project: project, refTag: refTag)
       }
 
+    self.viewModel.outputs.goToManagePledge
+      .observeForControllerAction()
+      .observeValues { [weak self] (params) in
+        let (project, reward, refTag) = params
+
+        self?.goToManagePledge(project: project, reward: reward, refTag: refTag)
+    }
+
     self.viewModel.outputs.configureChildViewControllersWithProject
       .observeForUI()
       .observeValues { [weak self] project, refTag in
@@ -186,6 +194,24 @@ public final class ProjectPamphletViewController: UIViewController {
     self.present(vc, animated: true)
   }
 
+  private func goToManagePledge(project: Project, reward: Reward, refTag _: RefTag?) {
+    let managePledgeViewController = ManagePledgeViewController.instantiate()
+    managePledgeViewController.configureWith(project: project, reward: reward)
+
+    let nav = UINavigationController(rootViewController: managePledgeViewController)
+    if AppEnvironment.current.device.userInterfaceIdiom == .pad {
+      _ = nav
+        |> \.modalPresentationStyle .~ .formSheet
+    }
+    self.present(nav, animated: true)
+  }
+
+  private func goToViewBacking(project: Project, user: User?) {
+    let backingViewController = BackingViewController.configuredWith(project: project, backer: user)
+
+    self.navigationController?.pushViewController(backingViewController, animated: true)
+  }
+
   private func updateContentInsets() {
     let buttonSize = self.pledgeCTAContainerView.pledgeCTAButton.systemLayoutSizeFitting(
       UIView.layoutFittingCompressedSize
@@ -203,8 +229,9 @@ public final class ProjectPamphletViewController: UIViewController {
 }
 
 extension ProjectPamphletViewController: PledgeCTAContainerViewDelegate {
-  func pledgeCTAButtonTapped() {
-    self.viewModel.inputs.backThisProjectTapped()
+
+  func pledgeCTAButtonTapped(_ state: PledgeStateCTAType) {
+    self.viewModel.inputs.pledgeCTAButtonTapped(state)
   }
 }
 

--- a/Kickstarter-iOS/Views/Controllers/ProjectPamphletViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/ProjectPamphletViewController.swift
@@ -143,6 +143,18 @@ public final class ProjectPamphletViewController: UIViewController {
         self?.goToManagePledge(project: project, reward: reward, refTag: refTag)
     }
 
+    self.viewModel.outputs.goToDeprecatedViewBacking
+      .observeForControllerAction()
+      .observeValues { [weak self] project, user in
+        self?.goToViewBacking(project: project, user: user)
+    }
+
+    self.viewModel.outputs.goToDeprecatedManagePledge
+      .observeForControllerAction()
+      .observeValues { [weak self] project, reward, refTag in
+        self?.goToDeprecatedPledge(project: project, reward: reward, refTag: refTag)
+    }
+
     self.viewModel.outputs.configureChildViewControllersWithProject
       .observeForUI()
       .observeValues { [weak self] project, refTag in
@@ -198,12 +210,16 @@ public final class ProjectPamphletViewController: UIViewController {
     let managePledgeViewController = ManagePledgeViewController.instantiate()
     managePledgeViewController.configureWith(project: project, reward: reward)
 
-    let nav = UINavigationController(rootViewController: managePledgeViewController)
-    if AppEnvironment.current.device.userInterfaceIdiom == .pad {
-      _ = nav
-        |> \.modalPresentationStyle .~ .formSheet
-    }
-    self.present(nav, animated: true)
+    self.navigationController?.pushViewController(managePledgeViewController, animated: true)
+  }
+
+  private func goToDeprecatedPledge(project: Project, reward: Reward, refTag _: RefTag?) {
+    let pledgeViewController = DeprecatedRewardPledgeViewController
+      .configuredWith(
+        project: project, reward: reward
+    )
+
+    self.navigationController?.pushViewController(pledgeViewController, animated: true)
   }
 
   private func goToViewBacking(project: Project, user: User?) {

--- a/Kickstarter-iOS/Views/Controllers/ProjectPamphletViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/ProjectPamphletViewController.swift
@@ -137,23 +137,23 @@ public final class ProjectPamphletViewController: UIViewController {
 
     self.viewModel.outputs.goToManageViewPledge
       .observeForControllerAction()
-      .observeValues { [weak self] (params) in
+      .observeValues { [weak self] params in
         let (project, reward, refTag) = params
 
         self?.goToManagePledge(project: project, reward: reward, refTag: refTag)
-    }
+      }
 
     self.viewModel.outputs.goToDeprecatedViewBacking
       .observeForControllerAction()
       .observeValues { [weak self] project, user in
         self?.goToViewBacking(project: project, user: user)
-    }
+      }
 
     self.viewModel.outputs.goToDeprecatedManagePledge
       .observeForControllerAction()
       .observeValues { [weak self] project, reward, refTag in
         self?.goToDeprecatedPledge(project: project, reward: reward, refTag: refTag)
-    }
+      }
 
     self.viewModel.outputs.configureChildViewControllersWithProject
       .observeForUI()
@@ -222,7 +222,7 @@ public final class ProjectPamphletViewController: UIViewController {
     let pledgeViewController = DeprecatedRewardPledgeViewController
       .configuredWith(
         project: project, reward: reward
-    )
+      )
     pledgeViewController.navigationItem.leftBarButtonItem = UIBarButtonItem(
       image: image(named: "icon--cross", tintColor: .ksr_navy_600),
       style: .plain,
@@ -238,7 +238,7 @@ public final class ProjectPamphletViewController: UIViewController {
     self.present(nav, animated: true, completion: nil)
   }
 
-  private func goToViewBacking(project: Project, user: User?) {
+  private func goToViewBacking(project: Project, user _: User?) {
     let backingViewController = BackingViewController.configuredWith(project: project, backer: nil)
 
     if AppEnvironment.current.device.userInterfaceIdiom == .pad {
@@ -267,7 +267,6 @@ public final class ProjectPamphletViewController: UIViewController {
 }
 
 extension ProjectPamphletViewController: PledgeCTAContainerViewDelegate {
-
   func pledgeCTAButtonTapped(_ state: PledgeStateCTAType) {
     self.viewModel.inputs.pledgeCTAButtonTapped(state)
   }

--- a/Kickstarter-iOS/Views/Controllers/RewardsCollectionViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/RewardsCollectionViewController.swift
@@ -147,18 +147,6 @@ final class RewardsCollectionViewController: UICollectionViewController {
         self?.goToDeprecatedPledge(project: project, reward: reward, refTag: refTag)
       }
 
-    self.viewModel.outputs.goToManagePledge
-      .observeForControllerAction()
-      .observeValues { [weak self] project, reward, refTag in
-        self?.goToManagePledge(project: project, reward: reward, refTag: refTag)
-      }
-
-    self.viewModel.outputs.goToViewBacking
-      .observeForControllerAction()
-      .observeValues { [weak self] project, user in
-        self?.goToViewBacking(project: project, user: user)
-      }
-
     self.viewModel.outputs.rewardsCollectionViewFooterIsHidden
       .observeForUI()
       .observeValues { [weak self] isHidden in
@@ -240,29 +228,11 @@ final class RewardsCollectionViewController: UICollectionViewController {
       ?|> \.isActive .~ !isHidden
   }
 
-  private func goToManagePledge(project: Project, reward: Reward, refTag _: RefTag?) {
-    let managePledgeViewController = ManagePledgeViewController.instantiate()
-    managePledgeViewController.configureWith(project: project, reward: reward)
-
-    let nav = UINavigationController(rootViewController: managePledgeViewController)
-    if AppEnvironment.current.device.userInterfaceIdiom == .pad {
-      _ = nav
-        |> \.modalPresentationStyle .~ .formSheet
-    }
-    self.present(nav, animated: true)
-  }
-
   private func goToPledge(project: Project, reward: Reward, refTag _: RefTag?) {
     let pledgeViewController = PledgeViewController.instantiate()
     pledgeViewController.configureWith(project: project, reward: reward)
 
     self.navigationController?.pushViewController(pledgeViewController, animated: true)
-  }
-
-  private func goToViewBacking(project: Project, user: User?) {
-    let backingViewController = BackingViewController.configuredWith(project: project, backer: user)
-
-    self.navigationController?.pushViewController(backingViewController, animated: true)
   }
 
   private func goToDeprecatedPledge(project: Project, reward: Reward, refTag _: RefTag?) {

--- a/Kickstarter-iOS/Views/PledgeCTAContainerView.swift
+++ b/Kickstarter-iOS/Views/PledgeCTAContainerView.swift
@@ -4,7 +4,7 @@ import Prelude
 import UIKit
 
 protocol PledgeCTAContainerViewDelegate: AnyObject {
-  func pledgeCTAButtonTapped()
+  func pledgeCTAButtonTapped(_ state: PledgeStateCTAType)
 }
 
 private enum Layout {
@@ -113,8 +113,8 @@ final class PledgeCTAContainerView: UIView {
 
     self.viewModel.outputs.notifyDelegateCTATapped
       .observeForUI()
-      .observeValues { [weak self] in
-        self?.delegate?.pledgeCTAButtonTapped()
+      .observeValues { [weak self] state in
+        self?.delegate?.pledgeCTAButtonTapped(state)
       }
 
     self.viewModel.outputs.buttonStyleType

--- a/Library/ViewModels/PledgeCTAContainerViewViewModel.swift
+++ b/Library/ViewModels/PledgeCTAContainerViewViewModel.swift
@@ -12,7 +12,7 @@ public protocol PledgeCTAContainerViewViewModelOutputs {
   var activityIndicatorIsHidden: Signal<Bool, Never> { get }
   var buttonStyleType: Signal<ButtonStyleType, Never> { get }
   var buttonTitleText: Signal<String, Never> { get }
-  var notifyDelegateCTATapped: Signal<(), Never> { get }
+  var notifyDelegateCTATapped: Signal<PledgeStateCTAType, Never> { get }
   var pledgeCTAButtonIsHidden: Signal<Bool, Never> { get }
   var pledgeRetryButtonIsHidden: Signal<Bool, Never> { get }
   var spacerIsHidden: Signal<Bool, Never> { get }
@@ -63,7 +63,8 @@ public final class PledgeCTAContainerViewViewModel: PledgeCTAContainerViewViewMo
       isLoading.filter(isFalse).ignoreValues()
     )
 
-    self.notifyDelegateCTATapped = self.pledgeCTAButtonTappedProperty.signal
+    self.notifyDelegateCTATapped = pledgeState
+      .takeWhen(self.pledgeCTAButtonTappedProperty.signal)
 
     self.pledgeRetryButtonIsHidden = inError
       .map(isFalse)
@@ -117,7 +118,7 @@ public final class PledgeCTAContainerViewViewModel: PledgeCTAContainerViewViewMo
   public let activityIndicatorIsHidden: Signal<Bool, Never>
   public let buttonStyleType: Signal<ButtonStyleType, Never>
   public let buttonTitleText: Signal<String, Never>
-  public let notifyDelegateCTATapped: Signal<Void, Never>
+  public let notifyDelegateCTATapped: Signal<PledgeStateCTAType, Never>
   public let pledgeCTAButtonIsHidden: Signal<Bool, Never>
   public let pledgeRetryButtonIsHidden: Signal<Bool, Never>
   public let spacerIsHidden: Signal<Bool, Never>

--- a/Library/ViewModels/PledgeCTAContainerViewViewModelTests.swift
+++ b/Library/ViewModels/PledgeCTAContainerViewViewModelTests.swift
@@ -12,7 +12,7 @@ internal final class PledgeCTAContainerViewViewModelTests: TestCase {
   let activityIndicatorIsHidden = TestObserver<Bool, Never>()
   let buttonStyleType = TestObserver<ButtonStyleType, Never>()
   let buttonTitleText = TestObserver<String, Never>()
-  let notifyDelegateCTATapped = TestObserver<Void, Never>()
+  let notifyDelegateCTATapped = TestObserver<PledgeStateCTAType, Never>()
   let pledgeCTAButtonIsHidden = TestObserver<Bool, Never>()
   let pledgeRetryButtonIsHidden = TestObserver<Bool, Never>()
   let spacerIsHidden = TestObserver<Bool, Never>()

--- a/Library/ViewModels/ProjectPamphletViewModel.swift
+++ b/Library/ViewModels/ProjectPamphletViewModel.swift
@@ -2,7 +2,6 @@ import KsApi
 import Prelude
 import ReactiveSwift
 public protocol ProjectPamphletViewModelInputs {
-
   /// Call with the project given to the view controller.
   func configureWith(projectOrParam: Either<Project, Param>, refTag: RefTag?)
 
@@ -95,7 +94,7 @@ public final class ProjectPamphletViewModel: ProjectPamphletViewModelType, Proje
       .map { (project, refTag, _) -> PledgeData in
         let r = reward(from: project.personalization.backing, inProject: project)
         return PledgeData(project: project, reward: r, refTag: refTag)
-    }
+      }
 
     self.goToManageViewPledge = goToManagePledge
       .filter { _ in featureNativeCheckoutPledgeViewIsEnabled() }
@@ -105,13 +104,13 @@ public final class ProjectPamphletViewModel: ProjectPamphletViewModelType, Proje
       .map { (project, refTag, _) -> PledgeData in
         let r = reward(from: project.personalization.backing, inProject: project)
         return PledgeData(project: project, reward: r, refTag: refTag)
-    }
+      }
 
     self.goToDeprecatedViewBacking = ctaButtonTapped
       .filter(shouldGoToDeprecatedViewBacking(_:_:state:))
-      .map { (project, _, _) in
+      .map { project, _, _ in
         (project, AppEnvironment.current.currentUser)
-    }
+      }
 
     self.goToRewards = ctaButtonTapped
       .filter { _, _, pledgeState in
@@ -324,27 +323,33 @@ private func reward(from backing: Backing?, inProject project: Project) -> Rewar
     ?? Reward.noReward
 }
 
-private func canShowManageViewPledgeScreen(_ project: Project,
-                                           _: RefTag?,
-                                           state: PledgeStateCTAType?) -> Bool {
+private func canShowManageViewPledgeScreen(
+  _ project: Project,
+  _: RefTag?,
+  state: PledgeStateCTAType?
+) -> Bool {
   guard let isBacking = project.personalization.isBacking, let state = state else {
     return false
   }
   return isBacking && (state == .manage || state == .viewBacking)
 }
 
-private func shouldGoToDeprecatedViewBacking(_ project: Project,
-                                             _: RefTag?,
-                                             state: PledgeStateCTAType?) -> Bool {
+private func shouldGoToDeprecatedViewBacking(
+  _ project: Project,
+  _: RefTag?,
+  state: PledgeStateCTAType?
+) -> Bool {
   guard let isBacking = project.personalization.isBacking, let state = state else {
     return false
   }
   return !featureNativeCheckoutPledgeViewIsEnabled() && isBacking && state == .viewBacking
 }
 
-private func shouldGoToDeprecatedManagePledge(_ project: Project,
-                                              _: RefTag?,
-                                              state: PledgeStateCTAType?) -> Bool {
+private func shouldGoToDeprecatedManagePledge(
+  _ project: Project,
+  _: RefTag?,
+  state: PledgeStateCTAType?
+) -> Bool {
   guard let isBacking = project.personalization.isBacking, let state = state else {
     return false
   }

--- a/Library/ViewModels/ProjectPamphletViewModel.swift
+++ b/Library/ViewModels/ProjectPamphletViewModel.swift
@@ -39,7 +39,7 @@ public protocol ProjectPamphletViewModelOutputs {
 
   var goToDeprecatedViewBacking: Signal<(Project, User?), Never> { get }
 
-  var goToManagePledge: Signal<PledgeData, Never> { get }
+  var goToManageViewPledge: Signal<PledgeData, Never> { get }
 
   /// Emits a project and refTag to be used to navigate to the reward selection screen.
   var goToRewards: Signal<(Project, RefTag?), Never> { get }
@@ -97,7 +97,7 @@ public final class ProjectPamphletViewModel: ProjectPamphletViewModelType, Proje
         return PledgeData(project: project, reward: r, refTag: refTag)
     }
 
-    self.goToManagePledge = goToManagePledge
+    self.goToManageViewPledge = goToManagePledge
       .filter { _ in featureNativeCheckoutPledgeViewIsEnabled() }
 
     self.goToDeprecatedManagePledge = ctaButtonTapped
@@ -223,7 +223,7 @@ public final class ProjectPamphletViewModel: ProjectPamphletViewModelType, Proje
   public let configurePledgeCTAView: Signal<(Either<Project, ErrorEnvelope>, Bool), Never>
   public let goToDeprecatedManagePledge: Signal<PledgeData, Never>
   public let goToDeprecatedViewBacking: Signal<(Project, User?), Never>
-  public let goToManagePledge: Signal<PledgeData, Never>
+  public let goToManageViewPledge: Signal<PledgeData, Never>
   public let goToRewards: Signal<(Project, RefTag?), Never>
   public let setNavigationBarHiddenAnimated: Signal<(Bool, Bool), Never>
   public let setNeedsStatusBarAppearanceUpdate: Signal<(), Never>

--- a/Library/ViewModels/ProjectPamphletViewModelTests.swift
+++ b/Library/ViewModels/ProjectPamphletViewModelTests.swift
@@ -505,7 +505,6 @@ final class ProjectPamphletViewModelTests: TestCase {
   }
 
   func testGoToDeprecatedViewBacking_NativeCheckoutPledgeViewFeature_Disabled() {
-
     let config = .template
       |> Config.lens.features .~ [Feature.nativeCheckoutPledgeView.rawValue: false]
     let user = User.template
@@ -541,9 +540,7 @@ final class ProjectPamphletViewModelTests: TestCase {
     }
   }
 
-  func testGoToViewBacking_NativeCheckoutPledgeViewFeature_Disabled() {
-
-  }
+  func testGoToViewBacking_NativeCheckoutPledgeViewFeature_Disabled() {}
 
   func testConfigurePledgeCTAView_fetchProjectSuccess_featureEnabled_experimentEnabled() {
     let config = Config.template

--- a/Library/ViewModels/RewardsCollectionViewModel.swift
+++ b/Library/ViewModels/RewardsCollectionViewModel.swift
@@ -19,9 +19,7 @@ public protocol RewardsCollectionViewModelOutputs {
   var configureRewardsCollectionViewFooterWithCount: Signal<Int, Never> { get }
   var flashScrollIndicators: Signal<Void, Never> { get }
   var goToDeprecatedPledge: Signal<PledgeData, Never> { get }
-  var goToManagePledge: Signal<PledgeData, Never> { get }
   var goToPledge: Signal<PledgeData, Never> { get }
-  var goToViewBacking: Signal<(Project, User?), Never> { get }
   var navigationBarShadowImageHidden: Signal<Bool, Never> { get }
   var reloadDataWithValues: Signal<[(Project, Either<Reward, Backing>)], Never> { get }
   var rewardsCollectionViewFooterIsHidden: Signal<Bool, Never> { get }
@@ -84,33 +82,6 @@ public final class RewardsCollectionViewModel: RewardsCollectionViewModelType,
       PledgeData(project: project, reward: reward, refTag: refTag)
     }
 
-    let goToViewBacking = project
-      .takePairWhen(selectedRewardFromId)
-      .filter { project, reward -> Bool in
-        project.state != .live && userIsBacking(reward: reward, inProject: project)
-      }
-      .map(first)
-
-    let goToManagePledge = Signal.combineLatest(
-      project,
-      selectedRewardFromId,
-      refTag
-    )
-    .filter { project, reward, _ -> Bool in
-      project.state == .live && userIsBacking(reward: reward, inProject: project)
-    }
-    .map { project, reward, refTag in
-      PledgeData(project: project, reward: reward, refTag: refTag)
-    }
-
-    self.goToManagePledge = goToManagePledge
-      .filter { _ in featureNativeCheckoutPledgeViewIsEnabled() }
-
-    self.goToViewBacking = goToViewBacking
-      .map { project in
-        (project, AppEnvironment.current.currentUser)
-      }
-
     self.goToPledge = goToPledge
       .filter { project, reward, _ in
         featureNativeCheckoutPledgeViewIsEnabled() && !userIsBacking(reward: reward, inProject: project)
@@ -172,9 +143,7 @@ public final class RewardsCollectionViewModel: RewardsCollectionViewModelType,
   public let configureRewardsCollectionViewFooterWithCount: Signal<Int, Never>
   public let flashScrollIndicators: Signal<Void, Never>
   public let goToDeprecatedPledge: Signal<PledgeData, Never>
-  public let goToManagePledge: Signal<PledgeData, Never>
   public let goToPledge: Signal<PledgeData, Never>
-  public let goToViewBacking: Signal<(Project, User?), Never>
   public let navigationBarShadowImageHidden: Signal<Bool, Never>
   public let reloadDataWithValues: Signal<[(Project, Either<Reward, Backing>)], Never>
   public let rewardsCollectionViewFooterIsHidden: Signal<Bool, Never>

--- a/Library/ViewModels/RewardsCollectionViewModelTests.swift
+++ b/Library/ViewModels/RewardsCollectionViewModelTests.swift
@@ -14,14 +14,9 @@ final class RewardsCollectionViewModelTests: TestCase {
   private let goToDeprecatedPledgeProject = TestObserver<Project, Never>()
   private let goToDeprecatedPledgeRefTag = TestObserver<RefTag?, Never>()
   private let goToDeprecatedPledgeReward = TestObserver<Reward, Never>()
-  private let goToManagePledgeProject = TestObserver<Project, Never>()
-  private let goToManagePledgeRefTag = TestObserver<RefTag?, Never>()
-  private let goToManagePledgeReward = TestObserver<Reward, Never>()
   private let goToPledgeProject = TestObserver<Project, Never>()
   private let goToPledgeRefTag = TestObserver<RefTag?, Never>()
   private let goToPledgeReward = TestObserver<Reward, Never>()
-  private let goToViewBackingProject = TestObserver<Project, Never>()
-  private let goToViewBackingUser = TestObserver<User?, Never>()
   private let navigationBarShadowImageHidden = TestObserver<Bool, Never>()
   private let reloadDataWithValues = TestObserver<[(Project, Either<Reward, Backing>)], Never>()
   private let reloadDataWithValuesProject = TestObserver<[Project], Never>()
@@ -37,14 +32,9 @@ final class RewardsCollectionViewModelTests: TestCase {
     self.vm.outputs.goToDeprecatedPledge.map { $0.project }.observe(self.goToDeprecatedPledgeProject.observer)
     self.vm.outputs.goToDeprecatedPledge.map { $0.reward }.observe(self.goToDeprecatedPledgeReward.observer)
     self.vm.outputs.goToDeprecatedPledge.map { $0.refTag }.observe(self.goToDeprecatedPledgeRefTag.observer)
-    self.vm.outputs.goToManagePledge.map { $0.project }.observe(self.goToManagePledgeProject.observer)
-    self.vm.outputs.goToManagePledge.map { $0.reward }.observe(self.goToManagePledgeReward.observer)
-    self.vm.outputs.goToManagePledge.map { $0.refTag }.observe(self.goToManagePledgeRefTag.observer)
     self.vm.outputs.goToPledge.map { $0.project }.observe(self.goToPledgeProject.observer)
     self.vm.outputs.goToPledge.map { $0.reward }.observe(self.goToPledgeReward.observer)
     self.vm.outputs.goToPledge.map { $0.refTag }.observe(self.goToPledgeRefTag.observer)
-    self.vm.outputs.goToViewBacking.map(first).observe(self.goToViewBackingProject.observer)
-    self.vm.outputs.goToViewBacking.map(second).observe(self.goToViewBackingUser.observer)
     self.vm.outputs.navigationBarShadowImageHidden.observe(self.navigationBarShadowImageHidden.observer)
     self.vm.outputs.reloadDataWithValues.observe(self.reloadDataWithValues.observer)
     self.vm.outputs.reloadDataWithValues.map { $0.map { $0.0 } }
@@ -99,8 +89,6 @@ final class RewardsCollectionViewModelTests: TestCase {
       self.goToPledgeProject.assertValues([project])
       self.goToPledgeReward.assertValues([project.rewards[0]])
       self.goToPledgeRefTag.assertValues([.activity])
-      self.goToViewBackingUser.assertDidNotEmitValue()
-      self.goToViewBackingProject.assertDidNotEmitValue()
       XCTAssertEqual(self.vm.outputs.selectedReward(), project.rewards[0])
 
       let lastCardRewardId = project.rewards.last!.id
@@ -114,8 +102,6 @@ final class RewardsCollectionViewModelTests: TestCase {
       self.goToPledgeProject.assertValues([project, project])
       self.goToPledgeReward.assertValues([project.rewards[0], project.rewards[endIndex - 1]])
       self.goToPledgeRefTag.assertValues([.activity, .activity])
-      self.goToViewBackingUser.assertDidNotEmitValue()
-      self.goToViewBackingProject.assertDidNotEmitValue()
       XCTAssertEqual(self.vm.outputs.selectedReward(), project.rewards[endIndex - 1])
     }
   }
@@ -143,8 +129,6 @@ final class RewardsCollectionViewModelTests: TestCase {
     self.goToPledgeProject.assertDidNotEmitValue()
     self.goToPledgeReward.assertDidNotEmitValue()
     self.goToPledgeRefTag.assertDidNotEmitValue()
-    self.goToViewBackingUser.assertDidNotEmitValue()
-    self.goToViewBackingProject.assertDidNotEmitValue()
     XCTAssertEqual(self.vm.outputs.selectedReward(), project.rewards[0])
 
     let lastCardRewardId = project.rewards.last!.id
@@ -158,134 +142,7 @@ final class RewardsCollectionViewModelTests: TestCase {
     self.goToPledgeProject.assertDidNotEmitValue()
     self.goToPledgeReward.assertDidNotEmitValue()
     self.goToPledgeRefTag.assertDidNotEmitValue()
-    self.goToViewBackingUser.assertDidNotEmitValue()
-    self.goToViewBackingProject.assertDidNotEmitValue()
     XCTAssertEqual(self.vm.outputs.selectedReward(), project.rewards[endIndex - 1])
-  }
-
-  func testGoToManagePledge_featureNativeCheckoutPledgeView_Enabled() {
-    let config = .template
-      |> Config.lens.features .~ [Feature.nativeCheckoutPledgeView.rawValue: true]
-
-    withEnvironment(config: config) {
-      let reward = Project.cosmicSurgery.rewards.first!
-      let backing = Backing.template
-        |> Backing.lens.reward .~ reward
-        |> Backing.lens.rewardId .~ reward.id
-
-      let project = Project.cosmicSurgery
-        |> Project.lens.personalization.backing .~ backing
-        |> Project.lens.personalization.isBacking .~ true
-
-      self.vm.inputs.configure(with: project, refTag: .activity)
-      self.vm.inputs.viewDidLoad()
-
-      self.goToManagePledgeRefTag.assertDidNotEmitValue()
-      self.goToManagePledgeReward.assertDidNotEmitValue()
-      self.goToManagePledgeProject.assertDidNotEmitValue()
-
-      XCTAssertNil(self.vm.outputs.selectedReward())
-
-      self.vm.inputs.rewardSelected(with: reward.id)
-
-      self.goToManagePledgeProject.assertValues([project])
-      self.goToManagePledgeReward.assertValues([project.rewards[0]])
-      self.goToManagePledgeRefTag.assertValues([.activity])
-
-      self.goToDeprecatedPledgeProject.assertDidNotEmitValue()
-      self.goToDeprecatedPledgeReward.assertDidNotEmitValue()
-      self.goToDeprecatedPledgeRefTag.assertDidNotEmitValue()
-
-      self.goToPledgeProject.assertDidNotEmitValue()
-      self.goToPledgeReward.assertDidNotEmitValue()
-      self.goToPledgeRefTag.assertDidNotEmitValue()
-
-      self.goToViewBackingUser.assertDidNotEmitValue()
-      self.goToViewBackingProject.assertDidNotEmitValue()
-
-      let lastCardRewardId = project.rewards.last!.id
-      let endIndex = project.rewards.endIndex
-
-      self.vm.inputs.rewardSelected(with: lastCardRewardId)
-
-      // The signal "goToManagePledge" doesn't emit again.
-      self.goToManagePledgeProject.assertValues([project])
-      self.goToManagePledgeReward.assertValues([project.rewards[0]])
-      self.goToManagePledgeRefTag.assertValues([.activity])
-
-      self.goToDeprecatedPledgeProject.assertDidNotEmitValue()
-      self.goToDeprecatedPledgeReward.assertDidNotEmitValue()
-      self.goToDeprecatedPledgeRefTag.assertDidNotEmitValue()
-
-      self.goToPledgeProject.assertValues([project])
-      self.goToPledgeReward.assertValues([project.rewards[endIndex - 1]])
-      self.goToPledgeRefTag.assertValues([.activity])
-
-      self.goToViewBackingUser.assertDidNotEmitValue()
-      self.goToViewBackingProject.assertDidNotEmitValue()
-    }
-  }
-
-  func testGoToManagePledge_featureNativeCheckoutPledgeView_Disabled() {
-    let config = .template
-      |> Config.lens.features .~ [Feature.nativeCheckoutPledgeView.rawValue: false]
-
-    withEnvironment(config: config) {
-      let reward = Project.cosmicSurgery.rewards.first!
-      let backing = Backing.template
-        |> Backing.lens.reward .~ reward
-        |> Backing.lens.rewardId .~ reward.id
-
-      let project = Project.cosmicSurgery
-        |> Project.lens.personalization.backing .~ backing
-        |> Project.lens.personalization.isBacking .~ true
-
-      self.vm.inputs.configure(with: project, refTag: .activity)
-      self.vm.inputs.viewDidLoad()
-
-      self.goToManagePledgeRefTag.assertDidNotEmitValue()
-      self.goToManagePledgeReward.assertDidNotEmitValue()
-      self.goToManagePledgeProject.assertDidNotEmitValue()
-
-      XCTAssertNil(self.vm.outputs.selectedReward())
-
-      self.vm.inputs.rewardSelected(with: reward.id)
-
-      self.goToDeprecatedPledgeProject.assertValues([project])
-      self.goToDeprecatedPledgeReward.assertValues([project.rewards[0]])
-      self.goToDeprecatedPledgeRefTag.assertValues([.activity])
-
-      self.goToManagePledgeProject.assertDidNotEmitValue()
-      self.goToManagePledgeReward.assertDidNotEmitValue()
-      self.goToManagePledgeRefTag.assertDidNotEmitValue()
-
-      self.goToPledgeProject.assertDidNotEmitValue()
-      self.goToPledgeReward.assertDidNotEmitValue()
-      self.goToPledgeRefTag.assertDidNotEmitValue()
-
-      self.goToViewBackingUser.assertDidNotEmitValue()
-      self.goToViewBackingProject.assertDidNotEmitValue()
-
-      let lastCardRewardId = project.rewards.last!.id
-      let endIndex = project.rewards.endIndex
-
-      self.vm.inputs.rewardSelected(with: lastCardRewardId)
-
-      self.goToDeprecatedPledgeProject.assertValues([project, project])
-      self.goToDeprecatedPledgeReward.assertValues([project.rewards[0], project.rewards[endIndex - 1]])
-      self.goToDeprecatedPledgeRefTag.assertValues([.activity, .activity])
-
-      self.goToPledgeProject.assertDidNotEmitValue()
-      self.goToPledgeReward.assertDidNotEmitValue()
-      self.goToPledgeRefTag.assertDidNotEmitValue()
-
-      self.goToManagePledgeProject.assertDidNotEmitValue()
-      self.goToManagePledgeReward.assertDidNotEmitValue()
-      self.goToManagePledgeRefTag.assertDidNotEmitValue()
-
-      self.goToViewBackingUser.assertDidNotEmitValue()
-      self.goToViewBackingProject.assertDidNotEmitValue()
-    }
   }
 
   func testRewardsCollectionViewFooterViewIsHidden() {
@@ -362,7 +219,6 @@ final class RewardsCollectionViewModelTests: TestCase {
     withEnvironment {
       self.goToPledgeProject.assertDidNotEmitValue()
       self.goToDeprecatedPledgeProject.assertDidNotEmitValue()
-      self.goToViewBackingProject.assertDidNotEmitValue()
 
       self.vm.inputs.configure(with: project, refTag: nil)
       self.vm.inputs.viewDidLoad()
@@ -373,7 +229,6 @@ final class RewardsCollectionViewModelTests: TestCase {
 
       self.goToPledgeProject.assertDidNotEmitValue()
       self.goToDeprecatedPledgeProject.assertDidNotEmitValue()
-      self.goToViewBackingProject.assertDidNotEmitValue()
     }
   }
 
@@ -393,7 +248,6 @@ final class RewardsCollectionViewModelTests: TestCase {
     withEnvironment(currentUser: user) {
       self.goToPledgeProject.assertDidNotEmitValue()
       self.goToDeprecatedPledgeProject.assertDidNotEmitValue()
-      self.goToViewBackingProject.assertDidNotEmitValue()
 
       self.vm.inputs.configure(with: project, refTag: nil)
       self.vm.inputs.viewDidLoad()
@@ -404,15 +258,11 @@ final class RewardsCollectionViewModelTests: TestCase {
 
       self.goToPledgeProject.assertDidNotEmitValue()
       self.goToDeprecatedPledgeProject.assertDidNotEmitValue()
-      self.goToViewBackingProject.assertDidNotEmitValue()
 
       self.vm.inputs.rewardSelected(with: reward.id)
 
       self.goToPledgeProject.assertDidNotEmitValue()
       self.goToDeprecatedPledgeProject.assertDidNotEmitValue()
-
-      self.goToViewBackingProject.assertValues([project])
-      self.goToViewBackingUser.assertValues([user])
     }
   }
 
@@ -432,7 +282,6 @@ final class RewardsCollectionViewModelTests: TestCase {
     withEnvironment(currentUser: user) {
       self.goToPledgeProject.assertDidNotEmitValue()
       self.goToDeprecatedPledgeProject.assertDidNotEmitValue()
-      self.goToViewBackingProject.assertDidNotEmitValue()
 
       self.vm.inputs.configure(with: project, refTag: nil)
       self.vm.inputs.viewDidLoad()
@@ -443,15 +292,11 @@ final class RewardsCollectionViewModelTests: TestCase {
 
       self.goToPledgeProject.assertDidNotEmitValue()
       self.goToDeprecatedPledgeProject.assertDidNotEmitValue()
-      self.goToViewBackingProject.assertDidNotEmitValue()
 
       self.vm.inputs.rewardSelected(with: Reward.noReward.id)
 
       self.goToPledgeProject.assertDidNotEmitValue()
       self.goToDeprecatedPledgeProject.assertDidNotEmitValue()
-
-      self.goToViewBackingProject.assertValues([project])
-      self.goToViewBackingUser.assertValues([user])
     }
   }
 }


### PR DESCRIPTION
# 📲 What
 - Presents the ManageViewPledge screen (blank for now) from the cta container.

# 🤔 Why
- This was decided to make the access to the screen easier, compared to what was proposed previously.

# 🛠 How
- Moved the code from `RewardsCollectionViewController` to `ProjectPamphletViewController`
- Moved tests to the classes to be tested

# 👀 See


| Managing 🐛 | Viewing Pledge 🦋 |
| --- | --- |
| ![manage_pledge_cta](https://user-images.githubusercontent.com/3709676/64560519-a4416080-d316-11e9-9c18-95fae7b8af25.gif) | ![view_pledge_cta](https://user-images.githubusercontent.com/3709676/64560554-b58a6d00-d316-11e9-8fb8-21c78dd9598a.gif) |

# ✅ Acceptance criteria

## With `featureNativeCheckoutPledgeView` enabled. 
- [ ] Select a non-backed project and tap the `Back this project` button.  The Rewards Carousel should be presented.
- [ ] Select a backed project and tap the `Manage` button. The  `ManageViewPledgeViewController` (blank) should be presented.
- [ ] Selected a backed and ended project and tap the `View your pledge` button. The  `ManageViewPledgeViewController` (blank) should be presented.
### Note: 
By tapping to view your pledge, note that the title shown is `Manage your pledge`. The logic to change the title based of the pledge and project states will be implemented in a different PR.

## With `featureNativeCheckoutPledgeView` disabled. 
On the Rewards Carousel screen:
- [ ] Select a non-backed project and tap the `Back this project` button.  The Rewards Carousel should be presented.
- [ ] Select a backed project and tap the `Manage` button. The `DeprecatedRewardPledgeViewController` should be presented.
- [ ] Selected a backed and ended project and tap the `View your pledge` button. The `BackingViewController` should be presented.

