### PR TITLE
[NT-980] Updating the Optimizely events dispatch interval

### DIFF
--- a/Kickstarter-iOS/AppDelegate.swift
+++ b/Kickstarter-iOS/AppDelegate.swift
@@ -155,8 +155,8 @@ internal final class AppDelegate: UIResponder, UIApplicationDelegate {
 
     self.viewModel.outputs.configureOptimizely
       .observeForUI()
-      .observeValues { [weak self] key, logLevel in
-        self?.configureOptimizely(with: key, logLevel: logLevel)
+      .observeValues { [weak self] key, logLevel, dispatchInterval in
+        self?.configureOptimizely(with: key, logLevel: logLevel, dispatchInterval: dispatchInterval)
       }
 
     self.viewModel.outputs.configureAppCenterWithData
@@ -323,8 +323,17 @@ internal final class AppDelegate: UIResponder, UIApplicationDelegate {
 
   // MARK: - Functions
 
-  private func configureOptimizely(with key: String, logLevel: OptimizelyLogLevelType) {
-    let optimizelyClient = OptimizelyClient(sdkKey: key, defaultLogLevel: logLevel.logLevel)
+  private func configureOptimizely(
+    with key: String,
+    logLevel: OptimizelyLogLevelType,
+    dispatchInterval: TimeInterval
+  ) {
+    let eventDispatcher = DefaultEventDispatcher(timerInterval: dispatchInterval)
+    let optimizelyClient = OptimizelyClient(
+      sdkKey: key,
+      eventDispatcher: eventDispatcher,
+      defaultLogLevel: logLevel.logLevel
+    )
 
     optimizelyClient.start { [weak self] result in
       let shouldUpdateClient = self?.viewModel.inputs.optimizelyConfigured(with: result)

--- a/Kickstarter-iOS/ViewModels/AppDelegateViewModel.swift
+++ b/Kickstarter-iOS/ViewModels/AppDelegateViewModel.swift
@@ -105,7 +105,7 @@ public protocol AppDelegateViewModelOutputs {
   var configureFabric: Signal<(), Never> { get }
 
   /// Emits when the application should configure Optimizely
-  var configureOptimizely: Signal<(String, OptimizelyLogLevelType), Never> { get }
+  var configureOptimizely: Signal<(String, OptimizelyLogLevelType, TimeInterval), Never> { get }
 
   /// Emits when the application should configure Qualtrics
   var configureQualtrics: Signal<QualtricsConfigData, Never> { get }
@@ -803,7 +803,7 @@ public final class AppDelegateViewModel: AppDelegateViewModelType, AppDelegateVi
   public let applicationIconBadgeNumber: Signal<Int, Never>
   public let configureAppCenterWithData: Signal<AppCenterConfigData, Never>
   public let configureFabric: Signal<(), Never>
-  public let configureOptimizely: Signal<(String, OptimizelyLogLevelType), Never>
+  public let configureOptimizely: Signal<(String, OptimizelyLogLevelType, TimeInterval), Never>
   public let configureQualtrics: Signal<QualtricsConfigData, Never>
   public let continueUserActivityReturnValue = MutableProperty(false)
   public let displayQualtricsSurvey: Signal<(), Never>
@@ -1020,9 +1020,10 @@ extension ShortcutItem {
   }
 }
 
-private func optimizelyData(for environment: Environment) -> (String, OptimizelyLogLevelType) {
+private func optimizelyData(for environment: Environment) -> (String, OptimizelyLogLevelType, TimeInterval) {
   let environmentType = environment.environmentType
   let logLevel = environment.mainBundle.isDebug ? OptimizelyLogLevelType.debug : OptimizelyLogLevelType.error
+  let dispatchInterval: TimeInterval = 5
 
   var sdkKey: String
 
@@ -1035,7 +1036,7 @@ private func optimizelyData(for environment: Environment) -> (String, Optimizely
     sdkKey = Secrets.OptimizelySDKKey.development
   }
 
-  return (sdkKey, logLevel)
+  return (sdkKey, logLevel, dispatchInterval)
 }
 
 private func visitorCookies() -> [HTTPCookie] {

--- a/Kickstarter-iOS/ViewModels/AppDelegateViewModelTests.swift
+++ b/Kickstarter-iOS/ViewModels/AppDelegateViewModelTests.swift
@@ -17,6 +17,7 @@ final class AppDelegateViewModelTests: TestCase {
   private let configureAppCenterWithData = TestObserver<AppCenterConfigData, Never>()
   private let configureOptimizelySDKKey = TestObserver<String, Never>()
   private let configureOptimizelyLogLevel = TestObserver<OptimizelyLogLevelType, Never>()
+  private let configureOptimizelyDispatchInterval = TestObserver<TimeInterval, Never>()
   private let configureFabric = TestObserver<(), Never>()
   private let configureQualtrics = TestObserver<QualtricsConfigData, Never>()
   private let didAcceptReceivingRemoteNotifications = TestObserver<(), Never>()
@@ -52,6 +53,7 @@ final class AppDelegateViewModelTests: TestCase {
     self.vm.outputs.configureFabric.observe(self.configureFabric.observer)
     self.vm.outputs.configureOptimizely.map(first).observe(self.configureOptimizelySDKKey.observer)
     self.vm.outputs.configureOptimizely.map(second).observe(self.configureOptimizelyLogLevel.observer)
+    self.vm.outputs.configureOptimizely.map(third).observe(self.configureOptimizelyDispatchInterval.observer)
     self.vm.outputs.configureQualtrics.observe(self.configureQualtrics.observer)
     self.vm.outputs.displayQualtricsSurvey.observe(self.displayQualtricsSurvey.observer)
     self.vm.outputs.evaluateQualtricsTargetingLogic.observe(self.evaluateQualtricsTargetingLogic.observer)
@@ -131,6 +133,8 @@ final class AppDelegateViewModelTests: TestCase {
     self.configureFabric.assertValueCount(1)
   }
 
+  // MARK: - Optimizely
+
   func testConfigureOptimizely_Production() {
     let mockService = MockService(serverConfig: ServerConfig.production)
 
@@ -209,6 +213,13 @@ final class AppDelegateViewModelTests: TestCase {
     }
   }
 
+  func testConfigureOptimizelyDispatchInterval() {
+    self.configureOptimizelyDispatchInterval.assertDidNotEmitValue()
+    self.vm.inputs.applicationDidFinishLaunching(application: UIApplication.shared, launchOptions: nil)
+
+    self.configureOptimizelyDispatchInterval.assertValues([5])
+  }
+
   func testOptimizelyConfiguration_IsSuccess() {
     let mockService = MockService(serverConfig: ServerConfig.staging)
 
@@ -239,6 +250,8 @@ final class AppDelegateViewModelTests: TestCase {
       XCTAssertFalse(shouldUpdateClient)
     }
   }
+
+  // MARK: - AppCenter
 
   func testConfigureAppCenter_AlphaApp_LoggedOut() {
     let alphaBundle = MockBundle(bundleIdentifier: KickstarterBundleIdentifier.alpha.rawValue, lang: "en")


### PR DESCRIPTION
# 📲 What

Updates the dispatch interval for the `DefaultEventDispatcher` on Optimizely to 5 seconds to reduce likelihood of backend race condition.

# 🤔 Why

The default dispatch interval on the `DefaultEventDispatcher` used by Optimizely to dispatch events and impressions was 60 seconds. This caused a race condition where sometimes the Kickstarter Ruby backend would attempt to send conversion event for an experiment whose "impression" hadn't been dispatched yet from the iOS SDK. By reducing the dispatch interval we hope to mitigate this race condition.

# 🛠 How

- Added the `dispatchTimeInterval` as part of the `configureOptimizely` output.
- set this value to 5 seconds
- added a test
