### PR TITLE
[NT-581] Re-set visitor cookie before fetching config

### DIFF
--- a/Kickstarter-iOS/ViewModels/AppDelegateViewModelTests.swift
+++ b/Kickstarter-iOS/ViewModels/AppDelegateViewModelTests.swift
@@ -1368,9 +1368,10 @@ final class AppDelegateViewModelTests: TestCase {
     )
     XCTAssertEqual(
       [
-        "api.kickstarter.com",
-        "www.kickstarter.com"
-      ],
+        AppEnvironment.current.apiService.serverConfig.apiBaseUrl.host,
+        AppEnvironment.current.apiService.serverConfig.webBaseUrl.host
+      ]
+      .compact(),
       AppEnvironment.current.cookieStorage.cookies!.map { $0.domain }.sorted()
     )
   }
@@ -1406,10 +1407,11 @@ final class AppDelegateViewModelTests: TestCase {
     )
     XCTAssertEqual(
       [
-        "api.kickstarter.com",
-        "api.kickstarter.com",
-        "www.kickstarter.com"
-      ],
+        AppEnvironment.current.apiService.serverConfig.apiBaseUrl.host,
+        AppEnvironment.current.apiService.serverConfig.apiBaseUrl.host,
+        AppEnvironment.current.apiService.serverConfig.webBaseUrl.host
+      ]
+      .compact(),
       AppEnvironment.current.cookieStorage.cookies!.map { $0.domain }.sorted()
     )
   }
@@ -1445,10 +1447,11 @@ final class AppDelegateViewModelTests: TestCase {
     )
     XCTAssertEqual(
       [
-        "api.kickstarter.com",
-        "api.kickstarter.com",
-        "www.kickstarter.com"
-      ],
+        AppEnvironment.current.apiService.serverConfig.apiBaseUrl.host,
+        AppEnvironment.current.apiService.serverConfig.apiBaseUrl.host,
+        AppEnvironment.current.apiService.serverConfig.webBaseUrl.host
+      ]
+      .compact(),
       AppEnvironment.current.cookieStorage.cookies!.map { $0.domain }.sorted()
     )
   }
@@ -1484,10 +1487,11 @@ final class AppDelegateViewModelTests: TestCase {
     )
     XCTAssertEqual(
       [
-        "api.kickstarter.com",
-        "api.kickstarter.com",
-        "www.kickstarter.com"
-      ],
+        AppEnvironment.current.apiService.serverConfig.apiBaseUrl.host,
+        AppEnvironment.current.apiService.serverConfig.apiBaseUrl.host,
+        AppEnvironment.current.apiService.serverConfig.webBaseUrl.host
+      ]
+      .compact(),
       AppEnvironment.current.cookieStorage.cookies!.map { $0.domain }.sorted()
     )
   }

--- a/Kickstarter-iOS/ViewModels/AppDelegateViewModelTests.swift
+++ b/Kickstarter-iOS/ViewModels/AppDelegateViewModelTests.swift
@@ -1366,6 +1366,13 @@ final class AppDelegateViewModelTests: TestCase {
       ["DEADBEEF-DEAD-BEEF-DEAD-DEADBEEFBEEF", "DEADBEEF-DEAD-BEEF-DEAD-DEADBEEFBEEF"],
       AppEnvironment.current.cookieStorage.cookies!.map { $0.value }
     )
+    XCTAssertEqual(
+      [
+        "api.kickstarter.com",
+        "www.kickstarter.com"
+      ],
+      AppEnvironment.current.cookieStorage.cookies!.map { $0.domain }.sorted()
+    )
   }
 
   func testVisitorCookies_ApplicationWillEnterForeground() {
@@ -1396,6 +1403,14 @@ final class AppDelegateViewModelTests: TestCase {
         "existing-cookie-value"
       ],
       AppEnvironment.current.cookieStorage.cookies!.map { $0.value }.sorted()
+    )
+    XCTAssertEqual(
+      [
+        "api.kickstarter.com",
+        "api.kickstarter.com",
+        "www.kickstarter.com"
+      ],
+      AppEnvironment.current.cookieStorage.cookies!.map { $0.domain }.sorted()
     )
   }
 
@@ -1428,6 +1443,14 @@ final class AppDelegateViewModelTests: TestCase {
       ],
       AppEnvironment.current.cookieStorage.cookies!.map { $0.value }.sorted()
     )
+    XCTAssertEqual(
+      [
+        "api.kickstarter.com",
+        "api.kickstarter.com",
+        "www.kickstarter.com"
+      ],
+      AppEnvironment.current.cookieStorage.cookies!.map { $0.domain }.sorted()
+    )
   }
 
   func testVisitorCookies_UserSessionEnded() {
@@ -1458,6 +1481,14 @@ final class AppDelegateViewModelTests: TestCase {
         "existing-cookie-value"
       ],
       AppEnvironment.current.cookieStorage.cookies!.map { $0.value }.sorted()
+    )
+    XCTAssertEqual(
+      [
+        "api.kickstarter.com",
+        "api.kickstarter.com",
+        "www.kickstarter.com"
+      ],
+      AppEnvironment.current.cookieStorage.cookies!.map { $0.domain }.sorted()
     )
   }
 

--- a/Kickstarter-iOS/ViewModels/AppDelegateViewModelTests.swift
+++ b/Kickstarter-iOS/ViewModels/AppDelegateViewModelTests.swift
@@ -1355,7 +1355,7 @@ final class AppDelegateViewModelTests: TestCase {
     )
   }
 
-  func testVisitorCookies() {
+  func testVisitorCookies_ApplicationDidFinishLaunching() {
     self.vm.inputs.applicationDidFinishLaunching(
       application: UIApplication.shared,
       launchOptions: [:]
@@ -1365,6 +1365,99 @@ final class AppDelegateViewModelTests: TestCase {
     XCTAssertEqual(
       ["DEADBEEF-DEAD-BEEF-DEAD-DEADBEEFBEEF", "DEADBEEF-DEAD-BEEF-DEAD-DEADBEEFBEEF"],
       AppEnvironment.current.cookieStorage.cookies!.map { $0.value }
+    )
+  }
+
+  func testVisitorCookies_ApplicationWillEnterForeground() {
+    let existingCookie = HTTPCookie(
+      properties: [
+        .name: "existing-cookie",
+        .value: "existing-cookie-value",
+        .domain: AppEnvironment.current.apiService.serverConfig.apiBaseUrl.host as Any,
+        .path: "/",
+        .version: 0,
+        .expires: Date.distantFuture,
+        .secure: true
+      ]
+    )
+
+    AppEnvironment.current.cookieStorage.setCookie(existingCookie!)
+
+    self.vm.inputs.applicationWillEnterForeground()
+
+    XCTAssertEqual(
+      ["existing-cookie", "vis", "vis"],
+      AppEnvironment.current.cookieStorage.cookies!.map { $0.name }.sorted()
+    )
+    XCTAssertEqual(
+      [
+        "DEADBEEF-DEAD-BEEF-DEAD-DEADBEEFBEEF",
+        "DEADBEEF-DEAD-BEEF-DEAD-DEADBEEFBEEF",
+        "existing-cookie-value"
+      ],
+      AppEnvironment.current.cookieStorage.cookies!.map { $0.value }.sorted()
+    )
+  }
+
+  func testVisitorCookies_UserSessionStarted() {
+    let existingCookie = HTTPCookie(
+      properties: [
+        .name: "existing-cookie",
+        .value: "existing-cookie-value",
+        .domain: AppEnvironment.current.apiService.serverConfig.apiBaseUrl.host as Any,
+        .path: "/",
+        .version: 0,
+        .expires: Date.distantFuture,
+        .secure: true
+      ]
+    )
+
+    AppEnvironment.current.cookieStorage.setCookie(existingCookie!)
+
+    self.vm.inputs.userSessionStarted()
+
+    XCTAssertEqual(
+      ["existing-cookie", "vis", "vis"],
+      AppEnvironment.current.cookieStorage.cookies!.map { $0.name }.sorted()
+    )
+    XCTAssertEqual(
+      [
+        "DEADBEEF-DEAD-BEEF-DEAD-DEADBEEFBEEF",
+        "DEADBEEF-DEAD-BEEF-DEAD-DEADBEEFBEEF",
+        "existing-cookie-value"
+      ],
+      AppEnvironment.current.cookieStorage.cookies!.map { $0.value }.sorted()
+    )
+  }
+
+  func testVisitorCookies_UserSessionEnded() {
+    let existingCookie = HTTPCookie(
+      properties: [
+        .name: "existing-cookie",
+        .value: "existing-cookie-value",
+        .domain: AppEnvironment.current.apiService.serverConfig.apiBaseUrl.host as Any,
+        .path: "/",
+        .version: 0,
+        .expires: Date.distantFuture,
+        .secure: true
+      ]
+    )
+
+    AppEnvironment.current.cookieStorage.setCookie(existingCookie!)
+
+    self.vm.inputs.userSessionEnded()
+
+    XCTAssertEqual(
+      ["existing-cookie", "vis", "vis"],
+      AppEnvironment.current.cookieStorage.cookies!.map { $0.name }.sorted()
+    )
+    XCTAssertEqual(
+      [
+        "DEADBEEF-DEAD-BEEF-DEAD-DEADBEEFBEEF",
+        "DEADBEEF-DEAD-BEEF-DEAD-DEADBEEFBEEF",
+        "existing-cookie-value"
+      ],
+      AppEnvironment.current.cookieStorage.cookies!.map { $0.value }.sorted()
     )
   }
 

--- a/KsApi/lib/Route.swift
+++ b/KsApi/lib/Route.swift
@@ -121,7 +121,7 @@ internal enum Route {
       return (.GET, url, [:], nil)
 
     case .config:
-      return (.GET, "/v1/app/ios/config", [:], nil)
+      return (.GET, "/v1/app/ios/config", ["no_cache": "\(Date().timeIntervalSince1970)"], nil)
 
     case let .createPledge(project, amount, reward, shippingLocation, tappedReward):
       let pledgeUrl = URL(string: project.urls.web.project)?


### PR DESCRIPTION
# 📲 What

- Ensures that `identifierForVendor` is set in our visitor cookie before fetching the config.
- Adds a `no_cache` query param to the request that fetches the config to ensure that it is not cached.

# 🤔 Why

We've found that in some scenarios, logging out in particular, we refresh the config without a visitor cookie being set. This causes unexpected behaviour in the way our A/B experiments work as the back-end depends on the identifier in this cookie in order to place the user into the experimental or control group.

We've also noticed that we are sometimes receiving `304 Not Modified` responses to our requests for the user config. We always want a fresh config when we request one.

# 🛠 How

- Moved the code that sets our visitor cookie to just before we fetch the user config.
  - I added a test to ensure that this does not modify existing cookies but only sets this new value.
- Added a query param called `no_cache` to our `config` `Route` which passes in the current timestamp as its value. This ensures that the backend sees each request as unique.

# ✅ Acceptance criteria

Using Charles proxy, observe the responses on the `/v1/app/ios/config` endpoint.

- [x] You should see a query param `no_cache` with the current timestamp as its value and this value should change with each request.
- [x] There should _always_ be a JSON response from this endpoint.
- [x] Run the app logged out, observe that you are (or aren't) in the experiment group. Log in, observe that your experiment membership didn't change. Log out, again observe that it didn't change.
- [x] Delete the app, install and run it again. Repeat the previous steps. Try to do this for both scenarios where you initially begin in either the control group or the experimental group and remain in those across login and logout events.