### PR TITLE
[NT-830] Removing user props

### DIFF
--- a/Library/Tracking/Koala.swift
+++ b/Library/Tracking/Koala.swift
@@ -2409,12 +2409,7 @@ private func shareTypeProperty(_ shareType: UIActivity.ActivityType?) -> String?
 private func userProperties(for user: User?, config: Config?, _ prefix: String = "user_") -> [String: Any] {
   var props: [String: Any] = [:]
 
-  props["is_admin"] = user?.isAdmin
-  props["backed_projects_count"] = user?.stats.backedProjectsCount
   props["country"] = user?.location?.country ?? config?.countryCode
-  props["facebook_account"] = user?.facebookConnected
-  props["watched_projects_count"] = user?.stats.starredProjectsCount
-  props["launched_projects_count"] = user?.stats.createdProjectsCount
   props["uid"] = user?.id
 
   return props.prefixedKeys(prefix)

--- a/Library/Tracking/KoalaTests.swift
+++ b/Library/Tracking/KoalaTests.swift
@@ -869,12 +869,7 @@ final class KoalaTests: TestCase {
     let props = client.properties.last
 
     XCTAssertEqual("US", props?["user_country"] as? String)
-    XCTAssertNil(props?["user_backed_projects_count"])
-    XCTAssertNil(props?["user_facebook_account"])
-    XCTAssertNil(props?["user_watched_projects_count"])
     XCTAssertNil(props?["user_uid"])
-    XCTAssertNil(props?["user_is_admin"])
-    XCTAssertNil(props?["user_launched_projects_count"])
   }
 
   func testUserProperties_loggedIn() {
@@ -895,13 +890,8 @@ final class KoalaTests: TestCase {
 
     let props = client.properties.last
 
-    XCTAssertEqual(5, props?["user_backed_projects_count"] as? Int)
     XCTAssertEqual("US", props?["user_country"] as? String)
-    XCTAssertEqual(true, props?["user_facebook_account"] as? Bool)
-    XCTAssertEqual(2, props?["user_watched_projects_count"] as? Int)
     XCTAssertEqual(10, props?["user_uid"] as? Int)
-    XCTAssertEqual(false, props?["user_is_admin"] as? Bool)
-    XCTAssertEqual(3, props?["user_launched_projects_count"] as? Int)
   }
 
   func testTabBarClicked() {


### PR DESCRIPTION
# 📲 What

We're removing any user props that could potentially give us data that is not up to date, in favor of sending that data from the backend.

# 🤔 Why

We want to populate the user attributes directly from the db instead of relying on the client to have the most up-to-date user information. As a result, we don't need the clients to send these user properties anymore.

# 🛠 How

Just delete them!

# ✅ Acceptance criteria

- [x] verify that the removed user properties no longer send
