### PR TITLE
[NT-1405] Use bonus support as total for No Reward

### DIFF
--- a/Kickstarter-iOS/Views/Controllers/ManagePledgeViewControllerTests.swift
+++ b/Kickstarter-iOS/Views/Controllers/ManagePledgeViewControllerTests.swift
@@ -176,14 +176,11 @@ final class ManagePledgeViewControllerTests: TestCase {
       |> \.backing.shippingAmount .~ nil
 
     envelope = envelope
+      |> \.backing.bonusAmount .~ Money(amount: 10.0, currency: .gbp, symbol: "£")
       |> \.backing.pledgedOn .~ TimeInterval(1_475_361_315)
       |> \.backing.amount .~ Money(amount: 10.0, currency: .gbp, symbol: "£")
       |> \.backing.backer.uid .~ user.id
       |> \.backing.backer.name .~ "Blob"
-      |> \.backing.reward .~ (
-        ManagePledgeViewBackingEnvelope.Backing.Reward.template
-          |> \.amount .~ Money(amount: 10.0, currency: .gbp, symbol: "£")
-      )
 
     let mockService = MockService(
       fetchManagePledgeViewBackingResult: .success(envelope),

--- a/Library/ViewModels/PledgeAmountSummaryViewModel.swift
+++ b/Library/ViewModels/PledgeAmountSummaryViewModel.swift
@@ -46,7 +46,7 @@ public class PledgeAmountSummaryViewModel: PledgeAmountSummaryViewModelType,
       .map {
         (
           $0.projectCountry,
-          $0.rewardMinimum,
+          $0.isNoReward ? ($0.bonusAmount ?? 0) : $0.rewardMinimum,
           $0.omitUSCurrencyCode
         )
       }

--- a/Library/ViewModels/PledgeAmountSummaryViewModelTests.swift
+++ b/Library/ViewModels/PledgeAmountSummaryViewModelTests.swift
@@ -111,14 +111,14 @@ final class PledgeAmountSummaryViewModelTests: TestCase {
 
   func testBonusAmountStackViewIsHidden_isTrue_WhenIsNoReward() {
     let data = PledgeAmountSummaryViewData(
-      bonusAmount: 0,
+      bonusAmount: 1,
       isNoReward: true,
       locationName: nil,
       omitUSCurrencyCode: true,
       projectCountry: Project.Country.us,
       pledgedOn: 1_568_666_243.0,
-      rewardMinimum: 30,
-      shippingAmount: 7.0
+      rewardMinimum: 0,
+      shippingAmount: 0
     )
 
     self.vm.inputs.configureWith(data)
@@ -143,5 +143,23 @@ final class PledgeAmountSummaryViewModelTests: TestCase {
     self.vm.inputs.viewDidLoad()
 
     self.shippingLocationStackViewIsHidden.assertValue(true)
+  }
+
+  func testPledgeAmountText_NoReward() {
+    let data = PledgeAmountSummaryViewData(
+      bonusAmount: 2,
+      isNoReward: true,
+      locationName: nil,
+      omitUSCurrencyCode: true,
+      projectCountry: Project.Country.us,
+      pledgedOn: 1_568_666_243.0,
+      rewardMinimum: 0,
+      shippingAmount: 0
+    )
+
+    self.vm.inputs.configureWith(data)
+    self.vm.inputs.viewDidLoad()
+
+    self.pledgeAmountText.assertValues(["$2.00"], "Bonus amount is used as pledge total for No Reward type")
   }
 }


### PR DESCRIPTION
# 📲 What

Fixes a bug from #1236 which caused the pledge total to be shown as `0.00` for the No Reward type.

# 🤔 Why

No Reward is a special type that we use for a 'fake' reward that allows a backer to contribute to a project without receiving a reward. This type has no minimum and our code was expecting to display the reward's minimum as the pledge amount whereas in the case of No Reward, the bonus support amount is the pledge amount.

# 🛠 How

Updated `PledgeAmountSummaryViewModel` to use the bonus support amount as pledge amount in the case of No Reward type.

# 👀 See

Trello, screenshots, external resources?

| Before 🐛 | After 🦋 |
| --- | --- |
| <img width="545" alt="image" src="https://user-images.githubusercontent.com/3735375/86063819-8fa69400-ba20-11ea-962b-be21256ba1f8.png"> | <img width="545" alt="image" src="https://user-images.githubusercontent.com/3735375/86063706-52da9d00-ba20-11ea-8cf5-71784a1f7928.png"> |

# ✅ Acceptance criteria

- [ ] Back a project for no reward, observe that the amounts are correctly displayed in the manage pledge view.