### PR TITLE
[NT-688] Project events & properties clean up

### DIFF
--- a/KsApi/models/Project.swift
+++ b/KsApi/models/Project.swift
@@ -153,7 +153,11 @@ public struct Project {
     public func hoursRemaining(from date: Date = Date(), using calendar: Calendar = .current) -> Int? {
       let deadlineDate = Date(timeIntervalSince1970: self.deadline)
 
-      return calendar.dateComponents([.hour], from: date, to: deadlineDate).hour
+      guard let hoursRemaining = calendar.dateComponents([.hour], from: date, to: deadlineDate).hour else {
+        return nil
+      }
+
+      return max(0, hoursRemaining)
     }
   }
 

--- a/KsApi/models/Project.swift
+++ b/KsApi/models/Project.swift
@@ -140,7 +140,9 @@ public struct Project {
     public var launchedAt: TimeInterval
     public var stateChangedAt: TimeInterval
 
-    // Returns project duration in Days
+    /**
+     Returns project duration in Days
+    */
     public func duration(using calendar: Calendar = .current) -> Int? {
       let deadlineDate = Date(timeIntervalSince1970: self.deadline)
       let launchedAtDate = Date(timeIntervalSince1970: self.launchedAt)

--- a/KsApi/models/Project.swift
+++ b/KsApi/models/Project.swift
@@ -139,6 +139,14 @@ public struct Project {
     public var featuredAt: TimeInterval?
     public var launchedAt: TimeInterval
     public var stateChangedAt: TimeInterval
+
+    // Returns project duration in Days
+    public func duration(using calendar: Calendar = .current) -> Int? {
+      let deadlineDate = Date(timeIntervalSince1970: self.deadline)
+      let launchedAtDate = Date(timeIntervalSince1970: self.launchedAt)
+
+      return calendar.dateComponents([.day], from: launchedAtDate, to: deadlineDate).day
+    }
   }
 
   public struct Personalization {

--- a/KsApi/models/Project.swift
+++ b/KsApi/models/Project.swift
@@ -142,7 +142,7 @@ public struct Project {
 
     /**
      Returns project duration in Days
-    */
+     */
     public func duration(using calendar: Calendar = .current) -> Int? {
       let deadlineDate = Date(timeIntervalSince1970: self.deadline)
       let launchedAtDate = Date(timeIntervalSince1970: self.launchedAt)

--- a/KsApi/models/Project.swift
+++ b/KsApi/models/Project.swift
@@ -147,6 +147,12 @@ public struct Project {
 
       return calendar.dateComponents([.day], from: launchedAtDate, to: deadlineDate).day
     }
+
+    public func hoursRemaining(from date: Date = Date(), using calendar: Calendar = .current) -> Int? {
+      let deadlineDate = Date(timeIntervalSince1970: self.deadline)
+
+      return calendar.dateComponents([.hour], from: date, to: deadlineDate).hour
+    }
   }
 
   public struct Personalization {

--- a/KsApi/models/ProjectTests.swift
+++ b/KsApi/models/ProjectTests.swift
@@ -207,4 +207,54 @@ final class ProjectTests: XCTestCase {
 
     XCTAssertEqual(2_000, project.stats.pledgedUsd)
   }
+
+  func testDuration() {
+    let launchedAt = DateComponents()
+      |> \.day .~ 15
+      |> \.month .~ 3
+      |> \.year .~ 2020
+      |> \.timeZone .~ TimeZone(secondsFromGMT: 0)
+
+    // 1 month after launch
+    let deadline = DateComponents()
+      |> \.day .~ 14
+      |> \.month .~ 4
+      |> \.year .~ 2020
+      |> \.timeZone .~ TimeZone(secondsFromGMT: 0)
+
+    let calendar = Calendar(identifier: .gregorian)
+
+    let deadlineInterval = calendar.date(from: deadline)?.timeIntervalSince1970
+    let launchedAtInterval = calendar.date(from: launchedAt)?.timeIntervalSince1970
+
+    let project = Project.template
+      |> Project.lens.dates.deadline .~ deadlineInterval!
+      |> Project.lens.dates.launchedAt .~ launchedAtInterval!
+
+    XCTAssertEqual(30, project.dates.duration(using: calendar))
+  }
+
+  func testHoursRemaining() {
+    let deadline = DateComponents()
+      |> \.day .~ 2
+      |> \.month .~ 3
+      |> \.year .~ 2020
+      |> \.timeZone .~ TimeZone(secondsFromGMT: 0)
+
+    // 24 hours before deadline
+    let now = DateComponents()
+      |> \.day .~ 1
+      |> \.month .~ 3
+      |> \.year .~ 2020
+      |> \.timeZone .~ TimeZone(secondsFromGMT: 0)
+
+    let calendar = Calendar(identifier: .gregorian)
+    let nowDate = calendar.date(from: now)
+    let deadlineInterval = calendar.date(from: deadline)?.timeIntervalSince1970
+
+    let project = Project.template
+      |> Project.lens.dates.deadline .~ deadlineInterval!
+
+    XCTAssertEqual(24, project.dates.hoursRemaining(from: nowDate!, using: calendar))
+  }
 }

--- a/KsApi/models/ProjectTests.swift
+++ b/KsApi/models/ProjectTests.swift
@@ -212,14 +212,14 @@ final class ProjectTests: XCTestCase {
     let launchedAt = DateComponents()
       |> \.day .~ 15
       |> \.month .~ 3
-      |> \.year .~ 2020
+      |> \.year .~ 2_020
       |> \.timeZone .~ TimeZone(secondsFromGMT: 0)
 
     // 1 month after launch
     let deadline = DateComponents()
       |> \.day .~ 14
       |> \.month .~ 4
-      |> \.year .~ 2020
+      |> \.year .~ 2_020
       |> \.timeZone .~ TimeZone(secondsFromGMT: 0)
 
     let calendar = Calendar(identifier: .gregorian)
@@ -238,14 +238,14 @@ final class ProjectTests: XCTestCase {
     let deadline = DateComponents()
       |> \.day .~ 2
       |> \.month .~ 3
-      |> \.year .~ 2020
+      |> \.year .~ 2_020
       |> \.timeZone .~ TimeZone(secondsFromGMT: 0)
 
     // 24 hours before deadline
     let now = DateComponents()
       |> \.day .~ 1
       |> \.month .~ 3
-      |> \.year .~ 2020
+      |> \.year .~ 2_020
       |> \.timeZone .~ TimeZone(secondsFromGMT: 0)
 
     let calendar = Calendar(identifier: .gregorian)

--- a/KsApi/models/ProjectTests.swift
+++ b/KsApi/models/ProjectTests.swift
@@ -257,4 +257,28 @@ final class ProjectTests: XCTestCase {
 
     XCTAssertEqual(24, project.dates.hoursRemaining(from: nowDate!, using: calendar))
   }
+
+  func testHoursRemaining_LessThanZero() {
+    let deadline = DateComponents()
+      |> \.day .~ 2
+      |> \.month .~ 3
+      |> \.year .~ 2_020
+      |> \.timeZone .~ TimeZone(secondsFromGMT: 0)
+
+    // 24 hours after deadline
+    let now = DateComponents()
+      |> \.day .~ 3
+      |> \.month .~ 3
+      |> \.year .~ 2_020
+      |> \.timeZone .~ TimeZone(secondsFromGMT: 0)
+
+    let calendar = Calendar(identifier: .gregorian)
+    let nowDate = calendar.date(from: now)
+    let deadlineInterval = calendar.date(from: deadline)?.timeIntervalSince1970
+
+    let project = Project.template
+      |> Project.lens.dates.deadline .~ deadlineInterval!
+
+    XCTAssertEqual(0, project.dates.hoursRemaining(from: nowDate!, using: calendar))
+  }
 }

--- a/KsApi/models/User.swift
+++ b/KsApi/models/User.swift
@@ -85,6 +85,14 @@ public struct User {
   public var isCreator: Bool {
     return (self.stats.createdProjectsCount ?? 0) > 0
   }
+
+  public var isRepeatCreator: Bool? {
+    guard let createdProjectsCount = self.stats.createdProjectsCount else {
+      return nil
+    }
+
+    return createdProjectsCount > 1
+  }
 }
 
 extension User: Equatable {}

--- a/KsApi/models/UserTests.swift
+++ b/KsApi/models/UserTests.swift
@@ -100,7 +100,6 @@ final class UserTests: XCTestCase {
     let repeatCreator = User.template
       |> User.lens.stats.createdProjectsCount .~ 2
 
-
     XCTAssertEqual(true, repeatCreator.isRepeatCreator)
     XCTAssertEqual(false, creator.isRepeatCreator)
     XCTAssertEqual(false, user.isRepeatCreator)

--- a/KsApi/models/UserTests.swift
+++ b/KsApi/models/UserTests.swift
@@ -92,4 +92,17 @@ final class UserTests: XCTestCase {
 
     XCTAssertEqual(user.value?.encode() as NSDictionary?, json as NSDictionary?)
   }
+
+  func testIsRepeatCreator() {
+    let user = User.template
+    let creator = User.template
+      |> User.lens.stats.createdProjectsCount .~ 1
+    let repeatCreator = User.template
+      |> User.lens.stats.createdProjectsCount .~ 2
+
+
+    XCTAssertEqual(true, repeatCreator.isRepeatCreator)
+    XCTAssertEqual(false, creator.isRepeatCreator)
+    XCTAssertEqual(false, user.isRepeatCreator)
+  }
 }

--- a/KsApi/models/UserTests.swift
+++ b/KsApi/models/UserTests.swift
@@ -102,6 +102,6 @@ final class UserTests: XCTestCase {
 
     XCTAssertEqual(true, repeatCreator.isRepeatCreator)
     XCTAssertEqual(false, creator.isRepeatCreator)
-    XCTAssertEqual(false, user.isRepeatCreator)
+    XCTAssertNil(user.isRepeatCreator)
   }
 }

--- a/Library/Tracking/Koala.swift
+++ b/Library/Tracking/Koala.swift
@@ -2103,7 +2103,7 @@ private func properties(
   reward: Reward? = nil,
   backing: Backing? = nil,
   prefix: String = "project_"
-  ) -> [String: Any] {
+) -> [String: Any] {
   var props: [String: Any] = [:]
 
   props["name"] = project.name

--- a/Library/Tracking/Koala.swift
+++ b/Library/Tracking/Koala.swift
@@ -2065,11 +2065,12 @@ private func projectProperties(
 ) -> [String: Any] {
   var props: [String: Any] = [:]
 
-  props["creator_uid"] = project.creator.id
   props["backers_count"] = project.stats.backersCount
   props["category"] = project.category.name
   props["country"] = project.country.countryCode
+  props["comments_count"] = project.stats.commentsCount
   props["currency"] = project.country.currencyCode
+  props["creator_uid"] = project.creator.id
   props["deadline"] = project.dates.deadline
   props["goal"] = project.stats.goal
   props["launched_at"] = project.dates.launchedAt
@@ -2082,20 +2083,23 @@ private func projectProperties(
   props["state"] = project.state.rawValue
   props["static_usd_rate"] = project.stats.staticUsdRate
   props["current_pledge_amount_usd"] = project.stats.pledgedUsd
-  props["is_repeat_creator"] = project.creator.isRepeatCreator
   props["goal_usd"] = project.stats.goalUsd
+  props["has_video"] = project.video != nil
 
   let now = dateType.init().date
   props["hours_remaining"] = project.dates.hoursRemaining(from: now, using: calendar)
   props["duration"] = project.dates.duration(using: calendar)
 
   var userProperties: [String: Any] = [:]
-  userProperties["has_starred"] = project.personalization.isStarred
+  userProperties["has_watched"] = project.personalization.isStarred
   userProperties["is_backer"] = project.personalization.isBacking
   userProperties["is_project_creator"] = project.creator.id == loggedInUser?.id
 
-  return props.prefixedKeys(prefix)
-    .withAllValuesFrom(userProperties.prefixedKeys("user_"))
+  let userProps = userProperties.prefixedKeys("user_")
+
+  return props
+    .withAllValuesFrom(userProps)
+    .prefixedKeys(prefix)
 }
 
 private func properties(

--- a/Library/Tracking/Koala.swift
+++ b/Library/Tracking/Koala.swift
@@ -2068,7 +2068,7 @@ private func projectProperties(
   props["backers_count"] = project.stats.backersCount
   props["category"] = project.category.name
   props["country"] = project.country.countryCode
-  props["comments_count"] = project.stats.commentsCount
+  props["comments_count"] = project.stats.commentsCount ?? 0
   props["currency"] = project.country.currencyCode
   props["creator_uid"] = project.creator.id
   props["deadline"] = project.dates.deadline
@@ -2085,6 +2085,7 @@ private func projectProperties(
   props["current_pledge_amount_usd"] = project.stats.pledgedUsd
   props["goal_usd"] = project.stats.goalUsd
   props["has_video"] = project.video != nil
+  props["updates_count"] = project.stats.updatesCount
 
   let now = dateType.init().date
   props["hours_remaining"] = project.dates.hoursRemaining(from: now, using: calendar)

--- a/Library/Tracking/Koala.swift
+++ b/Library/Tracking/Koala.swift
@@ -1294,6 +1294,12 @@ public final class Koala {
     )
   }
 
+  /**
+   Call when a project page is swiped to the next project.
+
+   - parameter project:      The next project being viewed.
+   - parameter refTag:       The ref tag used when swiping to the project.
+   */
   public func trackSwipedProject(_ project: Project, refTag: RefTag?) {
     var props = projectProperties(from: project, loggedInUser: self.loggedInUser)
     props["ref_tag"] = refTag?.stringTag
@@ -2044,17 +2050,18 @@ private func properties(
   project: Project,
   loggedInUser: User?,
   prefix: String = "project_"
-  ) -> [String: Any] {
+) -> [String: Any] {
   return projectProperties(from: project, loggedInUser: loggedInUser, prefix: prefix)
 }
 
-private func projectProperties(from project: Project,
-                                    reward: Reward? = nil,
-                                    backing: Backing? = nil,
-                                    loggedInUser: User? = nil,
-                                    dateType: DateProtocol.Type = AppEnvironment.current.dateType,
-                                    calendar: Calendar = AppEnvironment.current.calendar,
-                                    prefix: String = "project_"
+private func projectProperties(
+  from project: Project,
+  reward _: Reward? = nil,
+  backing _: Backing? = nil,
+  loggedInUser: User? = nil,
+  dateType: DateProtocol.Type = AppEnvironment.current.dateType,
+  calendar: Calendar = AppEnvironment.current.calendar,
+  prefix: String = "project_"
 ) -> [String: Any] {
   var props: [String: Any] = [:]
 

--- a/Library/Tracking/Koala.swift
+++ b/Library/Tracking/Koala.swift
@@ -1296,7 +1296,6 @@ public final class Koala {
 
   /**
    Call when a project page is swiped to the next project.
-
    - parameter project:      The next project being viewed.
    - parameter refTag:       The ref tag used when swiping to the project.
    */

--- a/Library/Tracking/Koala.swift
+++ b/Library/Tracking/Koala.swift
@@ -2074,6 +2074,9 @@ private func projectProperties(from project: Project,
   props["pledged"] = project.stats.pledged
   props["state"] = project.state.rawValue
   props["static_usd_rate"] = project.stats.staticUsdRate
+  props["current_pledge_amount_usd"] = project.stats.pledgedUsd
+  props["is_repeat_creator"] = project.creator.isRepeatCreator
+  props["goal_usd"] = project.stats.goalUsd
 
   let now = dateType.init().date
   props["hours_remaining"] = project.dates.hoursRemaining(from: now, using: calendar)

--- a/Library/Tracking/Koala.swift
+++ b/Library/Tracking/Koala.swift
@@ -1963,7 +1963,7 @@ public final class Koala {
     props["screen_height"] = UInt(self.screen.bounds.height)
     props["device_orientation"] = Koala.deviceOrientation
     props["is_voiceover_running"] = AppEnvironment.current.isVoiceOverRunning()
-    props["preferred_content_size_category"] = self.preferredContentSizeCategory
+    props["preferred_content_size_category"] = self.preferredContentSizeCategory?.rawValue
 
     props["mp_lib"] = "kickstarter_ios"
     props["koala_lib"] = "kickstarter_ios"
@@ -2072,7 +2072,7 @@ private func projectProperties(from project: Project,
   props["parent_category"] = project.category.parent?.name
   props["percent_raised"] = project.stats.fundingProgress
   props["pledged"] = project.stats.pledged
-  props["state"] = project.state
+  props["state"] = project.state.rawValue
   props["static_usd_rate"] = project.stats.staticUsdRate
 
   let now = dateType.init().date
@@ -2085,7 +2085,7 @@ private func projectProperties(from project: Project,
   userProperties["is_project_creator"] = project.creator.id == loggedInUser?.id
 
   return props.prefixedKeys(prefix)
-    .withAllValuesFrom(userProperties.prefixedKeys("user"))
+    .withAllValuesFrom(userProperties.prefixedKeys("user_"))
 }
 
 private func properties(update: Update, prefix: String = "update_") -> [String: Any] {

--- a/Library/Tracking/KoalaTests.swift
+++ b/Library/Tracking/KoalaTests.swift
@@ -165,13 +165,13 @@ final class KoalaTests: TestCase {
     XCTAssertEqual(project.creator.id, properties?["project_creator_uid"] as? Int)
     XCTAssertEqual(24 * 15, properties?["project_hours_remaining"] as? Int)
     XCTAssertEqual(30, properties?["project_duration"] as? Int)
-    XCTAssertEqual(1476657315, properties?["project_deadline"] as? Double)
-    XCTAssertEqual(1474065315, properties?["project_launched_at"] as? Double)
+    XCTAssertEqual(1_476_657_315, properties?["project_deadline"] as? Double)
+    XCTAssertEqual(1_474_065_315, properties?["project_launched_at"] as? Double)
     XCTAssertEqual(2, properties?["project_static_usd_rate"] as? Float)
     XCTAssertEqual("live", properties?["project_state"] as? String)
-    XCTAssertEqual(2000, properties?["project_current_pledge_amount_usd"] as? Int)
+    XCTAssertEqual(2_000, properties?["project_current_pledge_amount_usd"] as? Int)
     XCTAssertEqual(false, properties?["project_is_repeat_creator"] as? Bool)
-    XCTAssertEqual(4000, properties?["project_goal_usd"] as? Int)
+    XCTAssertEqual(4_000, properties?["project_goal_usd"] as? Int)
 
     XCTAssertNotNil(project.video)
 

--- a/Library/Tracking/KoalaTests.swift
+++ b/Library/Tracking/KoalaTests.swift
@@ -203,7 +203,7 @@ final class KoalaTests: TestCase {
     XCTAssertEqual(false, properties?["project_user_is_backer"] as? Bool)
     XCTAssertEqual(false, properties?["project_user_has_watched"] as? Bool)
 
-    XCTAssertEqual(24, properties?.keys.filter { $0.hasPrefix("project_") }.count)
+    XCTAssertEqual(25, properties?.keys.filter { $0.hasPrefix("project_") }.count)
   }
 
   func testProjectProperties_LoggedInBacker() {
@@ -223,7 +223,7 @@ final class KoalaTests: TestCase {
     XCTAssertEqual(true, properties?["project_user_is_backer"] as? Bool)
     XCTAssertEqual(false, properties?["project_user_has_watched"] as? Bool)
 
-    XCTAssertEqual(24, properties?.keys.filter { $0.hasPrefix("project_") }.count)
+    XCTAssertEqual(25, properties?.keys.filter { $0.hasPrefix("project_") }.count)
   }
 
   func testProjectProperties_LoggedInStarrer() {
@@ -243,7 +243,7 @@ final class KoalaTests: TestCase {
     XCTAssertEqual(false, properties?["project_user_is_backer"] as? Bool)
     XCTAssertEqual(true, properties?["project_user_has_watched"] as? Bool)
 
-    XCTAssertEqual(24, properties?.keys.filter { $0.hasPrefix("project_") }.count)
+    XCTAssertEqual(25, properties?.keys.filter { $0.hasPrefix("project_") }.count)
   }
 
   func testProjectProperties_LoggedInCreator() {
@@ -263,7 +263,7 @@ final class KoalaTests: TestCase {
     XCTAssertEqual(false, properties?["project_user_is_backer"] as? Bool)
     XCTAssertEqual(false, properties?["project_user_has_watched"] as? Bool)
 
-    XCTAssertEqual(24, properties?.keys.filter { $0.hasPrefix("project_") }.count)
+    XCTAssertEqual(25, properties?.keys.filter { $0.hasPrefix("project_") }.count)
   }
 
   func testDiscoveryProperties() {

--- a/Library/Tracking/KoalaTests.swift
+++ b/Library/Tracking/KoalaTests.swift
@@ -169,6 +169,9 @@ final class KoalaTests: TestCase {
     XCTAssertEqual(1474065315, properties?["project_launched_at"] as? Double)
     XCTAssertEqual(2, properties?["project_static_usd_rate"] as? Float)
     XCTAssertEqual("live", properties?["project_state"] as? String)
+    XCTAssertEqual(2000, properties?["project_current_pledge_amount_usd"] as? Int)
+    XCTAssertEqual(false, properties?["project_is_repeat_creator"] as? Bool)
+    XCTAssertEqual(4000, properties?["project_goal_usd"] as? Int)
 
     XCTAssertNotNil(project.video)
 
@@ -179,7 +182,7 @@ final class KoalaTests: TestCase {
     XCTAssertNil(properties?["user_is_backer"])
     XCTAssertNil(properties?["user_has_starred"])
 
-    XCTAssertEqual(17, properties?.keys.filter { $0.hasPrefix("project_") }.count)
+    XCTAssertEqual(20, properties?.keys.filter { $0.hasPrefix("project_") }.count)
   }
 
   func testProjectProperties_LoggedInUser() {
@@ -200,7 +203,7 @@ final class KoalaTests: TestCase {
     XCTAssertEqual(false, properties?["user_is_backer"] as? Bool)
     XCTAssertEqual(false, properties?["user_has_starred"] as? Bool)
 
-    XCTAssertEqual(17, properties?.keys.filter { $0.hasPrefix("project_") }.count)
+    XCTAssertEqual(20, properties?.keys.filter { $0.hasPrefix("project_") }.count)
   }
 
   func testProjectProperties_LoggedInBacker() {
@@ -219,6 +222,8 @@ final class KoalaTests: TestCase {
     XCTAssertEqual(false, properties?["user_is_project_creator"] as? Bool)
     XCTAssertEqual(true, properties?["user_is_backer"] as? Bool)
     XCTAssertEqual(false, properties?["user_has_starred"] as? Bool)
+
+    XCTAssertEqual(20, properties?.keys.filter { $0.hasPrefix("project_") }.count)
   }
 
   func testProjectProperties_LoggedInStarrer() {
@@ -237,6 +242,8 @@ final class KoalaTests: TestCase {
     XCTAssertEqual(false, properties?["user_is_project_creator"] as? Bool)
     XCTAssertEqual(false, properties?["user_is_backer"] as? Bool)
     XCTAssertEqual(true, properties?["user_has_starred"] as? Bool)
+
+    XCTAssertEqual(20, properties?.keys.filter { $0.hasPrefix("project_") }.count)
   }
 
   func testProjectProperties_LoggedInCreator() {
@@ -255,6 +262,8 @@ final class KoalaTests: TestCase {
     XCTAssertEqual(true, properties?["user_is_project_creator"] as? Bool)
     XCTAssertEqual(false, properties?["user_is_backer"] as? Bool)
     XCTAssertEqual(false, properties?["user_has_starred"] as? Bool)
+
+    XCTAssertEqual(20, properties?.keys.filter { $0.hasPrefix("project_") }.count)
   }
 
   func testDiscoveryProperties() {

--- a/Library/Tracking/KoalaTests.swift
+++ b/Library/Tracking/KoalaTests.swift
@@ -160,6 +160,7 @@ final class KoalaTests: TestCase {
     XCTAssertEqual(project.id, properties?["project_pid"] as? Int)
     XCTAssertEqual(project.stats.pledged, properties?["project_pledged"] as? Int)
     XCTAssertEqual(project.stats.fundingProgress, properties?["project_percent_raised"] as? Float)
+    XCTAssertEqual(project.stats.updatesCount, properties?["project_updates_count"] as? Int)
     XCTAssertEqual(project.category.name, properties?["project_category"] as? String)
     XCTAssertEqual(project.category._parent?.name, properties?["project_parent_category"] as? String)
     XCTAssertEqual(project.location.name, properties?["project_location"] as? String)
@@ -181,7 +182,7 @@ final class KoalaTests: TestCase {
     XCTAssertNil(properties?["project_user_is_backer"])
     XCTAssertNil(properties?["project_user_has_starred"])
 
-    XCTAssertEqual(22, properties?.keys.filter { $0.hasPrefix("project_") }.count)
+    XCTAssertEqual(23, properties?.keys.filter { $0.hasPrefix("project_") }.count)
   }
 
   func testProjectProperties_LoggedInUser() {

--- a/Library/Tracking/KoalaTests.swift
+++ b/Library/Tracking/KoalaTests.swift
@@ -144,7 +144,8 @@ final class KoalaTests: TestCase {
     let koala = Koala(client: client, loggedInUser: nil)
     let project = Project.template
 
-    koala.trackProjectShow(project, refTag: .discovery, cookieRefTag: .recommended)
+    koala.trackProjectViewed(project, refTag: .discovery, cookieRefTag: .recommended)
+
     XCTAssertEqual(3, client.properties.count)
 
     let properties = client.properties.last
@@ -192,7 +193,7 @@ final class KoalaTests: TestCase {
     let loggedInUser = User.template |> \.id .~ 42
     let koala = Koala(client: client, loggedInUser: loggedInUser)
 
-    koala.trackProjectShow(project, refTag: nil, cookieRefTag: nil)
+    koala.trackProjectViewed(project, refTag: nil, cookieRefTag: nil)
     XCTAssertEqual(3, client.properties.count)
 
     let properties = client.properties.last
@@ -210,7 +211,7 @@ final class KoalaTests: TestCase {
     let loggedInUser = User.template |> \.id .~ 42
     let koala = Koala(client: client, loggedInUser: loggedInUser)
 
-    koala.trackProjectShow(project, refTag: nil, cookieRefTag: nil)
+    koala.trackProjectViewed(project, refTag: nil, cookieRefTag: nil)
     XCTAssertEqual(3, client.properties.count)
 
     let properties = client.properties.last
@@ -228,7 +229,7 @@ final class KoalaTests: TestCase {
     let loggedInUser = User.template |> \.id .~ 42
     let koala = Koala(client: client, loggedInUser: loggedInUser)
 
-    koala.trackProjectShow(project, refTag: nil, cookieRefTag: nil)
+    koala.trackProjectViewed(project, refTag: nil, cookieRefTag: nil)
     XCTAssertEqual(3, client.properties.count)
 
     let properties = client.properties.last
@@ -246,7 +247,7 @@ final class KoalaTests: TestCase {
     let loggedInUser = project.creator
     let koala = Koala(client: client, loggedInUser: loggedInUser)
 
-    koala.trackProjectShow(project, refTag: nil, cookieRefTag: nil)
+    koala.trackProjectViewed(project, refTag: nil, cookieRefTag: nil)
     XCTAssertEqual(3, client.properties.count)
 
     let properties = client.properties.last

--- a/Library/Tracking/KoalaTests.swift
+++ b/Library/Tracking/KoalaTests.swift
@@ -144,6 +144,7 @@ final class KoalaTests: TestCase {
     let koala = Koala(client: client, loggedInUser: nil)
     let project = Project.template
       |> Project.lens.stats.staticUsdRate .~ 2
+      |> Project.lens.stats.commentsCount .~ 10
 
     koala.trackProjectViewed(project, refTag: .discovery, cookieRefTag: .recommended)
 
@@ -170,19 +171,17 @@ final class KoalaTests: TestCase {
     XCTAssertEqual(2, properties?["project_static_usd_rate"] as? Float)
     XCTAssertEqual("live", properties?["project_state"] as? String)
     XCTAssertEqual(2_000, properties?["project_current_pledge_amount_usd"] as? Int)
-    XCTAssertEqual(false, properties?["project_is_repeat_creator"] as? Bool)
     XCTAssertEqual(4_000, properties?["project_goal_usd"] as? Int)
-
-    XCTAssertNotNil(project.video)
-
+    XCTAssertEqual(true, properties?["project_has_video"] as? Bool)
+    XCTAssertEqual(10, properties?["project_comments_count"] as? Int)
     XCTAssertEqual("discovery", properties?["ref_tag"] as? String)
     XCTAssertEqual("recommended", properties?["referrer_credit"] as? String)
 
-    XCTAssertEqual(false, properties?["user_is_project_creator"] as? Bool)
-    XCTAssertNil(properties?["user_is_backer"])
-    XCTAssertNil(properties?["user_has_starred"])
+    XCTAssertEqual(false, properties?["project_user_is_project_creator"] as? Bool)
+    XCTAssertNil(properties?["project_user_is_backer"])
+    XCTAssertNil(properties?["project_user_has_starred"])
 
-    XCTAssertEqual(20, properties?.keys.filter { $0.hasPrefix("project_") }.count)
+    XCTAssertEqual(22, properties?.keys.filter { $0.hasPrefix("project_") }.count)
   }
 
   func testProjectProperties_LoggedInUser() {
@@ -199,11 +198,11 @@ final class KoalaTests: TestCase {
 
     let properties = client.properties.last
 
-    XCTAssertEqual(false, properties?["user_is_project_creator"] as? Bool)
-    XCTAssertEqual(false, properties?["user_is_backer"] as? Bool)
-    XCTAssertEqual(false, properties?["user_has_starred"] as? Bool)
+    XCTAssertEqual(false, properties?["project_user_is_project_creator"] as? Bool)
+    XCTAssertEqual(false, properties?["project_user_is_backer"] as? Bool)
+    XCTAssertEqual(false, properties?["project_user_has_watched"] as? Bool)
 
-    XCTAssertEqual(20, properties?.keys.filter { $0.hasPrefix("project_") }.count)
+    XCTAssertEqual(24, properties?.keys.filter { $0.hasPrefix("project_") }.count)
   }
 
   func testProjectProperties_LoggedInBacker() {
@@ -219,11 +218,11 @@ final class KoalaTests: TestCase {
 
     let properties = client.properties.last
 
-    XCTAssertEqual(false, properties?["user_is_project_creator"] as? Bool)
-    XCTAssertEqual(true, properties?["user_is_backer"] as? Bool)
-    XCTAssertEqual(false, properties?["user_has_starred"] as? Bool)
+    XCTAssertEqual(false, properties?["project_user_is_project_creator"] as? Bool)
+    XCTAssertEqual(true, properties?["project_user_is_backer"] as? Bool)
+    XCTAssertEqual(false, properties?["project_user_has_watched"] as? Bool)
 
-    XCTAssertEqual(20, properties?.keys.filter { $0.hasPrefix("project_") }.count)
+    XCTAssertEqual(24, properties?.keys.filter { $0.hasPrefix("project_") }.count)
   }
 
   func testProjectProperties_LoggedInStarrer() {
@@ -239,11 +238,11 @@ final class KoalaTests: TestCase {
 
     let properties = client.properties.last
 
-    XCTAssertEqual(false, properties?["user_is_project_creator"] as? Bool)
-    XCTAssertEqual(false, properties?["user_is_backer"] as? Bool)
-    XCTAssertEqual(true, properties?["user_has_starred"] as? Bool)
+    XCTAssertEqual(false, properties?["project_user_is_project_creator"] as? Bool)
+    XCTAssertEqual(false, properties?["project_user_is_backer"] as? Bool)
+    XCTAssertEqual(true, properties?["project_user_has_watched"] as? Bool)
 
-    XCTAssertEqual(20, properties?.keys.filter { $0.hasPrefix("project_") }.count)
+    XCTAssertEqual(24, properties?.keys.filter { $0.hasPrefix("project_") }.count)
   }
 
   func testProjectProperties_LoggedInCreator() {
@@ -259,11 +258,11 @@ final class KoalaTests: TestCase {
 
     let properties = client.properties.last
 
-    XCTAssertEqual(true, properties?["user_is_project_creator"] as? Bool)
-    XCTAssertEqual(false, properties?["user_is_backer"] as? Bool)
-    XCTAssertEqual(false, properties?["user_has_starred"] as? Bool)
+    XCTAssertEqual(true, properties?["project_user_is_project_creator"] as? Bool)
+    XCTAssertEqual(false, properties?["project_user_is_backer"] as? Bool)
+    XCTAssertEqual(false, properties?["project_user_has_watched"] as? Bool)
 
-    XCTAssertEqual(20, properties?.keys.filter { $0.hasPrefix("project_") }.count)
+    XCTAssertEqual(24, properties?.keys.filter { $0.hasPrefix("project_") }.count)
   }
 
   func testDiscoveryProperties() {

--- a/Library/Tracking/KoalaTests.swift
+++ b/Library/Tracking/KoalaTests.swift
@@ -143,14 +143,15 @@ final class KoalaTests: TestCase {
     let client = MockTrackingClient()
     let koala = Koala(client: client, loggedInUser: nil)
     let project = Project.template
+      |> Project.lens.stats.staticUsdRate .~ 2
 
     koala.trackProjectViewed(project, refTag: .discovery, cookieRefTag: .recommended)
 
-    XCTAssertEqual(3, client.properties.count)
+    XCTAssertEqual(1, client.properties.count)
 
     let properties = client.properties.last
 
-    XCTAssertEqual("Project Page", client.events.last)
+    XCTAssertEqual("Project Page Viewed", client.events.last)
     XCTAssertEqual(project.stats.backersCount, properties?["project_backers_count"] as? Int)
     XCTAssertEqual(project.country.countryCode, properties?["project_country"] as? String)
     XCTAssertEqual(project.country.currencyCode, properties?["project_currency"] as? String)
@@ -158,31 +159,27 @@ final class KoalaTests: TestCase {
     XCTAssertEqual(project.id, properties?["project_pid"] as? Int)
     XCTAssertEqual(project.stats.pledged, properties?["project_pledged"] as? Int)
     XCTAssertEqual(project.stats.fundingProgress, properties?["project_percent_raised"] as? Float)
-    XCTAssertNotNil(project.video)
     XCTAssertEqual(project.category.name, properties?["project_category"] as? String)
     XCTAssertEqual(project.category._parent?.name, properties?["project_parent_category"] as? String)
     XCTAssertEqual(project.location.name, properties?["project_location"] as? String)
-    XCTAssertEqual(project.stats.backersCount, properties?["project_backers_count"] as? Int)
-
+    XCTAssertEqual(project.creator.id, properties?["project_creator_uid"] as? Int)
     XCTAssertEqual(24 * 15, properties?["project_hours_remaining"] as? Int)
-    XCTAssertEqual(60 * 60 * 24 * 30, properties?["project_duration"] as? Int)
+    XCTAssertEqual(30, properties?["project_duration"] as? Int)
+    XCTAssertEqual(1476657315, properties?["project_deadline"] as? Double)
+    XCTAssertEqual(1474065315, properties?["project_launched_at"] as? Double)
+    XCTAssertEqual(2, properties?["project_static_usd_rate"] as? Float)
+    XCTAssertEqual("live", properties?["project_state"] as? String)
+
+    XCTAssertNotNil(project.video)
 
     XCTAssertEqual("discovery", properties?["ref_tag"] as? String)
     XCTAssertEqual("recommended", properties?["referrer_credit"] as? String)
 
-    XCTAssertEqual(project.creator.id, properties?["creator_uid"] as? Int)
-    XCTAssertEqual(
-      project.creator.stats.backedProjectsCount,
-      properties?["creator_backed_projects_count"] as? Int
-    )
-    XCTAssertEqual(
-      project.creator.stats.createdProjectsCount,
-      properties?["creator_created_projects_count"] as? Int
-    )
-    XCTAssertEqual(
-      project.creator.stats.starredProjectsCount,
-      properties?["creator_starred_projects_count"] as? Int
-    )
+    XCTAssertEqual(false, properties?["user_is_project_creator"] as? Bool)
+    XCTAssertNil(properties?["user_is_backer"])
+    XCTAssertNil(properties?["user_has_starred"])
+
+    XCTAssertEqual(17, properties?.keys.filter { $0.hasPrefix("project_") }.count)
   }
 
   func testProjectProperties_LoggedInUser() {
@@ -194,13 +191,16 @@ final class KoalaTests: TestCase {
     let koala = Koala(client: client, loggedInUser: loggedInUser)
 
     koala.trackProjectViewed(project, refTag: nil, cookieRefTag: nil)
-    XCTAssertEqual(3, client.properties.count)
+
+    XCTAssertEqual(1, client.properties.count)
 
     let properties = client.properties.last
 
     XCTAssertEqual(false, properties?["user_is_project_creator"] as? Bool)
     XCTAssertEqual(false, properties?["user_is_backer"] as? Bool)
     XCTAssertEqual(false, properties?["user_has_starred"] as? Bool)
+
+    XCTAssertEqual(17, properties?.keys.filter { $0.hasPrefix("project_") }.count)
   }
 
   func testProjectProperties_LoggedInBacker() {
@@ -212,7 +212,7 @@ final class KoalaTests: TestCase {
     let koala = Koala(client: client, loggedInUser: loggedInUser)
 
     koala.trackProjectViewed(project, refTag: nil, cookieRefTag: nil)
-    XCTAssertEqual(3, client.properties.count)
+    XCTAssertEqual(1, client.properties.count)
 
     let properties = client.properties.last
 
@@ -230,7 +230,7 @@ final class KoalaTests: TestCase {
     let koala = Koala(client: client, loggedInUser: loggedInUser)
 
     koala.trackProjectViewed(project, refTag: nil, cookieRefTag: nil)
-    XCTAssertEqual(3, client.properties.count)
+    XCTAssertEqual(1, client.properties.count)
 
     let properties = client.properties.last
 
@@ -248,7 +248,7 @@ final class KoalaTests: TestCase {
     let koala = Koala(client: client, loggedInUser: loggedInUser)
 
     koala.trackProjectViewed(project, refTag: nil, cookieRefTag: nil)
-    XCTAssertEqual(3, client.properties.count)
+    XCTAssertEqual(1, client.properties.count)
 
     let properties = client.properties.last
 

--- a/Library/ViewModels/ProjectNavBarViewModel.swift
+++ b/Library/ViewModels/ProjectNavBarViewModel.swift
@@ -106,12 +106,6 @@ public final class ProjectNavBarViewModel: ProjectNavBarViewModelType,
     .skipRepeats { $0.opaque == $1.opaque }
 
     self.dismissViewController = self.closeButtonTappedProperty.signal
-
-    configuredProjectAndRefTag
-      .takeWhen(self.closeButtonTappedProperty.signal)
-      .observeValues { project, refTag in
-        AppEnvironment.current.koala.trackClosedProjectPage(project, refTag: refTag, gestureType: .tap)
-      }
   }
 
   fileprivate let projectAndRefTagProperty = MutableProperty<(Project, RefTag?)?>(nil)

--- a/Library/ViewModels/ProjectNavigatorViewModel.swift
+++ b/Library/ViewModels/ProjectNavigatorViewModel.swift
@@ -139,18 +139,7 @@ public final class ProjectNavigatorViewModel: ProjectNavigatorViewModelType,
     configData
       .takePairWhen(swipedToProjectAtIndexFromIndex)
       .observeValues { configData, pii in
-        let type = swipeType(currentIndex: pii.currentIndex, previousIndex: pii.previousIndex)
-        AppEnvironment.current.koala.trackSwipedProject(pii.project, refTag: configData.refTag, type: type)
-      }
-
-    Signal.combineLatest(configData, currentProject)
-      .takeWhen(self.finishInteractiveTransition)
-      .observeValues { configData, project in
-        AppEnvironment.current.koala.trackClosedProjectPage(
-          project,
-          refTag: configData.refTag,
-          gestureType: .swipe
-        )
+        AppEnvironment.current.koala.trackSwipedProject(pii.project, refTag: configData.refTag)
       }
   }
 

--- a/Library/ViewModels/ProjectNavigatorViewModelTests.swift
+++ b/Library/ViewModels/ProjectNavigatorViewModelTests.swift
@@ -404,7 +404,7 @@ internal final class ProjectNavigatorViewModelTests: TestCase {
 
     self.notifyDelegateTransitionedToProjectIndex.assertValues([1, 2, 1])
     XCTAssertEqual([
-     "Project Swiped", "Project Swiped", "Project Swiped"
+      "Project Swiped", "Project Swiped", "Project Swiped"
     ], self.trackingClient.events)
   }
 }

--- a/Library/ViewModels/ProjectNavigatorViewModelTests.swift
+++ b/Library/ViewModels/ProjectNavigatorViewModelTests.swift
@@ -156,13 +156,6 @@ internal final class ProjectNavigatorViewModelTests: TestCase {
     self.finishInteractiveTransition.assertValueCount(1)
     self.updateInteractiveTransition.assertValueCount(2)
     self.setTransitionAnimatorIsInFlight.assertValues([false, true, false])
-
-    XCTAssertEqual(["Closed Project Page"], self.trackingClient.events)
-    XCTAssertEqual(
-      ["swipe"],
-      self.trackingClient.properties(forKey: "gesture_type", as: String.self),
-      "Track swiped to close."
-    )
   }
 
   func testTransitionLifecycle_Overscroll_Cancel() {
@@ -395,25 +388,15 @@ internal final class ProjectNavigatorViewModelTests: TestCase {
     self.vm.inputs.pageTransition(completed: true, from: 0)
 
     self.notifyDelegateTransitionedToProjectIndex.assertValues([1])
-    XCTAssertEqual(["Swiped Project", "Project Navigate"], self.trackingClient.events)
-    XCTAssertEqual(
-      ["next", "next"],
-      self.trackingClient.properties(forKey: "type", as: String.self),
-      "Track next swipe."
-    )
+    XCTAssertEqual(["Project Swiped"], self.trackingClient.events)
 
     self.vm.inputs.willTransition(toProject: playlist[1], at: 2)
     self.vm.inputs.pageTransition(completed: true, from: 1)
 
     self.notifyDelegateTransitionedToProjectIndex.assertValues([1, 2])
     XCTAssertEqual(
-      ["Swiped Project", "Project Navigate", "Swiped Project", "Project Navigate"],
+      ["Project Swiped", "Project Swiped"],
       self.trackingClient.events
-    )
-    XCTAssertEqual(
-      ["next", "next", "next", "next"],
-      self.trackingClient.properties(forKey: "type", as: String.self),
-      "Track next swipe."
     )
 
     self.vm.inputs.willTransition(toProject: playlist[1], at: 1)
@@ -421,13 +404,7 @@ internal final class ProjectNavigatorViewModelTests: TestCase {
 
     self.notifyDelegateTransitionedToProjectIndex.assertValues([1, 2, 1])
     XCTAssertEqual([
-      "Swiped Project", "Project Navigate", "Swiped Project", "Project Navigate",
-      "Swiped Project", "Project Navigate"
+     "Project Swiped", "Project Swiped", "Project Swiped"
     ], self.trackingClient.events)
-    XCTAssertEqual(
-      ["next", "next", "next", "next", "previous", "previous"],
-      self.trackingClient.properties(forKey: "type", as: String.self),
-      "Track previous swipe."
-    )
   }
 }

--- a/Library/ViewModels/ProjectPamphletViewModel.swift
+++ b/Library/ViewModels/ProjectPamphletViewModel.swift
@@ -197,7 +197,7 @@ public final class ProjectPamphletViewModel: ProjectPamphletViewModelType, Proje
     .map { (project: $0.0, refTag: $0.1, cookieRefTag: $1, _: $2) }
     .take(first: 1)
     .observeValues { project, refTag, cookieRefTag, _ in
-      AppEnvironment.current.koala.trackProjectShow(
+      AppEnvironment.current.koala.trackProjectViewed(
         project,
         refTag: refTag,
         cookieRefTag: cookieRefTag

--- a/Library/ViewModels/ProjectPamphletViewModelTests.swift
+++ b/Library/ViewModels/ProjectPamphletViewModelTests.swift
@@ -154,12 +154,12 @@ final class ProjectPamphletViewModelTests: TestCase {
       self.trackingClient.events, "A project page event is tracked."
     )
     XCTAssertEqual(
-      [RefTag.category.stringTag, RefTag.category.stringTag, RefTag.category.stringTag],
+      [RefTag.category.stringTag],
       self.trackingClient.properties.compactMap { $0["ref_tag"] as? String },
       "The ref tag is tracked in the koala event."
     )
     XCTAssertEqual(
-      [RefTag.category.stringTag, RefTag.category.stringTag, RefTag.category.stringTag],
+      [RefTag.category.stringTag],
       self.trackingClient.properties.compactMap { $0["referrer_credit"] as? String },
       "The referral credit is tracked in the koala event."
     )
@@ -188,23 +188,22 @@ final class ProjectPamphletViewModelTests: TestCase {
 
     XCTAssertEqual(
       [
-        "Project Page Viewed", "Viewed Project Page", "Project Page", "Project Page Viewed",
-        "Viewed Project Page", "Project Page"
+        "Project Page Viewed", "Project Page Viewed"
       ],
       self.trackingClient.events, "A project page koala event is tracked."
     )
     XCTAssertEqual(
       [
-        RefTag.category.stringTag, RefTag.category.stringTag, RefTag.category.stringTag,
-        RefTag.recommended.stringTag, RefTag.recommended.stringTag, RefTag.recommended.stringTag
+        RefTag.category.stringTag,
+        RefTag.recommended.stringTag
       ],
       self.trackingClient.properties.compactMap { $0["ref_tag"] as? String },
       "The new ref tag is tracked in koala event."
     )
     XCTAssertEqual(
       [
-        RefTag.category.stringTag, RefTag.category.stringTag, RefTag.category.stringTag,
-        RefTag.category.stringTag, RefTag.category.stringTag, RefTag.category.stringTag
+        RefTag.category.stringTag,
+        RefTag.category.stringTag
       ],
       self.trackingClient.properties.compactMap { $0["referrer_credit"] as? String },
       "The referrer credit did not change, and is still category."
@@ -298,16 +297,16 @@ final class ProjectPamphletViewModelTests: TestCase {
     self.scheduler.advance()
 
     XCTAssertEqual(
-      ["Project Page Viewed", "Viewed Project Page", "Project Page"],
+      ["Project Page Viewed"],
       self.trackingClient.events, "A project page koala event is tracked."
     )
     XCTAssertEqual(
-      [RefTag.category.stringTag, RefTag.category.stringTag, RefTag.category.stringTag],
+      [RefTag.category.stringTag],
       self.trackingClient.properties.compactMap { $0["ref_tag"] as? String },
       "The ref tag is tracked in the koala event."
     )
     XCTAssertEqual(
-      [RefTag.category.stringTag, RefTag.category.stringTag, RefTag.category.stringTag],
+      [RefTag.category.stringTag],
       self.trackingClient.properties.compactMap { $0["referrer_credit"] as? String },
       "The referral credit is tracked in the koala event."
     )
@@ -336,23 +335,21 @@ final class ProjectPamphletViewModelTests: TestCase {
 
     XCTAssertEqual(
       [
-        "Project Page Viewed", "Viewed Project Page", "Project Page", "Project Page Viewed",
-        "Viewed Project Page", "Project Page"
+        "Project Page Viewed", "Project Page Viewed"
       ],
       self.trackingClient.events, "A project page koala event is tracked."
     )
     XCTAssertEqual(
       [
-        RefTag.category.stringTag, RefTag.category.stringTag, RefTag.category.stringTag,
-        RefTag.recommended.stringTag, RefTag.recommended.stringTag, RefTag.recommended.stringTag
+        RefTag.category.stringTag,
+        RefTag.recommended.stringTag
       ],
       self.trackingClient.properties.compactMap { $0["ref_tag"] as? String },
       "The new ref tag is tracked in koala event."
     )
     XCTAssertEqual(
       [
-        RefTag.category.stringTag, RefTag.category.stringTag, RefTag.category.stringTag,
-        RefTag.category.stringTag, RefTag.category.stringTag, RefTag.category.stringTag
+        RefTag.category.stringTag, RefTag.category.stringTag
       ],
       self.trackingClient.properties.compactMap { $0["referrer_credit"] as? String },
       "The referrer credit did not change, and is still category."
@@ -843,17 +840,15 @@ final class ProjectPamphletViewModelTests: TestCase {
     }
   }
 
-  func testbackThisButton_eventTracking() {
+  func testBackThisProjectButton_Tracking() {
     let config = Config.template |> \.features .~ [Feature.nativeCheckout.rawValue: true]
-    let client = MockTrackingClient()
     let project = Project.template
 
     withEnvironment(
       apiService: MockService(),
-      config: config,
-      koala: Koala(client: client)
+      config: config
     ) {
-      XCTAssertEqual([], client.events)
+      XCTAssertEqual([], self.trackingClient.events)
 
       self.configureInitialState(.left(project))
 
@@ -861,9 +856,10 @@ final class ProjectPamphletViewModelTests: TestCase {
       self.goToRewardsRefTag.assertDidNotEmitValue()
 
       self.vm.inputs.pledgeCTAButtonTapped(with: .pledge)
+
       XCTAssertEqual(
-        ["Project Page Viewed", "Viewed Project Page", "Project Page"],
-        client.events
+        ["Project Page Viewed"],
+        self.trackingClient.events
       )
     }
   }

--- a/Library/ViewModels/ProjectPamphletViewModelTests.swift
+++ b/Library/ViewModels/ProjectPamphletViewModelTests.swift
@@ -150,8 +150,8 @@ final class ProjectPamphletViewModelTests: TestCase {
     self.scheduler.advance()
 
     XCTAssertEqual(
-      ["Project Page Viewed", "Viewed Project Page", "Project Page"],
-      self.trackingClient.events, "A project page koala event is tracked."
+      ["Project Page Viewed"],
+      self.trackingClient.events, "A project page event is tracked."
     )
     XCTAssertEqual(
       [RefTag.category.stringTag, RefTag.category.stringTag, RefTag.category.stringTag],


### PR DESCRIPTION
# 📲 What

Cleans up our project events, properties and tests to align with new requirements.

# 🤔 Why

So that we're sending only what is needed for analytics purposes.

# 🛠 How

Lots of moving around and renaming things, deleting un-used props, and adding better test coverage.

# ♿️ Accessibility 

N/A

# 🏎 Performance

N/A

# ✅ Acceptance criteria

- [x] `Project Page Viewed` event fires when the project page is viewed
- [x] `Project Swiped` event fires when the project page controller is swiped to the next or previous project

The following properties are part of the `projectProperties` group, and are sent with all `Project` events:

- [x] `project_backers_count`
- [x] `project_category`
- [x] `project_country`
- [x] `project_creator_uid`
- [x] `project_currency`
- [x] `project_deadline` // time interval
- [x] `project_duration` // in days
- [x] `project_goal`
- [x] `project_hours_remaining` // in hours
- [x] `project_launched_at` // time interval
- [x] `project_location`
- [x] `project_name`
- [x] `project_parent_category`
- [x] `project_percent_raised`
- [x] `project_pid`
- [x] `project_pledged`
- [x] `project_has_video`
- [x] `project_current_pledge_amount_usd`
- [x] `project_goal_usd`
- [x] `project_state`
- [x] `project_static_usd_rate`
- [x] `project_user_has_watched`
- [x] `project_user_is_backer`
- [x] `project_user_is_project_creator`
- [x] `project_comments_count`


# ⏰ TODO

- [x] determine whether adding `project_tags` is a blocker for this PR: we don't currently have access to project tags in our `Project` model
- [x] get clarification on whether `project_is_repeat_creator` is actually sending the desired value