### PR TITLE
[NT-978] Landing page deeplink handling

### DIFF
--- a/Kickstarter-iOS/AppDelegate.swift
+++ b/Kickstarter-iOS/AppDelegate.swift
@@ -130,8 +130,10 @@ internal final class AppDelegate: UIResponder, UIApplicationDelegate {
     self.viewModel.outputs.goToLandingPage
       .observeForUI()
       .observeValues { [weak self] in
+        let isIpad = AppEnvironment.current.device.userInterfaceIdiom == .pad
+
         let landingPage = LandingPageViewController()
-          |> \.modalPresentationStyle .~ .fullScreen
+          |> \.modalPresentationStyle .~ (isIpad ? .formSheet : .fullScreen)
         self?.rootTabBarController?.present(landingPage, animated: true)
       }
 

--- a/Kickstarter-iOS/ViewModels/AppDelegateViewModel.swift
+++ b/Kickstarter-iOS/ViewModels/AppDelegateViewModel.swift
@@ -332,13 +332,16 @@ public final class AppDelegateViewModel: AppDelegateViewModelType, AppDelegateVi
     let deepLinkFromShortcut = performShortcutItem
       .switchMap(navigation(fromShortcutItem:))
 
-    let deepLink = Signal
+    let deeplinkActivated = Signal
       .merge(
         deepLinkFromUrl,
         deepLinkFromNotification,
         deepLinkFromShortcut
       )
       .skipNil()
+
+    let deepLink = deeplinkActivated
+      .filter { _ in shouldGoToLandingPage() == false }
 
     self.findRedirectUrl = deepLinkUrl
       .filter { Navigation.match($0) == .emailClick }


### PR DESCRIPTION
# 📲 What
 
- Adds a logic to handle deeplinks.

# 🤔 Why

- We still want to show the Landing Page if eligible users with `variant-1` or `variant-2` open the app through deeplink. In this case, we will show the Landing Page and redirect them to Discovery after dismissing the screen. 

# 🛠 How

- Added a filter so `deeplink` signal only emits if `shouldGoToLandingPage` is false.
- Added tests

# ✅ Acceptance criteria
In order to test this, follow the steps:
1. Build the app on a device in the release configuration
2. Set Launch setting to `Wait for executable to be launched`
3. Comment out the the switch statement on line 1117 and simply return `true`
4. Click a link from email / google to open the app through deeplink

- [x] The Landing Page should only be presented on the first time.