### PR TITLE
[NT-1236] Fix share URLs in messaging apps

### DIFF
--- a/Library/ProjectActivityItemProvider.swift
+++ b/Library/ProjectActivityItemProvider.swift
@@ -31,9 +31,6 @@ public final class ProjectActivityItemProvider: UIActivityItemProvider {
   }
 
   private func formattedString(for project: Project) -> String {
-    return """
-     \(project.name)\n
-     \(project.urls.web.project)
-    """
+    return [project.name, project.urls.web.project].joined(separator: "\n")
   }
 }

--- a/Library/ProjectActivityItemProviderTests.swift
+++ b/Library/ProjectActivityItemProviderTests.swift
@@ -9,10 +9,7 @@ class ProjectActivityItemProviderTests: XCTestCase {
     |> Project.lens.urls.web.project .~ "https://kickstarter.com/awesome-project"
 
   private var formattedString: String {
-    return """
-     \(self.project.name)\n
-     \(self.project.urls.web.project)
-    """
+    return [self.project.name, self.project.urls.web.project].joined(separator: "\n")
   }
 
   func testProviderInitReturnsCorrectPlaceholderItem() {

--- a/Library/ViewModels/ShareViewModel.swift
+++ b/Library/ViewModels/ShareViewModel.swift
@@ -195,20 +195,3 @@ private func activityController(forShareContext shareContext: ShareContext) -> U
 
   return controller
 }
-
-private func twitterInitialText(forShareContext shareContext: ShareContext) -> String {
-  switch shareContext {
-  case let .creatorDashboard(project):
-    return Strings.project_checkout_share_twitter_via_kickstarter(project_or_update_title: project.name)
-  case let .discovery(project):
-    return Strings.project_checkout_share_twitter_via_kickstarter(project_or_update_title: project.name)
-  case let .project(project):
-    return Strings.project_checkout_share_twitter_via_kickstarter(project_or_update_title: project.name)
-  case let .thanks(project):
-    return Strings.project_checkout_share_twitter_I_just_backed_project_on_kickstarter(
-      project_name: project.name
-    )
-  case let .update(_, update):
-    return Strings.social_update_number(update_number: String(update.sequence)) + ": " + update.title
-  }
-}


### PR DESCRIPTION
# 📲 What

Fixes broken shared project links in some messaging apps.

# 🤔 Why

We noticed that some URLs weren't being shared correctly in some apps, for example Telegram:

<img src="https://user-images.githubusercontent.com/3735375/82476537-1ad85580-9a83-11ea-8c91-dc96e7f0e66a.jpg" width="50%"/>

This appears to be due to a space character being incorrectly prepended to the beginning of the URL.

# 🛠 How

Updated the code that constructs this string to instead use the `joined(separator:)` function rather that multi-line string interpolation.

# ✅ Acceptance criteria

- [ ] Share a project link using messaging, observe that there are no spaces at the beginning of the project title or URL.