### PR TITLE
[NT-498] Prevent app freezing with accessibility inspector

### DIFF
--- a/Kickstarter-iOS/Views/Controllers/PledgeDescriptionViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/PledgeDescriptionViewController.swift
@@ -174,6 +174,8 @@ final class PledgeDescriptionViewController: UIViewController {
   }
 
   private func sizeAndTransformRewardCardView() {
+    guard !self.view.isHidden else { return }
+
     self.rewardCardContainerView.layoutIfNeeded()
 
     let cardContainerViewSize = self.rewardCardContainerView.bounds.size


### PR DESCRIPTION
# 📲 What

Fixes a app-freezing bug in the simulator when adjusting text size using the accessibility inspector in _Manage pledge_ views.

# 🤔 Why

Although this didn't appear to be happening on device we do often adjust text sizes with the inspector and this affects our development workflow. Also this seemed to point out something problematic in the layout and warranted further investigation.

# 🛠 How

- Added a `guard` clause to prevent calculating the thumbnail size when `PledgeDescriptionViewController` is hidden.

We hide `PledgeDescriptionViewController` when we are in any of the _Manage pledge_ flows other than _Choose another reward_. When this view is hidden it's not necessary to try to calculate the thumbnail size.

# ✅ Acceptance criteria

- [x] Run the app in simulator on `master`. Navigate to _Update pledge_ on a project that you've backed. Open the accessibility inspector and adjust text sizes, the app should freeze.
- [x] Check out this branch and repeat the steps above, the app should not freeze in any of the _Manage pledge_ views.