### PR TITLE
[NT-1366] Add header UI to add-ons selection view

### DIFF
--- a/Kickstarter-iOS/Views/Controllers/RewardAddOnSelectionViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/RewardAddOnSelectionViewController.swift
@@ -1,4 +1,67 @@
 import Foundation
+import Library
+import Prelude
 import UIKit
 
-final class RewardAddOnSelectionViewController: UITableViewController {}
+final class RewardAddOnSelectionViewController: UITableViewController {
+  // MARK: - Properties
+
+  public lazy var headerLabel: UILabel = UILabel(frame: .zero)
+  public lazy var headerView: UIView = UIView(frame: .zero)
+  public lazy var headerRootStackView: UIStackView = UIStackView(frame: .zero)
+
+  // MARK: - Lifecycle
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+
+    self.configureHeaderView()
+
+    self.navigationItem.title = localizedString(
+      key: "Edit_reward",
+      defaultValue: "Edit reward"
+    )
+
+    self.tableView.tableHeaderView = self.headerView
+    self.tableView.tableFooterView = UIView(frame: .zero)
+  }
+
+  override func viewDidLayoutSubviews() {
+    super.viewDidLayoutSubviews()
+
+    self.tableView.ksr_sizeHeaderFooterViewsToFit()
+  }
+
+  // MARK: - Configuration
+
+  private func configureHeaderView() {
+    _ = (self.headerRootStackView, self.headerView)
+      |> ksr_addSubviewToParent()
+      |> ksr_constrainViewToEdgesInParent(priority: UILayoutPriority(rawValue: 999))
+
+    _ = ([self.headerLabel], self.headerRootStackView)
+      |> ksr_addArrangedSubviewsToStackView()
+  }
+
+  // MARK: - Styles
+
+  override func bindStyles() {
+    super.bindStyles()
+
+    _ = self.view
+      |> checkoutBackgroundStyle
+
+    _ = self.headerLabel
+      |> \.numberOfLines .~ 0
+      |> \.font .~ UIFont.ksr_title1().bolded
+      |> \.text .~ localizedString(
+        key: "Customize_your_reward_with_optional_addons",
+        defaultValue: "Customize your reward with optional add-ons."
+      )
+
+    _ = self.headerRootStackView
+      |> \.isLayoutMarginsRelativeArrangement .~ true
+      |> \.layoutMargins .~ .init(topBottom: Styles.grid(3), leftRight: Styles.grid(4))
+      |> \.axis .~ .vertical
+  }
+}

--- a/Kickstarter-iOS/Views/Controllers/RewardAddOnSelectionViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/RewardAddOnSelectionViewController.swift
@@ -52,6 +52,9 @@ final class RewardAddOnSelectionViewController: UITableViewController {
       |> checkoutBackgroundStyle
 
     _ = self.headerLabel
+      |> checkoutBackgroundStyle
+
+    _ = self.headerLabel
       |> \.numberOfLines .~ 0
       |> \.font .~ UIFont.ksr_title1().bolded
       |> \.text .~ localizedString(


### PR DESCRIPTION
# 📲 What

Adds a basic header and title label to `RewardAddOnSelectionViewController`.

# 🤔 Why

This is a continuation of #1243 to get us started on building this view for add-ons selection.

# 🛠 How

Added the necessary subviews and set the label text.

**Note:** I will open a PR for the strings to be translated and link it here.

# 👀 See

| Before 🐛 | After 🦋 | Blended layers 🍭 |
| --- | --- | --- |
| ![image](https://user-images.githubusercontent.com/3735375/86187561-e8ddf880-baf0-11ea-993c-0bece2872648.png) | ![image](https://user-images.githubusercontent.com/3735375/86187481-bf24d180-baf0-11ea-8054-edd335a8ec09.png) | ![image](https://user-images.githubusercontent.com/3735375/86187924-e62fd300-baf1-11ea-8253-7be2a0386d09.png) |

# ♿️ Accessibility 

- [X] Supports Dynamic Type 

# 🏎 Performance

- [X] Optimized Blended Layers

# ✅ Acceptance criteria

- [ ] Navigate to a reward that has add-ons, selecting that reward displays this view controller with the label and text.

# ⏰ TODO

- [x] Add strings for translation