### PR TITLE
[NT-867] (1/2) Sign in with apple mutation

### DIFF
--- a/Kickstarter-iOS/Alpha.entitlements
+++ b/Kickstarter-iOS/Alpha.entitlements
@@ -4,6 +4,10 @@
   <dict>
     <key>aps-environment</key>
     <string>production</string>
+    <key>com.apple.developer.applesignin</key>
+    <array>
+      <string>Default</string>
+    </array>
     <key>com.apple.developer.associated-domains</key>
     <array>
       <string>applinks:www.kickstarter.com</string>

--- a/Kickstarter-iOS/Beta.entitlements
+++ b/Kickstarter-iOS/Beta.entitlements
@@ -4,6 +4,10 @@
   <dict>
     <key>aps-environment</key>
     <string>production</string>
+    <key>com.apple.developer.applesignin</key>
+    <array>
+      <string>Default</string>
+    </array>
     <key>com.apple.developer.associated-domains</key>
     <array>
       <string>applinks:www.kickstarter.com</string>

--- a/Kickstarter-iOS/Debug.entitlements
+++ b/Kickstarter-iOS/Debug.entitlements
@@ -1,29 +1,33 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>aps-environment</key>
-    <string>development</string>
-    <key>com.apple.developer.associated-domains</key>
-    <array>
-      <string>applinks:staging.kickstarter.com</string>
-      <string>applinks:native.dev.kickstarter.com</string>
-      <string>applinks:www.kickstarter.com</string>
-      <string>applinks:click.e.kickstarter.com</string>
-      <string>applinks:click.em.kickstarter.com</string>
-      <string>applinks:email.kickstarter.com</string>
-      <string>applinks:emails.kickstarter.com</string>
-      <string>applinks:e2.kickstarter.com</string>
-      <string>applinks:e3.kickstarter.com</string>
-      <string>webcredentials:kickstarter.com</string>
-    </array>
-    <key>com.apple.developer.icloud-container-identifiers</key>
-    <array/>
-    <key>com.apple.developer.in-app-payments</key>
-    <array>
-      <string>merchant.com.kickstarter</string>
-    </array>
-    <key>com.apple.developer.ubiquity-kvstore-identifier</key>
-    <string>$(TeamIdentifierPrefix)$(CFBundleIdentifier)</string>
-  </dict>
+<dict>
+	<key>aps-environment</key>
+	<string>development</string>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:staging.kickstarter.com</string>
+		<string>applinks:native.dev.kickstarter.com</string>
+		<string>applinks:www.kickstarter.com</string>
+		<string>applinks:click.e.kickstarter.com</string>
+		<string>applinks:click.em.kickstarter.com</string>
+		<string>applinks:email.kickstarter.com</string>
+		<string>applinks:emails.kickstarter.com</string>
+		<string>applinks:e2.kickstarter.com</string>
+		<string>applinks:e3.kickstarter.com</string>
+		<string>webcredentials:kickstarter.com</string>
+	</array>
+	<key>com.apple.developer.icloud-container-identifiers</key>
+	<array/>
+	<key>com.apple.developer.in-app-payments</key>
+	<array>
+		<string>merchant.com.kickstarter</string>
+	</array>
+	<key>com.apple.developer.ubiquity-kvstore-identifier</key>
+	<string>$(TeamIdentifierPrefix)$(CFBundleIdentifier)</string>
+</dict>
 </plist>

--- a/Kickstarter-iOS/Debug.entitlements
+++ b/Kickstarter-iOS/Debug.entitlements
@@ -1,33 +1,33 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
-	<key>aps-environment</key>
-	<string>development</string>
-	<key>com.apple.developer.applesignin</key>
-	<array>
-		<string>Default</string>
-	</array>
-	<key>com.apple.developer.associated-domains</key>
-	<array>
-		<string>applinks:staging.kickstarter.com</string>
-		<string>applinks:native.dev.kickstarter.com</string>
-		<string>applinks:www.kickstarter.com</string>
-		<string>applinks:click.e.kickstarter.com</string>
-		<string>applinks:click.em.kickstarter.com</string>
-		<string>applinks:email.kickstarter.com</string>
-		<string>applinks:emails.kickstarter.com</string>
-		<string>applinks:e2.kickstarter.com</string>
-		<string>applinks:e3.kickstarter.com</string>
-		<string>webcredentials:kickstarter.com</string>
-	</array>
-	<key>com.apple.developer.icloud-container-identifiers</key>
-	<array/>
-	<key>com.apple.developer.in-app-payments</key>
-	<array>
-		<string>merchant.com.kickstarter</string>
-	</array>
-	<key>com.apple.developer.ubiquity-kvstore-identifier</key>
-	<string>$(TeamIdentifierPrefix)$(CFBundleIdentifier)</string>
-</dict>
+  <dict>
+    <key>aps-environment</key>
+    <string>development</string>
+    <key>com.apple.developer.applesignin</key>
+    <array>
+      <string>Default</string>
+    </array>
+    <key>com.apple.developer.associated-domains</key>
+    <array>
+      <string>applinks:staging.kickstarter.com</string>
+      <string>applinks:native.dev.kickstarter.com</string>
+      <string>applinks:www.kickstarter.com</string>
+      <string>applinks:click.e.kickstarter.com</string>
+      <string>applinks:click.em.kickstarter.com</string>
+      <string>applinks:email.kickstarter.com</string>
+      <string>applinks:emails.kickstarter.com</string>
+      <string>applinks:e2.kickstarter.com</string>
+      <string>applinks:e3.kickstarter.com</string>
+      <string>webcredentials:kickstarter.com</string>
+    </array>
+    <key>com.apple.developer.icloud-container-identifiers</key>
+    <array/>
+    <key>com.apple.developer.in-app-payments</key>
+    <array>
+      <string>merchant.com.kickstarter</string>
+    </array>
+    <key>com.apple.developer.ubiquity-kvstore-identifier</key>
+    <string>$(TeamIdentifierPrefix)$(CFBundleIdentifier)</string>
+  </dict>
 </plist>

--- a/Kickstarter-iOS/Release.entitlements
+++ b/Kickstarter-iOS/Release.entitlements
@@ -4,6 +4,10 @@
 <dict>
 	<key>aps-environment</key>
 	<string>production</string>
+  <key>com.apple.developer.applesignin</key>
+  <array>
+    <string>Default</string>
+  </array>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>applinks:www.kickstarter.com</string>

--- a/Kickstarter-iOS/Views/Controllers/LoginToutViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/LoginToutViewController.swift
@@ -280,7 +280,7 @@ internal final class LoginToutViewController: UIViewController, MFMailComposeVie
       .observeValues { [weak self] in
         if #available(iOS 13, *) {
           self?.prepareContinueWithAppleRequest()
-        } 
+        }
       }
   }
 
@@ -528,22 +528,21 @@ private let separatorViewStyle: ViewStyle = { view in
 
 @available(iOS 13, *)
 extension LoginToutViewController: ASAuthorizationControllerDelegate {
-    func authorizationController(controller: ASAuthorizationController,
-                                 didCompleteWithAuthorization authorization: ASAuthorization) {
-      self.viewModel.inputs.continueWithAppleDidComplete(with: authorization)
-    }
+  func authorizationController(
+    controller _: ASAuthorizationController,
+    didCompleteWithAuthorization authorization: ASAuthorization
+  ) {
+    self.viewModel.inputs.continueWithAppleDidComplete(with: authorization)
+  }
 
-  
-
-    func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
-      self.viewModel.inputs.continueWithAppleDidComplete(with: error)
-    }
+  func authorizationController(controller _: ASAuthorizationController, didCompleteWithError error: Error) {
+    self.viewModel.inputs.continueWithAppleDidComplete(with: error)
+  }
 }
 
 @available(iOS 13.0, *)
 extension LoginViewController: ASAuthorizationControllerPresentationContextProviding {
-
-  func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
-        return self.view.window!
-    }
+  func presentationAnchor(for _: ASAuthorizationController) -> ASPresentationAnchor {
+    return self.view.window!
+  }
 }

--- a/Kickstarter-iOS/Views/Controllers/LoginToutViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/LoginToutViewController.swift
@@ -550,11 +550,11 @@ extension LoginToutViewController: ASAuthorizationControllerDelegate {
       lastName: fullName?.familyName,
       token: token
     ) as? SignInWithAppleData
-    self.viewModel.inputs.appleAuthorizationDidComplete(with: data)
+    self.viewModel.inputs.appleAuthorizationDidSucceed(with: data)
   }
 
   func authorizationController(controller _: ASAuthorizationController, didCompleteWithError error: Error) {
-    self.viewModel.inputs.appleAuthorizationDidComplete(with: error)
+    self.viewModel.inputs.appleAuthorizationDidFail(with: error)
   }
 }
 

--- a/Kickstarter-iOS/Views/Controllers/LoginToutViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/LoginToutViewController.swift
@@ -275,11 +275,11 @@ internal final class LoginToutViewController: UIViewController, MFMailComposeVie
           ?|> UILabel.lens.font .~ (isHidden ? UIFont.ksr_title2() : UIFont.ksr_subhead())
       }
 
-    self.viewModel.outputs.prepareSignInWithAppleRequest
+    self.viewModel.outputs.attemptAppleLogin
       .observeForUI()
       .observeValues { [weak self] in
         if #available(iOS 13, *) {
-          self?.prepareContinueWithAppleRequest()
+          self?.attemptAppleLogin()
         }
       }
 
@@ -363,7 +363,7 @@ internal final class LoginToutViewController: UIViewController, MFMailComposeVie
   }
 
   @available(iOS 13, *)
-  private func prepareContinueWithAppleRequest() {
+  private func attemptAppleLogin() {
     let appleIDRequest = ASAuthorizationAppleIDProvider().createRequest()
       |> \.requestedScopes .~ [.fullName, .email]
 

--- a/Kickstarter-iOS/Views/Controllers/LoginToutViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/LoginToutViewController.swift
@@ -362,7 +362,8 @@ internal final class LoginToutViewController: UIViewController, MFMailComposeVie
     // Create an authorization controller with the given requests.
     let authorizationController = ASAuthorizationController(authorizationRequests: requests)
     authorizationController.delegate = self
-    authorizationController.presentationContextProvider = self as? ASAuthorizationControllerPresentationContextProviding
+    authorizationController.presentationContextProvider = self
+      as? ASAuthorizationControllerPresentationContextProviding
     authorizationController.performRequests()
   }
 

--- a/Kickstarter-iOS/Views/Controllers/LoginToutViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/LoginToutViewController.swift
@@ -284,11 +284,11 @@ internal final class LoginToutViewController: UIViewController, MFMailComposeVie
       }
 
     if #available(iOS 13.0, *) {
-    self.viewModel.outputs.didSignInWithApple
-      .observeForUI()
-      .observeValues { [weak self] envelope in
-        self?.viewModel.inputs.didReceiveSignInWithAppleEnvelope(envelope)
-      }
+      self.viewModel.outputs.didSignInWithApple
+        .observeForUI()
+        .observeValues { [weak self] envelope in
+          self?.viewModel.inputs.didReceiveSignInWithAppleEnvelope(envelope)
+        }
     }
   }
 
@@ -536,20 +536,21 @@ extension LoginToutViewController: ASAuthorizationControllerDelegate {
     controller _: ASAuthorizationController,
     didCompleteWithAuthorization authorization: ASAuthorization
   ) {
-
     guard let credential = authorization.credential as? ASAuthorizationAppleIDCredential,
       let authToken = credential.authorizationCode else {
-        return
-      }
+      return
+    }
 
-      let fullName = credential.fullName
-      let token = String(data: authToken, encoding: .utf8)
+    let fullName = credential.fullName
+    let token = String(data: authToken, encoding: .utf8)
 
-      let data =  (appId: AppEnvironment.current.apiService.appId,
-                   firstName: fullName?.givenName,
-                   lastName: fullName?.familyName,
-                   token: token) as? SignInWithAppleData
-      self.viewModel.inputs.appleAuthorizationDidComplete(with: data)
+    let data = (
+      appId: AppEnvironment.current.apiService.appId,
+      firstName: fullName?.givenName,
+      lastName: fullName?.familyName,
+      token: token
+    ) as? SignInWithAppleData
+    self.viewModel.inputs.appleAuthorizationDidComplete(with: data)
   }
 
   func authorizationController(controller _: ASAuthorizationController, didCompleteWithError error: Error) {

--- a/Kickstarter-iOS/Views/Controllers/LoginToutViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/LoginToutViewController.swift
@@ -522,6 +522,8 @@ private let separatorViewStyle: ViewStyle = { view in
     |> \.translatesAutoresizingMaskIntoConstraints .~ false
 }
 
+// MARK: - ASAuthorizationControllerDelegate
+
 @available(iOS 13, *)
 extension LoginToutViewController: ASAuthorizationControllerDelegate {
   func authorizationController(
@@ -550,8 +552,10 @@ extension LoginToutViewController: ASAuthorizationControllerDelegate {
   }
 }
 
+// MARK: - ASAuthorizationControllerPresentationContextProviding
+
 @available(iOS 13.0, *)
-extension LoginViewController: ASAuthorizationControllerPresentationContextProviding {
+extension LoginToutViewController: ASAuthorizationControllerPresentationContextProviding {
   func presentationAnchor(for _: ASAuthorizationController) -> ASPresentationAnchor {
     guard let window = self.view.window else {
       return ASPresentationAnchor()

--- a/Kickstarter-iOS/Views/Controllers/LoginToutViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/LoginToutViewController.swift
@@ -356,8 +356,10 @@ internal final class LoginToutViewController: UIViewController, MFMailComposeVie
 
   @available(iOS 13, *)
   private func prepareContinueWithAppleRequest() {
-    let requests = [ASAuthorizationAppleIDProvider().createRequest(),
-                    ASAuthorizationPasswordProvider().createRequest()]
+    let appleIDRequest = ASAuthorizationAppleIDProvider().createRequest()
+    appleIDRequest.requestedScopes = [.fullName, .email]
+
+    let requests = [appleIDRequest]
 
     // Create an authorization controller with the given requests.
     let authorizationController = ASAuthorizationController(authorizationRequests: requests)
@@ -530,6 +532,8 @@ extension LoginToutViewController: ASAuthorizationControllerDelegate {
                                  didCompleteWithAuthorization authorization: ASAuthorization) {
       self.viewModel.inputs.continueWithAppleDidComplete(with: authorization)
     }
+
+  
 
     func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
       self.viewModel.inputs.continueWithAppleDidComplete(with: error)

--- a/Kickstarter-iOS/Views/Controllers/LoginToutViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/LoginToutViewController.swift
@@ -282,14 +282,6 @@ internal final class LoginToutViewController: UIViewController, MFMailComposeVie
           self?.attemptAppleLogin()
         }
       }
-
-    if #available(iOS 13.0, *) {
-      self.viewModel.outputs.didSignInWithApple
-        .observeForUI()
-        .observeValues { [weak self] envelope in
-          self?.viewModel.inputs.didReceiveSignInWithAppleEnvelope(envelope)
-        }
-    }
   }
 
   // MARK: - Functions

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -1144,6 +1144,7 @@
 		D67F29361F68333800E399A6 /* GraphSchema.swift in Sources */ = {isa = PBXBuildFile; fileRef = D67F29351F68333800E399A6 /* GraphSchema.swift */; };
 		D68F0B16243CFF3F009FC948 /* SignInWithAppleEnvelope.swift in Sources */ = {isa = PBXBuildFile; fileRef = D68F0B15243CFF3E009FC948 /* SignInWithAppleEnvelope.swift */; };
 		D68F0B18243F6730009FC948 /* SignInWithAppleEnvelopeTemplates.swift in Sources */ = {isa = PBXBuildFile; fileRef = D68F0B17243F6730009FC948 /* SignInWithAppleEnvelopeTemplates.swift */; };
+		D68F0B1A243FB688009FC948 /* SignInWithAppleEnvelopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D68F0B19243FB688009FC948 /* SignInWithAppleEnvelopeTests.swift */; };
 		D69C55142397166D00B0987A /* GraphBacking.swift in Sources */ = {isa = PBXBuildFile; fileRef = D69C55132397166D00B0987A /* GraphBacking.swift */; };
 		D69C5516239852CB00B0987A /* GraphBackingEnvelope.swift in Sources */ = {isa = PBXBuildFile; fileRef = D69C5515239852CB00B0987A /* GraphBackingEnvelope.swift */; };
 		D69C55182398534E00B0987A /* GraphBackingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D69C55172398534E00B0987A /* GraphBackingTests.swift */; };
@@ -2491,6 +2492,7 @@
 		D67F29351F68333800E399A6 /* GraphSchema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GraphSchema.swift; sourceTree = "<group>"; };
 		D68F0B15243CFF3E009FC948 /* SignInWithAppleEnvelope.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SignInWithAppleEnvelope.swift; sourceTree = "<group>"; };
 		D68F0B17243F6730009FC948 /* SignInWithAppleEnvelopeTemplates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInWithAppleEnvelopeTemplates.swift; sourceTree = "<group>"; };
+		D68F0B19243FB688009FC948 /* SignInWithAppleEnvelopeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInWithAppleEnvelopeTests.swift; sourceTree = "<group>"; };
 		D69BACEF21C856F2006EAA00 /* UIAlertControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIAlertControllerTests.swift; sourceTree = "<group>"; };
 		D69C55132397166D00B0987A /* GraphBacking.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GraphBacking.swift; sourceTree = "<group>"; };
 		D69C5515239852CB00B0987A /* GraphBackingEnvelope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphBackingEnvelope.swift; sourceTree = "<group>"; };
@@ -3957,7 +3959,6 @@
 		D01587771EEB2ED6006E7684 /* models */ = {
 			isa = PBXGroup;
 			children = (
-				D68F0B15243CFF3E009FC948 /* SignInWithAppleEnvelope.swift */,
 				D01587781EEB2ED6006E7684 /* AccessTokenEnvelope.swift */,
 				D01587791EEB2ED6006E7684 /* Activity.swift */,
 				D015877A1EEB2ED6006E7684 /* ActivityEnvelope.swift */,
@@ -4040,6 +4041,7 @@
 				D6AE52261FD1B41200BEC788 /* RootCategoriesEnvelope.swift */,
 				D01587E71EEB2ED7006E7684 /* ShippingRule.swift */,
 				D01587E81EEB2ED7006E7684 /* ShippingRulesEnvelope.swift */,
+				D68F0B15243CFF3E009FC948 /* SignInWithAppleEnvelope.swift */,
 				D01587E91EEB2ED7006E7684 /* StarEnvelope.swift */,
 				D01587EC1EEB2ED7006E7684 /* SurveyResponse.swift */,
 				D01587ED1EEB2ED7006E7684 /* SurveyResponseTests.swift */,
@@ -4062,6 +4064,7 @@
 				D01588251EEB2ED7006E7684 /* VoidEnvelope.swift */,
 				D01587971EEB2ED6006E7684 /* lenses */,
 				D01587EE1EEB2ED7006E7684 /* templates */,
+				D68F0B19243FB688009FC948 /* SignInWithAppleEnvelopeTests.swift */,
 			);
 			path = models;
 			sourceTree = "<group>";
@@ -5050,6 +5053,7 @@
 				D04AACA7218BB72100CF713E /* DiscoveryProjectCategoryViewModelTests.swift in Sources */,
 				A7ED1FD41E831C5C00BFFA01 /* DashboardRewardRowStackViewViewModelTests.swift in Sources */,
 				A7ED1F331E830FDC00BFFA01 /* RefTagTests.swift in Sources */,
+				D68F0B1A243FB688009FC948 /* SignInWithAppleEnvelopeTests.swift in Sources */,
 				A7ED1FDE1E831C5C00BFFA01 /* DiscoveryExpandableRowCellViewModelTests.swift in Sources */,
 				D6534D3E22E789B900E9D279 /* PledgePaymentMethodsViewModelTests.swift in Sources */,
 				A7ED1FC41E831C5C00BFFA01 /* ProjectActivitySuccessCellViewModelTests.swift in Sources */,

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -4042,6 +4042,7 @@
 				D01587E71EEB2ED7006E7684 /* ShippingRule.swift */,
 				D01587E81EEB2ED7006E7684 /* ShippingRulesEnvelope.swift */,
 				D68F0B15243CFF3E009FC948 /* SignInWithAppleEnvelope.swift */,
+				D68F0B19243FB688009FC948 /* SignInWithAppleEnvelopeTests.swift */,
 				D01587E91EEB2ED7006E7684 /* StarEnvelope.swift */,
 				D01587EC1EEB2ED7006E7684 /* SurveyResponse.swift */,
 				D01587ED1EEB2ED7006E7684 /* SurveyResponseTests.swift */,
@@ -4064,7 +4065,6 @@
 				D01588251EEB2ED7006E7684 /* VoidEnvelope.swift */,
 				D01587971EEB2ED6006E7684 /* lenses */,
 				D01587EE1EEB2ED7006E7684 /* templates */,
-				D68F0B19243FB688009FC948 /* SignInWithAppleEnvelopeTests.swift */,
 			);
 			path = models;
 			sourceTree = "<group>";

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -1196,6 +1196,8 @@
 		D6ED1B3E216D61E0007F7547 /* UpdateUserAccountMutation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6ED1B3D216D61E0007F7547 /* UpdateUserAccountMutation.swift */; };
 		D6ED386A1F796C26006CAAE9 /* GraphCategoriesEnvelopeLenses.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6ED38691F796C26006CAAE9 /* GraphCategoriesEnvelopeLenses.swift */; };
 		D6ED38A21F796FE5006CAAE9 /* GraphCategoriesEnvelopeTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6ED38A11F796FE5006CAAE9 /* GraphCategoriesEnvelopeTemplate.swift */; };
+		D6F5C60F2437DD2A00C1A79D /* SignInWithAppleMutation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6F5C60E2437DD2A00C1A79D /* SignInWithAppleMutation.swift */; };
+		D6F5C6112437E12300C1A79D /* SignInWithAppleInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6F5C6102437E12300C1A79D /* SignInWithAppleInput.swift */; };
 		D6F741A821836E5700C2DDA2 /* PaymentMethodsViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6F7416F21836C3D00C2DDA2 /* PaymentMethodsViewControllerTests.swift */; };
 		D70347901DBAABC30099C668 /* DiscoveryExpandableRowCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D703478F1DBAABC30099C668 /* DiscoveryExpandableRowCellViewModel.swift */; };
 		D703FC3120F7E280004A272D /* SettingsPrivacy.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D703FC3020F7E280004A272D /* SettingsPrivacy.storyboard */; };
@@ -2543,6 +2545,8 @@
 		D6ED1B3D216D61E0007F7547 /* UpdateUserAccountMutation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateUserAccountMutation.swift; sourceTree = "<group>"; };
 		D6ED38691F796C26006CAAE9 /* GraphCategoriesEnvelopeLenses.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphCategoriesEnvelopeLenses.swift; sourceTree = "<group>"; };
 		D6ED38A11F796FE5006CAAE9 /* GraphCategoriesEnvelopeTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphCategoriesEnvelopeTemplate.swift; sourceTree = "<group>"; };
+		D6F5C60E2437DD2A00C1A79D /* SignInWithAppleMutation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInWithAppleMutation.swift; sourceTree = "<group>"; };
+		D6F5C6102437E12300C1A79D /* SignInWithAppleInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInWithAppleInput.swift; sourceTree = "<group>"; };
 		D6F7416F21836C3D00C2DDA2 /* PaymentMethodsViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentMethodsViewControllerTests.swift; sourceTree = "<group>"; };
 		D6FB2A3C1FA27D0300B0D282 /* CategoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryTests.swift; sourceTree = "<group>"; };
 		D703478F1DBAABC30099C668 /* DiscoveryExpandableRowCellViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DiscoveryExpandableRowCellViewModel.swift; sourceTree = "<group>"; };
@@ -2793,6 +2797,7 @@
 				D6B686EA2191FEEE005F5DA7 /* UserSendEmailVerificationMutation.swift */,
 				D002CAE0218CF8F1009783F2 /* WatchProjectMutation.swift */,
 				D6ED1B3C216D617E007F7547 /* inputs */,
+				D6F5C60E2437DD2A00C1A79D /* SignInWithAppleMutation.swift */,
 			);
 			path = mutations;
 			sourceTree = "<group>";
@@ -4203,6 +4208,7 @@
 				8AF34C732342CBC2000B211D /* UpdateBackingInput.swift */,
 				8AF34C752342D1D2000B211D /* UpdateBackingInputTests.swift */,
 				D002CAE2218CF91D009783F2 /* WatchProjectInput.swift */,
+				D6F5C6102437E12300C1A79D /* SignInWithAppleInput.swift */,
 			);
 			path = inputs;
 			sourceTree = "<group>";
@@ -5707,6 +5713,7 @@
 				D015899B1EEB2ED7006E7684 /* Service.swift in Sources */,
 				D6ED1B39216D50BE007F7547 /* UserEmailFields.swift in Sources */,
 				D01588731EEB2ED7006E7684 /* FindFriendsEnvelope.swift in Sources */,
+				D6F5C6112437E12300C1A79D /* SignInWithAppleInput.swift in Sources */,
 				D63BBD31217F7212007E01F0 /* GraphUserCreditCard.swift in Sources */,
 				D79CF32E219CE51A00ECB73A /* CreatePaymentSourceInput.swift in Sources */,
 				D01588A51EEB2ED7006E7684 /* Project.DatesLenses.swift in Sources */,
@@ -5800,6 +5807,7 @@
 				D01588CD1EEB2ED7006E7684 /* ShippingRulesEnvelopeLenses.swift in Sources */,
 				D6B686EB2191FEEE005F5DA7 /* UserSendEmailVerificationMutation.swift in Sources */,
 				D76F070A24104E9500072C7B /* ProjectCreatorDetailsEnvelopeTemplate.swift in Sources */,
+				D6F5C60F2437DD2A00C1A79D /* SignInWithAppleMutation.swift in Sources */,
 				D67B6CD8221F46D700B63A6B /* Project.Country+Argo.swift in Sources */,
 				D01589871EEB2ED7006E7684 /* UpdatePledgeEnvelope.swift in Sources */,
 				D01588DD1EEB2ED7006E7684 /* User.NotificationsLenses.swift in Sources */,

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -1143,6 +1143,7 @@
 		D67DF564232ABB960051D207 /* ManagePledgeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D67DF563232ABB950051D207 /* ManagePledgeViewModel.swift */; };
 		D67F29361F68333800E399A6 /* GraphSchema.swift in Sources */ = {isa = PBXBuildFile; fileRef = D67F29351F68333800E399A6 /* GraphSchema.swift */; };
 		D68F0B16243CFF3F009FC948 /* SignInWithAppleEnvelope.swift in Sources */ = {isa = PBXBuildFile; fileRef = D68F0B15243CFF3E009FC948 /* SignInWithAppleEnvelope.swift */; };
+		D68F0B18243F6730009FC948 /* SignInWithAppleEnvelopeTemplates.swift in Sources */ = {isa = PBXBuildFile; fileRef = D68F0B17243F6730009FC948 /* SignInWithAppleEnvelopeTemplates.swift */; };
 		D69C55142397166D00B0987A /* GraphBacking.swift in Sources */ = {isa = PBXBuildFile; fileRef = D69C55132397166D00B0987A /* GraphBacking.swift */; };
 		D69C5516239852CB00B0987A /* GraphBackingEnvelope.swift in Sources */ = {isa = PBXBuildFile; fileRef = D69C5515239852CB00B0987A /* GraphBackingEnvelope.swift */; };
 		D69C55182398534E00B0987A /* GraphBackingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D69C55172398534E00B0987A /* GraphBackingTests.swift */; };
@@ -2489,6 +2490,7 @@
 		D67DF563232ABB950051D207 /* ManagePledgeViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ManagePledgeViewModel.swift; sourceTree = "<group>"; };
 		D67F29351F68333800E399A6 /* GraphSchema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GraphSchema.swift; sourceTree = "<group>"; };
 		D68F0B15243CFF3E009FC948 /* SignInWithAppleEnvelope.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SignInWithAppleEnvelope.swift; sourceTree = "<group>"; };
+		D68F0B17243F6730009FC948 /* SignInWithAppleEnvelopeTemplates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInWithAppleEnvelopeTemplates.swift; sourceTree = "<group>"; };
 		D69BACEF21C856F2006EAA00 /* UIAlertControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIAlertControllerTests.swift; sourceTree = "<group>"; };
 		D69C55132397166D00B0987A /* GraphBacking.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GraphBacking.swift; sourceTree = "<group>"; };
 		D69C5515239852CB00B0987A /* GraphBackingEnvelope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphBackingEnvelope.swift; sourceTree = "<group>"; };
@@ -4167,6 +4169,7 @@
 				D015880C1EEB2ED7006E7684 /* ShippingRulesEnvelopeTemplates.swift */,
 				D015880D1EEB2ED7006E7684 /* ShippingRuleTemplates.swift */,
 				3706408922A8B2B700889CBD /* ShippingTemplates.swift */,
+				D68F0B17243F6730009FC948 /* SignInWithAppleEnvelopeTemplates.swift */,
 				D015880E1EEB2ED7006E7684 /* StarEnvelopeTemplates.swift */,
 				D01588101EEB2ED7006E7684 /* SurveyResponseTemplates.swift */,
 				D01588111EEB2ED7006E7684 /* UpdateDraftTemplates.swift */,
@@ -5695,6 +5698,7 @@
 				77776BC6234BA6B700A42388 /* CancelBackingMutation.swift in Sources */,
 				D01588C51EEB2ED7006E7684 /* Reward.ShippingLenses.swift in Sources */,
 				7703B42223217D4F00169EF3 /* EnvironmentType.swift in Sources */,
+				D68F0B18243F6730009FC948 /* SignInWithAppleEnvelopeTemplates.swift in Sources */,
 				D01588D51EEB2ED7006E7684 /* UpdateDraftLenses.swift in Sources */,
 				8ACF558923E8D467001654A2 /* TryDecodable.swift in Sources */,
 				D01589211EEB2ED7006E7684 /* StarEnvelope.swift in Sources */,

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -1142,6 +1142,7 @@
 		D67B6CD8221F46D700B63A6B /* Project.Country+Argo.swift in Sources */ = {isa = PBXBuildFile; fileRef = D67B6CD7221F46D700B63A6B /* Project.Country+Argo.swift */; };
 		D67DF564232ABB960051D207 /* ManagePledgeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D67DF563232ABB950051D207 /* ManagePledgeViewModel.swift */; };
 		D67F29361F68333800E399A6 /* GraphSchema.swift in Sources */ = {isa = PBXBuildFile; fileRef = D67F29351F68333800E399A6 /* GraphSchema.swift */; };
+		D68F0B16243CFF3F009FC948 /* SignInWithAppleEnvelope.swift in Sources */ = {isa = PBXBuildFile; fileRef = D68F0B15243CFF3E009FC948 /* SignInWithAppleEnvelope.swift */; };
 		D69C55142397166D00B0987A /* GraphBacking.swift in Sources */ = {isa = PBXBuildFile; fileRef = D69C55132397166D00B0987A /* GraphBacking.swift */; };
 		D69C5516239852CB00B0987A /* GraphBackingEnvelope.swift in Sources */ = {isa = PBXBuildFile; fileRef = D69C5515239852CB00B0987A /* GraphBackingEnvelope.swift */; };
 		D69C55182398534E00B0987A /* GraphBackingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D69C55172398534E00B0987A /* GraphBackingTests.swift */; };
@@ -2487,6 +2488,7 @@
 		D67B6CD7221F46D700B63A6B /* Project.Country+Argo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Project.Country+Argo.swift"; sourceTree = "<group>"; };
 		D67DF563232ABB950051D207 /* ManagePledgeViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ManagePledgeViewModel.swift; sourceTree = "<group>"; };
 		D67F29351F68333800E399A6 /* GraphSchema.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GraphSchema.swift; sourceTree = "<group>"; };
+		D68F0B15243CFF3E009FC948 /* SignInWithAppleEnvelope.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SignInWithAppleEnvelope.swift; sourceTree = "<group>"; };
 		D69BACEF21C856F2006EAA00 /* UIAlertControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIAlertControllerTests.swift; sourceTree = "<group>"; };
 		D69C55132397166D00B0987A /* GraphBacking.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GraphBacking.swift; sourceTree = "<group>"; };
 		D69C5515239852CB00B0987A /* GraphBackingEnvelope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphBackingEnvelope.swift; sourceTree = "<group>"; };
@@ -3953,6 +3955,7 @@
 		D01587771EEB2ED6006E7684 /* models */ = {
 			isa = PBXGroup;
 			children = (
+				D68F0B15243CFF3E009FC948 /* SignInWithAppleEnvelope.swift */,
 				D01587781EEB2ED6006E7684 /* AccessTokenEnvelope.swift */,
 				D01587791EEB2ED6006E7684 /* Activity.swift */,
 				D015877A1EEB2ED6006E7684 /* ActivityEnvelope.swift */,
@@ -5805,6 +5808,7 @@
 				D0158A131EEB30A2006E7684 /* DiscoveryEnvelopeTemplates.swift in Sources */,
 				D01588431EEB2ED7006E7684 /* Activity.swift in Sources */,
 				D01588CD1EEB2ED7006E7684 /* ShippingRulesEnvelopeLenses.swift in Sources */,
+				D68F0B16243CFF3F009FC948 /* SignInWithAppleEnvelope.swift in Sources */,
 				D6B686EB2191FEEE005F5DA7 /* UserSendEmailVerificationMutation.swift in Sources */,
 				D76F070A24104E9500072C7B /* ProjectCreatorDetailsEnvelopeTemplate.swift in Sources */,
 				D6F5C60F2437DD2A00C1A79D /* SignInWithAppleMutation.swift in Sources */,

--- a/KsApi/MockService.swift
+++ b/KsApi/MockService.swift
@@ -1239,12 +1239,12 @@
       return SignalProducer(value: GraphMutationEmptyResponseEnvelope())
     }
 
-    internal func signInWithApple(input: SignInWithAppleInput)
+    internal func signInWithApple(input _: SignInWithAppleInput)
       -> SignalProducer<SignInWithAppleEnvelope, GraphError> {
-        if let error = signInWithAppleError {
-          return SignalProducer(error: error)
-        }
-        return SignalProducer(value: SignInWithAppleEnvelope(apiAccessToken: "api_access_token"))
+      if let error = signInWithAppleError {
+        return SignalProducer(error: error)
+      }
+      return SignalProducer(value: SignInWithAppleEnvelope(apiAccessToken: "api_access_token"))
     }
 
     internal func signup(

--- a/KsApi/MockService.swift
+++ b/KsApi/MockService.swift
@@ -1240,11 +1240,11 @@
     }
 
     internal func signInWithApple(input: SignInWithAppleInput)
-      -> SignalProducer<GraphMutationEmptyResponseEnvelope, GraphError> {
+      -> SignalProducer<SignInWithAppleEnvelope, GraphError> {
         if let error = signInWithAppleError {
           return SignalProducer(error: error)
         }
-      return SignalProducer(value: GraphMutationEmptyResponseEnvelope())
+        return SignalProducer(value: SignInWithAppleEnvelope(apiAccessToken: "api_access_token"))
     }
 
     internal func signup(

--- a/KsApi/MockService.swift
+++ b/KsApi/MockService.swift
@@ -144,8 +144,7 @@
     fileprivate let sendEmailVerificationResponse: GraphMutationEmptyResponseEnvelope?
     fileprivate let sendEmailVerificationError: GraphError?
 
-    fileprivate let signInWithAppleResponse: SignInWithAppleEnvelope?
-    fileprivate let signInWithAppleError: GraphError?
+    fileprivate let signInWithAppleResult: Result<SignInWithAppleEnvelope, GraphError>?
 
     fileprivate let signupResponse: AccessTokenEnvelope?
     fileprivate let signupError: ErrorEnvelope?
@@ -283,8 +282,7 @@
       resetPasswordError: ErrorEnvelope? = nil,
       sendEmailVerificationResponse: GraphMutationEmptyResponseEnvelope? = nil,
       sendEmailVerificationError: GraphError? = nil,
-      signInWithAppleResponse: SignInWithAppleEnvelope? = nil,
-      signInWithAppleError: GraphError? = nil,
+      signInWithAppleResult: Result<SignInWithAppleEnvelope, GraphError>? = nil,
       signupResponse: AccessTokenEnvelope? = nil,
       signupError: ErrorEnvelope? = nil,
       unfollowFriendError: ErrorEnvelope? = nil,
@@ -479,9 +477,7 @@
 
       self.sendEmailVerificationError = sendEmailVerificationError
 
-      self.signInWithAppleResponse = signInWithAppleResponse
-
-      self.signInWithAppleError = signInWithAppleError
+      self.signInWithAppleResult = signInWithAppleResult
 
       self.signupResponse = signupResponse
 
@@ -1241,10 +1237,10 @@
 
     internal func signInWithApple(input _: SignInWithAppleInput)
       -> SignalProducer<SignInWithAppleEnvelope, GraphError> {
-      if let error = signInWithAppleError {
+        if let error = self.signInWithAppleResult?.error {
         return SignalProducer(error: error)
       }
-      return SignalProducer(value: SignInWithAppleEnvelope.template)
+        return SignalProducer(value: self.signInWithAppleResult?.value ?? SignInWithAppleEnvelope.template)
     }
 
     internal func signup(

--- a/KsApi/MockService.swift
+++ b/KsApi/MockService.swift
@@ -1237,10 +1237,10 @@
 
     internal func signInWithApple(input _: SignInWithAppleInput)
       -> SignalProducer<SignInWithAppleEnvelope, GraphError> {
-        if let error = self.signInWithAppleResult?.error {
+      if let error = self.signInWithAppleResult?.error {
         return SignalProducer(error: error)
       }
-        return SignalProducer(value: self.signInWithAppleResult?.value ?? SignInWithAppleEnvelope.template)
+      return SignalProducer(value: self.signInWithAppleResult?.value ?? SignInWithAppleEnvelope.template)
     }
 
     internal func signup(

--- a/KsApi/MockService.swift
+++ b/KsApi/MockService.swift
@@ -1244,7 +1244,7 @@
       if let error = signInWithAppleError {
         return SignalProducer(error: error)
       }
-      return SignalProducer(value: SignInWithAppleEnvelope(apiAccessToken: "api_access_token"))
+      return SignalProducer(value: SignInWithAppleEnvelope.template)
     }
 
     internal func signup(

--- a/KsApi/MockService.swift
+++ b/KsApi/MockService.swift
@@ -144,7 +144,7 @@
     fileprivate let sendEmailVerificationResponse: GraphMutationEmptyResponseEnvelope?
     fileprivate let sendEmailVerificationError: GraphError?
 
-    fileprivate let signInWithAppleResponse: GraphMutationEmptyResponseEnvelope?
+    fileprivate let signInWithAppleResponse: SignInWithAppleEnvelope?
     fileprivate let signInWithAppleError: GraphError?
 
     fileprivate let signupResponse: AccessTokenEnvelope?
@@ -283,7 +283,7 @@
       resetPasswordError: ErrorEnvelope? = nil,
       sendEmailVerificationResponse: GraphMutationEmptyResponseEnvelope? = nil,
       sendEmailVerificationError: GraphError? = nil,
-      signInWithAppleResponse: GraphMutationEmptyResponseEnvelope? = nil,
+      signInWithAppleResponse: SignInWithAppleEnvelope? = nil,
       signInWithAppleError: GraphError? = nil,
       signupResponse: AccessTokenEnvelope? = nil,
       signupError: ErrorEnvelope? = nil,

--- a/KsApi/MockService.swift
+++ b/KsApi/MockService.swift
@@ -144,6 +144,9 @@
     fileprivate let sendEmailVerificationResponse: GraphMutationEmptyResponseEnvelope?
     fileprivate let sendEmailVerificationError: GraphError?
 
+    fileprivate let signInWithAppleResponse: GraphMutationEmptyResponseEnvelope?
+    fileprivate let signInWithAppleError: GraphError?
+
     fileprivate let signupResponse: AccessTokenEnvelope?
     fileprivate let signupError: ErrorEnvelope?
 
@@ -280,6 +283,8 @@
       resetPasswordError: ErrorEnvelope? = nil,
       sendEmailVerificationResponse: GraphMutationEmptyResponseEnvelope? = nil,
       sendEmailVerificationError: GraphError? = nil,
+      signInWithAppleResponse: GraphMutationEmptyResponseEnvelope? = nil,
+      signInWithAppleError: GraphError? = nil,
       signupResponse: AccessTokenEnvelope? = nil,
       signupError: ErrorEnvelope? = nil,
       unfollowFriendError: ErrorEnvelope? = nil,
@@ -473,6 +478,10 @@
       self.sendEmailVerificationResponse = sendEmailVerificationResponse
 
       self.sendEmailVerificationError = sendEmailVerificationError
+
+      self.signInWithAppleResponse = signInWithAppleResponse
+
+      self.signInWithAppleError = signInWithAppleError
 
       self.signupResponse = signupResponse
 
@@ -1227,6 +1236,14 @@
       if let error = sendEmailVerificationError {
         return SignalProducer(error: error)
       }
+      return SignalProducer(value: GraphMutationEmptyResponseEnvelope())
+    }
+
+    internal func signInWithApple(input: SignInWithAppleInput)
+      -> SignalProducer<GraphMutationEmptyResponseEnvelope, GraphError> {
+        if let error = signInWithAppleError {
+          return SignalProducer(error: error)
+        }
       return SignalProducer(value: GraphMutationEmptyResponseEnvelope())
     }
 

--- a/KsApi/Service.swift
+++ b/KsApi/Service.swift
@@ -441,7 +441,7 @@ public struct Service: ServiceType {
   }
 
   public func signInWithApple(input: SignInWithAppleInput)
-     -> SignalProducer<GraphMutationEmptyResponseEnvelope, GraphError> {
+     -> SignalProducer<SignInWithAppleEnvelope, GraphError> {
      return applyMutation(mutation: SignInWithAppleMutation(input: input))
    }
 

--- a/KsApi/Service.swift
+++ b/KsApi/Service.swift
@@ -440,6 +440,11 @@ public struct Service: ServiceType {
     return applyMutation(mutation: UserSendEmailVerificationMutation(input: input))
   }
 
+  public func signInWithApple(input: SignInWithAppleInput)
+     -> SignalProducer<GraphMutationEmptyResponseEnvelope, GraphError> {
+     return applyMutation(mutation: SignInWithAppleMutation(input: input))
+   }
+
   public func signup(
     name: String,
     email: String,

--- a/KsApi/Service.swift
+++ b/KsApi/Service.swift
@@ -441,9 +441,9 @@ public struct Service: ServiceType {
   }
 
   public func signInWithApple(input: SignInWithAppleInput)
-     -> SignalProducer<SignInWithAppleEnvelope, GraphError> {
-     return applyMutation(mutation: SignInWithAppleMutation(input: input))
-   }
+    -> SignalProducer<SignInWithAppleEnvelope, GraphError> {
+    return applyMutation(mutation: SignInWithAppleMutation(input: input))
+  }
 
   public func signup(
     name: String,

--- a/KsApi/ServiceType.swift
+++ b/KsApi/ServiceType.swift
@@ -494,7 +494,7 @@ extension ServiceType {
     var headers: [String: String] = [:]
     headers["Accept-Language"] = self.language
     headers["Authorization"] = self.authorizationHeader
-    headers["Kickstarter-App-Id"] = "kickstarter.kickstarter.com.kickalpha"
+    headers["Kickstarter-App-Id"] = self.appId
     headers["Kickstarter-iOS-App"] = self.buildVersion
     headers["User-Agent"] = Self.userAgent
     headers["X-KICKSTARTER-CLIENT"] = self.serverConfig.apiClientAuth.clientId

--- a/KsApi/ServiceType.swift
+++ b/KsApi/ServiceType.swift
@@ -291,7 +291,7 @@ public protocol ServiceType {
 
   /// Signin with Apple
   func signInWithApple(input: SignInWithAppleInput)
-    -> SignalProducer<GraphMutationEmptyResponseEnvelope, GraphError>
+    -> SignalProducer<SignInWithAppleEnvelope, GraphError>
 
   /// Signup with email.
   func signup(

--- a/KsApi/ServiceType.swift
+++ b/KsApi/ServiceType.swift
@@ -494,7 +494,7 @@ extension ServiceType {
     var headers: [String: String] = [:]
     headers["Accept-Language"] = self.language
     headers["Authorization"] = self.authorizationHeader
-    headers["Kickstarter-App-Id"] = self.appId
+    headers["Kickstarter-App-Id"] = "kickstarter.kickstarter.com.kickalpha"
     headers["Kickstarter-iOS-App"] = self.buildVersion
     headers["User-Agent"] = Self.userAgent
     headers["X-KICKSTARTER-CLIENT"] = self.serverConfig.apiClientAuth.clientId

--- a/KsApi/ServiceType.swift
+++ b/KsApi/ServiceType.swift
@@ -289,6 +289,10 @@ public protocol ServiceType {
   func sendVerificationEmail(input: EmptyInput)
     -> SignalProducer<GraphMutationEmptyResponseEnvelope, GraphError>
 
+  /// Signin with Apple
+  func signInWithApple(input: SignInWithAppleInput)
+    -> SignalProducer<GraphMutationEmptyResponseEnvelope, GraphError>
+
   /// Signup with email.
   func signup(
     name: String, email: String, password: String, passwordConfirmation: String,

--- a/KsApi/extensions/NSURLSession.swift
+++ b/KsApi/extensions/NSURLSession.swift
@@ -85,8 +85,7 @@ internal extension URLSession {
       .start(on: scheduler)
       .flatMapError { _ in
         SignalProducer(error: .couldNotParseErrorEnvelopeJSON)
-
-    } // NSError
+      } // NSError
       .flatMap(.concat) { data, response -> SignalProducer<Data, ErrorEnvelope> in
         guard let response = response as? HTTPURLResponse else { fatalError() }
 

--- a/KsApi/extensions/NSURLSession.swift
+++ b/KsApi/extensions/NSURLSession.swift
@@ -17,6 +17,10 @@ internal extension URLSession {
     -> SignalProducer<Data, GraphError> {
     let producer = self.reactive.data(with: request)
 
+      URLSession.shared.dataTask(with: request) { (data, response, error) in
+        print(data)
+      }.resume()
+
     return producer
       .start(on: scheduler)
       .flatMapError { error -> SignalProducer<(Data, URLResponse), GraphError> in
@@ -83,7 +87,10 @@ internal extension URLSession {
 
     return producer
       .start(on: scheduler)
-      .flatMapError { _ in SignalProducer(error: .couldNotParseErrorEnvelopeJSON) } // NSError
+      .flatMapError { _ in
+        SignalProducer(error: .couldNotParseErrorEnvelopeJSON)
+
+    } // NSError
       .flatMap(.concat) { data, response -> SignalProducer<Data, ErrorEnvelope> in
         guard let response = response as? HTTPURLResponse else { fatalError() }
 

--- a/KsApi/extensions/NSURLSession.swift
+++ b/KsApi/extensions/NSURLSession.swift
@@ -83,9 +83,7 @@ internal extension URLSession {
 
     return producer
       .start(on: scheduler)
-      .flatMapError { _ in
-        SignalProducer(error: .couldNotParseErrorEnvelopeJSON)
-      } // NSError
+      .flatMapError { _ in SignalProducer(error: .couldNotParseErrorEnvelopeJSON) } // NSError
       .flatMap(.concat) { data, response -> SignalProducer<Data, ErrorEnvelope> in
         guard let response = response as? HTTPURLResponse else { fatalError() }
 

--- a/KsApi/extensions/NSURLSession.swift
+++ b/KsApi/extensions/NSURLSession.swift
@@ -17,10 +17,6 @@ internal extension URLSession {
     -> SignalProducer<Data, GraphError> {
     let producer = self.reactive.data(with: request)
 
-      URLSession.shared.dataTask(with: request) { (data, response, error) in
-        print(data)
-      }.resume()
-
     return producer
       .start(on: scheduler)
       .flatMapError { error -> SignalProducer<(Data, URLResponse), GraphError> in

--- a/KsApi/models/AccessTokenEnvelope.swift
+++ b/KsApi/models/AccessTokenEnvelope.swift
@@ -5,6 +5,11 @@ import Runes
 public struct AccessTokenEnvelope {
   public let accessToken: String
   public let user: User
+
+  public init(accessToken: String, user: User) {
+    self.accessToken = accessToken
+    self.user = user
+  }
 }
 
 extension AccessTokenEnvelope: Argo.Decodable {

--- a/KsApi/models/SignInWithAppleEnvelope.swift
+++ b/KsApi/models/SignInWithAppleEnvelope.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+public struct SignInWithAppleEnvelope: Decodable {
+  public var apiAccessToken: String
+}

--- a/KsApi/models/SignInWithAppleEnvelope.swift
+++ b/KsApi/models/SignInWithAppleEnvelope.swift
@@ -9,9 +9,6 @@ public struct SignInWithAppleEnvelope: Decodable {
   }
 
   public struct User: Decodable {
-    public let id: String
-    public var intID: Int? {
-      return decompose(id: self.id)
-    }
+    public let uid: String
   }
 }

--- a/KsApi/models/SignInWithAppleEnvelope.swift
+++ b/KsApi/models/SignInWithAppleEnvelope.swift
@@ -1,5 +1,18 @@
 import Foundation
 
 public struct SignInWithAppleEnvelope: Decodable {
-  public var apiAccessToken: String
+
+  public let signInWithApple: SignInWithApple
+
+  public struct SignInWithApple: Decodable {
+    public let apiAccessToken: String
+    public let user: SignInWithAppleEnvelope.User
+  }
+
+  public struct User: Decodable {
+    public let id: String
+    public var intID: Int? {
+      return decompose(id: self.id)
+    }
+  }
 }

--- a/KsApi/models/SignInWithAppleEnvelope.swift
+++ b/KsApi/models/SignInWithAppleEnvelope.swift
@@ -1,7 +1,6 @@
 import Foundation
 
 public struct SignInWithAppleEnvelope: Decodable {
-
   public let signInWithApple: SignInWithApple
 
   public struct SignInWithApple: Decodable {

--- a/KsApi/models/SignInWithAppleEnvelopeTests.swift
+++ b/KsApi/models/SignInWithAppleEnvelopeTests.swift
@@ -8,7 +8,7 @@ final class SignInWithAppleEnvelopeTests: XCTestCase {
       "signInWithApple": {
         "apiAccessToken": "api_access_token",
         "user": {
-          "id": "VXNlci0x"
+          "uid": "1"
         }
       }
     }
@@ -19,8 +19,7 @@ final class SignInWithAppleEnvelopeTests: XCTestCase {
     do {
       let envelope = try JSONDecoder().decode(SignInWithAppleEnvelope.self, from: data)
       XCTAssertEqual(envelope.signInWithApple.apiAccessToken, "api_access_token")
-      XCTAssertEqual(envelope.signInWithApple.user.id, "VXNlci0x")
-      XCTAssertEqual(envelope.signInWithApple.user.intID, 1)
+      XCTAssertEqual(envelope.signInWithApple.user.uid, "1")
     } catch {
       XCTFail("\(error)")
     }

--- a/KsApi/models/SignInWithAppleEnvelopeTests.swift
+++ b/KsApi/models/SignInWithAppleEnvelopeTests.swift
@@ -1,0 +1,28 @@
+@testable import KsApi
+import XCTest
+
+final class SignInWithAppleEnvelopeTests: XCTestCase {
+  func testSignInWithEnvelopeEnvelopeDecoding() {
+    let jsonString = """
+    {
+      "signInWithApple": {
+        "apiAccessToken": "api_access_token",
+        "user": {
+          "id": "VXNlci0x"
+        }
+      }
+    }
+    """
+
+    let data = Data(jsonString.utf8)
+
+    do {
+      let envelope = try JSONDecoder().decode(SignInWithAppleEnvelope.self, from: data)
+      XCTAssertEqual(envelope.signInWithApple.apiAccessToken, "api_access_token")
+      XCTAssertEqual(envelope.signInWithApple.user.id, "VXNlci0x")
+      XCTAssertEqual(envelope.signInWithApple.user.intID, 1)
+    } catch {
+      XCTFail("\(error)")
+    }
+  }
+}

--- a/KsApi/models/templates/SignInWithAppleEnvelopeTemplates.swift
+++ b/KsApi/models/templates/SignInWithAppleEnvelopeTemplates.swift
@@ -4,7 +4,7 @@ extension SignInWithAppleEnvelope {
   public static let template = SignInWithAppleEnvelope(
     signInWithApple: SignInWithAppleEnvelope.SignInWithApple(
       apiAccessToken: "api_access_token",
-      user: SignInWithAppleEnvelope.User(id: "1")
+      user: SignInWithAppleEnvelope.User(uid: "1")
     )
   )
 }

--- a/KsApi/models/templates/SignInWithAppleEnvelopeTemplates.swift
+++ b/KsApi/models/templates/SignInWithAppleEnvelopeTemplates.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+extension SignInWithAppleEnvelope {
+  public static let template = SignInWithAppleEnvelope(
+    signInWithApple: SignInWithAppleEnvelope.SignInWithApple(
+      apiAccessToken: "api_access_token",
+      user: SignInWithAppleEnvelope.User(id: "1")
+    )
+  )
+}

--- a/KsApi/mutations/SignInWithAppleMutation.swift
+++ b/KsApi/mutations/SignInWithAppleMutation.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+public struct SignInWithAppleMutation<T: GraphMutationInput>: GraphMutation {
+  var input: T
+
+  public init(input: T) {
+    self.input = input
+  }
+
+  public var description: String {
+    return """
+    mutation signInWithApple($input: SignInWithAppleInput!) {
+      createOrSignInAppleUser(input: $input) {
+        apiAccessToken
+      }
+    }
+    """
+  }
+}

--- a/KsApi/mutations/SignInWithAppleMutation.swift
+++ b/KsApi/mutations/SignInWithAppleMutation.swift
@@ -13,7 +13,7 @@ public struct SignInWithAppleMutation<T: GraphMutationInput>: GraphMutation {
       signInWithApple(input: $input) {
         apiAccessToken
         user {
-          id
+          uid
         }
       }
     }

--- a/KsApi/mutations/SignInWithAppleMutation.swift
+++ b/KsApi/mutations/SignInWithAppleMutation.swift
@@ -10,7 +10,7 @@ public struct SignInWithAppleMutation<T: GraphMutationInput>: GraphMutation {
   public var description: String {
     return """
     mutation signInWithApple($input: SignInWithAppleInput!) {
-      createOrSignInAppleUser(input: $input) {
+      signInWithApple(input: $input) {
         apiAccessToken
       }
     }

--- a/KsApi/mutations/SignInWithAppleMutation.swift
+++ b/KsApi/mutations/SignInWithAppleMutation.swift
@@ -12,6 +12,9 @@ public struct SignInWithAppleMutation<T: GraphMutationInput>: GraphMutation {
     mutation signInWithApple($input: SignInWithAppleInput!) {
       signInWithApple(input: $input) {
         apiAccessToken
+        user {
+          id
+        }
       }
     }
     """

--- a/KsApi/mutations/inputs/SignInWithAppleInput.swift
+++ b/KsApi/mutations/inputs/SignInWithAppleInput.swift
@@ -1,11 +1,13 @@
 import Foundation
 
 public struct SignInWithAppleInput: GraphMutationInput {
+  public let appId: String
   public let authCode: String
-  public let firstName: String
-  public let lastName: String
+  public let firstName: String?
+  public let lastName: String?
 
-  public init(authCode: String, firstName: String, lastName: String) {
+  public init(appId: String, authCode: String, firstName: String?, lastName: String?) {
+    self.appId = appId
     self.authCode = authCode
     self.firstName = firstName
     self.lastName = lastName
@@ -13,9 +15,10 @@ public struct SignInWithAppleInput: GraphMutationInput {
 
   public func toInputDictionary() -> [String: Any] {
     return [
+      "iosAppId": appId,
       "authCode": authCode,
-      "firstName": firstName,
-      "lastName": lastName
+      "firstName": firstName ?? "",
+      "lastName": lastName ?? ""
     ]
   }
 }

--- a/KsApi/mutations/inputs/SignInWithAppleInput.swift
+++ b/KsApi/mutations/inputs/SignInWithAppleInput.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+public struct SignInWithAppleInput: GraphMutationInput {
+  public let authCode: String
+  public let firstName: String
+  public let lastName: String
+
+  public init(authCode: String, firstName: String, lastName: String) {
+    self.authCode = authCode
+    self.firstName = firstName
+    self.lastName = lastName
+  }
+
+  public func toInputDictionary() -> [String: Any] {
+    return [
+      "authCode": authCode,
+      "firstName": firstName,
+      "lastName": lastName
+    ]
+  }
+}

--- a/KsApi/mutations/inputs/SignInWithAppleInput.swift
+++ b/KsApi/mutations/inputs/SignInWithAppleInput.swift
@@ -17,8 +17,8 @@ public struct SignInWithAppleInput: GraphMutationInput {
     return [
       "iosAppId": appId,
       "authCode": authCode,
-      "firstName": firstName ?? "",
-      "lastName": lastName ?? ""
-    ]
+      "firstName": firstName,
+      "lastName": lastName
+    ].compact()
   }
 }

--- a/Library/Tracking/Koala.swift
+++ b/Library/Tracking/Koala.swift
@@ -1374,11 +1374,9 @@ public final class Koala {
    - parameter params: The optional Discover params if the project is being watched from Discover
    */
 
-  public func trackWatchProjectButtonClicked(
-    project: Project,
-    location: LocationContext,
-    params: DiscoveryParams? = nil
-  ) {
+  public func trackWatchProjectButtonClicked(project: Project,
+                                             location: LocationContext,
+                                             params: DiscoveryParams? = nil) {
     var props = projectProperties(from: project, loggedInUser: self.loggedInUser)
 
     if let discoveryParams = params {

--- a/Library/Tracking/Koala.swift
+++ b/Library/Tracking/Koala.swift
@@ -1374,9 +1374,11 @@ public final class Koala {
    - parameter params: The optional Discover params if the project is being watched from Discover
    */
 
-  public func trackWatchProjectButtonClicked(project: Project,
-                                             location: LocationContext,
-                                             params: DiscoveryParams? = nil) {
+  public func trackWatchProjectButtonClicked(
+    project: Project,
+    location: LocationContext,
+    params: DiscoveryParams? = nil
+  ) {
     var props = projectProperties(from: project, loggedInUser: self.loggedInUser)
 
     if let discoveryParams = params {

--- a/Library/ViewModels/LoginToutViewModel.swift
+++ b/Library/ViewModels/LoginToutViewModel.swift
@@ -15,7 +15,7 @@ public protocol LoginToutViewModelInputs {
 
   /// Call when Apple completes authorization
   @available(iOS 13.0, *)
-  func appleAuthorizationDidComplete(with authorization: ASAuthorization)
+  func appleAuthorizationDidComplete(with data: SignInWithAppleData?)
 
   /// Call when Apple completes authorization with error
   @available(iOS 13.0, *)
@@ -198,8 +198,7 @@ public final class LoginToutViewModel: LoginToutViewModelType, LoginToutViewMode
     // MARK: - Sign-in with Apple
 
     if #available(iOS 13.0, *) {
-      let appleSignInInput = self.appleAuthorizationDidCompleteWithAuthorizatonProperty.signal
-        .map(continueWithAppleData(from:))
+      let appleSignInInput = self.appleAuthorizationDidCompleteWithDataProperty.signal
         .skipNil()
         .map { data in
           SignInWithAppleInput(appId: data.appId,
@@ -276,12 +275,12 @@ public final class LoginToutViewModel: LoginToutViewModelType, LoginToutViewMode
 
   // This property is being set as lazy because we can't use @available in computed properties.
   @available(iOS 13.0, *)
-  private lazy var appleAuthorizationDidCompleteWithAuthorizatonProperty =
-    MutableProperty<ASAuthorization?>(nil)
+  private lazy var appleAuthorizationDidCompleteWithDataProperty =
+    MutableProperty<SignInWithAppleData?>(nil)
 
   @available(iOS 13.0, *)
-  public func appleAuthorizationDidComplete(with authorization: ASAuthorization) {
-    self.appleAuthorizationDidCompleteWithAuthorizatonProperty.value = authorization
+  public func appleAuthorizationDidComplete(with data: SignInWithAppleData?) {
+    self.appleAuthorizationDidCompleteWithDataProperty.value = data
   }
 
   fileprivate let appleAuthorizationDidCompleteWithErrorProperty = MutableProperty<Error?>(nil)

--- a/Library/ViewModels/LoginToutViewModel.swift
+++ b/Library/ViewModels/LoginToutViewModel.swift
@@ -20,9 +20,6 @@ public protocol LoginToutViewModelInputs {
   @available(iOS 13.0, *)
   func appleAuthorizationDidFail(with error: Error)
 
-  /// Call when the SignInWithAppleEnvelope is received from the server
-  func didReceiveSignInWithAppleEnvelope(_ envelope: SignInWithAppleEnvelope)
-
   /// Call when the environment has been logged into
   func environmentLoggedIn()
 
@@ -58,10 +55,6 @@ public protocol LoginToutViewModelOutputs {
 
   /// Emits when Facebook login should start
   var attemptFacebookLogin: Signal<(), Never> { get }
-
-  /// Emits after the signInWithApple mutation returns a value.
-  @available(iOS 13.0, *)
-  var didSignInWithApple: Signal<SignInWithAppleEnvelope, Never> { get }
 
   /// Emits when the controller should be dismissed.
   var dismissViewController: Signal<(), Never> { get }
@@ -213,7 +206,10 @@ public final class LoginToutViewModel: LoginToutViewModelType, LoginToutViewMode
             .materialize()
         }
 
-      self.didSignInWithApple = appleSignInEvent.values()
+      // This is temporary uniquely to prove that the mutation is working properly for review purposes.
+      appleSignInEvent.observeValues { v in
+        print("=== Sign In With Apple ===\n\(v) ")
+      }
     }
 
     // MARK: - Tracking
@@ -292,11 +288,6 @@ public final class LoginToutViewModel: LoginToutViewModelType, LoginToutViewMode
     self.rewardProperty.value = reward
   }
 
-  fileprivate let didReceiveSignInWithAppleEnvelopeProperty = MutableProperty<SignInWithAppleEnvelope?>(nil)
-  public func didReceiveSignInWithAppleEnvelope(_ envelope: SignInWithAppleEnvelope) {
-    self.didReceiveSignInWithAppleEnvelopeProperty.value = envelope
-  }
-
   fileprivate let environmentLoggedInProperty = MutableProperty(())
   public func environmentLoggedIn() {
     self.environmentLoggedInProperty.value = ()
@@ -344,7 +335,6 @@ public final class LoginToutViewModel: LoginToutViewModelType, LoginToutViewMode
 
   public let attemptAppleLogin: Signal<(), Never>
   public let attemptFacebookLogin: Signal<(), Never>
-  public private(set) var didSignInWithApple: Signal<SignInWithAppleEnvelope, Never> = .empty
   public let dismissViewController: Signal<(), Never>
   public let headlineLabelHidden: Signal<Bool, Never>
   public let isLoading: Signal<Bool, Never>

--- a/Library/ViewModels/LoginToutViewModel.swift
+++ b/Library/ViewModels/LoginToutViewModel.swift
@@ -191,9 +191,8 @@ public final class LoginToutViewModel: LoginToutViewModelType, LoginToutViewMode
       facebookLoginAttemptFailAlert,
       genericFacebookErrorAlert
     )
-    let logIntoEnvironmentWithFacebook = facebookLogin.values()
 
-    self.logIntoEnvironment = logIntoEnvironmentWithFacebook
+    self.logIntoEnvironment = facebookLogin.values()
 
     // MARK: - Sign-in with Apple
 

--- a/Library/ViewModels/LoginToutViewModel.swift
+++ b/Library/ViewModels/LoginToutViewModel.swift
@@ -13,11 +13,9 @@ public protocol LoginToutViewModelInputs {
   func configureWith(_ intent: LoginIntent, project: Project?, reward: Reward?)
 
   /// Call when Apple completes authorization
-  @available(iOS 13.0, *)
   func appleAuthorizationDidSucceed(with data: SignInWithAppleData?)
 
   /// Call when Apple completes authorization with error
-  @available(iOS 13.0, *)
   func appleAuthorizationDidFail(with error: Error)
 
   /// Call when the environment has been logged into

--- a/Library/ViewModels/LoginToutViewModel.swift
+++ b/Library/ViewModels/LoginToutViewModel.swift
@@ -186,28 +186,26 @@ public final class LoginToutViewModel: LoginToutViewModelType, LoginToutViewMode
 
     // MARK: - Sign-in with Apple
 
-    if #available(iOS 13.0, *) {
-      let appleSignInInput = self.appleAuthorizationDidSucceedWithDataProperty.signal
-        .skipNil()
-        .map { data in
-          SignInWithAppleInput(
-            appId: data.appId,
-            authCode: data.token,
-            firstName: data.firstName,
-            lastName: data.lastName
-          )
-        }
-
-      let appleSignInEvent = appleSignInInput
-        .switchMap { input in
-          AppEnvironment.current.apiService.signInWithApple(input: input)
-            .materialize()
-        }
-
-      // This is temporary uniquely to prove that the mutation is working properly for review purposes.
-      appleSignInEvent.observeValues { v in
-        print("=== Sign In With Apple ===\n\(v) ")
+    let appleSignInInput = self.appleAuthorizationDidSucceedWithDataProperty.signal
+      .skipNil()
+      .map { data in
+        SignInWithAppleInput(
+          appId: data.appId,
+          authCode: data.token,
+          firstName: data.firstName,
+          lastName: data.lastName
+        )
       }
+
+    let appleSignInEvent = appleSignInInput
+      .switchMap { input in
+        AppEnvironment.current.apiService.signInWithApple(input: input)
+          .materialize()
+      }
+
+    // This is temporary uniquely to prove that the mutation is working properly for review purposes.
+    appleSignInEvent.observeValues { v in
+      print("=== Sign In With Apple ===\n\(v) ")
     }
 
     // MARK: - Tracking

--- a/Library/ViewModels/LoginToutViewModel.swift
+++ b/Library/ViewModels/LoginToutViewModel.swift
@@ -200,10 +200,12 @@ public final class LoginToutViewModel: LoginToutViewModelType, LoginToutViewMode
       let appleSignInInput = self.appleAuthorizationDidCompleteWithDataProperty.signal
         .skipNil()
         .map { data in
-          SignInWithAppleInput(appId: data.appId,
-                               authCode: data.token,
-                               firstName: data.firstName,
-                               lastName: data.lastName)
+          SignInWithAppleInput(
+            appId: data.appId,
+            authCode: data.token,
+            firstName: data.firstName,
+            lastName: data.lastName
+          )
         }
 
       let appleSignInEvent = appleSignInInput
@@ -347,7 +349,7 @@ public final class LoginToutViewModel: LoginToutViewModelType, LoginToutViewMode
   }
 
   public let attemptFacebookLogin: Signal<(), Never>
-  private(set) public var didSignInWithApple: Signal<SignInWithAppleEnvelope, Never> = .empty
+  public private(set) var didSignInWithApple: Signal<SignInWithAppleEnvelope, Never> = .empty
   public let dismissViewController: Signal<(), Never>
   public let headlineLabelHidden: Signal<Bool, Never>
   public let isLoading: Signal<Bool, Never>

--- a/Library/ViewModels/LoginToutViewModel.swift
+++ b/Library/ViewModels/LoginToutViewModel.swift
@@ -197,6 +197,7 @@ public final class LoginToutViewModel: LoginToutViewModelType, LoginToutViewMode
                                            lastName: data.lastName)
 
           _ = AppEnvironment.current.apiService.signInWithApple(input: input)
+            .materialize()
       }
     }
 

--- a/Library/ViewModels/LoginToutViewModel.swift
+++ b/Library/ViewModels/LoginToutViewModel.swift
@@ -206,7 +206,6 @@ public final class LoginToutViewModel: LoginToutViewModelType, LoginToutViewMode
       }
     }
 
-
     // MARK: - Tracking
 
     let trackingData = Signal.combineLatest(
@@ -314,9 +313,9 @@ public final class LoginToutViewModel: LoginToutViewModelType, LoginToutViewMode
   }
 
   fileprivate let signupButtonPressedProperty = MutableProperty(())
-   public func signupButtonPressed() {
-     self.signupButtonPressedProperty.value = ()
-   }
+  public func signupButtonPressed() {
+    self.signupButtonPressedProperty.value = ()
+  }
 
   fileprivate let userSessionStartedProperty = MutableProperty(())
   public func userSessionStarted() {

--- a/Library/ViewModels/LoginToutViewModel.swift
+++ b/Library/ViewModels/LoginToutViewModel.swift
@@ -53,6 +53,9 @@ public protocol LoginToutViewModelInputs {
 }
 
 public protocol LoginToutViewModelOutputs {
+  /// Emits when Apple login should start
+  var attemptAppleLogin: Signal<Void, Never> { get }
+
   /// Emits when Facebook login should start
   var attemptFacebookLogin: Signal<(), Never> { get }
 
@@ -77,9 +80,6 @@ public protocol LoginToutViewModelOutputs {
 
   /// Emits when a login success notification should be posted.
   var postNotification: Signal<(Notification, Notification), Never> { get }
-
-  /// Emits when Continue with Apple button is tapped.
-  var prepareSignInWithAppleRequest: Signal<Void, Never> { get }
 
   /// Emits when should show Facebook error alert with AlertError
   var showFacebookErrorAlert: Signal<AlertError, Never> { get }
@@ -139,7 +139,7 @@ public final class LoginToutViewModel: LoginToutViewModelType, LoginToutViewMode
           .materialize()
       }
 
-    self.prepareSignInWithAppleRequest = self.appleLoginButtonPressedProperty.signal.ignoreValues()
+    self.attemptAppleLogin = self.appleLoginButtonPressedProperty.signal.ignoreValues()
 
     let tfaRequiredError = facebookLogin.errors()
       .filter { $0.ksrCode == .TfaRequired }
@@ -342,6 +342,7 @@ public final class LoginToutViewModel: LoginToutViewModelType, LoginToutViewMode
     self.viewWillAppearProperty.value = ()
   }
 
+  public let attemptAppleLogin: Signal<(), Never>
   public let attemptFacebookLogin: Signal<(), Never>
   public private(set) var didSignInWithApple: Signal<SignInWithAppleEnvelope, Never> = .empty
   public let dismissViewController: Signal<(), Never>
@@ -350,7 +351,6 @@ public final class LoginToutViewModel: LoginToutViewModelType, LoginToutViewMode
   public let logInContextText: Signal<String, Never>
   public let logIntoEnvironment: Signal<AccessTokenEnvelope, Never>
   public let postNotification: Signal<(Notification, Notification), Never>
-  public let prepareSignInWithAppleRequest: Signal<(), Never>
   public let startFacebookConfirmation: Signal<(ErrorEnvelope.FacebookUser?, String), Never>
   public let startLogin: Signal<(), Never>
   public let startSignup: Signal<(), Never>

--- a/Library/ViewModels/LoginToutViewModel.swift
+++ b/Library/ViewModels/LoginToutViewModel.swift
@@ -376,29 +376,3 @@ private func statusString(_ forStatus: LoginIntent) -> String {
     return Strings.Pledge_to_projects_and_view_all_your_saved_and_backed_projects_in_one_place()
   }
 }
-
-@available(iOS 13.0, *)
-private func continueWithAppleData(from authorization: ASAuthorization?) -> SignInWithAppleData? {
-  guard let authorization = authorization else {
-    return nil
-  }
-
-  switch authorization.credential {
-  case let appleIDCredential as ASAuthorizationAppleIDCredential:
-
-    guard let authToken = appleIDCredential.authorizationCode else {
-      return nil
-    }
-
-    let fullName = appleIDCredential.fullName
-    let firstName = fullName?.givenName
-    let lastName = fullName?.familyName
-    let token = String(data: authToken, encoding: .utf8)
-    let appId = AppEnvironment.current.apiService.appId
-
-    return (appId: appId, firstName: firstName, lastName: lastName, token: token) as? SignInWithAppleData
-
-  default:
-    return nil
-  }
-}

--- a/Library/ViewModels/LoginToutViewModel.swift
+++ b/Library/ViewModels/LoginToutViewModel.swift
@@ -204,13 +204,17 @@ public final class LoginToutViewModel: LoginToutViewModelType, LoginToutViewMode
             .materialize()
         }
 
-      let fetchUserEvent = appleSignInEvent.values()
-        .switchMap { envelope in
-          AppEnvironment.current.apiService.fetchUser(userId: envelope.signInWithApple.user.intID!)
+      let userId = appleSignInEvent.values()
+        .map(\.signInWithApple.user.intID)
+        .skipNil()
+
+      let fetchUserEvent = userId
+        .switchMap { id in
+          AppEnvironment.current.apiService.fetchUser(userId: id)
             .ksr_delay(AppEnvironment.current.apiDelayInterval, on: AppEnvironment.current.scheduler)
             .prefix(SignalProducer([AppEnvironment.current.currentUser].compact()))
             .materialize()
-      }
+        }
       
       let logIntoEnvironmentWithApple = appleSignInEvent.values()
         .map(\.signInWithApple.apiAccessToken)

--- a/Library/ViewModels/LoginToutViewModel.swift
+++ b/Library/ViewModels/LoginToutViewModel.swift
@@ -1,4 +1,3 @@
-import AuthenticationServices
 import FBSDKLoginKit
 import KsApi
 import Prelude
@@ -15,11 +14,11 @@ public protocol LoginToutViewModelInputs {
 
   /// Call when Apple completes authorization
   @available(iOS 13.0, *)
-  func appleAuthorizationDidComplete(with data: SignInWithAppleData?)
+  func appleAuthorizationDidSucceed(with data: SignInWithAppleData?)
 
   /// Call when Apple completes authorization with error
   @available(iOS 13.0, *)
-  func appleAuthorizationDidComplete(with error: Error)
+  func appleAuthorizationDidFail(with error: Error)
 
   /// Call when the SignInWithAppleEnvelope is received from the server
   func didReceiveSignInWithAppleEnvelope(_ envelope: SignInWithAppleEnvelope)
@@ -197,7 +196,7 @@ public final class LoginToutViewModel: LoginToutViewModelType, LoginToutViewMode
     // MARK: - Sign-in with Apple
 
     if #available(iOS 13.0, *) {
-      let appleSignInInput = self.appleAuthorizationDidCompleteWithDataProperty.signal
+      let appleSignInInput = self.appleAuthorizationDidSucceedWithDataProperty.signal
         .skipNil()
         .map { data in
           SignInWithAppleInput(
@@ -274,19 +273,14 @@ public final class LoginToutViewModel: LoginToutViewModelType, LoginToutViewMode
     self.appleLoginButtonPressedProperty.value = ()
   }
 
-  // This property is being set as lazy because we can't use @available in computed properties.
-  @available(iOS 13.0, *)
-  private lazy var appleAuthorizationDidCompleteWithDataProperty =
-    MutableProperty<SignInWithAppleData?>(nil)
-
-  @available(iOS 13.0, *)
-  public func appleAuthorizationDidComplete(with data: SignInWithAppleData?) {
-    self.appleAuthorizationDidCompleteWithDataProperty.value = data
+  fileprivate let appleAuthorizationDidSucceedWithDataProperty = MutableProperty<SignInWithAppleData?>(nil)
+  public func appleAuthorizationDidSucceed(with data: SignInWithAppleData?) {
+    self.appleAuthorizationDidSucceedWithDataProperty.value = data
   }
 
-  fileprivate let appleAuthorizationDidCompleteWithErrorProperty = MutableProperty<Error?>(nil)
-  public func appleAuthorizationDidComplete(with error: Error) {
-    self.appleAuthorizationDidCompleteWithErrorProperty.value = error
+  fileprivate let appleAuthorizationDidFailWithErrorProperty = MutableProperty<Error?>(nil)
+  public func appleAuthorizationDidFail(with error: Error) {
+    self.appleAuthorizationDidFailWithErrorProperty.value = error
   }
 
   fileprivate let loginIntentProperty = MutableProperty<LoginIntent?>(.loginTab)

--- a/Library/ViewModels/LoginToutViewModelTests.swift
+++ b/Library/ViewModels/LoginToutViewModelTests.swift
@@ -609,7 +609,7 @@ final class LoginToutViewModelTests: TestCase {
         .first
 
       XCTAssertEqual("api_access_token", value?.signInWithApple.apiAccessToken)
-      XCTAssertEqual("1", value?.signInWithApple.user.id)
+      XCTAssertEqual("1", value?.signInWithApple.user.uid)
     }
   }
 }

--- a/Library/ViewModels/LoginToutViewModelTests.swift
+++ b/Library/ViewModels/LoginToutViewModelTests.swift
@@ -31,9 +31,6 @@ final class LoginToutViewModelTests: TestCase {
 
     self.vm.outputs.attemptAppleLogin.observe(self.attemptAppleLogin.observer)
     self.vm.outputs.attemptFacebookLogin.observe(self.attemptFacebookLogin.observer)
-    if #available(iOS 13.0, *) {
-      self.vm.outputs.didSignInWithApple.observe(self.didSignInWithApple.observer)
-    }
     self.vm.outputs.dismissViewController.observe(self.dismissViewController.observer)
     self.vm.outputs.headlineLabelHidden.observe(self.headlineLabelHidden.observer)
     self.vm.outputs.isLoading.observe(self.isLoading.observer)
@@ -590,28 +587,6 @@ final class LoginToutViewModelTests: TestCase {
     self.vm.inputs.userSessionStarted()
 
     self.dismissViewController.assertValueCount(1)
-  }
-
-  @available(iOS 13, *)
-  func testDidSignInWithApple() {
-    let response = SignInWithAppleEnvelope.template
-
-    withEnvironment(apiService: MockService(signInWithAppleResponse: response)) {
-      let data = SignInWithAppleData(
-        appId: "com.kickstarter.test",
-        firstName: "Nino",
-        lastName: "Teixeira",
-        token: "apple_auth_token"
-      )
-
-      self.vm.inputs.appleAuthorizationDidSucceed(with: data)
-
-      let value = self.didSignInWithApple.values
-        .first
-
-      XCTAssertEqual("api_access_token", value?.signInWithApple.apiAccessToken)
-      XCTAssertEqual("1", value?.signInWithApple.user.uid)
-    }
   }
 
   func testAttemptAppleLogin() {

--- a/Library/ViewModels/LoginToutViewModelTests.swift
+++ b/Library/ViewModels/LoginToutViewModelTests.swift
@@ -1,8 +1,8 @@
+import AuthenticationServices
 @testable import FBSDKCoreKit
 @testable import FBSDKLoginKit
 @testable import KsApi
 @testable import Library
-import AuthenticationServices
 import Prelude
 import ReactiveExtensions
 import ReactiveExtensions_TestHelpers
@@ -13,7 +13,7 @@ final class LoginToutViewModelTests: TestCase {
   fileprivate let vm: LoginToutViewModelType = LoginToutViewModel()
 
   fileprivate let attemptFacebookLogin = TestObserver<(), Never>()
-    fileprivate let didSignInWithApple = TestObserver<SignInWithAppleEnvelope, Never>()
+  fileprivate let didSignInWithApple = TestObserver<SignInWithAppleEnvelope, Never>()
   fileprivate let dismissViewController = TestObserver<(), Never>()
   fileprivate let headlineLabelHidden = TestObserver<Bool, Never>()
   fileprivate let isLoading = TestObserver<Bool, Never>()
@@ -593,11 +593,9 @@ final class LoginToutViewModelTests: TestCase {
 
   @available(iOS 13, *)
   func testDidSignInWithApple() {
-
     let response = SignInWithAppleEnvelope.template
 
     withEnvironment(apiService: MockService(signInWithAppleResponse: response)) {
-
       let data = SignInWithAppleData(
         appId: "com.kickstarter.test",
         firstName: "Nino",

--- a/Library/ViewModels/LoginToutViewModelTests.swift
+++ b/Library/ViewModels/LoginToutViewModelTests.swift
@@ -13,7 +13,6 @@ final class LoginToutViewModelTests: TestCase {
 
   fileprivate let attemptAppleLogin = TestObserver<(), Never>()
   fileprivate let attemptFacebookLogin = TestObserver<(), Never>()
-  fileprivate let didSignInWithApple = TestObserver<SignInWithAppleEnvelope, Never>()
   fileprivate let dismissViewController = TestObserver<(), Never>()
   fileprivate let headlineLabelHidden = TestObserver<Bool, Never>()
   fileprivate let isLoading = TestObserver<Bool, Never>()

--- a/Library/ViewModels/LoginToutViewModelTests.swift
+++ b/Library/ViewModels/LoginToutViewModelTests.swift
@@ -11,6 +11,7 @@ import XCTest
 final class LoginToutViewModelTests: TestCase {
   fileprivate let vm: LoginToutViewModelType = LoginToutViewModel()
 
+  fileprivate let attemptAppleLogin = TestObserver<(), Never>()
   fileprivate let attemptFacebookLogin = TestObserver<(), Never>()
   fileprivate let didSignInWithApple = TestObserver<SignInWithAppleEnvelope, Never>()
   fileprivate let dismissViewController = TestObserver<(), Never>()
@@ -19,7 +20,6 @@ final class LoginToutViewModelTests: TestCase {
   fileprivate let logInContextText = TestObserver<String, Never>()
   fileprivate let logIntoEnvironment = TestObserver<AccessTokenEnvelope, Never>()
   fileprivate let postNotification = TestObserver<(Notification.Name, Notification.Name), Never>()
-  fileprivate let prepareSignInWithAppleRequest = TestObserver<(), Never>()
   fileprivate let showFacebookErrorAlert = TestObserver<AlertError, Never>()
   fileprivate let startFacebookConfirmation = TestObserver<String, Never>()
   fileprivate let startLogin = TestObserver<(), Never>()
@@ -29,6 +29,7 @@ final class LoginToutViewModelTests: TestCase {
   override func setUp() {
     super.setUp()
 
+    self.vm.outputs.attemptAppleLogin.observe(self.attemptAppleLogin.observer)
     self.vm.outputs.attemptFacebookLogin.observe(self.attemptFacebookLogin.observer)
     if #available(iOS 13.0, *) {
       self.vm.outputs.didSignInWithApple.observe(self.didSignInWithApple.observer)
@@ -39,7 +40,6 @@ final class LoginToutViewModelTests: TestCase {
     self.vm.outputs.logInContextText.observe(self.logInContextText.observer)
     self.vm.outputs.logIntoEnvironment.observe(self.logIntoEnvironment.observer)
     self.vm.outputs.postNotification.map { ($0.0.name, $0.1.name) }.observe(self.postNotification.observer)
-    self.vm.outputs.prepareSignInWithAppleRequest.observe(self.prepareSignInWithAppleRequest.observer)
     self.vm.outputs.showFacebookErrorAlert.observe(self.showFacebookErrorAlert.observer)
     self.vm.outputs.startFacebookConfirmation.map { _, token in token }
       .observe(self.startFacebookConfirmation.observer)
@@ -614,11 +614,11 @@ final class LoginToutViewModelTests: TestCase {
     }
   }
 
-  func testPrepareSignInWithAppleRequest() {
-    self.prepareSignInWithAppleRequest.assertDidNotEmitValue()
+  func testAttemptAppleLogin() {
+    self.attemptAppleLogin.assertDidNotEmitValue()
 
     self.vm.inputs.appleLoginButtonPressed()
 
-    self.prepareSignInWithAppleRequest.assertValueCount(1)
+    self.attemptAppleLogin.assertValueCount(1)
   }
 }

--- a/Library/ViewModels/LoginToutViewModelTests.swift
+++ b/Library/ViewModels/LoginToutViewModelTests.swift
@@ -1,4 +1,3 @@
-import AuthenticationServices
 @testable import FBSDKCoreKit
 @testable import FBSDKLoginKit
 @testable import KsApi
@@ -20,6 +19,7 @@ final class LoginToutViewModelTests: TestCase {
   fileprivate let logInContextText = TestObserver<String, Never>()
   fileprivate let logIntoEnvironment = TestObserver<AccessTokenEnvelope, Never>()
   fileprivate let postNotification = TestObserver<(Notification.Name, Notification.Name), Never>()
+  fileprivate let prepareSignInWithAppleRequest = TestObserver<(), Never>()
   fileprivate let showFacebookErrorAlert = TestObserver<AlertError, Never>()
   fileprivate let startFacebookConfirmation = TestObserver<String, Never>()
   fileprivate let startLogin = TestObserver<(), Never>()
@@ -39,6 +39,7 @@ final class LoginToutViewModelTests: TestCase {
     self.vm.outputs.logInContextText.observe(self.logInContextText.observer)
     self.vm.outputs.logIntoEnvironment.observe(self.logIntoEnvironment.observer)
     self.vm.outputs.postNotification.map { ($0.0.name, $0.1.name) }.observe(self.postNotification.observer)
+    self.vm.outputs.prepareSignInWithAppleRequest.observe(self.prepareSignInWithAppleRequest.observer)
     self.vm.outputs.showFacebookErrorAlert.observe(self.showFacebookErrorAlert.observer)
     self.vm.outputs.startFacebookConfirmation.map { _, token in token }
       .observe(self.startFacebookConfirmation.observer)
@@ -603,7 +604,7 @@ final class LoginToutViewModelTests: TestCase {
         token: "apple_auth_token"
       )
 
-      self.vm.inputs.appleAuthorizationDidComplete(with: data)
+      self.vm.inputs.appleAuthorizationDidSucceed(with: data)
 
       let value = self.didSignInWithApple.values
         .first
@@ -611,5 +612,13 @@ final class LoginToutViewModelTests: TestCase {
       XCTAssertEqual("api_access_token", value?.signInWithApple.apiAccessToken)
       XCTAssertEqual("1", value?.signInWithApple.user.uid)
     }
+  }
+
+  func testPrepareSignInWithAppleRequest() {
+    self.prepareSignInWithAppleRequest.assertDidNotEmitValue()
+
+    self.vm.inputs.appleLoginButtonPressed()
+
+    self.prepareSignInWithAppleRequest.assertValueCount(1)
   }
 }


### PR DESCRIPTION
# 📲 What
- Adds the `signInWithApple` mutation to the codebase.
** Note: ** This PR only contains the mutation. It doesn't fetch the user from v1, thus doesn't login into our Environment. This will be done in the second part of this work.

# 🤔 Why

- This work is part of the Sign-In With Apple epic. The mutation will allow users to login using the `Sign in with Apple` functionality.

[JIRA ticket](https://kickstarter.atlassian.net/browse/NT-867)

# 🛠 How

- Added the Sign in with Apple capability
- Created the `SignInWithAppleInput` containing `appId`, `firstName`, `lastName`, and `authToken` (provided by Apple)
- Created the `SignInWithAppleEnvelope` to be decoded once graphQL returns a value
- A new `didSignInWithApple` output was created.
- Added tests

# ✅ Acceptance criteria
To test this, change the environment to `Development`

- [ ] Being logged out, go to login/signup screen and tap the `Continue with Apple` button. Complete the CWA flow. The `didSignInWithApple` output should emit a signal with a `apiAccessToken` and a `user` (from graphQL).
