### PR TITLE
[NT-814] Partition key value precedence

### DIFF
--- a/Library/Tracking/TrackingClientConfiguration.swift
+++ b/Library/Tracking/TrackingClientConfiguration.swift
@@ -105,7 +105,7 @@ private let dataLakeRecordDictionary: TrackingClientRecordDictionary = { event, 
       "event": event,
       "properties": properties
     ],
-    "partition-key": UUID().uuidString
+    "partition-key": partitionKey()
   ]
 }
 
@@ -135,4 +135,10 @@ private let dataLakeUrl: TrackingClientURL = { environmentType in
   }
 
   return URL(string: urlString)
+}
+
+private func partitionKey() -> String {
+  return AppEnvironment.current.currentUser.flatMap { $0.id }.map(String.init)
+    .coalesceWith(AppEnvironment.current.device.identifierForVendor?.uuidString)
+    .coalesceWith(UUID().uuidString)
 }


### PR DESCRIPTION
# 📲 What

Updates the value of `partition-key` in the record dictionary for our DataLake tracking client.

# 🤔 Why

Instead of just using a random UUID for this value we would like to use the user's ID (when available), the device identifier if the user's ID is not available, and a random UUID as a fail-safe value.

**Note:** As per the Apple [docs](https://developer.apple.com/documentation/uikit/uidevice/1620059-identifierforvendor), the `identifierForVendor` can only sometimes be `nil` if the device has not yet been unlocked. This probably only affects apps that access this value in the background but seeing as this can potentially be `nil` we coalesce using a non-nil `UUID` string.

# 🛠 How

Updated the partition key value to coalesce from user ID through to `identifierForVendor` and lastly `UUID().uuidString`.

# ✅ Acceptance criteria

- [x] If logged in the `partition-key` value should be that of the User's ID.
- [x] If logged out the value should be that of the device identifier `identifierForVendor` value.
- [x] If neither of these are available the value should be a random UUID. This is only proven by the unit tests.