### PR TITLE
[NT-621] Editorial header tracking

### DIFF
--- a/Library/Koala/Koala.swift
+++ b/Library/Koala/Koala.swift
@@ -491,7 +491,6 @@ public final class Koala {
    */
   public func trackDiscovery(params: DiscoveryParams, page: Int) {
     var props = properties(params: params).withAllValuesFrom(["page": page])
-    props["current_variants"] = AppEnvironment.current.config?.abExperimentsArray
 
     self.track(event: "Loaded Discovery Results", properties: props)
 
@@ -594,6 +593,13 @@ public final class Koala {
    */
   public func trackDiscoveryPullToRefresh() {
     self.track(event: "Triggered Refresh")
+  }
+
+  /**
+   Call when the user taps the editorial header at the top of Discovery
+ */
+  public func trackEditorialHeaderTapped(refTag: RefTag) {
+    self.track(event: "Editorial Card Clicked", properties: ["refTag": refTag.stringTag])
   }
 
   // MARK: - Checkout Events
@@ -1366,7 +1372,6 @@ public final class Koala {
     var props = properties(project: project, loggedInUser: self.loggedInUser)
     props["ref_tag"] = refTag?.stringTag
     props["referrer_credit"] = cookieRefTag?.stringTag
-    props["current_variants"] = AppEnvironment.current.config?.abExperimentsArray
 
     // Deprecated event
     self.track(
@@ -2043,10 +2048,16 @@ public final class Koala {
   private func defaultProperties() -> [String: Any] {
     var props: [String: Any] = [:]
 
+    let enabledFeatureFlags = self.config?.features
+      .filter { k, v in v == true }
+      .keys
+      .sorted()
+
     props["manufacturer"] = "Apple"
     props["app_version"] = self.bundle.infoDictionary?["CFBundleVersion"]
     props["app_release"] = self.bundle.infoDictionary?["CFBundleShortVersionString"]
-    props["current_variants"] = AppEnvironment.current.config?.abExperimentsArray
+    props["current_variants"] = self.config?.abExperimentsArray.sorted()
+    props["enabled_feature_flags"] = enabledFeatureFlags
     props["model"] = Koala.deviceModel
     props["distinct_id"] = self.distinctId
     props["device_fingerprint"] = self.distinctId

--- a/Library/Koala/Koala.swift
+++ b/Library/Koala/Koala.swift
@@ -597,7 +597,7 @@ public final class Koala {
 
   /**
    Call when the user taps the editorial header at the top of Discovery
- */
+   */
   public func trackEditorialHeaderTapped(refTag: RefTag) {
     self.track(event: "Editorial Card Clicked", properties: ["refTag": refTag.stringTag])
   }
@@ -2049,7 +2049,7 @@ public final class Koala {
     var props: [String: Any] = [:]
 
     let enabledFeatureFlags = self.config?.features
-      .filter { k, v in v == true }
+      .filter { _, v in v == true }
       .keys
       .sorted()
 

--- a/Library/Koala/Koala.swift
+++ b/Library/Koala/Koala.swift
@@ -2049,15 +2049,15 @@ public final class Koala {
     var props: [String: Any] = [:]
 
     let enabledFeatureFlags = self.config?.features
-      .filter { _, v in v == true }
+      .filter { key, value in key.starts(with: "ios_") && value }
       .keys
       .sorted()
 
     props["manufacturer"] = "Apple"
     props["app_version"] = self.bundle.infoDictionary?["CFBundleVersion"]
     props["app_release"] = self.bundle.infoDictionary?["CFBundleShortVersionString"]
-    props["current_variants"] = self.config?.abExperimentsArray.sorted()
-    props["enabled_feature_flags"] = enabledFeatureFlags
+    props["current_variants"] = self.config?.abExperimentsArray.sorted() ?? []
+    props["enabled_feature_flags"] = enabledFeatureFlags ?? []
     props["model"] = Koala.deviceModel
     props["distinct_id"] = self.distinctId
     props["device_fingerprint"] = self.distinctId

--- a/Library/Koala/KoalaTests.swift
+++ b/Library/Koala/KoalaTests.swift
@@ -11,6 +11,16 @@ final class KoalaTests: TestCase {
     let config = Config.template
       |> Config.lens.countryCode .~ "GB"
       |> Config.lens.locale .~ "en"
+      |> Config.lens.abExperiments .~ [
+        "native_checkout": "experimental",
+        "other_experiment": "control"
+        ]
+      |> Config.lens.features .~ [
+        "ios_feature_something": false,
+        "ios_feature_checkout": true,
+        "ios_feature_go_rewardless": true
+
+    ]
     let device = MockDevice(userInterfaceIdiom: .phone)
     let screen = MockScreen()
     let koala = Koala(
@@ -36,6 +46,11 @@ final class KoalaTests: TestCase {
     XCTAssertEqual(UInt(screen.bounds.width), properties?["screen_width"] as? UInt)
     XCTAssertEqual(UInt(screen.bounds.height), properties?["screen_height"] as? UInt)
 
+    XCTAssertEqual(["native_checkout[experimental]", "other_experiment[control]"],
+                   properties?["current_variants"] as? [String])
+    XCTAssertEqual(["ios_feature_checkout",
+                    "ios_feature_go_rewardless"],
+                   properties?["enabled_feature_flags"] as? [String])
     XCTAssertEqual("kickstarter_ios", properties?["mp_lib"] as? String)
     XCTAssertEqual("native", properties?["client_type"] as? String)
     XCTAssertEqual("phone", properties?["device_format"] as? String)

--- a/Library/Koala/KoalaTests.swift
+++ b/Library/Koala/KoalaTests.swift
@@ -16,6 +16,7 @@ final class KoalaTests: TestCase {
         "other_experiment": "control"
       ]
       |> Config.lens.features .~ [
+        "android_flag": true,
         "ios_feature_something": false,
         "ios_feature_checkout": true,
         "ios_feature_go_rewardless": true

--- a/Library/Koala/KoalaTests.swift
+++ b/Library/Koala/KoalaTests.swift
@@ -14,13 +14,12 @@ final class KoalaTests: TestCase {
       |> Config.lens.abExperiments .~ [
         "native_checkout": "experimental",
         "other_experiment": "control"
-        ]
+      ]
       |> Config.lens.features .~ [
         "ios_feature_something": false,
         "ios_feature_checkout": true,
         "ios_feature_go_rewardless": true
-
-    ]
+      ]
     let device = MockDevice(userInterfaceIdiom: .phone)
     let screen = MockScreen()
     let koala = Koala(
@@ -46,11 +45,17 @@ final class KoalaTests: TestCase {
     XCTAssertEqual(UInt(screen.bounds.width), properties?["screen_width"] as? UInt)
     XCTAssertEqual(UInt(screen.bounds.height), properties?["screen_height"] as? UInt)
 
-    XCTAssertEqual(["native_checkout[experimental]", "other_experiment[control]"],
-                   properties?["current_variants"] as? [String])
-    XCTAssertEqual(["ios_feature_checkout",
-                    "ios_feature_go_rewardless"],
-                   properties?["enabled_feature_flags"] as? [String])
+    XCTAssertEqual(
+      ["native_checkout[experimental]", "other_experiment[control]"],
+      properties?["current_variants"] as? [String]
+    )
+    XCTAssertEqual(
+      [
+        "ios_feature_checkout",
+        "ios_feature_go_rewardless"
+      ],
+      properties?["enabled_feature_flags"] as? [String]
+    )
     XCTAssertEqual("kickstarter_ios", properties?["mp_lib"] as? String)
     XCTAssertEqual("native", properties?["client_type"] as? String)
     XCTAssertEqual("phone", properties?["device_format"] as? String)

--- a/Library/ViewModels/DiscoveryPageViewModel.swift
+++ b/Library/ViewModels/DiscoveryPageViewModel.swift
@@ -350,8 +350,8 @@ public final class DiscoveryPageViewModel: DiscoveryPageViewModelType, Discovery
 
     self.discoveryEditorialCellTappedWithValueProperty.signal
       .skipNil()
-      .observeValues { _, refTag in
-        AppEnvironment.current.koala.trackEditorialHeaderTapped(refTag: refTag)
+      .observeValues { tagId in
+        AppEnvironment.current.koala.trackEditorialHeaderTapped(refTag: RefTag.projectCollection(tagId))
       }
   }
 

--- a/Library/ViewModels/DiscoveryPageViewModel.swift
+++ b/Library/ViewModels/DiscoveryPageViewModel.swift
@@ -348,6 +348,12 @@ public final class DiscoveryPageViewModel: DiscoveryPageViewModelType, Discovery
 
     self.goToEditorialProjectList = self.discoveryEditorialCellTappedWithValueProperty.signal
       .skipNil()
+
+    self.discoveryEditorialCellTappedWithValueProperty.signal
+      .skipNil()
+      .observeValues { _, refTag in
+        AppEnvironment.current.koala.trackEditorialHeaderTapped(refTag: refTag)
+    }
   }
 
   fileprivate let configUpdatedProperty = MutableProperty<Config?>(nil)

--- a/Library/ViewModels/DiscoveryPageViewModel.swift
+++ b/Library/ViewModels/DiscoveryPageViewModel.swift
@@ -353,7 +353,7 @@ public final class DiscoveryPageViewModel: DiscoveryPageViewModelType, Discovery
       .skipNil()
       .observeValues { _, refTag in
         AppEnvironment.current.koala.trackEditorialHeaderTapped(refTag: refTag)
-    }
+      }
   }
 
   fileprivate let configUpdatedProperty = MutableProperty<Config?>(nil)

--- a/Library/ViewModels/DiscoveryPageViewModelTests.swift
+++ b/Library/ViewModels/DiscoveryPageViewModelTests.swift
@@ -1266,19 +1266,19 @@ internal final class DiscoveryPageViewModelTests: TestCase {
   func testTrackEditorialHeaderTapped() {
     XCTAssertEqual([], self.trackingClient.events)
 
-    self.vm.inputs.discoveryEditorialCellTapped(with: "123", refTag: RefTag.editorial(.goRewardless))
+    self.vm.inputs.discoveryEditorialCellTapped(with: .goRewardless)
 
     XCTAssertEqual(["Editorial Card Clicked"], self.trackingClient.events)
     XCTAssertEqual(
-      ["editorial_go_rewardless"],
+      ["ios_project_collection_tag_518"],
       self.trackingClient.properties(forKey: "refTag", as: String.self)
     )
 
-    self.vm.inputs.discoveryEditorialCellTapped(with: "321", refTag: RefTag.editorial(.goRewardless))
+    self.vm.inputs.discoveryEditorialCellTapped(with: .goRewardless)
 
     XCTAssertEqual(["Editorial Card Clicked", "Editorial Card Clicked"], self.trackingClient.events)
     XCTAssertEqual(
-      ["editorial_go_rewardless", "editorial_go_rewardless"],
+      ["ios_project_collection_tag_518", "ios_project_collection_tag_518"],
       self.trackingClient.properties(forKey: "refTag")
     )
   }

--- a/Library/ViewModels/DiscoveryPageViewModelTests.swift
+++ b/Library/ViewModels/DiscoveryPageViewModelTests.swift
@@ -1271,13 +1271,17 @@ internal final class DiscoveryPageViewModelTests: TestCase {
     self.vm.inputs.discoveryEditorialCellTapped(with: "123", refTag: RefTag.editorial(.goRewardless))
 
     XCTAssertEqual(["Editorial Card Clicked"], self.trackingClient.events)
-    XCTAssertEqual(["editorial_go_rewardless"],
-                   self.trackingClient.properties(forKey: "refTag", as: String.self))
+    XCTAssertEqual(
+      ["editorial_go_rewardless"],
+      self.trackingClient.properties(forKey: "refTag", as: String.self)
+    )
 
     self.vm.inputs.discoveryEditorialCellTapped(with: "321", refTag: RefTag.editorial(.goRewardless))
 
     XCTAssertEqual(["Editorial Card Clicked", "Editorial Card Clicked"], self.trackingClient.events)
-    XCTAssertEqual(["editorial_go_rewardless", "editorial_go_rewardless"],
-                   self.trackingClient.properties(forKey: "refTag"))
+    XCTAssertEqual(
+      ["editorial_go_rewardless", "editorial_go_rewardless"],
+      self.trackingClient.properties(forKey: "refTag")
+    )
   }
 }

--- a/Library/ViewModels/DiscoveryPageViewModelTests.swift
+++ b/Library/ViewModels/DiscoveryPageViewModelTests.swift
@@ -1264,4 +1264,20 @@ internal final class DiscoveryPageViewModelTests: TestCase {
       self.goToEditorialProjectListRefTag.assertValues([.editorial(.goRewardless), .editorial(.goRewardless)])
     }
   }
+
+  func testTrackEditorialHeaderTapped() {
+    XCTAssertEqual([], self.trackingClient.events)
+
+    self.vm.inputs.discoveryEditorialCellTapped(with: "123", refTag: RefTag.editorial(.goRewardless))
+
+    XCTAssertEqual(["Editorial Card Clicked"], self.trackingClient.events)
+    XCTAssertEqual(["editorial_go_rewardless"],
+                   self.trackingClient.properties(forKey: "refTag", as: String.self))
+
+    self.vm.inputs.discoveryEditorialCellTapped(with: "321", refTag: RefTag.editorial(.goRewardless))
+
+    XCTAssertEqual(["Editorial Card Clicked", "Editorial Card Clicked"], self.trackingClient.events)
+    XCTAssertEqual(["editorial_go_rewardless", "editorial_go_rewardless"],
+                   self.trackingClient.properties(forKey: "refTag"))
+  }
 }


### PR DESCRIPTION
#📲 What

Adds required tracking to the editorial header feature.

# 🤔 Why

So we can track how this feature performs.

# 🛠 How

- adds `Editorial Card Clicked` tracking event when the editorial header on the Discovery screen is tapped
- cleans up our usage of the `Config` in `Koala`
- added missing tests for `current_variant` default properties
- added `enabled_feature_flags` to the `defaultProperties` for better tracking of features controlled via feature flag

# ♿️ Accessibility 

N/A

# 🏎 Performance

N/A

# ✅ Acceptance criteria

- [x] In `Edit Schemes` turn on the `KOALA_TRACKING` argument, then run the app and toggle the "Go rewardless" feature flag to _enabled_. Then, from the discovery screen, tap the "Go rewardless" header -- you should see a Koala tracking event in the console `[Koala Track]: Editorial Card Clicked`
- [x] for all Koala tracking events, you should now see a default property `enabled_feature_flags` with an array of all enabled feature flags

# ⏰ TODO

- [ ] wait for #965 to merge and resolve conflicts