### PR TITLE
[NT-1011] Upgrade Facebook SDK

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -7,7 +7,7 @@ github "kickstarter/Kickstarter-ReactiveExtensions" "48a3f507995a6bdae964ddf9f23
 
 github "Alamofire/AlamofireImage" "8e635e6151212f8871a321bbdd980af7c31af73b"
 github "optimizely/swift-sdk" == 3.1.0
-github "facebook/facebook-objc-sdk" == 5.0.2
+github "facebook/facebook-objc-sdk" == 6.2.0
 github "microsoft/appcenter-sdk-apple" == 2.5.0
 github "ReactiveCocoa/ReactiveSwift" == 6.1.0
 github "stripe/stripe-ios" == 18.0.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -2,7 +2,7 @@ binary "https://s3-us-west-2.amazonaws.com/si-mobile-sdks/ios/Qualtrics.json" "1
 github "Alamofire/Alamofire" "5.0.0-rc.3"
 github "Alamofire/AlamofireImage" "8e635e6151212f8871a321bbdd980af7c31af73b"
 github "ReactiveCocoa/ReactiveSwift" "6.1.0"
-github "facebook/facebook-objc-sdk" "v5.0.2"
+github "facebook/facebook-objc-sdk" "v6.2.0"
 github "kickstarter/Kickstarter-Prelude" "9118beee2b37fa5fc5a4f56502c1fa99030b9f9e"
 github "kickstarter/Kickstarter-ReactiveExtensions" "48a3f507995a6bdae964ddf9f2347af6bf74a19f"
 github "microsoft/appcenter-sdk-apple" "2.5.0"

--- a/Kickstarter-iOS/Views/Cells/FindFriendsFacebookConnectCell.swift
+++ b/Kickstarter-iOS/Views/Cells/FindFriendsFacebookConnectCell.swift
@@ -25,7 +25,6 @@ internal final class FindFriendsFacebookConnectCell: UITableViewCell, ValueCell 
 
   internal lazy var fbLoginManager: LoginManager = {
     let manager = LoginManager()
-    manager.loginBehavior = .browser
     manager.defaultAudience = .friends
     return manager
   }()

--- a/Kickstarter-iOS/Views/Controllers/LoginToutViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/LoginToutViewController.swift
@@ -24,7 +24,6 @@ internal final class LoginToutViewController: UIViewController, MFMailComposeVie
 
   private lazy var fbLoginManager: LoginManager = {
     let manager = LoginManager()
-    manager.loginBehavior = .browser
     manager.defaultAudience = .friends
     return manager
   }()


### PR DESCRIPTION
# 📲 What

Upgrades the Facebook SDK to v6.2.0, which fixes an iOS 13 bug where users were unable to log in or sign up using Facebook.

# 🤔 Why

Users need to be able to log in/signup using Facebook.

# 🛠 How

- Updated the Cartfile to specify `6.2.0` as the `facebook/facebook-objc-sdk` version, and then ran `carthage update facebook-objc-sdk`
- removed references to `loginBehaviour` in the Facebook `loginManager` since they deprecated that configuration:
![image](https://user-images.githubusercontent.com/3156796/77174583-a8092900-6a97-11ea-8843-60179d4bd595.png)


# 👀 See

![Ujk0p5Ga8S](https://user-images.githubusercontent.com/3156796/77174615-b6efdb80-6a97-11ea-8200-703b47a7fa1a.gif)

# ✅ Acceptance criteria

- [ ] Test cases 1 - 4 described in the [Facebook testing Guru card](https://app.getguru.com/card/iqKqg9aT/Testing-Facebook-Login-on-iOS)
