### PR TITLE
[NT-259] Consume v1 converted total pledged on Project Page

### DIFF
--- a/Kickstarter-iOS/Views/Controllers/ProjectPamphletContentViewControllerConversionTests.swift
+++ b/Kickstarter-iOS/Views/Controllers/ProjectPamphletContentViewControllerConversionTests.swift
@@ -18,6 +18,7 @@ internal final class ProjectPamphletContentViewControllerConversionTests: TestCa
       |> Project.lens.dates.launchedAt .~ launchedAt
       |> Project.lens.state .~ .live
       |> Project.lens.stats.pledged .~ (self.cosmicSurgery.stats.goal * 3 / 4)
+      |> \.stats.convertedPledgedAmount .~ 21_615
 
     self.cosmicSurgery = project
 
@@ -115,6 +116,7 @@ internal final class ProjectPamphletContentViewControllerConversionTests: TestCa
       |> Project.lens.stats.currency .~ "USD"
       |> Project.lens.stats.currentCurrency .~ "SEK"
       |> Project.lens.stats.currentCurrencyRate .~ 3.0
+      |> Project.lens.stats.convertedPledgedAmount .~ 49_500
 
     withEnvironment(countryCode: "SE") {
       let vc = ProjectPamphletViewController.configuredWith(projectOrParam: .left(cosmicSurgery), refTag: nil)

--- a/Kickstarter-iOS/Views/Controllers/ProjectPamphletContentViewControllerConversionTests.swift
+++ b/Kickstarter-iOS/Views/Controllers/ProjectPamphletContentViewControllerConversionTests.swift
@@ -18,7 +18,7 @@ internal final class ProjectPamphletContentViewControllerConversionTests: TestCa
       |> Project.lens.dates.launchedAt .~ launchedAt
       |> Project.lens.state .~ .live
       |> Project.lens.stats.pledged .~ (self.cosmicSurgery.stats.goal * 3 / 4)
-      |> \.stats.convertedPledgedAmount .~ 21_615
+      |> Project.lens.stats.convertedPledgedAmount .~ 21_615
 
     self.cosmicSurgery = project
 

--- a/Kickstarter-iOS/Views/Controllers/ProjectPamphletContentViewControllerTests.swift
+++ b/Kickstarter-iOS/Views/Controllers/ProjectPamphletContentViewControllerTests.swift
@@ -17,6 +17,7 @@ internal final class ProjectPamphletContentViewControllerTests: TestCase {
       |> (Project.lens.creator.avatar .. User.Avatar.lens.small) .~ ""
       |> Project.lens.dates.deadline .~ deadline
       |> Project.lens.dates.launchedAt .~ launchedAt
+      |> Project.lens.stats.convertedPledgedAmount .~ 21_615
 
     self.cosmicSurgery = project
 
@@ -55,6 +56,7 @@ internal final class ProjectPamphletContentViewControllerTests: TestCase {
       |> Project.lens.dates.stateChangedAt .~ deadline
       |> Project.lens.dates.deadline .~ deadline
       |> Project.lens.state .~ .successful
+      |> Project.lens.stats.convertedPledgedAmount .~ 29_236
 
     Language.allLanguages.forEach { language in
       withEnvironment(language: language, locale: .init(identifier: language.rawValue)) {
@@ -110,6 +112,7 @@ internal final class ProjectPamphletContentViewControllerTests: TestCase {
       |> Project.lens.rewards %~ { rewards in [rewards[0]] }
       |> Project.lens.state .~ .live
       |> Project.lens.personalization.isBacking .~ true
+      |> Project.lens.stats.convertedPledgedAmount .~ 29_236
       |> Project.lens.personalization.backing %~~ { _, _ in
         .template
           |> Backing.lens.amount .~ 5
@@ -147,6 +150,7 @@ internal final class ProjectPamphletContentViewControllerTests: TestCase {
       |> Project.lens.state .~ .successful
       |> Project.lens.personalization.isBacking .~ true
       |> Project.lens.personalization.backing .~ backing
+      |> Project.lens.stats.convertedPledgedAmount .~ 29_236
 
     combos(Language.allLanguages, [Device.phone4_7inch, Device.phone5_8inch, Device.pad]).forEach {
       language, device in
@@ -215,6 +219,7 @@ internal final class ProjectPamphletContentViewControllerTests: TestCase {
 
   func testMinimalAndFullProjectOverlap() {
     let project = self.cosmicSurgery!
+      |> Project.lens.stats.convertedPledgedAmount .~ 29_236
 
     withEnvironment(apiService: MockService(fetchProjectResponse: project)) {
       [Device.phone4_7inch, Device.phone5_8inch, Device.pad].forEach { device in

--- a/Kickstarter-iOS/Views/Controllers/ProjectPamphletViewControllerTests.swift
+++ b/Kickstarter-iOS/Views/Controllers/ProjectPamphletViewControllerTests.swift
@@ -53,6 +53,7 @@ internal final class ProjectPamphletViewControllerTests: TestCase {
       |> Project.lens.personalization.isBacking .~ true
       |> Project.lens.personalization.backing .~ backing
       |> Project.lens.state .~ .live
+      |> Project.lens.stats.convertedPledgedAmount .~ 29_236
 
     combos(Language.allLanguages, Device.allCases).forEach { language, device in
       withEnvironment(
@@ -83,6 +84,7 @@ internal final class ProjectPamphletViewControllerTests: TestCase {
       |> Project.lens.personalization.isBacking .~ true
       |> Project.lens.personalization.backing .~ .template
       |> Project.lens.state .~ .successful
+      |> Project.lens.stats.convertedPledgedAmount .~ 29_236
 
     combos(Language.allLanguages, Device.allCases).forEach { language, device in
       withEnvironment(
@@ -108,12 +110,15 @@ internal final class ProjectPamphletViewControllerTests: TestCase {
       |> \.features .~ [Feature.nativeCheckout.rawValue: true]
       |> \.abExperiments .~ [Experiment.Name.nativeCheckoutV1.rawValue: "experimental"]
 
+    let liveProject = self.project
+      |> Project.lens.stats.convertedPledgedAmount .~ 1_964
+
     combos(Language.allLanguages, Device.allCases).forEach { language, device in
       withEnvironment(
-        apiService: MockService(fetchProjectResponse: project),
+        apiService: MockService(fetchProjectResponse: liveProject),
         config: config, currentUser: .template, language: language
       ) {
-        let vc = ProjectPamphletViewController.configuredWith(projectOrParam: .left(project), refTag: nil)
+        let vc = ProjectPamphletViewController.configuredWith(projectOrParam: .left(liveProject), refTag: nil)
 
         let (parent, _) = traitControllers(device: device, orientation: .portrait, child: vc)
         parent.view.frame.size.height = device == .pad ? 1_200 : parent.view.frame.size.height
@@ -200,6 +205,7 @@ internal final class ProjectPamphletViewControllerTests: TestCase {
       |> (Project.lens.creator.avatar .. User.Avatar.lens.small) .~ ""
       |> Project.lens.personalization.isBacking .~ false
       |> Project.lens.state .~ .successful
+      |> Project.lens.stats.convertedPledgedAmount .~ 29_236
 
     combos(Language.allLanguages, Device.allCases).forEach { language, device in
       withEnvironment(
@@ -227,12 +233,15 @@ internal final class ProjectPamphletViewControllerTests: TestCase {
       |> \.features .~ [Feature.nativeCheckout.rawValue: true]
       |> \.abExperiments .~ [Experiment.Name.nativeCheckoutV1.rawValue: "experimental"]
 
+    let liveProject = self.project
+      |> Project.lens.stats.convertedPledgedAmount .~ 1_964
+
     combos(Language.allLanguages, Device.allCases).forEach { language, device in
       withEnvironment(
-        apiService: MockService(fetchProjectResponse: project),
+        apiService: MockService(fetchProjectResponse: liveProject),
         config: config, currentUser: nil, language: language
       ) {
-        let vc = ProjectPamphletViewController.configuredWith(projectOrParam: .left(project), refTag: nil)
+        let vc = ProjectPamphletViewController.configuredWith(projectOrParam: .left(liveProject), refTag: nil)
 
         let (parent, _) = traitControllers(device: device, orientation: .portrait, child: vc)
         parent.view.frame.size.height = device == .pad ? 1_200 : parent.view.frame.size.height
@@ -253,6 +262,7 @@ internal final class ProjectPamphletViewControllerTests: TestCase {
       |> (Project.lens.creator.avatar .. User.Avatar.lens.small) .~ ""
       |> Project.lens.personalization.isBacking .~ false
       |> Project.lens.state .~ .successful
+      |> Project.lens.stats.convertedPledgedAmount .~ 29_236
 
     combos(Language.allLanguages, Device.allCases).forEach { language, device in
       withEnvironment(
@@ -282,13 +292,16 @@ internal final class ProjectPamphletViewControllerTests: TestCase {
     let language = Language.en
     let device = Device.phone4_7inch
 
+    let liveProject = self.project
+      |> Project.lens.stats.convertedPledgedAmount .~ 1_964
+
     // All we want to see here is that the pledge CTA button is hidden
 
     withEnvironment(
-      apiService: MockService(fetchProjectResponse: self.project),
+      apiService: MockService(fetchProjectResponse: liveProject),
       config: config, currentUser: nil, language: language
     ) {
-      let vc = ProjectPamphletViewController.configuredWith(projectOrParam: .left(project), refTag: nil)
+      let vc = ProjectPamphletViewController.configuredWith(projectOrParam: .left(liveProject), refTag: nil)
       _ = traitControllers(device: device, orientation: .portrait, child: vc)
 
       FBSnapshotVerifyView(vc.view, identifier: "lang_\(language)_device_\(device)")
@@ -302,12 +315,15 @@ internal final class ProjectPamphletViewControllerTests: TestCase {
     let language = Language.en
     let device = Device.phone4_7inch
 
+    let liveProject = self.project
+      |> Project.lens.stats.convertedPledgedAmount .~ 1_964
+
     // All we want to see here is that the pledge CTA button is hidden
     withEnvironment(
-      apiService: MockService(fetchProjectResponse: self.project),
+      apiService: MockService(fetchProjectResponse: liveProject),
       config: config, language: language
     ) {
-      let vc = ProjectPamphletViewController.configuredWith(projectOrParam: .left(project), refTag: nil)
+      let vc = ProjectPamphletViewController.configuredWith(projectOrParam: .left(liveProject), refTag: nil)
 
       let (parent, _) = traitControllers(device: device, orientation: .portrait, child: vc)
       parent.view.frame.size.height = device == .pad ? 2_300 : 1_800

--- a/KsApi/models/Project.swift
+++ b/KsApi/models/Project.swift
@@ -54,6 +54,7 @@ public struct Project {
   public struct Stats {
     public var backersCount: Int
     public var commentsCount: Int?
+    public var convertedPledged: Double
     /// The currency code of the project ex. USD
     public var currency: String
     /// The currency code of the User's preferred currency ex. SEK
@@ -235,6 +236,7 @@ extension Project.Stats: Argo.Decodable {
     let tmp1 = curry(Project.Stats.init)
       <^> json <| "backers_count"
       <*> json <|? "comments_count"
+      <*> json <| "converted_pledged_amount"
       <*> json <| "currency"
       <*> json <|? "current_currency"
       <*> json <|? "fx_rate"

--- a/KsApi/models/Project.swift
+++ b/KsApi/models/Project.swift
@@ -54,7 +54,7 @@ public struct Project {
   public struct Stats {
     public var backersCount: Int
     public var commentsCount: Int?
-    public var convertedPledged: Double
+    public var convertedPledgedAmount: Int?
     /// The currency code of the project ex. USD
     public var currency: String
     /// The currency code of the User's preferred currency ex. SEK
@@ -86,11 +86,6 @@ public struct Project {
     /// Goal amount converted to USD.
     public var goalUsd: Int {
       return Int(floor(Float(self.goal) * self.staticUsdRate))
-    }
-
-    /// Pledged amount converted to current currency.
-    public var pledgedCurrentCurrency: Int? {
-      return self.currentCurrencyRate.map { Int(floor(Float(self.pledged) * $0)) }
     }
 
     /// Goal amount converted to current currency.
@@ -236,7 +231,7 @@ extension Project.Stats: Argo.Decodable {
     let tmp1 = curry(Project.Stats.init)
       <^> json <| "backers_count"
       <*> json <|? "comments_count"
-      <*> json <| "converted_pledged_amount"
+      <*> json <|? "converted_pledged_amount"
       <*> json <| "currency"
       <*> json <|? "current_currency"
       <*> json <|? "fx_rate"

--- a/KsApi/models/lenses/Project.StatsLenses.swift
+++ b/KsApi/models/lenses/Project.StatsLenses.swift
@@ -7,6 +7,7 @@ extension Project.Stats {
       set: { .init(
         backersCount: $1.backersCount,
         commentsCount: $1.commentsCount,
+        convertedPledged: $1.convertedPledged,
         currency: $1.currency,
         currentCurrency: $1.currentCurrency,
         currentCurrencyRate: $1.currentCurrencyRate,

--- a/KsApi/models/lenses/Project.StatsLenses.swift
+++ b/KsApi/models/lenses/Project.StatsLenses.swift
@@ -7,7 +7,7 @@ extension Project.Stats {
       set: { .init(
         backersCount: $1.backersCount,
         commentsCount: $1.commentsCount,
-        convertedPledged: $1.convertedPledged,
+        convertedPledgedAmount: $1.convertedPledgedAmount,
         currency: $1.currency,
         currentCurrency: $1.currentCurrency,
         currentCurrencyRate: $1.currentCurrencyRate,

--- a/KsApi/models/lenses/ProjectLenses.swift
+++ b/KsApi/models/lenses/ProjectLenses.swift
@@ -294,6 +294,10 @@ extension Lens where Whole == Project, Part == Project.Stats {
     return Project.lens.stats .. lens(\Project.Stats.commentsCount)
   }
 
+  public var convertedPledgedAmount: Lens<Project, Int?> {
+    return Project.lens.stats .. lens(\Project.Stats.convertedPledgedAmount)
+  }
+
   public var currency: Lens<Project, String> {
     return Project.lens.stats .. lens(\Project.Stats.currency)
   }

--- a/KsApi/models/templates/ProjectStatsTemplate.swift
+++ b/KsApi/models/templates/ProjectStatsTemplate.swift
@@ -4,6 +4,7 @@ extension Project.Stats {
   internal static let template = Project.Stats(
     backersCount: 10,
     commentsCount: 10,
+    convertedPledged: 1_500,
     currency: "USD",
     currentCurrency: nil,
     currentCurrencyRate: 1.5,

--- a/KsApi/models/templates/ProjectStatsTemplate.swift
+++ b/KsApi/models/templates/ProjectStatsTemplate.swift
@@ -4,7 +4,7 @@ extension Project.Stats {
   internal static let template = Project.Stats(
     backersCount: 10,
     commentsCount: 10,
-    convertedPledged: 1_500,
+    convertedPledgedAmount: 2_000,
     currency: "USD",
     currentCurrency: nil,
     currentCurrencyRate: 1.5,

--- a/Library/ViewModels/ProjectPamphletMainCellViewModel.swift
+++ b/Library/ViewModels/ProjectPamphletMainCellViewModel.swift
@@ -358,7 +358,7 @@ private func pledgeAmountAndGoalAndCountry(
   }
 
   guard let goalCurrentCurrency = project.stats.goalCurrentCurrency,
-    let pledgedCurrentCurrency = project.stats.pledgedCurrentCurrency,
+    let pledgedCurrentCurrency = project.stats.convertedPledgedAmount,
     let currentCountry = project.stats.currentCountry else {
     return (project.stats.pledgedUsd, project.stats.goalUsd, Project.Country.us)
   }

--- a/Library/ViewModels/ProjectPamphletMainCellViewModelTests.swift
+++ b/Library/ViewModels/ProjectPamphletMainCellViewModelTests.swift
@@ -75,6 +75,7 @@ final class ProjectPamphletMainCellViewModelTests: TestCase {
       |> Project.lens.stats.currency .~ Project.Country.gb.currencyCode
       |> Project.lens.stats.currentCurrency .~ Project.Country.us.currencyCode
       |> Project.lens.stats.currentCurrencyRate .~ 1.2
+      |> Project.lens.stats.convertedPledgedAmount .~ 1_200
     self.vm.inputs.configureWith(project: nonUSProject)
 
     self.statsStackViewAccessibilityLabel.assertValues(


### PR DESCRIPTION
# 📲 What 
- Shows converted total pledged based on the value of `convertedPledgedAmount` returned by the API on the Project Page.

<img width="361" alt="Screenshot 2019-09-10 at 17 34 42" src="https://user-images.githubusercontent.com/3709676/64652290-7aa93780-d3f1-11e9-822f-54e4dcc72b14.png">

# 🤔 Why
- This allows us to have one source of truth and avoids the calculation of conversions to be done on the client side.

# 🛠 How
- Added a new property `convertedPledgedAmount` to our Project model.
- Changed logic to present the value of that property instead of calculating conversion value based on project conversion rate.
- Updated tests.

# ✅ Acceptance criteria

- [x] iOS and web should show the same values for converted pledged amount  minimum on the Project Page.