### PR TITLE
[NT-400] Pledge View attributedString crash fix

### DIFF
--- a/Kickstarter-iOS/Views/Controllers/PledgeViewControllerTests.swift
+++ b/Kickstarter-iOS/Views/Controllers/PledgeViewControllerTests.swift
@@ -43,6 +43,7 @@ final class PledgeViewControllerTests: TestCase {
         controller.configureWith(project: .template, reward: reward, refTag: nil, context: .update)
         let (parent, _) = traitControllers(device: device, orientation: .portrait, child: controller)
 
+        self.scheduler.advance(by: .milliseconds(10))
         self.scheduler.run()
 
         FBSnapshotVerifyView(parent.view, identifier: "lang_\(language)_device_\(device)")

--- a/Library/ViewModels/PledgeViewModel.swift
+++ b/Library/ViewModels/PledgeViewModel.swift
@@ -138,6 +138,7 @@ public class PledgeViewModel: PledgeViewModelType, PledgeViewModelInputs, Pledge
       project,
       project.takeWhen(self.traitCollectionDidChangeSignal)
     )
+    .ksr_debounce(.milliseconds(10), on: AppEnvironment.current.scheduler)
     .map(attributedConfirmationString(with:))
     .skipNil()
 

--- a/Library/ViewModels/PledgeViewModelTests.swift
+++ b/Library/ViewModels/PledgeViewModelTests.swift
@@ -244,7 +244,7 @@ final class PledgeViewModelTests: TestCase {
     let dateComponents = DateComponents()
       |> \.month .~ 11
       |> \.day .~ 1
-      |> \.year .~ 2019
+      |> \.year .~ 2_019
       |> \.timeZone .~ TimeZone.init(secondsFromGMT: 0)
 
     let calendar = Calendar(identifier: .gregorian)
@@ -254,7 +254,7 @@ final class PledgeViewModelTests: TestCase {
       let date = AppEnvironment.current.calendar.date(from: dateComponents)
 
       let project = Project.template
-      |> Project.lens.dates.deadline .~ date!.timeIntervalSince1970
+        |> Project.lens.dates.deadline .~ date!.timeIntervalSince1970
       let reward = Reward.template
         |> Reward.lens.shipping.enabled .~ true
 
@@ -269,7 +269,7 @@ final class PledgeViewModelTests: TestCase {
       self.confirmationLabelAttributedText.assertValueCount(1)
       self.confirmationLabelText.assertValues([
         "If the project reaches its funding goal, you will be charged on November 1, 2019."
-        ])
+      ])
 
       self.vm.inputs.traitCollectionDidChange()
       self.vm.inputs.traitCollectionDidChange()
@@ -281,7 +281,8 @@ final class PledgeViewModelTests: TestCase {
       self.confirmationLabelAttributedText.assertValueCount(2)
       self.confirmationLabelText.assertValues([
         "If the project reaches its funding goal, you will be charged on November 1, 2019.",
-        "If the project reaches its funding goal, you will be charged on November 1, 2019."])
+        "If the project reaches its funding goal, you will be charged on November 1, 2019."
+      ])
     }
   }
 

--- a/Library/ViewModels/PledgeViewModelTests.swift
+++ b/Library/ViewModels/PledgeViewModelTests.swift
@@ -24,6 +24,7 @@ final class PledgeViewModelTests: TestCase {
   private let configureWithPledgeViewDataReward = TestObserver<Reward, Never>()
 
   private let confirmationLabelAttributedText = TestObserver<NSAttributedString, Never>()
+  private let confirmationLabelText = TestObserver<String, Never>()
   private let confirmationLabelHidden = TestObserver<Bool, Never>()
 
   private let continueViewHidden = TestObserver<Bool, Never>()
@@ -82,6 +83,8 @@ final class PledgeViewModelTests: TestCase {
     self.vm.outputs.submitButtonHidden.observe(self.submitButtonHidden.observer)
     self.vm.outputs.submitButtonTitle.observe(self.submitButtonTitle.observer)
     self.vm.outputs.confirmationLabelAttributedText.observe(self.confirmationLabelAttributedText.observer)
+    self.vm.outputs.confirmationLabelAttributedText.map { $0.string }
+      .observe(self.confirmationLabelText.observer)
     self.vm.outputs.confirmationLabelHidden.observe(self.confirmationLabelHidden.observer)
 
     self.vm.outputs.continueViewHidden.observe(self.continueViewHidden.observer)
@@ -234,6 +237,51 @@ final class PledgeViewModelTests: TestCase {
       self.shippingLocationViewHidden.assertValues([false])
       self.configureSummaryCellWithDataPledgeTotal.assertValues([reward.minimum])
       self.configureSummaryCellWithDataProject.assertValues([project])
+    }
+  }
+
+  func testUpdateContext_ConfirmationLabel() {
+    let dateComponents = DateComponents()
+      |> \.month .~ 11
+      |> \.day .~ 1
+      |> \.year .~ 2019
+      |> \.timeZone .~ TimeZone.init(secondsFromGMT: 0)
+
+    let calendar = Calendar(identifier: .gregorian)
+      |> \.timeZone .~ TimeZone.init(secondsFromGMT: 0)!
+
+    withEnvironment(calendar: calendar, locale: Locale(identifier: "en")) {
+      let date = AppEnvironment.current.calendar.date(from: dateComponents)
+
+      let project = Project.template
+      |> Project.lens.dates.deadline .~ date!.timeIntervalSince1970
+      let reward = Reward.template
+        |> Reward.lens.shipping.enabled .~ true
+
+      self.vm.inputs.configureWith(project: project, reward: reward, refTag: .projectPage, context: .update)
+      self.vm.inputs.viewDidLoad()
+
+      self.confirmationLabelHidden.assertValues([false])
+      self.confirmationLabelAttributedText.assertDidNotEmitValue()
+
+      scheduler.advance(by: .milliseconds(10))
+
+      self.confirmationLabelAttributedText.assertValueCount(1)
+      self.confirmationLabelText.assertValues([
+        "If the project reaches its funding goal, you will be charged on November 1, 2019."
+        ])
+
+      self.vm.inputs.traitCollectionDidChange()
+      self.vm.inputs.traitCollectionDidChange()
+
+      self.confirmationLabelAttributedText.assertValueCount(1, "Debounces signals")
+
+      scheduler.advance(by: .milliseconds(10))
+
+      self.confirmationLabelAttributedText.assertValueCount(2)
+      self.confirmationLabelText.assertValues([
+        "If the project reaches its funding goal, you will be charged on November 1, 2019.",
+        "If the project reaches its funding goal, you will be charged on November 1, 2019."])
     }
   }
 


### PR DESCRIPTION
# 📲 What

Fixes a crash on `PledgeViewController` when the devices is rotated or the dynamic type size is changed.

# 🤔 Why

Because crashes are bad.

# 🛠 How

This crash was due to some strange async-like behavior when parsing an html string using:

```
NSMutableAttributedString(
    data: Data(string.utf8),
    options: [
      .documentType: NSAttributedString.DocumentType.html,
      .characterEncoding: String.Encoding.utf8.rawValue
    ],
    documentAttributes: nil
  )
```

We're not super sure what's actually the root cause of this issue, since during debugging we were able to see that this call was happening on the main thread. What we observed was that parsing an html string would actually cause a subsequent call to `traitCollectionDidChange` to occur in what would appear to be an infinite loop. Debouncing the trigger to the `attributedConfirmationString` function seems to solve the issue, although it seems to possibly be related to a [deeper issue with constructing an attributed string with html options.](https://forums.developer.apple.com/thread/115405)

# 👀 See

| Pledge View | Update Pledge View |
| --- | --- |
| ![a1Wnw8QpKc](https://user-images.githubusercontent.com/3156796/67044876-2f262f80-f0fb-11e9-801e-b717a427c516.gif) | ![bLOVJEI5NG](https://user-images.githubusercontent.com/3156796/67044939-5250df00-f0fb-11e9-83c1-208f62d208f0.gif) |

# ✅ Acceptance criteria

- [x] Navigate to the pledge screen and rotate to landscape. There should be no crash. Repeat by increasing dynamic type size - there should be no crash.
- [x] Navigate to the update pledge screen and rotate to landscape. There should be no crash. Repeat by increasing dynamic type size - there should be no crash.
