### PR TITLE
[NT-1299] Apple Sign In Processing View dismissal bugfix

### DIFF
--- a/Library/ViewModels/LoginToutViewModel.swift
+++ b/Library/ViewModels/LoginToutViewModel.swift
@@ -180,6 +180,8 @@ public final class LoginToutViewModel: LoginToutViewModelType, LoginToutViewMode
           userInfo: [UserInfoKeys.context: PushNotificationDialog.Context.login]
         )
       ))
+      // Post notifications on the next run loop to avoid race condition with VCs being deallocated.
+      .ksr_delay(.nanoseconds(0), on: AppEnvironment.current.scheduler)
 
     self.dismissViewController = self.viewIsPresentedProperty.signal
       .filter(isTrue)

--- a/Library/ViewModels/LoginToutViewModelTests.swift
+++ b/Library/ViewModels/LoginToutViewModelTests.swift
@@ -9,7 +9,7 @@ import ReactiveSwift
 import XCTest
 
 final class LoginToutViewModelTests: TestCase {
-  fileprivate let vm: LoginToutViewModelType = LoginToutViewModel()
+  fileprivate var vm: LoginToutViewModelType!
 
   fileprivate let appleButtonHidden = TestObserver<Bool, Never>()
   fileprivate let attemptAppleLogin = TestObserver<(), Never>()
@@ -30,6 +30,8 @@ final class LoginToutViewModelTests: TestCase {
 
   override func setUp() {
     super.setUp()
+
+    self.vm = LoginToutViewModel()
 
     self.vm.outputs.appleButtonHidden.observe(self.appleButtonHidden.observer)
     self.vm.outputs.attemptAppleLogin.observe(self.attemptAppleLogin.observer)
@@ -221,6 +223,12 @@ final class LoginToutViewModelTests: TestCase {
     )
 
     self.vm.inputs.environmentLoggedIn()
+
+    self.postNotification.assertDidNotEmitValue()
+
+    self.scheduler.advance()
+
+    // Notifications are posted on the next run loop
     XCTAssertEqual(self.postNotification.values.first?.0, .ksr_sessionStarted, "Login notification posted.")
     XCTAssertEqual(
       self.postNotification.values.first?.1, .ksr_showNotificationsDialog,


### PR DESCRIPTION
# 📲 What

Fixes an bug which caused the processing view to never dismiss after logging in via Apple Sign In from the profile tab.

# 🤔 Why

A number of things are happening all at once here:

- Apple Pay Sign In event completes.
- User object is refreshed.
- User is logged into the environment.
- Notifications are posted for the app to update its state.
- Processing view is dismissed.

Once the notifications are posted about the user login state having changed our `RootViewModel` recreates all of the VCs and sets them again on the tab bar. This was causing the `LoginToutViewController` to be deallocated before the observing closure could execute and hide the processing view.

One way of solving this would be to have another input on the view model to inform of the processing view having been dismissed. Another fairly simple solution is to place the posting of the notifications on the next run loop with a zero nanosecond delay. This PR implements the latter and adds a test.

# 🛠 How

Imposed a zero nanosecond delay on `LoginToutViewModel`'s `postNotification` output to ensure that it will emit last.

# ✅ Acceptance criteria

- [ ] In a logged out state, tap on the profile tab, sign in with Apple - you should _not_ find yourself stuck with the processing view never dismissing.