### PR TITLE
[NT-620] Skip danger for external contributors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,7 +92,7 @@ jobs:
 
       - run:
           name: Danger
-          command: bundle exec danger --verbose
+          command: bin/danger.sh
 
   # Kickstarter tests
   kickstarter-tests:

--- a/bin/danger.sh
+++ b/bin/danger.sh
@@ -1,3 +1,7 @@
 #!/bin/sh
 
-[ ! -z $DANGER_GITHUB_API_TOKEN ] && bundle exec danger --verbose || echo "Skipping Danger for External Contributor"
+if [ ! -z $DANGER_GITHUB_API_TOKEN ]; then
+  bundle exec danger --verbose;
+else
+  echo "Skipping Danger for External Contributor";
+fi

--- a/bin/danger.sh
+++ b/bin/danger.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+[ ! -z $DANGER_GITHUB_API_TOKEN ] && bundle exec danger --verbose || echo "Skipping Danger for External Contributor"


### PR DESCRIPTION
# 📲 What

Does not run Danger on PRs from external contributors.

# 🤔 Why

We received an external contribution recently and the CircleCI workflow that runs Danger is failing because it does not have access to `DANGER_GITHUB_API_TOKEN`.

# 🛠 How

- Moved the command that we previously used to execute Danger into a bash script and updated it so that it will not run if this environment variable is not available.
  - This is the solution described in Danger's docs for not exposing environment vars - https://danger.systems/guides/troubleshooting.html#i-want-to-only-run-danger-for-internal-branches
- CircleCI also recommends [explicitly disabling](https://circleci.com/docs/2.0/oss/#pass-secrets-to-builds-from-forked-pull-requests) passing of secrets to builds that run on forks.

# 👀 See

<img width="556" alt="image" src="https://user-images.githubusercontent.com/3735375/69390043-c3e3f600-0c82-11ea-958d-fa50e93771cf.png">

# ✅ Acceptance criteria

- [ ] Danger still runs on our own branches.
- [ ] Once this is merged into #949, all CircleCI workflows should pass.