### PR TITLE
[NT-484] Tracking event for Cancel Pledge

### DIFF
--- a/Library/Koala/Koala.swift
+++ b/Library/Koala/Koala.swift
@@ -602,7 +602,6 @@ public final class Koala {
   public func trackCancelPledgeButtonClicked(project: Project, backing: Backing) {
     let props = properties(project: project, loggedInUser: self.loggedInUser)
       .withAllValuesFrom(["pledge_total": backing.amount])
-      .withAllValuesFrom(["project_parent_category":  project.category.parent?.name])
 
     self.track(event: "Cancel Pledge Button Clicked", properties: props)
   }

--- a/Library/Koala/Koala.swift
+++ b/Library/Koala/Koala.swift
@@ -599,6 +599,14 @@ public final class Koala {
     }
   }
 
+  public func trackCancelPledgeButtonClicked(project: Project, backing: Backing) {
+    let props = properties(project: project, loggedInUser: self.loggedInUser)
+      .withAllValuesFrom(["pledge_total": backing.amount])
+      .withAllValuesFrom(["project_parent_category":  project.category.parent?.name])
+
+    self.track(event: "Cancel Pledge Button Clicked", properties: props)
+  }
+
   public func trackSelectRewardButtonClicked(
     project: Project,
     reward: Reward?,

--- a/Library/Koala/KoalaTests.swift
+++ b/Library/Koala/KoalaTests.swift
@@ -568,4 +568,17 @@ final class KoalaTests: TestCase {
     XCTAssertEqual(["Select Reward Button Clicked"], client.events)
     XCTAssertEqual("Back this page", properties?["screen"] as? String)
   }
+
+  func testTrackCancelPledgeButtonClicked() {
+    let client = MockTrackingClient()
+    let loggedInUser = User.template
+
+    let koala = Koala(client: client, loggedInUser: loggedInUser)
+
+    koala.trackCancelPledgeButtonClicked(
+      project: .template,
+      backing: .template
+    )
+    XCTAssertEqual(["Cancel Pledge Button Clicked"], client.events)
+  }
 }

--- a/Library/ViewModels/CancelPledgeViewModel.swift
+++ b/Library/ViewModels/CancelPledgeViewModel.swift
@@ -37,8 +37,12 @@ public final class CancelPledgeViewModel: CancelPledgeViewModelType, CancelPledg
     )
     .map(first)
 
+    let project = initialData
+      .map(first)
     let backing = initialData
       .map(second)
+
+    let projectAndBacking = Signal.combineLatest(project, backing)
 
     self.cancellationDetailsAttributedText = Signal.merge(
       initialData,
@@ -93,6 +97,15 @@ public final class CancelPledgeViewModel: CancelPledgeViewModelType, CancelPledg
       cancelPledgeEvent.map { $0.isTerminating }.mapConst(true)
     )
     .skipRepeats()
+
+    //Tracking
+    projectAndBacking
+      .takeWhen(self.cancelPledgeButtonTappedProperty.signal)
+      .observeValues { AppEnvironment.current.koala.trackCancelPledgeButtonClicked(
+        project: $0,
+        backing: $1
+      )
+    }
   }
 
   private let cancelPledgeButtonTappedProperty = MutableProperty(())

--- a/Library/ViewModels/CancelPledgeViewModel.swift
+++ b/Library/ViewModels/CancelPledgeViewModel.swift
@@ -98,14 +98,14 @@ public final class CancelPledgeViewModel: CancelPledgeViewModelType, CancelPledg
     )
     .skipRepeats()
 
-    //Tracking
+    // Tracking
     projectAndBacking
       .takeWhen(self.cancelPledgeButtonTappedProperty.signal)
       .observeValues { AppEnvironment.current.koala.trackCancelPledgeButtonClicked(
         project: $0,
         backing: $1
       )
-    }
+      }
   }
 
   private let cancelPledgeButtonTappedProperty = MutableProperty(())

--- a/Library/ViewModels/CancelPledgeViewModelTests.swift
+++ b/Library/ViewModels/CancelPledgeViewModelTests.swift
@@ -222,4 +222,19 @@ final class CancelPledgeViewModelTests: TestCase {
       self.cancelPledgeError.assertValues(["You can't cancel your pledge right now."])
     }
   }
+
+  func testTrackingEvents() {
+    let mockService = MockService(cancelBackingResult: .init(success: .init()))
+
+    withEnvironment(apiService: mockService) {
+      self.vm.inputs.configure(with: .template, backing: .template)
+      self.vm.inputs.viewDidLoad()
+
+      self.cancelPledgeButtonEnabled.assertValues([true])
+
+      self.vm.inputs.cancelPledgeButtonTapped()
+
+      XCTAssertEqual(["Cancel Pledge Button Clicked"], self.trackingClient.events)
+    }
+  }
 }


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What
Improvements in monitoring user behavior for v1 checkout. This tracks canceled pledges.

# 🤔 Why

We now have the `Cancel Pledge Button Clicked` event

# ✅ Acceptance criteria

- [ ] Navigate to a live and backed project. Go to the manage menu and tap `Cancel Pledge`.  Tap on `Yes, Cancel it` button and you should see the event triggered.

