### PR TITLE
[NT-261] Pass refParam with Apple Pay backings

### DIFF
--- a/Kickstarter-iOS/Views/Controllers/PledgeViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/PledgeViewController.swift
@@ -82,7 +82,7 @@ final class PledgeViewController: UIViewController, MessageBannerViewControllerP
 
   // MARK: - Lifecycle
 
-  func configureWith(project: Project, reward: Reward, refTag: RefTag? = nil) {
+  func configureWith(project: Project, reward: Reward, refTag: RefTag?) {
     self.viewModel.inputs.configureWith(project: project, reward: reward, refTag: refTag)
   }
 

--- a/Kickstarter-iOS/Views/Controllers/PledgeViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/PledgeViewController.swift
@@ -82,8 +82,8 @@ final class PledgeViewController: UIViewController, MessageBannerViewControllerP
 
   // MARK: - Lifecycle
 
-  func configureWith(project: Project, reward: Reward) {
-    self.viewModel.inputs.configureWith(project: project, reward: reward)
+  func configureWith(project: Project, reward: Reward, refTag: RefTag? = nil) {
+    self.viewModel.inputs.configureWith(project: project, reward: reward, refTag: refTag)
   }
 
   override func viewDidLoad() {

--- a/Kickstarter-iOS/Views/Controllers/RewardsCollectionViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/RewardsCollectionViewController.swift
@@ -228,9 +228,9 @@ final class RewardsCollectionViewController: UICollectionViewController {
       ?|> \.isActive .~ !isHidden
   }
 
-  private func goToPledge(project: Project, reward: Reward, refTag _: RefTag?) {
+  private func goToPledge(project: Project, reward: Reward, refTag: RefTag?) {
     let pledgeViewController = PledgeViewController.instantiate()
-    pledgeViewController.configureWith(project: project, reward: reward)
+    pledgeViewController.configureWith(project: project, reward: reward, refTag: refTag)
 
     self.navigationController?.pushViewController(pledgeViewController, animated: true)
   }

--- a/KsApi/mutations/inputs/CreateApplePayBackingInput.swift
+++ b/KsApi/mutations/inputs/CreateApplePayBackingInput.swift
@@ -6,19 +6,21 @@ public struct CreateApplePayBackingInput: GraphMutationInput {
   let paymentInstrumentName: String
   let paymentNetwork: String
   let projectId: String
+  let refParam: String?
   let rewardId: String?
   let stripeToken: String
   let transactionIdentifier: String
 
   public init(
     amount: String, locationId: String?, paymentInstrumentName: String, paymentNetwork: String,
-    projectId: String, rewardId: String?, stripeToken: String, transactionIdentifier: String
+    projectId: String, refParam: String?, rewardId: String?, stripeToken: String, transactionIdentifier: String
   ) {
     self.amount = amount
     self.locationId = locationId
     self.paymentInstrumentName = paymentInstrumentName
     self.paymentNetwork = paymentNetwork
     self.projectId = projectId
+    self.refParam = refParam
     self.rewardId = rewardId
     self.stripeToken = stripeToken
     self.transactionIdentifier = transactionIdentifier
@@ -40,6 +42,10 @@ public struct CreateApplePayBackingInput: GraphMutationInput {
 
     if let rewardId = self.rewardId {
       inputDictionary["rewardId"] = rewardId
+    }
+
+    if let refParam = self.refParam {
+      inputDictionary["refParam"] = refParam
     }
 
     return inputDictionary

--- a/KsApi/mutations/inputs/CreateApplePayBackingInput.swift
+++ b/KsApi/mutations/inputs/CreateApplePayBackingInput.swift
@@ -13,7 +13,8 @@ public struct CreateApplePayBackingInput: GraphMutationInput {
 
   public init(
     amount: String, locationId: String?, paymentInstrumentName: String, paymentNetwork: String,
-    projectId: String, refParam: String?, rewardId: String?, stripeToken: String, transactionIdentifier: String
+    projectId: String, refParam: String?, rewardId: String?, stripeToken: String,
+    transactionIdentifier: String
   ) {
     self.amount = amount
     self.locationId = locationId

--- a/KsApi/mutations/inputs/CreateApplePayBackingInputTests.swift
+++ b/KsApi/mutations/inputs/CreateApplePayBackingInputTests.swift
@@ -10,6 +10,7 @@ final class CreateApplePayBackingInputTests: XCTestCase {
       paymentInstrumentName: "instrumentName",
       paymentNetwork: "paymentNetwork",
       projectId: "12345",
+      refParam: "activity",
       rewardId: "321",
       stripeToken: "stripeTokenXYZ",
       transactionIdentifier: "transactionId"
@@ -22,6 +23,7 @@ final class CreateApplePayBackingInputTests: XCTestCase {
     XCTAssertEqual(inputDictionary["paymentInstrumentName"] as? String, "instrumentName")
     XCTAssertEqual(inputDictionary["paymentNetwork"] as? String, "paymentNetwork")
     XCTAssertEqual(inputDictionary["projectId"] as? String, "12345")
+    XCTAssertEqual(inputDictionary["refParam"] as? String, "activity")
     XCTAssertEqual(inputDictionary["rewardId"] as? String, "321")
     XCTAssertEqual(inputDictionary["token"] as? String, "stripeTokenXYZ")
     XCTAssertEqual(inputDictionary["transactionIdentifier"] as? String, "transactionId")
@@ -34,6 +36,7 @@ final class CreateApplePayBackingInputTests: XCTestCase {
       paymentInstrumentName: "instrumentName",
       paymentNetwork: "paymentNetwork",
       projectId: "12345",
+      refParam: nil,
       rewardId: nil,
       stripeToken: "stripeTokenXYZ",
       transactionIdentifier: "transactionId"
@@ -49,5 +52,6 @@ final class CreateApplePayBackingInputTests: XCTestCase {
     XCTAssertEqual(inputDictionary["transactionIdentifier"] as? String, "transactionId")
     XCTAssertNil(inputDictionary["locationId"])
     XCTAssertNil(inputDictionary["rewardId"])
+    XCTAssertNil(inputDictionary["refParam"])
   }
 }

--- a/Library/CreateApplePayBackingInput+Constructor.swift
+++ b/Library/CreateApplePayBackingInput+Constructor.swift
@@ -8,7 +8,8 @@ extension CreateApplePayBackingInput {
     pledgeAmount: Double,
     selectedShippingRule: ShippingRule?,
     pkPaymentData: PKPaymentData,
-    stripeToken: String
+    stripeToken: String,
+    refTag: RefTag?
   ) -> CreateApplePayBackingInput {
     let pledgeAmountDecimal = Decimal(pledgeAmount)
     var shippingAmountDecimal: Decimal = Decimal()
@@ -30,6 +31,7 @@ extension CreateApplePayBackingInput {
       paymentInstrumentName: pkPaymentData.displayName,
       paymentNetwork: pkPaymentData.network,
       projectId: project.graphID,
+      refParam: refTag?.description,
       rewardId: rewardId,
       stripeToken: stripeToken,
       transactionIdentifier: pkPaymentData.transactionIdentifier

--- a/Library/CreateApplePayBackingInputConstructorTests.swift
+++ b/Library/CreateApplePayBackingInputConstructorTests.swift
@@ -19,7 +19,8 @@ final class CreateApplePayBackingInputConstructorTests: XCTestCase {
         network: "Visa",
         transactionIdentifier: "12345"
       ),
-      stripeToken: "stripe-token"
+      stripeToken: "stripe-token",
+      refTag: RefTag.projectPage
     )
 
     XCTAssertEqual(input.amount, "10.00")
@@ -30,6 +31,7 @@ final class CreateApplePayBackingInputConstructorTests: XCTestCase {
     XCTAssertNil(input.rewardId)
     XCTAssertEqual(input.stripeToken, "stripe-token")
     XCTAssertEqual(input.transactionIdentifier, "12345")
+    XCTAssertEqual(input.refParam, "project_page")
   }
 
   func testCreateApplePayBackingInput_WithShipping() {
@@ -49,7 +51,8 @@ final class CreateApplePayBackingInputConstructorTests: XCTestCase {
         network: "Visa",
         transactionIdentifier: "12345"
       ),
-      stripeToken: "stripe-token"
+      stripeToken: "stripe-token",
+      refTag: nil
     )
 
     XCTAssertEqual(input.amount, "15.00")
@@ -60,5 +63,6 @@ final class CreateApplePayBackingInputConstructorTests: XCTestCase {
     XCTAssertEqual(input.rewardId, reward.graphID)
     XCTAssertEqual(input.stripeToken, "stripe-token")
     XCTAssertEqual(input.transactionIdentifier, "12345")
+    XCTAssertNil(input.refParam)
   }
 }

--- a/Library/ViewModels/PledgeViewModelTests.swift
+++ b/Library/ViewModels/PledgeViewModelTests.swift
@@ -88,7 +88,7 @@ final class PledgeViewModelTests: TestCase {
       let reward = Reward.template
         |> Reward.lens.shipping.enabled .~ false
 
-      self.vm.inputs.configureWith(project: project, reward: reward)
+      self.vm.inputs.configureWith(project: project, reward: reward, refTag: .projectPage)
       self.vm.inputs.viewDidLoad()
 
       self.configurePaymentMethodsViewControllerWithUser.assertDidNotEmitValue()
@@ -111,7 +111,7 @@ final class PledgeViewModelTests: TestCase {
       let reward = Reward.template
         |> Reward.lens.shipping.enabled .~ true
 
-      self.vm.inputs.configureWith(project: project, reward: reward)
+      self.vm.inputs.configureWith(project: project, reward: reward, refTag: .projectPage)
       self.vm.inputs.viewDidLoad()
 
       self.configurePaymentMethodsViewControllerWithUser.assertDidNotEmitValue()
@@ -135,7 +135,7 @@ final class PledgeViewModelTests: TestCase {
       |> Reward.lens.shipping.enabled .~ false
 
     withEnvironment(currentUser: .template) {
-      self.vm.inputs.configureWith(project: project, reward: reward)
+      self.vm.inputs.configureWith(project: project, reward: reward, refTag: .projectPage)
       self.vm.inputs.viewDidLoad()
 
       self.configurePaymentMethodsViewControllerWithUser.assertValues([User.template])
@@ -158,7 +158,7 @@ final class PledgeViewModelTests: TestCase {
       |> Reward.lens.shipping.enabled .~ true
 
     withEnvironment(currentUser: .template) {
-      self.vm.inputs.configureWith(project: project, reward: reward)
+      self.vm.inputs.configureWith(project: project, reward: reward, refTag: .projectPage)
       self.vm.inputs.viewDidLoad()
 
       self.configurePaymentMethodsViewControllerWithUser.assertValues([User.template])
@@ -181,7 +181,7 @@ final class PledgeViewModelTests: TestCase {
       |> Reward.lens.shipping .~ (.template |> Reward.Shipping.lens.enabled .~ true)
 
     withEnvironment(currentUser: .template) {
-      self.vm.inputs.configureWith(project: project, reward: reward)
+      self.vm.inputs.configureWith(project: project, reward: reward, refTag: .projectPage)
       self.vm.inputs.viewDidLoad()
 
       self.configurePaymentMethodsViewControllerWithUser.assertValues([User.template])
@@ -213,7 +213,7 @@ final class PledgeViewModelTests: TestCase {
       |> Reward.lens.shipping .~ (.template |> Reward.Shipping.lens.enabled .~ true)
 
     withEnvironment(currentUser: .template) {
-      self.vm.inputs.configureWith(project: project, reward: reward)
+      self.vm.inputs.configureWith(project: project, reward: reward, refTag: .projectPage)
       self.vm.inputs.viewDidLoad()
 
       self.configurePaymentMethodsViewControllerWithUser.assertValues([User.template])
@@ -258,7 +258,7 @@ final class PledgeViewModelTests: TestCase {
       |> Reward.lens.shipping.enabled .~ true
 
     withEnvironment(currentUser: .template) {
-      self.vm.inputs.configureWith(project: project, reward: reward)
+      self.vm.inputs.configureWith(project: project, reward: reward, refTag: .projectPage)
       self.vm.inputs.viewDidLoad()
 
       self.configurePaymentMethodsViewControllerWithUser.assertValues([User.template])
@@ -302,7 +302,7 @@ final class PledgeViewModelTests: TestCase {
     let user = User.template
 
     withEnvironment(currentUser: nil) {
-      self.vm.inputs.configureWith(project: project, reward: reward)
+      self.vm.inputs.configureWith(project: project, reward: reward, refTag: .projectPage)
       self.vm.inputs.viewDidLoad()
 
       self.configurePaymentMethodsViewControllerWithUser.assertDidNotEmitValue()
@@ -337,7 +337,7 @@ final class PledgeViewModelTests: TestCase {
       |> Reward.lens.shipping .~ (.template |> Reward.Shipping.lens.enabled .~ true)
 
     withEnvironment(currentUser: .template) {
-      self.vm.inputs.configureWith(project: project, reward: reward)
+      self.vm.inputs.configureWith(project: project, reward: reward, refTag: .projectPage)
       self.vm.inputs.viewDidLoad()
 
       self.configurePaymentMethodsViewControllerWithUser.assertValues([User.template])
@@ -424,7 +424,7 @@ final class PledgeViewModelTests: TestCase {
       self.configureStripeIntegrationMerchantId.assertDidNotEmitValue()
       self.configureStripeIntegrationPublishableKey.assertDidNotEmitValue()
 
-      self.vm.inputs.configureWith(project: .template, reward: .template)
+      self.vm.inputs.configureWith(project: .template, reward: .template, refTag: .projectPage)
       self.vm.inputs.viewDidLoad()
 
       self.configureStripeIntegrationMerchantId.assertValues([Secrets.ApplePay.merchantIdentifier])
@@ -439,7 +439,7 @@ final class PledgeViewModelTests: TestCase {
       self.configureStripeIntegrationMerchantId.assertDidNotEmitValue()
       self.configureStripeIntegrationPublishableKey.assertDidNotEmitValue()
 
-      self.vm.inputs.configureWith(project: .template, reward: .template)
+      self.vm.inputs.configureWith(project: .template, reward: .template, refTag: .activity)
       self.vm.inputs.viewDidLoad()
 
       self.configureStripeIntegrationMerchantId.assertValues([Secrets.ApplePay.merchantIdentifier])
@@ -452,7 +452,7 @@ final class PledgeViewModelTests: TestCase {
     let reward = Reward.noReward
       |> Reward.lens.minimum .~ 5
 
-    self.vm.inputs.configureWith(project: project, reward: reward)
+    self.vm.inputs.configureWith(project: project, reward: reward, refTag: .projectPage)
     self.vm.inputs.viewDidLoad()
 
     self.goToApplePayPaymentAuthorizationProject.assertDidNotEmitValue()
@@ -477,7 +477,7 @@ final class PledgeViewModelTests: TestCase {
       |> Reward.lens.shipping.enabled .~ true
     let shippingRule = ShippingRule.template
 
-    self.vm.inputs.configureWith(project: project, reward: reward)
+    self.vm.inputs.configureWith(project: project, reward: reward, refTag: .projectPage)
     self.vm.inputs.viewDidLoad()
 
     self.goToApplePayPaymentAuthorizationProject.assertDidNotEmitValue()
@@ -504,7 +504,7 @@ final class PledgeViewModelTests: TestCase {
       |> Reward.lens.shipping.enabled .~ true
     let shippingRule = ShippingRule.template
 
-    self.vm.inputs.configureWith(project: project, reward: reward)
+    self.vm.inputs.configureWith(project: project, reward: reward, refTag: .projectPage)
     self.vm.inputs.viewDidLoad()
 
     self.vm.inputs.shippingRuleSelected(shippingRule)
@@ -528,7 +528,7 @@ final class PledgeViewModelTests: TestCase {
     let reward = Reward.noReward
       |> Reward.lens.minimum .~ 5
 
-    self.vm.inputs.configureWith(project: project, reward: reward)
+    self.vm.inputs.configureWith(project: project, reward: reward, refTag: .projectPage)
     self.vm.inputs.viewDidLoad()
 
     self.vm.inputs.applePayButtonTapped()
@@ -548,7 +548,7 @@ final class PledgeViewModelTests: TestCase {
     let reward = Reward.noReward
       |> Reward.lens.minimum .~ 5
 
-    self.vm.inputs.configureWith(project: project, reward: reward)
+    self.vm.inputs.configureWith(project: project, reward: reward, refTag: .projectPage)
     self.vm.inputs.viewDidLoad()
 
     self.vm.inputs.applePayButtonTapped()
@@ -570,7 +570,7 @@ final class PledgeViewModelTests: TestCase {
     let reward = Reward.noReward
       |> Reward.lens.minimum .~ 5
 
-    self.vm.inputs.configureWith(project: project, reward: reward)
+    self.vm.inputs.configureWith(project: project, reward: reward, refTag: .projectPage)
     self.vm.inputs.viewDidLoad()
 
     self.vm.inputs.applePayButtonTapped()
@@ -589,7 +589,7 @@ final class PledgeViewModelTests: TestCase {
     let project = Project.template
     let reward = Reward.noReward
 
-    self.vm.inputs.configureWith(project: project, reward: reward)
+    self.vm.inputs.configureWith(project: project, reward: reward, refTag: .projectPage)
     self.vm.inputs.viewDidLoad()
 
     self.vm.inputs.applePayButtonTapped()
@@ -611,7 +611,7 @@ final class PledgeViewModelTests: TestCase {
     let reward = Reward.noReward
       |> Reward.lens.minimum .~ 5
 
-    self.vm.inputs.configureWith(project: project, reward: reward)
+    self.vm.inputs.configureWith(project: project, reward: reward, refTag: .projectPage)
     self.vm.inputs.viewDidLoad()
 
     self.vm.inputs.applePayButtonTapped()
@@ -632,7 +632,7 @@ final class PledgeViewModelTests: TestCase {
       let reward = Reward.noReward
         |> Reward.lens.minimum .~ 5
 
-      self.vm.inputs.configureWith(project: project, reward: reward)
+      self.vm.inputs.configureWith(project: project, reward: reward, refTag: .projectPage)
       self.vm.inputs.viewDidLoad()
 
       self.vm.inputs.applePayButtonTapped()
@@ -667,7 +667,7 @@ final class PledgeViewModelTests: TestCase {
       let project = Project.template
       let reward = Reward.noReward
 
-      self.vm.inputs.configureWith(project: project, reward: reward)
+      self.vm.inputs.configureWith(project: project, reward: reward, refTag: .projectPage)
       self.vm.inputs.viewDidLoad()
 
       self.vm.inputs.applePayButtonTapped()
@@ -700,7 +700,7 @@ final class PledgeViewModelTests: TestCase {
       let reward = Reward.noReward
         |> Reward.lens.minimum .~ 5
 
-      self.vm.inputs.configureWith(project: project, reward: reward)
+      self.vm.inputs.configureWith(project: project, reward: reward, refTag: .projectPage)
       self.vm.inputs.viewDidLoad()
 
       self.vm.inputs.applePayButtonTapped()

--- a/Library/ViewModels/PledgeViewModelTests.swift
+++ b/Library/ViewModels/PledgeViewModelTests.swift
@@ -677,11 +677,12 @@ final class PledgeViewModelTests: TestCase {
       self.configureWithPledgeViewDataProject.assertValues([project])
       self.configureWithPledgeViewDataReward.assertValues([reward])
 
+      self.configureSummaryCellWithDataPledgeTotal.assertValues([reward.minimum])
+      self.configureSummaryCellWithDataProject.assertValues([project])
+
       self.continueViewHidden.assertValues([true])
       self.paymentMethodsViewHidden.assertValues([false])
       self.shippingLocationViewHidden.assertValues([true])
-      self.configureSummaryCellWithDataPledgeTotal.assertValues([reward.minimum])
-      self.configureSummaryCellWithDataProject.assertValues([project])
 
       self.vm.inputs.applePayButtonTapped()
 


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Passes through the `refTag` from the project page all the way to the `createApplePayBacking` request.

# 🤔 Why

So we can track the referrer on Apple Pay backings.

# 🛠 How

Passes the `RefTag` from the project page to the `PledgeViewController`, which then passes it as part of the mutation input for the `createApplePayBacking` mutation. The `refTag` is always optional.

# ✅ Acceptance criteria

To test Apple Pay transactions, you must run the app on a device that is Apple Pay capable.
- [x] On *Staging*, with the *Native Checkout* and *Native Pledge Screen* feature flags turned *ON*, from "Discovery", navigate to any project and select any reward. You should see the "Apple Pay" button. Tap the "Apple Pay" button and complete the transaction. In the console, you should see `⚪️ [KsApi] Input:` which will show you the mutation input for the `createApplePayBacking` mutation. In the input, you should see the key `refParam`.

