### PR TITLE
[NT-885] Added Project Page Viewed event

### DIFF
--- a/Library/ViewModels/ProjectPamphletViewModel.swift
+++ b/Library/ViewModels/ProjectPamphletViewModel.swift
@@ -171,9 +171,8 @@ public final class ProjectPamphletViewModel: ProjectPamphletViewModelType, Proje
       self.viewDidAppearAnimated.signal.ignoreValues()
     )
     .map(unpack)
-      .map { (arg) in
-        let (project, refTag, _) = arg
-        let cookieRefTag = cookieRefTagFor(project: project) ?? refTag
+    .map { project, refTag, _ in
+      let cookieRefTag = cookieRefTagFor(project: project) ?? refTag
 
       return (project: project, refTag: refTag, cookieRefTag: cookieRefTag)
     }
@@ -185,7 +184,7 @@ public final class ProjectPamphletViewModel: ProjectPamphletViewModelType, Proje
           refTag: refTag,
           cookieRefTag: cookieRefTag
         )
-    }
+      }
 
     freshProjectRefTagAndCookieRefTag
       .observeValues { project, refTag, _ in
@@ -201,8 +200,8 @@ public final class ProjectPamphletViewModel: ProjectPamphletViewModelType, Proje
             userId: deviceIdentifier(uuid: UUID()),
             attributes: properties,
             eventTags: eventTags
-        )
-    }
+          )
+      }
 
     Signal.combineLatest(cookieRefTag.skipNil(), freshProjectAndRefTag.map(first))
       .take(first: 1)

--- a/Library/ViewModels/ProjectPamphletViewModel.swift
+++ b/Library/ViewModels/ProjectPamphletViewModel.swift
@@ -166,22 +166,42 @@ public final class ProjectPamphletViewModel: ProjectPamphletViewModelType, Proje
       }
       .take(first: 1)
 
-    Signal.zip(
+    let freshProjectRefTagAndCookieRefTag: Signal<(Project, RefTag?, RefTag?), Never> = Signal.zip(
       freshProjectAndRefTag.skip(first: 1),
       self.viewDidAppearAnimated.signal.ignoreValues()
     )
     .map(unpack)
-    .map { project, refTag, _ in
-      let cookieRefTag = cookieRefTagFor(project: project) ?? refTag
+      .map { (arg) in
+        let (project, refTag, _) = arg
+        let cookieRefTag = cookieRefTagFor(project: project) ?? refTag
 
       return (project: project, refTag: refTag, cookieRefTag: cookieRefTag)
     }
-    .observeValues { project, refTag, cookieRefTag in
-      AppEnvironment.current.koala.trackProjectViewed(
-        project,
-        refTag: refTag,
-        cookieRefTag: cookieRefTag
-      )
+
+    freshProjectRefTagAndCookieRefTag
+      .observeValues { project, refTag, cookieRefTag in
+        AppEnvironment.current.koala.trackProjectViewed(
+          project,
+          refTag: refTag,
+          cookieRefTag: cookieRefTag
+        )
+    }
+
+    freshProjectRefTagAndCookieRefTag
+      .observeValues { project, refTag, _ in
+        let (properties, eventTags) = optimizelyTrackingAttributesAndEventTags(
+          with: AppEnvironment.current.currentUser,
+          project: project,
+          refTag: refTag
+        )
+
+        try? AppEnvironment.current.optimizelyClient?
+          .track(
+            eventKey: "Project Page Viewed",
+            userId: deviceIdentifier(uuid: UUID()),
+            attributes: properties,
+            eventTags: eventTags
+        )
     }
 
     Signal.combineLatest(cookieRefTag.skipNil(), freshProjectAndRefTag.map(first))

--- a/Library/ViewModels/ProjectPamphletViewModelTests.swift
+++ b/Library/ViewModels/ProjectPamphletViewModelTests.swift
@@ -851,9 +851,8 @@ final class ProjectPamphletViewModelTests: TestCase {
       XCTAssertEqual(self.optimizelyClient.trackedEventTags?["project_user_has_watched"] as? Bool, nil)
     }
   }
- 
-  func testOptimizelyTrackingProjectPageViewed_LoggedOut() {
 
+  func testOptimizelyTrackingProjectPageViewed_LoggedOut() {
     withEnvironment(currentUser: nil) {
       self.vm.inputs.configureWith(projectOrParam: .left(.template), refTag: .discovery)
       self.vm.inputs.viewDidLoad()

--- a/Library/ViewModels/ProjectPamphletViewModelTests.swift
+++ b/Library/ViewModels/ProjectPamphletViewModelTests.swift
@@ -815,6 +815,77 @@ final class ProjectPamphletViewModelTests: TestCase {
   }
 
   // swiftlint:disable line_length
+
+  func testOptimizelyTrackingProjectPageViewed_LoggedIn() {
+    let user = User.template
+      |> \.location .~ Location.template
+      |> \.stats.backedProjectsCount .~ 50
+
+    withEnvironment(currentUser: user) {
+      self.vm.inputs.configureWith(projectOrParam: .left(.template), refTag: .discovery)
+      self.vm.inputs.viewDidLoad()
+      self.vm.inputs.viewDidAppear(animated: false)
+
+      self.scheduler.advance()
+
+      XCTAssertEqual(self.optimizelyClient.trackedUserId, "DEADBEEF-DEAD-BEEF-DEAD-DEADBEEFBEEF")
+      XCTAssertEqual(self.optimizelyClient.trackedEventKey, "Project Page Viewed")
+
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_backed_projects_count"] as? Int, 50)
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_launched_projects_count"] as? Int, nil)
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_country"] as? String, "us")
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_facebook_account"] as? Bool, nil)
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_display_language"] as? String, "en")
+
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_ref_tag"] as? String, "discovery")
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_referrer_credit"] as? String, "discovery")
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_os_version"] as? String, "MockSystemVersion")
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_user_is_logged_in"] as? Bool, true)
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_app_release_version"] as? String, "1.2.3.4.5.6.7.8.9.0")
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_apple_pay_device"] as? Bool, true)
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_device_format"] as? String, "phone")
+
+      XCTAssertEqual(self.optimizelyClient.trackedEventTags?["project_subcategory"] as? String, "Art")
+      XCTAssertEqual(self.optimizelyClient.trackedEventTags?["project_category"] as? String, nil)
+      XCTAssertEqual(self.optimizelyClient.trackedEventTags?["project_country"] as? String, "us")
+      XCTAssertEqual(self.optimizelyClient.trackedEventTags?["project_user_has_watched"] as? Bool, nil)
+    }
+  }
+ 
+  func testOptimizelyTrackingProjectPageViewed_LoggedOut() {
+
+    withEnvironment(currentUser: nil) {
+      self.vm.inputs.configureWith(projectOrParam: .left(.template), refTag: .discovery)
+      self.vm.inputs.viewDidLoad()
+      self.vm.inputs.viewDidAppear(animated: false)
+
+      self.scheduler.advance()
+
+      XCTAssertEqual(self.optimizelyClient.trackedUserId, "DEADBEEF-DEAD-BEEF-DEAD-DEADBEEFBEEF")
+      XCTAssertEqual(self.optimizelyClient.trackedEventKey, "Project Page Viewed")
+
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_backed_projects_count"] as? Int, nil)
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_launched_projects_count"] as? Int, nil)
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_country"] as? String, "us")
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_facebook_account"] as? Bool, nil)
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_display_language"] as? String, "en")
+
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_ref_tag"] as? String, "discovery")
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_referrer_credit"] as? String, "discovery")
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_os_version"] as? String, "MockSystemVersion")
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_user_is_logged_in"] as? Bool, false)
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_app_release_version"] as? String, "1.2.3.4.5.6.7.8.9.0")
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_apple_pay_device"] as? Bool, true)
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_device_format"] as? String, "phone")
+
+      XCTAssertEqual(self.optimizelyClient.trackedEventTags?["project_subcategory"] as? String, "Art")
+      XCTAssertEqual(self.optimizelyClient.trackedEventTags?["project_category"] as? String, nil)
+      XCTAssertEqual(self.optimizelyClient.trackedEventTags?["project_country"] as? String, "us")
+      XCTAssertEqual(self.optimizelyClient.trackedEventTags?["project_user_has_watched"] as? Bool, nil)
+    }
+  }
+
+  // swiftlint:disable line_length
   func testOptimizelyTrackingPledgeCTAButtonTapped_LoggedOut_NonBacked() {
     self.vm.inputs.configureWith(projectOrParam: .left(.template), refTag: .discovery)
     self.vm.inputs.viewDidLoad()


### PR DESCRIPTION
# 📲 What

- Tracks the `Project Page Viewed` event on Optimizely.

# 🤔 Why

- This event was missing and we need it before releasing the next build.
[JIRA ticket](https://kickstarter.atlassian.net/browse/NT-885)

# 🛠 How

- On `ProjectPamphletViewModel`, a signal `freshProjectRefTagAndCookieRefTag` was created to make sure the same properties are being sent to both Optimizely and DataLake.
- Added tests

# ✅ Acceptance criteria

- [ ] Select a project on Discovery. Once the ProjectPage is presented, a `Project Page Viewed` Optimizely event show appear on our logs.