### PR TITLE
[NT-1317] Send Optimizely Events with the SDK

### DIFF
--- a/Library/OptimizelyClientType.swift
+++ b/Library/OptimizelyClientType.swift
@@ -7,6 +7,7 @@ public protocol OptimizelyClientType: AnyObject {
   func getVariationKey(experimentKey: String, userId: String, attributes: [String: Any?]?) throws -> String
   func allExperiments() -> [String]
   func isFeatureEnabled(featureKey: String, userId: String, attributes: [String: Any?]?) -> Bool
+  func track(eventKey: String, userId: String, attributes: [String: Any?]?, eventTags: [String: Any]?) throws
 }
 
 extension OptimizelyClientType {
@@ -81,6 +82,21 @@ extension OptimizelyClientType {
 
 // MARK: - Tracking Properties
 
+public func optimizelyClientTrackingAttributesAndEventTags(
+  with project: Project? = nil,
+  refTag: RefTag? = nil
+) -> ([String: Any], [String: Any]) {
+  let properties = optimizelyUserAttributes(with: project, refTag: refTag)
+
+  let eventTags: [String: Any] = ([
+    "project_subcategory": project?.category.name,
+    "project_category": project?.category.parentName,
+    "project_country": project?.location.country.lowercased(),
+    "project_user_has_watched": project?.personalization.isStarred
+  ] as [String: Any?]).compact()
+  return (properties, eventTags)
+}
+
 public func optimizelyProperties(environment: Environment? = AppEnvironment.current) -> [String: Any]? {
   guard let env = environment, let optimizelyClient = env.optimizelyClient else {
     return nil
@@ -120,7 +136,7 @@ public func optimizelyProperties(environment: Environment? = AppEnvironment.curr
     "optimizely_experiments": allExperiments
   ]
 }
-
+  
 public func optimizelyUserAttributes(
   with project: Project? = nil,
   refTag: RefTag? = nil

--- a/Library/OptimizelyClientType.swift
+++ b/Library/OptimizelyClientType.swift
@@ -78,24 +78,19 @@ extension OptimizelyClientType {
       attributes: optimizelyUserAttributes()
     )
   }
+  
+  public func track(eventName: String) {
+    let userAttributes = optimizelyUserAttributes()
+    let userId = deviceIdentifier(uuid: UUID())
+
+    try? self.track(eventKey: eventName,
+                    userId: userId,
+                    attributes: userAttributes,
+                    eventTags: nil)
+  }
 }
 
 // MARK: - Tracking Properties
-
-public func optimizelyClientTrackingAttributesAndEventTags(
-  with project: Project? = nil,
-  refTag: RefTag? = nil
-) -> ([String: Any], [String: Any]) {
-  let properties = optimizelyUserAttributes(with: project, refTag: refTag)
-
-  let eventTags: [String: Any] = ([
-    "project_subcategory": project?.category.name,
-    "project_category": project?.category.parentName,
-    "project_country": project?.location.country.lowercased(),
-    "project_user_has_watched": project?.personalization.isStarred
-  ] as [String: Any?]).compact()
-  return (properties, eventTags)
-}
 
 public func optimizelyProperties(environment: Environment? = AppEnvironment.current) -> [String: Any]? {
   guard let env = environment, let optimizelyClient = env.optimizelyClient else {
@@ -136,7 +131,7 @@ public func optimizelyProperties(environment: Environment? = AppEnvironment.curr
     "optimizely_experiments": allExperiments
   ]
 }
-  
+ 
 public func optimizelyUserAttributes(
   with project: Project? = nil,
   refTag: RefTag? = nil

--- a/Library/TestHelpers/MockOptimizelyClient.swift
+++ b/Library/TestHelpers/MockOptimizelyClient.swift
@@ -19,6 +19,13 @@ internal class MockOptimizelyClient: OptimizelyClientType {
   var features: [String: Bool] = [:]
   var getVariantPathCalled: Bool = false
   var userAttributes: [String: Any?]?
+  
+  // MARK: - Event Tracking Test Properties
+  
+  var trackedAttributes: [String: Any?]?
+  var trackedEventKey: String?
+  var trackedEventTags: [String: Any?]?
+  var trackedUserId: String?
 
   internal func activate(experimentKey: String, userId: String, attributes: [String: Any?]?) throws
     -> String {
@@ -50,9 +57,42 @@ internal class MockOptimizelyClient: OptimizelyClientType {
       }
 
       return experimentVariant
-    }
+  }
+
+  func track(eventKey: String, userId: String, attributes: [String: Any?]?, eventTags: [String: Any]?)
+    throws {
+    self.trackedEventKey = eventKey
+    self.trackedAttributes = attributes
+    self.trackedEventTags = eventTags
+    self.trackedUserId = userId
+  }
 
   func allExperiments() -> [String] {
     return self.allKnownExperiments
+  }
+}
+
+extension TestCase {
+  func assertBaseUserAttributesLoggedOut() {
+    XCTAssertEqual(
+      self.optimizelyClient.trackedAttributes?["session_os_version"] as? String,
+      "MockSystemVersion"
+    )
+    XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_user_is_logged_in"] as? Bool, false)
+    XCTAssertEqual(
+      self.optimizelyClient.trackedAttributes?["session_app_release_version"] as? String,
+      "1.2.3.4.5.6.7.8.9.0"
+    )
+    XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_apple_pay_device"] as? Bool, true)
+    XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_device_format"] as? String, "phone")
+
+    XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_country"] as? String, "us")
+    XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_display_language"] as? String, "en")
+
+    XCTAssertNil(self.optimizelyClient.trackedAttributes?["session_ref_tag"] as? String)
+    XCTAssertNil(self.optimizelyClient.trackedAttributes?["session_referrer_credit"] as? String)
+    XCTAssertNil(self.optimizelyClient.trackedAttributes?["user_backed_projects_count"] as? Int)
+    XCTAssertNil(self.optimizelyClient.trackedAttributes?["user_launched_projects_count"] as? Int)
+    XCTAssertNil(self.optimizelyClient.trackedAttributes?["user_facebook_account"] as? Bool)
   }
 }

--- a/Library/TestHelpers/MockOptimizelyClient.swift
+++ b/Library/TestHelpers/MockOptimizelyClient.swift
@@ -24,7 +24,6 @@ internal class MockOptimizelyClient: OptimizelyClientType {
   
   var trackedAttributes: [String: Any?]?
   var trackedEventKey: String?
-  var trackedEventTags: [String: Any?]?
   var trackedUserId: String?
 
   internal func activate(experimentKey: String, userId: String, attributes: [String: Any?]?) throws
@@ -58,12 +57,10 @@ internal class MockOptimizelyClient: OptimizelyClientType {
 
       return experimentVariant
   }
-
-  func track(eventKey: String, userId: String, attributes: [String: Any?]?, eventTags: [String: Any]?)
-    throws {
+  
+  func track(eventKey: String, userId: String, attributes: [String: Any?]?, eventTags: [String: Any]?) throws {
     self.trackedEventKey = eventKey
     self.trackedAttributes = attributes
-    self.trackedEventTags = eventTags
     self.trackedUserId = userId
   }
 

--- a/Library/ViewModels/CategorySelectionViewModel.swift
+++ b/Library/ViewModels/CategorySelectionViewModel.swift
@@ -108,20 +108,17 @@ public final class CategorySelectionViewModel: CategorySelectionViewModelType,
 
     // Tracking
 
-    self.skipButtonTappedProperty.signal
-      .observeValues { _ in
-        let optimizelyProps = optimizelyProperties() ?? [:]
+    self.skipButtonTappedProperty.signal.observeValues { _ in
+      let optimizelyProps = optimizelyProperties() ?? [:]
+      AppEnvironment.current.koala.trackOnboardingSkipButtonClicked(optimizelyProperties: optimizelyProps)
+      trackOptimizelyClientButtonClicked(buttonTitle: "Skip")
+    }
 
-        AppEnvironment.current.koala.trackOnboardingSkipButtonClicked(optimizelyProperties: optimizelyProps)
-      }
-
-    self.continueButtonTappedProperty.signal
-      .observeValues { _ in
-        let optimizelyProps = optimizelyProperties() ?? [:]
-
-        AppEnvironment.current.koala
-          .trackOnboardingContinueButtonClicked(optimizelyProperties: optimizelyProps)
-      }
+    self.continueButtonTappedProperty.signal.observeValues { buttonTitle in
+      let optimizelyProps = optimizelyProperties() ?? [:]
+      AppEnvironment.current.koala.trackOnboardingContinueButtonClicked(optimizelyProperties: optimizelyProps)
+      trackOptimizelyClientButtonClicked(buttonTitle: "Continue")
+    }
   }
 
   private let categorySelectedWithValueProperty = MutableProperty<(IndexPath, KsApi.Category)?>(nil)
@@ -256,4 +253,15 @@ private func cache(_ categories: [KsApi.Category]) {
   let data = try? JSONEncoder().encode(categories)
 
   AppEnvironment.current.userDefaults.onboardingCategories = data
+}
+
+private func trackOptimizelyClientButtonClicked(buttonTitle: String) {
+  let (properties, eventTags) = optimizelyClientTrackingAttributesAndEventTags()
+
+  let eventName = "\(buttonTitle) Button Clicked"
+
+  try? AppEnvironment.current.optimizelyClient?.track(eventKey: eventName,
+                                                      userId: deviceIdentifier(uuid: UUID()),
+                                                      attributes: properties,
+                                                      eventTags: eventTags)
 }

--- a/Library/ViewModels/CategorySelectionViewModel.swift
+++ b/Library/ViewModels/CategorySelectionViewModel.swift
@@ -256,12 +256,6 @@ private func cache(_ categories: [KsApi.Category]) {
 }
 
 private func trackOptimizelyClientButtonClicked(buttonTitle: String) {
-  let (properties, eventTags) = optimizelyClientTrackingAttributesAndEventTags()
-
   let eventName = "\(buttonTitle) Button Clicked"
-
-  try? AppEnvironment.current.optimizelyClient?.track(eventKey: eventName,
-                                                      userId: deviceIdentifier(uuid: UUID()),
-                                                      attributes: properties,
-                                                      eventTags: eventTags)
+  AppEnvironment.current.optimizelyClient?.track(eventName: eventName)
 }

--- a/Library/ViewModels/CategorySelectionViewModelTests.swift
+++ b/Library/ViewModels/CategorySelectionViewModelTests.swift
@@ -334,6 +334,10 @@ final class CategorySelectionViewModelTests: TestCase {
       self.vm.inputs.categorySelected(with: (artIndexPath, .art))
       self.vm.inputs.categorySelected(with: (illustrationIndexPath, .illustration))
       self.vm.inputs.categorySelected(with: (gamesIndexPath, .games))
+      
+      XCTAssertNil(self.optimizelyClient.trackedEventKey)
+      XCTAssertNil(self.optimizelyClient.trackedAttributes)
+      XCTAssertNil(self.optimizelyClient.trackedEventTags)
 
       XCTAssertNil(mockKVStore.onboardingCategories)
       XCTAssertFalse(mockKVStore.hasCompletedCategoryPersonalizationFlow)
@@ -349,9 +353,11 @@ final class CategorySelectionViewModelTests: TestCase {
 
       XCTAssertEqual(encodedCategories, mockKVStore.onboardingCategories)
       XCTAssertTrue(mockKVStore.hasCompletedCategoryPersonalizationFlow)
-
+      
+      XCTAssertEqual("Continue Button Clicked", self.optimizelyClient.trackedEventKey)
       XCTAssertEqual(["Onboarding Continue Button Clicked"], self.trackingClient.events)
       XCTAssertEqual(self.trackingClient.properties(forKey: "context_location"), ["onboarding"])
+      assertBaseUserAttributesLoggedOut()
     }
   }
 
@@ -422,13 +428,19 @@ final class CategorySelectionViewModelTests: TestCase {
       self.scheduler.advance()
 
       self.dismiss.assertDidNotEmitValue()
+      
+      XCTAssertNil(self.optimizelyClient.trackedEventKey)
+      XCTAssertNil(self.optimizelyClient.trackedAttributes)
+      XCTAssertNil(self.optimizelyClient.trackedEventTags)
 
       self.vm.inputs.skipButtonTapped()
 
       self.dismiss.assertValueCount(1)
-
+      
+      XCTAssertEqual(self.optimizelyClient.trackedEventKey, "Skip Button Clicked")
       XCTAssertEqual(self.trackingClient.events, ["Onboarding Skip Button Clicked"])
       XCTAssertEqual(self.trackingClient.properties(forKey: "context_location"), ["onboarding"])
+      assertBaseUserAttributesLoggedOut()
     }
   }
 }

--- a/Library/ViewModels/CategorySelectionViewModelTests.swift
+++ b/Library/ViewModels/CategorySelectionViewModelTests.swift
@@ -337,7 +337,7 @@ final class CategorySelectionViewModelTests: TestCase {
       
       XCTAssertNil(self.optimizelyClient.trackedEventKey)
       XCTAssertNil(self.optimizelyClient.trackedAttributes)
-      XCTAssertNil(self.optimizelyClient.trackedEventTags)
+
 
       XCTAssertNil(mockKVStore.onboardingCategories)
       XCTAssertFalse(mockKVStore.hasCompletedCategoryPersonalizationFlow)
@@ -431,7 +431,7 @@ final class CategorySelectionViewModelTests: TestCase {
       
       XCTAssertNil(self.optimizelyClient.trackedEventKey)
       XCTAssertNil(self.optimizelyClient.trackedAttributes)
-      XCTAssertNil(self.optimizelyClient.trackedEventTags)
+
 
       self.vm.inputs.skipButtonTapped()
 

--- a/Library/ViewModels/DiscoveryPageViewModel.swift
+++ b/Library/ViewModels/DiscoveryPageViewModel.swift
@@ -444,6 +444,18 @@ public final class DiscoveryPageViewModel: DiscoveryPageViewModelType, Discovery
 
     let personalizationCellTappedAndRefTag = self.personalizationCellTappedProperty.signal
       .mapConst(RefTag.onboarding)
+    
+    personalizationCellTappedAndRefTag
+      .observeValues { refTag in
+        let attributes = optimizelyUserAttributes(refTag: refTag)
+        
+        try? AppEnvironment.current.optimizelyClient?.track(
+        eventKey: "Editorial Card Clicked",
+        userId: deviceIdentifier(uuid: UUID()),
+        attributes: attributes,
+        eventTags: nil
+        )
+      }
 
     let editorialCellTappedAndRefTag = self.discoveryEditorialCellTappedWithValueProperty.signal
       .skipNil()

--- a/Library/ViewModels/DiscoveryPageViewModel.swift
+++ b/Library/ViewModels/DiscoveryPageViewModel.swift
@@ -447,14 +447,7 @@ public final class DiscoveryPageViewModel: DiscoveryPageViewModelType, Discovery
     
     personalizationCellTappedAndRefTag
       .observeValues { refTag in
-        let attributes = optimizelyUserAttributes(refTag: refTag)
-        
-        try? AppEnvironment.current.optimizelyClient?.track(
-        eventKey: "Editorial Card Clicked",
-        userId: deviceIdentifier(uuid: UUID()),
-        attributes: attributes,
-        eventTags: nil
-        )
+        AppEnvironment.current.optimizelyClient?.track(eventName: "Editorial Card Clicked")
       }
 
     let editorialCellTappedAndRefTag = self.discoveryEditorialCellTappedWithValueProperty.signal

--- a/Library/ViewModels/DiscoveryPageViewModelTests.swift
+++ b/Library/ViewModels/DiscoveryPageViewModelTests.swift
@@ -1512,6 +1512,8 @@ internal final class DiscoveryPageViewModelTests: TestCase {
       self.vm.inputs.personalizationCellTapped()
 
       XCTAssertEqual(["Explore Page Viewed", "Editorial Card Clicked"], self.trackingClient.events)
+      XCTAssertEqual("Editorial Card Clicked", mockOpClient.trackedEventKey)
+
       XCTAssertEqual(
         [nil, "ios_experiment_onboarding_1"],
         self.trackingClient.properties(forKey: "session_ref_tag")

--- a/Library/ViewModels/LandingPageViewModel.swift
+++ b/Library/ViewModels/LandingPageViewModel.swift
@@ -42,6 +42,15 @@ public final class LandingPageViewModel: LandingPageViewModelType, LandingPageVi
 
         AppEnvironment.current.koala
           .trackOnboardingGetStartedButtonClicked(optimizelyProperties: optimizelyProps)
+        
+        let (properties, eventTags) = optimizelyClientTrackingAttributesAndEventTags()
+        try? AppEnvironment.current.optimizelyClient?
+          .track(
+            eventKey: "Get Started Button Clicked",
+            userId: deviceIdentifier(uuid: UUID()),
+            attributes: properties,
+            eventTags: eventTags
+          )
       }
   }
 

--- a/Library/ViewModels/LandingPageViewModel.swift
+++ b/Library/ViewModels/LandingPageViewModel.swift
@@ -43,14 +43,7 @@ public final class LandingPageViewModel: LandingPageViewModelType, LandingPageVi
         AppEnvironment.current.koala
           .trackOnboardingGetStartedButtonClicked(optimizelyProperties: optimizelyProps)
         
-        let (properties, eventTags) = optimizelyClientTrackingAttributesAndEventTags()
-        try? AppEnvironment.current.optimizelyClient?
-          .track(
-            eventKey: "Get Started Button Clicked",
-            userId: deviceIdentifier(uuid: UUID()),
-            attributes: properties,
-            eventTags: eventTags
-          )
+        AppEnvironment.current.optimizelyClient?.track(eventName: "Get Started Button Clicked")
       }
   }
 

--- a/Library/ViewModels/LandingPageViewModelTests.swift
+++ b/Library/ViewModels/LandingPageViewModelTests.swift
@@ -28,8 +28,11 @@ internal final class LandingPageViewModelTests: TestCase {
   }
 
   func testTrackingGetStartedButtonTapped() {
+    XCTAssertEqual(self.optimizelyClient.trackedEventKey, nil)
+    
     self.viewModel.inputs.ctaButtonTapped()
 
+    XCTAssertEqual(self.optimizelyClient.trackedEventKey, "Get Started Button Clicked")
     XCTAssertEqual(self.trackingClient.events, ["Onboarding Get Started Button Clicked"])
     XCTAssertEqual(
       self.trackingClient.properties(forKey: "context_location"),

--- a/Library/ViewModels/LandingViewModel.swift
+++ b/Library/ViewModels/LandingViewModel.swift
@@ -31,6 +31,15 @@ public final class LandingViewModel: LandingViewModelType, LandingViewModelInput
 
         AppEnvironment.current.koala
           .trackOnboardingGetStartedButtonClicked(optimizelyProperties: optimizelyProps)
+        
+        let (properties, eventTags) = optimizelyClientTrackingAttributesAndEventTags()
+        try? AppEnvironment.current.optimizelyClient?
+          .track(
+            eventKey: "Get Started Button Clicked",
+            userId: deviceIdentifier(uuid: UUID()),
+            attributes: properties,
+            eventTags: eventTags
+          )
       }
   }
 

--- a/Library/ViewModels/LandingViewModel.swift
+++ b/Library/ViewModels/LandingViewModel.swift
@@ -32,14 +32,7 @@ public final class LandingViewModel: LandingViewModelType, LandingViewModelInput
         AppEnvironment.current.koala
           .trackOnboardingGetStartedButtonClicked(optimizelyProperties: optimizelyProps)
         
-        let (properties, eventTags) = optimizelyClientTrackingAttributesAndEventTags()
-        try? AppEnvironment.current.optimizelyClient?
-          .track(
-            eventKey: "Get Started Button Clicked",
-            userId: deviceIdentifier(uuid: UUID()),
-            attributes: properties,
-            eventTags: eventTags
-          )
+        AppEnvironment.current.optimizelyClient?.track(eventName: "Get Started Button Clicked")
       }
   }
 

--- a/Library/ViewModels/LandingViewModelTests.swift
+++ b/Library/ViewModels/LandingViewModelTests.swift
@@ -20,14 +20,19 @@ final class LandingViewModelTests: TestCase {
   func testGoToCategorySelection() {
     self.goToCategorySelection.assertDidNotEmitValue()
 
+    XCTAssertNil(self.optimizelyClient.trackedEventKey)
+    XCTAssertNil(self.optimizelyClient.trackedAttributes)
+    XCTAssertNil(self.optimizelyClient.trackedEventTags)
     XCTAssertEqual(self.trackingClient.events, [])
 
     self.vm.inputs.getStartedButtonTapped()
 
     self.goToCategorySelection.assertValueCount(1)
 
+    XCTAssertEqual(self.optimizelyClient.trackedEventKey, "Get Started Button Clicked")
     XCTAssertEqual(self.trackingClient.events, ["Onboarding Get Started Button Clicked"])
     XCTAssertEqual(self.trackingClient.properties(forKey: "context_location"), ["landing_page"])
+    assertBaseUserAttributesLoggedOut()
   }
 
   func testHasSeenCategoryPersonalizationFlowPropertyIsSet() {

--- a/Library/ViewModels/LandingViewModelTests.swift
+++ b/Library/ViewModels/LandingViewModelTests.swift
@@ -22,7 +22,6 @@ final class LandingViewModelTests: TestCase {
 
     XCTAssertNil(self.optimizelyClient.trackedEventKey)
     XCTAssertNil(self.optimizelyClient.trackedAttributes)
-    XCTAssertNil(self.optimizelyClient.trackedEventTags)
     XCTAssertEqual(self.trackingClient.events, [])
 
     self.vm.inputs.getStartedButtonTapped()

--- a/Library/ViewModels/PledgeCTAContainerViewViewModelTests.swift
+++ b/Library/ViewModels/PledgeCTAContainerViewViewModelTests.swift
@@ -195,6 +195,8 @@ internal final class PledgeCTAContainerViewViewModelTests: TestCase {
       )
       XCTAssertEqual(optimizelyClient.userAttributes?["session_apple_pay_device"] as? Bool, true)
       XCTAssertEqual(optimizelyClient.userAttributes?["session_device_format"] as? String, "phone")
+      
+      XCTAssertNil(optimizelyClient.trackedEventTags)
     }
   }
 
@@ -239,6 +241,8 @@ internal final class PledgeCTAContainerViewViewModelTests: TestCase {
       )
       XCTAssertEqual(optimizelyClient.userAttributes?["session_apple_pay_device"] as? Bool, true)
       XCTAssertEqual(optimizelyClient.userAttributes?["session_device_format"] as? String, "phone")
+      
+      XCTAssertNil(optimizelyClient.trackedEventTags)
     }
   }
 
@@ -281,6 +285,8 @@ internal final class PledgeCTAContainerViewViewModelTests: TestCase {
       )
       XCTAssertEqual(optimizelyClient.userAttributes?["session_apple_pay_device"] as? Bool, true)
       XCTAssertEqual(optimizelyClient.userAttributes?["session_device_format"] as? String, "phone")
+      
+      XCTAssertNil(optimizelyClient.trackedEventTags)
     }
   }
 
@@ -325,6 +331,8 @@ internal final class PledgeCTAContainerViewViewModelTests: TestCase {
       )
       XCTAssertEqual(optimizelyClient.userAttributes?["session_apple_pay_device"] as? Bool, true)
       XCTAssertEqual(optimizelyClient.userAttributes?["session_device_format"] as? String, "phone")
+      
+      XCTAssertNil(optimizelyClient.trackedEventTags)
     }
   }
 

--- a/Library/ViewModels/PledgeCTAContainerViewViewModelTests.swift
+++ b/Library/ViewModels/PledgeCTAContainerViewViewModelTests.swift
@@ -195,8 +195,6 @@ internal final class PledgeCTAContainerViewViewModelTests: TestCase {
       )
       XCTAssertEqual(optimizelyClient.userAttributes?["session_apple_pay_device"] as? Bool, true)
       XCTAssertEqual(optimizelyClient.userAttributes?["session_device_format"] as? String, "phone")
-      
-      XCTAssertNil(optimizelyClient.trackedEventTags)
     }
   }
 
@@ -241,8 +239,6 @@ internal final class PledgeCTAContainerViewViewModelTests: TestCase {
       )
       XCTAssertEqual(optimizelyClient.userAttributes?["session_apple_pay_device"] as? Bool, true)
       XCTAssertEqual(optimizelyClient.userAttributes?["session_device_format"] as? String, "phone")
-      
-      XCTAssertNil(optimizelyClient.trackedEventTags)
     }
   }
 
@@ -286,7 +282,7 @@ internal final class PledgeCTAContainerViewViewModelTests: TestCase {
       XCTAssertEqual(optimizelyClient.userAttributes?["session_apple_pay_device"] as? Bool, true)
       XCTAssertEqual(optimizelyClient.userAttributes?["session_device_format"] as? String, "phone")
       
-      XCTAssertNil(optimizelyClient.trackedEventTags)
+
     }
   }
 
@@ -331,8 +327,6 @@ internal final class PledgeCTAContainerViewViewModelTests: TestCase {
       )
       XCTAssertEqual(optimizelyClient.userAttributes?["session_apple_pay_device"] as? Bool, true)
       XCTAssertEqual(optimizelyClient.userAttributes?["session_device_format"] as? String, "phone")
-      
-      XCTAssertNil(optimizelyClient.trackedEventTags)
     }
   }
 

--- a/Library/ViewModels/PledgeViewModel.swift
+++ b/Library/ViewModels/PledgeViewModel.swift
@@ -622,6 +622,7 @@ public class PledgeViewModel: PledgeViewModelType, PledgeViewModelInputs, Pledge
         let cookieRefTag = cookieRefTagFor(project: project) ?? refTag
         let optimizelyProps = optimizelyProperties() ?? [:]
 
+        AppEnvironment.current.optimizelyClient?.track(eventName: "Pledge Screen Viewed")
         AppEnvironment.current.koala.trackCheckoutPaymentPageViewed(
           project: project,
           reward: reward,
@@ -630,22 +631,6 @@ public class PledgeViewModel: PledgeViewModelType, PledgeViewModelInputs, Pledge
           cookieRefTag: cookieRefTag,
           optimizelyProperties: optimizelyProps
         )
-      }
-    
-    initialData
-      .observeValues { project, _, refTag, _ in
-        let (properties, eventTags) = optimizelyClientTrackingAttributesAndEventTags(
-          with: project,
-          refTag: refTag
-        )
-        
-        try? AppEnvironment.current.optimizelyClient?
-          .track(
-            eventKey: "Pledge Screen Viewed",
-            userId: deviceIdentifier(uuid: UUID()),
-            attributes: properties,
-            eventTags: eventTags
-          )
       }
 
     createBackingData
@@ -665,22 +650,8 @@ public class PledgeViewModel: PledgeViewModelType, PledgeViewModelInputs, Pledge
       }
     
     createBackingDataAndIsApplePay.takeWhen(createBackingCompletionEvents)
-    .observeValues { data, isApplePay in
-      let (properties, eventTags) = optimizelyClientTrackingAttributesAndEventTags(
-        with: data.project,
-        refTag: data.refTag
-      )
-
-      let allEventTags = eventTags
-        .withAllValuesFrom(optimizelyCheckoutEventTags(createBackingData: data, isApplePay: isApplePay))
-
-      try? AppEnvironment.current.optimizelyClient?
-        .track(
-          eventKey: "App Completed Checkout",
-          userId: deviceIdentifier(uuid: UUID()),
-          attributes: properties,
-          eventTags: allEventTags
-        )
+      .observeValues { data, isApplePay in
+      AppEnvironment.current.optimizelyClient?.track(eventName: "App Completed Checkout")
     }
 
     Signal.combineLatest(project, updateBackingData, context)

--- a/Library/ViewModels/PledgeViewModelTests.swift
+++ b/Library/ViewModels/PledgeViewModelTests.swift
@@ -1250,6 +1250,87 @@ final class PledgeViewModelTests: TestCase {
       )
     }
   }
+  
+  func testApplePay_OptimizelyExperimentTracking() {
+    let createBacking = CreateBackingEnvelope.CreateBacking(
+      checkout: Checkout(
+        id: "Q2hlY2tvdXQtMQ==",
+        state: .successful,
+        backing: .init(clientSecret: nil, requiresAction: false)
+      )
+    )
+    let mockService = MockService(
+      createBackingResult:
+      Result.success(CreateBackingEnvelope(createBacking: createBacking))
+    )
+
+    let optimizelyClient = MockOptimizelyClient()
+      |> \.experiments .~ [
+        OptimizelyExperiment.Key.pledgeCTACopy.rawValue: OptimizelyExperiment.Variant.variant1.rawValue
+      ]
+
+    withEnvironment(apiService: mockService, currentUser: .template, optimizelyClient: optimizelyClient) {
+      let project = Project.template
+      let reward = Reward.noReward
+        |> Reward.lens.minimum .~ 5
+
+      XCTAssertNil(optimizelyClient.trackedAttributes)
+
+      self.vm.inputs.configureWith(project: project, reward: reward, refTag: .projectPage, context: .pledge)
+      self.vm.inputs.viewDidLoad()
+
+      XCTAssertEqual(optimizelyClient.trackedEventKey, "Pledge Screen Viewed")
+
+      self.vm.inputs.applePayButtonTapped()
+
+      self.vm.inputs.paymentAuthorizationDidAuthorizePayment(
+        paymentData: (displayName: "Visa 123", network: "Visa", transactionIdentifier: "12345")
+      )
+
+      XCTAssertEqual(
+        PKPaymentAuthorizationStatus.success,
+        self.vm.inputs.stripeTokenCreated(token: "stripe_token", error: nil)
+      )
+
+      self.vm.inputs.paymentAuthorizationViewControllerDidFinish()
+
+      self.scheduler.run()
+
+      XCTAssertEqual(optimizelyClient.trackedUserId, "DEADBEEF-DEAD-BEEF-DEAD-DEADBEEFBEEF")
+      XCTAssertEqual(optimizelyClient.trackedEventKey, "App Completed Checkout")
+
+      XCTAssertEqual(optimizelyClient.trackedAttributes?["user_backed_projects_count"] as? Int, nil)
+      XCTAssertEqual(optimizelyClient.trackedAttributes?["user_launched_projects_count"] as? Int, nil)
+      XCTAssertEqual(optimizelyClient.trackedAttributes?["user_country"] as? String, "us")
+      XCTAssertEqual(optimizelyClient.trackedAttributes?["user_facebook_account"] as? Bool, nil)
+      XCTAssertEqual(optimizelyClient.trackedAttributes?["user_display_language"] as? String, "en")
+
+      XCTAssertEqual(optimizelyClient.trackedAttributes?["session_ref_tag"] as? String, "project_page")
+      XCTAssertEqual(
+        optimizelyClient.trackedAttributes?["session_referrer_credit"] as? String, "project_page"
+      )
+      XCTAssertEqual(
+        optimizelyClient.trackedAttributes?["session_os_version"] as? String, "MockSystemVersion"
+      )
+      XCTAssertEqual(optimizelyClient.trackedAttributes?["session_user_is_logged_in"] as? Bool, true)
+      XCTAssertEqual(
+        optimizelyClient.trackedAttributes?["session_app_release_version"] as? String, "1.2.3.4.5.6.7.8.9.0"
+      )
+      XCTAssertEqual(optimizelyClient.trackedAttributes?["session_apple_pay_device"] as? Bool, true)
+      XCTAssertEqual(optimizelyClient.trackedAttributes?["session_device_format"] as? String, "phone")
+
+      XCTAssertEqual(optimizelyClient.trackedEventTags?["project_subcategory"] as? String, "Art")
+      XCTAssertEqual(optimizelyClient.trackedEventTags?["project_category"] as? String, nil)
+      XCTAssertEqual(optimizelyClient.trackedEventTags?["project_country"] as? String, "us")
+      XCTAssertEqual(optimizelyClient.trackedEventTags?["project_user_has_watched"] as? Bool, nil)
+
+      XCTAssertEqual(optimizelyClient.trackedEventTags?["checkout_amount"] as? Double, 5.0)
+      XCTAssertEqual(optimizelyClient.trackedEventTags?["checkout_payment_type"] as? String, "APPLE_PAY")
+      XCTAssertEqual(optimizelyClient.trackedEventTags?["revenue"] as? Int, 500)
+      XCTAssertEqual(optimizelyClient.trackedEventTags?["currency"] as? String, "USD")
+      XCTAssertEqual(optimizelyClient.trackedEventTags?["category"] as? String, "Art")
+    }
+  }
 
   func testApplePay_GoToThanks_WhenRefTag_IsNil() {
     let createBacking = CreateBackingEnvelope.CreateBacking(
@@ -1485,6 +1566,74 @@ final class PledgeViewModelTests: TestCase {
         ["Checkout Payment Page Viewed", "Pledge Submit Button Clicked"],
         self.trackingClient.events
       )
+    }
+  }
+  
+  func testCreateBacking_Success_OptimizelyExperimentTracking() {
+    let createBacking = CreateBackingEnvelope.CreateBacking(
+      checkout: Checkout(
+        id: "Q2hlY2tvdXQtMQ==",
+        state: .verifying,
+        backing: .init(clientSecret: nil, requiresAction: false)
+      )
+    )
+    let mockService = MockService(
+      createBackingResult:
+      Result.success(CreateBackingEnvelope(createBacking: createBacking))
+    )
+
+    let optimizelyClient = MockOptimizelyClient()
+      |> \.experiments .~ [
+        OptimizelyExperiment.Key.pledgeCTACopy.rawValue: OptimizelyExperiment.Variant.variant1.rawValue
+      ]
+
+    withEnvironment(apiService: mockService, currentUser: .template, optimizelyClient: optimizelyClient) {
+      XCTAssertNil(optimizelyClient.trackedAttributes)
+
+      self.vm.inputs.configureWith(project: .template, reward: .template, refTag: .activity, context: .pledge)
+      self.vm.inputs.viewDidLoad()
+
+      XCTAssertEqual(optimizelyClient.trackedEventKey, "Pledge Screen Viewed")
+
+      self.vm.inputs.pledgeAmountViewControllerDidUpdate(
+        with: (amount: 25.0, min: 10.0, max: 10_000.0, isValid: true)
+      )
+
+      self.vm.inputs.submitButtonTapped()
+
+      self.scheduler.run()
+
+      XCTAssertEqual(optimizelyClient.trackedUserId, "DEADBEEF-DEAD-BEEF-DEAD-DEADBEEFBEEF")
+      XCTAssertEqual(optimizelyClient.trackedEventKey, "App Completed Checkout")
+
+      XCTAssertEqual(optimizelyClient.trackedAttributes?["user_backed_projects_count"] as? Int, nil)
+      XCTAssertEqual(optimizelyClient.trackedAttributes?["user_launched_projects_count"] as? Int, nil)
+      XCTAssertEqual(optimizelyClient.trackedAttributes?["user_country"] as? String, "us")
+      XCTAssertEqual(optimizelyClient.trackedAttributes?["user_facebook_account"] as? Bool, nil)
+      XCTAssertEqual(optimizelyClient.trackedAttributes?["user_display_language"] as? String, "en")
+
+      XCTAssertEqual(optimizelyClient.trackedAttributes?["session_ref_tag"] as? String, "activity")
+      XCTAssertEqual(optimizelyClient.trackedAttributes?["session_referrer_credit"] as? String, "activity")
+      XCTAssertEqual(
+        optimizelyClient.trackedAttributes?["session_os_version"] as? String, "MockSystemVersion"
+      )
+      XCTAssertEqual(optimizelyClient.trackedAttributes?["session_user_is_logged_in"] as? Bool, true)
+      XCTAssertEqual(
+        optimizelyClient.trackedAttributes?["session_app_release_version"] as? String, "1.2.3.4.5.6.7.8.9.0"
+      )
+      XCTAssertEqual(optimizelyClient.trackedAttributes?["session_apple_pay_device"] as? Bool, true)
+      XCTAssertEqual(optimizelyClient.trackedAttributes?["session_device_format"] as? String, "phone")
+
+      XCTAssertEqual(optimizelyClient.trackedEventTags?["project_subcategory"] as? String, "Art")
+      XCTAssertEqual(optimizelyClient.trackedEventTags?["project_category"] as? String, nil)
+      XCTAssertEqual(optimizelyClient.trackedEventTags?["project_country"] as? String, "us")
+      XCTAssertEqual(optimizelyClient.trackedEventTags?["project_user_has_watched"] as? Bool, nil)
+
+      XCTAssertEqual(optimizelyClient.trackedEventTags?["checkout_amount"] as? Double, 25.0)
+      XCTAssertEqual(optimizelyClient.trackedEventTags?["checkout_payment_type"] as? String, "CREDIT_CARD")
+      XCTAssertEqual(optimizelyClient.trackedEventTags?["revenue"] as? Int, 2_500)
+      XCTAssertEqual(optimizelyClient.trackedEventTags?["currency"] as? String, "USD")
+      XCTAssertEqual(optimizelyClient.trackedEventTags?["category"] as? String, "Art")
     }
   }
 
@@ -3816,7 +3965,108 @@ final class PledgeViewModelTests: TestCase {
       XCTAssertEqual(trackingClient.properties(forKey: "project_user_has_watched", as: Bool.self), [nil])
     }
   }
+  
+  func testTrackingEvents_OptimizelyClient_PledgeScreenViewed_LoggedOut() {
+    let project = Project.template
+      |> \.category.parentId .~ Project.Category.art.id
+      |> \.category.parentName .~ Project.Category.art.name
+    
+    self.vm.inputs.configureWith(project: project, reward: .template, refTag: .discovery, context: .pledge)
 
+    XCTAssertEqual([], self.trackingClient.events)
+    self.vm.inputs.viewDidLoad()
+
+    XCTAssertEqual(["Checkout Payment Page Viewed"], self.trackingClient.events)
+
+    XCTAssertEqual(self.optimizelyClient.trackedUserId, "DEADBEEF-DEAD-BEEF-DEAD-DEADBEEFBEEF")
+    XCTAssertEqual(self.optimizelyClient.trackedEventKey, "Pledge Screen Viewed")
+    
+    XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_backed_projects_count"] as? Int, nil)
+    XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_launched_projects_count"] as? Int, nil)
+    XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_country"] as? String, "us")
+    XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_facebook_account"] as? Bool, nil)
+    XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_display_language"] as? String, "en")
+    
+    XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_ref_tag"] as? String, "discovery")
+      XCTAssertEqual(
+        self.optimizelyClient.trackedAttributes?["session_referrer_credit"] as? String,
+        "discovery"
+      )
+      XCTAssertEqual(
+        self.optimizelyClient.trackedAttributes?["session_os_version"] as? String,
+        "MockSystemVersion"
+      )
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_user_is_logged_in"] as? Bool, false)
+      XCTAssertEqual(
+        self.optimizelyClient.trackedAttributes?["session_app_release_version"] as? String,
+        "1.2.3.4.5.6.7.8.9.0"
+      )
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_apple_pay_device"] as? Bool, true)
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_device_format"] as? String, "phone")
+
+      XCTAssertEqual(self.optimizelyClient.trackedEventTags?["project_subcategory"] as? String, "Art")
+      XCTAssertEqual(self.optimizelyClient.trackedEventTags?["project_category"] as? String, "Art")
+      XCTAssertEqual(self.optimizelyClient.trackedEventTags?["project_country"] as? String, "us")
+      XCTAssertEqual(self.optimizelyClient.trackedEventTags?["project_user_has_watched"] as? String, nil)
+    }
+  
+  func testTrackingEvents_OptimizelyClient_PledgeScreenViewed_LoggedIn() {
+     let user = User.template
+       |> \.location .~ Location.template
+       |> \.stats.backedProjectsCount .~ 50
+       |> \.stats.createdProjectsCount .~ 25
+       |> \.facebookConnected .~ true
+
+     withEnvironment(currentUser: user) {
+       let project = Project.template
+         |> \.category.parentId .~ Project.Category.art.id
+         |> \.category.parentName .~ Project.Category.art.name
+         |> Project.lens.stats.currentCurrency .~ "USD"
+         |> \.personalization.isStarred .~ true
+
+       self.vm.inputs.configureWith(
+         project: project, reward: .template, refTag: .discovery, context: .pledge
+       )
+      
+        XCTAssertEqual([], self.trackingClient.events)
+        self.vm.inputs.viewDidLoad()
+        
+        XCTAssertEqual(["Checkout Payment Page Viewed"], self.trackingClient.events)
+
+        XCTAssertEqual(self.optimizelyClient.trackedUserId, "DEADBEEF-DEAD-BEEF-DEAD-DEADBEEFBEEF")
+        XCTAssertEqual(self.optimizelyClient.trackedEventKey, "Pledge Screen Viewed")
+        
+        XCTAssertNil(self.optimizelyClient.trackedAttributes?["user_distinct_id"] as? String)
+        XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_backed_projects_count"] as? Int, 50)
+        XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_launched_projects_count"] as? Int, 25)
+        XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_country"] as? String, "us")
+        XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_facebook_account"] as? Bool, true)
+        XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_display_language"] as? String, "en")
+      
+        XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_ref_tag"] as? String, "discovery")
+        XCTAssertEqual(
+          self.optimizelyClient.trackedAttributes?["session_referrer_credit"] as? String,
+          "discovery"
+        )
+        XCTAssertEqual(
+          self.optimizelyClient.trackedAttributes?["session_os_version"] as? String,
+          "MockSystemVersion"
+        )
+        XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_user_is_logged_in"] as? Bool, true)
+        XCTAssertEqual(
+          self.optimizelyClient.trackedAttributes?["session_app_release_version"] as? String,
+          "1.2.3.4.5.6.7.8.9.0"
+        )
+        XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_apple_pay_device"] as? Bool, true)
+        XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_device_format"] as? String, "phone")
+
+        XCTAssertEqual(self.optimizelyClient.trackedEventTags?["project_subcategory"] as? String, "Art")
+        XCTAssertEqual(self.optimizelyClient.trackedEventTags?["project_category"] as? String, "Art")
+        XCTAssertEqual(self.optimizelyClient.trackedEventTags?["project_country"] as? String, "us")
+        XCTAssertEqual(self.optimizelyClient.trackedEventTags?["project_user_has_watched"] as? Bool, true)
+      }
+  }
+      
   func testTrackingEvents_PledgeScreenViewed_LoggedIn() {
     let user = User.template
       |> \.location .~ Location.template
@@ -3858,6 +4108,73 @@ final class PledgeViewModelTests: TestCase {
       XCTAssertEqual(trackingClient.properties(forKey: "project_category"), ["Art"])
       XCTAssertEqual(trackingClient.properties(forKey: "project_country"), ["US"])
       XCTAssertEqual(trackingClient.properties(forKey: "project_user_has_watched", as: Bool.self), [true])
+    }
+  }
+  
+  func testTrackingEvents_PledgeScreenViewed_DistinctID_LoggedIn_Beta_Staging() {
+    let user = User.template
+      |> \.location .~ Location.template
+      |> \.stats.backedProjectsCount .~ 50
+      |> \.stats.createdProjectsCount .~ 25
+      |> \.facebookConnected .~ true
+
+    let mockBundle = MockBundle(
+      bundleIdentifier: KickstarterBundleIdentifier.beta.rawValue,
+      lang: Language.en.rawValue
+    )
+
+    let mockService = MockService(serverConfig: ServerConfig.staging)
+
+    withEnvironment(apiService: mockService, currentUser: user, mainBundle: mockBundle) {
+      let project = Project.template
+        |> \.category.parentId .~ Project.Category.art.id
+        |> \.category.parentName .~ Project.Category.art.name
+        |> Project.lens.stats.currentCurrency .~ "USD"
+        |> \.personalization.isStarred .~ true
+
+      self.vm.inputs.configureWith(
+        project: project, reward: .template, refTag: .discovery, context: .pledge
+      )
+
+      XCTAssertEqual([], self.trackingClient.events)
+      self.vm.inputs.viewDidLoad()
+
+      XCTAssertEqual(
+        self.optimizelyClient.trackedAttributes?["user_distinct_id"] as? String,
+        "DEADBEEF-DEAD-BEEF-DEAD-DEADBEEFBEEF"
+      )
+    }
+  }
+  
+  func testTrackingEvents_PledgeScreenViewed_DistinctID_LoggedIn_Release_Production() {
+    let user = User.template
+      |> \.location .~ Location.template
+      |> \.stats.backedProjectsCount .~ 50
+      |> \.stats.createdProjectsCount .~ 25
+      |> \.facebookConnected .~ true
+
+    let mockBundle = MockBundle(
+      bundleIdentifier: KickstarterBundleIdentifier.release.rawValue,
+      lang: Language.en.rawValue
+    )
+
+    let mockService = MockService(serverConfig: ServerConfig.production)
+
+    withEnvironment(apiService: mockService, currentUser: user, mainBundle: mockBundle) {
+      let project = Project.template
+        |> \.category.parentId .~ Project.Category.art.id
+        |> \.category.parentName .~ Project.Category.art.name
+        |> Project.lens.stats.currentCurrency .~ "USD"
+        |> \.personalization.isStarred .~ true
+
+      self.vm.inputs.configureWith(
+        project: project, reward: .template, refTag: .discovery, context: .pledge
+      )
+
+      XCTAssertEqual([], self.trackingClient.events)
+      self.vm.inputs.viewDidLoad()
+
+      XCTAssertNil(self.optimizelyClient.trackedAttributes?["user_distinct_id"] as? String)
     }
   }
 

--- a/Library/ViewModels/PledgeViewModelTests.swift
+++ b/Library/ViewModels/PledgeViewModelTests.swift
@@ -1304,11 +1304,6 @@ final class PledgeViewModelTests: TestCase {
       XCTAssertEqual(optimizelyClient.trackedAttributes?["user_country"] as? String, "us")
       XCTAssertEqual(optimizelyClient.trackedAttributes?["user_facebook_account"] as? Bool, nil)
       XCTAssertEqual(optimizelyClient.trackedAttributes?["user_display_language"] as? String, "en")
-
-      XCTAssertEqual(optimizelyClient.trackedAttributes?["session_ref_tag"] as? String, "project_page")
-      XCTAssertEqual(
-        optimizelyClient.trackedAttributes?["session_referrer_credit"] as? String, "project_page"
-      )
       XCTAssertEqual(
         optimizelyClient.trackedAttributes?["session_os_version"] as? String, "MockSystemVersion"
       )
@@ -1318,17 +1313,6 @@ final class PledgeViewModelTests: TestCase {
       )
       XCTAssertEqual(optimizelyClient.trackedAttributes?["session_apple_pay_device"] as? Bool, true)
       XCTAssertEqual(optimizelyClient.trackedAttributes?["session_device_format"] as? String, "phone")
-
-      XCTAssertEqual(optimizelyClient.trackedEventTags?["project_subcategory"] as? String, "Art")
-      XCTAssertEqual(optimizelyClient.trackedEventTags?["project_category"] as? String, nil)
-      XCTAssertEqual(optimizelyClient.trackedEventTags?["project_country"] as? String, "us")
-      XCTAssertEqual(optimizelyClient.trackedEventTags?["project_user_has_watched"] as? Bool, nil)
-
-      XCTAssertEqual(optimizelyClient.trackedEventTags?["checkout_amount"] as? Double, 5.0)
-      XCTAssertEqual(optimizelyClient.trackedEventTags?["checkout_payment_type"] as? String, "APPLE_PAY")
-      XCTAssertEqual(optimizelyClient.trackedEventTags?["revenue"] as? Int, 500)
-      XCTAssertEqual(optimizelyClient.trackedEventTags?["currency"] as? String, "USD")
-      XCTAssertEqual(optimizelyClient.trackedEventTags?["category"] as? String, "Art")
     }
   }
 
@@ -1611,9 +1595,6 @@ final class PledgeViewModelTests: TestCase {
       XCTAssertEqual(optimizelyClient.trackedAttributes?["user_country"] as? String, "us")
       XCTAssertEqual(optimizelyClient.trackedAttributes?["user_facebook_account"] as? Bool, nil)
       XCTAssertEqual(optimizelyClient.trackedAttributes?["user_display_language"] as? String, "en")
-
-      XCTAssertEqual(optimizelyClient.trackedAttributes?["session_ref_tag"] as? String, "activity")
-      XCTAssertEqual(optimizelyClient.trackedAttributes?["session_referrer_credit"] as? String, "activity")
       XCTAssertEqual(
         optimizelyClient.trackedAttributes?["session_os_version"] as? String, "MockSystemVersion"
       )
@@ -1623,17 +1604,6 @@ final class PledgeViewModelTests: TestCase {
       )
       XCTAssertEqual(optimizelyClient.trackedAttributes?["session_apple_pay_device"] as? Bool, true)
       XCTAssertEqual(optimizelyClient.trackedAttributes?["session_device_format"] as? String, "phone")
-
-      XCTAssertEqual(optimizelyClient.trackedEventTags?["project_subcategory"] as? String, "Art")
-      XCTAssertEqual(optimizelyClient.trackedEventTags?["project_category"] as? String, nil)
-      XCTAssertEqual(optimizelyClient.trackedEventTags?["project_country"] as? String, "us")
-      XCTAssertEqual(optimizelyClient.trackedEventTags?["project_user_has_watched"] as? Bool, nil)
-
-      XCTAssertEqual(optimizelyClient.trackedEventTags?["checkout_amount"] as? Double, 25.0)
-      XCTAssertEqual(optimizelyClient.trackedEventTags?["checkout_payment_type"] as? String, "CREDIT_CARD")
-      XCTAssertEqual(optimizelyClient.trackedEventTags?["revenue"] as? Int, 2_500)
-      XCTAssertEqual(optimizelyClient.trackedEventTags?["currency"] as? String, "USD")
-      XCTAssertEqual(optimizelyClient.trackedEventTags?["category"] as? String, "Art")
     }
   }
 
@@ -3987,28 +3957,20 @@ final class PledgeViewModelTests: TestCase {
     XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_facebook_account"] as? Bool, nil)
     XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_display_language"] as? String, "en")
     
-    XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_ref_tag"] as? String, "discovery")
-      XCTAssertEqual(
-        self.optimizelyClient.trackedAttributes?["session_referrer_credit"] as? String,
-        "discovery"
-      )
-      XCTAssertEqual(
-        self.optimizelyClient.trackedAttributes?["session_os_version"] as? String,
-        "MockSystemVersion"
-      )
-      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_user_is_logged_in"] as? Bool, false)
-      XCTAssertEqual(
-        self.optimizelyClient.trackedAttributes?["session_app_release_version"] as? String,
-        "1.2.3.4.5.6.7.8.9.0"
-      )
-      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_apple_pay_device"] as? Bool, true)
-      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_device_format"] as? String, "phone")
-
-      XCTAssertEqual(self.optimizelyClient.trackedEventTags?["project_subcategory"] as? String, "Art")
-      XCTAssertEqual(self.optimizelyClient.trackedEventTags?["project_category"] as? String, "Art")
-      XCTAssertEqual(self.optimizelyClient.trackedEventTags?["project_country"] as? String, "us")
-      XCTAssertEqual(self.optimizelyClient.trackedEventTags?["project_user_has_watched"] as? String, nil)
-    }
+    XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_ref_tag"] as? String, nil)
+    XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_referrer_credit"] as? String, nil)
+    XCTAssertEqual(
+      self.optimizelyClient.trackedAttributes?["session_os_version"] as? String,
+      "MockSystemVersion"
+    )
+    XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_user_is_logged_in"] as? Bool, false)
+    XCTAssertEqual(
+      self.optimizelyClient.trackedAttributes?["session_app_release_version"] as? String,
+      "1.2.3.4.5.6.7.8.9.0"
+    )
+    XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_apple_pay_device"] as? Bool, true)
+    XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_device_format"] as? String, "phone")
+  }
   
   func testTrackingEvents_OptimizelyClient_PledgeScreenViewed_LoggedIn() {
      let user = User.template
@@ -4042,12 +4004,6 @@ final class PledgeViewModelTests: TestCase {
         XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_country"] as? String, "us")
         XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_facebook_account"] as? Bool, true)
         XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_display_language"] as? String, "en")
-      
-        XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_ref_tag"] as? String, "discovery")
-        XCTAssertEqual(
-          self.optimizelyClient.trackedAttributes?["session_referrer_credit"] as? String,
-          "discovery"
-        )
         XCTAssertEqual(
           self.optimizelyClient.trackedAttributes?["session_os_version"] as? String,
           "MockSystemVersion"
@@ -4059,11 +4015,6 @@ final class PledgeViewModelTests: TestCase {
         )
         XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_apple_pay_device"] as? Bool, true)
         XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_device_format"] as? String, "phone")
-
-        XCTAssertEqual(self.optimizelyClient.trackedEventTags?["project_subcategory"] as? String, "Art")
-        XCTAssertEqual(self.optimizelyClient.trackedEventTags?["project_category"] as? String, "Art")
-        XCTAssertEqual(self.optimizelyClient.trackedEventTags?["project_country"] as? String, "us")
-        XCTAssertEqual(self.optimizelyClient.trackedEventTags?["project_user_has_watched"] as? Bool, true)
       }
   }
       

--- a/Library/ViewModels/ProjectDescriptionViewModel.swift
+++ b/Library/ViewModels/ProjectDescriptionViewModel.swift
@@ -160,16 +160,7 @@ public final class ProjectDescriptionViewModel: ProjectDescriptionViewModelType,
           cookieRefTag: cookieRefTag,
           optimizelyProperties: optimizelyProps
         )
-        
-        let (properties, eventTags) = optimizelyClientTrackingAttributesAndEventTags(with: project,
-                                                                                     refTag: refTag)
-        try? AppEnvironment.current.optimizelyClient?
-        .track(
-          eventKey: "Campaign Details Pledge Button Clicked",
-          userId: deviceIdentifier(uuid: UUID()),
-          attributes: properties,
-          eventTags: eventTags
-        )
+        AppEnvironment.current.optimizelyClient?.track(eventName: "Campaign Details Pledge Button Clicked")
       }
 
     project

--- a/Library/ViewModels/ProjectDescriptionViewModel.swift
+++ b/Library/ViewModels/ProjectDescriptionViewModel.swift
@@ -160,6 +160,16 @@ public final class ProjectDescriptionViewModel: ProjectDescriptionViewModelType,
           cookieRefTag: cookieRefTag,
           optimizelyProperties: optimizelyProps
         )
+        
+        let (properties, eventTags) = optimizelyClientTrackingAttributesAndEventTags(with: project,
+                                                                                     refTag: refTag)
+        try? AppEnvironment.current.optimizelyClient?
+        .track(
+          eventKey: "Campaign Details Pledge Button Clicked",
+          userId: deviceIdentifier(uuid: UUID()),
+          attributes: properties,
+          eventTags: eventTags
+        )
       }
 
     project

--- a/Library/ViewModels/ProjectDescriptionViewModelTests.swift
+++ b/Library/ViewModels/ProjectDescriptionViewModelTests.swift
@@ -490,8 +490,6 @@ final class ProjectDescriptionViewModelTests: TestCase {
       XCTAssertEqual(optimizelyClient.trackedUserId, nil)
       XCTAssertEqual(optimizelyClient.trackedEventKey, nil)
       XCTAssertNil(optimizelyClient.trackedAttributes)
-      XCTAssertNil(optimizelyClient.trackedEventTags)
-
       self.pledgeCTAContainerViewIsHidden.assertValues([true])
     }
   }
@@ -518,7 +516,6 @@ final class ProjectDescriptionViewModelTests: TestCase {
       XCTAssertEqual(optimizelyClient.trackedUserId, nil)
       XCTAssertEqual(optimizelyClient.trackedEventKey, nil)
       XCTAssertNil(optimizelyClient.trackedAttributes)
-      XCTAssertNil(optimizelyClient.trackedEventTags)
 
       self.pledgeCTAContainerViewIsHidden.assertValues([true])
     }
@@ -545,7 +542,6 @@ final class ProjectDescriptionViewModelTests: TestCase {
       XCTAssertEqual(optimizelyClient.trackedUserId, nil)
       XCTAssertEqual(optimizelyClient.trackedEventKey, nil)
       XCTAssertNil(optimizelyClient.trackedAttributes)
-      XCTAssertNil(optimizelyClient.trackedEventTags)
 
       self.pledgeCTAContainerViewIsHidden.assertValues([true])
       self.vm.inputs.pledgeCTAButtonTapped(with: .pledge)
@@ -569,8 +565,6 @@ final class ProjectDescriptionViewModelTests: TestCase {
       
       // Optimizely Client
       XCTAssertEqual(optimizelyClient.trackedEventKey, "Campaign Details Pledge Button Clicked")
-      XCTAssertEqual(optimizelyClient.trackedAttributes?["session_ref_tag"] as? String, "discovery")
-      XCTAssertEqual(optimizelyClient.trackedAttributes?["session_referrer_credit"] as? String, "discovery")
       XCTAssertEqual(
         optimizelyClient.trackedAttributes?["session_os_version"] as? String,
         "MockSystemVersion"
@@ -582,10 +576,6 @@ final class ProjectDescriptionViewModelTests: TestCase {
       )
       XCTAssertEqual(optimizelyClient.trackedAttributes?["session_apple_pay_device"] as? Bool, true)
       XCTAssertEqual(optimizelyClient.trackedAttributes?["session_device_format"] as? String, "phone")
-      XCTAssertEqual(optimizelyClient.trackedEventTags?["project_subcategory"] as? String, "Art")
-      XCTAssertEqual(optimizelyClient.trackedEventTags?["project_category"] as? String, nil)
-      XCTAssertEqual(optimizelyClient.trackedEventTags?["project_country"] as? String, "us")
-      XCTAssertEqual(optimizelyClient.trackedEventTags?["project_user_has_watched"] as? Bool, nil)
     }
   }
 }

--- a/Library/ViewModels/ProjectPamphletMainCellViewModel.swift
+++ b/Library/ViewModels/ProjectPamphletMainCellViewModel.swift
@@ -351,6 +351,19 @@ public final class ProjectPamphletMainCellViewModel: ProjectPamphletMainCellView
           cookieRefTag: cookieRefTag,
           optimizelyProperties: optyProperties ?? [:]
         )
+        
+        let (properties, eventTags) = optimizelyClientTrackingAttributesAndEventTags(
+          with: projectAndRefTag.0,
+          refTag: projectAndRefTag.1
+        )
+        
+        try? AppEnvironment.current.optimizelyClient?
+          .track(
+            eventKey: "Campaign Details Button Clicked",
+            userId: deviceIdentifier(uuid: UUID()),
+            attributes: properties,
+            eventTags: eventTags
+          )
       }
 
     projectAndRefTag
@@ -368,6 +381,19 @@ public final class ProjectPamphletMainCellViewModel: ProjectPamphletMainCellView
           cookieRefTag: cookieRefTag,
           optimizelyProperties: optyProperties ?? [:]
         )
+        
+        let (properties, eventTags) = optimizelyClientTrackingAttributesAndEventTags(
+          with: projectAndRefTag.0,
+          refTag: projectAndRefTag.1
+        )
+        
+        try? AppEnvironment.current.optimizelyClient?
+          .track(
+            eventKey: "Creator Details Clicked",
+            userId: deviceIdentifier(uuid: UUID()),
+            attributes: properties,
+            eventTags: eventTags
+          )
       }
   }
 

--- a/Library/ViewModels/ProjectPamphletMainCellViewModel.swift
+++ b/Library/ViewModels/ProjectPamphletMainCellViewModel.swift
@@ -351,19 +351,8 @@ public final class ProjectPamphletMainCellViewModel: ProjectPamphletMainCellView
           cookieRefTag: cookieRefTag,
           optimizelyProperties: optyProperties ?? [:]
         )
-        
-        let (properties, eventTags) = optimizelyClientTrackingAttributesAndEventTags(
-          with: projectAndRefTag.0,
-          refTag: projectAndRefTag.1
-        )
-        
-        try? AppEnvironment.current.optimizelyClient?
-          .track(
-            eventKey: "Campaign Details Button Clicked",
-            userId: deviceIdentifier(uuid: UUID()),
-            attributes: properties,
-            eventTags: eventTags
-          )
+
+        AppEnvironment.current.optimizelyClient?.track(eventName: "Campaign Details Button Clicked")
       }
 
     projectAndRefTag
@@ -382,18 +371,7 @@ public final class ProjectPamphletMainCellViewModel: ProjectPamphletMainCellView
           optimizelyProperties: optyProperties ?? [:]
         )
         
-        let (properties, eventTags) = optimizelyClientTrackingAttributesAndEventTags(
-          with: projectAndRefTag.0,
-          refTag: projectAndRefTag.1
-        )
-        
-        try? AppEnvironment.current.optimizelyClient?
-          .track(
-            eventKey: "Creator Details Clicked",
-            userId: deviceIdentifier(uuid: UUID()),
-            attributes: properties,
-            eventTags: eventTags
-          )
+        AppEnvironment.current.optimizelyClient?.track(eventName: "Creator Details Clicked")
       }
   }
 

--- a/Library/ViewModels/ProjectPamphletMainCellViewModelTests.swift
+++ b/Library/ViewModels/ProjectPamphletMainCellViewModelTests.swift
@@ -680,6 +680,149 @@ final class ProjectPamphletMainCellViewModelTests: TestCase {
       )
     }
   }
+  
+  func testOptimizelyTrackingCreatorBylineTapped_LiveProject_LoggedIn_NonBacked() {
+    let creatorDetails = ProjectCreatorDetailsEnvelope.template
+
+    let user = User.template
+      |> \.location .~ Location.template
+      |> \.stats.backedProjectsCount .~ 50
+
+    let project = Project.template
+      |> Project.lens.state .~ .live
+      |> Project.lens.personalization.isBacking .~ false
+
+    withEnvironment(currentUser: user) {
+      self.vm.inputs.configureWith(value: (project, .discovery, (creatorDetails, false), []))
+      self.vm.inputs.awakeFromNib()
+
+      XCTAssertEqual(self.optimizelyClient.trackedUserId, nil)
+      XCTAssertEqual(self.optimizelyClient.trackedEventKey, nil)
+      XCTAssertNil(self.optimizelyClient.trackedAttributes)
+      XCTAssertNil(self.optimizelyClient.trackedEventTags)
+
+      self.vm.inputs.creatorBylineTapped()
+
+      self.notifyDelegateToGoToCreatorFromByline.assertValues([project])
+
+      XCTAssertEqual(self.optimizelyClient.trackedUserId, "DEADBEEF-DEAD-BEEF-DEAD-DEADBEEFBEEF")
+      XCTAssertEqual(self.optimizelyClient.trackedEventKey, "Creator Details Clicked")
+
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_backed_projects_count"] as? Int, 50)
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_launched_projects_count"] as? Int, nil)
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_country"] as? String, "us")
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_facebook_account"] as? Bool, nil)
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_display_language"] as? String, "en")
+
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_ref_tag"] as? String, "discovery")
+      XCTAssertEqual(
+        self.optimizelyClient.trackedAttributes?["session_referrer_credit"] as? String,
+        "discovery"
+      )
+      XCTAssertEqual(
+        self.optimizelyClient.trackedAttributes?["session_os_version"] as? String,
+        "MockSystemVersion"
+      )
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_user_is_logged_in"] as? Bool, true)
+      XCTAssertEqual(
+        self.optimizelyClient.trackedAttributes?["session_app_release_version"] as? String,
+        "1.2.3.4.5.6.7.8.9.0"
+      )
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_apple_pay_device"] as? Bool, true)
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_device_format"] as? String, "phone")
+
+      XCTAssertEqual(self.optimizelyClient.trackedEventTags?["project_subcategory"] as? String, "Art")
+      XCTAssertEqual(self.optimizelyClient.trackedEventTags?["project_category"] as? String, nil)
+      XCTAssertEqual(self.optimizelyClient.trackedEventTags?["project_country"] as? String, "us")
+      XCTAssertEqual(self.optimizelyClient.trackedEventTags?["project_user_has_watched"] as? Bool, nil)
+    }
+  }
+  
+  func testOptimizelyTrackingCampaignDetailsButtonTapped_NonLiveProject_LoggedIn_Backed() {
+    let creatorDetails = ProjectCreatorDetailsEnvelope.template
+    let user = User.template
+      |> \.location .~ Location.template
+      |> \.stats.backedProjectsCount .~ 50
+
+    let project = Project.template
+      |> Project.lens.state .~ .successful
+      |> Project.lens.personalization.isBacking .~ true
+
+    withEnvironment(currentUser: user) {
+      self.vm.inputs.configureWith(value: (project, .discovery, (creatorDetails, false), []))
+      self.vm.inputs.awakeFromNib()
+
+      XCTAssertEqual(self.optimizelyClient.trackedUserId, nil)
+      XCTAssertEqual(self.optimizelyClient.trackedEventKey, nil)
+      XCTAssertNil(self.optimizelyClient.trackedAttributes)
+      XCTAssertNil(self.optimizelyClient.trackedEventTags)
+
+      self.vm.inputs.readMoreButtonTapped()
+
+      XCTAssertEqual(self.optimizelyClient.trackedUserId, nil)
+      XCTAssertEqual(self.optimizelyClient.trackedEventKey, nil)
+      XCTAssertNil(self.optimizelyClient.trackedAttributes)
+      XCTAssertNil(self.optimizelyClient.trackedEventTags)
+    }
+  }
+
+  func testOptimizelyTrackingCampaignDetailsButtonTapped_LiveProject_LoggedIn_NonBacked() {
+    let creatorDetails = ProjectCreatorDetailsEnvelope.template
+
+    let user = User.template
+      |> \.location .~ Location.template
+      |> \.stats.backedProjectsCount .~ 50
+
+    let project = Project.template
+      |> Project.lens.state .~ .live
+      |> Project.lens.personalization.backing .~ nil
+
+    withEnvironment(currentUser: user) {
+      self.vm.inputs.configureWith(value: (project, .discovery, (creatorDetails, false), []))
+      self.vm.inputs.awakeFromNib()
+
+      XCTAssertEqual(self.optimizelyClient.trackedUserId, nil)
+      XCTAssertEqual(self.optimizelyClient.trackedEventKey, nil)
+      XCTAssertNil(self.optimizelyClient.trackedAttributes)
+      XCTAssertNil(self.optimizelyClient.trackedEventTags)
+
+      self.vm.inputs.readMoreButtonTapped()
+
+      self.notifyDelegateToGoToCampaignWithProject.assertValues([project])
+      self.notifyDelegateToGoToCampaignWithRefTag.assertValues([.discovery])
+
+      XCTAssertEqual(self.optimizelyClient.trackedUserId, "DEADBEEF-DEAD-BEEF-DEAD-DEADBEEFBEEF")
+      XCTAssertEqual(self.optimizelyClient.trackedEventKey, "Campaign Details Button Clicked")
+
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_backed_projects_count"] as? Int, 50)
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_launched_projects_count"] as? Int, nil)
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_country"] as? String, "us")
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_facebook_account"] as? Bool, nil)
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_display_language"] as? String, "en")
+
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_ref_tag"] as? String, "discovery")
+      XCTAssertEqual(
+        self.optimizelyClient.trackedAttributes?["session_referrer_credit"] as? String,
+        "discovery"
+      )
+      XCTAssertEqual(
+        self.optimizelyClient.trackedAttributes?["session_os_version"] as? String,
+        "MockSystemVersion"
+      )
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_user_is_logged_in"] as? Bool, true)
+      XCTAssertEqual(
+        self.optimizelyClient.trackedAttributes?["session_app_release_version"] as? String,
+        "1.2.3.4.5.6.7.8.9.0"
+      )
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_apple_pay_device"] as? Bool, true)
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_device_format"] as? String, "phone")
+
+      XCTAssertEqual(self.optimizelyClient.trackedEventTags?["project_subcategory"] as? String, "Art")
+      XCTAssertEqual(self.optimizelyClient.trackedEventTags?["project_category"] as? String, nil)
+      XCTAssertEqual(self.optimizelyClient.trackedEventTags?["project_country"] as? String, "us")
+      XCTAssertEqual(self.optimizelyClient.trackedEventTags?["project_user_has_watched"] as? Bool, nil)
+    }
+  }
 
   func testTrackingCampaignDetailsButtonTapped_LiveProject_LoggedIn_NonBacked() {
     let creatorDetails = ProjectCreatorDetailsEnvelope.template

--- a/Library/ViewModels/ProjectPamphletMainCellViewModelTests.swift
+++ b/Library/ViewModels/ProjectPamphletMainCellViewModelTests.swift
@@ -699,7 +699,6 @@ final class ProjectPamphletMainCellViewModelTests: TestCase {
       XCTAssertEqual(self.optimizelyClient.trackedUserId, nil)
       XCTAssertEqual(self.optimizelyClient.trackedEventKey, nil)
       XCTAssertNil(self.optimizelyClient.trackedAttributes)
-      XCTAssertNil(self.optimizelyClient.trackedEventTags)
 
       self.vm.inputs.creatorBylineTapped()
 
@@ -714,11 +713,6 @@ final class ProjectPamphletMainCellViewModelTests: TestCase {
       XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_facebook_account"] as? Bool, nil)
       XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_display_language"] as? String, "en")
 
-      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_ref_tag"] as? String, "discovery")
-      XCTAssertEqual(
-        self.optimizelyClient.trackedAttributes?["session_referrer_credit"] as? String,
-        "discovery"
-      )
       XCTAssertEqual(
         self.optimizelyClient.trackedAttributes?["session_os_version"] as? String,
         "MockSystemVersion"
@@ -730,11 +724,6 @@ final class ProjectPamphletMainCellViewModelTests: TestCase {
       )
       XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_apple_pay_device"] as? Bool, true)
       XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_device_format"] as? String, "phone")
-
-      XCTAssertEqual(self.optimizelyClient.trackedEventTags?["project_subcategory"] as? String, "Art")
-      XCTAssertEqual(self.optimizelyClient.trackedEventTags?["project_category"] as? String, nil)
-      XCTAssertEqual(self.optimizelyClient.trackedEventTags?["project_country"] as? String, "us")
-      XCTAssertEqual(self.optimizelyClient.trackedEventTags?["project_user_has_watched"] as? Bool, nil)
     }
   }
   
@@ -755,14 +744,17 @@ final class ProjectPamphletMainCellViewModelTests: TestCase {
       XCTAssertEqual(self.optimizelyClient.trackedUserId, nil)
       XCTAssertEqual(self.optimizelyClient.trackedEventKey, nil)
       XCTAssertNil(self.optimizelyClient.trackedAttributes)
-      XCTAssertNil(self.optimizelyClient.trackedEventTags)
 
       self.vm.inputs.readMoreButtonTapped()
 
-      XCTAssertEqual(self.optimizelyClient.trackedUserId, nil)
-      XCTAssertEqual(self.optimizelyClient.trackedEventKey, nil)
-      XCTAssertNil(self.optimizelyClient.trackedAttributes)
-      XCTAssertNil(self.optimizelyClient.trackedEventTags)
+      XCTAssertEqual(self.optimizelyClient.trackedUserId, "DEADBEEF-DEAD-BEEF-DEAD-DEADBEEFBEEF")
+      XCTAssertEqual(self.optimizelyClient.trackedEventKey, "Campaign Details Button Clicked")
+      
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_backed_projects_count"] as? Int, 50)
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_launched_projects_count"] as? Int, nil)
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_country"] as? String, "us")
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_facebook_account"] as? Bool, nil)
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_display_language"] as? String, "en")
     }
   }
 
@@ -784,7 +776,6 @@ final class ProjectPamphletMainCellViewModelTests: TestCase {
       XCTAssertEqual(self.optimizelyClient.trackedUserId, nil)
       XCTAssertEqual(self.optimizelyClient.trackedEventKey, nil)
       XCTAssertNil(self.optimizelyClient.trackedAttributes)
-      XCTAssertNil(self.optimizelyClient.trackedEventTags)
 
       self.vm.inputs.readMoreButtonTapped()
 
@@ -799,12 +790,6 @@ final class ProjectPamphletMainCellViewModelTests: TestCase {
       XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_country"] as? String, "us")
       XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_facebook_account"] as? Bool, nil)
       XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_display_language"] as? String, "en")
-
-      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_ref_tag"] as? String, "discovery")
-      XCTAssertEqual(
-        self.optimizelyClient.trackedAttributes?["session_referrer_credit"] as? String,
-        "discovery"
-      )
       XCTAssertEqual(
         self.optimizelyClient.trackedAttributes?["session_os_version"] as? String,
         "MockSystemVersion"
@@ -816,11 +801,6 @@ final class ProjectPamphletMainCellViewModelTests: TestCase {
       )
       XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_apple_pay_device"] as? Bool, true)
       XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_device_format"] as? String, "phone")
-
-      XCTAssertEqual(self.optimizelyClient.trackedEventTags?["project_subcategory"] as? String, "Art")
-      XCTAssertEqual(self.optimizelyClient.trackedEventTags?["project_category"] as? String, nil)
-      XCTAssertEqual(self.optimizelyClient.trackedEventTags?["project_country"] as? String, "us")
-      XCTAssertEqual(self.optimizelyClient.trackedEventTags?["project_user_has_watched"] as? Bool, nil)
     }
   }
 

--- a/Library/ViewModels/ProjectPamphletViewModel.swift
+++ b/Library/ViewModels/ProjectPamphletViewModel.swift
@@ -195,19 +195,7 @@ public final class ProjectPamphletViewModel: ProjectPamphletViewModelType, Proje
           cookieRefTag: cookieRefTag,
           optimizelyProperties: optimizelyProps
         )
-        
-        let (properties, eventTags) = optimizelyClientTrackingAttributesAndEventTags(
-          with: project,
-          refTag: refTag
-        )
-
-        try? AppEnvironment.current.optimizelyClient?
-          .track(
-            eventKey: "Project Page Viewed",
-            userId: deviceIdentifier(uuid: UUID()),
-            attributes: properties,
-            eventTags: eventTags
-          )
+        AppEnvironment.current.optimizelyClient?.track(eventName: "Project Page Viewed")
       }
 
     Signal.combineLatest(cookieRefTag.skipNil(), freshProjectAndRefTag.map(first))
@@ -223,18 +211,7 @@ public final class ProjectPamphletViewModel: ProjectPamphletViewModelType, Proje
     Signal.combineLatest(project, refTag)
       .takeWhen(shouldTrackCTATappedEvent)
       .observeValues { project, refTag in
-        let (properties, eventTags) = optimizelyClientTrackingAttributesAndEventTags(
-          with: project,
-          refTag: refTag
-        )
-
-        try? AppEnvironment.current.optimizelyClient?
-          .track(
-            eventKey: "Project Page Pledge Button Clicked",
-            userId: deviceIdentifier(uuid: UUID()),
-            attributes: properties,
-            eventTags: eventTags
-          )
+        AppEnvironment.current.optimizelyClient?.track(eventName: "Project Page Pledge Button Clicked")
       }
   }
 

--- a/Library/ViewModels/ProjectPamphletViewModelTests.swift
+++ b/Library/ViewModels/ProjectPamphletViewModelTests.swift
@@ -894,6 +894,306 @@ final class ProjectPamphletViewModelTests: TestCase {
       XCTAssertNotNil(properties?["optimizely_experiments"], "Event includes Optimizely properties")
     }
   }
+  
+  func testOptimizelyTrackingProjectPageViewed_LoggedIn() {
+    let user = User.template
+      |> \.location .~ Location.template
+      |> \.stats.backedProjectsCount .~ 50
+
+    withEnvironment(currentUser: user) {
+      self.vm.inputs.configureWith(projectOrParam: .left(.template), refTag: .discovery)
+      self.vm.inputs.viewDidLoad()
+      self.vm.inputs.viewDidAppear(animated: false)
+
+      self.scheduler.advance()
+
+      XCTAssertEqual(self.optimizelyClient.trackedUserId, "DEADBEEF-DEAD-BEEF-DEAD-DEADBEEFBEEF")
+      XCTAssertEqual(self.optimizelyClient.trackedEventKey, "Project Page Viewed")
+
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_backed_projects_count"] as? Int, 50)
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_launched_projects_count"] as? Int, nil)
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_country"] as? String, "us")
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_facebook_account"] as? Bool, nil)
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_display_language"] as? String, "en")
+
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_ref_tag"] as? String, "discovery")
+      XCTAssertEqual(
+        self.optimizelyClient.trackedAttributes?["session_referrer_credit"] as? String,
+        "discovery"
+      )
+      XCTAssertEqual(
+        self.optimizelyClient.trackedAttributes?["session_os_version"] as? String,
+        "MockSystemVersion"
+      )
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_user_is_logged_in"] as? Bool, true)
+      XCTAssertEqual(
+        self.optimizelyClient.trackedAttributes?["session_app_release_version"] as? String,
+        "1.2.3.4.5.6.7.8.9.0"
+      )
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_apple_pay_device"] as? Bool, true)
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_device_format"] as? String, "phone")
+
+      XCTAssertEqual(self.optimizelyClient.trackedEventTags?["project_subcategory"] as? String, "Art")
+      XCTAssertEqual(self.optimizelyClient.trackedEventTags?["project_category"] as? String, nil)
+      XCTAssertEqual(self.optimizelyClient.trackedEventTags?["project_country"] as? String, "us")
+      XCTAssertEqual(self.optimizelyClient.trackedEventTags?["project_user_has_watched"] as? Bool, nil)
+    }
+  }
+  
+  func testOptimizelyTrackingProjectPageViewed_LoggedOut() {
+    withEnvironment(currentUser: nil) {
+      self.vm.inputs.configureWith(projectOrParam: .left(.template), refTag: .discovery)
+      self.vm.inputs.viewDidLoad()
+      self.vm.inputs.viewDidAppear(animated: false)
+
+      self.scheduler.advance()
+
+      XCTAssertEqual(self.optimizelyClient.trackedUserId, "DEADBEEF-DEAD-BEEF-DEAD-DEADBEEFBEEF")
+      XCTAssertEqual(self.optimizelyClient.trackedEventKey, "Project Page Viewed")
+
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_backed_projects_count"] as? Int, nil)
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_launched_projects_count"] as? Int, nil)
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_country"] as? String, "us")
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_facebook_account"] as? Bool, nil)
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_display_language"] as? String, "en")
+
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_ref_tag"] as? String, "discovery")
+      XCTAssertEqual(
+        self.optimizelyClient.trackedAttributes?["session_referrer_credit"] as? String,
+        "discovery"
+      )
+      XCTAssertEqual(
+        self.optimizelyClient.trackedAttributes?["session_os_version"] as? String,
+        "MockSystemVersion"
+      )
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_user_is_logged_in"] as? Bool, false)
+      XCTAssertEqual(
+        self.optimizelyClient.trackedAttributes?["session_app_release_version"] as? String,
+        "1.2.3.4.5.6.7.8.9.0"
+      )
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_apple_pay_device"] as? Bool, true)
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_device_format"] as? String, "phone")
+
+      XCTAssertEqual(self.optimizelyClient.trackedEventTags?["project_subcategory"] as? String, "Art")
+      XCTAssertEqual(self.optimizelyClient.trackedEventTags?["project_category"] as? String, nil)
+      XCTAssertEqual(self.optimizelyClient.trackedEventTags?["project_country"] as? String, "us")
+      XCTAssertEqual(self.optimizelyClient.trackedEventTags?["project_user_has_watched"] as? Bool, nil)
+    }
+  }
+
+  func testOptimizelyTrackingPledgeCTAButtonTapped_LoggedOut_NonBacked() {
+    self.vm.inputs.configureWith(projectOrParam: .left(.template), refTag: .discovery)
+    self.vm.inputs.viewDidLoad()
+
+    XCTAssertEqual(self.optimizelyClient.trackedUserId, nil)
+    XCTAssertEqual(self.optimizelyClient.trackedEventKey, nil)
+    XCTAssertNil(self.optimizelyClient.trackedAttributes)
+    XCTAssertNil(self.optimizelyClient.trackedEventTags)
+
+    self.vm.inputs.pledgeCTAButtonTapped(with: .manage)
+
+    XCTAssertEqual(self.optimizelyClient.trackedUserId, nil)
+    XCTAssertEqual(self.optimizelyClient.trackedEventKey, nil)
+    XCTAssertNil(self.optimizelyClient.trackedAttributes)
+    XCTAssertNil(self.optimizelyClient.trackedEventTags)
+
+    // Only track for non-backed, pledge state
+    self.vm.inputs.pledgeCTAButtonTapped(with: .pledge)
+
+    XCTAssertEqual(self.optimizelyClient.trackedUserId, "DEADBEEF-DEAD-BEEF-DEAD-DEADBEEFBEEF")
+    XCTAssertEqual(self.optimizelyClient.trackedEventKey, "Project Page Pledge Button Clicked")
+
+    XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_backed_projects_count"] as? Int, nil)
+    XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_launched_projects_count"] as? Int, nil)
+    XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_country"] as? String, "us")
+    XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_facebook_account"] as? Bool, nil)
+    XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_display_language"] as? String, "en")
+
+    XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_ref_tag"] as? String, "discovery")
+    XCTAssertEqual(
+      self.optimizelyClient.trackedAttributes?["session_referrer_credit"] as? String,
+      "discovery"
+    )
+    XCTAssertEqual(
+      self.optimizelyClient.trackedAttributes?["session_os_version"] as? String,
+      "MockSystemVersion"
+    )
+    XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_user_is_logged_in"] as? Bool, false)
+    XCTAssertEqual(
+      self.optimizelyClient.trackedAttributes?["session_app_release_version"] as? String,
+      "1.2.3.4.5.6.7.8.9.0"
+    )
+    XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_apple_pay_device"] as? Bool, true)
+    XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_device_format"] as? String, "phone")
+
+    XCTAssertEqual(self.optimizelyClient.trackedEventTags?["project_subcategory"] as? String, "Art")
+    XCTAssertEqual(self.optimizelyClient.trackedEventTags?["project_category"] as? String, nil)
+    XCTAssertEqual(self.optimizelyClient.trackedEventTags?["project_country"] as? String, "us")
+    XCTAssertEqual(self.optimizelyClient.trackedEventTags?["project_user_has_watched"] as? String, nil)
+  }
+
+  func testOptimizelyTrackingPledgeCTAButtonTapped_LoggedOut_Backed() {
+    let project = Project.cosmicSurgery
+      |> Project.lens.state .~ .live
+      |> Project.lens.personalization.isBacking .~ true
+      |> Project.lens.personalization.backing .~ (
+        .template
+          |> Backing.lens.reward .~ Reward.otherReward
+          |> Backing.lens.rewardId .~ Reward.otherReward.id
+          |> Backing.lens.shippingAmount .~ 10
+          |> Backing.lens.amount .~ 700.0
+      )
+
+    self.vm.inputs.configureWith(projectOrParam: .left(project), refTag: .discovery)
+    self.vm.inputs.viewDidLoad()
+
+    XCTAssertEqual(self.optimizelyClient.trackedUserId, nil)
+    XCTAssertEqual(self.optimizelyClient.trackedEventKey, nil)
+    XCTAssertNil(self.optimizelyClient.trackedAttributes)
+    XCTAssertNil(self.optimizelyClient.trackedEventTags)
+
+    self.vm.inputs.pledgeCTAButtonTapped(with: .manage)
+
+    XCTAssertEqual(self.optimizelyClient.trackedUserId, nil)
+    XCTAssertEqual(self.optimizelyClient.trackedEventKey, nil)
+    XCTAssertNil(self.optimizelyClient.trackedAttributes)
+    XCTAssertNil(self.optimizelyClient.trackedEventTags)
+
+    // Only track for non-backed, pledge state
+    self.vm.inputs.pledgeCTAButtonTapped(with: .manage)
+
+    // Project is backed, no tracking
+    XCTAssertEqual(self.optimizelyClient.trackedUserId, nil)
+    XCTAssertEqual(self.optimizelyClient.trackedEventKey, nil)
+    XCTAssertNil(self.optimizelyClient.trackedAttributes)
+    XCTAssertNil(self.optimizelyClient.trackedEventTags)
+  }
+  
+  func testOptimizelyTrackingPledgeCTAButtonTapped_SeeTheRewards() {
+    let project = Project.cosmicSurgery
+
+    self.vm.inputs.configureWith(projectOrParam: .left(project), refTag: .discovery)
+    self.vm.inputs.viewDidLoad()
+
+    XCTAssertEqual(self.optimizelyClient.trackedEventKey, nil)
+
+    self.vm.inputs.pledgeCTAButtonTapped(with: .seeTheRewards)
+
+    XCTAssertEqual(self.optimizelyClient.trackedEventKey, "Project Page Pledge Button Clicked")
+  }
+
+  func testOptimizelyTrackingPledgeCTAButtonTapped_ViewTheRewards() {
+    let project = Project.cosmicSurgery
+
+    self.vm.inputs.configureWith(projectOrParam: .left(project), refTag: .discovery)
+    self.vm.inputs.viewDidLoad()
+
+    XCTAssertEqual(self.optimizelyClient.trackedEventKey, nil)
+
+    self.vm.inputs.pledgeCTAButtonTapped(with: .viewTheRewards)
+
+    XCTAssertEqual(self.optimizelyClient.trackedEventKey, "Project Page Pledge Button Clicked")
+  }
+  
+  func testOptimizelyTrackingPledgeCTAButtonTapped_LoggedIn_NonBacked() {
+    let user = User.template
+      |> \.location .~ Location.template
+      |> \.stats.backedProjectsCount .~ 50
+
+    withEnvironment(currentUser: user) {
+      self.vm.inputs.configureWith(projectOrParam: .left(.template), refTag: .discovery)
+      self.vm.inputs.viewDidLoad()
+
+      XCTAssertEqual(self.optimizelyClient.trackedUserId, nil)
+      XCTAssertEqual(self.optimizelyClient.trackedEventKey, nil)
+      XCTAssertNil(self.optimizelyClient.trackedAttributes)
+      XCTAssertNil(self.optimizelyClient.trackedEventTags)
+
+      self.vm.inputs.pledgeCTAButtonTapped(with: .manage)
+
+      XCTAssertEqual(self.optimizelyClient.trackedUserId, nil)
+      XCTAssertEqual(self.optimizelyClient.trackedEventKey, nil)
+      XCTAssertNil(self.optimizelyClient.trackedAttributes)
+      XCTAssertNil(self.optimizelyClient.trackedEventTags)
+
+      // Only track for non-backed, pledge state
+      self.vm.inputs.pledgeCTAButtonTapped(with: .pledge)
+
+      XCTAssertEqual(self.optimizelyClient.trackedUserId, "DEADBEEF-DEAD-BEEF-DEAD-DEADBEEFBEEF")
+      XCTAssertEqual(self.optimizelyClient.trackedEventKey, "Project Page Pledge Button Clicked")
+
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_backed_projects_count"] as? Int, 50)
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_launched_projects_count"] as? Int, nil)
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_country"] as? String, "us")
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_facebook_account"] as? Bool, nil)
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_display_language"] as? String, "en")
+
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_ref_tag"] as? String, "discovery")
+      XCTAssertEqual(
+        self.optimizelyClient.trackedAttributes?["session_referrer_credit"] as? String,
+        "discovery"
+      )
+      XCTAssertEqual(
+        self.optimizelyClient.trackedAttributes?["session_os_version"] as? String,
+        "MockSystemVersion"
+      )
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_user_is_logged_in"] as? Bool, true)
+      XCTAssertEqual(
+        self.optimizelyClient.trackedAttributes?["session_app_release_version"] as? String,
+        "1.2.3.4.5.6.7.8.9.0"
+      )
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_apple_pay_device"] as? Bool, true)
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_device_format"] as? String, "phone")
+
+      XCTAssertEqual(self.optimizelyClient.trackedEventTags?["project_subcategory"] as? String, "Art")
+      XCTAssertEqual(self.optimizelyClient.trackedEventTags?["project_category"] as? String, nil)
+      XCTAssertEqual(self.optimizelyClient.trackedEventTags?["project_country"] as? String, "us")
+      XCTAssertEqual(self.optimizelyClient.trackedEventTags?["project_user_has_watched"] as? Bool, nil)
+    }
+  }
+
+  func testOptimizelyTrackingPledgeCTAButtonTapped_LoggedIn_Backed() {
+    let user = User.template
+      |> \.location .~ Location.template
+      |> \.stats.backedProjectsCount .~ 50
+
+    let project = Project.cosmicSurgery
+      |> Project.lens.state .~ .live
+      |> Project.lens.personalization.isBacking .~ true
+      |> Project.lens.personalization.backing .~ (
+        .template
+          |> Backing.lens.reward .~ Reward.otherReward
+          |> Backing.lens.rewardId .~ Reward.otherReward.id
+          |> Backing.lens.shippingAmount .~ 10
+          |> Backing.lens.amount .~ 700.0
+      )
+
+    withEnvironment(currentUser: user) {
+      self.vm.inputs.configureWith(projectOrParam: .left(project), refTag: .discovery)
+      self.vm.inputs.viewDidLoad()
+
+      XCTAssertEqual(self.optimizelyClient.trackedUserId, nil)
+      XCTAssertEqual(self.optimizelyClient.trackedEventKey, nil)
+      XCTAssertNil(self.optimizelyClient.trackedAttributes)
+      XCTAssertNil(self.optimizelyClient.trackedEventTags)
+
+      self.vm.inputs.pledgeCTAButtonTapped(with: .manage)
+
+      XCTAssertEqual(self.optimizelyClient.trackedUserId, nil)
+      XCTAssertEqual(self.optimizelyClient.trackedEventKey, nil)
+      XCTAssertNil(self.optimizelyClient.trackedAttributes)
+      XCTAssertNil(self.optimizelyClient.trackedEventTags)
+
+      // Only track for non-backed, pledge state
+      self.vm.inputs.pledgeCTAButtonTapped(with: .manage)
+
+      // Project is backed, no tracking
+      XCTAssertEqual(self.optimizelyClient.trackedUserId, nil)
+      XCTAssertEqual(self.optimizelyClient.trackedEventKey, nil)
+      XCTAssertNil(self.optimizelyClient.trackedAttributes)
+      XCTAssertNil(self.optimizelyClient.trackedEventTags)
+    }
+  }
 
   func testPopToRootViewController() {
     self.vm.inputs.configureWith(projectOrParam: .left(.template), refTag: nil)

--- a/Library/ViewModels/ProjectPamphletViewModelTests.swift
+++ b/Library/ViewModels/ProjectPamphletViewModelTests.swift
@@ -915,12 +915,6 @@ final class ProjectPamphletViewModelTests: TestCase {
       XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_country"] as? String, "us")
       XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_facebook_account"] as? Bool, nil)
       XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_display_language"] as? String, "en")
-
-      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_ref_tag"] as? String, "discovery")
-      XCTAssertEqual(
-        self.optimizelyClient.trackedAttributes?["session_referrer_credit"] as? String,
-        "discovery"
-      )
       XCTAssertEqual(
         self.optimizelyClient.trackedAttributes?["session_os_version"] as? String,
         "MockSystemVersion"
@@ -932,11 +926,6 @@ final class ProjectPamphletViewModelTests: TestCase {
       )
       XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_apple_pay_device"] as? Bool, true)
       XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_device_format"] as? String, "phone")
-
-      XCTAssertEqual(self.optimizelyClient.trackedEventTags?["project_subcategory"] as? String, "Art")
-      XCTAssertEqual(self.optimizelyClient.trackedEventTags?["project_category"] as? String, nil)
-      XCTAssertEqual(self.optimizelyClient.trackedEventTags?["project_country"] as? String, "us")
-      XCTAssertEqual(self.optimizelyClient.trackedEventTags?["project_user_has_watched"] as? Bool, nil)
     }
   }
   
@@ -956,12 +945,6 @@ final class ProjectPamphletViewModelTests: TestCase {
       XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_country"] as? String, "us")
       XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_facebook_account"] as? Bool, nil)
       XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_display_language"] as? String, "en")
-
-      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_ref_tag"] as? String, "discovery")
-      XCTAssertEqual(
-        self.optimizelyClient.trackedAttributes?["session_referrer_credit"] as? String,
-        "discovery"
-      )
       XCTAssertEqual(
         self.optimizelyClient.trackedAttributes?["session_os_version"] as? String,
         "MockSystemVersion"
@@ -973,11 +956,6 @@ final class ProjectPamphletViewModelTests: TestCase {
       )
       XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_apple_pay_device"] as? Bool, true)
       XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_device_format"] as? String, "phone")
-
-      XCTAssertEqual(self.optimizelyClient.trackedEventTags?["project_subcategory"] as? String, "Art")
-      XCTAssertEqual(self.optimizelyClient.trackedEventTags?["project_category"] as? String, nil)
-      XCTAssertEqual(self.optimizelyClient.trackedEventTags?["project_country"] as? String, "us")
-      XCTAssertEqual(self.optimizelyClient.trackedEventTags?["project_user_has_watched"] as? Bool, nil)
     }
   }
 
@@ -988,14 +966,12 @@ final class ProjectPamphletViewModelTests: TestCase {
     XCTAssertEqual(self.optimizelyClient.trackedUserId, nil)
     XCTAssertEqual(self.optimizelyClient.trackedEventKey, nil)
     XCTAssertNil(self.optimizelyClient.trackedAttributes)
-    XCTAssertNil(self.optimizelyClient.trackedEventTags)
 
     self.vm.inputs.pledgeCTAButtonTapped(with: .manage)
 
     XCTAssertEqual(self.optimizelyClient.trackedUserId, nil)
     XCTAssertEqual(self.optimizelyClient.trackedEventKey, nil)
     XCTAssertNil(self.optimizelyClient.trackedAttributes)
-    XCTAssertNil(self.optimizelyClient.trackedEventTags)
 
     // Only track for non-backed, pledge state
     self.vm.inputs.pledgeCTAButtonTapped(with: .pledge)
@@ -1009,11 +985,6 @@ final class ProjectPamphletViewModelTests: TestCase {
     XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_facebook_account"] as? Bool, nil)
     XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_display_language"] as? String, "en")
 
-    XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_ref_tag"] as? String, "discovery")
-    XCTAssertEqual(
-      self.optimizelyClient.trackedAttributes?["session_referrer_credit"] as? String,
-      "discovery"
-    )
     XCTAssertEqual(
       self.optimizelyClient.trackedAttributes?["session_os_version"] as? String,
       "MockSystemVersion"
@@ -1025,11 +996,6 @@ final class ProjectPamphletViewModelTests: TestCase {
     )
     XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_apple_pay_device"] as? Bool, true)
     XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_device_format"] as? String, "phone")
-
-    XCTAssertEqual(self.optimizelyClient.trackedEventTags?["project_subcategory"] as? String, "Art")
-    XCTAssertEqual(self.optimizelyClient.trackedEventTags?["project_category"] as? String, nil)
-    XCTAssertEqual(self.optimizelyClient.trackedEventTags?["project_country"] as? String, "us")
-    XCTAssertEqual(self.optimizelyClient.trackedEventTags?["project_user_has_watched"] as? String, nil)
   }
 
   func testOptimizelyTrackingPledgeCTAButtonTapped_LoggedOut_Backed() {
@@ -1050,14 +1016,12 @@ final class ProjectPamphletViewModelTests: TestCase {
     XCTAssertEqual(self.optimizelyClient.trackedUserId, nil)
     XCTAssertEqual(self.optimizelyClient.trackedEventKey, nil)
     XCTAssertNil(self.optimizelyClient.trackedAttributes)
-    XCTAssertNil(self.optimizelyClient.trackedEventTags)
 
     self.vm.inputs.pledgeCTAButtonTapped(with: .manage)
 
     XCTAssertEqual(self.optimizelyClient.trackedUserId, nil)
     XCTAssertEqual(self.optimizelyClient.trackedEventKey, nil)
     XCTAssertNil(self.optimizelyClient.trackedAttributes)
-    XCTAssertNil(self.optimizelyClient.trackedEventTags)
 
     // Only track for non-backed, pledge state
     self.vm.inputs.pledgeCTAButtonTapped(with: .manage)
@@ -1066,7 +1030,6 @@ final class ProjectPamphletViewModelTests: TestCase {
     XCTAssertEqual(self.optimizelyClient.trackedUserId, nil)
     XCTAssertEqual(self.optimizelyClient.trackedEventKey, nil)
     XCTAssertNil(self.optimizelyClient.trackedAttributes)
-    XCTAssertNil(self.optimizelyClient.trackedEventTags)
   }
   
   func testOptimizelyTrackingPledgeCTAButtonTapped_SeeTheRewards() {
@@ -1107,14 +1070,14 @@ final class ProjectPamphletViewModelTests: TestCase {
       XCTAssertEqual(self.optimizelyClient.trackedUserId, nil)
       XCTAssertEqual(self.optimizelyClient.trackedEventKey, nil)
       XCTAssertNil(self.optimizelyClient.trackedAttributes)
-      XCTAssertNil(self.optimizelyClient.trackedEventTags)
+
 
       self.vm.inputs.pledgeCTAButtonTapped(with: .manage)
 
       XCTAssertEqual(self.optimizelyClient.trackedUserId, nil)
       XCTAssertEqual(self.optimizelyClient.trackedEventKey, nil)
       XCTAssertNil(self.optimizelyClient.trackedAttributes)
-      XCTAssertNil(self.optimizelyClient.trackedEventTags)
+
 
       // Only track for non-backed, pledge state
       self.vm.inputs.pledgeCTAButtonTapped(with: .pledge)
@@ -1127,12 +1090,6 @@ final class ProjectPamphletViewModelTests: TestCase {
       XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_country"] as? String, "us")
       XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_facebook_account"] as? Bool, nil)
       XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_display_language"] as? String, "en")
-
-      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_ref_tag"] as? String, "discovery")
-      XCTAssertEqual(
-        self.optimizelyClient.trackedAttributes?["session_referrer_credit"] as? String,
-        "discovery"
-      )
       XCTAssertEqual(
         self.optimizelyClient.trackedAttributes?["session_os_version"] as? String,
         "MockSystemVersion"
@@ -1144,11 +1101,6 @@ final class ProjectPamphletViewModelTests: TestCase {
       )
       XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_apple_pay_device"] as? Bool, true)
       XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_device_format"] as? String, "phone")
-
-      XCTAssertEqual(self.optimizelyClient.trackedEventTags?["project_subcategory"] as? String, "Art")
-      XCTAssertEqual(self.optimizelyClient.trackedEventTags?["project_category"] as? String, nil)
-      XCTAssertEqual(self.optimizelyClient.trackedEventTags?["project_country"] as? String, "us")
-      XCTAssertEqual(self.optimizelyClient.trackedEventTags?["project_user_has_watched"] as? Bool, nil)
     }
   }
 
@@ -1175,14 +1127,14 @@ final class ProjectPamphletViewModelTests: TestCase {
       XCTAssertEqual(self.optimizelyClient.trackedUserId, nil)
       XCTAssertEqual(self.optimizelyClient.trackedEventKey, nil)
       XCTAssertNil(self.optimizelyClient.trackedAttributes)
-      XCTAssertNil(self.optimizelyClient.trackedEventTags)
+
 
       self.vm.inputs.pledgeCTAButtonTapped(with: .manage)
 
       XCTAssertEqual(self.optimizelyClient.trackedUserId, nil)
       XCTAssertEqual(self.optimizelyClient.trackedEventKey, nil)
       XCTAssertNil(self.optimizelyClient.trackedAttributes)
-      XCTAssertNil(self.optimizelyClient.trackedEventTags)
+
 
       // Only track for non-backed, pledge state
       self.vm.inputs.pledgeCTAButtonTapped(with: .manage)
@@ -1191,7 +1143,6 @@ final class ProjectPamphletViewModelTests: TestCase {
       XCTAssertEqual(self.optimizelyClient.trackedUserId, nil)
       XCTAssertEqual(self.optimizelyClient.trackedEventKey, nil)
       XCTAssertNil(self.optimizelyClient.trackedAttributes)
-      XCTAssertNil(self.optimizelyClient.trackedEventTags)
     }
   }
 


### PR DESCRIPTION
# 📲 What

Send the Optimizely client events through the app

# 🤔 Why

Sending events to Optimizely's dashboard through the DataLake proved to have issues and the short term solution is to send those events through the client SDK. 

# 🛠 How

- Reverted changes in this PR: https://github.com/kickstarter/ios-oss/pull/1205
- Event information can be found here: https://kickstarter.atlassian.net/browse/NT-1317

# ✅ Acceptance criteria

- [x] Tests pass and events are sent to Optimizely correctly
