### PR TITLE
[NT-214] Fix pledge tracking events

### DIFF
--- a/Library/Tracking/Koala.swift
+++ b/Library/Tracking/Koala.swift
@@ -255,12 +255,14 @@ public final class Koala {
    - newPledge:    pledging to the project without an existing backing
    */
   public enum PledgeContext {
+    case fixErroredPledge
     case changeReward
     case manageReward
     case newPledge
 
     var trackingString: String {
       switch self {
+      case .fixErroredPledge: return "fix_errored_pledge"
       case .changeReward: return "change_reward"
       case .manageReward: return "manage_reward"
       case .newPledge: return "new_pledge"
@@ -617,6 +619,13 @@ public final class Koala {
     self.track(event: "Manage Pledge Option Clicked", properties: props)
   }
 
+  public func trackFixPledgeButtonClicked(project: Project) {
+    let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
+      .withAllValuesFrom(contextProperties(pledgeFlowContext: .fixErroredPledge))
+
+    self.track(event: "Fix Pledge Button Clicked", properties: props)
+  }
+
   /* Call when a reward is selected
 
    parameters:
@@ -700,6 +709,27 @@ public final class Koala {
       refTag: refTag?.stringTag
     )
   }
+
+  public func trackPledgeSubmitButtonClicked(
+    project: Project,
+    reward: Reward,
+    context: Koala.PledgeContext,
+    refTag: RefTag?
+  ) {
+    let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
+      .withAllValuesFrom(pledgeProperties(from: reward))
+      // the context is always "newPledge" for this event
+      .withAllValuesFrom(contextProperties(pledgeFlowContext: context))
+
+    self.track(
+      event: DataLakeWhiteListedEvent.pledgeSubmitButtonClicked.rawValue,
+      location: .pledgeScreen,
+      properties: props,
+      refTag: refTag?.stringTag
+    )
+  }
+
+  
 
   /* Call when the Add New Card button is clicked from the pledge screen
 

--- a/Library/Tracking/Koala.swift
+++ b/Library/Tracking/Koala.swift
@@ -567,9 +567,12 @@ public final class Koala {
   ) {
     let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
 
+    let fixPledgeProps = projectProperties(from: project, loggedInUser: self.loggedInUser)
+      .withAllValuesFrom(contextProperties(pledgeFlowContext: .fixErroredPledge))
+
     switch stateType {
     case .fix:
-      self.track(event: "Fix Pledge Button Clicked", properties: props)
+      self.track(event: "Manage Pledge Button Clicked", properties: fixPledgeProps)
     case .pledge:
       self.track(
         event: DataLakeWhiteListedEvent.projectPagePledgeButtonClicked.rawValue,
@@ -718,7 +721,6 @@ public final class Koala {
   ) {
     let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
       .withAllValuesFrom(pledgeProperties(from: reward))
-      // the context is always "newPledge" for this event
       .withAllValuesFrom(contextProperties(pledgeFlowContext: context))
 
     self.track(
@@ -728,8 +730,6 @@ public final class Koala {
       refTag: refTag?.stringTag
     )
   }
-
-  
 
   /* Call when the Add New Card button is clicked from the pledge screen
 

--- a/Library/Tracking/KoalaTests.swift
+++ b/Library/Tracking/KoalaTests.swift
@@ -631,7 +631,7 @@ final class KoalaTests: TestCase {
 
     koala.trackPledgeCTAButtonClicked(stateType: .fix, project: project)
 
-    XCTAssertEqual(["Fix Pledge Button Clicked"], client.events)
+    XCTAssertEqual(["Manage Pledge Button Clicked"], client.events)
   }
 
   func testTrackPledgeCTAButtonClicked_PledgeState() {

--- a/Library/Tracking/TrackingHelpers.swift
+++ b/Library/Tracking/TrackingHelpers.swift
@@ -5,10 +5,12 @@ final class TrackingHelpers {
     switch viewContext {
     case .pledge:
       return Koala.PledgeContext.newPledge
-    case .fixPaymentMethod, .update, .changePaymentMethod:
+    case .update, .changePaymentMethod:
       return Koala.PledgeContext.manageReward
     case .updateReward:
       return Koala.PledgeContext.changeReward
+    case .fixPaymentMethod:
+      return Koala.PledgeContext.fixErroredPledge
     }
   }
 }

--- a/Library/ViewModels/ManagePledgeViewModel.swift
+++ b/Library/ViewModels/ManagePledgeViewModel.swift
@@ -156,10 +156,10 @@ public final class ManagePledgeViewModel:
       }
 
     project
-      .takePairWhen(fixButtonTappedSignal)
+      .takePairWhen(self.fixButtonTappedSignal)
       .observeValues {
         AppEnvironment.current.koala.trackFixPledgeButtonClicked(project: $0.0)
-    }
+      }
   }
 
   private let (beginRefreshSignal, beginRefreshObserver) = Signal<Void, Never>.pipe()

--- a/Library/ViewModels/ManagePledgeViewModel.swift
+++ b/Library/ViewModels/ManagePledgeViewModel.swift
@@ -154,6 +154,12 @@ public final class ManagePledgeViewModel:
       .observeValues {
         AppEnvironment.current.koala.trackManagePledgeOptionClicked(project: $0, managePledgeMenuCTA: $1)
       }
+
+    project
+      .takePairWhen(fixButtonTappedSignal)
+      .observeValues {
+        AppEnvironment.current.koala.trackFixPledgeButtonClicked(project: $0.0)
+    }
   }
 
   private let (beginRefreshSignal, beginRefreshObserver) = Signal<Void, Never>.pipe()

--- a/Library/ViewModels/ManagePledgeViewModelTests.swift
+++ b/Library/ViewModels/ManagePledgeViewModelTests.swift
@@ -548,6 +548,20 @@ internal final class ManagePledgeViewModelTests: TestCase {
     XCTAssertEqual(["Manage Pledge Option Clicked"], self.trackingClient.events)
   }
 
+  func testFixPaymentTrackingEvents() {
+    let project = Project.template
+      |> Project.lens.personalization.backing .~ Backing.template
+
+    self.vm.inputs.configureWith(project)
+    self.vm.inputs.viewDidLoad()
+
+    XCTAssertEqual([], self.trackingClient.events)
+
+    self.vm.inputs.fixButtonTapped()
+
+    XCTAssertEqual(["Fix Pledge Button Clicked"], self.trackingClient.events)
+  }
+
   func testEndRefreshing() {
     let project = Project.template |> Project.lens.personalization.backing .~ .template
     let mockService = MockService(fetchProjectResponse: project)

--- a/Library/ViewModels/PledgeViewModel.swift
+++ b/Library/ViewModels/PledgeViewModel.swift
@@ -634,6 +634,17 @@ public class PledgeViewModel: PledgeViewModelType, PledgeViewModelInputs, Pledge
           refTag: refTag
         )
       }
+
+    Signal.combineLatest(project, updateBackingData, context)
+      .takeWhen(updateButtonTapped)
+      .observeValues { project, data, context in
+        AppEnvironment.current.koala.trackPledgeSubmitButtonClicked(
+          project: project,
+          reward: data.reward,
+          context: TrackingHelpers.pledgeContext(for: context),
+          refTag: nil
+        )
+      }
   }
 
   // MARK: - Inputs


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

We add tracking events: `Manage Pledge Button Fixed`, `Fix Pledge Button Clicked`, `Pledge Submit Button Clicked`

# 🤔 Why

The events are added to monitor the fixing errored pledges feature.

# 🛠 How

ToDo

# ✅ Acceptance criteria

- [x] Tap `Manage` on project page in the fix pledge flow. `Manage Pledge Button Clicked` event should emit.
- [x] Tap the `Fix` button on manage pledge screen. `Fix Pledge Button Clicked` event should emit.
- [x]  Tap `Retry` or `Confirm` in the fix payment screen. `Pledge Submit Button Clicked` event should emit.
