### PR TITLE
[NT-930] Add Project Creator Details Query and VM outputs

### DIFF
--- a/Kickstarter-iOS/DataSources/ProjectPamphletContentDataSource.swift
+++ b/Kickstarter-iOS/DataSources/ProjectPamphletContentDataSource.swift
@@ -25,10 +25,10 @@ internal final class ProjectPamphletContentDataSource: ValueCellDataSource {
     )
   }
 
-  internal func load(projectAndRefTag: (Project, RefTag?)) {
+  internal func load(data: ProjectPamphletContentData) {
     self.clearValues()
 
-    let (project, _) = projectAndRefTag
+    let (project, creatorDetails, refTag) = data
 
     if currentUserIsCreator(of: project) {
       self.set(
@@ -39,7 +39,7 @@ internal final class ProjectPamphletContentDataSource: ValueCellDataSource {
     }
 
     self.set(
-      values: [projectAndRefTag],
+      values: [(project, refTag)],
       cellClass: ProjectPamphletMainCell.self,
       inSection: Section.main.rawValue
     )

--- a/Kickstarter-iOS/DataSources/ProjectPamphletContentDataSourceTests.swift
+++ b/Kickstarter-iOS/DataSources/ProjectPamphletContentDataSourceTests.swift
@@ -16,7 +16,7 @@ final class ProjectPamphletContentDataSourceTests: TestCase {
       |> Project.lens.creator .~ user
 
     withEnvironment(currentUser: user) {
-      self.dataSource.load(projectAndRefTag: (project, .discovery))
+      self.dataSource.load(data: (project, (nil, false), .discovery))
 
       XCTAssertEqual(1, self.dataSource.tableView(self.tableView, numberOfRowsInSection: viewProgressSection))
     }
@@ -30,7 +30,7 @@ final class ProjectPamphletContentDataSourceTests: TestCase {
     let project = Project.template
 
     withEnvironment(currentUser: user) {
-      self.dataSource.load(projectAndRefTag: (project, .discovery))
+      self.dataSource.load(data: (project, (nil, false), .discovery))
 
       XCTAssertEqual(0, self.dataSource.tableView(self.tableView, numberOfRowsInSection: viewProgressSection))
     }
@@ -42,7 +42,7 @@ final class ProjectPamphletContentDataSourceTests: TestCase {
       lang: "en"
     )
     withEnvironment(config: config, mainBundle: releaseBundle) {
-      self.dataSource.load(projectAndRefTag: (.template, .discovery))
+      self.dataSource.load(data: (.template, (nil, false), .discovery))
 
       XCTAssertEqual(8, self.dataSource.numberOfSections(in: self.tableView))
     }

--- a/Kickstarter-iOS/Views/Controllers/ProjectPamphletContentViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/ProjectPamphletContentViewController.swift
@@ -59,10 +59,10 @@ public final class ProjectPamphletContentViewController: UITableViewController {
   public override func bindViewModel() {
     super.bindViewModel()
 
-    self.viewModel.outputs.loadProjectAndRefTagIntoDataSource
+    self.viewModel.outputs.loadProjectPamphletContentDataIntoDataSource
       .observeForUI()
-      .observeValues { [weak self] projectAndRefTag in
-        self?.dataSource.load(projectAndRefTag: projectAndRefTag)
+      .observeValues { [weak self] data in
+        self?.dataSource.load(data: data)
         self?.tableView.reloadData()
       }
 

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -374,6 +374,8 @@
 		8A8099F822E2156E00373E66 /* RewardPledgeNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A8099F722E2156E00373E66 /* RewardPledgeNavigationController.swift */; };
 		8AA117F323A414BF00F7E339 /* Qualtrics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8AD7953123A286D800998C79 /* Qualtrics.framework */; };
 		8AA117F523A4160800F7E339 /* MockQualtricsResultType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AA117F423A4160800F7E339 /* MockQualtricsResultType.swift */; };
+		8AA4E6B22405B2560095D516 /* ProjectCreatorDetailsEnvelope.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AA4E6B12405B2560095D516 /* ProjectCreatorDetailsEnvelope.swift */; };
+		8AA4E6B42405B6280095D516 /* ProjectCreatorDetailsEnvelopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AA4E6B32405B6280095D516 /* ProjectCreatorDetailsEnvelopeTests.swift */; };
 		8AA5248F2384CA7900FD52CF /* EditorialProjectsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AA5248E2384CA7900FD52CF /* EditorialProjectsViewController.swift */; };
 		8AA524912384CAAC00FD52CF /* EditorialProjectsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AA524902384CAAC00FD52CF /* EditorialProjectsViewModel.swift */; };
 		8AA524932384CAC100FD52CF /* EditorialProjectsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AA524922384CAC100FD52CF /* EditorialProjectsViewModelTests.swift */; };
@@ -1775,6 +1777,8 @@
 		8A8099F022E2142C00373E66 /* RewardCardContainerViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RewardCardContainerViewModel.swift; sourceTree = "<group>"; };
 		8A8099F722E2156E00373E66 /* RewardPledgeNavigationController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RewardPledgeNavigationController.swift; sourceTree = "<group>"; };
 		8AA117F423A4160800F7E339 /* MockQualtricsResultType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockQualtricsResultType.swift; sourceTree = "<group>"; };
+		8AA4E6B12405B2560095D516 /* ProjectCreatorDetailsEnvelope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectCreatorDetailsEnvelope.swift; sourceTree = "<group>"; };
+		8AA4E6B32405B6280095D516 /* ProjectCreatorDetailsEnvelopeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectCreatorDetailsEnvelopeTests.swift; sourceTree = "<group>"; };
 		8AA5248E2384CA7900FD52CF /* EditorialProjectsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorialProjectsViewController.swift; sourceTree = "<group>"; };
 		8AA524902384CAAC00FD52CF /* EditorialProjectsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorialProjectsViewModel.swift; sourceTree = "<group>"; };
 		8AA524922384CAC100FD52CF /* EditorialProjectsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorialProjectsViewModelTests.swift; sourceTree = "<group>"; };
@@ -3958,8 +3962,8 @@
 				D01587931EEB2ED6006E7684 /* FriendStatsEnvelope.swift */,
 				D01587941EEB2ED6006E7684 /* FriendStatsEnvelopeTests.swift */,
 				D69C55132397166D00B0987A /* GraphBacking.swift */,
-				D69C55172398534E00B0987A /* GraphBackingTests.swift */,
 				D69C5515239852CB00B0987A /* GraphBackingEnvelope.swift */,
+				D69C55172398534E00B0987A /* GraphBackingTests.swift */,
 				D002CAE4218CF951009783F2 /* GraphMutationWatchProjectResponseEnvelope.swift */,
 				D63BBD30217F7212007E01F0 /* GraphUserCreditCard.swift */,
 				77DB53292215D0AA0078991C /* GraphUserCreditCardTests.swift */,
@@ -3985,6 +3989,8 @@
 				D01587D91EEB2ED7006E7684 /* Project.Video.swift */,
 				D01587DA1EEB2ED7006E7684 /* Project.VideoTests.swift */,
 				D01587DB1EEB2ED7006E7684 /* ProjectActivityEnvelope.swift */,
+				8AA4E6B12405B2560095D516 /* ProjectCreatorDetailsEnvelope.swift */,
+				8AA4E6B32405B6280095D516 /* ProjectCreatorDetailsEnvelopeTests.swift */,
 				D01587DC1EEB2ED7006E7684 /* ProjectNotification.swift */,
 				D01587DD1EEB2ED7006E7684 /* ProjectsEnvelope.swift */,
 				D01587DE1EEB2ED7006E7684 /* ProjectStatsEnvelope.swift */,
@@ -5747,6 +5753,7 @@
 				D0E78C3622A980A600AAB645 /* ClearUserUnseenActivityEnvelope.swift in Sources */,
 				D0158A1A1EEB30A2006E7684 /* Project.PhotoTemplates.swift in Sources */,
 				8AF34C722342CBAD000B211D /* UpdateBackingMutation.swift in Sources */,
+				8AA4E6B22405B2560095D516 /* ProjectCreatorDetailsEnvelope.swift in Sources */,
 				D01588B51EEB2ED7006E7684 /* ProjectNotificationLenses.swift in Sources */,
 				D015882B1EEB2ED7006E7684 /* NSURLSession.swift in Sources */,
 				D79440572203A63300D0A747 /* CreatePaymentSourceEnvelope.swift in Sources */,
@@ -5792,6 +5799,7 @@
 				D01589A21EEB2ED7006E7684 /* ServiceTypeTests.swift in Sources */,
 				D0D10C0F1EEB4550005EBAD0 /* LocationTests.swift in Sources */,
 				D0D10C121EEB4550005EBAD0 /* Project.CountryTests.swift in Sources */,
+				8AA4E6B42405B6280095D516 /* ProjectCreatorDetailsEnvelopeTests.swift in Sources */,
 				D0D10C0B1EEB4550005EBAD0 /* ErrorEnvelopeTests.swift in Sources */,
 				D0D10C031EEB4550005EBAD0 /* BackingTests.swift in Sources */,
 				D0D10C091EEB4550005EBAD0 /* CreatePledgeEnvelopeTests.swift in Sources */,

--- a/KsApi/GraphSchema.swift
+++ b/KsApi/GraphSchema.swift
@@ -173,6 +173,7 @@ public enum Query {
   }
 
   public enum Project {
+    case creator(NonEmptySet<User>)
     case id
     case name
     case slug
@@ -192,17 +193,18 @@ public enum Query {
     }
   }
 
-  public enum User {
+  public indirect enum User {
     case backedProjects(Set<QueryArg<Never>>, NonEmptySet<Connection<Project>>)
     case backings(status: String, Set<QueryArg<Never>>, NonEmptySet<Connection<Backing>>)
+    case backingsCount
     case biography
     case chosenCurrency
     case conversations(Set<QueryArg<Never>>, NonEmptySet<Connection<Conversation>>)
     case createdProjects(Set<QueryArg<Never>>, NonEmptySet<Connection<Project>>)
     case drop
     case email
-    indirect case followers(Set<QueryArg<Never>>, NonEmptySet<Connection<User>>)
-    indirect case following(Set<QueryArg<Never>>, NonEmptySet<Connection<User>>)
+    case followers(Set<QueryArg<Never>>, NonEmptySet<Connection<User>>)
+    case following(Set<QueryArg<Never>>, NonEmptySet<Connection<User>>)
     case hasPassword
     case hasUnreadMessages
     case id
@@ -212,6 +214,7 @@ public enum Query {
     case isEmailVerified
     case isFollowing
     case isSocializing
+    case launchedProjects(NonEmptySet<LaunchedProjects>)
     case location(NonEmptySet<Location>)
     case membershipProjects(Set<QueryArg<Never>>, NonEmptySet<Connection<Project>>)
     case name
@@ -237,6 +240,10 @@ public enum Query {
       case errorReason
       case project(NonEmptySet<Project>)
       case status
+    }
+
+    public enum LaunchedProjects {
+      case totalCount
     }
   }
 }
@@ -364,6 +371,7 @@ extension Query.Category.ProjectsConnection.Argument: CustomStringConvertible {
 extension Query.Project: QueryType {
   public var description: String {
     switch self {
+    case .creator: return "creator"
     case .id: return "id"
     case .name: return "name"
     case .slug: return "slug"
@@ -392,6 +400,7 @@ extension Query.User: QueryType {
     switch self {
     case let .backings(status, args, fields):
       return "backings(status: \(status))\(connection(args, fields))"
+    case .backingsCount: return "backingsCount"
     case .biography: return "biography"
     case let .backedProjects(args, fields): return "backedProjects\(connection(args, fields))"
     case let .conversations(args, fields): return "conversations\(connection(args, fields))"
@@ -410,6 +419,7 @@ extension Query.User: QueryType {
     case .isEmailVerified: return "isEmailVerified"
     case .isFollowing: return "isFollowing"
     case .isSocializing: return "isSocializing"
+    case let .launchedProjects(fields): return "launchedProjects { \(join(fields)) }"
     case let .location(fields): return "location { \(join(fields)) }"
     case let .membershipProjects(args, fields): return "membershipProjects\(connection(args, fields))"
     case .name: return "name"
@@ -439,6 +449,14 @@ extension Query.User.Backing: QueryType {
     case .errorReason: return "errorReason"
     case let .project(fields): return "project { \(join(fields)) }"
     case .status: return "status"
+    }
+  }
+}
+
+extension Query.User.LaunchedProjects: QueryType {
+  public var description: String {
+    switch self {
+    case .totalCount: return "totalCount"
     }
   }
 }

--- a/KsApi/GraphSchema.swift
+++ b/KsApi/GraphSchema.swift
@@ -371,7 +371,7 @@ extension Query.Category.ProjectsConnection.Argument: CustomStringConvertible {
 extension Query.Project: QueryType {
   public var description: String {
     switch self {
-    case .creator: return "creator"
+    case let .creator(fields): return "creator { \(join(fields)) }"
     case .id: return "id"
     case .name: return "name"
     case .slug: return "slug"

--- a/KsApi/MockService.swift
+++ b/KsApi/MockService.swift
@@ -93,10 +93,12 @@
     fileprivate let fetchProjectResponse: Project?
     fileprivate let fetchProjectError: ErrorEnvelope?
 
-    fileprivate let fetchProjectNotificationsResponse: [ProjectNotification]
-
     fileprivate let fetchProjectsResponse: [Project]?
     fileprivate let fetchProjectsError: ErrorEnvelope?
+
+    fileprivate let fetchProjectCreatorDetailsResult: Result<ProjectCreatorDetailsEnvelope, GraphError>?
+
+    fileprivate let fetchProjectNotificationsResponse: [ProjectNotification]
 
     fileprivate let fetchProjectStatsResponse: ProjectStatsEnvelope?
     fileprivate let fetchProjectStatsError: ErrorEnvelope?
@@ -246,10 +248,11 @@
       publishUpdateError: ErrorEnvelope? = nil,
       fetchMessageThreadResult: Result<MessageThread?, ErrorEnvelope>? = nil,
       fetchMessageThreadsResponse: [MessageThread]? = nil,
-      fetchProjectActivitiesResponse: [Activity]? = nil,
-      fetchProjectActivitiesError: ErrorEnvelope? = nil,
       fetchProjectResponse: Project? = nil,
       fetchProjectError: ErrorEnvelope? = nil,
+      fetchProjectActivitiesResponse: [Activity]? = nil,
+      fetchProjectActivitiesError: ErrorEnvelope? = nil,
+      fetchProjectCreatorDetailsResult: Result<ProjectCreatorDetailsEnvelope, GraphError>? = nil,
       fetchProjectNotificationsResponse: [ProjectNotification]? = nil,
       fetchProjectsResponse: [Project]? = nil,
       fetchProjectsError: ErrorEnvelope? = nil,
@@ -418,6 +421,8 @@
       ]
 
       self.fetchProjectsResponse = fetchProjectsResponse ?? []
+
+      self.fetchProjectCreatorDetailsResult = fetchProjectCreatorDetailsResult
 
       self.fetchProjectsError = fetchProjectsError
 
@@ -986,6 +991,11 @@
       return .empty
     }
 
+    func fetchProjectCreatorDetails(query _: NonEmptySet<Query>)
+      -> SignalProducer<ProjectCreatorDetailsEnvelope, GraphError> {
+      return producer(for: self.fetchProjectCreatorDetailsResult)
+    }
+
     internal func fetchProjects(member _: Bool) -> SignalProducer<ProjectsEnvelope, ErrorEnvelope> {
       if let error = fetchProjectsError {
         return SignalProducer(error: error)
@@ -1448,9 +1458,10 @@
             publishUpdateError: $1.publishUpdateError,
             fetchMessageThreadResult: $1.fetchMessageThreadResult,
             fetchMessageThreadsResponse: $1.fetchMessageThreadsResponse,
+            fetchProjectResponse: $1.fetchProjectResponse,
             fetchProjectActivitiesResponse: $1.fetchProjectActivitiesResponse,
             fetchProjectActivitiesError: $1.fetchProjectActivitiesError,
-            fetchProjectResponse: $1.fetchProjectResponse,
+            fetchProjectCreatorDetailsResult: $1.fetchProjectCreatorDetailsResult,
             fetchProjectNotificationsResponse: $1.fetchProjectNotificationsResponse,
             fetchProjectsResponse: $1.fetchProjectsResponse,
             fetchProjectsError: $1.fetchProjectsError,

--- a/KsApi/Service.swift
+++ b/KsApi/Service.swift
@@ -292,10 +292,6 @@ public struct Service: ServiceType {
     return request(.project(.id(project.id)))
   }
 
-  public func fetchProjectNotifications() -> SignalProducer<[ProjectNotification], ErrorEnvelope> {
-    return request(.projectNotifications)
-  }
-
   public func fetchProjectActivities(forProject project: Project) ->
     SignalProducer<ProjectActivityEnvelope, ErrorEnvelope> {
     return request(.projectActivities(project))
@@ -304,6 +300,14 @@ public struct Service: ServiceType {
   public func fetchProjectActivities(paginationUrl: String)
     -> SignalProducer<ProjectActivityEnvelope, ErrorEnvelope> {
     return requestPagination(paginationUrl)
+  }
+
+  public func fetchProjectCreatorDetails(query: NonEmptySet<Query>) -> SignalProducer<ProjectCreatorDetailsEnvelope, GraphError> {
+    return fetch(query: query)
+  }
+
+  public func fetchProjectNotifications() -> SignalProducer<[ProjectNotification], ErrorEnvelope> {
+    return request(.projectNotifications)
   }
 
   public func fetchProjects(member: Bool) -> SignalProducer<ProjectsEnvelope, ErrorEnvelope> {

--- a/KsApi/Service.swift
+++ b/KsApi/Service.swift
@@ -302,7 +302,8 @@ public struct Service: ServiceType {
     return requestPagination(paginationUrl)
   }
 
-  public func fetchProjectCreatorDetails(query: NonEmptySet<Query>) -> SignalProducer<ProjectCreatorDetailsEnvelope, GraphError> {
+  public func fetchProjectCreatorDetails(query: NonEmptySet<Query>)
+    -> SignalProducer<ProjectCreatorDetailsEnvelope, GraphError> {
     return fetch(query: query)
   }
 

--- a/KsApi/ServiceType.swift
+++ b/KsApi/ServiceType.swift
@@ -193,6 +193,10 @@ public protocol ServiceType {
   func fetchProjectActivities(paginationUrl: String) ->
     SignalProducer<ProjectActivityEnvelope, ErrorEnvelope>
 
+  /// Fetch the project creator details for a project with a given query.
+  func fetchProjectCreatorDetails(query: NonEmptySet<Query>)
+    -> SignalProducer<ProjectCreatorDetailsEnvelope, GraphError>
+
   /// Fetch the user's project notifications.
   func fetchProjectNotifications() -> SignalProducer<[ProjectNotification], ErrorEnvelope>
 

--- a/KsApi/models/ProjectCreatorDetailsEnvelope.swift
+++ b/KsApi/models/ProjectCreatorDetailsEnvelope.swift
@@ -1,16 +1,16 @@
 import Foundation
 
 public struct ProjectCreatorDetailsEnvelope {
+  public let backingsCount: Int
   public let id: String
-  public let lastLogin: TimeInterval
   public let launchedProjectsCount: Int
 }
 
 extension ProjectCreatorDetailsEnvelope: Decodable {
   private enum CodingKeys: String, CodingKey {
+    case backingsCount
     case creator
     case id
-    case lastLogin
     case launchedProjects
     case project
     case totalCount
@@ -21,8 +21,9 @@ extension ProjectCreatorDetailsEnvelope: Decodable {
       .nestedContainer(keyedBy: CodingKeys.self, forKey: .project)
       .nestedContainer(keyedBy: CodingKeys.self, forKey: .creator)
 
+    self.backingsCount = try values
+      .decode(Int.self, forKey: .backingsCount)
     self.id = try values.decode(String.self, forKey: .id)
-    self.lastLogin = try values.decode(TimeInterval.self, forKey: .lastLogin)
     self.launchedProjectsCount = try values
       .nestedContainer(keyedBy: CodingKeys.self, forKey: .launchedProjects)
       .decode(Int.self, forKey: .totalCount)

--- a/KsApi/models/ProjectCreatorDetailsEnvelope.swift
+++ b/KsApi/models/ProjectCreatorDetailsEnvelope.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct ProjectCreatorDetailsEnvelope {
+public struct ProjectCreatorDetailsEnvelope: Equatable {
   public let backingsCount: Int
   public let id: String
   public let launchedProjectsCount: Int

--- a/KsApi/models/ProjectCreatorDetailsEnvelope.swift
+++ b/KsApi/models/ProjectCreatorDetailsEnvelope.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+public struct ProjectCreatorDetailsEnvelope {
+  public let id: String
+  public let lastLogin: TimeInterval
+  public let launchedProjectsCount: Int
+}
+
+extension ProjectCreatorDetailsEnvelope: Decodable {
+  private enum CodingKeys: String, CodingKey {
+    case creator
+    case id
+    case lastLogin
+    case launchedProjects
+    case project
+    case totalCount
+  }
+
+  public init(from decoder: Decoder) throws {
+    let values = try decoder.container(keyedBy: CodingKeys.self)
+      .nestedContainer(keyedBy: CodingKeys.self, forKey: .project)
+      .nestedContainer(keyedBy: CodingKeys.self, forKey: .creator)
+
+    self.id = try values.decode(String.self, forKey: .id)
+    self.lastLogin = try values.decode(TimeInterval.self, forKey: .lastLogin)
+    self.launchedProjectsCount = try values
+      .nestedContainer(keyedBy: CodingKeys.self, forKey: .launchedProjects)
+      .decode(Int.self, forKey: .totalCount)
+  }
+}

--- a/KsApi/models/ProjectCreatorDetailsEnvelopeTests.swift
+++ b/KsApi/models/ProjectCreatorDetailsEnvelopeTests.swift
@@ -7,7 +7,7 @@ final class ProjectCreatorDetailsEnvelopeTests: XCTestCase {
       "project": [
         "creator": [
           "id": "VXNlci0xOTMxNzE1OTI4",
-          "lastLogin": 1_581_718_873,
+          "backingsCount": 152,
           "launchedProjects": [
             "totalCount": 6
           ]
@@ -23,7 +23,7 @@ final class ProjectCreatorDetailsEnvelopeTests: XCTestCase {
     let value = try? JSONDecoder().decode(ProjectCreatorDetailsEnvelope.self, from: data)
 
     XCTAssertEqual(value?.id, "VXNlci0xOTMxNzE1OTI4")
-    XCTAssertEqual(value?.lastLogin, 1_581_718_873)
+    XCTAssertEqual(value?.backingsCount, 152)
     XCTAssertEqual(value?.launchedProjectsCount, 6)
   }
 

--- a/KsApi/models/ProjectCreatorDetailsEnvelopeTests.swift
+++ b/KsApi/models/ProjectCreatorDetailsEnvelopeTests.swift
@@ -1,0 +1,49 @@
+@testable import KsApi
+import XCTest
+
+final class ProjectCreatorDetailsEnvelopeTests: XCTestCase {
+  func testJSONParsing_WithCompleteData() {
+    let dictionary: [String: Any] = [
+      "project": [
+        "creator": [
+          "id": "VXNlci0xOTMxNzE1OTI4",
+          "lastLogin": 1_581_718_873,
+          "launchedProjects": [
+            "totalCount": 6
+          ]
+        ]
+      ]
+    ]
+
+    guard let data = try? JSONSerialization.data(withJSONObject: dictionary, options: []) else {
+      XCTFail("Should have data")
+      return
+    }
+
+    let value = try? JSONDecoder().decode(ProjectCreatorDetailsEnvelope.self, from: data)
+
+    XCTAssertEqual(value?.id, "VXNlci0xOTMxNzE1OTI4")
+    XCTAssertEqual(value?.lastLogin, 1_581_718_873)
+    XCTAssertEqual(value?.launchedProjectsCount, 6)
+  }
+
+  func testJSONParsing_WithPartialData() {
+    let dictionary: [String: Any] = [
+      "project": [
+        "creator": [
+          "id": "VXNlci0xOTMxNzE1OTI4",
+          "lastLogin": 1_581_718_873
+        ]
+      ]
+    ]
+
+    guard let data = try? JSONSerialization.data(withJSONObject: dictionary, options: []) else {
+      XCTFail("Should have data")
+      return
+    }
+
+    let value = try? JSONDecoder().decode(ProjectCreatorDetailsEnvelope.self, from: data)
+
+    XCTAssertNil(value)
+  }
+}

--- a/Library/ViewModels/ProjectPamphletContentViewModel.swift
+++ b/Library/ViewModels/ProjectPamphletContentViewModel.swift
@@ -183,3 +183,19 @@ private func goToBackingData(forProject project: Project, rewardOrBacking: Eithe
 
   return project
 }
+
+private func projectCreatorDetailsQuery(withSlug slug: String) -> NonEmptySet<Query> {
+  return Query.project(
+    slug: slug,
+    .id +| [
+      .creator(
+        .id +| [
+          .backingsCount,
+          .launchedProjects(
+            .totalCount +| []
+          )
+        ]
+      )
+    ]
+  ) +| []
+}

--- a/Library/ViewModels/ProjectPamphletContentViewModel.swift
+++ b/Library/ViewModels/ProjectPamphletContentViewModel.swift
@@ -76,7 +76,7 @@ public final class ProjectPamphletContentViewModel: ProjectPamphletContentViewMo
 
     let data = Signal.combineLatest(
       projectAndRefTag,
-      projectCreatorDetails.values().logEvents(identifier: "***")
+      projectCreatorDetails.values()
     )
     .map { projectAndRefTag, creatorDetails in (projectAndRefTag.0, creatorDetails, projectAndRefTag.1) }
 

--- a/Library/ViewModels/ProjectPamphletContentViewModelTests.swift
+++ b/Library/ViewModels/ProjectPamphletContentViewModelTests.swift
@@ -6,7 +6,7 @@ import ReactiveSwift
 import XCTest
 
 final class ProjectPamphletContentViewModelTests: TestCase {
-  fileprivate var vm: ProjectPamphletContentViewModelType!
+  fileprivate let vm: ProjectPamphletContentViewModelType = ProjectPamphletContentViewModel()
 
   fileprivate let goToBacking = TestObserver<Project, Never>()
   fileprivate let goToComments = TestObserver<Project, Never>()
@@ -23,8 +23,6 @@ final class ProjectPamphletContentViewModelTests: TestCase {
 
   override func setUp() {
     super.setUp()
-
-    self.vm = ProjectPamphletContentViewModel()
 
     self.vm.outputs.goToBacking.observe(self.goToBacking.observer)
     self.vm.outputs.goToComments.observe(self.goToComments.observer)

--- a/Library/ViewModels/ProjectPamphletContentViewModelTests.swift
+++ b/Library/ViewModels/ProjectPamphletContentViewModelTests.swift
@@ -498,7 +498,9 @@ final class ProjectPamphletContentViewModelTests: TestCase {
       self.loadProjectIntoDataSourceProject
         .assertValues([project], "Load the full project into the data source.")
       self.loadProjectIntoDataSourceRefTag.assertValues([.discovery], "Load the refTag into the data source.")
-      self.loadMinimalProjectIntoDataSource.assertValues([], "Do not load the minimal version of the project.")
+      self.loadMinimalProjectIntoDataSource.assertValues(
+        [], "Do not load the minimal version of the project."
+      )
 
       // End presentation.
       self.vm.inputs.viewWillAppear(animated: false)

--- a/Library/ViewModels/ProjectPamphletContentViewModelTests.swift
+++ b/Library/ViewModels/ProjectPamphletContentViewModelTests.swift
@@ -6,7 +6,7 @@ import ReactiveSwift
 import XCTest
 
 final class ProjectPamphletContentViewModelTests: TestCase {
-  fileprivate let vm: ProjectPamphletContentViewModelType = ProjectPamphletContentViewModel()
+  fileprivate var vm: ProjectPamphletContentViewModelType!
 
   fileprivate let goToBacking = TestObserver<Project, Never>()
   fileprivate let goToComments = TestObserver<Project, Never>()
@@ -14,6 +14,9 @@ final class ProjectPamphletContentViewModelTests: TestCase {
   fileprivate let goToRewardPledgeProject = TestObserver<Project, Never>()
   fileprivate let goToRewardPledgeReward = TestObserver<Reward, Never>()
   fileprivate let goToUpdates = TestObserver<Project, Never>()
+  fileprivate let loadProjectIntoDataSourceCreatorDetailsEnvelope
+    = TestObserver<ProjectCreatorDetailsEnvelope?, Never>()
+  fileprivate let loadProjectIntoDataSourceCreatorDetailsIsLoading = TestObserver<Bool, Never>()
   fileprivate let loadProjectIntoDataSourceProject = TestObserver<Project, Never>()
   fileprivate let loadProjectIntoDataSourceRefTag = TestObserver<RefTag?, Never>()
   fileprivate let loadMinimalProjectIntoDataSource = TestObserver<Project, Never>()
@@ -21,15 +24,21 @@ final class ProjectPamphletContentViewModelTests: TestCase {
   override func setUp() {
     super.setUp()
 
+    self.vm = ProjectPamphletContentViewModel()
+
     self.vm.outputs.goToBacking.observe(self.goToBacking.observer)
     self.vm.outputs.goToComments.observe(self.goToComments.observer)
     self.vm.outputs.goToDashboard.observe(self.goToDashboard.observer)
     self.vm.outputs.goToRewardPledge.map(first).observe(self.goToRewardPledgeProject.observer)
     self.vm.outputs.goToRewardPledge.map(second).observe(self.goToRewardPledgeReward.observer)
     self.vm.outputs.goToUpdates.observe(self.goToUpdates.observer)
-    self.vm.outputs.loadProjectAndRefTagIntoDataSource.map(first)
+    self.vm.outputs.loadProjectPamphletContentDataIntoDataSource.map(first)
       .observe(self.loadProjectIntoDataSourceProject.observer)
-    self.vm.outputs.loadProjectAndRefTagIntoDataSource.map(second)
+    self.vm.outputs.loadProjectPamphletContentDataIntoDataSource.map(second).map(first)
+      .observe(self.loadProjectIntoDataSourceCreatorDetailsEnvelope.observer)
+    self.vm.outputs.loadProjectPamphletContentDataIntoDataSource.map(second).map(second)
+      .observe(self.loadProjectIntoDataSourceCreatorDetailsIsLoading.observer)
+    self.vm.outputs.loadProjectPamphletContentDataIntoDataSource.map(third)
       .observe(self.loadProjectIntoDataSourceRefTag.observer)
     self.vm.outputs.loadMinimalProjectIntoDataSource.observe(self.loadMinimalProjectIntoDataSource.observer)
   }
@@ -389,5 +398,145 @@ final class ProjectPamphletContentViewModelTests: TestCase {
       [.discovery, .discovery], "Nothing new emits."
     )
     self.loadMinimalProjectIntoDataSource.assertValues([project], "Nothing new emits.")
+  }
+
+  func testLoadProjectIntoDataSource_CreatorDetailsLoaded() {
+    let project = Project.template
+
+    let envelope = ProjectCreatorDetailsEnvelope(backingsCount: 25, id: "123", launchedProjectsCount: 50)
+
+    let mockService = MockService(fetchProjectCreatorDetailsResult: .success(envelope))
+
+    withEnvironment(apiService: mockService) {
+      self.vm.inputs.configureWith(value: (project, .discovery))
+      self.vm.inputs.viewDidLoad()
+
+      self.loadProjectIntoDataSourceCreatorDetailsIsLoading.assertValues([], "Nothing emits immediately.")
+      self.loadProjectIntoDataSourceCreatorDetailsEnvelope.assertValues([], "Nothing emits immediately.")
+      self.loadProjectIntoDataSourceProject.assertValues([], "Nothing emits immediately.")
+      self.loadProjectIntoDataSourceRefTag.assertValues([], "Nothing emits immediately.")
+      self.loadMinimalProjectIntoDataSource.assertValues([], "Nothing emits immediately.")
+
+      // Begin presentation. When presenting the project `animated` will be false since it is embedded in the
+      // navigator controller.
+      self.vm.inputs.viewWillAppear(animated: false)
+      self.vm.inputs.viewDidAppear(animated: false)
+
+      self.loadProjectIntoDataSourceCreatorDetailsIsLoading.assertValues([true], "Starts loading.")
+      self.loadProjectIntoDataSourceCreatorDetailsEnvelope.assertValues([nil], "Emits nil as view appears")
+      self.loadProjectIntoDataSourceProject
+        .assertValues([project], "Load the full project into the data source.")
+      self.loadProjectIntoDataSourceRefTag.assertValues(
+        [.discovery], "Load the refTag into the data source."
+      )
+      self.loadMinimalProjectIntoDataSource.assertValues(
+        [], "Do not load the minimal version of the project."
+      )
+
+      // End presentation.
+      self.vm.inputs.viewWillAppear(animated: false)
+      self.vm.inputs.viewDidAppear(animated: false)
+
+      self.loadProjectIntoDataSourceCreatorDetailsIsLoading.assertValues([true])
+      self.loadProjectIntoDataSourceCreatorDetailsEnvelope.assertValues([nil])
+      self.loadProjectIntoDataSourceProject
+        .assertValues([project], "Nothing new emits when the view is done.")
+      self.loadProjectIntoDataSourceRefTag.assertValues(
+        [.discovery], "Nothing new emits when the view is done."
+      )
+      self.loadMinimalProjectIntoDataSource.assertValues([], "Nothing new emits when the view is done.")
+
+      // Simulate a new version of the project coming through
+      self.vm.inputs.configureWith(value: (project, .discovery))
+
+      self.loadProjectIntoDataSourceCreatorDetailsIsLoading.assertValues([true, true])
+      self.loadProjectIntoDataSourceCreatorDetailsEnvelope.assertValues([nil, nil])
+      self.loadProjectIntoDataSourceProject.assertValues(
+        [project, project], "The new project is loaded into data source"
+      )
+      self.loadProjectIntoDataSourceRefTag.assertValues(
+        [.discovery, .discovery], "The new refTag is loaded into data source"
+      )
+      self.loadMinimalProjectIntoDataSource.assertValues([], "Nothing new emits when the view is done.")
+
+      self.scheduler.advance()
+
+      self.loadProjectIntoDataSourceCreatorDetailsIsLoading.assertValues(
+        [true, true, false], "isLoading is false"
+      )
+      self.loadProjectIntoDataSourceCreatorDetailsEnvelope.assertValues(
+        [nil, nil, envelope], "ProjectCreatorDetailsEnvelope is returned"
+      )
+      self.loadProjectIntoDataSourceProject.assertValues([project, project, project])
+      self.loadProjectIntoDataSourceRefTag.assertValues([.discovery, .discovery, .discovery])
+      self.loadMinimalProjectIntoDataSource.assertValues([])
+    }
+  }
+
+  func testLoadProjectIntoDataSource_CreatorDetailsFailure() {
+    let project = Project.template
+
+    let mockService = MockService(fetchProjectCreatorDetailsResult: .failure(.invalidInput))
+
+    withEnvironment(apiService: mockService) {
+      self.vm.inputs.configureWith(value: (project, .discovery))
+      self.vm.inputs.viewDidLoad()
+
+      self.loadProjectIntoDataSourceCreatorDetailsIsLoading.assertValues([], "Nothing emits immediately.")
+      self.loadProjectIntoDataSourceCreatorDetailsEnvelope.assertValues([], "Nothing emits immediately.")
+      self.loadProjectIntoDataSourceProject.assertValues([], "Nothing emits immediately.")
+      self.loadProjectIntoDataSourceRefTag.assertValues([], "Nothing emits immediately.")
+      self.loadMinimalProjectIntoDataSource.assertValues([], "Nothing emits immediately.")
+
+      // Begin presentation. When presenting the project `animated` will be false since it is embedded in the
+      // navigator controller.
+      self.vm.inputs.viewWillAppear(animated: false)
+      self.vm.inputs.viewDidAppear(animated: false)
+
+      self.loadProjectIntoDataSourceCreatorDetailsIsLoading.assertValues([true], "Starts loading.")
+      self.loadProjectIntoDataSourceCreatorDetailsEnvelope.assertValues([nil], "Emits nil as view appears")
+      self.loadProjectIntoDataSourceProject
+        .assertValues([project], "Load the full project into the data source.")
+      self.loadProjectIntoDataSourceRefTag.assertValues([.discovery], "Load the refTag into the data source.")
+      self.loadMinimalProjectIntoDataSource.assertValues([], "Do not load the minimal version of the project.")
+
+      // End presentation.
+      self.vm.inputs.viewWillAppear(animated: false)
+      self.vm.inputs.viewDidAppear(animated: false)
+
+      self.loadProjectIntoDataSourceCreatorDetailsIsLoading.assertValues([true])
+      self.loadProjectIntoDataSourceCreatorDetailsEnvelope.assertValues([nil])
+      self.loadProjectIntoDataSourceProject
+        .assertValues([project], "Nothing new emits when the view is done.")
+      self.loadProjectIntoDataSourceRefTag.assertValues(
+        [.discovery], "Nothing new emits when the view is done."
+      )
+      self.loadMinimalProjectIntoDataSource.assertValues([], "Nothing new emits when the view is done.")
+
+      // Simulate a new version of the project coming through
+      self.vm.inputs.configureWith(value: (project, .discovery))
+
+      self.loadProjectIntoDataSourceCreatorDetailsIsLoading.assertValues([true, true])
+      self.loadProjectIntoDataSourceCreatorDetailsEnvelope.assertValues([nil, nil])
+      self.loadProjectIntoDataSourceProject.assertValues(
+        [project, project], "The new project is loaded into data source"
+      )
+      self.loadProjectIntoDataSourceRefTag.assertValues(
+        [.discovery, .discovery], "The new refTag is loaded into data source"
+      )
+      self.loadMinimalProjectIntoDataSource.assertValues([], "Nothing new emits when the view is done.")
+
+      self.scheduler.advance()
+
+      self.loadProjectIntoDataSourceCreatorDetailsIsLoading.assertValues(
+        [true, true, false], "isLoading is false"
+      )
+      self.loadProjectIntoDataSourceCreatorDetailsEnvelope.assertValues(
+        [nil, nil, nil], "nil is returned"
+      )
+      self.loadProjectIntoDataSourceProject.assertValues([project, project, project])
+      self.loadProjectIntoDataSourceRefTag.assertValues([.discovery, .discovery, .discovery])
+      self.loadMinimalProjectIntoDataSource.assertValues([])
+    }
   }
 }


### PR DESCRIPTION
# 📲 What

Adds a query for us to fetch some additional project creator details from GraphQL when a project page loads.

**Note:** This emits what we expect to need to configure the cell that will display this data, that is the `ProjectCreatorDetailsEnvelope` result and an `isLoading` boolean to indicate whether we are still fetching the results.

# 🤔 Why

As part of an experiment that we are running we would like to display some additional data to surface trust indicators to users. These values are not available from the v1 API so we are fetching them from GraphQL.

# 🛠 How

- Added `ProjectCreatorDetailsEnvelope`.
- Added `fetchProjectCreatorDetails` to `ServiceType`.
- Added some types to `ProjectPamphletContentViewModel` to improve the frequently changing interface of its datasource loading output.
- Updated `GraphSchema`.
- Added tests.

# ✅ Acceptance criteria

- [ ] Upon a project page loading observe that `(nil, true)` is emitted to put the cell in an initial loading state.
- [ ] Once the GraphQL request successfully completes observe that `(result, false)` is emitted.
- [ ] If the request fails observe that `(nil, false)` is emitted.