### PR TITLE
[NT-1032] Watch Project Button Clicked Event

### DIFF
--- a/Kickstarter-iOS/DataSources/DiscoveryProjectsDataSource.swift
+++ b/Kickstarter-iOS/DataSources/DiscoveryProjectsDataSource.swift
@@ -5,6 +5,7 @@ import UIKit
 struct DiscoveryProjectCellRowValue {
   let project: Project
   let category: KsApi.Category?
+  let discoveryParams: DiscoveryParams?
 }
 
 internal final class DiscoveryProjectsDataSource: ValueCellDataSource {
@@ -36,7 +37,11 @@ internal final class DiscoveryProjectsDataSource: ValueCellDataSource {
     self.clearValues(section: Section.projects.rawValue)
 
     projects.forEach { project in
-      let value = DiscoveryProjectCellRowValue(project: project, category: params?.category)
+      let value = DiscoveryProjectCellRowValue(
+        project: project,
+        category: params?.category,
+        discoveryParams: params
+      )
 
       _ = self.appendRow(
         value: value,

--- a/Kickstarter-iOS/DataSources/ThanksProjectsDataSource.swift
+++ b/Kickstarter-iOS/DataSources/ThanksProjectsDataSource.swift
@@ -5,7 +5,7 @@ import UIKit
 internal final class ThanksProjectsDataSource: ValueCellDataSource {
   internal func loadData(projects: [Project], category: KsApi.Category) {
     let values = projects.map { (project) -> DiscoveryProjectCellRowValue in
-      DiscoveryProjectCellRowValue(project: project, category: category)
+      DiscoveryProjectCellRowValue(project: project, category: category, discoveryParams: nil)
     }
 
     self.set(values: values, cellClass: DiscoveryPostcardCell.self, inSection: 0)

--- a/Kickstarter-iOS/Views/Cells/DiscoveryPostcardCell.swift
+++ b/Kickstarter-iOS/Views/Cells/DiscoveryPostcardCell.swift
@@ -333,7 +333,11 @@ internal final class DiscoveryPostcardCell: UITableViewCell, ValueCell {
 
   internal func configureWith(value: DiscoveryProjectCellRowValue) {
     self.viewModel.inputs.configureWith(project: value.project, category: value.category)
-    self.watchProjectViewModel.inputs.configure(with: value.project)
+    self.watchProjectViewModel.inputs.configure(with: (
+      value.project,
+      Koala.LocationContext.discovery,
+      value.discoveryParams
+    ))
   }
 
   internal override func layoutSubviews() {

--- a/Kickstarter-iOS/Views/Controllers/ProjectNavBarViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/ProjectNavBarViewController.swift
@@ -25,7 +25,7 @@ public final class ProjectNavBarViewController: UIViewController {
   internal func configureWith(project: Project, refTag: RefTag?) {
     self.viewModel.inputs.configureWith(project: project, refTag: refTag)
     self.shareViewModel.inputs.configureWith(shareContext: .project(project), shareContextView: nil)
-    self.watchProjectViewModel.inputs.configure(with: project)
+    self.watchProjectViewModel.inputs.configure(with: (project, Koala.LocationContext.projectPage, nil))
   }
 
   internal func setDidScrollToTop(_ didScrollToTop: Bool) {

--- a/Library/Tracking/Koala.swift
+++ b/Library/Tracking/Koala.swift
@@ -47,6 +47,7 @@ public final class Koala {
     case tabBarClicked = "Tab Bar Clicked"
     case thanksPageViewed = "Thanks Page Viewed"
     case twoFactorConfirmationViewed = "Two-Factor Confirmation Viewed"
+    case watchProjectButtonClicked = "Watch Project Button Clicked"
 
     static func allWhiteListedEvents() -> [String] {
       return DataLakeWhiteListedEvent.allCases.map { $0.rawValue }
@@ -197,29 +198,6 @@ public final class Koala {
       case .swipe: return "swipe"
       case .tap: return "tap"
       }
-    }
-  }
-
-  /// Determines which swipe was used.
-  public enum SwipeType: String {
-    case next
-    case previous
-
-    fileprivate var trackingString: String {
-      switch self {
-      case .next: return "next"
-      case .previous: return "previous"
-      }
-    }
-  }
-
-  /// Determines the place from which the project was saved.
-  public enum SaveContext: String {
-    case discovery
-    case project
-
-    fileprivate var trackingString: String {
-      return self.rawValue
     }
   }
 
@@ -1389,25 +1367,23 @@ public final class Koala {
     )
   }
 
-  public func trackProjectSave(_ project: Project, context: SaveContext) {
-    guard let isStarred = project.personalization.isStarred else { return }
+  /**
+   Call when a project is watched/saved.
+   - parameter project: The project being watched
+   - parameter location: The location context of where the project is being watched from
+   - parameter params: The optional Discover params if the project is being watched from Discover
+   */
 
-    let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
-      .withAllValuesFrom(["context": context.trackingString])
+  public func trackWatchProjectButtonClicked(project: Project, location: LocationContext, params: DiscoveryParams? = nil) {
+    var props = projectProperties(from: project, loggedInUser: self.loggedInUser)
 
-    // Deprecated event
-    self.track(
-      event: isStarred ? "Project Star" : "Project Unstar",
-      properties: props.withAllValuesFrom(deprecatedProps)
-    )
-
-    self.track(
-      event: isStarred ? "Starred Project" : "Unstarred Project",
-      properties: props.withAllValuesFrom(deprecatedProps)
-    )
+    if let discoveryParams = params {
+      props = props.withAllValuesFrom(discoveryProperties(from: discoveryParams))
+    }
 
     self.track(
-      event: isStarred ? "Saved Project" : "Unsaved Project",
+      event: DataLakeWhiteListedEvent.watchProjectButtonClicked.rawValue,
+      location: location,
       properties: props
     )
   }

--- a/Library/Tracking/Koala.swift
+++ b/Library/Tracking/Koala.swift
@@ -1374,7 +1374,9 @@ public final class Koala {
    - parameter params: The optional Discover params if the project is being watched from Discover
    */
 
-  public func trackWatchProjectButtonClicked(project: Project, location: LocationContext, params: DiscoveryParams? = nil) {
+  public func trackWatchProjectButtonClicked(project: Project,
+                                             location: LocationContext,
+                                             params: DiscoveryParams? = nil) {
     var props = projectProperties(from: project, loggedInUser: self.loggedInUser)
 
     if let discoveryParams = params {

--- a/Library/Tracking/KoalaTests.swift
+++ b/Library/Tracking/KoalaTests.swift
@@ -549,6 +549,38 @@ final class KoalaTests: TestCase {
     XCTAssertEqual("Apple", callBackProperties?["session_device_manufacturer"] as? String)
   }
 
+  func testWatchProjectButtonClicked_DiscoveryLocationContext() {
+    let client = MockTrackingClient()
+    let koala = Koala(client: client)
+
+    koala.trackWatchProjectButtonClicked(
+      project: .template,
+      location: .discovery,
+      params: DiscoveryParams.recommendedDefaults
+    )
+
+    XCTAssertEqual(["Watch Project Button Clicked"], client.events)
+    XCTAssertEqual("explore_screen", client.properties.last?["context_location"] as? String)
+
+    self.assertProjectProperties(client.properties.last)
+    self.assertDiscoveryProperties(client.properties.last)
+  }
+
+  func testWatchProjectButtonClicked_ProjectPageLocationContext() {
+    let client = MockTrackingClient()
+    let koala = Koala(client: client)
+
+    koala.trackWatchProjectButtonClicked(
+      project: .template,
+      location: .projectPage
+    )
+
+    XCTAssertEqual(["Watch Project Button Clicked"], client.events)
+    XCTAssertEqual("project_screen", client.properties.last?["context_location"] as? String)
+
+    self.assertProjectProperties(client.properties.last)
+  }
+
   func testTrackViewedAccount() {
     let client = MockTrackingClient()
     let koala = Koala(client: client)
@@ -1112,6 +1144,26 @@ final class KoalaTests: TestCase {
 
     koala.track2FAViewed()
     XCTAssertEqual("two_factor_auth_verify_screen", client.properties.last?["context_location"] as? String)
+  }
+
+  /*
+   Helper for testing discoverProperties from a template DiscoveryParams.recommendedDefaults
+   */
+
+  private func assertDiscoveryProperties(_ props: [String: Any]?) {
+    XCTAssertEqual(true, props?["discover_recommended"] as? Bool)
+    XCTAssertEqual(false, props?["discover_everything"] as? Bool)
+    XCTAssertEqual("recs_home", props?["discover_ref_tag"] as? String)
+
+    XCTAssertNil(props?["discover_pwl"] as? Bool)
+    XCTAssertNil(props?["discover_social"] as? Bool)
+    XCTAssertNil(props?["discover_watched"] as? Bool)
+    XCTAssertNil(props?["discover_subcategory_id"] as? Int)
+    XCTAssertNil(props?["discover_subcategory_name"] as? String)
+    XCTAssertNil(props?["discover_category_id"] as? Int)
+    XCTAssertNil(props?["discover_category_name"] as? String)
+    XCTAssertNil(props?["discover_sort"] as? String)
+    XCTAssertNil(props?["discover_search_term"] as? String)
   }
 
   /*

--- a/Library/ViewModels/ProjectNavigatorViewModel.swift
+++ b/Library/ViewModels/ProjectNavigatorViewModel.swift
@@ -186,10 +186,6 @@ public final class ProjectNavigatorViewModel: ProjectNavigatorViewModelType,
   public var outputs: ProjectNavigatorViewModelOutputs { return self }
 }
 
-private func swipeType(currentIndex: Int?, previousIndex: Int?) -> Koala.SwipeType {
-  return (currentIndex ?? 0) > (previousIndex ?? 0) ? .next : .previous
-}
-
 private struct ConfigData {
   fileprivate let project: Project
   fileprivate let refTag: RefTag


### PR DESCRIPTION
# 📲 What

Adds the whitelisted `Watch Project Button Clicked` event that fires when the "Watch" button is tapped either on the discover cards or in the project page.

# 🤔 Why

So we can track when users tap the "Watch" button in Amplitude.

# 🛠 How

- adds `Watch Project Button Clicked` event to the datalake whitelisted events enum
- updates the naming of the tracking function, adds project properties, optionally discovery properties, and context location
- in `WatchProjectViewModel`, the event will be queued immediately when the user taps the button (previously we would wait for the request to succeed before tracking)

# 👀 See

![image](https://user-images.githubusercontent.com/3156796/78076396-56ed1500-7374-11ea-85d3-8d8f84577c35.png)

# ✅ Acceptance criteria

Make sure you have the `KOALA_TRACKING_ENABLED` environment variable enabled while testing.

- [ ] Launch the app. Tap the "Save" icon on any discovery postcard cell. You should see in the logs a tracking event for the data lake: `Watch Project Button Clicked` with the `context_location` property set to `explore_screen`, and the event should contain project properties and discovery properties.
- [ ] Launch the app. Navigate to any project. Tap the "Save" icon on the navigation bar in the project page. You should see in the logs a tracking event for the data lake: `Watch Project Button Clicked` with the `context_location` property set to `project_screen`, and the event properties should include project properties.
