### PR TITLE
[NT-1023] Add Temporary Checkout Completed event

### DIFF
--- a/Kickstarter-iOS/ViewModels/AppDelegateViewModel.swift
+++ b/Kickstarter-iOS/ViewModels/AppDelegateViewModel.swift
@@ -641,11 +641,7 @@ public final class AppDelegateViewModel: AppDelegateViewModelType, AppDelegateVi
 
     self.applicationDidEnterBackgroundProperty.signal
       .observeValues {
-        let (properties, eventTags) = optimizelyTrackingAttributesAndEventTags(
-          with: AppEnvironment.current.currentUser,
-          project: nil,
-          refTag: nil
-        )
+        let (properties, eventTags) = optimizelyTrackingAttributesAndEventTags()
 
         try? AppEnvironment.current.optimizelyClient?
           .track(
@@ -1125,19 +1121,8 @@ private func shouldGoToLandingPage() -> Bool {
     return false
   }
 
-  let userAttributes = optimizelyUserAttributes(
-    with: AppEnvironment.current.currentUser,
-    project: nil,
-    refTag: nil
-  )
-
   let optimizelyVariant = AppEnvironment.current.optimizelyClient?
-    .variant(
-      for: OptimizelyExperiment.Key.nativeOnboarding,
-      userId: deviceIdentifier(uuid: UUID()),
-      isAdmin: AppEnvironment.current.currentUser?.isAdmin ?? false,
-      userAttributes: userAttributes
-    )
+    .variant(for: OptimizelyExperiment.Key.nativeOnboarding)
 
   switch optimizelyVariant {
   case .variant1, .variant2:

--- a/Library/OptimizelyClientTypeTests.swift
+++ b/Library/OptimizelyClientTypeTests.swift
@@ -1,3 +1,4 @@
+@testable import KsApi
 @testable import Library
 import Prelude
 import XCTest
@@ -10,7 +11,7 @@ final class OptimizelyClientTypeTests: TestCase {
 
     XCTAssertEqual(
       OptimizelyExperiment.Variant.variant1,
-      mockClient.variant(for: .pledgeCTACopy, userId: "123", isAdmin: false),
+      mockClient.variant(for: .pledgeCTACopy),
       "Returns the correction variation"
     )
     XCTAssertTrue(mockClient.activatePathCalled)
@@ -25,7 +26,7 @@ final class OptimizelyClientTypeTests: TestCase {
 
     XCTAssertEqual(
       OptimizelyExperiment.Variant.control,
-      mockClient.variant(for: .pledgeCTACopy, userId: "123", isAdmin: false),
+      mockClient.variant(for: .pledgeCTACopy),
       "Returns the control variant if error is thrown"
     )
     XCTAssertTrue(mockClient.activatePathCalled)
@@ -37,7 +38,7 @@ final class OptimizelyClientTypeTests: TestCase {
 
     XCTAssertEqual(
       OptimizelyExperiment.Variant.control,
-      mockClient.variant(for: .pledgeCTACopy, userId: "123", isAdmin: false),
+      mockClient.variant(for: .pledgeCTACopy),
       "Returns the control variant if experiment key is not found"
     )
     XCTAssertTrue(mockClient.activatePathCalled)
@@ -51,7 +52,7 @@ final class OptimizelyClientTypeTests: TestCase {
 
     XCTAssertEqual(
       OptimizelyExperiment.Variant.control,
-      mockClient.variant(for: .pledgeCTACopy, userId: "123", isAdmin: false),
+      mockClient.variant(for: .pledgeCTACopy),
       "Returns the control variant if the variant is not recognized"
     )
     XCTAssertTrue(mockClient.activatePathCalled)
@@ -63,12 +64,16 @@ final class OptimizelyClientTypeTests: TestCase {
       |> \.experiments .~
       [OptimizelyExperiment.Key.pledgeCTACopy.rawValue: OptimizelyExperiment.Variant.variant1.rawValue]
 
-    XCTAssertEqual(
-      OptimizelyExperiment.Variant.variant1,
-      mockClient.variant(for: .pledgeCTACopy, userId: "123", isAdmin: true),
-      "Returns the correction variation"
-    )
-    XCTAssertFalse(mockClient.activatePathCalled)
-    XCTAssertTrue(mockClient.getVariantPathCalled)
+    let user = User.template |> User.lens.isAdmin .~ true
+
+    withEnvironment(currentUser: user) {
+      XCTAssertEqual(
+        OptimizelyExperiment.Variant.variant1,
+        mockClient.variant(for: .pledgeCTACopy),
+        "Returns the correction variation"
+      )
+      XCTAssertFalse(mockClient.activatePathCalled)
+      XCTAssertTrue(mockClient.getVariantPathCalled)
+    }
   }
 }

--- a/Library/OptimizelyExperiment.swift
+++ b/Library/OptimizelyExperiment.swift
@@ -21,20 +21,10 @@ extension OptimizelyExperiment {
     project: Project,
     refTag: RefTag?
   ) -> OptimizelyExperiment.Variant? {
-    let userAttributes = optimizelyUserAttributes(
-      with: AppEnvironment.current.currentUser,
-      project: project,
-      refTag: refTag
-    )
-
-    let optimizelyVariant = AppEnvironment.current.optimizelyClient?
+    return AppEnvironment.current.optimizelyClient?
       .variant(
         for: OptimizelyExperiment.Key.nativeProjectPageCampaignDetails,
-        userId: deviceIdentifier(uuid: UUID()),
-        isAdmin: AppEnvironment.current.currentUser?.isAdmin ?? false,
-        userAttributes: userAttributes
+        userAttributes: optimizelyUserAttributes(with: project, refTag: refTag)
       )
-
-    return optimizelyVariant
   }
 }

--- a/Library/ViewModels/LandingPageViewModel.swift
+++ b/Library/ViewModels/LandingPageViewModel.swift
@@ -38,11 +38,7 @@ public final class LandingPageViewModel: LandingPageViewModelType, LandingPageVi
 
     self.ctaButtonTappedSignal
       .observeValues {
-        let (properties, eventTags) = optimizelyTrackingAttributesAndEventTags(
-          with: AppEnvironment.current.currentUser,
-          project: nil,
-          refTag: nil
-        )
+        let (properties, eventTags) = optimizelyTrackingAttributesAndEventTags()
 
         try? AppEnvironment.current.optimizelyClient?
           .track(
@@ -73,19 +69,8 @@ public final class LandingPageViewModel: LandingPageViewModelType, LandingPageVi
 }
 
 private func cards() -> [LandingPageCardType]? {
-  let userAttributes = optimizelyUserAttributes(
-    with: AppEnvironment.current.currentUser,
-    project: nil,
-    refTag: nil
-  )
-
   let optimizelyVariant = AppEnvironment.current.optimizelyClient?
-    .variant(
-      for: OptimizelyExperiment.Key.nativeOnboarding,
-      userId: deviceIdentifier(uuid: UUID()),
-      isAdmin: AppEnvironment.current.currentUser?.isAdmin ?? false,
-      userAttributes: userAttributes
-    )
+    .variant(for: OptimizelyExperiment.Key.nativeOnboarding)
 
   guard let variant = optimizelyVariant else {
     return nil

--- a/Library/ViewModels/PledgeCTAContainerViewViewModel.swift
+++ b/Library/ViewModels/PledgeCTAContainerViewViewModel.swift
@@ -151,18 +151,10 @@ private func pledgeCTA(project: Project, refTag: RefTag?, backing: Backing?) -> 
       return PledgeStateCTAType.viewYourRewards
     }
 
-    let userAttributes = optimizelyUserAttributes(
-      with: AppEnvironment.current.currentUser,
-      project: project,
-      refTag: refTag
-    )
-
     let optimizelyVariant = AppEnvironment.current.optimizelyClient?
       .variant(
         for: OptimizelyExperiment.Key.pledgeCTACopy,
-        userId: deviceIdentifier(uuid: UUID()),
-        isAdmin: AppEnvironment.current.currentUser?.isAdmin ?? false,
-        userAttributes: userAttributes
+        userAttributes: optimizelyUserAttributes(with: project, refTag: refTag)
       )
 
     if let variant = optimizelyVariant, project.state == .live {

--- a/Library/ViewModels/PledgeViewModel.swift
+++ b/Library/ViewModels/PledgeViewModel.swift
@@ -599,8 +599,7 @@ public class PledgeViewModel: PledgeViewModelType, PledgeViewModelInputs, Pledge
     initialData
       .observeValues { project, _, refTag, _ in
         let (properties, eventTags) = optimizelyTrackingAttributesAndEventTags(
-          with: AppEnvironment.current.currentUser,
-          project: project,
+          with: project,
           refTag: refTag
         )
 
@@ -627,6 +626,25 @@ public class PledgeViewModel: PledgeViewModelType, PledgeViewModelInputs, Pledge
           checkoutData: checkoutData,
           refTag: refTag
         )
+      }
+
+    createBackingDataAndIsApplePay.takeWhen(createBackingCompletionEvents)
+      .observeValues { data, isApplePay in
+        let (properties, eventTags) = optimizelyTrackingAttributesAndEventTags(
+          with: data.project,
+          refTag: data.refTag
+        )
+
+        let allEventTags = eventTags
+          .withAllValuesFrom(optimizelyCheckoutEventTags(createBackingData: data, isApplePay: isApplePay))
+
+        try? AppEnvironment.current.optimizelyClient?
+          .track(
+            eventKey: "Temporary Completed Checkout",
+            userId: deviceIdentifier(uuid: UUID()),
+            attributes: properties,
+            eventTags: allEventTags
+          )
       }
   }
 
@@ -891,4 +909,28 @@ private func checkoutPropertiesData(
     shippingAmount: shippingAmount,
     userHasStoredApplePayCard: userHasEligibleStoredApplePayCard
   )
+}
+
+private func optimizelyCheckoutEventTags(
+  createBackingData: CreateBackingData,
+  isApplePay: Bool
+) -> [String: Any] {
+  let pledgeTotal = createBackingData.pledgeAmount
+
+  let pledgeTotalUsdCents = pledgeTotal
+    .multiplyingCurrency(Double(createBackingData.project.stats.staticUsdRate))
+    .multiplyingCurrency(100.0)
+    .rounded()
+
+  let paymentType = isApplePay
+    ? Backing.PaymentType.applePay.rawValue
+    : Backing.PaymentType.creditCard.rawValue
+
+  return [
+    "checkout_amount": pledgeTotal,
+    "checkout_payment_type": paymentType,
+    "revenue": Int(pledgeTotalUsdCents),
+    "currency": createBackingData.project.stats.currency,
+    "category": createBackingData.project.category.name
+  ]
 }

--- a/Library/ViewModels/PledgeViewModel.swift
+++ b/Library/ViewModels/PledgeViewModel.swift
@@ -640,7 +640,7 @@ public class PledgeViewModel: PledgeViewModelType, PledgeViewModelInputs, Pledge
 
         try? AppEnvironment.current.optimizelyClient?
           .track(
-            eventKey: "Temporary Completed Checkout",
+            eventKey: "App Completed Checkout",
             userId: deviceIdentifier(uuid: UUID()),
             attributes: properties,
             eventTags: allEventTags

--- a/Library/ViewModels/PledgeViewModelTests.swift
+++ b/Library/ViewModels/PledgeViewModelTests.swift
@@ -1149,7 +1149,12 @@ final class PledgeViewModelTests: TestCase {
       Result.success(CreateBackingEnvelope(createBacking: createBacking))
     )
 
-    withEnvironment(apiService: mockService, currentUser: .template) {
+    let optimizelyClient = MockOptimizelyClient()
+      |> \.experiments .~ [
+        OptimizelyExperiment.Key.pledgeCTACopy.rawValue: OptimizelyExperiment.Variant.variant1.rawValue
+      ]
+
+    withEnvironment(apiService: mockService, currentUser: .template, optimizelyClient: optimizelyClient) {
       let project = Project.template
       let reward = Reward.noReward
         |> Reward.lens.minimum .~ 5
@@ -1202,6 +1207,40 @@ final class PledgeViewModelTests: TestCase {
         ["Checkout Payment Page Viewed"],
         self.trackingClient.events
       )
+
+      XCTAssertEqual(optimizelyClient.trackedUserId, "DEADBEEF-DEAD-BEEF-DEAD-DEADBEEFBEEF")
+      XCTAssertEqual(optimizelyClient.trackedEventKey, "Temporary Completed Checkout")
+
+      XCTAssertEqual(optimizelyClient.trackedAttributes?["user_backed_projects_count"] as? Int, nil)
+      XCTAssertEqual(optimizelyClient.trackedAttributes?["user_launched_projects_count"] as? Int, nil)
+      XCTAssertEqual(optimizelyClient.trackedAttributes?["user_country"] as? String, "us")
+      XCTAssertEqual(optimizelyClient.trackedAttributes?["user_facebook_account"] as? Bool, nil)
+      XCTAssertEqual(optimizelyClient.trackedAttributes?["user_display_language"] as? String, "en")
+
+      XCTAssertEqual(optimizelyClient.trackedAttributes?["session_ref_tag"] as? String, "project_page")
+      XCTAssertEqual(
+        optimizelyClient.trackedAttributes?["session_referrer_credit"] as? String, "project_page"
+      )
+      XCTAssertEqual(
+        optimizelyClient.trackedAttributes?["session_os_version"] as? String, "MockSystemVersion"
+      )
+      XCTAssertEqual(optimizelyClient.trackedAttributes?["session_user_is_logged_in"] as? Bool, true)
+      XCTAssertEqual(
+        optimizelyClient.trackedAttributes?["session_app_release_version"] as? String, "1.2.3.4.5.6.7.8.9.0"
+      )
+      XCTAssertEqual(optimizelyClient.trackedAttributes?["session_apple_pay_device"] as? Bool, true)
+      XCTAssertEqual(optimizelyClient.trackedAttributes?["session_device_format"] as? String, "phone")
+
+      XCTAssertEqual(optimizelyClient.trackedEventTags?["project_subcategory"] as? String, "Art")
+      XCTAssertEqual(optimizelyClient.trackedEventTags?["project_category"] as? String, nil)
+      XCTAssertEqual(optimizelyClient.trackedEventTags?["project_country"] as? String, "us")
+      XCTAssertEqual(optimizelyClient.trackedEventTags?["project_user_has_watched"] as? Bool, nil)
+
+      XCTAssertEqual(optimizelyClient.trackedAttributes?["checkout_amount"] as? Double, 5.0)
+      XCTAssertEqual(optimizelyClient.trackedAttributes?["checkout_payment_type"] as? String, "APPLE_PAY")
+      XCTAssertEqual(optimizelyClient.trackedAttributes?["revenue"] as? Int, 500)
+      XCTAssertEqual(optimizelyClient.trackedAttributes?["currency"] as? String, "USD")
+      XCTAssertEqual(optimizelyClient.trackedAttributes?["category"] as? String, "Art")
     }
   }
 
@@ -1382,7 +1421,12 @@ final class PledgeViewModelTests: TestCase {
       Result.success(CreateBackingEnvelope(createBacking: createBacking))
     )
 
-    withEnvironment(apiService: mockService, currentUser: .template) {
+    let optimizelyClient = MockOptimizelyClient()
+      |> \.experiments .~ [
+        OptimizelyExperiment.Key.pledgeCTACopy.rawValue: OptimizelyExperiment.Variant.variant1.rawValue
+      ]
+
+    withEnvironment(apiService: mockService, currentUser: .template, optimizelyClient: optimizelyClient) {
       self.vm.inputs.configureWith(project: .template, reward: .template, refTag: .activity, context: .pledge)
       self.vm.inputs.viewDidLoad()
 
@@ -1437,6 +1481,38 @@ final class PledgeViewModelTests: TestCase {
         ["Checkout Payment Page Viewed", "Pledge Submit Button Clicked"],
         self.trackingClient.events
       )
+
+      XCTAssertEqual(optimizelyClient.trackedUserId, "DEADBEEF-DEAD-BEEF-DEAD-DEADBEEFBEEF")
+      XCTAssertEqual(optimizelyClient.trackedEventKey, "Temporary Completed Checkout")
+
+      XCTAssertEqual(optimizelyClient.trackedAttributes?["user_backed_projects_count"] as? Int, nil)
+      XCTAssertEqual(optimizelyClient.trackedAttributes?["user_launched_projects_count"] as? Int, nil)
+      XCTAssertEqual(optimizelyClient.trackedAttributes?["user_country"] as? String, "us")
+      XCTAssertEqual(optimizelyClient.trackedAttributes?["user_facebook_account"] as? Bool, nil)
+      XCTAssertEqual(optimizelyClient.trackedAttributes?["user_display_language"] as? String, "en")
+
+      XCTAssertEqual(optimizelyClient.trackedAttributes?["session_ref_tag"] as? String, "activity")
+      XCTAssertEqual(optimizelyClient.trackedAttributes?["session_referrer_credit"] as? String, "activity")
+      XCTAssertEqual(
+        optimizelyClient.trackedAttributes?["session_os_version"] as? String, "MockSystemVersion"
+      )
+      XCTAssertEqual(optimizelyClient.trackedAttributes?["session_user_is_logged_in"] as? Bool, true)
+      XCTAssertEqual(
+        optimizelyClient.trackedAttributes?["session_app_release_version"] as? String, "1.2.3.4.5.6.7.8.9.0"
+      )
+      XCTAssertEqual(optimizelyClient.trackedAttributes?["session_apple_pay_device"] as? Bool, true)
+      XCTAssertEqual(optimizelyClient.trackedAttributes?["session_device_format"] as? String, "phone")
+
+      XCTAssertEqual(optimizelyClient.trackedEventTags?["project_subcategory"] as? String, "Art")
+      XCTAssertEqual(optimizelyClient.trackedEventTags?["project_category"] as? String, nil)
+      XCTAssertEqual(optimizelyClient.trackedEventTags?["project_country"] as? String, "us")
+      XCTAssertEqual(optimizelyClient.trackedEventTags?["project_user_has_watched"] as? Bool, nil)
+
+      XCTAssertEqual(optimizelyClient.trackedAttributes?["checkout_amount"] as? Double, 25.0)
+      XCTAssertEqual(optimizelyClient.trackedAttributes?["checkout_payment_type"] as? String, "CREDIT_CARD")
+      XCTAssertEqual(optimizelyClient.trackedAttributes?["revenue"] as? Int, 2_500)
+      XCTAssertEqual(optimizelyClient.trackedAttributes?["currency"] as? String, "USD")
+      XCTAssertEqual(optimizelyClient.trackedAttributes?["category"] as? String, "Art")
     }
   }
 

--- a/Library/ViewModels/PledgeViewModelTests.swift
+++ b/Library/ViewModels/PledgeViewModelTests.swift
@@ -1236,11 +1236,11 @@ final class PledgeViewModelTests: TestCase {
       XCTAssertEqual(optimizelyClient.trackedEventTags?["project_country"] as? String, "us")
       XCTAssertEqual(optimizelyClient.trackedEventTags?["project_user_has_watched"] as? Bool, nil)
 
-      XCTAssertEqual(optimizelyClient.trackedAttributes?["checkout_amount"] as? Double, 5.0)
-      XCTAssertEqual(optimizelyClient.trackedAttributes?["checkout_payment_type"] as? String, "APPLE_PAY")
-      XCTAssertEqual(optimizelyClient.trackedAttributes?["revenue"] as? Int, 500)
-      XCTAssertEqual(optimizelyClient.trackedAttributes?["currency"] as? String, "USD")
-      XCTAssertEqual(optimizelyClient.trackedAttributes?["category"] as? String, "Art")
+      XCTAssertEqual(optimizelyClient.trackedEventTags?["checkout_amount"] as? Double, 5.0)
+      XCTAssertEqual(optimizelyClient.trackedEventTags?["checkout_payment_type"] as? String, "APPLE_PAY")
+      XCTAssertEqual(optimizelyClient.trackedEventTags?["revenue"] as? Int, 500)
+      XCTAssertEqual(optimizelyClient.trackedEventTags?["currency"] as? String, "USD")
+      XCTAssertEqual(optimizelyClient.trackedEventTags?["category"] as? String, "Art")
     }
   }
 
@@ -1508,11 +1508,11 @@ final class PledgeViewModelTests: TestCase {
       XCTAssertEqual(optimizelyClient.trackedEventTags?["project_country"] as? String, "us")
       XCTAssertEqual(optimizelyClient.trackedEventTags?["project_user_has_watched"] as? Bool, nil)
 
-      XCTAssertEqual(optimizelyClient.trackedAttributes?["checkout_amount"] as? Double, 25.0)
-      XCTAssertEqual(optimizelyClient.trackedAttributes?["checkout_payment_type"] as? String, "CREDIT_CARD")
-      XCTAssertEqual(optimizelyClient.trackedAttributes?["revenue"] as? Int, 2_500)
-      XCTAssertEqual(optimizelyClient.trackedAttributes?["currency"] as? String, "USD")
-      XCTAssertEqual(optimizelyClient.trackedAttributes?["category"] as? String, "Art")
+      XCTAssertEqual(optimizelyClient.trackedEventTags?["checkout_amount"] as? Double, 25.0)
+      XCTAssertEqual(optimizelyClient.trackedEventTags?["checkout_payment_type"] as? String, "CREDIT_CARD")
+      XCTAssertEqual(optimizelyClient.trackedEventTags?["revenue"] as? Int, 2_500)
+      XCTAssertEqual(optimizelyClient.trackedEventTags?["currency"] as? String, "USD")
+      XCTAssertEqual(optimizelyClient.trackedEventTags?["category"] as? String, "Art")
     }
   }
 

--- a/Library/ViewModels/PledgeViewModelTests.swift
+++ b/Library/ViewModels/PledgeViewModelTests.swift
@@ -1251,7 +1251,7 @@ final class PledgeViewModelTests: TestCase {
       self.scheduler.run()
 
       XCTAssertEqual(optimizelyClient.trackedUserId, "DEADBEEF-DEAD-BEEF-DEAD-DEADBEEFBEEF")
-      XCTAssertEqual(optimizelyClient.trackedEventKey, "Temporary Completed Checkout")
+      XCTAssertEqual(optimizelyClient.trackedEventKey, "App Completed Checkout")
 
       XCTAssertEqual(optimizelyClient.trackedAttributes?["user_backed_projects_count"] as? Int, nil)
       XCTAssertEqual(optimizelyClient.trackedAttributes?["user_launched_projects_count"] as? Int, nil)
@@ -1556,7 +1556,7 @@ final class PledgeViewModelTests: TestCase {
       self.scheduler.run()
 
       XCTAssertEqual(optimizelyClient.trackedUserId, "DEADBEEF-DEAD-BEEF-DEAD-DEADBEEFBEEF")
-      XCTAssertEqual(optimizelyClient.trackedEventKey, "Temporary Completed Checkout")
+      XCTAssertEqual(optimizelyClient.trackedEventKey, "App Completed Checkout")
 
       XCTAssertEqual(optimizelyClient.trackedAttributes?["user_backed_projects_count"] as? Int, nil)
       XCTAssertEqual(optimizelyClient.trackedAttributes?["user_launched_projects_count"] as? Int, nil)

--- a/Library/ViewModels/ProjectDescriptionViewModel.swift
+++ b/Library/ViewModels/ProjectDescriptionViewModel.swift
@@ -151,8 +151,7 @@ public final class ProjectDescriptionViewModel: ProjectDescriptionViewModelType,
       .takeWhen(self.pledgeCTAButtonTappedProperty.signal)
       .observeValues { project, refTag in
         let (properties, eventTags) = optimizelyTrackingAttributesAndEventTags(
-          with: AppEnvironment.current.currentUser,
-          project: project,
+          with: project,
           refTag: refTag
         )
 

--- a/Library/ViewModels/ProjectPamphletContentViewModel.swift
+++ b/Library/ViewModels/ProjectPamphletContentViewModel.swift
@@ -255,18 +255,10 @@ private func projectCreatorDetailsQuery(withSlug slug: String) -> NonEmptySet<Qu
 private func projectPageConversionCreatorDetailsExperiment(
   project: Project, refTag: RefTag?
 ) -> OptimizelyExperiment.Variant? {
-  let userAttributes = optimizelyUserAttributes(
-    with: AppEnvironment.current.currentUser,
-    project: project,
-    refTag: refTag
-  )
-
   let optimizelyVariant = AppEnvironment.current.optimizelyClient?
     .variant(
       for: OptimizelyExperiment.Key.nativeProjectPageConversionCreatorDetails,
-      userId: deviceIdentifier(uuid: UUID()),
-      isAdmin: AppEnvironment.current.currentUser?.isAdmin ?? false,
-      userAttributes: userAttributes
+      userAttributes: optimizelyUserAttributes(with: project, refTag: refTag)
     )
 
   return optimizelyVariant

--- a/Library/ViewModels/ProjectPamphletMainCellViewModel.swift
+++ b/Library/ViewModels/ProjectPamphletMainCellViewModel.swift
@@ -336,8 +336,7 @@ public final class ProjectPamphletMainCellViewModel: ProjectPamphletMainCellView
       .takeWhen(shouldTrackCTATappedEvent)
       .observeValues { projectAndRefTag in
         let (properties, eventTags) = optimizelyTrackingAttributesAndEventTags(
-          with: AppEnvironment.current.currentUser,
-          project: projectAndRefTag.0,
+          with: projectAndRefTag.0,
           refTag: projectAndRefTag.1
         )
 
@@ -354,8 +353,7 @@ public final class ProjectPamphletMainCellViewModel: ProjectPamphletMainCellView
       .takeWhen(self.creatorBylineTappedProperty.signal)
       .observeValues { projectAndRefTag in
         let (properties, eventTags) = optimizelyTrackingAttributesAndEventTags(
-          with: AppEnvironment.current.currentUser,
-          project: projectAndRefTag.0,
+          with: projectAndRefTag.0,
           refTag: projectAndRefTag.1
         )
 

--- a/Library/ViewModels/ProjectPamphletViewModel.swift
+++ b/Library/ViewModels/ProjectPamphletViewModel.swift
@@ -189,8 +189,7 @@ public final class ProjectPamphletViewModel: ProjectPamphletViewModelType, Proje
     freshProjectRefTagAndCookieRefTag
       .observeValues { project, refTag, _ in
         let (properties, eventTags) = optimizelyTrackingAttributesAndEventTags(
-          with: AppEnvironment.current.currentUser,
-          project: project,
+          with: project,
           refTag: refTag
         )
 
@@ -216,8 +215,7 @@ public final class ProjectPamphletViewModel: ProjectPamphletViewModelType, Proje
       .takeWhen(shouldTrackCTATappedEvent)
       .observeValues { project, refTag in
         let (properties, eventTags) = optimizelyTrackingAttributesAndEventTags(
-          with: AppEnvironment.current.currentUser,
-          project: project,
+          with: project,
           refTag: refTag
         )
 


### PR DESCRIPTION
# 📲 What

- Adds `Temporary Checkout Completed` to be sent to Optimizely once a checkout completes.
- Refactors some of our Optimizely tracking functions to reduce repetition at callsites.

# 🤔 Why

- There are currently _reasons_ that the `Checkout Completed` event is not tracking correctly from the back-end. We are using this event as a temporary workaround for _reasons_.
- Decided to tidy up these functions to instead get user-related info from the environment and to also not _require_ some arguments. This tidies up most of the callsites.

# 🛠 How

- Added the event and tags.
- Refactored some code.

# 👀 See

Example JSON that is posted to Optimizely for this event:

```json
"snapshots": [
  {
    "events": [
      {
        "tags": {
          "category": "Publishing",
          "checkout_amount": 1,
          "project_user_has_watched": false,
          "revenue": 130,
          "project_subcategory": "Publishing",
          "project_country": "gb",
          "checkout_payment_type": "CREDIT_CARD",
          "currency": "GBP"
        },
        "key": "Temporary Completed Checkout",
        "timestamp": 1585254754335,
        "revenue": 130,
        "entity_id": "17851500012",
        "uuid": "2A85F177-3328-4EC6-BF16-8D62EDA5EB02"
      }
    ]
  }
],
"visitor_id": "5AC5FC52-9EFD-4521-A38F-3DA7A5127748"
```

# ✅ Acceptance criteria

Place yourself in an experimental variant on Optimizely, complete a checkout with a credit card and with Apple Pay. Observe the following for both:

- [ ] In the console, debug info displaying JSON containing similar data to the above (`checkout_payment_type` changes to `APPLE_PAY` when using that payment method).
- [ ] Verify this info on Optimizely's back-end (I was not yet able to confirm this).