### PR TITLE
[NT-806] Ensure that getVariationKey is called for admin users

### DIFF
--- a/Library/OptimizelyClientType.swift
+++ b/Library/OptimizelyClientType.swift
@@ -2,15 +2,28 @@ import Foundation
 
 public protocol OptimizelyClientType: AnyObject {
   func activate(experimentKey: String, userId: String, attributes: [String: Any?]?) throws -> String
+  func getVariationKey(experimentKey: String, userId: String, attributes: [String: Any?]?) throws -> String
 }
 
 extension OptimizelyClientType {
   public func variant(
     for experiment: OptimizelyExperiment.Key,
-    userId: String
+    userId: String,
+    isAdmin: Bool
   ) -> OptimizelyExperiment.Variant {
+    let variationString: String?
+    if isAdmin {
+      variationString = try? self.getVariationKey(
+        experimentKey: experiment.rawValue, userId: userId, attributes: nil
+      )
+    } else {
+      variationString = try? self.activate(
+        experimentKey: experiment.rawValue, userId: userId, attributes: nil
+      )
+    }
+
     guard
-      let variation = try? self.activate(experimentKey: experiment.rawValue, userId: userId, attributes: nil),
+      let variation = variationString,
       let variant = OptimizelyExperiment.Variant(rawValue: variation)
     else {
       return .control

--- a/Library/OptimizelyClientTypeTests.swift
+++ b/Library/OptimizelyClientTypeTests.swift
@@ -10,9 +10,11 @@ final class OptimizelyClientTypeTests: TestCase {
 
     XCTAssertEqual(
       OptimizelyExperiment.Variant.variant1,
-      mockClient.variant(for: .pledgeCTACopy, userId: "123"),
+      mockClient.variant(for: .pledgeCTACopy, userId: "123", isAdmin: false),
       "Returns the correction variation"
     )
+    XCTAssertTrue(mockClient.activatePathCalled)
+    XCTAssertFalse(mockClient.getVariantPathCalled)
   }
 
   func testVariantForExperiment_ThrowsError() {
@@ -23,9 +25,11 @@ final class OptimizelyClientTypeTests: TestCase {
 
     XCTAssertEqual(
       OptimizelyExperiment.Variant.control,
-      mockClient.variant(for: .pledgeCTACopy, userId: "123"),
+      mockClient.variant(for: .pledgeCTACopy, userId: "123", isAdmin: false),
       "Returns the control variant if error is thrown"
     )
+    XCTAssertTrue(mockClient.activatePathCalled)
+    XCTAssertFalse(mockClient.getVariantPathCalled)
   }
 
   func testVariantForExperiment_ExperimentNotFound() {
@@ -33,9 +37,11 @@ final class OptimizelyClientTypeTests: TestCase {
 
     XCTAssertEqual(
       OptimizelyExperiment.Variant.control,
-      mockClient.variant(for: .pledgeCTACopy, userId: "123"),
+      mockClient.variant(for: .pledgeCTACopy, userId: "123", isAdmin: false),
       "Returns the control variant if experiment key is not found"
     )
+    XCTAssertTrue(mockClient.activatePathCalled)
+    XCTAssertFalse(mockClient.getVariantPathCalled)
   }
 
   func testVariantForExperiment_UnknownVariant() {
@@ -45,8 +51,24 @@ final class OptimizelyClientTypeTests: TestCase {
 
     XCTAssertEqual(
       OptimizelyExperiment.Variant.control,
-      mockClient.variant(for: .pledgeCTACopy, userId: "123"),
+      mockClient.variant(for: .pledgeCTACopy, userId: "123", isAdmin: false),
       "Returns the control variant if the variant is not recognized"
     )
+    XCTAssertTrue(mockClient.activatePathCalled)
+    XCTAssertFalse(mockClient.getVariantPathCalled)
+  }
+
+  func testVariantForExperiment_NoError_LoggedIn_IsAdmin() {
+    let mockClient = MockOptimizelyClient()
+      |> \.experiments .~
+      [OptimizelyExperiment.Key.pledgeCTACopy.rawValue: OptimizelyExperiment.Variant.variant1.rawValue]
+
+    XCTAssertEqual(
+      OptimizelyExperiment.Variant.variant1,
+      mockClient.variant(for: .pledgeCTACopy, userId: "123", isAdmin: true),
+      "Returns the correction variation"
+    )
+    XCTAssertFalse(mockClient.activatePathCalled)
+    XCTAssertTrue(mockClient.getVariantPathCalled)
   }
 }

--- a/Library/TestHelpers/MockOptimizelyClient.swift
+++ b/Library/TestHelpers/MockOptimizelyClient.swift
@@ -3,16 +3,30 @@ import Library
 internal struct MockOptimizelyError: Error {}
 
 internal class MockOptimizelyClient: OptimizelyClientType {
+  var activatePathCalled: Bool = false
   var experiments: [String: String] = [:]
   var error: MockOptimizelyError?
+  var getVariantPathCalled: Bool = false
 
-  internal func activate(experimentKey: String, userId _: String, attributes _: [String: Any?]?) throws
+  internal func activate(experimentKey: String, userId: String, attributes: [String: Any?]?) throws
+    -> String {
+    self.activatePathCalled = true
+    return try self.experiment(forKey: experimentKey, userId: userId, attributes: attributes)
+  }
+
+  internal func getVariationKey(experimentKey: String, userId: String, attributes: [String: Any?]?) throws
+    -> String {
+    self.getVariantPathCalled = true
+    return try self.experiment(forKey: experimentKey, userId: userId, attributes: attributes)
+  }
+
+  private func experiment(forKey key: String, userId _: String, attributes _: [String: Any?]?) throws
     -> String {
     if let error = self.error {
       throw error
     }
 
-    guard let experimentVariant = self.experiments[experimentKey] else {
+    guard let experimentVariant = self.experiments[key] else {
       return OptimizelyExperiment.Variant.control.rawValue
     }
 

--- a/Library/ViewModels/PledgeCTAContainerViewViewModel.swift
+++ b/Library/ViewModels/PledgeCTAContainerViewViewModel.swift
@@ -132,7 +132,11 @@ public final class PledgeCTAContainerViewViewModel: PledgeCTAContainerViewViewMo
 private func pledgeCTA(project: Project, backing: Backing?) -> PledgeStateCTAType {
   let uuid = deviceIdentifier(uuid: UUID())
   let optimizelyVariant = AppEnvironment.current.optimizelyClient?
-    .variant(for: OptimizelyExperiment.Key.pledgeCTACopy, userId: uuid)
+    .variant(
+      for: OptimizelyExperiment.Key.pledgeCTACopy,
+      userId: uuid,
+      isAdmin: AppEnvironment.current.currentUser?.isAdmin ?? false
+    )
 
   guard let projectBacking = backing, project.personalization.isBacking == .some(true) else {
     if currentUserIsCreator(of: project) {

--- a/Library/ViewModels/PledgeCTAContainerViewViewModelTests.swift
+++ b/Library/ViewModels/PledgeCTAContainerViewViewModelTests.swift
@@ -173,6 +173,8 @@ internal final class PledgeCTAContainerViewViewModelTests: TestCase {
       self.buttonTitleText.assertValues(["See the rewards"])
       self.spacerIsHidden.assertValues([true])
       self.stackViewIsHidden.assertValues([true])
+      XCTAssertTrue(optimizelyClient.activatePathCalled)
+      XCTAssertFalse(optimizelyClient.getVariantPathCalled)
     }
   }
 
@@ -192,6 +194,31 @@ internal final class PledgeCTAContainerViewViewModelTests: TestCase {
       self.buttonTitleText.assertValues(["View the rewards"])
       self.spacerIsHidden.assertValues([true])
       self.stackViewIsHidden.assertValues([true])
+      XCTAssertTrue(optimizelyClient.activatePathCalled)
+      XCTAssertFalse(optimizelyClient.getVariantPathCalled)
+    }
+  }
+
+  func testPledgeCTA_NonBacker_LiveProject_LoggedIn_OptimizelyExperimental_Variant1_IsAdmin() {
+    let user = User.template
+      |> User.lens.id .~ 5
+      |> User.lens.isAdmin .~ true
+    let project = Project.template
+      |> Project.lens.personalization.backing .~ nil
+      |> Project.lens.personalization.isBacking .~ false
+
+    let optimizelyClient = MockOptimizelyClient()
+      |> \.experiments .~
+      [OptimizelyExperiment.Key.pledgeCTACopy.rawValue: OptimizelyExperiment.Variant.variant1.rawValue]
+
+    withEnvironment(currentUser: user, optimizelyClient: optimizelyClient) {
+      self.vm.inputs.configureWith(value: (.left(project), false))
+      self.buttonStyleType.assertValues([ButtonStyleType.green])
+      self.buttonTitleText.assertValues(["See the rewards"])
+      self.spacerIsHidden.assertValues([true])
+      self.stackViewIsHidden.assertValues([true])
+      XCTAssertFalse(optimizelyClient.activatePathCalled)
+      XCTAssertTrue(optimizelyClient.getVariantPathCalled)
     }
   }
 


### PR DESCRIPTION
# 📲 What

Ensures that for admin users we call `getVariationKey(experimentKey:userId:attributes:)` instead of `activate(experimentKey:userId:attributes:)`.

# 🤔 Why

`activate(experimentKey:userId:attributes:)` records an impression on Optimizely affecting our experiment groups and costing us money.

# 🛠 How

- Added `getVariationKey(experimentKey:userId:attributes:)` to `OptimizelyClientType`.
- Added a means to test this via `MockOptimizelyClient`.

# 👀 See

[Optimizely docs](https://docs.developers.optimizely.com/full-stack/docs/get-variation-swift)

# ✅ Acceptance criteria

- [x] Log in as non-admin, the `activate` path should be called.
- [x] Log in as an admin user, the `getVariation` path should be called.