### PR TITLE
[NT-488] Allow users to update to No Reward

### DIFF
--- a/Kickstarter-iOS/Library/SharedFunctionsTests.swift
+++ b/Kickstarter-iOS/Library/SharedFunctionsTests.swift
@@ -84,7 +84,7 @@ internal final class SharedFunctionsTests: XCTestCase {
       selectedShippingRule: nil
     )
 
-    XCTAssertNil(params.rewardId)
+    XCTAssertEqual(params.rewardId, "UmV3YXJkLTA=")
     XCTAssertEqual(params.pledgeTotal, "10.00")
     XCTAssertNil(params.locationId)
   }

--- a/Library/CreateApplePayBackingInputConstructorTests.swift
+++ b/Library/CreateApplePayBackingInputConstructorTests.swift
@@ -28,7 +28,7 @@ final class CreateApplePayBackingInputConstructorTests: XCTestCase {
     XCTAssertEqual(input.paymentInstrumentName, "Visa 123")
     XCTAssertEqual(input.paymentNetwork, "Visa")
     XCTAssertEqual(input.projectId, project.graphID)
-    XCTAssertNil(input.rewardId)
+    XCTAssertEqual(input.rewardId, "UmV3YXJkLTA=")
     XCTAssertEqual(input.stripeToken, "stripe-token")
     XCTAssertEqual(input.transactionIdentifier, "12345")
     XCTAssertEqual(input.refParam, "project_page")

--- a/Library/CreateBackingConstructorTests.swift
+++ b/Library/CreateBackingConstructorTests.swift
@@ -21,7 +21,7 @@ final class CreateBackingInputConstructorTests: XCTestCase {
     XCTAssertEqual(input.amount, "10.00")
     XCTAssertNil(input.locationId)
     XCTAssertEqual(input.projectId, project.graphID)
-    XCTAssertNil(input.rewardId)
+    XCTAssertEqual(input.rewardId, "UmV3YXJkLTA=")
     XCTAssertEqual(input.refParam, "project_page")
     XCTAssertEqual(input.paymentSourceId, "123")
   }

--- a/Library/SharedFunctions.swift
+++ b/Library/SharedFunctions.swift
@@ -251,7 +251,7 @@ internal func sanitizedPledgeParameters(
   let pledgeTotal = NSDecimalNumber(decimal: pledgeAmountDecimal + shippingAmountDecimal)
   let formattedPledgeTotal = Format.decimalCurrency(for: pledgeTotal.doubleValue)
 
-  let rewardId = reward == Reward.noReward ? nil : reward.graphID
+  let rewardId = reward.graphID
 
   return (formattedPledgeTotal, rewardId, shippingLocationId)
 }


### PR DESCRIPTION
# 📲 What

Allows us to update our backing to No Reward.

# 🤔 Why

A bug existed on the back-end which was preventing this. That has since [been fixed](https://github.com/kickstarter/kickstarter/pull/17818) and this updates the app to support it.

# 🛠 How

Pass a relay ID of `0` when updating to No Reward.

# ✅ Acceptance criteria

- [ ] Create a backing selecting any reward. Update that backing to No Reward. The change should reflect. (Note that #914 fixes the navigation back to Manage Pledge VC after update).