### PR TITLE
[NT-735] Remove Apple Sign In from enterprise profiles

### DIFF
--- a/Kickstarter-iOS/Alpha.entitlements
+++ b/Kickstarter-iOS/Alpha.entitlements
@@ -4,10 +4,6 @@
   <dict>
     <key>aps-environment</key>
     <string>production</string>
-    <key>com.apple.developer.applesignin</key>
-    <array>
-      <string>Default</string>
-    </array>
     <key>com.apple.developer.associated-domains</key>
     <array>
       <string>applinks:www.kickstarter.com</string>

--- a/Kickstarter-iOS/Beta.entitlements
+++ b/Kickstarter-iOS/Beta.entitlements
@@ -4,10 +4,6 @@
   <dict>
     <key>aps-environment</key>
     <string>production</string>
-    <key>com.apple.developer.applesignin</key>
-    <array>
-      <string>Default</string>
-    </array>
     <key>com.apple.developer.associated-domains</key>
     <array>
       <string>applinks:www.kickstarter.com</string>


### PR DESCRIPTION
# 📲 What

Removes Sign In With Apple entitlement from our Enterprise provisioning profiles.

# 🤔 Why

I noticed that our most recent merge to `master` failed to distribute a beta build because of this value in the provisioning profile. Sign In With Apple is not supported by Enterprise accounts which our Alpha and Beta profiles belong to. I should have noticed this up when I reviewed #1165 🤦‍♂️ 

# 🛠 How

Removed the entitlement from Alpha and Beta profiles.