### PR TITLE
[NT-1019] Cache selected categories in NSCache

### DIFF
--- a/Kickstarter-iOS/DataSources/CategorySelectionDataSource.swift
+++ b/Kickstarter-iOS/DataSources/CategorySelectionDataSource.swift
@@ -14,8 +14,8 @@ internal final class CategorySelectionDataSource: ValueCellDataSource {
     for (section, subcategories) in categories.enumerated() {
       let indexedSubcategories = subcategories.enumerated().map { index, value in
         CategoryPillCellValue(
-          name: value.name,
-          id: value.id,
+          name: value.displayName,
+          category: value.category,
           indexPath: IndexPath(item: index, section: section)
         )
       }

--- a/Kickstarter-iOS/DataSources/CategorySelectionDataSourceTests.swift
+++ b/Kickstarter-iOS/DataSources/CategorySelectionDataSourceTests.swift
@@ -1,4 +1,5 @@
 @testable import Kickstarter_Framework
+@testable import KsApi
 import Prelude
 import XCTest
 
@@ -11,9 +12,9 @@ final class CategorySelectionDataSourceTests: XCTestCase {
 
   func testLoadValues() {
     self.dataSource.load(["title1", "title2", "title3"], categories: [
-      [("one", 1), ("two", 2)],
-      [("red", 3), ("green", 4)],
-      [("monday", 5)]
+      [("one", KsApi.Category.art), ("two", KsApi.Category.illustration)],
+      [("red", KsApi.Category.games), ("green", KsApi.Category.tabletopGames)],
+      [("monday", KsApi.Category.filmAndVideo)]
     ])
 
     XCTAssertEqual(3, self.dataSource.numberOfSections(in: self.collectionView))
@@ -24,9 +25,9 @@ final class CategorySelectionDataSourceTests: XCTestCase {
 
   func testValues() {
     self.dataSource.load(["title1", "title2", "title3"], categories: [
-      [("one", 1), ("two", 2)],
-      [("red", 3), ("green", 4)],
-      [("monday", 5)]
+      [("one", KsApi.Category.art), ("two", KsApi.Category.illustration)],
+      [("red", KsApi.Category.games), ("green", KsApi.Category.tabletopGames)],
+      [("monday", KsApi.Category.filmAndVideo)]
     ])
 
     let indexPath0 = IndexPath(item: 0, section: 0)
@@ -35,26 +36,26 @@ final class CategorySelectionDataSourceTests: XCTestCase {
     let indexPath11 = IndexPath(item: 1, section: 1)
     let indexPath2 = IndexPath(item: 0, section: 2)
 
-    let value0 = self.dataSource[indexPath0] as? (String, Int, IndexPath?)
-    let value01 = self.dataSource[indexPath01] as? (String, Int, IndexPath?)
-    let value1 = self.dataSource[indexPath1] as? (String, Int, IndexPath?)
-    let value11 = self.dataSource[indexPath11] as? (String, Int, IndexPath?)
-    let value2 = self.dataSource[indexPath2] as? (String, Int, IndexPath?)
+    let value0 = self.dataSource[indexPath0] as? (String, KsApi.Category, IndexPath?)
+    let value01 = self.dataSource[indexPath01] as? (String, KsApi.Category, IndexPath?)
+    let value1 = self.dataSource[indexPath1] as? (String, KsApi.Category, IndexPath?)
+    let value11 = self.dataSource[indexPath11] as? (String, KsApi.Category, IndexPath?)
+    let value2 = self.dataSource[indexPath2] as? (String, KsApi.Category, IndexPath?)
 
     XCTAssertEqual("one", value0?.0)
-    XCTAssertEqual(1, value0?.1)
+    XCTAssertEqual(KsApi.Category.art, value0?.1)
     XCTAssertEqual(indexPath0, value0?.2)
     XCTAssertEqual("two", value01?.0)
-    XCTAssertEqual(2, value01?.1)
+    XCTAssertEqual(KsApi.Category.illustration, value01?.1)
     XCTAssertEqual(indexPath01, value01?.2)
     XCTAssertEqual("red", value1?.0)
-    XCTAssertEqual(3, value1?.1)
+    XCTAssertEqual(KsApi.Category.games, value1?.1)
     XCTAssertEqual(indexPath1, value1?.2)
     XCTAssertEqual("green", value11?.0)
-    XCTAssertEqual(4, value11?.1)
+    XCTAssertEqual(KsApi.Category.tabletopGames, value11?.1)
     XCTAssertEqual(indexPath11, value11?.2)
     XCTAssertEqual("monday", value2?.0)
-    XCTAssertEqual(5, value2?.1)
+    XCTAssertEqual(KsApi.Category.filmAndVideo, value2?.1)
     XCTAssertEqual(indexPath2, value2?.2)
   }
 }

--- a/Kickstarter-iOS/Views/Cells/CategoryPillCell.swift
+++ b/Kickstarter-iOS/Views/Cells/CategoryPillCell.swift
@@ -1,8 +1,8 @@
+import KsApi
 import Library
 import Prelude
 import ReactiveSwift
 import UIKit
-import KsApi
 
 protocol CategoryPillCellDelegate: AnyObject {
   func categoryPillCell(

--- a/Kickstarter-iOS/Views/Cells/CategoryPillCell.swift
+++ b/Kickstarter-iOS/Views/Cells/CategoryPillCell.swift
@@ -2,12 +2,13 @@ import Library
 import Prelude
 import ReactiveSwift
 import UIKit
+import KsApi
 
 protocol CategoryPillCellDelegate: AnyObject {
   func categoryPillCell(
     _ cell: CategoryPillCell,
     didTapAtIndex index: IndexPath,
-    withId id: Int
+    withCategory category: KsApi.Category
   )
 }
 
@@ -56,10 +57,10 @@ final class CategoryPillCell: UICollectionViewCell, ValueCell {
 
     self.viewModel.outputs.notifyDelegatePillCellTapped
       .observeForUI()
-      .observeValues { [weak self] indexPath, id in
+      .observeValues { [weak self] indexPath, category in
         guard let self = self else { return }
 
-        self.delegate?.categoryPillCell(self, didTapAtIndex: indexPath, withId: id)
+        self.delegate?.categoryPillCell(self, didTapAtIndex: indexPath, withCategory: category)
       }
   }
 

--- a/Kickstarter-iOS/Views/Controllers/CategorySelectionViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/CategorySelectionViewController.swift
@@ -281,9 +281,11 @@ extension CategorySelectionViewController: UICollectionViewDelegateFlowLayout {
 // MARK: - CategoryPillCellDelegate
 
 extension CategorySelectionViewController: CategoryPillCellDelegate {
-  func categoryPillCell(_ cell: CategoryPillCell,
-                        didTapAtIndex index: IndexPath,
-                        withCategory category: KsApi.Category) {
+  func categoryPillCell(
+    _ cell: CategoryPillCell,
+    didTapAtIndex index: IndexPath,
+    withCategory category: KsApi.Category
+  ) {
     self.viewModel.inputs.categorySelected(with: (index, category))
 
     let shouldSelectCell = self.viewModel.outputs.shouldSelectCell(at: index)

--- a/Kickstarter-iOS/Views/Controllers/CategorySelectionViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/CategorySelectionViewController.swift
@@ -281,8 +281,10 @@ extension CategorySelectionViewController: UICollectionViewDelegateFlowLayout {
 // MARK: - CategoryPillCellDelegate
 
 extension CategorySelectionViewController: CategoryPillCellDelegate {
-  func categoryPillCell(_ cell: CategoryPillCell, didTapAtIndex index: IndexPath, withId id: Int) {
-    self.viewModel.inputs.categorySelected(with: (index, id))
+  func categoryPillCell(_ cell: CategoryPillCell,
+                        didTapAtIndex index: IndexPath,
+                        withCategory category: KsApi.Category) {
+    self.viewModel.inputs.categorySelected(with: (index, category))
 
     let shouldSelectCell = self.viewModel.outputs.shouldSelectCell(at: index)
 

--- a/Kickstarter-iOS/Views/Controllers/DiscoveryPageViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/DiscoveryPageViewController.swift
@@ -243,7 +243,7 @@ internal final class DiscoveryPageViewController: UITableViewController {
       .observeValues { [weak self] categories in
         let curatedProjectsVC = CuratedProjectsViewController.instantiate()
         curatedProjectsVC.configure(with: categories)
-        
+
         let isIpad = AppEnvironment.current.device.userInterfaceIdiom == .pad
 
         let navController = NavigationController(rootViewController: curatedProjectsVC)

--- a/Kickstarter-iOS/Views/Controllers/DiscoveryPageViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/DiscoveryPageViewController.swift
@@ -240,8 +240,10 @@ internal final class DiscoveryPageViewController: UITableViewController {
 
     self.viewModel.outputs.goToCuratedProjects
       .observeForUI()
-      .observeValues { [weak self] _ in
+      .observeValues { [weak self] categories in
         let curatedProjectsVC = CuratedProjectsViewController.instantiate()
+        curatedProjectsVC.configure(with: categories)
+        
         let isIpad = AppEnvironment.current.device.userInterfaceIdiom == .pad
 
         let navController = NavigationController(rootViewController: curatedProjectsVC)

--- a/Library/KSCache.swift
+++ b/Library/KSCache.swift
@@ -7,6 +7,7 @@ public final class KSCache {
   public static let ksr_discoveryFiltersCategories = "discovery_filters_view_model_root_categories"
   public static let ksr_findFriendsFollowing = "find_friends_follow_view_model"
   public static let ksr_messageThreadHasUnreadMessages = "message_thread_has_unread_messages"
+  public static let ksr_onboardingCategories = "onboarding_categories"
   public static let ksr_projectSaved = "project_saved"
 
   public init() {}

--- a/Library/OptimizelyClientType.swift
+++ b/Library/OptimizelyClientType.swift
@@ -36,6 +36,31 @@ extension OptimizelyClientType {
 
     return variant
   }
+
+  /*
+   Calls `getVariation` on the Optimizely SDK for the given experiment,
+   using the default attributes and deviceId
+
+   Does *not* record an Optimizely impression. If you wish to record an experiment impression, use
+   `variant(for experiment)`
+   */
+
+  public func getVariation(for experiment: OptimizelyExperiment.Key) -> OptimizelyExperiment.Variant {
+    let userId = deviceIdentifier(uuid: UUID())
+    let attributes = optimizelyUserAttributes(with: AppEnvironment.current.currentUser)
+    let variationString = try? self.getVariationKey(
+      experimentKey: experiment.rawValue, userId: userId, attributes: attributes
+    )
+
+    guard
+      let variation = variationString,
+      let variant = OptimizelyExperiment.Variant(rawValue: variation)
+    else {
+      return .control
+    }
+
+    return variant
+  }
 }
 
 public func optimizelyTrackingAttributesAndEventTags(

--- a/Library/OptimizelyClientType.swift
+++ b/Library/OptimizelyClientType.swift
@@ -42,7 +42,7 @@ extension OptimizelyClientType {
    using the default attributes and deviceId
 
    Does *not* record an Optimizely impression. If you wish to record an experiment impression, use
-   `variant(for experiment)`
+   `variant(for experiment)`, which calls `activate` on the Optimizely SDK
    */
 
   public func getVariation(for experiment: OptimizelyExperiment.Key) -> OptimizelyExperiment.Variant {

--- a/Library/ViewModels/CategoryPillCellViewModel.swift
+++ b/Library/ViewModels/CategoryPillCellViewModel.swift
@@ -1,6 +1,6 @@
 import Foundation
-import Prelude
 import KsApi
+import Prelude
 import ReactiveSwift
 
 public typealias CategoryPillCellValue = (name: String, category: KsApi.Category, indexPath: IndexPath?)

--- a/Library/ViewModels/CategoryPillCellViewModel.swift
+++ b/Library/ViewModels/CategoryPillCellViewModel.swift
@@ -1,8 +1,9 @@
 import Foundation
 import Prelude
+import KsApi
 import ReactiveSwift
 
-public typealias CategoryPillCellValue = (name: String, id: Int, indexPath: IndexPath?)
+public typealias CategoryPillCellValue = (name: String, category: KsApi.Category, indexPath: IndexPath?)
 
 public protocol CategoryPillCellViewModelInputs {
   func configure(with value: CategoryPillCellValue)
@@ -13,7 +14,7 @@ public protocol CategoryPillCellViewModelInputs {
 public protocol CategoryPillCellViewModelOutputs {
   var buttonTitle: Signal<String, Never> { get }
   var isSelected: Signal<Bool, Never> { get }
-  var notifyDelegatePillCellTapped: Signal<(IndexPath, Int), Never> { get }
+  var notifyDelegatePillCellTapped: Signal<(IndexPath, KsApi.Category), Never> { get }
 }
 
 public protocol CategoryPillCellViewModelType {
@@ -32,7 +33,7 @@ public final class CategoryPillCellViewModel: CategoryPillCellViewModelType,
           return nil
         }
 
-        return (index, value.id)
+        return (index, value.category)
       }
 
     self.isSelected = self.isSelectedProperty.signal.skipRepeats()
@@ -58,7 +59,7 @@ public final class CategoryPillCellViewModel: CategoryPillCellViewModelType,
 
   public let buttonTitle: Signal<String, Never>
   public let isSelected: Signal<Bool, Never>
-  public let notifyDelegatePillCellTapped: Signal<(IndexPath, Int), Never>
+  public let notifyDelegatePillCellTapped: Signal<(IndexPath, KsApi.Category), Never>
 
   public var inputs: CategoryPillCellViewModelInputs { return self }
   public var outputs: CategoryPillCellViewModelOutputs { return self }

--- a/Library/ViewModels/CategoryPillCellViewModelTests.swift
+++ b/Library/ViewModels/CategoryPillCellViewModelTests.swift
@@ -10,7 +10,7 @@ final class CategoryPillCellViewModelTests: TestCase {
   private let buttonTitle = TestObserver<String, Never>()
   private let isSelected = TestObserver<Bool, Never>()
   private let notifyDelegatePillCellTappedIndexPath = TestObserver<IndexPath, Never>()
-  private let notifyDelegatePillCellTappedId = TestObserver<Int, Never>()
+  private let notifyDelegatePillCellTappedCategory = TestObserver<KsApi.Category, Never>()
 
   private let vm: CategoryPillCellViewModelType = CategoryPillCellViewModel()
 
@@ -22,7 +22,7 @@ final class CategoryPillCellViewModelTests: TestCase {
     self.vm.outputs.notifyDelegatePillCellTapped.map(first)
       .observe(self.notifyDelegatePillCellTappedIndexPath.observer)
     self.vm.outputs.notifyDelegatePillCellTapped.map(second)
-      .observe(self.notifyDelegatePillCellTappedId.observer)
+      .observe(self.notifyDelegatePillCellTappedCategory.observer)
   }
 
   func testButtonTitle() {
@@ -30,7 +30,7 @@ final class CategoryPillCellViewModelTests: TestCase {
 
     self.buttonTitle.assertDidNotEmitValue()
 
-    self.vm.inputs.configure(with: ("title", 2, indexPath))
+    self.vm.inputs.configure(with: ("title", .art, indexPath))
 
     self.buttonTitle.assertValues(["title"])
   }
@@ -40,7 +40,7 @@ final class CategoryPillCellViewModelTests: TestCase {
 
     self.isSelected.assertDidNotEmitValue()
 
-    self.vm.inputs.configure(with: ("title", 2, indexPath))
+    self.vm.inputs.configure(with: ("title", .art, indexPath))
 
     self.vm.inputs.setIsSelected(selected: true)
 
@@ -55,12 +55,12 @@ final class CategoryPillCellViewModelTests: TestCase {
     let indexPath = IndexPath(item: 0, section: 0)
 
     self.notifyDelegatePillCellTappedIndexPath.assertDidNotEmitValue()
-    self.notifyDelegatePillCellTappedId.assertDidNotEmitValue()
+    self.notifyDelegatePillCellTappedCategory.assertDidNotEmitValue()
 
-    self.vm.inputs.configure(with: ("title", 2, indexPath))
+    self.vm.inputs.configure(with: ("title", .art, indexPath))
     self.vm.inputs.pillCellTapped()
 
     self.notifyDelegatePillCellTappedIndexPath.assertValues([indexPath])
-    self.notifyDelegatePillCellTappedId.assertValues([2])
+    self.notifyDelegatePillCellTappedCategory.assertValues([.art])
   }
 }

--- a/Library/ViewModels/CategorySelectionViewModel.swift
+++ b/Library/ViewModels/CategorySelectionViewModel.swift
@@ -200,7 +200,7 @@ private func categoryData(from rootCategories: [KsApi.Category]) -> ([String], [
     sectionTitles.append(category.name)
 
     let subcategoryData = subcategories.compactMap { subcategory -> (String, KsApi.Category)? in
-      return (subcategory.name, subcategory)
+      (subcategory.name, subcategory)
     }
 
     let allProjects = (Strings.All_category_name_Projects(category_name: category.name), category)

--- a/Library/ViewModels/CategorySelectionViewModel.swift
+++ b/Library/ViewModels/CategorySelectionViewModel.swift
@@ -73,9 +73,11 @@ public final class CategorySelectionViewModel: CategorySelectionViewModelType,
       .takeWhen(self.continueButtonTappedProperty.signal)
       .map(Array.init)
       .sort { $0.name < $1.name }
-      .on { _ in
+      .on(value: { categories in
         AppEnvironment.current.userDefaults.hasCompletedCategoryPersonalizationFlow = true
-      }
+
+        cache(categories)
+      })
 
     self.postNotification = self.goToCuratedProjects
       .map { _ in Notification(name: .ksr_onboardingCompleted) }
@@ -219,4 +221,8 @@ private func updatedSelectedValues<T: Hashable>(selectedValues: Set<T>, currentV
   }
 
   return updatedValues
+}
+
+private func cache(_ categories: [KsApi.Category]) {
+  AppEnvironment.current.cache[KSCache.ksr_onboardingCategories] = categories
 }

--- a/Library/ViewModels/CategorySelectionViewModelTests.swift
+++ b/Library/ViewModels/CategorySelectionViewModelTests.swift
@@ -12,7 +12,7 @@ final class CategorySelectionViewModelTests: TestCase {
   private let isLoading = TestObserver<Bool, Never>()
   private let loadCategorySectionTitles = TestObserver<[String], Never>()
   private let loadCategorySectionNames = TestObserver<[[String]], Never>()
-  private let loadCategorySectionCategoryIds = TestObserver<[[Int]], Never>()
+  private let loadCategorySectionCategories = TestObserver<[[KsApi.Category]], Never>()
   private let postNotification = TestObserver<Notification, Never>()
   private let showErrorMessage = TestObserver<String, Never>()
   private let warningLabelIsHidden = TestObserver<Bool, Never>()
@@ -28,7 +28,7 @@ final class CategorySelectionViewModelTests: TestCase {
     self.vm.outputs.loadCategorySections.map(second).map { $0.map { $0.map { $0.0 } } }
       .observe(self.loadCategorySectionNames.observer)
     self.vm.outputs.loadCategorySections.map(second).map { $0.map { $0.map { $0.1 } } }
-      .observe(self.loadCategorySectionCategoryIds.observer)
+      .observe(self.loadCategorySectionCategories.observer)
     self.vm.outputs.postNotification.observe(self.postNotification.observer)
     self.vm.outputs.showErrorMessage.observe(self.showErrorMessage.observer)
     self.vm.outputs.warningLabelIsHidden.observe(self.warningLabelIsHidden.observer)
@@ -41,19 +41,12 @@ final class CategorySelectionViewModelTests: TestCase {
       .filmAndVideo
     ])
 
-    let artId = Category.art.intID ?? 0
-    let illustrationId = Category.illustration.intID ?? 0
-    let gamesId = Category.games.intID ?? 0
-    let tabletopId = Category.tabletopGames.intID ?? 0
-    let filmAndVideoId = Category.filmAndVideo.intID ?? 0
-    let documentaryId = Category.documentary.intID ?? 0
-
     let mockService = MockService(fetchGraphCategoriesResponse: categoriesResponse)
 
     withEnvironment(apiService: mockService) {
       self.loadCategorySectionTitles.assertDidNotEmitValue()
       self.loadCategorySectionNames.assertDidNotEmitValue()
-      self.loadCategorySectionCategoryIds.assertDidNotEmitValue()
+      self.loadCategorySectionCategories.assertDidNotEmitValue()
 
       self.vm.inputs.viewDidLoad()
 
@@ -67,11 +60,11 @@ final class CategorySelectionViewModelTests: TestCase {
           ["All Film & Video Projects", "Documentary"]
         ]
       ])
-      self.loadCategorySectionCategoryIds.assertValues([
+      self.loadCategorySectionCategories.assertValues([
         [
-          [gamesId, tabletopId],
-          [artId, illustrationId],
-          [filmAndVideoId, documentaryId]
+          [.games, .tabletopGames],
+          [.art, .illustration],
+          [.filmAndVideo, .documentary]
         ]
       ])
     }
@@ -88,14 +81,6 @@ final class CategorySelectionViewModelTests: TestCase {
       .games,
       .filmAndVideo
     ])
-
-    let artId = Category.art.intID ?? 0
-    let illustrationId = Category.illustration.intID ?? 0
-    let gamesId = Category.games.intID ?? 0
-    let tabletopId = Category.tabletopGames.intID ?? 0
-    let filmAndVideoId = Category.filmAndVideo.intID ?? 0
-    let documentaryId = Category.documentary.intID ?? 0
-    let unknownId = Category.tabletopGames.intID ?? 0
 
     let mockService = MockService(fetchGraphCategoriesResponse: categoriesResponse)
 
@@ -116,12 +101,12 @@ final class CategorySelectionViewModelTests: TestCase {
           ["All Cool Stuff Projects", "Tabletop Games"]
         ]
       ])
-      self.loadCategorySectionCategoryIds.assertValues([
+      self.loadCategorySectionCategories.assertValues([
         [
-          [gamesId, tabletopId],
-          [artId, illustrationId],
-          [filmAndVideoId, documentaryId],
-          [unknownId, tabletopId]
+          [.games, .tabletopGames],
+          [.art, .illustration],
+          [.filmAndVideo, .documentary],
+          [unknownCategory, .tabletopGames]
         ]
       ])
     }
@@ -144,13 +129,6 @@ final class CategorySelectionViewModelTests: TestCase {
     let filmAndVideoIndexPath = IndexPath(item: 0, section: 2)
     let documentaryIndexPath = IndexPath(item: 1, section: 2)
 
-    let artId = Category.art.intID ?? 0
-    let illustrationId = Category.illustration.intID ?? 0
-    let gamesId = Category.games.intID ?? 0
-    let tabletopId = Category.tabletopGames.intID ?? 0
-    let filmAndVideoId = Category.filmAndVideo.intID ?? 0
-    let documentaryId = Category.documentary.intID ?? 0
-
     let mockService = MockService(fetchGraphCategoriesResponse: categoriesResponse)
 
     withEnvironment(apiService: mockService) {
@@ -165,7 +143,7 @@ final class CategorySelectionViewModelTests: TestCase {
       XCTAssertFalse(self.vm.outputs.shouldSelectCell(at: filmAndVideoIndexPath))
       XCTAssertFalse(self.vm.outputs.shouldSelectCell(at: documentaryIndexPath))
 
-      self.vm.inputs.categorySelected(with: (artIndexPath, artId))
+      self.vm.inputs.categorySelected(with: (artIndexPath, .art))
 
       XCTAssertTrue(self.vm.outputs.shouldSelectCell(at: artIndexPath), "All Art Projects is selected")
       XCTAssertFalse(self.vm.outputs.shouldSelectCell(at: illustrationIndexPath))
@@ -174,7 +152,7 @@ final class CategorySelectionViewModelTests: TestCase {
       XCTAssertFalse(self.vm.outputs.shouldSelectCell(at: filmAndVideoIndexPath))
       XCTAssertFalse(self.vm.outputs.shouldSelectCell(at: documentaryIndexPath))
 
-      self.vm.inputs.categorySelected(with: (artIndexPath, artId))
+      self.vm.inputs.categorySelected(with: (artIndexPath, .art))
 
       XCTAssertFalse(self.vm.outputs.shouldSelectCell(at: artIndexPath), "All Art Projects is de-selected")
       XCTAssertFalse(self.vm.outputs.shouldSelectCell(at: illustrationIndexPath))
@@ -184,12 +162,12 @@ final class CategorySelectionViewModelTests: TestCase {
       XCTAssertFalse(self.vm.outputs.shouldSelectCell(at: documentaryIndexPath))
 
       // Select all categories
-      self.vm.inputs.categorySelected(with: (artIndexPath, artId))
-      self.vm.inputs.categorySelected(with: (illustrationIndexPath, illustrationId))
-      self.vm.inputs.categorySelected(with: (gamesIndexPath, gamesId))
-      self.vm.inputs.categorySelected(with: (tabletopIndexPath, tabletopId))
-      self.vm.inputs.categorySelected(with: (filmAndVideoIndexPath, filmAndVideoId))
-      self.vm.inputs.categorySelected(with: (documentaryIndexPath, documentaryId))
+      self.vm.inputs.categorySelected(with: (artIndexPath, .art))
+      self.vm.inputs.categorySelected(with: (illustrationIndexPath, .illustration))
+      self.vm.inputs.categorySelected(with: (gamesIndexPath, .games))
+      self.vm.inputs.categorySelected(with: (tabletopIndexPath, .tabletopGames))
+      self.vm.inputs.categorySelected(with: (filmAndVideoIndexPath, .filmAndVideo))
+      self.vm.inputs.categorySelected(with: (documentaryIndexPath, .documentary))
 
       // All categories selected
       XCTAssertTrue(self.vm.outputs.shouldSelectCell(at: artIndexPath))
@@ -218,13 +196,6 @@ final class CategorySelectionViewModelTests: TestCase {
     let filmAndVideoIndexPath = IndexPath(item: 0, section: 2)
     let documentaryIndexPath = IndexPath(item: 1, section: 2)
 
-    let artId = Category.art.intID ?? 0
-    let illustrationId = Category.illustration.intID ?? 0
-    let gamesId = Category.games.intID ?? 0
-    let tabletopId = Category.tabletopGames.intID ?? 0
-    let filmAndVideoId = Category.filmAndVideo.intID ?? 0
-    let documentaryId = Category.documentary.intID ?? 0
-
     let mockService = MockService(fetchGraphCategoriesResponse: categoriesResponse)
 
     withEnvironment(apiService: mockService) {
@@ -235,34 +206,34 @@ final class CategorySelectionViewModelTests: TestCase {
 
       self.continueButtonEnabled.assertValues([false])
 
-      self.vm.inputs.categorySelected(with: (tabletopIndexPath, tabletopId))
+      self.vm.inputs.categorySelected(with: (tabletopIndexPath, .tabletopGames))
 
       self.continueButtonEnabled.assertValues([false, true])
 
-      self.vm.inputs.categorySelected(with: (artIndexPath, artId))
+      self.vm.inputs.categorySelected(with: (artIndexPath, .art))
 
       self.continueButtonEnabled.assertValues([false, true])
 
-      self.vm.inputs.categorySelected(with: (gamesIndexPath, gamesId))
+      self.vm.inputs.categorySelected(with: (gamesIndexPath, .games))
 
       self.continueButtonEnabled.assertValues([false, true])
 
-      self.vm.inputs.categorySelected(with: (documentaryIndexPath, documentaryId))
+      self.vm.inputs.categorySelected(with: (documentaryIndexPath, .documentary))
 
       self.continueButtonEnabled.assertValues([false, true])
 
-      self.vm.inputs.categorySelected(with: (illustrationIndexPath, illustrationId))
+      self.vm.inputs.categorySelected(with: (illustrationIndexPath, .illustration))
 
       self.continueButtonEnabled.assertValues([false, true])
 
-      self.vm.inputs.categorySelected(with: (filmAndVideoIndexPath, filmAndVideoId))
+      self.vm.inputs.categorySelected(with: (filmAndVideoIndexPath, .filmAndVideo))
 
       self.continueButtonEnabled.assertValues(
         [false, true, false],
         "Continue button disabled when > 5 categories selected"
       )
 
-      self.vm.inputs.categorySelected(with: (filmAndVideoIndexPath, filmAndVideoId))
+      self.vm.inputs.categorySelected(with: (filmAndVideoIndexPath, .filmAndVideo))
 
       self.continueButtonEnabled.assertValues(
         [false, true, false, true],
@@ -288,13 +259,6 @@ final class CategorySelectionViewModelTests: TestCase {
     let filmAndVideoIndexPath = IndexPath(item: 0, section: 2)
     let documentaryIndexPath = IndexPath(item: 1, section: 2)
 
-    let artId = Category.art.intID ?? 0
-    let illustrationId = Category.illustration.intID ?? 0
-    let gamesId = Category.games.intID ?? 0
-    let tabletopId = Category.tabletopGames.intID ?? 0
-    let filmAndVideoId = Category.filmAndVideo.intID ?? 0
-    let documentaryId = Category.documentary.intID ?? 0
-
     let mockService = MockService(fetchGraphCategoriesResponse: categoriesResponse)
 
     withEnvironment(apiService: mockService) {
@@ -305,34 +269,34 @@ final class CategorySelectionViewModelTests: TestCase {
 
       self.warningLabelIsHidden.assertValues([true])
 
-      self.vm.inputs.categorySelected(with: (tabletopIndexPath, tabletopId))
+      self.vm.inputs.categorySelected(with: (tabletopIndexPath, .tabletopGames))
 
       self.warningLabelIsHidden.assertValues([true])
 
-      self.vm.inputs.categorySelected(with: (artIndexPath, artId))
+      self.vm.inputs.categorySelected(with: (artIndexPath, .art))
 
       self.warningLabelIsHidden.assertValues([true])
 
-      self.vm.inputs.categorySelected(with: (gamesIndexPath, gamesId))
+      self.vm.inputs.categorySelected(with: (gamesIndexPath, .games))
 
       self.warningLabelIsHidden.assertValues([true])
 
-      self.vm.inputs.categorySelected(with: (documentaryIndexPath, documentaryId))
+      self.vm.inputs.categorySelected(with: (documentaryIndexPath, .documentary))
 
       self.warningLabelIsHidden.assertValues([true])
 
-      self.vm.inputs.categorySelected(with: (illustrationIndexPath, illustrationId))
+      self.vm.inputs.categorySelected(with: (illustrationIndexPath, .illustration))
 
       self.warningLabelIsHidden.assertValues([true])
 
-      self.vm.inputs.categorySelected(with: (filmAndVideoIndexPath, filmAndVideoId))
+      self.vm.inputs.categorySelected(with: (filmAndVideoIndexPath, .filmAndVideo))
 
       self.warningLabelIsHidden.assertValues(
         [true, false],
         "Warning label shown when > 5 categories selected"
       )
 
-      self.vm.inputs.categorySelected(with: (filmAndVideoIndexPath, filmAndVideoId))
+      self.vm.inputs.categorySelected(with: (filmAndVideoIndexPath, .filmAndVideo))
 
       self.warningLabelIsHidden.assertValues(
         [true, false, true],
@@ -355,10 +319,6 @@ final class CategorySelectionViewModelTests: TestCase {
     let illustrationIndexPath = IndexPath(item: 1, section: 0)
     let gamesIndexPath = IndexPath(item: 0, section: 1)
 
-    let artId = Category.art.intID ?? 0
-    let illustrationId = Category.illustration.intID ?? 0
-    let gamesId = Category.games.intID ?? 0
-
     let mockService = MockService(fetchGraphCategoriesResponse: categoriesResponse)
 
     withEnvironment(apiService: mockService) {
@@ -367,9 +327,9 @@ final class CategorySelectionViewModelTests: TestCase {
 
       self.scheduler.advance()
 
-      self.vm.inputs.categorySelected(with: (artIndexPath, artId))
-      self.vm.inputs.categorySelected(with: (illustrationIndexPath, illustrationId))
-      self.vm.inputs.categorySelected(with: (gamesIndexPath, gamesId))
+      self.vm.inputs.categorySelected(with: (artIndexPath, .art))
+      self.vm.inputs.categorySelected(with: (illustrationIndexPath, .illustration))
+      self.vm.inputs.categorySelected(with: (gamesIndexPath, .games))
 
       self.vm.inputs.continueButtonTapped()
 
@@ -388,8 +348,6 @@ final class CategorySelectionViewModelTests: TestCase {
 
     let artIndexPath = IndexPath(item: 0, section: 0)
     let illustrationIndexPath = IndexPath(item: 1, section: 0)
-    let artId = Category.art.intID ?? 0
-    let illustrationId = Category.illustration.intID ?? 0
 
     let mockService = MockService(fetchGraphCategoriesResponse: categoriesResponse)
 
@@ -398,8 +356,8 @@ final class CategorySelectionViewModelTests: TestCase {
 
       self.scheduler.advance()
 
-      self.vm.inputs.categorySelected(with: (artIndexPath, artId))
-      self.vm.inputs.categorySelected(with: (illustrationIndexPath, illustrationId))
+      self.vm.inputs.categorySelected(with: (artIndexPath, .art))
+      self.vm.inputs.categorySelected(with: (illustrationIndexPath, .illustration))
 
       self.postNotification.assertDidNotEmitValue()
       XCTAssertFalse(mockKVStore.hasCompletedCategoryPersonalizationFlow)

--- a/Library/ViewModels/CategorySelectionViewModelTests.swift
+++ b/Library/ViewModels/CategorySelectionViewModelTests.swift
@@ -342,8 +342,10 @@ final class CategorySelectionViewModelTests: TestCase {
         [.art, .games, .illustration]
       ])
 
-      XCTAssertEqual([.art, .games, .illustration],
-                     self.cache[KSCache.ksr_onboardingCategories] as? [KsApi.Category])
+      XCTAssertEqual(
+        [.art, .games, .illustration],
+        self.cache[KSCache.ksr_onboardingCategories] as? [KsApi.Category]
+      )
       XCTAssertTrue(mockKVStore.hasCompletedCategoryPersonalizationFlow)
     }
   }

--- a/Library/ViewModels/DiscoveryPageViewModel.swift
+++ b/Library/ViewModels/DiscoveryPageViewModel.swift
@@ -574,14 +574,8 @@ private func shouldShowPersonalization() -> Bool {
     return false
   }
 
-  let userAttributes = optimizelyUserAttributes()
   guard let variant = AppEnvironment.current.optimizelyClient?
-    .variant(
-      for: .onboardingCategoryPersonalizationFlow,
-      userId: deviceIdentifier(uuid: UUID()),
-      isAdmin: AppEnvironment.current.currentUser?.isAdmin ?? false,
-      userAttributes: userAttributes
-    ) else {
+    .getVariation(for: .onboardingCategoryPersonalizationFlow) else {
     return false
   }
 

--- a/Library/ViewModels/DiscoveryPageViewModel.swift
+++ b/Library/ViewModels/DiscoveryPageViewModel.swift
@@ -89,8 +89,8 @@ public protocol DiscoveryPageViewModelOutputs {
   /// Emits a project and ref tag that we should go to from the activity sample.
   var goToActivityProject: Signal<(Project, RefTag), Never> { get }
 
-  /// Emits an array of categoryIds used to generate a curated list of projects
-  var goToCuratedProjects: Signal<[Int], Never> { get }
+  /// Emits an array of KsApi.Category objects used to generate a curated list of projects
+  var goToCuratedProjects: Signal<[KsApi.Category], Never> { get }
 
   /// Emits a refTag for the editorial project list
   var goToEditorialProjectList: Signal<DiscoveryParams.TagID, Never> { get }
@@ -389,7 +389,8 @@ public final class DiscoveryPageViewModel: DiscoveryPageViewModelType, Discovery
     }
 
     self.goToCuratedProjects = self.personalizationCellTappedProperty.signal
-      .map(cachedCategoryIds)
+      .map(cachedCategories)
+      .skipNil()
 
     self.dismissPersonalizationCell = self.personalizationCellDismissTappedProperty.signal
       .on { _ in
@@ -537,7 +538,7 @@ public final class DiscoveryPageViewModel: DiscoveryPageViewModelType, Discovery
   public let configureEditorialTableViewHeader: Signal<String, Never>
   public let dismissPersonalizationCell: Signal<Void, Never>
   public let goToActivityProject: Signal<(Project, RefTag), Never>
-  public let goToCuratedProjects: Signal<[Int], Never>
+  public let goToCuratedProjects: Signal<[KsApi.Category], Never>
   public let goToEditorialProjectList: Signal<DiscoveryParams.TagID, Never>
   public let goToLoginSignup: Signal<LoginIntent, Never>
   public let goToProjectPlaylist: Signal<(Project, [Project], RefTag), Never>
@@ -592,9 +593,8 @@ private func shouldShowPersonalization() -> Bool {
   }
 }
 
-private func cachedCategoryIds() -> [Int] {
-  // TODO: this will return cached categories
-  return []
+private func cachedCategories() -> [KsApi.Category]? {
+  return AppEnvironment.current.cache[KSCache.ksr_onboardingCategories] as? [KsApi.Category]
 }
 
 private func emptyState(forParams params: DiscoveryParams) -> EmptyState? {

--- a/Library/ViewModels/DiscoveryPageViewModelTests.swift
+++ b/Library/ViewModels/DiscoveryPageViewModelTests.swift
@@ -15,7 +15,7 @@ internal final class DiscoveryPageViewModelTests: TestCase {
   fileprivate let dismissPersonalizationCell = TestObserver<Void, Never>()
   fileprivate let goToActivityProject = TestObserver<Project, Never>()
   fileprivate let goToActivityProjectRefTag = TestObserver<RefTag, Never>()
-  fileprivate let goToCuratedProjects = TestObserver<[Int], Never>()
+  fileprivate let goToCuratedProjects = TestObserver<[KsApi.Category], Never>()
   fileprivate let goToEditorialProjectList = TestObserver<DiscoveryParams.TagID, Never>()
   fileprivate let goToPlaylist = TestObserver<[Project], Never>()
   fileprivate let goToPlaylistProject = TestObserver<Project, Never>()
@@ -1390,6 +1390,8 @@ internal final class DiscoveryPageViewModelTests: TestCase {
 
       self.showPersonalization.assertValues([true])
 
+      XCTAssertTrue(mockOpClient.getVariantPathCalled)
+
       // Change the filter
       self.vm.inputs.selectedFilter(.defaults |> DiscoveryParams.lens.category .~ Category.art)
       self.showPersonalization.assertValues([true, false], "Section hides on non-default filters")
@@ -1565,6 +1567,9 @@ internal final class DiscoveryPageViewModelTests: TestCase {
           OptimizelyExperiment.Variant.variant1.rawValue
       ]
 
+    let categories = [KsApi.Category.art, KsApi.Category.illustration]
+    self.cache[KSCache.ksr_onboardingCategories] = categories
+
     let defaultFilter = DiscoveryParams.recommendedDefaults
 
     withEnvironment(
@@ -1582,7 +1587,7 @@ internal final class DiscoveryPageViewModelTests: TestCase {
 
       self.vm.inputs.personalizationCellTapped()
 
-      self.goToCuratedProjects.assertValues([[]])
+      self.goToCuratedProjects.assertValues([[.art, .illustration]])
     }
   }
 


### PR DESCRIPTION
# 📲 What

Caches categories selected during the onboarding flow in NSCache. Also refactors how we keep track of selected categories by passing in the whole `Category` object into the cells so they can be passed back with the delegate callback. This improves performance because we don't have to iterate through nested arrays.

# 🤔 Why

The `CuratedProjectsViewController` needs to be configured with an array of `KsApi.Category`s. This is because the `DiscoveryParams` object which is used to populate the query parameters of the `/discover` requests takes a `Category` object instead of a `categoryId`.

When presenting the `CuratedPrjoectsViewController` from the explore screen, we need to pass in an array of previously selected `Category` objects. This array will now come from an `NSCache`.

# 🛠 How

- cache the selected array of `Category`s in our `NSCache` when the user taps "Continue" on the `CategorySelectionViewController`
- retrieve the cached array in `DiscoveryPageViewModel` when the user taps the personalization card
- also refactors the data source of the `CategorySelectionViewController` screen to take an array of `(displayName: String, category: KsApi.Category)` so that the category can be passed back to the `CategorySelectionViewModel` upon selection. This means we don't need a function to transform selected `categoryIds` into category objects, which improves performance
- changes the way we check the Optimizely experiment variant in `DiscoveryPageViewModel`: instead of calling `variant(for:)`, which uses `activate` under the hood, this PR adds a new helper function called `getVariation` which calls `getVariation` on the Optimizely SDK under the hood. This will not trigger an experiment impression.

# 👀 See

![DFjOjRPo7O](https://user-images.githubusercontent.com/3156796/77550310-5988cf80-6e87-11ea-8cae-7319e2751664.gif)


# ✅ Acceptance criteria

- [x] Delete any old builds from the simulator. Then, run the app. You should see the new onboarding screen. Navigate to the category selection screen and select a few categories. Tap "Continue". Then tap "Done" on the curated projects screen. You should see the personalization cell at the top of discovery. Tap the cell, and you should see the curated projects screen presented, with projects populated from the categories you selected during the onboarding flow.
