### PR TITLE
[NT-1296, NT-1297] Manage Pledge view info bugfixes

### DIFF
--- a/Library/ViewModels/ManagePledgeViewModelTests.swift
+++ b/Library/ViewModels/ManagePledgeViewModelTests.swift
@@ -669,7 +669,11 @@ internal final class ManagePledgeViewModelTests: TestCase {
       )
 
     let envelope = ManagePledgeViewBackingEnvelope.template
-      |> \.backing .~ (.template |> \.addOns .~ nil)
+      |> \.backing .~ (
+        .template
+          |> \.addOns .~ nil
+          |> \.reward .~ nil // no reward
+      )
 
     // Pledge amount 25
     let initialPledgeViewSummaryData = ManagePledgeSummaryViewData(
@@ -688,7 +692,7 @@ internal final class ManagePledgeViewModelTests: TestCase {
       projectCountry: project.country,
       projectDeadline: 1_476_657_315.0,
       projectState: ProjectState.live,
-      rewardMinimum: 159.0,
+      rewardMinimum: 0,
       shippingAmount: envelope.backing.shippingAmount?.amount
     )
 
@@ -709,7 +713,7 @@ internal final class ManagePledgeViewModelTests: TestCase {
       projectCountry: project.country,
       projectDeadline: 1_476_657_315.0,
       projectState: ProjectState.live,
-      rewardMinimum: 159.0,
+      rewardMinimum: 0,
       shippingAmount: envelope.backing.shippingAmount?.amount
     )
 
@@ -734,7 +738,7 @@ internal final class ManagePledgeViewModelTests: TestCase {
     let expectedRewardReceivedData = ManageViewPledgeRewardReceivedViewData(
       project: project,
       backerCompleted: false,
-      estimatedDeliveryOn: 1_506_897_315.0,
+      estimatedDeliveryOn: 0,
       backingState: .pledged
     )
 
@@ -756,7 +760,7 @@ internal final class ManagePledgeViewModelTests: TestCase {
       self.configurePledgeSummaryView.assertValues([initialPledgeViewSummaryData])
 
       self.loadProjectAndRewardsIntoDataSourceProject.assertValues([project])
-      self.loadProjectAndRewardsIntoDataSourceReward.assertValues([[.template]])
+      self.loadProjectAndRewardsIntoDataSourceReward.assertValues([[.noReward]])
       self.configureRewardReceivedWithData.assertValues([expectedRewardReceivedData])
       self.title.assertValues(["Manage your pledge"])
     }
@@ -779,11 +783,12 @@ internal final class ManagePledgeViewModelTests: TestCase {
       ])
       self.configurePledgeSummaryView.assertValues([
         initialPledgeViewSummaryData,
+        initialPledgeViewSummaryData,
         updatedPledgeViewSummaryData
       ])
 
       self.loadProjectAndRewardsIntoDataSourceProject.assertValues([project, project, project])
-      self.loadProjectAndRewardsIntoDataSourceReward.assertValues([[.template], [.template], [.template]])
+      self.loadProjectAndRewardsIntoDataSourceReward.assertValues([[.noReward], [.noReward], [.noReward]])
       self.configureRewardReceivedWithData.assertValues([
         expectedRewardReceivedData,
         expectedRewardReceivedData,

--- a/Library/ViewModels/RewardCardViewModel.swift
+++ b/Library/ViewModels/RewardCardViewModel.swift
@@ -173,7 +173,7 @@ private func localizedDescription(project: Project, reward: Reward) -> String {
 }
 
 private func rewardTitle(project: Project, reward: Reward) -> NSAttributedString {
-  guard project.personalization.isBacking == true else {
+  guard project.personalization.isBacking == true || currentUserIsCreator(of: project) else {
     return NSAttributedString(
       string: reward.isNoReward ? Strings.Pledge_without_a_reward() : reward.title.coalesceWith("")
     )


### PR DESCRIPTION
# 📲 What

Bugfixes from UAT testing on Manage Pledge View:

- Some summary data was not correctly displayed when viewing the pledge as a creator.
- Add-on rewards were shown twice in the list.

# 🤔 Why

Due to the two different back-ends that we are retrieving data from for this view the structure differs and has to be handled differently depending on the creator/backer context.

# 🛠 How

 I've made some in-line code comments to explain.

# ✅ Acceptance criteria

Create a project with add-ons and back it as a different user.

- [ ] Pledge info is shown correctly as a backer.
- [ ] Pledge info is shown correctly as a creator.
- [ ] There are no duplicate add-ons in the list.