### PR TITLE
[NT-1015] Project Card Clicked Event

### DIFF
--- a/Library/Tracking/Koala.swift
+++ b/Library/Tracking/Koala.swift
@@ -37,6 +37,7 @@ public final class Koala {
     case loginOrSignupPageViewed = "Log In or Signup Page Viewed"
     case loginSubmitButtonClicked = "Log In Submit Button Clicked"
     case pledgeSubmitButtonClicked = "Pledge Submit Button Clicked"
+    case projectCardClicked = "Project Card Clicked"
     case projectPagePledgeButtonClicked = "Project Page Pledge Button Clicked"
     case projectPageViewed = "Project Page Viewed"
     case projectSwiped = "Project Swiped"
@@ -534,6 +535,24 @@ public final class Koala {
       event: DataLakeWhiteListedEvent.collectionViewed.rawValue,
       location: .editorialProjects,
       properties: discoveryProperties(from: params)
+    )
+  }
+
+  /**
+   Call when a project card is clicked from a list of projects
+   - parameter project: the Project corresponding to the card that was clicked
+   - parameter params: the DiscoveryParams associated with the list of projects
+   - parameter location: the location context of the event
+   */
+
+  public func trackProjectCardClicked(project: Project, params: DiscoveryParams, location: LocationContext) {
+    let props = discoveryProperties(from: params)
+      .withAllValuesFrom(projectProperties(from: project, loggedInUser: self.loggedInUser))
+
+    self.track(
+      event: DataLakeWhiteListedEvent.projectCardClicked.rawValue,
+      location: location,
+      properties: props
     )
   }
 
@@ -1128,13 +1147,6 @@ public final class Koala {
   public func trackCheckoutFinishJumpToDiscovery(project: Project) {
     self.track(
       event: "Checkout Finished Discover More",
-      properties: projectProperties(from: project, loggedInUser: self.loggedInUser)
-    )
-  }
-
-  public func trackCheckoutFinishJumpToProject(project: Project) {
-    self.track(
-      event: "Checkout Finished Discover Open Project",
       properties: projectProperties(from: project, loggedInUser: self.loggedInUser)
     )
   }

--- a/Library/Tracking/KoalaTests.swift
+++ b/Library/Tracking/KoalaTests.swift
@@ -549,6 +549,23 @@ final class KoalaTests: TestCase {
     XCTAssertEqual("Apple", callBackProperties?["session_device_manufacturer"] as? String)
   }
 
+  func testProjectCardClicked() {
+    let client = MockTrackingClient()
+    let koala = Koala(client: client)
+
+    koala.trackProjectCardClicked(
+      project: Project.template,
+      params: DiscoveryParams.recommendedDefaults,
+      location: .discovery
+    )
+
+    XCTAssertEqual(["Project Card Clicked"], client.events)
+    XCTAssertEqual("explore_screen", client.properties.last?["context_location"] as? String)
+
+    self.assertProjectProperties(client.properties.last)
+    self.assertDiscoveryProperties(client.properties.last)
+  }
+
   func testWatchProjectButtonClicked_DiscoveryLocationContext() {
     let client = MockTrackingClient()
     let koala = Koala(client: client)

--- a/Library/ViewModels/DiscoveryPageViewModel.swift
+++ b/Library/ViewModels/DiscoveryPageViewModel.swift
@@ -458,6 +458,16 @@ public final class DiscoveryPageViewModel: DiscoveryPageViewModelType, Discovery
         )
       }
 
+    paramsChanged
+      .takePairWhen(self.tappedProject.signal.skipNil())
+      .observeValues { params, project in
+        AppEnvironment.current.koala.trackProjectCardClicked(
+          project: project,
+          params: params,
+          location: .discovery
+        )
+      }
+
     self.goToLoginSignup
       .observeValues { AppEnvironment.current.koala.trackLoginOrSignupButtonClicked(intent: $0) }
   }

--- a/Library/ViewModels/DiscoveryPageViewModelTests.swift
+++ b/Library/ViewModels/DiscoveryPageViewModelTests.swift
@@ -412,6 +412,8 @@ internal final class DiscoveryPageViewModelTests: TestCase {
         "Go to the project with discovery ref tag."
       )
 
+      XCTAssertEqual(["Explore Page Viewed", "Project Card Clicked"], self.trackingClient.events)
+
       self.vm.inputs.selectedFilter(.defaults
         |> DiscoveryParams.lens.category .~ Category.art)
       self.vm.inputs.tapped(project: project)
@@ -423,8 +425,24 @@ internal final class DiscoveryPageViewModelTests: TestCase {
         "Go to the project with the category sort ref tag."
       )
 
+      XCTAssertEqual([
+        "Explore Page Viewed",
+        "Project Card Clicked",
+        "Explore Page Viewed",
+        "Project Card Clicked"
+      ], self.trackingClient.events)
+
       self.vm.inputs.selectedFilter(.defaults |> DiscoveryParams.lens.staffPicks .~ true)
       self.vm.inputs.tapped(project: project)
+
+      XCTAssertEqual([
+        "Explore Page Viewed",
+        "Project Card Clicked",
+        "Explore Page Viewed",
+        "Project Card Clicked",
+        "Explore Page Viewed",
+        "Project Card Clicked"
+      ], self.trackingClient.events)
 
       self.goToPlaylist.assertValueCount(3, "New playlist for project emits.")
       self.goToPlaylistProject.assertValues([project, project, project])
@@ -435,6 +453,17 @@ internal final class DiscoveryPageViewModelTests: TestCase {
 
       self.vm.inputs.selectedFilter(.defaults |> DiscoveryParams.lens.social .~ true)
       self.vm.inputs.tapped(project: project)
+
+      XCTAssertEqual([
+        "Explore Page Viewed",
+        "Project Card Clicked",
+        "Explore Page Viewed",
+        "Project Card Clicked",
+        "Explore Page Viewed",
+        "Project Card Clicked",
+        "Explore Page Viewed",
+        "Project Card Clicked"
+      ], self.trackingClient.events)
 
       self.goToPlaylist.assertValueCount(4, "New playlist for project emits.")
       self.goToPlaylistProject.assertValues([project, project, project, project])
@@ -456,6 +485,20 @@ internal final class DiscoveryPageViewModelTests: TestCase {
 
       self.vm.inputs.configureWith(sort: .endingSoon)
       self.vm.inputs.tapped(project: project)
+
+      XCTAssertEqual([
+        "Explore Page Viewed",
+        "Project Card Clicked",
+        "Explore Page Viewed",
+        "Project Card Clicked",
+        "Explore Page Viewed",
+        "Project Card Clicked",
+        "Explore Page Viewed",
+        "Project Card Clicked",
+        "Explore Page Viewed",
+        "Project Card Clicked"
+      ], self.trackingClient.events)
+
       self.goToPlaylistProject.assertValues([project, project, project, project, project])
       self.goToPlaylistRefTag.assertValues(
         [

--- a/Library/ViewModels/ThanksViewModel.swift
+++ b/Library/ViewModels/ThanksViewModel.swift
@@ -185,11 +185,6 @@ public final class ThanksViewModel: ThanksViewModelType, ThanksViewModelInputs, 
       }
 
     self.projectTappedProperty.signal.skipNil().map { project in
-      let recommendedParams = DiscoveryParams.defaults
-        |> DiscoveryParams.lens.backed .~ false
-        |> DiscoveryParams.lens.perPage .~ 6
-        |> DiscoveryParams.lens.recommended .~ true
-
       return (project, recommendedParams)
     }.observeValues { project, params in
       AppEnvironment.current.koala.trackProjectCardClicked(
@@ -293,10 +288,6 @@ private func relatedProjects(
   SignalProducer<[Project], Never> {
   let base = DiscoveryParams.lens.perPage .~ 3 <> DiscoveryParams.lens.backed .~ false
 
-  let recommendedParams = DiscoveryParams.defaults |> base
-    |> DiscoveryParams.lens.perPage .~ 6
-    |> DiscoveryParams.lens.recommended .~ true
-
   let similarToParams = DiscoveryParams.defaults |> base
     |> DiscoveryParams.lens.similarTo .~ project
 
@@ -350,3 +341,8 @@ private func shuffle(projects xs: [Project]) -> [Project] {
     return xs
   }
 }
+
+private let recommendedParams = DiscoveryParams.defaults
+  |> DiscoveryParams.lens.backed .~ false
+  |> DiscoveryParams.lens.perPage .~ 6
+  |> DiscoveryParams.lens.recommended .~ true

--- a/Library/ViewModels/ThanksViewModelTests.swift
+++ b/Library/ViewModels/ThanksViewModelTests.swift
@@ -248,7 +248,7 @@ final class ThanksViewModelTests: TestCase {
         [
           "Triggered App Store Rating Dialog",
           "Thanks Page Viewed",
-          "Checkout Finished Discover Open Project"
+          "Project Card Clicked"
         ],
         self.trackingClient.events
       )


### PR DESCRIPTION
# 📲 What

Adds the "Project Card Clicked" event when a project is selected from discovery or the thanks page.

# 🤔 Why

So we can track what projects users are navigating to from various locations.

# 🛠 How

- add the `Project Card Clicked` event to the data lake whitelist
- fire the event when a project is clicked from discovery
- fire the event when a project is clicked from the Thanks page

# 👀 See

![image](https://user-images.githubusercontent.com/3156796/82501508-60b50e00-9ac3-11ea-9815-d40ea0b1e9c5.png)

# ✅ Acceptance criteria

- [x] turn the `KOALA_TRACKING` environment flag to `true`, then run the app and a tap a project from discovery. You should see the `Project Card Clicked` event
- [x] Run the app and back a project. On the Thanks page, tap any project. You should see the `Project Card Clicked` event
