### PR TITLE
[NT-329] Show alert when using invalid pledge amount with Apple Pay

### DIFF
--- a/Kickstarter-iOS/Views/Controllers/PledgeViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/PledgeViewController.swift
@@ -289,6 +289,12 @@ final class PledgeViewController: UIViewController, MessageBannerViewControllerP
       .observeValues { [weak self] errorMessage in
         self?.messageBannerViewController?.showBanner(with: .error, message: errorMessage)
       }
+
+    self.viewModel.outputs.showApplePayAlert
+      .observeForControllerAction()
+      .observeValues { [weak self] title, message in
+        self?.presentApplePayInvalidAmountAlert(title: title, message: message)
+    }
   }
 
   private func goToPaymentAuthorization(_ paymentAuthorizationData: PaymentAuthorizationData) {
@@ -312,6 +318,10 @@ final class PledgeViewController: UIViewController, MessageBannerViewControllerP
   private func goToThanks(project: Project) {
     let thanksVC = ThanksViewController.configuredWith(project: project)
     self.navigationController?.pushViewController(thanksVC, animated: true)
+  }
+
+  private func presentApplePayInvalidAmountAlert(title: String, message: String) {
+    self.present(UIAlertController.alert(title, message: message), animated: true)
   }
 
   // MARK: - Actions

--- a/Kickstarter-iOS/Views/Controllers/PledgeViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/PledgeViewController.swift
@@ -294,7 +294,7 @@ final class PledgeViewController: UIViewController, MessageBannerViewControllerP
       .observeForControllerAction()
       .observeValues { [weak self] title, message in
         self?.presentApplePayInvalidAmountAlert(title: title, message: message)
-    }
+      }
   }
 
   private func goToPaymentAuthorization(_ paymentAuthorizationData: PaymentAuthorizationData) {

--- a/Library/ViewModels/ChangeEmailViewModel.swift
+++ b/Library/ViewModels/ChangeEmailViewModel.swift
@@ -55,7 +55,7 @@ public final class ChangeEmailViewModel: ChangeEmailViewModelType, ChangeEmailVi
 
     let triggerSaveAction = self.saveButtonEnabledProperty.signal
       .takeWhen(self.dismissKeyboard)
-      .filter { isTrue($0) }
+      .filter(isTrue)
       .ignoreValues()
 
     let changeEmailEvent = Signal.combineLatest(

--- a/Library/ViewModels/ChangePasswordViewModel.swift
+++ b/Library/ViewModels/ChangePasswordViewModel.swift
@@ -69,7 +69,7 @@ public class ChangePasswordViewModel: ChangePasswordViewModelType,
 
     let autoSaveSignal = self.saveButtonIsEnabled
       .takeWhen(self.confirmNewPasswordDoneEditingProperty.signal)
-      .filter { isTrue($0) }
+      .filter(isTrue)
       .ignoreValues()
 
     let triggerSaveAction = Signal.merge(autoSaveSignal, self.saveButtonTappedProperty.signal)

--- a/Library/ViewModels/PledgeAmountViewModel.swift
+++ b/Library/ViewModels/PledgeAmountViewModel.swift
@@ -18,7 +18,7 @@ public protocol PledgeAmountViewModelInputs {
 }
 
 public protocol PledgeAmountViewModelOutputs {
-  var amount: Signal<(Double, Bool), Never> { get }
+  var amount: Signal<(Double, Double, Double, Bool), Never> { get }
   var currency: Signal<String, Never> { get }
   var doneButtonIsEnabled: Signal<Bool, Never> { get }
   var generateSelectionFeedback: Signal<Void, Never> { get }
@@ -133,11 +133,11 @@ public final class PledgeAmountViewModel: PledgeAmountViewModelType,
 
     self.amount = updatedValue
       .map { min, max, value in
-        (rounded(value), min <= value && value <= max)
+        (rounded(value), min, max, min <= value && value <= max)
       }
 
     let isValueValid = self.amount
-      .map(second)
+      .map { $0.3 }
       .skipRepeats()
 
     self.doneButtonIsEnabled = isValueValid
@@ -167,7 +167,7 @@ public final class PledgeAmountViewModel: PledgeAmountViewModelType,
 
     self.stepperValue = Signal.merge(
       minValue,
-      self.amount.map(first)
+      self.amount.map { $0.0 }
     )
     .skipRepeats()
 
@@ -203,7 +203,7 @@ public final class PledgeAmountViewModel: PledgeAmountViewModelType,
     self.textFieldValueProperty.value = value
   }
 
-  public let amount: Signal<(Double, Bool), Never>
+  public let amount: Signal<(Double, Double, Double, Bool), Never>
   public let currency: Signal<String, Never>
   public let doneButtonIsEnabled: Signal<Bool, Never>
   public let generateSelectionFeedback: Signal<Void, Never>

--- a/Library/ViewModels/PledgeAmountViewModel.swift
+++ b/Library/ViewModels/PledgeAmountViewModel.swift
@@ -18,7 +18,7 @@ public protocol PledgeAmountViewModelInputs {
 }
 
 public protocol PledgeAmountViewModelOutputs {
-  var amount: Signal<(Double, Double, Double, Bool), Never> { get }
+  var amount: Signal<PledgeAmountData, Never> { get }
   var currency: Signal<String, Never> { get }
   var doneButtonIsEnabled: Signal<Bool, Never> { get }
   var generateSelectionFeedback: Signal<Void, Never> { get }
@@ -203,7 +203,7 @@ public final class PledgeAmountViewModel: PledgeAmountViewModelType,
     self.textFieldValueProperty.value = value
   }
 
-  public let amount: Signal<(Double, Double, Double, Bool), Never>
+  public let amount: Signal<PledgeAmountData, Never>
   public let currency: Signal<String, Never>
   public let doneButtonIsEnabled: Signal<Bool, Never>
   public let generateSelectionFeedback: Signal<Void, Never>

--- a/Library/ViewModels/PledgeAmountViewModelTests.swift
+++ b/Library/ViewModels/PledgeAmountViewModelTests.swift
@@ -29,10 +29,10 @@ internal final class PledgeAmountViewModelTests: TestCase {
   override func setUp() {
     super.setUp()
 
-    self.vm.outputs.amount.map { $0.3 }.observe(self.amountIsValid.observer)
-    self.vm.outputs.amount.map { $0.2 }.observe(self.amountMax.observer)
-    self.vm.outputs.amount.map { $0.1 }.observe(self.amountMin.observer)
-    self.vm.outputs.amount.map { $0.0 }.observe(self.amountValue.observer)
+    self.vm.outputs.amount.map { $0.isValid }.observe(self.amountIsValid.observer)
+    self.vm.outputs.amount.map { $0.max }.observe(self.amountMax.observer)
+    self.vm.outputs.amount.map { $0.min }.observe(self.amountMin.observer)
+    self.vm.outputs.amount.map { $0.amount }.observe(self.amountValue.observer)
     self.vm.outputs.currency.observe(self.currency.observer)
     self.vm.outputs.doneButtonIsEnabled.observe(self.doneButtonIsEnabled.observer)
     self.vm.outputs.generateSelectionFeedback.observe(self.generateSelectionFeedback.observer)

--- a/Library/ViewModels/PledgeAmountViewModelTests.swift
+++ b/Library/ViewModels/PledgeAmountViewModelTests.swift
@@ -8,6 +8,8 @@ internal final class PledgeAmountViewModelTests: TestCase {
   private let vm: PledgeAmountViewModelType = PledgeAmountViewModel()
 
   private let amountIsValid = TestObserver<Bool, Never>()
+  private let amountMax = TestObserver<Double, Never>()
+  private let amountMin = TestObserver<Double, Never>()
   private let amountValue = TestObserver<Double, Never>()
   private let currency = TestObserver<String, Never>()
   private let doneButtonIsEnabled = TestObserver<Bool, Never>()
@@ -27,8 +29,10 @@ internal final class PledgeAmountViewModelTests: TestCase {
   override func setUp() {
     super.setUp()
 
-    self.vm.outputs.amount.map(second).observe(self.amountIsValid.observer)
-    self.vm.outputs.amount.map(first).observe(self.amountValue.observer)
+    self.vm.outputs.amount.map { $0.3 }.observe(self.amountIsValid.observer)
+    self.vm.outputs.amount.map { $0.2 }.observe(self.amountMax.observer)
+    self.vm.outputs.amount.map { $0.1 }.observe(self.amountMin.observer)
+    self.vm.outputs.amount.map { $0.0 }.observe(self.amountValue.observer)
     self.vm.outputs.currency.observe(self.currency.observer)
     self.vm.outputs.doneButtonIsEnabled.observe(self.doneButtonIsEnabled.observer)
     self.vm.outputs.generateSelectionFeedback.observe(self.generateSelectionFeedback.observer)
@@ -61,6 +65,8 @@ internal final class PledgeAmountViewModelTests: TestCase {
     self.vm.inputs.configureWith(project: project, reward: Reward.postcards)
 
     self.amountIsValid.assertValues([true])
+    self.amountMin.assertValues([6])
+    self.amountMax.assertValues([10_000])
     self.amountValue.assertValues([690])
     self.currency.assertValues(["$"])
     self.stepperMinValue.assertValue(PledgeAmountStepperConstants.min)
@@ -74,6 +80,8 @@ internal final class PledgeAmountViewModelTests: TestCase {
     self.vm.inputs.configureWith(project: .template, reward: Reward.noReward)
 
     self.amountIsValid.assertValues([true])
+    self.amountMin.assertValues([1])
+    self.amountMax.assertValues([10_000])
     self.amountValue.assertValues([1])
     self.currency.assertValues(["$"])
     self.stepperMinValue.assertValue(PledgeAmountStepperConstants.min)
@@ -90,6 +98,8 @@ internal final class PledgeAmountViewModelTests: TestCase {
     self.vm.inputs.configureWith(project: project, reward: Reward.noReward)
 
     self.amountIsValid.assertValues([true])
+    self.amountMin.assertValues([10])
+    self.amountMax.assertValues([200_000])
     self.amountValue.assertValues([10])
     self.currency.assertValues(["MX$"])
     self.stepperMinValue.assertValue(PledgeAmountStepperConstants.min)
@@ -109,6 +119,8 @@ internal final class PledgeAmountViewModelTests: TestCase {
     self.vm.inputs.configureWith(project: project, reward: Reward.noReward)
 
     self.amountIsValid.assertValues([true])
+    self.amountMin.assertValues([1])
+    self.amountMax.assertValues([10_000])
     self.amountValue.assertValues([1])
     self.currency.assertValues(["$"])
     self.stepperMinValue.assertValue(PledgeAmountStepperConstants.min)
@@ -122,6 +134,8 @@ internal final class PledgeAmountViewModelTests: TestCase {
     self.vm.inputs.configureWith(project: .template, reward: .template)
 
     self.amountIsValid.assertValues([true])
+    self.amountMin.assertValues([10])
+    self.amountMax.assertValues([10_000])
     self.amountValue.assertValues([10])
     self.currency.assertValues(["$"])
     self.stepperMinValue.assertValue(PledgeAmountStepperConstants.min)
@@ -141,6 +155,8 @@ internal final class PledgeAmountViewModelTests: TestCase {
     self.vm.inputs.configureWith(project: project, reward: reward)
 
     self.amountIsValid.assertValues([true])
+    self.amountMin.assertValues([200])
+    self.amountMax.assertValues([1_200_000])
     self.amountValue.assertValues([200])
     self.currency.assertValues(["¥"])
     self.stepperMinValue.assertValue(PledgeAmountStepperConstants.min)
@@ -791,22 +807,32 @@ internal final class PledgeAmountViewModelTests: TestCase {
     self.vm.inputs.configureWith(project: .template, reward: .template)
 
     self.amountIsValid.assertValues([true])
+    self.amountMin.assertValues([10])
+    self.amountMax.assertValues([10_000])
     self.amountValue.assertValue(10)
 
     self.vm.inputs.textFieldValueChanged("11")
     self.amountIsValid.assertValues([true, true])
+    self.amountMin.assertValues([10, 10])
+    self.amountMax.assertValues([10_000, 10_000])
     self.amountValue.assertValues([10, 11])
 
     self.vm.inputs.textFieldValueChanged("")
     self.amountIsValid.assertValues([true, true, false])
+    self.amountMin.assertValues([10, 10, 10])
+    self.amountMax.assertValues([10_000, 10_000, 10_000])
     self.amountValue.assertValues([10, 11, 0])
 
     self.vm.inputs.textFieldValueChanged("5")
     self.amountIsValid.assertValues([true, true, false, false])
+    self.amountMin.assertValues([10, 10, 10, 10])
+    self.amountMax.assertValues([10_000, 10_000, 10_000, 10_000])
     self.amountValue.assertValues([10, 11, 0, 5])
 
     self.vm.inputs.textFieldValueChanged(nil)
     self.amountIsValid.assertValues([true, true, false, false, false])
+    self.amountMin.assertValues([10, 10, 10, 10, 10])
+    self.amountMax.assertValues([10_000, 10_000, 10_000, 10_000, 10_000])
     self.amountValue.assertValues([10, 11, 0, 5, 0])
   }
 
@@ -816,36 +842,50 @@ internal final class PledgeAmountViewModelTests: TestCase {
 
     self.vm.inputs.configureWith(project: .template, reward: .template)
     self.amountIsValid.assertValues([true])
+    self.amountMin.assertValues([10])
+    self.amountMax.assertValues([10_000])
     self.amountValue.assertValues([10])
     self.textFieldValue.assertValues(["10"])
 
     self.vm.inputs.textFieldDidEndEditing(nil)
     self.amountIsValid.assertValues([true])
+    self.amountMin.assertValues([10])
+    self.amountMax.assertValues([10_000])
     self.amountValue.assertValues([10])
     self.textFieldValue.assertValues(["10"])
 
     self.vm.inputs.textFieldDidEndEditing("16")
     self.amountIsValid.assertValues([true, true])
+    self.amountMin.assertValues([10, 10])
+    self.amountMax.assertValues([10_000, 10_000])
     self.amountValue.assertValues([10, 16])
     self.textFieldValue.assertValues(["10", "16"])
 
     self.vm.inputs.textFieldDidEndEditing(String(maxValue))
     self.amountIsValid.assertValues([true, true, false])
+    self.amountMin.assertValues([10, 10, 10])
+    self.amountMax.assertValues([10_000, 10_000, 10_000])
     self.amountValue.assertValues([10, 16, maxValue])
     self.textFieldValue.assertValues(["10", "16", maxValueFormatted])
 
     self.vm.inputs.textFieldDidEndEditing("0")
     self.amountIsValid.assertValues([true, true, false, false])
+    self.amountMin.assertValues([10, 10, 10, 10])
+    self.amountMax.assertValues([10_000, 10_000, 10_000, 10_000])
     self.amountValue.assertValues([10, 16, maxValue, 0])
     self.textFieldValue.assertValues(["10", "16", maxValueFormatted, "0"])
 
     self.vm.inputs.textFieldDidEndEditing("17")
     self.amountIsValid.assertValues([true, true, false, false, true])
+    self.amountMin.assertValues([10, 10, 10, 10, 10])
+    self.amountMax.assertValues([10_000, 10_000, 10_000, 10_000, 10_000])
     self.amountValue.assertValues([10, 16, maxValue, 0, 17])
     self.textFieldValue.assertValues(["10", "16", maxValueFormatted, "0", "17"])
 
     self.vm.inputs.textFieldDidEndEditing("")
     self.amountIsValid.assertValues([true, true, false, false, true])
+    self.amountMin.assertValues([10, 10, 10, 10, 10])
+    self.amountMax.assertValues([10_000, 10_000, 10_000, 10_000, 10_000])
     self.amountValue.assertValues([10, 16, maxValue, 0, 17])
     self.textFieldValue.assertValues(["10", "16", maxValueFormatted, "0", "17"])
   }
@@ -882,6 +922,8 @@ internal final class PledgeAmountViewModelTests: TestCase {
     self.vm.inputs.configureWith(project: .template, reward: .template)
 
     self.amountIsValid.assertValues([true])
+    self.amountMin.assertValues([10])
+    self.amountMax.assertValues([10_000])
     self.amountValue.assertValues([10])
     self.doneButtonIsEnabled.assertValues([true])
     self.labelTextColor.assertValues([green])
@@ -890,6 +932,8 @@ internal final class PledgeAmountViewModelTests: TestCase {
 
     self.vm.inputs.textFieldValueChanged("10")
     self.amountIsValid.assertValues([true, true])
+    self.amountMin.assertValues([10, 10])
+    self.amountMax.assertValues([10_000, 10_000])
     self.amountValue.assertValues([10, 10])
     self.doneButtonIsEnabled.assertValues([true])
     self.labelTextColor.assertValues([green])
@@ -898,6 +942,8 @@ internal final class PledgeAmountViewModelTests: TestCase {
 
     self.vm.inputs.textFieldValueChanged("10.")
     self.amountIsValid.assertValues([true, true, true])
+    self.amountMin.assertValues([10, 10, 10])
+    self.amountMax.assertValues([10_000, 10_000, 10_000])
     self.amountValue.assertValues([10, 10, 10])
     self.doneButtonIsEnabled.assertValues([true])
     self.labelTextColor.assertValues([green])
@@ -906,6 +952,8 @@ internal final class PledgeAmountViewModelTests: TestCase {
 
     self.vm.inputs.textFieldValueChanged("10.0")
     self.amountIsValid.assertValues([true, true, true, true])
+    self.amountMin.assertValues([10, 10, 10, 10])
+    self.amountMax.assertValues([10_000, 10_000, 10_000, 10_000])
     self.amountValue.assertValues([10, 10, 10, 10])
     self.doneButtonIsEnabled.assertValues([true])
     self.labelTextColor.assertValues([green])
@@ -914,6 +962,8 @@ internal final class PledgeAmountViewModelTests: TestCase {
 
     self.vm.inputs.textFieldValueChanged("10.00")
     self.amountIsValid.assertValues([true, true, true, true, true])
+    self.amountMin.assertValues([10, 10, 10, 10, 10])
+    self.amountMax.assertValues([10_000, 10_000, 10_000, 10_000, 10_000])
     self.amountValue.assertValues([10, 10, 10, 10, 10])
     self.doneButtonIsEnabled.assertValues([true])
     self.labelTextColor.assertValues([green])
@@ -922,6 +972,8 @@ internal final class PledgeAmountViewModelTests: TestCase {
 
     self.vm.inputs.textFieldValueChanged("10.01")
     self.amountIsValid.assertValues([true, true, true, true, true, true])
+    self.amountMin.assertValues([10, 10, 10, 10, 10, 10])
+    self.amountMax.assertValues([10_000, 10_000, 10_000, 10_000, 10_000, 10_000])
     self.amountValue.assertValues([10, 10, 10, 10, 10, 10.01])
     self.doneButtonIsEnabled.assertValues([true])
     self.labelTextColor.assertValues([green])
@@ -930,6 +982,8 @@ internal final class PledgeAmountViewModelTests: TestCase {
 
     self.vm.inputs.textFieldValueChanged("10.010")
     self.amountIsValid.assertValues([true, true, true, true, true, true, true])
+    self.amountMin.assertValues([10, 10, 10, 10, 10, 10, 10])
+    self.amountMax.assertValues([10_000, 10_000, 10_000, 10_000, 10_000, 10_000, 10_000])
     self.amountValue.assertValues([10, 10, 10, 10, 10, 10.01, 10.01])
     self.doneButtonIsEnabled.assertValues([true])
     self.labelTextColor.assertValues([green])
@@ -938,6 +992,8 @@ internal final class PledgeAmountViewModelTests: TestCase {
 
     self.vm.inputs.textFieldValueChanged("10.0100")
     self.amountIsValid.assertValues([true, true, true, true, true, true, true, true])
+    self.amountMin.assertValues([10, 10, 10, 10, 10, 10, 10, 10])
+    self.amountMax.assertValues([10_000, 10_000, 10_000, 10_000, 10_000, 10_000, 10_000, 10_000])
     self.amountValue.assertValues([10, 10, 10, 10, 10, 10.01, 10.01, 10.01])
     self.doneButtonIsEnabled.assertValues([true])
     self.labelTextColor.assertValues([green])
@@ -946,6 +1002,8 @@ internal final class PledgeAmountViewModelTests: TestCase {
 
     self.vm.inputs.textFieldValueChanged("10.019")
     self.amountIsValid.assertValues([true, true, true, true, true, true, true, true, true])
+    self.amountMin.assertValues([10, 10, 10, 10, 10, 10, 10, 10, 10])
+    self.amountMax.assertValues([10_000, 10_000, 10_000, 10_000, 10_000, 10_000, 10_000, 10_000, 10_000])
     self.amountValue.assertValues([10, 10, 10, 10, 10, 10.01, 10.01, 10.01, 10.02])
     self.doneButtonIsEnabled.assertValues([true])
     self.labelTextColor.assertValues([green])
@@ -954,6 +1012,8 @@ internal final class PledgeAmountViewModelTests: TestCase {
 
     self.vm.inputs.textFieldValueChanged("10.0194444444")
     self.amountIsValid.assertValues([true, true, true, true, true, true, true, true, true, true])
+    self.amountMin.assertValues([10, 10, 10, 10, 10, 10, 10, 10, 10, 10])
+    self.amountMax.assertValues([10_000, 10_000, 10_000, 10_000, 10_000, 10_000, 10_000, 10_000, 10_000, 10_000])
     self.amountValue.assertValues([10, 10, 10, 10, 10, 10.01, 10.01, 10.01, 10.02, 10.02])
     self.doneButtonIsEnabled.assertValues([true])
     self.labelTextColor.assertValues([green])
@@ -962,6 +1022,8 @@ internal final class PledgeAmountViewModelTests: TestCase {
 
     self.vm.inputs.textFieldValueChanged("9.999")
     self.amountIsValid.assertValues([true, true, true, true, true, true, true, true, true, true, false])
+    self.amountMin.assertValues([10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10])
+    self.amountMax.assertValues([10_000, 10_000, 10_000, 10_000, 10_000, 10_000, 10_000, 10_000, 10_000, 10_000, 10_000])
     self.amountValue.assertValues([10, 10, 10, 10, 10, 10.01, 10.01, 10.01, 10.02, 10.02, 10])
     self.doneButtonIsEnabled.assertValues([true, false])
     self.labelTextColor.assertValues([green, red])
@@ -970,6 +1032,8 @@ internal final class PledgeAmountViewModelTests: TestCase {
 
     self.vm.inputs.textFieldValueChanged("9.99")
     self.amountIsValid.assertValues([true, true, true, true, true, true, true, true, true, true, false, false])
+    self.amountMin.assertValues([10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10])
+    self.amountMax.assertValues([10_000, 10_000, 10_000, 10_000, 10_000, 10_000, 10_000, 10_000, 10_000, 10_000, 10_000, 10_000])
     self.amountValue.assertValues([10, 10, 10, 10, 10, 10.01, 10.01, 10.01, 10.02, 10.02, 10, 9.99])
     self.doneButtonIsEnabled.assertValues([true, false])
     self.labelTextColor.assertValues([green, red])

--- a/Library/ViewModels/PledgeViewModel.swift
+++ b/Library/ViewModels/PledgeViewModel.swift
@@ -33,7 +33,7 @@ public typealias PaymentAuthorizationData = (
   selectedShippingRule: ShippingRule?, merchantIdentifier: String
 )
 public typealias PKPaymentData = (displayName: String, network: String, transactionIdentifier: String)
-public typealias PledgeAmountData = (amount: Double, isValid: Bool)
+public typealias PledgeAmountData = (amount: Double, min: Double, max: Double, isValid: Bool)
 
 public protocol PledgeViewModelInputs {
   func applePayButtonTapped()
@@ -68,6 +68,7 @@ public protocol PledgeViewModelOutputs {
   var paymentMethodsViewHidden: Signal<Bool, Never> { get }
   var sectionSeparatorsHidden: Signal<Bool, Never> { get }
   var shippingLocationViewHidden: Signal<Bool, Never> { get }
+  var showApplePayAlert: Signal<(String, String), Never> { get }
   var updatePledgeButtonEnabled: Signal<Bool, Never> { get }
 }
 
@@ -101,7 +102,7 @@ public class PledgeViewModel: PledgeViewModelType, PledgeViewModelInputs, Pledge
       .map(isNotNil)
 
     let pledgeAmount = Signal.merge(
-      self.pledgeAmountDataSignal.map(first),
+      self.pledgeAmountDataSignal.map { $0.amount },
       reward.map { $0.minimum }
     )
 
@@ -147,11 +148,14 @@ public class PledgeViewModel: PledgeViewModelType, PledgeViewModelInputs, Pledge
       self.configurePaymentMethodsViewControllerWithValue, self.creditCardSelectedSignal
     )
 
+    let pledgeAmountIsValid = self.pledgeAmountDataSignal
+      .map { $0.isValid }
+
     self.updatePledgeButtonEnabled = Signal.combineLatest(
       paymentSourceSelected.mapConst(true),
-      self.pledgeAmountDataSignal.map(second)
+      pledgeAmountIsValid
     )
-    .map { paymentSourceSelected, amountInputIsValid in paymentSourceSelected && amountInputIsValid }
+    .map { paymentSourceSelected, pledgeAmountIsValid in paymentSourceSelected && pledgeAmountIsValid }
 
     self.shippingLocationViewHidden = reward
       .map { $0.shipping.enabled }
@@ -219,8 +223,37 @@ public class PledgeViewModel: PledgeViewModelType, PledgeViewModelInputs, Pledge
         PKPaymentAuthorizationViewController.merchantIdentifier
       ) as PaymentAuthorizationData }
 
-    self.goToApplePayPaymentAuthorization = paymentAuthorizationData
+    let goToApplePayPaymentAuthorization = pledgeAmountIsValid
       .takeWhen(self.applePayButtonTappedSignal)
+      .filter { isTrue($0) }
+
+    let showApplePayAlert = pledgeAmountIsValid
+      .takeWhen(self.applePayButtonTappedSignal)
+      .filter { isFalse($0) }
+
+    self.goToApplePayPaymentAuthorization = paymentAuthorizationData
+      .takeWhen(goToApplePayPaymentAuthorization)
+
+    self.showApplePayAlert = Signal.combineLatest(
+      project,
+      self.pledgeAmountDataSignal
+    )
+    .takeWhen(showApplePayAlert)
+    .map { project, pledgeAmountData in (project, pledgeAmountData.min, pledgeAmountData.max) }
+    .map { project, min, max in
+      (
+        localizedString(key: "Almost_there", defaultValue: "Almost there!"),
+        localizedString(
+          key: "Please_enter_a_pledge_amount_between_min_and_max",
+          defaultValue: "Please enter a pledge amount between %{min} and %{max}.",
+          count: nil,
+          substitutions: [
+            "min": "\(Format.currency(min, country: project.country, omitCurrencyCode: false))",
+            "max": "\(Format.currency(max, country: project.country, omitCurrencyCode: false))"
+          ]
+        )
+      )
+    }
 
     let pkPaymentData = self.pkPaymentSignal
       .map { pkPayment -> PKPaymentData? in
@@ -401,6 +434,7 @@ public class PledgeViewModel: PledgeViewModelType, PledgeViewModelInputs, Pledge
   public let paymentMethodsViewHidden: Signal<Bool, Never>
   public let sectionSeparatorsHidden: Signal<Bool, Never>
   public let shippingLocationViewHidden: Signal<Bool, Never>
+  public let showApplePayAlert: Signal<(String, String), Never>
   public let updatePledgeButtonEnabled: Signal<Bool, Never>
 
   public var inputs: PledgeViewModelInputs { return self }

--- a/Library/ViewModels/PledgeViewModel.swift
+++ b/Library/ViewModels/PledgeViewModel.swift
@@ -225,7 +225,7 @@ public class PledgeViewModel: PledgeViewModelType, PledgeViewModelInputs, Pledge
 
     let goToApplePayPaymentAuthorization = pledgeAmountIsValid
       .takeWhen(self.applePayButtonTappedSignal)
-      .filter { isTrue($0) }
+      .filter(isTrue)
 
     let showApplePayAlert = pledgeAmountIsValid
       .takeWhen(self.applePayButtonTappedSignal)

--- a/Library/ViewModels/PledgeViewModel.swift
+++ b/Library/ViewModels/PledgeViewModel.swift
@@ -229,7 +229,7 @@ public class PledgeViewModel: PledgeViewModelType, PledgeViewModelInputs, Pledge
 
     let showApplePayAlert = pledgeAmountIsValid
       .takeWhen(self.applePayButtonTappedSignal)
-      .filter { isFalse($0) }
+      .filter(isFalse)
 
     self.goToApplePayPaymentAuthorization = paymentAuthorizationData
       .takeWhen(goToApplePayPaymentAuthorization)

--- a/Library/ViewModels/PledgeViewModelTests.swift
+++ b/Library/ViewModels/PledgeViewModelTests.swift
@@ -44,6 +44,8 @@ final class PledgeViewModelTests: TestCase {
   private let paymentMethodsViewHidden = TestObserver<Bool, Never>()
   private let sectionSeparatorsHidden = TestObserver<Bool, Never>()
   private let shippingLocationViewHidden = TestObserver<Bool, Never>()
+  private let showApplePayAlertMessage = TestObserver<String, Never>()
+  private let showApplePayAlertTitle = TestObserver<String, Never>()
   private let updatePledgeButtonEnabled = TestObserver<Bool, Never>()
 
   override func setUp() {
@@ -97,6 +99,8 @@ final class PledgeViewModelTests: TestCase {
     self.vm.outputs.updatePledgeButtonEnabled.observe(self.updatePledgeButtonEnabled.observer)
     self.vm.outputs.sectionSeparatorsHidden.observe(self.sectionSeparatorsHidden.observer)
     self.vm.outputs.shippingLocationViewHidden.observe(self.shippingLocationViewHidden.observer)
+    self.vm.outputs.showApplePayAlert.map(second).observe(self.showApplePayAlertMessage.observer)
+    self.vm.outputs.showApplePayAlert.map(first).observe(self.showApplePayAlertTitle.observer)
   }
 
   func testPledgeContext_LoggedIn() {
@@ -427,24 +431,24 @@ final class PledgeViewModelTests: TestCase {
       self.configureSummaryCellWithDataPledgeTotal.assertValues([reward.minimum])
       self.configureSummaryCellWithDataProject.assertValues([project])
 
-      let amount1 = 66.0
+      let data1 = (amount: 66.0, min: 10.0, max: 10_000.0, isValid: true)
 
-      self.vm.inputs.pledgeAmountViewControllerDidUpdate(with: (amount: amount1, isValid: true))
+      self.vm.inputs.pledgeAmountViewControllerDidUpdate(with: data1)
 
       self.configureWithPledgeViewDataProject.assertValues([project])
       self.configureWithPledgeViewDataReward.assertValues([reward])
 
-      self.configureSummaryCellWithDataPledgeTotal.assertValues([reward.minimum, amount1])
+      self.configureSummaryCellWithDataPledgeTotal.assertValues([reward.minimum, data1.amount])
       self.configureSummaryCellWithDataProject.assertValues([project, project])
 
-      let amount2 = 99.0
+      let data2 = (amount: 99.0, min: 10.0, max: 10_000.0, isValid: true)
 
-      self.vm.inputs.pledgeAmountViewControllerDidUpdate(with: (amount: amount2, isValid: true))
+      self.vm.inputs.pledgeAmountViewControllerDidUpdate(with: data2)
 
       self.configureWithPledgeViewDataProject.assertValues([project])
       self.configureWithPledgeViewDataReward.assertValues([reward])
 
-      self.configureSummaryCellWithDataPledgeTotal.assertValues([reward.minimum, amount1, amount2])
+      self.configureSummaryCellWithDataPledgeTotal.assertValues([reward.minimum, data1.amount, data2.amount])
       self.configureSummaryCellWithDataProject.assertValues([project, project, project])
     }
   }
@@ -520,15 +524,15 @@ final class PledgeViewModelTests: TestCase {
       ])
       self.configureSummaryCellWithDataProject.assertValues([project, project])
 
-      let amount1 = 200.0
+      let data1 = (amount: 200.0, min: 10.0, max: 10_000.0, isValid: true)
 
-      self.vm.inputs.pledgeAmountViewControllerDidUpdate(with: (amount: amount1, isValid: true))
+      self.vm.inputs.pledgeAmountViewControllerDidUpdate(with: data1)
 
       self.configureWithPledgeViewDataProject.assertValues([project])
       self.configureWithPledgeViewDataReward.assertValues([reward])
 
       self.configureSummaryCellWithDataPledgeTotal.assertValues(
-        [reward.minimum, reward.minimum + shippingRule1.cost, shippingRule1.cost + amount1]
+        [reward.minimum, reward.minimum + shippingRule1.cost, shippingRule1.cost + data1.amount]
       )
       self.configureSummaryCellWithDataProject.assertValues([project, project, project])
 
@@ -544,15 +548,15 @@ final class PledgeViewModelTests: TestCase {
         [
           reward.minimum,
           reward.minimum + shippingRule1.cost,
-          shippingRule1.cost + amount1,
-          shippingRule2.cost + amount1
+          shippingRule1.cost + data1.amount,
+          shippingRule2.cost + data1.amount
         ]
       )
       self.configureSummaryCellWithDataProject.assertValues([project, project, project, project])
 
-      let amount2 = 1_999.0
+      let data2 = (amount: 1_999.0, min: 10.0, max: 10_000.0, isValid: true)
 
-      self.vm.inputs.pledgeAmountViewControllerDidUpdate(with: (amount: amount2, isValid: true))
+      self.vm.inputs.pledgeAmountViewControllerDidUpdate(with: data2)
 
       self.configureWithPledgeViewDataProject.assertValues([project])
       self.configureWithPledgeViewDataReward.assertValues([reward])
@@ -561,9 +565,9 @@ final class PledgeViewModelTests: TestCase {
         [
           reward.minimum,
           reward.minimum + shippingRule1.cost,
-          shippingRule1.cost + amount1,
-          shippingRule2.cost + amount1,
-          shippingRule2.cost + amount2
+          shippingRule1.cost + data1.amount,
+          shippingRule2.cost + data1.amount,
+          shippingRule2.cost + data2.amount
         ]
       )
       self.configureSummaryCellWithDataProject.assertValues([project, project, project, project, project])
@@ -606,8 +610,10 @@ final class PledgeViewModelTests: TestCase {
     let project = Project.template
     let reward = Reward.noReward
       |> Reward.lens.minimum .~ 5
+    let pledgeAmountData = (amount: 99.0, min: 5.0, max: 10_000.0, isValid: true)
 
     self.vm.inputs.configureWith(project: project, reward: reward, refTag: .projectPage, context: .pledge)
+    self.vm.inputs.pledgeAmountViewControllerDidUpdate(with: pledgeAmountData)
     self.vm.inputs.viewDidLoad()
 
     self.goToApplePayPaymentAuthorizationProject.assertDidNotEmitValue()
@@ -631,8 +637,10 @@ final class PledgeViewModelTests: TestCase {
       |> Reward.lens.minimum .~ 25
       |> Reward.lens.shipping.enabled .~ true
     let shippingRule = ShippingRule.template
+    let pledgeAmountData = (amount: 99.0, min: 25.0, max: 10_000.0, isValid: true)
 
     self.vm.inputs.configureWith(project: project, reward: reward, refTag: .projectPage, context: .pledge)
+    self.vm.inputs.pledgeAmountViewControllerDidUpdate(with: pledgeAmountData)
     self.vm.inputs.viewDidLoad()
 
     self.goToApplePayPaymentAuthorizationProject.assertDidNotEmitValue()
@@ -652,14 +660,58 @@ final class PledgeViewModelTests: TestCase {
     self.goToApplePayPaymentAuthorizationMerchantId.assertValues([Secrets.ApplePay.merchantIdentifier])
   }
 
+  func testShowApplePayAlert_WhenApplePayButtonTapped_PledgeInputAmount_AboveMax() {
+    let project = Project.template
+    let reward = Reward.template
+      |> Reward.lens.minimum .~ 25
+    let pledgeAmountData = (amount: 20_000.0, min: 25.0, max: 10_000.0, isValid: false)
+
+    self.vm.inputs.configureWith(project: project, reward: reward, refTag: .projectPage, context: .pledge)
+    self.vm.inputs.pledgeAmountViewControllerDidUpdate(with: pledgeAmountData)
+    self.vm.inputs.viewDidLoad()
+
+    self.showApplePayAlertMessage.assertDidNotEmitValue()
+    self.showApplePayAlertTitle.assertDidNotEmitValue()
+
+    self.vm.inputs.applePayButtonTapped()
+
+    self.showApplePayAlertMessage.assertValues(
+      ["Please enter a pledge amount between US$ 25 and US$ 10,000."]
+    )
+    self.showApplePayAlertTitle.assertValues(["Almost there!"])
+  }
+
+  func testShowApplePayAlert_WhenApplePayButtonTapped_PledgeInputAmount_BellowMin() {
+    let project = Project.template
+    let reward = Reward.template
+      |> Reward.lens.minimum .~ 25
+    let pledgeAmountData = (amount: 10.0, min: 25.0, max: 10_000.0, isValid: false)
+
+    self.vm.inputs.configureWith(project: project, reward: reward, refTag: .projectPage, context: .pledge)
+    self.vm.inputs.pledgeAmountViewControllerDidUpdate(with: pledgeAmountData)
+    self.vm.inputs.viewDidLoad()
+
+    self.showApplePayAlertMessage.assertDidNotEmitValue()
+    self.showApplePayAlertTitle.assertDidNotEmitValue()
+
+    self.vm.inputs.applePayButtonTapped()
+
+    self.showApplePayAlertMessage.assertValues(
+      ["Please enter a pledge amount between US$ 25 and US$ 10,000."]
+    )
+    self.showApplePayAlertTitle.assertValues(["Almost there!"])
+  }
+
   func testPaymentAuthorizationViewControllerDidFinish_WithoutCompletingTransaction() {
     let project = Project.template
     let reward = Reward.template
       |> Reward.lens.minimum .~ 25
       |> Reward.lens.shipping.enabled .~ true
     let shippingRule = ShippingRule.template
+    let pledgeAmountData = (amount: 99.0, min: 25.0, max: 10_000.0, isValid: true)
 
     self.vm.inputs.configureWith(project: project, reward: reward, refTag: .projectPage, context: .pledge)
+    self.vm.inputs.pledgeAmountViewControllerDidUpdate(with: pledgeAmountData)
     self.vm.inputs.viewDidLoad()
 
     self.vm.inputs.shippingRuleSelected(shippingRule)
@@ -936,13 +988,17 @@ final class PledgeViewModelTests: TestCase {
       self.vm.inputs.viewDidLoad()
       self.updatePledgeButtonEnabled.assertDidNotEmitValue()
 
-      self.vm.inputs.pledgeAmountViewControllerDidUpdate(with: (amount: 25, isValid: true))
+      let data1 = (amount: 25.0, min: 10.0, max: 10_000.0, isValid: true)
+
+      self.vm.inputs.pledgeAmountViewControllerDidUpdate(with: data1)
       self.updatePledgeButtonEnabled.assertDidNotEmitValue()
 
       self.vm.inputs.creditCardSelected(with: "123")
       self.updatePledgeButtonEnabled.assertValues([true])
 
-      self.vm.inputs.pledgeAmountViewControllerDidUpdate(with: (amount: 25, isValid: false))
+      let data2 = (amount: 5.0, min: 10.0, max: 10_000.0, isValid: false)
+
+      self.vm.inputs.pledgeAmountViewControllerDidUpdate(with: data2)
       self.updatePledgeButtonEnabled.assertValues([true, false])
     }
   }
@@ -965,7 +1021,9 @@ final class PledgeViewModelTests: TestCase {
       self.createBackingError.assertDidNotEmitValue()
 
       self.vm.inputs.creditCardSelected(with: "123")
-      self.vm.inputs.pledgeAmountViewControllerDidUpdate(with: (amount: 25, isValid: true))
+      self.vm.inputs.pledgeAmountViewControllerDidUpdate(
+        with: (amount: 25.0, min: 10.0, max: 10_000.0, isValid: true)
+      )
 
       self.updatePledgeButtonEnabled.assertValues([true])
 
@@ -996,7 +1054,9 @@ final class PledgeViewModelTests: TestCase {
       self.createBackingError.assertDidNotEmitValue()
 
       self.vm.inputs.creditCardSelected(with: "123")
-      self.vm.inputs.pledgeAmountViewControllerDidUpdate(with: (amount: 25, isValid: true))
+      self.vm.inputs.pledgeAmountViewControllerDidUpdate(
+        with: (amount: 25.0, min: 10.0, max: 10_000.0, isValid: true)
+      )
 
       self.updatePledgeButtonEnabled.assertValues([true])
 


### PR DESCRIPTION
# 📲 What

If a user enters incorrect pledge amount (bellow `min` or above `max`) and taps the `Apple Pay` button we now show an alert with more instructions.

# 🤔 Why

Since Apple is not fond of disabling `Apple Pay` button we have to have a way of local validation of the input when user goes through `Apple Pay` path.

# 🛠 How

Simply checking the input & its min, max values when evaluating the `Apple Pay` button tap logic.

Please note that this PR is mostly tests since we're now passing more values in the `amount` tuple so our tests suite had to be updated to account for those.

# 👀 See

<img width="300" alt="Screen Shot 2019-10-03 at 3 50 07 PM" src="https://user-images.githubusercontent.com/387596/66169617-e304c680-e5f5-11e9-8283-74622226d0af.png">

# ✅ Acceptance criteria

On device that supports `Apple Pay` (has `Apple Pay` setup in the `Wallet.app`) go to the new pledge screen and

- [x] Enter pledge amount value that is `smaller` than the `min` value (initial value) > this should result into alert being shown when tapping the `Apple Pay` button
- [x] Enter pledge amount value that is `larger` than the `max` value (usually 10k but depends on the project) > this should result into alert being shown when tapping the `Apple Pay` button
- [x] Enter pledge amount value that is between `min` and `max` value > this should result into the native Apple Pay sheet being shown

# ⏰ TODO

- [ ] Update to use generated strings
