### PR TITLE
[NT-991] Creator string translates

### DIFF
--- a/Kickstarter-iOS/Locales/de.lproj/Localizable.strings
+++ b/Kickstarter-iOS/Locales/de.lproj/Localizable.strings
@@ -1505,7 +1505,7 @@
 "projects_count_newline_saved.other" = "%{projects_count}\ngespeichert";
 "projects_count_newline_saved.two" = "2\ngespeichert";
 "projects_count_newline_saved.zero" = "0\ngespeichert";
-"projects_launched_count_created_projects_backed_count_backed" = "%{projects_launched_count} created • %{projects_backed_count} backed";
+"projects_launched_count_created_projects_backed_count_backed" = "%{projects_launched_count} erstellt• %{projects_backed_count} unterstützt";
 "push_notifications.alert.buttons.close" = "Schließen";
 "push_notifications.alert.buttons.view" = "Anzeigen";
 "remaining_count_left_of_limit_count" = "%{remaining_count} übrig von %{limit_count}";

--- a/Kickstarter-iOS/Locales/es.lproj/Localizable.strings
+++ b/Kickstarter-iOS/Locales/es.lproj/Localizable.strings
@@ -1506,7 +1506,7 @@
 "projects_count_newline_saved.other" = "%{projects_count}\nguardados";
 "projects_count_newline_saved.two" = "2\nguardados";
 "projects_count_newline_saved.zero" = "0\nguardados";
-"projects_launched_count_created_projects_backed_count_backed" = "%{projects_launched_count} created • %{projects_backed_count} backed";
+"projects_launched_count_created_projects_backed_count_backed" = "%{projects_launched_count} creados • %{projects_backed_count} patrocinados";
 "push_notifications.alert.buttons.close" = "Cerrar";
 "push_notifications.alert.buttons.view" = "Ver";
 "remaining_count_left_of_limit_count" = "%{remaining_count} restante de %{limit_count}";

--- a/Kickstarter-iOS/Locales/fr.lproj/Localizable.strings
+++ b/Kickstarter-iOS/Locales/fr.lproj/Localizable.strings
@@ -1505,7 +1505,7 @@
 "projects_count_newline_saved.other" = "%{projects_count}\nprojets enregistrés";
 "projects_count_newline_saved.two" = "2\nprojets enregistrés";
 "projects_count_newline_saved.zero" = "0\nprojets enregistrés";
-"projects_launched_count_created_projects_backed_count_backed" = "%{projects_launched_count} created • %{projects_backed_count} backed";
+"projects_launched_count_created_projects_backed_count_backed" = "%{projects_launched_count} projets créés • %{projects_backed_count} projets soutenus";
 "push_notifications.alert.buttons.close" = "Fermer";
 "push_notifications.alert.buttons.view" = "Afficher";
 "remaining_count_left_of_limit_count" = "%{remaining_count} sur %{limit_count}";

--- a/Kickstarter-iOS/Locales/ja.lproj/Localizable.strings
+++ b/Kickstarter-iOS/Locales/ja.lproj/Localizable.strings
@@ -1505,7 +1505,7 @@
 "projects_count_newline_saved.other" = "%{projects_count} \n保存済み";
 "projects_count_newline_saved.two" = "2\n件保存済み";
 "projects_count_newline_saved.zero" = "0\n件保存済み";
-"projects_launched_count_created_projects_backed_count_backed" = "%{projects_launched_count} created • %{projects_backed_count} backed";
+"projects_launched_count_created_projects_backed_count_backed" = "%{projects_launched_count}件作成済み・%{projects_backed_count}件バック済み";
 "push_notifications.alert.buttons.close" = "閉じる";
 "push_notifications.alert.buttons.view" = "みる";
 "remaining_count_left_of_limit_count" = "%{limit_count} 個中のこり%{remaining_count} 個";

--- a/Library/Strings.swift
+++ b/Library/Strings.swift
@@ -22377,10 +22377,10 @@ projets enregistrés"
    "%{projects_launched_count} created • %{projects_backed_count} backed"
 
    - **en**: "%{projects_launched_count} created • %{projects_backed_count} backed"
-   - **de**: "%{projects_launched_count} created • %{projects_backed_count} backed"
-   - **es**: "%{projects_launched_count} created • %{projects_backed_count} backed"
-   - **fr**: "%{projects_launched_count} created • %{projects_backed_count} backed"
-   - **ja**: "%{projects_launched_count} created • %{projects_backed_count} backed"
+   - **de**: "%{projects_launched_count} erstellt• %{projects_backed_count} unterstützt"
+   - **es**: "%{projects_launched_count} creados • %{projects_backed_count} patrocinados"
+   - **fr**: "%{projects_launched_count} projets créés • %{projects_backed_count} projets soutenus"
+   - **ja**: "%{projects_launched_count}件作成済み・%{projects_backed_count}件バック済み"
   */
   public static func projects_launched_count_created_projects_backed_count_backed(projects_launched_count: String, projects_backed_count: String) -> String {
     return localizedString(


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Translations for experiment copy.
# 🤔 Why

So users can read the copy in their preferred language.


# ✅ Acceptance criteria

- [x] The `{x} created` and `{x} backed` strings are translated  


