### PR TITLE
[NT-707] Naming changes and white-listing clean events

### DIFF
--- a/Library/Tracking/Koala.swift
+++ b/Library/Tracking/Koala.swift
@@ -620,9 +620,11 @@ public final class Koala {
     screen: CheckoutContext
   ) {
     let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
-      .withAllValuesFrom(["screen": screen.trackingString,
-                          "backer_reward_minimum": reward?.minimum,
-                          "pledge_total": backing?.amount])
+      .withAllValuesFrom([
+        "screen": screen.trackingString,
+        "backer_reward_minimum": reward?.minimum,
+        "pledge_total": backing?.amount
+      ])
 
     self.track(event: "Select Reward Button Clicked", properties: props)
   }
@@ -2182,7 +2184,7 @@ private func discoveryProperties(
   let parentCategoryProps = params.category?.parent.map { properties(category: $0) }
 
   result = result.withAllValuesFrom(categoryProps ?? [:])
-  result = result.withAllValuesFrom(parentCategoryProps ?? [:] )
+  result = result.withAllValuesFrom(parentCategoryProps ?? [:])
 
   result["everything"] = result.isEmpty
   result["sort"] = params.sort?.rawValue

--- a/Library/Tracking/Koala.swift
+++ b/Library/Tracking/Koala.swift
@@ -434,8 +434,10 @@ public final class Koala {
 
   /// Call when the activities screen is shown.
   public func trackActivities(count: Int) {
-    self.track(event: DataLakeWhiteListedEvents.activityFeedViewed.rawValue,
-               properties: ["activities_count": count])
+    self.track(
+      event: DataLakeWhiteListedEvents.activityFeedViewed.rawValue,
+      properties: ["activities_count": count]
+    )
   }
 
   // MARK: - Application Lifecycle
@@ -502,8 +504,10 @@ public final class Koala {
   public func trackTabBarClicked(_ tabBarItemLabel: TabBarItemLabel) {
     let label = tabBarItemLabel.trackingString
 
-    self.track(event: DataLakeWhiteListedEvents.tabBarClicked.rawValue,
-               properties: ["ios_tab_bar_label": label])
+    self.track(
+      event: DataLakeWhiteListedEvents.tabBarClicked.rawValue,
+      properties: ["ios_tab_bar_label": label]
+    )
   }
 
   // MARK: - Discovery Events
@@ -550,8 +554,10 @@ public final class Koala {
    Call when the user taps the editorial header at the top of Discovery
    */
   public func trackEditorialHeaderTapped(refTag: RefTag) {
-    self.track(event: DataLakeWhiteListedEvents.editorialCardClicked.rawValue,
-               properties: [:], refTag: refTag.stringTag)
+    self.track(
+      event: DataLakeWhiteListedEvents.editorialCardClicked.rawValue,
+      properties: [:], refTag: refTag.stringTag
+    )
   }
 
   /**
@@ -560,8 +566,10 @@ public final class Koala {
    - parameter params: The DiscoveryParams associated with the collection
    */
   public func trackCollectionViewed(params: DiscoveryParams) {
-    self.track(event: DataLakeWhiteListedEvents.collectionViewed.rawValue,
-               properties: discoveryProperties(from: params))
+    self.track(
+      event: DataLakeWhiteListedEvents.collectionViewed.rawValue,
+      properties: discoveryProperties(from: params)
+    )
   }
 
   // MARK: - Checkout Events
@@ -1342,8 +1350,10 @@ public final class Koala {
   public func trackSwipedProject(_ project: Project, refTag: RefTag?) {
     let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
 
-    self.track(event: DataLakeWhiteListedEvents.projectSwiped.rawValue,
-               properties: props, refTag: refTag?.stringTag)
+    self.track(
+      event: DataLakeWhiteListedEvents.projectSwiped.rawValue,
+      properties: props, refTag: refTag?.stringTag
+    )
   }
 
   public func trackProjectSave(_ project: Project, context: SaveContext) {

--- a/Library/Tracking/Koala.swift
+++ b/Library/Tracking/Koala.swift
@@ -21,7 +21,7 @@ public final class Koala {
   private var preferredContentSizeCategoryObserver: Any?
   private let screen: UIScreenType
 
-  private enum DataLakeWhiteListedEvents: String, CaseIterable {
+  private enum DataLakeWhiteListedEvent: String, CaseIterable {
     case explorePageViewed = "Explore Page Viewed"
     case exploreSortClicked = "Explore Sort Clicked"
     case activityFeedViewed = "Activity Feed Viewed"
@@ -35,7 +35,7 @@ public final class Koala {
     case projectPageViewed = "Project Page Viewed"
 
     static func allWhiteListedEvents() -> [String] {
-      return DataLakeWhiteListedEvents.allCases.map { $0.rawValue }
+      return DataLakeWhiteListedEvent.allCases.map { $0.rawValue }
     }
   }
 
@@ -435,7 +435,7 @@ public final class Koala {
   /// Call when the activities screen is shown.
   public func trackActivities(count: Int) {
     self.track(
-      event: DataLakeWhiteListedEvents.activityFeedViewed.rawValue,
+      event: DataLakeWhiteListedEvent.activityFeedViewed.rawValue,
       properties: ["activities_count": count]
     )
   }
@@ -505,7 +505,7 @@ public final class Koala {
     let label = tabBarItemLabel.trackingString
 
     self.track(
-      event: DataLakeWhiteListedEvents.tabBarClicked.rawValue,
+      event: DataLakeWhiteListedEvent.tabBarClicked.rawValue,
       properties: ["ios_tab_bar_label": label]
     )
   }
@@ -521,7 +521,7 @@ public final class Koala {
   public func trackDiscovery(params: DiscoveryParams) {
     let props = discoveryProperties(from: params)
 
-    self.track(event: DataLakeWhiteListedEvents.explorePageViewed.rawValue, properties: props)
+    self.track(event: DataLakeWhiteListedEvent.explorePageViewed.rawValue, properties: props)
   }
 
   /**
@@ -531,7 +531,7 @@ public final class Koala {
    */
   public func trackDiscoveryModalSelectedFilter(params: DiscoveryParams) {
     self.track(
-      event: DataLakeWhiteListedEvents.filterClicked.rawValue,
+      event: DataLakeWhiteListedEvent.filterClicked.rawValue,
       properties: discoveryProperties(from: params)
     )
   }
@@ -547,7 +547,7 @@ public final class Koala {
         "discover_sort": sort.rawValue
       ])
 
-    self.track(event: DataLakeWhiteListedEvents.exploreSortClicked.rawValue, properties: props)
+    self.track(event: DataLakeWhiteListedEvent.exploreSortClicked.rawValue, properties: props)
   }
 
   /**
@@ -555,7 +555,7 @@ public final class Koala {
    */
   public func trackEditorialHeaderTapped(refTag: RefTag) {
     self.track(
-      event: DataLakeWhiteListedEvents.editorialCardClicked.rawValue,
+      event: DataLakeWhiteListedEvent.editorialCardClicked.rawValue,
       properties: [:], refTag: refTag.stringTag
     )
   }
@@ -567,7 +567,7 @@ public final class Koala {
    */
   public func trackCollectionViewed(params: DiscoveryParams) {
     self.track(
-      event: DataLakeWhiteListedEvents.collectionViewed.rawValue,
+      event: DataLakeWhiteListedEvent.collectionViewed.rawValue,
       properties: discoveryProperties(from: params)
     )
   }
@@ -1298,7 +1298,7 @@ public final class Koala {
 
   /// Call once when the search view is initially shown.
   public func trackProjectSearchView() {
-    self.track(event: DataLakeWhiteListedEvents.searchPageViewed.rawValue)
+    self.track(event: DataLakeWhiteListedEvent.searchPageViewed.rawValue)
   }
 
   // Call when projects have been obtained from a search.
@@ -1315,7 +1315,7 @@ public final class Koala {
         "has_results": hasResults
       ])
 
-    self.track(event: DataLakeWhiteListedEvents.searchResultsLoaded.rawValue, properties: props)
+    self.track(event: DataLakeWhiteListedEvent.searchResultsLoaded.rawValue, properties: props)
   }
 
   // MARK: - Project Events
@@ -1335,7 +1335,7 @@ public final class Koala {
     let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
 
     self.track(
-      event: DataLakeWhiteListedEvents.projectPageViewed.rawValue,
+      event: DataLakeWhiteListedEvent.projectPageViewed.rawValue,
       properties: props,
       refTag: refTag?.stringTag,
       referrerCredit: cookieRefTag?.stringTag
@@ -1351,7 +1351,7 @@ public final class Koala {
     let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
 
     self.track(
-      event: DataLakeWhiteListedEvents.projectSwiped.rawValue,
+      event: DataLakeWhiteListedEvent.projectSwiped.rawValue,
       properties: props, refTag: refTag?.stringTag
     )
   }
@@ -1996,7 +1996,7 @@ public final class Koala {
       properties: props
     )
 
-    if DataLakeWhiteListedEvents.allWhiteListedEvents().contains(event) {
+    if DataLakeWhiteListedEvent.allWhiteListedEvents().contains(event) {
       self.dataLakeClient.track(
         event: event,
         properties: props

--- a/Library/Tracking/Koala.swift
+++ b/Library/Tracking/Koala.swift
@@ -550,9 +550,7 @@ public final class Koala {
     project: Project, screen: CheckoutContext
   ) {
     let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
-      .withAllValuesFrom(["screen": screen.trackingString,
-                          "backer_reward_minimum": reward?.minimum,
-                          "pledge_total": backing?.amount])
+      .withAllValuesFrom(["screen": screen.trackingString])
 
     switch stateType {
     case .fix:

--- a/Library/Tracking/Koala.swift
+++ b/Library/Tracking/Koala.swift
@@ -434,7 +434,8 @@ public final class Koala {
 
   /// Call when the activities screen is shown.
   public func trackActivities(count: Int) {
-    self.track(event: "Activity Feed Viewed", properties: ["activities_count": count])
+    self.track(event: DataLakeWhiteListedEvents.activityFeedViewed.rawValue,
+               properties: ["activities_count": count])
   }
 
   // MARK: - Application Lifecycle
@@ -501,7 +502,8 @@ public final class Koala {
   public func trackTabBarClicked(_ tabBarItemLabel: TabBarItemLabel) {
     let label = tabBarItemLabel.trackingString
 
-    self.track(event: "Tab Bar Clicked", properties: ["ios_tab_bar_label": label])
+    self.track(event: DataLakeWhiteListedEvents.tabBarClicked.rawValue,
+               properties: ["ios_tab_bar_label": label])
   }
 
   // MARK: - Discovery Events
@@ -515,7 +517,7 @@ public final class Koala {
   public func trackDiscovery(params: DiscoveryParams) {
     let props = discoveryProperties(from: params)
 
-    self.track(event: "Explore Page Viewed", properties: props)
+    self.track(event: DataLakeWhiteListedEvents.explorePageViewed.rawValue, properties: props)
   }
 
   /**
@@ -525,7 +527,7 @@ public final class Koala {
    */
   public func trackDiscoveryModalSelectedFilter(params: DiscoveryParams) {
     self.track(
-      event: "Filter Clicked",
+      event: DataLakeWhiteListedEvents.filterClicked.rawValue,
       properties: discoveryProperties(from: params)
     )
   }
@@ -541,14 +543,15 @@ public final class Koala {
         "discover_sort": sort.rawValue
       ])
 
-    self.track(event: "Explore Sort Clicked", properties: props)
+    self.track(event: DataLakeWhiteListedEvents.exploreSortClicked.rawValue, properties: props)
   }
 
   /**
    Call when the user taps the editorial header at the top of Discovery
    */
   public func trackEditorialHeaderTapped(refTag: RefTag) {
-    self.track(event: "Editorial Card Clicked", properties: [:], refTag: refTag.stringTag)
+    self.track(event: DataLakeWhiteListedEvents.editorialCardClicked.rawValue,
+               properties: [:], refTag: refTag.stringTag)
   }
 
   /**
@@ -557,7 +560,8 @@ public final class Koala {
    - parameter params: The DiscoveryParams associated with the collection
    */
   public func trackCollectionViewed(params: DiscoveryParams) {
-    self.track(event: "Collection Viewed", properties: discoveryProperties(from: params))
+    self.track(event: DataLakeWhiteListedEvents.collectionViewed.rawValue,
+               properties: discoveryProperties(from: params))
   }
 
   // MARK: - Checkout Events
@@ -622,8 +626,8 @@ public final class Koala {
     let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
       .withAllValuesFrom([
         "screen": screen.trackingString,
-        "backer_reward_minimum": reward?.minimum,
-        "pledge_total": backing?.amount
+        "backer_reward_minimum": reward?.minimum as Any,
+        "pledge_total": backing?.amount as Any
       ])
 
     self.track(event: "Select Reward Button Clicked", properties: props)
@@ -1286,7 +1290,7 @@ public final class Koala {
 
   /// Call once when the search view is initially shown.
   public func trackProjectSearchView() {
-    self.track(event: "Search Page Viewed")
+    self.track(event: DataLakeWhiteListedEvents.searchPageViewed.rawValue)
   }
 
   // Call when projects have been obtained from a search.
@@ -1303,7 +1307,7 @@ public final class Koala {
         "has_results": hasResults
       ])
 
-    self.track(event: "Search Results Loaded", properties: props)
+    self.track(event: DataLakeWhiteListedEvents.searchResultsLoaded.rawValue, properties: props)
   }
 
   // MARK: - Project Events
@@ -1323,7 +1327,7 @@ public final class Koala {
     let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
 
     self.track(
-      event: "Project Page Viewed",
+      event: DataLakeWhiteListedEvents.projectPageViewed.rawValue,
       properties: props,
       refTag: refTag?.stringTag,
       referrerCredit: cookieRefTag?.stringTag
@@ -1338,7 +1342,8 @@ public final class Koala {
   public func trackSwipedProject(_ project: Project, refTag: RefTag?) {
     let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
 
-    self.track(event: "Project Swiped", properties: props, refTag: refTag?.stringTag)
+    self.track(event: DataLakeWhiteListedEvents.projectSwiped.rawValue,
+               properties: props, refTag: refTag?.stringTag)
   }
 
   public func trackProjectSave(_ project: Project, context: SaveContext) {

--- a/Library/Tracking/Koala.swift
+++ b/Library/Tracking/Koala.swift
@@ -2188,8 +2188,9 @@ private func discoveryProperties(
   let categoryProps = params.category.map { properties(category: $0, prefix: "subcategory_") }
   let parentCategoryProps = params.category?.parent.map { properties(category: $0) }
 
-  result = result.withAllValuesFrom(categoryProps ?? [:])
-  result = result.withAllValuesFrom(parentCategoryProps ?? [:])
+  result = result
+    .withAllValuesFrom(categoryProps ?? [:])
+    .withAllValuesFrom(parentCategoryProps ?? [:])
 
   result["everything"] = result.isEmpty
   result["sort"] = params.sort?.rawValue

--- a/Library/Tracking/Koala.swift
+++ b/Library/Tracking/Koala.swift
@@ -2073,7 +2073,7 @@ private func projectProperties(
   var props: [String: Any] = [:]
 
   props["backers_count"] = project.stats.backersCount
-  props["category"] = project.category.name
+  props["subcategory"] = project.category.name
   props["country"] = project.country.countryCode
   props["comments_count"] = project.stats.commentsCount ?? 0
   props["currency"] = project.country.currencyCode
@@ -2084,15 +2084,17 @@ private func projectProperties(
   props["location"] = project.location.name
   props["name"] = project.name
   props["pid"] = project.id
-  props["parent_category"] = project.category.parent?.name
+  props["category"] = project.category.parent?.name
   props["percent_raised"] = project.stats.fundingProgress
-  props["pledged"] = project.stats.pledged
   props["state"] = project.state.rawValue
   props["static_usd_rate"] = project.stats.staticUsdRate
+  props["current_pledge_amount"] = project.stats.pledged
   props["current_pledge_amount_usd"] = project.stats.pledgedUsd
   props["goal_usd"] = project.stats.goalUsd
   props["has_video"] = project.video != nil
   props["updates_count"] = project.stats.updatesCount
+  props["prelaunch_activated"] = project.prelaunchActivated
+  props["rewards_count"] = project.rewards.count
 
   let now = dateType.init().date
   props["hours_remaining"] = project.dates.hoursRemaining(from: now, using: calendar)

--- a/Library/Tracking/Koala.swift
+++ b/Library/Tracking/Koala.swift
@@ -2202,34 +2202,34 @@ private func discoveryProperties(
   prefix: String = "discover_"
 ) -> [String: Any] {
   var result: [String: Any] = [:]
-  var unprefixedResult: [String: Any] = [:]
 
   // NB: All filters should be added here since `result["everything"]` is derived from this.
   result["recommended"] = params.recommended
   result["social"] = params.social
-  result["staff_picks"] = params.staffPicks
-  result["starred"] = params.starred
+  result["pwl"] = params.staffPicks
+  result["watched"] = params.starred
   result["tag"] = params.tagId?.rawValue
-  result = result.withAllValuesFrom(params.category.map(properties(category:)) ?? [:])
+  let categoryProps = params.category.map { properties(category: $0, prefix: "subcategory_") }
+  let parentCategoryProps = params.category?.parent.map { properties(category: $0) }
+
+  result = result.withAllValuesFrom(categoryProps ?? [:])
+  result = result.withAllValuesFrom(parentCategoryProps ?? [:] )
 
   result["everything"] = result.isEmpty
   result["sort"] = params.sort?.rawValue
   result["ref_tag"] = RefTag.fromParams(params).stringTag
+  result["search_term"] = params.query
 
-  unprefixedResult["search_term"] = params.query
-
-  return result.prefixedKeys(prefix).withAllValuesFrom(unprefixedResult)
+  return result.prefixedKeys(prefix)
 }
 
-private func properties(category: KsApi.Category) -> [String: Any] {
+private func properties(category: KsApi.Category, prefix: String = "category_") -> [String: Any] {
   var result: [String: Any] = [:]
 
-  result["category_id"] = category.intID
-  result["category_name"] = category.name
+  result["id"] = category.intID
+  result["name"] = category.name
 
-  let parentProperties = category.parent.map(properties(category:)) ?? [:]
-  return result
-    .withAllValuesFrom(parentProperties.prefixedKeys("parent_"))
+  return result.prefixedKeys(prefix)
 }
 
 private func properties(

--- a/Library/Tracking/Koala.swift
+++ b/Library/Tracking/Koala.swift
@@ -549,8 +549,10 @@ public final class Koala {
     stateType: PledgeStateCTAType,
     project: Project, screen: CheckoutContext
   ) {
-    let props = properties(project: project)
-      .withAllValuesFrom(["screen": screen.trackingString])
+    let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
+      .withAllValuesFrom(["screen": screen.trackingString,
+                          "backer_reward_minimum": reward?.minimum,
+                          "pledge_total": backing?.amount])
 
     switch stateType {
     case .fix:
@@ -569,28 +571,28 @@ public final class Koala {
   }
 
   public func trackCancelPledgeButtonClicked(project: Project, backing: Backing) {
-    let props = properties(project: project, loggedInUser: self.loggedInUser)
+    let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
       .withAllValuesFrom(["pledge_total": backing.amount])
 
     self.track(event: "Cancel Pledge Button Clicked", properties: props)
   }
 
   public func trackUpdatePaymentMethodButton(project: Project, pledgeAmount: Double) {
-    let props = properties(project: project, loggedInUser: self.loggedInUser)
+    let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
       .withAllValuesFrom(["pledge_total": pledgeAmount])
 
     self.track(event: "Update Payment Method Button Clicked", properties: props)
   }
 
   public func trackUpdatePledgeButtonClicked(project: Project, pledgeAmount: Double) {
-    let props = properties(project: project, loggedInUser: self.loggedInUser)
+    let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
       .withAllValuesFrom(["pledge_total": pledgeAmount])
 
     self.track(event: "Update Pledge Button Clicked", properties: props)
   }
 
   public func trackManagePledgeOptionClicked(project: Project, managePledgeMenuCTA: ManagePledgeMenuCTAType) {
-    let props = properties(project: project, loggedInUser: self.loggedInUser)
+    let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
       .withAllValuesFrom(["cta": managePledgeMenuCTA.trackingString])
 
     self.track(event: "Manage Pledge Option Clicked", properties: props)
@@ -602,27 +604,29 @@ public final class Koala {
     backing: Backing?,
     screen: CheckoutContext
   ) {
-    let props = properties(project: project, reward: reward, backing: backing)
-      .withAllValuesFrom(["screen": screen.trackingString])
+    let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
+      .withAllValuesFrom(["screen": screen.trackingString,
+                          "backer_reward_minimum": reward?.minimum,
+                          "pledge_total": backing?.amount])
 
     self.track(event: "Select Reward Button Clicked", properties: props)
   }
 
   public func trackPledgeScreenViewed(project: Project) {
-    let props = properties(project: project, loggedInUser: self.loggedInUser)
+    let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
 
     self.track(event: "Pledge Screen Viewed", properties: props)
   }
 
   public func trackPledgeButtonClicked(project: Project, pledgeAmount: Double) {
-    let props = properties(project: project, loggedInUser: self.loggedInUser)
+    let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
       .withAllValuesFrom(["pledge_total": pledgeAmount])
 
     self.track(event: "Pledge Button Clicked", properties: props)
   }
 
   public func trackAddNewCardButtonClicked(project: Project) {
-    let props = properties(project: project, loggedInUser: self.loggedInUser)
+    let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
 
     self.track(event: "Add New Card Button Clicked", properties: props)
   }
@@ -632,7 +636,7 @@ public final class Koala {
     reward: Reward,
     pledgeContext: PledgeContext
   ) {
-    let props = properties(project: project, loggedInUser: self.loggedInUser)
+    let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
       .withAllValuesFrom(properties(reward: reward))
       .withAllValuesFrom(["pledge_context": pledgeContext.trackingString])
 
@@ -647,7 +651,7 @@ public final class Koala {
     pageContext: CheckoutPageContext,
     pledgeContext: PledgeContext
   ) {
-    let props = properties(project: project, loggedInUser: self.loggedInUser)
+    let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
       .withAllValuesFrom(properties(reward: reward))
       .withAllValuesFrom([
         "pledge_context": pledgeContext.trackingString,
@@ -675,7 +679,7 @@ public final class Koala {
     ]
     extraProps["payment_method"] = paymentMethod?.trackingString
 
-    let props = properties(project: project, loggedInUser: self.loggedInUser)
+    let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
       .withAllValuesFrom(properties(reward: reward))
       .withAllValuesFrom(extraProps)
 
@@ -683,7 +687,7 @@ public final class Koala {
   }
 
   public func trackChangedPledgeAmount(_ project: Project, reward: Reward, pledgeContext: PledgeContext) {
-    let props = properties(project: project, loggedInUser: self.loggedInUser)
+    let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
       .withAllValuesFrom(properties(reward: reward))
       .withAllValuesFrom(["pledge_context": pledgeContext.trackingString])
 
@@ -697,7 +701,7 @@ public final class Koala {
     reward: Reward,
     pledgeContext: PledgeContext
   ) {
-    let props = properties(project: project, loggedInUser: self.loggedInUser)
+    let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
       .withAllValuesFrom(properties(reward: reward))
       .withAllValuesFrom(["pledge_context": pledgeContext.trackingString])
 
@@ -707,7 +711,7 @@ public final class Koala {
   }
 
   public func trackSelectedReward(project: Project, reward: Reward, pledgeContext: PledgeContext) {
-    let props = properties(project: project, loggedInUser: self.loggedInUser)
+    let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
       .withAllValuesFrom(properties(reward: reward))
       .withAllValuesFrom(["pledge_context": pledgeContext.trackingString])
 
@@ -717,7 +721,7 @@ public final class Koala {
   }
 
   public func trackClosedReward(project: Project, reward: Reward, pledgeContext: PledgeContext) {
-    let props = properties(project: project, loggedInUser: self.loggedInUser)
+    let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
       .withAllValuesFrom(properties(reward: reward))
       .withAllValuesFrom(["pledge_context": pledgeContext.trackingString])
 
@@ -838,7 +842,7 @@ public final class Koala {
   // MARK: - Comments Events
 
   public func trackLoadNewerComments(project: Project, update: Update?, context: CommentsContext) {
-    let props = properties(project: project, loggedInUser: self.loggedInUser)
+    let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
       .withAllValuesFrom(update.map { properties(update: $0) } ?? [:])
       .withAllValuesFrom(["context": context.trackingString])
 
@@ -859,7 +863,7 @@ public final class Koala {
     page: Int,
     context: CommentsContext
   ) {
-    let props = properties(project: project, loggedInUser: self.loggedInUser)
+    let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
       .withAllValuesFrom(update.map { properties(update: $0) } ?? [:])
       .withAllValuesFrom(["page_count": page, "context": context.trackingString])
 
@@ -879,7 +883,7 @@ public final class Koala {
     update: Update?,
     context: CommentDialogContext
   ) {
-    let props = properties(project: project, loggedInUser: self.loggedInUser)
+    let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
       .withAllValuesFrom(update.map { properties(update: $0) } ?? [:])
       .withAllValuesFrom(
         [
@@ -897,7 +901,7 @@ public final class Koala {
     update: Update?,
     context: CommentDialogContext
   ) {
-    let props = properties(project: project, loggedInUser: self.loggedInUser)
+    let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
       .withAllValuesFrom(update.map { properties(update: $0) } ?? [:])
       .withAllValuesFrom(
         [
@@ -915,7 +919,7 @@ public final class Koala {
     update: Update?,
     context: CommentDialogContext
   ) {
-    let props = properties(project: project, loggedInUser: self.loggedInUser)
+    let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
       .withAllValuesFrom(update.map { properties(update: $0) } ?? [:])
       .withAllValuesFrom(
         [
@@ -929,7 +933,7 @@ public final class Koala {
   }
 
   public func trackCommentCreate(comment: Comment, project: Project) {
-    let props = properties(project: project, loggedInUser: self.loggedInUser)
+    let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
       .withAllValuesFrom(properties(comment: comment))
       .withAllValuesFrom(deprecatedProps)
 
@@ -937,7 +941,7 @@ public final class Koala {
   }
 
   public func trackCommentCreate(comment: Comment, update: Update, project: Project) {
-    let props = properties(project: project, loggedInUser: self.loggedInUser)
+    let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
       .withAllValuesFrom(properties(update: update))
       .withAllValuesFrom(properties(comment: comment))
       .withAllValuesFrom(deprecatedProps)
@@ -946,7 +950,7 @@ public final class Koala {
   }
 
   public func trackCommentsView(project: Project, update: Update?, context: CommentsContext) {
-    let props = properties(project: project, loggedInUser: self.loggedInUser)
+    let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
       .withAllValuesFrom(update.map { properties(update: $0) } ?? [:])
       .withAllValuesFrom(["context": context.trackingString])
 
@@ -1066,21 +1070,21 @@ public final class Koala {
   public func trackCheckoutFinishJumpToDiscovery(project: Project) {
     self.track(
       event: "Checkout Finished Discover More",
-      properties: properties(project: project, loggedInUser: self.loggedInUser)
+      properties: projectProperties(from: project, loggedInUser: self.loggedInUser)
     )
   }
 
   public func trackCheckoutFinishJumpToProject(project: Project) {
     self.track(
       event: "Checkout Finished Discover Open Project",
-      properties: properties(project: project, loggedInUser: self.loggedInUser)
+      properties: projectProperties(from: project, loggedInUser: self.loggedInUser)
     )
   }
 
   public func trackTriggeredAppStoreRatingDialog(project: Project) {
     self.track(
       event: "Triggered App Store Rating Dialog",
-      properties: properties(project: project, loggedInUser: self.loggedInUser)
+      properties: projectProperties(from: project, loggedInUser: self.loggedInUser)
     )
   }
 
@@ -1089,33 +1093,33 @@ public final class Koala {
   public func trackDashboardClosedProjectSwitcher(onProject project: Project) {
     self.track(
       event: "Closed Project Switcher",
-      properties: properties(project: project, loggedInUser: self.loggedInUser)
+      properties: projectProperties(from: project, loggedInUser: self.loggedInUser)
     )
   }
 
   public func trackDashboardSeeAllRewards(project: Project) {
     self.track(
       event: "Showed All Rewards",
-      properties: properties(project: project, loggedInUser: self.loggedInUser)
+      properties: projectProperties(from: project, loggedInUser: self.loggedInUser)
     )
   }
 
   public func trackDashboardSeeMoreReferrers(project: Project) {
     self.track(
       event: "Showed All Referrers",
-      properties: properties(project: project, loggedInUser: self.loggedInUser)
+      properties: projectProperties(from: project, loggedInUser: self.loggedInUser)
     )
   }
 
   public func trackDashboardShowProjectSwitcher(onProject project: Project) {
     self.track(
       event: "Showed Project Switcher",
-      properties: properties(project: project, loggedInUser: self.loggedInUser)
+      properties: projectProperties(from: project, loggedInUser: self.loggedInUser)
     )
   }
 
   public func trackDashboardSwitchProject(_ project: Project) {
-    let props = properties(project: project, loggedInUser: self.loggedInUser)
+    let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
 
     self.track(event: "Switched Projects", properties: props)
 
@@ -1127,7 +1131,7 @@ public final class Koala {
   }
 
   public func trackDashboardView(project: Project) {
-    let props = properties(project: project, loggedInUser: self.loggedInUser)
+    let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
 
     self.track(event: "Viewed Project Dashboard", properties: props)
 
@@ -1141,7 +1145,7 @@ public final class Koala {
   // MARK: - Project activity
 
   public func trackViewedProjectActivity(project: Project) {
-    let props = properties(project: project, loggedInUser: self.loggedInUser)
+    let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
 
     self.track(event: "Viewed Project Activity", properties: props)
     // deprecated
@@ -1152,7 +1156,7 @@ public final class Koala {
   }
 
   public func trackLoadedNewerProjectActivity(project: Project) {
-    let props = properties(project: project, loggedInUser: self.loggedInUser)
+    let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
 
     self.track(event: "Loaded Newer Project Activity", properties: props)
     // deprecated
@@ -1163,7 +1167,7 @@ public final class Koala {
   }
 
   public func trackLoadedOlderProjectActivity(project: Project, page: Int) {
-    let props = properties(project: project, loggedInUser: self.loggedInUser)
+    let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
       .withAllValuesFrom(["page_count": page])
 
     self.track(event: "Loaded Older Project Activity", properties: props)
@@ -1177,7 +1181,7 @@ public final class Koala {
   // MARK: - Messages
 
   public func trackMessageThreadsView(mailbox: Mailbox, project: Project?, refTag: RefTag) {
-    let props = (project.flatMap { properties(project: $0, loggedInUser: self.loggedInUser) } ?? [:])
+    let props = (project.flatMap { projectProperties(from: $0, loggedInUser: self.loggedInUser) } ?? [:])
       .withAllValuesFrom(["ref_tag": refTag.stringTag])
 
     switch mailbox {
@@ -1197,13 +1201,13 @@ public final class Koala {
   }
 
   public func trackViewedMessageSearch(project: Project?) {
-    let props = project.flatMap { properties(project: $0, loggedInUser: self.loggedInUser) } ?? [:]
+    let props = project.flatMap { projectProperties(from: $0, loggedInUser: self.loggedInUser) } ?? [:]
 
     self.track(event: "Viewed Message Search", properties: props)
   }
 
   public func trackViewedMessageSearchResults(term: String, project: Project?, hasResults: Bool) {
-    let props = (project.flatMap { properties(project: $0, loggedInUser: self.loggedInUser) } ?? [:])
+    let props = (project.flatMap { projectProperties(from: $0, loggedInUser: self.loggedInUser) } ?? [:])
       .withAllValuesFrom(["term": term])
     let _deprecatedProps = props.withAllValuesFrom(deprecatedProps)
 
@@ -1217,7 +1221,7 @@ public final class Koala {
   }
 
   public func trackClearedMessageSearchTerm(project: Project?) {
-    let props = project.flatMap { properties(project: $0, loggedInUser: self.loggedInUser) } ?? [:]
+    let props = project.flatMap { projectProperties(from: $0, loggedInUser: self.loggedInUser) } ?? [:]
 
     self.track(
       event: "Cleared Message Search Term",
@@ -1226,7 +1230,7 @@ public final class Koala {
   }
 
   public func trackMessageThreadView(project: Project) {
-    let props = properties(project: project, loggedInUser: self.loggedInUser)
+    let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
 
     self.track(
       event: "Message Thread View",
@@ -1237,7 +1241,7 @@ public final class Koala {
   }
 
   public func trackViewedMessageEditor(project: Project, context: MessageDialogContext) {
-    let props = properties(project: project, loggedInUser: self.loggedInUser)
+    let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
       .withAllValuesFrom(["message_type": "single", "context": context.rawValue])
 
     self.track(event: "Viewed Message Editor", properties: props)
@@ -1250,7 +1254,7 @@ public final class Koala {
    - parameter context: The place where the message was sent from.
    */
   public func trackMessageSent(project: Project, context: MessageDialogContext) {
-    let props = properties(project: project, loggedInUser: self.loggedInUser)
+    let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
       .withAllValuesFrom(["message_type": "single", "context": context.rawValue])
 
     self.track(
@@ -1327,7 +1331,7 @@ public final class Koala {
   public func trackProjectSave(_ project: Project, context: SaveContext) {
     guard let isStarred = project.personalization.isStarred else { return }
 
-    let props = properties(project: project, loggedInUser: self.loggedInUser)
+    let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
       .withAllValuesFrom(["context": context.trackingString])
 
     // Deprecated event
@@ -1348,7 +1352,7 @@ public final class Koala {
   }
 
   public func trackOpenedExternalLink(project: Project, context: ExternalLinkContext) {
-    let props = properties(project: project, loggedInUser: self.loggedInUser)
+    let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
       .withAllValuesFrom(["context": context.trackingString])
 
     self.track(event: "Opened External Link", properties: props)
@@ -1455,7 +1459,7 @@ public final class Koala {
     project: Project?,
     context: NewsletterContext
   ) {
-    let props = project.flatMap { properties(project: $0, loggedInUser: self.loggedInUser) } ?? [:]
+    let props = project.flatMap { projectProperties(from: $0, loggedInUser: self.loggedInUser) } ?? [:]
       .withAllValuesFrom(["context": context.trackingString, "type": newsletter.trackingString])
 
     self.track(
@@ -1648,7 +1652,7 @@ public final class Koala {
   }
 
   public func trackChangedUpdateDraftVisibility(forProject project: Project, isPublic: Bool) {
-    var props = properties(project: project, loggedInUser: self.loggedInUser)
+    var props = projectProperties(from: project, loggedInUser: self.loggedInUser)
     props["type"] = isPublic ? "public" : "backers_only"
     self.track(event: "Changed Visibility", properties: props)
   }
@@ -1690,7 +1694,7 @@ public final class Koala {
   }
 
   private func updateDraftProperties(project: Project) -> [String: Any] {
-    var props = properties(project: project, loggedInUser: self.loggedInUser)
+    var props = projectProperties(from: project, loggedInUser: self.loggedInUser)
     props["context"] = "update_draft"
     return props
   }
@@ -1700,7 +1704,7 @@ public final class Koala {
   public func trackViewedPledge(forProject project: Project) {
     self.track(
       event: "Viewed Pledge Info",
-      properties: properties(project: project, loggedInUser: self.loggedInUser)
+      properties: projectProperties(from: project, loggedInUser: self.loggedInUser)
     )
 
     // Deprecated event
@@ -1754,7 +1758,7 @@ public final class Koala {
 
     self.track(
       event: "Completed Project Video",
-      properties: properties(project: project, loggedInUser: self.loggedInUser)
+      properties: projectProperties(from: project, loggedInUser: self.loggedInUser)
     )
   }
 
@@ -1764,7 +1768,7 @@ public final class Koala {
 
     self.track(
       event: "Paused Project Video",
-      properties: properties(project: project, loggedInUser: self.loggedInUser)
+      properties: projectProperties(from: project, loggedInUser: self.loggedInUser)
     )
   }
 
@@ -1774,7 +1778,7 @@ public final class Koala {
 
     self.track(
       event: "Resumed Project Video",
-      properties: properties(project: project, loggedInUser: self.loggedInUser)
+      properties: projectProperties(from: project, loggedInUser: self.loggedInUser)
     )
   }
 
@@ -1784,7 +1788,7 @@ public final class Koala {
 
     self.track(
       event: "Started Project Video",
-      properties: properties(project: project, loggedInUser: self.loggedInUser)
+      properties: projectProperties(from: project, loggedInUser: self.loggedInUser)
     )
   }
 
@@ -1795,7 +1799,7 @@ public final class Koala {
     reward: Reward,
     pledgeContext: PledgeContext
   ) {
-    let props = properties(project: project, loggedInUser: self.loggedInUser)
+    let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
       .withAllValuesFrom(properties(reward: reward))
       .withAllValuesFrom(["pledge_context": pledgeContext.trackingString])
 
@@ -1813,7 +1817,7 @@ public final class Koala {
     reward: Reward,
     pledgeContext: PledgeContext
   ) {
-    let props = properties(project: project, loggedInUser: self.loggedInUser)
+    let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
       .withAllValuesFrom(properties(reward: reward))
       .withAllValuesFrom(["pledge_context": pledgeContext.trackingString])
 
@@ -1828,7 +1832,7 @@ public final class Koala {
     reward: Reward,
     pledgeContext: PledgeContext
   ) {
-    let props = properties(project: project, loggedInUser: self.loggedInUser)
+    let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
       .withAllValuesFrom(properties(reward: reward))
       .withAllValuesFrom(["pledge_context": pledgeContext.trackingString])
 
@@ -1842,7 +1846,7 @@ public final class Koala {
     reward: Reward,
     pledgeContext: PledgeContext
   ) {
-    let props = properties(project: project, loggedInUser: self.loggedInUser)
+    let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
       .withAllValuesFrom(properties(reward: reward))
       .withAllValuesFrom(["pledge_context": pledgeContext.trackingString])
 
@@ -1856,7 +1860,7 @@ public final class Koala {
     reward: Reward,
     pledgeContext: PledgeContext
   ) {
-    let props = properties(project: project, loggedInUser: self.loggedInUser)
+    let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
       .withAllValuesFrom(properties(reward: reward))
       .withAllValuesFrom(["pledge_context": pledgeContext.trackingString])
 
@@ -1868,7 +1872,7 @@ public final class Koala {
     reward: Reward,
     pledgeContext: PledgeContext
   ) {
-    let props = properties(project: project, loggedInUser: self.loggedInUser)
+    let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
       .withAllValuesFrom(properties(reward: reward))
       .withAllValuesFrom(["pledge_context": pledgeContext.trackingString])
     self.track(event: "Apple Pay Canceled", properties: props.withAllValuesFrom(deprecatedProps))
@@ -1890,7 +1894,7 @@ public final class Koala {
     project: Project,
     pledgeContext: PledgeContext
   ) {
-    let props = properties(project: project, loggedInUser: self.loggedInUser)
+    let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
       .withAllValuesFrom(properties(reward: reward))
       .withAllValuesFrom(["pledge_context": pledgeContext.trackingString])
 
@@ -1902,7 +1906,7 @@ public final class Koala {
     project: Project,
     pledgeContext: PledgeContext
   ) {
-    let props = properties(project: project, loggedInUser: self.loggedInUser)
+    let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
       .withAllValuesFrom(properties(reward: reward))
       .withAllValuesFrom(["pledge_context": pledgeContext.trackingString])
 
@@ -2061,20 +2065,8 @@ public final class Koala {
 
 // MARK: - Project Properties
 
-// FIXME: remove the function below and replace with projectProperties
-
-private func properties(
-  project: Project,
-  loggedInUser: User?,
-  prefix: String = "project_"
-) -> [String: Any] {
-  return projectProperties(from: project, loggedInUser: loggedInUser, prefix: prefix)
-}
-
 private func projectProperties(
   from project: Project,
-  reward _: Reward? = nil,
-  backing _: Backing? = nil,
   loggedInUser: User? = nil,
   dateType: DateProtocol.Type = AppEnvironment.current.dateType,
   calendar: Calendar = AppEnvironment.current.calendar,
@@ -2118,39 +2110,6 @@ private func projectProperties(
   return props
     .withAllValuesFrom(userProps)
     .prefixedKeys(prefix)
-}
-
-private func properties(
-  project: Project,
-  reward: Reward? = nil,
-  backing: Backing? = nil,
-  prefix: String = "project_"
-) -> [String: Any] {
-  var props: [String: Any] = [:]
-
-  props["name"] = project.name
-  props["pid"] = project.id
-  props["category"] = project.category.name
-  props["has_video"] = project.video != nil
-  props["location"] = project.location.name
-  props["country"] = project.country.countryCode
-
-  let now = AppEnvironment.current.dateType.init().timeIntervalSince1970
-  props["hours_remaining"] = Int(ceil(max(0.0, (project.dates.deadline - now) / 3_600.0)))
-
-  props["percent_raised"] = project.stats.fundingProgress
-
-  var rewardProperties: [String: Any] = [:]
-  rewardProperties["backer_reward_minimum"] = reward?.minimum
-
-  var backingProperties: [String: Any] = [:]
-  backingProperties["pledge_total"] = backing?.amount
-
-  props["currency"] = project.country.currencyCode
-
-  return props.prefixedKeys(prefix)
-    .withAllValuesFrom(rewardProperties)
-    .withAllValuesFrom(backingProperties)
 }
 
 private func properties(update: Update, prefix: String = "update_") -> [String: Any] {
@@ -2244,19 +2203,19 @@ private func properties(
 
   switch shareContext {
   case let .creatorDashboard(project):
-    result = result.withAllValuesFrom(properties(project: project, loggedInUser: loggedInUser))
+    result = result.withAllValuesFrom(projectProperties(from: project, loggedInUser: loggedInUser))
     result["context"] = "creator_dashboard"
   case let .discovery(project):
-    result = result.withAllValuesFrom(properties(project: project, loggedInUser: loggedInUser))
+    result = result.withAllValuesFrom(projectProperties(from: project, loggedInUser: loggedInUser))
     result["context"] = "discovery"
   case let .project(project):
-    result = result.withAllValuesFrom(properties(project: project, loggedInUser: loggedInUser))
+    result = result.withAllValuesFrom(projectProperties(from: project, loggedInUser: loggedInUser))
     result["context"] = "project"
   case let .thanks(project):
-    result = result.withAllValuesFrom(properties(project: project, loggedInUser: loggedInUser))
+    result = result.withAllValuesFrom(projectProperties(from: project, loggedInUser: loggedInUser))
     result["context"] = "thanks"
   case let .update(project, update):
-    result = result.withAllValuesFrom(properties(project: project, loggedInUser: loggedInUser))
+    result = result.withAllValuesFrom(projectProperties(from: project, loggedInUser: loggedInUser))
     result = result.withAllValuesFrom(properties(update: update))
     result["context"] = "update"
   }

--- a/Library/Tracking/KoalaTests.swift
+++ b/Library/Tracking/KoalaTests.swift
@@ -146,6 +146,7 @@ final class KoalaTests: TestCase {
     let project = Project.template
       |> Project.lens.stats.staticUsdRate .~ 2
       |> Project.lens.stats.commentsCount .~ 10
+      |> Project.lens.prelaunchActivated .~ true
 
     koala.trackProjectViewed(project, refTag: .discovery, cookieRefTag: .recommended)
 
@@ -159,11 +160,10 @@ final class KoalaTests: TestCase {
     XCTAssertEqual(project.country.currencyCode, properties?["project_currency"] as? String)
     XCTAssertEqual(project.stats.goal, properties?["project_goal"] as? Int)
     XCTAssertEqual(project.id, properties?["project_pid"] as? Int)
-    XCTAssertEqual(project.stats.pledged, properties?["project_pledged"] as? Int)
     XCTAssertEqual(project.stats.fundingProgress, properties?["project_percent_raised"] as? Float)
     XCTAssertEqual(project.stats.updatesCount, properties?["project_updates_count"] as? Int)
-    XCTAssertEqual(project.category.name, properties?["project_category"] as? String)
-    XCTAssertEqual(project.category._parent?.name, properties?["project_parent_category"] as? String)
+    XCTAssertEqual(project.category.name, properties?["project_subcategory"] as? String)
+    XCTAssertEqual(project.category._parent?.name, properties?["project_category"] as? String)
     XCTAssertEqual(project.location.name, properties?["project_location"] as? String)
     XCTAssertEqual(project.creator.id, properties?["project_creator_uid"] as? Int)
     XCTAssertEqual(24 * 15, properties?["project_hours_remaining"] as? Int)
@@ -172,10 +172,14 @@ final class KoalaTests: TestCase {
     XCTAssertEqual(1_474_065_315, properties?["project_launched_at"] as? Double)
     XCTAssertEqual(2, properties?["project_static_usd_rate"] as? Float)
     XCTAssertEqual("live", properties?["project_state"] as? String)
+    XCTAssertEqual(project.stats.pledged, properties?["project_current_pledge_amount"] as? Int)
     XCTAssertEqual(2_000, properties?["project_current_pledge_amount_usd"] as? Int)
     XCTAssertEqual(4_000, properties?["project_goal_usd"] as? Int)
     XCTAssertEqual(true, properties?["project_has_video"] as? Bool)
     XCTAssertEqual(10, properties?["project_comments_count"] as? Int)
+    XCTAssertEqual(true, properties?["project_prelaunch_activated"] as? Bool)
+    XCTAssertEqual(0, properties?["project_rewards_count"] as? Int)
+
     XCTAssertEqual("discovery", properties?["ref_tag"] as? String)
     XCTAssertEqual("recommended", properties?["referrer_credit"] as? String)
 
@@ -183,7 +187,7 @@ final class KoalaTests: TestCase {
     XCTAssertNil(properties?["project_user_is_backer"])
     XCTAssertNil(properties?["project_user_has_starred"])
 
-    XCTAssertEqual(23, properties?.keys.filter { $0.hasPrefix("project_") }.count)
+    XCTAssertEqual(25, properties?.keys.filter { $0.hasPrefix("project_") }.count)
   }
 
   func testProjectProperties_LoggedInUser() {
@@ -204,7 +208,7 @@ final class KoalaTests: TestCase {
     XCTAssertEqual(false, properties?["project_user_is_backer"] as? Bool)
     XCTAssertEqual(false, properties?["project_user_has_watched"] as? Bool)
 
-    XCTAssertEqual(25, properties?.keys.filter { $0.hasPrefix("project_") }.count)
+    XCTAssertEqual(26, properties?.keys.filter { $0.hasPrefix("project_") }.count)
   }
 
   func testProjectProperties_LoggedInBacker() {
@@ -224,7 +228,7 @@ final class KoalaTests: TestCase {
     XCTAssertEqual(true, properties?["project_user_is_backer"] as? Bool)
     XCTAssertEqual(false, properties?["project_user_has_watched"] as? Bool)
 
-    XCTAssertEqual(25, properties?.keys.filter { $0.hasPrefix("project_") }.count)
+    XCTAssertEqual(26, properties?.keys.filter { $0.hasPrefix("project_") }.count)
   }
 
   func testProjectProperties_LoggedInStarrer() {
@@ -244,7 +248,7 @@ final class KoalaTests: TestCase {
     XCTAssertEqual(false, properties?["project_user_is_backer"] as? Bool)
     XCTAssertEqual(true, properties?["project_user_has_watched"] as? Bool)
 
-    XCTAssertEqual(25, properties?.keys.filter { $0.hasPrefix("project_") }.count)
+    XCTAssertEqual(26, properties?.keys.filter { $0.hasPrefix("project_") }.count)
   }
 
   func testProjectProperties_LoggedInCreator() {
@@ -264,7 +268,7 @@ final class KoalaTests: TestCase {
     XCTAssertEqual(false, properties?["project_user_is_backer"] as? Bool)
     XCTAssertEqual(false, properties?["project_user_has_watched"] as? Bool)
 
-    XCTAssertEqual(25, properties?.keys.filter { $0.hasPrefix("project_") }.count)
+    XCTAssertEqual(26, properties?.keys.filter { $0.hasPrefix("project_") }.count)
   }
 
   func testDiscoveryProperties() {

--- a/Library/Tracking/KoalaTests.swift
+++ b/Library/Tracking/KoalaTests.swift
@@ -181,7 +181,6 @@ final class KoalaTests: TestCase {
     XCTAssertEqual(true, properties?["project_prelaunch_activated"] as? Bool)
     XCTAssertEqual(0, properties?["project_rewards_count"] as? Int)
 
-
     XCTAssertEqual(false, properties?["project_user_is_project_creator"] as? Bool)
     XCTAssertNil(properties?["project_user_is_backer"])
     XCTAssertNil(properties?["project_user_has_starred"])
@@ -882,9 +881,13 @@ final class KoalaTests: TestCase {
 
     koala.trackProjectViewed(Project.template) // white-listed event
 
-    XCTAssertEqual(["App Open", "Opened App", "Project Page Viewed"], koalaClient.events,
-                   "White-listed event is tracked by koala client")
-    XCTAssertEqual(["Project Page Viewed"], dataLakeClient.events,
-                   "White-listed event is tracked by data lake client")
+    XCTAssertEqual(
+      ["App Open", "Opened App", "Project Page Viewed"], koalaClient.events,
+      "White-listed event is tracked by koala client"
+    )
+    XCTAssertEqual(
+      ["Project Page Viewed"], dataLakeClient.events,
+      "White-listed event is tracked by data lake client"
+    )
   }
 }

--- a/Library/Tracking/KoalaTests.swift
+++ b/Library/Tracking/KoalaTests.swift
@@ -869,4 +869,22 @@ final class KoalaTests: TestCase {
     ], client.events)
     XCTAssertEqual("search", client.properties.last?["ios_tab_bar_label"] as? String)
   }
+
+  func testLakeWhiteList() {
+    let koalaClient = MockTrackingClient()
+    let dataLakeClient = MockTrackingClient()
+    let koala = Koala(dataLakeClient: dataLakeClient, client: koalaClient)
+
+    koala.trackAppOpen() // non-white-listed event
+
+    XCTAssertEqual(["App Open", "Opened App"], koalaClient.events, "Event is tracked by koala client")
+    XCTAssertEqual([], dataLakeClient.events, "Event is not tracked by data lake client")
+
+    koala.trackProjectViewed(Project.template) // white-listed event
+
+    XCTAssertEqual(["App Open", "Opened App", "Project Page Viewed"], koalaClient.events,
+                   "White-listed event is tracked by koala client")
+    XCTAssertEqual(["Project Page Viewed"], dataLakeClient.events,
+                   "White-listed event is tracked by data lake client")
+  }
 }

--- a/Library/Tracking/KoalaTests.swift
+++ b/Library/Tracking/KoalaTests.swift
@@ -292,18 +292,18 @@ final class KoalaTests: TestCase {
 
     let properties = client.properties.last
 
-    XCTAssertEqual(30, properties?["discover_category_id"] as? Int)
-    XCTAssertEqual("Documentary", properties?["discover_category_name"] as? String)
+    XCTAssertEqual(30, properties?["discover_subcategory_id"] as? Int)
+    XCTAssertEqual("Documentary", properties?["discover_subcategory_name"] as? String)
     XCTAssertEqual(false, properties?["discover_recommended"] as? Bool)
     XCTAssertEqual(false, properties?["discover_social"] as? Bool)
-    XCTAssertEqual(true, properties?["discover_staff_picks"] as? Bool)
-    XCTAssertEqual(false, properties?["discover_starred"] as? Bool)
+    XCTAssertEqual(true, properties?["discover_pwl"] as? Bool)
+    XCTAssertEqual(false, properties?["discover_watched"] as? Bool)
     XCTAssertEqual(false, properties?["discover_everything"] as? Bool)
-    XCTAssertEqual(Category.filmAndVideo.intID, properties?["discover_parent_category_id"] as? Int)
-    XCTAssertEqual(Category.filmAndVideo.name, properties?["discover_parent_category_name"] as? String)
+    XCTAssertEqual(Category.filmAndVideo.intID, properties?["discover_category_id"] as? Int)
+    XCTAssertEqual(Category.filmAndVideo.name, properties?["discover_category_name"] as? String)
     XCTAssertEqual("popularity", properties?["discover_sort"] as? String)
     XCTAssertEqual("ios_project_collection_tag_518", properties?["discover_ref_tag"] as? String)
-    XCTAssertEqual("collage", properties?["search_term"] as? String)
+    XCTAssertEqual("collage", properties?["discover_search_term"] as? String)
   }
 
   func testDiscoveryProperties_NoCategory() {

--- a/Library/Tracking/KoalaTests.swift
+++ b/Library/Tracking/KoalaTests.swift
@@ -186,7 +186,7 @@ final class KoalaTests: TestCase {
     XCTAssertNil(properties?["project_user_is_backer"])
     XCTAssertNil(properties?["project_user_has_starred"])
 
-    XCTAssertEqual(23, properties?.keys.filter { $0.hasPrefix("project_") }.count)
+    XCTAssertEqual(25, properties?.keys.filter { $0.hasPrefix("project_") }.count)
 
     XCTAssertEqual("discovery", properties?["session_ref_tag"] as? String)
     XCTAssertEqual("recommended", properties?["session_referrer_credit"] as? String)

--- a/Library/Tracking/KoalaTests.swift
+++ b/Library/Tracking/KoalaTests.swift
@@ -324,10 +324,11 @@ final class KoalaTests: TestCase {
     let properties = client.properties.last
 
     XCTAssertNil(properties?["discover_category_id"])
+    XCTAssertNil(properties?["discover_subcategory_id"])
     XCTAssertEqual(false, properties?["discover_recommended"] as? Bool)
     XCTAssertEqual(false, properties?["discover_social"] as? Bool)
-    XCTAssertEqual(true, properties?["discover_staff_picks"] as? Bool)
-    XCTAssertEqual(false, properties?["discover_starred"] as? Bool)
+    XCTAssertEqual(true, properties?["discover_pwl"] as? Bool)
+    XCTAssertEqual(false, properties?["discover_watched"] as? Bool)
     XCTAssertEqual(false, properties?["discover_everything"] as? Bool)
     XCTAssertEqual("popularity", properties?["discover_sort"] as? String)
   }
@@ -346,11 +347,12 @@ final class KoalaTests: TestCase {
     let properties = client.properties.last
 
     XCTAssertNil(properties?["discover_category_id"])
+    XCTAssertNil(properties?["discover_subcategory_id"])
     XCTAssertNil(properties?["discover_recommended"])
     XCTAssertNil(properties?["discover_social"])
-    XCTAssertNil(properties?["discover_staff_picks"])
-    XCTAssertNil(properties?["discover_starred"])
-    XCTAssertNil(properties?["discover_term"])
+    XCTAssertNil(properties?["discover_pwl"])
+    XCTAssertNil(properties?["discover_watched"])
+    XCTAssertNil(properties?["discover_search_term"])
     XCTAssertEqual(true, properties?["discover_everything"] as? Bool)
     XCTAssertEqual("magic", properties?["discover_sort"] as? String)
   }

--- a/Library/ViewModels/DiscoveryFiltersViewModelTests.swift
+++ b/Library/ViewModels/DiscoveryFiltersViewModelTests.swift
@@ -116,7 +116,7 @@ internal final class DiscoveryFiltersViewModelTests: TestCase {
     XCTAssertEqual(["Filter Clicked"], self.trackingClient.events)
     XCTAssertEqual(
       [Category.documentary.intID],
-      self.trackingClient.properties(forKey: "discover_category_id", as: Int.self)
+      self.trackingClient.properties(forKey: "discover_subcategory_id", as: Int.self)
     )
   }
 

--- a/Library/ViewModels/DiscoveryPageViewModelTests.swift
+++ b/Library/ViewModels/DiscoveryPageViewModelTests.swift
@@ -173,7 +173,7 @@ internal final class DiscoveryPageViewModelTests: TestCase {
     )
     XCTAssertEqual(
       [nil, 1],
-      self.trackingClient.properties(forKey: "discover_category_id", as: Int.self),
+      self.trackingClient.properties(forKey: "discover_subcategory_id", as: Int.self),
       "The updated category is tracked."
     )
 
@@ -1271,7 +1271,7 @@ internal final class DiscoveryPageViewModelTests: TestCase {
     XCTAssertEqual(["Editorial Card Clicked"], self.trackingClient.events)
     XCTAssertEqual(
       ["ios_project_collection_tag_518"],
-      self.trackingClient.properties(forKey: "ref_tag", as: String.self)
+      self.trackingClient.properties(forKey: "session_ref_tag", as: String.self)
     )
 
     self.vm.inputs.discoveryEditorialCellTapped(with: .goRewardless)
@@ -1279,7 +1279,7 @@ internal final class DiscoveryPageViewModelTests: TestCase {
     XCTAssertEqual(["Editorial Card Clicked", "Editorial Card Clicked"], self.trackingClient.events)
     XCTAssertEqual(
       ["ios_project_collection_tag_518", "ios_project_collection_tag_518"],
-      self.trackingClient.properties(forKey: "ref_tag")
+      self.trackingClient.properties(forKey: "session_ref_tag")
     )
   }
 

--- a/Library/ViewModels/ProjectPamphletViewModelTests.swift
+++ b/Library/ViewModels/ProjectPamphletViewModelTests.swift
@@ -155,12 +155,12 @@ final class ProjectPamphletViewModelTests: TestCase {
     )
     XCTAssertEqual(
       [RefTag.category.stringTag],
-      self.trackingClient.properties.compactMap { $0["ref_tag"] as? String },
+      self.trackingClient.properties.compactMap { $0["session_ref_tag"] as? String },
       "The ref tag is tracked in the koala event."
     )
     XCTAssertEqual(
       [RefTag.category.stringTag],
-      self.trackingClient.properties.compactMap { $0["referrer_credit"] as? String },
+      self.trackingClient.properties.compactMap { $0["session_referrer_credit"] as? String },
       "The referral credit is tracked in the koala event."
     )
     XCTAssertEqual(
@@ -197,7 +197,7 @@ final class ProjectPamphletViewModelTests: TestCase {
         RefTag.category.stringTag,
         RefTag.recommended.stringTag
       ],
-      self.trackingClient.properties.compactMap { $0["ref_tag"] as? String },
+      self.trackingClient.properties.compactMap { $0["session_ref_tag"] as? String },
       "The new ref tag is tracked in koala event."
     )
     XCTAssertEqual(
@@ -205,7 +205,7 @@ final class ProjectPamphletViewModelTests: TestCase {
         RefTag.category.stringTag,
         RefTag.category.stringTag
       ],
-      self.trackingClient.properties.compactMap { $0["referrer_credit"] as? String },
+      self.trackingClient.properties.compactMap { $0["session_referrer_credit"] as? String },
       "The referrer credit did not change, and is still category."
     )
     XCTAssertEqual(
@@ -302,12 +302,12 @@ final class ProjectPamphletViewModelTests: TestCase {
     )
     XCTAssertEqual(
       [RefTag.category.stringTag],
-      self.trackingClient.properties.compactMap { $0["ref_tag"] as? String },
+      self.trackingClient.properties.compactMap { $0["session_ref_tag"] as? String },
       "The ref tag is tracked in the koala event."
     )
     XCTAssertEqual(
       [RefTag.category.stringTag],
-      self.trackingClient.properties.compactMap { $0["referrer_credit"] as? String },
+      self.trackingClient.properties.compactMap { $0["session_referrer_credit"] as? String },
       "The referral credit is tracked in the koala event."
     )
     XCTAssertEqual(
@@ -344,14 +344,14 @@ final class ProjectPamphletViewModelTests: TestCase {
         RefTag.category.stringTag,
         RefTag.recommended.stringTag
       ],
-      self.trackingClient.properties.compactMap { $0["ref_tag"] as? String },
+      self.trackingClient.properties.compactMap { $0["session_ref_tag"] as? String },
       "The new ref tag is tracked in koala event."
     )
     XCTAssertEqual(
       [
         RefTag.category.stringTag, RefTag.category.stringTag
       ],
-      self.trackingClient.properties.compactMap { $0["referrer_credit"] as? String },
+      self.trackingClient.properties.compactMap { $0["session_referrer_credit"] as? String },
       "The referrer credit did not change, and is still category."
     )
     XCTAssertEqual(

--- a/Library/ViewModels/SettingsAccountViewModelTests.swift
+++ b/Library/ViewModels/SettingsAccountViewModelTests.swift
@@ -72,21 +72,17 @@ internal final class SettingsAccountViewModelTests: TestCase {
 
   func testTrackViewedAccount() {
     let koalaClient = MockTrackingClient()
-    let dataLakeClient = MockTrackingClient()
 
-    withEnvironment(koala: Koala(dataLakeClient: dataLakeClient, client: koalaClient)) {
+    withEnvironment(koala: Koala(client: koalaClient)) {
       XCTAssertEqual([], koalaClient.events)
-      XCTAssertEqual([], dataLakeClient.events)
 
       self.vm.inputs.viewDidAppear()
 
       XCTAssertEqual(["Viewed Account"], koalaClient.events)
-      XCTAssertEqual(["Viewed Account"], dataLakeClient.events)
 
       self.vm.inputs.viewDidAppear()
 
       XCTAssertEqual(["Viewed Account", "Viewed Account"], koalaClient.events)
-      XCTAssertEqual(["Viewed Account", "Viewed Account"], dataLakeClient.events)
     }
   }
 }


### PR DESCRIPTION
# 📲 What

Updates some of the naming of certain props to reflect latest changes from insights team. Also adds white-listing on "clean" events, so that only white-listed events are sent to the data lake.

# 🤔 Why

More event cleanup and ensuring that only clean events go to the data lake.

# ♿️ Accessibility 

N/A

# 🏎 Performance

N/A

# ✅ Acceptance criteria

Testing white-listing:
- [x] Ensure that `KOALA_TRACKING_ENABLED` is set to `true`, then run the app. On app launch, you should see the event `App Open` track on the Koala client. You should *not* see it track on the data lake client.
- [x] Navigate to a project page. You should the event `Project Page Viewed` track on **both** the Koala and Lake clients

Testing discovery props changes:
- [x] navigate to a subcategory on discovery (ex. Ceramics). On the `Explore Page Viewed` event, you should see: 
    - [x] the property `discover_category_name`, and it should say `Art` (the parent category)
    - [x] the property `discover_subcategory_name` and it should say `Ceramics` (the current category)
   - [x] the properties `discover_category_id` and `discover_subcategory_id`
- [x] navigate to the "Projects We Love" filter. the `Explore Page Viewed` event should fire with a property `discover_pwl: true`
- [x] navigate to the "Saved" filter. The `Explore Page Viewed` event should fire with a property `discover_watched: true`
