### PR TITLE
[NT-777] Fix project modal dismissal

### DIFF
--- a/Kickstarter-iOS/Views/Controllers/ProjectNavigatorViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/ProjectNavigatorViewController.swift
@@ -9,7 +9,11 @@ internal protocol ProjectNavigatorDelegate: AnyObject {
 }
 
 internal final class ProjectNavigatorViewController: UIPageViewController {
-  fileprivate let transitionAnimator = ProjectNavigatorTransitionAnimator()
+  fileprivate lazy var transitionAnimator: ProjectNavigatorTransitionAnimator? = {
+    guard #available(iOS 13.0, *) else { return ProjectNavigatorTransitionAnimator() }
+    return nil
+  }()
+
   fileprivate weak var navigatorDelegate: ProjectNavigatorDelegate?
   fileprivate let pageDataSource: ProjectNavigatorPagesDataSource!
   fileprivate let viewModel: ProjectNavigatorViewModelType = ProjectNavigatorViewModel()
@@ -96,7 +100,7 @@ internal final class ProjectNavigatorViewController: UIPageViewController {
     self.viewModel.outputs.cancelInteractiveTransition
       .observeForControllerAction()
       .observeValues { [weak self] in
-        self?.transitionAnimator.cancel()
+        self?.transitionAnimator?.cancel()
       }
 
     self.viewModel.outputs.dismissViewController
@@ -108,7 +112,7 @@ internal final class ProjectNavigatorViewController: UIPageViewController {
     self.viewModel.outputs.finishInteractiveTransition
       .observeForControllerAction()
       .observeValues { [weak self] in
-        self?.transitionAnimator.finish()
+        self?.transitionAnimator?.finish()
       }
 
     self.viewModel.outputs.notifyDelegateTransitionedToProjectIndex
@@ -120,7 +124,7 @@ internal final class ProjectNavigatorViewController: UIPageViewController {
     self.viewModel.outputs.setTransitionAnimatorIsInFlight
       .observeForUI()
       .observeValues { [weak self] in
-        self?.transitionAnimator.isInFlight = $0
+        self?.transitionAnimator?.isInFlight = $0
       }
 
     self.viewModel.outputs.setNeedsStatusBarAppearanceUpdate
@@ -131,7 +135,7 @@ internal final class ProjectNavigatorViewController: UIPageViewController {
       .observeForControllerAction()
       .observeValues { [weak self] translation in
         guard let _self = self else { return }
-        self?.transitionAnimator.update(translation / _self.view.bounds.height)
+        self?.transitionAnimator?.update(translation / _self.view.bounds.height)
       }
   }
 
@@ -169,6 +173,8 @@ extension ProjectNavigatorViewController: ProjectPamphletViewControllerDelegate 
     _: ProjectPamphletViewController,
     panGestureRecognizerDidChange recognizer: UIPanGestureRecognizer
   ) {
+    if #available(iOS 13.0, *) { return }
+
     guard let scrollView = recognizer.view as? UIScrollView else { return }
 
     self.viewModel.inputs.panning(
@@ -236,7 +242,7 @@ extension ProjectNavigatorViewController: UIViewControllerTransitioningDelegate 
 
   func interactionControllerForDismissal(using _: UIViewControllerAnimatedTransitioning)
     -> UIViewControllerInteractiveTransitioning? {
-    return self.transitionAnimator.isInFlight ? self.transitionAnimator : nil
+    return self.transitionAnimator?.isInFlight == true ? self.transitionAnimator : nil
   }
 }
 


### PR DESCRIPTION
# 📲 What

Disables our custom dismissal of the project modal on iOS 13.

# 🤔 Why

This behaviour appears to be broken on iOS 13, views are positioned incorrectly and after dismissal the screen just goes blank. While there may be other ways to work around this, the built-in modal behaviour on iOS 13 works well and is arguably an improvement on what we have. I think that the easiest approach is to keep our current behaviour for iOS 12 and to disable it for 13+.

# 🛠 How

- Return `nil` for the animator object on iOS 13.
- Don't call the view model input with the panning gesture values on iOS 13.

# 👀 See

| iOS 13 with custom animation 🐛 | iOS 12 (current behaviour) | iOS 13+ 🦋 |
| --- | --- | --- |
| ![2020-01-09 13 27 47](https://user-images.githubusercontent.com/3735375/72106312-ffdf2300-32e3-11ea-922b-3db99e0def57.gif) | <img src="https://user-images.githubusercontent.com/3735375/72097523-6b6bc500-32d1-11ea-962a-72ccdee6e675.gif"/> | <img src="https://user-images.githubusercontent.com/3735375/72097512-63ac2080-32d1-11ea-8b3f-a152947d8874.gif"/> |

# ✅ Acceptance criteria

Run the app in Xcode 11 on the 12.4 and 13.3 simulators.

- [x] Dismissal behaviour is unchanged on iOS 12.
- [x] Project modal is presented using the new card-style modal on iOS 13 and the user is still able to pan down to dismiss the modal.