### PR TITLE
[NT-872] Hide back this project button for project creators

### DIFF
--- a/Library/ViewModels/ProjectDescriptionViewModel.swift
+++ b/Library/ViewModels/ProjectDescriptionViewModel.swift
@@ -223,6 +223,7 @@ private func shouldShowPledgeButton(project: Project, refTag: RefTag?) -> Bool {
   let notBacking = project.personalization.backing == nil
   let isVariant2 = OptimizelyExperiment
     .projectCampaignExperiment(project: project, refTag: refTag) == .variant2
+  let isNotCreator = currentUserIsCreator(of: project) == false
 
-  return [isLive, notBacking, isVariant2].allSatisfy(isTrue)
+  return [isLive, notBacking, isVariant2, isNotCreator].allSatisfy(isTrue)
 }

--- a/Library/ViewModels/ProjectDescriptionViewModelTests.swift
+++ b/Library/ViewModels/ProjectDescriptionViewModelTests.swift
@@ -461,5 +461,30 @@ final class ProjectDescriptionViewModelTests: TestCase {
     }
   }
 
+  func testConfigurePledgeCTAContainerView_LiveProject_NonBacker_Variant2_IsCreatorOfProject() {
+    let user = User.template
+    let project = Project.template
+      |> Project.lens.creator .~ user
+      |> Project.lens.state .~ .live
+      |> Project.lens.personalization.backing .~ nil
+      |> Project.lens.personalization.isBacking .~ false
+
+    let optimizelyClient = MockOptimizelyClient()
+      |> \.experiments .~ [
+        OptimizelyExperiment.Key.nativeProjectPageCampaignDetails.rawValue: OptimizelyExperiment.Variant.variant2.rawValue
+      ]
+
+    withEnvironment(currentUser: user, optimizelyClient: optimizelyClient) {
+      self.pledgeCTAContainerViewIsHidden.assertDidNotEmitValue()
+      self.goToRewardsProject.assertDidNotEmitValue()
+      self.goToRewardsRefTag.assertDidNotEmitValue()
+
+      self.vm.inputs.configureWith(value: (project, .discovery))
+      self.vm.inputs.viewDidLoad()
+
+      self.pledgeCTAContainerViewIsHidden.assertValues([true])
+    }
+  }
+
   // swiftlint:enable line_length
 }


### PR DESCRIPTION
# 📲 What

Hides the _back this project_ button for project creators.

# 🤔 Why

Creators are not allowed to back their own projects.

# 🛠 How

Added in a line to the logic that hides this view that includes checking that the current user is not the creator of the project.

# ✅ Acceptance criteria

- [ ] _Back this project_ button is hidden on the campaign description to creators if it's their own project.