### PR TITLE
[NT-] Localizations - Rewards received

### DIFF
--- a/Kickstarter-iOS/Locales/de.lproj/Localizable.strings
+++ b/Kickstarter-iOS/Locales/de.lproj/Localizable.strings
@@ -408,7 +408,7 @@
 "Reward_Surveys.zero" = "%{reward_survey_count} Befragungen";
 "Reward_delivered" = "Belohnung versandt?";
 "Reward_estimated_for_delivery_in_date" = "Voraussichtliche Lieferung der <b>Belohnung</b> im %{delivery_date}";
-"Reward_received" = "Reward received";
+"Reward_received" = "Belohnung erhalten";
 "Reward_selected" = "Ausgewählte Belohnung";
 "Reward_surveys" = "Befragungen";
 "Rewards_count_rewards.few" = "%{rewards_count} Belohnungen";

--- a/Kickstarter-iOS/Locales/es.lproj/Localizable.strings
+++ b/Kickstarter-iOS/Locales/es.lproj/Localizable.strings
@@ -408,7 +408,7 @@
 "Reward_Surveys.zero" = "%{reward_survey_count} cuestionarios";
 "Reward_delivered" = "¿Recompensa entregada?";
 "Reward_estimated_for_delivery_in_date" = "<b>Recompensa</b> estimada para entregarse en %{delivery_date}";
-"Reward_received" = "Reward received";
+"Reward_received" = "Recompensa recibida";
 "Reward_selected" = "Recompensa seleccionada";
 "Reward_surveys" = "Cuestionarios sobre recompensas";
 "Rewards_count_rewards.few" = "%{rewards_count} recompensas";

--- a/Kickstarter-iOS/Locales/ja.lproj/Localizable.strings
+++ b/Kickstarter-iOS/Locales/ja.lproj/Localizable.strings
@@ -408,7 +408,7 @@
 "Reward_Surveys.zero" = "%{reward_survey_count} リワードのサーベイ";
 "Reward_delivered" = "リワードを受け取りましたか？";
 "Reward_estimated_for_delivery_in_date" = "<b>リワード</b>の配達予定日は%{delivery_date}";
-"Reward_received" = "Reward received";
+"Reward_received" = "リワードを受け取りました";
 "Reward_selected" = "選択中のリワード";
 "Reward_surveys" = "リワードのサーベイ";
 "Rewards_count_rewards.few" = "%{rewards_count} 種類のリワード";

--- a/Library/Strings.swift
+++ b/Library/Strings.swift
@@ -6735,10 +6735,10 @@ daring ideas."
    "Reward received"
 
    - **en**: "Reward received"
-   - **de**: "Reward received"
-   - **es**: "Reward received"
+   - **de**: "Belohnung erhalten"
+   - **es**: "Recompensa recibida"
    - **fr**: "Récompense reçue"
-   - **ja**: "Reward received"
+   - **ja**: "リワードを受け取りました"
   */
   public static func Reward_received() -> String {
     return localizedString(


### PR DESCRIPTION
# 📲 What

Adds localizations for German, Spanish and Japanese.

# 🤔 Why

Previously these 3 translations were missing.

# 👀 See

| 🇺🇸  | 🇩🇪  | 🇪🇸 | 🇫🇷 | 🇯🇵 |
| --- | --- | --- | --- | --- |
|  |  |  |  |  |

# ♿️ Accessibility 

- [ ] VoiceOver reads strings in their respective language

# ✅ Acceptance criteria

1. Navigate to manage pledge screen
2. Make sure this is not `No reward` and its status is backing status is `collected`

- [ ] English shows translated reward received text in the label
- [ ] German shows translated reward received text in the label
- [ ] Spanish shows translated reward received text in the label
- [ ] French shows translated reward received text in the label
- [ ] Japanese shows translated reward received text in the label