### PR TITLE
[NT-593] Editorial Project Navigation

### DIFF
--- a/Kickstarter-iOS/DataSources/DiscoveryProjectsDataSourceTest.swift
+++ b/Kickstarter-iOS/DataSources/DiscoveryProjectsDataSourceTest.swift
@@ -25,7 +25,9 @@ final class DiscoveryProjectsDataSourceTests: XCTestCase {
   func testEditorial() {
     let section = DiscoveryProjectsDataSource.Section.editorial.rawValue
 
-    let editorialValue = (title: "title", subtitle: "subtitle", imageName: "", tag: "123", RefTag.activity)
+    let editorialValue: DiscoveryEditorialCellValue = (
+      title: "title", subtitle: "subtitle", imageName: "", tagId: .goRewardless
+    )
 
     self.dataSource.showEditorial(value: editorialValue)
 

--- a/Kickstarter-iOS/Views/Cells/DiscoveryEditorialCell.swift
+++ b/Kickstarter-iOS/Views/Cells/DiscoveryEditorialCell.swift
@@ -7,8 +7,7 @@ import UIKit
 protocol DiscoveryEditorialCellDelegate: AnyObject {
   func discoveryEditorialCellTapped(
     _ cell: DiscoveryEditorialCell,
-    tag: String,
-    refTag: RefTag
+    tagId: DiscoveryParams.TagID
   )
 }
 
@@ -49,10 +48,10 @@ final class DiscoveryEditorialCell: UITableViewCell, ValueCell {
 
     self.viewModel.outputs.notifyDelegateViewTapped
       .observeForUI()
-      .observeValues { [weak self] tag, refTag in
+      .observeValues { [weak self] tagId in
         guard let self = self else { return }
 
-        self.delegate?.discoveryEditorialCellTapped(self, tag: tag, refTag: refTag)
+        self.delegate?.discoveryEditorialCellTapped(self, tagId: tagId)
       }
 
     self.viewModel.outputs.imageName

--- a/Kickstarter-iOS/Views/Controllers/DiscoveryPageViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/DiscoveryPageViewController.swift
@@ -210,8 +210,8 @@ internal final class DiscoveryPageViewController: UITableViewController {
 
     self.viewModel.outputs.goToEditorialProjectList
       .observeForControllerAction()
-      .observeValues { [weak self] tag, refTag in
-        self?.goToEditorialProjectList(using: tag, refTag: refTag)
+      .observeValues { [weak self] tagId in
+        self?.goToEditorialProjectList(using: tagId)
       }
   }
 
@@ -273,8 +273,10 @@ internal final class DiscoveryPageViewController: UITableViewController {
     self.present(controller, animated: true, completion: nil)
   }
 
-  fileprivate func goToEditorialProjectList(using tag: String, refTag _: RefTag) {
-    // TODO:
+  fileprivate func goToEditorialProjectList(using tagId: DiscoveryParams.TagID) {
+    let vc = EditorialProjectsViewController.instantiate()
+    vc.configure(with: tagId)
+    self.present(vc, animated: true)
   }
 
   fileprivate func goTo(project: Project, refTag: RefTag) {
@@ -355,8 +357,8 @@ extension DiscoveryPageViewController: DiscoveryOnboardingCellDelegate {
 // MARK: - DiscoveryEditorialCellDelegate
 
 extension DiscoveryPageViewController: DiscoveryEditorialCellDelegate {
-  func discoveryEditorialCellTapped(_: DiscoveryEditorialCell, tag: String, refTag: RefTag) {
-    self.viewModel.inputs.discoveryEditorialCellTapped(with: tag, refTag: refTag)
+  func discoveryEditorialCellTapped(_: DiscoveryEditorialCell, tagId: DiscoveryParams.TagID) {
+    self.viewModel.inputs.discoveryEditorialCellTapped(with: tagId)
   }
 }
 

--- a/Kickstarter-iOS/Views/Controllers/EditorialProjectsViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/EditorialProjectsViewController.swift
@@ -37,9 +37,6 @@ public final class EditorialProjectsViewController: UIViewController {
       for: .touchUpInside
     )
 
-    // Will be moved to be a testable output of VC that presents this one
-    self.viewModel.inputs.configure(with: .goRewardless)
-
     self.viewModel.inputs.viewDidLoad()
   }
 
@@ -128,6 +125,12 @@ public final class EditorialProjectsViewController: UIViewController {
 
     // remove once header has content
     self.headerView.heightAnchor.constraint(equalToConstant: 300).isActive = true
+  }
+
+  // MARK: - Accessors
+
+  func configure(with tagId: DiscoveryParams.TagID) {
+    self.viewModel.inputs.configure(with: tagId)
   }
 
   // MARK: - Actions

--- a/Library/RefTag.swift
+++ b/Library/RefTag.swift
@@ -13,11 +13,11 @@ public enum RefTag {
   case dashboardActivity
   case discovery
   case discoveryWithSort(DiscoveryParams.Sort)
-  case editorial(RefTag.EditorialCollection)
   case messageThread
   case profile
   case profileBacked
   case profileSaved
+  case projectCollection(DiscoveryParams.TagID)
   case projectPage
   case push
   case recommended
@@ -33,10 +33,6 @@ public enum RefTag {
   case thanks
   case unrecognized(String)
   case update
-
-  public enum EditorialCollection {
-    case goRewardless
-  }
 
   /**
    Create a RefTag value from a code string. If a ref tag cannot be matched, an `.unrecognized` tag is
@@ -122,14 +118,14 @@ public enum RefTag {
       return "discovery"
     case let .discoveryWithSort(sort):
       return "discovery" + sortRefTagSuffix(sort)
-    case let .editorial(collection):
-      return "editorial_\(collection.description)"
     case .messageThread:
       return "message_thread"
     case .profile:
       return "profile"
     case .profileBacked:
       return "profile_backed"
+    case let .projectCollection(tagId):
+      return "ios_project_collection_tag_\(tagId.rawValue)"
     case .profileSaved:
       return "profile_saved"
     case .projectPage:
@@ -167,20 +163,9 @@ public enum RefTag {
 }
 
 extension RefTag: Equatable {}
-extension RefTag.EditorialCollection: Equatable {}
-
 extension RefTag: CustomStringConvertible {
   public var description: String {
     return self.stringTag
-  }
-}
-
-extension RefTag.EditorialCollection: CustomStringConvertible {
-  public var description: String {
-    switch self {
-    case .goRewardless:
-      return "go_rewardless"
-    }
   }
 }
 

--- a/Library/ViewModels/DiscoveryEditorialViewModel.swift
+++ b/Library/ViewModels/DiscoveryEditorialViewModel.swift
@@ -1,8 +1,9 @@
 import Foundation
+import KsApi
 import ReactiveSwift
 
 public typealias DiscoveryEditorialCellValue = (
-  title: String, subtitle: String, imageName: String, tag: String, refTag: RefTag
+  title: String, subtitle: String, imageName: String, tagId: DiscoveryParams.TagID
 )
 
 public protocol DiscoveryEditorialViewModelInputs {
@@ -12,7 +13,7 @@ public protocol DiscoveryEditorialViewModelInputs {
 
 public protocol DiscoveryEditorialViewModelOutputs {
   var imageName: Signal<String, Never> { get }
-  var notifyDelegateViewTapped: Signal<(String, RefTag), Never> { get }
+  var notifyDelegateViewTapped: Signal<DiscoveryParams.TagID, Never> { get }
   var subtitleText: Signal<String, Never> { get }
   var titleText: Signal<String, Never> { get }
 }
@@ -33,7 +34,7 @@ public final class DiscoveryEditorialViewModel: DiscoveryEditorialViewModelType,
 
     self.notifyDelegateViewTapped = configureWithValue
       .takeWhen(self.editorialCellTappedSignal)
-      .map { ($0.tag, $0.refTag) }
+      .map { $0.tagId }
   }
 
   private let configureWithValueProperty = MutableProperty<DiscoveryEditorialCellValue?>(nil)
@@ -49,7 +50,7 @@ public final class DiscoveryEditorialViewModel: DiscoveryEditorialViewModelType,
   public let imageName: Signal<String, Never>
   public let subtitleText: Signal<String, Never>
   public let titleText: Signal<String, Never>
-  public let notifyDelegateViewTapped: Signal<(String, RefTag), Never>
+  public let notifyDelegateViewTapped: Signal<DiscoveryParams.TagID, Never>
 
   public var inputs: DiscoveryEditorialViewModelInputs { return self }
   public var outputs: DiscoveryEditorialViewModelOutputs { return self }

--- a/Library/ViewModels/DiscoveryEditorialViewModelTests.swift
+++ b/Library/ViewModels/DiscoveryEditorialViewModelTests.swift
@@ -10,8 +10,7 @@ final class DiscoveryEditorialViewModelTests: TestCase {
   private let vm: DiscoveryEditorialViewModelType = DiscoveryEditorialViewModel()
 
   private let imageName = TestObserver<String, Never>()
-  private let notifyDelegateViewTappedRefTag = TestObserver<RefTag, Never>()
-  private let notifyDelegateViewTappedTag = TestObserver<String, Never>()
+  private let notifyDelegateViewTapped = TestObserver<DiscoveryParams.TagID, Never>()
   private let subtitleText = TestObserver<String, Never>()
   private let titleText = TestObserver<String, Never>()
 
@@ -20,9 +19,7 @@ final class DiscoveryEditorialViewModelTests: TestCase {
 
     self.vm.outputs.imageName.observe(self.imageName.observer)
     self.vm.outputs.subtitleText.observe(self.subtitleText.observer)
-    self.vm.outputs.notifyDelegateViewTapped.map(first).observe(self.notifyDelegateViewTappedTag.observer)
-    self.vm.outputs.notifyDelegateViewTapped.map(second)
-      .observe(self.notifyDelegateViewTappedRefTag.observer)
+    self.vm.outputs.notifyDelegateViewTapped.observe(self.notifyDelegateViewTapped.observer)
     self.vm.outputs.titleText.observe(self.titleText.observer)
   }
 
@@ -34,39 +31,35 @@ final class DiscoveryEditorialViewModelTests: TestCase {
     self.imageName.assertDidNotEmitValue()
     self.titleText.assertDidNotEmitValue()
     self.subtitleText.assertDidNotEmitValue()
-    self.notifyDelegateViewTappedTag.assertDidNotEmitValue()
-    self.notifyDelegateViewTappedRefTag.assertDidNotEmitValue()
+    self.notifyDelegateViewTapped.assertDidNotEmitValue()
 
-    self.vm.inputs.configureWith((
-      title: "hello",
-      subtitle: "boop",
-      imageName: "image",
-      tag: "123", refTag:
-      RefTag.editorial(.goRewardless)
-    ))
+    self.vm.inputs.configureWith(
+      (
+        title: "hello",
+        subtitle: "boop",
+        imageName: "image",
+        tagId: .goRewardless
+      )
+    )
 
     self.imageName.assertValues(["image"])
     self.titleText.assertValues(["hello"])
     self.subtitleText.assertValues(["boop"])
-    self.notifyDelegateViewTappedTag.assertDidNotEmitValue()
-    self.notifyDelegateViewTappedRefTag.assertDidNotEmitValue()
+    self.notifyDelegateViewTapped.assertDidNotEmitValue()
   }
 
   func testEditorialCellTapped() {
-    self.vm.inputs.configureWith((
-      title: "hello",
-      subtitle: "boop",
-      imageName: "image",
-      tag: "123", refTag:
-      RefTag.editorial(.goRewardless)
-    ))
+    self.vm.inputs.configureWith(
+      (
+        title: "hello",
+        subtitle: "boop",
+        imageName: "image",
+        tagId: .goRewardless
+      )
+    )
 
-    self.notifyDelegateViewTappedRefTag.assertDidNotEmitValue()
-    self.notifyDelegateViewTappedTag.assertDidNotEmitValue()
-
+    self.notifyDelegateViewTapped.assertDidNotEmitValue()
     self.vm.inputs.editorialCellTapped()
-
-    self.notifyDelegateViewTappedRefTag.assertValues([RefTag.editorial(.goRewardless)])
-    self.notifyDelegateViewTappedTag.assertValues(["123"])
+    self.notifyDelegateViewTapped.assertValues([.goRewardless])
   }
 }

--- a/Library/ViewModels/DiscoveryPageViewModel.swift
+++ b/Library/ViewModels/DiscoveryPageViewModel.swift
@@ -455,8 +455,8 @@ private func saveSeen(activities: [Activity]) {
 }
 
 private func refTag(fromParams params: DiscoveryParams, project _: Project) -> RefTag {
-  if params.tagId != nil, params.tagId == .goRewardless {
-    return .projectCollection(DiscoveryParams.TagID.goRewardless)
+  if let tagId = params.tagId {
+    return .projectCollection(tagId)
   }
 
   if params.category != nil {

--- a/Library/ViewModels/DiscoveryPageViewModel.swift
+++ b/Library/ViewModels/DiscoveryPageViewModel.swift
@@ -425,7 +425,7 @@ private func saveSeen(activities: [Activity]) {
 
 private func refTag(fromParams params: DiscoveryParams, project _: Project) -> RefTag {
   if params.tagId != nil, params.tagId == .goRewardless {
-    return .editorial(.goRewardless)
+    return .projectCollection(DiscoveryParams.TagID.goRewardless)
   }
 
   if params.category != nil {

--- a/Library/ViewModels/DiscoveryPageViewModel.swift
+++ b/Library/ViewModels/DiscoveryPageViewModel.swift
@@ -11,7 +11,7 @@ public protocol DiscoveryPageViewModelInputs {
   func currentEnvironmentChanged(environment: EnvironmentType)
 
   /// Call when the editioral cell is tapped
-  func discoveryEditorialCellTapped(with tag: String, refTag: RefTag)
+  func discoveryEditorialCellTapped(with tagId: DiscoveryParams.TagID)
 
   /// Call when the user pulls tableView to refresh
   func pulledToRefresh()
@@ -64,7 +64,7 @@ public protocol DiscoveryPageViewModelOutputs {
   var goToActivityProject: Signal<(Project, RefTag), Never> { get }
 
   /// Emits a refTag for the editorial project list
-  var goToEditorialProjectList: Signal<(String, RefTag), Never> { get }
+  var goToEditorialProjectList: Signal<DiscoveryParams.TagID, Never> { get }
 
   /// Emits a project, playlist, ref tag that we should go to from discovery.
   var goToProjectPlaylist: Signal<(Project, [Project], RefTag), Never> { get }
@@ -315,8 +315,7 @@ public final class DiscoveryPageViewModel: DiscoveryPageViewModelType, Discovery
           title: Strings.Back_it_because_you_believe_in_it(),
           subtitle: Strings.Find_projects_that_speak_to_you(),
           imageName: "go-rewardless-home",
-          tag: "250",
-          refTag: RefTag.editorial(.goRewardless)
+          tagId: .goRewardless
         )
       }
 
@@ -329,9 +328,10 @@ public final class DiscoveryPageViewModel: DiscoveryPageViewModelType, Discovery
     self.currentEnvironmentChangedProperty.value = environment
   }
 
-  fileprivate let discoveryEditorialCellTappedWithValueProperty = MutableProperty<(String, RefTag)?>(nil)
-  public func discoveryEditorialCellTapped(with tag: String, refTag: RefTag) {
-    self.discoveryEditorialCellTappedWithValueProperty.value = (tag, refTag)
+  fileprivate let discoveryEditorialCellTappedWithValueProperty
+    = MutableProperty<DiscoveryParams.TagID?>(nil)
+  public func discoveryEditorialCellTapped(with tagId: DiscoveryParams.TagID) {
+    self.discoveryEditorialCellTappedWithValueProperty.value = tagId
   }
 
   fileprivate let pulledToRefreshProperty = MutableProperty(())
@@ -397,7 +397,7 @@ public final class DiscoveryPageViewModel: DiscoveryPageViewModelType, Discovery
   public let activitiesForSample: Signal<[Activity], Never>
   public let asyncReloadData: Signal<Void, Never>
   public let goToActivityProject: Signal<(Project, RefTag), Never>
-  public let goToEditorialProjectList: Signal<(String, RefTag), Never>
+  public let goToEditorialProjectList: Signal<DiscoveryParams.TagID, Never>
   public let goToProjectPlaylist: Signal<(Project, [Project], RefTag), Never>
   public let goToProjectUpdate: Signal<(Project, Update), Never>
   public let hideEmptyState: Signal<Void, Never>
@@ -424,6 +424,10 @@ private func saveSeen(activities: [Activity]) {
 }
 
 private func refTag(fromParams params: DiscoveryParams, project _: Project) -> RefTag {
+  if params.tagId != nil, params.tagId == .goRewardless {
+    return .editorial(.goRewardless)
+  }
+
   if params.category != nil {
     return .categoryWithSort(params.sort ?? .magic)
   } else if params.recommended == .some(true) {

--- a/Library/ViewModels/DiscoveryPageViewModelTests.swift
+++ b/Library/ViewModels/DiscoveryPageViewModelTests.swift
@@ -991,7 +991,7 @@ internal final class DiscoveryPageViewModelTests: TestCase {
       self.goToPlaylist.assertValues([discoveryEnvelope.projects], "Project playlist emits.")
       self.goToPlaylistProject.assertValues([project])
       self.goToPlaylistRefTag.assertValues(
-        [.editorial(.goRewardless)],
+        [.projectCollection(DiscoveryParams.TagID.goRewardless)],
         "Go to the project with Go Rewardless Editorial ref tag."
       )
     }

--- a/Library/ViewModels/DiscoveryPageViewModelTests.swift
+++ b/Library/ViewModels/DiscoveryPageViewModelTests.swift
@@ -13,8 +13,7 @@ internal final class DiscoveryPageViewModelTests: TestCase {
   fileprivate let asyncReloadData = TestObserver<(), Never>()
   fileprivate let goToActivityProject = TestObserver<Project, Never>()
   fileprivate let goToActivityProjectRefTag = TestObserver<RefTag, Never>()
-  fileprivate let goToEditorialProjectListRefTag = TestObserver<RefTag, Never>()
-  fileprivate let goToEditorialProjectListTag = TestObserver<String, Never>()
+  fileprivate let goToEditorialProjectList = TestObserver<DiscoveryParams.TagID, Never>()
   fileprivate let goToPlaylist = TestObserver<[Project], Never>()
   fileprivate let goToPlaylistProject = TestObserver<Project, Never>()
   fileprivate let goToPlaylistRefTag = TestObserver<RefTag, Never>()
@@ -29,9 +28,8 @@ internal final class DiscoveryPageViewModelTests: TestCase {
   private let scrollToProjectRow = TestObserver<Int, Never>()
   fileprivate let showEditorialHeader = TestObserver<Void, Never>()
   fileprivate let showEditorialHeaderImageName = TestObserver<String, Never>()
-  fileprivate let showEditorialHeaderRefTag = TestObserver<RefTag, Never>()
   fileprivate let showEditorialHeaderSubtitle = TestObserver<String, Never>()
-  fileprivate let showEditorialHeaderTag = TestObserver<String, Never>()
+  fileprivate let showEditorialHeaderTagId = TestObserver<DiscoveryParams.TagID, Never>()
   fileprivate let showEditorialHeaderTitle = TestObserver<String, Never>()
   fileprivate let showEmptyState = TestObserver<EmptyState, Never>()
   fileprivate let showOnboarding = TestObserver<Bool, Never>()
@@ -46,9 +44,7 @@ internal final class DiscoveryPageViewModelTests: TestCase {
     self.vm.outputs.hideEmptyState.observe(self.hideEmptyState.observer)
     self.vm.outputs.goToActivityProject.map(first).observe(self.goToActivityProject.observer)
     self.vm.outputs.goToActivityProject.map(second).observe(self.goToActivityProjectRefTag.observer)
-    self.vm.outputs.goToEditorialProjectList.map(first).observe(self.goToEditorialProjectListTag.observer)
-    self.vm.outputs.goToEditorialProjectList.map(second)
-      .observe(self.goToEditorialProjectListRefTag.observer)
+    self.vm.outputs.goToEditorialProjectList.observe(self.goToEditorialProjectList.observer)
     self.vm.outputs.goToProjectPlaylist.map(first).observe(self.goToPlaylistProject.observer)
     self.vm.outputs.goToProjectPlaylist.map(second).observe(self.goToPlaylist.observer)
     self.vm.outputs.goToProjectPlaylist.map(third).observe(self.goToPlaylistRefTag.observer)
@@ -58,12 +54,11 @@ internal final class DiscoveryPageViewModelTests: TestCase {
     self.vm.outputs.scrollToProjectRow.observe(self.scrollToProjectRow.observer)
     self.vm.outputs.setScrollsToTop.observe(self.setScrollsToTop.observer)
     self.vm.outputs.showEditorialHeader.ignoreValues().observe(self.showEditorialHeader.observer)
-    self.vm.outputs.showEditorialHeader.map { $0.refTag }.observe(self.showEditorialHeaderRefTag.observer)
     self.vm.outputs.showEditorialHeader.map { $0.title }.observe(self.showEditorialHeaderTitle.observer)
     self.vm.outputs.showEditorialHeader.map { $0.subtitle }.observe(self.showEditorialHeaderSubtitle.observer)
     self.vm.outputs.showEditorialHeader.map { $0.imageName }
       .observe(self.showEditorialHeaderImageName.observer)
-    self.vm.outputs.showEditorialHeader.map { $0.tag }.observe(self.showEditorialHeaderTag.observer)
+    self.vm.outputs.showEditorialHeader.map { $0.tagId }.observe(self.showEditorialHeaderTagId.observer)
     self.vm.outputs.showEmptyState.observe(self.showEmptyState.observer)
     self.vm.outputs.showOnboarding.observe(self.showOnboarding.observer)
 
@@ -574,8 +569,7 @@ internal final class DiscoveryPageViewModelTests: TestCase {
       self.showEditorialHeaderTitle.assertValues(["Back it because you believe in it."])
       self.showEditorialHeaderSubtitle.assertValues(["Find projects that speak to you ▶"])
       self.showEditorialHeaderImageName.assertValues(["go-rewardless-home"])
-      self.showEditorialHeaderTag.assertValues(["250"])
-      self.showEditorialHeaderRefTag.assertValues([RefTag.editorial(.goRewardless)])
+      self.showEditorialHeaderTagId.assertValues([.goRewardless])
     }
   }
 
@@ -607,8 +601,7 @@ internal final class DiscoveryPageViewModelTests: TestCase {
       self.showEditorialHeaderTitle.assertValues(["Back it because you believe in it."])
       self.showEditorialHeaderSubtitle.assertValues(["Find projects that speak to you ▶"])
       self.showEditorialHeaderImageName.assertValues(["go-rewardless-home"])
-      self.showEditorialHeaderTag.assertValues(["250"])
-      self.showEditorialHeaderRefTag.assertValues([RefTag.editorial(.goRewardless)])
+      self.showEditorialHeaderTagId.assertValues([.goRewardless])
     }
   }
 
@@ -971,17 +964,36 @@ internal final class DiscoveryPageViewModelTests: TestCase {
       self.scheduler.advance()
 
       self.showEditorialHeader.assertValueCount(1)
-      self.goToEditorialProjectListTag.assertDidNotEmitValue()
+      self.goToEditorialProjectList.assertDidNotEmitValue()
 
-      self.vm.inputs.discoveryEditorialCellTapped(with: "123", refTag: RefTag.editorial(.goRewardless))
+      self.vm.inputs.discoveryEditorialCellTapped(with: .goRewardless)
 
-      self.goToEditorialProjectListTag.assertValues(["123"])
-      self.goToEditorialProjectListRefTag.assertValues([.editorial(.goRewardless)])
+      self.goToEditorialProjectList.assertValues([.goRewardless])
+    }
+  }
 
-      self.vm.inputs.discoveryEditorialCellTapped(with: "321", refTag: RefTag.editorial(.goRewardless))
+  func testGoToEditorialProject() {
+    let project = Project.template
+    let discoveryEnvelope = .template
+      |> DiscoveryEnvelope.lens.projects .~ (
+        (0...2).map { id in .template |> Project.lens.id .~ (100 + id) }
+      )
 
-      self.goToEditorialProjectListTag.assertValues(["123", "321"])
-      self.goToEditorialProjectListRefTag.assertValues([.editorial(.goRewardless), .editorial(.goRewardless)])
+    withEnvironment(apiService: MockService(fetchDiscoveryResponse: discoveryEnvelope)) {
+      self.vm.inputs.configureWith(sort: .magic)
+      self.vm.inputs.viewWillAppear()
+      self.vm.inputs.viewDidAppear()
+      self.vm.inputs.selectedFilter(.defaults |> DiscoveryParams.lens.tagId .~ .goRewardless)
+      self.scheduler.advance()
+
+      self.vm.inputs.tapped(project: project)
+
+      self.goToPlaylist.assertValues([discoveryEnvelope.projects], "Project playlist emits.")
+      self.goToPlaylistProject.assertValues([project])
+      self.goToPlaylistRefTag.assertValues(
+        [.editorial(.goRewardless)],
+        "Go to the project with Go Rewardless Editorial ref tag."
+      )
     }
   }
 }


### PR DESCRIPTION
# 📲 What

Fills in the navigation from `DiscoveryEditorialCell` -> `DiscoverPageViewController` -> `EditorialProjectsViewController` -> `DiscoverPageViewController` -> `ProjectNavigatorViewController` and ensures that the correct `RefTag` makes it through to the end.

# 🤔 Why

Continuation of the works for our Go Rewardless editorial campaign.

# 🛠 How

- Updated delegate methods to pass `DiscoveryParams.TagID` value.
- Inferred the `RefTag` from `DiscoveryParams` as it had been done before.
- Updated tests.

# ✅ Acceptance criteria

- [x] Tap on the Go Rewardless Editorial cell on Discovery, select a project from the list, using a breakpoint or Charles, verify that you're seeing the correct `RefTag`.