### PR TITLE
[NT-791] Disable dark mode

### DIFF
--- a/Kickstarter-iOS/Info.plist
+++ b/Kickstarter-iOS/Info.plist
@@ -150,5 +150,7 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>UIUserInterfaceStyle</key>
+	<string>Light</string>
 </dict>
 </plist>


### PR DESCRIPTION
# 📲 What

Disables dark mode support in the app.

# 🤔 Why

We're not supporting dark mode yet and opting out of support fixes a number of visual bugs that would otherwise be seen.

# 🛠 How

Added the `UIUserInterfaceStyle` key to our `Info.plist` file with a value of `Light` which forces the app to always be shown in _light_ mode.

# ✅ Acceptance criteria

- [x] Run the app on a simulator or device with dark mode enabled and observe that the visual bugs reported by me on Slack are not evident.