### PR TITLE
[NT-647] Track event for experimental variants

### DIFF
--- a/Library/Tracking/Koala.swift
+++ b/Library/Tracking/Koala.swift
@@ -599,20 +599,16 @@ public final class Koala {
     switch stateType {
     case .fix:
       self.track(event: "Fix Pledge Button Clicked", properties: props)
-    case .pledge:
+    case .pledge, .seeTheRewards, .viewTheRewards:
       self.track(event: DataLakeWhiteListedEvent.projectPagePledgeButtonClicked.rawValue, properties: props)
     case .manage:
       self.track(event: "Manage Pledge Button Clicked", properties: props)
-    case .seeTheRewards:
-      self.track(event: "See the Rewards Button Clicked", properties: props)
     case .viewBacking:
       self.track(event: "View Your Pledge Button Clicked", properties: props)
     case .viewRewards:
       self.track(event: "View Rewards Button Clicked", properties: props)
     case .viewYourRewards:
       self.track(event: "View Your Rewards Button Clicked", properties: props)
-    case .viewTheRewards:
-      self.track(event: "View the Rewards Button Clicked", properties: props)
     }
   }
 

--- a/Library/Tracking/KoalaTests.swift
+++ b/Library/Tracking/KoalaTests.swift
@@ -681,6 +681,30 @@ final class KoalaTests: TestCase {
     XCTAssertEqual(["View Rewards Button Clicked"], client.events)
   }
 
+  func testTrackPledgeCTAButtonClicked_ViewTheRewardsState() {
+    let client = MockTrackingClient()
+    let project = Project.template
+    let loggedInUser = User.template |> \.id .~ 42
+
+    let koala = Koala(client: client, loggedInUser: loggedInUser)
+
+    koala.trackPledgeCTAButtonClicked(stateType: .viewTheRewards, project: project)
+
+    XCTAssertEqual(["Project Page Pledge Button Clicked"], client.events)
+  }
+
+  func testTrackPledgeCTAButtonClicked_SeeTheRewardsState() {
+    let client = MockTrackingClient()
+    let project = Project.template
+    let loggedInUser = User.template |> \.id .~ 42
+
+    let koala = Koala(client: client, loggedInUser: loggedInUser)
+
+    koala.trackPledgeCTAButtonClicked(stateType: .seeTheRewards, project: project)
+
+    XCTAssertEqual(["Project Page Pledge Button Clicked"], client.events)
+  }
+
   func testTrackPledgeCTAButtonClicked_ViewYourRewardsState() {
     let client = MockTrackingClient()
     let user = User.template |> \.id .~ 42


### PR DESCRIPTION
# 📲 What

Tracks the `DataLakeWhiteListedEvent.projectPagePledgeButtonClicked` event for `.seeTheRewards` and `.viewTheRewards` in addition to the `.pledge` CTA state.

# 🤔 Why

We weren't tracking this event in experimental variants, this corrects that.

# 🛠 How

Moved the necessary cases around in the switch statement where this was handled.

# ✅ Acceptance criteria

- [ ] Tapping the pledge button to back a project in any of these three states should track the `Project Page Pledge Button Clicked` event.