### PR TITLE
[NT-728] Adds staging and native.dev as Associated domains

### DIFF
--- a/Kickstarter-iOS/Alpha.entitlements
+++ b/Kickstarter-iOS/Alpha.entitlements
@@ -1,21 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>aps-environment</key>
-    <string>production</string>
-    <key>com.apple.developer.associated-domains</key>
-    <array>
-      <string>applinks:www.kickstarter.com</string>
-      <string>applinks:click.e.kickstarter.com</string>
-      <string>applinks:click.em.kickstarter.com</string>
-      <string>applinks:email.kickstarter.com</string>
-      <string>applinks:emails.kickstarter.com</string>
-      <string>applinks:e2.kickstarter.com</string>
-      <string>applinks:e3.kickstarter.com</string>
-      <string>webcredentials:kickstarter.com</string>
-    </array>
-    <key>com.apple.developer.ubiquity-kvstore-identifier</key>
-    <string>$(TeamIdentifierPrefix)$(CFBundleIdentifier)</string>
-  </dict>
+<dict>
+	<key>aps-environment</key>
+	<string>production</string>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:www.kickstarter.com</string>
+		<string>applinks:native.dev.kickstarter.com</string>
+		<string>applinks:staging.kickstarter.com</string>
+		<string>applinks:click.e.kickstarter.com</string>
+		<string>applinks:click.em.kickstarter.com</string>
+		<string>applinks:email.kickstarter.com</string>
+		<string>applinks:emails.kickstarter.com</string>
+		<string>applinks:e2.kickstarter.com</string>
+		<string>applinks:e3.kickstarter.com</string>
+		<string>webcredentials:kickstarter.com</string>
+	</array>
+	<key>com.apple.developer.ubiquity-kvstore-identifier</key>
+	<string>$(TeamIdentifierPrefix)$(CFBundleIdentifier)</string>
+</dict>
 </plist>

--- a/Kickstarter-iOS/Alpha.entitlements
+++ b/Kickstarter-iOS/Alpha.entitlements
@@ -1,23 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
-	<key>aps-environment</key>
-	<string>production</string>
-	<key>com.apple.developer.associated-domains</key>
-	<array>
-		<string>applinks:www.kickstarter.com</string>
-		<string>applinks:native.dev.kickstarter.com</string>
-		<string>applinks:staging.kickstarter.com</string>
-		<string>applinks:click.e.kickstarter.com</string>
-		<string>applinks:click.em.kickstarter.com</string>
-		<string>applinks:email.kickstarter.com</string>
-		<string>applinks:emails.kickstarter.com</string>
-		<string>applinks:e2.kickstarter.com</string>
-		<string>applinks:e3.kickstarter.com</string>
-		<string>webcredentials:kickstarter.com</string>
-	</array>
-	<key>com.apple.developer.ubiquity-kvstore-identifier</key>
-	<string>$(TeamIdentifierPrefix)$(CFBundleIdentifier)</string>
-</dict>
+  <dict>
+    <key>aps-environment</key>
+    <string>production</string>
+    <key>com.apple.developer.associated-domains</key>
+    <array>
+      <string>applinks:www.kickstarter.com</string>
+      <string>applinks:native.dev.kickstarter.com</string>
+      <string>applinks:staging.kickstarter.com</string>
+      <string>applinks:click.e.kickstarter.com</string>
+      <string>applinks:click.em.kickstarter.com</string>
+      <string>applinks:email.kickstarter.com</string>
+      <string>applinks:emails.kickstarter.com</string>
+      <string>applinks:e2.kickstarter.com</string>
+      <string>applinks:e3.kickstarter.com</string>
+      <string>webcredentials:kickstarter.com</string>
+    </array>
+    <key>com.apple.developer.ubiquity-kvstore-identifier</key>
+    <string>$(TeamIdentifierPrefix)$(CFBundleIdentifier)</string>
+  </dict>
 </plist>

--- a/Kickstarter-iOS/Beta.entitlements
+++ b/Kickstarter-iOS/Beta.entitlements
@@ -7,6 +7,8 @@
     <key>com.apple.developer.associated-domains</key>
     <array>
       <string>applinks:www.kickstarter.com</string>
+      <string>applinks:native.dev.kickstarter.com</string>
+      <string>applinks:staging.kickstarter.com</string>
       <string>applinks:click.e.kickstarter.com</string>
       <string>applinks:click.em.kickstarter.com</string>
       <string>applinks:email.kickstarter.com</string>

--- a/Kickstarter-iOS/Debug.entitlements
+++ b/Kickstarter-iOS/Debug.entitlements
@@ -6,6 +6,8 @@
 	<string>development</string>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
+		<string>applinks:staging.kickstarter.com</string>
+		<string>applinks:native.dev.kickstarter.com</string>
 		<string>applinks:www.kickstarter.com</string>
 		<string>applinks:click.e.kickstarter.com</string>
 		<string>applinks:click.em.kickstarter.com</string>

--- a/Kickstarter-iOS/Debug.entitlements
+++ b/Kickstarter-iOS/Debug.entitlements
@@ -1,29 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
-	<key>aps-environment</key>
-	<string>development</string>
-	<key>com.apple.developer.associated-domains</key>
-	<array>
-		<string>applinks:staging.kickstarter.com</string>
-		<string>applinks:native.dev.kickstarter.com</string>
-		<string>applinks:www.kickstarter.com</string>
-		<string>applinks:click.e.kickstarter.com</string>
-		<string>applinks:click.em.kickstarter.com</string>
-		<string>applinks:email.kickstarter.com</string>
-		<string>applinks:emails.kickstarter.com</string>
-		<string>applinks:e2.kickstarter.com</string>
-		<string>applinks:e3.kickstarter.com</string>
-		<string>webcredentials:kickstarter.com</string>
-	</array>
-	<key>com.apple.developer.icloud-container-identifiers</key>
-	<array/>
-	<key>com.apple.developer.in-app-payments</key>
-	<array>
-		<string>merchant.com.kickstarter</string>
-	</array>
-	<key>com.apple.developer.ubiquity-kvstore-identifier</key>
-	<string>$(TeamIdentifierPrefix)$(CFBundleIdentifier)</string>
-</dict>
+  <dict>
+    <key>aps-environment</key>
+    <string>development</string>
+    <key>com.apple.developer.associated-domains</key>
+    <array>
+      <string>applinks:staging.kickstarter.com</string>
+      <string>applinks:native.dev.kickstarter.com</string>
+      <string>applinks:www.kickstarter.com</string>
+      <string>applinks:click.e.kickstarter.com</string>
+      <string>applinks:click.em.kickstarter.com</string>
+      <string>applinks:email.kickstarter.com</string>
+      <string>applinks:emails.kickstarter.com</string>
+      <string>applinks:e2.kickstarter.com</string>
+      <string>applinks:e3.kickstarter.com</string>
+      <string>webcredentials:kickstarter.com</string>
+    </array>
+    <key>com.apple.developer.icloud-container-identifiers</key>
+    <array/>
+    <key>com.apple.developer.in-app-payments</key>
+    <array>
+      <string>merchant.com.kickstarter</string>
+    </array>
+    <key>com.apple.developer.ubiquity-kvstore-identifier</key>
+    <string>$(TeamIdentifierPrefix)$(CFBundleIdentifier)</string>
+  </dict>
 </plist>


### PR DESCRIPTION
# 📲 What

- Adds staging and native.dev to our list of Associated domains.

# 🤔 Why

- This is part of the work to set up deep/universal links on test environments.
- Related [PR](https://github.com/kickstarter/kickstarter/pull/18615)
- [JIRA ticket](https://kickstarter.atlassian.net/browse/NT-728)

# 🛠 How

- Adding `staging.kickstarter.com` and `native.dev.kickstarter.co￼m` to `Alpha.entitlements` and `Debug.entitlements` plists.

# ✅ Acceptance criteria

- This will be tested once we are ready for emails coming from staging/test environments.
