### PR TITLE
[NT- 401] Pledge increment fix

### DIFF
--- a/Kickstarter-iOS/Views/Controllers/PledgeAmountViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/PledgeAmountViewController.swift
@@ -118,7 +118,6 @@ final class PledgeAmountViewController: UIViewController {
     self.minPledgeAmountLabel.rac.text = self.viewModel.outputs.minPledgeAmountLabelText
     self.stepper.rac.maximumValue = self.viewModel.outputs.stepperMaxValue
     self.stepper.rac.minimumValue = self.viewModel.outputs.stepperMinValue
-    self.stepper.rac.stepValue = self.viewModel.outputs.stepperStepValue
     self.stepper.rac.value = self.viewModel.outputs.stepperValue
 
     self.viewModel.outputs.generateSelectionFeedback
@@ -186,6 +185,7 @@ extension PledgeAmountViewController: UITextFieldDelegate {
 
 private func stepperStyle(_ stepper: UIStepper) -> UIStepper {
   return stepper
+    |> \.stepValue .~ 1.0
     |> \.tintColor .~ UIColor.clear
     <> UIStepper.lens.decrementImage(for: .normal) .~ image(named: "stepper-decrement-normal")
     <> UIStepper.lens.decrementImage(for: .disabled) .~ image(named: "stepper-decrement-disabled")

--- a/Library/ViewModels/PledgeAmountViewModel.swift
+++ b/Library/ViewModels/PledgeAmountViewModel.swift
@@ -28,7 +28,6 @@ public protocol PledgeAmountViewModelOutputs {
   var minPledgeAmountLabelText: Signal<String, Never> { get }
   var stepperMaxValue: Signal<Double, Never> { get }
   var stepperMinValue: Signal<Double, Never> { get }
-  var stepperStepValue: Signal<Double, Never> { get }
   var stepperValue: Signal<Double, Never> { get }
   var textFieldIsFirstResponder: Signal<Bool, Never> { get }
   var textFieldTextColor: Signal<UIColor?, Never> { get }
@@ -160,8 +159,6 @@ public final class PledgeAmountViewModel: PledgeAmountViewModelType,
       )
     }
 
-    self.stepperStepValue = minValue
-
     self.stepperValue = Signal.merge(
       minValue,
       self.amount.map { $0.0 }
@@ -210,7 +207,6 @@ public final class PledgeAmountViewModel: PledgeAmountViewModelType,
   public let minPledgeAmountLabelText: Signal<String, Never>
   public let stepperMaxValue: Signal<Double, Never>
   public let stepperMinValue: Signal<Double, Never>
-  public let stepperStepValue: Signal<Double, Never>
   public let stepperValue: Signal<Double, Never>
   public let textFieldTextColor: Signal<UIColor?, Never>
   public let textFieldIsFirstResponder: Signal<Bool, Never>

--- a/Library/ViewModels/PledgeAmountViewModelTests.swift
+++ b/Library/ViewModels/PledgeAmountViewModelTests.swift
@@ -20,7 +20,6 @@ internal final class PledgeAmountViewModelTests: TestCase {
   private let minPledgeAmountLabelText = TestObserver<String, Never>()
   private let stepperMaxValue = TestObserver<Double, Never>()
   private let stepperMinValue = TestObserver<Double, Never>()
-  private let stepperStepValue = TestObserver<Double, Never>()
   private let stepperValue = TestObserver<Double, Never>()
   private let textFieldIsFirstResponder = TestObserver<Bool, Never>()
   private let textFieldTextColor = TestObserver<UIColor?, Never>()
@@ -44,7 +43,6 @@ internal final class PledgeAmountViewModelTests: TestCase {
     self.vm.outputs.minPledgeAmountLabelText.observe(self.minPledgeAmountLabelText.observer)
     self.vm.outputs.stepperMaxValue.observe(self.stepperMaxValue.observer)
     self.vm.outputs.stepperMinValue.observe(self.stepperMinValue.observer)
-    self.vm.outputs.stepperStepValue.observe(self.stepperStepValue.observer)
     self.vm.outputs.stepperValue.observe(self.stepperValue.observer)
     self.vm.outputs.textFieldIsFirstResponder.observe(self.textFieldIsFirstResponder.observer)
     self.vm.outputs.textFieldTextColor.observe(self.textFieldTextColor.observer)
@@ -71,7 +69,6 @@ internal final class PledgeAmountViewModelTests: TestCase {
     self.currency.assertValues(["$"])
     self.stepperMinValue.assertValue(PledgeAmountStepperConstants.min)
     self.stepperMaxValue.assertValue(PledgeAmountStepperConstants.max)
-    self.stepperStepValue.assertValue(6)
     self.stepperValue.assertValues([6, 690])
     self.textFieldValue.assertValues(["690"])
   }
@@ -86,7 +83,6 @@ internal final class PledgeAmountViewModelTests: TestCase {
     self.currency.assertValues(["$"])
     self.stepperMinValue.assertValue(PledgeAmountStepperConstants.min)
     self.stepperMaxValue.assertValue(PledgeAmountStepperConstants.max)
-    self.stepperStepValue.assertValue(1)
     self.stepperValue.assertValues([1])
     self.textFieldValue.assertValues(["1"])
   }
@@ -104,7 +100,6 @@ internal final class PledgeAmountViewModelTests: TestCase {
     self.currency.assertValues(["MX$"])
     self.stepperMinValue.assertValue(PledgeAmountStepperConstants.min)
     self.stepperMaxValue.assertValue(PledgeAmountStepperConstants.max)
-    self.stepperStepValue.assertValue(10)
     self.stepperValue.assertValues([10])
     self.textFieldValue.assertValues(["10"])
   }
@@ -125,7 +120,6 @@ internal final class PledgeAmountViewModelTests: TestCase {
     self.currency.assertValues(["$"])
     self.stepperMinValue.assertValue(PledgeAmountStepperConstants.min)
     self.stepperMaxValue.assertValue(PledgeAmountStepperConstants.max)
-    self.stepperStepValue.assertValue(1)
     self.stepperValue.assertValues([1])
     self.textFieldValue.assertValues(["1"])
   }
@@ -140,7 +134,6 @@ internal final class PledgeAmountViewModelTests: TestCase {
     self.currency.assertValues(["$"])
     self.stepperMinValue.assertValue(PledgeAmountStepperConstants.min)
     self.stepperMaxValue.assertValue(PledgeAmountStepperConstants.max)
-    self.stepperStepValue.assertValue(10)
     self.stepperValue.assertValues([10])
     self.textFieldValue.assertValues(["10"])
   }
@@ -161,7 +154,6 @@ internal final class PledgeAmountViewModelTests: TestCase {
     self.currency.assertValues(["¥"])
     self.stepperMinValue.assertValue(PledgeAmountStepperConstants.min)
     self.stepperMaxValue.assertValue(PledgeAmountStepperConstants.max)
-    self.stepperStepValue.assertValue(200)
     self.stepperValue.assertValues([200])
     self.textFieldValue.assertValues(["200"])
   }


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Before the stepper step value was being incremented by the minimum amount that can be pledged to the reward. Now step value is set to `1.0`

# 🤔 Why
This is a bug fix.

# 🛠 How

Removed the `stepperStepValue` output as it is no longer set to the minimum value.
# 👀 See

Trello, screenshots, external resources?

| Before 🐛 | After 🦋 |
| --- | --- |
|![before-increment-fix](https://user-images.githubusercontent.com/11362005/67042216-6b569180-f0f5-11e9-8cb8-20459ab3ddd6.gif)|![increment-fix](https://user-images.githubusercontent.com/11362005/67042226-727d9f80-f0f5-11e9-9945-8d5ded28f748.gif)|

# ✅ Acceptance criteria

- [ ] Back a project with a reward (e.g. $10 reward). On the pledge screen tap the stepper.
 The pledge amount should increment by 1 currency unit (e.g. tapping + on the stepper increases my pledge from $10 to $11).

