### PR TITLE
[NT-912] Read More Button Loading State

### DIFF
--- a/Kickstarter-iOS/Views/Cells/ProjectPamphletMainCell.swift
+++ b/Kickstarter-iOS/Views/Cells/ProjectPamphletMainCell.swift
@@ -3,6 +3,12 @@ import Library
 import Prelude
 import UIKit
 
+private enum Layout {
+  enum Button {
+    static let height: CGFloat = 48
+  }
+}
+
 internal protocol ProjectPamphletMainCellDelegate: VideoViewControllerDelegate {
   func projectPamphletMainCell(_ cell: ProjectPamphletMainCell, addChildController child: UIViewController)
   func projectPamphletMainCell(
@@ -50,7 +56,7 @@ internal final class ProjectPamphletMainCell: UITableViewCell, ValueCell {
   @IBOutlet fileprivate var projectNameAndCreatorStackView: UIStackView!
   @IBOutlet fileprivate var projectNameLabel: UILabel!
   @IBOutlet fileprivate var progressBarAndStatsStackView: UIStackView!
-  @IBOutlet fileprivate var readMoreButton: UIButton!
+  @IBOutlet fileprivate var readMoreButton: LoadingButton!
   @IBOutlet fileprivate var spacerView: UIView!
   @IBOutlet fileprivate var stateLabel: UILabel!
   @IBOutlet fileprivate var statsStackView: UIStackView!
@@ -70,6 +76,9 @@ internal final class ProjectPamphletMainCell: UITableViewCell, ValueCell {
       action: #selector(self.readMoreButtonTapped),
       for: .touchUpInside
     )
+
+    self.readMoreButton.heightAnchor
+      .constraint(greaterThanOrEqualToConstant: Layout.Button.height).isActive = true
 
     self.viewModel.inputs.awakeFromNib()
   }
@@ -229,6 +238,9 @@ internal final class ProjectPamphletMainCell: UITableViewCell, ValueCell {
       |> UILabel.lens.textColor .~ .white
       |> UILabel.lens.font .~ .ksr_headline(size: 12)
       |> UILabel.lens.text %~ { _ in Strings.Youre_a_backer() }
+
+    _ = self.readMoreButton
+      |> \.activityIndicatorStyle .~ .gray
   }
 
   internal override func bindViewModel() {
@@ -261,6 +273,12 @@ internal final class ProjectPamphletMainCell: UITableViewCell, ValueCell {
     self.stateLabel.rac.hidden = self.viewModel.outputs.stateLabelHidden
     self.statsStackView.rac.accessibilityLabel = self.viewModel.outputs.statsStackViewAccessibilityLabel
     self.youreABackerContainerView.rac.hidden = self.viewModel.outputs.youreABackerLabelHidden
+
+    self.viewModel.outputs.readMoreButtonIsLoading
+      .observeForUI()
+      .observeValues { [weak self] isLoading in
+        self?.readMoreButton.isLoading = isLoading
+      }
 
     self.viewModel.outputs.configureVideoPlayerController
       .observeForUI()

--- a/Kickstarter-iOS/Views/LoadingButton.swift
+++ b/Kickstarter-iOS/Views/LoadingButton.swift
@@ -13,6 +13,12 @@ final class LoadingButton: UIButton {
       |> \.translatesAutoresizingMaskIntoConstraints .~ false
   }()
 
+  public var activityIndicatorStyle: UIActivityIndicatorView.Style = .white {
+    didSet {
+      self.activityIndicator.style = self.activityIndicatorStyle
+    }
+  }
+
   public var isLoading: Bool = false {
     didSet {
       self.viewModel.inputs.isLoading(self.isLoading)

--- a/Kickstarter-iOS/Views/Storyboards/ProjectPamphlet.storyboard
+++ b/Kickstarter-iOS/Views/Storyboards/ProjectPamphlet.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15702" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="GbK-FV-Iaj">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="GbK-FV-Iaj">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15704"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -267,7 +267,7 @@
                                                                             <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                             <nil key="highlightedColor"/>
                                                                         </label>
-                                                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wJh-2e-un6">
+                                                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wJh-2e-un6" customClass="LoadingButton" customModule="Kickstarter_Framework" customModuleProvider="target">
                                                                             <rect key="frame" x="0.0" y="38.5" width="400" height="34"/>
                                                                             <state key="normal">
                                                                                 <color key="titleColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/Library/ViewModels/ProjectPamphletMainCellViewModel.swift
+++ b/Library/ViewModels/ProjectPamphletMainCellViewModel.swift
@@ -101,6 +101,9 @@ public protocol ProjectPamphletMainCellViewModelOutputs {
   /// Emits the text color of the backer and deadline title label.
   var projectUnsuccessfulLabelTextColor: Signal<UIColor, Never> { get }
 
+  /// Emits when the read more button is loading.
+  var readMoreButtonIsLoading: Signal<Bool, Never> { get }
+
   /// Emits the button style of the read more about this campaign button
   var readMoreButtonStyle: Signal<ProjectCampaignButtonStyleType, Never> { get }
 
@@ -257,6 +260,18 @@ public final class ProjectPamphletMainCellViewModel: ProjectPamphletMainCellView
       self.projectAndRefTagProperty.signal.skipNil().mapConst(1.0),
       self.awakeFromNibProperty.signal.mapConst(0.0)
     )
+
+    /* Read more button has initial loading state in second experiment variant
+     * while rewards are being loaded.
+     */
+    self.readMoreButtonIsLoading = Signal.combineLatest(
+      project,
+      projectCampaignExperimentVariant
+    )
+    .map { project, variant in
+      project.rewards.isEmpty && variant == .variant2
+    }
+    .skipRepeats()
   }
 
   private let awakeFromNibProperty = MutableProperty(())
@@ -320,6 +335,7 @@ public final class ProjectPamphletMainCellViewModel: ProjectPamphletMainCellView
   public let projectStateLabelText: Signal<String, Never>
   public let projectStateLabelTextColor: Signal<UIColor, Never>
   public let projectUnsuccessfulLabelTextColor: Signal<UIColor, Never>
+  public let readMoreButtonIsLoading: Signal<Bool, Never>
   public let readMoreButtonStyle: Signal<ProjectCampaignButtonStyleType, Never>
   public let readMoreButtonTitle: Signal<String, Never>
   public let spacerViewHidden: Signal<Bool, Never>

--- a/Library/ViewModels/ProjectPamphletMainCellViewModelTests.swift
+++ b/Library/ViewModels/ProjectPamphletMainCellViewModelTests.swift
@@ -33,6 +33,7 @@ final class ProjectPamphletMainCellViewModelTests: TestCase {
   private let projectStateLabelText = TestObserver<String, Never>()
   private let projectStateLabelTextColor = TestObserver<UIColor, Never>()
   private let projectUnsuccessfulLabelTextColor = TestObserver<UIColor, Never>()
+  private let readMoreButtonIsLoading = TestObserver<Bool, Never>()
   private let readMoreButtonStyle = TestObserver<ProjectCampaignButtonStyleType, Never>()
   private let readMoreButtonTitle = TestObserver<String, Never>()
   private let spacerViewHidden = TestObserver<Bool, Never>()
@@ -70,6 +71,7 @@ final class ProjectPamphletMainCellViewModelTests: TestCase {
     self.vm.outputs.projectStateLabelText.observe(self.projectStateLabelText.observer)
     self.vm.outputs.projectStateLabelTextColor.observe(self.projectStateLabelTextColor.observer)
     self.vm.outputs.projectUnsuccessfulLabelTextColor.observe(self.projectUnsuccessfulLabelTextColor.observer)
+    self.vm.outputs.readMoreButtonIsLoading.observe(self.readMoreButtonIsLoading.observer)
     self.vm.outputs.readMoreButtonStyle.observe(self.readMoreButtonStyle.observer)
     self.vm.outputs.readMoreButtonTitle.observe(self.readMoreButtonTitle.observer)
     self.vm.outputs.spacerViewHidden.observe(self.spacerViewHidden.observer)
@@ -572,4 +574,85 @@ final class ProjectPamphletMainCellViewModelTests: TestCase {
 
     self.notifyDelegateToGoToCreator.assertValues([project])
   }
+
+  // swiftlint:disable line_length
+  func testReadMoreButtonIsLoading_Control() {
+    let project = Project.template
+
+    self.readMoreButtonIsLoading.assertDidNotEmitValue()
+
+    let optimizelyClient = MockOptimizelyClient()
+      |> \.experiments .~ [
+        OptimizelyExperiment.Key.nativeProjectPageCampaignDetails.rawValue: OptimizelyExperiment.Variant.control.rawValue
+      ]
+
+    withEnvironment(optimizelyClient: optimizelyClient) {
+      self.vm.inputs.configureWith(value: (project, nil))
+      self.vm.inputs.awakeFromNib()
+
+      self.readMoreButtonIsLoading.assertValues([false])
+    }
+  }
+
+  func testReadMoreButtonIsLoading_Variant1() {
+    let project = Project.template
+
+    self.readMoreButtonIsLoading.assertDidNotEmitValue()
+
+    let optimizelyClient = MockOptimizelyClient()
+      |> \.experiments .~ [
+        OptimizelyExperiment.Key.nativeProjectPageCampaignDetails.rawValue: OptimizelyExperiment.Variant.variant1.rawValue
+      ]
+
+    withEnvironment(optimizelyClient: optimizelyClient) {
+      self.vm.inputs.configureWith(value: (project, nil))
+      self.vm.inputs.awakeFromNib()
+
+      self.readMoreButtonIsLoading.assertValues([false])
+    }
+  }
+
+  func testReadMoreButtonIsLoading_Variant2_NoRewards() {
+    let project = Project.template
+
+    self.readMoreButtonIsLoading.assertDidNotEmitValue()
+
+    let optimizelyClient = MockOptimizelyClient()
+      |> \.experiments .~ [
+        OptimizelyExperiment.Key.nativeProjectPageCampaignDetails.rawValue: OptimizelyExperiment.Variant.variant2.rawValue
+      ]
+
+    withEnvironment(optimizelyClient: optimizelyClient) {
+      self.vm.inputs.configureWith(value: (project, nil))
+      self.vm.inputs.awakeFromNib()
+
+      self.readMoreButtonIsLoading.assertValues([true])
+
+      let projectWithRewards = Project.cosmicSurgery
+
+      self.vm.inputs.configureWith(value: (projectWithRewards, nil))
+
+      self.readMoreButtonIsLoading.assertValues([true, false])
+    }
+  }
+
+  func testReadMoreButtonIsLoading_Variant2_HasRewards() {
+    let project = Project.cosmicSurgery
+
+    self.readMoreButtonIsLoading.assertDidNotEmitValue()
+
+    let optimizelyClient = MockOptimizelyClient()
+      |> \.experiments .~ [
+        OptimizelyExperiment.Key.nativeProjectPageCampaignDetails.rawValue: OptimizelyExperiment.Variant.variant2.rawValue
+      ]
+
+    withEnvironment(optimizelyClient: optimizelyClient) {
+      self.vm.inputs.configureWith(value: (project, nil))
+      self.vm.inputs.awakeFromNib()
+
+      self.readMoreButtonIsLoading.assertValues([false])
+    }
+  }
+
+  // swiftlint:enable line_length
 }


### PR DESCRIPTION
# 📲 What

Adds a loading state to the `readMoreButton` in `ProjectPamphletMainCell` while the `Project` is refreshed in the second variant of `projectCampaignExperiment`.

# 🤔 Why

In the second variant we need to know that the rewards have been loaded in order to present them from the campaign details view.

# 🛠 How

- Changed `readMoreButton` to be a `LoadingButton`.
- Added an output that sets `isLoading` to `true` if a project's rewards are empty.

# 👀 See

| Variant1 | Variant2 |
| --- | --- |
| ![2020-02-21 11 38 57](https://user-images.githubusercontent.com/3735375/75065982-d3035b80-549e-11ea-8136-f21209f059dd.gif) | ![2020-02-21 11 39 51](https://user-images.githubusercontent.com/3735375/75066040-ec0c0c80-549e-11ea-82f8-b8b7b2372b4c.gif) |

# ✅ Acceptance criteria

Easiest way to test is to just hard-code the return value from `OptimizelyExperiment.projectCampaignExperiment(project:refTag:)` (`.control`, `.variant1`, `.variant2`).

When navigating to a project.

- [ ] For the `.control` group the regular _read more_ button should be displayed, no loading indicator.
- [ ] For the `.variant1` group the new _read more_ button should be displayed, no loading indicator.
- [ ] For the `.variant2` group the new _read more_ button should be displayed with loading indicator while project is refreshed.