### PR TITLE
Adds required inputs for Optimizely experiments running on app launch

### DIFF
--- a/Kickstarter-iOS/AppDelegate.swift
+++ b/Kickstarter-iOS/AppDelegate.swift
@@ -332,6 +332,8 @@ internal final class AppDelegate: UIResponder, UIApplicationDelegate {
       if let shouldUpdateClient = shouldUpdateClient, shouldUpdateClient {
         print("🔮 Optimizely SDK Successfully Configured")
         AppEnvironment.updateOptimizelyClient(optimizelyClient)
+
+        self?.viewModel.inputs.didUpdateOptimizelyClient(optimizelyClient)
       }
     }
   }

--- a/Kickstarter-iOS/ViewModels/AppDelegateViewModel.swift
+++ b/Kickstarter-iOS/ViewModels/AppDelegateViewModel.swift
@@ -69,6 +69,9 @@ public protocol AppDelegateViewModelInputs {
   /// Call when the config has been updated the AppEnvironment
   func didUpdateConfig(_ config: Config)
 
+  /// Call when the Optimizely client has been updated in the AppEnvironment
+  func didUpdateOptimizelyClient(_ client: OptimizelyClientType)
+
   /// Call when the redirect URL has been found, see `findRedirectUrl` for more information.
   func foundRedirectUrl(_ url: URL)
 
@@ -726,6 +729,11 @@ public final class AppDelegateViewModel: AppDelegateViewModelType, AppDelegateVi
   fileprivate let didUpdateConfigProperty = MutableProperty<Config?>(nil)
   public func didUpdateConfig(_ config: Config) {
     self.didUpdateConfigProperty.value = config
+  }
+
+  fileprivate let didUpdateOptimizelyClientProperty = MutableProperty<OptimizelyClientType?>(nil)
+  public func didUpdateOptimizelyClient(_ client: OptimizelyClientType) {
+    self.didUpdateOptimizelyClientProperty.value = client
   }
 
   private let foundRedirectUrlProperty = MutableProperty<URL?>(nil)

--- a/Library/OptimizelyClientType.swift
+++ b/Library/OptimizelyClientType.swift
@@ -56,9 +56,9 @@ public func optimizelyTrackingAttributesAndEventTags(
 }
 
 public func optimizelyUserAttributes(
-  with user: User?,
-  project: Project?,
-  refTag: RefTag?
+  with user: User? = nil,
+  project: Project? = nil,
+  refTag: RefTag? = nil
 ) -> [String: Any] {
   let properties: [String: Any] = [
     "user_backed_projects_count": user?.stats.backedProjectsCount,

--- a/Library/SharedFunctions.swift
+++ b/Library/SharedFunctions.swift
@@ -180,7 +180,7 @@ internal func classNameWithoutModule(_ class: AnyClass) -> String {
     .joined(separator: ".")
 }
 
-internal func deviceIdentifier(uuid: UUIDType, env: Environment = AppEnvironment.current) -> String {
+public func deviceIdentifier(uuid: UUIDType, env: Environment = AppEnvironment.current) -> String {
   guard let identifier = env.device.identifierForVendor else {
     return uuid.uuidString
   }


### PR DESCRIPTION
# 📲 What

In order to access experiment variants in the `AppDelegateViewModel`, we need an input for when the OptimizelyClient has been updated in the `AppEnvironment`, among other things.

# 🤔 Why

This PR adds some of that shared functionality that we need on multiple feature branches to reduce duplication of work and merge conflicts.

# ✅ Acceptance criteria

There are no user-facing changes here, just exposing functions and adding an input to be used on other feature branches.
