### PR TITLE
[NT-719] Pledge properties

### DIFF
--- a/Library/Tracking/Koala.swift
+++ b/Library/Tracking/Koala.swift
@@ -572,7 +572,7 @@ public final class Koala {
     )
   }
 
-  // MARK: - Checkout Events
+  // MARK: - Pledge Events
 
   public func trackPledgeCTAButtonClicked(
     stateType: PledgeStateCTAType,
@@ -625,20 +625,20 @@ public final class Koala {
     self.track(event: "Manage Pledge Option Clicked", properties: props)
   }
 
-  public func trackSelectRewardButtonClicked(
+  public func trackRewardClicked(
     project: Project,
-    reward: Reward?,
+    reward: Reward,
     backing: Backing?,
     screen: CheckoutContext
   ) {
     let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
+      .withAllValuesFrom(pledgeProperties(from: reward))
       .withAllValuesFrom([
-        "screen": screen.trackingString,
-        "backer_reward_minimum": reward?.minimum as Any,
+        "pledge_context": screen.trackingString,
         "pledge_total": backing?.amount as Any
       ])
 
-    self.track(event: "Select Reward Button Clicked", properties: props)
+    self.track(event: "Reward Clicked", properties: props)
   }
 
   public func trackPledgeScreenViewed(project: Project) {
@@ -666,7 +666,7 @@ public final class Koala {
     pledgeContext: PledgeContext
   ) {
     let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
-      .withAllValuesFrom(properties(reward: reward))
+      .withAllValuesFrom(pledgeProperties(from: reward))
       .withAllValuesFrom(["pledge_context": pledgeContext.trackingString])
 
     self.track(event: "Checkout Cancel", properties: props.withAllValuesFrom(deprecatedProps))
@@ -681,7 +681,7 @@ public final class Koala {
     pledgeContext: PledgeContext
   ) {
     let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
-      .withAllValuesFrom(properties(reward: reward))
+      .withAllValuesFrom(pledgeProperties(from: reward))
       .withAllValuesFrom([
         "pledge_context": pledgeContext.trackingString,
         "type": buttonType.trackingString,
@@ -709,7 +709,7 @@ public final class Koala {
     extraProps["payment_method"] = paymentMethod?.trackingString
 
     let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
-      .withAllValuesFrom(properties(reward: reward))
+      .withAllValuesFrom(pledgeProperties(from: reward))
       .withAllValuesFrom(extraProps)
 
     self.track(event: "Errored Reward Pledge Button Click", properties: props)
@@ -717,7 +717,7 @@ public final class Koala {
 
   public func trackChangedPledgeAmount(_ project: Project, reward: Reward, pledgeContext: PledgeContext) {
     let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
-      .withAllValuesFrom(properties(reward: reward))
+      .withAllValuesFrom(pledgeProperties(from: reward))
       .withAllValuesFrom(["pledge_context": pledgeContext.trackingString])
 
     self.track(event: "Checkout Amount Changed", properties: props.withAllValuesFrom(deprecatedProps))
@@ -731,7 +731,7 @@ public final class Koala {
     pledgeContext: PledgeContext
   ) {
     let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
-      .withAllValuesFrom(properties(reward: reward))
+      .withAllValuesFrom(pledgeProperties(from: reward))
       .withAllValuesFrom(["pledge_context": pledgeContext.trackingString])
 
     self.track(event: "Checkout Location Changed", properties: props.withAllValuesFrom(deprecatedProps))
@@ -741,7 +741,7 @@ public final class Koala {
 
   public func trackSelectedReward(project: Project, reward: Reward, pledgeContext: PledgeContext) {
     let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
-      .withAllValuesFrom(properties(reward: reward))
+      .withAllValuesFrom(pledgeProperties(from: reward))
       .withAllValuesFrom(["pledge_context": pledgeContext.trackingString])
 
     self.track(event: "Reward Checkout", properties: props.withAllValuesFrom(deprecatedProps))
@@ -751,7 +751,7 @@ public final class Koala {
 
   public func trackClosedReward(project: Project, reward: Reward, pledgeContext: PledgeContext) {
     let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
-      .withAllValuesFrom(properties(reward: reward))
+      .withAllValuesFrom(pledgeProperties(from: reward))
       .withAllValuesFrom(["pledge_context": pledgeContext.trackingString])
 
     self.track(event: "Closed Reward", properties: props)
@@ -1828,7 +1828,7 @@ public final class Koala {
     pledgeContext: PledgeContext
   ) {
     let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
-      .withAllValuesFrom(properties(reward: reward))
+      .withAllValuesFrom(pledgeProperties(from: reward))
       .withAllValuesFrom(["pledge_context": pledgeContext.trackingString])
 
     // deprecated
@@ -1846,7 +1846,7 @@ public final class Koala {
     pledgeContext: PledgeContext
   ) {
     let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
-      .withAllValuesFrom(properties(reward: reward))
+      .withAllValuesFrom(pledgeProperties(from: reward))
       .withAllValuesFrom(["pledge_context": pledgeContext.trackingString])
 
     // deprecated
@@ -1861,7 +1861,7 @@ public final class Koala {
     pledgeContext: PledgeContext
   ) {
     let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
-      .withAllValuesFrom(properties(reward: reward))
+      .withAllValuesFrom(pledgeProperties(from: reward))
       .withAllValuesFrom(["pledge_context": pledgeContext.trackingString])
 
     self.track(event: "Apple Pay Stripe Token Created", properties: props.withAllValuesFrom(deprecatedProps))
@@ -1875,7 +1875,7 @@ public final class Koala {
     pledgeContext: PledgeContext
   ) {
     let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
-      .withAllValuesFrom(properties(reward: reward))
+      .withAllValuesFrom(pledgeProperties(from: reward))
       .withAllValuesFrom(["pledge_context": pledgeContext.trackingString])
 
     self.track(event: "Apple Pay Stripe Token Errored", properties: props.withAllValuesFrom(deprecatedProps))
@@ -1889,7 +1889,7 @@ public final class Koala {
     pledgeContext: PledgeContext
   ) {
     let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
-      .withAllValuesFrom(properties(reward: reward))
+      .withAllValuesFrom(pledgeProperties(from: reward))
       .withAllValuesFrom(["pledge_context": pledgeContext.trackingString])
 
     self.track(event: "Apple Pay Finished", properties: props.withAllValuesFrom(deprecatedProps))
@@ -1901,7 +1901,7 @@ public final class Koala {
     pledgeContext: PledgeContext
   ) {
     let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
-      .withAllValuesFrom(properties(reward: reward))
+      .withAllValuesFrom(pledgeProperties(from: reward))
       .withAllValuesFrom(["pledge_context": pledgeContext.trackingString])
     self.track(event: "Apple Pay Canceled", properties: props.withAllValuesFrom(deprecatedProps))
 
@@ -1923,7 +1923,7 @@ public final class Koala {
     pledgeContext: PledgeContext
   ) {
     let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
-      .withAllValuesFrom(properties(reward: reward))
+      .withAllValuesFrom(pledgeProperties(from: reward))
       .withAllValuesFrom(["pledge_context": pledgeContext.trackingString])
 
     self.track(event: "Expanded Reward Description", properties: props)
@@ -1935,7 +1935,7 @@ public final class Koala {
     pledgeContext: PledgeContext
   ) {
     let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
-      .withAllValuesFrom(properties(reward: reward))
+      .withAllValuesFrom(pledgeProperties(from: reward))
       .withAllValuesFrom(["pledge_context": pledgeContext.trackingString])
 
     self.track(event: "Expanded Unavailable Reward", properties: props)
@@ -2180,6 +2180,23 @@ private func properties(userActivity: NSUserActivity) -> [String: Any] {
   return props
 }
 
+// MARK: - Pledge Properties
+
+private func pledgeProperties(from reward: Reward, prefix: String = "pledge_backer_reward_")
+  -> [String: Any] {
+  var result: [String: Any] = [:]
+
+  result["has_items"] = !reward.rewardsItems.isEmpty
+  result["id"] = reward.id
+  result["is_limited_quantity"] = reward.limit != nil
+  result["is_limited_time"] = reward.endsAt != nil
+  result["minimum"] = reward.minimum
+  result["shipping_enabled"] = reward.shipping.enabled
+  result["shipping_preference"] = reward.shipping.preference?.trackingString
+
+  return result.prefixedKeys(prefix)
+}
+
 // MARK: - Discovery Properties
 
 private func discoveryProperties(
@@ -2248,22 +2265,6 @@ private func properties(
   }
 
   return result
-}
-
-private func properties(reward: Reward, prefix: String = "backer_reward_") -> [String: Any] {
-  guard reward != Reward.noReward else { return [:] }
-
-  var result: [String: Any] = [:]
-
-  result["id"] = reward.id
-  result["is_limited_quantity"] = reward.limit == nil
-  // result["is_limited_time"] = // implement when reward scheduling is supported
-  result["minimum"] = reward.minimum
-  result["shipping_enabled"] = reward.shipping.enabled
-  result["shipping_preference"] = reward.shipping.preference?.trackingString
-  result["has_items"] = !reward.rewardsItems.isEmpty
-
-  return result.prefixedKeys(prefix)
 }
 
 private func shareTypeProperty(_ shareType: UIActivity.ActivityType?) -> String? {

--- a/Library/Tracking/Koala.swift
+++ b/Library/Tracking/Koala.swift
@@ -628,14 +628,12 @@ public final class Koala {
   public func trackRewardClicked(
     project: Project,
     reward: Reward,
-    backing: Backing?,
     screen: CheckoutContext
   ) {
     let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
       .withAllValuesFrom(pledgeProperties(from: reward))
       .withAllValuesFrom([
-        "pledge_context": screen.trackingString,
-        "pledge_total": backing?.amount as Any
+        "pledge_context": screen.trackingString
       ])
 
     self.track(event: "Reward Clicked", properties: props)

--- a/Library/Tracking/Koala.swift
+++ b/Library/Tracking/Koala.swift
@@ -636,7 +636,7 @@ public final class Koala {
         "pledge_context": screen.trackingString
       ])
 
-    self.track(event: "Reward Clicked", properties: props)
+    self.track(event: "Select Reward Button Clicked", properties: props)
   }
 
   public func trackPledgeScreenViewed(project: Project) {

--- a/Library/Tracking/KoalaTests.swift
+++ b/Library/Tracking/KoalaTests.swift
@@ -164,7 +164,7 @@ final class KoalaTests: TestCase {
     let project = Project.template
       |> Project.lens.category .~ (Category.illustration
         |> Category.lens.id .~ "123"
-        |> Category.lens.parentId .~ "321" )
+        |> Category.lens.parentId .~ "321")
       |> Project.lens.stats.staticUsdRate .~ 2
       |> Project.lens.stats.commentsCount .~ 10
       |> Project.lens.prelaunchActivated .~ true

--- a/Library/Tracking/KoalaTests.swift
+++ b/Library/Tracking/KoalaTests.swift
@@ -6,6 +6,8 @@ import ReactiveExtensions_TestHelpers
 import XCTest
 
 final class KoalaTests: TestCase {
+  // MARK: - Session Properties Tests
+
   func testSessionProperties() {
     let bundle = MockBundle()
     let client = MockTrackingClient()
@@ -154,7 +156,9 @@ final class KoalaTests: TestCase {
     XCTAssertEqual("Face Down", props?["session_device_orientation"] as? String)
   }
 
-  func testTrackProject() {
+  // MARK: - Project Properties Tests
+
+  func testProjectProperties() {
     let client = MockTrackingClient()
     let koala = Koala(client: client, loggedInUser: nil)
     let project = Project.template
@@ -288,6 +292,8 @@ final class KoalaTests: TestCase {
     XCTAssertEqual(25, properties?.keys.filter { $0.hasPrefix("project_") }.count)
   }
 
+  // MARK: - Discovery Properties Tests
+
   func testDiscoveryProperties() {
     let client = MockTrackingClient()
     let params = .defaults
@@ -376,6 +382,67 @@ final class KoalaTests: TestCase {
     XCTAssertNil(properties?["discover_search_term"])
     XCTAssertEqual(true, properties?["discover_everything"] as? Bool)
     XCTAssertEqual("magic", properties?["discover_sort"] as? String)
+  }
+
+  // MARK: - Pledge Properties Tests
+
+  func testPledgeProperties() {
+    let client = MockTrackingClient()
+    let koala = Koala(client: client)
+
+    let project = Project.cosmicSurgery
+    let reward = Reward.template
+
+    koala.trackRewardClicked(project: project, reward: reward, backing: nil, screen: .backThisPage)
+
+    let props = client.properties.last
+
+    XCTAssertEqual(false, props?["pledge_backer_reward_has_items"] as? Bool)
+    XCTAssertEqual(1, props?["pledge_backer_reward_id"] as? Int)
+    XCTAssertEqual(true, props?["pledge_backer_reward_is_limited_quantity"] as? Bool)
+    XCTAssertEqual(false, props?["pledge_backer_reward_is_limited_time"] as? Bool)
+    XCTAssertEqual(10.00, props?["pledge_backer_reward_minimum"] as? Double)
+    XCTAssertEqual(false, props?["pledge_backer_reward_shipping_enabled"] as? Bool)
+
+    XCTAssertNil(props?["pledge_backer_reward_shipping_preference"] as? String)
+  }
+
+  func testPledgeProperties_NoReward() {
+    let client = MockTrackingClient()
+    let koala = Koala(client: client)
+
+    let project = Project.cosmicSurgery
+    let reward = Reward.noReward
+      |> Reward.lens.minimum .~ 5.0
+
+    koala.trackRewardClicked(project: project, reward: reward, backing: nil, screen: .backThisPage)
+
+    let props = client.properties.last
+
+    XCTAssertEqual(false, props?["pledge_backer_reward_has_items"] as? Bool)
+    XCTAssertEqual(0, props?["pledge_backer_reward_id"] as? Int)
+    XCTAssertEqual(false, props?["pledge_backer_reward_is_limited_quantity"] as? Bool)
+    XCTAssertEqual(false, props?["pledge_backer_reward_is_limited_time"] as? Bool)
+    XCTAssertEqual(5.00, props?["pledge_backer_reward_minimum"] as? Double)
+    XCTAssertEqual(false, props?["pledge_backer_reward_shipping_enabled"] as? Bool)
+
+    XCTAssertNil(props?["pledge_backer_reward_shipping_preference"] as? String)
+  }
+
+  func testPledgeProperties_ShippingPreference() {
+    let client = MockTrackingClient()
+    let koala = Koala(client: client)
+
+    let project = Project.cosmicSurgery
+    let reward = Reward.template
+      |> Reward.lens.shipping .~ (Reward.Shipping.template
+        |> Reward.Shipping.lens.preference .~ Reward.Shipping.Preference.restricted)
+
+    koala.trackRewardClicked(project: project, reward: reward, backing: nil, screen: .backThisPage)
+
+    let props = client.properties.last
+
+    XCTAssertEqual("restricted", props?["pledge_backer_reward_shipping_preference"] as? String)
   }
 
   func testTrackViewedPaymentMethods() {
@@ -627,7 +694,7 @@ final class KoalaTests: TestCase {
 
     let koala = Koala(client: client, loggedInUser: loggedInUser)
 
-    koala.trackSelectRewardButtonClicked(
+    koala.trackRewardClicked(
       project: project,
       reward: reward,
       backing: backing,
@@ -636,8 +703,8 @@ final class KoalaTests: TestCase {
 
     let properties = client.properties.last
 
-    XCTAssertEqual(["Select Reward Button Clicked"], client.events)
-    XCTAssertEqual("Back this page", properties?["screen"] as? String)
+    XCTAssertEqual(["Reward Clicked"], client.events)
+    XCTAssertEqual("Back this page", properties?["pledge_context"] as? String)
   }
 
   func testTrackCancelPledgeButtonClicked() {

--- a/Library/Tracking/KoalaTests.swift
+++ b/Library/Tracking/KoalaTests.swift
@@ -393,7 +393,7 @@ final class KoalaTests: TestCase {
     let project = Project.cosmicSurgery
     let reward = Reward.template
 
-    koala.trackRewardClicked(project: project, reward: reward, backing: nil, screen: .backThisPage)
+    koala.trackRewardClicked(project: project, reward: reward, screen: .backThisPage)
 
     let props = client.properties.last
 
@@ -415,7 +415,7 @@ final class KoalaTests: TestCase {
     let reward = Reward.noReward
       |> Reward.lens.minimum .~ 5.0
 
-    koala.trackRewardClicked(project: project, reward: reward, backing: nil, screen: .backThisPage)
+    koala.trackRewardClicked(project: project, reward: reward, screen: .backThisPage)
 
     let props = client.properties.last
 
@@ -438,7 +438,7 @@ final class KoalaTests: TestCase {
       |> Reward.lens.shipping .~ (Reward.Shipping.template
         |> Reward.Shipping.lens.preference .~ Reward.Shipping.Preference.restricted)
 
-    koala.trackRewardClicked(project: project, reward: reward, backing: nil, screen: .backThisPage)
+    koala.trackRewardClicked(project: project, reward: reward, screen: .backThisPage)
 
     let props = client.properties.last
 
@@ -686,10 +686,7 @@ final class KoalaTests: TestCase {
   func testTrackSelectRewardButtonClicked() {
     let client = MockTrackingClient()
     let reward = Reward.template
-    let backing = .template
-      |> Backing.lens.reward .~ reward
-    let project = .template
-      |> Project.lens.personalization.backing .~ backing
+    let project = Project.template
     let loggedInUser = User.template |> \.id .~ 42
 
     let koala = Koala(client: client, loggedInUser: loggedInUser)
@@ -697,13 +694,12 @@ final class KoalaTests: TestCase {
     koala.trackRewardClicked(
       project: project,
       reward: reward,
-      backing: backing,
       screen: .backThisPage
     )
 
     let properties = client.properties.last
 
-    XCTAssertEqual(["Reward Clicked"], client.events)
+    XCTAssertEqual(["Select Reward Button Clicked"], client.events)
     XCTAssertEqual("Back this page", properties?["pledge_context"] as? String)
   }
 

--- a/Library/ViewModels/DeprecatedRewardPledgeViewModelTests.swift
+++ b/Library/ViewModels/DeprecatedRewardPledgeViewModelTests.swift
@@ -1936,7 +1936,7 @@ internal final class DeprecatedRewardPledgeViewModelTests: TestCase {
     )
     XCTAssertEqual(
       [reward.id, reward.id, reward.id, reward.id, reward.id, reward.id],
-      self.trackingClient.properties(forKey: "backer_reward_id", as: Int.self)
+      self.trackingClient.properties(forKey: "pledge_backer_reward_id", as: Int.self)
     )
   }
 

--- a/Library/ViewModels/RewardCardContainerViewModel.swift
+++ b/Library/ViewModels/RewardCardContainerViewModel.swift
@@ -84,7 +84,6 @@ public final class RewardCardContainerViewModel: RewardCardContainerViewModelTyp
         AppEnvironment.current.koala.trackRewardClicked(
           project: project,
           reward: reward,
-          backing: nil,
           screen: .backThisPage
         )
       }

--- a/Library/ViewModels/RewardCardContainerViewModel.swift
+++ b/Library/ViewModels/RewardCardContainerViewModel.swift
@@ -78,14 +78,13 @@ public final class RewardCardContainerViewModel: RewardCardContainerViewModelTyp
       .map { $0.id }
 
     // Tracking
-    projectAndRewardOrBacking
+    projectAndReward
       .takeWhen(self.pledgeButtonTappedProperty.signal)
-      .observeValues { projectAndRewardOrBacking in
-        let (project, rewardOrBacking) = projectAndRewardOrBacking
-        AppEnvironment.current.koala.trackSelectRewardButtonClicked(
+      .observeValues { project, reward in
+        AppEnvironment.current.koala.trackRewardClicked(
           project: project,
-          reward: rewardOrBacking.left,
-          backing: rewardOrBacking.right,
+          reward: reward,
+          backing: nil,
           screen: .backThisPage
         )
       }

--- a/Library/ViewModels/RewardCardContainerViewModelTests.swift
+++ b/Library/ViewModels/RewardCardContainerViewModelTests.swift
@@ -813,7 +813,7 @@ final class RewardCardContainerViewModelTests: TestCase {
 
       self.vm.inputs.pledgeButtonTapped()
 
-      XCTAssertEqual(["Reward Clicked"], client.events)
+      XCTAssertEqual(["Select Reward Button Clicked"], client.events)
     }
   }
 

--- a/Library/ViewModels/RewardCardContainerViewModelTests.swift
+++ b/Library/ViewModels/RewardCardContainerViewModelTests.swift
@@ -813,7 +813,7 @@ final class RewardCardContainerViewModelTests: TestCase {
 
       self.vm.inputs.pledgeButtonTapped()
 
-      XCTAssertEqual(["Select Reward Button Clicked"], client.events)
+      XCTAssertEqual(["Reward Clicked"], client.events)
     }
   }
 


### PR DESCRIPTION
#📲 What

Adds pledge properties as per the new specs.

# 🤔 Why

Event cleanup.

# 🛠 How

Created a new `pledgeProperties` function to match the updated specs.

# ♿️ Accessibility 

N/A

# 🏎 Performance

N/A

# ✅ Acceptance criteria

When testing events, make sure the environment variable `KOALA_TRACKING` is set to `true`.

Testing `No Reward`
Navigate to any project, and select the "No reward" option from the rewards carousel. In the console, you should see the event `Select Reward Button Clicked` tracked with the following properties:

- [x] `pledge_backer_reward_id` // should be 0 for no reward
- [x] `pledge_backer_reward_has_items` // should be `false` for no reward
- [x] `pledge_backer_reward_is_limited_quantity` // should be `false` for no reward
- [x] `pledge_backer_reward_is_limited_time` // should be `false` for no reward
- [x] `pledge_backer_reward_minimum`
- [x] `pledge_backer_reward_shipping_enabled` // should be `false` for no reward

Testing `Reward`
Navigate to any project, and select a reward option from the rewards carousel that not `No reward`. In the console, you should see the event `Select Reward Button Clicked` tracked event with the following properties:

- [x] `pledge_backer_reward_id`
- [x] `pledge_backer_reward_has_items`
- [x] `pledge_backer_reward_is_limited_quantity` // should be `true` if reward is limited in quantity
- [x] `pledge_backer_reward_is_limited_time` // should be `true` if reward is limited in time
- [x] `pledge_backer_reward_minimum` // should be the reward's minimum in the project's currency
- [x] `pledge_backer_reward_shipping_enabled`
- [x] `pledge_backer_reward_shipping_preference` // could be `none`, `restricted` or `unrestricted` depending on the reward's shipping preferences
