### PR TITLE
[NT-214] Add Tracking Event on Tapping Manage in Activity Feed

### DIFF
--- a/Library/Tracking/Koala.swift
+++ b/Library/Tracking/Koala.swift
@@ -849,6 +849,20 @@ public final class Koala {
     )
   }
 
+  /** Call when the Manage button is tapped on the activity feed to fix an errored pledge.
+
+   - parameter project: the project that was pledged to.
+   */
+  public func trackActivitiesManagePledgeButtonClicked(project: Project) {
+    let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
+      .withAllValuesFrom(contextProperties(pledgeFlowContext: .fixErroredPledge))
+    self.track(
+      event: DataLakeApprovedEvent.managePledgeButtonClicked.rawValue,
+      location: .activities,
+      properties: props
+    )
+  }
+
   // MARK: - Login/Signup Events
 
   /* Call when the Login or Signup button entry-point is tapped

--- a/Library/ViewModels/ActivitiesViewModelTests.swift
+++ b/Library/ViewModels/ActivitiesViewModelTests.swift
@@ -550,6 +550,30 @@ final class ActivitiesViewModelTests: TestCase {
     self.goToManagePledgeBackingParam.assertValues([.id(backingId)])
   }
 
+  func testTracking_GoToManagePledge() {
+    withEnvironment(
+      apiService: MockService(fetchActivitiesResponse: [.template]),
+      currentUser: .template
+    ) {
+      self.vm.inputs.viewDidLoad()
+      self.vm.inputs.viewWillAppear(animated: false)
+      self.vm.inputs.userSessionStarted()
+      self.scheduler.advance()
+
+      let backing = GraphBacking.template
+        |> \.project .~ .template
+
+      XCTAssertEqual(self.trackingClient.events, ["Activity Feed Viewed"])
+
+      self.vm.inputs.erroredBackingViewDidTapManage(with: backing)
+
+      XCTAssertEqual(
+        self.trackingClient.events,
+        ["Activity Feed Viewed", "Manage Pledge Button Clicked"]
+      )
+    }
+  }
+
   func testUpdateUserInEnvironmentOnManagePledgeViewDidFinish() {
     let user = User.template
 


### PR DESCRIPTION
# 📲 What

Adds the event `Manage Pledge Button Clicked` when tapping manage on an errored pledge in the activities feed.

# 🤔 Why

This is a tracking event that we still needed to add for fixing errored pledges.

# 🛠 How

Added the event and tests.

# ✅ Acceptance criteria

- [ ] Tap _manage_ on an errored pledge cell in `ActivitiesViewController`, observe that this event is tracked.