### PR TITLE
[NT-1366] Add-Ons Header Font Size Fix

### DIFF
--- a/Kickstarter-iOS/Views/Controllers/RewardAddOnSelectionViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/RewardAddOnSelectionViewController.swift
@@ -73,7 +73,7 @@ final class RewardAddOnSelectionViewController: UITableViewController {
 
     _ = self.headerLabel
       |> \.numberOfLines .~ 0
-      |> \.font .~ UIFont.ksr_title1().bolded
+      |> \.font .~ UIFont.ksr_title2().bolded
       |> \.text .~ localizedString(
         key: "Customize_your_reward_with_optional_addons",
         defaultValue: "Customize your reward with optional add-ons."

--- a/Kickstarter-iOS/Views/PillsView.swift
+++ b/Kickstarter-iOS/Views/PillsView.swift
@@ -33,7 +33,7 @@ private class PillView: UIView {
     self.label.textAlignment = .center
     self.label.font = data.font
     self.label.textColor = data.textColor
-    self.label.backgroundColor = data.backgroundColor
+    self.backgroundColor = data.backgroundColor
 
     self.addSubview(self.label)
   }


### PR DESCRIPTION
# 📲 What

- Fixes the font size for the add-ons selection view header.
- Minor tweak to the `PillView` `backgroundColor` which fixes visual artifact see in _before_ screenshot below.

# 🤔 Why

The font size didn't match the designs.

# 🛠 How

Updates the font and color 🎨 

# 👀 See

| Before 🐛 | After 🦋 |
| --- | --- |
| <img width="545" alt="image" src="https://user-images.githubusercontent.com/3735375/87456408-bede0900-c5bb-11ea-9c7b-7724dcfd7a67.png"> | <img width="545" alt="image" src="https://user-images.githubusercontent.com/3735375/87456314-9524e200-c5bb-11ea-84b3-eac69a149cdc.png"> |

# ✅ Acceptance criteria

- [x] @colleenmacd to confirm font size.