### PR TITLE
[NT-692] Prepare Data Lake Request with auth headers

### DIFF
--- a/Library/Tracking/TrackingClientConfiguration.swift
+++ b/Library/Tracking/TrackingClientConfiguration.swift
@@ -121,7 +121,7 @@ private let dataLakeRequest: TrackingClientRequest = { config, environmentType, 
     ["Content-Type": "application/json; charset=utf-8"]
   )
 
-  return request
+  return AppEnvironment.current.apiService.preparedRequest(forRequest: request)
 }
 
 private let dataLakeUrl: TrackingClientURL = { environmentType in


### PR DESCRIPTION
# 📲 What

Prepares requests sent to our Data Lake tracking endpoint with authentication headers.

# 🛠 How

Pass the request to our `Service.preparedRequest()` function before returning it to the client.

# ✅ Acceptance criteria

Inspect requests in Charles:

- [x] Observe that Data Lake requests include the `client_id` and `Authorization` header.