### PR TITLE
[NT-983] Removing unused errored backings code

### DIFF
--- a/Kickstarter-iOS/Views/Controllers/ActivitiesViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/ActivitiesViewController.swift
@@ -84,12 +84,6 @@ internal final class ActivitiesViewController: UITableViewController {
         self?.tableView.reloadData()
       }
 
-    self.viewModel.outputs.erroredBackings
-      .observeForUI()
-      .observeValues { backings in
-        print(backings)
-      }
-
     self.viewModel.outputs.showFacebookConnectSection
       .observeForUI()
       .observeValues { [weak self] source, shouldShow in

--- a/Library/ViewModels/ActivitiesViewModel.swift
+++ b/Library/ViewModels/ActivitiesViewModel.swift
@@ -68,9 +68,6 @@ public protocol ActivitiesViewModelOutputs {
   /// Emits when should remove Find Friends section.
   var deleteFindFriendsSection: Signal<(), Never> { get }
 
-  /// Emits an array of errored backings to be displayed on the top of the list of projects.
-  var erroredBackings: Signal<[GraphBacking], Never> { get }
-
   /// Emits when we should dismiss the empty state controller.
   var hideEmptyState: Signal<(), Never> { get }
 
@@ -185,20 +182,6 @@ public final class ActivitiesViewModel: ActivitiesViewModelType, ActitiviesViewM
         self.userSessionEndedProperty.signal
       )
       .map { AppEnvironment.current.currentUser }
-
-    let erroredBackingsEvent = currentUser
-      .switchMap { _ in
-        AppEnvironment.current.apiService.fetchGraphUserBackings(
-          query: UserQueries.backings(GraphBacking.Status.errored.rawValue).query
-        )
-        .ksr_delay(AppEnvironment.current.apiDelayInterval, on: AppEnvironment.current.scheduler)
-        .map { envelope in
-          envelope.me.backings.nodes
-        }
-        .materialize()
-      }
-
-    self.erroredBackings = erroredBackingsEvent.values()
 
     let loggedInForEmptyState = self.activities
       .filter { AppEnvironment.current.currentUser != nil && $0.isEmpty }
@@ -393,7 +376,6 @@ public final class ActivitiesViewModel: ActivitiesViewModelType, ActitiviesViewM
   public let clearBadgeValue: Signal<(), Never>
   public let deleteFacebookConnectSection: Signal<(), Never>
   public let deleteFindFriendsSection: Signal<(), Never>
-  public let erroredBackings: Signal<[GraphBacking], Never>
   public let hideEmptyState: Signal<(), Never>
   public let isRefreshing: Signal<Bool, Never>
   public let goToFriends: Signal<FriendsSource, Never>

--- a/Library/ViewModels/ActivitiesViewModelTests.swift
+++ b/Library/ViewModels/ActivitiesViewModelTests.swift
@@ -9,7 +9,6 @@ final class ActivitiesViewModelTests: TestCase {
 
   fileprivate let activitiesPresent = TestObserver<Bool, Never>()
   fileprivate let clearBadgeValue = TestObserver<(), Never>()
-  fileprivate let erroredBackings = TestObserver<[GraphBacking], Never>()
   fileprivate let isRefreshing = TestObserver<Bool, Never>()
   fileprivate let goToProject = TestObserver<Project, Never>()
   fileprivate let goToSurveyResponse = TestObserver<SurveyResponse, Never>()
@@ -38,7 +37,6 @@ final class ActivitiesViewModelTests: TestCase {
     self.vm.outputs.goToProject.map { $0.1 }.observe(self.showRefTag.observer)
     self.vm.outputs.deleteFacebookConnectSection.observe(self.deleteFacebookConnectSection.observer)
     self.vm.outputs.deleteFindFriendsSection.observe(self.deleteFindFriendsSection.observer)
-    self.vm.outputs.erroredBackings.observe(self.erroredBackings.observer)
     self.vm.outputs.goToFriends.observe(self.goToFriends.observer)
     self.vm.outputs.goToSurveyResponse.observe(self.goToSurveyResponse.observer)
     self.vm.outputs.showEmptyStateIsLoggedIn.observe(self.showEmptyStateIsLoggedIn.observer)
@@ -541,21 +539,6 @@ final class ActivitiesViewModelTests: TestCase {
       self.vm.inputs.viewWillAppear(animated: false)
 
       self.unansweredSurveyResponse.assertValues([[surveyResponse]])
-    }
-  }
-
-  func testErroredBackings() {
-    let envelope = GraphBackingEnvelope.erroredBackings
-    let backingsResponse = UserEnvelope<GraphBackingEnvelope>(me: envelope)
-
-    withEnvironment(apiService: MockService(fetchGraphUserBackingsResponse: backingsResponse)) {
-      self.erroredBackings.assertDidNotEmitValue()
-
-      self.vm.inputs.viewDidLoad()
-
-      self.scheduler.advance()
-
-      self.erroredBackings.assertValues([[GraphBacking.errored]])
     }
   }
 


### PR DESCRIPTION
#📲 What

Removes some code that was making a network request for an incomplete feature. This feature is currently being developed [on a feature branch.](https://github.com/kickstarter/ios-oss/tree/feature-errored-pledges), and should never have been merged into master.

# 🤔 Why

Because we shouldn't be making network requests for data that is not being used.

# 🛠 How

Deleted the unused code. This code will be re-added as part of the complete feature when the `feature-errored-pledges` branch merges.

# ✅ Acceptance criteria

- [ ] Run the app and sign in. Navigate to the Activity tab. Observe in the logs that the errored backings query is not dispatched.
