### PR TITLE
[NT-532] Add backing status strings for creator context

### DIFF
--- a/Kickstarter-iOS/Locales/de.lproj/Localizable.strings
+++ b/Kickstarter-iOS/Locales/de.lproj/Localizable.strings
@@ -558,8 +558,8 @@
 "We_couldnt_find_anything_for_search_term" = "Es wurden keine Ergebnisse für die Suche \"%{search_term}\" gefunden.";
 "We_couldnt_process_your_pledge" = "Dein Finanzierungsbeitrag konnte nicht bearbeitet werden.";
 "We_dont_allow_cancelations_that_will_cause_a_project_to_fall_short_of_its_goal_within_the_last_24_hours" = "Es ist nicht gestattet, innerhalb der letzten 24 Stunden vor Beendigung eines Projekts einen Finanzierungsbeitrag zurückzuziehen, wenn dadurch das Finanzierungsziel nicht mehr erreicht werden würde.";
-"We_re_processing_this_pledge_pull_to_refresh" = "We're processing this pledge—pull to refresh.";
-"We_re_processing_your_pledge_pull_to_refresh" = "We're processing your pledge—pull to refresh.";
+"We_re_processing_this_pledge_pull_to_refresh" = "Der Finanzierungsbeitrag wird derzeit bearbeitet — zur Aktualisierung nach unten ziehen.";
+"We_re_processing_your_pledge_pull_to_refresh" = "Dein Finanzierungsbeitrag wird derzeit bearbeitet — zur Aktualisierung nach unten ziehen.";
 "We_think_youll_like_these_too" = "Wir denken, diese Projekte könnten dir auch gefallen";
 "We_use_your_activity_internally_to_make_recommendations_for_you" = "Deine Aktivitäten werden intern genutzt, um dir Empfehlungen zu unterbreiten. Um dies zu deaktivieren, wähle \"Empfehlungen\" einfach ab.";
 "We_ve_been_unable_to_send_email" = "Wir konnten keine E-Mails an diese Adresse senden. Bitte prüfe, ob sie richtig eingegeben wurde.";

--- a/Kickstarter-iOS/Locales/es.lproj/Localizable.strings
+++ b/Kickstarter-iOS/Locales/es.lproj/Localizable.strings
@@ -558,8 +558,8 @@
 "We_couldnt_find_anything_for_search_term" = "La búsqueda \"%{search_term}\" no dio resultados.";
 "We_couldnt_process_your_pledge" = "No pudimos procesar tu contribución.";
 "We_dont_allow_cancelations_that_will_cause_a_project_to_fall_short_of_its_goal_within_the_last_24_hours" = "No permitimos cancelaciones que ocasionen que un proyecto no alcance su meta en las últimas 24 horas.";
-"We_re_processing_this_pledge_pull_to_refresh" = "We're processing this pledge—pull to refresh.";
-"We_re_processing_your_pledge_pull_to_refresh" = "We're processing your pledge—pull to refresh.";
+"We_re_processing_this_pledge_pull_to_refresh" = "Estamos procesando la contribución, desliza para actualizar.";
+"We_re_processing_your_pledge_pull_to_refresh" = "Estamos procesando tu actualización, desliza para actualizar.";
 "We_think_youll_like_these_too" = "¡Te van a encantar, también!";
 "We_use_your_activity_internally_to_make_recommendations_for_you" = "Utilizamos tu actividad internamente para hacerte recomendaciones. Desactiva las recomendaciones si no quieres recibirlas.";
 "We_ve_been_unable_to_send_email" = "No pudimos enviar el correo electrónico a esta dirección. Asegúrate de que esté escrita correctamente.";

--- a/Kickstarter-iOS/Locales/fr.lproj/Localizable.strings
+++ b/Kickstarter-iOS/Locales/fr.lproj/Localizable.strings
@@ -558,8 +558,8 @@
 "We_couldnt_find_anything_for_search_term" = "Pas de résultats pour « %{search_term} ».";
 "We_couldnt_process_your_pledge" = "Impossible de traiter votre engagement.";
 "We_dont_allow_cancelations_that_will_cause_a_project_to_fall_short_of_its_goal_within_the_last_24_hours" = "Les annulations qui empêcheraient le créateur d'atteindre son objectif de financement sont interdits dans les dernières 24 heures de la campagne.";
-"We_re_processing_this_pledge_pull_to_refresh" = "We're processing this pledge—pull to refresh.";
-"We_re_processing_your_pledge_pull_to_refresh" = "We're processing your pledge—pull to refresh.";
+"We_re_processing_this_pledge_pull_to_refresh" = "Cet engagement est en cours de traitement, veuillez tirer sur la page pour actualiser.";
+"We_re_processing_your_pledge_pull_to_refresh" = "Votre engagement est en cours de traitement, veuillez tirer sur la page pour actualiser.";
 "We_think_youll_like_these_too" = "D'autres projets qui pourraient vous plaire";
 "We_use_your_activity_internally_to_make_recommendations_for_you" = "À l'interne, nous nous servons de vos activités pour vous faire des recommandations. Si vous ne souhaitez pas participer, nous vous invitons à désactiver vos recommandations.";
 "We_ve_been_unable_to_send_email" = "Échec de l'envoi. Veuillez vérifier l'orthographe de votre adresse e-mail.";

--- a/Library/Strings.swift
+++ b/Library/Strings.swift
@@ -9151,9 +9151,9 @@ catch your eye?"
    "We're processing this pledge—pull to refresh."
 
    - **en**: "We're processing this pledge—pull to refresh."
-   - **de**: "We're processing this pledge—pull to refresh."
-   - **es**: "We're processing this pledge—pull to refresh."
-   - **fr**: "We're processing this pledge—pull to refresh."
+   - **de**: "Der Finanzierungsbeitrag wird derzeit bearbeitet — zur Aktualisierung nach unten ziehen."
+   - **es**: "Estamos procesando la contribución, desliza para actualizar."
+   - **fr**: "Cet engagement est en cours de traitement, veuillez tirer sur la page pour actualiser."
    - **ja**: "We're processing this pledge—pull to refresh."
   */
   public static func We_re_processing_this_pledge_pull_to_refresh() -> String {
@@ -9168,9 +9168,9 @@ catch your eye?"
    "We're processing your pledge—pull to refresh."
 
    - **en**: "We're processing your pledge—pull to refresh."
-   - **de**: "We're processing your pledge—pull to refresh."
-   - **es**: "We're processing your pledge—pull to refresh."
-   - **fr**: "We're processing your pledge—pull to refresh."
+   - **de**: "Dein Finanzierungsbeitrag wird derzeit bearbeitet — zur Aktualisierung nach unten ziehen."
+   - **es**: "Estamos procesando tu actualización, desliza para actualizar."
+   - **fr**: "Votre engagement est en cours de traitement, veuillez tirer sur la page pour actualiser."
    - **ja**: "We're processing your pledge—pull to refresh."
   */
   public static func We_re_processing_your_pledge_pull_to_refresh() -> String {


### PR DESCRIPTION
# 📲 What

Continues the work in #934 and adds the strings that would be seen on `ManagePledgeViewController` to describe the `Backing.Status` in a creator context.

# 🤔 Why

It is possible for a creator to see this information when navigating to a backing via their dashboard.

# 🛠 How

Added strings and tests!

# ✅ Acceptance criteria

- [ ] Confirm the strings match the [ticket](https://dripsprint.atlassian.net/browse/NT-532)