### PR TITLE
[NT-1136] Add "Processing" loader to Login/Signup Screen

### DIFF
--- a/Kickstarter-iOS/Views/Controllers/LandingPageViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/LandingPageViewController.swift
@@ -255,6 +255,7 @@ private let logoImageViewStyle: ImageViewStyle = { imageView in
     |> \.tintColor .~ .ksr_green_500
     |> \.contentMode .~ .scaleAspectFit
     |> \.translatesAutoresizingMaskIntoConstraints .~ false
+    |> \.accessibilityLabel %~ { _ in Strings.general_accessibility_kickstarter() }
 }
 
 private let pageControlStyle: PageControlStyle = { pageControl in

--- a/Kickstarter-iOS/Views/Controllers/LandingViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/LandingViewController.swift
@@ -186,6 +186,7 @@ private let logoImageViewStyle: ImageViewStyle = { imageView in
   imageView
     |> \.image .~ image(named: "kickstarter-logo")?.withRenderingMode(.alwaysTemplate)
     |> \.tintColor .~ UIColor.ksr_green_500
+    |> \.accessibilityLabel %~ { _ in Strings.general_accessibility_kickstarter() }
 }
 
 private let titleLabelStyle: LabelStyle = { label in

--- a/Kickstarter-iOS/Views/Controllers/LoginToutViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/LoginToutViewController.swift
@@ -9,7 +9,7 @@ import ReactiveSwift
 import UIKit
 
 internal final class LoginToutViewController: UIViewController,
-MFMailComposeViewControllerDelegate, ProcessingViewPresenting {
+  MFMailComposeViewControllerDelegate, ProcessingViewPresenting {
   // MARK: - Properties
 
   @available(iOS 13.0, *)
@@ -286,14 +286,14 @@ MFMailComposeViewControllerDelegate, ProcessingViewPresenting {
       }
 
     self.viewModel.outputs.isLoading
-    .observeForUI()
-    .observeValues { [weak self] isLoading in
-      if isLoading {
-        self?.showProcessingView()
-      } else {
-        self?.hideProcessingView()
+      .observeForUI()
+      .observeValues { [weak self] isLoading in
+        if isLoading {
+          self?.showProcessingView()
+        } else {
+          self?.hideProcessingView()
+        }
       }
-    }
   }
 
   // MARK: - Functions

--- a/Kickstarter-iOS/Views/Controllers/LoginToutViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/LoginToutViewController.swift
@@ -8,7 +8,8 @@ import Prelude
 import ReactiveSwift
 import UIKit
 
-internal final class LoginToutViewController: UIViewController, MFMailComposeViewControllerDelegate {
+internal final class LoginToutViewController: UIViewController,
+MFMailComposeViewControllerDelegate, ProcessingViewPresenting {
   // MARK: - Properties
 
   @available(iOS 13.0, *)
@@ -39,6 +40,7 @@ internal final class LoginToutViewController: UIViewController, MFMailComposeVie
 
   private lazy var loginContextStackView = { UIStackView() }()
   private lazy var logoImageView = { UIImageView(frame: .zero) }()
+  internal var processingView: ProcessingView? = ProcessingView(frame: .zero)
   private lazy var rootStackView = { UIStackView() }()
   private lazy var scrollView = {
     UIScrollView(frame: .zero)
@@ -73,13 +75,7 @@ internal final class LoginToutViewController: UIViewController, MFMailComposeVie
   override func viewDidLoad() {
     super.viewDidLoad()
 
-    #warning("This will be replaced with the configureTransparentNavigationBar() function, instead.")
-    _ = self.navigationController?.navigationBar
-      ?|> \.backgroundColor .~ .clear
-      ?|> \.shadowImage .~ UIImage()
-      ?|> \.isTranslucent .~ true
-
-    self.navigationController?.navigationBar.setBackgroundImage(UIImage(), for: .default)
+    self.navigationController?.configureTransparentNavigationBar()
 
     self.configureViews()
     self.setupConstraints()
@@ -288,6 +284,16 @@ internal final class LoginToutViewController: UIViewController, MFMailComposeVie
       .observeValues { [weak self] message in
         self?.present(UIAlertController.genericError(message), animated: true)
       }
+
+    self.viewModel.outputs.isLoading
+    .observeForUI()
+    .observeValues { [weak self] isLoading in
+      if isLoading {
+        self?.showProcessingView()
+      } else {
+        self?.hideProcessingView()
+      }
+    }
   }
 
   // MARK: - Functions

--- a/Kickstarter-iOS/Views/Controllers/LoginToutViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/LoginToutViewController.swift
@@ -526,6 +526,7 @@ private let logoImageViewStyle: ImageViewStyle = { imageView in
     |> \.tintColor .~ .ksr_green_500
     |> \.contentMode .~ .scaleAspectFit
     |> \.translatesAutoresizingMaskIntoConstraints .~ false
+    |> \.accessibilityLabel %~ { _ in Strings.general_accessibility_kickstarter() }
 }
 
 private let separatorViewStyle: ViewStyle = { view in

--- a/Kickstarter-iOS/Views/Controllers/PledgeViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/PledgeViewController.swift
@@ -9,7 +9,7 @@ protocol PledgeViewControllerDelegate: AnyObject {
 }
 
 final class PledgeViewController: UIViewController,
-MessageBannerViewControllerPresenting, ProcessingViewPresenting {
+  MessageBannerViewControllerPresenting, ProcessingViewPresenting {
   // MARK: - Properties
 
   private lazy var confirmationLabel: UILabel = { UILabel(frame: .zero) }()

--- a/Kickstarter-iOS/Views/Controllers/PledgeViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/PledgeViewController.swift
@@ -8,7 +8,8 @@ protocol PledgeViewControllerDelegate: AnyObject {
   func pledgeViewControllerDidUpdatePledge(_ viewController: PledgeViewController, message: String)
 }
 
-final class PledgeViewController: UIViewController, MessageBannerViewControllerPresenting {
+final class PledgeViewController: UIViewController,
+MessageBannerViewControllerPresenting, ProcessingViewPresenting {
   // MARK: - Properties
 
   private lazy var confirmationLabel: UILabel = { UILabel(frame: .zero) }()
@@ -37,7 +38,7 @@ final class PledgeViewController: UIViewController, MessageBannerViewControllerP
       |> \.delegate .~ self
   }()
 
-  private lazy var processingView: ProcessingView = { ProcessingView(frame: .zero) }()
+  internal var processingView: ProcessingView? = ProcessingView(frame: .zero)
 
   private lazy var continueViewController = {
     PledgeContinueViewController.instantiate()
@@ -425,20 +426,6 @@ final class PledgeViewController: UIViewController, MessageBannerViewControllerP
     ) { [weak self] status, _, error in
       self?.viewModel.inputs.scaFlowCompleted(with: status, error: error)
     }
-  }
-
-  private func showProcessingView() {
-    guard let window = UIApplication.shared.keyWindow else {
-      return
-    }
-
-    _ = (self.processingView, window)
-      |> ksr_addSubviewToParent()
-      |> ksr_constrainViewToEdgesInParent()
-  }
-
-  private func hideProcessingView() {
-    self.processingView.removeFromSuperview()
   }
 }
 

--- a/Kickstarter-iOS/Views/ProcessingView.swift
+++ b/Kickstarter-iOS/Views/ProcessingView.swift
@@ -3,6 +3,13 @@ import Library
 import Prelude
 import UIKit
 
+protocol ProcessingViewPresenting {
+  var processingView: ProcessingView? { get set }
+
+  func showProcessingView()
+  func hideProcessingView()
+}
+
 final class ProcessingView: UIView {
   private lazy var activityIndicator = { UIActivityIndicatorView(frame: .zero)
     |> \.translatesAutoresizingMaskIntoConstraints .~ false
@@ -87,4 +94,22 @@ private let stackViewStyle: StackViewStyle = { stackView in
     |> \.alignment .~ .center
     |> \.distribution .~ .fill
     |> \.spacing .~ Styles.grid(3)
+}
+
+extension ProcessingViewPresenting where Self: UIViewController {
+  func showProcessingView() {
+    self.processingView?.removeFromSuperview()
+
+    guard let window = UIApplication.shared.keyWindow, let processingView = self.processingView else {
+      return
+    }
+
+    _ = (processingView, window)
+      |> ksr_addSubviewToParent()
+      |> ksr_constrainViewToEdgesInParent()
+  }
+
+  func hideProcessingView() {
+    self.processingView?.removeFromSuperview()
+  }
 }

--- a/Kickstarter-iOS/Views/ProcessingView.swift
+++ b/Kickstarter-iOS/Views/ProcessingView.swift
@@ -37,7 +37,7 @@ final class ProcessingView: UIView {
     super.bindStyles()
 
     _ = self
-      |> \.backgroundColor .~ UIColor.ksr_soft_black.withAlphaComponent(0.8)
+      |> processingViewStyle
 
     _ = self.activityIndicator
       |> activityIndicatorStyle
@@ -68,6 +68,15 @@ final class ProcessingView: UIView {
   }
 }
 
+// MARK: - Styles
+
+private let processingViewStyle: ViewStyle = { view in
+  view
+    |> \.backgroundColor .~ UIColor.ksr_soft_black.withAlphaComponent(0.8)
+    |> \.isAccessibilityElement .~ true
+    |> \.accessibilityLabel %~ { _ in Strings.project_checkout_finalizing_title() }
+}
+
 private let activityIndicatorStyle: ActivityIndicatorStyle = { activityIndicator in
   activityIndicator
     |> \.style .~ .white
@@ -75,6 +84,7 @@ private let activityIndicatorStyle: ActivityIndicatorStyle = { activityIndicator
 
 private let processingLabelStyle: LabelStyle = { label in
   label
+    |> \.isAccessibilityElement .~ false
     |> \.font .~ UIFont.ksr_callout()
     |> \.textColor .~ UIColor.white
     |> \.textAlignment .~ .center
@@ -107,6 +117,13 @@ extension ProcessingViewPresenting where Self: UIViewController {
     _ = (processingView, window)
       |> ksr_addSubviewToParent()
       |> ksr_constrainViewToEdgesInParent()
+
+    if AppEnvironment.current.isVoiceOverRunning() {
+      UIAccessibility.post(
+        notification: UIAccessibility.Notification.layoutChanged,
+        argument: processingView
+      )
+    }
   }
 
   func hideProcessingView() {

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -4573,7 +4573,6 @@
 						CreatedOnToolsVersion = 7.2.1;
 						DevelopmentTeam = 48YBP49Y5N;
 						LastSwiftMigration = 1000;
-						ProvisioningStyle = Manual;
 						SystemCapabilities = {
 							com.apple.OMC = {
 								enabled = 1;
@@ -5437,7 +5436,6 @@
 				7720BA6E22DE79BF0071FDA1 /* UIViewController+Presentation.swift in Sources */,
 				7793B16D21077AEB007857C0 /* SettingsHeaderView.swift in Sources */,
 				8AD7953423A2C95000998C79 /* QualtricsTypes.swift in Sources */,
-				D710ADF9243D18EA00DC7199 /* PledgeViewCTAContainerView.swift in Sources */,
 				8A8099EB22E213F100373E66 /* RewardCardView.swift in Sources */,
 				A70F1F321D8A3E85007DA8E9 /* ProjectPamphletViewController.swift in Sources */,
 				77FA6C7120F3DD6C00809E31 /* SettingsDataSource.swift in Sources */,
@@ -6491,8 +6489,10 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = "app-icon-debug";
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = "Kickstarter-iOS/Debug.entitlements";
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = 48YBP49Y5N;
+				DEVELOPMENT_TEAM = "";
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "Kickstarter-iOS/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -6503,7 +6503,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.kickstarter.kickstarter.debug;
 				PRODUCT_MODULE_NAME = Kickstarter_iOS;
 				PRODUCT_NAME = KickDebug;
-				PROVISIONING_PROFILE_SPECIFIER = "match Development com.kickstarter.kickstarter.debug";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -4571,7 +4571,6 @@
 					};
 					A7D1F9441C850B7C000D41D5 = {
 						CreatedOnToolsVersion = 7.2.1;
-						DevelopmentTeam = 48YBP49Y5N;
 						LastSwiftMigration = 1000;
 						SystemCapabilities = {
 							com.apple.OMC = {
@@ -6490,7 +6489,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = "Kickstarter-iOS/Debug.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = "";
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -6489,9 +6489,9 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = "Kickstarter-iOS/Debug.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 48YBP49Y5N;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "Kickstarter-iOS/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/Library/ViewModels/LoginToutViewModel.swift
+++ b/Library/ViewModels/LoginToutViewModel.swift
@@ -127,6 +127,7 @@ public final class LoginToutViewModel: LoginToutViewModelType, LoginToutViewMode
     let facebookLogin = tokenString
       .switchMap { token in
         AppEnvironment.current.apiService.login(facebookAccessToken: token, code: nil)
+          .ksr_delay(AppEnvironment.current.apiDelayInterval, on: AppEnvironment.current.scheduler)
           .on(
             starting: {
               isLoading.value = true
@@ -135,7 +136,6 @@ public final class LoginToutViewModel: LoginToutViewModelType, LoginToutViewMode
               isLoading.value = false
             }
           )
-          .ksr_delay(AppEnvironment.current.apiDelayInterval, on: AppEnvironment.current.scheduler)
           .materialize()
       }
 
@@ -207,6 +207,7 @@ public final class LoginToutViewModel: LoginToutViewModelType, LoginToutViewMode
     let appleSignInEvent = appleSignInInput
       .switchMap { input in
         AppEnvironment.current.apiService.signInWithApple(input: input)
+          .ksr_delay(AppEnvironment.current.apiDelayInterval, on: AppEnvironment.current.scheduler)
           .on(
             starting: {
               isLoading.value = true
@@ -215,7 +216,6 @@ public final class LoginToutViewModel: LoginToutViewModelType, LoginToutViewMode
               isLoading.value = false
             }
           )
-          .ksr_delay(AppEnvironment.current.apiDelayInterval, on: AppEnvironment.current.scheduler)
           .materialize()
       }
 
@@ -229,6 +229,7 @@ public final class LoginToutViewModel: LoginToutViewModelType, LoginToutViewMode
     let fetchUserEvent = userId
       .switchMap { id in
         AppEnvironment.current.apiService.fetchUser(userId: id)
+          .ksr_delay(AppEnvironment.current.apiDelayInterval, on: AppEnvironment.current.scheduler)
           .on(
             starting: {
               isLoading.value = true
@@ -237,7 +238,6 @@ public final class LoginToutViewModel: LoginToutViewModelType, LoginToutViewMode
               isLoading.value = false
             }
           )
-          .ksr_delay(AppEnvironment.current.apiDelayInterval, on: AppEnvironment.current.scheduler)
           .materialize()
       }
 

--- a/Library/ViewModels/LoginToutViewModelTests.swift
+++ b/Library/ViewModels/LoginToutViewModelTests.swift
@@ -203,9 +203,12 @@ final class LoginToutViewModelTests: TestCase {
 
     self.vm.inputs.facebookLoginSuccess(result: result)
 
+    self.isLoading.assertValues([true])
+
     // Wait enough time for API request to be made.
     scheduler.advance()
 
+    self.isLoading.assertValues([true, false])
     self.logIntoEnvironment.assertValueCount(1, "Log into environment.")
     XCTAssertEqual(
       [
@@ -244,11 +247,13 @@ final class LoginToutViewModelTests: TestCase {
 
     self.vm.inputs.facebookLoginButtonPressed()
 
+    self.isLoading.assertDidNotEmitValue()
     self.attemptFacebookLogin.assertValueCount(1, "Attempt Facebook login emitted")
     self.showFacebookErrorAlert.assertValueCount(0, "Facebook login fail does not emit")
 
     self.vm.inputs.facebookLoginFail(error: error)
 
+    self.isLoading.assertDidNotEmitValue()
     self.showFacebookErrorAlert.assertValues(
       [AlertError.facebookLoginAttemptFail(error: error)],
       "Show Facebook Attempt Login error"
@@ -277,11 +282,13 @@ final class LoginToutViewModelTests: TestCase {
 
     self.vm.inputs.facebookLoginButtonPressed()
 
+    self.isLoading.assertDidNotEmitValue()
     self.attemptFacebookLogin.assertValueCount(1, "Attempt Facebook login emitted")
     self.showFacebookErrorAlert.assertValueCount(0, "Facebook login fail does not emit")
 
     self.vm.inputs.facebookLoginFail(error: error)
 
+    self.isLoading.assertDidNotEmitValue()
     self.showFacebookErrorAlert.assertValues(
       [AlertError.facebookLoginAttemptFail(error: error)],
       "Show Facebook Attempt Login error"
@@ -331,9 +338,11 @@ final class LoginToutViewModelTests: TestCase {
       vm.inputs.facebookLoginButtonPressed()
       vm.inputs.facebookLoginSuccess(result: result)
 
+      self.isLoading.assertValues([true])
       // Wait enough time for API request to be made.
       scheduler.advance()
 
+      self.isLoading.assertValues([true, false])
       showFacebookErrorAlert.assertValues([AlertError.facebookTokenFail], "Show Facebook token fail error")
       XCTAssertEqual(
         [
@@ -379,9 +388,11 @@ final class LoginToutViewModelTests: TestCase {
       vm.inputs.facebookLoginButtonPressed()
       vm.inputs.facebookLoginSuccess(result: result)
 
+      self.isLoading.assertValues([true])
       // Wait enough time for API request to be made.
       scheduler.advance()
 
+      self.isLoading.assertValues([true, false])
       showFacebookErrorAlert.assertValues(
         [AlertError.genericFacebookError(envelope: error)],
         "Show Facebook account taken error"
@@ -430,9 +441,11 @@ final class LoginToutViewModelTests: TestCase {
       vm.inputs.facebookLoginButtonPressed()
       vm.inputs.facebookLoginSuccess(result: result)
 
+      self.isLoading.assertValues([true])
       // Wait enough time for API request to be made.
       scheduler.advance()
 
+      self.isLoading.assertValues([true, false])
       showFacebookErrorAlert.assertValues(
         [AlertError.genericFacebookError(envelope: error)],
         "Show Facebook account taken error"
@@ -483,13 +496,15 @@ final class LoginToutViewModelTests: TestCase {
 
       startTwoFactorChallenge.assertDidNotEmitValue()
 
+      self.isLoading.assertValues([true])
       // Wait enough time for API request to be made.
       scheduler.advance()
 
-      startTwoFactorChallenge.assertValues(["12344566"], "TFA challenge emitted with token")
-      logIntoEnvironment.assertValueCount(0, "Did not log into environment.")
-      showFacebookErrorAlert.assertValueCount(0, "Facebook login fail does not emit")
-      startFacebookConfirmation.assertValueCount(0, "Facebook confirmation did not emit")
+      self.isLoading.assertValues([true, false])
+      self.startTwoFactorChallenge.assertValues(["12344566"], "TFA challenge emitted with token")
+      self.logIntoEnvironment.assertValueCount(0, "Did not log into environment.")
+      self.showFacebookErrorAlert.assertValueCount(0, "Facebook login fail does not emit")
+      self.startFacebookConfirmation.assertValueCount(0, "Facebook confirmation did not emit")
       XCTAssertEqual(
         [
           "Log In or Signup Page Viewed",
@@ -534,13 +549,17 @@ final class LoginToutViewModelTests: TestCase {
       vm.inputs.facebookLoginButtonPressed()
       vm.inputs.facebookLoginSuccess(result: result)
 
+      self.isLoading.assertValues([true])
       // Wait enough time for API request to be made.
       scheduler.advance()
 
-      startFacebookConfirmation.assertValues(["12344566"], "Start Facebook confirmation emitted with token")
-
-      logIntoEnvironment.assertValueCount(0, "Did not log into environment.")
-      showFacebookErrorAlert.assertValueCount(0, "Facebook login fail does not emit")
+      self.isLoading.assertValues([true, false])
+      self.startFacebookConfirmation.assertValues(
+        ["12344566"],
+        "Start Facebook confirmation emitted with token"
+      )
+      self.logIntoEnvironment.assertValueCount(0, "Did not log into environment.")
+      self.showFacebookErrorAlert.assertValueCount(0, "Facebook login fail does not emit")
       XCTAssertEqual(
         [
           "Log In or Signup Page Viewed",
@@ -551,12 +570,15 @@ final class LoginToutViewModelTests: TestCase {
 
       self.vm.inputs.viewWillAppear()
 
-      startFacebookConfirmation.assertValues(["12344566"], "Facebook confirmation didn't start again.")
+      self.startFacebookConfirmation.assertValues(["12344566"], "Facebook confirmation didn't start again.")
 
-      vm.inputs.facebookLoginButtonPressed()
-      vm.inputs.facebookLoginSuccess(result: result)
+      self.vm.inputs.facebookLoginButtonPressed()
+      self.vm.inputs.facebookLoginSuccess(result: result)
+
+      self.isLoading.assertValues([true, false, true])
       scheduler.advance()
 
+      self.isLoading.assertValues([true, false, true, false])
       startFacebookConfirmation.assertValues(
         ["12344566", "12344566"],
         "Start Facebook confirmation emitted with token"
@@ -625,10 +647,15 @@ final class LoginToutViewModelTests: TestCase {
         token: "apple_auth_token"
       )
 
+      self.isLoading.assertDidNotEmitValue()
       self.showAppleErrorAlert.assertDidNotEmitValue()
 
       self.vm.inputs.appleAuthorizationDidSucceed(with: data)
 
+      self.isLoading.assertValues([true])
+      scheduler.advance()
+
+      self.isLoading.assertValues([true, false])
       self.showAppleErrorAlert.assertValue("Something went wrong.")
     }
   }
@@ -645,11 +672,15 @@ final class LoginToutViewModelTests: TestCase {
         token: "apple_auth_token"
       )
 
+      self.isLoading.assertDidNotEmitValue()
       self.showAppleErrorAlert.assertDidNotEmitValue()
 
       self.vm.inputs.appleAuthorizationDidSucceed(with: data)
 
-      self.scheduler.run()
+      self.isLoading.assertValues([true])
+      self.scheduler.advance()
+
+      self.isLoading.assertValues([true, false])
       self.showAppleErrorAlert.assertValue(
         "The operation couldn’t be completed. (KsApi.ErrorEnvelope error 1.)"
       )
@@ -675,12 +706,15 @@ final class LoginToutViewModelTests: TestCase {
         token: "apple_auth_token"
       )
 
+      self.isLoading.assertDidNotEmitValue()
       self.logIntoEnvironment.assertDidNotEmitValue()
 
       self.vm.inputs.appleAuthorizationDidSucceed(with: data)
 
+      self.isLoading.assertValues([true])
       self.scheduler.run()
 
+      self.isLoading.assertValues([true, false])
       self.logIntoEnvironment.assertValueCount(1)
 
       let value = self.logIntoEnvironment.values.first
@@ -690,7 +724,7 @@ final class LoginToutViewModelTests: TestCase {
     }
   }
 
-  func testAttemptAppleLogin() {
+  func testAttemptAppleLogin_Tracking() {
     self.vm.inputs.configureWith(.generic, project: nil, reward: nil)
     self.vm.inputs.viewWillAppear()
 


### PR DESCRIPTION
# 📲 What

Adds the "Processing" full-screen loader view to the Login/Signup screen, and presents the loader view while the sign-in-with-apple and user requests are in flight. We will also show the loader when the login with Facebook request is in flight.

# 🤔 Why

So that we can give some indication to the user that something is happening after they authenticate with Apple and Facebook.

# 🛠 How

- made a protocol and protocol extension `ProcessingViewPresenting` where the showing/hiding functions will live
- conformed both `PledgeViewController` and `LoginToutViewController` to `ProcessingViewPresenting`
- the `isLoading` output already existed in `LoginToutViewModel`, but wasn't being used. This PR couples the `isLoading` output to the `signInWithApple` mutation, as well as the `fetchUser` request
- added VM tests
- added Voice Over support
- added accessibility labels to the Kickstarter logos which were missing

# 👀 See

![GyjckC8Cm1](https://user-images.githubusercontent.com/3156796/79897165-4cec8e00-83d7-11ea-8ccc-547ea8529b9d.gif)


# ♿️ Accessibility 

- [x] Works with VoiceOver
- [x] Supports Dynamic Type 

# ✅ Acceptance criteria

- [x] Run the app on your device, with iOS 13 and above. Navigate to the login/signup screen, and tap "Continue with Apple". Authenticate with Apple, and then you should see the "Processing" view momentarily until the request completes.

