### PR TITLE
[NT-883] Send user attributes with Optimizely's "activate" function

### DIFF
--- a/Kickstarter-iOS/Views/PledgeCTAContainerView.swift
+++ b/Kickstarter-iOS/Views/PledgeCTAContainerView.swift
@@ -156,7 +156,7 @@ final class PledgeCTAContainerView: UIView {
 
   // MARK: - Configuration
 
-  func configureWith(value: (projectOrError: Either<Project, ErrorEnvelope>, isLoading: Bool)) {
+  func configureWith(value: (projectOrError: Either<(Project, RefTag?), ErrorEnvelope>, isLoading: Bool)) {
     self.viewModel.inputs.configureWith(value: value)
   }
 

--- a/Library/OptimizelyClientType.swift
+++ b/Library/OptimizelyClientType.swift
@@ -13,24 +13,17 @@ extension OptimizelyClientType {
     for experiment: OptimizelyExperiment.Key,
     userId: String,
     isAdmin: Bool,
-    project: Project? = nil,
-    refTag: RefTag? = nil
+    userAttributes: [String: Any]? = nil
   ) -> OptimizelyExperiment.Variant {
-    let properties = optimizelyUserTrackingAttributes(
-      with: AppEnvironment.current.currentUser,
-      project: project,
-      refTag: refTag
-    )
-
     let variationString: String?
 
     if isAdmin {
       variationString = try? self.getVariationKey(
-        experimentKey: experiment.rawValue, userId: userId, attributes: properties
+        experimentKey: experiment.rawValue, userId: userId, attributes: userAttributes
       )
     } else {
       variationString = try? self.activate(
-        experimentKey: experiment.rawValue, userId: userId, attributes: properties
+        experimentKey: experiment.rawValue, userId: userId, attributes: userAttributes
       )
     }
 
@@ -50,7 +43,7 @@ public func optimizelyTrackingAttributesAndEventTags(
   project: Project,
   refTag: RefTag?
 ) -> ([String: Any], [String: Any]) {
-  let properties = optimizelyUserTrackingAttributes(with: user, project: project, refTag: refTag)
+  let properties = optimizelyUserAttributes(with: user, project: project, refTag: refTag)
 
   let eventTags: [String: Any] = ([
     "project_subcategory": project.category.name,
@@ -62,7 +55,7 @@ public func optimizelyTrackingAttributesAndEventTags(
   return (properties, eventTags)
 }
 
-private func optimizelyUserTrackingAttributes(
+public func optimizelyUserAttributes(
   with user: User?,
   project: Project?,
   refTag: RefTag?

--- a/Library/OptimizelyClientType.swift
+++ b/Library/OptimizelyClientType.swift
@@ -12,16 +12,25 @@ extension OptimizelyClientType {
   public func variant(
     for experiment: OptimizelyExperiment.Key,
     userId: String,
-    isAdmin: Bool
+    isAdmin: Bool,
+    project: Project? = nil,
+    refTag: RefTag? = nil
   ) -> OptimizelyExperiment.Variant {
+    let properties = optimizelyUserTrackingAttributes(
+      with: AppEnvironment.current.currentUser,
+      project: project,
+      refTag: refTag
+    )
+
     let variationString: String?
+
     if isAdmin {
       variationString = try? self.getVariationKey(
-        experimentKey: experiment.rawValue, userId: userId, attributes: nil
+        experimentKey: experiment.rawValue, userId: userId, attributes: properties
       )
     } else {
       variationString = try? self.activate(
-        experimentKey: experiment.rawValue, userId: userId, attributes: nil
+        experimentKey: experiment.rawValue, userId: userId, attributes: properties
       )
     }
 
@@ -41,21 +50,7 @@ public func optimizelyTrackingAttributesAndEventTags(
   project: Project,
   refTag: RefTag?
 ) -> ([String: Any], [String: Any]) {
-  let properties: [String: Any] = [
-    "user_backed_projects_count": user?.stats.backedProjectsCount,
-    "user_launched_projects_count": user?.stats.createdProjectsCount,
-    "user_country": (user?.location?.country ?? AppEnvironment.current.config?.countryCode)?.lowercased(),
-    "user_facebook_account": user?.facebookConnected,
-    "user_display_language": AppEnvironment.current.language.rawValue,
-    "session_ref_tag": refTag?.stringTag,
-    "session_referrer_credit": (cookieRefTagFor(project: project) ?? refTag)?.stringTag,
-    "session_os_version": AppEnvironment.current.device.systemVersion,
-    "session_user_is_logged_in": user != nil,
-    "session_app_release_version": AppEnvironment.current.mainBundle.shortVersionString,
-    "session_apple_pay_device": AppEnvironment.current.applePayCapabilities.applePayDevice(),
-    "session_device_format": AppEnvironment.current.device.deviceFormat
-  ]
-  .compact()
+  let properties = optimizelyUserTrackingAttributes(with: user, project: project, refTag: refTag)
 
   let eventTags: [String: Any] = ([
     "project_subcategory": project.category.name,
@@ -65,4 +60,28 @@ public func optimizelyTrackingAttributesAndEventTags(
   ] as [String: Any?]).compact()
 
   return (properties, eventTags)
+}
+
+private func optimizelyUserTrackingAttributes(
+  with user: User?,
+  project: Project?,
+  refTag: RefTag?
+) -> [String: Any] {
+  let properties: [String: Any] = [
+    "user_backed_projects_count": user?.stats.backedProjectsCount,
+    "user_launched_projects_count": user?.stats.createdProjectsCount,
+    "user_country": (user?.location?.country ?? AppEnvironment.current.config?.countryCode)?.lowercased(),
+    "user_facebook_account": user?.facebookConnected,
+    "user_display_language": AppEnvironment.current.language.rawValue,
+    "session_ref_tag": refTag?.stringTag,
+    "session_referrer_credit": project.flatMap(cookieRefTagFor(project:)).coalesceWith(refTag)?.stringTag,
+    "session_os_version": AppEnvironment.current.device.systemVersion,
+    "session_user_is_logged_in": user != nil,
+    "session_app_release_version": AppEnvironment.current.mainBundle.shortVersionString,
+    "session_apple_pay_device": AppEnvironment.current.applePayCapabilities.applePayDevice(),
+    "session_device_format": AppEnvironment.current.device.deviceFormat
+  ]
+  .compact()
+
+  return properties
 }

--- a/Library/TestHelpers/MockOptimizelyClient.swift
+++ b/Library/TestHelpers/MockOptimizelyClient.swift
@@ -24,8 +24,10 @@ internal class MockOptimizelyClient: OptimizelyClientType {
     return try self.experiment(forKey: experimentKey, userId: userId, attributes: attributes)
   }
 
-  private func experiment(forKey key: String, userId _: String, attributes _: [String: Any?]?) throws
+  private func experiment(forKey key: String, userId _: String, attributes: [String: Any?]?) throws
     -> String {
+      self.trackedAttributes = attributes
+
     if let error = self.error {
       throw error
     }

--- a/Library/TestHelpers/MockOptimizelyClient.swift
+++ b/Library/TestHelpers/MockOptimizelyClient.swift
@@ -4,13 +4,15 @@ internal struct MockOptimizelyError: Error {}
 
 internal class MockOptimizelyClient: OptimizelyClientType {
   // MARK: - Experiment Activation Test Properties
+
   var activatePathCalled: Bool = false
   var experiments: [String: String] = [:]
   var error: MockOptimizelyError?
   var getVariantPathCalled: Bool = false
   var userAttributes: [String: Any?]?
-  
+
   // MARK: - Event Tracking Test Properties
+
   var trackedAttributes: [String: Any?]?
   var trackedEventKey: String?
   var trackedEventTags: [String: Any?]?

--- a/Library/TestHelpers/MockOptimizelyClient.swift
+++ b/Library/TestHelpers/MockOptimizelyClient.swift
@@ -3,10 +3,14 @@ import Library
 internal struct MockOptimizelyError: Error {}
 
 internal class MockOptimizelyClient: OptimizelyClientType {
+  // MARK: - Experiment Activation Test Properties
   var activatePathCalled: Bool = false
   var experiments: [String: String] = [:]
   var error: MockOptimizelyError?
   var getVariantPathCalled: Bool = false
+  var userAttributes: [String: Any?]?
+  
+  // MARK: - Event Tracking Test Properties
   var trackedAttributes: [String: Any?]?
   var trackedEventKey: String?
   var trackedEventTags: [String: Any?]?
@@ -26,7 +30,7 @@ internal class MockOptimizelyClient: OptimizelyClientType {
 
   private func experiment(forKey key: String, userId _: String, attributes: [String: Any?]?) throws
     -> String {
-      self.trackedAttributes = attributes
+    self.userAttributes = attributes
 
     if let error = self.error {
       throw error

--- a/Library/ViewModels/PledgeCTAContainerViewViewModel.swift
+++ b/Library/ViewModels/PledgeCTAContainerViewViewModel.swift
@@ -142,7 +142,7 @@ private func pledgeCTA(project: Project, refTag: RefTag?, backing: Backing?) -> 
     if currentUserIsCreator(of: project) {
       return PledgeStateCTAType.viewYourRewards
     }
-    
+
     let userAttributes = optimizelyUserAttributes(
       with: AppEnvironment.current.currentUser,
       project: project,

--- a/Library/ViewModels/PledgeCTAContainerViewViewModel.swift
+++ b/Library/ViewModels/PledgeCTAContainerViewViewModel.swift
@@ -142,14 +142,19 @@ private func pledgeCTA(project: Project, refTag: RefTag?, backing: Backing?) -> 
     if currentUserIsCreator(of: project) {
       return PledgeStateCTAType.viewYourRewards
     }
+    
+    let userAttributes = optimizelyUserAttributes(
+      with: AppEnvironment.current.currentUser,
+      project: project,
+      refTag: refTag
+    )
 
     let optimizelyVariant = AppEnvironment.current.optimizelyClient?
       .variant(
         for: OptimizelyExperiment.Key.pledgeCTACopy,
         userId: deviceIdentifier(uuid: UUID()),
         isAdmin: AppEnvironment.current.currentUser?.isAdmin ?? false,
-        project: project,
-        refTag: refTag
+        userAttributes: userAttributes
       )
 
     if let variant = optimizelyVariant, project.state == .live {

--- a/Library/ViewModels/PledgeCTAContainerViewViewModel.swift
+++ b/Library/ViewModels/PledgeCTAContainerViewViewModel.swift
@@ -4,7 +4,7 @@ import ReactiveExtensions
 import ReactiveSwift
 
 public protocol PledgeCTAContainerViewViewModelInputs {
-  func configureWith(value: (projectOrError: Either<Project, ErrorEnvelope>, isLoading: Bool))
+  func configureWith(value: (projectOrError: Either<(Project, RefTag?), ErrorEnvelope>, isLoading: Bool))
   func pledgeCTAButtonTapped()
 }
 
@@ -41,6 +41,12 @@ public final class PledgeCTAContainerViewViewModel: PledgeCTAContainerViewViewMo
     let project = projectOrError
       .map(Either.left)
       .skipNil()
+      .map(first)
+
+    let refTag = projectOrError
+      .map(Either.left)
+      .skipNil()
+      .map(second)
 
     let projectError = projectOrError
       .map(Either.right)
@@ -50,8 +56,8 @@ public final class PledgeCTAContainerViewViewModel: PledgeCTAContainerViewViewMo
       .negate()
 
     let backing = project.map { $0.personalization.backing }
-    let pledgeState = Signal.combineLatest(project, backing)
-      .map(pledgeCTA(project:backing:))
+    let pledgeState = Signal.combineLatest(project, refTag, backing)
+      .map(pledgeCTA(project:refTag:backing:))
 
     let inError = Signal.merge(
       projectError.ignoreValues().mapConst(true),
@@ -102,8 +108,10 @@ public final class PledgeCTAContainerViewViewModel: PledgeCTAContainerViewViewMo
   }
 
   fileprivate let projectOrErrorProperty =
-    MutableProperty<(Either<Project, ErrorEnvelope>, isLoading: Bool)?>(nil)
-  public func configureWith(value: (projectOrError: Either<Project, ErrorEnvelope>, isLoading: Bool)) {
+    MutableProperty<(Either<(Project, RefTag?), ErrorEnvelope>, isLoading: Bool)?>(nil)
+  public func configureWith(
+    value: (projectOrError: Either<(Project, RefTag?), ErrorEnvelope>, isLoading: Bool)
+  ) {
     self.projectOrErrorProperty.value = value
   }
 
@@ -129,7 +137,7 @@ public final class PledgeCTAContainerViewViewModel: PledgeCTAContainerViewViewMo
 
 // MARK: - Functions
 
-private func pledgeCTA(project: Project, backing: Backing?) -> PledgeStateCTAType {
+private func pledgeCTA(project: Project, refTag: RefTag?, backing: Backing?) -> PledgeStateCTAType {
   guard let projectBacking = backing, project.personalization.isBacking == .some(true) else {
     if currentUserIsCreator(of: project) {
       return PledgeStateCTAType.viewYourRewards
@@ -139,7 +147,9 @@ private func pledgeCTA(project: Project, backing: Backing?) -> PledgeStateCTATyp
       .variant(
         for: OptimizelyExperiment.Key.pledgeCTACopy,
         userId: deviceIdentifier(uuid: UUID()),
-        isAdmin: AppEnvironment.current.currentUser?.isAdmin ?? false
+        isAdmin: AppEnvironment.current.currentUser?.isAdmin ?? false,
+        project: project,
+        refTag: refTag
       )
 
     if let variant = optimizelyVariant, project.state == .live {

--- a/Library/ViewModels/PledgeCTAContainerViewViewModelTests.swift
+++ b/Library/ViewModels/PledgeCTAContainerViewViewModelTests.swift
@@ -156,16 +156,16 @@ internal final class PledgeCTAContainerViewViewModelTests: TestCase {
     self.spacerIsHidden.assertValues([true])
     self.stackViewIsHidden.assertValues([true])
   }
-  
+
   func testPledgeCTA_LiveProject_LoggedOut_OptimizelyExperimental_Variant1() {
     let project = Project.template
       |> Project.lens.personalization.backing .~ nil
       |> Project.lens.personalization.isBacking .~ false
-    
+
     let optimizelyClient = MockOptimizelyClient()
       |> \.experiments .~
       [OptimizelyExperiment.Key.pledgeCTACopy.rawValue: OptimizelyExperiment.Variant.variant1.rawValue]
-    
+
     withEnvironment(currentUser: nil, optimizelyClient: optimizelyClient) {
       self.vm.inputs.configureWith(value: (.left((project, .discovery)), false))
       self.buttonStyleType.assertValues([ButtonStyleType.green])
@@ -174,24 +174,28 @@ internal final class PledgeCTAContainerViewViewModelTests: TestCase {
       self.stackViewIsHidden.assertValues([true])
       XCTAssertTrue(optimizelyClient.activatePathCalled)
       XCTAssertFalse(optimizelyClient.getVariantPathCalled)
-      
+
       XCTAssertNil(optimizelyClient.userAttributes?["user_backed_projects_count"] as? Int)
       XCTAssertNil(optimizelyClient.userAttributes?["user_launched_projects_count"] as? Int)
       XCTAssertNil(optimizelyClient.userAttributes?["user_facebook_account"] as? Bool)
-      XCTAssertEqual(optimizelyClient.userAttributes?["user_country"] as? String,
-                     "us",
-                     "Country is populated from the config")
+      XCTAssertEqual(
+        optimizelyClient.userAttributes?["user_country"] as? String,
+        "us",
+        "Country is populated from the config"
+      )
       XCTAssertEqual(optimizelyClient.userAttributes?["user_display_language"] as? String, "en")
-      
+
       XCTAssertEqual(optimizelyClient.userAttributes?["session_ref_tag"] as? String, "discovery")
       XCTAssertEqual(optimizelyClient.userAttributes?["session_referrer_credit"] as? String, "discovery")
       XCTAssertEqual(optimizelyClient.userAttributes?["session_os_version"] as? String, "MockSystemVersion")
       XCTAssertEqual(optimizelyClient.userAttributes?["session_user_is_logged_in"] as? Bool, false)
-      XCTAssertEqual(optimizelyClient.userAttributes?["session_app_release_version"] as? String,
-                     "1.2.3.4.5.6.7.8.9.0")
+      XCTAssertEqual(
+        optimizelyClient.userAttributes?["session_app_release_version"] as? String,
+        "1.2.3.4.5.6.7.8.9.0"
+      )
       XCTAssertEqual(optimizelyClient.userAttributes?["session_apple_pay_device"] as? Bool, true)
       XCTAssertEqual(optimizelyClient.userAttributes?["session_device_format"] as? String, "phone")
-      
+
       XCTAssertNil(optimizelyClient.trackedEventTags)
     }
   }
@@ -220,22 +224,24 @@ internal final class PledgeCTAContainerViewViewModelTests: TestCase {
       self.stackViewIsHidden.assertValues([true])
       XCTAssertTrue(optimizelyClient.activatePathCalled)
       XCTAssertFalse(optimizelyClient.getVariantPathCalled)
-      
+
       XCTAssertEqual(optimizelyClient.userAttributes?["user_backed_projects_count"] as? Int, 50)
       XCTAssertEqual(optimizelyClient.userAttributes?["user_launched_projects_count"] as? Int, 25)
       XCTAssertEqual(optimizelyClient.userAttributes?["user_country"] as? String, "us")
       XCTAssertEqual(optimizelyClient.userAttributes?["user_facebook_account"] as? Bool, true)
       XCTAssertEqual(optimizelyClient.userAttributes?["user_display_language"] as? String, "en")
-      
+
       XCTAssertEqual(optimizelyClient.userAttributes?["session_ref_tag"] as? String, "discovery")
       XCTAssertEqual(optimizelyClient.userAttributes?["session_referrer_credit"] as? String, "discovery")
       XCTAssertEqual(optimizelyClient.userAttributes?["session_os_version"] as? String, "MockSystemVersion")
       XCTAssertEqual(optimizelyClient.userAttributes?["session_user_is_logged_in"] as? Bool, true)
-      XCTAssertEqual(optimizelyClient.userAttributes?["session_app_release_version"] as? String,
-                     "1.2.3.4.5.6.7.8.9.0")
+      XCTAssertEqual(
+        optimizelyClient.userAttributes?["session_app_release_version"] as? String,
+        "1.2.3.4.5.6.7.8.9.0"
+      )
       XCTAssertEqual(optimizelyClient.userAttributes?["session_apple_pay_device"] as? Bool, true)
       XCTAssertEqual(optimizelyClient.userAttributes?["session_device_format"] as? String, "phone")
-  
+
       XCTAssertNil(optimizelyClient.trackedEventTags)
     }
   }
@@ -262,22 +268,24 @@ internal final class PledgeCTAContainerViewViewModelTests: TestCase {
       self.stackViewIsHidden.assertValues([true])
       XCTAssertTrue(optimizelyClient.activatePathCalled)
       XCTAssertFalse(optimizelyClient.getVariantPathCalled)
-      
+
       XCTAssertEqual(optimizelyClient.userAttributes?["user_backed_projects_count"] as? Int, 50)
       XCTAssertEqual(optimizelyClient.userAttributes?["user_launched_projects_count"] as? Int, 25)
       XCTAssertEqual(optimizelyClient.userAttributes?["user_country"] as? String, "us")
       XCTAssertEqual(optimizelyClient.userAttributes?["user_facebook_account"] as? Bool, true)
       XCTAssertEqual(optimizelyClient.userAttributes?["user_display_language"] as? String, "en")
-      
+
       XCTAssertEqual(optimizelyClient.userAttributes?["session_ref_tag"] as? String, "discovery")
       XCTAssertEqual(optimizelyClient.userAttributes?["session_referrer_credit"] as? String, "discovery")
       XCTAssertEqual(optimizelyClient.userAttributes?["session_os_version"] as? String, "MockSystemVersion")
       XCTAssertEqual(optimizelyClient.userAttributes?["session_user_is_logged_in"] as? Bool, true)
-      XCTAssertEqual(optimizelyClient.userAttributes?["session_app_release_version"] as? String,
-                     "1.2.3.4.5.6.7.8.9.0")
+      XCTAssertEqual(
+        optimizelyClient.userAttributes?["session_app_release_version"] as? String,
+        "1.2.3.4.5.6.7.8.9.0"
+      )
       XCTAssertEqual(optimizelyClient.userAttributes?["session_apple_pay_device"] as? Bool, true)
       XCTAssertEqual(optimizelyClient.userAttributes?["session_device_format"] as? String, "phone")
-      
+
       XCTAssertNil(optimizelyClient.trackedEventTags)
     }
   }
@@ -306,22 +314,24 @@ internal final class PledgeCTAContainerViewViewModelTests: TestCase {
       self.stackViewIsHidden.assertValues([true])
       XCTAssertFalse(optimizelyClient.activatePathCalled)
       XCTAssertTrue(optimizelyClient.getVariantPathCalled)
-      
+
       XCTAssertEqual(optimizelyClient.userAttributes?["user_backed_projects_count"] as? Int, 50)
       XCTAssertEqual(optimizelyClient.userAttributes?["user_launched_projects_count"] as? Int, 25)
       XCTAssertEqual(optimizelyClient.userAttributes?["user_country"] as? String, "us")
       XCTAssertEqual(optimizelyClient.userAttributes?["user_facebook_account"] as? Bool, true)
       XCTAssertEqual(optimizelyClient.userAttributes?["user_display_language"] as? String, "en")
-      
+
       XCTAssertEqual(optimizelyClient.userAttributes?["session_ref_tag"] as? String, "discovery")
       XCTAssertEqual(optimizelyClient.userAttributes?["session_referrer_credit"] as? String, "discovery")
       XCTAssertEqual(optimizelyClient.userAttributes?["session_os_version"] as? String, "MockSystemVersion")
       XCTAssertEqual(optimizelyClient.userAttributes?["session_user_is_logged_in"] as? Bool, true)
-      XCTAssertEqual(optimizelyClient.userAttributes?["session_app_release_version"] as? String,
-                     "1.2.3.4.5.6.7.8.9.0")
+      XCTAssertEqual(
+        optimizelyClient.userAttributes?["session_app_release_version"] as? String,
+        "1.2.3.4.5.6.7.8.9.0"
+      )
       XCTAssertEqual(optimizelyClient.userAttributes?["session_apple_pay_device"] as? Bool, true)
       XCTAssertEqual(optimizelyClient.userAttributes?["session_device_format"] as? String, "phone")
-      
+
       XCTAssertNil(optimizelyClient.trackedEventTags)
     }
   }
@@ -350,7 +360,7 @@ internal final class PledgeCTAContainerViewViewModelTests: TestCase {
         optimizelyClient.getVariantPathCalled,
         "Optimizely client should not be called when the pledge button won't be shown"
       )
-      
+
       XCTAssertNil(optimizelyClient.userAttributes)
     }
   }

--- a/Library/ViewModels/ProjectPamphletViewModelTests.swift
+++ b/Library/ViewModels/ProjectPamphletViewModelTests.swift
@@ -631,14 +631,14 @@ final class ProjectPamphletViewModelTests: TestCase {
       self.configureInitialState(.left(project))
 
       self.configurePledgeCTAViewProject.assertValues([project])
-
       self.configurePledgeCTAViewIsLoading.assertValues([true])
+      self.configurePledgeCTAViewRefTag.assertValues([.discovery])
 
       self.scheduler.run()
 
       self.configurePledgeCTAViewProject.assertValues([project, projectFull, projectFull])
-
       self.configurePledgeCTAViewIsLoading.assertValues([true, true, false])
+      self.configurePledgeCTAViewRefTag.assertValues([.discovery, .discovery, .discovery])
     }
   }
 
@@ -661,16 +661,19 @@ final class ProjectPamphletViewModelTests: TestCase {
     ) {
       self.configurePledgeCTAViewProject.assertDidNotEmitValue()
       self.configurePledgeCTAViewIsLoading.assertDidNotEmitValue()
+      self.configurePledgeCTAViewRefTag.assertDidNotEmitValue()
 
       self.configureInitialState(.left(project))
 
       self.configurePledgeCTAViewProject.assertDidNotEmitValue()
       self.configurePledgeCTAViewIsLoading.assertDidNotEmitValue()
+      self.configurePledgeCTAViewRefTag.assertDidNotEmitValue()
 
       self.scheduler.run()
 
       self.configurePledgeCTAViewProject.assertDidNotEmitValue()
       self.configurePledgeCTAViewIsLoading.assertDidNotEmitValue()
+      self.configurePledgeCTAViewRefTag.assertDidNotEmitValue()
     }
   }
 
@@ -689,16 +692,20 @@ final class ProjectPamphletViewModelTests: TestCase {
     ) {
       self.configurePledgeCTAViewProject.assertDidNotEmitValue()
       self.configurePledgeCTAViewIsLoading.assertDidNotEmitValue()
+      self.configurePledgeCTAViewRefTag.assertDidNotEmitValue()
 
       self.configureInitialState(.left(project))
 
       self.configurePledgeCTAViewProject.assertValues([project])
       self.configurePledgeCTAViewIsLoading.assertValues([true])
+      self.configurePledgeCTAViewRefTag.assertValues([.discovery])
 
       self.scheduler.run()
 
+      self.configurePledgeCTAViewProject.assertValues([project, project])
       self.configurePledgeCTAViewErrorEnvelope.assertValueCount(1)
       self.configurePledgeCTAViewIsLoading.assertValues([true, false, false])
+      self.configurePledgeCTAViewRefTag.assertValues([.discovery, .discovery])
     }
   }
 
@@ -717,16 +724,19 @@ final class ProjectPamphletViewModelTests: TestCase {
     ) {
       self.configurePledgeCTAViewProject.assertDidNotEmitValue()
       self.configurePledgeCTAViewIsLoading.assertDidNotEmitValue()
+      self.configurePledgeCTAViewRefTag.assertDidNotEmitValue()
 
       self.configureInitialState(.left(project))
 
       self.configurePledgeCTAViewProject.assertDidNotEmitValue()
       self.configurePledgeCTAViewIsLoading.assertDidNotEmitValue()
+      self.configurePledgeCTAViewRefTag.assertDidNotEmitValue()
 
       self.scheduler.run()
 
       self.configurePledgeCTAViewProject.assertDidNotEmitValue()
       self.configurePledgeCTAViewIsLoading.assertDidNotEmitValue()
+      self.configurePledgeCTAViewRefTag.assertDidNotEmitValue()
     }
   }
 
@@ -748,6 +758,7 @@ final class ProjectPamphletViewModelTests: TestCase {
     withEnvironment(apiService: mockService, config: config, mainBundle: releaseBundle) {
       self.configurePledgeCTAViewProject.assertDidNotEmitValue()
       self.configurePledgeCTAViewIsLoading.assertDidNotEmitValue()
+      self.configurePledgeCTAViewRefTag.assertDidNotEmitValue()
 
       self.vm.inputs.configureWith(projectOrParam: .left(project), refTag: .discovery)
       self.vm.inputs.viewDidLoad()
@@ -755,11 +766,13 @@ final class ProjectPamphletViewModelTests: TestCase {
 
       self.configurePledgeCTAViewProject.assertValues([project])
       self.configurePledgeCTAViewIsLoading.assertValues([true])
+      self.configurePledgeCTAViewRefTag.assertValues([.discovery])
 
       self.scheduler.advance()
 
       self.configurePledgeCTAViewProject.assertValues([project, project, projectFull])
       self.configurePledgeCTAViewIsLoading.assertValues([true, true, false])
+      self.configurePledgeCTAViewRefTag.assertValues([.discovery, .discovery, .discovery])
     }
 
     withEnvironment(
@@ -771,6 +784,7 @@ final class ProjectPamphletViewModelTests: TestCase {
 
       self.configurePledgeCTAViewProject.assertValues([project, project, projectFull, projectFull])
       self.configurePledgeCTAViewIsLoading.assertValues([true, true, false, true])
+      self.configurePledgeCTAViewRefTag.assertValues([.discovery, .discovery, .discovery, .discovery])
 
       self.scheduler.advance()
 
@@ -781,6 +795,12 @@ final class ProjectPamphletViewModelTests: TestCase {
                                                        projectFull,
                                                        backedProject])
       self.configurePledgeCTAViewIsLoading.assertValues([true, true, false, true, true, false])
+      self.configurePledgeCTAViewRefTag.assertValues([.discovery,
+                                                      .discovery,
+                                                      .discovery,
+                                                      .discovery,
+                                                      .discovery,
+                                                      .discovery])
     }
   }
 
@@ -801,17 +821,20 @@ final class ProjectPamphletViewModelTests: TestCase {
     withEnvironment(apiService: mockService, config: config, mainBundle: releaseBundle) {
       self.configurePledgeCTAViewProject.assertDidNotEmitValue()
       self.configurePledgeCTAViewIsLoading.assertDidNotEmitValue()
+      self.configurePledgeCTAViewRefTag.assertDidNotEmitValue()
 
       self.vm.inputs.configureWith(projectOrParam: .left(project), refTag: .discovery)
       self.vm.inputs.viewDidLoad()
 
       self.configurePledgeCTAViewProject.assertValues([project])
       self.configurePledgeCTAViewIsLoading.assertValues([true])
+      self.configurePledgeCTAViewRefTag.assertValues([.discovery])
 
       self.scheduler.advance()
 
       self.configurePledgeCTAViewProject.assertValues([project, project, projectFull])
       self.configurePledgeCTAViewIsLoading.assertValues([true, true, false])
+      self.configurePledgeCTAViewRefTag.assertValues([.discovery, .discovery, .discovery])
     }
 
     withEnvironment(
@@ -823,6 +846,7 @@ final class ProjectPamphletViewModelTests: TestCase {
 
       self.configurePledgeCTAViewProject.assertValues([project, project, projectFull, projectFull])
       self.configurePledgeCTAViewIsLoading.assertValues([true, true, false, true])
+      self.configurePledgeCTAViewRefTag.assertValues([.discovery, .discovery, .discovery, .discovery])
 
       self.scheduler.advance()
 
@@ -833,6 +857,12 @@ final class ProjectPamphletViewModelTests: TestCase {
                                                        projectFull,
                                                        updatedProject])
       self.configurePledgeCTAViewIsLoading.assertValues([true, true, false, true, true, false])
+      self.configurePledgeCTAViewRefTag.assertValues([.discovery,
+                                                      .discovery,
+                                                      .discovery,
+                                                      .discovery,
+                                                      .discovery,
+                                                      .discovery])
     }
   }
 
@@ -852,17 +882,20 @@ final class ProjectPamphletViewModelTests: TestCase {
     withEnvironment(apiService: mockService, config: config, mainBundle: releaseBundle) {
       self.configurePledgeCTAViewProject.assertDidNotEmitValue()
       self.configurePledgeCTAViewIsLoading.assertDidNotEmitValue()
+      self.configurePledgeCTAViewRefTag.assertDidNotEmitValue()
 
       self.vm.inputs.configureWith(projectOrParam: .left(project), refTag: .discovery)
       self.vm.inputs.viewDidLoad()
 
       self.configurePledgeCTAViewProject.assertDidNotEmitValue()
       self.configurePledgeCTAViewIsLoading.assertDidNotEmitValue()
+      self.configurePledgeCTAViewRefTag.assertDidNotEmitValue()
 
       self.scheduler.advance()
 
       self.configurePledgeCTAViewProject.assertDidNotEmitValue()
       self.configurePledgeCTAViewIsLoading.assertDidNotEmitValue()
+      self.configurePledgeCTAViewRefTag.assertDidNotEmitValue()
     }
 
     withEnvironment(
@@ -894,6 +927,7 @@ final class ProjectPamphletViewModelTests: TestCase {
 
       self.configurePledgeCTAViewProject.assertDidNotEmitValue()
       self.configurePledgeCTAViewIsLoading.assertDidNotEmitValue()
+      self.configurePledgeCTAViewRefTag.assertDidNotEmitValue()
     }
   }
 
@@ -908,6 +942,7 @@ final class ProjectPamphletViewModelTests: TestCase {
 
       self.configurePledgeCTAViewProject.assertDidNotEmitValue()
       self.configurePledgeCTAViewIsLoading.assertDidNotEmitValue()
+      self.configurePledgeCTAViewRefTag.assertDidNotEmitValue()
     }
   }
 
@@ -927,17 +962,20 @@ final class ProjectPamphletViewModelTests: TestCase {
     withEnvironment(apiService: mockService, config: config) {
       self.configurePledgeCTAViewProject.assertDidNotEmitValue()
       self.configurePledgeCTAViewIsLoading.assertDidNotEmitValue()
+      self.configurePledgeCTAViewRefTag.assertDidNotEmitValue()
 
       self.vm.inputs.configureWith(projectOrParam: .left(project), refTag: .discovery)
       self.vm.inputs.viewDidLoad()
 
       self.configurePledgeCTAViewProject.assertValues([project])
       self.configurePledgeCTAViewIsLoading.assertValues([true])
+      self.configurePledgeCTAViewRefTag.assertValues([.discovery])
 
       self.scheduler.advance()
 
       self.configurePledgeCTAViewProject.assertValues([project, projectFull, projectFull])
       self.configurePledgeCTAViewIsLoading.assertValues([true, true, false])
+      self.configurePledgeCTAViewRefTag.assertValues([.discovery, .discovery, .discovery])
     }
 
     withEnvironment(
@@ -958,6 +996,12 @@ final class ProjectPamphletViewModelTests: TestCase {
                                                        projectFull2,
                                                        projectFull2])
       self.configurePledgeCTAViewIsLoading.assertValues([true, true, false, true, true, false])
+      self.configurePledgeCTAViewRefTag.assertValues([.discovery,
+                                                      .discovery,
+                                                      .discovery,
+                                                      .discovery,
+                                                      .discovery,
+                                                      .discovery])
     }
   }
 

--- a/Library/ViewModels/ProjectPamphletViewModelTests.swift
+++ b/Library/ViewModels/ProjectPamphletViewModelTests.swift
@@ -788,19 +788,23 @@ final class ProjectPamphletViewModelTests: TestCase {
 
       self.scheduler.advance()
 
-      self.configurePledgeCTAViewProject.assertValues([project,
-                                                       project,
-                                                       projectFull,
-                                                       projectFull,
-                                                       projectFull,
-                                                       backedProject])
+      self.configurePledgeCTAViewProject.assertValues([
+        project,
+        project,
+        projectFull,
+        projectFull,
+        projectFull,
+        backedProject
+      ])
       self.configurePledgeCTAViewIsLoading.assertValues([true, true, false, true, true, false])
-      self.configurePledgeCTAViewRefTag.assertValues([.discovery,
-                                                      .discovery,
-                                                      .discovery,
-                                                      .discovery,
-                                                      .discovery,
-                                                      .discovery])
+      self.configurePledgeCTAViewRefTag.assertValues([
+        .discovery,
+        .discovery,
+        .discovery,
+        .discovery,
+        .discovery,
+        .discovery
+      ])
     }
   }
 
@@ -850,19 +854,23 @@ final class ProjectPamphletViewModelTests: TestCase {
 
       self.scheduler.advance()
 
-      self.configurePledgeCTAViewProject.assertValues([project,
-                                                       project,
-                                                       projectFull,
-                                                       projectFull,
-                                                       projectFull,
-                                                       updatedProject])
+      self.configurePledgeCTAViewProject.assertValues([
+        project,
+        project,
+        projectFull,
+        projectFull,
+        projectFull,
+        updatedProject
+      ])
       self.configurePledgeCTAViewIsLoading.assertValues([true, true, false, true, true, false])
-      self.configurePledgeCTAViewRefTag.assertValues([.discovery,
-                                                      .discovery,
-                                                      .discovery,
-                                                      .discovery,
-                                                      .discovery,
-                                                      .discovery])
+      self.configurePledgeCTAViewRefTag.assertValues([
+        .discovery,
+        .discovery,
+        .discovery,
+        .discovery,
+        .discovery,
+        .discovery
+      ])
     }
   }
 
@@ -989,19 +997,23 @@ final class ProjectPamphletViewModelTests: TestCase {
 
       self.scheduler.advance()
 
-      self.configurePledgeCTAViewProject.assertValues([project,
-                                                       projectFull,
-                                                       projectFull,
-                                                       projectFull,
-                                                       projectFull2,
-                                                       projectFull2])
+      self.configurePledgeCTAViewProject.assertValues([
+        project,
+        projectFull,
+        projectFull,
+        projectFull,
+        projectFull2,
+        projectFull2
+      ])
       self.configurePledgeCTAViewIsLoading.assertValues([true, true, false, true, true, false])
-      self.configurePledgeCTAViewRefTag.assertValues([.discovery,
-                                                      .discovery,
-                                                      .discovery,
-                                                      .discovery,
-                                                      .discovery,
-                                                      .discovery])
+      self.configurePledgeCTAViewRefTag.assertValues([
+        .discovery,
+        .discovery,
+        .discovery,
+        .discovery,
+        .discovery,
+        .discovery
+      ])
     }
   }
 


### PR DESCRIPTION
# 📲 What

Sends user attributes with Optimizely's `activate` and `getVariation` functions so that we can segment experiments based on user attributes.

# 🤔 Why

We might want to take advantage of Optimizely's experiment segmentation to bucket users into variations based on their user attributes. In order to do this, we need to send the user attributes with the `activate` and `getVariation` functions.

# ✅ Acceptance criteria

- [ ] whitelist your device_id into the control group - you should see the "Back this project" button as normal
- [ ] whitelist your device_id into the variation-1 group - you should see the "See the rewards" button as normal
- [ ] whitelist your device_id into the variation-2 group - you should see the "View the rewards" button as normal
