### PR TITLE
[NT-645] More tweaks to property names and cleanup

### DIFF
--- a/Library/Tracking/Koala.swift
+++ b/Library/Tracking/Koala.swift
@@ -506,7 +506,7 @@ public final class Koala {
 
     self.track(
       event: DataLakeWhiteListedEvent.tabBarClicked.rawValue,
-      properties: ["ios_tab_bar_label": label]
+      properties: ["tab_bar_label": label]
     )
   }
 
@@ -2023,21 +2023,20 @@ public final class Koala {
     props["cellular_connection"] = CTTelephonyNetworkInfo().serviceCurrentRadioAccessTechnology
     props["client_type"] = "native"
     props["current_variants"] = self.config?.abExperimentsArray.sorted()
+    props["display_language"] = AppEnvironment.current.language.rawValue
 
-    props["device_fingerprint"] = self.distinctId
     props["device_format"] = self.deviceFormat
     props["device_manufacturer"] = "Apple"
     props["device_model"] = Koala.deviceModel
     props["device_orientation"] = self.deviceOrientation
-    props["distinct_id"] = self.distinctId
+    props["device_distinct_id"] = self.distinctId
 
     props["enabled_features"] = enabledFeatureFlags
-    props["iphone_uuid"] = self.distinctId
     props["is_voiceover_running"] = AppEnvironment.current.isVoiceOverRunning()
     props["mp_lib"] = "kickstarter_ios"
     props["os"] = self.device.systemName
     props["os_version"] = self.device.systemVersion
-    props["time"] = Date().timeIntervalSince1970
+    props["time"] = AppEnvironment.current.dateType.init().timeIntervalSince1970
     props["app_build_number"] = self.bundle.infoDictionary?["CFBundleVersion"]
     props["app_release_version"] = self.bundle.infoDictionary?["CFBundleShortVersionString"]
     props["screen_width"] = UInt(self.screen.bounds.width)

--- a/Library/Tracking/Koala.swift
+++ b/Library/Tracking/Koala.swift
@@ -2298,6 +2298,7 @@ private func userProperties(for user: User?, config: Config?, _ prefix: String =
   props["country"] = user?.location?.country ?? config?.countryCode
   props["facebook_account"] = user?.facebookConnected
   props["watched_projects_count"] = user?.stats.starredProjectsCount
+  props["launched_projects_count"] = user?.stats.createdProjectsCount
   props["uid"] = user?.id
 
   return props.prefixedKeys(prefix)

--- a/Library/Tracking/KoalaTests.swift
+++ b/Library/Tracking/KoalaTests.swift
@@ -810,6 +810,7 @@ final class KoalaTests: TestCase {
     XCTAssertNil(props?["user_watched_projects_count"])
     XCTAssertNil(props?["user_uid"])
     XCTAssertNil(props?["user_is_admin"])
+    XCTAssertNil(props?["user_launched_projects_count"])
   }
 
   func testUserProperties_loggedIn() {
@@ -820,6 +821,7 @@ final class KoalaTests: TestCase {
       |> User.lens.location .~ Location.usa
       |> User.lens.facebookConnected .~ true
       |> User.lens.stats.starredProjectsCount .~ 2
+      |> User.lens.stats.createdProjectsCount .~ 3
       |> User.lens.id .~ 10
       |> User.lens.isAdmin .~ false
 
@@ -835,6 +837,7 @@ final class KoalaTests: TestCase {
     XCTAssertEqual(2, props?["user_watched_projects_count"] as? Int)
     XCTAssertEqual(10, props?["user_uid"] as? Int)
     XCTAssertEqual(false, props?["user_is_admin"] as? Bool)
+    XCTAssertEqual(3, props?["user_launched_projects_count"] as? Int)
   }
 
   func testTabBarClicked() {

--- a/Library/Tracking/KoalaTests.swift
+++ b/Library/Tracking/KoalaTests.swift
@@ -54,20 +54,33 @@ final class KoalaTests: TestCase {
     XCTAssertEqual("1234567890", properties?["session_app_build_number"] as? String)
     XCTAssertEqual("1.2.3.4.5.6.7.8.9.0", properties?["session_app_release_version"] as? String)
     XCTAssertEqual("phone", properties?["session_device_format"] as? String)
-    XCTAssertEqual("abc-123", properties?["session_device_fingerprint"] as? String)
     XCTAssertEqual("Apple", properties?["session_device_manufacturer"] as? String)
     XCTAssertEqual("Portrait", properties?["session_device_orientation"] as? String)
-    XCTAssertEqual("abc-123", properties?["session_distinct_id"] as? String)
+    XCTAssertEqual("abc-123", properties?["session_device_distinct_id"] as? String)
 
     XCTAssertEqual("MockSystemName", properties?["session_os"] as? String)
     XCTAssertEqual("MockSystemVersion", properties?["session_os_version"] as? String)
     XCTAssertEqual(UInt(screen.bounds.width), properties?["session_screen_width"] as? UInt)
     XCTAssertEqual("kickstarter_ios", properties?["session_mp_lib"] as? String)
-    XCTAssertEqual("abc-123", properties?["session_iphone_uuid"] as? String)
     XCTAssertEqual(false, properties?["session_user_logged_in"] as? Bool)
     XCTAssertEqual("ios", properties?["session_client_platform"] as? String)
+    XCTAssertEqual("en", properties?["session_display_language"] as? String)
+    XCTAssertEqual(1475361315, properties?["session_time"] as? Double)
 
-    XCTAssertEqual(25, properties?.keys.filter { $0.hasPrefix("session_") }.count)
+    XCTAssertEqual(24, properties?.keys.filter { $0.hasPrefix("session_") }.count)
+  }
+
+  func testSessionProperties_Language() {
+    withEnvironment(language: Language.es) {
+      let client = MockTrackingClient()
+      let koala = Koala(client: client)
+
+      koala.trackAppOpen()
+
+      let properties = client.properties.last
+
+      XCTAssertEqual("es", properties?["session_display_language"] as? String)
+    }
   }
 
   func testSessionProperties_VoiceOver() {
@@ -837,17 +850,17 @@ final class KoalaTests: TestCase {
     koala.trackTabBarClicked(tabBarActivity)
 
     XCTAssertEqual(["Tab Bar Clicked"], client.events)
-    XCTAssertEqual("activity", client.properties.last?["ios_tab_bar_label"] as? String)
+    XCTAssertEqual("activity", client.properties.last?["tab_bar_label"] as? String)
 
     koala.trackTabBarClicked(tabBarDashboard)
 
     XCTAssertEqual(["Tab Bar Clicked", "Tab Bar Clicked"], client.events)
-    XCTAssertEqual("dashboard", client.properties.last?["ios_tab_bar_label"] as? String)
+    XCTAssertEqual("dashboard", client.properties.last?["tab_bar_label"] as? String)
 
     koala.trackTabBarClicked(tabBarHome)
 
     XCTAssertEqual(["Tab Bar Clicked", "Tab Bar Clicked", "Tab Bar Clicked"], client.events)
-    XCTAssertEqual("discovery", client.properties.last?["ios_tab_bar_label"] as? String)
+    XCTAssertEqual("discovery", client.properties.last?["tab_bar_label"] as? String)
 
     koala.trackTabBarClicked(tabBarProfile)
 
@@ -855,7 +868,7 @@ final class KoalaTests: TestCase {
       ["Tab Bar Clicked", "Tab Bar Clicked", "Tab Bar Clicked", "Tab Bar Clicked"],
       client.events
     )
-    XCTAssertEqual("profile", client.properties.last?["ios_tab_bar_label"] as? String)
+    XCTAssertEqual("profile", client.properties.last?["tab_bar_label"] as? String)
 
     koala.trackTabBarClicked(tabBarSearch)
 
@@ -866,7 +879,7 @@ final class KoalaTests: TestCase {
       "Tab Bar Clicked",
       "Tab Bar Clicked"
     ], client.events)
-    XCTAssertEqual("search", client.properties.last?["ios_tab_bar_label"] as? String)
+    XCTAssertEqual("search", client.properties.last?["tab_bar_label"] as? String)
   }
 
   func testLakeWhiteList() {

--- a/Library/Tracking/KoalaTests.swift
+++ b/Library/Tracking/KoalaTests.swift
@@ -65,7 +65,7 @@ final class KoalaTests: TestCase {
     XCTAssertEqual(false, properties?["session_user_logged_in"] as? Bool)
     XCTAssertEqual("ios", properties?["session_client_platform"] as? String)
     XCTAssertEqual("en", properties?["session_display_language"] as? String)
-    XCTAssertEqual(1475361315, properties?["session_time"] as? Double)
+    XCTAssertEqual(1_475_361_315, properties?["session_time"] as? Double)
 
     XCTAssertEqual(24, properties?.keys.filter { $0.hasPrefix("session_") }.count)
   }

--- a/Library/ViewModels/RootViewModelTests.swift
+++ b/Library/ViewModels/RootViewModelTests.swift
@@ -394,19 +394,19 @@ final class RootViewModelTests: TestCase {
 
     self.selectedIndex.assertValues([0, 1], "Selects index immediately.")
     XCTAssertEqual(["Tab Bar Clicked"], self.trackingClient.events)
-    XCTAssertEqual(["activity"], self.trackingClient.properties(forKey: "ios_tab_bar_label"))
+    XCTAssertEqual(["activity"], self.trackingClient.properties(forKey: "tab_bar_label"))
 
     self.vm.inputs.didSelect(index: 0)
 
     self.selectedIndex.assertValues([0, 1, 0], "Selects index immediately.")
     XCTAssertEqual(["Tab Bar Clicked", "Tab Bar Clicked"], self.trackingClient.events)
-    XCTAssertEqual(["activity", "discovery"], self.trackingClient.properties(forKey: "ios_tab_bar_label"))
+    XCTAssertEqual(["activity", "discovery"], self.trackingClient.properties(forKey: "tab_bar_label"))
 
     self.vm.inputs.didSelect(index: 10)
 
     self.selectedIndex.assertValues([0, 1, 0, 3], "Selects index immediately.")
     XCTAssertEqual(["Tab Bar Clicked", "Tab Bar Clicked"], self.trackingClient.events)
-    XCTAssertEqual(["activity", "discovery"], self.trackingClient.properties(forKey: "ios_tab_bar_label"))
+    XCTAssertEqual(["activity", "discovery"], self.trackingClient.properties(forKey: "tab_bar_label"))
   }
 
   func testScrollToTop() {


### PR DESCRIPTION
# 📲 What

Renames some props, consolidates others that were essentially duplicate.

# 🤔 Why

More cleanup following sync with Product.

# ✅ Acceptance criteria

- [x] `session_iphone_uuid` and `session_device_fingerprint` session props are removed in favor of a single `session_device_distinct_id` prop
- [x] `ios_tab_bar_label` is renamed to `tab_bar_label`
- [x] `session_display_language` has been added and corresponds with the current language