### PR TITLE
[NT-871] (3/3) Landing page first session

### DIFF
--- a/Kickstarter-iOS/AppDelegate.swift
+++ b/Kickstarter-iOS/AppDelegate.swift
@@ -340,6 +340,7 @@ internal final class AppDelegate: UIResponder, UIApplicationDelegate {
       if let shouldUpdateClient = shouldUpdateClient, shouldUpdateClient {
         print("🔮 Optimizely SDK Successfully Configured")
         AppEnvironment.updateOptimizelyClient(optimizelyClient)
+        self?.viewModel.inputs.optimizelyUpdatedInEnvironment()
       }
     }
   }

--- a/Kickstarter-iOS/ViewModels/AppDelegateViewModel.swift
+++ b/Kickstarter-iOS/ViewModels/AppDelegateViewModel.swift
@@ -1089,7 +1089,13 @@ private func qualtricsConfigData() -> QualtricsConfigData {
 }
 
 private func shouldGoToLandingPage() -> Bool {
-  guard AppEnvironment.current.currentUser == nil else {
+  let hasNotSeenLandingPage = [
+    AppEnvironment.current.ubiquitousStore.hasSeenLandingPage,
+    AppEnvironment.current.userDefaults.hasSeenLandingPage
+  ]
+  .allSatisfy(isFalse)
+
+  guard AppEnvironment.current.currentUser == nil, hasNotSeenLandingPage else {
     AppEnvironment.current.ubiquitousStore.hasSeenLandingPage = true
     AppEnvironment.current.userDefaults.hasSeenLandingPage = true
 
@@ -1109,14 +1115,10 @@ private func shouldGoToLandingPage() -> Bool {
       isAdmin: AppEnvironment.current.currentUser?.isAdmin ?? false,
       userAttributes: userAttributes
     )
-  
+
   switch optimizelyVariant {
   case .variant1, .variant2:
-    return [
-      AppEnvironment.current.ubiquitousStore.hasSeenLandingPage,
-      AppEnvironment.current.userDefaults.hasSeenLandingPage
-    ]
-    .allSatisfy(isFalse)
+    return hasNotSeenLandingPage
   case .control, nil:
     return false
   }

--- a/Kickstarter-iOS/ViewModels/AppDelegateViewModel.swift
+++ b/Kickstarter-iOS/ViewModels/AppDelegateViewModel.swift
@@ -1090,13 +1090,11 @@ private func qualtricsConfigData() -> QualtricsConfigData {
 
 private func shouldGoToLandingPage() -> Bool {
   let hasNotSeenLandingPage = [
-    AppEnvironment.current.ubiquitousStore.hasSeenLandingPage,
     AppEnvironment.current.userDefaults.hasSeenLandingPage
   ]
   .allSatisfy(isFalse)
 
   guard AppEnvironment.current.currentUser == nil, hasNotSeenLandingPage else {
-    AppEnvironment.current.ubiquitousStore.hasSeenLandingPage = true
     AppEnvironment.current.userDefaults.hasSeenLandingPage = true
 
     return false

--- a/Kickstarter-iOS/ViewModels/AppDelegateViewModel.swift
+++ b/Kickstarter-iOS/ViewModels/AppDelegateViewModel.swift
@@ -1116,8 +1116,11 @@ private func shouldGoToLandingPage() -> Bool {
 
   switch variant {
   case .variant1, .variant2:
-    return !AppEnvironment.current.ubiquitousStore.hasSeenLandingPage &&
-      !AppEnvironment.current.userDefaults.hasSeenLandingPage
+    return [
+      AppEnvironment.current.ubiquitousStore.hasSeenLandingPage,
+      AppEnvironment.current.userDefaults.hasSeenLandingPage
+    ]
+    .allSatisfy(isFalse)
   case .control:
     return false
   }

--- a/Kickstarter-iOS/ViewModels/AppDelegateViewModel.swift
+++ b/Kickstarter-iOS/ViewModels/AppDelegateViewModel.swift
@@ -1109,19 +1109,15 @@ private func shouldGoToLandingPage() -> Bool {
       isAdmin: AppEnvironment.current.currentUser?.isAdmin ?? false,
       userAttributes: userAttributes
     )
-
-  guard let variant = optimizelyVariant else {
-    return false
-  }
-
-  switch variant {
+  
+  switch optimizelyVariant {
   case .variant1, .variant2:
     return [
       AppEnvironment.current.ubiquitousStore.hasSeenLandingPage,
       AppEnvironment.current.userDefaults.hasSeenLandingPage
     ]
     .allSatisfy(isFalse)
-  case .control:
+  case .control, nil:
     return false
   }
 }

--- a/Kickstarter-iOS/ViewModels/AppDelegateViewModel.swift
+++ b/Kickstarter-iOS/ViewModels/AppDelegateViewModel.swift
@@ -1089,10 +1089,7 @@ private func qualtricsConfigData() -> QualtricsConfigData {
 }
 
 private func shouldGoToLandingPage() -> Bool {
-  let hasNotSeenLandingPage = [
-    AppEnvironment.current.userDefaults.hasSeenLandingPage
-  ]
-  .allSatisfy(isFalse)
+  let hasNotSeenLandingPage = !AppEnvironment.current.userDefaults.hasSeenLandingPage
 
   guard AppEnvironment.current.currentUser == nil, hasNotSeenLandingPage else {
     AppEnvironment.current.userDefaults.hasSeenLandingPage = true

--- a/Kickstarter-iOS/ViewModels/AppDelegateViewModel.swift
+++ b/Kickstarter-iOS/ViewModels/AppDelegateViewModel.swift
@@ -1089,6 +1089,13 @@ private func qualtricsConfigData() -> QualtricsConfigData {
 }
 
 private func shouldGoToLandingPage() -> Bool {
+  guard AppEnvironment.current.currentUser == nil else {
+    AppEnvironment.current.ubiquitousStore.hasSeenLandingPage = true
+    AppEnvironment.current.userDefaults.hasSeenLandingPage = true
+
+    return false
+  }
+
   let userAttributes = optimizelyUserAttributes(
     with: AppEnvironment.current.currentUser,
     project: nil,

--- a/Kickstarter-iOS/ViewModels/AppDelegateViewModelTests.swift
+++ b/Kickstarter-iOS/ViewModels/AppDelegateViewModelTests.swift
@@ -2118,7 +2118,7 @@ final class AppDelegateViewModelTests: TestCase {
   func testGoToLandingPage_EmitsIf_OptimizelyIsNotControl_HasNotSeenLandingPage() {
     let optimizelyClient = MockOptimizelyClient()
       |> \.experiments .~
-    [OptimizelyExperiment.Key.nativeOnboarding.rawValue: OptimizelyExperiment.Variant.variant1.rawValue]
+      [OptimizelyExperiment.Key.nativeOnboarding.rawValue: OptimizelyExperiment.Variant.variant1.rawValue]
 
     withEnvironment(currentUser: nil, optimizelyClient: optimizelyClient) {
       self.vm.inputs.applicationDidFinishLaunching(application: UIApplication.shared, launchOptions: nil)
@@ -2134,7 +2134,7 @@ final class AppDelegateViewModelTests: TestCase {
   func testGoToLandingPage_DoesNotEmitIf_OptimizelyIsControl_UserHasNotSeenLandingPage() {
     let optimizelyClient = MockOptimizelyClient()
       |> \.experiments .~
-    [OptimizelyExperiment.Key.nativeOnboarding.rawValue: OptimizelyExperiment.Variant.control.rawValue]
+      [OptimizelyExperiment.Key.nativeOnboarding.rawValue: OptimizelyExperiment.Variant.control.rawValue]
 
     withEnvironment(currentUser: nil, optimizelyClient: optimizelyClient) {
       self.vm.inputs.applicationDidFinishLaunching(application: UIApplication.shared, launchOptions: nil)
@@ -2148,10 +2148,10 @@ final class AppDelegateViewModelTests: TestCase {
   func testGoToLandingPage_DoesNotEmitIf_OptimizelyIsNotControl_UserHasSeenLandingPage() {
     let optimizelyClient = MockOptimizelyClient()
       |> \.experiments .~
-    [OptimizelyExperiment.Key.nativeOnboarding.rawValue: OptimizelyExperiment.Variant.variant2.rawValue]
+      [OptimizelyExperiment.Key.nativeOnboarding.rawValue: OptimizelyExperiment.Variant.variant2.rawValue]
 
     let userDefaults = MockKeyValueStore()
-    userDefaults.hasSeenLandingPage = true
+      |> \.hasSeenLandingPage .~ true
 
     withEnvironment(currentUser: nil, optimizelyClient: optimizelyClient, userDefaults: userDefaults) {
       self.vm.inputs.applicationDidFinishLaunching(application: UIApplication.shared, launchOptions: nil)

--- a/Kickstarter-iOS/ViewModels/AppDelegateViewModelTests.swift
+++ b/Kickstarter-iOS/ViewModels/AppDelegateViewModelTests.swift
@@ -27,6 +27,7 @@ final class AppDelegateViewModelTests: TestCase {
   private let goToActivity = TestObserver<(), Never>()
   private let goToDashboard = TestObserver<Param?, Never>()
   private let goToDiscovery = TestObserver<DiscoveryParams?, Never>()
+  private let goToLandingPage = TestObserver<(), Never>()
   private let goToProjectActivities = TestObserver<Param, Never>()
   private let goToLogin = TestObserver<(), Never>()
   private let goToProfile = TestObserver<(), Never>()
@@ -60,6 +61,7 @@ final class AppDelegateViewModelTests: TestCase {
     self.vm.outputs.goToActivity.observe(self.goToActivity.observer)
     self.vm.outputs.goToDashboard.observe(self.goToDashboard.observer)
     self.vm.outputs.goToDiscovery.observe(self.goToDiscovery.observer)
+    self.vm.outputs.goToLandingPage.observe(self.goToLandingPage.observer)
     self.vm.outputs.goToLogin.observe(self.goToLogin.observer)
     self.vm.outputs.goToProfile.observe(self.goToProfile.observer)
     self.vm.outputs.goToMobileSafari.observe(self.goToMobileSafari.observer)
@@ -2110,6 +2112,53 @@ final class AppDelegateViewModelTests: TestCase {
       self.displayQualtricsSurvey.assertDidNotEmitValue()
       self.evaluateQualtricsTargetingLogic.assertValueCount(1)
       XCTAssertEqual(mockQualtricsPropertiesType.values[firstAppSessionKey], 0)
+    }
+  }
+
+  func testGoToLandingPage_EmitsIf_OptimizelyIsNotControl_HasNotSeenLandingPage() {
+    let optimizelyClient = MockOptimizelyClient()
+      |> \.experiments .~
+    [OptimizelyExperiment.Key.nativeOnboarding.rawValue: OptimizelyExperiment.Variant.variant1.rawValue]
+
+    withEnvironment(currentUser: nil, optimizelyClient: optimizelyClient) {
+      self.vm.inputs.applicationDidFinishLaunching(application: UIApplication.shared, launchOptions: nil)
+
+      self.goToLandingPage.assertDidNotEmitValue()
+
+      self.vm.inputs.optimizelyUpdatedInEnvironment()
+
+      self.goToLandingPage.assertValueCount(1)
+    }
+  }
+
+  func testGoToLandingPage_DoesNotEmitIf_OptimizelyIsControl_UserHasNotSeenLandingPage() {
+    let optimizelyClient = MockOptimizelyClient()
+      |> \.experiments .~
+    [OptimizelyExperiment.Key.nativeOnboarding.rawValue: OptimizelyExperiment.Variant.control.rawValue]
+
+    withEnvironment(currentUser: nil, optimizelyClient: optimizelyClient) {
+      self.vm.inputs.applicationDidFinishLaunching(application: UIApplication.shared, launchOptions: nil)
+
+      self.vm.inputs.optimizelyUpdatedInEnvironment()
+
+      self.goToLandingPage.assertDidNotEmitValue()
+    }
+  }
+
+  func testGoToLandingPage_DoesNotEmitIf_OptimizelyIsNotControl_UserHasSeenLandingPage() {
+    let optimizelyClient = MockOptimizelyClient()
+      |> \.experiments .~
+    [OptimizelyExperiment.Key.nativeOnboarding.rawValue: OptimizelyExperiment.Variant.variant2.rawValue]
+
+    let userDefaults = MockKeyValueStore()
+    userDefaults.hasSeenLandingPage = true
+
+    withEnvironment(currentUser: nil, optimizelyClient: optimizelyClient, userDefaults: userDefaults) {
+      self.vm.inputs.applicationDidFinishLaunching(application: UIApplication.shared, launchOptions: nil)
+
+      self.vm.inputs.optimizelyUpdatedInEnvironment()
+
+      self.goToLandingPage.assertDidNotEmitValue()
     }
   }
 }

--- a/Kickstarter-iOS/ViewModels/AppDelegateViewModelTests.swift
+++ b/Kickstarter-iOS/ViewModels/AppDelegateViewModelTests.swift
@@ -2161,6 +2161,23 @@ final class AppDelegateViewModelTests: TestCase {
       self.goToLandingPage.assertDidNotEmitValue()
     }
   }
+
+  func testGoToLandingPage_DoesNotEmitIf_UserIsLoggedIn() {
+    let optimizelyClient = MockOptimizelyClient()
+      |> \.experiments .~
+      [OptimizelyExperiment.Key.nativeOnboarding.rawValue: OptimizelyExperiment.Variant.variant1.rawValue]
+
+    let userDefaults = MockKeyValueStore()
+      |> \.hasSeenLandingPage .~ false
+
+    withEnvironment(currentUser: .template, optimizelyClient: optimizelyClient, userDefaults: userDefaults) {
+      self.vm.inputs.applicationDidFinishLaunching(application: UIApplication.shared, launchOptions: nil)
+
+      self.vm.inputs.optimizelyUpdatedInEnvironment()
+
+      self.goToLandingPage.assertDidNotEmitValue()
+    }
+  }
 }
 
 private func qualtricsProps() -> [String: String] {

--- a/Kickstarter-iOS/Views/Controllers/LandingPageViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/LandingPageViewController.swift
@@ -45,7 +45,7 @@ public final class LandingPageViewController: UIViewController {
     self.setupConstraints()
     self.ctaButton.addTarget(
       self,
-      action: #selector(LandingPageViewController.ctaBUttonTapped),
+      action: #selector(LandingPageViewController.ctaButtonTapped),
       for: .touchUpInside
     )
 
@@ -61,6 +61,12 @@ public final class LandingPageViewController: UIViewController {
       .observeForUI()
       .observeValues { [weak self] cards in
         self?.configureCards(with: cards)
+      }
+
+    self.viewModel.outputs.dismissViewController
+      .observeForUI()
+      .observeValues { [weak self] in
+        self?.dismiss(animated: true)
       }
   }
 
@@ -141,8 +147,8 @@ public final class LandingPageViewController: UIViewController {
     ])
   }
 
-  @objc private func ctaBUttonTapped() {
-    self.dismiss(animated: true)
+  @objc private func ctaButtonTapped() {
+    self.viewModel.inputs.ctaButtonTapped()
   }
 
   private func configureCards(with _: [UIView]) {}

--- a/Kickstarter-iOS/Views/Controllers/LandingPageViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/LandingPageViewController.swift
@@ -67,20 +67,20 @@ public final class LandingPageViewController: UIViewController {
       .observeForUI()
       .observeValues { [weak self] cards in
         self?.configureCards(with: cards)
-    }
+      }
 
     self.viewModel.outputs.dismissViewController
       .observeForUI()
       .observeValues { [weak self] in
         self?.dismiss(animated: true)
-    }
+      }
 
     self.viewModel.outputs.numberOfPages
       .observeForUI()
       .observeValues { [weak self] count in
         _ = self?.pageControl
           ?|> \.numberOfPages .~ count
-    }
+      }
   }
 
   // MARK: - Styles
@@ -239,7 +239,7 @@ private let descriptionLabelStyle: LabelStyle = { label in
     |> \.textAlignment .~ .center
     |> \.text %~ { _ in
       Strings.Pledge_to_projects_and_view_all_your_saved_and_backed_projects_in_one_place()
-  }
+    }
 }
 
 private let labelsStackViewStyle: StackViewStyle = { stackView in

--- a/Library/KeyValueStoreType.swift
+++ b/Library/KeyValueStoreType.swift
@@ -6,6 +6,7 @@ public enum AppKeys: String {
   case deniedNotificationContexts = "com.kickstarter.KeyValueStoreType.deniedNotificationContexts"
   case favoriteCategoryIds = "favorite_category_ids"
   case hasSeenFavoriteCategoryAlert = "com.kickstarter.KeyValueStoreType.hasSeenFavoriteCategoryAlert"
+  case hasSeenLandingPage = "com.kickstarter.KeyValueStoreType.hasSeenLandingPage"
   case hasSeenSaveProjectAlert = "com.kickstarter.KeyValueStoreType.hasSeenSaveProjectAlert"
   case lastSeenActivitySampleId = "com.kickstarter.KeyValueStoreType.lastSeenActivitySampleId"
   case seenAppRating = "com.kickstarter.KeyValueStoreType.hasSeenAppRating"
@@ -31,6 +32,7 @@ public protocol KeyValueStoreType: AnyObject {
   var hasClosedFindFriendsInActivity: Bool { get set }
   var hasSeenAppRating: Bool { get set }
   var hasSeenFavoriteCategoryAlert: Bool { get set }
+  var hasSeenLandingPage: Bool { get set }
   var hasSeenGamesNewsletterPrompt: Bool { get set }
   var hasSeenSaveProjectAlert: Bool { get set }
   var lastSeenActivitySampleId: Int { get set }
@@ -88,6 +90,15 @@ extension KeyValueStoreType {
     }
     set {
       self.set(newValue, forKey: AppKeys.hasSeenFavoriteCategoryAlert.rawValue)
+    }
+  }
+
+  public var hasSeenLandingPage: Bool {
+    get {
+      return self.bool(forKey: AppKeys.hasSeenLandingPage.rawValue)
+    }
+    set {
+      self.set(newValue, forKey: AppKeys.hasSeenLandingPage.rawValue)
     }
   }
 

--- a/Library/SharedFunctions.swift
+++ b/Library/SharedFunctions.swift
@@ -180,7 +180,7 @@ internal func classNameWithoutModule(_ class: AnyClass) -> String {
     .joined(separator: ".")
 }
 
-internal func deviceIdentifier(uuid: UUIDType, env: Environment = AppEnvironment.current) -> String {
+public func deviceIdentifier(uuid: UUIDType, env: Environment = AppEnvironment.current) -> String {
   guard let identifier = env.device.identifierForVendor else {
     return uuid.uuidString
   }

--- a/Library/ViewModels/LandingPageViewModel.swift
+++ b/Library/ViewModels/LandingPageViewModel.swift
@@ -2,8 +2,8 @@ import ReactiveSwift
 import UIKit
 
 public protocol LandingPageViewModelInputs {
-  func viewDidLoad()
   func ctaButtonTapped()
+  func viewDidLoad()
 }
 
 public protocol LandingPageViewModelOutputs {

--- a/Library/ViewModels/LandingPageViewModel.swift
+++ b/Library/ViewModels/LandingPageViewModel.swift
@@ -25,13 +25,17 @@ public final class LandingPageViewModel: LandingPageViewModelType, LandingPageVi
       .skipNil()
 
     self.dismissViewController = self.ctaButtonTappedSignal
-      .on(value: { _ in
-        AppEnvironment.current.ubiquitousStore.hasSeenLandingPage = true
-        AppEnvironment.current.userDefaults.hasSeenLandingPage = true
-      })
 
     self.numberOfPages = self.landingPageCards
       .map(\.count)
+
+    // Koala
+
+    self.viewDidLoadSignal
+      .observeValues { _ in
+        AppEnvironment.current.ubiquitousStore.hasSeenLandingPage = true
+        AppEnvironment.current.userDefaults.hasSeenLandingPage = true
+      }
   }
 
   private let (ctaButtonTappedSignal, ctaButtonTappedObserver) = Signal<(), Never>.pipe()

--- a/Library/ViewModels/LandingPageViewModel.swift
+++ b/Library/ViewModels/LandingPageViewModel.swift
@@ -29,8 +29,6 @@ public final class LandingPageViewModel: LandingPageViewModelType, LandingPageVi
     self.numberOfPages = self.landingPageCards
       .map(\.count)
 
-    // Koala
-
     self.viewDidLoadSignal
       .observeValues { _ in
         AppEnvironment.current.userDefaults.hasSeenLandingPage = true

--- a/Library/ViewModels/LandingPageViewModel.swift
+++ b/Library/ViewModels/LandingPageViewModel.swift
@@ -33,7 +33,6 @@ public final class LandingPageViewModel: LandingPageViewModelType, LandingPageVi
 
     self.viewDidLoadSignal
       .observeValues { _ in
-        AppEnvironment.current.ubiquitousStore.hasSeenLandingPage = true
         AppEnvironment.current.userDefaults.hasSeenLandingPage = true
       }
   }

--- a/Library/ViewModels/LandingPageViewModel.swift
+++ b/Library/ViewModels/LandingPageViewModel.swift
@@ -19,7 +19,6 @@ public protocol LandingPageViewModelType {
 
 public final class LandingPageViewModel: LandingPageViewModelType, LandingPageViewModelInputs,
   LandingPageViewModelOutputs {
-
   public init() {
     self.landingPageCards = self.viewDidLoadSignal
       .map(cards)
@@ -32,7 +31,7 @@ public final class LandingPageViewModel: LandingPageViewModelType, LandingPageVi
       })
 
     self.numberOfPages = self.landingPageCards
-    .map(\.count)
+      .map(\.count)
   }
 
   private let (ctaButtonTappedSignal, ctaButtonTappedObserver) = Signal<(), Never>.pipe()

--- a/Library/ViewModels/LandingPageViewModel.swift
+++ b/Library/ViewModels/LandingPageViewModel.swift
@@ -3,9 +3,11 @@ import UIKit
 
 public protocol LandingPageViewModelInputs {
   func viewDidLoad()
+  func ctaButtonTapped()
 }
 
 public protocol LandingPageViewModelOutputs {
+  var dismissViewController: Signal<(), Never> { get }
   var landingPageCards: Signal<[UIView], Never> { get }
 }
 
@@ -20,6 +22,17 @@ public final class LandingPageViewModel: LandingPageViewModelType, LandingPageVi
     self.landingPageCards = self.viewDidLoadSignal
       .map(cards)
       .skipNil()
+
+    self.dismissViewController = self.ctaButtonTappedSignal
+      .on(value: { _ in
+        AppEnvironment.current.ubiquitousStore.hasSeenLandingPage = true
+        AppEnvironment.current.userDefaults.hasSeenLandingPage = true
+      })
+  }
+
+  private let (ctaButtonTappedSignal, ctaButtonTappedObserver) = Signal<(), Never>.pipe()
+  public func ctaButtonTapped() {
+    self.ctaButtonTappedObserver.send(value: ())
   }
 
   private let (viewDidLoadSignal, viewDidLoadObserver) = Signal<(), Never>.pipe()
@@ -27,6 +40,7 @@ public final class LandingPageViewModel: LandingPageViewModelType, LandingPageVi
     self.viewDidLoadObserver.send(value: ())
   }
 
+  public let dismissViewController: Signal<(), Never>
   public let landingPageCards: Signal<[UIView], Never>
 
   public var inputs: LandingPageViewModelInputs { return self }

--- a/Library/ViewModels/LandingPageViewModelTests.swift
+++ b/Library/ViewModels/LandingPageViewModelTests.swift
@@ -6,10 +6,8 @@ import UIKit
 import XCTest
 
 internal final class LandingPageViewModelTests: TestCase {
-
   private let dismissViewController = TestObserver<(), Never>()
   private let viewModel: LandingPageViewModelType = LandingPageViewModel()
-
 
   override func setUp() {
     super.setUp()
@@ -29,9 +27,8 @@ internal final class LandingPageViewModelTests: TestCase {
     let userDefaults = MockKeyValueStore()
 
     withEnvironment(currentUser: nil, userDefaults: userDefaults) {
-
       let hasSeenLandingPageKey = AppKeys.hasSeenLandingPage.rawValue
-      
+
       XCTAssertFalse(userDefaults.bool(forKey: hasSeenLandingPageKey))
 
       self.viewModel.inputs.ctaButtonTapped()

--- a/Library/ViewModels/LandingPageViewModelTests.swift
+++ b/Library/ViewModels/LandingPageViewModelTests.swift
@@ -27,7 +27,7 @@ internal final class LandingPageViewModelTests: TestCase {
     self.dismissViewController.assertValueCount(1)
   }
 
-  func testUserDefaultsUpdates_OnButtonTap() {
+  func testUserDefaultsUpdates_OnViewDidLoad() {
     let userDefaults = MockKeyValueStore()
 
     withEnvironment(currentUser: nil, userDefaults: userDefaults) {
@@ -35,7 +35,7 @@ internal final class LandingPageViewModelTests: TestCase {
 
       XCTAssertFalse(userDefaults.bool(forKey: hasSeenLandingPageKey))
 
-      self.viewModel.inputs.ctaButtonTapped()
+      self.viewModel.inputs.viewDidLoad()
 
       XCTAssertTrue(userDefaults.bool(forKey: hasSeenLandingPageKey))
     }

--- a/Library/ViewModels/LandingPageViewModelTests.swift
+++ b/Library/ViewModels/LandingPageViewModelTests.swift
@@ -6,9 +6,37 @@ import UIKit
 import XCTest
 
 internal final class LandingPageViewModelTests: TestCase {
-  fileprivate let vm: LandingPageViewModelType = LandingPageViewModel()
+
+  private let dismissViewController = TestObserver<(), Never>()
+  private let viewModel: LandingPageViewModelType = LandingPageViewModel()
+
 
   override func setUp() {
     super.setUp()
+
+    self.viewModel.outputs.dismissViewController.observe(self.dismissViewController.observer)
+  }
+
+  func testDismissViewController_OnButtonTap() {
+    self.dismissViewController.assertDidNotEmitValue()
+
+    self.viewModel.inputs.ctaButtonTapped()
+
+    self.dismissViewController.assertValueCount(1)
+  }
+
+  func testUserDefaultsUpdates_OnButtonTap() {
+    let userDefaults = MockKeyValueStore()
+
+    withEnvironment(currentUser: nil, userDefaults: userDefaults) {
+
+      let hasSeenLandingPageKey = AppKeys.hasSeenLandingPage.rawValue
+      
+      XCTAssertFalse(userDefaults.bool(forKey: hasSeenLandingPageKey))
+
+      self.viewModel.inputs.ctaButtonTapped()
+
+      XCTAssertTrue(userDefaults.bool(forKey: hasSeenLandingPageKey))
+    }
   }
 }


### PR DESCRIPTION
# 📲 What

- It adds the logic to only show `LandingPageViewController` on the first app session **_and_** if the user part of `variant-1` or `variant-2` of the Optimizely `native_onboarding_series_new_backers` experiment.

# 🤔 Why

- This is the last part of the Landing Page work.
[JIRA ticket](https://kickstarter.atlassian.net/browse/NT-871)

# 🛠 How

- Created the `goToLandingPage` output on the AppDelegateViewModel that emits the experiment variants to determine if the LandingPage should be presented.
- Added the `hasSeenLandingPage` to the KeyValueStore in order to keep track if the user has seen the landing page.
- Added tests

# ✅ Acceptance criteria

- [ ] On a fresh build, open the app and inspect with Charles to see which variant you got.
- [ ] If you got `control`, the Landing Page shouldn't be presented
- [ ] If you got `variant-1` or `variant-2`, the LandingPage should be presented
- [ ] If you saw the LandingPage, tap the `Get started` button. The ViewController should be dismissed and the Landing Page should no longer be shown.
