### PR TITLE
[NT-589] Add ios_go_rewardless feature flag to beta tools

### DIFF
--- a/Library/Extensions/Feature+Helpers.swift
+++ b/Library/Extensions/Feature+Helpers.swift
@@ -1,6 +1,10 @@
 import Foundation
 import KsApi
 
+public func featureGoRewardlessIsEnabled() -> Bool {
+  return Feature.goRewardless.isEnabled()
+}
+
 public func featureNativeCheckoutIsEnabled() -> Bool {
   return Feature.nativeCheckout.isEnabled()
 }

--- a/Library/Extensions/Feature+HelpersTests.swift
+++ b/Library/Extensions/Feature+HelpersTests.swift
@@ -5,6 +5,32 @@ import Prelude
 import XCTest
 
 final class FeatureHelpersTests: TestCase {
+  // MARK: - goRewardless
+
+  func testFeatureGoRewardlessIsEnabled_isTrue() {
+    let config = Config.template
+      |> \.features .~ [Feature.goRewardless.rawValue: true]
+
+    withEnvironment(config: config) {
+      XCTAssertTrue(featureGoRewardlessIsEnabled())
+    }
+  }
+
+  func testFeatureGoRewardlessIsEnabled_isFalse() {
+    let config = Config.template
+      |> \.features .~ [Feature.goRewardless.rawValue: false]
+
+    withEnvironment(config: config) {
+      XCTAssertFalse(featureGoRewardlessIsEnabled())
+    }
+  }
+
+  func testFeatureGoRewardlessIsEnabled_isFalse_whenNil() {
+    withEnvironment(config: .template) {
+      XCTAssertFalse(featureGoRewardlessIsEnabled())
+    }
+  }
+
   // MARK: - nativeCheckout
 
   func testFeatureNativeCheckoutIsEnabled_isTrue() {

--- a/Library/Feature.swift
+++ b/Library/Feature.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 public enum Feature: String {
+  case goRewardless = "ios_go_rewardless"
   case nativeCheckout = "ios_native_checkout"
   case nativeCheckoutPledgeView = "ios_native_checkout_pledge_view"
 }
@@ -8,6 +9,7 @@ public enum Feature: String {
 extension Feature: CustomStringConvertible {
   public var description: String {
     switch self {
+    case .goRewardless: return "Go Rewardless"
     case .nativeCheckout: return "Native Checkout"
     case .nativeCheckoutPledgeView: return "Native Checkout Pledge View"
     }

--- a/Library/ViewModels/FeatureFlagToolsViewModel.swift
+++ b/Library/ViewModels/FeatureFlagToolsViewModel.swift
@@ -66,7 +66,8 @@ public final class FeatureFlagToolsViewModel: FeatureFlagToolsViewModelType, Fea
         environmentFeatures?[featureEnabledPair.feature.rawValue] = enabled
 
         return environmentFeatures
-      }.skipNil()
+      }
+      .skipNil()
   }
 
   private let setFeatureEnabledAtIndexProperty = MutableProperty<(Int, Bool)?>(nil)


### PR DESCRIPTION
# 📲 What

Adds the `ios_go_rewardless` feature flag to our beta tools menu.

# 🤔 Why

Allows us to feature-flag the upcoming _Go Rewardless_ editorial campaign.

# 🛠 How

- Added the flag to the back-end in https://github.com/kickstarter/kickstarter/pull/18139.
- Added it to our `Feature` `enum`.

# 👀 See

<img width="50%" alt="image" src="https://user-images.githubusercontent.com/3735375/69197104-5d75a100-0ae5-11ea-9d7d-c92f6827b07e.png">

# ✅ Acceptance criteria

- [ ] Switch appears in beta tools.
- [ ] Tests pass.