### PR TITLE
[NT-1404] Distribute alpha builds from feature branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -276,6 +276,23 @@ jobs:
       - store_artifacts:
           path: /tmp/xcode_raw.log
 
+  deploy_alpha:
+    <<: *base_job
+    steps:
+      - restore_cache:
+          keys:
+            - source-v1-{{ .Branch }}-{{ .Revision }}
+            - source-v1-{{ .Branch }}-
+            - source-v1-
+      - checkout
+      - save_cache:
+          key: source-v1-{{ .Branch }}-{{ .Revision }}
+          paths:
+            - ".git"
+      - run:
+          name: Deploy Alpha
+          command: make alpha
+
   deploy_beta:
     <<: *base_job
     steps:
@@ -546,6 +563,16 @@ workflows:
           filters:
             branches:
               only: /beta-dist-.*/
+      - deploy_alpha:
+          filters:
+            branches:
+              only: /.*feature.*/
+          requires:
+            - build-and-cache
+            - kickstarter-tests
+            - kickstarter-ui-tests
+            - library-tests
+            - ksapi-tests
       - deploy_beta:
           filters:
             branches:
@@ -571,7 +598,6 @@ workflows:
             branches:
               only:
                 - /alpha-dist.*/
-                - /.*feature.*/
           requires:
             - build-and-cache
             - kickstarter-tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -566,7 +566,7 @@ workflows:
       - deploy_alpha:
           filters:
             branches:
-              only: /.*feature.*/
+              only: /^((?!alpha\-dist).*feature.*)*$/
           requires:
             - build-and-cache
             - kickstarter-tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -569,7 +569,9 @@ workflows:
       - alpha:
           filters:
             branches:
-              only: /alpha-dist.*/
+              only:
+                - /alpha-dist.*/
+                - /.*feature.*/
           requires:
             - build-and-cache
             - kickstarter-tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -562,10 +562,12 @@ workflows:
       - refresh_app_store_dsyms:
           filters:
             branches:
+              # matches all branches that begin with 'beta-dist'
               only: /beta-dist-.*/
       - deploy_alpha:
           filters:
             branches:
+              # matches all branches that contain 'feature' but do not contain 'alpha-dist'
               only: /^((?!alpha\-dist).*feature.*)*$/
           requires:
             - build-and-cache
@@ -586,6 +588,7 @@ workflows:
       - beta:
           filters:
             branches:
+              # matches all branches that begin with 'beta-dist'
               only: /beta-dist-.*/
           requires:
             - build-and-cache
@@ -596,6 +599,7 @@ workflows:
       - alpha:
           filters:
             branches:
+              # matches all branches that begin with 'alpha-dist'
               only: /alpha-dist.*/
           requires:
             - build-and-cache
@@ -606,6 +610,7 @@ workflows:
       - itunes:
           filters:
             branches:
+              # matches branch named exactly `itunes-dist`
               only: itunes-dist
           requires:
             - build-and-cache
@@ -618,7 +623,11 @@ experimental:
   notify:
     branches:
       only:
+        # matches branch named exactly `master`
         - master
+        # matches all branches that begin with 'alpha-dist'
         - /alpha-dist.*/
+        # matches all branches that begin with 'beta-dist'
         - /beta-dist-.*/
+        # matches branch named exactly `itunes-dist`
         - itunes-dist

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -596,8 +596,7 @@ workflows:
       - alpha:
           filters:
             branches:
-              only:
-                - /alpha-dist.*/
+              only: /alpha-dist.*/
           requires:
             - build-and-cache
             - kickstarter-tests

--- a/.fastlane/Fastfile
+++ b/.fastlane/Fastfile
@@ -238,7 +238,8 @@ platform :ios do
       app_name: options[:app_name],
       ipa: options[:ipa],
       dsym: options[:dsym],
-      notify_testers: true
+      notify_testers: true,
+      release_notes: notes
     )
   end
 

--- a/.fastlane/Fastfile
+++ b/.fastlane/Fastfile
@@ -231,7 +231,7 @@ platform :ios do
   end
 
   private_lane :upload_appcenter do |options|
-    notes = changelog
+    notes = "Branch: #{git_branch}, Recent changes: #{changelog}"
     appcenter_upload(
       api_token: ENV["APPCENTER_API_TOKEN"],
       owner_name: ENV["APPCENTER_OWNER_NAME"],

--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,19 @@ deploy:
 
 	@echo "Deploy has been kicked off to CircleCI!"
 
+alpha:
+	@echo "Adding remotes..."
+	@git remote add oss https://github.com/kickstarter/ios-oss
+	@git remote add private https://github.com/kickstarter/ios-private
+
+	@echo "Deploying private/alpha-dist-$(COMMIT)..."
+
+	@git branch -f alpha-dist-$(COMMIT)
+	@git push -f private alpha-dist-$(COMMIT)
+	@git branch -d alpha-dist-$(COMMIT)
+
+	@echo "Deploy has been kicked off to CircleCI!"
+
 beta:
 	@echo "Adding remotes..."
 	@git remote add oss https://github.com/kickstarter/ios-oss

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ DIST_BRANCH = $(RELEASE)-dist
 FABRIC_SDK_VERSION ?= 3.13.2
 FABRIC_SDK_URL ?= https://s3.amazonaws.com/kits-crashlytics-com/ios/com.twitter.crashlytics.ios/INSERT_SDK_VERSION/com.crashlytics.ios-manual.zip
 COMMIT ?= $(CIRCLE_SHA1)
+CURRENT_BRANCH ?= $(CIRCLE_BRANCH)
 
 ifeq ($(PLATFORM),iOS)
 	DESTINATION ?= 'platform=iOS Simulator,name=$(IPHONE_NAME),OS=$(IOS_VERSION)'
@@ -91,11 +92,11 @@ alpha:
 	@git remote add oss https://github.com/kickstarter/ios-oss
 	@git remote add private https://github.com/kickstarter/ios-private
 
-	@echo "Deploying private/alpha-dist-$(COMMIT)..."
+	@echo "Deploying private/alpha-dist-$(CURRENT_BRANCH)-$(COMMIT)..."
 
-	@git branch -f alpha-dist-$(COMMIT)
-	@git push -f private alpha-dist-$(COMMIT)
-	@git branch -d alpha-dist-$(COMMIT)
+	@git branch -f alpha-dist-$(CURRENT_BRANCH)-$(COMMIT)
+	@git push -f private alpha-dist-$(CURRENT_BRANCH)-$(COMMIT)
+	@git branch -d alpha-dist-$(CURRENT_BRANCH)-$(COMMIT)
 
 	@echo "Deploy has been kicked off to CircleCI!"
 


### PR DESCRIPTION
# 📲 What

Updates our CircleCI configuration to distribute an alpha build from feature branches.

# 🤔 Why

This will assist us in our UAT process when merging to feature branches not yet merged into the master branch.

# 🛠 How

- Added a wildcard branch for triggering alpha builds on `/.*feature.*/`.
- Updated the description of alpha builds to include the branch name.

# ✅ Acceptance criteria

- [x] We've confirmed that the commit to this branch distributed an alpha build.