### PR TITLE
[NT-409] Fix issue with feature flags ordering

### DIFF
--- a/Library/ViewModels/FeatureFlagToolsViewModel.swift
+++ b/Library/ViewModels/FeatureFlagToolsViewModel.swift
@@ -47,12 +47,13 @@ public final class FeatureFlagToolsViewModel: FeatureFlagToolsViewModelType, Fea
       return features
     }
 
-    self.reloadWithData = features
+    let sortedFeatures = features
       .map { features in features.sorted { $0.feature.description < $1.feature.description } }
 
-    self.updateConfigWithFeatures = features
-      .takePairWhen(self.setFeatureEnabledAtIndexProperty.signal
-        .skipNil())
+    self.reloadWithData = sortedFeatures
+
+    self.updateConfigWithFeatures = sortedFeatures
+      .takePairWhen(self.setFeatureEnabledAtIndexProperty.signal.skipNil())
       .map(unpack)
       .map { features, index, enabled -> Features? in
         let featureEnabledPair = features[index]

--- a/Library/ViewModels/FeatureFlagToolsViewModelTests.swift
+++ b/Library/ViewModels/FeatureFlagToolsViewModelTests.swift
@@ -78,12 +78,12 @@ final class FeatureFlagToolsViewModelTests: TestCase {
   func testUpdateFeatureFlagEnabledValue() {
     let originalFeatures = [
       Feature.nativeCheckoutPledgeView.rawValue: true,
-      Feature.nativeCheckout.rawValue: true,
+      Feature.nativeCheckout.rawValue: true
     ]
 
     let expectedFeatures = [
       Feature.nativeCheckout.rawValue: true,
-      Feature.nativeCheckoutPledgeView.rawValue: false,
+      Feature.nativeCheckoutPledgeView.rawValue: false
     ]
 
     let mockConfig = Config.template

--- a/Library/ViewModels/FeatureFlagToolsViewModelTests.swift
+++ b/Library/ViewModels/FeatureFlagToolsViewModelTests.swift
@@ -76,43 +76,47 @@ final class FeatureFlagToolsViewModelTests: TestCase {
   }
 
   func testUpdateFeatureFlagEnabledValue() {
-    let mockConfig = Config.template
-      |> \.features .~ [
-        Feature.nativeCheckout.rawValue: true,
-        "some_unknown_feature": false
-      ]
+    let originalFeatures = [
+      Feature.nativeCheckoutPledgeView.rawValue: true,
+      Feature.nativeCheckout.rawValue: true,
+    ]
 
-    let updatedFeatures = [Feature.nativeCheckout.rawValue: false, "some_unknown_feature": false]
+    let expectedFeatures = [
+      Feature.nativeCheckout.rawValue: true,
+      Feature.nativeCheckoutPledgeView.rawValue: false,
+    ]
+
+    let mockConfig = Config.template
+      |> \.features .~ originalFeatures
 
     withEnvironment(config: mockConfig) {
       self.vm.inputs.viewDidLoad()
 
-      self.reloadWithDataFeatures.assertValues([[Feature.nativeCheckout]])
-      self.reloadWithDataEnabledValues.assertValues([[true]])
+      self.reloadWithDataFeatures.assertValues([[Feature.nativeCheckout, Feature.nativeCheckoutPledgeView]])
+      self.reloadWithDataEnabledValues.assertValues([[true, true]])
 
       self.vm.inputs.setFeatureAtIndexEnabled(index: 0, isEnabled: true)
 
       self.updateConfigWithFeatures.assertValues([], "Doesn't update when the enabled value is the same.")
 
-      self.vm.inputs.setFeatureAtIndexEnabled(index: 0, isEnabled: false)
+      self.vm.inputs.setFeatureAtIndexEnabled(index: 1, isEnabled: false)
 
-      self.updateConfigWithFeatures
-        .assertValues(
-          [updatedFeatures],
-          "Updates the correct feature."
-        )
+      self.updateConfigWithFeatures.assertValues([expectedFeatures])
     }
 
     let updatedConfig = Config.template
-      |> \.features .~ updatedFeatures
+      |> \.features .~ expectedFeatures
 
     withEnvironment(config: updatedConfig) {
       self.vm.inputs.didUpdateConfig()
 
       scheduler.run()
 
-      self.reloadWithDataFeatures.assertValues([[Feature.nativeCheckout], [Feature.nativeCheckout]])
-      self.reloadWithDataEnabledValues.assertValues([[true], [false]])
+      self.reloadWithDataFeatures.assertValues([
+        [Feature.nativeCheckout, Feature.nativeCheckoutPledgeView],
+        [Feature.nativeCheckout, Feature.nativeCheckoutPledgeView]
+      ])
+      self.reloadWithDataEnabledValues.assertValues([[true, true], [true, false]])
     }
   }
 }


### PR DESCRIPTION
# 📲 What

#877 has recently broken the way we can toggle feature flags ON and OFF so this PR fixes that.

# 🤔 Why

The toggling was previously broken due to sorting only being applied to the data source (not the actual data being sorted).

`reloadWithData` did get the sorted array while `updateConfigWithFeatures` did not ... therefore when the data was fetched from the server in un-sorted order it would cause weird behaviour (the data displayed would not reflect the data being toggled ON/OFF).

# 🛠 How

This PR should fix that by both applying sort to `updateConfigWithFeatures` as well as adding tests to cover this case.

# ✅ Acceptance criteria

In order to test this we should test both scenarios. For that please put the following code in `FeatureFlagToolsViewModel.swift` on line `46`.

Since the feature toggles are returned in random order you might need to run the app couple times.

```swift
.map { configFeatures in
  var features = [FeatureEnabled]()

  for (key, value) in configFeatures {
    guard let feature = Feature(rawValue: key) else {
      continue
    }

    features.append((feature: feature, isEnabled: value))
  }
  print("*** features: \(features)")
  return features
}
```

A) Feature toggles are received in alphabetical order

- [x] Verify that feature toggles are printed in alphabetical order (the above print statement)
- [x] Toggle feature toggles `ON` and `OFF` and double check they're affecting app's behaviour (proper native checkout flow)

B) Feature toggles are not received in alphabetical order

- [x] Verify that feature toggles are printed in non-alphabetical order (the above print statement)
- [x] Toggle feature toggles `ON` and `OFF` and double check they're affecting app's behaviour (proper native checkout flow)