### PR TITLE
[NT-645] Clean user properties & session properties

### DIFF
--- a/Library/Tracking/Koala.swift
+++ b/Library/Tracking/Koala.swift
@@ -1299,7 +1299,11 @@ public final class Koala {
     refTag: RefTag? = nil,
     cookieRefTag: RefTag? = nil
   ) {
-    let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
+    var props = projectProperties(from: project, loggedInUser: self.loggedInUser)
+
+    // TODO: move ref_tag and referrer_credit to session properties
+    props["ref_tag"] = refTag?.stringTag
+    props["referrer_credit"] = cookieRefTag?.stringTag
 
     self.track(
       event: "Project Page Viewed",
@@ -1315,7 +1319,8 @@ public final class Koala {
    - parameter refTag:       The ref tag used when swiping to the project.
    */
   public func trackSwipedProject(_ project: Project, refTag: RefTag?) {
-    let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
+    var props = projectProperties(from: project, loggedInUser: self.loggedInUser)
+    props["ref_tag"] = refTag?.stringTag
 
     self.track(event: "Project Swiped", properties: props, refTag: refTag?.stringTag)
   }

--- a/Library/Tracking/Koala.swift
+++ b/Library/Tracking/Koala.swift
@@ -2167,17 +2167,6 @@ private func properties(comment: Comment, prefix: String = "comment_") -> [Strin
   return properties.prefixedKeys(prefix)
 }
 
-private func properties(user: User, prefix: String = "user_") -> [String: Any] {
-  var properties: [String: Any] = [:]
-
-  properties["uid"] = user.id
-  properties["backed_projects_count"] = user.stats.backedProjectsCount
-  properties["created_projects_count"] = user.stats.createdProjectsCount
-  properties["starred_projects_count"] = user.stats.starredProjectsCount
-
-  return properties.prefixedKeys(prefix)
-}
-
 private func properties(userActivity: NSUserActivity) -> [String: Any] {
   var props: [String: Any] = [:]
 

--- a/Library/Tracking/Koala.swift
+++ b/Library/Tracking/Koala.swift
@@ -1948,10 +1948,12 @@ public final class Koala {
   }
 
   // Private tracking method that merges in default properties.
-  private func track(event: String,
-                     properties: [String: Any] = [:],
-                     refTag: String? = nil,
-                     referrerCredit: String? = nil) {
+  private func track(
+    event: String,
+    properties: [String: Any] = [:],
+    refTag: String? = nil,
+    referrerCredit: String? = nil
+  ) {
     let props = self.sessionProperties(refTag: refTag, referrerCredit: referrerCredit)
       .withAllValuesFrom(userProperties(for: self.loggedInUser, config: self.config))
       .withAllValuesFrom(properties)
@@ -1971,9 +1973,11 @@ public final class Koala {
 
   // MARK: - Session Properties
 
-  private func sessionProperties(refTag: String?,
-                                 referrerCredit: String?,
-                                 prefix: String = "session_") -> [String: Any] {
+  private func sessionProperties(
+    refTag: String?,
+    referrerCredit: String?,
+    prefix: String = "session_"
+  ) -> [String: Any] {
     var props: [String: Any] = [:]
 
     let enabledFeatureFlags = self.config?.features

--- a/Library/Tracking/Koala.swift
+++ b/Library/Tracking/Koala.swift
@@ -2012,8 +2012,6 @@ public final class Koala {
     props["user_agent"] = Service.userAgent
     props["user_logged_in"] = self.loggedInUser != nil
     props["wifi_connection"] = Reachability.current == .wifi
-
-    // unconfirmed
     props["client_platform"] = self.clientPlatform
 
     return props.prefixedKeys(prefix)

--- a/Library/Tracking/Koala.swift
+++ b/Library/Tracking/Koala.swift
@@ -1960,7 +1960,6 @@ public final class Koala {
   // MARK: - Session Properties
 
   private func sessionProperties(_ prefix: String = "session_") -> [String: Any] {
-
     var props: [String: Any] = [:]
 
     let enabledFeatureFlags = self.config?.features

--- a/Library/Tracking/KoalaTests.swift
+++ b/Library/Tracking/KoalaTests.swift
@@ -20,7 +20,7 @@ final class KoalaTests: TestCase {
         "ios_feature_something": false,
         "ios_feature_checkout": true,
         "ios_feature_go_rewardless": true
-    ]
+      ]
     let device = MockDevice(userInterfaceIdiom: .phone)
     let screen = MockScreen()
     let koala = Koala(

--- a/Library/Tracking/KoalaTests.swift
+++ b/Library/Tracking/KoalaTests.swift
@@ -38,15 +38,6 @@ final class KoalaTests: TestCase {
 
     let properties = client.properties.last
 
-    // FIXME: The following properties cannot be reliably tested
-    //    XCTAssertEqual(false, properties?["session_apple_pay_capable"] as? Bool)
-    //    XCTAssertEqual(false, properties?["session_apple_pay_device"] as? Bool)
-    //    XCTAssertEqual("User-agent", properties?["session_user_agent"] as? String)
-    //    XCTAssertEqual("wifi", properties?["session_wifi_connection"] as? String)
-    //    XCTAssertEqual(["service": "at-t"], properties?["session_cellular_connection"] as? [String: String])
-    //    XCTAssertEqual("", properties?["session_user_agent"] as? String)
-    //    XCTAssertEqual("", properties?["session_device_model"] as? String)
-
     XCTAssertEqual(
       ["native_checkout[experimental]", "other_experiment[control]"],
       properties?["session_current_variants"] as? [String]

--- a/Library/Tracking/KoalaTests.swift
+++ b/Library/Tracking/KoalaTests.swift
@@ -781,7 +781,7 @@ final class KoalaTests: TestCase {
     let config = Config.template |> Config.lens.countryCode .~ "US"
     let koala = Koala(client: client, config: config, loggedInUser: nil)
 
-    koala.trackActivities(count: 1)
+    koala.trackAppOpen()
 
     let props = client.properties.last
 
@@ -806,7 +806,7 @@ final class KoalaTests: TestCase {
 
     let koala = Koala(client: client, loggedInUser: user)
 
-    koala.trackActivities(count: 1)
+    koala.trackAppOpen()
 
     let props = client.properties.last
 

--- a/Library/Tracking/KoalaTests.swift
+++ b/Library/Tracking/KoalaTests.swift
@@ -5,7 +5,7 @@ import ReactiveExtensions_TestHelpers
 import XCTest
 
 final class KoalaTests: TestCase {
-  func testDefaultProperties() {
+  func testSessionProperties() {
     let bundle = MockBundle()
     let client = MockTrackingClient()
     let config = Config.template
@@ -20,55 +20,66 @@ final class KoalaTests: TestCase {
         "ios_feature_something": false,
         "ios_feature_checkout": true,
         "ios_feature_go_rewardless": true
-      ]
+    ]
     let device = MockDevice(userInterfaceIdiom: .phone)
     let screen = MockScreen()
     let koala = Koala(
-      bundle: bundle, client: client, config: config, device: device, loggedInUser: nil,
-      screen: screen
+      bundle: bundle,
+      client: client,
+      config: config,
+      device: device,
+      loggedInUser: nil,
+      screen: screen,
+      distinctId: "abc-123"
     )
 
     koala.trackAppOpen()
-    XCTAssertEqual(["App Open", "Opened App"], client.events)
 
     let properties = client.properties.last
 
-    XCTAssertEqual("Apple", properties?["manufacturer"] as? String)
-
-    XCTAssertEqual(bundle.infoDictionary?["CFBundleVersion"] as? Int, properties?["app_version"] as? Int)
-    XCTAssertEqual(
-      bundle.infoDictionary?["CFBundleShortVersionString"] as? String,
-      properties?["app_release"] as? String
-    )
-    XCTAssertNotNil(properties?["model"])
-    XCTAssertEqual(device.systemName, properties?["os"] as? String)
-    XCTAssertEqual(device.systemVersion, properties?["os_version"] as? String)
-    XCTAssertEqual(UInt(screen.bounds.width), properties?["screen_width"] as? UInt)
-    XCTAssertEqual(UInt(screen.bounds.height), properties?["screen_height"] as? UInt)
+    // FIXME: The following properties cannot be reliably tested
+    //    XCTAssertEqual(false, properties?["session_apple_pay_capable"] as? Bool)
+    //    XCTAssertEqual(false, properties?["session_apple_pay_device"] as? Bool)
+    //    XCTAssertEqual("User-agent", properties?["session_user_agent"] as? String)
+    //    XCTAssertEqual("wifi", properties?["session_wifi_connection"] as? String)
+    //    XCTAssertEqual(["service": "at-t"], properties?["session_cellular_connection"] as? [String: String])
+    //    XCTAssertEqual("", properties?["session_user_agent"] as? String)
+    //    XCTAssertEqual("", properties?["session_device_model"] as? String)
 
     XCTAssertEqual(
       ["native_checkout[experimental]", "other_experiment[control]"],
-      properties?["current_variants"] as? [String]
+      properties?["session_current_variants"] as? [String]
     )
     XCTAssertEqual(
       [
         "ios_feature_checkout",
         "ios_feature_go_rewardless"
       ],
-      properties?["enabled_feature_flags"] as? [String]
+      properties?["session_enabled_features"] as? [String]
     )
-    XCTAssertEqual("kickstarter_ios", properties?["mp_lib"] as? String)
-    XCTAssertEqual("native", properties?["client_type"] as? String)
-    XCTAssertEqual("phone", properties?["device_format"] as? String)
-    XCTAssertEqual("ios", properties?["client_platform"] as? String)
 
-    XCTAssertNil(properties?["user_uid"])
-    XCTAssertEqual(false, properties?["user_logged_in"] as? Bool)
-    XCTAssertNil(properties?["user_is_admin"])
-    XCTAssertEqual("GB", properties?["user_country"] as? String)
+    XCTAssertEqual("native", properties?["session_client_type"] as? String)
+    XCTAssertEqual("1234567890", properties?["session_app_version"] as? String)
+    XCTAssertEqual("1.2.3.4.5.6.7.8.9.0", properties?["session_app_release"] as? String)
+    XCTAssertEqual("iPhone 10", properties?["session_device"] as? String)
+    XCTAssertEqual("phone", properties?["session_device_format"] as? String)
+    XCTAssertEqual("abc-123", properties?["session_device_fingerprint"] as? String)
+    XCTAssertEqual("Apple", properties?["session_device_manufacturer"] as? String)
+    XCTAssertEqual("Portrait", properties?["session_device_orientation"] as? String)
+    XCTAssertEqual("abc-123", properties?["session_distinct_id"] as? String)
+
+    XCTAssertEqual("MockSystemName", properties?["session_os"] as? String)
+    XCTAssertEqual("MockSystemVersion", properties?["session_os_version"] as? String)
+    XCTAssertEqual(UInt(screen.bounds.width), properties?["session_screen_width"] as? UInt)
+    XCTAssertEqual("kickstarter_ios", properties?["session_mp_lib"] as? String)
+    XCTAssertEqual("abc-123", properties?["session_iphone_uuid"] as? String)
+    XCTAssertEqual(false, properties?["session_user_logged_in"] as? Bool)
+    XCTAssertEqual("ios", properties?["session_client_platform"] as? String)
+
+    XCTAssertEqual(26, properties?.keys.filter { $0.hasPrefix("session_") }.count)
   }
 
-  func testDefaultPropertiesVoiceOver() {
+  func testSessionProperties_VoiceOver() {
     let client = MockTrackingClient()
     let koala = Koala(client: client)
 
@@ -77,7 +88,7 @@ final class KoalaTests: TestCase {
 
       let properties = client.properties.last
 
-      XCTAssertEqual(true, properties?["is_voiceover_running"] as? Bool)
+      XCTAssertEqual(true, properties?["session_is_voiceover_running"] as? Bool)
     }
 
     withEnvironment(isVoiceOverRunning: { false }) {
@@ -85,58 +96,58 @@ final class KoalaTests: TestCase {
 
       let properties = client.properties.last
 
-      XCTAssertEqual(false, properties?["is_voiceover_running"] as? Bool)
+      XCTAssertEqual(false, properties?["session_is_voiceover_running"] as? Bool)
     }
   }
 
-  func testDefaultPropertiesWithLoggedInUser() {
+  func testSessionProperties_LoggedIn() {
     let client = MockTrackingClient()
-    let user = User.template
-      |> \.stats.backedProjectsCount .~ 2
-      |> \.stats.createdProjectsCount .~ 3
-      |> \.stats.starredProjectsCount .~ 4
-      |> \.location .~ .template
-    let koala = Koala(client: client, loggedInUser: user)
+    let koala = Koala(client: client, loggedInUser: User.template)
 
     koala.trackAppOpen()
-    XCTAssertEqual(["App Open", "Opened App"], client.events)
 
     let properties = client.properties.last
 
-    XCTAssertEqual(user.id, properties?["user_uid"] as? Int)
-    XCTAssertEqual(true, properties?["user_logged_in"] as? Bool)
-    XCTAssertEqual(user.isAdmin, properties?["user_is_admin"] as? Bool)
-    XCTAssertEqual(user.stats.backedProjectsCount, properties?["user_backed_projects_count"] as? Int)
-    XCTAssertEqual(user.stats.createdProjectsCount, properties?["user_created_projects_count"] as? Int)
-    XCTAssertEqual(user.stats.starredProjectsCount, properties?["user_starred_projects_count"] as? Int)
-    XCTAssertEqual(user.location?.country, properties?["user_country"] as? String)
+    XCTAssertEqual(true, properties?["session_user_logged_in"] as? Bool)
   }
 
-  func testDeviceFormatAndClientPlatform_ForIPhoneIdiom() {
+  func testSessionProperties_DeviceFormatAndClientPlatform_ForIPhoneIdiom() {
     let client = MockTrackingClient()
     let koala = Koala(client: client, device: MockDevice(userInterfaceIdiom: .phone), loggedInUser: nil)
     koala.trackAppOpen()
 
-    XCTAssertEqual("phone", client.properties.last?["device_format"] as? String)
-    XCTAssertEqual("ios", client.properties.last?["client_platform"] as? String)
+    XCTAssertEqual("phone", client.properties.last?["session_device_format"] as? String)
+    XCTAssertEqual("ios", client.properties.last?["session_client_platform"] as? String)
   }
 
-  func testDeviceFormatAndClientPlatform_ForIPadIdiom() {
+  func testSessionProperties_DeviceFormatAndClientPlatform_ForIPadIdiom() {
     let client = MockTrackingClient()
     let koala = Koala(client: client, device: MockDevice(userInterfaceIdiom: .pad), loggedInUser: nil)
     koala.trackAppOpen()
 
-    XCTAssertEqual("tablet", client.properties.last?["device_format"] as? String)
-    XCTAssertEqual("ios", client.properties.last?["client_platform"] as? String)
+    XCTAssertEqual("tablet", client.properties.last?["session_device_format"] as? String)
+    XCTAssertEqual("ios", client.properties.last?["session_client_platform"] as? String)
   }
 
-  func testDeviceFormatAndClientPlatform_ForTvIdiom() {
+  func testSessionProperties_DeviceFormatAndClientPlatform_ForTvIdiom() {
     let client = MockTrackingClient()
     let koala = Koala(client: client, device: MockDevice(userInterfaceIdiom: .tv), loggedInUser: nil)
     koala.trackAppOpen()
 
-    XCTAssertEqual("tv", client.properties.last?["device_format"] as? String)
-    XCTAssertEqual("tvos", client.properties.last?["client_platform"] as? String)
+    XCTAssertEqual("tv", client.properties.last?["session_device_format"] as? String)
+    XCTAssertEqual("tvos", client.properties.last?["session_client_platform"] as? String)
+  }
+
+  func testSessionProperties_DeviceOrientation() {
+    let client = MockTrackingClient()
+    let device = MockDevice(orientation: .faceDown)
+    let koala = Koala(client: client, device: device)
+
+    koala.trackAppOpen()
+
+    let props = client.properties.last
+
+    XCTAssertEqual("Face Down", props?["session_device_orientation"] as? String)
   }
 
   func testTrackProject() {
@@ -414,8 +425,8 @@ final class KoalaTests: TestCase {
 
     XCTAssertEqual(["App Open", "Opened App"], client.events)
     XCTAssertEqual(["App Open", "Opened App"], callBackEvents)
-    XCTAssertEqual("Apple", client.properties.last?["manufacturer"] as? String)
-    XCTAssertEqual("Apple", callBackProperties?["manufacturer"] as? String)
+    XCTAssertEqual("Apple", client.properties.last?["session_device_manufacturer"] as? String)
+    XCTAssertEqual("Apple", callBackProperties?["session_device_manufacturer"] as? String)
   }
 
   func testTrackViewedAccount() {

--- a/Library/Tracking/KoalaTests.swift
+++ b/Library/Tracking/KoalaTests.swift
@@ -60,9 +60,8 @@ final class KoalaTests: TestCase {
     )
 
     XCTAssertEqual("native", properties?["session_client_type"] as? String)
-    XCTAssertEqual("1234567890", properties?["session_app_version"] as? String)
-    XCTAssertEqual("1.2.3.4.5.6.7.8.9.0", properties?["session_app_release"] as? String)
-    XCTAssertEqual("iPhone 10", properties?["session_device"] as? String)
+    XCTAssertEqual("1234567890", properties?["session_app_build_number"] as? String)
+    XCTAssertEqual("1.2.3.4.5.6.7.8.9.0", properties?["session_app_release_version"] as? String)
     XCTAssertEqual("phone", properties?["session_device_format"] as? String)
     XCTAssertEqual("abc-123", properties?["session_device_fingerprint"] as? String)
     XCTAssertEqual("Apple", properties?["session_device_manufacturer"] as? String)
@@ -77,7 +76,7 @@ final class KoalaTests: TestCase {
     XCTAssertEqual(false, properties?["session_user_logged_in"] as? Bool)
     XCTAssertEqual("ios", properties?["session_client_platform"] as? String)
 
-    XCTAssertEqual(26, properties?.keys.filter { $0.hasPrefix("session_") }.count)
+    XCTAssertEqual(25, properties?.keys.filter { $0.hasPrefix("session_") }.count)
   }
 
   func testSessionProperties_VoiceOver() {
@@ -187,14 +186,15 @@ final class KoalaTests: TestCase {
     XCTAssertEqual(4_000, properties?["project_goal_usd"] as? Int)
     XCTAssertEqual(true, properties?["project_has_video"] as? Bool)
     XCTAssertEqual(10, properties?["project_comments_count"] as? Int)
-    XCTAssertEqual("discovery", properties?["ref_tag"] as? String)
-    XCTAssertEqual("recommended", properties?["referrer_credit"] as? String)
 
     XCTAssertEqual(false, properties?["project_user_is_project_creator"] as? Bool)
     XCTAssertNil(properties?["project_user_is_backer"])
     XCTAssertNil(properties?["project_user_has_starred"])
 
     XCTAssertEqual(23, properties?.keys.filter { $0.hasPrefix("project_") }.count)
+
+    XCTAssertEqual("discovery", properties?["session_ref_tag"] as? String)
+    XCTAssertEqual("recommended", properties?["session_referrer_credit"] as? String)
   }
 
   func testProjectProperties_LoggedInUser() {

--- a/Library/UIDeviceType.swift
+++ b/Library/UIDeviceType.swift
@@ -32,8 +32,10 @@ internal struct MockDevice: UIDeviceType {
   internal let systemVersion: String = "MockSystemVersion"
   internal let userInterfaceIdiom: UIUserInterfaceIdiom
 
-  internal init(userInterfaceIdiom: UIUserInterfaceIdiom = .phone,
-                orientation: UIDeviceOrientation = .portrait) {
+  internal init(
+    userInterfaceIdiom: UIUserInterfaceIdiom = .phone,
+    orientation: UIDeviceOrientation = .portrait
+  ) {
     self.userInterfaceIdiom = userInterfaceIdiom
     self.orientation = orientation
   }

--- a/Library/UIDeviceType.swift
+++ b/Library/UIDeviceType.swift
@@ -6,6 +6,7 @@ import UIKit
 public protocol UIDeviceType {
   var identifierForVendor: UUID? { get }
   var modelCode: String { get }
+  var name: String { get }
   var systemName: String { get }
   var systemVersion: String { get }
   var userInterfaceIdiom: UIUserInterfaceIdiom { get }
@@ -24,6 +25,7 @@ extension UIDevice: UIDeviceType {
 internal struct MockDevice: UIDeviceType {
   internal let identifierForVendor = UUID(uuidString: "DEADBEEF-DEAD-BEEF-DEAD-DEADBEEFBEEF")
   internal let modelCode = "MockmodelCode"
+  internal let name = "iPhone 10"
   internal let systemName = "MockSystemName"
   internal let systemVersion: String = "MockSystemVersion"
   internal let userInterfaceIdiom: UIUserInterfaceIdiom

--- a/Library/UIDeviceType.swift
+++ b/Library/UIDeviceType.swift
@@ -7,6 +7,7 @@ public protocol UIDeviceType {
   var identifierForVendor: UUID? { get }
   var modelCode: String { get }
   var name: String { get }
+  var orientation: UIDeviceOrientation { get }
   var systemName: String { get }
   var systemVersion: String { get }
   var userInterfaceIdiom: UIUserInterfaceIdiom { get }
@@ -26,11 +27,14 @@ internal struct MockDevice: UIDeviceType {
   internal let identifierForVendor = UUID(uuidString: "DEADBEEF-DEAD-BEEF-DEAD-DEADBEEFBEEF")
   internal let modelCode = "MockmodelCode"
   internal let name = "iPhone 10"
+  internal let orientation: UIDeviceOrientation
   internal let systemName = "MockSystemName"
   internal let systemVersion: String = "MockSystemVersion"
   internal let userInterfaceIdiom: UIUserInterfaceIdiom
 
-  internal init(userInterfaceIdiom: UIUserInterfaceIdiom = .phone) {
+  internal init(userInterfaceIdiom: UIUserInterfaceIdiom = .phone,
+                orientation: UIDeviceOrientation = .portrait) {
     self.userInterfaceIdiom = userInterfaceIdiom
+    self.orientation = orientation
   }
 }

--- a/Library/UIDeviceType.swift
+++ b/Library/UIDeviceType.swift
@@ -6,7 +6,6 @@ import UIKit
 public protocol UIDeviceType {
   var identifierForVendor: UUID? { get }
   var modelCode: String { get }
-  var name: String { get }
   var orientation: UIDeviceOrientation { get }
   var systemName: String { get }
   var systemVersion: String { get }
@@ -26,7 +25,6 @@ extension UIDevice: UIDeviceType {
 internal struct MockDevice: UIDeviceType {
   internal let identifierForVendor = UUID(uuidString: "DEADBEEF-DEAD-BEEF-DEAD-DEADBEEFBEEF")
   internal let modelCode = "MockmodelCode"
-  internal let name = "iPhone 10"
   internal let orientation: UIDeviceOrientation
   internal let systemName = "MockSystemName"
   internal let systemVersion: String = "MockSystemVersion"


### PR DESCRIPTION
#📲 What

Adds clean user properties and session properties, with tests.

# 🤔 Why

Part of the data cleanup project.

# 🛠 How

- cleans up `defaultProperties` and rename to `sessionProperties`
- adds `userProperties` to decouple user props from session props

Now, instead of having user properties in the `defaultProperties` function, we build them separately and join all properties together with:

```
let props = self.sessionProperties()
    .withAllValuesFrom(userProperties())
    .withAllValuesFrom(eventProperties)
```

Note that unfortunately, we're not in a good place to test some of the session properties that don't have mocks. I've made a note and filed a separate tech debt ticket to address this so we can be sure to test all session properties in the near future.

# ♿️ Accessibility 

N/A

# 🏎 Performance

N/A

# ✅ Acceptance criteria

- [ ] Verify that all the tests in `KoalaTests.swift` are correct

Verify that the following session properties are sent on every tracking event:
- [x] `apple_pay_capable`
- [x] `apple_pay_device`
- [x] `cellular_connection`
- [x] `client_type`
- [x] `current_variants`
- [x] `device`
- [x] `device_fingerprint`
- [x] `device_format`
- [x] `device_manufacturer`
- [x] `device_model`
- [x] `device_orientation`
- [x] `distinct_id`
- [x] `enabled_features`
- [x] `iphone_uuid`
- [x] `is_voiceover_running`
- [x] `mp_lib`
- [x] `os`
- [x] `os_version`
- [x] `time`
- [x] `app_version`
- [x] `app_release` // might re-name to app_build
- [x] `screen_width`
- [x] `user_agent`
- [x] `user_logged_in`
- [x] `wifi_connection`
- [x] `client_platform`

Verify that the following user properties are sent on every tracking event:
- [x] `user_is_admin` // only if logged in
- [x] `user_backed_projects_count` // only if logged in
- [x] `user_country`
- [x] `user_facebook_account` // only if logged in
- [x] `user_watched_projects_count` // only if logged in
- [x] `user_uid` // only if logged in

# ⏰ TODO

- [x] finalize exact native session props
