### PR TITLE
[NT-1040] Project Summary Carousel UI

### DIFF
--- a/Kickstarter-iOS/DataSources/ProjectSummaryCarouselDataSource.swift
+++ b/Kickstarter-iOS/DataSources/ProjectSummaryCarouselDataSource.swift
@@ -1,0 +1,33 @@
+import Foundation
+import KsApi
+import Library
+import UIKit
+
+internal final class ProjectSummaryCarouselDataSource: ValueCellDataSource {
+  public private(set) var greatestCombinedTextHeight: CGFloat = 0
+
+  internal enum Section: Int {
+    case summary
+  }
+
+  func load(_ values: [ProjectSummaryItem]) {
+    // TODO: iterate over values, calculate greatest item height and cache it
+
+    self.greatestCombinedTextHeight = 300
+
+    self.set(
+      values: values,
+      cellClass: ProjectSummaryCarouselCell.self,
+      inSection: Section.summary.rawValue
+    )
+  }
+
+  override func configureCell(collectionCell cell: UICollectionViewCell, withValue value: Any) {
+    switch (cell, value) {
+    case let (cell as ProjectSummaryCarouselCell, value as Int):
+      cell.configureWith(value: value)
+    default:
+      assertionFailure("Unrecognized (cell, value) combo.")
+    }
+  }
+}

--- a/Kickstarter-iOS/DataSources/ProjectSummaryCarouselDataSourceTests.swift
+++ b/Kickstarter-iOS/DataSources/ProjectSummaryCarouselDataSourceTests.swift
@@ -1,0 +1,9 @@
+import Foundation
+@testable import Kickstarter_Framework
+@testable import KsApi
+@testable import Library
+import Prelude
+import XCTest
+
+// TODO: fill in tests once we have the correct model
+final class ProjectSummaryCarouselDataSourceTests: TestCase {}

--- a/Kickstarter-iOS/Views/Cells/ProjectPamphletMainCell.swift
+++ b/Kickstarter-iOS/Views/Cells/ProjectPamphletMainCell.swift
@@ -73,6 +73,7 @@ internal final class ProjectPamphletMainCell: UITableViewCell, ValueCell {
   private lazy var projectSummaryCarouselView: ProjectSummaryCarouselView = {
     ProjectSummaryCarouselView(frame: .zero)
   }()
+
   @IBOutlet fileprivate var progressBarAndStatsStackView: UIStackView!
   @IBOutlet fileprivate var readMoreButton: LoadingButton!
   @IBOutlet fileprivate var readMoreStackView: UIStackView!
@@ -105,6 +106,9 @@ internal final class ProjectPamphletMainCell: UITableViewCell, ValueCell {
     self.creatorBylineView.addGestureRecognizer(self.creatorBylineTapGesture)
 
     self.blurbAndReadMoreStackView.insertArrangedSubview(self.projectSummaryCarouselView, at: 1)
+
+    // TODO: move to view model output.
+    self.projectSummaryCarouselView.configure(with: [1, 2, 3])
 
     self.viewModel.inputs.awakeFromNib()
   }
@@ -157,9 +161,6 @@ internal final class ProjectPamphletMainCell: UITableViewCell, ValueCell {
     _ = self.categoryStackView
       |> UIStackView.lens.spacing .~ Styles.grid(1)
 
-    _ = self.categoryAndLocationStackView
-      |> UIStackView.lens.layoutMargins .~ .init(top: 0, left: 0, bottom: Styles.grid(1), right: 0)
-
     _ = self.categoryIconImageView
       |> UIImageView.lens.contentMode .~ .scaleAspectFit
       |> UIImageView.lens.tintColor .~ .ksr_dark_grey_500
@@ -175,6 +176,12 @@ internal final class ProjectPamphletMainCell: UITableViewCell, ValueCell {
       ? Styles.grid(16)
       : Styles.grid(4)
 
+    _ = self.categoryAndLocationStackView
+      |> UIStackView.lens.isLayoutMarginsRelativeArrangement .~ true
+      |> UIStackView.lens.layoutMargins .~ .init(
+        top: 0, left: leftRightInsets, bottom: Styles.grid(1), right: leftRightInsets
+      )
+
     _ = self.contentStackView
       |> UIStackView.lens.layoutMargins %~~ { _, stackView in
         stackView.traitCollection.isRegularRegular
@@ -189,8 +196,8 @@ internal final class ProjectPamphletMainCell: UITableViewCell, ValueCell {
       |> UIStackView.lens.isLayoutMarginsRelativeArrangement .~ true
 
     _ = self.readMoreStackView
-    |> UIStackView.lens.layoutMargins .~ UIEdgeInsets(leftRight: leftRightInsets)
-    |> UIStackView.lens.isLayoutMarginsRelativeArrangement .~ true
+      |> UIStackView.lens.layoutMargins .~ UIEdgeInsets(leftRight: leftRightInsets)
+      |> UIStackView.lens.isLayoutMarginsRelativeArrangement .~ true
 
     _ = self.conversionLabel
       |> UILabel.lens.textColor .~ .ksr_text_dark_grey_400
@@ -259,6 +266,8 @@ internal final class ProjectPamphletMainCell: UITableViewCell, ValueCell {
       |> UILabel.lens.backgroundColor .~ .white
 
     _ = self.progressBarAndStatsStackView
+      |> UIStackView.lens.layoutMargins .~ UIEdgeInsets(leftRight: leftRightInsets)
+      |> UIStackView.lens.isLayoutMarginsRelativeArrangement .~ true
       |> UIStackView.lens.spacing .~ Styles.grid(2)
 
     _ = self.stateLabel

--- a/Kickstarter-iOS/Views/Cells/ProjectPamphletMainCell.swift
+++ b/Kickstarter-iOS/Views/Cells/ProjectPamphletMainCell.swift
@@ -81,6 +81,7 @@ internal final class ProjectPamphletMainCell: UITableViewCell, ValueCell {
   @IBOutlet fileprivate var stateLabel: UILabel!
   @IBOutlet fileprivate var statsStackView: UIStackView!
   @IBOutlet fileprivate var youreABackerContainerView: UIView!
+  @IBOutlet fileprivate var youreABackerContainerViewLeadingConstraint: NSLayoutConstraint!
   @IBOutlet fileprivate var youreABackerLabel: UILabel!
 
   internal override func awakeFromNib() {
@@ -105,10 +106,10 @@ internal final class ProjectPamphletMainCell: UITableViewCell, ValueCell {
 
     self.creatorBylineView.addGestureRecognizer(self.creatorBylineTapGesture)
 
-    self.blurbAndReadMoreStackView.insertArrangedSubview(self.projectSummaryCarouselView, at: 1)
-
     // TODO: move to view model output.
-    self.projectSummaryCarouselView.configure(with: [1, 2, 3])
+    // Uncomment to tests, currently commented to not break snapshots
+//    self.blurbAndReadMoreStackView.insertArrangedSubview(self.projectSummaryCarouselView, at: 1)
+//    self.projectSummaryCarouselView.configure(with: [1, 2, 3])
 
     self.viewModel.inputs.awakeFromNib()
   }
@@ -172,14 +173,14 @@ internal final class ProjectPamphletMainCell: UITableViewCell, ValueCell {
       |> UILabel.lens.font .~ .ksr_body(size: 12)
       |> UILabel.lens.backgroundColor .~ .white
 
-    let leftRightInsets: CGFloat = self.traitCollection.isRegularRegular
+    let leftRightInsetValue: CGFloat = self.traitCollection.isRegularRegular
       ? Styles.grid(16)
       : Styles.grid(4)
 
     _ = self.categoryAndLocationStackView
       |> UIStackView.lens.isLayoutMarginsRelativeArrangement .~ true
-      |> UIStackView.lens.layoutMargins .~ .init(
-        top: 0, left: leftRightInsets, bottom: Styles.grid(1), right: leftRightInsets
+      |> UIStackView.lens.layoutMargins .~ UIEdgeInsets(
+        leftRight: leftRightInsetValue
       )
 
     _ = self.contentStackView
@@ -192,11 +193,11 @@ internal final class ProjectPamphletMainCell: UITableViewCell, ValueCell {
       |> UIStackView.lens.spacing .~ Styles.grid(4)
 
     _ = self.blurbStackView
-      |> UIStackView.lens.layoutMargins .~ UIEdgeInsets(leftRight: leftRightInsets)
+      |> UIStackView.lens.layoutMargins .~ UIEdgeInsets(leftRight: leftRightInsetValue)
       |> UIStackView.lens.isLayoutMarginsRelativeArrangement .~ true
 
     _ = self.readMoreStackView
-      |> UIStackView.lens.layoutMargins .~ UIEdgeInsets(leftRight: leftRightInsets)
+      |> UIStackView.lens.layoutMargins .~ UIEdgeInsets(leftRight: leftRightInsetValue)
       |> UIStackView.lens.isLayoutMarginsRelativeArrangement .~ true
 
     _ = self.conversionLabel
@@ -252,7 +253,7 @@ internal final class ProjectPamphletMainCell: UITableViewCell, ValueCell {
 
     _ = self.projectNameAndCreatorStackView
       |> UIStackView.lens.spacing .~ Styles.grid(2)
-      |> UIStackView.lens.layoutMargins .~ UIEdgeInsets(leftRight: leftRightInsets)
+      |> UIStackView.lens.layoutMargins .~ UIEdgeInsets(leftRight: leftRightInsetValue)
       |> UIStackView.lens.isLayoutMarginsRelativeArrangement .~ true
 
     _ = self.projectNameLabel
@@ -266,7 +267,7 @@ internal final class ProjectPamphletMainCell: UITableViewCell, ValueCell {
       |> UILabel.lens.backgroundColor .~ .white
 
     _ = self.progressBarAndStatsStackView
-      |> UIStackView.lens.layoutMargins .~ UIEdgeInsets(leftRight: leftRightInsets)
+      |> UIStackView.lens.layoutMargins .~ UIEdgeInsets(leftRight: leftRightInsetValue)
       |> UIStackView.lens.isLayoutMarginsRelativeArrangement .~ true
       |> UIStackView.lens.spacing .~ Styles.grid(2)
 
@@ -277,6 +278,8 @@ internal final class ProjectPamphletMainCell: UITableViewCell, ValueCell {
     _ = self.statsStackView
       |> UIStackView.lens.isAccessibilityElement .~ true
       |> UIStackView.lens.backgroundColor .~ .white
+
+    _ = self.youreABackerContainerViewLeadingConstraint.constant = leftRightInsetValue
 
     _ = self.youreABackerContainerView
       |> roundedStyle(cornerRadius: 2)

--- a/Kickstarter-iOS/Views/Cells/ProjectPamphletMainCell.swift
+++ b/Kickstarter-iOS/Views/Cells/ProjectPamphletMainCell.swift
@@ -279,7 +279,8 @@ internal final class ProjectPamphletMainCell: UITableViewCell, ValueCell {
       |> UIStackView.lens.isAccessibilityElement .~ true
       |> UIStackView.lens.backgroundColor .~ .white
 
-    _ = self.youreABackerContainerViewLeadingConstraint.constant = leftRightInsetValue
+    _ = self.youreABackerContainerViewLeadingConstraint
+      |> \.constant .~ leftRightInsetValue
 
     _ = self.youreABackerContainerView
       |> roundedStyle(cornerRadius: 2)

--- a/Kickstarter-iOS/Views/Cells/ProjectPamphletMainCell.swift
+++ b/Kickstarter-iOS/Views/Cells/ProjectPamphletMainCell.swift
@@ -46,6 +46,7 @@ internal final class ProjectPamphletMainCell: UITableViewCell, ValueCell {
   @IBOutlet fileprivate var backersSubtitleLabel: UILabel!
   @IBOutlet fileprivate var backersTitleLabel: UILabel!
   @IBOutlet fileprivate var blurbAndReadMoreStackView: UIStackView!
+  @IBOutlet fileprivate var blurbStackView: UIStackView!
   @IBOutlet fileprivate var categoryStackView: UIStackView!
   @IBOutlet fileprivate var categoryAndLocationStackView: UIStackView!
   @IBOutlet fileprivate var categoryIconImageView: UIImageView!
@@ -69,8 +70,12 @@ internal final class ProjectPamphletMainCell: UITableViewCell, ValueCell {
   @IBOutlet fileprivate var projectImageContainerView: UIView!
   @IBOutlet fileprivate var projectNameAndCreatorStackView: UIStackView!
   @IBOutlet fileprivate var projectNameLabel: UILabel!
+  private lazy var projectSummaryCarouselView: ProjectSummaryCarouselView = {
+    ProjectSummaryCarouselView(frame: .zero)
+  }()
   @IBOutlet fileprivate var progressBarAndStatsStackView: UIStackView!
   @IBOutlet fileprivate var readMoreButton: LoadingButton!
+  @IBOutlet fileprivate var readMoreStackView: UIStackView!
   @IBOutlet fileprivate var spacerView: UIView!
   @IBOutlet fileprivate var stateLabel: UILabel!
   @IBOutlet fileprivate var statsStackView: UIStackView!
@@ -98,6 +103,8 @@ internal final class ProjectPamphletMainCell: UITableViewCell, ValueCell {
       |> ksr_addArrangedSubviewsToStackView()
 
     self.creatorBylineView.addGestureRecognizer(self.creatorBylineTapGesture)
+
+    self.blurbAndReadMoreStackView.insertArrangedSubview(self.projectSummaryCarouselView, at: 1)
 
     self.viewModel.inputs.awakeFromNib()
   }
@@ -164,14 +171,26 @@ internal final class ProjectPamphletMainCell: UITableViewCell, ValueCell {
       |> UILabel.lens.font .~ .ksr_body(size: 12)
       |> UILabel.lens.backgroundColor .~ .white
 
+    let leftRightInsets: CGFloat = self.traitCollection.isRegularRegular
+      ? Styles.grid(16)
+      : Styles.grid(4)
+
     _ = self.contentStackView
       |> UIStackView.lens.layoutMargins %~~ { _, stackView in
         stackView.traitCollection.isRegularRegular
-          ? .init(topBottom: Styles.grid(6), leftRight: Styles.grid(16))
-          : .init(top: Styles.grid(4), left: Styles.grid(4), bottom: Styles.grid(3), right: Styles.grid(4))
+          ? .init(topBottom: Styles.grid(6))
+          : .init(top: Styles.grid(4), left: 0, bottom: Styles.grid(3), right: 0)
       }
       |> UIStackView.lens.isLayoutMarginsRelativeArrangement .~ true
       |> UIStackView.lens.spacing .~ Styles.grid(4)
+
+    _ = self.blurbStackView
+      |> UIStackView.lens.layoutMargins .~ UIEdgeInsets(leftRight: leftRightInsets)
+      |> UIStackView.lens.isLayoutMarginsRelativeArrangement .~ true
+
+    _ = self.readMoreStackView
+    |> UIStackView.lens.layoutMargins .~ UIEdgeInsets(leftRight: leftRightInsets)
+    |> UIStackView.lens.isLayoutMarginsRelativeArrangement .~ true
 
     _ = self.conversionLabel
       |> UILabel.lens.textColor .~ .ksr_text_dark_grey_400
@@ -226,6 +245,8 @@ internal final class ProjectPamphletMainCell: UITableViewCell, ValueCell {
 
     _ = self.projectNameAndCreatorStackView
       |> UIStackView.lens.spacing .~ Styles.grid(2)
+      |> UIStackView.lens.layoutMargins .~ UIEdgeInsets(leftRight: leftRightInsets)
+      |> UIStackView.lens.isLayoutMarginsRelativeArrangement .~ true
 
     _ = self.projectNameLabel
       |> UILabel.lens.font %~~ { _, label in

--- a/Kickstarter-iOS/Views/Cells/ProjectSummaryCarouselCell.swift
+++ b/Kickstarter-iOS/Views/Cells/ProjectSummaryCarouselCell.swift
@@ -1,0 +1,19 @@
+import Foundation
+import Library
+import UIKit
+
+final class ProjectSummaryCarouselCell: UICollectionViewCell {
+  override init(frame: CGRect) {
+    super.init(frame: frame)
+
+    self.backgroundColor = .gray
+  }
+
+  required init?(coder _: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+}
+
+extension ProjectSummaryCarouselCell: ValueCell {
+  func configureWith(value _: Int) {}
+}

--- a/Kickstarter-iOS/Views/ProjectSummaryCarouselView.swift
+++ b/Kickstarter-iOS/Views/ProjectSummaryCarouselView.swift
@@ -1,16 +1,104 @@
 import Foundation
+import Library
+import Prelude
 import UIKit
 
 final class ProjectSummaryCarouselView: UIView {
+  // MARK: - Properties
+
+  private lazy var collectionView: UICollectionView = {
+    UICollectionView(frame: .zero, collectionViewLayout: self.layout)
+      |> \.alwaysBounceHorizontal .~ true
+      |> \.dataSource .~ self.dataSource
+      |> \.delegate .~ self
+      |> \.showsHorizontalScrollIndicator .~ false
+  }()
+
+  private let dataSource = ProjectSummaryCarouselDataSource()
+
+  private let layout: UICollectionViewFlowLayout = {
+    UICollectionViewFlowLayout()
+      |> \.minimumInteritemSpacing .~ Styles.grid(2)
+      |> \.sectionInset .~ .init(leftRight: Styles.grid(4))
+      |> \.scrollDirection .~ .horizontal
+  }()
+
+  private let viewModel: ProjectSummaryCarouselViewModelType = ProjectSummaryCarouselViewModel()
+
+  // MARK: - Lifecycle
+
   override init(frame: CGRect) {
     super.init(frame: frame)
 
-    self.backgroundColor = .red
+    self.dataSource.load([1, 2, 3])
 
-    self.heightAnchor.constraint(equalToConstant: 50).isActive = true
+    self.configureViews()
+    self.setupConstraints()
+    self.bindViewModel()
   }
 
-  required init?(coder: NSCoder) {
+  required init?(coder _: NSCoder) {
     fatalError("init(coder:) has not been implemented")
+  }
+
+  // MARK: - Accessors
+
+  func configure(with _: [ProjectSummaryItem]) {}
+
+  // MARK: - Configuration
+
+  private func configureViews() {
+    self.addSubview(self.collectionView)
+
+    self.collectionView.register(
+      ProjectSummaryCarouselCell.self,
+      forCellWithReuseIdentifier: ProjectSummaryCarouselCell.defaultReusableId
+    )
+  }
+
+  private func setupConstraints() {
+    _ = (self.collectionView, self)
+      |> ksr_constrainViewToEdgesInParent()
+
+    self.collectionView.heightAnchor.constraint(
+      equalToConstant: self.dataSource.greatestCombinedTextHeight
+    )
+    .isActive = true
+  }
+
+  // MARK: - View model
+
+  override func bindViewModel() {
+    super.bindViewModel()
+
+    self.viewModel.outputs.loadProjectSummaryItemsIntoDataSource
+      .observeForUI()
+      .observeValues { [weak self] items in
+        self?.dataSource.load(items)
+      }
+  }
+
+  // MARK: - Styles
+
+  override func bindStyles() {
+    super.bindStyles()
+
+    _ = self.collectionView
+      |> \.backgroundColor .~ .white
+  }
+}
+
+// MARK: - UICollectionViewDelegateFlowLayout
+
+extension ProjectSummaryCarouselView: UICollectionViewDelegateFlowLayout {
+  func collectionView(
+    _: UICollectionView,
+    layout _: UICollectionViewLayout,
+    sizeForItemAt _: IndexPath
+  ) -> CGSize {
+    return CGSize(
+      width: UIScreen.main.bounds.width / 2,
+      height: self.dataSource.greatestCombinedTextHeight
+    )
   }
 }

--- a/Kickstarter-iOS/Views/ProjectSummaryCarouselView.swift
+++ b/Kickstarter-iOS/Views/ProjectSummaryCarouselView.swift
@@ -1,0 +1,16 @@
+import Foundation
+import UIKit
+
+final class ProjectSummaryCarouselView: UIView {
+  override init(frame: CGRect) {
+    super.init(frame: frame)
+
+    self.backgroundColor = .red
+
+    self.heightAnchor.constraint(equalToConstant: 50).isActive = true
+  }
+
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+}

--- a/Kickstarter-iOS/Views/ProjectSummaryCarouselView.swift
+++ b/Kickstarter-iOS/Views/ProjectSummaryCarouselView.swift
@@ -30,8 +30,6 @@ final class ProjectSummaryCarouselView: UIView {
   override init(frame: CGRect) {
     super.init(frame: frame)
 
-    self.dataSource.load([1, 2, 3])
-
     self.configureViews()
     self.setupConstraints()
     self.bindViewModel()

--- a/Kickstarter-iOS/Views/ProjectSummaryCarouselView.swift
+++ b/Kickstarter-iOS/Views/ProjectSummaryCarouselView.swift
@@ -14,6 +14,8 @@ final class ProjectSummaryCarouselView: UIView {
       |> \.showsHorizontalScrollIndicator .~ false
   }()
 
+  private var collectionViewHeightConstraint: NSLayoutConstraint?
+
   private let dataSource = ProjectSummaryCarouselDataSource()
 
   private let layout: UICollectionViewFlowLayout = {
@@ -41,7 +43,9 @@ final class ProjectSummaryCarouselView: UIView {
 
   // MARK: - Accessors
 
-  func configure(with _: [ProjectSummaryItem]) {}
+  func configure(with items: [ProjectSummaryItem]) {
+    self.viewModel.inputs.configure(with: items)
+  }
 
   // MARK: - Configuration
 
@@ -58,10 +62,9 @@ final class ProjectSummaryCarouselView: UIView {
     _ = (self.collectionView, self)
       |> ksr_constrainViewToEdgesInParent()
 
-    self.collectionView.heightAnchor.constraint(
-      equalToConstant: self.dataSource.greatestCombinedTextHeight
-    )
-    .isActive = true
+    self.collectionViewHeightConstraint = self.collectionView.heightAnchor.constraint(equalToConstant: 0)
+    self.collectionViewHeightConstraint?.priority = .defaultLow
+    self.collectionViewHeightConstraint?.isActive = true
   }
 
   // MARK: - View model
@@ -72,7 +75,11 @@ final class ProjectSummaryCarouselView: UIView {
     self.viewModel.outputs.loadProjectSummaryItemsIntoDataSource
       .observeForUI()
       .observeValues { [weak self] items in
-        self?.dataSource.load(items)
+        guard let self = self else { return }
+
+        self.dataSource.load(items)
+        self.collectionView.reloadData()
+        self.collectionViewHeightConstraint?.constant = self.dataSource.greatestCombinedTextHeight
       }
   }
 

--- a/Kickstarter-iOS/Views/ProjectSummaryCarouselView.swift
+++ b/Kickstarter-iOS/Views/ProjectSummaryCarouselView.swift
@@ -52,10 +52,7 @@ final class ProjectSummaryCarouselView: UIView {
   private func configureViews() {
     self.addSubview(self.collectionView)
 
-    self.collectionView.register(
-      ProjectSummaryCarouselCell.self,
-      forCellWithReuseIdentifier: ProjectSummaryCarouselCell.defaultReusableId
-    )
+    self.collectionView.register(ProjectSummaryCarouselCell.self)
   }
 
   private func setupConstraints() {
@@ -63,8 +60,8 @@ final class ProjectSummaryCarouselView: UIView {
       |> ksr_constrainViewToEdgesInParent()
 
     self.collectionViewHeightConstraint = self.collectionView.heightAnchor.constraint(equalToConstant: 0)
-    self.collectionViewHeightConstraint?.priority = .defaultLow
-    self.collectionViewHeightConstraint?.isActive = true
+      |> \.priority .~ .defaultLow
+      |> \.isActive .~ true
   }
 
   // MARK: - View model

--- a/Kickstarter-iOS/Views/Storyboards/ProjectPamphlet.storyboard
+++ b/Kickstarter-iOS/Views/Storyboards/ProjectPamphlet.storyboard
@@ -481,7 +481,7 @@
                                         <constraint firstItem="IK9-ug-5QA" firstAttribute="leading" secondItem="9h4-fT-eHX" secondAttribute="leading" id="fK0-jK-FWw"/>
                                         <constraint firstItem="QP9-3e-ZCa" firstAttribute="bottom" secondItem="IK9-ug-5QA" secondAttribute="bottom" id="gZL-ti-X7r"/>
                                         <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="IK9-ug-5QA" secondAttribute="bottom" id="i6z-G2-rVD"/>
-                                        <constraint firstItem="wDa-3z-Se6" firstAttribute="leading" secondItem="1IS-yr-alv" secondAttribute="leadingMargin" id="zYn-30-syQ"/>
+                                        <constraint firstItem="wDa-3z-Se6" firstAttribute="leading" secondItem="9h4-fT-eHX" secondAttribute="leading" id="zYn-30-syQ"/>
                                         <constraint firstItem="IK9-ug-5QA" firstAttribute="top" secondItem="9h4-fT-eHX" secondAttribute="top" id="zoK-u5-hc2"/>
                                     </constraints>
                                 </tableViewCellContentView>
@@ -520,6 +520,7 @@
                                     <outlet property="stateLabel" destination="b0m-Ky-7kD" id="rf0-6I-cY1"/>
                                     <outlet property="statsStackView" destination="N0V-lF-GzK" id="rPf-34-EZf"/>
                                     <outlet property="youreABackerContainerView" destination="wDa-3z-Se6" id="spi-eC-ggZ"/>
+                                    <outlet property="youreABackerContainerViewLeadingConstraint" destination="zYn-30-syQ" id="2sV-tm-yCD"/>
                                     <outlet property="youreABackerLabel" destination="fwt-iA-zud" id="yBZ-uc-2Yd"/>
                                 </connections>
                             </tableViewCell>

--- a/Kickstarter-iOS/Views/Storyboards/ProjectPamphlet.storyboard
+++ b/Kickstarter-iOS/Views/Storyboards/ProjectPamphlet.storyboard
@@ -220,7 +220,7 @@
                                                     <rect key="frame" x="0.0" y="0.0" width="400" height="225"/>
                                                     <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <constraints>
-                                                        <constraint firstAttribute="height" secondItem="75t-f6-UeR" secondAttribute="width" multiplier="9:16" id="9KJ-w0-mkb"/>
+                                                        <constraint firstAttribute="height" secondItem="75t-f6-UeR" secondAttribute="width" multiplier="9:16" priority="750" id="9KJ-w0-mkb"/>
                                                     </constraints>
                                                 </view>
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="L33-xl-Z3r">
@@ -261,18 +261,28 @@
                                                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="18" translatesAutoresizingMaskIntoConstraints="NO" id="kjm-6n-fSC">
                                                                     <rect key="frame" x="0.0" y="70.5" width="400" height="304.5"/>
                                                                     <subviews>
-                                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" " textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="CwG-l3-j3Y">
+                                                                        <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="CTM-I8-Acx">
                                                                             <rect key="frame" x="0.0" y="0.0" width="400" height="20.5"/>
-                                                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                                            <nil key="highlightedColor"/>
-                                                                        </label>
-                                                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wJh-2e-un6" customClass="LoadingButton" customModule="Kickstarter_Framework" customModuleProvider="target">
+                                                                            <subviews>
+                                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" " textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="CwG-l3-j3Y">
+                                                                                    <rect key="frame" x="0.0" y="0.0" width="400" height="20.5"/>
+                                                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                                                    <nil key="highlightedColor"/>
+                                                                                </label>
+                                                                            </subviews>
+                                                                        </stackView>
+                                                                        <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="AcD-ZN-ip9">
                                                                             <rect key="frame" x="0.0" y="38.5" width="400" height="34"/>
-                                                                            <state key="normal">
-                                                                                <color key="titleColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                                            </state>
-                                                                        </button>
+                                                                            <subviews>
+                                                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wJh-2e-un6" customClass="LoadingButton" customModule="Kickstarter_Framework" customModuleProvider="target">
+                                                                                    <rect key="frame" x="0.0" y="0.0" width="400" height="34"/>
+                                                                                    <state key="normal">
+                                                                                        <color key="titleColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                                                    </state>
+                                                                                </button>
+                                                                            </subviews>
+                                                                        </stackView>
                                                                         <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="Fhy-mo-ew5">
                                                                             <rect key="frame" x="0.0" y="90.5" width="400" height="15"/>
                                                                             <subviews>
@@ -479,6 +489,7 @@
                                     <outlet property="backersSubtitleLabel" destination="URk-7h-lZh" id="Kcd-wc-vg2"/>
                                     <outlet property="backersTitleLabel" destination="bQ7-oG-PQC" id="bBr-7v-iZa"/>
                                     <outlet property="blurbAndReadMoreStackView" destination="kjm-6n-fSC" id="k6y-KB-o97"/>
+                                    <outlet property="blurbStackView" destination="CTM-I8-Acx" id="NQd-GX-jY7"/>
                                     <outlet property="categoryAndLocationStackView" destination="Fhy-mo-ew5" id="hu6-lQ-PLY"/>
                                     <outlet property="categoryIconImageView" destination="7a8-pp-g9p" id="nAc-fG-Bwi"/>
                                     <outlet property="categoryNameLabel" destination="S5r-Co-VIi" id="NfU-3k-PDf"/>
@@ -504,6 +515,7 @@
                                     <outlet property="projectNameAndCreatorStackView" destination="pdi-6q-B1m" id="AHs-By-hzg"/>
                                     <outlet property="projectNameLabel" destination="xNB-te-3Jz" id="F6w-6p-hW1"/>
                                     <outlet property="readMoreButton" destination="wJh-2e-un6" id="9sF-rI-Jw6"/>
+                                    <outlet property="readMoreStackView" destination="AcD-ZN-ip9" id="RbW-l0-qZC"/>
                                     <outlet property="spacerView" destination="ksD-Dw-vWm" id="MJU-Do-faC"/>
                                     <outlet property="stateLabel" destination="b0m-Ky-7kD" id="rf0-6I-cY1"/>
                                     <outlet property="statsStackView" destination="N0V-lF-GzK" id="rPf-34-EZf"/>

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -373,6 +373,7 @@
 		8A8099F522E2143000373E66 /* RewardCardContainerViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A8099EE22E2142C00373E66 /* RewardCardContainerViewModelTests.swift */; };
 		8A8099F622E2143400373E66 /* RewardCardViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A8099EF22E2142C00373E66 /* RewardCardViewModelTests.swift */; };
 		8A8099F822E2156E00373E66 /* RewardPledgeNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A8099F722E2156E00373E66 /* RewardPledgeNavigationController.swift */; };
+		8A8F5CD12433E47F00007DB4 /* ProjectSummaryCarouselViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A8F5CD02433E47F00007DB4 /* ProjectSummaryCarouselViewModelTests.swift */; };
 		8AA117F323A414BF00F7E339 /* Qualtrics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8AD7953123A286D800998C79 /* Qualtrics.framework */; };
 		8AA117F523A4160800F7E339 /* MockQualtricsResultType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AA117F423A4160800F7E339 /* MockQualtricsResultType.swift */; };
 		8AA4E6B22405B2560095D516 /* ProjectCreatorDetailsEnvelope.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AA4E6B12405B2560095D516 /* ProjectCreatorDetailsEnvelope.swift */; };
@@ -1790,6 +1791,7 @@
 		8A8099EF22E2142C00373E66 /* RewardCardViewModelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RewardCardViewModelTests.swift; sourceTree = "<group>"; };
 		8A8099F022E2142C00373E66 /* RewardCardContainerViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RewardCardContainerViewModel.swift; sourceTree = "<group>"; };
 		8A8099F722E2156E00373E66 /* RewardPledgeNavigationController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RewardPledgeNavigationController.swift; sourceTree = "<group>"; };
+		8A8F5CD02433E47F00007DB4 /* ProjectSummaryCarouselViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectSummaryCarouselViewModelTests.swift; sourceTree = "<group>"; };
 		8AA117F423A4160800F7E339 /* MockQualtricsResultType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockQualtricsResultType.swift; sourceTree = "<group>"; };
 		8AA4E6B12405B2560095D516 /* ProjectCreatorDetailsEnvelope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectCreatorDetailsEnvelope.swift; sourceTree = "<group>"; };
 		8AA4E6B32405B6280095D516 /* ProjectCreatorDetailsEnvelopeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectCreatorDetailsEnvelopeTests.swift; sourceTree = "<group>"; };
@@ -3822,6 +3824,7 @@
 				A7B1EBB01D901DE800BEE8B3 /* ProjectPamphletViewModel.swift */,
 				A7ED1F541E831C5C00BFFA01 /* ProjectPamphletViewModelTests.swift */,
 				8AB0E0132432D03A008E975E /* ProjectSummaryCarouselViewModel.swift */,
+				8A8F5CD02433E47F00007DB4 /* ProjectSummaryCarouselViewModelTests.swift */,
 				59392C1D1D7095B3001C99A4 /* ProjectUpdatesViewModel.swift */,
 				A7ED1FA11E831C5C00BFFA01 /* ProjectUpdatesViewModelTests.swift */,
 				A7F441A81D005A9400FE6FC5 /* ResetPasswordViewModel.swift */,
@@ -5111,6 +5114,7 @@
 				A7ED20031E831C5C00BFFA01 /* TwoFactorViewModelTests.swift in Sources */,
 				D09362B0225D803600E1411A /* UIViewController+URLTests.swift in Sources */,
 				A7ED1FDF1E831C5C00BFFA01 /* DiscoveryFiltersViewModelTests.swift in Sources */,
+				8A8F5CD12433E47F00007DB4 /* ProjectSummaryCarouselViewModelTests.swift in Sources */,
 				A7ED1FDC1E831C5C00BFFA01 /* DashboardVideoCellViewModelTests.swift in Sources */,
 				3706409022A9BE9400889CBD /* DateFormatterTests.swift in Sources */,
 				778F891E22D5414F00D095C5 /* Feature+HelpersTests.swift in Sources */,

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -389,6 +389,10 @@
 		8AA5B06B235E25820022F5F0 /* AppCenterAnalytics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8AA5B067235E25820022F5F0 /* AppCenterAnalytics.framework */; };
 		8AAA9BD822F49EC200F12976 /* UIColor+Mixing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AAA9BD722F49EC200F12976 /* UIColor+Mixing.swift */; };
 		8AB0E00C24314967008E975E /* ProjectSummaryCarouselView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB0E00B24314967008E975E /* ProjectSummaryCarouselView.swift */; };
+		8AB0E00E2432B396008E975E /* ProjectSummaryCarouselDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB0E00D2432B396008E975E /* ProjectSummaryCarouselDataSource.swift */; };
+		8AB0E0102432B3B5008E975E /* ProjectSummaryCarouselDataSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB0E00F2432B3B5008E975E /* ProjectSummaryCarouselDataSourceTests.swift */; };
+		8AB0E0122432B4C9008E975E /* ProjectSummaryCarouselCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB0E0112432B4C9008E975E /* ProjectSummaryCarouselCell.swift */; };
+		8AB0E0142432D03A008E975E /* ProjectSummaryCarouselViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB0E0132432D03A008E975E /* ProjectSummaryCarouselViewModel.swift */; };
 		8AB55D5023C3FAA6002F5E64 /* Qualtrics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8AD7953123A286D800998C79 /* Qualtrics.framework */; };
 		8ACF558723E8D444001654A2 /* Argo+ToPrimitive.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ACF558623E8D444001654A2 /* Argo+ToPrimitive.swift */; };
 		8ACF558923E8D467001654A2 /* TryDecodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ACF558823E8D467001654A2 /* TryDecodable.swift */; };
@@ -1801,6 +1805,10 @@
 		8AA5B067235E25820022F5F0 /* AppCenterAnalytics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppCenterAnalytics.framework; path = Carthage/Build/iOS/AppCenterAnalytics.framework; sourceTree = "<group>"; };
 		8AAA9BD722F49EC200F12976 /* UIColor+Mixing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+Mixing.swift"; sourceTree = "<group>"; };
 		8AB0E00B24314967008E975E /* ProjectSummaryCarouselView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectSummaryCarouselView.swift; sourceTree = "<group>"; };
+		8AB0E00D2432B396008E975E /* ProjectSummaryCarouselDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectSummaryCarouselDataSource.swift; sourceTree = "<group>"; };
+		8AB0E00F2432B3B5008E975E /* ProjectSummaryCarouselDataSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectSummaryCarouselDataSourceTests.swift; sourceTree = "<group>"; };
+		8AB0E0112432B4C9008E975E /* ProjectSummaryCarouselCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectSummaryCarouselCell.swift; sourceTree = "<group>"; };
+		8AB0E0132432D03A008E975E /* ProjectSummaryCarouselViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectSummaryCarouselViewModel.swift; sourceTree = "<group>"; };
 		8ACF558623E8D444001654A2 /* Argo+ToPrimitive.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Argo+ToPrimitive.swift"; sourceTree = "<group>"; };
 		8ACF558823E8D467001654A2 /* TryDecodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TryDecodable.swift; sourceTree = "<group>"; };
 		8ACF558E23EA08DB001654A2 /* TryDecodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TryDecodableTests.swift; sourceTree = "<group>"; };
@@ -3049,9 +3057,11 @@
 				9D9F57D11D131AF200CE81DE /* ProjectActivityUpdateCell.swift */,
 				A75A29291CE0B7EA00D35E5C /* ProjectBannerCell.swift */,
 				597073B01D07281800B00444 /* ProjectNotificationCell.swift */,
+				D668509E236B38E000EE9AC2 /* ProjectPamphletCreatorHeaderCell.swift */,
 				A7CA8BB61D8F14260086A3E9 /* ProjectPamphletMainCell.swift */,
 				A71199F81DD8E42A0072D478 /* ProjectPamphletMinimalCell.swift */,
 				A79F52FF1D8F50CE00C051B8 /* ProjectPamphletSubpageCell.swift */,
+				8AB0E0112432B4C9008E975E /* ProjectSummaryCarouselCell.swift */,
 				77EFBAE42268E01400DA5C3C /* RewardCell.swift */,
 				D7A37C8E1E2EB01700EA066D /* SearchEmptyStateCell.swift */,
 				D0971E15221E083100DFEF9B /* SelectCurrencyCell.swift */,
@@ -3070,7 +3080,6 @@
 				3780C8602208F8C1002117D1 /* SettingsTextInputCell.swift */,
 				3767EDAA22CFFED40088E8E4 /* ShippingRuleCell.swift */,
 				014A8E1A1CE3CE34003BF51C /* ThanksCategoryCell.swift */,
-				D668509E236B38E000EE9AC2 /* ProjectPamphletCreatorHeaderCell.swift */,
 			);
 			path = Cells;
 			sourceTree = "<group>";
@@ -3543,6 +3552,8 @@
 				5970739E1D07277100B00444 /* ProjectNotificationsDataSource.swift */,
 				A747A8B81D45893100AF199A /* ProjectPamphletContentDataSource.swift */,
 				A7ED20101E83229E00BFFA01 /* ProjectPamphletContentDataSourceTests.swift */,
+				8AB0E00D2432B396008E975E /* ProjectSummaryCarouselDataSource.swift */,
+				8AB0E00F2432B3B5008E975E /* ProjectSummaryCarouselDataSourceTests.swift */,
 				77EFBAE62268E37200DA5C3C /* RewardsCollectionViewDataSource.swift */,
 				77EFBAE82268E3D200DA5C3C /* RewardsCollectionViewDataSourceTests.swift */,
 				A75CFA4E1CCDB322004CD5FA /* SearchDataSource.swift */,
@@ -3810,6 +3821,7 @@
 				A7ED1FA01E831C5C00BFFA01 /* ProjectPamphletSubpageCellViewModelTests.swift */,
 				A7B1EBB01D901DE800BEE8B3 /* ProjectPamphletViewModel.swift */,
 				A7ED1F541E831C5C00BFFA01 /* ProjectPamphletViewModelTests.swift */,
+				8AB0E0132432D03A008E975E /* ProjectSummaryCarouselViewModel.swift */,
 				59392C1D1D7095B3001C99A4 /* ProjectUpdatesViewModel.swift */,
 				A7ED1FA11E831C5C00BFFA01 /* ProjectUpdatesViewModelTests.swift */,
 				A7F441A81D005A9400FE6FC5 /* ResetPasswordViewModel.swift */,
@@ -4826,6 +4838,7 @@
 				A7F441E11D005A9400FE6FC5 /* ResetPasswordViewModel.swift in Sources */,
 				774D98D423A94EDB00FC81C2 /* OptimizelyExperiment.swift in Sources */,
 				A734A2671D21A1790080BBD5 /* WKNavigationActionData.swift in Sources */,
+				8AB0E0142432D03A008E975E /* ProjectSummaryCarouselViewModel.swift in Sources */,
 				A7C93FB61D44142900C2DF9B /* ProjectDescriptionViewModel.swift in Sources */,
 				8AFB8C97233E9977006779B5 /* CreatePaymentSourceInput+Constructor.swift in Sources */,
 				9D8772131D19E84E003A4E96 /* ProjectActivityLaunchCellViewModel.swift in Sources */,
@@ -5337,6 +5350,7 @@
 				A7CC14361D00E73D00035C52 /* FindFriendsViewController.swift in Sources */,
 				3708DD43220A5A5700F8E569 /* SettingsGroupedFooterView.swift in Sources */,
 				A7CA8BB71D8F14260086A3E9 /* ProjectPamphletMainCell.swift in Sources */,
+				8AB0E0122432B4C9008E975E /* ProjectSummaryCarouselCell.swift in Sources */,
 				593AC5CF1D33F4BF002613F4 /* DashboardFundingCell.swift in Sources */,
 				A71003E31CDD077200B4F4D7 /* MessageCell.swift in Sources */,
 				01B3B0301E78890800B8BF46 /* BackerDashboardPagesDataSource.swift in Sources */,
@@ -5424,6 +5438,7 @@
 				770DF32A2106210900A6D0F1 /* SettingsNotificationsDataSource.swift in Sources */,
 				018F1F841C8E182200643DAA /* LoginViewController.swift in Sources */,
 				77752F5E219B39EA00E7DA7D /* SettingsAccountWarningCell.swift in Sources */,
+				8AB0E00E2432B396008E975E /* ProjectSummaryCarouselDataSource.swift in Sources */,
 				3780C8622208F8C8002117D1 /* SettingsTextInputCell.swift in Sources */,
 				597073A01D07277100B00444 /* ProjectNotificationsDataSource.swift in Sources */,
 				A757E9EF1D19C37F00A5C978 /* ActivitySurveyResponseCell.swift in Sources */,
@@ -5509,6 +5524,7 @@
 				A7ED20441E8323E900BFFA01 /* ResetPasswordViewControllerTests.swift in Sources */,
 				A7ED20491E8323E900BFFA01 /* DiscoveryPageViewControllerTests.swift in Sources */,
 				A7ED20151E83229E00BFFA01 /* DiscoveryFiltersDataSourceTests.swift in Sources */,
+				8AB0E0102432B3B5008E975E /* ProjectSummaryCarouselDataSourceTests.swift in Sources */,
 				77A3C53D219CCF1300824FC1 /* SettingsAccountDataSourceTests.swift in Sources */,
 				8A61E1E423D1202000CA9603 /* MockQualtricsPropertiesType.swift in Sources */,
 				D60CAB922208A1B60083FA40 /* SelectCurrencyViewControllerTests.swift in Sources */,

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -388,6 +388,7 @@
 		8AA5B06A235E25820022F5F0 /* AppCenterCrashes.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8AA5B066235E25820022F5F0 /* AppCenterCrashes.framework */; };
 		8AA5B06B235E25820022F5F0 /* AppCenterAnalytics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8AA5B067235E25820022F5F0 /* AppCenterAnalytics.framework */; };
 		8AAA9BD822F49EC200F12976 /* UIColor+Mixing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AAA9BD722F49EC200F12976 /* UIColor+Mixing.swift */; };
+		8AB0E00C24314967008E975E /* ProjectSummaryCarouselView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB0E00B24314967008E975E /* ProjectSummaryCarouselView.swift */; };
 		8AB55D5023C3FAA6002F5E64 /* Qualtrics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8AD7953123A286D800998C79 /* Qualtrics.framework */; };
 		8ACF558723E8D444001654A2 /* Argo+ToPrimitive.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ACF558623E8D444001654A2 /* Argo+ToPrimitive.swift */; };
 		8ACF558923E8D467001654A2 /* TryDecodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ACF558823E8D467001654A2 /* TryDecodable.swift */; };
@@ -1799,6 +1800,7 @@
 		8AA5B066235E25820022F5F0 /* AppCenterCrashes.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppCenterCrashes.framework; path = Carthage/Build/iOS/AppCenterCrashes.framework; sourceTree = "<group>"; };
 		8AA5B067235E25820022F5F0 /* AppCenterAnalytics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppCenterAnalytics.framework; path = Carthage/Build/iOS/AppCenterAnalytics.framework; sourceTree = "<group>"; };
 		8AAA9BD722F49EC200F12976 /* UIColor+Mixing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+Mixing.swift"; sourceTree = "<group>"; };
+		8AB0E00B24314967008E975E /* ProjectSummaryCarouselView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectSummaryCarouselView.swift; sourceTree = "<group>"; };
 		8ACF558623E8D444001654A2 /* Argo+ToPrimitive.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Argo+ToPrimitive.swift"; sourceTree = "<group>"; };
 		8ACF558823E8D467001654A2 /* TryDecodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TryDecodable.swift; sourceTree = "<group>"; };
 		8ACF558E23EA08DB001654A2 /* TryDecodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TryDecodableTests.swift; sourceTree = "<group>"; };
@@ -2957,6 +2959,7 @@
 				7758A83120979BE50018B96D /* DiscoveryProjectCategoryView.swift */,
 				595CDAB71D3537180051C816 /* FundingGraphView.swift */,
 				A7ED205B1E83240D00BFFA01 /* FundingGraphViewTests.swift */,
+				D6050F51240463AC00E029D2 /* LandingPageStatsView.swift */,
 				77FD8B45216D6245000A95AC /* LoadingBarButtonItemView.swift */,
 				370C8B63234FCC6F00DE75DD /* LoadingButton.swift */,
 				77BF99B622652C9500513CE3 /* MultiLineButton.swift */,
@@ -2965,6 +2968,7 @@
 				D741577A2284849000C0B907 /* PledgeCTAContainerView.swift */,
 				374F507822614A1000DE6746 /* PledgeFooterView.swift */,
 				015706BA1E68DE580087DD68 /* ProfileSortBarView.swift */,
+				8AB0E00B24314967008E975E /* ProjectSummaryCarouselView.swift */,
 				A78012641D2EEA620027396E /* ReferralChartView.swift */,
 				8A8099EA22E213F100373E66 /* RewardCardContainerView.swift */,
 				8A23EF0722F11470001262E1 /* RewardCardContainerViewTests.swift */,
@@ -2983,7 +2987,6 @@
 				8A14E09523971BD000387824 /* ShimmerLoadingViews */,
 				A73923AA1D272242004524C3 /* Storyboards */,
 				A7D8B67F1DCCD4B9009BF854 /* Transitions */,
-				D6050F51240463AC00E029D2 /* LandingPageStatsView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -5452,6 +5455,7 @@
 				770187C022FDCFCA0019129D /* PledgeViewControllerMessageDisplaying.swift in Sources */,
 				D60C8BF12143167200D96152 /* SettingsAccountViewController.swift in Sources */,
 				8A8099EC22E213F100373E66 /* RewardCardContainerView.swift in Sources */,
+				8AB0E00C24314967008E975E /* ProjectSummaryCarouselView.swift in Sources */,
 				014D62991E6E22920033D2BD /* BackerDashboardEmptyStateCell.swift in Sources */,
 				D7237099211A3DA9001EA4CA /* SettingsFollowCell.swift in Sources */,
 				A7CC143E1D00E74F00035C52 /* FindFriendsFriendFollowCell.swift in Sources */,

--- a/Library/ViewModels/ProjectSummaryCarouselViewModel.swift
+++ b/Library/ViewModels/ProjectSummaryCarouselViewModel.swift
@@ -1,0 +1,36 @@
+import Foundation
+import KsApi
+import Prelude
+import ReactiveSwift
+
+public typealias ProjectSummaryItem = Int
+
+public protocol ProjectSummaryCarouselViewModelInputs {
+  func configure(with items: [ProjectSummaryItem])
+}
+
+public protocol ProjectSummaryCarouselViewModelOutputs {
+  var loadProjectSummaryItemsIntoDataSource: Signal<[ProjectSummaryItem], Never> { get }
+}
+
+public protocol ProjectSummaryCarouselViewModelType {
+  var inputs: ProjectSummaryCarouselViewModelInputs { get }
+  var outputs: ProjectSummaryCarouselViewModelOutputs { get }
+}
+
+public final class ProjectSummaryCarouselViewModel: ProjectSummaryCarouselViewModelType,
+  ProjectSummaryCarouselViewModelInputs, ProjectSummaryCarouselViewModelOutputs {
+  public init() {
+    self.loadProjectSummaryItemsIntoDataSource = self.itemsProperty.signal.skipNil()
+  }
+
+  private let itemsProperty = MutableProperty<[ProjectSummaryItem]?>(nil)
+  public func configure(with items: [ProjectSummaryItem]) {
+    self.itemsProperty.value = items
+  }
+
+  public let loadProjectSummaryItemsIntoDataSource: Signal<[ProjectSummaryItem], Never>
+
+  public var inputs: ProjectSummaryCarouselViewModelInputs { return self }
+  public var outputs: ProjectSummaryCarouselViewModelOutputs { return self }
+}

--- a/Library/ViewModels/ProjectSummaryCarouselViewModelTests.swift
+++ b/Library/ViewModels/ProjectSummaryCarouselViewModelTests.swift
@@ -1,0 +1,27 @@
+import Foundation
+import Library
+import ReactiveExtensions
+import ReactiveExtensions_TestHelpers
+
+final class ProjectSummaryCarouselViewModelViewModelTests: TestCase {
+  private let vm: ProjectSummaryCarouselViewModelType = ProjectSummaryCarouselViewModel()
+
+  private let loadProjectSummaryItemsIntoDataSource = TestObserver<[ProjectSummaryItem], Never>()
+
+  override func setUp() {
+    super.setUp()
+
+    self.vm.outputs.loadProjectSummaryItemsIntoDataSource
+      .observe(self.loadProjectSummaryItemsIntoDataSource.observer)
+  }
+
+  func testLoadProjectSummaryItemsIntoDataSource() {
+    self.loadProjectSummaryItemsIntoDataSource.assertDidNotEmitValue()
+
+    let items: [ProjectSummaryItem] = [1, 2, 3]
+
+    self.vm.inputs.configure(with: items)
+
+    self.loadProjectSummaryItemsIntoDataSource.assertValues([items])
+  }
+}


### PR DESCRIPTION
# 📲 What

Adds the UI and basic data source for the Project Summary Carousel experiment.

**Note:** Subsequent PRs will retrieve the items from GraphQL, add detail to the cells and also perform the max height calculations.

# 🤔 Why

We are planning to run an experiment to display horizontally scrollable project summary cells on the project page.

# 🛠 How

- Added a collection view to the `ProjectPamphletMainCell`.
- Restructured the view to allow this collection view to scroll edge-to-edge.
- Added a basic data source which will be updated when we are retrieving the summary items from GraphQL.

# 👀 See

<img src="https://user-images.githubusercontent.com/3735375/78073516-e6cf9680-7355-11ea-9bb6-9ba6a2def9fe.gif" width="50%" />


# ✅ Acceptance criteria

Uncomment lines 111-112 in `ProjectPamphletMainCell` to populate the datasource and display empty cells.

- [ ] Navigate to any project, you should see the empty cells below the project blurb.
- [ ] You should not observe any other UI regression on the project page.