### PR TITLE
[NT-453] [Investment Day] - Fix ViewModels protocols conformance

### DIFF
--- a/Kickstarter-iOS/Views/Cells/RewardCell.swift
+++ b/Kickstarter-iOS/Views/Cells/RewardCell.swift
@@ -13,7 +13,7 @@ final class RewardCell: UICollectionViewCell, ValueCell {
   // MARK: - Properties
 
   internal weak var delegate: RewardCellDelegate?
-  private let viewModel = RewardCellViewModel()
+  private let viewModel: RewardCellViewModelType = RewardCellViewModel()
 
   internal let rewardCardContainerView = RewardCardContainerView(frame: .zero)
   private lazy var scrollView = {

--- a/Kickstarter-iOS/Views/Cells/SettingsFollowCell.swift
+++ b/Kickstarter-iOS/Views/Cells/SettingsFollowCell.swift
@@ -12,7 +12,7 @@ internal protocol SettingsFollowCellDelegate: AnyObject {
 }
 
 internal final class SettingsFollowCell: UITableViewCell, ValueCell {
-  fileprivate let viewModel = SettingsFollowCellViewModel()
+  fileprivate let viewModel: SettingsFollowCellViewModelType = SettingsFollowCellViewModel()
   internal weak var delegate: SettingsFollowCellDelegate?
 
   @IBOutlet fileprivate var followingLabel: UILabel!

--- a/Kickstarter-iOS/Views/Cells/SettingsPrivacyDeleteAccountCell.swift
+++ b/Kickstarter-iOS/Views/Cells/SettingsPrivacyDeleteAccountCell.swift
@@ -10,7 +10,7 @@ internal protocol SettingsPrivacyDeleteAccountCellDelegate: AnyObject {
 }
 
 internal final class SettingsPrivacyDeleteAccountCell: UITableViewCell, ValueCell {
-  fileprivate let viewModel = SettingsDeleteAccountCellViewModel()
+  fileprivate let viewModel: SettingsDeleteAccountCellViewModelType = SettingsDeleteAccountCellViewModel()
   internal weak var delegate: SettingsPrivacyDeleteAccountCellDelegate?
 
   @IBOutlet fileprivate var deleteAccountButton: UIButton!

--- a/Kickstarter-iOS/Views/Cells/SettingsPrivacyRecommendationCell.swift
+++ b/Kickstarter-iOS/Views/Cells/SettingsPrivacyRecommendationCell.swift
@@ -6,7 +6,7 @@ import ReactiveSwift
 import UIKit
 
 internal final class SettingsPrivacyRecommendationCell: UITableViewCell, ValueCell {
-  fileprivate let viewModel = SettingsRecommendationsCellViewModel()
+  fileprivate let viewModel: SettingsRecommendationsCellViewModelType = SettingsRecommendationsCellViewModel()
 
   @IBOutlet fileprivate var recommendationsLabel: UILabel!
   @IBOutlet fileprivate var recommendationsSwitch: UISwitch!

--- a/Kickstarter-iOS/Views/Cells/SettingsPrivacyRequestDataCell.swift
+++ b/Kickstarter-iOS/Views/Cells/SettingsPrivacyRequestDataCell.swift
@@ -11,7 +11,7 @@ internal protocol SettingsRequestDataCellDelegate: AnyObject {
 }
 
 internal final class SettingsPrivacyRequestDataCell: UITableViewCell, ValueCell {
-  fileprivate let viewModel = SettingsRequestDataCellViewModel()
+  fileprivate let viewModel: SettingsRequestDataCellViewModelType = SettingsRequestDataCellViewModel()
   internal weak var delegate: SettingsRequestDataCellDelegate?
 
   @IBOutlet fileprivate var containerView: UIView!

--- a/Kickstarter-iOS/Views/Cells/SettingsPrivacySwitchCell.swift
+++ b/Kickstarter-iOS/Views/Cells/SettingsPrivacySwitchCell.swift
@@ -16,7 +16,7 @@ final class SettingsPrivacySwitchCell: UITableViewCell, ValueCell, NibLoading {
   @IBOutlet fileprivate var switchButton: UISwitch!
   @IBOutlet fileprivate var separatorViews: [UIView]!
 
-  private let viewModel = SettingsPrivacySwitchCellViewModel()
+  private let viewModel: SettingsPrivacySwitchCellViewModelType = SettingsPrivacySwitchCellViewModel()
 
   weak var delegate: SettingsPrivacySwitchCellDelegate?
 
@@ -28,7 +28,7 @@ final class SettingsPrivacySwitchCell: UITableViewCell, ValueCell, NibLoading {
   }
 
   func configureWith(value: SettingsPrivacySwitchCellValue) {
-    self.viewModel.configure(with: value.user)
+    self.viewModel.inputs.configure(with: value.user)
 
     _ = self.titleLabel
       |> \.text .~ value.cellType.title
@@ -69,9 +69,9 @@ final class SettingsPrivacySwitchCell: UITableViewCell, ValueCell, NibLoading {
   override func bindViewModel() {
     super.bindViewModel()
 
-    self.switchButton.rac.on = self.viewModel.privacySwitchIsOn
+    self.switchButton.rac.on = self.viewModel.outputs.privacySwitchIsOn
 
-    self.viewModel.privacySwitchToggledOn
+    self.viewModel.outputs.privacySwitchToggledOn
       .observeForControllerAction()
       .observeValues { [weak self] privacyEnabled in
         guard let self = self else { return }
@@ -81,6 +81,6 @@ final class SettingsPrivacySwitchCell: UITableViewCell, ValueCell, NibLoading {
   }
 
   @IBAction func switchToggled(_ sender: UISwitch) {
-    self.viewModel.switchToggled(on: sender.isOn)
+    self.viewModel.inputs.switchToggled(on: sender.isOn)
   }
 }

--- a/Kickstarter-iOS/Views/Controllers/FeatureFlagToolsViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/FeatureFlagToolsViewController.swift
@@ -9,7 +9,7 @@ final class FeatureFlagToolsViewController: UITableViewController {
 
   private var features = [(Feature, Bool)]()
   private let reuseId = "FeatureFlagTools.TableViewCell"
-  private let viewModel = FeatureFlagToolsViewModel()
+  private let viewModel: FeatureFlagToolsViewModelType = FeatureFlagToolsViewModel()
 
   static func instantiate() -> FeatureFlagToolsViewController {
     return FeatureFlagToolsViewController(style: .plain)

--- a/Kickstarter-iOS/Views/Controllers/ManagePledgeSummaryViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/ManagePledgeSummaryViewController.swift
@@ -21,12 +21,12 @@ final class ManagePledgeSummaryViewController: UIViewController {
   private lazy var totalAmountStackView: UIStackView = { UIStackView(frame: .zero) }()
   private lazy var totalLabel: UILabel = { UILabel(frame: .zero) }()
 
-  private let viewModel = ManagePledgeSummaryViewModel()
+  private let viewModel: ManagePledgeSummaryViewModelType = ManagePledgeSummaryViewModel()
 
   // MARK: - Lifecycle
 
   public func configureWith(_ project: Project) {
-    self.viewModel.configureWith(project)
+    self.viewModel.inputs.configureWith(project)
   }
 
   override func viewDidLoad() {

--- a/Kickstarter-iOS/Views/Controllers/PledgeAmountViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/PledgeAmountViewController.swift
@@ -15,7 +15,7 @@ final class PledgeAmountViewController: UIViewController {
   // MARK: - Properties
 
   public weak var delegate: PledgeAmountViewControllerDelegate?
-  private let viewModel = PledgeAmountViewModel()
+  private let viewModel: PledgeAmountViewModelType = PledgeAmountViewModel()
 
   private lazy var adaptableStackView: UIStackView = { UIStackView(frame: .zero) }()
   private lazy var amountInputView: AmountInputView = { AmountInputView(frame: .zero) }()

--- a/Kickstarter-iOS/Views/Controllers/PledgeContinueViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/PledgeContinueViewController.swift
@@ -6,7 +6,7 @@ final class PledgeContinueViewController: UIViewController {
   // MARK: - Properties
 
   private let continueButton = UIButton(type: .custom)
-  private let viewModel = PledgeContinueViewModel()
+  private let viewModel: PledgeContinueViewModelType = PledgeContinueViewModel()
 
   // MARK: - Lifecycle
 

--- a/Kickstarter-iOS/Views/Controllers/PledgeDescriptionViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/PledgeDescriptionViewController.swift
@@ -49,7 +49,7 @@ final class PledgeDescriptionViewController: UIViewController {
       |> \.translatesAutoresizingMaskIntoConstraints .~ false
   }()
 
-  private let viewModel = PledgeDescriptionViewModel()
+  private let viewModel: PledgeDescriptionViewModelType = PledgeDescriptionViewModel()
 
   // MARK: - Lifecycle
 

--- a/Kickstarter-iOS/Views/Controllers/PledgeSummaryViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/PledgeSummaryViewController.swift
@@ -17,7 +17,7 @@ final class PledgeSummaryViewController: UIViewController {
 
   private lazy var termsTextView: UITextView = { UITextView(frame: .zero) |> \.delegate .~ self }()
   private lazy var titleLabel: UILabel = { UILabel(frame: .zero) }()
-  private let viewModel = PledgeSummaryViewModel()
+  private let viewModel: PledgeSummaryViewModelType = PledgeSummaryViewModel()
 
   // MARK: - Lifecycle
 

--- a/Kickstarter-iOS/Views/Controllers/RewardsCollectionViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/RewardsCollectionViewController.swift
@@ -32,7 +32,7 @@ final class RewardsCollectionViewController: UICollectionViewController {
   private var collectionViewBottomConstraintSuperview: NSLayoutConstraint?
   private var collectionViewBottomConstraintFooterView: NSLayoutConstraint?
 
-  private let viewModel = RewardsCollectionViewModel()
+  private let viewModel: RewardsCollectionViewModelType = RewardsCollectionViewModel()
 
   static func instantiate(with project: Project, refTag: RefTag?) -> RewardsCollectionViewController {
     let rewardsCollectionVC = RewardsCollectionViewController()

--- a/Library/ViewModels/RewardsCollectionViewModel.swift
+++ b/Library/ViewModels/RewardsCollectionViewModel.swift
@@ -26,7 +26,7 @@ public protocol RewardsCollectionViewModelOutputs {
   func selectedReward() -> Reward?
 }
 
-protocol RewardsCollectionViewModelType {
+public protocol RewardsCollectionViewModelType {
   var inputs: RewardsCollectionViewModelInputs { get }
   var outputs: RewardsCollectionViewModelOutputs { get }
 }


### PR DESCRIPTION
# 📲 What
 - Makes viewModels explicitly conform to their respective protocols.

# 🤔 Why
- As pointed by @dusi , by doing that we avoid classes to access viewModels properties directly, making the access possible strictly by `inputs`.

# 🛠 How
- Searched for viewModels failing to follow that pattern and replaces `let viewModel = ViewModel()` with `let viewModel: ViewModelType = ViewModel()`.

# ✅ Acceptance criteria

- [ ] No difference should be notices throughout the app.
