### PR TITLE
[NT-1359] Allow custom HQ environment in debug tools

### DIFF
--- a/Kickstarter-iOS/Library/QualtricsTypes.swift
+++ b/Kickstarter-iOS/Library/QualtricsTypes.swift
@@ -16,7 +16,7 @@ enum QualtricsIntercept {
     switch AppEnvironment.current.environmentType {
     case .production:
       return "SI_eUKtARDK3785TQF"
-    case .development, .local, .staging:
+    case .development, .local, .staging, .custom:
       return "SI_emv4HRmzWkde0Jf"
     }
   }

--- a/Kickstarter-iOS/ViewModels/AppDelegateViewModel.swift
+++ b/Kickstarter-iOS/ViewModels/AppDelegateViewModel.swift
@@ -1101,7 +1101,7 @@ private func optimizelyData(for environment: Environment) -> (String, Optimizely
     sdkKey = Secrets.OptimizelySDKKey.production
   case .staging:
     sdkKey = Secrets.OptimizelySDKKey.staging
-  case .development, .local:
+  case .development, .local, .custom:
     sdkKey = Secrets.OptimizelySDKKey.development
   }
 

--- a/Kickstarter-iOS/Views/Controllers/BetaToolsViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/BetaToolsViewController.swift
@@ -215,6 +215,7 @@ internal final class BetaToolsViewController: UITableViewController {
       self?.viewModel.inputs.setEnvironment(.custom(url))
     }
     customAlertController.addAction(submitAction)
+    customAlertController.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
 
     EnvironmentType.allCases.forEach { environment in
       alert.addAction(UIAlertAction(title: environment.description, style: .default) { [weak self] _ in

--- a/Kickstarter-iOS/Views/Controllers/BetaToolsViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/BetaToolsViewController.swift
@@ -204,9 +204,26 @@ internal final class BetaToolsViewController: UITableViewController {
       sourceView: sourceView
     )
 
+    let customAlertController = UIAlertController(
+      title: "Custom HQ",
+      message: "Enter the name of the HQ environment, e.g. for \"native.dev\" enter \"native\"",
+      preferredStyle: .alert
+    )
+    customAlertController.addTextField()
+    let submitAction = UIAlertAction(title: "Update", style: .default) { [weak self] _ in
+      guard let url = customAlertController.textFields?[0].text else { return }
+      self?.viewModel.inputs.setEnvironment(.custom(url))
+    }
+    customAlertController.addAction(submitAction)
+
     EnvironmentType.allCases.forEach { environment in
-      alert.addAction(UIAlertAction(title: environment.rawValue, style: .default) { [weak self] _ in
-        self?.viewModel.inputs.setEnvironment(environment)
+      alert.addAction(UIAlertAction(title: environment.description, style: .default) { [weak self] _ in
+        switch environment {
+        case .custom:
+          self?.present(customAlertController, animated: true)
+        default:
+          self?.viewModel.inputs.setEnvironment(environment)
+        }
       })
     }
 

--- a/KsApi/ServerConfig.swift
+++ b/KsApi/ServerConfig.swift
@@ -90,6 +90,19 @@ public struct ServerConfig: ServerConfigType {
 
   public static func config(for environment: EnvironmentType) -> ServerConfigType {
     switch environment {
+    case let .custom(url):
+      guard let url = url else {
+        return ServerConfig.development
+      }
+      return ServerConfig(
+        apiBaseUrl: URL(string: "https://api-\(url).dev.kickstarter.com")!,
+        webBaseUrl: URL(string: "https://\(url).dev.kickstarter.com")!,
+        apiClientAuth: ClientAuth.development,
+        basicHTTPAuth: BasicHTTPAuth.development,
+        graphQLEndpointUrl: URL(string: "https://\(url).dev.kickstarter.com")!
+          .appendingPathComponent(gqlPath),
+        environment: EnvironmentType.custom(url)
+      )
     case .local:
       return ServerConfig.local
     case .development:

--- a/Library/AppEnvironment.swift
+++ b/Library/AppEnvironment.swift
@@ -369,7 +369,7 @@ public struct AppEnvironment: AppEnvironmentType {
     data["apiService.serverConfig.basicHTTPAuth.username"] = env.apiService.serverConfig.basicHTTPAuth?.username
     data["apiService.serverConfig.basicHTTPAuth.password"] = env.apiService.serverConfig.basicHTTPAuth?.password
     data["apiService.serverConfig.webBaseUrl"] = env.apiService.serverConfig.webBaseUrl.absoluteString
-    data["apiService.serverConfig.environment"] = env.apiService.serverConfig.environment.rawValue
+    data["apiService.serverConfig.environment"] = env.apiService.serverConfig.environment.description
     data["apiService.language"] = env.apiService.language
     data["apiService.currency"] = env.apiService.currency
     data["config"] = env.config?.encode()

--- a/Library/EnvironmentType.swift
+++ b/Library/EnvironmentType.swift
@@ -1,17 +1,52 @@
 import Foundation
 
-public enum EnvironmentType: String, CaseIterable {
-  case production = "Production"
-  case staging = "Staging"
-  case development = "Development"
-  case local = "Local"
+public enum EnvironmentType: CaseIterable, CustomStringConvertible, Equatable {
+  case custom(String?)
+  case production
+  case staging
+  case development
+  case local
+
+  public init?(rawValue: String) {
+    let allCases = EnvironmentType.allCases.filter { c -> Bool in
+      if case .custom = c { return false }
+      return true
+    }
+
+    for envCase in allCases where envCase.description == rawValue {
+      self = envCase
+      return
+    }
+
+    self = .custom(rawValue)
+  }
 
   public var stripePublishableKey: String {
     switch self {
     case .production:
       return Secrets.StripePublishableKey.production
-    case .staging, .development, .local:
+    case .staging, .development, .local, .custom:
       return Secrets.StripePublishableKey.staging
+    }
+  }
+
+  public static var allCases: [EnvironmentType] {
+    return [.custom(nil), .production, .staging, .development, .local]
+  }
+
+  public var description: String {
+    switch self {
+    case let .custom(url):
+      guard let url = url else { return "Custom" }
+      return url
+    case .production:
+      return "Production"
+    case .staging:
+      return "Staging"
+    case .development:
+      return "Development"
+    case .local:
+      return "Local"
     }
   }
 }

--- a/Library/EnvironmentType.swift
+++ b/Library/EnvironmentType.swift
@@ -37,8 +37,7 @@ public enum EnvironmentType: CaseIterable, CustomStringConvertible, Equatable {
   public var description: String {
     switch self {
     case let .custom(url):
-      guard let url = url else { return "Custom" }
-      return url
+      return url ?? "Custom"
     case .production:
       return "Production"
     case .staging:

--- a/Library/OptimizelyClientType.swift
+++ b/Library/OptimizelyClientType.swift
@@ -110,7 +110,7 @@ public func optimizelyProperties(environment: Environment? = AppEnvironment.curr
     sdkKey = Secrets.OptimizelySDKKey.production
   case .staging:
     sdkKey = Secrets.OptimizelySDKKey.staging
-  case .development, .local:
+  case .development, .local, .custom:
     sdkKey = Secrets.OptimizelySDKKey.development
   }
 
@@ -129,7 +129,7 @@ public func optimizelyProperties(environment: Environment? = AppEnvironment.curr
 
   return [
     "optimizely_api_key": sdkKey,
-    "optimizely_environment": environmentType.rawValue,
+    "optimizely_environment": environmentType.description,
     "optimizely_experiments": allExperiments
   ]
 }

--- a/Library/ViewModels/BetaToolsViewModel.swift
+++ b/Library/ViewModels/BetaToolsViewModel.swift
@@ -112,7 +112,7 @@ public final class BetaToolsViewModel: BetaToolsViewModelType,
       serverConfigEnvironmentFromAppEnvironment,
       self.updateEnvironment
     )
-    .map { $0.rawValue }
+    .map { $0.description }
 
     self.reloadWithData = Signal.combineLatest(
       currentLanguageString,


### PR DESCRIPTION
# 📲 What

Allows one to enter a custom HQ environment in debug tools.

**Note:** I was unable to test this as the HQ environments appeared to be down at the time.

# 🤔 Why

This has been a requirement from time-to-time so no better time to add it than the present!

# 🛠 How

- Added a `custom` `EnvironmentType` with an associated value which we use to construct the HQ url.
- Added a text prompt when selecting this `EnvironmentType` to capture the value.

# 👀 See

| Prompt | Configured |
| --- | --- |
| <img height="584" alt="image" src="https://user-images.githubusercontent.com/3735375/84840443-63d4e880-aff4-11ea-81b1-bd429a196d2b.png"> | <img src="https://user-images.githubusercontent.com/3735375/84840474-7cdd9980-aff4-11ea-9a08-a840fe159ced.png" height="584" /> |

# ✅ Acceptance criteria

- [ ] Navigate to debug tools, change to the custom environment, enter the name of a valid HQ environment. Requests should be made to that environment.
- [ ] Restarting the app should retain the configured environment.