### PR TITLE
[NT-721] Updating Project Page Viewed event timing

### DIFF
--- a/Library/Tracking/Koala.swift
+++ b/Library/Tracking/Koala.swift
@@ -2132,6 +2132,8 @@ private func projectProperties(
   props["goal_usd"] = project.stats.goalUsd
   props["has_video"] = project.video != nil
   props["prelaunch_activated"] = project.prelaunchActivated
+  props["rewards_count"] = project.rewards.count
+  props["updates_count"] = project.stats.updatesCount
 
   let now = dateType.init().date
   props["hours_remaining"] = project.dates.hoursRemaining(from: now, using: calendar)

--- a/Library/Tracking/KoalaTests.swift
+++ b/Library/Tracking/KoalaTests.swift
@@ -158,6 +158,7 @@ final class KoalaTests: TestCase {
     let client = MockTrackingClient()
     let koala = Koala(client: client, loggedInUser: nil)
     let project = Project.template
+      |> Project.lens.rewards .~ [Reward.template]
       |> Project.lens.category .~ (Category.illustration
         |> Category.lens.id .~ "123"
         |> Category.lens.parentId .~ "321" )
@@ -196,12 +197,14 @@ final class KoalaTests: TestCase {
     XCTAssertEqual(true, properties?["project_has_video"] as? Bool)
     XCTAssertEqual(10, properties?["project_comments_count"] as? Int)
     XCTAssertEqual(true, properties?["project_prelaunch_activated"] as? Bool)
+    XCTAssertEqual(1, properties?["project_rewards_count"] as? Int)
+    XCTAssertEqual(1, properties?["project_updates_count"] as? Int)
 
     XCTAssertEqual(false, properties?["project_user_is_project_creator"] as? Bool)
     XCTAssertNil(properties?["project_user_is_backer"])
     XCTAssertNil(properties?["project_user_has_starred"])
 
-    XCTAssertEqual(26, properties?.keys.filter { $0.hasPrefix("project_") }.count)
+    XCTAssertEqual(28, properties?.keys.filter { $0.hasPrefix("project_") }.count)
 
     XCTAssertEqual("discovery", properties?["session_ref_tag"] as? String)
     XCTAssertEqual("recommended", properties?["session_referrer_credit"] as? String)
@@ -225,7 +228,7 @@ final class KoalaTests: TestCase {
     XCTAssertEqual(false, properties?["project_user_is_backer"] as? Bool)
     XCTAssertEqual(false, properties?["project_user_has_watched"] as? Bool)
 
-    XCTAssertEqual(25, properties?.keys.filter { $0.hasPrefix("project_") }.count)
+    XCTAssertEqual(27, properties?.keys.filter { $0.hasPrefix("project_") }.count)
   }
 
   func testProjectProperties_LoggedInBacker() {
@@ -245,7 +248,7 @@ final class KoalaTests: TestCase {
     XCTAssertEqual(true, properties?["project_user_is_backer"] as? Bool)
     XCTAssertEqual(false, properties?["project_user_has_watched"] as? Bool)
 
-    XCTAssertEqual(25, properties?.keys.filter { $0.hasPrefix("project_") }.count)
+    XCTAssertEqual(27, properties?.keys.filter { $0.hasPrefix("project_") }.count)
   }
 
   func testProjectProperties_LoggedInStarrer() {
@@ -265,7 +268,7 @@ final class KoalaTests: TestCase {
     XCTAssertEqual(false, properties?["project_user_is_backer"] as? Bool)
     XCTAssertEqual(true, properties?["project_user_has_watched"] as? Bool)
 
-    XCTAssertEqual(25, properties?.keys.filter { $0.hasPrefix("project_") }.count)
+    XCTAssertEqual(27, properties?.keys.filter { $0.hasPrefix("project_") }.count)
   }
 
   func testProjectProperties_LoggedInCreator() {
@@ -285,7 +288,7 @@ final class KoalaTests: TestCase {
     XCTAssertEqual(false, properties?["project_user_is_backer"] as? Bool)
     XCTAssertEqual(false, properties?["project_user_has_watched"] as? Bool)
 
-    XCTAssertEqual(25, properties?.keys.filter { $0.hasPrefix("project_") }.count)
+    XCTAssertEqual(27, properties?.keys.filter { $0.hasPrefix("project_") }.count)
   }
 
   func testDiscoveryProperties() {

--- a/Library/Tracking/KoalaTests.swift
+++ b/Library/Tracking/KoalaTests.swift
@@ -161,7 +161,7 @@ final class KoalaTests: TestCase {
       |> Project.lens.rewards .~ [Reward.template]
       |> Project.lens.category .~ (Category.illustration
         |> Category.lens.id .~ "123"
-        |> Category.lens.parentId .~ "321" )
+        |> Category.lens.parentId .~ "321")
       |> Project.lens.stats.staticUsdRate .~ 2
       |> Project.lens.stats.commentsCount .~ 10
       |> Project.lens.prelaunchActivated .~ true

--- a/Library/ViewModels/ProjectPamphletViewModel.swift
+++ b/Library/ViewModels/ProjectPamphletViewModel.swift
@@ -189,14 +189,17 @@ public final class ProjectPamphletViewModel: ProjectPamphletViewModelType, Proje
       }
       .take(first: 1)
 
-    Signal.combineLatest(
-      freshProjectAndRefTag,
-      cookieRefTag,
+    Signal.zip(
+      freshProjectAndRefTag.skip(first: 1),
       self.viewDidAppearAnimated.signal.ignoreValues()
     )
-    .map { (project: $0.0, refTag: $0.1, cookieRefTag: $1, _: $2) }
-    .take(first: 1)
-    .observeValues { project, refTag, cookieRefTag, _ in
+    .map(unpack)
+    .map { project, refTag, _ in
+      let cookieRefTag = cookieRefTagFor(project: project) ?? refTag
+      
+      return (project: project, refTag: refTag, cookieRefTag: cookieRefTag)
+    }
+    .observeValues { project, refTag, cookieRefTag in
       AppEnvironment.current.koala.trackProjectViewed(
         project,
         refTag: refTag,

--- a/Library/ViewModels/ProjectPamphletViewModel.swift
+++ b/Library/ViewModels/ProjectPamphletViewModel.swift
@@ -196,7 +196,7 @@ public final class ProjectPamphletViewModel: ProjectPamphletViewModelType, Proje
     .map(unpack)
     .map { project, refTag, _ in
       let cookieRefTag = cookieRefTagFor(project: project) ?? refTag
-      
+
       return (project: project, refTag: refTag, cookieRefTag: cookieRefTag)
     }
     .observeValues { project, refTag, cookieRefTag in

--- a/Library/ViewModels/ProjectPamphletViewModelTests.swift
+++ b/Library/ViewModels/ProjectPamphletViewModelTests.swift
@@ -213,36 +213,41 @@ final class ProjectPamphletViewModelTests: TestCase {
       "A single cookie has been set."
     )
   }
-  
+
   func testProjectPageViewed_Tracking_OnError() {
     let service = MockService(fetchProjectError: .couldNotParseJSON)
-    
+
     withEnvironment(apiService: service) {
       self.configureInitialState(.init(left: .template))
-      
+
       self.scheduler.advance()
-      
-      XCTAssertEqual([],
-                     self.trackingClient.events,
-                     "Project Page Viewed doesnt track if the request fails")
+
+      XCTAssertEqual(
+        [],
+        self.trackingClient.events,
+        "Project Page Viewed doesnt track if the request fails"
+      )
     }
   }
-  
+
   func testProjectPaveViewed_OnViewDidAppear() {
     self.configureInitialState(.init(left: .template))
-    
+
     self.scheduler.advance()
-    
-    XCTAssertEqual(["Project Page Viewed"],
-                   self.trackingClient.events)
-    
+
+    XCTAssertEqual(
+      ["Project Page Viewed"],
+      self.trackingClient.events
+    )
+
     self.vm.inputs.viewDidAppear(animated: true)
-    
+
     self.scheduler.advance()
-    
-    XCTAssertEqual(["Project Page Viewed", "Project Page Viewed"],
-                   self.trackingClient.events)
-    
+
+    XCTAssertEqual(
+      ["Project Page Viewed", "Project Page Viewed"],
+      self.trackingClient.events
+    )
   }
 
   func testMockCookieStorageSet_SeparateSchedulers() {


### PR DESCRIPTION
# 📲 What

Updates the logic of when the `Project Page Viewed` event fires so that we can track all project properties.

# 🤔 Why

Previously, we were firing the `Project Page Viewed` event right when the project page is configured. Because we prefix the `fetchProject` request with a partial project object, the `Project Page Viewed` event was being sent with incomplete `projectProperties`. 

Now, we wait for the `fetchProject` request to complete with the full project object before we track the `Project Page Viewed` event -- this allows us to send the event with all project properties.

# 🛠 How

Shuffling around the view model logic for the `Project Page Viewed` event.

# ✅ Acceptance criteria

Make sure you have the `KOALA_TRACKING` environment variable set to `true`

- [x] Navigate to any project. You should eventually see the `Project Page Viewed` event fire with the following properties populated:
    - `project_rewards_count` // should not be zero
    - `project_updates_count`
    - `project_comments_count`
- [x] Tap "Back this project" to navigate to the rewards carousel, then tap the X to close the rewards carousel. You should see the project page again and the `Project Page Viewed` event should fire again.