### PR TITLE
[NT-1257] Sign In With Apple Killswitch Feature Flag

### DIFF
--- a/Kickstarter-iOS/Views/Controllers/LoginToutViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/LoginToutViewController.swift
@@ -261,6 +261,9 @@ internal final class LoginToutViewController: UIViewController,
         self?.goToHelpType(helpType)
       }
 
+    if #available(iOS 13.0, *) {
+      self.appleLoginButton.rac.hidden = self.viewModel.outputs.appleButtonHidden
+    }
     self.contextLabel.rac.text = self.viewModel.outputs.logInContextText
     self.bringCreativeProjectsToLifeLabel.rac.hidden = self.viewModel.outputs.headlineLabelHidden
 

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -421,6 +421,7 @@
 		8AA5B06A235E25820022F5F0 /* AppCenterCrashes.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8AA5B066235E25820022F5F0 /* AppCenterCrashes.framework */; };
 		8AA5B06B235E25820022F5F0 /* AppCenterAnalytics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8AA5B067235E25820022F5F0 /* AppCenterAnalytics.framework */; };
 		8AAA9BD822F49EC200F12976 /* UIColor+Mixing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AAA9BD722F49EC200F12976 /* UIColor+Mixing.swift */; };
+		8AAFEAE92474535D004A88F8 /* OptimizelyFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AAFEAE82474535C004A88F8 /* OptimizelyFeature.swift */; };
 		8AB0E00C24314967008E975E /* ProjectSummaryCarouselView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB0E00B24314967008E975E /* ProjectSummaryCarouselView.swift */; };
 		8AB0E00E2432B396008E975E /* ProjectSummaryCarouselDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB0E00D2432B396008E975E /* ProjectSummaryCarouselDataSource.swift */; };
 		8AB0E0102432B3B5008E975E /* ProjectSummaryCarouselDataSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB0E00F2432B3B5008E975E /* ProjectSummaryCarouselDataSourceTests.swift */; };
@@ -1889,6 +1890,7 @@
 		8AA5B066235E25820022F5F0 /* AppCenterCrashes.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppCenterCrashes.framework; path = Carthage/Build/iOS/AppCenterCrashes.framework; sourceTree = "<group>"; };
 		8AA5B067235E25820022F5F0 /* AppCenterAnalytics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppCenterAnalytics.framework; path = Carthage/Build/iOS/AppCenterAnalytics.framework; sourceTree = "<group>"; };
 		8AAA9BD722F49EC200F12976 /* UIColor+Mixing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+Mixing.swift"; sourceTree = "<group>"; };
+		8AAFEAE82474535C004A88F8 /* OptimizelyFeature.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OptimizelyFeature.swift; sourceTree = "<group>"; };
 		8AB0E00B24314967008E975E /* ProjectSummaryCarouselView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectSummaryCarouselView.swift; sourceTree = "<group>"; };
 		8AB0E00D2432B396008E975E /* ProjectSummaryCarouselDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectSummaryCarouselDataSource.swift; sourceTree = "<group>"; };
 		8AB0E00F2432B3B5008E975E /* ProjectSummaryCarouselDataSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectSummaryCarouselDataSourceTests.swift; sourceTree = "<group>"; };
@@ -3443,6 +3445,7 @@
 				D706478F23A2BF4B00B33C20 /* OptimizelyClientType.swift */,
 				774D98D823A96E7500FC81C2 /* OptimizelyClientTypeTests.swift */,
 				D7B962B42396E963003AA616 /* OptimizelyExperiment.swift */,
+				8AAFEAE82474535C004A88F8 /* OptimizelyFeature.swift */,
 				771123FA23BF9E7E00BA5702 /* OptimizelyLogLevelType.swift */,
 				1611EF5D23ABD1550051CDCC /* OptimizelyResultType.swift */,
 				A77D7B061CBAAF5D0077586B /* Paginate.swift */,
@@ -4940,6 +4943,7 @@
 				A755115F1C8642C3005355CF /* Format.swift in Sources */,
 				598D96CB1D42AE85003F3F66 /* ActivitySampleProjectCellViewModel.swift in Sources */,
 				01C7CDB31D13462A00D9E0D1 /* DashboardRewardsCellViewModel.swift in Sources */,
+				8AAFEAE92474535D004A88F8 /* OptimizelyFeature.swift in Sources */,
 				A7D121091D15B08200F364FD /* CountBadgeView.swift in Sources */,
 				77216CE220EFE7F70061BE82 /* FacebookConnectionType.swift in Sources */,
 				D7ADDFE722E0DAFA00157D83 /* RewardCellProjectBackingStateType.swift in Sources */,

--- a/Library/OptimizelyClientType.swift
+++ b/Library/OptimizelyClientType.swift
@@ -5,6 +5,7 @@ import Prelude
 public protocol OptimizelyClientType: AnyObject {
   func activate(experimentKey: String, userId: String, attributes: [String: Any?]?) throws -> String
   func getVariationKey(experimentKey: String, userId: String, attributes: [String: Any?]?) throws -> String
+  func isFeatureEnabled(featureKey: String, userId: String, attributes: [String: Any?]?) -> Bool
   func track(eventKey: String, userId: String, attributes: [String: Any?]?, eventTags: [String: Any]?) throws
 }
 
@@ -61,6 +62,14 @@ extension OptimizelyClientType {
     }
 
     return variant
+  }
+
+  public func isFeatureEnabled(featureKey: String) -> Bool {
+    return self.isFeatureEnabled(
+      featureKey: featureKey,
+      userId: deviceIdentifier(uuid: UUID()),
+      attributes: optimizelyUserAttributes()
+    )
   }
 }
 

--- a/Library/OptimizelyClientTypeTests.swift
+++ b/Library/OptimizelyClientTypeTests.swift
@@ -76,4 +76,20 @@ final class OptimizelyClientTypeTests: TestCase {
       XCTAssertTrue(mockClient.getVariantPathCalled)
     }
   }
+
+  func testIsFeatureEnabled() {
+    let mockClient = MockOptimizelyClient()
+      |> \.features .~ [
+        "my_enabled_feature": true,
+        "my_disabled_feature": false
+      ]
+
+    XCTAssertTrue(mockClient.isFeatureEnabled(featureKey: "my_enabled_feature", userId: "1", attributes: [:]))
+    XCTAssertFalse(
+      mockClient.isFeatureEnabled(featureKey: "my_disabled_feature", userId: "1", attributes: [:])
+    )
+    XCTAssertFalse(
+      mockClient.isFeatureEnabled(featureKey: "my_missing_feature", userId: "1", attributes: [:])
+    )
+  }
 }

--- a/Library/OptimizelyFeature.swift
+++ b/Library/OptimizelyFeature.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+public enum OptimizelyFeature {
+  public enum Key: String {
+    case signInWithApple = "ios_sign_in_with_apple"
+  }
+}

--- a/Library/OptimizelyFeature.swift
+++ b/Library/OptimizelyFeature.swift
@@ -2,6 +2,6 @@ import Foundation
 
 public enum OptimizelyFeature {
   public enum Key: String {
-    case signInWithApple = "ios_sign_in_with_apple"
+    case signInWithAppleKillswitch = "ios_sign_in_with_apple_killswitch"
   }
 }

--- a/Library/TestHelpers/MockOptimizelyClient.swift
+++ b/Library/TestHelpers/MockOptimizelyClient.swift
@@ -15,6 +15,7 @@ internal class MockOptimizelyClient: OptimizelyClientType {
   var activatePathCalled: Bool = false
   var experiments: [String: String] = [:]
   var error: MockOptimizelyError?
+  var features: [String: Bool] = [:]
   var getVariantPathCalled: Bool = false
   var userAttributes: [String: Any?]?
 
@@ -36,6 +37,10 @@ internal class MockOptimizelyClient: OptimizelyClientType {
       self.getVariantPathCalled = true
       return try self.experiment(forKey: experimentKey, userId: userId, attributes: attributes)
     }
+
+  func isFeatureEnabled(featureKey: String, userId _: String, attributes _: [String: Any?]?) -> Bool {
+    return self.features[featureKey] == true
+  }
 
   private func experiment(forKey key: String, userId _: String, attributes: [String: Any?]?) throws
     -> String {

--- a/Library/ViewModels/LoginToutViewModel.swift
+++ b/Library/ViewModels/LoginToutViewModel.swift
@@ -53,6 +53,9 @@ public protocol LoginToutViewModelInputs {
 }
 
 public protocol LoginToutViewModelOutputs {
+  /// Emits whether the Sign In With Apple Button should be hidden.
+  var appleButtonHidden: Signal<Bool, Never> { get }
+
   /// Emits when Apple login should start
   var attemptAppleLogin: Signal<Void, Never> { get }
 
@@ -260,6 +263,14 @@ public final class LoginToutViewModel: LoginToutViewModelType, LoginToutViewMode
 
     self.logIntoEnvironment = Signal.merge(logIntoEnvironmentWithApple, logIntoEnvironmentWithFacebook)
 
+    self.appleButtonHidden = self.viewWillAppearProperty.signal
+      .map { _ in
+        AppEnvironment.current.optimizelyClient?.isFeatureEnabled(
+          featureKey: OptimizelyFeature.Key.signInWithApple.rawValue
+        ) ?? false
+      }
+      .negate()
+
     // MARK: - Tracking
 
     let trackingData = Signal.combineLatest(
@@ -391,6 +402,7 @@ public final class LoginToutViewModel: LoginToutViewModelType, LoginToutViewMode
     self.viewWillAppearProperty.value = ()
   }
 
+  public let appleButtonHidden: Signal<Bool, Never>
   public let attemptAppleLogin: Signal<(), Never>
   public let attemptFacebookLogin: Signal<(), Never>
   public let dismissViewController: Signal<(), Never>

--- a/Library/ViewModels/LoginToutViewModel.swift
+++ b/Library/ViewModels/LoginToutViewModel.swift
@@ -266,10 +266,9 @@ public final class LoginToutViewModel: LoginToutViewModelType, LoginToutViewMode
     self.appleButtonHidden = self.viewWillAppearProperty.signal
       .map { _ in
         AppEnvironment.current.optimizelyClient?.isFeatureEnabled(
-          featureKey: OptimizelyFeature.Key.signInWithApple.rawValue
+          featureKey: OptimizelyFeature.Key.signInWithAppleKillswitch.rawValue
         ) ?? false
       }
-      .negate()
 
     // MARK: - Tracking
 

--- a/Library/ViewModels/LoginToutViewModelTests.swift
+++ b/Library/ViewModels/LoginToutViewModelTests.swift
@@ -11,6 +11,7 @@ import XCTest
 final class LoginToutViewModelTests: TestCase {
   fileprivate let vm: LoginToutViewModelType = LoginToutViewModel()
 
+  fileprivate let appleButtonHidden = TestObserver<Bool, Never>()
   fileprivate let attemptAppleLogin = TestObserver<(), Never>()
   fileprivate let attemptFacebookLogin = TestObserver<(), Never>()
   fileprivate let didSignInWithApple = TestObserver<SignInWithAppleEnvelope, Never>()
@@ -30,6 +31,7 @@ final class LoginToutViewModelTests: TestCase {
   override func setUp() {
     super.setUp()
 
+    self.vm.outputs.appleButtonHidden.observe(self.appleButtonHidden.observer)
     self.vm.outputs.attemptAppleLogin.observe(self.attemptAppleLogin.observer)
     self.vm.outputs.attemptFacebookLogin.observe(self.attemptFacebookLogin.observer)
     self.vm.outputs.dismissViewController.observe(self.dismissViewController.observer)
@@ -740,5 +742,51 @@ final class LoginToutViewModelTests: TestCase {
       trackingClient.events
     )
     self.attemptAppleLogin.assertValueCount(1)
+  }
+
+  func testAppleButtonHidden_FeatureEnabled() {
+    let mockOptimizelyClient = MockOptimizelyClient()
+      |> \.features .~ [
+        OptimizelyFeature.Key.signInWithApple.rawValue: true
+      ]
+
+    self.appleButtonHidden.assertDidNotEmitValue()
+
+    withEnvironment(optimizelyClient: mockOptimizelyClient) {
+      self.vm.inputs.configureWith(.generic, project: nil, reward: nil)
+      self.vm.inputs.viewWillAppear()
+
+      self.appleButtonHidden.assertValues([false])
+    }
+  }
+
+  func testAppleButtonHidden_FeatureDisabled() {
+    let mockOptimizelyClient = MockOptimizelyClient()
+      |> \.features .~ [
+        OptimizelyFeature.Key.signInWithApple.rawValue: false
+      ]
+
+    self.appleButtonHidden.assertDidNotEmitValue()
+
+    withEnvironment(optimizelyClient: mockOptimizelyClient) {
+      self.vm.inputs.configureWith(.generic, project: nil, reward: nil)
+      self.vm.inputs.viewWillAppear()
+
+      self.appleButtonHidden.assertValues([true])
+    }
+  }
+
+  func testAppleButtonHidden_FeatureMissing() {
+    let mockOptimizelyClient = MockOptimizelyClient()
+      |> \.features .~ [:]
+
+    self.appleButtonHidden.assertDidNotEmitValue()
+
+    withEnvironment(optimizelyClient: mockOptimizelyClient) {
+      self.vm.inputs.configureWith(.generic, project: nil, reward: nil)
+      self.vm.inputs.viewWillAppear()
+
+      self.appleButtonHidden.assertValues([true])
+    }
   }
 }

--- a/Library/ViewModels/LoginToutViewModelTests.swift
+++ b/Library/ViewModels/LoginToutViewModelTests.swift
@@ -747,23 +747,7 @@ final class LoginToutViewModelTests: TestCase {
   func testAppleButtonHidden_FeatureEnabled() {
     let mockOptimizelyClient = MockOptimizelyClient()
       |> \.features .~ [
-        OptimizelyFeature.Key.signInWithApple.rawValue: true
-      ]
-
-    self.appleButtonHidden.assertDidNotEmitValue()
-
-    withEnvironment(optimizelyClient: mockOptimizelyClient) {
-      self.vm.inputs.configureWith(.generic, project: nil, reward: nil)
-      self.vm.inputs.viewWillAppear()
-
-      self.appleButtonHidden.assertValues([false])
-    }
-  }
-
-  func testAppleButtonHidden_FeatureDisabled() {
-    let mockOptimizelyClient = MockOptimizelyClient()
-      |> \.features .~ [
-        OptimizelyFeature.Key.signInWithApple.rawValue: false
+        OptimizelyFeature.Key.signInWithAppleKillswitch.rawValue: true
       ]
 
     self.appleButtonHidden.assertDidNotEmitValue()
@@ -773,6 +757,22 @@ final class LoginToutViewModelTests: TestCase {
       self.vm.inputs.viewWillAppear()
 
       self.appleButtonHidden.assertValues([true])
+    }
+  }
+
+  func testAppleButtonHidden_FeatureDisabled() {
+    let mockOptimizelyClient = MockOptimizelyClient()
+      |> \.features .~ [
+        OptimizelyFeature.Key.signInWithAppleKillswitch.rawValue: false
+      ]
+
+    self.appleButtonHidden.assertDidNotEmitValue()
+
+    withEnvironment(optimizelyClient: mockOptimizelyClient) {
+      self.vm.inputs.configureWith(.generic, project: nil, reward: nil)
+      self.vm.inputs.viewWillAppear()
+
+      self.appleButtonHidden.assertValues([false])
     }
   }
 
@@ -786,7 +786,7 @@ final class LoginToutViewModelTests: TestCase {
       self.vm.inputs.configureWith(.generic, project: nil, reward: nil)
       self.vm.inputs.viewWillAppear()
 
-      self.appleButtonHidden.assertValues([true])
+      self.appleButtonHidden.assertValues([false])
     }
   }
 }


### PR DESCRIPTION
# 📲 What

Adds an `ios_sign_in_with_apple` feature flag that acts as a killswitch (hides the button if enabled).

# 🤔 Why

We will soon roll out Sign In With Apple in our next release and we would just like to be able to turn this off if necessary via a feature flag.

# 🛠 How

- Added `ios_sign_in_with_apple_killswitch` feature flag on Optimizely.
- Add behaviour to hide the Sign In With Apple button if this feature is `enabled`. If it is `disabled` or missing,  the button will be shown.

# 👀 See

| Killswitch `enabled` 🟢  | Killswitch `disabled` 🔴 | Killswitch _missing_ 💭 |
| --- | --- | --- |
| <img width="584" alt="image" src="https://user-images.githubusercontent.com/3735375/82378947-e9a44a80-99da-11ea-81de-440f03ea09a4.png"> | <img width="584" alt="image" src="https://user-images.githubusercontent.com/3735375/82378755-96ca9300-99da-11ea-97e4-35319d9c873b.png"> | <img width="584" alt="image" src="https://user-images.githubusercontent.com/3735375/82378755-96ca9300-99da-11ea-97e4-35319d9c873b.png"> |

# ✅ Acceptance criteria

- [ ] Enable the `ios_sign_in_with_apple_killswitch` feature flag. Observe that upon re-launching the app, the _Continue with Apple button_ is **hidden**.
- [ ] Disable the `ios_sign_in_with_apple_killswitch` feature flag. Observe that upon re-launching the app, the _Continue with Apple button_ is **visible**.
- [ ] Temporary rename the feature flag so that it is seen as removed. Observe that upon re-launching the app, the _Continue with Apple button_ is **visible**.