### PR TITLE
[NT-650, NT-1135, NT-1052] Add Errored Pledges to badge count

### DIFF
--- a/Kickstarter-iOS/DataSources/ActivitiesDataSource.swift
+++ b/Kickstarter-iOS/DataSources/ActivitiesDataSource.swift
@@ -41,6 +41,10 @@ internal final class ActivitiesDataSource: ValueCellDataSource {
   }
 
   internal func load(erroredBackings: [GraphBacking]) {
+    self.clearValues(section: Section.erroredBackings.rawValue)
+
+    guard !erroredBackings.isEmpty else { return }
+
     self.set(
       values: [erroredBackings],
       cellClass: ActivityErroredBackingsCell.self,

--- a/Kickstarter-iOS/DataSources/ActivitiesDataSourceTests.swift
+++ b/Kickstarter-iOS/DataSources/ActivitiesDataSourceTests.swift
@@ -105,5 +105,9 @@ final class ActivitiesDataSourceTests: XCTestCase {
     XCTAssertEqual("ActivityErroredBackingsCell", self.dataSource.reusableId(item: 0, section: section))
 
     self.dataSource.load(erroredBackings: [])
+
+    XCTAssertEqual(1, self.dataSource.numberOfSections(in: self.tableView))
+    XCTAssertEqual(0, self.dataSource.tableView(self.tableView, numberOfRowsInSection: section))
+    XCTAssertEqual(nil, self.dataSource.reusableId(item: 0, section: section))
   }
 }

--- a/Kickstarter-iOS/ViewModels/AppDelegateViewModel.swift
+++ b/Kickstarter-iOS/ViewModels/AppDelegateViewModel.swift
@@ -424,7 +424,7 @@ public final class AppDelegateViewModel: AppDelegateViewModelType, AppDelegateVi
       .filter(third >>> isTrue)
       .map { project, vcs, _ -> [UIViewController] in
         let vc = ManagePledgeViewController.instantiate()
-        vc.configureWith(project: project)
+        vc.configureWith(projectOrParam: .left(project))
         return vcs + [vc]
       }
       .map { vcs -> RewardPledgeNavigationController in

--- a/Kickstarter-iOS/Views/Cells/ActivityErroredBackingsCell.swift
+++ b/Kickstarter-iOS/Views/Cells/ActivityErroredBackingsCell.swift
@@ -12,6 +12,14 @@ final class ActivityErroredBackingsCell: UITableViewCell, ValueCell {
   }()
 
   private let rootStackView: UIStackView = { UIStackView(frame: .zero) }()
+  public weak var delegate: ErroredBackingViewDelegate? {
+    didSet {
+      self.rootStackView.arrangedSubviews
+        .compactMap { $0 as? ErroredBackingView }
+        .forEach { $0.delegate = self.delegate }
+    }
+  }
+
   private let viewModel: ActivityErroredBackingsCellViewModelType =
     ActivityErroredBackingsCellViewModel()
 
@@ -82,7 +90,7 @@ final class ActivityErroredBackingsCell: UITableViewCell, ValueCell {
 
     let erroredBackingsViews = backings.map { backing -> ErroredBackingView in
       let view = ErroredBackingView()
-        |> \.delegate .~ self
+        |> \.delegate .~ self.delegate
       view.configureWith(value: backing)
       return view
     }
@@ -127,8 +135,4 @@ private let contentViewStyle: ViewStyle = { view in
 private let rootStackViewStyle: StackViewStyle = { stackView in
   stackView
     |> verticalStackViewStyle
-}
-
-extension ActivityErroredBackingsCell: ErroredBackingViewDelegate {
-  func erroredBackingViewDidTapManage(_: ErroredBackingView, backing _: GraphBacking) {}
 }

--- a/Kickstarter-iOS/Views/Controllers/ActivitiesViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/ActivitiesViewController.swift
@@ -9,6 +9,7 @@ internal final class ActivitiesViewController: UITableViewController {
   fileprivate let dataSource = ActivitiesDataSource()
   private var sessionEndedObserver: Any?
   private var sessionStartedObserver: Any?
+  private var userUpdatedObserver: Any?
 
   fileprivate var emptyStatesController: EmptyStatesViewController?
 
@@ -28,11 +29,21 @@ internal final class ActivitiesViewController: UITableViewController {
       .addObserver(forName: .ksr_sessionEnded, object: nil, queue: nil) { [weak self] _ in
         self?.viewModel.inputs.userSessionEnded()
       }
+
+    self.userUpdatedObserver = NotificationCenter.default
+      .addObserver(forName: Notification.Name.ksr_userUpdated, object: nil, queue: nil) { [weak self] _ in
+        self?.viewModel.inputs.currentUserUpdated()
+      }
   }
 
   deinit {
-    self.sessionEndedObserver.doIfSome(NotificationCenter.default.removeObserver)
-    self.sessionStartedObserver.doIfSome(NotificationCenter.default.removeObserver)
+    [
+      self.sessionEndedObserver,
+      self.sessionStartedObserver,
+      self.userUpdatedObserver
+    ]
+    .compact()
+    .forEach(NotificationCenter.default.removeObserver)
   }
 
   internal override func viewDidLayoutSubviews() {

--- a/Kickstarter-iOS/Views/Controllers/ActivitiesViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/ActivitiesViewController.swift
@@ -177,6 +177,12 @@ internal final class ActivitiesViewController: UITableViewController {
         self?.goToUpdate(project: project, update: update)
       }
 
+    self.viewModel.outputs.goToManagePledge
+      .observeForControllerAction()
+      .observeValues { [weak self] param in
+        self?.goToManagePledge(param: param)
+      }
+
     self.viewModel.outputs.clearBadgeValue
       .observeForUI()
       .observeValues { [weak self] in
@@ -202,6 +208,8 @@ internal final class ActivitiesViewController: UITableViewController {
     } else if let cell = cell as? FindFriendsHeaderCell, cell.delegate == nil {
       cell.delegate = self
     } else if let cell = cell as? ActivitySurveyResponseCell, cell.delegate == nil {
+      cell.delegate = self
+    } else if let cell = cell as? ActivityErroredBackingsCell, cell.delegate == nil {
       cell.delegate = self
     }
 
@@ -248,6 +256,11 @@ internal final class ActivitiesViewController: UITableViewController {
     self.navigationController?.pushViewController(vc, animated: true)
   }
 
+  fileprivate func goToManagePledge(param: Param) {
+    let vc = ManagePledgeViewController.controller(with: .right(param), delegate: self)
+    self.present(vc, animated: true)
+  }
+
   fileprivate func deleteFacebookSection() {
     self.tableView.beginUpdates()
 
@@ -265,11 +278,15 @@ internal final class ActivitiesViewController: UITableViewController {
   }
 }
 
+// MARK: - ActivityUpdateCellDelegate
+
 extension ActivitiesViewController: ActivityUpdateCellDelegate {
   internal func activityUpdateCellTappedProjectImage(activity: Activity) {
     self.viewModel.inputs.activityUpdateCellTappedProjectImage(activity: activity)
   }
 }
+
+// MARK: - FindFriendsHeaderCellDelegate
 
 extension ActivitiesViewController: FindFriendsHeaderCellDelegate {
   func findFriendsHeaderCellDismissHeader() {
@@ -280,6 +297,8 @@ extension ActivitiesViewController: FindFriendsHeaderCellDelegate {
     self.viewModel.inputs.findFriendsHeaderCellGoToFriends()
   }
 }
+
+// MARK: - FindFriendsFacebookConnectCellDelegate
 
 extension ActivitiesViewController: FindFriendsFacebookConnectCellDelegate {
   func findFriendsFacebookConnectCellDidFacebookConnectUser() {
@@ -295,11 +314,15 @@ extension ActivitiesViewController: FindFriendsFacebookConnectCellDelegate {
   }
 }
 
+// MARK: - ActivitySurveyResponseCellDelegate
+
 extension ActivitiesViewController: ActivitySurveyResponseCellDelegate {
   func activityTappedRespondNow(forSurveyResponse surveyResponse: SurveyResponse) {
     self.viewModel.inputs.tappedRespondNow(forSurveyResponse: surveyResponse)
   }
 }
+
+// MARK: - EmptyStatesViewControllerDelegate
 
 extension ActivitiesViewController: EmptyStatesViewControllerDelegate {
   func emptyStatesViewController(
@@ -320,3 +343,22 @@ extension ActivitiesViewController: SurveyResponseViewControllerDelegate {
 }
 
 extension ActivitiesViewController: TabBarControllerScrollable {}
+
+// MARK: - ErroredBackingViewDelegate
+
+extension ActivitiesViewController: ErroredBackingViewDelegate {
+  func erroredBackingViewDidTapManage(_: ErroredBackingView, backing: GraphBacking) {
+    self.viewModel.inputs.erroredBackingViewDidTapManage(with: backing)
+  }
+}
+
+// MARK: - ManagePledgeViewControllerDelegate
+
+extension ActivitiesViewController: ManagePledgeViewControllerDelegate {
+  func managePledgeViewController(
+    _: ManagePledgeViewController,
+    managePledgeViewControllerFinishedWithMessage _: String?
+  ) {
+    self.viewModel.inputs.managePledgeViewControllerDidFinish()
+  }
+}

--- a/Kickstarter-iOS/Views/Controllers/ManagePledgeViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/ManagePledgeViewController.swift
@@ -483,11 +483,12 @@ extension ManagePledgeViewController: MessageDialogViewControllerDelegate {
 extension ManagePledgeViewController {
   public static func controller(
     with projectOrParam: Either<Project, Param>,
-    delegate _: ManagePledgeViewControllerDelegate? = nil
+    delegate: ManagePledgeViewControllerDelegate? = nil
   ) -> UINavigationController {
     let managePledgeViewController = ManagePledgeViewController
       .instantiate()
     managePledgeViewController.configureWith(projectOrParam: projectOrParam)
+    managePledgeViewController.delegate = delegate
 
     let closeButton = UIBarButtonItem(
       image: UIImage(named: "icon--cross"),

--- a/Kickstarter-iOS/Views/Controllers/ManagePledgeViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/ManagePledgeViewController.swift
@@ -253,8 +253,8 @@ final class ManagePledgeViewController: UIViewController, MessageBannerViewContr
 
   // MARK: - Configuration
 
-  func configureWith(project: Project) {
-    self.viewModel.inputs.configureWith(project)
+  func configureWith(projectOrParam: Either<Project, Param>) {
+    self.viewModel.inputs.configureWith(projectOrParam)
   }
 
   private func setupConstraints() {
@@ -478,4 +478,39 @@ extension ManagePledgeViewController: MessageDialogViewControllerDelegate {
   }
 
   internal func messageDialog(_: MessageDialogViewController, postedMessage _: Message) {}
+}
+
+extension ManagePledgeViewController {
+  public static func controller(
+    with projectOrParam: Either<Project, Param>,
+    delegate _: ManagePledgeViewControllerDelegate? = nil
+  ) -> UINavigationController {
+    let managePledgeViewController = ManagePledgeViewController
+      .instantiate()
+    managePledgeViewController.configureWith(projectOrParam: projectOrParam)
+
+    let closeButton = UIBarButtonItem(
+      image: UIImage(named: "icon--cross"),
+      style: .plain,
+      target: managePledgeViewController,
+      action: #selector(ManagePledgeViewController.closeButtonTapped)
+    )
+
+    _ = closeButton
+      |> \.width .~ Styles.minTouchSize.width
+      |> \.accessibilityLabel %~ { _ in Strings.Dismiss() }
+
+    managePledgeViewController.navigationItem.setLeftBarButton(closeButton, animated: false)
+
+    let navigationController = RewardPledgeNavigationController(
+      rootViewController: managePledgeViewController
+    )
+
+    if AppEnvironment.current.device.userInterfaceIdiom == .pad {
+      _ = navigationController
+        |> \.modalPresentationStyle .~ .pageSheet
+    }
+
+    return navigationController
+  }
 }

--- a/Kickstarter-iOS/Views/Controllers/ManagePledgeViewControllerTests.swift
+++ b/Kickstarter-iOS/Views/Controllers/ManagePledgeViewControllerTests.swift
@@ -52,7 +52,7 @@ final class ManagePledgeViewControllerTests: TestCase {
     combos(Language.allLanguages, [Device.phone4_7inch, Device.pad]).forEach { language, device in
       withEnvironment(apiService: mockService, currentUser: user, language: language) {
         let controller = ManagePledgeViewController.instantiate()
-        controller.configureWith(project: backedProject)
+        controller.configureWith(projectOrParam: .left(backedProject))
         let (parent, _) = traitControllers(device: device, orientation: .portrait, child: controller)
         parent.view.frame.size.height = 1_200
 
@@ -99,7 +99,7 @@ final class ManagePledgeViewControllerTests: TestCase {
 
     withEnvironment(apiService: mockService, currentUser: user, language: language) {
       let controller = ManagePledgeViewController.instantiate()
-      controller.configureWith(project: backedProject)
+      controller.configureWith(projectOrParam: .left(backedProject))
       let (parent, _) = traitControllers(device: device, orientation: .portrait, child: controller)
 
       self.scheduler.run()
@@ -145,7 +145,7 @@ final class ManagePledgeViewControllerTests: TestCase {
     withEnvironment(currentUser: user, language: language) {
       withEnvironment(apiService: mockService, currentUser: user, language: language) {
         let controller = ManagePledgeViewController.instantiate()
-        controller.configureWith(project: backedProject)
+        controller.configureWith(projectOrParam: .left(backedProject))
         let (parent, _) = traitControllers(
           device: device,
           orientation: .portrait,
@@ -197,7 +197,7 @@ final class ManagePledgeViewControllerTests: TestCase {
     withEnvironment(currentUser: user, language: language) {
       withEnvironment(apiService: mockService, currentUser: user, language: language) {
         let controller = ManagePledgeViewController.instantiate()
-        controller.configureWith(project: backedProject)
+        controller.configureWith(projectOrParam: .left(backedProject))
         let (parent, _) = traitControllers(
           device: device,
           orientation: .portrait,
@@ -245,7 +245,7 @@ final class ManagePledgeViewControllerTests: TestCase {
     combos(Language.allLanguages, Device.allCases).forEach { language, device in
       withEnvironment(apiService: mockService, currentUser: user, language: language) {
         let controller = ManagePledgeViewController.instantiate()
-        controller.configureWith(project: backedProject)
+        controller.configureWith(projectOrParam: .left(backedProject))
         let (parent, _) = traitControllers(device: device, orientation: .portrait, child: controller)
 
         self.scheduler.run()

--- a/Kickstarter-iOS/Views/Controllers/PledgeAmountViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/PledgeAmountViewController.swift
@@ -144,7 +144,7 @@ final class PledgeAmountViewController: UIViewController {
       }
   }
 
-  override func didMove(toParent parent: UIViewController?) {
+  override func didMove(toParent _: UIViewController?) {
     self.verticalSpacer.isHidden = true
   }
 

--- a/Kickstarter-iOS/Views/Controllers/ProjectPamphletViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/ProjectPamphletViewController.swift
@@ -200,7 +200,7 @@ public final class ProjectPamphletViewController: UIViewController, MessageBanne
   private func goToManageViewPledge(project: Project) {
     let vc = ManagePledgeViewController.instantiate()
       |> \.delegate .~ self
-    vc.configureWith(project: project)
+    vc.configureWith(projectOrParam: .left(project))
 
     let nc = RewardPledgeNavigationController(rootViewController: vc)
 

--- a/KsApi/models/GraphBacking.swift
+++ b/KsApi/models/GraphBacking.swift
@@ -7,8 +7,8 @@ public struct GraphBacking: Swift.Decodable, Equatable {
 
   public struct Project: Swift.Decodable, Equatable {
     public var finalCollectionDate: String?
-    public var id: String
     public var name: String
+    public var pid: Int
     public var slug: String
   }
 

--- a/KsApi/models/GraphBackingTests.swift
+++ b/KsApi/models/GraphBackingTests.swift
@@ -12,7 +12,7 @@ final class GraphBackingTests: XCTestCase {
             "status": "errored",
             "project": {
               "finalCollectionDate": "2020-04-08T15:15:05Z",
-              "id": "UHJvamVjdC0yMDQ4MTExNDEw",
+              "pid": 65,
               "name": "Cool project",
               "slug": "/cool-project"
             }
@@ -37,7 +37,7 @@ final class GraphBackingTests: XCTestCase {
       let project = backing?.project
 
       XCTAssertEqual("2020-04-08T15:15:05Z", project?.finalCollectionDate)
-      XCTAssertEqual("UHJvamVjdC0yMDQ4MTExNDEw", project?.id)
+      XCTAssertEqual(65, project?.pid)
       XCTAssertEqual("Cool project", project?.name)
       XCTAssertEqual("/cool-project", project?.slug)
     } catch {

--- a/KsApi/models/User.swift
+++ b/KsApi/models/User.swift
@@ -4,6 +4,7 @@ import Runes
 
 public struct User {
   public var avatar: Avatar
+  public var erroredBackingsCount: Int?
   public var facebookConnected: Bool?
   public var id: Int
   public var isAdmin: Bool?
@@ -110,6 +111,7 @@ extension User: Argo.Decodable {
   public static func decode(_ json: JSON) -> Decoded<User> {
     let tmp1 = pure(curry(User.init))
       <*> json <| "avatar"
+      <*> json <|? "errored_backings_count"
       <*> json <|? "facebook_connected"
       <*> json <| "id"
     let tmp2 = tmp1

--- a/KsApi/models/lenses/UserLenses.swift
+++ b/KsApi/models/lenses/UserLenses.swift
@@ -6,6 +6,7 @@ extension User {
       view: { $0.avatar },
       set: { User(
         avatar: $0,
+        erroredBackingsCount: $1.erroredBackingsCount,
         facebookConnected: $1.facebookConnected,
         id: $1.id,
         isAdmin: $1.isAdmin,
@@ -18,7 +19,30 @@ extension User {
         optedOutOfRecommendations: $1.optedOutOfRecommendations,
         showPublicProfile: $1.showPublicProfile,
         social: $1.social,
-        stats: $1.stats, unseenActivityCount: $1.unseenActivityCount
+        stats: $1.stats,
+        unseenActivityCount: $1.unseenActivityCount
+      ) }
+    )
+
+    public static let erroredBackingsCount = Lens<User, Int?>(
+      view: { $0.erroredBackingsCount },
+      set: { User(
+        avatar: $1.avatar,
+        erroredBackingsCount: $0,
+        facebookConnected: $1.facebookConnected,
+        id: $1.id,
+        isAdmin: $1.isAdmin,
+        isFriend: $1.isFriend,
+        location: $1.location,
+        name: $1.name,
+        needsFreshFacebookToken: $1.needsFreshFacebookToken,
+        newsletters: $1.newsletters,
+        notifications: $1.notifications,
+        optedOutOfRecommendations: $1.optedOutOfRecommendations,
+        showPublicProfile: $1.showPublicProfile,
+        social: $1.social,
+        stats: $1.stats,
+        unseenActivityCount: $1.unseenActivityCount
       ) }
     )
 
@@ -26,6 +50,7 @@ extension User {
       view: { $0.facebookConnected },
       set: { User(
         avatar: $1.avatar,
+        erroredBackingsCount: $1.erroredBackingsCount,
         facebookConnected: $0,
         id: $1.id,
         isAdmin: $1.isAdmin,
@@ -37,7 +62,8 @@ extension User {
         optedOutOfRecommendations: $1.optedOutOfRecommendations,
         showPublicProfile: $1.showPublicProfile,
         social: $1.social,
-        stats: $1.stats, unseenActivityCount: $1.unseenActivityCount
+        stats: $1.stats,
+        unseenActivityCount: $1.unseenActivityCount
       ) }
     )
 
@@ -45,6 +71,7 @@ extension User {
       view: { $0.id },
       set: { User(
         avatar: $1.avatar,
+        erroredBackingsCount: $1.erroredBackingsCount,
         facebookConnected: $1.facebookConnected,
         id: $0,
         isAdmin: $1.isAdmin,
@@ -56,7 +83,8 @@ extension User {
         notifications: $1.notifications,
         optedOutOfRecommendations: $1.optedOutOfRecommendations,
         showPublicProfile: $1.showPublicProfile,
-        social: $1.social, stats: $1.stats, unseenActivityCount: $1.unseenActivityCount
+        social: $1.social, stats: $1.stats,
+        unseenActivityCount: $1.unseenActivityCount
       ) }
     )
 
@@ -64,6 +92,7 @@ extension User {
       view: { $0.isAdmin },
       set: { User(
         avatar: $1.avatar,
+        erroredBackingsCount: $1.erroredBackingsCount,
         facebookConnected: $1.facebookConnected,
         id: $1.id,
         isAdmin: $0,
@@ -75,7 +104,8 @@ extension User {
         notifications: $1.notifications,
         optedOutOfRecommendations: $1.optedOutOfRecommendations,
         showPublicProfile: $1.showPublicProfile,
-        social: $1.social, stats: $1.stats, unseenActivityCount: $1.unseenActivityCount
+        social: $1.social, stats: $1.stats,
+        unseenActivityCount: $1.unseenActivityCount
       ) }
     )
 
@@ -83,6 +113,7 @@ extension User {
       view: { $0.isFriend },
       set: { User(
         avatar: $1.avatar,
+        erroredBackingsCount: $1.erroredBackingsCount,
         facebookConnected: $1.facebookConnected,
         id: $1.id,
         isAdmin: $1.isAdmin,
@@ -94,7 +125,8 @@ extension User {
         notifications: $1.notifications,
         optedOutOfRecommendations: $1.optedOutOfRecommendations,
         showPublicProfile: $1.showPublicProfile,
-        social: $1.social, stats: $1.stats, unseenActivityCount: $1.unseenActivityCount
+        social: $1.social, stats: $1.stats,
+        unseenActivityCount: $1.unseenActivityCount
       ) }
     )
 
@@ -102,6 +134,7 @@ extension User {
       view: { $0.location },
       set: { User(
         avatar: $1.avatar,
+        erroredBackingsCount: $1.erroredBackingsCount,
         facebookConnected: $1.facebookConnected,
         id: $1.id,
         isAdmin: $1.isAdmin,
@@ -113,7 +146,8 @@ extension User {
         notifications: $1.notifications,
         optedOutOfRecommendations: $1.optedOutOfRecommendations,
         showPublicProfile: $1.showPublicProfile,
-        social: $1.social, stats: $1.stats, unseenActivityCount: $1.unseenActivityCount
+        social: $1.social, stats: $1.stats,
+        unseenActivityCount: $1.unseenActivityCount
       ) }
     )
 
@@ -121,6 +155,7 @@ extension User {
       view: { $0.name },
       set: { User(
         avatar: $1.avatar,
+        erroredBackingsCount: $1.erroredBackingsCount,
         facebookConnected: $1.facebookConnected,
         id: $1.id,
         isAdmin: $1.isAdmin,
@@ -133,7 +168,8 @@ extension User {
         optedOutOfRecommendations: $1.optedOutOfRecommendations,
         showPublicProfile: $1.showPublicProfile,
         social: $1.social,
-        stats: $1.stats, unseenActivityCount: $1.unseenActivityCount
+        stats: $1.stats,
+        unseenActivityCount: $1.unseenActivityCount
       ) }
     )
 
@@ -141,6 +177,7 @@ extension User {
       view: { $0.needsFreshFacebookToken },
       set: { User(
         avatar: $1.avatar,
+        erroredBackingsCount: $1.erroredBackingsCount,
         facebookConnected: $1.facebookConnected,
         id: $1.id,
         isAdmin: $1.isAdmin,
@@ -153,7 +190,8 @@ extension User {
         optedOutOfRecommendations: $1.optedOutOfRecommendations,
         showPublicProfile: $1.showPublicProfile,
         social: $1.social,
-        stats: $1.stats, unseenActivityCount: $1.unseenActivityCount
+        stats: $1.stats,
+        unseenActivityCount: $1.unseenActivityCount
       ) }
     )
 
@@ -161,6 +199,7 @@ extension User {
       view: { $0.newsletters },
       set: { User(
         avatar: $1.avatar,
+        erroredBackingsCount: $1.erroredBackingsCount,
         facebookConnected: $1.facebookConnected,
         id: $1.id,
         isAdmin: $1.isAdmin,
@@ -173,7 +212,8 @@ extension User {
         optedOutOfRecommendations: $1.optedOutOfRecommendations,
         showPublicProfile: $1.showPublicProfile,
         social: $1.social,
-        stats: $1.stats, unseenActivityCount: $1.unseenActivityCount
+        stats: $1.stats,
+        unseenActivityCount: $1.unseenActivityCount
       ) }
     )
 
@@ -181,6 +221,7 @@ extension User {
       view: { $0.notifications },
       set: { User(
         avatar: $1.avatar,
+        erroredBackingsCount: $1.erroredBackingsCount,
         facebookConnected: $1.facebookConnected,
         id: $1.id,
         isAdmin: $1.isAdmin,
@@ -193,7 +234,8 @@ extension User {
         optedOutOfRecommendations: $1.optedOutOfRecommendations,
         showPublicProfile: $1.showPublicProfile,
         social: $1.social,
-        stats: $1.stats, unseenActivityCount: $1.unseenActivityCount
+        stats: $1.stats,
+        unseenActivityCount: $1.unseenActivityCount
       ) }
     )
 
@@ -201,6 +243,7 @@ extension User {
       view: { $0.optedOutOfRecommendations },
       set: { User(
         avatar: $1.avatar,
+        erroredBackingsCount: $1.erroredBackingsCount,
         facebookConnected: $1.facebookConnected,
         id: $1.id,
         isAdmin: $1.isAdmin,
@@ -213,7 +256,8 @@ extension User {
         optedOutOfRecommendations: $0,
         showPublicProfile: $1.showPublicProfile,
         social: $1.social,
-        stats: $1.stats, unseenActivityCount: $1.unseenActivityCount
+        stats: $1.stats,
+        unseenActivityCount: $1.unseenActivityCount
       ) }
     )
 
@@ -221,6 +265,7 @@ extension User {
       view: { $0.showPublicProfile },
       set: { User(
         avatar: $1.avatar,
+        erroredBackingsCount: $1.erroredBackingsCount,
         facebookConnected: $1.facebookConnected,
         id: $1.id,
         isAdmin: $1.isAdmin,
@@ -233,7 +278,8 @@ extension User {
         optedOutOfRecommendations: $1.optedOutOfRecommendations,
         showPublicProfile: $0,
         social: $1.social,
-        stats: $1.stats, unseenActivityCount: $1.unseenActivityCount
+        stats: $1.stats,
+        unseenActivityCount: $1.unseenActivityCount
       ) }
     )
 
@@ -241,6 +287,7 @@ extension User {
       view: { $0.social },
       set: { User(
         avatar: $1.avatar,
+        erroredBackingsCount: $1.erroredBackingsCount,
         facebookConnected: $1.facebookConnected,
         id: $1.id,
         isAdmin: $1.isAdmin,
@@ -253,7 +300,8 @@ extension User {
         optedOutOfRecommendations: $1.optedOutOfRecommendations,
         showPublicProfile: $1.showPublicProfile,
         social: $0,
-        stats: $1.stats, unseenActivityCount: $1.unseenActivityCount
+        stats: $1.stats,
+        unseenActivityCount: $1.unseenActivityCount
       ) }
     )
 
@@ -261,6 +309,7 @@ extension User {
       view: { $0.stats },
       set: { User(
         avatar: $1.avatar,
+        erroredBackingsCount: $1.erroredBackingsCount,
         facebookConnected: $1.facebookConnected,
         id: $1.id,
         isAdmin: $1.isAdmin,
@@ -281,6 +330,7 @@ extension User {
       view: { $0.unseenActivityCount },
       set: { User(
         avatar: $1.avatar,
+        erroredBackingsCount: $1.erroredBackingsCount,
         facebookConnected: $1.facebookConnected,
         id: $1.id,
         isAdmin: $1.isAdmin,

--- a/KsApi/models/templates/GraphBackingTemplates.swift
+++ b/KsApi/models/templates/GraphBackingTemplates.swift
@@ -16,8 +16,8 @@ extension GraphBacking {
 extension GraphBacking.Project {
   internal static let template = GraphBacking.Project(
     finalCollectionDate: "2020-04-08T15:15:05Z",
-    id: "1",
     name: "Cool project",
+    pid: 1,
     slug: "/cool-project"
   )
 }

--- a/KsApi/queries/UserQueries.swift
+++ b/KsApi/queries/UserQueries.swift
@@ -62,7 +62,7 @@ public func backingsQueryFields(status: String) -> NonEmptySet<Query.User> {
           .status +| [
             .errorReason,
             .project(
-              .id +| [
+              .pid +| [
                 .name,
                 .slug,
                 .finalCollectionDate

--- a/KsApi/queries/UserQueriesTests.swift
+++ b/KsApi/queries/UserQueriesTests.swift
@@ -39,11 +39,11 @@ final class UserQueriesTests: XCTestCase {
   func testBackingsQuery() {
     let query = Query.user(backingsQueryFields(status: GraphBacking.Status.errored.rawValue))
     XCTAssertEqual(
-      "me { backings(status: errored) { nodes { errorReason project { finalCollectionDate id name slug } status } totalCount } id }",
+      "me { backings(status: errored) { nodes { errorReason project { finalCollectionDate name pid slug } status } totalCount } id }",
       query.description
     )
     XCTAssertEqual(
-      "{ me { backings(status: errored) { nodes { errorReason project { finalCollectionDate id name slug } status } totalCount } id } }",
+      "{ me { backings(status: errored) { nodes { errorReason project { finalCollectionDate name pid slug } status } totalCount } id } }",
       Query.build(NonEmptySet(query))
     )
   }

--- a/Library/ViewModels/ActivitiesViewModel.swift
+++ b/Library/ViewModels/ActivitiesViewModel.swift
@@ -7,6 +7,9 @@ public protocol ActitiviesViewModelInputs {
   /// Called when the project image in an update activity cell is tapped.
   func activityUpdateCellTappedProjectImage(activity: Activity)
 
+  /// Called when the user tapped to fix an errored pledge.
+  func erroredBackingViewDidTapManage(with backing: GraphBacking)
+
   /// Call when the Find Friends section is dismissed.
   func findFriendsHeaderCellDismissHeader()
 
@@ -21,6 +24,9 @@ public protocol ActitiviesViewModelInputs {
 
   /// Call when an alert should be shown.
   func findFriendsFacebookConnectCellShowErrorAlert(_ alert: AlertError)
+
+  /// Call when the ManagePledgeViewController made changes.
+  func managePledgeViewControllerDidFinish()
 
   /// Call when the feed should be refreshed, e.g. pull-to-refresh.
   func refresh()
@@ -76,6 +82,9 @@ public protocol ActivitiesViewModelOutputs {
 
   /// Emits when should transition to Friends view with source (.Activity).
   var goToFriends: Signal<FriendsSource, Never> { get }
+
+  /// Emits a project Param to navigate to ManagePledgeViewController.
+  var goToManagePledge: Signal<Param, Never> { get }
 
   /// Emits a project and ref tag that should be used to present a project controller.
   var goToProject: Signal<(Project, RefTag), Never> { get }
@@ -171,12 +180,15 @@ public final class ActivitiesViewModel: ActivitiesViewModelType, ActitiviesViewM
     )
     .ignoreValues()
 
-    self.updateUserInEnvironment = self.clearBadgeValue
-      .filter { _ in AppEnvironment.current.currentUser != nil }
-      .switchMap { _ in
-        updatedUserWithClearedActivityCountProducer()
-          .ksr_delay(AppEnvironment.current.apiDelayInterval, on: AppEnvironment.current.scheduler)
-      }
+    self.updateUserInEnvironment = Signal.merge(
+      self.clearBadgeValue,
+      self.managePledgeViewControllerDidFinishProperty.signal
+    )
+    .filter { _ in AppEnvironment.current.currentUser != nil }
+    .switchMap { _ in
+      updatedUserWithClearedActivityCountProducer()
+        .ksr_delay(AppEnvironment.current.apiDelayInterval, on: AppEnvironment.current.scheduler)
+    }
 
     let currentUser = Signal
       .merge(
@@ -306,6 +318,11 @@ public final class ActivitiesViewModel: ActivitiesViewModelType, ActitiviesViewM
         return SignalProducer(value: (project, update))
       }
 
+    self.goToManagePledge = self.erroredBackingViewDidTapManageWithBackingProperty.signal
+      .map { $0?.project?.pid }
+      .skipNil()
+      .map(Param.id)
+
     Signal.zip(pageCount, paginatedActivities)
       .filter { pageCount, _ in
         pageCount == 1
@@ -323,6 +340,16 @@ public final class ActivitiesViewModel: ActivitiesViewModelType, ActitiviesViewM
   fileprivate let dismissFindFriendsSectionProperty = MutableProperty(())
   public func findFriendsHeaderCellDismissHeader() {
     self.dismissFindFriendsSectionProperty.value = ()
+  }
+
+  fileprivate let erroredBackingViewDidTapManageWithBackingProperty = MutableProperty<GraphBacking?>(nil)
+  public func erroredBackingViewDidTapManage(with backing: GraphBacking) {
+    self.erroredBackingViewDidTapManageWithBackingProperty.value = backing
+  }
+
+  fileprivate let managePledgeViewControllerDidFinishProperty = MutableProperty(())
+  public func managePledgeViewControllerDidFinish() {
+    self.managePledgeViewControllerDidFinishProperty.value = ()
   }
 
   fileprivate let goToFriendsProperty = MutableProperty(())
@@ -398,6 +425,7 @@ public final class ActivitiesViewModel: ActivitiesViewModelType, ActitiviesViewM
   public let hideEmptyState: Signal<(), Never>
   public let isRefreshing: Signal<Bool, Never>
   public let goToFriends: Signal<FriendsSource, Never>
+  public let goToManagePledge: Signal<Param, Never>
   public let goToProject: Signal<(Project, RefTag), Never>
   public let goToSurveyResponse: Signal<SurveyResponse, Never>
   public let goToUpdate: Signal<(Project, Update), Never>

--- a/Library/ViewModels/ActivitiesViewModel.swift
+++ b/Library/ViewModels/ActivitiesViewModel.swift
@@ -212,6 +212,7 @@ public final class ActivitiesViewModel: ActivitiesViewModelType, ActitiviesViewM
       .map { AppEnvironment.current.currentUser }
 
     let erroredBackingsEvent = currentUser
+      .skipNil()
       .switchMap { _ in
         AppEnvironment.current.apiService.fetchGraphUserBackings(
           query: UserQueries.backings(GraphBacking.Status.errored.rawValue).query
@@ -224,7 +225,6 @@ public final class ActivitiesViewModel: ActivitiesViewModelType, ActitiviesViewM
       }
 
     self.erroredBackings = erroredBackingsEvent.values()
-      .filter { !$0.isEmpty }
 
     let loggedInForEmptyState = self.activities
       .filter { AppEnvironment.current.currentUser != nil && $0.isEmpty }

--- a/Library/ViewModels/ActivitiesViewModelTests.swift
+++ b/Library/ViewModels/ActivitiesViewModelTests.swift
@@ -17,6 +17,7 @@ final class ActivitiesViewModelTests: TestCase {
   fileprivate let deleteFindFriendsSection = TestObserver<(), Never>()
   fileprivate let hideEmptyState = TestObserver<(), Never>()
   fileprivate let goToFriends = TestObserver<FriendsSource, Never>()
+  fileprivate let goToManagePledge = TestObserver<Param, Never>()
   fileprivate let showEmptyStateIsLoggedIn = TestObserver<Bool, Never>()
   fileprivate let showFacebookConnectSection = TestObserver<Bool, Never>()
   fileprivate let showFacebookConnectSectionSource = TestObserver<FriendsSource, Never>()
@@ -39,6 +40,7 @@ final class ActivitiesViewModelTests: TestCase {
     self.vm.outputs.deleteFindFriendsSection.observe(self.deleteFindFriendsSection.observer)
     self.vm.outputs.goToFriends.observe(self.goToFriends.observer)
     self.vm.outputs.goToSurveyResponse.observe(self.goToSurveyResponse.observer)
+    self.vm.outputs.goToManagePledge.observe(self.goToManagePledge.observer)
     self.vm.outputs.showEmptyStateIsLoggedIn.observe(self.showEmptyStateIsLoggedIn.observer)
     self.vm.outputs.showFacebookConnectSection.map { $0.1 }.observe(self.showFacebookConnectSection.observer)
     self.vm.outputs.showFacebookConnectSection.map { $0.0 }
@@ -520,6 +522,29 @@ final class ActivitiesViewModelTests: TestCase {
         [[surveyResponse], [surveyResponse]],
         "Same unanswered survey emits."
       )
+    }
+  }
+
+  func testGoToManagePledge() {
+    self.goToManagePledge.assertDidNotEmitValue()
+
+    let backing = GraphBacking.template
+      |> \.project .~ .template
+
+    self.vm.inputs.erroredBackingViewDidTapManage(with: backing)
+
+    self.goToManagePledge.assertValues([.id(backing.project?.pid ?? 0)])
+  }
+
+  func testUpdateUserInEnvironmentOnManagePledgeViewDidFinish() {
+    let user = User.template
+
+    withEnvironment(currentUser: user) {
+      self.updateUserInEnvironment.assertDidNotEmitValue()
+
+      self.vm.inputs.managePledgeViewControllerDidFinish()
+
+      self.updateUserInEnvironment.assertValues([user])
     }
   }
 

--- a/Library/ViewModels/ManagePledgeViewModel.swift
+++ b/Library/ViewModels/ManagePledgeViewModel.swift
@@ -380,6 +380,7 @@ private func projectBackingQuery(withSlug slug: String) -> NonEmptySet<Query> {
             ]
           ),
           .errorReason,
+          .location(.name +| []),
           .pledgedOn,
           .reward(
             .name +| [

--- a/Library/ViewModels/ManagePledgeViewModel.swift
+++ b/Library/ViewModels/ManagePledgeViewModel.swift
@@ -14,7 +14,7 @@ public enum ManagePledgeAlertAction: CaseIterable {
 
 public protocol ManagePledgeViewModelInputs {
   func beginRefresh()
-  func configureWith(_ project: Project)
+  func configureWith(_ projectOrParam: Either<Project, Param>)
   func cancelPledgeDidFinish(with message: String)
   func fixButtonTapped()
   func menuButtonTapped()
@@ -51,25 +51,28 @@ public protocol ManagePledgeViewModelType {
 public final class ManagePledgeViewModel:
   ManagePledgeViewModelType, ManagePledgeViewModelInputs, ManagePledgeViewModelOutputs {
   public init() {
-    let initialProject = Signal.combineLatest(self.configureWithProjectSignal, self.viewDidLoadSignal)
-      .map(first)
+    let projectOrParam = Signal.combineLatest(
+      self.configureWithProjectOrParamSignal,
+      self.viewDidLoadSignal
+    )
+    .map(first)
 
     let shouldBeginRefresh = Signal.merge(
       self.pledgeViewControllerDidUpdatePledgeWithMessageSignal.ignoreValues(),
       self.beginRefreshSignal
     )
 
-    let refreshProjectEvent = initialProject
-      .takeWhen(shouldBeginRefresh)
-      .switchMap { project in
-        AppEnvironment.current.apiService.fetchProject(param: Param.id(project.id))
-          .ksr_delay(AppEnvironment.current.apiDelayInterval, on: AppEnvironment.current.scheduler)
+    let fetchProjectEvent = projectOrParam
+      .switchMap { projectOrParam in
+        fetchProject(projectOrParam: projectOrParam)
           .materialize()
       }
 
+    let project = fetchProjectEvent.values()
+
     let shouldFetchGraphBackingWithProject = Signal.merge(
-      initialProject,
-      initialProject.takeWhen(shouldBeginRefresh)
+      project,
+      project.takeWhen(shouldBeginRefresh)
     )
 
     let graphBackingEvent = shouldFetchGraphBackingWithProject
@@ -88,11 +91,10 @@ public final class ManagePledgeViewModel:
     let backing = graphBackingEnvelope
       .map { $0.backing }
 
-    self.endRefreshing = refreshProjectEvent
+    self.endRefreshing = graphBackingEvent
+      .skip(first: 1) // TODO: Confirm this is correct when loading state is added
       .filter { $0.isTerminating }
       .ignoreValues()
-
-    let project = Signal.merge(initialProject, refreshProjectEvent.values())
 
     let projectAndReward = project
       .filterMap { project in
@@ -112,6 +114,7 @@ public final class ManagePledgeViewModel:
       .map { project, env in managePledgeSummaryViewData(with: project, envelope: env) }
       .skipNil()
 
+    // TODO: Configure with GraphQL backing
     self.configureRewardReceivedWithProject = project
 
     self.configureRewardSummaryView = projectAndReward
@@ -152,7 +155,7 @@ public final class ManagePledgeViewModel:
 
     self.notifyDelegateManagePledgeViewControllerFinishedWithMessage = Signal.merge(
       self.cancelPledgeDidFinishWithMessageProperty.signal,
-      refreshProjectEvent.mapConst(nil)
+      graphBackingEvent.mapConst(nil)
     )
 
     self.rewardReceivedViewControllerViewIsHidden = projectAndReward
@@ -194,9 +197,10 @@ public final class ManagePledgeViewModel:
     self.beginRefreshObserver.send(value: ())
   }
 
-  private let (configureWithProjectSignal, configureWithProjectObserver) = Signal<Project, Never>.pipe()
-  public func configureWith(_ project: Project) {
-    self.configureWithProjectObserver.send(value: project)
+  private let (configureWithProjectOrParamSignal, configureWithProjectOrParamObserver)
+    = Signal<Either<Project, Param>, Never>.pipe()
+  public func configureWith(_ projectOrParam: Either<Project, Param>) {
+    self.configureWithProjectOrParamObserver.send(value: projectOrParam)
   }
 
   private let cancelPledgeDidFinishWithMessageProperty = MutableProperty<String?>(nil)
@@ -256,6 +260,18 @@ public final class ManagePledgeViewModel:
 }
 
 // MARK: - Functions
+
+private func fetchProject(projectOrParam: Either<Project, Param>)
+  -> SignalProducer<Project, ErrorEnvelope> {
+  if let project = projectOrParam.left {
+    return SignalProducer(value: project)
+  } else {
+    let param = projectOrParam.ifLeft({ Param.id($0.id) }, ifRight: id)
+
+    return AppEnvironment.current.apiService.fetchProject(param: param)
+      .ksr_delay(AppEnvironment.current.apiDelayInterval, on: AppEnvironment.current.scheduler)
+  }
+}
 
 private func actionSheetMenuOptionsFor(project: Project) -> [ManagePledgeAlertAction] {
   guard project.state == .live else {

--- a/Library/ViewModels/ManagePledgeViewModelTests.swift
+++ b/Library/ViewModels/ManagePledgeViewModelTests.swift
@@ -77,7 +77,7 @@ internal final class ManagePledgeViewModelTests: TestCase {
     withEnvironment(apiService: mockService) {
       self.title.assertDidNotEmitValue()
 
-      self.vm.inputs.configureWith(project)
+      self.vm.inputs.configureWith(.left(project))
       self.vm.inputs.viewDidLoad()
 
       self.scheduler.advance()
@@ -98,7 +98,7 @@ internal final class ManagePledgeViewModelTests: TestCase {
     let mockService = MockService(fetchManagePledgeViewBackingResult: .success(envelope))
 
     withEnvironment(apiService: mockService) {
-      self.vm.inputs.configureWith(finishedProject)
+      self.vm.inputs.configureWith(.left(finishedProject))
       self.vm.inputs.viewDidLoad()
 
       self.scheduler.advance()
@@ -128,7 +128,7 @@ internal final class ManagePledgeViewModelTests: TestCase {
     )
 
     withEnvironment(apiService: mockService) {
-      self.vm.inputs.configureWith(project)
+      self.vm.inputs.configureWith(.left(project))
 
       self.vm.inputs.viewDidLoad()
 
@@ -170,7 +170,7 @@ internal final class ManagePledgeViewModelTests: TestCase {
     )
 
     withEnvironment(apiService: mockService) {
-      self.vm.inputs.configureWith(project)
+      self.vm.inputs.configureWith(.left(project))
 
       self.vm.inputs.viewDidLoad()
 
@@ -189,7 +189,7 @@ internal final class ManagePledgeViewModelTests: TestCase {
     let project = Project.template
       |> Project.lens.personalization.backing .~ Backing.template
 
-    self.vm.inputs.configureWith(project)
+    self.vm.inputs.configureWith(.left(project))
 
     self.vm.inputs.viewDidLoad()
 
@@ -203,7 +203,7 @@ internal final class ManagePledgeViewModelTests: TestCase {
     let project = Project.template
       |> Project.lens.personalization.backing .~ Backing.template
 
-    self.vm.inputs.configureWith(project)
+    self.vm.inputs.configureWith(.left(project))
 
     self.vm.inputs.viewDidLoad()
 
@@ -214,7 +214,7 @@ internal final class ManagePledgeViewModelTests: TestCase {
     let project = Project.template
       |> Project.lens.state .~ .live
 
-    self.vm.inputs.configureWith(project)
+    self.vm.inputs.configureWith(.left(project))
     self.vm.inputs.viewDidLoad()
 
     self.showActionSheetMenuWithOptions.assertDidNotEmitValue()
@@ -236,7 +236,7 @@ internal final class ManagePledgeViewModelTests: TestCase {
     let project = Project.template
       |> Project.lens.state .~ .successful
 
-    self.vm.inputs.configureWith(project)
+    self.vm.inputs.configureWith(.left(project))
     self.vm.inputs.viewDidLoad()
 
     self.showActionSheetMenuWithOptions.assertDidNotEmitValue()
@@ -254,7 +254,7 @@ internal final class ManagePledgeViewModelTests: TestCase {
       |> Project.lens.state .~ .live
       |> Project.lens.personalization.backing .~ backing
 
-    self.vm.inputs.configureWith(project)
+    self.vm.inputs.configureWith(.left(project))
     self.vm.inputs.viewDidLoad()
 
     self.showActionSheetMenuWithOptions.assertDidNotEmitValue()
@@ -278,7 +278,7 @@ internal final class ManagePledgeViewModelTests: TestCase {
     )
 
     withEnvironment(apiService: mockService) {
-      self.vm.inputs.configureWith(project)
+      self.vm.inputs.configureWith(.left(project))
       self.vm.inputs.viewDidLoad()
 
       self.scheduler.advance()
@@ -304,7 +304,7 @@ internal final class ManagePledgeViewModelTests: TestCase {
     )
 
     withEnvironment(apiService: mockService) {
-      self.vm.inputs.configureWith(.template)
+      self.vm.inputs.configureWith(.left(.template))
       self.vm.inputs.viewDidLoad()
 
       self.scheduler.advance()
@@ -326,7 +326,7 @@ internal final class ManagePledgeViewModelTests: TestCase {
     let project = Project.template
       |> Project.lens.personalization.backing .~ Backing.template
 
-    self.vm.inputs.configureWith(project)
+    self.vm.inputs.configureWith(.left(project))
     self.vm.inputs.viewDidLoad()
 
     self.goToChangePaymentMethodProject.assertDidNotEmitValue()
@@ -343,7 +343,7 @@ internal final class ManagePledgeViewModelTests: TestCase {
     let project = Project.template
       |> Project.lens.personalization.backing .~ Backing.template
 
-    self.vm.inputs.configureWith(project)
+    self.vm.inputs.configureWith(.left(project))
     self.vm.inputs.viewDidLoad()
 
     self.goToContactCreatorSubject.assertDidNotEmitValue()
@@ -357,7 +357,7 @@ internal final class ManagePledgeViewModelTests: TestCase {
   }
 
   func testGoToRewards() {
-    self.vm.inputs.configureWith(Project.template)
+    self.vm.inputs.configureWith(.left(Project.template))
     self.vm.inputs.viewDidLoad()
 
     self.goToRewards.assertDidNotEmitValue()
@@ -372,7 +372,7 @@ internal final class ManagePledgeViewModelTests: TestCase {
     let project = Project.template
       |> Project.lens.personalization.backing .~ Backing.template
 
-    self.vm.inputs.configureWith(project)
+    self.vm.inputs.configureWith(.left(project))
     self.vm.inputs.viewDidLoad()
 
     self.goToUpdatePledgeProject.assertDidNotEmitValue()
@@ -394,7 +394,7 @@ internal final class ManagePledgeViewModelTests: TestCase {
       |> Project.lens.rewards .~ ([Reward.noReward] + Project.cosmicSurgery.rewards.suffix(from: 1))
       |> Project.lens.personalization .. Project.Personalization.lens.backing .~ backing
 
-    self.vm.inputs.configureWith(project)
+    self.vm.inputs.configureWith(.left(project))
     self.vm.inputs.viewDidLoad()
 
     self.rewardReceivedViewControllerViewIsHidden.assertValues([true])
@@ -409,7 +409,7 @@ internal final class ManagePledgeViewModelTests: TestCase {
       |> Project.lens.rewards .~ ([Reward.noReward] + Project.cosmicSurgery.rewards.suffix(from: 1))
       |> Project.lens.personalization .. Project.Personalization.lens.backing .~ backing
 
-    self.vm.inputs.configureWith(project)
+    self.vm.inputs.configureWith(.left(project))
     self.vm.inputs.viewDidLoad()
 
     self.rewardReceivedViewControllerViewIsHidden.assertValues([true])
@@ -424,7 +424,7 @@ internal final class ManagePledgeViewModelTests: TestCase {
       |> Project.lens.rewards .~ ([Reward.noReward] + Project.cosmicSurgery.rewards.suffix(from: 1))
       |> Project.lens.personalization .. Project.Personalization.lens.backing .~ backing
 
-    self.vm.inputs.configureWith(project)
+    self.vm.inputs.configureWith(.left(project))
     self.vm.inputs.viewDidLoad()
 
     self.rewardReceivedViewControllerViewIsHidden.assertValues([true])
@@ -439,7 +439,7 @@ internal final class ManagePledgeViewModelTests: TestCase {
       |> Project.lens.rewards .~ ([Reward.noReward] + Project.cosmicSurgery.rewards.suffix(from: 1))
       |> Project.lens.personalization .. Project.Personalization.lens.backing .~ backing
 
-    self.vm.inputs.configureWith(project)
+    self.vm.inputs.configureWith(.left(project))
     self.vm.inputs.viewDidLoad()
 
     self.rewardReceivedViewControllerViewIsHidden.assertValues([true])
@@ -454,7 +454,7 @@ internal final class ManagePledgeViewModelTests: TestCase {
       |> Project.lens.rewards .~ ([Reward.noReward] + Project.cosmicSurgery.rewards.suffix(from: 1))
       |> Project.lens.personalization .. Project.Personalization.lens.backing .~ backing
 
-    self.vm.inputs.configureWith(project)
+    self.vm.inputs.configureWith(.left(project))
     self.vm.inputs.viewDidLoad()
 
     self.rewardReceivedViewControllerViewIsHidden.assertValues([true])
@@ -467,7 +467,7 @@ internal final class ManagePledgeViewModelTests: TestCase {
     let project = Project.template
       |> Project.lens.personalization .. Project.Personalization.lens.backing .~ backing
 
-    self.vm.inputs.configureWith(project)
+    self.vm.inputs.configureWith(.left(project))
     self.vm.inputs.viewDidLoad()
 
     self.rewardReceivedViewControllerViewIsHidden.assertValues([true])
@@ -480,7 +480,7 @@ internal final class ManagePledgeViewModelTests: TestCase {
     let project = Project.cosmicSurgery
       |> Project.lens.personalization .. Project.Personalization.lens.backing .~ backing
 
-    self.vm.inputs.configureWith(project)
+    self.vm.inputs.configureWith(.left(project))
     self.vm.inputs.viewDidLoad()
 
     self.rewardReceivedViewControllerViewIsHidden.assertValues([true])
@@ -493,7 +493,7 @@ internal final class ManagePledgeViewModelTests: TestCase {
     let project = Project.cosmicSurgery
       |> Project.lens.personalization .. Project.Personalization.lens.backing .~ backing
 
-    self.vm.inputs.configureWith(project)
+    self.vm.inputs.configureWith(.left(project))
     self.vm.inputs.viewDidLoad()
 
     self.rewardReceivedViewControllerViewIsHidden.assertValues([false])
@@ -506,7 +506,7 @@ internal final class ManagePledgeViewModelTests: TestCase {
     let project = Project.cosmicSurgery
       |> Project.lens.personalization .. Project.Personalization.lens.backing .~ backing
 
-    self.vm.inputs.configureWith(project)
+    self.vm.inputs.configureWith(.left(project))
     self.vm.inputs.viewDidLoad()
 
     self.rewardReceivedViewControllerViewIsHidden.assertValues([true])
@@ -519,7 +519,7 @@ internal final class ManagePledgeViewModelTests: TestCase {
     let project = Project.cosmicSurgery
       |> Project.lens.personalization .. Project.Personalization.lens.backing .~ backing
 
-    self.vm.inputs.configureWith(project)
+    self.vm.inputs.configureWith(.left(project))
     self.vm.inputs.viewDidLoad()
 
     self.rewardReceivedViewControllerViewIsHidden.assertValues([true])
@@ -532,7 +532,7 @@ internal final class ManagePledgeViewModelTests: TestCase {
     let project = Project.cosmicSurgery
       |> Project.lens.personalization .. Project.Personalization.lens.backing .~ backing
 
-    self.vm.inputs.configureWith(project)
+    self.vm.inputs.configureWith(.left(project))
     self.vm.inputs.viewDidLoad()
 
     self.rewardReceivedViewControllerViewIsHidden.assertValues([true])
@@ -545,14 +545,14 @@ internal final class ManagePledgeViewModelTests: TestCase {
     let project = Project.template
       |> Project.lens.personalization .. Project.Personalization.lens.backing .~ backing
 
-    self.vm.inputs.configureWith(project)
+    self.vm.inputs.configureWith(.left(project))
     self.vm.inputs.viewDidLoad()
 
     self.rewardReceivedViewControllerViewIsHidden.assertValues([true])
   }
 
   func testNotifyDelegateManagePledgeViewControllerFinishedWithMessage_CancellingPledge() {
-    self.vm.inputs.configureWith(Project.template)
+    self.vm.inputs.configureWith(.left(Project.template))
     self.vm.inputs.viewDidLoad()
 
     self.notifyDelegateManagePledgeViewControllerFinishedWithMessage.assertDidNotEmitValue()
@@ -564,7 +564,7 @@ internal final class ManagePledgeViewModelTests: TestCase {
   }
 
   func testNotifyDelegateManagePledgeViewControllerFinishedWithMessage_UpdatingPledge() {
-    self.vm.inputs.configureWith(Project.template)
+    self.vm.inputs.configureWith(.left(Project.template))
     self.vm.inputs.viewDidLoad()
 
     self.notifyDelegateManagePledgeViewControllerFinishedWithMessage.assertDidNotEmitValue()
@@ -580,13 +580,11 @@ internal final class ManagePledgeViewModelTests: TestCase {
       |> Backing.lens.amount .~ 5.00
     let project = Project.cosmicSurgery
       |> Project.lens.personalization.backing .~ backing
-    let updatedBacking = backing |> Backing.lens.amount .~ 10.00
-    let updatedProject = project
-      |> Project.lens.personalization.backing .~ updatedBacking
 
     let envelope = ManagePledgeViewBackingEnvelope.template
 
-    let pledgeViewSummaryData = ManagePledgeSummaryViewData(
+    // Pledge amount 25
+    let initialPledgeViewSummaryData = ManagePledgeSummaryViewData(
       backerId: envelope.backing.backer.uid,
       backerName: envelope.backing.backer.name,
       backerSequence: envelope.backing.sequence,
@@ -595,7 +593,25 @@ internal final class ManagePledgeViewModelTests: TestCase {
       locationName: "Brooklyn, NY",
       needsConversion: true,
       omitUSCurrencyCode: true,
-      pledgeAmount: envelope.backing.amount.amount,
+      pledgeAmount: 25,
+      pledgedOn: envelope.backing.pledgedOn,
+      projectCountry: project.country,
+      projectDeadline: 1_476_657_315.0,
+      projectState: ProjectState.live,
+      shippingAmount: envelope.backing.shippingAmount?.amount
+    )
+
+    // Pledge amount 50
+    let updatedPledgeViewSummaryData = ManagePledgeSummaryViewData(
+      backerId: envelope.backing.backer.uid,
+      backerName: envelope.backing.backer.name,
+      backerSequence: envelope.backing.sequence,
+      backingState: BackingState.pledged,
+      currentUserIsCreatorOfProject: false,
+      locationName: "Brooklyn, NY",
+      needsConversion: true,
+      omitUSCurrencyCode: true,
+      pledgeAmount: 50,
       pledgedOn: envelope.backing.pledgedOn,
       projectCountry: project.country,
       projectDeadline: 1_476_657_315.0,
@@ -611,12 +627,14 @@ internal final class ManagePledgeViewModelTests: TestCase {
       paymentType: .creditCard
     )
 
-    let mockService = MockService(
-      fetchManagePledgeViewBackingResult: .success(envelope),
-      fetchProjectResponse: updatedProject
-    )
+    let initialBackingEnvelope = ManagePledgeViewBackingEnvelope.template
+      |> \.backing.amount.amount .~ 25
+    let updatedBackingEnvelope = ManagePledgeViewBackingEnvelope.template
+      |> \.backing.amount.amount .~ 50
 
-    withEnvironment(apiService: mockService) {
+    withEnvironment(
+      apiService: MockService(fetchManagePledgeViewBackingResult: .success(initialBackingEnvelope))
+    ) {
       self.showSuccessBannerWithMessage.assertDidNotEmitValue()
       self.configurePaymentMethodView.assertDidNotEmitValue()
       self.configurePledgeSummaryView.assertDidNotEmitValue()
@@ -625,22 +643,42 @@ internal final class ManagePledgeViewModelTests: TestCase {
       self.configureRewardReceivedWithProject.assertDidNotEmitValue()
       self.title.assertDidNotEmitValue()
 
-      self.vm.inputs.configureWith(project)
+      self.vm.inputs.configureWith(.left(project))
       self.vm.inputs.viewDidLoad()
 
+      self.scheduler.advance()
+
+      self.configurePaymentMethodView.assertValues([pledgePaymentMethodViewData])
+      self.configurePledgeSummaryView.assertValues([initialPledgeViewSummaryData])
+
+      self.configureRewardSummaryViewProject.assertValues([project])
+      self.configureRewardSummaryViewReward.assertValues([.template])
+      self.configureRewardReceivedWithProject.assertValues([project])
+      self.title.assertValues(["Manage your pledge"])
+    }
+
+    withEnvironment(
+      apiService: MockService(fetchManagePledgeViewBackingResult: .success(updatedBackingEnvelope))
+    ) {
       self.vm.inputs.pledgeViewControllerDidUpdatePledgeWithMessage("Got it! Your changes have been saved.")
 
       self.scheduler.run()
 
       self.showSuccessBannerWithMessage.assertValues(["Got it! Your changes have been saved."])
 
-      self.configurePaymentMethodView.assertValues([pledgePaymentMethodViewData])
-      self.configurePledgeSummaryView.assertValues([pledgeViewSummaryData])
+      self.configurePaymentMethodView.assertValues([
+        pledgePaymentMethodViewData,
+        pledgePaymentMethodViewData
+      ])
+      self.configurePledgeSummaryView.assertValues([
+        initialPledgeViewSummaryData,
+        updatedPledgeViewSummaryData
+      ])
 
-      self.configureRewardSummaryViewProject.assertValues([project, updatedProject])
-      self.configureRewardSummaryViewReward.assertValues([.template, .template])
-      self.configureRewardReceivedWithProject.assertValues([project, updatedProject])
-      self.title.assertValues(["Manage your pledge"])
+      self.configureRewardSummaryViewProject.assertValues([project])
+      self.configureRewardSummaryViewReward.assertValues([.template])
+      self.configureRewardReceivedWithProject.assertValues([project])
+      self.title.assertValues(["Manage your pledge", "Manage your pledge"])
     }
   }
 
@@ -648,7 +686,7 @@ internal final class ManagePledgeViewModelTests: TestCase {
     let project = Project.template
       |> Project.lens.personalization.backing .~ Backing.template
 
-    self.vm.inputs.configureWith(project)
+    self.vm.inputs.configureWith(.left(project))
     self.vm.inputs.viewDidLoad()
 
     XCTAssertEqual([], self.trackingClient.events)
@@ -663,7 +701,7 @@ internal final class ManagePledgeViewModelTests: TestCase {
     let project = Project.template
       |> Project.lens.personalization.backing .~ Backing.template
 
-    self.vm.inputs.configureWith(project)
+    self.vm.inputs.configureWith(.left(project))
     self.vm.inputs.viewDidLoad()
 
     XCTAssertEqual([], self.trackingClient.events)
@@ -674,13 +712,12 @@ internal final class ManagePledgeViewModelTests: TestCase {
   }
 
   func testEndRefreshing() {
-    let project = Project.template |> Project.lens.personalization.backing .~ .template
-    let mockService = MockService(fetchProjectResponse: project)
+    let mockService = MockService(fetchManagePledgeViewBackingResult: .success(.template))
 
     withEnvironment(apiService: mockService) {
       self.endRefreshing.assertDidNotEmitValue()
 
-      self.vm.inputs.configureWith(.template)
+      self.vm.inputs.configureWith(.left(.template))
       self.vm.inputs.viewDidLoad()
 
       self.endRefreshing.assertDidNotEmitValue()
@@ -717,7 +754,7 @@ internal final class ManagePledgeViewModelTests: TestCase {
       |> Project.lens.personalization.backing .~ Backing.template
     let reward = Project.cosmicSurgery.rewards.filter { $0.id == Backing.template.rewardId }.first!
 
-    self.vm.inputs.configureWith(project)
+    self.vm.inputs.configureWith(.left(project))
     self.vm.inputs.viewDidLoad()
 
     self.vm.inputs.fixButtonTapped()

--- a/Library/ViewModels/PledgeAmountSummaryViewModel.swift
+++ b/Library/ViewModels/PledgeAmountSummaryViewModel.swift
@@ -50,7 +50,6 @@ public class PledgeAmountSummaryViewModel: PledgeAmountSummaryViewModelType,
       .skipNil()
 
     self.shippingAmountText = data.map { ($0.projectCountry, $0.shippingAmount ?? 0, $0.omitUSCurrencyCode) }
-      .filter { _, shippingAmount, _ in shippingAmount > 0 }
       .map(shippingValue(with:amount:omitUSCurrencyCode:))
       .skipNil()
 

--- a/Library/ViewModels/PledgeAmountSummaryViewModelTests.swift
+++ b/Library/ViewModels/PledgeAmountSummaryViewModelTests.swift
@@ -44,6 +44,24 @@ final class PledgeAmountSummaryViewModelTests: TestCase {
     self.shippingLocationText.assertValue("Shipping: United States")
   }
 
+  func testTextOutputsEmitTheCorrectValue_ZeroShippingAmount() {
+    let data = PledgeAmountSummaryViewData(
+      projectCountry: Project.Country.us,
+      pledgeAmount: 30.0,
+      pledgedOn: 1_568_666_243.0,
+      shippingAmount: 0,
+      locationName: "United States",
+      omitUSCurrencyCode: true
+    )
+
+    self.vm.inputs.configureWith(data)
+    self.vm.inputs.viewDidLoad()
+
+    self.pledgeAmountText.assertValue("$30.00")
+    self.shippingAmountText.assertValue("+$0.00")
+    self.shippingLocationText.assertValue("Shipping: United States")
+  }
+
   func testShippingLocationStackViewIsHidden_isTrue_WhenLocationNameIsNil() {
     let data = PledgeAmountSummaryViewData(
       projectCountry: Project.Country.us,


### PR DESCRIPTION
# 📲 What

- Adds errored pledges to the badge count shown on the activities tab.
- Presents the `ManagePledgeViewController` from `ActivitiesViewController` when fixing an errored pledge.
- Refreshes the current user after `ManagePledgeViewController` completes.

**Note:** There is some additional work to be done to show a loading state for `ManagePledgeViewController`, currently the view might appear and be unpopulated briefly until the data loads. This work will also ensure that the project and graph backing producers are correctly combined/zipped.

# 🤔 Why

This is a continuation of the work to allow a user to fix their errored pledges. We currently display a badge count for unseen activities, this count will now include the amount for errored pledges (if any).

# 🛠 How

- Added `erroredBackingsCount` to `User`.
- Updated `RootViewModel` to include this count in the total badge count.
- Included the behaviour so that, when clearing their unseen activity count, the errored pledge count will remain until those are addressed.

# ✅ Acceptance criteria

Get some backings into an errored state (not easy).

- [ ] The errored pledge count is added to the unseen activity count on the activity tab.
- [ ] Tapping to view activities only subtracts the activity count from the total.
- [ ] The errored pledge count is only reduced by fixing errored pledges.
- [ ] Any push notification payloads that include a badge count (while you have errored pledges) should behave as above (unseen activities count + errored pledge count).