### PR TITLE
[NT-1368] Reward Add-On Card UI

### DIFF
--- a/Kickstarter-iOS/DataSources/RewardAddOnSelectionDataSourceTests.swift
+++ b/Kickstarter-iOS/DataSources/RewardAddOnSelectionDataSourceTests.swift
@@ -11,7 +11,7 @@ final class RewardsAddOnSelectionDataSourceTests: XCTestCase {
   func testLoadRewards() {
     let project = Project.cosmicSurgery
     let rewardsData = project.rewards.map { reward -> RewardAddOnCellData in
-      .init(project: project, reward: reward)
+      .init(project: project, reward: reward, shippingRule: .template)
     }
 
     self.dataSource.load(rewardsData)

--- a/Kickstarter-iOS/Views/Cells/RewardAddOnCell.swift
+++ b/Kickstarter-iOS/Views/Cells/RewardAddOnCell.swift
@@ -8,7 +8,7 @@ final class RewardAddOnCell: UITableViewCell, ValueCell {
   // MARK: - Properties
 
   private lazy var containerView: UIView = { UIView(frame: .zero) }()
-  private lazy var rewardCardView: RewardCardView = { RewardCardView(frame: .zero) }()
+  private lazy var rewardAddOnCardView: RewardAddOnCardView = { RewardAddOnCardView(frame: .zero) }()
 
   override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
     super.init(style: style, reuseIdentifier: reuseIdentifier)
@@ -28,7 +28,7 @@ final class RewardAddOnCell: UITableViewCell, ValueCell {
       |> ksr_addSubviewToParent()
       |> ksr_constrainViewToMarginsInParent()
 
-    _ = (self.rewardCardView, self.containerView)
+    _ = (self.rewardAddOnCardView, self.containerView)
       |> ksr_addSubviewToParent()
       |> ksr_constrainViewToMarginsInParent(priority: UILayoutPriority(rawValue: 999))
   }
@@ -50,7 +50,7 @@ final class RewardAddOnCell: UITableViewCell, ValueCell {
   }
 
   internal func configureWith(value: RewardAddOnCellData) {
-    self.rewardCardView.configure(with: (value.project, value.reward, .pledge))
+    self.rewardAddOnCardView.configure(with: (value.project, value.reward, .pledge, value.shippingRule))
 
     self.contentView.setNeedsLayout()
     self.contentView.layoutIfNeeded()
@@ -69,5 +69,5 @@ private let containerViewStyle: ViewStyle = { (view: UIView) in
 private let contentViewStyle: ViewStyle = { (view: UIView) in
   view
     |> checkoutBackgroundStyle
-    |> \.layoutMargins .~ .init(leftRight: Styles.grid(3))
+    |> \.layoutMargins .~ .init(leftRight: Styles.grid(4))
 }

--- a/Kickstarter-iOS/Views/PillsView.swift
+++ b/Kickstarter-iOS/Views/PillsView.swift
@@ -18,7 +18,7 @@ public struct PillData: Equatable {
 
 private class PillView: UIView {
   private var data: PillData
-  private var label: UILabel = UILabel(frame: .zero)
+  private var label = UILabel(frame: .zero)
 
   public init(with data: PillData) {
     self.data = data

--- a/Kickstarter-iOS/Views/PillsView.swift
+++ b/Kickstarter-iOS/Views/PillsView.swift
@@ -1,0 +1,148 @@
+import Library
+import UIKit
+
+public struct PillsViewData: Equatable {
+  public let interimLineSpacing: CGFloat
+  public let interimPillSpacing: CGFloat
+  public let margins: UIEdgeInsets
+  public let pills: [PillData]
+}
+
+public struct PillData: Equatable {
+  public let backgroundColor: UIColor
+  public let font: UIFont
+  public let margins: UIEdgeInsets
+  public let text: String
+  public let textColor: UIColor
+}
+
+private class PillView: UIView {
+  private var data: PillData
+  private var label: UILabel = UILabel(frame: .zero)
+
+  public init(with data: PillData) {
+    self.data = data
+
+    super.init(frame: .zero)
+
+    self.layer.cornerRadius = Styles.grid(1)
+    self.layer.masksToBounds = true
+
+    self.label.numberOfLines = 0
+    self.label.text = data.text
+    self.label.textAlignment = .center
+    self.label.font = data.font
+    self.label.textColor = data.textColor
+    self.label.backgroundColor = data.backgroundColor
+
+    self.addSubview(self.label)
+  }
+
+  override func layoutSubviews() {
+    super.layoutSubviews()
+
+    self.label.frame = self.bounds
+  }
+
+  public override func sizeThatFits(_ size: CGSize) -> CGSize {
+    guard let text = self.label.text else { return .zero }
+
+    /**
+     Note, this is currently sufficient but needs some more work to support very long text
+     in order to wrap correctly. We should add an `NSParagraphStyle` with word-wrapping options.
+     */
+    let textSize = (text as NSString).boundingRect(
+      with: size,
+      options: [.usesLineFragmentOrigin, .usesFontLeading],
+      attributes: [.font: self.data.font],
+      context: nil
+    )
+
+    let leftAndRightMargins = self.data.margins.left + self.data.margins.right
+    let topAndBottomMargins = self.data.margins.top + self.data.margins.bottom
+
+    return CGSize(width: textSize.width + leftAndRightMargins, height: textSize.height + topAndBottomMargins)
+  }
+
+  required init?(coder _: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+}
+
+public final class PillsView: UIView {
+  private var heightCache = NSCache<UIView, NSValue>()
+  private var data: PillsViewData?
+  private var pillViews: [UIView] = []
+  private var preferredSize: CGSize = .zero
+
+  public func configure(with data: PillsViewData) {
+    guard data != self.data else { return }
+
+    self.heightCache.removeAllObjects()
+    self.pillViews.forEach { $0.removeFromSuperview() }
+
+    self.data = data
+    self.pillViews = data.pills.map(PillView.init(with:))
+
+    self.pillViews.forEach(self.addSubview(_:))
+  }
+
+  public override func layoutSubviews() {
+    super.layoutSubviews()
+
+    guard let data = self.data, !self.pillViews.isEmpty else { return }
+
+    let leftAndRightMargins = data.margins.left + data.margins.right
+
+    let constrainedSize = CGSize(
+      width: self.bounds.size.width - leftAndRightMargins,
+      height: UIView.noIntrinsicMetric
+    )
+
+    var x = data.margins.left
+    var y = data.margins.top
+
+    var pillsIterator = self.pillViews.makeIterator()
+
+    var prevViewSize: CGSize?
+
+    while let pillView = pillsIterator.next() {
+      let size: CGSize
+
+      if let cachedSize = self.heightCache.object(forKey: pillView) {
+        size = cachedSize.cgSizeValue
+      } else {
+        size = pillView.sizeThatFits(constrainedSize)
+        self.heightCache.setObject(NSValue(cgSize: size), forKey: pillView)
+      }
+
+      let nextMaxX = x + size.width
+      let canFitOnLine = nextMaxX <= constrainedSize.width
+
+      if !canFitOnLine {
+        x = data.margins.left
+        y += size.height + data.interimLineSpacing
+      }
+
+      pillView.frame = CGRect(
+        origin: CGPoint(x: x, y: y),
+        size: size
+      )
+
+      x += pillView.frame.maxX + data.interimPillSpacing
+
+      prevViewSize = size
+    }
+
+    self.preferredSize = CGSize(
+      width: self.bounds.size.width,
+      height: y + (prevViewSize?.height ?? 0) + data.margins.bottom
+    )
+  }
+
+  public override var intrinsicContentSize: CGSize {
+    self.layoutIfNeeded()
+
+    return self.preferredSize
+  }
+}

--- a/Kickstarter-iOS/Views/RewardAddOnCardView.swift
+++ b/Kickstarter-iOS/Views/RewardAddOnCardView.swift
@@ -1,0 +1,279 @@
+import Foundation
+import KsApi
+import Library
+import Prelude
+import ReactiveSwift
+
+protocol RewardAddOnCardViewDelegate: AnyObject {
+  func rewardAddOnCardView(_ rewardAddOnCardView: RewardAddOnCardView, didTapWithRewardId rewardId: Int)
+}
+
+public final class RewardAddOnCardView: UIView {
+  // MARK: - Properties
+
+  weak var delegate: RewardAddOnCardViewDelegate?
+  private let viewModel: RewardAddOnCardViewModelType = RewardAddOnCardViewModel()
+
+  private let rootStackView: UIStackView = {
+    UIStackView(frame: .zero)
+      |> \.translatesAutoresizingMaskIntoConstraints .~ false
+      |> \.insetsLayoutMarginsFromSafeArea .~ false
+  }()
+
+  private let amountConversionLabel = UILabel(frame: .zero)
+  private let amountLabel = UILabel(frame: .zero)
+  private let descriptionLabel = UILabel(frame: .zero)
+  private let includedItemsSeparator: UIView = UIView(frame: .zero)
+  private let includedItemsStackView = UIStackView(frame: .zero)
+  private let includedItemsTitleLabel = UILabel(frame: .zero)
+  private let includedItemsLabel = UILabel(frame: .zero)
+  private let pillsView: PillsView = PillsView(frame: .zero)
+  private var pillsViewHeightConstraint: NSLayoutConstraint?
+
+  private let rewardTitleLabel = UILabel(frame: .zero)
+  private let titleAmountStackView = UIStackView(frame: .zero)
+
+  override init(frame: CGRect) {
+    super.init(frame: frame)
+
+    self.configureViews()
+    self.setupConstraints()
+    self.bindViewModel()
+  }
+
+  required init?(coder _: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  public override func layoutSubviews() {
+    super.layoutSubviews()
+
+    self.pillsViewHeightConstraint?.constant = self.pillsView.intrinsicContentSize.height
+  }
+
+  public override func bindStyles() {
+    super.bindStyles()
+
+    _ = self
+      |> checkoutWhiteBackgroundStyle
+
+    _ = [
+      self.rootStackView,
+      self.titleAmountStackView,
+      self.includedItemsStackView
+    ]
+      ||> { stackView in
+        stackView
+          |> sectionStackViewStyle
+      }
+
+    _ = self.rootStackView
+      |> baseStackViewStyle
+
+    _ = self.titleAmountStackView
+      |> titleAmountStackViewStyle
+
+    _ = self.includedItemsSeparator
+      |> separatorStyle
+
+    _ = self.includedItemsStackView
+      |> includedItemsStackViewStyle
+
+    _ = self.includedItemsTitleLabel
+      |> baseRewardLabelStyle
+      |> \.font .~ UIFont.ksr_callout().weighted(.semibold)
+      |> \.text %~ { _ in Strings.project_view_pledge_includes() }
+      |> \.textColor .~ UIColor.ksr_text_dark_grey_500
+
+    _ = self.includedItemsLabel
+      |> baseRewardLabelStyle
+      |> \.font .~ .ksr_callout()
+
+    _ = self.descriptionLabel
+      |> baseRewardLabelStyle
+      |> descriptionLabelStyle
+
+    _ = self.rewardTitleLabel
+      |> baseRewardLabelStyle
+      |> rewardTitleLabelStyle
+
+    _ = self.amountLabel
+      |> baseRewardLabelStyle
+      |> amountLabelStyle
+
+    _ = self.amountConversionLabel
+      |> baseRewardLabelStyle
+      |> convertedAmountLabelStyle
+  }
+
+  public override func bindViewModel() {
+    super.bindViewModel()
+
+    self.amountConversionLabel.rac.hidden = self.viewModel.outputs.amountConversionLabelHidden
+    self.amountConversionLabel.rac.text = self.viewModel.outputs.amountConversionLabelText
+    self.descriptionLabel.rac.text = self.viewModel.outputs.descriptionLabelText
+    self.includedItemsStackView.rac.hidden = self.viewModel.outputs.includedItemsStackViewHidden
+    self.includedItemsLabel.rac.attributedText = self.viewModel.outputs.includedItemsLabelAttributedText
+    self.amountLabel.rac.attributedText = self.viewModel.outputs.amountLabelAttributedText
+    self.pillsView.rac.hidden = self.viewModel.outputs.pillsViewHidden
+    self.rewardTitleLabel.rac.text = self.viewModel.outputs.rewardTitleLabelText
+
+    self.viewModel.outputs.rewardSelected
+      .observeForUI()
+      .observeValues { [weak self] rewardId in
+        guard let self = self else { return }
+
+        self.delegate?.rewardAddOnCardView(self, didTapWithRewardId: rewardId)
+      }
+
+    self.viewModel.outputs.cardUserInteractionIsEnabled
+      .observeForUI()
+      .observeValues { [weak self] isUserInteractionEnabled in
+        _ = self
+          ?|> \.isUserInteractionEnabled .~ isUserInteractionEnabled
+      }
+
+    self.viewModel.outputs.reloadPills
+      .observeForUI()
+      .observeValues { [weak self] values in
+        self?.configurePillsView(values)
+      }
+  }
+
+  // MARK: - Private Helpers
+
+  private func configureViews() {
+    _ = (self.rootStackView, self)
+      |> ksr_addSubviewToParent()
+      |> ksr_constrainViewToEdgesInParent()
+
+    let rootSubviews = [
+      self.rewardTitleLabel,
+      self.titleAmountStackView,
+      self.descriptionLabel,
+      self.includedItemsStackView,
+      self.pillsView
+    ]
+
+    _ = (rootSubviews, self.rootStackView)
+      |> ksr_addArrangedSubviewsToStackView()
+
+    let titleAmountViews = [self.rewardTitleLabel, self.amountLabel, self.amountConversionLabel]
+
+    _ = (titleAmountViews, self.titleAmountStackView)
+      |> ksr_addArrangedSubviewsToStackView()
+
+    let includedItemsViews = [
+      self.includedItemsSeparator,
+      self.includedItemsTitleLabel,
+      self.includedItemsLabel
+    ]
+
+    _ = (includedItemsViews, self.includedItemsStackView)
+      |> ksr_addArrangedSubviewsToStackView()
+
+    let tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(self.rewardCardTapped))
+    self.addGestureRecognizer(tapGestureRecognizer)
+  }
+
+  private func setupConstraints() {
+    let pillsViewHeightConstraint = self.pillsView.heightAnchor.constraint(equalToConstant: 0)
+    self.pillsViewHeightConstraint = pillsViewHeightConstraint
+
+    let pillCollectionViewConstraints = [
+      self.includedItemsSeparator.heightAnchor.constraint(equalToConstant: 1),
+      pillsViewHeightConstraint
+    ]
+
+    NSLayoutConstraint.activate(pillCollectionViewConstraints)
+  }
+
+  private func configurePillsView(_ pills: [String]) {
+    let pillData = pills.map { text -> PillData in
+      PillData(
+        backgroundColor: UIColor.ksr_celebrate_100,
+        font: UIFont.ksr_footnote().bolded,
+        margins: UIEdgeInsets(topBottom: Styles.gridHalf(2), leftRight: Styles.gridHalf(3)),
+        text: text,
+        textColor: .ksr_dark_grey_500
+      )
+    }
+
+    let data = PillsViewData(
+      interimLineSpacing: Styles.grid(1),
+      interimPillSpacing: Styles.grid(1),
+      margins: .zero,
+      pills: pillData
+    )
+
+    self.pillsView.configure(with: data)
+  }
+
+  // MARK: - Configuration
+
+  internal func configure(with data: RewardAddOnCardViewData) {
+    self.viewModel.inputs.configure(with: data)
+
+    self.layoutIfNeeded()
+  }
+
+  // MARK: - Selectors
+
+  @objc func rewardCardTapped() {
+    self.viewModel.inputs.rewardAddOnCardTapped()
+  }
+}
+
+// MARK: - Styles
+
+private let baseRewardLabelStyle: LabelStyle = { label in
+  label
+    |> \.numberOfLines .~ 0
+    |> \.textAlignment .~ .left
+    |> \.lineBreakMode .~ .byWordWrapping
+}
+
+private let baseStackViewStyle: StackViewStyle = { stackView in
+  stackView
+    |> \.spacing .~ Styles.grid(3)
+}
+
+private let includedItemsStackViewStyle: StackViewStyle = { stackView in
+  stackView |> \.spacing .~ Styles.grid(2)
+}
+
+private let amountLabelStyle: LabelStyle = { label in
+  label
+    |> \.textColor .~ .ksr_green_500
+    |> \.font .~ UIFont.ksr_title3().bolded
+}
+
+private let convertedAmountLabelStyle: LabelStyle = { label in
+  label
+    |> \.textColor .~ .ksr_dark_grey_500
+    |> \.font .~ UIFont.ksr_footnote().weighted(.medium)
+}
+
+private let titleAmountStackViewStyle: StackViewStyle = { stackView in
+  stackView
+    |> \.axis .~ .vertical
+    |> \.spacing .~ Styles.gridHalf(1)
+}
+
+private let rewardTitleLabelStyle: LabelStyle = { label in
+  label
+    |> \.textColor .~ .ksr_soft_black
+    |> \.font .~ UIFont.ksr_title3().bolded
+}
+
+private let sectionStackViewStyle: StackViewStyle = { stackView in
+  stackView
+    |> \.axis .~ .vertical
+    |> \.spacing .~ Styles.grid(1)
+}
+
+private let descriptionLabelStyle: LabelStyle = { label in
+  label
+    |> \.textColor .~ .ksr_soft_black
+    |> \.font .~ UIFont.ksr_body()
+}

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -368,6 +368,7 @@
 		80D73AF61D50F1A60099231F /* Navigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80E26A121D500C6A007B3022 /* Navigation.swift */; };
 		80E8EAC81D3EC65A007BDA4B /* Image.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80E8EAC71D3EC65A007BDA4B /* Image.swift */; };
 		80EAEF051D243C4E008C2353 /* Backing.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 80EAEF031D243C4E008C2353 /* Backing.storyboard */; };
+		8A00CCFF24BD439E00E12D49 /* RewardAddOnCardViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A00CCFE24BD439E00E12D49 /* RewardAddOnCardViewModelTests.swift */; };
 		8A05CB0E23DB82D3002B01EE /* CookieRefTagFunctions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A05CB0D23DB82D3002B01EE /* CookieRefTagFunctions.swift */; };
 		8A072D3A230223B200BA1538 /* UIImage+Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A072D39230223B200BA1538 /* UIImage+Color.swift */; };
 		8A08B521249C3352009CF74E /* EasyButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A08B520249C3352009CF74E /* EasyButton.swift */; };
@@ -422,6 +423,8 @@
 		8A49396524B54F9B00C3C3CE /* Reward+RewardAddOnSelectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A49396424B54F9B00C3C3CE /* Reward+RewardAddOnSelectionView.swift */; };
 		8A49396724B68FA500C3C3CE /* Reward+RewardAddOnSelectionViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A49396624B68FA500C3C3CE /* Reward+RewardAddOnSelectionViewTests.swift */; };
 		8A49396924B690E000C3C3CE /* RewardAddOnSelectionViewEnvelopeTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A49396824B690E000C3C3CE /* RewardAddOnSelectionViewEnvelopeTemplate.swift */; };
+		8A49396B24B7735100C3C3CE /* RewardAddOnCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A49396A24B7735100C3C3CE /* RewardAddOnCardView.swift */; };
+		8A49396F24B77B3500C3C3CE /* RewardAddOnCardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A49396E24B77B3500C3C3CE /* RewardAddOnCardViewModel.swift */; };
 		8A4DDAB32373427000ADE31D /* PledgeStatusLabelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A4DDAB22373427000ADE31D /* PledgeStatusLabelView.swift */; };
 		8A4DDAB52373429300ADE31D /* PledgeStatusLabelViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A4DDAB42373429300ADE31D /* PledgeStatusLabelViewModel.swift */; };
 		8A4DDAB72373A05000ADE31D /* PledgeStatusLabelViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A4DDAB62373A05000ADE31D /* PledgeStatusLabelViewModelTests.swift */; };
@@ -488,6 +491,7 @@
 		8AD7952F239EBDF600998C79 /* MockTrackingClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A213CE9239EAEA400BBB4C7 /* MockTrackingClient.swift */; };
 		8AD79530239EBDF600998C79 /* MockTrackingClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A213CE9239EAEA400BBB4C7 /* MockTrackingClient.swift */; };
 		8AD7953423A2C95000998C79 /* QualtricsTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD7953323A2C95000998C79 /* QualtricsTypes.swift */; };
+		8ADF4D7624BCCFD60018AD4B /* PillsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ADF4D7524BCCFD60018AD4B /* PillsView.swift */; };
 		8AE09C3A244537BE00036043 /* PledgeDisclaimerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE09C39244537BE00036043 /* PledgeDisclaimerView.swift */; };
 		8AE09C3C2446330100036043 /* PledgeDisclaimerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE09C3B2446330100036043 /* PledgeDisclaimerViewModel.swift */; };
 		8AE09C3E24463C4C00036043 /* PledgeDisclaimerViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE09C3D24463C4C00036043 /* PledgeDisclaimerViewModelTests.swift */; };
@@ -1889,6 +1893,7 @@
 		80E26A121D500C6A007B3022 /* Navigation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Navigation.swift; sourceTree = "<group>"; };
 		80E8EAC71D3EC65A007BDA4B /* Image.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Image.swift; sourceTree = "<group>"; };
 		80EAEF031D243C4E008C2353 /* Backing.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Backing.storyboard; sourceTree = "<group>"; };
+		8A00CCFE24BD439E00E12D49 /* RewardAddOnCardViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RewardAddOnCardViewModelTests.swift; sourceTree = "<group>"; };
 		8A05CB0D23DB82D3002B01EE /* CookieRefTagFunctions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CookieRefTagFunctions.swift; sourceTree = "<group>"; };
 		8A072D39230223B200BA1538 /* UIImage+Color.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+Color.swift"; sourceTree = "<group>"; };
 		8A08B520249C3352009CF74E /* EasyButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EasyButton.swift; sourceTree = "<group>"; };
@@ -1943,6 +1948,8 @@
 		8A49396424B54F9B00C3C3CE /* Reward+RewardAddOnSelectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Reward+RewardAddOnSelectionView.swift"; sourceTree = "<group>"; };
 		8A49396624B68FA500C3C3CE /* Reward+RewardAddOnSelectionViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Reward+RewardAddOnSelectionViewTests.swift"; sourceTree = "<group>"; };
 		8A49396824B690E000C3C3CE /* RewardAddOnSelectionViewEnvelopeTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RewardAddOnSelectionViewEnvelopeTemplate.swift; sourceTree = "<group>"; };
+		8A49396A24B7735100C3C3CE /* RewardAddOnCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RewardAddOnCardView.swift; sourceTree = "<group>"; };
+		8A49396E24B77B3500C3C3CE /* RewardAddOnCardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RewardAddOnCardViewModel.swift; sourceTree = "<group>"; };
 		8A4DDAB22373427000ADE31D /* PledgeStatusLabelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PledgeStatusLabelView.swift; sourceTree = "<group>"; };
 		8A4DDAB42373429300ADE31D /* PledgeStatusLabelViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PledgeStatusLabelViewModel.swift; sourceTree = "<group>"; };
 		8A4DDAB62373A05000ADE31D /* PledgeStatusLabelViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PledgeStatusLabelViewModelTests.swift; sourceTree = "<group>"; };
@@ -2005,6 +2012,7 @@
 		8AD486342359F34700A1463E /* STPPaymentHandler+StripePaymentHandlerActionStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "STPPaymentHandler+StripePaymentHandlerActionStatus.swift"; sourceTree = "<group>"; };
 		8AD7953123A286D800998C79 /* Qualtrics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Qualtrics.framework; path = Carthage/Build/iOS/Qualtrics.framework; sourceTree = "<group>"; };
 		8AD7953323A2C95000998C79 /* QualtricsTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QualtricsTypes.swift; sourceTree = "<group>"; };
+		8ADF4D7524BCCFD60018AD4B /* PillsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PillsView.swift; sourceTree = "<group>"; };
 		8AE09C39244537BE00036043 /* PledgeDisclaimerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PledgeDisclaimerView.swift; sourceTree = "<group>"; };
 		8AE09C3B2446330100036043 /* PledgeDisclaimerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PledgeDisclaimerViewModel.swift; sourceTree = "<group>"; };
 		8AE09C3D24463C4C00036043 /* PledgeDisclaimerViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PledgeDisclaimerViewModelTests.swift; sourceTree = "<group>"; };
@@ -3197,6 +3205,7 @@
 				370C8B63234FCC6F00DE75DD /* LoadingButton.swift */,
 				77BF99B622652C9500513CE3 /* MultiLineButton.swift */,
 				D63BBD382180BE5D007E01F0 /* PaymentMethodsFooterView.swift */,
+				8ADF4D7524BCCFD60018AD4B /* PillsView.swift */,
 				D741577A2284849000C0B907 /* PledgeCTAContainerView.swift */,
 				8AE09C39244537BE00036043 /* PledgeDisclaimerView.swift */,
 				374F507822614A1000DE6746 /* PledgeFooterView.swift */,
@@ -3205,6 +3214,7 @@
 				015706BA1E68DE580087DD68 /* ProfileSortBarView.swift */,
 				8AB0E00B24314967008E975E /* ProjectSummaryCarouselView.swift */,
 				A78012641D2EEA620027396E /* ReferralChartView.swift */,
+				8A49396A24B7735100C3C3CE /* RewardAddOnCardView.swift */,
 				8A8099EA22E213F100373E66 /* RewardCardContainerView.swift */,
 				8A23EF0722F11470001262E1 /* RewardCardContainerViewTests.swift */,
 				8A8099E922E213F100373E66 /* RewardCardView.swift */,
@@ -4119,6 +4129,8 @@
 				A7ED1FA11E831C5C00BFFA01 /* ProjectUpdatesViewModelTests.swift */,
 				A7F441A81D005A9400FE6FC5 /* ResetPasswordViewModel.swift */,
 				A7ED1F9B1E831C5C00BFFA01 /* ResetPasswordViewModelTests.swift */,
+				8A49396E24B77B3500C3C3CE /* RewardAddOnCardViewModel.swift */,
+				8A00CCFE24BD439E00E12D49 /* RewardAddOnCardViewModelTests.swift */,
 				8A45168C24B3D02700D8CAEF /* RewardAddOnSelectionViewModel.swift */,
 				8A49395E24B53D1900C3C3CE /* RewardAddOnSelectionViewModelTests.swift */,
 				8A8099F022E2142C00373E66 /* RewardCardContainerViewModel.swift */,
@@ -5195,6 +5207,7 @@
 				D67DF564232ABB960051D207 /* ManagePledgeViewModel.swift in Sources */,
 				D0A787BF2204D975006AE4F4 /* UITableView+AutoLayoutHeaderView.swift in Sources */,
 				D6050F4C240426FE00E029D2 /* LandingPageViewModel.swift in Sources */,
+				8A49396F24B77B3500C3C3CE /* RewardAddOnCardViewModel.swift in Sources */,
 				A76126B91C90C94000EDCCB9 /* UIView-Extensions.swift in Sources */,
 				A77D7B071CBAAF5D0077586B /* Paginate.swift in Sources */,
 				01F547ED1D53994B000A98EF /* TabBarItemStyles.swift in Sources */,
@@ -5402,6 +5415,7 @@
 				D798A748216698CE0053D097 /* SettingsAccountViewModelTests.swift in Sources */,
 				A7ED1F2D1E830FDC00BFFA01 /* LanguageTests.swift in Sources */,
 				8A13D17024985550007E2C0B /* PledgeExpandableRewardsHeaderViewModelTests.swift in Sources */,
+				8A00CCFF24BD439E00E12D49 /* RewardAddOnCardViewModelTests.swift in Sources */,
 				D76F0708241012C800072C7B /* CreatorBylineViewModelTests.swift in Sources */,
 				771E630E23426B74005967E8 /* CancelPledgeViewModelTests.swift in Sources */,
 				8A73EAD12339732900FF9051 /* PledgePaymentMethodCellViewModelTests.swift in Sources */,
@@ -5603,6 +5617,7 @@
 				59673CBD1D50ED380035AFD9 /* VideoViewController.swift in Sources */,
 				7727494523F350EE0065E9F2 /* CategorySelectionViewController.swift in Sources */,
 				D796867E20FF910300E54C61 /* SettingsPrivacyDataSource.swift in Sources */,
+				8ADF4D7624BCCFD60018AD4B /* PillsView.swift in Sources */,
 				77EFBAE72268E37200DA5C3C /* RewardsCollectionViewDataSource.swift in Sources */,
 				77F9A9B02135FB760082A11E /* FindFriendsCell.swift in Sources */,
 				771E3C632289DBA8003E7CF1 /* SheetOverlayViewController.swift in Sources */,
@@ -5819,6 +5834,7 @@
 				014D625B1E6E20BB0033D2BD /* BackerDashboardProjectsDataSource.swift in Sources */,
 				A78012651D2EEA620027396E /* ReferralChartView.swift in Sources */,
 				597073B21D07281800B00444 /* ProjectNotificationCell.swift in Sources */,
+				8A49396B24B7735100C3C3CE /* RewardAddOnCardView.swift in Sources */,
 				01DEFB961CB44A5D003709C0 /* TwoFactorViewController.swift in Sources */,
 				D6050F52240463AC00E029D2 /* LandingPageStatsView.swift in Sources */,
 				7717805A22F9ED130064A32F /* RewardsCollectionViewFooter.swift in Sources */,

--- a/KsApi/GraphSchema.swift
+++ b/KsApi/GraphSchema.swift
@@ -218,6 +218,7 @@ public enum Query {
     case isMaxPledge
     case items(Set<QueryArg<Never>>, NonEmptySet<Connection<Item>>)
     case limit
+    case limitPerBacker
     case name
     case remainingQuantity
     case shippingPreference
@@ -583,6 +584,7 @@ extension Query.Reward: QueryType {
     case .isMaxPledge: return "isMaxPledge"
     case let .items(args, fields): return "items" + connection(args, fields)
     case .limit: return "limit"
+    case .limitPerBacker: return "limitPerBacker"
     case .name: return "name"
     case .remainingQuantity: return "remainingQuantity"
     case .shippingPreference: return "shippingPreference"

--- a/KsApi/models/ManagePledgeViewBackingEnvelope.swift
+++ b/KsApi/models/ManagePledgeViewBackingEnvelope.swift
@@ -66,6 +66,7 @@ public struct ManagePledgeViewBackingEnvelope: Swift.Decodable {
       public var isMaxPledge: Bool
       public var items: [Item]?
       public var limit: Int?
+      public var limitPerBacker: Int?
       public var name: String
       public var remainingQuantity: Int?
       public var shippingPreference: ShippingPreference?
@@ -112,6 +113,7 @@ public extension ManagePledgeViewBackingEnvelope.Backing.Reward {
     case isMaxPledge
     case items
     case limit
+    case limitPerBacker
     case name
     case nodes
     case remainingQuantity
@@ -133,6 +135,7 @@ public extension ManagePledgeViewBackingEnvelope.Backing.Reward {
     self.items = try? values.nestedContainer(keyedBy: CodingKeys.self, forKey: .items)
       .decode([Item].self, forKey: .nodes)
     self.limit = try values.decodeIfPresent(Int.self, forKey: .limit)
+    self.limitPerBacker = try values.decodeIfPresent(Int.self, forKey: .limitPerBacker)
     self.name = try values.decode(String.self, forKey: .name)
     self.remainingQuantity = try values.decodeIfPresent(Int.self, forKey: .remainingQuantity)
     self.shippingPreference = try values.decodeIfPresent(ShippingPreference.self, forKey: .shippingPreference)

--- a/KsApi/models/ManagePledgeViewBackingEnvelopeTests.swift
+++ b/KsApi/models/ManagePledgeViewBackingEnvelopeTests.swift
@@ -94,6 +94,7 @@ final class ManagePledgeViewBackingEnvelopeTests: XCTestCase {
             ]
           ],
           "limit": 5,
+          "limitPerBacker": 2,
           "remainingQuantity": 10,
           "shippingPreference": "none",
           "amount": [
@@ -179,6 +180,7 @@ final class ManagePledgeViewBackingEnvelopeTests: XCTestCase {
       XCTAssertEqual(value.backing.reward?.items?[1].name, "Travel case")
 
       XCTAssertEqual(value.backing.reward?.limit, 5)
+      XCTAssertEqual(value.backing.reward?.limitPerBacker, 2)
       XCTAssertEqual(value.backing.reward?.remainingQuantity, 10)
 
       XCTAssertEqual(value.backing.reward?.amount, Money(amount: 129.0, currency: .usd, symbol: "$"))

--- a/KsApi/models/Reward+ManagePledgeView.swift
+++ b/KsApi/models/Reward+ManagePledgeView.swift
@@ -25,7 +25,8 @@ public extension Reward {
 
     let addOnData = AddOnData(
       isAddOn: true,
-      selectedQuantity: selectedAddOnQuantities[backingReward.id] ?? 0
+      selectedQuantity: selectedAddOnQuantities[backingReward.id] ?? 0,
+      limitPerBacker: backingReward.limitPerBacker
     )
 
     return Reward(

--- a/KsApi/models/Reward+RewardAddOnSelectionView.swift
+++ b/KsApi/models/Reward+RewardAddOnSelectionView.swift
@@ -25,7 +25,8 @@ public extension Reward {
 
     let addOnData = AddOnData(
       isAddOn: true,
-      selectedQuantity: selectedAddOnQuantities[reward.id] ?? 0
+      selectedQuantity: selectedAddOnQuantities[reward.id] ?? 0,
+      limitPerBacker: reward.limitPerBacker
     )
 
     return Reward(

--- a/KsApi/models/Reward.swift
+++ b/KsApi/models/Reward.swift
@@ -6,6 +6,7 @@ import Runes
 public struct AddOnData {
   public let isAddOn: Bool
   public let selectedQuantity: Int
+  public let limitPerBacker: Int?
 }
 
 public struct Reward {
@@ -78,7 +79,7 @@ extension Reward: Argo.Decodable {
   public static func decode(_ json: JSON) -> Decoded<Reward> {
     let tmp1 = curry(Reward.init)
       // Add-On data is not de-serialized, it's injected from GraphQL backing info.
-      <^> .success(AddOnData(isAddOn: false, selectedQuantity: 0))
+      <^> .success(AddOnData(isAddOn: false, selectedQuantity: 0, limitPerBacker: 0))
       <*> json <|? "backers_count"
       <*> json <| "converted_minimum"
       <*> (json <| "description" <|> json <| "reward")

--- a/KsApi/models/RewardAddOnSelectionViewEnvelope.swift
+++ b/KsApi/models/RewardAddOnSelectionViewEnvelope.swift
@@ -29,6 +29,7 @@ public struct RewardAddOnSelectionViewEnvelope: Swift.Decodable {
       public var isMaxPledge: Bool
       public var items: Items?
       public var limit: Int?
+      public var limitPerBacker: Int?
       public var name: String
       public var remainingQuantity: Int?
       public var shippingPreference: ShippingPreference?

--- a/KsApi/models/RewardAddOnSelectionViewEnvelopeTests.swift
+++ b/KsApi/models/RewardAddOnSelectionViewEnvelopeTests.swift
@@ -33,6 +33,7 @@ final class RewardAddOnSelectionViewEnvelopeTests: XCTestCase {
                 "nodes": []
               ],
               "limit": nil,
+              "limitPerBacker": 2,
               "name": "Crowdfunding Special",
               "remainingQuantity": nil,
               "startsAt": nil
@@ -67,6 +68,7 @@ final class RewardAddOnSelectionViewEnvelopeTests: XCTestCase {
       XCTAssertEqual(value.project.addOns?.nodes[0].isMaxPledge, false)
       XCTAssertEqual(value.project.addOns?.nodes[0].items?.nodes.count, 0)
       XCTAssertEqual(value.project.addOns?.nodes[0].limit, nil)
+      XCTAssertEqual(value.project.addOns?.nodes[0].limitPerBacker, 2)
       XCTAssertEqual(value.project.addOns?.nodes[0].remainingQuantity, nil)
       XCTAssertEqual(value.project.addOns?.nodes[0].startsAt, nil)
     } catch {

--- a/KsApi/queries/ManagePledgeViewQueries.swift
+++ b/KsApi/queries/ManagePledgeViewQueries.swift
@@ -83,6 +83,7 @@ public func managePledgeViewProjectBackingQuery(withBackingId backingId: String)
               .backersCount,
               .isMaxPledge,
               .limit,
+              .limitPerBacker,
               .items([], NonEmptySet(.nodes(.id +| [.name]))),
               .remainingQuantity,
               .shippingPreference,

--- a/KsApi/queries/ManagePledgeViewQueriesTests.swift
+++ b/KsApi/queries/ManagePledgeViewQueriesTests.swift
@@ -7,7 +7,7 @@ final class ManagePledgeViewQueriesTests: XCTestCase {
 
     // swiftformat:disable wrap
     let expected = """
-    { backing(id: "12345") { addOns { nodes { amount { amount currency symbol } backersCount description displayName estimatedDeliveryOn id isMaxPledge items { nodes { id name } } limit name remainingQuantity shippingPreference startsAt } } amount { amount currency symbol } backer { name uid } backerCompleted bonusAmount { amount currency symbol } cancelable creditCard: paymentSource { ... on CreditCard { expirationDate id lastFour paymentType type } } errorReason id location { name } pledgedOn project { name pid state } reward { amount { amount currency symbol } backersCount description displayName estimatedDeliveryOn id isMaxPledge items { nodes { id name } } name } sequence shippingAmount { amount currency symbol } status } }
+    { backing(id: "12345") { addOns { nodes { amount { amount currency symbol } backersCount description displayName estimatedDeliveryOn id isMaxPledge items { nodes { id name } } limit limitPerBacker name remainingQuantity shippingPreference startsAt } } amount { amount currency symbol } backer { name uid } backerCompleted bonusAmount { amount currency symbol } cancelable creditCard: paymentSource { ... on CreditCard { expirationDate id lastFour paymentType type } } errorReason id location { name } pledgedOn project { name pid state } reward { amount { amount currency symbol } backersCount description displayName estimatedDeliveryOn id isMaxPledge items { nodes { id name } } name } sequence shippingAmount { amount currency symbol } status } }
     """
     // swiftformat:enable wrap
 

--- a/KsApi/queries/RewardAddOnSelectionViewQueries.swift
+++ b/KsApi/queries/RewardAddOnSelectionViewQueries.swift
@@ -30,6 +30,7 @@ public func rewardAddOnSelectionViewAddOnsQuery(withProjectSlug slug: String) ->
               .backersCount,
               .isMaxPledge,
               .limit,
+              .limitPerBacker,
               .items([], NonEmptySet(.nodes(.id +| [.name]))),
               .remainingQuantity,
               .shippingPreference,

--- a/KsApi/queries/RewardAddOnSelectionViewQueriesTests.swift
+++ b/KsApi/queries/RewardAddOnSelectionViewQueriesTests.swift
@@ -7,7 +7,7 @@ final class RewardAddOnSelectionViewQueriesTests: XCTestCase {
 
     // swiftformat:disable wrap
     let expected = """
-    { project(slug: "project-slug") { actions { displayConvertAmount } addOns { nodes { amount { amount currency symbol } backersCount convertedAmount { amount currency symbol } description displayName estimatedDeliveryOn id isMaxPledge items { nodes { id name } } limit name remainingQuantity shippingPreference startsAt } } fxRate pid } }
+    { project(slug: "project-slug") { actions { displayConvertAmount } addOns { nodes { amount { amount currency symbol } backersCount convertedAmount { amount currency symbol } description displayName estimatedDeliveryOn id isMaxPledge items { nodes { id name } } limit limitPerBacker name remainingQuantity shippingPreference startsAt } } fxRate pid } }
     """
     // swiftformat:enable wrap
 

--- a/Library/SharedFunctions.swift
+++ b/Library/SharedFunctions.swift
@@ -96,8 +96,7 @@ internal func minAndMaxPledgeAmount(forProject project: Project, reward: Reward?
   // The country on the project cannot be trusted to have the min/max values, so first try looking
   // up the country in our launched countries array that we get back from the server config.
   let country = AppEnvironment.current.launchedCountries.countries
-    .filter { $0 == project.country }
-    .first
+    .first { $0 == project.country }
     .coalesceWith(project.country)
 
   switch reward {
@@ -167,16 +166,14 @@ public func updatedUserWithClearedActivityCountProducer() -> SignalProducer<User
 
 public func defaultShippingRule(fromShippingRules shippingRules: [ShippingRule]) -> ShippingRule? {
   let shippingRuleFromCurrentLocation = shippingRules
-    .filter { shippingRule in shippingRule.location.country == AppEnvironment.current.config?.countryCode }
-    .first
+    .first { shippingRule in shippingRule.location.country == AppEnvironment.current.config?.countryCode }
 
   if let shippingRuleFromCurrentLocation = shippingRuleFromCurrentLocation {
     return shippingRuleFromCurrentLocation
   }
 
   let shippingRuleInUSA = shippingRules
-    .filter { shippingRule in shippingRule.location.country == "US" }
-    .first
+    .first { shippingRule in shippingRule.location.country == "US" }
 
   return shippingRuleInUSA ?? shippingRules.first
 }

--- a/Library/Styles/Colors.swift
+++ b/Library/Styles/Colors.swift
@@ -18,6 +18,10 @@ extension UIColor {
         500: .ksr_blue_500
       ],
 
+      "Celebrate": [
+        100: .ksr_celebrate_100
+      ],
+
       "Cobalt": [
         500: .ksr_cobalt_500
       ],
@@ -99,6 +103,11 @@ extension UIColor {
   /// 0x2B60FF
   public static var ksr_blue_500: UIColor {
     return .hex(0x2B60FF)
+  }
+
+  /// 0xFFF2EC
+  public static var ksr_celebrate_100: UIColor {
+    return .hex(0xFFF2EC)
   }
 
   /// 0x4C6CF8

--- a/Library/Styles/Fonts.swift
+++ b/Library/Styles/Fonts.swift
@@ -7,6 +7,14 @@ extension UIFont {
       .map { UIFont(descriptor: $0, size: 0.0) } ?? self
   }
 
+  /// Returns a version of `self` with the desired weight.
+  public func weighted(_ weight: UIFont.Weight) -> UIFont {
+    let descriptor = self.fontDescriptor.addingAttributes([
+      .traits: [UIFontDescriptor.TraitKey.weight: weight]
+    ])
+    return UIFont(descriptor: descriptor, size: 0.0)
+  }
+
   /// Returns a italicized version of `self`.
   public var italicized: UIFont {
     return self.fontDescriptor.withSymbolicTraits(.traitItalic)

--- a/Library/ViewModels/PillCellViewModel.swift
+++ b/Library/ViewModels/PillCellViewModel.swift
@@ -3,6 +3,12 @@ import Prelude
 import ReactiveSwift
 import UIKit
 
+public typealias PillCellData = (
+  text: String,
+  textColor: UIColor,
+  backgroundColor: UIColor
+)
+
 public protocol PillCellViewModelInputs {
   func configure(with value: String)
 }

--- a/Library/ViewModels/RewardAddOnCardViewModel.swift
+++ b/Library/ViewModels/RewardAddOnCardViewModel.swift
@@ -1,0 +1,274 @@
+import KsApi
+import Prelude
+import ReactiveSwift
+
+public enum RewardAddOnCardViewContext {
+  case pledge
+  case manage
+}
+
+public typealias RewardAddOnCardViewData = (
+  project: Project,
+  reward: Reward,
+  context: RewardAddOnCardViewContext,
+  shippingRule: ShippingRule?
+)
+
+public protocol RewardAddOnCardViewModelInputs {
+  func configure(with data: RewardAddOnCardViewData)
+  func rewardAddOnCardTapped()
+}
+
+public protocol RewardAddOnCardViewModelOutputs {
+  var cardUserInteractionIsEnabled: Signal<Bool, Never> { get }
+  var amountConversionLabelHidden: Signal<Bool, Never> { get }
+  var amountConversionLabelText: Signal<String, Never> { get }
+  var amountLabelAttributedText: Signal<NSAttributedString, Never> { get }
+  var descriptionLabelText: Signal<String, Never> { get }
+  var includedItemsLabelAttributedText: Signal<NSAttributedString, Never> { get }
+  var includedItemsStackViewHidden: Signal<Bool, Never> { get }
+  var pillsViewHidden: Signal<Bool, Never> { get }
+  var reloadPills: Signal<[String], Never> { get }
+  var rewardSelected: Signal<Int, Never> { get }
+  var rewardTitleLabelText: Signal<String, Never> { get }
+}
+
+public protocol RewardAddOnCardViewModelType {
+  var inputs: RewardAddOnCardViewModelInputs { get }
+  var outputs: RewardAddOnCardViewModelOutputs { get }
+}
+
+public final class RewardAddOnCardViewModel: RewardAddOnCardViewModelType, RewardAddOnCardViewModelInputs,
+  RewardAddOnCardViewModelOutputs {
+  public init() {
+    let configData = self.configDataProperty.signal
+      .skipNil()
+
+    let project: Signal<Project, Never> = configData.map { $0.0 }
+    let reward: Signal<Reward, Never> = configData.map { $0.1 }
+
+    let projectAndReward = Signal.zip(project, reward)
+    let projectRewardShippingRule = configData.map {
+      project, reward, _, shippingRule in (project, reward, shippingRule)
+    }
+
+    self.amountConversionLabelHidden = project.map(needsConversion(project:) >>> negate)
+
+    self.amountConversionLabelText = projectRewardShippingRule
+      .filter(first >>> needsConversion(project:))
+      .map { project, reward, shippingRule -> (Project, Reward, Double) in
+        let convertedAmount = reward.minimum
+          .addingCurrency(shippingRule?.cost ?? 0)
+          .multiplyingCurrency(
+            Double(project.stats.currentCurrencyRate ?? project.stats.staticUsdRate)
+          )
+
+        return (project, reward, convertedAmount)
+      }
+      .map { project, _, amount in
+        Format.currency(
+          amount,
+          country: project.stats.currentCountry ?? .us,
+          omitCurrencyCode: project.stats.omitUSCurrencyCode
+        )
+      }
+      .map(Strings.About_reward_amount(reward_amount:))
+
+    self.amountLabelAttributedText = projectRewardShippingRule
+      .map(amountStringForReward)
+
+    self.descriptionLabelText = reward.map(\.description)
+
+    self.rewardTitleLabelText = reward.map(\.title).skipNil()
+
+    let rewardItemsIsEmpty = reward
+      .map { $0.rewardsItems.isEmpty }
+
+    let rewardAvailable = reward
+      .map { $0.remaining == 0 }.negate()
+
+    self.includedItemsStackViewHidden = rewardItemsIsEmpty.skipRepeats()
+
+    self.includedItemsLabelAttributedText = reward.map(\.rewardsItems)
+      .map(itemsLabelAttributedText)
+      .skipNil()
+
+    self.reloadPills = projectAndReward.map(pillValues(project:reward:))
+    self.pillsViewHidden = self.reloadPills.map { $0.isEmpty }
+
+    self.rewardSelected = reward
+      .takeWhen(self.rewardAddOnCardTappedProperty.signal)
+      .map { $0.id }
+
+    self.cardUserInteractionIsEnabled = rewardAvailable
+  }
+
+  private let configDataProperty = MutableProperty<RewardAddOnCardViewData?>(nil)
+  public func configure(with data: RewardAddOnCardViewData) {
+    self.configDataProperty.value = data
+  }
+
+  private let rewardAddOnCardTappedProperty = MutableProperty(())
+  public func rewardAddOnCardTapped() {
+    self.rewardAddOnCardTappedProperty.value = ()
+  }
+
+  public let amountConversionLabelHidden: Signal<Bool, Never>
+  public let amountConversionLabelText: Signal<String, Never>
+  public let amountLabelAttributedText: Signal<NSAttributedString, Never>
+  public let cardUserInteractionIsEnabled: Signal<Bool, Never>
+  public let descriptionLabelText: Signal<String, Never>
+  public let includedItemsLabelAttributedText: Signal<NSAttributedString, Never>
+  public let includedItemsStackViewHidden: Signal<Bool, Never>
+  public let pillsViewHidden: Signal<Bool, Never>
+  public let reloadPills: Signal<[String], Never>
+  public let rewardSelected: Signal<Int, Never>
+  public let rewardTitleLabelText: Signal<String, Never>
+
+  public var inputs: RewardAddOnCardViewModelInputs { return self }
+  public var outputs: RewardAddOnCardViewModelOutputs { return self }
+}
+
+// MARK: - Functions
+
+private func amountStringForReward(
+  project: Project,
+  reward: Reward,
+  shippingRule: ShippingRule?
+) -> NSAttributedString {
+  let font: UIFont = UIFont.ksr_footnote().weighted(.medium)
+  let foregroundColor: UIColor = UIColor.ksr_green_500
+
+  let min = minPledgeAmount(forProject: project, reward: reward)
+  let amountString = Format.currency(
+    min,
+    country: project.country,
+    omitCurrencyCode: project.stats.omitUSCurrencyCode
+  )
+
+  if let shippingRule = shippingRule {
+    let shippingAmount = Format.currency(
+      shippingRule.cost,
+      country: project.country,
+      omitCurrencyCode: project.stats.omitUSCurrencyCode
+    )
+
+    let combinedString = localizedString(
+      key: "reward_amount_plus_shipping_cost_each",
+      defaultValue: "%{reward_amount} + %{shipping_cost} shipping each",
+      substitutions: ["reward_amount": amountString, "shipping_cost": shippingAmount]
+    )
+
+    return combinedString.attributed(
+      with: font,
+      foregroundColor: foregroundColor,
+      attributes: [:],
+      bolding: [amountString]
+    )
+  }
+
+  return amountString.attributed(
+    with: font,
+    foregroundColor: foregroundColor,
+    attributes: [:],
+    bolding: [amountString]
+  )
+}
+
+private func itemsLabelAttributedText(_ items: [RewardsItem]) -> NSAttributedString? {
+  guard !items.isEmpty else { return nil }
+
+  let defaultAttributes: [NSAttributedString.Key: Any] = [
+    .font: UIFont.ksr_callout()
+  ]
+  let bulletPrefix = "•  "
+
+  let paragraphStyle = NSMutableParagraphStyle()
+  paragraphStyle.headIndent = (bulletPrefix as NSString).size(withAttributes: defaultAttributes).width
+  paragraphStyle.paragraphSpacing = Styles.grid(1)
+
+  let bulletedListAttributes: [NSAttributedString.Key: Any] = [.paragraphStyle: paragraphStyle]
+
+  let attributedString = NSMutableAttributedString()
+
+  items.map { rewardsItem -> NSAttributedString in
+    let itemString = rewardsItem.quantity > 1
+      ? "\(Format.wholeNumber(rewardsItem.quantity)) x \(rewardsItem.item.name)"
+      : rewardsItem.item.name
+
+    let suffix = rewardsItem.id == items.last?.id ? "" : "\n"
+
+    return NSAttributedString(
+      string: "\(bulletPrefix)\(itemString)\(suffix)",
+      attributes: defaultAttributes.withAllValuesFrom(bulletedListAttributes)
+    )
+  }
+  .forEach { bulletItem in attributedString.append(bulletItem) }
+
+  return attributedString
+}
+
+private func needsConversion(project: Project) -> Bool {
+  return project.stats.needsConversion
+}
+
+private func backingReward(fromProject project: Project) -> Reward? {
+  guard let backing = project.personalization.backing else {
+    return nil
+  }
+
+  return project.rewards
+    .first { $0.id == backing.rewardId || $0.id == backing.reward?.id }
+    .coalesceWith(.noReward)
+}
+
+private func pillValues(project: Project, reward: Reward) -> [String] {
+  return [
+    timeLeftString(project: project, reward: reward),
+    remainingString(reward: reward),
+    limitPerBackerString(reward: reward)
+  ]
+  .compact()
+}
+
+private func timeLeftString(project: Project, reward: Reward) -> String? {
+  let isUnlimitedOrAvailable = reward.limit == nil || reward.remaining ?? 0 > 0
+
+  if let endsAt = reward.endsAt,
+    endsAt > 0,
+    endsAt >= AppEnvironment.current.dateType.init().timeIntervalSince1970,
+    isUnlimitedOrAvailable {
+    let (time, unit) = Format.duration(
+      secondsInUTC: min(endsAt, project.dates.deadline),
+      abbreviate: true,
+      useToGo: false
+    )
+
+    return Strings.Time_left_left(time_left: time + " " + unit)
+  }
+
+  return nil
+}
+
+private func limitPerBackerString(reward: Reward) -> String? {
+  guard let limit = reward.addOnData?.limitPerBacker, limit > 0 else { return nil }
+
+  return localizedString(
+    key: "limit_limit_per_backer",
+    defaultValue: "Limit %{limit_per_backer}",
+    substitutions: ["limit_per_backer": "\(limit)"]
+  )
+}
+
+private func remainingString(reward: Reward) -> String? {
+  guard
+    let limit = reward.limit,
+    let remaining = reward.remaining,
+    remaining > 0
+  else { return nil }
+
+  return Strings.remaining_count_left_of_limit_count(
+    remaining_count: "\(remaining)",
+    limit_count: "\(limit)"
+  )
+}

--- a/Library/ViewModels/RewardAddOnCardViewModelTests.swift
+++ b/Library/ViewModels/RewardAddOnCardViewModelTests.swift
@@ -1,0 +1,630 @@
+import Foundation
+@testable import KsApi
+@testable import Library
+import Prelude
+import ReactiveExtensions
+import ReactiveExtensions_TestHelpers
+import ReactiveSwift
+import XCTest
+
+final class RewardAddOnCardViewModelTests: TestCase {
+  fileprivate let vm: RewardAddOnCardViewModelType = RewardAddOnCardViewModel()
+
+  private let cardUserInteractionIsEnabled = TestObserver<Bool, Never>()
+  private let amountConversionLabelHidden = TestObserver<Bool, Never>()
+  private let amountConversionLabelText = TestObserver<String, Never>()
+  private let amountLabelAttributedText = TestObserver<String, Never>()
+  private let descriptionLabelText = TestObserver<String, Never>()
+  private let estimatedDeliveryDateLabelHidden = TestObserver<Bool, Never>()
+  private let estimatedDeliveryDateLabelText = TestObserver<String, Never>()
+  private let includedItemsLabelAttributedText = TestObserver<String, Never>()
+  private let includedItemsStackViewHidden = TestObserver<Bool, Never>()
+  private let pillsViewHidden = TestObserver<Bool, Never>()
+  private let reloadPills = TestObserver<[String], Never>()
+  private let rewardSelected = TestObserver<Int, Never>()
+  private let rewardTitleLabelText = TestObserver<String, Never>()
+
+  override func setUp() {
+    super.setUp()
+
+    self.vm.outputs.amountLabelAttributedText.map(\.string)
+      .observe(self.amountLabelAttributedText.observer)
+    self.vm.outputs.amountConversionLabelHidden.observe(self.amountConversionLabelHidden.observer)
+    self.vm.outputs.amountConversionLabelText.observe(self.amountConversionLabelText.observer)
+    self.vm.outputs.cardUserInteractionIsEnabled.observe(self.cardUserInteractionIsEnabled.observer)
+    self.vm.outputs.descriptionLabelText.observe(self.descriptionLabelText.observer)
+    self.vm.outputs.includedItemsLabelAttributedText.map(\.string)
+      .observe(self.includedItemsLabelAttributedText.observer)
+    self.vm.outputs.includedItemsStackViewHidden.observe(self.includedItemsStackViewHidden.observer)
+    self.vm.outputs.pillsViewHidden.observe(self.pillsViewHidden.observer)
+    self.vm.outputs.reloadPills.observe(self.reloadPills.observer)
+    self.vm.outputs.rewardSelected.observe(self.rewardSelected.observer)
+    self.vm.outputs.rewardTitleLabelText.observe(self.rewardTitleLabelText.observer)
+  }
+
+  // MARK: - Reward Title
+
+  func testTitleLabel() {
+    let reward = .template
+      |> Reward.lens.title .~ "The thing"
+      |> Reward.lens.remaining .~ nil
+
+    self.vm.inputs.configure(with: (.template, reward, .pledge, nil))
+
+    self.rewardTitleLabelText.assertValues(["The thing"])
+  }
+
+  func testTitleLabel_NoTitle() {
+    let reward = .template
+      |> Reward.lens.title .~ nil
+      |> Reward.lens.remaining .~ nil
+
+    self.vm.inputs.configure(with: (.template, reward, .pledge, nil))
+
+    self.rewardTitleLabelText.assertValues([])
+  }
+
+  func testTitleLabel_Backed_AddOn() {
+    let project = Project.template
+      |> Project.lens.personalization.isBacking .~ true
+
+    let reward = .template
+      |> \.addOnData .~ AddOnData(isAddOn: true, selectedQuantity: 2, limitPerBacker: 2)
+      |> Reward.lens.title .~ "The thing"
+      |> Reward.lens.remaining .~ nil
+
+    self.vm.inputs.configure(with: (project, reward, .pledge, nil))
+
+    self.rewardTitleLabelText.assertValues(["The thing"])
+  }
+
+  // MARK: - Reward Minimum
+
+  func testMinimumLabel_US_Project_US_UserLocation() {
+    let project = Project.template
+      |> Project.lens.country .~ .us
+    let reward = .template |> Reward.lens.minimum .~ 1_000
+
+    withEnvironment(countryCode: "US") {
+      self.vm.inputs.configure(with: (project, reward, .pledge, nil))
+
+      self.amountLabelAttributedText.assertValues(
+        ["$1,000"],
+        "Reward minimum appears in project's currency, without a currency symbol."
+      )
+    }
+  }
+
+  func testMinimumLabel_US_Project_NonUS_UserLocation() {
+    let project = Project.template
+      |> Project.lens.country .~ .us
+    let reward = .template |> Reward.lens.minimum .~ 1_000
+
+    withEnvironment(countryCode: "MX") {
+      self.vm.inputs.configure(with: (project, reward, .pledge, nil))
+
+      self.amountLabelAttributedText.assertValues(
+        ["US$ 1,000"],
+        "Reward minimum appears in project's currency, with a currency symbol."
+      )
+    }
+  }
+
+  func testMinimumLabel_NonUS_Project_US_User_Currency_US_UserLocation() {
+    let project = Project.template
+      |> Project.lens.country .~ .gb
+      |> Project.lens.stats.currency .~ Project.Country.gb.currencyCode
+      |> Project.lens.stats.currentCurrency .~ Project.Country.us.currencyCode
+      |> Project.lens.stats.currentCurrencyRate .~ 0.5
+    let reward = .template |> Reward.lens.minimum .~ 1_000
+
+    withEnvironment(countryCode: "US") {
+      self.vm.inputs.configure(with: (project, reward, .pledge, nil))
+
+      self.amountLabelAttributedText.assertValues(
+        ["£1,000"],
+        "Reward minimum always appears in the project's currency."
+      )
+    }
+  }
+
+  func testMinimumLabel_NonUs_Project_US_UserCurrency_NonUS_UserLocation() {
+    let project = Project.template
+      |> Project.lens.country .~ .gb
+      |> Project.lens.stats.currency .~ Project.Country.gb.currencyCode
+      |> Project.lens.stats.currentCurrency .~ Project.Country.us.currencyCode
+      |> Project.lens.stats.currentCurrencyRate .~ 0.5
+    let reward = .template |> Reward.lens.minimum .~ 1_000
+
+    withEnvironment(countryCode: "MX") {
+      self.vm.inputs.configure(with: (project, reward, .pledge, nil))
+
+      self.amountLabelAttributedText.assertValues(
+        ["£1,000"],
+        "Reward minimum always appears in the project's currency."
+      )
+    }
+  }
+
+  func testMinimumLabel_NoReward_US_Project_US_UserLocation() {
+    let project = Project.template
+      |> Project.lens.country .~ .us
+    let reward = Reward.noReward
+
+    withEnvironment(countryCode: "US") {
+      self.vm.inputs.configure(with: (project, reward, .pledge, nil))
+
+      self.amountLabelAttributedText.assertValues(
+        ["$1"],
+        "No-reward min appears in the project's currency without a currency symbol"
+      )
+    }
+  }
+
+  func testMinimumLabel_NoReward_US_Project_NonUS_UserLocation() {
+    let project = Project.template
+      |> Project.lens.country .~ .us
+    let reward = Reward.noReward
+
+    withEnvironment(countryCode: "MX") {
+      self.vm.inputs.configure(with: (project, reward, .pledge, nil))
+
+      self.amountLabelAttributedText.assertValues(
+        ["US$ 1"],
+        "No-reward min appears in the project's currency with a currency symbol"
+      )
+    }
+  }
+
+  func testMinimumLabel_NoReward_NonUS_Project_US_UserLocation() {
+    let project = Project.template
+      |> Project.lens.country .~ Project.Country.mx
+    let reward = Reward.noReward
+
+    withEnvironment(countryCode: "US") {
+      self.vm.inputs.configure(with: (project, reward, .pledge, nil))
+
+      self.amountLabelAttributedText.assertValues(
+        ["MX$ 10"],
+        """
+        No-reward min always appears in the project's currency,
+        with the amount depending on the project's country
+        """
+      )
+    }
+  }
+
+  func testMinimumLabel_NoReward_NonUS_Project_NonUS_UserLocation() {
+    let project = Project.template
+      |> Project.lens.country .~ Project.Country.mx
+    let reward = Reward.noReward
+
+    withEnvironment(countryCode: "CA") {
+      self.vm.inputs.configure(with: (project, reward, .pledge, nil))
+
+      self.amountLabelAttributedText.assertValues(
+        ["MX$ 10"],
+        """
+        No-reward min always appears in the project's currency,
+        with the amount depending on the project's country
+        """
+      )
+    }
+  }
+
+  // MARK: - Included Items
+
+  func testItems() {
+    let reward = .template
+      |> Reward.lens.rewardsItems .~ [
+        .template
+          |> RewardsItem.lens.item .~ (
+            .template
+              |> Item.lens.name .~ "The thing"
+          ),
+        .template
+          |> RewardsItem.lens.quantity .~ 1_000
+          |> RewardsItem.lens.item .~ (
+            .template
+              |> Item.lens.name .~ "The other thing"
+          )
+      ]
+
+    self.vm.inputs.configure(with: (.template, reward, .pledge, nil))
+
+    self.includedItemsLabelAttributedText.assertValues(["•  The thing•  1,000 x The other thing"])
+    self.includedItemsStackViewHidden.assertValues([false])
+  }
+
+  func testItemsContainerHidden_WithNoItems() {
+    self.vm.inputs.configure(with: (
+      project: .template,
+      reward: .template |> Reward.lens.rewardsItems .~ [],
+      context: .pledge,
+      nil
+    ))
+
+    self.includedItemsStackViewHidden.assertValues([true])
+  }
+
+  // MARK: Description Label
+
+  func testDescriptionLabel() {
+    let project = Project.template
+    let reward = Reward.template
+
+    self.vm.inputs.configure(with: (project, reward, .pledge, nil))
+
+    self.descriptionLabelText.assertValues([reward.description])
+  }
+
+  // MARK: - Conversion Label
+
+  func testConversionLabel_US_UserCurrency_US_Location_US_Project_ConfiguredWithReward() {
+    let project = .template
+      |> Project.lens.country .~ .us
+      |> Project.lens.stats.currency .~ "USD"
+      |> Project.lens.stats.currentCurrency .~ "USD"
+    let reward = .template |> Reward.lens.minimum .~ 1_000
+
+    withEnvironment(countryCode: "US") {
+      self.vm.inputs.configure(with: (project, reward, .pledge, nil))
+
+      self.amountConversionLabelHidden.assertValues(
+        [true],
+        "US user with US currency preferences, viewing US project does not see conversion."
+      )
+      self.amountConversionLabelText.assertValueCount(0)
+    }
+  }
+
+  func testConversionLabel_US_UserCurrency_US_Location_NonUS_Project_ConfiguredWithReward() {
+    let project = .template
+      |> Project.lens.country .~ .ca
+      |> Project.lens.stats.currency .~ Project.Country.ca.currencyCode
+      |> Project.lens.stats.currentCurrency .~ Project.Country.us.currencyCode
+      |> Project.lens.stats.currentCurrencyRate .~ 2
+    let reward = .template |> Reward.lens.minimum .~ 1
+
+    withEnvironment(countryCode: "US") {
+      self.vm.inputs.configure(with: (project, reward, .pledge, nil))
+
+      self.amountConversionLabelHidden.assertValues(
+        [false],
+        """
+        US user with US currency preferences, viewing non-US project sees conversion.
+        """
+      )
+      self.amountConversionLabelText.assertValues(["About $2"], "Conversion without a currency symbol")
+    }
+  }
+
+  func testConversionLabel_US_Currency_NonUS_Location_NonUS_Project_ConfiguredWithReward() {
+    let project = .template
+      |> Project.lens.country .~ .ca
+      |> Project.lens.stats.currency .~ Project.Country.ca.currencyCode
+      |> Project.lens.stats.currentCurrency .~ Project.Country.us.currencyCode
+      |> Project.lens.stats.currentCurrencyRate .~ 2
+    let reward = .template |> Reward.lens.minimum .~ 1
+
+    withEnvironment(countryCode: "MX") {
+      self.vm.inputs.configure(with: (project, reward, .pledge, nil))
+
+      self.amountConversionLabelHidden.assertValues(
+        [false],
+        """
+        User with US currency preferences, non-US location, viewing non-US project sees conversion.
+        """
+      )
+      self.amountConversionLabelText.assertValues(["About US$ 2"], "Conversion label shows US symbol.")
+    }
+  }
+
+  func testConversionLabel_Unknown_Location_US_Project_ConfiguredWithReward_WithoutUserCurrency() {
+    let project = .template
+      |> Project.lens.country .~ .us
+      |> Project.lens.stats.currency .~ Project.Country.us.currencyCode
+      |> Project.lens.stats.currentCurrency .~ nil
+      |> Project.lens.stats.currentCurrencyRate .~ nil
+    let reward = .template |> Reward.lens.minimum .~ 1
+
+    withEnvironment(countryCode: "XX") {
+      self.vm.inputs.configure(with: (project, reward, .pledge, nil))
+
+      self.amountConversionLabelHidden.assertValues(
+        [true],
+        "Unknown-location, unknown-currency user viewing US project does not see conversion."
+      )
+    }
+  }
+
+  func testConversionLabel_Unknown_Location_NonUS_Project_ConfiguredWithReward_WithoutUserCurrency() {
+    let project = .template
+      |> Project.lens.country .~ .ca
+      |> Project.lens.stats.currency .~ Project.Country.ca.currencyCode
+      |> Project.lens.stats.currentCurrency .~ nil
+      |> Project.lens.stats.currentCurrencyRate .~ nil
+    let reward = .template
+      |> Reward.lens.minimum .~ 2
+
+    withEnvironment(countryCode: "XX") {
+      self.vm.inputs.configure(with: (project, reward, .pledge, nil))
+
+      self.amountConversionLabelHidden.assertValues(
+        [false],
+        "Unknown-location, unknown-currency user viewing non-US project sees conversion to USD."
+      )
+      self.amountConversionLabelText.assertValues(
+        ["About US$ 2"],
+        "Conversion label shows convertedMinimum value."
+      )
+    }
+  }
+
+  func testConversionLabel_NonUS_Location_NonUS_Locale_US_Project_ConfiguredWithReward() {
+    let project = .template
+      |> Project.lens.country .~ .us
+      |> Project.lens.stats.currency .~ Project.Country.us.currencyCode
+      |> Project.lens.stats.currentCurrency .~ Project.Country.mx.currencyCode
+      |> Project.lens.stats.currentCurrencyRate .~ 2
+    let reward = .template
+      |> Reward.lens.minimum .~ 1
+
+    withEnvironment(
+      apiService: MockService(currency: "MXN"), countryCode: "MX"
+    ) {
+      self.vm.inputs.configure(with: (project, reward, .pledge, nil))
+
+      self.amountConversionLabelHidden.assertValues(
+        [false],
+        "Mexican user viewing US project sees conversion."
+      )
+      self.amountConversionLabelText.assertValues(
+        ["About MX$ 2"],
+        "Conversion label shows convertedMinimum value."
+      )
+    }
+  }
+
+  func testConversionLabel_NonUS_Location_NonUS_Locale_US_Project_ConfiguredWithReward_WithShippingRule() {
+    let project = .template
+      |> Project.lens.country .~ .us
+      |> Project.lens.stats.currency .~ Project.Country.us.currencyCode
+      |> Project.lens.stats.currentCurrency .~ Project.Country.mx.currencyCode
+      |> Project.lens.stats.currentCurrencyRate .~ 2
+    let reward = .template
+      |> Reward.lens.minimum .~ 1
+      |> Reward.lens.shipping.enabled .~ true
+
+    withEnvironment(
+      apiService: MockService(currency: "MXN"), countryCode: "MX"
+    ) {
+      self.vm.inputs.configure(with: (project, reward, .pledge, .template))
+
+      self.amountConversionLabelHidden.assertValues(
+        [false],
+        "Mexican user viewing US project sees conversion."
+      )
+      self.amountConversionLabelText.assertValues(
+        ["About MX$ 12"],
+        "Conversion label shows convertedMinimum value including shipping amount."
+      )
+    }
+  }
+
+  func testConversionLabel_NonUS_Location_US_UserCurrency_US_Project_ConfiguredWithReward() {
+    let project = .template
+      |> Project.lens.country .~ .us
+      |> Project.lens.stats.currency .~ Project.Country.us.currencyCode
+      |> Project.lens.stats.currentCurrency .~ Project.Country.us.currencyCode
+    let reward = .template |> Reward.lens.minimum .~ 1_000
+
+    withEnvironment(countryCode: "GB") {
+      self.vm.inputs.configure(with: (project, reward, .pledge, nil))
+
+      self.amountConversionLabelHidden.assertValues(
+        [true],
+        "Non-US user location with USD user preferences viewing US project does not see conversion."
+      )
+      self.amountConversionLabelText.assertValueCount(0)
+    }
+  }
+
+  // MARK: - Card View
+
+  func testCardUserInteractionIsEnabled_NotLimitedReward() {
+    let project = Project.template
+    let reward = Reward.template
+      |> Reward.lens.remaining .~ nil
+      |> Reward.lens.minimum .~ 1_000
+
+    self.vm.inputs.configure(with: (project, reward, .pledge, nil))
+
+    self.cardUserInteractionIsEnabled.assertValues([true])
+  }
+
+  func testCardUserInteractionIsEnabled_NotAllGone() {
+    let project = Project.template
+    let reward = Reward.template
+      |> Reward.lens.remaining .~ 10
+      |> Reward.lens.minimum .~ 1_000.0
+
+    self.vm.inputs.configure(with: (project, reward, .pledge, nil))
+
+    self.cardUserInteractionIsEnabled.assertValues([true])
+  }
+
+  func testCardUserInteractionIsEnabled_AllGone() {
+    let project = Project.template
+    let reward = Reward.template
+      |> Reward.lens.remaining .~ 0
+      |> Reward.lens.minimum .~ 1_000.0
+
+    self.vm.inputs.configure(with: (project, reward, .pledge, nil))
+
+    self.cardUserInteractionIsEnabled.assertValues([false])
+  }
+
+  // MARK: - Pills
+
+  func testPillsLimitedReward() {
+    self.pillsViewHidden.assertValueCount(0)
+    self.reloadPills.assertValueCount(0)
+
+    let reward = Reward.postcards
+      |> Reward.lens.limit .~ 100
+      |> Reward.lens.remaining .~ 25
+
+    self.vm.inputs.configure(with: (.template, reward, .pledge, nil))
+
+    self.pillsViewHidden.assertValues([false])
+    self.reloadPills.assertValues([
+      ["25 left of 100"]
+    ])
+  }
+
+  func testPillsLimitedReward_HasBackers() {
+    self.pillsViewHidden.assertValueCount(0)
+    self.reloadPills.assertValueCount(0)
+
+    let reward = Reward.postcards
+      |> Reward.lens.limit .~ 100
+      |> Reward.lens.backersCount .~ 25
+      |> Reward.lens.remaining .~ 25
+
+    self.vm.inputs.configure(with: (.template, reward, .pledge, nil))
+
+    self.pillsViewHidden.assertValues([false])
+    self.reloadPills.assertValues([
+      ["25 left of 100"]
+    ])
+  }
+
+  func testPillsTimebasedReward_24hrs() {
+    self.pillsViewHidden.assertValueCount(0)
+    self.reloadPills.assertValueCount(0)
+
+    let reward = Reward.postcards
+      |> Reward.lens.limit .~ nil
+      |> Reward.lens.backersCount .~ nil
+      |> Reward.lens.remaining .~ nil
+      |> Reward.lens.endsAt .~ (MockDate().timeIntervalSince1970 + 60.0 * 60.0 * 24.0)
+
+    self.vm.inputs.configure(with: (.template, reward, .pledge, nil))
+
+    self.pillsViewHidden.assertValues([false])
+    self.reloadPills.assertValues([
+      ["24 hrs left"]
+    ])
+  }
+
+  func testPillsTimebasedReward_4days() {
+    self.pillsViewHidden.assertValueCount(0)
+    self.reloadPills.assertValueCount(0)
+
+    let date = AppEnvironment.current.calendar.date(byAdding: DateComponents(day: 4), to: MockDate().date)
+
+    let reward = Reward.postcards
+      |> Reward.lens.limit .~ nil
+      |> Reward.lens.backersCount .~ nil
+      |> Reward.lens.remaining .~ nil
+      |> Reward.lens.endsAt .~ date?.timeIntervalSince1970
+
+    self.vm.inputs.configure(with: (.template, reward, .pledge, nil))
+
+    self.pillsViewHidden.assertValues([false])
+    self.reloadPills.assertValues([
+      ["4 days left"]
+    ])
+  }
+
+  func testPillsTimebasedAndLimitedReward() {
+    self.pillsViewHidden.assertValueCount(0)
+    self.reloadPills.assertValueCount(0)
+
+    let date = AppEnvironment.current.calendar.date(byAdding: DateComponents(day: 4), to: MockDate().date)
+
+    let reward = Reward.postcards
+      |> Reward.lens.limit .~ 100
+      |> Reward.lens.backersCount .~ nil
+      |> Reward.lens.remaining .~ 75
+      |> Reward.lens.endsAt .~ date?.timeIntervalSince1970
+
+    self.vm.inputs.configure(with: (.template, reward, .pledge, nil))
+
+    self.pillsViewHidden.assertValues([false])
+    self.reloadPills.assertValues([
+      ["4 days left", "75 left of 100"]
+    ])
+  }
+
+  func testPillsTimebasedAndLimitedRewardLimitPerBacker() {
+    self.pillsViewHidden.assertValueCount(0)
+    self.reloadPills.assertValueCount(0)
+
+    let date = AppEnvironment.current.calendar.date(byAdding: DateComponents(day: 4), to: MockDate().date)
+
+    let reward = Reward.postcards
+      |> Reward.lens.addOnData .~ AddOnData(isAddOn: true, selectedQuantity: 0, limitPerBacker: 2)
+      |> Reward.lens.limit .~ 100
+      |> Reward.lens.backersCount .~ nil
+      |> Reward.lens.remaining .~ 75
+      |> Reward.lens.endsAt .~ date?.timeIntervalSince1970
+
+    self.vm.inputs.configure(with: (.template, reward, .pledge, nil))
+
+    self.pillsViewHidden.assertValues([false])
+    self.reloadPills.assertValues([
+      ["4 days left", "75 left of 100", "Limit 2"]
+    ])
+  }
+
+  func testPillsTimebasedAndLimitedReward_Unavailable_NoBackers() {
+    self.pillsViewHidden.assertValueCount(0)
+    self.reloadPills.assertValueCount(0)
+
+    let reward = Reward.postcards
+      |> Reward.lens.limit .~ 100
+      |> Reward.lens.backersCount .~ nil
+      |> Reward.lens.remaining .~ 0
+      |> Reward.lens.endsAt .~ (MockDate().date.timeIntervalSince1970 - 1)
+
+    self.vm.inputs.configure(with: (.template, reward, .pledge, nil))
+
+    self.pillsViewHidden.assertValues([true])
+    self.reloadPills.assertValues([[]])
+  }
+
+  func testPillsNonLimitedReward() {
+    self.pillsViewHidden.assertValueCount(0)
+    self.reloadPills.assertValueCount(0)
+
+    let reward = Reward.postcards
+      |> Reward.lens.limit .~ nil
+      |> Reward.lens.backersCount .~ nil
+      |> Reward.lens.endsAt .~ nil
+
+    self.vm.inputs.configure(with: (.template, reward, .pledge, nil))
+
+    self.pillsViewHidden.assertValues([true])
+    self.reloadPills.assertValues([[]])
+  }
+
+  func testPillsLimitedReward_LiveProject_HasBackers() {
+    self.pillsViewHidden.assertValueCount(0)
+    self.reloadPills.assertValueCount(0)
+
+    let reward = Reward.postcards
+      |> Reward.lens.limit .~ 100
+      |> Reward.lens.remaining .~ 50
+      |> Reward.lens.backersCount .~ 50
+
+    let project = Project.template
+      |> Project.lens.state .~ .live
+
+    self.vm.inputs.configure(with: (project, reward, .pledge, nil))
+
+    self.pillsViewHidden.assertValues([false])
+    self.reloadPills.assertValues([["50 left of 100"]])
+  }
+}

--- a/Library/ViewModels/RewardAddOnSelectionViewModel.swift
+++ b/Library/ViewModels/RewardAddOnSelectionViewModel.swift
@@ -5,6 +5,7 @@ import ReactiveSwift
 public struct RewardAddOnCellData: Equatable {
   public let project: Project
   public let reward: Reward
+  public let shippingRule: ShippingRule?
 }
 
 public protocol RewardAddOnSelectionViewModelInputs {
@@ -50,9 +51,15 @@ public final class RewardAddOnSelectionViewModel: RewardAddOnSelectionViewModelT
 
     let addOns = addOnsEvent.values()
 
+    let shippingRule = Signal.merge(
+      self.shippingRuleSelectedProperty.signal,
+      reward.filter { reward in !reward.shipping.enabled }.mapConst(nil)
+    )
+
     self.loadAddOnRewardsIntoDataSource = Signal.combineLatest(
       addOns,
-      project
+      project,
+      shippingRule
     )
     .map(rewardsData)
 
@@ -88,7 +95,8 @@ public final class RewardAddOnSelectionViewModel: RewardAddOnSelectionViewModelT
 
 private func rewardsData(
   from envelope: RewardAddOnSelectionViewEnvelope,
-  with project: Project
+  with project: Project,
+  shippingRule: ShippingRule?
 ) -> [RewardAddOnCellData] {
   guard let addOns = envelope.project.addOns?.nodes else { return [] }
 
@@ -110,5 +118,5 @@ private func rewardsData(
       dateFormatter: dateFormatter
     )
   }
-  .map { reward in .init(project: project, reward: reward) }
+  .map { reward in .init(project: project, reward: reward, shippingRule: shippingRule) }
 }

--- a/Library/ViewModels/RewardAddOnSelectionViewModelTests.swift
+++ b/Library/ViewModels/RewardAddOnSelectionViewModelTests.swift
@@ -65,7 +65,8 @@ final class RewardAddOnSelectionViewModelTests: TestCase {
 
     let expected = RewardAddOnCellData(
       project: project,
-      reward: addOnReward
+      reward: addOnReward,
+      shippingRule: nil
     )
 
     let mockService = MockService(fetchRewardAddOnsSelectionViewRewardsResult: .success(env))

--- a/Library/ViewModels/RewardCardViewModelTests.swift
+++ b/Library/ViewModels/RewardCardViewModelTests.swift
@@ -104,7 +104,7 @@ final class RewardCardViewModelTests: TestCase {
       |> Project.lens.personalization.isBacking .~ true
 
     let reward = .template
-      |> \.addOnData .~ AddOnData(isAddOn: true, selectedQuantity: 2)
+      |> \.addOnData .~ AddOnData(isAddOn: true, selectedQuantity: 2, limitPerBacker: 0)
       |> Reward.lens.title .~ "The thing"
       |> Reward.lens.remaining .~ nil
 

--- a/bin/ColorScript/Resources/Colors.json
+++ b/bin/ColorScript/Resources/Colors.json
@@ -2,6 +2,7 @@
   "apricot_500": "FFCBA9",
   "blue_500": "2B60FF",
   "cobalt_500": "4C6CF8",
+  "celebrate_100": "FFF2EC",
   "dark_grey_400": "9B9E9E",
   "dark_grey_500": "656868",
   "facebookBlue": "1877F2",


### PR DESCRIPTION
# 📲 What

Adds the UI elements to the `RewardAddOnCell` which we added in #1246.

**Note:** Interaction with the cell (adding to reward) will be added in a subsequent PR.

# 🤔 Why

These cells are similar to the standard `RewardCell` shown in the rewards carousel but differ enough to warrant a separate view.

# 🛠 How

- Brought over most of the UI elements from `RewardCardView` and updated/renamed them where necessary.
- Added `PillsView` which is a manual implementation of the the pills collection view that we have used elsewhere. We've found that sizing the collection view has been problematic and I wanted to see if doing this manually would improve things. So far it seems to be working well.
- Added VM and tests.

# 👀 See

| Before 🐛 | After 🦋 |
| --- | --- |
| <img width="545" alt="image" src="https://user-images.githubusercontent.com/3735375/86986005-70f27c80-c147-11ea-9439-50d568c71639.png"> | <img width="545" alt="image" src="https://user-images.githubusercontent.com/3735375/87377987-b648ec80-c541-11ea-9606-335be2b50040.png"> |

# ♿️ Accessibility 

- [X] Supports Dynamic Type 

# ✅ Acceptance criteria

- [ ] Navigate to a reward that has add-ons, observe that the new card UI is shown.