### PR TITLE
[NT-645] Adding category_id and removing rewards and updates counts

### DIFF
--- a/Library/Tracking/Koala.swift
+++ b/Library/Tracking/Koala.swift
@@ -2111,7 +2111,7 @@ private func projectProperties(
 
   props["backers_count"] = project.stats.backersCount
   props["subcategory"] = project.category.name
-  props["subcategory_id"] = project.category.intID
+  props["subcategory_id"] = project.category.id
   props["country"] = project.country.countryCode
   props["comments_count"] = project.stats.commentsCount ?? 0
   props["currency"] = project.country.currencyCode
@@ -2123,7 +2123,7 @@ private func projectProperties(
   props["name"] = project.name
   props["pid"] = project.id
   props["category"] = project.category.parent?.name
-  props["category_id"] = project.category.parent?.intID
+  props["category_id"] = project.category.parentId
   props["percent_raised"] = project.stats.fundingProgress
   props["state"] = project.state.rawValue
   props["static_usd_rate"] = project.stats.staticUsdRate

--- a/Library/Tracking/Koala.swift
+++ b/Library/Tracking/Koala.swift
@@ -2111,6 +2111,7 @@ private func projectProperties(
 
   props["backers_count"] = project.stats.backersCount
   props["subcategory"] = project.category.name
+  props["subcategory_id"] = project.category.intID
   props["country"] = project.country.countryCode
   props["comments_count"] = project.stats.commentsCount ?? 0
   props["currency"] = project.country.currencyCode
@@ -2122,6 +2123,7 @@ private func projectProperties(
   props["name"] = project.name
   props["pid"] = project.id
   props["category"] = project.category.parent?.name
+  props["category_id"] = project.category.parent?.intID
   props["percent_raised"] = project.stats.fundingProgress
   props["state"] = project.state.rawValue
   props["static_usd_rate"] = project.stats.staticUsdRate
@@ -2129,9 +2131,7 @@ private func projectProperties(
   props["current_pledge_amount_usd"] = project.stats.pledgedUsd
   props["goal_usd"] = project.stats.goalUsd
   props["has_video"] = project.video != nil
-  props["updates_count"] = project.stats.updatesCount
   props["prelaunch_activated"] = project.prelaunchActivated
-  props["rewards_count"] = project.rewards.count
 
   let now = dateType.init().date
   props["hours_remaining"] = project.dates.hoursRemaining(from: now, using: calendar)

--- a/Library/Tracking/KoalaTests.swift
+++ b/Library/Tracking/KoalaTests.swift
@@ -158,7 +158,9 @@ final class KoalaTests: TestCase {
     let client = MockTrackingClient()
     let koala = Koala(client: client, loggedInUser: nil)
     let project = Project.template
-      |> Project.lens.category .~ .illustration
+      |> Project.lens.category .~ (Category.illustration
+        |> Category.lens.id .~ "123"
+        |> Category.lens.parentId .~ "321" )
       |> Project.lens.stats.staticUsdRate .~ 2
       |> Project.lens.stats.commentsCount .~ 10
       |> Project.lens.prelaunchActivated .~ true
@@ -177,9 +179,9 @@ final class KoalaTests: TestCase {
     XCTAssertEqual(project.id, properties?["project_pid"] as? Int)
     XCTAssertEqual(project.stats.fundingProgress, properties?["project_percent_raised"] as? Float)
     XCTAssertEqual(project.category.name, properties?["project_subcategory"] as? String)
-    XCTAssertEqual(22, properties?["project_subcategory_id"] as? Int)
+    XCTAssertEqual("123", properties?["project_subcategory_id"] as? String)
     XCTAssertEqual("Art", properties?["project_category"] as? String)
-    XCTAssertEqual(1, properties?["project_category_id"] as? Int)
+    XCTAssertEqual("321", properties?["project_category_id"] as? String)
     XCTAssertEqual(project.location.name, properties?["project_location"] as? String)
     XCTAssertEqual(project.creator.id, properties?["project_creator_uid"] as? Int)
     XCTAssertEqual(24 * 15, properties?["project_hours_remaining"] as? Int)

--- a/Library/Tracking/KoalaTests.swift
+++ b/Library/Tracking/KoalaTests.swift
@@ -158,6 +158,7 @@ final class KoalaTests: TestCase {
     let client = MockTrackingClient()
     let koala = Koala(client: client, loggedInUser: nil)
     let project = Project.template
+      |> Project.lens.category .~ .illustration
       |> Project.lens.stats.staticUsdRate .~ 2
       |> Project.lens.stats.commentsCount .~ 10
       |> Project.lens.prelaunchActivated .~ true
@@ -175,9 +176,10 @@ final class KoalaTests: TestCase {
     XCTAssertEqual(project.stats.goal, properties?["project_goal"] as? Int)
     XCTAssertEqual(project.id, properties?["project_pid"] as? Int)
     XCTAssertEqual(project.stats.fundingProgress, properties?["project_percent_raised"] as? Float)
-    XCTAssertEqual(project.stats.updatesCount, properties?["project_updates_count"] as? Int)
     XCTAssertEqual(project.category.name, properties?["project_subcategory"] as? String)
-    XCTAssertEqual(project.category._parent?.name, properties?["project_category"] as? String)
+    XCTAssertEqual(22, properties?["project_subcategory_id"] as? Int)
+    XCTAssertEqual("Art", properties?["project_category"] as? String)
+    XCTAssertEqual(1, properties?["project_category_id"] as? Int)
     XCTAssertEqual(project.location.name, properties?["project_location"] as? String)
     XCTAssertEqual(project.creator.id, properties?["project_creator_uid"] as? Int)
     XCTAssertEqual(24 * 15, properties?["project_hours_remaining"] as? Int)
@@ -192,13 +194,12 @@ final class KoalaTests: TestCase {
     XCTAssertEqual(true, properties?["project_has_video"] as? Bool)
     XCTAssertEqual(10, properties?["project_comments_count"] as? Int)
     XCTAssertEqual(true, properties?["project_prelaunch_activated"] as? Bool)
-    XCTAssertEqual(0, properties?["project_rewards_count"] as? Int)
 
     XCTAssertEqual(false, properties?["project_user_is_project_creator"] as? Bool)
     XCTAssertNil(properties?["project_user_is_backer"])
     XCTAssertNil(properties?["project_user_has_starred"])
 
-    XCTAssertEqual(25, properties?.keys.filter { $0.hasPrefix("project_") }.count)
+    XCTAssertEqual(26, properties?.keys.filter { $0.hasPrefix("project_") }.count)
 
     XCTAssertEqual("discovery", properties?["session_ref_tag"] as? String)
     XCTAssertEqual("recommended", properties?["session_referrer_credit"] as? String)
@@ -222,7 +223,7 @@ final class KoalaTests: TestCase {
     XCTAssertEqual(false, properties?["project_user_is_backer"] as? Bool)
     XCTAssertEqual(false, properties?["project_user_has_watched"] as? Bool)
 
-    XCTAssertEqual(26, properties?.keys.filter { $0.hasPrefix("project_") }.count)
+    XCTAssertEqual(25, properties?.keys.filter { $0.hasPrefix("project_") }.count)
   }
 
   func testProjectProperties_LoggedInBacker() {
@@ -242,7 +243,7 @@ final class KoalaTests: TestCase {
     XCTAssertEqual(true, properties?["project_user_is_backer"] as? Bool)
     XCTAssertEqual(false, properties?["project_user_has_watched"] as? Bool)
 
-    XCTAssertEqual(26, properties?.keys.filter { $0.hasPrefix("project_") }.count)
+    XCTAssertEqual(25, properties?.keys.filter { $0.hasPrefix("project_") }.count)
   }
 
   func testProjectProperties_LoggedInStarrer() {
@@ -262,7 +263,7 @@ final class KoalaTests: TestCase {
     XCTAssertEqual(false, properties?["project_user_is_backer"] as? Bool)
     XCTAssertEqual(true, properties?["project_user_has_watched"] as? Bool)
 
-    XCTAssertEqual(26, properties?.keys.filter { $0.hasPrefix("project_") }.count)
+    XCTAssertEqual(25, properties?.keys.filter { $0.hasPrefix("project_") }.count)
   }
 
   func testProjectProperties_LoggedInCreator() {
@@ -282,7 +283,7 @@ final class KoalaTests: TestCase {
     XCTAssertEqual(false, properties?["project_user_is_backer"] as? Bool)
     XCTAssertEqual(false, properties?["project_user_has_watched"] as? Bool)
 
-    XCTAssertEqual(26, properties?.keys.filter { $0.hasPrefix("project_") }.count)
+    XCTAssertEqual(25, properties?.keys.filter { $0.hasPrefix("project_") }.count)
   }
 
   func testDiscoveryProperties() {


### PR DESCRIPTION
# 📲 What

Adds `category` and `subcategory` `id`s to project properties, and removes `rewards_count` and `updates_count` since we don't have that data at the point of tracking – we'll add these back in the near future.

# 🤔 Why

Clean up of tracking events.

# 🛠 How

More in-depth discussion of the change or implementation.

# ✅ Acceptance criteria

- [x] Navigate to a sub-category (ex. Ceramics). Then, select a project. You should see the `project_category_id` and `project_subcategory_id` properties. You should not see `project_rewards_count` or `project_updates_count`
