### PR TITLE
[NT-858] Replace .filter { ... }.first with .find(where: { ... })

### DIFF
--- a/Kickstarter-iOS/Views/Controllers/DashboardProjectsDrawerViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/DashboardProjectsDrawerViewController.swift
@@ -137,7 +137,7 @@ internal final class DashboardProjectsDrawerViewController: UITableViewControlle
   }
 
   fileprivate func accessibilityFocusOnFirstProject() {
-    let cell = self.tableView.visibleCells.filter { $0 is DashboardProjectsDrawerCell }.first
+    let cell = self.tableView.visibleCells.first { $0 is DashboardProjectsDrawerCell }
     if let cell = cell {
       UIAccessibility.post(notification: UIAccessibility.Notification.screenChanged, argument: cell)
     }

--- a/Kickstarter-iOS/Views/Controllers/ProjectPamphletContentViewControllerTests.swift
+++ b/Kickstarter-iOS/Views/Controllers/ProjectPamphletContentViewControllerTests.swift
@@ -165,7 +165,10 @@ internal final class ProjectPamphletContentViewControllerTests: TestCase {
   }
 
   func testBackerOfSoldOutReward() {
-    let soldOutReward = self.cosmicSurgery.rewards.filter { $0.remaining == 0 }.first!
+    guard let soldOutReward = self.cosmicSurgery.rewards.first(where: { $0.remaining == 0 }) else {
+      XCTFail("Should have a sold out reward")
+      return
+    }
     let project = self.cosmicSurgery
       |> Project.lens.rewards .~ [soldOutReward]
       |> Project.lens.state .~ .live

--- a/Kickstarter-iOS/Views/Controllers/SettingsPrivacyViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/SettingsPrivacyViewController.swift
@@ -86,7 +86,7 @@ internal final class SettingsPrivacyViewController: UITableViewController {
   }
 
   private func accessibilityFocusOnFollowingCell() {
-    let cell = self.tableView.visibleCells.filter { $0 is SettingsFollowCell }.first
+    let cell = self.tableView.visibleCells.first { $0 is SettingsFollowCell }
     if let cell = cell {
       UIAccessibility.post(notification: UIAccessibility.Notification.screenChanged, argument: cell)
     }

--- a/Kickstarter-iOS/Views/RewardCardContainerViewTests.swift
+++ b/Kickstarter-iOS/Views/RewardCardContainerViewTests.swift
@@ -4,6 +4,7 @@ import Foundation
 @testable import Library
 import Prelude
 import UIKit
+import XCTest
 
 final class RewardCardContainerViewTests: TestCase {
   override func setUp() {
@@ -318,7 +319,10 @@ final class RewardCardContainerViewTests: TestCase {
 
     combos([Language.en], [Device.phone4_7inch]).forEach { language, device in
       withEnvironment(config: mockConfig) {
-        let noReward = allRewards.filter { $0.1.isNoReward }.first!
+        guard let noReward = allRewards.first(where: { $0.1.isNoReward }) else {
+          XCTFail("Should have a reward")
+          return
+        }
         let (description, reward) = noReward
 
         let vc = rewardCardInViewController(
@@ -339,7 +343,10 @@ final class RewardCardContainerViewTests: TestCase {
 
     combos([Language.en], [Device.phone4_7inch]).forEach { language, device in
       withEnvironment(config: mockConfig) {
-        let noReward = allRewards.filter { $0.1.isNoReward }.first!
+        guard let noReward = allRewards.first(where: { $0.1.isNoReward }) else {
+          XCTFail("Should have a reward")
+          return
+        }
         let (description, reward) = noReward
         let project = Project.template
           |> Project.lens.personalization.isBacking .~ true

--- a/Library/SharedFunctions.swift
+++ b/Library/SharedFunctions.swift
@@ -44,10 +44,10 @@ public func currentUserIsCreator(of project: Project) -> Bool {
  */
 
 internal func reward(from backing: Backing, inProject project: Project) -> Reward {
-  let noRewardFromProject = project.rewards.filter { $0.id == Reward.noReward.id }.first
+  let noRewardFromProject = project.rewards.first { $0.id == Reward.noReward.id }
 
   return backing.reward
-    ?? project.rewards.filter { $0.id == backing.rewardId }.first
+    ?? project.rewards.first { $0.id == backing.rewardId }
     ?? noRewardFromProject
     ?? Reward.noReward
 }

--- a/Library/ViewModels/DashboardViewModel.swift
+++ b/Library/ViewModels/DashboardViewModel.swift
@@ -428,9 +428,9 @@ public func == (lhs: DashboardTitleViewData, rhs: DashboardTitleViewData) -> Boo
 private func find(projectForParam param: Param?, in projects: [Project]) -> Project? {
   guard let param = param else { return nil }
 
-  return projects.filter { project in
+  return projects.first { project in
     if case .id(project.id) = param { return true }
     if case .slug(project.slug) = param { return true }
     return false
-  }.first
+  }
 }

--- a/Library/ViewModels/PledgeCTAContainerViewViewModel.swift
+++ b/Library/ViewModels/PledgeCTAContainerViewViewModel.swift
@@ -188,7 +188,7 @@ private func subtitle(project: Project, pledgeState: PledgeStateCTAType) -> Stri
   let amount = formattedPledge(amount: backing.amount, project: project)
 
   let reward = backing.reward
-    ?? project.rewards.filter { $0.id == backing.rewardId }.first
+    ?? project.rewards.first { $0.id == backing.rewardId }
     ?? Reward.noReward
 
   guard let rewardTitle = reward.title else { return "\(amount)" }

--- a/Library/ViewModels/PledgePaymentMethodsViewModel.swift
+++ b/Library/ViewModels/PledgePaymentMethodsViewModel.swift
@@ -109,7 +109,7 @@ public final class PledgePaymentMethodsViewModel: PledgePaymentMethodsViewModelT
 
     self.updateSelectedCreditCard = allCards
       .takePairWhen(self.creditCardSelectedSignal)
-      .map { cards, id in cards.filter { $0.id == id }.first }
+      .map { cards, id in cards.first { $0.id == id } }
       .skipNil()
 
     self.goToAddCardScreen = Signal.combineLatest(self.addNewCardIntentProperty.signal.skipNil(), project)

--- a/Library/ViewModels/ProjectActivityBackingCellViewModel.swift
+++ b/Library/ViewModels/ProjectActivityBackingCellViewModel.swift
@@ -212,7 +212,7 @@ private func rewardSummary(activity: Activity, project: Project) -> String {
 
 private func reward(activity: Activity, project: Project) -> Reward? {
   guard let rewardId = activity.memberData.rewardId ?? activity.memberData.newRewardId else { return nil }
-  return project.rewards.filter { $0.id == rewardId }.first
+  return project.rewards.first { $0.id == rewardId }
 }
 
 private func title(activity: Activity) -> String {

--- a/Library/ViewModels/ProjectPamphletContentViewModel.swift
+++ b/Library/ViewModels/ProjectPamphletContentViewModel.swift
@@ -153,7 +153,7 @@ public final class ProjectPamphletContentViewModel: ProjectPamphletContentViewMo
 
 private func reward(forBacking backing: Backing, inProject project: Project) -> Reward? {
   return backing.reward
-    ?? project.rewards.filter { $0.id == backing.rewardId }.first
+    ?? project.rewards.first { $0.id == backing.rewardId }
     ?? Reward.noReward
 }
 

--- a/Library/ViewModels/UpdateDraftViewModel.swift
+++ b/Library/ViewModels/UpdateDraftViewModel.swift
@@ -212,7 +212,7 @@ public final class UpdateDraftViewModel: UpdateDraftViewModelType, UpdateDraftVi
 
     self.showRemoveAttachmentConfirmation = addedAttachments
       .takePairWhen(self.attachmentTappedProperty.signal)
-      .map { attachments, id in attachments.filter { $0.id == id }.first }
+      .map { attachments, id in attachments.first { $0.id == id } }
       .skipNil()
 
     let removeAttachmentEvent: Signal<Signal<UpdateDraft.Image, ErrorEnvelope>.Event, Never> = draft


### PR DESCRIPTION
# 📲 What

Replaces instances of `.filter { ... }.first` with `first(where: { ... })`.

# 🤔 Why

This is just a simple optimization to not do unnecessary work when picking the first item from collections. In the case of `filter` the entire collection is traversed and each element is evaluated against the condition whereas `.first(where:)` stops once it finds a match and returns that element.

# 🛠 How

Replaced use of `filter` with `first(where:)` where it made sense. 

For example, there are some places where we do something like:

```swift
.compactMap { $0 as? UIPageViewController }.first
```
This could be replaced with:
```swift
.first { $0 is UIPageViewController } as? UIPageViewController
```
I felt that the sacrifice in readability and no material performance gain here didn't justify making those sorts of changes.

# 👀 See

Swift's [Sequence](https://developer.apple.com/documentation/swift/sequence) type.

# ✅ Acceptance criteria

- [ ] No regressions introduced by these changes.