### PR TITLE
[NT-241]  Decimal Pledge Amount  in Manage Pledge CTA Fix

### DIFF
--- a/Library/Format.swift
+++ b/Library/Format.swift
@@ -66,6 +66,7 @@ public enum Format {
 
     return formatter.string(for: amount) ?? String(format: "%.2f", amount)
   }
+
   /**
    Formats an int with currency symbol into a string.
 

--- a/Library/Format.swift
+++ b/Library/Format.swift
@@ -66,7 +66,6 @@ public enum Format {
 
     return formatter.string(for: amount) ?? String(format: "%.2f", amount)
   }
-
   /**
    Formats an int with currency symbol into a string.
 

--- a/Library/ViewModels/PledgeCTAContainerViewViewModel.swift
+++ b/Library/ViewModels/PledgeCTAContainerViewViewModel.swift
@@ -162,7 +162,9 @@ private func formattedPledge(amount: Double, project: Project) -> String {
   let numberOfDecimalPlaces = amount.truncatingRemainder(dividingBy: 1) == 0 ? 0 : 2
   let formattedAmount = String(format: "%.\(numberOfDecimalPlaces)f", amount)
 
-  return Format.formattedCurrency(formattedAmount,
-                                  country: project.country,
-                                  omitCurrencyCode: project.stats.omitUSCurrencyCode)
+  return Format.formattedCurrency(
+    formattedAmount,
+    country: project.country,
+    omitCurrencyCode: project.stats.omitUSCurrencyCode
+  )
 }

--- a/Library/ViewModels/PledgeCTAContainerViewViewModel.swift
+++ b/Library/ViewModels/PledgeCTAContainerViewViewModel.swift
@@ -148,10 +148,7 @@ private func subtitle(project: Project, pledgeState: PledgeStateCTAType) -> Stri
 
   if pledgeState == .fix { return pledgeState.subtitleLabel ?? "" }
 
-  let amount = formattedAmountForRewardOrBacking(
-    project: project,
-    rewardOrBacking: .right(backing)
-  )
+  let amount = formattedPledge(amount: backing.amount, project: project)
 
   let reward = backing.reward
     ?? project.rewards.filter { $0.id == backing.rewardId }.first
@@ -159,4 +156,13 @@ private func subtitle(project: Project, pledgeState: PledgeStateCTAType) -> Stri
 
   guard let rewardTitle = reward.title else { return "\(amount)" }
   return "\(amount) • \(rewardTitle)"
+}
+
+private func formattedPledge(amount: Double, project: Project) -> String {
+  let numberOfDecimalPlaces = amount.truncatingRemainder(dividingBy: 1) == 0 ? 0 : 2
+  let formattedAmount = String(format: "%.\(numberOfDecimalPlaces)f", amount)
+
+  return Format.formattedCurrency(formattedAmount,
+                                  country: project.country,
+                                  omitCurrencyCode: project.stats.omitUSCurrencyCode)
 }

--- a/Library/ViewModels/PledgeCTAContainerViewViewModelTests.swift
+++ b/Library/ViewModels/PledgeCTAContainerViewViewModelTests.swift
@@ -54,6 +54,26 @@ internal final class PledgeCTAContainerViewViewModelTests: TestCase {
     self.stackViewIsHidden.assertValues([false])
   }
 
+  func testPledgeCTA_BackerWithDecimalAmount_LiveProject() {
+    let reward = .template
+      |> Reward.lens.title .~ "Magic Lamp"
+    let backing = .template
+      |> Backing.lens.reward .~ reward
+      |> Backing.lens.amount .~ 10.50
+    let project = Project.template
+      |> Project.lens.personalization.isBacking .~ true
+      |> Project.lens.personalization.backing .~ backing
+      |> Project.lens.stats.currentCurrency .~ "USD"
+
+    self.vm.inputs.configureWith(value: (.left(project), false))
+    self.buttonStyleType.assertValues([ButtonStyleType.blue])
+    self.buttonTitleText.assertValues([Strings.Manage()])
+    self.titleText.assertValues([Strings.Youre_a_backer()])
+    self.subtitleText.assertValues(["$10.50 • Magic Lamp"])
+    self.spacerIsHidden.assertValues([false])
+    self.stackViewIsHidden.assertValues([false])
+  }
+
   func testPledgeCTA_Backer_NonLiveProject() {
     let project = Project.template
       |> Project.lens.personalization.isBacking .~ true


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Users can now view their pledge amount correctly if they pledged w/ a decimal value.

# 🤔 Why

Some background context on why the change is needed.

# 🛠 How

`func formattedPledge(amount: Double, project: Project) -> String`  formats the backing amount. If the user backed with a whole amount we drop the decimal places.

# 👀 See

| Before 🐛 | After 🦋 |
| --- | --- |
|![Simulator Screen Shot - iPhone Xs - 2019-10-24 at 15 32 10](https://user-images.githubusercontent.com/11362005/67518792-78363080-f673-11e9-8e55-51ba367d0dc8.png)|![Simulator Screen Shot - iPhone Xs - 2019-10-24 at 15 28 33](https://user-images.githubusercontent.com/11362005/67518540-f8a86180-f672-11e9-9cc4-5f2bd6be1035.png)|

# ✅ Acceptance criteria

- [ ] Navigate to a live and pledged project. Make sure that the pledge amount is formatted correctly. You should see a decimal value if you pledge a decimal amount or a whole number if you did not.


