### PR TITLE
[NT-1162] Add OptimizelyProperties

### DIFF
--- a/Library/OptimizelyClientType.swift
+++ b/Library/OptimizelyClientType.swift
@@ -6,7 +6,7 @@ public protocol OptimizelyClientType: AnyObject {
   func activate(experimentKey: String, userId: String, attributes: [String: Any?]?) throws -> String
   func getVariationKey(experimentKey: String, userId: String, attributes: [String: Any?]?) throws -> String
   func track(eventKey: String, userId: String, attributes: [String: Any?]?, eventTags: [String: Any]?) throws
-  func allExperiments() -> [OptimizelyExperiment.Key]
+  func allExperiments() -> [String]
 }
 
 extension OptimizelyClientType {
@@ -47,11 +47,11 @@ extension OptimizelyClientType {
    `variant(for experiment)`, which calls `activate` on the Optimizely SDK
    */
 
-  public func getVariation(for experiment: OptimizelyExperiment.Key) -> OptimizelyExperiment.Variant {
+  public func getVariation(for experimentKey: String) -> OptimizelyExperiment.Variant {
     let userId = deviceIdentifier(uuid: UUID())
     let attributes = optimizelyUserAttributes()
     let variationString = try? self.getVariationKey(
-      experimentKey: experiment.rawValue, userId: userId, attributes: attributes
+      experimentKey: experimentKey, userId: userId, attributes: attributes
     )
 
     guard
@@ -66,8 +66,8 @@ extension OptimizelyClientType {
 
   /* Returns all experiments the app knows about */
 
-  public func allExperiments() -> [OptimizelyExperiment.Key] {
-    return OptimizelyExperiment.Key.allCases
+  public func allExperiments() -> [String] {
+    return OptimizelyExperiment.Key.allCases.map { $0.rawValue }
   }
 }
 
@@ -96,18 +96,18 @@ public func optimizelyProperties(environment: Environment? = AppEnvironment.curr
   let allExperiments = optimizelyClient.allExperiments().map { experimentKey -> [String: String] in
     do {
       let variation = try optimizelyClient.getVariationKey(
-        experimentKey: experimentKey.rawValue,
+        experimentKey: experimentKey,
         userId: userId,
         attributes: attributes
       )
 
       return [
-        "optimizely_experiment_slug": experimentKey.rawValue,
+        "optimizely_experiment_slug": experimentKey,
         "optimizely_variant_id": variation
       ]
     } catch {
       return [
-        "optimizely_experiment_slug": experimentKey.rawValue,
+        "optimizely_experiment_slug": experimentKey,
         "optimizely_variant_id": "unknown"
       ]
     }

--- a/Library/OptimizelyClientType.swift
+++ b/Library/OptimizelyClientType.swift
@@ -6,6 +6,7 @@ public protocol OptimizelyClientType: AnyObject {
   func activate(experimentKey: String, userId: String, attributes: [String: Any?]?) throws -> String
   func getVariationKey(experimentKey: String, userId: String, attributes: [String: Any?]?) throws -> String
   func track(eventKey: String, userId: String, attributes: [String: Any?]?, eventTags: [String: Any]?) throws
+  func allExperiments() -> [OptimizelyExperiment.Key]
 }
 
 extension OptimizelyClientType {
@@ -62,9 +63,63 @@ extension OptimizelyClientType {
 
     return variant
   }
+
+  /* Returns all experiments the app knows about */
+
+  public func allExperiments() -> [OptimizelyExperiment.Key] {
+    return OptimizelyExperiment.Key.allCases
+  }
 }
 
 // MARK: - Tracking Properties
+
+public func optimizelyProperties(environment: Environment? = AppEnvironment.current) -> [String: Any]? {
+  guard let env = environment, let optimizelyClient = env.optimizelyClient else {
+    return nil
+  }
+
+  let environmentType = env.environmentType
+  let userId = deviceIdentifier(uuid: UUID())
+  let attributes = optimizelyUserAttributes()
+
+  var sdkKey: String
+
+  switch environmentType {
+  case .production:
+    sdkKey = Secrets.OptimizelySDKKey.production
+  case .staging:
+    sdkKey = Secrets.OptimizelySDKKey.staging
+  case .development, .local:
+    sdkKey = Secrets.OptimizelySDKKey.development
+  }
+
+  let allExperiments = optimizelyClient.allExperiments().map { experimentKey -> [String: String] in
+    do {
+      let variation = try optimizelyClient.getVariationKey(
+        experimentKey: experimentKey.rawValue,
+        userId: userId,
+
+        attributes: attributes
+      )
+
+      return [
+        "optimizely_experiment_slug": experimentKey.rawValue,
+        "optimizely_variant_id": variation
+      ]
+    } catch {
+      return [
+        "optimizely_experiment_slug": experimentKey.rawValue,
+        "optimizely_variant_id": "none"
+      ]
+    }
+  }
+
+  return [
+    "optimizely_api_key": sdkKey,
+    "optimizely_environment": environmentType.rawValue,
+    "optimizely_experiments": allExperiments
+  ]
+}
 
 public func optimizelyTrackingAttributesAndEventTags(
   with project: Project? = nil,
@@ -89,7 +144,7 @@ public func optimizelyUserAttributes(
   let user = AppEnvironment.current.currentUser
 
   let properties: [String: Any] = [
-    "user_distinct_id": debugAdminDeviceIdentifier(),
+    "user_distinct_id": debugDeviceIdentifier(),
     "user_backed_projects_count": user?.stats.backedProjectsCount,
     "user_launched_projects_count": user?.stats.createdProjectsCount,
     "user_country": (user?.location?.country ?? AppEnvironment.current.config?.countryCode)?.lowercased(),
@@ -114,7 +169,7 @@ private func sessionRefTagProperties(with project: Project?, refTag: RefTag?) ->
   ] as [String: Any?]).compact()
 }
 
-private func debugAdminDeviceIdentifier() -> String? {
+private func debugDeviceIdentifier() -> String? {
   guard
     AppEnvironment.current.environmentType != .production,
     AppEnvironment.current.mainBundle.isRelease == false

--- a/Library/OptimizelyClientType.swift
+++ b/Library/OptimizelyClientType.swift
@@ -94,23 +94,16 @@ public func optimizelyProperties(environment: Environment? = AppEnvironment.curr
   }
 
   let allExperiments = optimizelyClient.allExperiments().map { experimentKey -> [String: String] in
-    do {
-      let variation = try optimizelyClient.getVariationKey(
-        experimentKey: experimentKey,
-        userId: userId,
-        attributes: attributes
-      )
+    let variation = try? optimizelyClient.getVariationKey(
+      experimentKey: experimentKey,
+      userId: userId,
+      attributes: attributes
+    )
 
-      return [
-        "optimizely_experiment_slug": experimentKey,
-        "optimizely_variant_id": variation
-      ]
-    } catch {
-      return [
-        "optimizely_experiment_slug": experimentKey,
-        "optimizely_variant_id": "unknown"
-      ]
-    }
+    return [
+      "optimizely_experiment_slug": experimentKey,
+      "optimizely_variant_id": variation ?? "unknown"
+    ]
   }
 
   return [

--- a/Library/OptimizelyClientType.swift
+++ b/Library/OptimizelyClientType.swift
@@ -98,7 +98,6 @@ public func optimizelyProperties(environment: Environment? = AppEnvironment.curr
       let variation = try optimizelyClient.getVariationKey(
         experimentKey: experimentKey.rawValue,
         userId: userId,
-
         attributes: attributes
       )
 
@@ -109,7 +108,7 @@ public func optimizelyProperties(environment: Environment? = AppEnvironment.curr
     } catch {
       return [
         "optimizely_experiment_slug": experimentKey.rawValue,
-        "optimizely_variant_id": "none"
+        "optimizely_variant_id": "unknown"
       ]
     }
   }

--- a/Library/OptimizelyClientTypeTests.swift
+++ b/Library/OptimizelyClientTypeTests.swift
@@ -148,7 +148,7 @@ final class OptimizelyClientTypeTests: TestCase {
         ],
         [
           "optimizely_experiment_slug": "onboarding_category_personalization_flow",
-          "optimizely_variant_id": "none" // Not found in experiments
+          "optimizely_variant_id": "unknown" // Not found in experiments
         ]
       ], optimizelyExperiments)
 

--- a/Library/OptimizelyClientTypeTests.swift
+++ b/Library/OptimizelyClientTypeTests.swift
@@ -109,7 +109,7 @@ final class OptimizelyClientTypeTests: TestCase {
     }
   }
 
-  func testOptimizelyProperties_Production() {
+  func testOptimizelyProperties() {
     let mockOptimizelyClient = MockOptimizelyClient()
       |> \.experiments .~ [
         OptimizelyExperiment.Key.nativeOnboarding.rawValue:

--- a/Library/OptimizelyClientTypeTests.swift
+++ b/Library/OptimizelyClientTypeTests.swift
@@ -76,4 +76,100 @@ final class OptimizelyClientTypeTests: TestCase {
       XCTAssertTrue(mockClient.getVariantPathCalled)
     }
   }
+
+  func testGetVariation() {
+    let mockOptimizelyClient = MockOptimizelyClient()
+      |> \.experiments .~
+      [OptimizelyExperiment.Key.pledgeCTACopy.rawValue: OptimizelyExperiment.Variant.variant1.rawValue]
+
+    withEnvironment(currentUser: User.template, optimizelyClient: mockOptimizelyClient) {
+      let variation = mockOptimizelyClient.getVariation(for: .pledgeCTACopy)
+      let userAttributes = mockOptimizelyClient.userAttributes
+
+      XCTAssertEqual(.variant1, variation)
+      XCTAssertTrue(mockOptimizelyClient.getVariantPathCalled)
+
+      assertUserAttributes(userAttributes)
+    }
+  }
+
+  func testGetVariation_Error() {
+    let mockOptimizelyClient = MockOptimizelyClient()
+      |> \.experiments .~
+      [OptimizelyExperiment.Key.pledgeCTACopy.rawValue: OptimizelyExperiment.Variant.variant1.rawValue]
+
+    withEnvironment(currentUser: User.template, optimizelyClient: mockOptimizelyClient) {
+      let variation = mockOptimizelyClient.getVariation(for: .nativeMeProjectSummary)
+      let userAttributes = mockOptimizelyClient.userAttributes
+
+      XCTAssertEqual(.control, variation, "Defaults to control when error is thrown")
+      XCTAssertTrue(mockOptimizelyClient.getVariantPathCalled)
+
+      assertUserAttributes(userAttributes)
+    }
+  }
+
+  func testOptimizelyProperties_Production() {
+    let mockOptimizelyClient = MockOptimizelyClient()
+      |> \.experiments .~ [
+        OptimizelyExperiment.Key.nativeOnboarding.rawValue:
+          OptimizelyExperiment.Variant.control.rawValue,
+        OptimizelyExperiment.Key.nativeMeProjectSummary.rawValue:
+          OptimizelyExperiment.Variant.variant1.rawValue,
+        OptimizelyExperiment.Key.nativeProjectPageCampaignDetails.rawValue:
+          OptimizelyExperiment.Variant.variant2.rawValue
+      ]
+      |> \.allKnownExperiments .~ [
+        OptimizelyExperiment.Key.nativeOnboarding,
+        OptimizelyExperiment.Key.nativeMeProjectSummary,
+        OptimizelyExperiment.Key.nativeProjectPageCampaignDetails,
+        OptimizelyExperiment.Key.onboardingCategoryPersonalizationFlow
+      ]
+    let mockService = MockService(serverConfig: ServerConfig.staging)
+
+    withEnvironment(apiService: mockService, optimizelyClient: mockOptimizelyClient) {
+      let properties = optimizelyProperties()
+      let optimizelyExperiments = properties?["optimizely_experiments"] as? [[String: String]]
+
+      XCTAssertEqual("Staging", properties?["optimizely_environment"] as? String)
+      XCTAssertEqual(Secrets.OptimizelySDKKey.staging, properties?["optimizely_api_key"] as? String)
+      XCTAssertEqual([
+        [
+          "optimizely_experiment_slug": "native_onboarding_series_new_backers",
+          "optimizely_variant_id": "control"
+        ],
+        [
+          "optimizely_experiment_slug": "native_me_project_summary",
+          "optimizely_variant_id": "variant-1"
+        ],
+        [
+          "optimizely_experiment_slug": "native_project_page_campaign_details",
+          "optimizely_variant_id": "variant-2"
+        ],
+        [
+          "optimizely_experiment_slug": "onboarding_category_personalization_flow",
+          "optimizely_variant_id": "none" // Not found in experiments
+        ]
+      ], optimizelyExperiments)
+
+      XCTAssertEqual(4, optimizelyExperiments?.count)
+    }
+  }
+
+  private func assertUserAttributes(_ userAttributes: [String: Any?]?) {
+    XCTAssertEqual("us", userAttributes?["user_country"] as? String)
+    XCTAssertEqual("en", userAttributes?["user_display_language"] as? String)
+    XCTAssertEqual("MockSystemVersion", userAttributes?["session_os_version"] as? String)
+    XCTAssertEqual("1.2.3.4.5.6.7.8.9.0", userAttributes?["session_app_release_version"] as? String)
+    XCTAssertEqual(true, userAttributes?["session_apple_pay_device"] as? Bool)
+    XCTAssertEqual("phone", userAttributes?["session_device_format"] as? String)
+    XCTAssertEqual(true, userAttributes?["session_user_is_logged_in"] as? Bool)
+
+    XCTAssertNil(userAttributes?["user_facebook_account"] as? Bool)
+    XCTAssertNil(userAttributes?["user_backed_projects_count"] as? Int)
+    XCTAssertNil(userAttributes?["user_launched_projects_count"] as? Int)
+    XCTAssertNil(userAttributes?["user_distinct_id"] as? String)
+    XCTAssertNil(userAttributes?["session_referrer_credit"] as? String)
+    XCTAssertNil(userAttributes?["session_ref_tag"] as? String)
+  }
 }

--- a/Library/OptimizelyClientTypeTests.swift
+++ b/Library/OptimizelyClientTypeTests.swift
@@ -80,10 +80,10 @@ final class OptimizelyClientTypeTests: TestCase {
   func testGetVariation() {
     let mockOptimizelyClient = MockOptimizelyClient()
       |> \.experiments .~
-      [OptimizelyExperiment.Key.pledgeCTACopy.rawValue: OptimizelyExperiment.Variant.variant1.rawValue]
+      ["fake_experiment": OptimizelyExperiment.Variant.variant1.rawValue]
 
     withEnvironment(currentUser: User.template, optimizelyClient: mockOptimizelyClient) {
-      let variation = mockOptimizelyClient.getVariation(for: .pledgeCTACopy)
+      let variation = mockOptimizelyClient.getVariation(for: "fake_experiment")
       let userAttributes = mockOptimizelyClient.userAttributes
 
       XCTAssertEqual(.variant1, variation)
@@ -96,10 +96,10 @@ final class OptimizelyClientTypeTests: TestCase {
   func testGetVariation_Error() {
     let mockOptimizelyClient = MockOptimizelyClient()
       |> \.experiments .~
-      [OptimizelyExperiment.Key.pledgeCTACopy.rawValue: OptimizelyExperiment.Variant.variant1.rawValue]
+      ["fake_experiment": OptimizelyExperiment.Variant.variant1.rawValue]
 
     withEnvironment(currentUser: User.template, optimizelyClient: mockOptimizelyClient) {
-      let variation = mockOptimizelyClient.getVariation(for: .nativeMeProjectSummary)
+      let variation = mockOptimizelyClient.getVariation(for: "other_experiment")
       let userAttributes = mockOptimizelyClient.userAttributes
 
       XCTAssertEqual(.control, variation, "Defaults to control when error is thrown")
@@ -112,18 +112,18 @@ final class OptimizelyClientTypeTests: TestCase {
   func testOptimizelyProperties() {
     let mockOptimizelyClient = MockOptimizelyClient()
       |> \.experiments .~ [
-        OptimizelyExperiment.Key.nativeOnboarding.rawValue:
+        "fake_experiment_1":
           OptimizelyExperiment.Variant.control.rawValue,
-        OptimizelyExperiment.Key.nativeMeProjectSummary.rawValue:
+        "fake_experiment_2":
           OptimizelyExperiment.Variant.variant1.rawValue,
-        OptimizelyExperiment.Key.nativeProjectPageCampaignDetails.rawValue:
+        "fake_experiment_3":
           OptimizelyExperiment.Variant.variant2.rawValue
       ]
       |> \.allKnownExperiments .~ [
-        OptimizelyExperiment.Key.nativeOnboarding,
-        OptimizelyExperiment.Key.nativeMeProjectSummary,
-        OptimizelyExperiment.Key.nativeProjectPageCampaignDetails,
-        OptimizelyExperiment.Key.onboardingCategoryPersonalizationFlow
+        "fake_experiment_1",
+        "fake_experiment_2",
+        "fake_experiment_3",
+        "fake_experiment_4"
       ]
     let mockService = MockService(serverConfig: ServerConfig.staging)
 
@@ -135,19 +135,19 @@ final class OptimizelyClientTypeTests: TestCase {
       XCTAssertEqual(Secrets.OptimizelySDKKey.staging, properties?["optimizely_api_key"] as? String)
       XCTAssertEqual([
         [
-          "optimizely_experiment_slug": "native_onboarding_series_new_backers",
+          "optimizely_experiment_slug": "fake_experiment_1",
           "optimizely_variant_id": "control"
         ],
         [
-          "optimizely_experiment_slug": "native_me_project_summary",
+          "optimizely_experiment_slug": "fake_experiment_2",
           "optimizely_variant_id": "variant-1"
         ],
         [
-          "optimizely_experiment_slug": "native_project_page_campaign_details",
+          "optimizely_experiment_slug": "fake_experiment_3",
           "optimizely_variant_id": "variant-2"
         ],
         [
-          "optimizely_experiment_slug": "onboarding_category_personalization_flow",
+          "optimizely_experiment_slug": "fake_experiment_4",
           "optimizely_variant_id": "unknown" // Not found in experiments
         ]
       ], optimizelyExperiments)

--- a/Library/OptimizelyExperiment.swift
+++ b/Library/OptimizelyExperiment.swift
@@ -2,7 +2,7 @@ import Foundation
 import KsApi
 
 public enum OptimizelyExperiment {
-  public enum Key: String {
+  public enum Key: String, CaseIterable {
     case nativeOnboarding = "native_onboarding_series_new_backers"
     case pledgeCTACopy = "pledge_cta_copy"
     case onboardingCategoryPersonalizationFlow = "onboarding_category_personalization_flow"

--- a/Library/TestHelpers/MockOptimizelyClient.swift
+++ b/Library/TestHelpers/MockOptimizelyClient.swift
@@ -13,6 +13,7 @@ internal class MockOptimizelyClient: OptimizelyClientType {
   // MARK: - Experiment Activation Test Properties
 
   var activatePathCalled: Bool = false
+  var allKnownExperiments: [OptimizelyExperiment.Key] = []
   var experiments: [String: String] = [:]
   var error: MockOptimizelyError?
   var getVariantPathCalled: Bool = false
@@ -46,7 +47,7 @@ internal class MockOptimizelyClient: OptimizelyClientType {
       }
 
       guard let experimentVariant = self.experiments[key] else {
-        return OptimizelyExperiment.Variant.control.rawValue
+        throw MockOptimizelyError.generic
       }
 
       return experimentVariant
@@ -58,6 +59,10 @@ internal class MockOptimizelyClient: OptimizelyClientType {
     self.trackedAttributes = attributes
     self.trackedEventTags = eventTags
     self.trackedUserId = userId
+  }
+
+  func allExperiments() -> [OptimizelyExperiment.Key] {
+    return self.allKnownExperiments
   }
 }
 

--- a/Library/TestHelpers/MockOptimizelyClient.swift
+++ b/Library/TestHelpers/MockOptimizelyClient.swift
@@ -13,7 +13,7 @@ internal class MockOptimizelyClient: OptimizelyClientType {
   // MARK: - Experiment Activation Test Properties
 
   var activatePathCalled: Bool = false
-  var allKnownExperiments: [OptimizelyExperiment.Key] = []
+  var allKnownExperiments: [String] = []
   var experiments: [String: String] = [:]
   var error: MockOptimizelyError?
   var getVariantPathCalled: Bool = false
@@ -61,7 +61,7 @@ internal class MockOptimizelyClient: OptimizelyClientType {
     self.trackedUserId = userId
   }
 
-  func allExperiments() -> [OptimizelyExperiment.Key] {
+  func allExperiments() -> [String] {
     return self.allKnownExperiments
   }
 }

--- a/Library/ViewModels/DiscoveryPageViewModel.swift
+++ b/Library/ViewModels/DiscoveryPageViewModel.swift
@@ -583,7 +583,7 @@ private func shouldShowPersonalization() -> Bool {
   }
 
   guard let variant = AppEnvironment.current.optimizelyClient?
-    .getVariation(for: .onboardingCategoryPersonalizationFlow) else {
+    .getVariation(for: OptimizelyExperiment.Key.onboardingCategoryPersonalizationFlow.rawValue) else {
     return false
   }
 


### PR DESCRIPTION
# 📲 What

Adds a set of "Optimizely Properties" that will be sent with certain events to the data lake.

# 🤔 Why

We want to be able to analyze experiment results in Amplitude. As part of this work, we will send some Optimizely data along with certain events to the data lake, to be passed forward to Amplitude from there. This PR adds the `optimizelyProperties()` function that will generate these properties to be sent with desired events.

# 🛠 How

- adds `optimizelyProperties` function, which calls `getVariation` on all known experiments. If `getVariation` throws an error, we report the variant as "unknown" for that experiment
- adds tests for `optimizelyProperties`
- adds tests for our helper `getVariation` function that didn't have tests previously

# ♿️ Accessibility 

N/A

# 🏎 Performance

N/A

# ✅ Acceptance criteria

The `optimizelyProperties` function isn't being used anywhere yet, so all that's needed is code review and test review.
