### PR TITLE
[NT-717] Add Qualtrics custom properties and feature flag

### DIFF
--- a/Kickstarter-iOS/ViewModels/AppDelegateViewModel.swift
+++ b/Kickstarter-iOS/ViewModels/AppDelegateViewModel.swift
@@ -615,13 +615,20 @@ public final class AppDelegateViewModel: AppDelegateViewModelType, AppDelegateVi
     .filter(isTrue)
     .mapConst(0)
 
-    self.configureQualtrics = self.applicationLaunchOptionsProperty.signal.map { _ in
+    self.configureQualtrics = Signal.zip(
+      self.applicationLaunchOptionsProperty.signal,
+      self.didUpdateConfigProperty.signal
+    )
+    .filter { _ in featureQualtricsIsEnabled() }
+    .map { _ in
       .init(
         brandId: Secrets.Qualtrics.brandId,
         zoneId: Secrets.Qualtrics.zoneId,
         interceptId: QualtricsIntercept.survey.interceptId,
         stringProperties: [
-          "bundle_id": AppEnvironment.current.mainBundle.bundleIdentifier.coalesceWith("")
+          "bundle_id": AppEnvironment.current.mainBundle.bundleIdentifier.coalesceWith(""),
+          "language": AppEnvironment.current.language.rawValue,
+          "logged_in": "\(AppEnvironment.current.currentUser != nil)"
         ]
       )
     }

--- a/Library/Extensions/Feature+Helpers.swift
+++ b/Library/Extensions/Feature+Helpers.swift
@@ -13,6 +13,10 @@ public func featureNativeCheckoutPledgeViewIsEnabled() -> Bool {
   return Feature.nativeCheckoutPledgeView.isEnabled()
 }
 
+public func featureQualtricsIsEnabled() -> Bool {
+  return Feature.qualtrics.isEnabled()
+}
+
 extension Feature {
   fileprivate func isEnabled(in environment: Environment = AppEnvironment.current) -> Bool {
     guard let features = environment.config?.features, !features.isEmpty else { return false }

--- a/Library/Extensions/Feature+HelpersTests.swift
+++ b/Library/Extensions/Feature+HelpersTests.swift
@@ -82,4 +82,30 @@ final class FeatureHelpersTests: TestCase {
       XCTAssertFalse(featureNativeCheckoutPledgeViewIsEnabled())
     }
   }
+
+  // MARK: - Qualtrics
+
+  func testFeatureQualtrics_isTrue() {
+    let config = Config.template
+      |> \.features .~ [Feature.qualtrics.rawValue: true]
+
+    withEnvironment(config: config) {
+      XCTAssertTrue(featureQualtricsIsEnabled())
+    }
+  }
+
+  func testFeatureQualtrics_isFalse() {
+    let config = Config.template
+      |> \.features .~ [Feature.qualtrics.rawValue: false]
+
+    withEnvironment(config: config) {
+      XCTAssertFalse(featureQualtricsIsEnabled())
+    }
+  }
+
+  func testFeatureQualtrics_isFalse_whenNil() {
+    withEnvironment(config: .template) {
+      XCTAssertFalse(featureQualtricsIsEnabled())
+    }
+  }
 }

--- a/Library/Feature.swift
+++ b/Library/Feature.swift
@@ -4,6 +4,7 @@ public enum Feature: String {
   case goRewardless = "ios_go_rewardless"
   case nativeCheckout = "ios_native_checkout"
   case nativeCheckoutPledgeView = "ios_native_checkout_pledge_view"
+  case qualtrics = "ios_qualtrics"
 }
 
 extension Feature: CustomStringConvertible {
@@ -12,6 +13,7 @@ extension Feature: CustomStringConvertible {
     case .goRewardless: return "Go Rewardless"
     case .nativeCheckout: return "Native Checkout"
     case .nativeCheckoutPledgeView: return "Native Checkout Pledge View"
+    case .qualtrics: return "Qualtrics"
     }
   }
 }


### PR DESCRIPTION
# 📲 What

Adds `language` and `logged_in` custom properties as well handling `ios_qualtrics` feature flag.

# 🤔 Why

We need additional custom properties in order to do more granular filtering for Qualtrics intercepts. We only want to show surveys to logged in, English-language users.

# 🛠 How

- Added the custom properties.
- Added the feature flag.
- Added tests.

# ✅ Acceptance criteria

- [x] As a logged in user the Qualtrics SDK should be configured (observe console).
- [ ] As a logged out user the Qualtrics SDK should be _not_ configured (observe console).

# ⏰ TODO

- [ ] Merge Feature Flag (https://github.com/kickstarter/kickstarter/pull/18486).