### PR TITLE
[NT-394] Fix loading button title restoration

### DIFF
--- a/Kickstarter-iOS/Views/LoadingButton.swift
+++ b/Kickstarter-iOS/Views/LoadingButton.swift
@@ -115,7 +115,7 @@ final class LoadingButton: UIButton {
     let states: [UIControl.State] = [.disabled, .highlighted, .normal, .selected]
 
     states.compactMap { state -> (String, UIControl.State)? in
-      guard let title = self.title(for: state) else { return nil }
+      guard let title = self.originalTitles[state.rawValue] else { return nil }
       return (title, state)
     }
     .forEach { title, state in


### PR DESCRIPTION
# 📲 What

Fixes a small bug which left our button title empty after the loader was hidden.

# 🤔 Why

This was just a small oversight in #892.

# 🛠 How

Fixed what was essentially just a copy-paste error.

# 👀 See

| Before 🐛 | After 🦋 |
| --- | --- |
| <img width="545" alt="image" src="https://user-images.githubusercontent.com/3735375/67822051-50343c00-fa7c-11e9-8352-7ea35b22959d.png"> | <img width="545" alt="image" src="https://user-images.githubusercontent.com/3735375/67821978-1c591680-fa7c-11e9-8007-ad29a1a0fe60.png"> |

# ♿️ Accessibility 

- [ ] Tap targets use minimum of 44x44 pts dimensions
- [ ] Works with VoiceOver
- [ ] Supports Dynamic Type 

# ✅ Acceptance criteria

- [ ] Update your pledge, after loading completes the button title should be set again. Use Charles proxy with breakpoints or slow down animations to confirm.