### PR TITLE
[NT-877] Read more about this campaign tracking bugfix

### DIFF
--- a/Library/SharedFunctions.swift
+++ b/Library/SharedFunctions.swift
@@ -22,6 +22,18 @@ internal func userIsBacking(reward: Reward, inProject project: Project) -> Bool 
 }
 
 /**
+ Determines if the personalization data in the project implies that the current user is backing the
+ project passed in.
+
+ - parameter project: A project.
+
+ - returns: A boolean.
+ */
+internal func userIsBackingProject(_ project: Project) -> Bool {
+  return project.personalization.backing != nil || project.personalization.isBacking == .some(true)
+}
+
+/**
  Determines if the current user is the creator for a given project.
 
  - parameter project: A project.

--- a/Library/ViewModels/ProjectPamphletMainCellViewModel.swift
+++ b/Library/ViewModels/ProjectPamphletMainCellViewModel.swift
@@ -328,9 +328,8 @@ public final class ProjectPamphletMainCellViewModel: ProjectPamphletMainCellView
 
     let shouldTrackCTATappedEvent = projectAndRefTag
       .takeWhen(self.readMoreButtonTappedProperty.signal)
-      .logEvents(identifier: "***")
       .filter { project, _ in
-        project.state == .live && project.personalization.backing == nil
+        project.state == .live && userIsBackingProject(project) == false
       }
 
     // optimizely tracking

--- a/Library/ViewModels/ProjectPamphletMainCellViewModel.swift
+++ b/Library/ViewModels/ProjectPamphletMainCellViewModel.swift
@@ -328,7 +328,10 @@ public final class ProjectPamphletMainCellViewModel: ProjectPamphletMainCellView
 
     let shouldTrackCTATappedEvent = projectAndRefTag
       .takeWhen(self.readMoreButtonTappedProperty.signal)
-      .filter { project, _ in project.state == .live && project.personalization.isBacking == false }
+      .logEvents(identifier: "***")
+      .filter { project, _ in
+        project.state == .live && project.personalization.backing == nil
+      }
 
     // optimizely tracking
     projectAndRefTag

--- a/Library/ViewModels/ProjectPamphletMainCellViewModelTests.swift
+++ b/Library/ViewModels/ProjectPamphletMainCellViewModelTests.swift
@@ -720,7 +720,7 @@ final class ProjectPamphletMainCellViewModelTests: TestCase {
 
     let project = Project.template
       |> Project.lens.state .~ .live
-      |> Project.lens.personalization.isBacking .~ false
+      |> Project.lens.personalization.backing .~ nil
 
     withEnvironment(currentUser: user) {
       self.vm.inputs.configureWith(value: (project, .discovery, (creatorDetails, false)))


### PR DESCRIPTION
# 📲 What

Fixes a tracking event that wasn't being sent to Optimizely when `Read more about this campaign` was tapped.

# 🤔 Why

Tracking this event is necessary for our metrics.

# 🛠 How

The bug was that we were checking if `project.personalization.isBacking` was `false`. In this case `isBacking` can also be `nil` so comparing a `nil` value to `false` fails. We could coalesce this `nil` to `false` but I figured we can also just check to see whether the actual `backing` property is `nil` for the same result.

# ✅ Acceptance criteria

Place yourself in variant 1 or 2 for `native_project_page_campaign_details`. Open Charles Proxy.

- [x] Navigate to a project page, tap on the `Read more about this campaign` button. Observe that an event was tracked for `Campaign Details Button Clicked`.