### PR TITLE
[NT-1119] Category selection screen content inset bug

### DIFF
--- a/Kickstarter-iOS/Views/Controllers/CategorySelectionViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/CategorySelectionViewController.swift
@@ -147,11 +147,22 @@ public final class CategorySelectionViewController: UIViewController {
     let topSafeAreaInset = self.view.safeAreaInsets.top
     let bottomInset = self.buttonView.frame.height - bottomSafeAreaInset
     let topInset = self.headerView.frame.height - topSafeAreaInset + Styles.grid(2) // collection view's inset
+    let prevTopInset = self.collectionView.contentInset.top
 
-    self.collectionView.contentInset.bottom = bottomInset
-    self.collectionView.contentInset.top = topInset
-    self.collectionView.scrollIndicatorInsets.bottom = bottomInset
-    self.collectionView.scrollIndicatorInsets.top = topInset
+    self.pillLayout.shouldInvalidateLayout = prevTopInset != topInset
+
+    self.collectionView.contentInset = .init(
+      top: topInset,
+      left: self.collectionView.contentInset.left,
+      bottom: bottomInset,
+      right: self.collectionView.contentInset.right
+    )
+    self.collectionView.scrollIndicatorInsets = .init(
+      top: topInset,
+      left: self.collectionView.scrollIndicatorInsets.left,
+      bottom: bottomInset,
+      right: self.collectionView.scrollIndicatorInsets.right
+    )
   }
 
   public override func bindViewModel() {

--- a/Kickstarter-iOS/Views/Controllers/LandingViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/LandingViewController.swift
@@ -151,12 +151,11 @@ public final class LandingViewController: UIViewController {
     let stackViewHeight = self.rootStackView.bounds.height
     let viewHeight = self.view.bounds.height
     let buttonHeight = self.getStartedButton.bounds.height + Styles.grid(3) // padding
+    let inset = (viewHeight / 2) - stackViewHeight
 
-    if stackViewHeight > viewHeight {
+    if stackViewHeight > viewHeight || inset < 0 {
       self.scrollView.contentInset.top = 0
     } else {
-      let inset = (viewHeight / 2) - stackViewHeight
-
       self.scrollView.contentInset.top = inset
     }
 

--- a/Kickstarter-iOS/Views/Layouts/PillLayout.swift
+++ b/Kickstarter-iOS/Views/Layouts/PillLayout.swift
@@ -2,6 +2,8 @@ import Prelude
 import UIKit
 
 class PillLayout: UICollectionViewFlowLayout {
+  var shouldInvalidateLayout: Bool = true
+
   // MARK: - Lifecycle
 
   required init(
@@ -50,5 +52,11 @@ class PillLayout: UICollectionViewFlowLayout {
     }
 
     return layoutAttributes
+  }
+
+  override func invalidateLayout() {
+    if self.shouldInvalidateLayout {
+      super.invalidateLayout()
+    }
   }
 }


### PR DESCRIPTION
# 📲 What

Fixes a bug that was causing the category selection screen to "jump" when the user selects more than 5 categories.

# 🤔 Why

Because the jumpy behavior wasn't ideal when selecting categories.

# 🛠 How

The "jumpiness" that was observed when the user selects more than 5 categories was a result of the collection view's `contentInset` being updated to accommodate for the larger height of the button container view. As it turns out, updating a collection view's `contentInset` causes `invalidateLayout` to be called on the collection view layout, which essentially re-draws the entire collection view, losing the users current content offset and causing the perceived "jump".

In order to prevent `invalidateLayout` from being called, we override `invalidateLayout` in our custom `PillLayout` class, and only allow the layout to be invalidated if it's absolutely necessary.

This PR also fixes a bug in `LandingViewController` where the top `contentInset` value was incorrect for large dynamic type sizes.

# 👀 See

![RIT023qSGp](https://user-images.githubusercontent.com/3156796/78603354-fe12f600-7825-11ea-9986-756f5e58dab6.gif)


# ✅ Acceptance criteria

- [x]  Delete any old builds on the simulator. Run the app. You should see the onboarding flow appear. Tap "Get Started". On the category selection screen, scroll down a little bit. Select a few categories. The scroll position should not change. Select > 5 categories. You should see the warning label appear below the "Continue" button. The scroll position should not change.


