### PR TITLE
[NT-1404] Improve branch name in release notes

### DIFF
--- a/.fastlane/Fastfile
+++ b/.fastlane/Fastfile
@@ -171,10 +171,15 @@ platform :ios do
 
   desc "Upload Alpha to AppCenter"
   lane :alpha_appcenter do
+    notes = "Branch: #{git_branch}, Recent changes: #{changelog}"
+      .sub("alpha-dist-", "") # strip branch prefix and trailing hyphen
+      .sub("-#{last_git_commit[:commit_hash]}", "") # strip last hyphen and commit hash
+
     upload_appcenter(
       app_name: "KickAlpha",
       ipa: "#{gym_dir}/KickAlpha.ipa",
-      dsym: "#{gym_dir}/KickAlpha.app.dSYM.zip"
+      dsym: "#{gym_dir}/KickAlpha.app.dSYM.zip",
+      notes: notes
     )
 
     upload_dsyms(dsym: "#{gym_dir}/KickAlpha.app.dSYM.zip")
@@ -231,7 +236,7 @@ platform :ios do
   end
 
   private_lane :upload_appcenter do |options|
-    notes = "Branch: #{git_branch}, Recent changes: #{changelog}"
+    notes = (options[:notes] || changelog)
     appcenter_upload(
       api_token: ENV["APPCENTER_API_TOKEN"],
       owner_name: ENV["APPCENTER_OWNER_NAME"],


### PR DESCRIPTION
# 📲 What

- Improves readability of the branch name for our automatic alpha build distributions.
- Reverts the notes changes for non-alpha builds (that is betas built from master).

# 🤔 Why

In order to surface the feature that the branch represents, the name is carried through to the release notes. This can be a little hard to parse though, so instead of seeing something like `alpha-dist-NT-1140-feature-add-ons-phase-1-4150311a067050f98361c7aff4749a336d28330c`, we're stripping out the `alpha-dist-` prefix (used to trigger an alpha build), and the commit hash (used for uniqueness), this leaves the branch name easier to read as `NT-1140-feature-add-ons-phase-1`.

# 🛠 How

Added some ruby string replacement.