### PR TITLE
[NT-1256] iOS 12 pledge screen scroll view insets bug

### DIFF
--- a/Kickstarter-iOS/Views/Controllers/PledgeViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/PledgeViewController.swift
@@ -155,17 +155,6 @@ final class PledgeViewController: UIViewController,
     self.viewModel.inputs.viewDidLoad()
   }
 
-  override func viewDidLayoutSubviews() {
-    super.viewDidLayoutSubviews()
-
-    self.rootScrollView.contentInset = UIEdgeInsets(
-      top: self.rootScrollView.contentInset.top,
-      left: self.rootScrollView.contentInset.left,
-      bottom: self.pledgeCTAContainerView.frame.size.height - self.view.safeAreaInsets.bottom,
-      right: self.rootScrollView.contentInset.right
-    )
-  }
-
   deinit {
     self.sessionStartedObserver.doIfSome(NotificationCenter.default.removeObserver)
   }
@@ -214,8 +203,7 @@ final class PledgeViewController: UIViewController,
   }
 
   private func setupConstraints() {
-    _ = (self.rootScrollView, self.view)
-      |> ksr_constrainViewToEdgesInParent()
+    self.rootScrollView.translatesAutoresizingMaskIntoConstraints = false
 
     _ = (self.rootContainerView, self.rootScrollView)
       |> ksr_constrainViewToEdgesInParent()
@@ -224,6 +212,10 @@ final class PledgeViewController: UIViewController,
       |> ksr_constrainViewToMarginsInParent()
 
     NSLayoutConstraint.activate([
+      self.rootScrollView.topAnchor.constraint(equalTo: self.view.topAnchor),
+      self.rootScrollView.leftAnchor.constraint(equalTo: self.view.leftAnchor),
+      self.rootScrollView.rightAnchor.constraint(equalTo: self.view.rightAnchor),
+      self.rootScrollView.bottomAnchor.constraint(equalTo: self.pledgeCTAContainerView.topAnchor),
       self.pledgeCTAContainerView.leftAnchor.constraint(equalTo: self.view.leftAnchor),
       self.pledgeCTAContainerView.rightAnchor.constraint(equalTo: self.view.rightAnchor),
       self.pledgeCTAContainerView.bottomAnchor.constraint(equalTo: self.view.bottomAnchor),

--- a/Kickstarter-iOS/Views/Controllers/PledgeViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/PledgeViewController.swift
@@ -203,8 +203,6 @@ final class PledgeViewController: UIViewController,
   }
 
   private func setupConstraints() {
-    self.rootScrollView.translatesAutoresizingMaskIntoConstraints = false
-
     _ = (self.rootContainerView, self.rootScrollView)
       |> ksr_constrainViewToEdgesInParent()
 


### PR DESCRIPTION
# 📲 What

Fixes a bug in iOS 12 where presenting a VC from the pledge screen caused the scroll view insets to be reset to zero, which caused the pledge button container to overlap some content near the bottom of the screen.

# 🤔 Why/How

This was a strange one. For some reason on iOS 12.4, presenting a VC on top of a scroll view with its `contentInsetAdjustmentBehavior` set to `automatic` (the default), caused the content insets to abruptly be reset back to zero when the presented VC is dismissed. Strangely, examining the `contentInsets` after the dismissal showed that the `adjustedContentInsets` were still correctly set, but visually the scroll view appeared to have an `adjustedContentInset` of `.zero`. Setting the `contentInsetAdjustmentBehavior` on the `rootScrollView` to `.zero` seemed to fix the issue, but it caused a strange side effect where the scroll view no longer bounced properly.

As a workaround, this PR pins the `rootScrollView`'s `bottom` to the top of the `pledgeCTAContainerView` so we don't rely on the `contentInsets` being correct.

# 👀 See

Trello, screenshots, external resources?

| After 🦋 | Before 🐛 |
| --- | --- |
| ![xMB3tAfJzs](https://user-images.githubusercontent.com/3156796/82256058-adfa7980-9923-11ea-95d6-e52c462a4591.gif) | ![Fo4wht5WaJ](https://user-images.githubusercontent.com/3156796/82256111-c5d1fd80-9923-11ea-8d7e-fd5f074f583e.gif) |

# ✅ Acceptance criteria

- [x] on an iOS 12 device, navigate to the pledge screen and check that the view scrolls up fully without obscuring content. Then, tap the "New Payment Method" button and close the view. Check that the view scrolls up fully without obscuring content.
- [x] on an iOS 13 device, navigate to the pledge screen and check that the view scrolls up fully without obscuring content. Then, tap the "New Payment Method" button and close the view. Check that the view scrolls up fully without obscuring content.

