### PR TITLE
[NT-330] Update Pledge UI

### DIFF
--- a/Kickstarter-iOS/Views/Controllers/ManageViewPledgeViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/ManageViewPledgeViewController.swift
@@ -83,7 +83,7 @@ final class ManageViewPledgeViewController: UIViewController {
     super.bindStyles()
 
     _ = self.view
-      |> viewStyle
+      |> checkoutBackgroundStyle
 
     _ = self.closeButton
       |> \.accessibilityLabel %~ { _ in Strings.Dismiss() }
@@ -130,6 +130,12 @@ final class ManageViewPledgeViewController: UIViewController {
       .observeForControllerAction()
       .observeValues { [weak self] options in
         self?.showActionSheetMenuWithOptions(options)
+      }
+
+    self.viewModel.outputs.goToUpdatePledge
+      .observeForControllerAction()
+      .observeValues { [weak self] project, reward in
+        self?.goToUpdatePledge(project: project, reward: reward)
       }
   }
 
@@ -190,10 +196,12 @@ final class ManageViewPledgeViewController: UIViewController {
 
     options.forEach { option in
       let title: String
+      var handler: ((UIAlertAction) -> ())?
 
       switch option {
       case .updatePledge:
         title = Strings.Update_pledge()
+        handler = { _ in self.viewModel.inputs.updatePledgeTapped() }
       case .changePaymentMethod:
         title = Strings.Change_payment_method()
       case .chooseAnotherReward:
@@ -207,7 +215,7 @@ final class ManageViewPledgeViewController: UIViewController {
       let style: UIAlertAction.Style = option == .cancelPledge ? .destructive : .default
 
       actionSheet.addAction(
-        UIAlertAction(title: title, style: style)
+        UIAlertAction(title: title, style: style, handler: handler)
       )
     }
 
@@ -221,6 +229,13 @@ final class ManageViewPledgeViewController: UIViewController {
   @objc private func closeButtonTapped() {
     self.dismiss(animated: true)
   }
+
+  private func goToUpdatePledge(project: Project, reward: Reward) {
+    let vc = UpdatePledgeViewController.instantiate()
+    vc.configureWith(project: project, reward: reward, refTag: nil)
+
+    self.show(vc, sender: nil)
+  }
 }
 
 // MARK: Styles
@@ -228,11 +243,6 @@ final class ManageViewPledgeViewController: UIViewController {
 private let rootScrollViewStyle = { (scrollView: UIScrollView) in
   scrollView
     |> \.alwaysBounceVertical .~ true
-}
-
-private let viewStyle: ViewStyle = { (view: UIView) in
-  view
-    |> \.backgroundColor .~ UIColor.ksr_grey_400
 }
 
 private let rootStackViewStyle: StackViewStyle = { stackView in

--- a/Kickstarter-iOS/Views/Controllers/RewardPledgeNavigationController.swift
+++ b/Kickstarter-iOS/Views/Controllers/RewardPledgeNavigationController.swift
@@ -13,7 +13,6 @@ final class RewardPledgeNavigationController: UINavigationController {
 
     _ = self.navigationBar
       ?|> \.isTranslucent .~ false
-      ?|> \.barTintColor .~ .ksr_grey_400
 
     self.navigationBar.shadowImage = UIImage()
   }
@@ -32,9 +31,21 @@ extension RewardPledgeNavigationController: UINavigationControllerDelegate {
     case (.pop, is PledgeViewController, is RewardPledgeTransitionAnimatorDelegate):
       return RewardPledgePopTransitionAnimator()
     default:
-      // We're not performing any custom transition, bring back the standard divider line
-      self.navigationBar.shadowImage = nil
       return nil
     }
+  }
+
+  func navigationController(
+    _: UINavigationController, willShow viewController: UIViewController, animated _: Bool
+  ) {
+    let barTintColor: UIColor
+
+    if viewController is RewardsCollectionViewController {
+      barTintColor = .ksr_grey_400
+    } else {
+      barTintColor = .ksr_grey_300
+    }
+
+    _ = self.navigationBar ?|> \.barTintColor .~ barTintColor
   }
 }

--- a/Kickstarter-iOS/Views/Controllers/UpdatePledgeViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/UpdatePledgeViewController.swift
@@ -1,0 +1,205 @@
+import KsApi
+import Library
+import Prelude
+import Stripe
+import UIKit
+
+final class UpdatePledgeViewController: UIViewController, MessageBannerViewControllerPresenting {
+  // MARK: - Properties
+
+  private lazy var pledgeAmountViewController = {
+    PledgeAmountViewController.instantiate()
+      |> \.delegate .~ self
+  }()
+
+  internal var messageBannerViewController: MessageBannerViewController?
+
+  private lazy var confirmationLabel: UILabel = {
+    UILabel(frame: .zero)
+  }()
+
+  private lazy var shippingLocationViewController = {
+    PledgeShippingLocationViewController.instantiate()
+      |> \.delegate .~ self
+  }()
+
+  private lazy var summaryViewController = {
+    PledgeSummaryViewController.instantiate()
+  }()
+
+  private lazy var rootScrollView: UIScrollView = { UIScrollView(frame: .zero) }()
+  private lazy var rootStackView: UIStackView = {
+    UIStackView(frame: .zero)
+      |> \.translatesAutoresizingMaskIntoConstraints .~ false
+  }()
+
+  private var sessionStartedObserver: Any?
+  private let viewModel: UpdatePledgeViewModelType = UpdatePledgeViewModel()
+
+  // MARK: - Lifecycle
+
+  func configureWith(project: Project, reward: Reward, refTag: RefTag?) {
+    self.viewModel.inputs.configureWith(project: project, reward: reward, refTag: refTag)
+  }
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+
+    _ = self
+      |> \.extendedLayoutIncludesOpaqueBars .~ true
+
+    self.messageBannerViewController = self.configureMessageBannerViewController(on: self)
+
+    _ = self
+      |> \.title %~ { _ in Strings.Update_pledge() }
+
+    _ = (self.rootScrollView, self.view)
+      |> ksr_addSubviewToParent()
+      |> ksr_constrainViewToEdgesInParent()
+
+    _ = (self.rootStackView, self.rootScrollView)
+      |> ksr_addSubviewToParent()
+      |> ksr_constrainViewToEdgesInParent()
+
+    self.view.addGestureRecognizer(
+      UITapGestureRecognizer(target: self, action: #selector(UpdatePledgeViewController.dismissKeyboard))
+    )
+
+    self.configureChildViewControllers()
+    self.setupConstraints()
+
+    self.viewModel.inputs.viewDidLoad()
+  }
+
+  deinit {
+    self.sessionStartedObserver.doIfSome(NotificationCenter.default.removeObserver)
+  }
+
+  // MARK: - Configuration
+
+  private func configureChildViewControllers() {
+    let childViewControllers = [
+      self.pledgeAmountViewController,
+      self.shippingLocationViewController,
+      self.summaryViewController
+    ]
+
+    let arrangedSubviews = [
+      self.pledgeAmountViewController.view,
+      self.shippingLocationViewController.view,
+      self.summaryViewController.view,
+      self.confirmationLabel
+    ]
+    .compact()
+
+    arrangedSubviews.forEach { view in
+      self.rootStackView.addArrangedSubview(view)
+    }
+
+    childViewControllers.forEach { viewController in
+      self.addChild(viewController)
+      viewController.didMove(toParent: self)
+    }
+  }
+
+  private func setupConstraints() {
+    self.rootStackView.widthAnchor.constraint(equalTo: self.rootScrollView.widthAnchor).isActive = true
+  }
+
+  // MARK: - Styles
+
+  override func bindStyles() {
+    super.bindStyles()
+
+    _ = self.view
+      |> checkoutBackgroundStyle
+
+    _ = self.rootScrollView
+      |> rootScrollViewStyle
+
+    _ = self.rootStackView
+      |> checkoutRootStackViewStyle
+
+    _ = self.confirmationLabel
+      |> \.numberOfLines .~ 0
+      |> checkoutBackgroundStyle
+  }
+
+  // MARK: - View model
+
+  override func bindViewModel() {
+    super.bindViewModel()
+
+    self.viewModel.outputs.configureWithData
+      .observeForUI()
+      .observeValues { [weak self] data in
+        self?.pledgeAmountViewController.configureWith(value: data)
+        self?.shippingLocationViewController.configureWith(value: data)
+      }
+
+    self.viewModel.outputs.configureSummaryViewControllerWithData
+      .observeForUI()
+      .observeValues { [weak self] project, pledgeTotal in
+        self?.summaryViewController.configureWith(value: (project, pledgeTotal))
+      }
+
+    Keyboard.change
+      .observeForUI()
+      .observeValues { [weak self] change in
+        self?.rootScrollView.handleKeyboardVisibilityDidChange(change)
+      }
+
+    self.shippingLocationViewController.view.rac.hidden
+      = self.viewModel.outputs.shippingLocationViewHidden
+
+    self.confirmationLabel.rac.attributedText = self.viewModel.outputs.confirmationLabelAttributedText
+  }
+
+  // MARK: - Actions
+
+  @objc private func dismissKeyboard() {
+    self.view.endEditing(true)
+  }
+}
+
+// MARK: - PledgeAmountViewControllerDelegate
+
+extension UpdatePledgeViewController: PledgeAmountViewControllerDelegate {
+  func pledgeAmountViewController(
+    _: PledgeAmountViewController,
+    didUpdateAmount amount: Double
+  ) {
+    self.viewModel.inputs.pledgeAmountDidUpdate(to: amount)
+  }
+}
+
+// MARK: - PledgeShippingLocationViewControllerDelegate
+
+extension UpdatePledgeViewController: PledgeShippingLocationViewControllerDelegate {
+  func pledgeShippingLocationViewController(
+    _: PledgeShippingLocationViewController,
+    didSelect shippingRule: ShippingRule
+  ) {
+    self.viewModel.inputs.shippingRuleSelected(shippingRule)
+  }
+}
+
+// MARK: - UpdatePledgeViewControllerMessageDisplaying
+
+extension UpdatePledgeViewController: PledgeViewControllerMessageDisplaying {
+  func pledgeViewController(_: UIViewController, didErrorWith message: String) {
+    self.messageBannerViewController?.showBanner(with: .error, message: message)
+  }
+
+  func pledgeViewController(_: UIViewController, didSucceedWith message: String) {
+    self.messageBannerViewController?.showBanner(with: .success, message: message)
+  }
+}
+
+// MARK: - Styles
+
+private let rootScrollViewStyle: ScrollStyle = { scrollView in
+  scrollView
+    |> UIScrollView.lens.showsVerticalScrollIndicator .~ false
+    |> \.alwaysBounceVertical .~ true
+}

--- a/Kickstarter-iOS/Views/Controllers/UpdatePledgeViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/UpdatePledgeViewController.swift
@@ -14,6 +14,10 @@ final class UpdatePledgeViewController: UIViewController, MessageBannerViewContr
 
   internal var messageBannerViewController: MessageBannerViewController?
 
+  private lazy var confirmButton: UIButton = {
+    UIButton(type: .custom)
+  }()
+
   private lazy var confirmationLabel: UILabel = {
     UILabel(frame: .zero)
   }()
@@ -71,8 +75,10 @@ final class UpdatePledgeViewController: UIViewController, MessageBannerViewContr
     self.viewModel.inputs.viewDidLoad()
   }
 
-  deinit {
-    self.sessionStartedObserver.doIfSome(NotificationCenter.default.removeObserver)
+  override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+    super.traitCollectionDidChange(previousTraitCollection)
+
+    self.viewModel.inputs.traitCollectionDidChange()
   }
 
   // MARK: - Configuration
@@ -88,7 +94,8 @@ final class UpdatePledgeViewController: UIViewController, MessageBannerViewContr
       self.pledgeAmountViewController.view,
       self.shippingLocationViewController.view,
       self.summaryViewController.view,
-      self.confirmationLabel
+      self.confirmationLabel,
+      self.confirmButton
     ]
     .compact()
 
@@ -103,7 +110,10 @@ final class UpdatePledgeViewController: UIViewController, MessageBannerViewContr
   }
 
   private func setupConstraints() {
-    self.rootStackView.widthAnchor.constraint(equalTo: self.rootScrollView.widthAnchor).isActive = true
+    NSLayoutConstraint.activate([
+      self.rootStackView.widthAnchor.constraint(equalTo: self.rootScrollView.widthAnchor),
+      self.confirmButton.heightAnchor.constraint(greaterThanOrEqualToConstant: Styles.minTouchSize.height)
+    ])
   }
 
   // MARK: - Styles
@@ -119,6 +129,10 @@ final class UpdatePledgeViewController: UIViewController, MessageBannerViewContr
 
     _ = self.rootStackView
       |> checkoutRootStackViewStyle
+
+    _ = self.confirmButton
+      |> greenButtonStyle
+      |> UIButton.lens.title(for: .normal) %~ { _ in Strings.Confirm() }
 
     _ = self.confirmationLabel
       |> \.numberOfLines .~ 0
@@ -181,18 +195,6 @@ extension UpdatePledgeViewController: PledgeShippingLocationViewControllerDelega
     didSelect shippingRule: ShippingRule
   ) {
     self.viewModel.inputs.shippingRuleSelected(shippingRule)
-  }
-}
-
-// MARK: - UpdatePledgeViewControllerMessageDisplaying
-
-extension UpdatePledgeViewController: PledgeViewControllerMessageDisplaying {
-  func pledgeViewController(_: UIViewController, didErrorWith message: String) {
-    self.messageBannerViewController?.showBanner(with: .error, message: message)
-  }
-
-  func pledgeViewController(_: UIViewController, didSucceedWith message: String) {
-    self.messageBannerViewController?.showBanner(with: .success, message: message)
   }
 }
 

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -305,6 +305,7 @@
 		8A73EAD7233A8F5800FF9051 /* UpdatePledgeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A73EAD6233A8F5800FF9051 /* UpdatePledgeViewModel.swift */; };
 		8A73EAD9233B00A500FF9051 /* NSMutableAttributedString+SetFontKeepingTraits.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A73EAD8233B00A500FF9051 /* NSMutableAttributedString+SetFontKeepingTraits.swift */; };
 		8A73EADC233BDC0A00FF9051 /* UpdatePledgeViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A73EADA233BDBBE00FF9051 /* UpdatePledgeViewModelTests.swift */; };
+		8A73EADE233BE12D00FF9051 /* NSMutableAttributedString+SetFontKeepingTraitsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A73EADD233BE12D00FF9051 /* NSMutableAttributedString+SetFontKeepingTraitsTests.swift */; };
 		8A8099EB22E213F100373E66 /* RewardCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A8099E922E213F100373E66 /* RewardCardView.swift */; };
 		8A8099EC22E213F100373E66 /* RewardCardContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A8099EA22E213F100373E66 /* RewardCardContainerView.swift */; };
 		8A8099F122E2142C00373E66 /* RewardCardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A8099ED22E2142C00373E66 /* RewardCardViewModel.swift */; };
@@ -1659,6 +1660,7 @@
 		8A73EAD6233A8F5800FF9051 /* UpdatePledgeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdatePledgeViewModel.swift; sourceTree = "<group>"; };
 		8A73EAD8233B00A500FF9051 /* NSMutableAttributedString+SetFontKeepingTraits.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSMutableAttributedString+SetFontKeepingTraits.swift"; sourceTree = "<group>"; };
 		8A73EADA233BDBBE00FF9051 /* UpdatePledgeViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdatePledgeViewModelTests.swift; sourceTree = "<group>"; };
+		8A73EADD233BE12D00FF9051 /* NSMutableAttributedString+SetFontKeepingTraitsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSMutableAttributedString+SetFontKeepingTraitsTests.swift"; sourceTree = "<group>"; };
 		8A8099E922E213F100373E66 /* RewardCardView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RewardCardView.swift; sourceTree = "<group>"; };
 		8A8099EA22E213F100373E66 /* RewardCardContainerView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RewardCardContainerView.swift; sourceTree = "<group>"; };
 		8A8099ED22E2142C00373E66 /* RewardCardViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RewardCardViewModel.swift; sourceTree = "<group>"; };
@@ -3125,6 +3127,7 @@
 				37D99C2222247F4A008EF839 /* NSBundleType+Tests.swift */,
 				A78537F71CB5803B00385B73 /* NSHTTPCookieStorageType.swift */,
 				8A73EAD8233B00A500FF9051 /* NSMutableAttributedString+SetFontKeepingTraits.swift */,
+				8A73EADD233BE12D00FF9051 /* NSMutableAttributedString+SetFontKeepingTraitsTests.swift */,
 				37EB3E4B228CF4A400076E4C /* NumberFormatter.swift */,
 				37EB3E4D228CF4FB00076E4C /* NumberFormatterTests.swift */,
 				A77D7B061CBAAF5D0077586B /* Paginate.swift */,
@@ -4931,6 +4934,7 @@
 				A7ED1FB21E831C5C00BFFA01 /* DashboardTitleViewViewModelTests.swift in Sources */,
 				A7ED1F3A1E830FDC00BFFA01 /* UILabel+SimpleHTMLTests.swift in Sources */,
 				D6ED1B37216D0C64007F7547 /* ChangeEmailViewModelTests.swift in Sources */,
+				8A73EADE233BE12D00FF9051 /* NSMutableAttributedString+SetFontKeepingTraitsTests.swift in Sources */,
 				A7ED1F271E830FDC00BFFA01 /* AppEnvironmentTests.swift in Sources */,
 				D775953C22725289005EE69B /* PledgeDescriptionViewModelTests.swift in Sources */,
 				D78E039022930DF80043E92F /* PledgeCTAContainerViewViewModelTests.swift in Sources */,

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -304,6 +304,7 @@
 		8A73EAD5233A8F1E00FF9051 /* UpdatePledgeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A73EAD4233A8F1E00FF9051 /* UpdatePledgeViewController.swift */; };
 		8A73EAD7233A8F5800FF9051 /* UpdatePledgeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A73EAD6233A8F5800FF9051 /* UpdatePledgeViewModel.swift */; };
 		8A73EAD9233B00A500FF9051 /* NSMutableAttributedString+SetFontKeepingTraits.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A73EAD8233B00A500FF9051 /* NSMutableAttributedString+SetFontKeepingTraits.swift */; };
+		8A73EADC233BDC0A00FF9051 /* UpdatePledgeViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A73EADA233BDBBE00FF9051 /* UpdatePledgeViewModelTests.swift */; };
 		8A8099EB22E213F100373E66 /* RewardCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A8099E922E213F100373E66 /* RewardCardView.swift */; };
 		8A8099EC22E213F100373E66 /* RewardCardContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A8099EA22E213F100373E66 /* RewardCardContainerView.swift */; };
 		8A8099F122E2142C00373E66 /* RewardCardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A8099ED22E2142C00373E66 /* RewardCardViewModel.swift */; };
@@ -1657,6 +1658,7 @@
 		8A73EAD4233A8F1E00FF9051 /* UpdatePledgeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdatePledgeViewController.swift; sourceTree = "<group>"; };
 		8A73EAD6233A8F5800FF9051 /* UpdatePledgeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdatePledgeViewModel.swift; sourceTree = "<group>"; };
 		8A73EAD8233B00A500FF9051 /* NSMutableAttributedString+SetFontKeepingTraits.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSMutableAttributedString+SetFontKeepingTraits.swift"; sourceTree = "<group>"; };
+		8A73EADA233BDBBE00FF9051 /* UpdatePledgeViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdatePledgeViewModelTests.swift; sourceTree = "<group>"; };
 		8A8099E922E213F100373E66 /* RewardCardView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RewardCardView.swift; sourceTree = "<group>"; };
 		8A8099EA22E213F100373E66 /* RewardCardContainerView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RewardCardContainerView.swift; sourceTree = "<group>"; };
 		8A8099ED22E2142C00373E66 /* RewardCardViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RewardCardViewModel.swift; sourceTree = "<group>"; };
@@ -3531,6 +3533,8 @@
 				A7ED1F761E831C5C00BFFA01 /* LoginToutViewModelTests.swift */,
 				A7698B291D00602800953FD3 /* LoginViewModel.swift */,
 				A7ED1F931E831C5C00BFFA01 /* LoginViewModelTests.swift */,
+				D65BF350232FE88300B15B25 /* ManagePledgeSummaryViewModel.swift */,
+				D65BF352233023E400B15B25 /* ManagePledgeSummaryViewModelTests.swift */,
 				D67DF563232ABB950051D207 /* ManageViewPledgeViewModel.swift */,
 				D61440FD23200F09002A6507 /* ManageViewPledgeViewModelTests.swift */,
 				D04AAC1B218BB70C00CF713E /* MessageBannerViewModel.swift */,
@@ -3567,8 +3571,6 @@
 				3706408722A8A6F200889CBD /* PledgeShippingLocationViewModelTests.swift */,
 				D0237C2522BD7B540092C792 /* PledgeSummaryViewModel.swift */,
 				D0D19BC922BD886F0043A4E5 /* PledgeSummaryViewModelTests.swift */,
-				D65BF350232FE88300B15B25 /* ManagePledgeSummaryViewModel.swift */,
-				D65BF352233023E400B15B25 /* ManagePledgeSummaryViewModelTests.swift */,
 				37DEC1E62257C9F30051EF9B /* PledgeViewModel.swift */,
 				37DEC21F2257CA0A0051EF9B /* PledgeViewModelTests.swift */,
 				A7F441A31D005A9400FE6FC5 /* ProfileViewModel.swift */,
@@ -3671,6 +3673,7 @@
 				809F8B651D08B4FF005BADD9 /* UpdateDraftViewModel.swift */,
 				A7ED1FA81E831C5C00BFFA01 /* UpdateDraftViewModelTests.swift */,
 				8A73EAD6233A8F5800FF9051 /* UpdatePledgeViewModel.swift */,
+				8A73EADA233BDBBE00FF9051 /* UpdatePledgeViewModelTests.swift */,
 				59673CBE1D50EE9B0035AFD9 /* VideoViewModel.swift */,
 				A7ED1F9C1E831C5C00BFFA01 /* VideoViewModelTests.swift */,
 				D08CD1FE21913166009F89F0 /* WatchProjectViewModel.swift */,
@@ -4883,6 +4886,7 @@
 				A7ED1FC51E831C5C00BFFA01 /* CommentsEmptyStateCellViewModelTests.swift in Sources */,
 				A7ED1F391E830FDC00BFFA01 /* UILabel+IBClearTests.swift in Sources */,
 				D614410023200FD3002A6507 /* ManageViewPledgeViewControllerTests.swift in Sources */,
+				8A73EADC233BDC0A00FF9051 /* UpdatePledgeViewModelTests.swift in Sources */,
 				3706408422A8A68600889CBD /* PledgeAmountViewModelTests.swift in Sources */,
 				D79CF40521B0840E00ECB73A /* AddNewCardViewModelTests.swift in Sources */,
 				D7A86A3B1F324EB300C7DA53 /* MostPopularSearchProjectCellViewModelTests.swift in Sources */,

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -301,6 +301,9 @@
 		8A072D3A230223B200BA1538 /* UIImage+Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A072D39230223B200BA1538 /* UIImage+Color.swift */; };
 		8A142EBD23354BFD00FB43AB /* AddNewCardIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A142EBC23354BFD00FB43AB /* AddNewCardIntent.swift */; };
 		8A23EF0822F11470001262E1 /* RewardCardContainerViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A23EF0722F11470001262E1 /* RewardCardContainerViewTests.swift */; };
+		8A73EAD5233A8F1E00FF9051 /* UpdatePledgeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A73EAD4233A8F1E00FF9051 /* UpdatePledgeViewController.swift */; };
+		8A73EAD7233A8F5800FF9051 /* UpdatePledgeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A73EAD6233A8F5800FF9051 /* UpdatePledgeViewModel.swift */; };
+		8A73EAD9233B00A500FF9051 /* NSMutableAttributedString+SetFontKeepingTraits.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A73EAD8233B00A500FF9051 /* NSMutableAttributedString+SetFontKeepingTraits.swift */; };
 		8A8099EB22E213F100373E66 /* RewardCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A8099E922E213F100373E66 /* RewardCardView.swift */; };
 		8A8099EC22E213F100373E66 /* RewardCardContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A8099EA22E213F100373E66 /* RewardCardContainerView.swift */; };
 		8A8099F122E2142C00373E66 /* RewardCardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A8099ED22E2142C00373E66 /* RewardCardViewModel.swift */; };
@@ -1651,6 +1654,9 @@
 		8A072D39230223B200BA1538 /* UIImage+Color.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+Color.swift"; sourceTree = "<group>"; };
 		8A142EBC23354BFD00FB43AB /* AddNewCardIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddNewCardIntent.swift; sourceTree = "<group>"; };
 		8A23EF0722F11470001262E1 /* RewardCardContainerViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RewardCardContainerViewTests.swift; sourceTree = "<group>"; };
+		8A73EAD4233A8F1E00FF9051 /* UpdatePledgeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdatePledgeViewController.swift; sourceTree = "<group>"; };
+		8A73EAD6233A8F5800FF9051 /* UpdatePledgeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdatePledgeViewModel.swift; sourceTree = "<group>"; };
+		8A73EAD8233B00A500FF9051 /* NSMutableAttributedString+SetFontKeepingTraits.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSMutableAttributedString+SetFontKeepingTraits.swift"; sourceTree = "<group>"; };
 		8A8099E922E213F100373E66 /* RewardCardView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RewardCardView.swift; sourceTree = "<group>"; };
 		8A8099EA22E213F100373E66 /* RewardCardContainerView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RewardCardContainerView.swift; sourceTree = "<group>"; };
 		8A8099ED22E2142C00373E66 /* RewardCardViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RewardCardViewModel.swift; sourceTree = "<group>"; };
@@ -3032,6 +3038,7 @@
 				01DEFB941CB44A5D003709C0 /* TwoFactorViewController.swift */,
 				A7ED203F1E8323E900BFFA01 /* TwoFactorViewControllerTests.swift */,
 				803BDF731D11AF7C004A785A /* UpdateDraftViewController.swift */,
+				8A73EAD4233A8F1E00FF9051 /* UpdatePledgeViewController.swift */,
 				8072F41C1D46B75200999EF1 /* UpdatePreviewViewController.swift */,
 				A731BF8B1D1EE44E00A734AC /* UpdateViewController.swift */,
 				59673CBC1D50ED380035AFD9 /* VideoViewController.swift */,
@@ -3051,6 +3058,7 @@
 		A7C725771C85D36D005A016B /* Library */ = {
 			isa = PBXGroup;
 			children = (
+				8A142EBC23354BFD00FB43AB /* AddNewCardIntent.swift */,
 				A709697D1D143D1300DB39D3 /* AlertError.swift */,
 				A7C725781C85D36D005A016B /* AppEnvironment.swift */,
 				A7ED1F121E830FDC00BFFA01 /* AppEnvironmentTests.swift */,
@@ -3114,6 +3122,7 @@
 				A7C725911C85D36D005A016B /* NSBundleType.swift */,
 				37D99C2222247F4A008EF839 /* NSBundleType+Tests.swift */,
 				A78537F71CB5803B00385B73 /* NSHTTPCookieStorageType.swift */,
+				8A73EAD8233B00A500FF9051 /* NSMutableAttributedString+SetFontKeepingTraits.swift */,
 				37EB3E4B228CF4A400076E4C /* NumberFormatter.swift */,
 				37EB3E4D228CF4FB00076E4C /* NumberFormatterTests.swift */,
 				A77D7B061CBAAF5D0077586B /* Paginate.swift */,
@@ -3208,7 +3217,6 @@
 				A73378F91D0AE33B00C91445 /* Styles */,
 				A7ED1F421E831BA200BFFA01 /* TestHelpers */,
 				A7F4418D1D005A9400FE6FC5 /* ViewModels */,
-				8A142EBC23354BFD00FB43AB /* AddNewCardIntent.swift */,
 			);
 			path = Library;
 			sourceTree = "<group>";
@@ -3662,6 +3670,7 @@
 				A7ED1FA71E831C5C00BFFA01 /* TwoFactorViewModelTests.swift */,
 				809F8B651D08B4FF005BADD9 /* UpdateDraftViewModel.swift */,
 				A7ED1FA81E831C5C00BFFA01 /* UpdateDraftViewModelTests.swift */,
+				8A73EAD6233A8F5800FF9051 /* UpdatePledgeViewModel.swift */,
 				59673CBE1D50EE9B0035AFD9 /* VideoViewModel.swift */,
 				A7ED1F9C1E831C5C00BFFA01 /* VideoViewModelTests.swift */,
 				D08CD1FE21913166009F89F0 /* WatchProjectViewModel.swift */,
@@ -4708,6 +4717,7 @@
 				A755116B1C8642C3005355CF /* UILabel+SimpleHTML.swift in Sources */,
 				A721DF621C8CF503000CB97C /* TrackingClientType.swift in Sources */,
 				5955E6811D21805200B4153D /* DashboardReferrersCellViewModel.swift in Sources */,
+				8A73EAD9233B00A500FF9051 /* NSMutableAttributedString+SetFontKeepingTraits.swift in Sources */,
 				A75C81201D210C4700B5AD03 /* UpdateActivityItemProvider.swift in Sources */,
 				A7F441B91D005A9400FE6FC5 /* CommentCellViewModel.swift in Sources */,
 				9D7536CF1D78D88D00A7623B /* SurveyResponseViewModel.swift in Sources */,
@@ -4726,6 +4736,7 @@
 				77F6E73521222E7C005A5C55 /* EmailFrequency.swift in Sources */,
 				A7EDEE571D83453F00780B34 /* PKPaymentAuthorizationViewController+Helpers.swift in Sources */,
 				D0237C2622BD7B540092C792 /* PledgeSummaryViewModel.swift in Sources */,
+				8A73EAD7233A8F5800FF9051 /* UpdatePledgeViewModel.swift in Sources */,
 				01A7A4C01C9690220036E553 /* UITextField+LocalizedPlaceholderKey.swift in Sources */,
 				0176E13B1C9742FD009CA092 /* UIBarButtonItem.swift in Sources */,
 				D63BBD35217FAB85007E01F0 /* PaymentMethodsViewModel.swift in Sources */,
@@ -5082,6 +5093,7 @@
 				A75A29251CE0AE5A00D35E5C /* MessagesViewController.swift in Sources */,
 				A7CC14361D00E73D00035C52 /* FindFriendsViewController.swift in Sources */,
 				3708DD43220A5A5700F8E569 /* SettingsGroupedFooterView.swift in Sources */,
+				8A73EAD5233A8F1E00FF9051 /* UpdatePledgeViewController.swift in Sources */,
 				A7CA8BB71D8F14260086A3E9 /* ProjectPamphletMainCell.swift in Sources */,
 				593AC5CF1D33F4BF002613F4 /* DashboardFundingCell.swift in Sources */,
 				A71003E31CDD077200B4F4D7 /* MessageCell.swift in Sources */,

--- a/Library/NSMutableAttributedString+SetFontKeepingTraits.swift
+++ b/Library/NSMutableAttributedString+SetFontKeepingTraits.swift
@@ -1,0 +1,26 @@
+import Foundation
+import UIKit
+
+extension NSMutableAttributedString {
+  func setFontKeepingTraits(to font: UIFont, color: UIColor? = nil) {
+    self.beginEditing()
+
+    self.enumerateAttribute(.font, in: NSRange(location: 0, length: self.length)) { value, range, _ in
+      guard let currentFont = value as? UIFont, let newFontDescriptor = currentFont.fontDescriptor
+        .withFamily(font.familyName)
+        .withSymbolicTraits(currentFont.fontDescriptor.symbolicTraits) else { return }
+
+      let newFont = UIFont(descriptor: newFontDescriptor, size: font.pointSize)
+
+      self.removeAttribute(.font, range: range)
+      self.addAttribute(.font, value: newFont, range: range)
+
+      if let color = color {
+        self.removeAttribute(.foregroundColor, range: range)
+        self.addAttribute(.foregroundColor, value: color, range: range)
+      }
+    }
+
+    self.endEditing()
+  }
+}

--- a/Library/NSMutableAttributedString+SetFontKeepingTraitsTests.swift
+++ b/Library/NSMutableAttributedString+SetFontKeepingTraitsTests.swift
@@ -1,0 +1,47 @@
+@testable import Library
+import XCTest
+
+final class NSMutableAttributedString_SetFontKeepingTraitsTests: XCTestCase {
+  func test() {
+    let string = "What a lovely string"
+    let initialFont = UIFont.systemFont(ofSize: 12.0)
+    let initialColor = UIColor.blue
+
+    let replacementFont = UIFont.ksr_body()
+    let replacementColor = UIColor.ksr_green_500
+
+    let attributedString = NSMutableAttributedString(
+      string: string,
+      attributes: [
+        .font: initialFont,
+        .foregroundColor: initialColor
+      ]
+    )
+
+    let range = NSRange(location: 0, length: attributedString.length)
+
+    attributedString
+      .enumerateAttribute(.font, in: range) { value, _, _ in
+        XCTAssertEqual((value as? UIFont)?.fontName, initialFont.fontName)
+        XCTAssertEqual((value as? UIFont)?.pointSize, initialFont.pointSize)
+      }
+
+    attributedString
+      .enumerateAttribute(.foregroundColor, in: range) { value, _, _ in
+        XCTAssertEqual(value as? UIColor, initialColor)
+      }
+
+    attributedString.setFontKeepingTraits(to: replacementFont, color: replacementColor)
+
+    attributedString
+      .enumerateAttribute(.font, in: range) { value, _, _ in
+        XCTAssertEqual((value as? UIFont)?.fontName, replacementFont.fontName)
+        XCTAssertEqual((value as? UIFont)?.pointSize, replacementFont.pointSize)
+      }
+
+    attributedString
+      .enumerateAttribute(.foregroundColor, in: range) { value, _, _ in
+        XCTAssertEqual(value as? UIColor, replacementColor)
+      }
+  }
+}

--- a/Library/ViewModels/ManageViewPledgeViewModel.swift
+++ b/Library/ViewModels/ManageViewPledgeViewModel.swift
@@ -14,6 +14,7 @@ public enum ManagePledgeAlertAction: CaseIterable {
 public protocol ManageViewPledgeViewModelInputs {
   func configureWith(_ project: Project, reward: Reward)
   func menuButtonTapped()
+  func updatePledgeTapped()
   func viewDidLoad()
 }
 
@@ -21,6 +22,7 @@ public protocol ManageViewPledgeViewModelOutputs {
   var configurePaymentMethodView: Signal<Project, Never> { get }
   var configurePledgeSummaryView: Signal<Project, Never> { get }
   var configureRewardSummaryView: Signal<Reward, Never> { get }
+  var goToUpdatePledge: Signal<(Project, Reward), Never> { get }
   var showActionSheetMenuWithOptions: Signal<[ManagePledgeAlertAction], Never> { get }
   var title: Signal<String, Never> { get }
 }
@@ -60,6 +62,9 @@ public final class ManageViewPledgeViewModel:
           return [.contactCreator]
         }
       }
+
+    self.goToUpdatePledge = projectAndReward
+      .takeWhen(self.updatePledgeTappedSignal)
   }
 
   private let (projectAndRewardSignal, projectAndRewardObserver) = Signal<(Project, Reward), Never>.pipe()
@@ -72,6 +77,11 @@ public final class ManageViewPledgeViewModel:
     self.menuButtonTappedObserver.send(value: ())
   }
 
+  private let (updatePledgeTappedSignal, updatePledgeTappedObserver) = Signal<Void, Never>.pipe()
+  public func updatePledgeTapped() {
+    self.updatePledgeTappedObserver.send(value: ())
+  }
+
   private let (viewDidLoadSignal, viewDidLoadObserver) = Signal<(), Never>.pipe()
   public func viewDidLoad() {
     self.viewDidLoadObserver.send(value: ())
@@ -80,6 +90,7 @@ public final class ManageViewPledgeViewModel:
   public let configurePaymentMethodView: Signal<Project, Never>
   public let configurePledgeSummaryView: Signal<Project, Never>
   public let configureRewardSummaryView: Signal<Reward, Never>
+  public let goToUpdatePledge: Signal<(Project, Reward), Never>
   public let showActionSheetMenuWithOptions: Signal<[ManagePledgeAlertAction], Never>
   public let title: Signal<String, Never>
 

--- a/Library/ViewModels/UpdatePledgeViewModel.swift
+++ b/Library/ViewModels/UpdatePledgeViewModel.swift
@@ -1,0 +1,133 @@
+import Foundation
+import KsApi
+import PassKit
+import Prelude
+import ReactiveSwift
+
+public protocol UpdatePledgeViewModelInputs {
+  func configureWith(project: Project, reward: Reward, refTag: RefTag?)
+  func pledgeAmountDidUpdate(to amount: Double)
+  func shippingRuleSelected(_ shippingRule: ShippingRule)
+  func viewDidLoad()
+}
+
+public protocol UpdatePledgeViewModelOutputs {
+  var configureSummaryViewControllerWithData: Signal<(Project, Double), Never> { get }
+  var configureWithData: Signal<(project: Project, reward: Reward), Never> { get }
+  var shippingLocationViewHidden: Signal<Bool, Never> { get }
+  var confirmationLabelAttributedText: Signal<NSAttributedString, Never> { get }
+}
+
+public protocol UpdatePledgeViewModelType {
+  var inputs: UpdatePledgeViewModelInputs { get }
+  var outputs: UpdatePledgeViewModelOutputs { get }
+}
+
+public class UpdatePledgeViewModel: UpdatePledgeViewModelType, UpdatePledgeViewModelInputs,
+  UpdatePledgeViewModelOutputs {
+  public init() {
+    let initialData = Signal.combineLatest(
+      self.configureWithDataProperty.signal,
+      self.viewDidLoadProperty.signal
+    )
+    .map(first)
+    .skipNil()
+
+    let project = initialData.map(first)
+    let reward = initialData.map(second)
+
+    let pledgeAmount = Signal.merge(
+      self.pledgeAmountSignal,
+      reward.map { $0.minimum }
+    )
+
+    let initialShippingAmount = initialData.mapConst(0.0)
+    let shippingAmount = self.shippingRuleSelectedSignal
+      .map { $0.cost }
+    let shippingCost = Signal.merge(shippingAmount, initialShippingAmount)
+
+    let pledgeTotal = Signal.combineLatest(pledgeAmount, shippingCost).map(+)
+
+    self.configureWithData = initialData.map { (project: $0.0, reward: $0.1) }
+
+    self.configureSummaryViewControllerWithData = project
+      .takePairWhen(pledgeTotal)
+      .map { project, total in (project, total) }
+
+    self.shippingLocationViewHidden = reward
+      .map { $0.shipping.enabled }
+      .negate()
+
+    self.confirmationLabelAttributedText = project
+      .map(attributedConfirmationString(with:))
+      .skipNil()
+  }
+
+  // MARK: - Inputs
+
+  private let configureWithDataProperty = MutableProperty<(Project, Reward, RefTag?)?>(nil)
+  public func configureWith(project: Project, reward: Reward, refTag: RefTag?) {
+    self.configureWithDataProperty.value = (project, reward, refTag)
+  }
+
+  private let (pledgeAmountSignal, pledgeAmountObserver) = Signal<Double, Never>.pipe()
+  public func pledgeAmountDidUpdate(to amount: Double) {
+    self.pledgeAmountObserver.send(value: amount)
+  }
+
+  private let (shippingRuleSelectedSignal, shippingRuleSelectedObserver) = Signal<ShippingRule, Never>.pipe()
+  public func shippingRuleSelected(_ shippingRule: ShippingRule) {
+    self.shippingRuleSelectedObserver.send(value: shippingRule)
+  }
+
+  private let viewDidLoadProperty = MutableProperty(())
+  public func viewDidLoad() {
+    self.viewDidLoadProperty.value = ()
+  }
+
+  // MARK: - Outputs
+
+  public let configureSummaryViewControllerWithData: Signal<(Project, Double), Never>
+  public let configureWithData: Signal<(project: Project, reward: Reward), Never>
+  public let shippingLocationViewHidden: Signal<Bool, Never>
+  public let confirmationLabelAttributedText: Signal<NSAttributedString, Never>
+
+  public var inputs: UpdatePledgeViewModelInputs { return self }
+  public var outputs: UpdatePledgeViewModelOutputs { return self }
+}
+
+private func attributedConfirmationString(with project: Project) -> NSAttributedString? {
+  let string = Strings.If_the_project_reaches_its_funding_goal_you_will_be_charged_on_project_deadline(
+    project_deadline: Format.date(
+      secondsInUTC: project.dates.deadline,
+      template: "MMMM d, yyyy"
+    )
+  )
+
+  guard let attributedString = try? NSMutableAttributedString(
+    data: Data(string.utf8),
+    options: [
+      .documentType: NSAttributedString.DocumentType.html,
+      .characterEncoding: String.Encoding.utf8.rawValue
+    ],
+    documentAttributes: nil
+  ) else { return nil }
+
+  let paragraphStyle = NSMutableParagraphStyle()
+  paragraphStyle.alignment = .center
+
+  let attributes: String.Attributes = [
+    .paragraphStyle: paragraphStyle
+  ]
+
+  let fullRange = (attributedString.string as NSString).range(of: attributedString.string)
+
+  attributedString.addAttributes(attributes, range: fullRange)
+
+  attributedString.setFontKeepingTraits(
+    to: UIFont.ksr_caption1(),
+    color: UIColor.ksr_text_dark_grey_500
+  )
+
+  return attributedString
+}

--- a/Library/ViewModels/UpdatePledgeViewModelTests.swift
+++ b/Library/ViewModels/UpdatePledgeViewModelTests.swift
@@ -1,0 +1,275 @@
+import Foundation
+@testable import KsApi
+@testable import Library
+import PassKit
+import Prelude
+import ReactiveExtensions
+import ReactiveExtensions_TestHelpers
+import ReactiveSwift
+import XCTest
+
+final class UpdatePledgeViewModelTests: TestCase {
+  private let vm: UpdatePledgeViewModelType = UpdatePledgeViewModel()
+
+  private let configureSummaryCellWithDataPledgeTotal = TestObserver<Double, Never>()
+  private let configureSummaryCellWithDataProject = TestObserver<Project, Never>()
+  private let configureWithPledgeViewDataProject = TestObserver<Project, Never>()
+  private let configureWithPledgeViewDataReward = TestObserver<Reward, Never>()
+  private let confirmationLabelAttributedText = TestObserver<NSAttributedString, Never>()
+  private let shippingLocationViewHidden = TestObserver<Bool, Never>()
+
+  override func setUp() {
+    super.setUp()
+
+    self.vm.outputs.configureSummaryViewControllerWithData.map(second)
+      .observe(self.configureSummaryCellWithDataPledgeTotal.observer)
+    self.vm.outputs.configureSummaryViewControllerWithData.map(first)
+      .observe(self.configureSummaryCellWithDataProject.observer)
+
+    self.vm.outputs.configureWithData.map { $0.project }
+      .observe(self.configureWithPledgeViewDataProject.observer)
+    self.vm.outputs.configureWithData.map { $0.reward }
+      .observe(self.configureWithPledgeViewDataReward.observer)
+
+    self.vm.outputs.confirmationLabelAttributedText.observe(self.confirmationLabelAttributedText.observer)
+
+    self.vm.outputs.shippingLocationViewHidden.observe(self.shippingLocationViewHidden.observer)
+  }
+
+  func testShipping_Disabled() {
+    let project = Project.template
+    let reward = Reward.template
+      |> Reward.lens.shipping.enabled .~ false
+
+    self.vm.inputs.configureWith(project: project, reward: reward, refTag: .projectPage)
+    self.vm.inputs.viewDidLoad()
+
+    self.configureWithPledgeViewDataProject.assertValues([project])
+    self.configureWithPledgeViewDataReward.assertValues([reward])
+
+    self.shippingLocationViewHidden.assertValues([true])
+    self.configureSummaryCellWithDataPledgeTotal.assertValues([reward.minimum])
+    self.configureSummaryCellWithDataProject.assertValues([project])
+  }
+
+  func testShipping_Enabled() {
+    let project = Project.template
+    let reward = Reward.template
+      |> Reward.lens.shipping.enabled .~ true
+
+    self.vm.inputs.configureWith(project: project, reward: reward, refTag: .projectPage)
+    self.vm.inputs.viewDidLoad()
+
+    self.configureWithPledgeViewDataProject.assertValues([project])
+    self.configureWithPledgeViewDataReward.assertValues([reward])
+
+    self.shippingLocationViewHidden.assertValues([false])
+    self.configureSummaryCellWithDataPledgeTotal.assertValues([reward.minimum])
+    self.configureSummaryCellWithDataProject.assertValues([project])
+  }
+
+  func testShippingRuleSelectedDefaultShippingRule() {
+    let project = Project.template
+    let reward = Reward.template
+      |> Reward.lens.shipping .~ (.template |> Reward.Shipping.lens.enabled .~ true)
+
+    self.vm.inputs.configureWith(project: project, reward: reward, refTag: .projectPage)
+    self.vm.inputs.viewDidLoad()
+
+    self.configureWithPledgeViewDataProject.assertValues([project])
+    self.configureWithPledgeViewDataReward.assertValues([reward])
+
+    self.shippingLocationViewHidden.assertValues([false])
+    self.configureSummaryCellWithDataPledgeTotal.assertValues([reward.minimum])
+    self.configureSummaryCellWithDataProject.assertValues([project])
+
+    let defaultShippingRule = ShippingRule.template
+      |> ShippingRule.lens.cost .~ 5
+
+    self.vm.inputs.shippingRuleSelected(defaultShippingRule)
+
+    self.configureSummaryCellWithDataPledgeTotal
+      .assertValues([reward.minimum, reward.minimum + defaultShippingRule.cost])
+    self.configureSummaryCellWithDataProject.assertValues([project, project])
+  }
+
+  func testShippingRuleSelectedUpdatedShippingRule() {
+    let project = Project.template
+    let reward = Reward.template
+      |> Reward.lens.shipping .~ (.template |> Reward.Shipping.lens.enabled .~ true)
+
+    self.vm.inputs.configureWith(project: project, reward: reward, refTag: .projectPage)
+    self.vm.inputs.viewDidLoad()
+
+    self.configureWithPledgeViewDataProject.assertValues([project])
+    self.configureWithPledgeViewDataReward.assertValues([reward])
+
+    self.shippingLocationViewHidden.assertValues([false])
+    self.configureSummaryCellWithDataPledgeTotal.assertValues([reward.minimum])
+    self.configureSummaryCellWithDataProject.assertValues([project])
+
+    let defaultShippingRule = ShippingRule.template
+      |> ShippingRule.lens.cost .~ 5
+
+    self.vm.inputs.shippingRuleSelected(defaultShippingRule)
+
+    self.configureSummaryCellWithDataPledgeTotal
+      .assertValues([reward.minimum, reward.minimum + defaultShippingRule.cost])
+    self.configureSummaryCellWithDataProject.assertValues([project, project])
+
+    let selectedShippingRule = ShippingRule.template
+      |> ShippingRule.lens.cost .~ 5
+      |> ShippingRule.lens.location .~ .australia
+
+    self.vm.inputs.shippingRuleSelected(selectedShippingRule)
+
+    self.configureSummaryCellWithDataPledgeTotal.assertValues([
+      reward.minimum,
+      reward.minimum + defaultShippingRule.cost,
+      reward.minimum + selectedShippingRule.cost
+    ])
+    self.configureSummaryCellWithDataProject.assertValues([project, project, project])
+  }
+
+  func testPledgeAmountUpdates() {
+    let project = Project.template
+    let reward = Reward.template
+      |> Reward.lens.shipping.enabled .~ true
+
+    self.vm.inputs.configureWith(project: project, reward: reward, refTag: .projectPage)
+    self.vm.inputs.viewDidLoad()
+
+    self.configureWithPledgeViewDataProject.assertValues([project])
+    self.configureWithPledgeViewDataReward.assertValues([reward])
+
+    self.shippingLocationViewHidden.assertValues([false])
+
+    self.configureSummaryCellWithDataPledgeTotal.assertValues([reward.minimum])
+    self.configureSummaryCellWithDataProject.assertValues([project])
+
+    let amount1 = 66.0
+
+    self.vm.inputs.pledgeAmountDidUpdate(to: amount1)
+
+    self.configureWithPledgeViewDataProject.assertValues([project])
+    self.configureWithPledgeViewDataReward.assertValues([reward])
+
+    self.configureSummaryCellWithDataPledgeTotal.assertValues([reward.minimum, amount1])
+    self.configureSummaryCellWithDataProject.assertValues([project, project])
+
+    let amount2 = 99.0
+
+    self.vm.inputs.pledgeAmountDidUpdate(to: amount2)
+
+    self.configureWithPledgeViewDataProject.assertValues([project])
+    self.configureWithPledgeViewDataReward.assertValues([reward])
+
+    self.configureSummaryCellWithDataPledgeTotal.assertValues([reward.minimum, amount1, amount2])
+    self.configureSummaryCellWithDataProject.assertValues([project, project, project])
+  }
+
+  func testSelectedShippingRuleAndPledgeAmountUpdates() {
+    let project = Project.template
+    let reward = Reward.template
+      |> Reward.lens.shipping .~ (.template |> Reward.Shipping.lens.enabled .~ true)
+
+    self.vm.inputs.configureWith(project: project, reward: reward, refTag: .projectPage)
+    self.vm.inputs.viewDidLoad()
+
+    self.configureWithPledgeViewDataProject.assertValues([project])
+    self.configureWithPledgeViewDataReward.assertValues([reward])
+
+    self.shippingLocationViewHidden.assertValues([false])
+
+    self.configureSummaryCellWithDataPledgeTotal.assertValues([reward.minimum])
+    self.configureSummaryCellWithDataProject.assertValues([project])
+
+    let shippingRule1 = ShippingRule.template
+      |> ShippingRule.lens.cost .~ 20.0
+
+    self.vm.inputs.shippingRuleSelected(shippingRule1)
+
+    self.configureWithPledgeViewDataProject.assertValues([project])
+    self.configureWithPledgeViewDataReward.assertValues([reward])
+
+    self.configureSummaryCellWithDataPledgeTotal.assertValues([
+      reward.minimum,
+      reward.minimum + shippingRule1.cost
+    ])
+    self.configureSummaryCellWithDataProject.assertValues([project, project])
+
+    let amount1 = 200.0
+
+    self.vm.inputs.pledgeAmountDidUpdate(to: amount1)
+
+    self.configureWithPledgeViewDataProject.assertValues([project])
+    self.configureWithPledgeViewDataReward.assertValues([reward])
+
+    self.configureSummaryCellWithDataPledgeTotal.assertValues(
+      [reward.minimum, reward.minimum + shippingRule1.cost, shippingRule1.cost + amount1]
+    )
+    self.configureSummaryCellWithDataProject.assertValues([project, project, project])
+
+    let shippingRule2 = ShippingRule.template
+      |> ShippingRule.lens.cost .~ 123.0
+
+    self.vm.inputs.shippingRuleSelected(shippingRule2)
+
+    self.configureWithPledgeViewDataProject.assertValues([project])
+    self.configureWithPledgeViewDataReward.assertValues([reward])
+
+    self.configureSummaryCellWithDataPledgeTotal.assertValues(
+      [
+        reward.minimum,
+        reward.minimum + shippingRule1.cost,
+        shippingRule1.cost + amount1,
+        shippingRule2.cost + amount1
+      ]
+    )
+    self.configureSummaryCellWithDataProject.assertValues([project, project, project, project])
+
+    let amount2 = 1_999.0
+
+    self.vm.inputs.pledgeAmountDidUpdate(to: amount2)
+
+    self.configureWithPledgeViewDataProject.assertValues([project])
+    self.configureWithPledgeViewDataReward.assertValues([reward])
+
+    self.configureSummaryCellWithDataPledgeTotal.assertValues(
+      [
+        reward.minimum,
+        reward.minimum + shippingRule1.cost,
+        shippingRule1.cost + amount1,
+        shippingRule2.cost + amount1,
+        shippingRule2.cost + amount2
+      ]
+    )
+    self.configureSummaryCellWithDataProject.assertValues([project, project, project, project, project])
+  }
+
+  func testConfirmationLabelAttributedText() {
+    let project = Project.template
+    let reward = Reward.template
+      |> Reward.lens.shipping.enabled .~ false
+
+    self.confirmationLabelAttributedText.assertDidNotEmitValue()
+
+    self.vm.inputs.configureWith(project: project, reward: reward, refTag: .projectPage)
+    self.vm.inputs.viewDidLoad()
+
+    XCTAssertEqual(
+      self.confirmationLabelAttributedText.values.map { $0.string },
+      ["If the project reaches its funding goal, you will be charged on October 16, 2016."]
+    )
+
+    self.vm.inputs.traitCollectionDidChange()
+
+    XCTAssertEqual(
+      self.confirmationLabelAttributedText.values.map { $0.string },
+      [
+        "If the project reaches its funding goal, you will be charged on October 16, 2016.",
+        "If the project reaches its funding goal, you will be charged on October 16, 2016."
+      ]
+    )
+  }
+}


### PR DESCRIPTION
# 📲 What

Adds `UpdatePledgeViewController`, the UI and wires up of the VM outputs.

**Note:** Upcoming PR's will add the `updateBacking` mutation and the currency conversion below the total shown on [Abstract](https://app.goabstract.com/projects/a94cda80-1e60-11e8-8903-0b9b4e24ea4b/branches/master/collections/09e55cf7-092d-4126-bc77-f41f430d4578?collectionLayerId=3a41848b-988c-44eb-9c55-6ca845c88e77&mode=design).

# 🤔 Why

This is the UI work for what will eventually allow the user to update their pledge.

# 🛠 How

This does duplicate some functionality from `PledgeViewModel` unfortunately and I'm still somewhat in two minds about whether we should rather try to configure `PledgeViewModel` with a state/context that would hide and show the things that we don't want to see on this screen.

@ifbarrera and I chatted about this and leaned towards the new view model just because there's a ton of stuff in `PledgeViewModel` that is not needed here and also most of the views are nested VCs so the view itself is fairly straightforward.

Inviting thoughts on this!

# 👀 See

| Before 🐛 | After 🦋 |
| --- | --- |
| <img width="545" alt="image" src="https://user-images.githubusercontent.com/3735375/65636747-c0403580-df97-11e9-9448-791d519e7156.png"> | <img width="545" alt="image" src="https://user-images.githubusercontent.com/3735375/65636778-d64df600-df97-11e9-9236-c83ce5380ecc.png"> |

# ✅ Acceptance criteria

With the native pledge view feature flag enabled, navigate to a project you've backed which is still live, tap on `Manage`, select `Update Pledge` from the top-right context menu.

- [ ] The `UpdatePledgeViewController` is displayed.
- [ ] The stepper adjusts the amount.
- [ ] The amount can be adjusted via the text field.
- [ ] The shipping location can be changed and the total reflects this.
- [ ] The shipping location is not shown for rewards that do not have shipping enabled.
- [ ] Confirmation text appears above the `Confirm` button including the project's deadline.