### PR TITLE
[NT-886] Category Personalization Experiment Tracking

### DIFF
--- a/Kickstarter-iOS/Views/Controllers/CategorySelectionViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/CategorySelectionViewController.swift
@@ -184,6 +184,10 @@ public final class CategorySelectionViewController: UIViewController {
         self?.present(UIAlertController.genericError(message), animated: true)
       }
 
+    self.viewModel.outputs.dismiss
+      .observeForControllerAction()
+      .observeValues { [weak self] in self?.dismiss(animated: true) }
+
     self.warningLabel.rac.hidden = self.viewModel.outputs.warningLabelIsHidden
     self.continueButton.rac.enabled = self.viewModel.outputs.continueButtonEnabled
   }
@@ -228,7 +232,7 @@ public final class CategorySelectionViewController: UIViewController {
   // MARK: - Accessors
 
   @objc func skipButtonTapped() {
-    self.dismiss(animated: true)
+    self.viewModel.inputs.skipButtonTapped()
   }
 
   @objc func continueButtonTapped() {

--- a/Kickstarter-iOS/Views/Controllers/CuratedProjectsViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/CuratedProjectsViewController.swift
@@ -119,7 +119,7 @@ final class CuratedProjectsViewController: UIViewController {
       .observeForUI()
       .observeValues { [weak self] message in
         self?.present(UIAlertController.genericError(message), animated: true)
-    }
+      }
   }
 
   // MARK: - Styles

--- a/Library/TestHelpers/MockOptimizelyClient.swift
+++ b/Library/TestHelpers/MockOptimizelyClient.swift
@@ -57,11 +57,15 @@ internal class MockOptimizelyClient: OptimizelyClientType {
 
 extension TestCase {
   func assertBaseUserAttributesLoggedOut() {
-    XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_os_version"] as? String,
-                   "MockSystemVersion")
+    XCTAssertEqual(
+      self.optimizelyClient.trackedAttributes?["session_os_version"] as? String,
+      "MockSystemVersion"
+    )
     XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_user_is_logged_in"] as? Bool, false)
-    XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_app_release_version"] as? String,
-                   "1.2.3.4.5.6.7.8.9.0")
+    XCTAssertEqual(
+      self.optimizelyClient.trackedAttributes?["session_app_release_version"] as? String,
+      "1.2.3.4.5.6.7.8.9.0"
+    )
     XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_apple_pay_device"] as? Bool, true)
     XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_device_format"] as? String, "phone")
 

--- a/Library/TestHelpers/MockOptimizelyClient.swift
+++ b/Library/TestHelpers/MockOptimizelyClient.swift
@@ -1,4 +1,5 @@
 import Library
+import XCTest
 
 internal struct MockOptimizelyError: Error {}
 
@@ -51,5 +52,26 @@ internal class MockOptimizelyClient: OptimizelyClientType {
     self.trackedAttributes = attributes
     self.trackedEventTags = eventTags
     self.trackedUserId = userId
+  }
+}
+
+extension TestCase {
+  func assertBaseUserAttributesLoggedOut() {
+    XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_os_version"] as? String,
+                   "MockSystemVersion")
+    XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_user_is_logged_in"] as? Bool, false)
+    XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_app_release_version"] as? String,
+                   "1.2.3.4.5.6.7.8.9.0")
+    XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_apple_pay_device"] as? Bool, true)
+    XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_device_format"] as? String, "phone")
+
+    XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_country"] as? String, "us")
+    XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_display_language"] as? String, "en")
+
+    XCTAssertNil(self.optimizelyClient.trackedAttributes?["session_ref_tag"] as? String)
+    XCTAssertNil(self.optimizelyClient.trackedAttributes?["session_referrer_credit"] as? String)
+    XCTAssertNil(self.optimizelyClient.trackedAttributes?["user_backed_projects_count"] as? Int)
+    XCTAssertNil(self.optimizelyClient.trackedAttributes?["user_launched_projects_count"] as? Int)
+    XCTAssertNil(self.optimizelyClient.trackedAttributes?["user_facebook_account"] as? Bool)
   }
 }

--- a/Library/ViewModels/CategorySelectionViewModel.swift
+++ b/Library/ViewModels/CategorySelectionViewModel.swift
@@ -8,11 +8,13 @@ public typealias CategorySectionData = (name: String, id: Int)
 public protocol CategorySelectionViewModelInputs {
   func categorySelected(with value: (IndexPath, Int))
   func continueButtonTapped()
+  func skipButtonTapped()
   func viewDidLoad()
 }
 
 public protocol CategorySelectionViewModelOutputs {
   var continueButtonEnabled: Signal<Bool, Never> { get }
+  var dismiss: Signal<Void, Never> { get }
   var goToCuratedProjects: Signal<[KsApi.Category], Never> { get }
   var isLoading: Signal<Bool, Never> { get }
   // A tuple of Section Titles: [String], and Categories Section Data (Name and Id): [[String, Int]]
@@ -100,6 +102,30 @@ public final class CategorySelectionViewModel: CategorySelectionViewModelType,
       shouldDisplayWarningLabel.negate()
     )
     .skipRepeats()
+
+    self.dismiss = self.skipButtonTappedProperty.signal
+
+    // Tracking
+
+    Signal.merge(self.skipButtonTappedProperty.signal.mapConst("Skip"),
+                 self.continueButtonTappedProperty.signal.mapConst("Continue"))
+      .observeValues { buttonTitle in
+        let (properties, eventTags) = optimizelyTrackingAttributesAndEventTags(
+          with: AppEnvironment.current.currentUser,
+          project: nil,
+          refTag: nil
+        )
+
+        let eventName = "\(buttonTitle) Button Clicked"
+
+        try? AppEnvironment.current.optimizelyClient?
+          .track(
+            eventKey: eventName,
+            userId: deviceIdentifier(uuid: UUID()),
+            attributes: properties,
+            eventTags: eventTags
+          )
+      }
   }
 
   private let categorySelectedWithValueProperty = MutableProperty<(IndexPath, Int)?>(nil)
@@ -110,6 +136,11 @@ public final class CategorySelectionViewModel: CategorySelectionViewModelType,
   private let continueButtonTappedProperty = MutableProperty(())
   public func continueButtonTapped() {
     self.continueButtonTappedProperty.value = ()
+  }
+
+  private let skipButtonTappedProperty = MutableProperty(())
+  public func skipButtonTapped() {
+    self.skipButtonTappedProperty.value = ()
   }
 
   private let shouldSelectCellAtIndexProperty = MutableProperty<IndexPath?>(nil)
@@ -126,6 +157,7 @@ public final class CategorySelectionViewModel: CategorySelectionViewModelType,
   }
 
   public let continueButtonEnabled: Signal<Bool, Never>
+  public let dismiss: Signal<Void, Never>
   public let goToCuratedProjects: Signal<[KsApi.Category], Never>
   public let isLoading: Signal<Bool, Never>
   public let loadCategorySections: Signal<([String], [[CategorySectionData]]), Never>

--- a/Library/ViewModels/CategorySelectionViewModel.swift
+++ b/Library/ViewModels/CategorySelectionViewModel.swift
@@ -107,25 +107,27 @@ public final class CategorySelectionViewModel: CategorySelectionViewModelType,
 
     // Tracking
 
-    Signal.merge(self.skipButtonTappedProperty.signal.mapConst("Skip"),
-                 self.continueButtonTappedProperty.signal.mapConst("Continue"))
-      .observeValues { buttonTitle in
-        let (properties, eventTags) = optimizelyTrackingAttributesAndEventTags(
-          with: AppEnvironment.current.currentUser,
-          project: nil,
-          refTag: nil
+    Signal.merge(
+      self.skipButtonTappedProperty.signal.mapConst("Skip"),
+      self.continueButtonTappedProperty.signal.mapConst("Continue")
+    )
+    .observeValues { buttonTitle in
+      let (properties, eventTags) = optimizelyTrackingAttributesAndEventTags(
+        with: AppEnvironment.current.currentUser,
+        project: nil,
+        refTag: nil
+      )
+
+      let eventName = "\(buttonTitle) Button Clicked"
+
+      try? AppEnvironment.current.optimizelyClient?
+        .track(
+          eventKey: eventName,
+          userId: deviceIdentifier(uuid: UUID()),
+          attributes: properties,
+          eventTags: eventTags
         )
-
-        let eventName = "\(buttonTitle) Button Clicked"
-
-        try? AppEnvironment.current.optimizelyClient?
-          .track(
-            eventKey: eventName,
-            userId: deviceIdentifier(uuid: UUID()),
-            attributes: properties,
-            eventTags: eventTags
-          )
-      }
+    }
   }
 
   private let categorySelectedWithValueProperty = MutableProperty<(IndexPath, Int)?>(nil)

--- a/Library/ViewModels/CategorySelectionViewModelTests.swift
+++ b/Library/ViewModels/CategorySelectionViewModelTests.swift
@@ -8,6 +8,7 @@ import XCTest
 
 final class CategorySelectionViewModelTests: TestCase {
   private let continueButtonEnabled = TestObserver<Bool, Never>()
+  private let dismiss = TestObserver<Void, Never>()
   private let goToCuratedProjects = TestObserver<[KsApi.Category], Never>()
   private let isLoading = TestObserver<Bool, Never>()
   private let loadCategorySectionTitles = TestObserver<[String], Never>()
@@ -22,6 +23,7 @@ final class CategorySelectionViewModelTests: TestCase {
     super.setUp()
 
     self.vm.outputs.continueButtonEnabled.observe(self.continueButtonEnabled.observer)
+    self.vm.outputs.dismiss.observe(self.dismiss.observer)
     self.vm.outputs.goToCuratedProjects.observe(self.goToCuratedProjects.observer)
     self.vm.outputs.isLoading.observe(self.isLoading.observer)
     self.vm.outputs.loadCategorySections.map(first).observe(self.loadCategorySectionTitles.observer)
@@ -341,7 +343,7 @@ final class CategorySelectionViewModelTests: TestCase {
     }
   }
 
-  func testGoToCuratedProjects_Emits_WhenContinueButtonIsTapped() {
+  func testGoToCuratedProjects() {
     let categoriesResponse = RootCategoriesEnvelope.init(rootCategories: [
       // sucbcat: .illustration
       .art,
@@ -371,11 +373,19 @@ final class CategorySelectionViewModelTests: TestCase {
       self.vm.inputs.categorySelected(with: (illustrationIndexPath, illustrationId))
       self.vm.inputs.categorySelected(with: (gamesIndexPath, gamesId))
 
+      XCTAssertNil(self.optimizelyClient.trackedEventKey)
+      XCTAssertNil(self.optimizelyClient.trackedAttributes)
+      XCTAssertNil(self.optimizelyClient.trackedEventTags)
+
       self.vm.inputs.continueButtonTapped()
 
       self.goToCuratedProjects.assertValues([
         [.art, .games, .illustration]
       ])
+
+      XCTAssertEqual("Continue Button Clicked", self.optimizelyClient.trackedEventKey)
+
+      assertBaseUserAttributesLoggedOut()
     }
   }
 
@@ -440,6 +450,30 @@ final class CategorySelectionViewModelTests: TestCase {
       self.scheduler.advance()
 
       self.isLoading.assertValues([true, false])
+    }
+  }
+
+  func testDismiss() {
+    let categoriesResponse = RootCategoriesEnvelope.init(rootCategories: [.art])
+    let mockService = MockService(fetchGraphCategoriesResponse: categoriesResponse)
+
+    withEnvironment(apiService: mockService) {
+      self.vm.inputs.viewDidLoad()
+      self.scheduler.advance()
+
+      self.dismiss.assertDidNotEmitValue()
+
+      XCTAssertNil(self.optimizelyClient.trackedEventKey)
+      XCTAssertNil(self.optimizelyClient.trackedAttributes)
+      XCTAssertNil(self.optimizelyClient.trackedEventTags)
+
+      self.vm.inputs.skipButtonTapped()
+
+      self.dismiss.assertValueCount(1)
+
+      XCTAssertEqual(self.optimizelyClient.trackedEventKey, "Skip Button Clicked")
+
+      assertBaseUserAttributesLoggedOut()
     }
   }
 }

--- a/Library/ViewModels/CategorySelectionViewModelTests.swift
+++ b/Library/ViewModels/CategorySelectionViewModelTests.swift
@@ -338,6 +338,7 @@ final class CategorySelectionViewModelTests: TestCase {
       XCTAssertNil(self.optimizelyClient.trackedEventKey)
       XCTAssertNil(self.optimizelyClient.trackedAttributes)
       XCTAssertNil(self.optimizelyClient.trackedEventTags)
+
       XCTAssertNil(self.cache[KSCache.ksr_onboardingCategories])
       XCTAssertFalse(mockKVStore.hasCompletedCategoryPersonalizationFlow)
 
@@ -347,14 +348,14 @@ final class CategorySelectionViewModelTests: TestCase {
         [.art, .games, .illustration]
       ])
 
-      XCTAssertEqual("Continue Button Clicked", self.optimizelyClient.trackedEventKey)
-
-      assertBaseUserAttributesLoggedOut()
       XCTAssertEqual(
         [.art, .games, .illustration],
         self.cache[KSCache.ksr_onboardingCategories] as? [KsApi.Category]
       )
       XCTAssertTrue(mockKVStore.hasCompletedCategoryPersonalizationFlow)
+
+      XCTAssertEqual("Continue Button Clicked", self.optimizelyClient.trackedEventKey)
+      assertBaseUserAttributesLoggedOut()
     }
   }
 

--- a/Library/ViewModels/LandingViewModel.swift
+++ b/Library/ViewModels/LandingViewModel.swift
@@ -22,6 +22,25 @@ public final class LandingViewModel: LandingViewModelType, LandingViewModelInput
     }
 
     self.goToCategorySelection = self.getStartedButtonTappedProperty.signal
+
+    // Tracking
+
+    self.getStartedButtonTappedProperty.signal
+      .observeValues {
+        let (properties, eventTags) = optimizelyTrackingAttributesAndEventTags(
+          with: AppEnvironment.current.currentUser,
+          project: nil,
+          refTag: nil
+        )
+
+        try? AppEnvironment.current.optimizelyClient?
+          .track(
+            eventKey: "Get Started Button Clicked",
+            userId: deviceIdentifier(uuid: UUID()),
+            attributes: properties,
+            eventTags: eventTags
+          )
+      }
   }
 
   private let getStartedButtonTappedProperty = MutableProperty(())

--- a/Library/ViewModels/LandingViewModelTests.swift
+++ b/Library/ViewModels/LandingViewModelTests.swift
@@ -20,9 +20,17 @@ final class LandingViewModelTests: TestCase {
   func testGoToCategorySelection() {
     self.goToCategorySelection.assertDidNotEmitValue()
 
+    XCTAssertNil(self.optimizelyClient.trackedEventKey)
+    XCTAssertNil(self.optimizelyClient.trackedAttributes)
+    XCTAssertNil(self.optimizelyClient.trackedEventTags)
+
     self.vm.inputs.getStartedButtonTapped()
 
     self.goToCategorySelection.assertValueCount(1)
+
+    XCTAssertEqual(self.optimizelyClient.trackedEventKey, "Get Started Button Clicked")
+
+    assertBaseUserAttributesLoggedOut()
   }
 
   func testHasSeenCategoryPersonalizationFlowPropertyIsSet() {


### PR DESCRIPTION
# 📲 What

Adds a few Optimizely tracking events to the category personalization flow.

# 🤔 Why

So we can evaluate the effectiveness of the feature in helping new users find projects they'll be interested in.

# 🛠 How

- adds `Get Started Button Clicked` event
- adds `Continue Button Clicked` event
- adds `Skip Button Clicked` event

# ✅ Acceptance criteria

To force the category personalization flow to present on app launch, comment out the body of the `shouldSeeCategoryPersonalization()` function in `AppDelegateViewModel.swift` and instead `return true`.

- [x] Launch the app. You should see the onboarding flow appear. Tap "Get Started". You should see the Optimizely SDK log that an event was fired. Choose some categories. Then tap "Continue". You should see the Optimizely SDK log that an event called `Continue Button Clicked` was fired.
- [x] Launch the app. You should see the onboarding flow appear. Tap "Get Started". You should be navigated to the category selection screen. Tap "Skip" on the top right. You should see the Optimizely SDK log that an event called `Skip Button Clicked` was fired.
