### PR TITLE
Configure OptimizelyLogLevel based on bundle type

### DIFF
--- a/Kickstarter-iOS/AppDelegate.swift
+++ b/Kickstarter-iOS/AppDelegate.swift
@@ -301,8 +301,8 @@ internal final class AppDelegate: UIResponder, UIApplicationDelegate {
 
   // MARK: - Functions
 
-  private func configureOptimizely(with key: String, logLevel: KSROptimizelyLogLevel) {
-    let optimizelyClient = OptimizelyClient(sdkKey: key, defaultLogLevel: logLevel.optimizelyLogLevel)
+  private func configureOptimizely(with key: String, logLevel: OptimizelyLogLevelType) {
+    let optimizelyClient = OptimizelyClient(sdkKey: key, defaultLogLevel: logLevel.logLevel)
 
     optimizelyClient.start { [weak self] result in
       let shouldUpdateClient = self?.viewModel.inputs.optimizelyConfigured(with: result)

--- a/Kickstarter-iOS/AppDelegate.swift
+++ b/Kickstarter-iOS/AppDelegate.swift
@@ -154,8 +154,8 @@ internal final class AppDelegate: UIResponder, UIApplicationDelegate {
 
     self.viewModel.outputs.configureOptimizely
       .observeForUI()
-      .observeValues { [weak self] key in
-        self?.configureOptimizely(with: key)
+      .observeValues { [weak self] key, logLevel in
+        self?.configureOptimizely(with: key, logLevel: logLevel)
       }
 
     self.viewModel.outputs.configureAppCenterWithData
@@ -301,8 +301,8 @@ internal final class AppDelegate: UIResponder, UIApplicationDelegate {
 
   // MARK: - Functions
 
-  private func configureOptimizely(with key: String) {
-    let optimizelyClient = OptimizelyClient(sdkKey: key)
+  private func configureOptimizely(with key: String, logLevel: KSROptimizelyLogLevel) {
+    let optimizelyClient = OptimizelyClient(sdkKey: key, defaultLogLevel: logLevel.optimizelyLogLevel)
 
     optimizelyClient.start { [weak self] result in
       let shouldUpdateClient = self?.viewModel.inputs.optimizelyConfigured(with: result)

--- a/Kickstarter-iOS/Library/Optimizely+OptimizelyClientType.swift
+++ b/Kickstarter-iOS/Library/Optimizely+OptimizelyClientType.swift
@@ -14,3 +14,14 @@ extension OptimizelyResult: OptimizelyResultType {
     }
   }
 }
+
+extension KSROptimizelyLogLevel {
+  public var optimizelyLogLevel: OptimizelyLogLevel {
+    switch self {
+    case .error:
+      return OptimizelyLogLevel.error
+    case .debug:
+      return OptimizelyLogLevel.debug
+    }
+  }
+}

--- a/Kickstarter-iOS/Library/Optimizely+OptimizelyClientType.swift
+++ b/Kickstarter-iOS/Library/Optimizely+OptimizelyClientType.swift
@@ -15,8 +15,8 @@ extension OptimizelyResult: OptimizelyResultType {
   }
 }
 
-extension KSROptimizelyLogLevel {
-  public var optimizelyLogLevel: OptimizelyLogLevel {
+extension OptimizelyLogLevelType {
+  public var logLevel: OptimizelyLogLevel {
     switch self {
     case .error:
       return OptimizelyLogLevel.error

--- a/Kickstarter-iOS/ViewModels/AppDelegateViewModel.swift
+++ b/Kickstarter-iOS/ViewModels/AppDelegateViewModel.swift
@@ -19,11 +19,6 @@ public enum NotificationAuthorizationStatus {
   case provisional
 }
 
-public enum KSROptimizelyLogLevel {
-  case error
-  case debug
-}
-
 public protocol AppDelegateViewModelInputs {
   /// Call when the application is handed off to.
   func applicationContinueUserActivity(_ userActivity: NSUserActivity) -> Bool
@@ -100,7 +95,7 @@ public protocol AppDelegateViewModelOutputs {
   var configureFabric: Signal<(), Never> { get }
 
   /// Emits when the application should configure Optimizely
-  var configureOptimizely: Signal<(String, KSROptimizelyLogLevel), Never> { get }
+  var configureOptimizely: Signal<(String, OptimizelyLogLevelType), Never> { get }
 
   /// Return this value in the delegate method.
   var continueUserActivityReturnValue: MutableProperty<Bool> { get }
@@ -745,7 +740,7 @@ public final class AppDelegateViewModel: AppDelegateViewModelType, AppDelegateVi
   public let applicationIconBadgeNumber: Signal<Int, Never>
   public let configureAppCenterWithData: Signal<AppCenterConfigData, Never>
   public let configureFabric: Signal<(), Never>
-  public let configureOptimizely: Signal<(String, KSROptimizelyLogLevel), Never>
+  public let configureOptimizely: Signal<(String, OptimizelyLogLevelType), Never>
   public let continueUserActivityReturnValue = MutableProperty(false)
   public let findRedirectUrl: Signal<URL, Never>
   public let forceLogout: Signal<(), Never>
@@ -959,9 +954,9 @@ extension ShortcutItem {
   }
 }
 
-private func optimizelyData(for environment: Environment) -> (String, KSROptimizelyLogLevel) {
+private func optimizelyData(for environment: Environment) -> (String, OptimizelyLogLevelType) {
   let environmentType = environment.environmentType
-  let logLevel = environment.mainBundle.isDebug ? KSROptimizelyLogLevel.debug : KSROptimizelyLogLevel.error
+  let logLevel = environment.mainBundle.isDebug ? OptimizelyLogLevelType.debug : OptimizelyLogLevelType.error
 
   var sdkKey: String
 

--- a/Kickstarter-iOS/ViewModels/AppDelegateViewModelTests.swift
+++ b/Kickstarter-iOS/ViewModels/AppDelegateViewModelTests.swift
@@ -17,7 +17,7 @@ final class AppDelegateViewModelTests: TestCase {
   fileprivate let configureAppCenterWithData = TestObserver<AppCenterConfigData, Never>()
   fileprivate let configureFabric = TestObserver<(), Never>()
   fileprivate let configureOptimizelySDKKey = TestObserver<String, Never>()
-  fileprivate let configureOptimizelyLogLevel = TestObserver<KSROptimizelyLogLevel, Never>()
+  fileprivate let configureOptimizelyLogLevel = TestObserver<OptimizelyLogLevelType, Never>()
   fileprivate let didAcceptReceivingRemoteNotifications = TestObserver<(), Never>()
   private let findRedirectUrl = TestObserver<URL, Never>()
   fileprivate let forceLogout = TestObserver<(), Never>()
@@ -155,7 +155,7 @@ final class AppDelegateViewModelTests: TestCase {
       self.vm.inputs.applicationDidFinishLaunching(application: UIApplication.shared, launchOptions: nil)
 
       self.configureOptimizelyLogLevel
-        .assertValues([KSROptimizelyLogLevel.error])
+        .assertValues([OptimizelyLogLevelType.error])
     }
   }
 
@@ -169,7 +169,7 @@ final class AppDelegateViewModelTests: TestCase {
       self.vm.inputs.applicationDidFinishLaunching(application: UIApplication.shared, launchOptions: nil)
 
       self.configureOptimizelyLogLevel
-        .assertValues([KSROptimizelyLogLevel.error])
+        .assertValues([OptimizelyLogLevelType.error])
     }
   }
 
@@ -183,7 +183,7 @@ final class AppDelegateViewModelTests: TestCase {
       self.vm.inputs.applicationDidFinishLaunching(application: UIApplication.shared, launchOptions: nil)
 
       self.configureOptimizelyLogLevel
-        .assertValues([KSROptimizelyLogLevel.error])
+        .assertValues([OptimizelyLogLevelType.error])
     }
   }
 
@@ -197,7 +197,7 @@ final class AppDelegateViewModelTests: TestCase {
       self.vm.inputs.applicationDidFinishLaunching(application: UIApplication.shared, launchOptions: nil)
 
       self.configureOptimizelyLogLevel
-        .assertValues([KSROptimizelyLogLevel.debug])
+        .assertValues([OptimizelyLogLevelType.debug])
     }
   }
 

--- a/Kickstarter-iOS/ViewModels/AppDelegateViewModelTests.swift
+++ b/Kickstarter-iOS/ViewModels/AppDelegateViewModelTests.swift
@@ -47,7 +47,7 @@ final class AppDelegateViewModelTests: TestCase {
     self.vm.outputs.configureFabric.observe(self.configureFabric.observer)
     self.vm.outputs.configureOptimizely.map(first).observe(self.configureOptimizelySDKKey.observer)
     self.vm.outputs.configureOptimizely.map(second).observe(self.configureOptimizelyLogLevel.observer)
-    self.vm.outputs.findRedirectUrl.observe(self.findRedirectUrl.observer)    
+    self.vm.outputs.findRedirectUrl.observe(self.findRedirectUrl.observer)
     self.vm.outputs.forceLogout.observe(self.forceLogout.observer)
     self.vm.outputs.goToActivity.observe(self.goToActivity.observer)
     self.vm.outputs.goToDashboard.observe(self.goToDashboard.observer)
@@ -150,7 +150,7 @@ final class AppDelegateViewModelTests: TestCase {
       bundleIdentifier: KickstarterBundleIdentifier.release.rawValue,
       lang: Language.en.rawValue
     )
-    
+
     withEnvironment(mainBundle: mockBundle) {
       self.vm.inputs.applicationDidFinishLaunching(application: UIApplication.shared, launchOptions: nil)
 

--- a/Kickstarter-iOS/ViewModels/AppDelegateViewModelTests.swift
+++ b/Kickstarter-iOS/ViewModels/AppDelegateViewModelTests.swift
@@ -16,7 +16,8 @@ final class AppDelegateViewModelTests: TestCase {
   fileprivate let applicationIconBadgeNumber = TestObserver<Int, Never>()
   fileprivate let configureAppCenterWithData = TestObserver<AppCenterConfigData, Never>()
   fileprivate let configureFabric = TestObserver<(), Never>()
-  fileprivate let configureOptimizely = TestObserver<String, Never>()
+  fileprivate let configureOptimizelySDKKey = TestObserver<String, Never>()
+  fileprivate let configureOptimizelyLogLevel = TestObserver<KSROptimizelyLogLevel, Never>()
   fileprivate let didAcceptReceivingRemoteNotifications = TestObserver<(), Never>()
   private let findRedirectUrl = TestObserver<URL, Never>()
   fileprivate let forceLogout = TestObserver<(), Never>()
@@ -44,8 +45,9 @@ final class AppDelegateViewModelTests: TestCase {
     self.vm.outputs.applicationIconBadgeNumber.observe(self.applicationIconBadgeNumber.observer)
     self.vm.outputs.configureAppCenterWithData.observe(self.configureAppCenterWithData.observer)
     self.vm.outputs.configureFabric.observe(self.configureFabric.observer)
-    self.vm.outputs.configureOptimizely.observe(self.configureOptimizely.observer)
-    self.vm.outputs.findRedirectUrl.observe(self.findRedirectUrl.observer)
+    self.vm.outputs.configureOptimizely.map(first).observe(self.configureOptimizelySDKKey.observer)
+    self.vm.outputs.configureOptimizely.map(second).observe(self.configureOptimizelyLogLevel.observer)
+    self.vm.outputs.findRedirectUrl.observe(self.findRedirectUrl.observer)    
     self.vm.outputs.forceLogout.observe(self.forceLogout.observer)
     self.vm.outputs.goToActivity.observe(self.goToActivity.observer)
     self.vm.outputs.goToDashboard.observe(self.goToDashboard.observer)
@@ -127,7 +129,8 @@ final class AppDelegateViewModelTests: TestCase {
     withEnvironment(apiService: mockService) {
       self.vm.inputs.applicationDidFinishLaunching(application: UIApplication.shared, launchOptions: nil)
 
-      self.configureOptimizely.assertValues([Secrets.OptimizelySDKKey.production])
+      self.configureOptimizelySDKKey
+        .assertValues([Secrets.OptimizelySDKKey.production])
     }
   }
 
@@ -137,7 +140,64 @@ final class AppDelegateViewModelTests: TestCase {
     withEnvironment(apiService: mockService) {
       self.vm.inputs.applicationDidFinishLaunching(application: UIApplication.shared, launchOptions: nil)
 
-      self.configureOptimizely.assertValues([Secrets.OptimizelySDKKey.staging])
+      self.configureOptimizelySDKKey
+        .assertValues([Secrets.OptimizelySDKKey.staging])
+    }
+  }
+
+  func testConfigureOptimizely_Release() {
+    let mockBundle = MockBundle(
+      bundleIdentifier: KickstarterBundleIdentifier.release.rawValue,
+      lang: Language.en.rawValue
+    )
+    
+    withEnvironment(mainBundle: mockBundle) {
+      self.vm.inputs.applicationDidFinishLaunching(application: UIApplication.shared, launchOptions: nil)
+
+      self.configureOptimizelyLogLevel
+        .assertValues([KSROptimizelyLogLevel.error])
+    }
+  }
+
+  func testConfigureOptimizely_Alpha() {
+    let mockBundle = MockBundle(
+      bundleIdentifier: KickstarterBundleIdentifier.alpha.rawValue,
+      lang: Language.en.rawValue
+    )
+
+    withEnvironment(mainBundle: mockBundle) {
+      self.vm.inputs.applicationDidFinishLaunching(application: UIApplication.shared, launchOptions: nil)
+
+      self.configureOptimizelyLogLevel
+        .assertValues([KSROptimizelyLogLevel.error])
+    }
+  }
+
+  func testConfigureOptimizely_Beta() {
+    let mockBundle = MockBundle(
+      bundleIdentifier: KickstarterBundleIdentifier.beta.rawValue,
+      lang: Language.en.rawValue
+    )
+
+    withEnvironment(mainBundle: mockBundle) {
+      self.vm.inputs.applicationDidFinishLaunching(application: UIApplication.shared, launchOptions: nil)
+
+      self.configureOptimizelyLogLevel
+        .assertValues([KSROptimizelyLogLevel.error])
+    }
+  }
+
+  func testConfigureOptimizely_Debug() {
+    let mockBundle = MockBundle(
+      bundleIdentifier: KickstarterBundleIdentifier.debug.rawValue,
+      lang: Language.en.rawValue
+    )
+
+    withEnvironment(mainBundle: mockBundle) {
+      self.vm.inputs.applicationDidFinishLaunching(application: UIApplication.shared, launchOptions: nil)
+
+      self.configureOptimizelyLogLevel
+        .assertValues([KSROptimizelyLogLevel.debug])
     }
   }
 
@@ -147,7 +207,8 @@ final class AppDelegateViewModelTests: TestCase {
     withEnvironment(apiService: mockService) {
       self.vm.inputs.applicationDidFinishLaunching(application: UIApplication.shared, launchOptions: nil)
 
-      self.configureOptimizely.assertValues([Secrets.OptimizelySDKKey.staging])
+      self.configureOptimizelySDKKey
+        .assertValues([Secrets.OptimizelySDKKey.staging])
 
       let shouldUpdateClient = self.vm.inputs.optimizelyConfigured(with: MockOptimizelyResult())
 
@@ -162,7 +223,8 @@ final class AppDelegateViewModelTests: TestCase {
     withEnvironment(apiService: mockService) {
       self.vm.inputs.applicationDidFinishLaunching(application: UIApplication.shared, launchOptions: nil)
 
-      self.configureOptimizely.assertValues([Secrets.OptimizelySDKKey.staging])
+      self.configureOptimizelySDKKey
+        .assertValues([Secrets.OptimizelySDKKey.staging])
 
       let shouldUpdateClient = self.vm.inputs.optimizelyConfigured(with: mockResult)
 

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -209,6 +209,7 @@
 		770E441321137E7400396D46 /* SettingsNotificationPickerCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 770E441221137E7400396D46 /* SettingsNotificationPickerCell.swift */; };
 		770E441521137F3700396D46 /* SettingsNotificationPickerCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 770E441421137F3700396D46 /* SettingsNotificationPickerCell.xib */; };
 		770E46252114E15D00396D46 /* Crashlytics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 770E45ED2114E15D00396D46 /* Crashlytics.framework */; };
+		771123FB23BF9E7E00BA5702 /* OptimizelyLogLevelType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 771123FA23BF9E7E00BA5702 /* OptimizelyLogLevelType.swift */; };
 		771669D0210B93BE007A64A4 /* SettingsNotificationsDataSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 771669CF210B93BE007A64A4 /* SettingsNotificationsDataSourceTests.swift */; };
 		7717805A22F9ED130064A32F /* RewardsCollectionViewFooter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7717805922F9ED130064A32F /* RewardsCollectionViewFooter.swift */; };
 		771E3C632289DBA8003E7CF1 /* SheetOverlayViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 771E3C622289DBA8003E7CF1 /* SheetOverlayViewController.swift */; };
@@ -1638,6 +1639,7 @@
 		770E441221137E7400396D46 /* SettingsNotificationPickerCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsNotificationPickerCell.swift; sourceTree = "<group>"; };
 		770E441421137F3700396D46 /* SettingsNotificationPickerCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SettingsNotificationPickerCell.xib; sourceTree = "<group>"; };
 		770E45ED2114E15D00396D46 /* Crashlytics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Crashlytics.framework; path = Frameworks/Fabric/Crashlytics.framework; sourceTree = "<group>"; };
+		771123FA23BF9E7E00BA5702 /* OptimizelyLogLevelType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptimizelyLogLevelType.swift; sourceTree = "<group>"; };
 		771669CF210B93BE007A64A4 /* SettingsNotificationsDataSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsNotificationsDataSourceTests.swift; sourceTree = "<group>"; };
 		7717805922F9ED130064A32F /* RewardsCollectionViewFooter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RewardsCollectionViewFooter.swift; sourceTree = "<group>"; };
 		771E3C622289DBA8003E7CF1 /* SheetOverlayViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SheetOverlayViewController.swift; sourceTree = "<group>"; };
@@ -3319,6 +3321,7 @@
 				37EB3E4D228CF4FB00076E4C /* NumberFormatterTests.swift */,
 				D706478F23A2BF4B00B33C20 /* OptimizelyClientType.swift */,
 				774D98D823A96E7500FC81C2 /* OptimizelyClientTypeTests.swift */,
+				771123FA23BF9E7E00BA5702 /* OptimizelyLogLevelType.swift */,
 				1611EF5D23ABD1550051CDCC /* OptimizelyResultType.swift */,
 				A77D7B061CBAAF5D0077586B /* Paginate.swift */,
 				A7ED1F1C1E830FDC00BFFA01 /* PaginateTests.swift */,
@@ -4878,6 +4881,7 @@
 				9D9F581B1D1324E200CE81DE /* DashboardViewModel.swift in Sources */,
 				D796867C20FE655300E54C61 /* SettingsFollowCellViewModel.swift in Sources */,
 				D79A01A42242E8CD004BC6A8 /* AppEnvironmentType.swift in Sources */,
+				771123FB23BF9E7E00BA5702 /* OptimizelyLogLevelType.swift in Sources */,
 				A7FC8C061C8F1DEA00C3B49B /* CircleAvatarImageView.swift in Sources */,
 				771E630C23426B27005967E8 /* CancelPledgeViewModel.swift in Sources */,
 				A7CA8C0E1D8F241A0086A3E9 /* ProjectNavBarViewModel.swift in Sources */,

--- a/Library/OptimizelyLogLevelType.swift
+++ b/Library/OptimizelyLogLevelType.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+public enum OptimizelyLogLevelType {
+  case error
+  case debug
+}


### PR DESCRIPTION
# 📲 What

Configures the Optimizely SDK's log level based on the bundle type. For debug builds, the log level is `.debug`, which gives us as much debugging information as possible. For release builds, the log level is set to `.error` which is the highest possible log level, only logging severe errors.

# 🤔 Why

To prevent excessive logging on release builds.

# 🛠 How

Added an additional output type `KSROptimizelyLogLevel` to the `configureOptimizely` output which will either be `.debug` or `.error` depending on the main bundle type.

# ♿️ Accessibility 

N/A

# 🏎 Performance

N/A

# ✅ Acceptance criteria

- [x] Run the app on a debug build. Observe in the console the following log: `[OPTIMIZELY] [DEBUG] SDK Version: 3.1.0`
- [x] Run the app on a release build. The console should not log any messages related to Pptimizely, with the exception of `🔮 Optimizely SDK Successfully Configured`
