### PR TITLE
[NT-876] Pop ProjectPamphlet to root after project is backed

### DIFF
--- a/Kickstarter-iOS/Views/Controllers/ProjectPamphletViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/ProjectPamphletViewController.swift
@@ -164,6 +164,12 @@ public final class ProjectPamphletViewController: UIViewController, MessageBanne
           self?.messageBannerViewController?.showBanner(with: .success, message: message)
         })
       }
+
+    self.viewModel.outputs.popToRootViewController
+      .observeForControllerAction()
+      .observeValues { [weak self] in
+        self?.navigationController?.popToRootViewController(animated: false)
+      }
   }
 
   public override func willTransition(

--- a/Library/ViewModels/ProjectPamphletViewModel.swift
+++ b/Library/ViewModels/ProjectPamphletViewModel.swift
@@ -50,6 +50,9 @@ public protocol ProjectPamphletViewModelOutputs {
   /// Emits a project and refTag to be used to navigate to the reward selection screen.
   var goToRewards: Signal<(Project, RefTag?), Never> { get }
 
+  /// Emits when the navigation stack should be popped to the root view controller.
+  var popToRootViewController: Signal<(), Never> { get }
+
   /// Emits two booleans that determine if the navigation bar should be hidden, and if it should be animated.
   var setNavigationBarHiddenAnimated: Signal<(Bool, Bool), Never> { get }
 
@@ -69,6 +72,8 @@ public final class ProjectPamphletViewModel: ProjectPamphletViewModelType, Proje
   ProjectPamphletViewModelOutputs {
   public init() {
     let isLoading = MutableProperty(false)
+
+    self.popToRootViewController = self.didBackProjectProperty.signal.ignoreValues()
 
     let freshProjectAndRefTagEvent = self.configDataProperty.signal.skipNil()
       .takePairWhen(Signal.merge(
@@ -263,6 +268,7 @@ public final class ProjectPamphletViewModel: ProjectPamphletViewModelType, Proje
   public let dismissManagePledgeAndShowMessageBannerWithMessage: Signal<String, Never>
   public let goToManagePledge: Signal<Project, Never>
   public let goToRewards: Signal<(Project, RefTag?), Never>
+  public let popToRootViewController: Signal<(), Never>
   public let setNavigationBarHiddenAnimated: Signal<(Bool, Bool), Never>
   public let setNeedsStatusBarAppearanceUpdate: Signal<(), Never>
   public let topLayoutConstraintConstant: Signal<CGFloat, Never>

--- a/Library/ViewModels/ProjectPamphletViewModelTests.swift
+++ b/Library/ViewModels/ProjectPamphletViewModelTests.swift
@@ -23,11 +23,11 @@ final class ProjectPamphletViewModelTests: TestCase {
   private let goToManageViewPledge = TestObserver<Project, Never>()
   private let goToRewardsProject = TestObserver<Project, Never>()
   private let goToRewardsRefTag = TestObserver<RefTag?, Never>()
+  private let popToRootViewController = TestObserver<(), Never>()
   private let setNavigationBarHidden = TestObserver<Bool, Never>()
   private let setNavigationBarAnimated = TestObserver<Bool, Never>()
   private let setNeedsStatusBarAppearanceUpdate = TestObserver<(), Never>()
   private let topLayoutConstraintConstant = TestObserver<CGFloat, Never>()
-  private let popToRootViewController = TestObserver<(), Never>()
 
   internal override func setUp() {
     super.setUp()

--- a/Library/ViewModels/ProjectPamphletViewModelTests.swift
+++ b/Library/ViewModels/ProjectPamphletViewModelTests.swift
@@ -27,6 +27,7 @@ final class ProjectPamphletViewModelTests: TestCase {
   private let setNavigationBarAnimated = TestObserver<Bool, Never>()
   private let setNeedsStatusBarAppearanceUpdate = TestObserver<(), Never>()
   private let topLayoutConstraintConstant = TestObserver<CGFloat, Never>()
+  private let popToRootViewController = TestObserver<(), Never>()
 
   internal override func setUp() {
     super.setUp()
@@ -64,6 +65,7 @@ final class ProjectPamphletViewModelTests: TestCase {
     self.vm.outputs.goToManagePledge.observe(self.goToManageViewPledge.observer)
     self.vm.outputs.goToRewards.map(first).observe(self.goToRewardsProject.observer)
     self.vm.outputs.goToRewards.map(second).observe(self.goToRewardsRefTag.observer)
+    self.vm.outputs.popToRootViewController.observe(self.popToRootViewController.observer)
     self.vm.outputs.setNavigationBarHiddenAnimated.map(first)
       .observe(self.setNavigationBarHidden.observer)
     self.vm.outputs.setNavigationBarHiddenAnimated.map(second)
@@ -1009,6 +1011,17 @@ final class ProjectPamphletViewModelTests: TestCase {
       XCTAssertNil(self.optimizelyClient.trackedAttributes)
       XCTAssertNil(self.optimizelyClient.trackedEventTags)
     }
+  }
+
+  func testPopToRootViewController() {
+    self.vm.inputs.configureWith(projectOrParam: .left(.template), refTag: nil)
+    self.vm.inputs.viewDidLoad()
+
+    self.popToRootViewController.assertDidNotEmitValue()
+
+    self.vm.inputs.didBackProject()
+
+    self.popToRootViewController.assertValueCount(1)
   }
 
   // MARK: - Functions


### PR DESCRIPTION
# 📲 What

Pops the `ProjectPamphletViewController`'s navigation stack to root after a project is backed.

**Note:** This is based off #1072's branch.

# 🤔 Why

Now that we are presenting the checkout flow from the project campaign details in #1072, once the thanks page is presented and dismissed we want the user to land back on the project page and not the campaign details page. If they exit out of the checkout flow earlier than completion then we do want them to return to the campaign details page.

# 🛠 How

We were already observing the `projectBacked` notification in order to refresh the project after backing. We've now repurposed this signal to pop the navigation stack.

# 👀 See

| Before 🐛 | After 🦋 |
| --- | --- |
| ![2020-02-19 16 22 56](https://user-images.githubusercontent.com/3735375/74888973-708e4c00-5334-11ea-9bf3-8857979d6664.gif) | ![2020-02-19 16 25 05](https://user-images.githubusercontent.com/3735375/74888991-7ab04a80-5334-11ea-9873-7d779cabb229.gif) |

# ✅ Acceptance criteria

- [x] Tap _Back this project_ on the project campaign details. Upon completing the checkout flow and observing the thanks screen, dismissing the modal should land back on the project view.