### PR TITLE
[NT-912] Experimental read more button loading bugfix

### DIFF
--- a/Library/ViewModels/LoadingButtonViewModel.swift
+++ b/Library/ViewModels/LoadingButtonViewModel.swift
@@ -23,7 +23,6 @@ public final class LoadingButtonViewModel:
   public init() {
     let isLoading = self.isLoadingProperty.signal
       .skipNil()
-      .skipRepeats()
 
     self.isUserInteractionEnabled = isLoading
       .negate()

--- a/Library/ViewModels/LoadingButtonViewModelTests.swift
+++ b/Library/ViewModels/LoadingButtonViewModelTests.swift
@@ -19,45 +19,15 @@ final class LoadingButtonViewModelTests: TestCase {
     self.vm.outputs.stopLoading.observe(self.stopLoading.observer)
   }
 
-  func testIsUserInteractionEnabled() {
-    self.vm.inputs.isLoading(false)
-    self.isUserInteractionEnabled.assertValues([true])
-
-    self.vm.inputs.isLoading(false)
-    self.isUserInteractionEnabled.assertValues([true])
-
+  func testIsLoading() {
     self.vm.inputs.isLoading(true)
-    self.isUserInteractionEnabled.assertValues([true, false])
-
-    self.vm.inputs.isLoading(true)
-    self.isUserInteractionEnabled.assertValues([true, false])
-  }
-
-  func testStartLoading() {
-    self.vm.inputs.isLoading(true)
+    self.isUserInteractionEnabled.assertValues([false])
     self.startLoading.assertValueCount(1)
+    self.stopLoading.assertValueCount(0)
 
-    self.vm.inputs.isLoading(true)
+    self.vm.inputs.isLoading(false)
+    self.isUserInteractionEnabled.assertValues([false, true])
     self.startLoading.assertValueCount(1)
-
-    self.vm.inputs.isLoading(false)
-    self.startLoading.assertValueCount(1)
-
-    self.vm.inputs.isLoading(true)
-    self.startLoading.assertValueCount(2)
-  }
-
-  func testStopLoading() {
-    self.vm.inputs.isLoading(false)
     self.stopLoading.assertValueCount(1)
-
-    self.vm.inputs.isLoading(false)
-    self.stopLoading.assertValueCount(1)
-
-    self.vm.inputs.isLoading(true)
-    self.stopLoading.assertValueCount(1)
-
-    self.vm.inputs.isLoading(false)
-    self.stopLoading.assertValueCount(2)
   }
 }

--- a/Library/ViewModels/ProjectPamphletMainCellViewModel.swift
+++ b/Library/ViewModels/ProjectPamphletMainCellViewModel.swift
@@ -324,7 +324,6 @@ public final class ProjectPamphletMainCellViewModel: ProjectPamphletMainCellView
     .map { project, variant in
       project.rewards.isEmpty && variant == .variant2
     }
-    .skipRepeats()
 
     let shouldTrackCTATappedEvent = projectAndRefTag
       .takeWhen(self.readMoreButtonTappedProperty.signal)

--- a/Library/ViewModels/ProjectPamphletMainCellViewModelTests.swift
+++ b/Library/ViewModels/ProjectPamphletMainCellViewModelTests.swift
@@ -846,7 +846,7 @@ final class ProjectPamphletMainCellViewModelTests: TestCase {
 
       self.vm.inputs.configureWith(value: (projectWithRewards, nil, (creatorDetails, false)))
 
-      self.readMoreButtonIsLoading.assertValues([true, false])
+      self.readMoreButtonIsLoading.assertValues([true, false, false])
     }
   }
 


### PR DESCRIPTION
# 📲 What

Addresses a bug in which the _read more_ button in our `native_project_page_campaign_details` experiment would sometimes not show the loading indicator correctly.

# 🤔 Why

This button is meant to display a loading indicator until the `Project` has been refreshed and hydrated with its rewards.

# 🛠 How

Removed some problematic `skipRepeats()` that were preventing the button from being put back into a loading state after the cell was reused by the table view.

# ✅ Acceptance criteria

Using link conditioner, charles, airplane mode, or your favourite method of breaking your internet connectivity, put yourself in variants 1 or 2 of the `native_project_page_campaign_details` experiment. Navigate to a project.

- [x] In variant 2 observe that if the project refresh errors, the read more button remains spinning and disables to taps.
- [x] In variant 1 observe that the button is tappable without a loading indicator.
- [x] In all scenarios of **variant 2**, the read more button should not cause the view to freeze or be tappable until rewards have been refreshed.