### PR TITLE
[NT-780] Add device identifier to prepared request headers

### DIFF
--- a/KsApi/MockService.swift
+++ b/KsApi/MockService.swift
@@ -10,6 +10,7 @@
     internal let language: String
     internal let currency: String
     internal let buildVersion: String
+    internal let deviceIdentifier: String
 
     fileprivate let addNewCreditCardResult: Result<CreatePaymentSourceEnvelope, GraphError>?
 
@@ -177,7 +178,8 @@
       oauthToken: OauthTokenAuthType?,
       language: String,
       currency: String,
-      buildVersion: String = "1"
+      buildVersion: String = "1",
+      deviceIdentifier: String = "DEADBEEF-DEAD-BEEF-DEAD-DEADBEEFBEEF"
     ) {
       self.init(
         appId: appId,
@@ -186,6 +188,7 @@
         language: language,
         currency: currency,
         buildVersion: buildVersion,
+        deviceIdentifier: deviceIdentifier,
         fetchActivitiesResponse: nil
       )
     }
@@ -197,6 +200,7 @@
       language: String = "en",
       currency: String = "USD",
       buildVersion: String = "1",
+      deviceIdentifier: String = "DEADBEEF-DEAD-BEEF-DEAD-DEADBEEFBEEF",
       addNewCreditCardResult: Result<CreatePaymentSourceEnvelope, GraphError>? = nil,
       cancelBackingResult: Result<GraphMutationEmptyResponseEnvelope, GraphError>? = nil,
       changeEmailError: GraphError? = nil,
@@ -304,6 +308,7 @@
       self.language = language
       self.currency = currency
       self.buildVersion = buildVersion
+      self.deviceIdentifier = deviceIdentifier
 
       self.addNewCreditCardResult = addNewCreditCardResult
 

--- a/KsApi/Service.swift
+++ b/KsApi/Service.swift
@@ -19,6 +19,7 @@ public struct Service: ServiceType {
   public let language: String
   public let currency: String
   public let buildVersion: String
+  public let deviceIdentifier: String
 
   public init(
     appId: String = Bundle.main.bundleIdentifier ?? "com.kickstarter.kickstarter",
@@ -26,7 +27,8 @@ public struct Service: ServiceType {
     oauthToken: OauthTokenAuthType? = nil,
     language: String = "en",
     currency: String = "USD",
-    buildVersion: String = Bundle.main._buildVersion
+    buildVersion: String = Bundle.main._buildVersion,
+    deviceIdentifier: String = UIDevice.current.identifierForVendor.coalesceWith(UUID()).uuidString
   ) {
     self.appId = appId
     self.serverConfig = serverConfig
@@ -34,6 +36,7 @@ public struct Service: ServiceType {
     self.language = language
     self.currency = currency
     self.buildVersion = buildVersion
+    self.deviceIdentifier = deviceIdentifier
 
     // Global override required for injecting custom User-Agent header in ajax requests
     UserDefaults.standard.register(defaults: ["UserAgent": Service.userAgent])

--- a/KsApi/ServiceType.swift
+++ b/KsApi/ServiceType.swift
@@ -18,6 +18,7 @@ public protocol ServiceType {
   var language: String { get }
   var currency: String { get }
   var buildVersion: String { get }
+  var deviceIdentifier: String { get }
 
   init(
     appId: String,
@@ -25,7 +26,8 @@ public protocol ServiceType {
     oauthToken: OauthTokenAuthType?,
     language: String,
     currency: String,
-    buildVersion: String
+    buildVersion: String,
+    deviceIdentifier: String
   )
 
   /// Returns a new service with the oauth token replaced.
@@ -508,6 +510,7 @@ extension ServiceType {
     headers["Kickstarter-iOS-App"] = self.buildVersion
     headers["User-Agent"] = Self.userAgent
     headers["X-KICKSTARTER-CLIENT"] = self.serverConfig.apiClientAuth.clientId
+    headers["Kickstarter-iOS-App-UUID"] = self.deviceIdentifier
 
     return headers
   }

--- a/KsApi/ServiceTypeTests.swift
+++ b/KsApi/ServiceTypeTests.swift
@@ -21,7 +21,8 @@ final class ServiceTypeTests: XCTestCase {
       token: "cafebeef"
     ),
     language: "ksr",
-    buildVersion: "1234567890"
+    buildVersion: "1234567890",
+    deviceIdentifier: "DEADBEEF-DEAD-BEEF-DEAD-DEADBEEFBEEF"
   )
 
   private let anonAdHocService = Service(
@@ -37,7 +38,8 @@ final class ServiceTypeTests: XCTestCase {
         password: "password"
       ),
       graphQLEndpointUrl: URL(string: "http://ksr.dev/graph")!
-    )
+    ),
+    deviceIdentifier: "DEADBEEF-DEAD-BEEF-DEAD-DEADBEEFBEEF"
   )
 
   private let anonService = Service(
@@ -50,7 +52,8 @@ final class ServiceTypeTests: XCTestCase {
       ),
       basicHTTPAuth: nil,
       graphQLEndpointUrl: URL(string: "http://ksr.dev/graph")!
-    )
+    ),
+    deviceIdentifier: "DEADBEEF-DEAD-BEEF-DEAD-DEADBEEFBEEF"
   )
 
   func testEquals() {
@@ -97,7 +100,8 @@ final class ServiceTypeTests: XCTestCase {
         "Accept-Language": "ksr",
         "Kickstarter-App-Id": "com.kickstarter.test",
         "X-KICKSTARTER-CLIENT": "deadbeef",
-        "User-Agent": userAgent()
+        "User-Agent": userAgent(),
+        "Kickstarter-iOS-App-UUID": "DEADBEEF-DEAD-BEEF-DEAD-DEADBEEFBEEF"
       ],
       request.allHTTPHeaderFields!
     )
@@ -118,7 +122,8 @@ final class ServiceTypeTests: XCTestCase {
         "Accept-Language": "ksr",
         "Kickstarter-App-Id": "com.kickstarter.test",
         "X-KICKSTARTER-CLIENT": "deadbeef",
-        "User-Agent": userAgent()
+        "User-Agent": userAgent(),
+        "Kickstarter-iOS-App-UUID": "DEADBEEF-DEAD-BEEF-DEAD-DEADBEEFBEEF"
       ],
       request.allHTTPHeaderFields!
     )
@@ -140,7 +145,8 @@ final class ServiceTypeTests: XCTestCase {
         "Accept-Language": "ksr",
         "Kickstarter-App-Id": "com.kickstarter.test",
         "X-KICKSTARTER-CLIENT": "deadbeef",
-        "User-Agent": userAgent()
+        "User-Agent": userAgent(),
+        "Kickstarter-iOS-App-UUID": "DEADBEEF-DEAD-BEEF-DEAD-DEADBEEFBEEF"
       ],
       request.allHTTPHeaderFields!
     )
@@ -163,7 +169,8 @@ final class ServiceTypeTests: XCTestCase {
         "Kickstarter-App-Id": "com.kickstarter.test",
         "Content-Type": "application/json; charset=utf-8",
         "X-KICKSTARTER-CLIENT": "deadbeef",
-        "User-Agent": userAgent()
+        "User-Agent": userAgent(),
+        "Kickstarter-iOS-App-UUID": "DEADBEEF-DEAD-BEEF-DEAD-DEADBEEFBEEF"
       ],
       request.allHTTPHeaderFields!
     )
@@ -193,7 +200,8 @@ final class ServiceTypeTests: XCTestCase {
         "Accept-Language": "ksr",
         "Kickstarter-App-Id": "com.kickstarter.test",
         "X-KICKSTARTER-CLIENT": "deadbeef",
-        "User-Agent": userAgent()
+        "User-Agent": userAgent(),
+        "Kickstarter-iOS-App-UUID": "DEADBEEF-DEAD-BEEF-DEAD-DEADBEEFBEEF"
       ],
       request.allHTTPHeaderFields!
     )
@@ -216,7 +224,8 @@ final class ServiceTypeTests: XCTestCase {
         "Accept-Language": "en",
         "Kickstarter-App-Id": "com.kickstarter.test",
         "X-KICKSTARTER-CLIENT": "deadbeef",
-        "User-Agent": userAgent()
+        "User-Agent": userAgent(),
+        "Kickstarter-iOS-App-UUID": "DEADBEEF-DEAD-BEEF-DEAD-DEADBEEFBEEF"
       ],
       request.allHTTPHeaderFields!
     )
@@ -236,7 +245,8 @@ final class ServiceTypeTests: XCTestCase {
           password: "password"
         ),
         graphQLEndpointUrl: URL(string: "http://ksr.dev/graph")!
-      )
+      ),
+      deviceIdentifier: "DEADBEEF-DEAD-BEEF-DEAD-DEADBEEFBEEF"
     )
 
     let url = URL(string: "http://api.ksr.com/v1/test?key=value")!
@@ -253,7 +263,8 @@ final class ServiceTypeTests: XCTestCase {
         "Accept-Language": "en",
         "Kickstarter-App-Id": "com.kickstarter.test",
         "X-KICKSTARTER-CLIENT": "deadbeef",
-        "User-Agent": userAgent()
+        "User-Agent": userAgent(),
+        "Kickstarter-iOS-App-UUID": "DEADBEEF-DEAD-BEEF-DEAD-DEADBEEFBEEF"
       ],
       request.allHTTPHeaderFields!
     )
@@ -282,6 +293,10 @@ final class ServiceTypeTests: XCTestCase {
     XCTAssertEqual(request?.allHTTPHeaderFields?["Kickstarter-iOS-App"], self.service.buildVersion)
     XCTAssertEqual(request?.allHTTPHeaderFields?["X-KICKSTARTER-CLIENT"], "deadbeef")
     XCTAssertEqual(request?.allHTTPHeaderFields?["User-Agent"], userAgent())
+    XCTAssertEqual(
+      request?.allHTTPHeaderFields?["Kickstarter-iOS-App-UUID"],
+      "DEADBEEF-DEAD-BEEF-DEAD-DEADBEEFBEEF"
+    )
   }
 
   func testGraphMutationRequestBody() {


### PR DESCRIPTION
# 📲 What

Adds the device identifier to our prepared request headers for requests to v1 endpoints and GraphQL queries/mutations.

# 🤔 Why

In order to properly attribute our _Completed Checkout_ server-side events to Optimizely experimental variants, we need to send the `device_distinct_id` to the server so that Optimizely tracking calls can be made using the `device_distinct_id` instead of the user's ID.

# 🛠 How

Added a header, `Kickstarter-iOS-App-UUID` which will be set using the device's `identifierForVendor` value.

**Note:** As mentioned in #1044, according to the Apple [docs](https://developer.apple.com/documentation/uikit/uidevice/1620059-identifierforvendor), the `identifierForVendor` _can_ be `nil` but this is only when the device has been restarted and not yet unlocked. There should not be any scenario in which we're instantiating our `Service` struct when this value is `nil` but if that were to happen then this value would just coalesce to a random UUID string.

# ✅ Acceptance criteria

Run the app in the simulator and using Charles Proxy observe the following:

- [x] The `Kickstarter-iOS-App-UUID` header is present in all requests to the v1 API and its value is the device's identifier.
- [x] The `Kickstarter-iOS-App-UUID` header is present in all requests to GraphQL and its value is the device's identifier.
- [x] Deleting and reinstalling the app generates a new value.