### PR TITLE
[NT-783] Send prelaunch project links to safari instead of opening in the app

### DIFF
--- a/Kickstarter-iOS/ViewModels/UpdateViewModel.swift
+++ b/Kickstarter-iOS/ViewModels/UpdateViewModel.swift
@@ -104,8 +104,6 @@ internal final class UpdateViewModel: UpdateViewModelType, UpdateViewModelInputs
         return nil
       }
 
-    self.goToComments = possiblyGoToComments.skipNil()
-
     let possiblyGoToProject = navigationAction
       .map { action in
         action.navigationType == .linkActivated
@@ -113,7 +111,14 @@ internal final class UpdateViewModel: UpdateViewModelType, UpdateViewModelInputs
           : nil
       }
 
-    self.goToProject = project
+    let possiblyGoToUpdate = navigationAction
+      .map { action in
+        action.navigationType == .linkActivated
+          ? Navigation.Project.updateWithRequest(action.request)
+          : nil
+      }
+
+    let projectAndRefTag = project
       .takePairWhen(possiblyGoToProject)
       .switchMap { (project, projectParamAndRefTag) -> SignalProducer<(Project, RefTag), Never> in
 
@@ -131,15 +136,30 @@ internal final class UpdateViewModel: UpdateViewModelType, UpdateViewModelInputs
         return producer.map { ($0, refTag ?? RefTag.update) }
       }
 
-    self.goToSafariBrowser = Signal.zip(navigationAction, possiblyGoToProject, possiblyGoToComments)
-      .filter { action, goToProject, goToComments in
-        Navigation.Project.updateWithRequest(action.request) == nil
-          && action.navigationType == .linkActivated
-          && goToProject == nil
-          && goToComments == nil
+    self.goToComments = possiblyGoToComments.skipNil()
+    self.goToProject = projectAndRefTag.filter { project, _ in project.prelaunchActivated != .some(true) }
+
+    let projectIsPrelaunch = projectAndRefTag.filter { project, _ in project.prelaunchActivated == true }
+    let notProjectNotCommentsNotUpdate = Signal.zip(
+      possiblyGoToProject,
+      possiblyGoToComments,
+      possiblyGoToUpdate
+    )
+    .filter { goToProject, goToComments, goToUpdate in
+      goToProject == nil && goToComments == nil && goToUpdate == nil
+    }.logEvents(identifier: "*** NOT PROJECT NOT COMMENTS**")
+
+    let goToExternalLink = Signal.zip(navigationAction, notProjectNotCommentsNotUpdate).map(first)
+    let goToPrelaunchPage = Signal.zip(navigationAction, projectIsPrelaunch).map(first)
+
+    self.goToSafariBrowser = Signal.merge(goToExternalLink, goToPrelaunchPage)
+      .filterMap { action in
+        guard action.navigationType == .linkActivated else {
+          return nil
+        }
+
+        return action.request.url
       }
-      .map { action, _, _ in action.request.url }
-      .skipNil()
 
     project
       .takeWhen(self.goToSafariBrowser)

--- a/Kickstarter-iOS/ViewModels/UpdateViewModel.swift
+++ b/Kickstarter-iOS/ViewModels/UpdateViewModel.swift
@@ -147,7 +147,7 @@ internal final class UpdateViewModel: UpdateViewModelType, UpdateViewModelInputs
     )
     .filter { goToProject, goToComments, goToUpdate in
       goToProject == nil && goToComments == nil && goToUpdate == nil
-    }.logEvents(identifier: "*** NOT PROJECT NOT COMMENTS**")
+    }
 
     let goToExternalLink = Signal.zip(navigationAction, notProjectNotCommentsNotUpdate).map(first)
     let goToPrelaunchPage = Signal.zip(navigationAction, projectIsPrelaunch).map(first)

--- a/Kickstarter-iOS/ViewModels/UpdateViewModelTests.swift
+++ b/Kickstarter-iOS/ViewModels/UpdateViewModelTests.swift
@@ -147,6 +147,8 @@ final class UpdateViewModelTests: TestCase {
       self.vm.inputs.decidePolicyFor(navigationAction: navigationAction).rawValue
     )
     self.goToComments.assertValues([self.update])
+    self.goToProject.assertDidNotEmitValue()
+    self.goToSafariBrowser.assertDidNotEmitValue()
   }
 
   func testGoToSafariBrowser() {


### PR DESCRIPTION
# 📲 What

Fixes a bug where we were incorrectly displaying prelaunch projects in the app when they were accessed through a link in a project update.

# 🤔 Why

A few months ago we added the "prelaunch" feature to project pages on web. Since native apps don't support prelaunch project pages, we updated our universal link handling for project links to check whether the project was a prelaunch project, and if it was, we send the user to mobile web instead of opening the project page in the app.

However, we missed adding this check in the `UpdateViewController`, which supports opening project links natively in the app. This meant that it was possible for a user to tap on a prelaunch project link from a project update and be presented with an incomplete project page natively.

# 🛠 How

We now check whether the project is a `prelaunchActivated` project before presenting the project page natively. If the project is a prelaunch project, we load the project url in a safari webview. If the project is not a `prelaunchActivated` project, then we present the native project page as before.

One thing I noticed which wasn't great is that project links make a network request but give no indication to the user that something is happening (ie. we don't show a loader). This can make it seem like opening the link is "hanging" when in fact a request is being made.

# 👀 See

![IMG_1C216DA6672D-1](https://user-images.githubusercontent.com/3156796/73489262-52a67a80-4378-11ea-98bf-ef4944af8c34.jpeg)


# ✅ Acceptance criteria

This can only be reliably tested by building a `Release` configuration of the app on a device, then doing the following:
- [ ] Search for the project "Ark Worlds: MOBA Card Game", then tap "Updates" and click on the first one called "Prelaunch page is up". Then, click on the link on the update. The link should open in a safari webview that's presented modally
