### PR TITLE
[NT-941] Add distinct_id to Optimizely attributes for admins

### DIFF
--- a/Library/OptimizelyClientType.swift
+++ b/Library/OptimizelyClientType.swift
@@ -61,7 +61,7 @@ public func optimizelyUserAttributes(
   refTag: RefTag?
 ) -> [String: Any] {
   let properties: [String: Any] = [
-    "user_distinct_id": debugAdminDeviceIdentifier(with: user),
+    "user_distinct_id": debugAdminDeviceIdentifier(),
     "user_backed_projects_count": user?.stats.backedProjectsCount,
     "user_launched_projects_count": user?.stats.createdProjectsCount,
     "user_country": (user?.location?.country ?? AppEnvironment.current.config?.countryCode)?.lowercased(),
@@ -80,11 +80,10 @@ public func optimizelyUserAttributes(
   return properties
 }
 
-private func debugAdminDeviceIdentifier(with user: User?) -> String? {
+private func debugAdminDeviceIdentifier() -> String? {
   guard
     AppEnvironment.current.environmentType != .production,
-    AppEnvironment.current.mainBundle.isRelease == false,
-    user?.isAdmin == true
+    AppEnvironment.current.mainBundle.isRelease == false
   else { return nil }
 
   return deviceIdentifier(uuid: UUID())

--- a/Library/OptimizelyClientType.swift
+++ b/Library/OptimizelyClientType.swift
@@ -61,7 +61,7 @@ public func optimizelyUserAttributes(
   refTag: RefTag?
 ) -> [String: Any] {
   let properties: [String: Any] = [
-    "user_distinct_id": user?.isAdmin == true ? deviceIdentifier(uuid: UUID()) : nil,
+    "user_distinct_id": debugAdminDeviceIdentifier(with: user),
     "user_backed_projects_count": user?.stats.backedProjectsCount,
     "user_launched_projects_count": user?.stats.createdProjectsCount,
     "user_country": (user?.location?.country ?? AppEnvironment.current.config?.countryCode)?.lowercased(),
@@ -78,4 +78,14 @@ public func optimizelyUserAttributes(
   .compact()
 
   return properties
+}
+
+private func debugAdminDeviceIdentifier(with user: User?) -> String? {
+  guard
+    AppEnvironment.current.environmentType != .production,
+    AppEnvironment.current.mainBundle.isRelease == false,
+    user?.isAdmin == true
+  else { return nil }
+
+  return deviceIdentifier(uuid: UUID())
 }

--- a/Library/OptimizelyClientType.swift
+++ b/Library/OptimizelyClientType.swift
@@ -61,6 +61,7 @@ public func optimizelyUserAttributes(
   refTag: RefTag?
 ) -> [String: Any] {
   let properties: [String: Any] = [
+    "user_distinct_id": user?.isAdmin == true ? deviceIdentifier(uuid: UUID()) : nil,
     "user_backed_projects_count": user?.stats.backedProjectsCount,
     "user_launched_projects_count": user?.stats.createdProjectsCount,
     "user_country": (user?.location?.country ?? AppEnvironment.current.config?.countryCode)?.lowercased(),

--- a/Library/ViewModels/PledgeViewModelTests.swift
+++ b/Library/ViewModels/PledgeViewModelTests.swift
@@ -3761,6 +3761,56 @@ final class PledgeViewModelTests: TestCase {
       XCTAssertEqual(self.optimizelyClient.trackedUserId, "DEADBEEF-DEAD-BEEF-DEAD-DEADBEEFBEEF")
       XCTAssertEqual(self.optimizelyClient.trackedEventKey, "Pledge Screen Viewed")
 
+      XCTAssertNil(self.optimizelyClient.trackedAttributes?["user_distinct_id"] as? String)
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_backed_projects_count"] as? Int, 50)
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_launched_projects_count"] as? Int, 25)
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_country"] as? String, "us")
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_facebook_account"] as? Bool, true)
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_display_language"] as? String, "en")
+
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_ref_tag"] as? String, "discovery")
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_referrer_credit"] as? String, "discovery")
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_os_version"] as? String, "MockSystemVersion")
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_user_is_logged_in"] as? Bool, true)
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_app_release_version"] as? String, "1.2.3.4.5.6.7.8.9.0")
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_apple_pay_device"] as? Bool, true)
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_device_format"] as? String, "phone")
+
+      XCTAssertEqual(self.optimizelyClient.trackedEventTags?["project_subcategory"] as? String, "Art")
+      XCTAssertEqual(self.optimizelyClient.trackedEventTags?["project_category"] as? String, "Art")
+      XCTAssertEqual(self.optimizelyClient.trackedEventTags?["project_country"] as? String, "us")
+      XCTAssertEqual(self.optimizelyClient.trackedEventTags?["project_user_has_watched"] as? Bool, true)
+    }
+  }
+
+  func testTrackingEvents_PledgeScreenViewed_LoggedIn_IsAdmin() {
+    let user = User.template
+      |> \.location .~ Location.template
+      |> \.stats.backedProjectsCount .~ 50
+      |> \.stats.createdProjectsCount .~ 25
+      |> \.facebookConnected .~ true
+      |> \.isAdmin .~ true
+
+    withEnvironment(currentUser: user) {
+      let project = Project.template
+        |> \.category.parentId .~ Project.Category.art.id
+        |> \.category.parentName .~ Project.Category.art.name
+        |> Project.lens.stats.currentCurrency .~ "USD"
+        |> \.personalization.isStarred .~ true
+
+      self.vm.inputs.configureWith(
+        project: project, reward: .template, refTag: .discovery, context: .pledge
+      )
+
+      XCTAssertEqual([], self.trackingClient.events)
+      self.vm.inputs.viewDidLoad()
+
+      XCTAssertEqual(["Checkout Payment Page Viewed"], self.trackingClient.events)
+
+      XCTAssertEqual(self.optimizelyClient.trackedUserId, "DEADBEEF-DEAD-BEEF-DEAD-DEADBEEFBEEF")
+      XCTAssertEqual(self.optimizelyClient.trackedEventKey, "Pledge Screen Viewed")
+
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_distinct_id"] as? String,  "DEADBEEF-DEAD-BEEF-DEAD-DEADBEEFBEEF")
       XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_backed_projects_count"] as? Int, 50)
       XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_launched_projects_count"] as? Int, 25)
       XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_country"] as? String, "us")

--- a/Library/ViewModels/PledgeViewModelTests.swift
+++ b/Library/ViewModels/PledgeViewModelTests.swift
@@ -3783,13 +3783,12 @@ final class PledgeViewModelTests: TestCase {
     }
   }
 
-  func testTrackingEvents_PledgeScreenViewed_LoggedIn_IsAdmin_Beta_Staging() {
+  func testTrackingEvents_PledgeScreenViewed_DistinctID_LoggedIn_Beta_Staging() {
     let user = User.template
       |> \.location .~ Location.template
       |> \.stats.backedProjectsCount .~ 50
       |> \.stats.createdProjectsCount .~ 25
       |> \.facebookConnected .~ true
-      |> \.isAdmin .~ true
 
     let mockBundle = MockBundle(
       bundleIdentifier: KickstarterBundleIdentifier.beta.rawValue,
@@ -3819,13 +3818,12 @@ final class PledgeViewModelTests: TestCase {
     }
   }
 
-  func testTrackingEvents_PledgeScreenViewed_LoggedIn_IsAdmin_Release_Production() {
+  func testTrackingEvents_PledgeScreenViewed_DistinctID_LoggedIn_Release_Production() {
     let user = User.template
       |> \.location .~ Location.template
       |> \.stats.backedProjectsCount .~ 50
       |> \.stats.createdProjectsCount .~ 25
       |> \.facebookConnected .~ true
-      |> \.isAdmin .~ true
 
     let mockBundle = MockBundle(
       bundleIdentifier: KickstarterBundleIdentifier.release.rawValue,


### PR DESCRIPTION
# 📲 What

Adds a `user_distinct_id` attribute to Optimizely events ~~for admins~~ in the staging environment.

**Note:** If merged this is a patch on `release-4.3.0`.

# 🤔 Why

We are hoping that this will assist us in verifying that the data we are sending to Optimizely is being received correctly. Currently we are seeing data in Optimizely's dashboard but we are not able to connect it to a specific session/event. By adding the `distinct_id` ~~for admins~~ in staging we hope to test this without compromising user anonymity in production.

# 🛠 How

- Added `user_distinct_id` when:
  - The `EnvironmentType` is _not_ `production`.
  - The `BundleType` is _not_ `release`.
  - ~~The user's `isAdmin` value is `true`.~~

# ✅ Acceptance criteria

- [ ] We tested this on an alpha build and it served its purpose allowing us to validate that the correct data is being sent to Optimizely.