### PR TITLE
[NT-1175] Coalesce experimental variants to control

### DIFF
--- a/Library/OptimizelyExperiment.swift
+++ b/Library/OptimizelyExperiment.swift
@@ -22,7 +22,7 @@ extension OptimizelyExperiment {
   static func projectCampaignExperiment(
     project: Project,
     refTag: RefTag?
-  ) -> OptimizelyExperiment.Variant? {
+  ) -> OptimizelyExperiment.Variant {
     return AppEnvironment.current.optimizelyClient?
       .variant(
         for: OptimizelyExperiment.Key.nativeProjectPageCampaignDetails,

--- a/Library/OptimizelyExperiment.swift
+++ b/Library/OptimizelyExperiment.swift
@@ -27,6 +27,6 @@ extension OptimizelyExperiment {
       .variant(
         for: OptimizelyExperiment.Key.nativeProjectPageCampaignDetails,
         userAttributes: optimizelyUserAttributes(with: project, refTag: refTag)
-      )
+      ) ?? .control
   }
 }

--- a/Library/ViewModels/ProjectPamphletContentViewModel.swift
+++ b/Library/ViewModels/ProjectPamphletContentViewModel.swift
@@ -310,24 +310,24 @@ private func projectSummaryQuery(withSlug slug: String) -> NonEmptySet<Query> {
 
 private func projectPageConversionCreatorDetailsExperiment(
   project: Project, refTag: RefTag?
-) -> OptimizelyExperiment.Variant? {
+) -> OptimizelyExperiment.Variant {
   let optimizelyVariant = AppEnvironment.current.optimizelyClient?
     .variant(
       for: OptimizelyExperiment.Key.nativeProjectPageConversionCreatorDetails,
       userAttributes: optimizelyUserAttributes(with: project, refTag: refTag)
-    )
+    ) ?? .control
 
   return optimizelyVariant
 }
 
 private func projectPageConversionProjectSummaryExperiment(
   project: Project, refTag: RefTag?
-) -> OptimizelyExperiment.Variant? {
+) -> OptimizelyExperiment.Variant {
   let optimizelyVariant = AppEnvironment.current.optimizelyClient?
     .variant(
       for: OptimizelyExperiment.Key.nativeMeProjectSummary,
       userAttributes: optimizelyUserAttributes(with: project, refTag: refTag)
-    )
+    ) ?? .control
 
   return optimizelyVariant
 }

--- a/Library/ViewModels/ProjectPamphletMainCellViewModel.swift
+++ b/Library/ViewModels/ProjectPamphletMainCellViewModel.swift
@@ -214,7 +214,6 @@ public final class ProjectPamphletMainCellViewModel: ProjectPamphletMainCellView
 
     let projectCampaignExperimentVariant = projectAndRefTag
       .map(OptimizelyExperiment.projectCampaignExperiment)
-      .skipNil()
 
     self.configureCreatorBylineView = Signal.combineLatest(project, creatorDetails)
 

--- a/Library/ViewModels/ProjectPamphletMainCellViewModelTests.swift
+++ b/Library/ViewModels/ProjectPamphletMainCellViewModelTests.swift
@@ -555,6 +555,21 @@ final class ProjectPamphletMainCellViewModelTests: TestCase {
     }
   }
 
+  func testProjectCampaignCTA_OptimizelyControl_OptimizelyClientNotConfigured() {
+    let creatorDetails = ProjectCreatorDetailsEnvelope.template
+
+    self.readMoreButtonIsHidden.assertDidNotEmitValue()
+    self.readMoreButtonLargeIsHidden.assertDidNotEmitValue()
+
+    withEnvironment(optimizelyClient: nil) {
+      self.vm.inputs.configureWith(value: (.template, nil, (creatorDetails, false), []))
+      self.vm.inputs.awakeFromNib()
+
+      self.readMoreButtonIsHidden.assertValues([false])
+      self.readMoreButtonLargeIsHidden.assertValues([true])
+    }
+  }
+
   func testProjectCampaignCTA_OptimizelyExperimental_Variant1() {
     let creatorDetails = ProjectCreatorDetailsEnvelope.template
     let optimizelyClient = MockOptimizelyClient()


### PR DESCRIPTION
# 📲 What

Coalesces optional `OptimizelyExperiment.Variant?` values to `.control`.

# 🤔 Why

We've received a handful of bug reports in which the _read more about the campaign_ button is missing on the project page. We suspect this might occur if the Optimizely client fails to initialize and the `skipNil()` on the signal that configures the button causes it to never emit.

# 🛠 How

Coalesced `nil` values to `.control` in functions where we return an optional value for the variant.

# ✅ Acceptance criteria

- [ ] Prevent the Optimizely client from being configured, navigate to the project page. The read more button should be visible.