### PR TITLE
[NT-796] Fix sheet overlay on iOS 13

### DIFF
--- a/Kickstarter-iOS/Views/Controllers/PledgeContinueViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/PledgeContinueViewController.swift
@@ -77,7 +77,11 @@ final class PledgeContinueViewController: UIViewController {
     let navigationController = UINavigationController(rootViewController: loginSignupViewController)
     let navigationBarHeight = navigationController.navigationBar.bounds.height
 
-    self.presentViewControllerWithSheetOverlay(navigationController, offset: navigationBarHeight)
+    if #available(iOS 13.0, *) {
+      self.present(navigationController, animated: true)
+    } else {
+      self.presentViewControllerWithSheetOverlay(navigationController, offset: navigationBarHeight)
+    }
   }
 }
 

--- a/Kickstarter-iOS/Views/Controllers/PledgePaymentMethodsViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/PledgePaymentMethodsViewController.swift
@@ -182,7 +182,11 @@ final class PledgePaymentMethodsViewController: UIViewController {
     let navigationController = UINavigationController.init(rootViewController: addNewCardViewController)
     let offset = navigationController.navigationBar.bounds.height
 
-    self.presentViewControllerWithSheetOverlay(navigationController, offset: offset)
+    if #available(iOS 13.0, *) {
+      self.present(navigationController, animated: true)
+    } else {
+      self.presentViewControllerWithSheetOverlay(navigationController, offset: offset)
+    }
   }
 
   private func reloadPaymentMethods(

--- a/Kickstarter-iOS/Views/Transitions/SheetOverlayTransitionAnimator.swift
+++ b/Kickstarter-iOS/Views/Transitions/SheetOverlayTransitionAnimator.swift
@@ -58,7 +58,7 @@ final class SheetOverlayTransitionAnimator: NSObject, UIViewControllerAnimatedTr
     _ = (toVC.view, containerView)
       |> ksr_addSubviewToParent()
 
-    let toFrame = fromVC.view.frame
+    let toFrame = containerView.frame
 
     UIView.animate(
       withDuration: self.transitionDuration(using: transitionContext),
@@ -80,7 +80,7 @@ final class SheetOverlayTransitionAnimator: NSObject, UIViewControllerAnimatedTr
 
   private func animateDismissal(
     fromViewController fromVC: UIViewController,
-    toViewController toVC: UIViewController,
+    toViewController _: UIViewController,
     containerView: UIView,
     transitionContext: UIViewControllerContextTransitioning
   ) {
@@ -90,11 +90,12 @@ final class SheetOverlayTransitionAnimator: NSObject, UIViewControllerAnimatedTr
 
     _ = fromVC.view
       |> \.backgroundColor .~ .clear
+      |> \.frame .~ containerView.frame
 
     _ = containerView
       |> ksr_insertSubview(self.darkOverlayView, belowSubview: fromVC.view)
 
-    let toFrame = toVC.view.frame.offsetBy(dx: 0, dy: fromVC.view.frame.height)
+    let toFrame = containerView.frame.offsetBy(dx: 0, dy: fromVC.view.frame.height)
 
     UIView.animate(
       withDuration: self.transitionDuration(using: transitionContext),


### PR DESCRIPTION
# 📲 What

- Fixes the presentation of the `SheetOverlayTransitionAnimator` on iOS 13 so that the view extends beyond the safe area.
- Uses default modal presentation on iOS 13 for the login and add new card modals during checkout.

# 🤔 Why

This was a regression noticed after updating to iOS 13. The default modal presentation style is sufficient in 2 of 3 places that we use the `SheetOverlayViewController`, however for the presentation of the `PledgeShippingLocationViewController` we still need it for the custom vertical offset behaviour.

# 🛠 How

- Fixed the frame sizes in `SheetOverlayTransitionAnimator`.
- Added `#available` checks for iOS 13 to default to the built-in modal for that OS version.

# 👀 See

| iOS 12 | iOS 13 | iOS 13 login |
| --- | --- | --- |
| ![image](https://user-images.githubusercontent.com/3735375/74393711-b3de3d00-4dbf-11ea-99b7-83937af3dcef.png) | ![image](https://user-images.githubusercontent.com/3735375/74393772-e12aeb00-4dbf-11ea-9401-d8cb4ec54eca.png) | ![image](https://user-images.githubusercontent.com/3735375/74393807-fd2e8c80-4dbf-11ea-869b-e31a1cb830e2.png) |

# ✅ Acceptance criteria

iPhone running iOS 12.4:
iPad running iOS 12.4 or iOS 13.x.

- [x] Tapping _continue_ on pledge view when logged out presents login modal using `SheetOverlayViewController`.
- [x] Tapping _add new card_ on pledge view presents `AddNewCardViewController` using `SheetOverlayViewController`.
- [x] Selecting a shipping method presents `PledgeShippingLocationViewController` using `SheetOverlayViewController`.

iPhone running iOS 13.x:

- [x] Tapping _continue_ on pledge view when logged out presents login modal using the standard modal presentation style.
- [x] Tapping _add new card_ on pledge view presents `AddNewCardViewController` the standard modal presentation style.
- [x] Selecting a shipping method presents `PledgeShippingLocationViewController` using `SheetOverlayViewController`.