### PR TITLE
[NT-486] Tracking event for Update Payment Method

### DIFF
--- a/Library/Koala/Koala.swift
+++ b/Library/Koala/Koala.swift
@@ -606,6 +606,14 @@ public final class Koala {
     self.track(event: "Cancel Pledge Button Clicked", properties: props)
   }
 
+  public func trackUpdatePaymentMethodButton(project: Project, pledgeAmount: Double) {
+    let props = properties(project: project, loggedInUser: self.loggedInUser)
+      .withAllValuesFrom(["pledge_total": pledgeAmount])
+
+    self.track(event: "Update Payment Method Button Clicked", properties: props)
+  }
+
+
   public func trackSelectRewardButtonClicked(
     project: Project,
     reward: Reward?,

--- a/Library/Koala/Koala.swift
+++ b/Library/Koala/Koala.swift
@@ -613,7 +613,6 @@ public final class Koala {
     self.track(event: "Update Payment Method Button Clicked", properties: props)
   }
 
-
   public func trackSelectRewardButtonClicked(
     project: Project,
     reward: Reward?,

--- a/Library/Koala/KoalaTests.swift
+++ b/Library/Koala/KoalaTests.swift
@@ -581,4 +581,17 @@ final class KoalaTests: TestCase {
     )
     XCTAssertEqual(["Cancel Pledge Button Clicked"], client.events)
   }
+
+  func testTrackUpdatePaymentMethodClicked() {
+    let client = MockTrackingClient()
+    let loggedInUser = User.template
+    let koala = Koala(client: client, loggedInUser: loggedInUser)
+
+    koala.trackUpdatePaymentMethodButton(project: .template, pledgeAmount: 22.00)
+
+    let properties = client.properties.last
+
+    XCTAssertEqual(["Update Payment Method Button Clicked"], client.events)
+    XCTAssertEqual(22.00, properties?["pledge_total"] as? Double)
+  }
 }

--- a/Library/ViewModels/PledgeViewModel.swift
+++ b/Library/ViewModels/PledgeViewModel.swift
@@ -548,6 +548,17 @@ public class PledgeViewModel: PledgeViewModelType, PledgeViewModelInputs, Pledge
 
     self.submitButtonTitle = context.map { $0.submitButtonTitle }
     self.title = context.map { $0.title }
+    let projectAndPledgeAmount = Signal.combineLatest(context, project, pledgeAmount)
+
+    //Tracking
+    projectAndPledgeAmount
+      .filter { context, _, _ in context == .changePaymentMethod}
+      .takeWhen(updateButtonTapped)
+      .observeValues { AppEnvironment.current.koala.trackUpdatePaymentMethodButton(
+        project: $1,
+        pledgeAmount: $2
+      )
+      }
   }
 
   // MARK: - Inputs

--- a/Library/ViewModels/PledgeViewModel.swift
+++ b/Library/ViewModels/PledgeViewModel.swift
@@ -550,7 +550,7 @@ public class PledgeViewModel: PledgeViewModelType, PledgeViewModelInputs, Pledge
     self.title = context.map { $0.title }
     let contextAndProjectAndPledgeAmount = Signal.combineLatest(context, project, pledgeAmount)
 
-    //Tracking
+    // Tracking
     contextAndProjectAndPledgeAmount
       .filter { $0.0 == .changePaymentMethod }
       .takeWhen(updateButtonTapped)

--- a/Library/ViewModels/PledgeViewModel.swift
+++ b/Library/ViewModels/PledgeViewModel.swift
@@ -548,11 +548,11 @@ public class PledgeViewModel: PledgeViewModelType, PledgeViewModelInputs, Pledge
 
     self.submitButtonTitle = context.map { $0.submitButtonTitle }
     self.title = context.map { $0.title }
-    let projectAndPledgeAmount = Signal.combineLatest(context, project, pledgeAmount)
+    let contextAndProjectAndPledgeAmount = Signal.combineLatest(context, project, pledgeAmount)
 
     //Tracking
-    projectAndPledgeAmount
-      .filter { context, _, _ in context == .changePaymentMethod}
+    contextAndProjectAndPledgeAmount
+      .filter { $0.0 == .changePaymentMethod }
       .takeWhen(updateButtonTapped)
       .observeValues { AppEnvironment.current.koala.trackUpdatePaymentMethodButton(
         project: $1,

--- a/Library/ViewModels/PledgeViewModelTests.swift
+++ b/Library/ViewModels/PledgeViewModelTests.swift
@@ -3348,20 +3348,6 @@ final class PledgeViewModelTests: TestCase {
     }
   }
 
-  func testTrackingEvents_UpdatePaymentMethod() {
-    self.vm.inputs.configureWith(
-      project: .template, reward: .template,
-      refTag: nil, context: .changePaymentMethod
-    )
-    self.vm.inputs.viewDidLoad()
-
-    XCTAssertEqual([], self.trackingClient.events)
-
-    self.vm.inputs.submitButtonTapped()
-
-    XCTAssertEqual(["Update Payment Method Button Clicked"], self.trackingClient.events)
-  }
-
   func testUpdateBacking_RequiresSCA_Canceled() {
     let reward = Reward.postcards
       |> Reward.lens.shipping.enabled .~ true
@@ -3440,6 +3426,20 @@ final class PledgeViewModelTests: TestCase {
       self.popToRootViewController.assertDidNotEmitValue()
       self.showErrorBannerWithMessage.assertDidNotEmitValue()
     }
+  }
+
+  func testTrackingEvents_UpdatePaymentMethod() {
+    self.vm.inputs.configureWith(
+      project: .template, reward: .template,
+      refTag: nil, context: .changePaymentMethod
+    )
+    self.vm.inputs.viewDidLoad()
+
+    XCTAssertEqual([], self.trackingClient.events)
+
+    self.vm.inputs.submitButtonTapped()
+
+    XCTAssertEqual(["Update Payment Method Button Clicked"], self.trackingClient.events)
   }
 
   func testTrackingEvents_ContextIsUpdate() {

--- a/Library/ViewModels/PledgeViewModelTests.swift
+++ b/Library/ViewModels/PledgeViewModelTests.swift
@@ -3463,18 +3463,4 @@ final class PledgeViewModelTests: TestCase {
 
     XCTAssertEqual(["Update Pledge Button Clicked"], self.trackingClient.events)
   }
-
-  func testTrackingEvents_DoesNotEmit_ContextIsChangePaymentMethod() {
-    self.vm.inputs.configureWith(
-      project: .template, reward: .template, refTag: nil,
-      context: .changePaymentMethod
-    )
-    self.vm.inputs.viewDidLoad()
-
-    XCTAssertEqual([], self.trackingClient.events)
-
-    self.vm.inputs.submitButtonTapped()
-
-    XCTAssertEqual([], self.trackingClient.events)
-  }
 }

--- a/Library/ViewModels/PledgeViewModelTests.swift
+++ b/Library/ViewModels/PledgeViewModelTests.swift
@@ -3348,6 +3348,36 @@ final class PledgeViewModelTests: TestCase {
     }
   }
 
+  func testTrackingEvents_UpdatePaymentMethod() {
+    let updateBackingEnvelope = UpdateBackingEnvelope(
+      updateBacking: .init(
+        checkout: .init(
+          state: .successful,
+          backing: .init(
+            clientSecret: "client-secret",
+            requiresAction: true
+          )
+        )
+      )
+    )
+
+    let mockService = MockService(
+      updateBackingResult: .success(updateBackingEnvelope)
+    )
+
+    withEnvironment(apiService: mockService, currentUser: .template) {
+      self.vm.inputs.configureWith(project: .template, reward: .template,
+                                   refTag: nil, context: .changePaymentMethod)
+      self.vm.inputs.viewDidLoad()
+
+      XCTAssertEqual([], self.trackingClient.events)
+
+      self.vm.inputs.submitButtonTapped()
+
+      XCTAssertEqual(["Update Payment Method Button Clicked"], self.trackingClient.events)
+    }
+  }
+
   func testUpdateBacking_RequiresSCA_Canceled() {
     let reward = Reward.postcards
       |> Reward.lens.shipping.enabled .~ true

--- a/Library/ViewModels/PledgeViewModelTests.swift
+++ b/Library/ViewModels/PledgeViewModelTests.swift
@@ -3349,33 +3349,15 @@ final class PledgeViewModelTests: TestCase {
   }
 
   func testTrackingEvents_UpdatePaymentMethod() {
-    let updateBackingEnvelope = UpdateBackingEnvelope(
-      updateBacking: .init(
-        checkout: .init(
-          state: .successful,
-          backing: .init(
-            clientSecret: "client-secret",
-            requiresAction: true
-          )
-        )
-      )
-    )
+    self.vm.inputs.configureWith(project: .template, reward: .template,
+                                 refTag: nil, context: .changePaymentMethod)
+    self.vm.inputs.viewDidLoad()
 
-    let mockService = MockService(
-      updateBackingResult: .success(updateBackingEnvelope)
-    )
+    XCTAssertEqual([], self.trackingClient.events)
 
-    withEnvironment(apiService: mockService, currentUser: .template) {
-      self.vm.inputs.configureWith(project: .template, reward: .template,
-                                   refTag: nil, context: .changePaymentMethod)
-      self.vm.inputs.viewDidLoad()
+    self.vm.inputs.submitButtonTapped()
 
-      XCTAssertEqual([], self.trackingClient.events)
-
-      self.vm.inputs.submitButtonTapped()
-
-      XCTAssertEqual(["Update Payment Method Button Clicked"], self.trackingClient.events)
-    }
+    XCTAssertEqual(["Update Payment Method Button Clicked"], self.trackingClient.events)
   }
 
   func testUpdateBacking_RequiresSCA_Canceled() {

--- a/Library/ViewModels/PledgeViewModelTests.swift
+++ b/Library/ViewModels/PledgeViewModelTests.swift
@@ -3349,8 +3349,10 @@ final class PledgeViewModelTests: TestCase {
   }
 
   func testTrackingEvents_UpdatePaymentMethod() {
-    self.vm.inputs.configureWith(project: .template, reward: .template,
-                                 refTag: nil, context: .changePaymentMethod)
+    self.vm.inputs.configureWith(
+      project: .template, reward: .template,
+      refTag: nil, context: .changePaymentMethod
+    )
     self.vm.inputs.viewDidLoad()
 
     XCTAssertEqual([], self.trackingClient.events)


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Improvements in monitoring user behavior for v1 checkout. This tracks update payment methods.

# 🤔 Why

We now have the `Update Payment Method Button Clicked` event.

# ✅ Acceptance criteria

- [x] Navigate to a live and backed project. Go to the manage menu and tap `Change Payment Method`. Change your payment method and tap `Confirm`, you should see the `"Update Payment Method Button Clicked"` triggered.
