### PR TITLE
Handling for Unsupported Cards

### DIFF
--- a/Kickstarter-iOS/Views/Controllers/AddNewCardViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/AddNewCardViewController.swift
@@ -265,7 +265,9 @@ internal final class AddNewCardViewController: UIViewController,
       .observeForUI()
       .observeValues { [weak self] cardNumber, projectCountry in
         guard let _self = self else { return }
-        _self.cardBrandIsSupported(projectCountry: projectCountry, cardNumber: cardNumber, supportedCardBrands: _self.unsupportedCardBrands)
+        _self.cardBrandIsSupported(projectCountry: projectCountry,
+                                   cardNumber: cardNumber,
+                                   supportedCardBrands: _self.unsupportedCardBrands)
     }
 
     Keyboard.change
@@ -355,7 +357,8 @@ internal final class AddNewCardViewController: UIViewController,
     }
   }
 
-  private func cardBrandIsSupported(projectCountry: Location, cardNumber: String, supportedCardBrands _: [STPCardBrand]) {
+  private func cardBrandIsSupported(projectCountry: Location,
+                                    cardNumber: String, supportedCardBrands _: [STPCardBrand]) {
         let country = projectCountry.country
         let brand = STPCardValidator.brand(forNumber: cardNumber)
 

--- a/Kickstarter-iOS/Views/Controllers/AddNewCardViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/AddNewCardViewController.swift
@@ -363,16 +363,16 @@ internal final class AddNewCardViewController: UIViewController,
     projectLocation: Location,
     cardNumber: String, supportedCardBrands _: [STPCardBrand]
   ) {
-    let country = projectLocation.country
-    let brand = STPCardValidator.brand(forNumber: cardNumber)
-
-    if country != "US", self.unsupportedCardBrands.contains(brand) {
-      self.viewModel.inputs.cardBrand(isValid: false)
-    } else if country != "US", self.supportedCardBrands.contains(brand) {
-      self.viewModel.inputs.cardBrand(isValid: true)
-    } else if country == "US", self.allCardBrands.contains(brand) {
-      self.viewModel.inputs.cardBrand(isValid: true)
-    }
+//    let country = projectLocation.country
+//    let brand = STPCardValidator.brand(forNumber: cardNumber)
+//
+//    if country != "US", self.unsupportedCardBrands.contains(brand) {
+//      self.viewModel.inputs.cardBrand(isValid: false)
+//    } else if country != "US", self.supportedCardBrands.contains(brand) {
+//      self.viewModel.inputs.cardBrand(isValid: true)
+//    } else if country == "US", self.allCardBrands.contains(brand) {
+//      self.viewModel.inputs.cardBrand(isValid: true)
+//    }
   }
 
   private func dismissAndPresentMessageBanner(with message: String) {

--- a/Kickstarter-iOS/Views/Controllers/AddNewCardViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/AddNewCardViewController.swift
@@ -142,7 +142,6 @@ internal final class AddNewCardViewController: UIViewController,
     _ = self.creditCardValidationErrorLabel
       |> settingsDescriptionLabelStyle
       |> \.textColor .~ .ksr_red_400
-      |> \.text %~ { _ in Strings.Unsupported_card_type() }
 
     _ = self.scrollView
       |> \.alwaysBounceVertical .~ true
@@ -172,6 +171,7 @@ internal final class AddNewCardViewController: UIViewController,
 
   override func bindViewModel() {
     super.bindViewModel()
+    self.creditCardValidationErrorLabel.rac.text = self.viewModel.outputs.unsupportedCardError
 
     self.rememberThisCardToggleViewControllerContainer.rac.hidden =
       self.viewModel.outputs.rememberThisCardToggleViewControllerContainerIsHidden

--- a/Kickstarter-iOS/Views/Controllers/AddNewCardViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/AddNewCardViewController.swift
@@ -265,10 +265,12 @@ internal final class AddNewCardViewController: UIViewController,
       .observeForUI()
       .observeValues { [weak self] cardNumber, projectCountry in
         guard let _self = self else { return }
-        _self.cardBrandIsSupported(projectCountry: projectCountry,
-                                   cardNumber: cardNumber,
-                                   supportedCardBrands: _self.unsupportedCardBrands)
-    }
+        _self.cardBrandIsSupported(
+          projectCountry: projectCountry,
+          cardNumber: cardNumber,
+          supportedCardBrands: _self.unsupportedCardBrands
+        )
+      }
 
     Keyboard.change
       .observeForUI()
@@ -357,18 +359,20 @@ internal final class AddNewCardViewController: UIViewController,
     }
   }
 
-  private func cardBrandIsSupported(projectCountry: Location,
-                                    cardNumber: String, supportedCardBrands _: [STPCardBrand]) {
-        let country = projectCountry.country
-        let brand = STPCardValidator.brand(forNumber: cardNumber)
+  private func cardBrandIsSupported(
+    projectCountry: Location,
+    cardNumber: String, supportedCardBrands _: [STPCardBrand]
+  ) {
+    let country = projectCountry.country
+    let brand = STPCardValidator.brand(forNumber: cardNumber)
 
-        if country != "US" && self.unsupportedCardBrands.contains(brand) {
-          self.viewModel.inputs.cardBrand(isValid: false)
-        } else if country != "US" && self.supportedCardBrands.contains(brand) {
-          self.viewModel.inputs.cardBrand(isValid: true)
-        } else if country == "US" && self.allCardBrands.contains(brand) {
-          self.viewModel.inputs.cardBrand(isValid: true)
-      }
+    if country != "US", self.unsupportedCardBrands.contains(brand) {
+      self.viewModel.inputs.cardBrand(isValid: false)
+    } else if country != "US", self.supportedCardBrands.contains(brand) {
+      self.viewModel.inputs.cardBrand(isValid: true)
+    } else if country == "US", self.allCardBrands.contains(brand) {
+      self.viewModel.inputs.cardBrand(isValid: true)
+    }
   }
 
   private func dismissAndPresentMessageBanner(with message: String) {

--- a/Kickstarter-iOS/Views/Controllers/AddNewCardViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/AddNewCardViewController.swift
@@ -30,28 +30,6 @@ internal final class AddNewCardViewController: UIViewController,
   @IBOutlet private var stackView: UIStackView!
   @IBOutlet private var zipcodeView: SettingsFormFieldView!
 
-  private let allCardBrands: [STPCardBrand] = [
-    .amex,
-    .dinersClub,
-    .discover,
-    .JCB,
-    .masterCard,
-    .unionPay,
-    .visa
-  ]
-
-  private let supportedCardBrands: [STPCardBrand] = [
-    .amex,
-    .masterCard,
-    .visa
-  ]
-
-  private let unsupportedCardBrands: [STPCardBrand] = [
-    .dinersClub,
-    .discover,
-    .JCB
-  ]
-
   private var saveButtonView: LoadingBarButtonItemView!
 
   internal var messageBannerViewController: MessageBannerViewController?
@@ -261,17 +239,6 @@ internal final class AddNewCardViewController: UIViewController,
         self?.zipcodeView.textField.becomeFirstResponder()
       }
 
-    self.viewModel.outputs.cardNumberAndProjectLocation
-      .observeForUI()
-      .observeValues { [weak self] cardNumber, location in
-        guard let _self = self else { return }
-        _self.cardBrandIsSupported(
-          projectLocation: location,
-          cardNumber: cardNumber,
-          supportedCardBrands: _self.unsupportedCardBrands
-        )
-      }
-
     Keyboard.change
       .observeForUI()
       .observeValues { [weak self] change in
@@ -357,22 +324,6 @@ internal final class AddNewCardViewController: UIViewController,
         self.viewModel.inputs.stripeError(error)
       }
     }
-  }
-
-  private func cardBrandIsSupported(
-    projectLocation: Location,
-    cardNumber: String, supportedCardBrands _: [STPCardBrand]
-  ) {
-//    let country = projectLocation.country
-//    let brand = STPCardValidator.brand(forNumber: cardNumber)
-//
-//    if country != "US", self.unsupportedCardBrands.contains(brand) {
-//      self.viewModel.inputs.cardBrand(isValid: false)
-//    } else if country != "US", self.supportedCardBrands.contains(brand) {
-//      self.viewModel.inputs.cardBrand(isValid: true)
-//    } else if country == "US", self.allCardBrands.contains(brand) {
-//      self.viewModel.inputs.cardBrand(isValid: true)
-//    }
   }
 
   private func dismissAndPresentMessageBanner(with message: String) {

--- a/Kickstarter-iOS/Views/Controllers/AddNewCardViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/AddNewCardViewController.swift
@@ -171,7 +171,7 @@ internal final class AddNewCardViewController: UIViewController,
 
   override func bindViewModel() {
     super.bindViewModel()
-    self.creditCardValidationErrorLabel.rac.text = self.viewModel.outputs.unsupportedCardError
+    self.creditCardValidationErrorLabel.rac.text = self.viewModel.outputs.unsupportedCardBrandError
 
     self.rememberThisCardToggleViewControllerContainer.rac.hidden =
       self.viewModel.outputs.rememberThisCardToggleViewControllerContainerIsHidden
@@ -261,12 +261,12 @@ internal final class AddNewCardViewController: UIViewController,
         self?.zipcodeView.textField.becomeFirstResponder()
       }
 
-    self.viewModel.outputs.cardNumberAndProjectCountry
+    self.viewModel.outputs.cardNumberAndProjectLocation
       .observeForUI()
-      .observeValues { [weak self] cardNumber, projectCountry in
+      .observeValues { [weak self] cardNumber, location in
         guard let _self = self else { return }
         _self.cardBrandIsSupported(
-          projectCountry: projectCountry,
+          projectLocation: location,
           cardNumber: cardNumber,
           supportedCardBrands: _self.unsupportedCardBrands
         )
@@ -360,10 +360,10 @@ internal final class AddNewCardViewController: UIViewController,
   }
 
   private func cardBrandIsSupported(
-    projectCountry: Location,
+    projectLocation: Location,
     cardNumber: String, supportedCardBrands _: [STPCardBrand]
   ) {
-    let country = projectCountry.country
+    let country = projectLocation.country
     let brand = STPCardValidator.brand(forNumber: cardNumber)
 
     if country != "US", self.unsupportedCardBrands.contains(brand) {

--- a/Kickstarter-iOS/Views/Controllers/PledgePaymentMethodsViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/PledgePaymentMethodsViewController.swift
@@ -142,7 +142,7 @@ final class PledgePaymentMethodsViewController: UIViewController {
         self?.updateSelectedCard(to: card)
       }
 
-    self.viewModel.outputs.newCardScreenConfig
+    self.viewModel.outputs.goToAddCardScreen
       .observeForUI()
       .observeValues { [weak self] intent, project in
         self?.goToAddNewCard(intent: intent, project: project)
@@ -254,7 +254,7 @@ extension PledgePaymentMethodsViewController: PledgeCreditCardViewDelegate {
 
 extension PledgePaymentMethodsViewController: PledgeAddNewCardViewDelegate {
   func pledgeAddNewCardView(_: PledgeAddNewCardView, didTapAddNewCardWith intent: AddNewCardIntent) {
-    self.viewModel.inputs.goToAddNewCardScreen(intent: intent)
+    self.viewModel.inputs.addNewCardTapped(with: intent)
   }
 }
 

--- a/Kickstarter-iOS/Views/Controllers/PledgePaymentMethodsViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/PledgePaymentMethodsViewController.swift
@@ -125,7 +125,6 @@ final class PledgePaymentMethodsViewController: UIViewController {
       .observeForUI()
       .observeValues { [weak self] in
         guard let self = self else { return }
-
         self.delegate?.pledgePaymentMethodsViewControllerDidTapApplePayButton(self)
       }
 
@@ -142,6 +141,12 @@ final class PledgePaymentMethodsViewController: UIViewController {
       .observeValues { [weak self] card in
         self?.updateSelectedCard(to: card)
       }
+
+    self.viewModel.outputs.newCardScreenConfig
+      .observeForUI()
+      .observeValues { [weak self] intent, project in
+        self?.goToAddNewCard(intent: intent, project: project)
+    }
 
     self.applePayButton.rac.hidden = self.viewModel.outputs.applePayButtonHidden
     self.pledgeButton.rac.enabled = self.viewModel.outputs.pledgeButtonEnabled
@@ -170,6 +175,16 @@ final class PledgePaymentMethodsViewController: UIViewController {
   }
 
   // MARK: - Functions
+
+  private func goToAddNewCard(intent: AddNewCardIntent, project: Project) {
+    let addNewCardViewController = AddNewCardViewController.instantiate()
+      |> \.delegate .~ self
+    addNewCardViewController.configure(with: intent, project: project)
+    let navigationController = UINavigationController.init(rootViewController: addNewCardViewController)
+    let offset = navigationController.navigationBar.bounds.height
+
+    self.presentViewControllerWithSheetOverlay(navigationController, offset: offset)
+  }
 
   private func reloadPaymentMethods(with cards: [GraphUserCreditCard.CreditCard]) {
     self.cardsStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
@@ -239,13 +254,7 @@ extension PledgePaymentMethodsViewController: PledgeCreditCardViewDelegate {
 
 extension PledgePaymentMethodsViewController: PledgeAddNewCardViewDelegate {
   func pledgeAddNewCardView(_: PledgeAddNewCardView, didTapAddNewCardWith intent: AddNewCardIntent) {
-    let addNewCardViewController = AddNewCardViewController.instantiate()
-      |> \.delegate .~ self
-    addNewCardViewController.configure(with: intent)
-    let navigationController = UINavigationController.init(rootViewController: addNewCardViewController)
-    let offset = navigationController.navigationBar.bounds.height
-
-    self.presentViewControllerWithSheetOverlay(navigationController, offset: offset)
+    self.viewModel.inputs.goToAddNewCardScreen(intent: intent)
   }
 }
 

--- a/Kickstarter-iOS/Views/Controllers/PledgePaymentMethodsViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/PledgePaymentMethodsViewController.swift
@@ -146,7 +146,7 @@ final class PledgePaymentMethodsViewController: UIViewController {
       .observeForUI()
       .observeValues { [weak self] intent, project in
         self?.goToAddNewCard(intent: intent, project: project)
-    }
+      }
 
     self.applePayButton.rac.hidden = self.viewModel.outputs.applePayButtonHidden
     self.pledgeButton.rac.enabled = self.viewModel.outputs.pledgeButtonEnabled

--- a/Library/ViewModels/AddNewCardViewModel.swift
+++ b/Library/ViewModels/AddNewCardViewModel.swift
@@ -78,7 +78,7 @@ public final class AddNewCardViewModel: AddNewCardViewModelType, AddNewCardViewM
     let zipcode = self.zipcodeProperty.signal.skipNil()
     let zipcodeIsValid: Signal<Bool, Never> = zipcode.map { !$0.isEmpty }
 
-    let projectCountry = projectProperty.signal
+    let projectCountry = self.projectProperty.signal
       .skipNil()
       .map { $0.location }
 
@@ -186,12 +186,13 @@ public final class AddNewCardViewModel: AddNewCardViewModelType, AddNewCardViewM
       projectCountry
     )
 
-    self.unsupportedCardError = Signal.combineLatest(projectCountry, cardBrandIsValidProperty.signal)
+    self.unsupportedCardError = Signal.combineLatest(projectCountry, self.cardBrandIsValidProperty.signal)
       .map { projectCountry, isValid in
         projectCountry.country != "US" && !isValid ?
           Strings.You_cant_use_this_credit_card_to_back_a_project_from_project_country(
-            project_country: projectCountry.displayableName) : Strings.Unsupported_card_type()
-    }
+            project_country: projectCountry.displayableName
+          ) : Strings.Unsupported_card_type()
+      }
 
     // Koala
     self.viewWillAppearProperty.signal

--- a/Library/ViewModels/AddNewCardViewModel.swift
+++ b/Library/ViewModels/AddNewCardViewModel.swift
@@ -43,6 +43,7 @@ public protocol AddNewCardViewModelOutputs {
   var rememberThisCardToggleViewControllerIsOn: Signal<Bool, Never> { get }
   var saveButtonIsEnabled: Signal<Bool, Never> { get }
   var setStripePublishableKey: Signal<String, Never> { get }
+  var unsupportedCardError: Signal<String, Never> { get }
   var zipcodeTextFieldBecomeFirstResponder: Signal<Void, Never> { get }
 }
 
@@ -185,6 +186,13 @@ public final class AddNewCardViewModel: AddNewCardViewModelType, AddNewCardViewM
       projectCountry
     )
 
+    self.unsupportedCardError = Signal.combineLatest(projectCountry, cardBrandIsValidProperty.signal)
+      .map { projectCountry, isValid in
+        projectCountry.country != "US" && !isValid ?
+          Strings.You_cant_use_this_credit_card_to_back_a_project_from_project_country(
+            project_country: projectCountry.displayableName) : Strings.Unsupported_card_type()
+    }
+
     // Koala
     self.viewWillAppearProperty.signal
       .observeValues {
@@ -290,6 +298,7 @@ public final class AddNewCardViewModel: AddNewCardViewModelType, AddNewCardViewM
   public var rememberThisCardToggleViewControllerIsOn: Signal<Bool, Never>
   public let saveButtonIsEnabled: Signal<Bool, Never>
   public let setStripePublishableKey: Signal<String, Never>
+  public let unsupportedCardError: Signal<String, Never>
   public let zipcodeTextFieldBecomeFirstResponder: Signal<Void, Never>
 
   public var inputs: AddNewCardViewModelInputs { return self }

--- a/Library/ViewModels/AddNewCardViewModel.swift
+++ b/Library/ViewModels/AddNewCardViewModel.swift
@@ -78,7 +78,7 @@ public final class AddNewCardViewModel: AddNewCardViewModelType, AddNewCardViewM
     let zipcodeIsValid: Signal<Bool, Never> = zipcode.map { !$0.isEmpty }
 
     let project = self.addNewCardIntentAndProjectProperty.signal.skipNil()
-      .map { $0.1 }.skipNil()
+      .map { $0.1 }
 
 
     let cardBrandIsValid = Signal.combineLatest(
@@ -97,7 +97,7 @@ public final class AddNewCardViewModel: AddNewCardViewModelType, AddNewCardViewM
         brandValid || cardNumber.count < 2
     }
 
-    self.unsupportedCardBrandError = Signal.combineLatest(cardBrandIsValid, project)
+    self.unsupportedCardBrandError = Signal.combineLatest(cardBrandIsValid, project.skipNil())
       .map { _, project in
         Strings.You_cant_use_this_credit_card_to_back_a_project_from_project_country(
           project_country: project.location.displayableName
@@ -297,7 +297,9 @@ public final class AddNewCardViewModel: AddNewCardViewModelType, AddNewCardViewM
   public var outputs: AddNewCardViewModelOutputs { return self }
 }
 
-private func cardBrandIsSupported(project: Project, cardNumber: String) -> Bool {
+private func cardBrandIsSupported(project: Project?, cardNumber: String) -> Bool {
+  guard let project = project else { return true }
+
   let allOthers = project.location.country != Project.Country.us.countryCode
   let brand = STPCardValidator.brand(forNumber: cardNumber)
 

--- a/Library/ViewModels/PledgePaymentMethodsViewModel.swift
+++ b/Library/ViewModels/PledgePaymentMethodsViewModel.swift
@@ -13,7 +13,7 @@ public protocol PledgePaymentMethodsViewModelInputs {
   func updatePledgeButtonEnabled(isEnabled: Bool)
   func addNewCardViewControllerDidAdd(newCard card: GraphUserCreditCard.CreditCard)
   func viewDidLoad()
-  func goToAddNewCardScreen(intent: AddNewCardIntent)
+  func addNewCardTapped(with intent: AddNewCardIntent)
 }
 
 public protocol PledgePaymentMethodsViewModelOutputs {
@@ -24,7 +24,7 @@ public protocol PledgePaymentMethodsViewModelOutputs {
   var pledgeButtonEnabled: Signal<Bool, Never> { get }
   var reloadPaymentMethods: Signal<[GraphUserCreditCard.CreditCard], Never> { get }
   var updateSelectedCreditCard: Signal<GraphUserCreditCard.CreditCard, Never> { get }
-  var newCardScreenConfig: Signal<(AddNewCardIntent, Project), Never> { get }
+  var goToAddCardScreen: Signal<(AddNewCardIntent, Project), Never> { get }
 }
 
 public protocol PledgePaymentMethodsViewModelType {
@@ -85,7 +85,7 @@ public final class PledgePaymentMethodsViewModel: PledgePaymentMethodsViewModelT
 
     let project = configureWithValue.map { $0.project }
 
-    self.newCardScreenConfig = Signal.combineLatest(self.intentProperty.signal.skipNil(), project)
+    self.goToAddCardScreen = Signal.combineLatest(self.addNewCardIntentProperty.signal.skipNil(), project)
   }
 
   private let applePayButtonTappedProperty = MutableProperty(())
@@ -113,9 +113,9 @@ public final class PledgePaymentMethodsViewModel: PledgePaymentMethodsViewModelT
     self.newCreditCardProperty.value = card
   }
 
-  private let intentProperty = MutableProperty<AddNewCardIntent?>(nil)
-  public func goToAddNewCardScreen(intent: AddNewCardIntent) {
-    self.intentProperty.value = intent
+  private let addNewCardIntentProperty = MutableProperty<AddNewCardIntent?>(nil)
+  public func addNewCardTapped(with intent: AddNewCardIntent) {
+    self.addNewCardIntentProperty.value = intent
   }
 
   private let viewDidLoadProperty = MutableProperty(())
@@ -123,17 +123,17 @@ public final class PledgePaymentMethodsViewModel: PledgePaymentMethodsViewModelT
     self.viewDidLoadProperty.value = ()
   }
 
-  public var inputs: PledgePaymentMethodsViewModelInputs { return self }
-  public var outputs: PledgePaymentMethodsViewModelOutputs { return self }
-
   public let notifyDelegateApplePayButtonTapped: Signal<Void, Never>
   public let applePayButtonHidden: Signal<Bool, Never>
+  public let goToAddCardScreen: Signal<(AddNewCardIntent, Project), Never>
   public let notifyDelegateCreditCardSelected: Signal<String, Never>
   public let notifyDelegateLoadPaymentMethodsError: Signal<String, Never>
   public let pledgeButtonEnabled: Signal<Bool, Never>
   public let reloadPaymentMethods: Signal<[GraphUserCreditCard.CreditCard], Never>
   public let updateSelectedCreditCard: Signal<GraphUserCreditCard.CreditCard, Never>
-  public let newCardScreenConfig: Signal<(AddNewCardIntent, Project), Never>
+
+  public var inputs: PledgePaymentMethodsViewModelInputs { return self }
+  public var outputs: PledgePaymentMethodsViewModelOutputs { return self }
 }
 
 private func showApplePayButton(for project: Project, applePayCapable: Bool) -> Bool {

--- a/Library/ViewModels/PledgePaymentMethodsViewModel.swift
+++ b/Library/ViewModels/PledgePaymentMethodsViewModel.swift
@@ -85,7 +85,7 @@ public final class PledgePaymentMethodsViewModel: PledgePaymentMethodsViewModelT
 
     let project = configureWithValue.map { $0.project }
 
-    self.newCardScreenConfig = Signal.combineLatest(intentProperty.signal.skipNil(), project)
+    self.newCardScreenConfig = Signal.combineLatest(self.intentProperty.signal.skipNil(), project)
   }
 
   private let applePayButtonTappedProperty = MutableProperty(())

--- a/Library/ViewModels/PledgePaymentMethodsViewModel.swift
+++ b/Library/ViewModels/PledgePaymentMethodsViewModel.swift
@@ -18,13 +18,13 @@ public protocol PledgePaymentMethodsViewModelInputs {
 
 public protocol PledgePaymentMethodsViewModelOutputs {
   var applePayButtonHidden: Signal<Bool, Never> { get }
+  var goToAddCardScreen: Signal<(AddNewCardIntent, Project), Never> { get }
   var notifyDelegateApplePayButtonTapped: Signal<Void, Never> { get }
   var notifyDelegateCreditCardSelected: Signal<String, Never> { get }
   var notifyDelegateLoadPaymentMethodsError: Signal<String, Never> { get }
   var pledgeButtonEnabled: Signal<Bool, Never> { get }
   var reloadPaymentMethods: Signal<[GraphUserCreditCard.CreditCard], Never> { get }
   var updateSelectedCreditCard: Signal<GraphUserCreditCard.CreditCard, Never> { get }
-  var goToAddCardScreen: Signal<(AddNewCardIntent, Project), Never> { get }
 }
 
 public protocol PledgePaymentMethodsViewModelType {

--- a/Library/ViewModels/PledgePaymentMethodsViewModel.swift
+++ b/Library/ViewModels/PledgePaymentMethodsViewModel.swift
@@ -13,6 +13,7 @@ public protocol PledgePaymentMethodsViewModelInputs {
   func updatePledgeButtonEnabled(isEnabled: Bool)
   func addNewCardViewControllerDidAdd(newCard card: GraphUserCreditCard.CreditCard)
   func viewDidLoad()
+  func goToAddNewCardScreen(intent: AddNewCardIntent)
 }
 
 public protocol PledgePaymentMethodsViewModelOutputs {
@@ -23,6 +24,7 @@ public protocol PledgePaymentMethodsViewModelOutputs {
   var pledgeButtonEnabled: Signal<Bool, Never> { get }
   var reloadPaymentMethods: Signal<[GraphUserCreditCard.CreditCard], Never> { get }
   var updateSelectedCreditCard: Signal<GraphUserCreditCard.CreditCard, Never> { get }
+  var newCardScreenConfig: Signal<(AddNewCardIntent, Project), Never> { get }
 }
 
 public protocol PledgePaymentMethodsViewModelType {
@@ -80,6 +82,10 @@ public final class PledgePaymentMethodsViewModel: PledgePaymentMethodsViewModelT
       .takePairWhen(self.creditCardSelectedSignal)
       .map { cards, id in cards.filter { $0.id == id }.first }
       .skipNil()
+
+    let project = configureWithValue.map { $0.project }
+
+    self.newCardScreenConfig = Signal.combineLatest(intentProperty.signal.skipNil(), project)
   }
 
   private let applePayButtonTappedProperty = MutableProperty(())
@@ -107,6 +113,11 @@ public final class PledgePaymentMethodsViewModel: PledgePaymentMethodsViewModelT
     self.newCreditCardProperty.value = card
   }
 
+  private let intentProperty = MutableProperty<AddNewCardIntent?>(nil)
+  public func goToAddNewCardScreen(intent: AddNewCardIntent) {
+    self.intentProperty.value = intent
+  }
+
   private let viewDidLoadProperty = MutableProperty(())
   public func viewDidLoad() {
     self.viewDidLoadProperty.value = ()
@@ -122,6 +133,7 @@ public final class PledgePaymentMethodsViewModel: PledgePaymentMethodsViewModelT
   public let pledgeButtonEnabled: Signal<Bool, Never>
   public let reloadPaymentMethods: Signal<[GraphUserCreditCard.CreditCard], Never>
   public let updateSelectedCreditCard: Signal<GraphUserCreditCard.CreditCard, Never>
+  public let newCardScreenConfig: Signal<(AddNewCardIntent, Project), Never>
 }
 
 private func showApplePayButton(for project: Project, applePayCapable: Bool) -> Bool {

--- a/Library/ViewModels/PledgePaymentMethodsViewModelTests.swift
+++ b/Library/ViewModels/PledgePaymentMethodsViewModelTests.swift
@@ -9,6 +9,8 @@ final class PledgePaymentMethodsViewModelTests: TestCase {
   private let vm: PledgePaymentMethodsViewModelType = PledgePaymentMethodsViewModel()
 
   private let applePayButtonHidden = TestObserver<Bool, Never>()
+  private let goToAddCardIntent = TestObserver<AddNewCardIntent, Never>()
+  private let goToProject = TestObserver<Project, Never>()
   private let notifyDelegateApplePayButtonTapped = TestObserver<Void, Never>()
   private let notifyDelegateCreditCardSelected = TestObserver<String, Never>()
   private let notifyDelegateLoadPaymentMethodsError = TestObserver<String, Never>()
@@ -19,6 +21,8 @@ final class PledgePaymentMethodsViewModelTests: TestCase {
   override func setUp() {
     super.setUp()
     self.vm.outputs.applePayButtonHidden.observe(self.applePayButtonHidden.observer)
+    self.vm.outputs.goToAddCardScreen.map(first).observe(self.goToAddCardIntent.observer)
+    self.vm.outputs.goToAddCardScreen.map(second).observe(self.goToProject.observer)
     self.vm.outputs.notifyDelegateApplePayButtonTapped
       .observe(self.notifyDelegateApplePayButtonTapped.observer)
     self.vm.outputs.notifyDelegateCreditCardSelected
@@ -254,5 +258,16 @@ final class PledgePaymentMethodsViewModelTests: TestCase {
     self.vm.inputs.updatePledgeButtonEnabled(isEnabled: false)
 
     self.pledgeButtonEnabled.assertValues([false, true, false])
+  }
+
+  func testGoToAddNewCard() {
+    let project = Project.template
+
+    self.vm.inputs.configureWith((User.template, project, true))
+    self.vm.inputs.viewDidLoad()
+
+    self.vm.inputs.addNewCardTapped(with: .pledge)
+    self.goToAddCardIntent.assertValues([.pledge])
+    self.goToProject.assertValues([project])
   }
 }


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Users now know why they cannot add an unsupported card when adding a new card from the pledge flow.

# 🤔 Why
Users will not add an unsupported card and know to add a different card.

# 🛠 How

When adding a new card from the pledge flow add new card screen is now configured with the project. Also removed card brand validation logic from the `AddNewCardViewController` .

# 👀 See

![handling-unsupported-cards](https://user-images.githubusercontent.com/11362005/66060373-862ce180-e50b-11e9-83b0-c793d0a8f61c.gif)

# ✅ Acceptance criteria

- [ ] Navigate to a non-US project location. Back a project using a test `JCB`, `Discovery`,  or` Diners Club` [Stripe Test Cards](https://stripe.com/docs/testing)
- [ ] Error should appear stating the project location
