### PR TITLE
[NT-1210] Present Project modal fullscreen on iPad

### DIFF
--- a/Kickstarter-iOS/Views/Controllers/ActivitiesViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/ActivitiesViewController.swift
@@ -218,6 +218,9 @@ internal final class ActivitiesViewController: UITableViewController {
 
   fileprivate func present(project: Project, refTag: RefTag) {
     let vc = ProjectNavigatorViewController.configuredWith(project: project, refTag: refTag)
+    if UIDevice.current.userInterfaceIdiom == .pad {
+      vc.modalPresentationStyle = .fullScreen
+    }
     self.present(vc, animated: true, completion: nil)
   }
 

--- a/Kickstarter-iOS/Views/Controllers/BackerDashboardProjectsViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/BackerDashboardProjectsViewController.swift
@@ -127,6 +127,9 @@ internal final class BackerDashboardProjectsViewController: UITableViewControlle
       initialPlaylist: initialPlaylist,
       navigatorDelegate: self
     )
+    if UIDevice.current.userInterfaceIdiom == .pad {
+      vc.modalPresentationStyle = .fullScreen
+    }
     self.present(vc, animated: true, completion: nil)
   }
 

--- a/Kickstarter-iOS/Views/Controllers/CuratedProjectsViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/CuratedProjectsViewController.swift
@@ -164,7 +164,9 @@ final class CuratedProjectsViewController: UIViewController {
       initialPlaylist: projects,
       navigatorDelegate: self
     )
-
+    if UIDevice.current.userInterfaceIdiom == .pad {
+      vc.modalPresentationStyle = .fullScreen
+    }
     self.present(vc, animated: true, completion: nil)
   }
 }

--- a/Kickstarter-iOS/Views/Controllers/DashboardViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/DashboardViewController.swift
@@ -229,6 +229,9 @@ internal final class DashboardViewController: UITableViewController {
 
   private func goToProject(_ project: Project, refTag: RefTag) {
     let vc = ProjectNavigatorViewController.configuredWith(project: project, refTag: refTag)
+    if UIDevice.current.userInterfaceIdiom == .pad {
+      vc.modalPresentationStyle = .fullScreen
+    }
     self.present(vc, animated: true, completion: nil)
   }
 

--- a/Kickstarter-iOS/Views/Controllers/DiscoveryPageViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/DiscoveryPageViewController.swift
@@ -422,6 +422,9 @@ internal final class DiscoveryPageViewController: UITableViewController {
 
   fileprivate func goTo(project: Project, refTag: RefTag) {
     let vc = ProjectNavigatorViewController.configuredWith(project: project, refTag: refTag)
+    if UIDevice.current.userInterfaceIdiom == .pad {
+      vc.modalPresentationStyle = .fullScreen
+    }
     self.present(vc, animated: true, completion: nil)
   }
 
@@ -432,6 +435,9 @@ internal final class DiscoveryPageViewController: UITableViewController {
       initialPlaylist: initialPlaylist,
       navigatorDelegate: self
     )
+    if UIDevice.current.userInterfaceIdiom == .pad {
+      vc.modalPresentationStyle = .fullScreen
+    }
     self.present(vc, animated: true, completion: nil)
   }
 

--- a/Kickstarter-iOS/Views/Controllers/MessagesViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/MessagesViewController.swift
@@ -129,6 +129,9 @@ internal final class MessagesViewController: UITableViewController {
 
   fileprivate func goTo(project: Project, refTag: RefTag) {
     let vc = ProjectNavigatorViewController.configuredWith(project: project, refTag: refTag)
+    if UIDevice.current.userInterfaceIdiom == .pad {
+      vc.modalPresentationStyle = .fullScreen
+    }
     self.present(vc, animated: true, completion: nil)
   }
 

--- a/Kickstarter-iOS/Views/Controllers/ProjectActivitiesViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/ProjectActivitiesViewController.swift
@@ -113,6 +113,9 @@ internal final class ProjectActivitiesViewController: UITableViewController {
 
   internal func goToProject(project: Project) {
     let vc = ProjectNavigatorViewController.configuredWith(project: project, refTag: .dashboardActivity)
+    if UIDevice.current.userInterfaceIdiom == .pad {
+      vc.modalPresentationStyle = .fullScreen
+    }
     self.present(vc, animated: true, completion: nil)
   }
 

--- a/Kickstarter-iOS/Views/Controllers/SearchViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/SearchViewController.swift
@@ -198,6 +198,9 @@ internal final class SearchViewController: UITableViewController {
       initialPlaylist: projects,
       navigatorDelegate: self
     )
+    if UIDevice.current.userInterfaceIdiom == .pad {
+      vc.modalPresentationStyle = .fullScreen
+    }
     self.present(vc, animated: true, completion: nil)
   }
 

--- a/Kickstarter-iOS/Views/Controllers/ThanksViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/ThanksViewController.swift
@@ -208,6 +208,9 @@ internal final class ThanksViewController: UIViewController, UITableViewDelegate
       initialPlaylist: projects,
       navigatorDelegate: self
     )
+    if UIDevice.current.userInterfaceIdiom == .pad {
+      vc.modalPresentationStyle = .fullScreen
+    }
     self.present(vc, animated: true, completion: nil)
   }
 

--- a/Kickstarter-iOS/Views/Controllers/UpdateViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/UpdateViewController.swift
@@ -98,6 +98,9 @@ internal final class UpdateViewController: WebViewController {
 
   fileprivate func goTo(project: Project, refTag: RefTag) {
     let vc = ProjectNavigatorViewController.configuredWith(project: project, refTag: refTag)
+    if UIDevice.current.userInterfaceIdiom == .pad {
+      vc.modalPresentationStyle = .fullScreen
+    }
     self.present(vc, animated: true, completion: nil)
   }
 


### PR DESCRIPTION
# 📲 What

Presents the project page modal fullscreen on iPad.

# 🤔 Why

This was a request from our iPad users.

# 🛠 How

Updates each place that we present `ProjectNavigatorViewController` to have a `fullScreen` `modalPresentationStyle`.

# 👀 See

| Before 🐛 | After 🦋 |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/3735375/81623142-9cefbc80-93a7-11ea-84a9-0a846efe3ba8.png" /> | <img src="https://user-images.githubusercontent.com/3735375/81623091-7d589400-93a7-11ea-801d-f62abc8ad3b0.png" /> |

# ✅ Acceptance criteria

Project modals are presented fullscreen on iPad in all of the following places while iPhone presentation remains unchanged:

- [ ] Activities
- [ ] Discovery
- [ ] Curated Projects
- [ ] Dashboard
- [ ] Messages
- [ ] Project Activities
- [ ] Search
- [ ] Thanks
- [ ] Updates