### PR TITLE
[NT-1450] Allow Dissimilar Shipping Cost for Add-Ons

### DIFF
--- a/Kickstarter-iOS/Views/Controllers/PledgeAmountViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/PledgeAmountViewController.swift
@@ -198,8 +198,8 @@ final class PledgeAmountViewController: UIViewController {
 
   // MARK: - Accessors
 
-  func selectedShippingAmountChanged(to amount: Double) {
-    self.viewModel.inputs.selectedShippingAmountChanged(to: amount)
+  func unavailableAmountChanged(to amount: Double) {
+    self.viewModel.inputs.unavailableAmountChanged(to: amount)
   }
 }
 

--- a/Kickstarter-iOS/Views/Controllers/PledgeViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/PledgeViewController.swift
@@ -329,10 +329,10 @@ final class PledgeViewController: UIViewController,
         self?.pledgeCTAContainerView.configureWith(value: value)
       }
 
-    self.viewModel.outputs.notifyPledgeAmountViewControllerShippingAmountChanged
+    self.viewModel.outputs.notifyPledgeAmountViewControllerUnavailableAmountChanged
       .observeForUI()
       .observeValues { [weak self] amount in
-        self?.pledgeAmountViewController.selectedShippingAmountChanged(to: amount)
+        self?.pledgeAmountViewController.unavailableAmountChanged(to: amount)
       }
 
     self.viewModel.outputs.configureSummaryViewControllerWithData

--- a/KsApi/GraphSchema.swift
+++ b/KsApi/GraphSchema.swift
@@ -316,6 +316,7 @@ public enum Query {
   }
 
   public enum ShippingRule {
+    case cost(NonEmptySet<Money>)
     case id
     case location(NonEmptySet<Location>)
   }
@@ -580,6 +581,7 @@ extension Query.BankAccount: QueryType {
 extension Query.ShippingRule: QueryType {
   public var description: String {
     switch self {
+    case let .cost(fields): return "cost { \(join(fields)) }"
     case .id: return "id"
     case let .location(fields): return "location { \(join(fields)) }"
     }

--- a/KsApi/models/Reward+ManagePledgeView.swift
+++ b/KsApi/models/Reward+ManagePledgeView.swift
@@ -43,6 +43,7 @@ public extension Reward {
       remaining: backingReward.remainingQuantity,
       rewardsItems: rewardItemsData(from: backingReward, with: project),
       shipping: shippingData(from: backingReward),
+      shippingRules: nil,
       startsAt: backingReward.startsAt,
       title: backingReward.name
     )

--- a/KsApi/models/Reward+RewardAddOnSelectionView.swift
+++ b/KsApi/models/Reward+RewardAddOnSelectionView.swift
@@ -43,6 +43,7 @@ public extension Reward {
       remaining: reward.remainingQuantity,
       rewardsItems: rewardItemsData(from: reward, with: project),
       shipping: shippingData(from: reward),
+      shippingRules: shippingRulesData(from: reward),
       startsAt: reward.startsAt,
       title: reward.name
     )
@@ -84,4 +85,24 @@ private func shippingData(
     summary: nil,
     type: nil
   )
+}
+
+private func shippingRulesData(
+  from reward: RewardAddOnSelectionViewEnvelope.Project.Reward
+) -> [ShippingRule]? {
+  guard let shippingRules = reward.shippingRules else { return nil }
+
+  return shippingRules.map { shippingRule in
+    ShippingRule(
+      cost: shippingRule.cost.amount,
+      id: decompose(id: shippingRule.id),
+      location: Location(
+        country: shippingRule.location.country,
+        displayableName: shippingRule.location.displayableName,
+        id: decompose(id: shippingRule.location.id) ?? 0,
+        localizedName: shippingRule.location.countryName,
+        name: shippingRule.location.name
+      )
+    )
+  }
 }

--- a/KsApi/models/Reward.swift
+++ b/KsApi/models/Reward.swift
@@ -34,7 +34,8 @@ public struct Reward {
 
   /**
    Returns the closest matching `ShippingRule` for this `Reward` to `otherShippingRule`.
-   If no match is found `otherShippingRule` is returned.
+   If no match is found `otherShippingRule` is returned, this is to be backward-compatible
+   with v1 Rewards that do not include the `shippingRules` array.
    */
   public func shippingRule(matching otherShippingRule: ShippingRule?) -> ShippingRule? {
     return self.shippingRules?

--- a/KsApi/models/Reward.swift
+++ b/KsApi/models/Reward.swift
@@ -10,7 +10,7 @@ public struct AddOnData {
 }
 
 public struct Reward {
-  public var addOnData: AddOnData?
+  public var addOnData: AddOnData? // FIXME: to be removed in future
   public let backersCount: Int?
   public let convertedMinimum: Double
   public let description: String
@@ -22,7 +22,8 @@ public struct Reward {
   public let minimum: Double
   public let remaining: Int?
   public let rewardsItems: [RewardsItem]
-  public let shipping: Shipping
+  public let shipping: Shipping // only v1
+  public let shippingRules: [ShippingRule]? // only GraphQL
   public let startsAt: TimeInterval?
   public let title: String?
 
@@ -31,9 +32,19 @@ public struct Reward {
     return self.id == Reward.noReward.id
   }
 
+  /**
+   Returns the closest matching `ShippingRule` for this `Reward` to `otherShippingRule`.
+   If no match is found `otherShippingRule` is returned.
+   */
+  public func shippingRule(matching otherShippingRule: ShippingRule?) -> ShippingRule? {
+    return self.shippingRules?
+      .first { shippingRule in shippingRule.location.id == otherShippingRule?.location.id }
+      ?? otherShippingRule
+  }
+
   public struct Shipping: Swift.Decodable {
     public let enabled: Bool
-    public let location: Location?
+    public let location: Location? /// via v1 if `ShippingType` is `singleLocation`
     public let preference: Preference?
     public let summary: String?
     public let type: ShippingType?
@@ -94,6 +105,7 @@ extension Reward: Argo.Decodable {
     return tmp2
       <*> ((json <|| "rewards_items") <|> .success([]))
       <*> tryDecodable(json)
+      <*> json <||? "shipping_rules"
       <*> json <|? "starts_at"
       <*> json <|? "title"
   }

--- a/KsApi/models/RewardAddOnSelectionViewEnvelope.swift
+++ b/KsApi/models/RewardAddOnSelectionViewEnvelope.swift
@@ -52,11 +52,16 @@ public struct RewardAddOnSelectionViewEnvelope: Swift.Decodable {
       }
 
       public struct ShippingRule: Swift.Decodable {
+        public var cost: Money
         public var id: String
         public var location: Location
 
         public struct Location: Swift.Decodable {
+          public var country: String
+          public var countryName: String
+          public var displayableName: String
           public var id: String
+          public var name: String
         }
       }
     }

--- a/KsApi/models/RewardAddOnSelectionViewEnvelopeTests.swift
+++ b/KsApi/models/RewardAddOnSelectionViewEnvelopeTests.swift
@@ -40,9 +40,18 @@ final class RewardAddOnSelectionViewEnvelopeTests: XCTestCase {
               "shippingPreference": "restricted",
               "shippingRules": [
                 [
+                  "cost": [
+                    "amount": "15.0",
+                    "currency": "USD",
+                    "symbol": "$"
+                  ],
                   "id": "U2hpcHBpbmdSdWxlLTEwMzc5NTgz",
                   "location": [
-                    "id": "TG9jYXRpb24tMQ=="
+                    "country": "CA",
+                    "countryName": "Canada",
+                    "displayableName": "Canada",
+                    "id": "TG9jYXRpb24tMjM0MjQ3NzU=",
+                    "name": "Canada"
                   ]
                 ]
               ]
@@ -81,8 +90,17 @@ final class RewardAddOnSelectionViewEnvelopeTests: XCTestCase {
       XCTAssertEqual(value.project.addOns?.nodes[0].remainingQuantity, nil)
       XCTAssertEqual(value.project.addOns?.nodes[0].startsAt, nil)
       XCTAssertEqual(value.project.addOns?.nodes[0].shippingPreference, .restricted)
+      XCTAssertEqual(
+        value.project.addOns?.nodes[0].shippingRules?[0].cost,
+        Money(amount: 15.0, currency: .usd, symbol: "$")
+      )
       XCTAssertEqual(value.project.addOns?.nodes[0].shippingRules?[0].id, "U2hpcHBpbmdSdWxlLTEwMzc5NTgz")
-      XCTAssertEqual(value.project.addOns?.nodes[0].shippingRules?[0].location.id, "TG9jYXRpb24tMQ==")
+      XCTAssertEqual(value.project.addOns?.nodes[0].shippingRules?[0].location.id, "TG9jYXRpb24tMjM0MjQ3NzU=")
+      XCTAssertEqual(value.project.addOns?.nodes[0].shippingRules?[0].location.country, "CA")
+      XCTAssertEqual(value.project.addOns?.nodes[0].shippingRules?[0].location.countryName, "Canada")
+      XCTAssertEqual(value.project.addOns?.nodes[0].shippingRules?[0].location.displayableName, "Canada")
+      XCTAssertEqual(value.project.addOns?.nodes[0].shippingRules?[0].location.name, "Canada")
+
     } catch {
       XCTFail((error as NSError).description)
     }

--- a/KsApi/models/RewardTests.swift
+++ b/KsApi/models/RewardTests.swift
@@ -186,4 +186,38 @@ final class RewardTests: XCTestCase {
     XCTAssertEqual(false, reward.value?.shipping.enabled)
     XCTAssertEqual(.noShipping, reward.value?.shipping.type)
   }
+
+  func testRewardShippingRule_Match() {
+    let shippingRule1 = ShippingRule.template
+      |> ShippingRule.lens.cost .~ 5.0
+      |> ShippingRule.lens.location .~ (.template |> Location.lens.id .~ 1)
+    let shippingRule2 = ShippingRule.template
+      |> ShippingRule.lens.cost .~ 1.0
+      |> ShippingRule.lens.location .~ (.template |> Location.lens.id .~ 2)
+    let reward = Reward.template
+      |> Reward.lens.shippingRules .~ [shippingRule1, shippingRule2]
+
+    let match = ShippingRule.template
+      |> ShippingRule.lens.cost .~ 500.0
+      |> ShippingRule.lens.location .~ (.template |> Location.lens.id .~ 1)
+
+    XCTAssertEqual(reward.shippingRule(matching: match), shippingRule1)
+  }
+
+  func testRewardShippingRule_NoMatch() {
+    let shippingRule1 = ShippingRule.template
+      |> ShippingRule.lens.cost .~ 5.0
+      |> ShippingRule.lens.location .~ (.template |> Location.lens.id .~ 5)
+    let shippingRule2 = ShippingRule.template
+      |> ShippingRule.lens.cost .~ 1.0
+      |> ShippingRule.lens.location .~ (.template |> Location.lens.id .~ 2)
+    let reward = Reward.template
+      |> Reward.lens.shippingRules .~ [shippingRule1, shippingRule2]
+
+    let match = ShippingRule.template
+      |> ShippingRule.lens.cost .~ 500.0
+      |> ShippingRule.lens.location .~ (.template |> Location.lens.id .~ 1)
+
+    XCTAssertEqual(reward.shippingRule(matching: match), match)
+  }
 }

--- a/KsApi/models/lenses/RewardLenses.swift
+++ b/KsApi/models/lenses/RewardLenses.swift
@@ -18,6 +18,7 @@ extension Reward {
         remaining: $1.remaining,
         rewardsItems: $1.rewardsItems,
         shipping: $1.shipping,
+        shippingRules: $1.shippingRules,
         startsAt: $1.startsAt,
         title: $1.title
       ) }
@@ -39,6 +40,7 @@ extension Reward {
         remaining: $1.remaining,
         rewardsItems: $1.rewardsItems,
         shipping: $1.shipping,
+        shippingRules: $1.shippingRules,
         startsAt: $1.startsAt,
         title: $1.title
       ) }
@@ -60,6 +62,7 @@ extension Reward {
         remaining: $1.remaining,
         rewardsItems: $1.rewardsItems,
         shipping: $1.shipping,
+        shippingRules: $1.shippingRules,
         startsAt: $1.startsAt,
         title: $1.title
       ) }
@@ -81,6 +84,7 @@ extension Reward {
         remaining: $1.remaining,
         rewardsItems: $1.rewardsItems,
         shipping: $1.shipping,
+        shippingRules: $1.shippingRules,
         startsAt: $1.startsAt,
         title: $1.title
       ) }
@@ -102,6 +106,7 @@ extension Reward {
         remaining: $1.remaining,
         rewardsItems: $1.rewardsItems,
         shipping: $1.shipping,
+        shippingRules: $1.shippingRules,
         startsAt: $1.startsAt,
         title: $1.title
       ) }
@@ -123,6 +128,7 @@ extension Reward {
         remaining: $1.remaining,
         rewardsItems: $1.rewardsItems,
         shipping: $1.shipping,
+        shippingRules: $1.shippingRules,
         startsAt: $1.startsAt,
         title: $1.title
       ) }
@@ -144,6 +150,7 @@ extension Reward {
         remaining: $1.remaining,
         rewardsItems: $1.rewardsItems,
         shipping: $1.shipping,
+        shippingRules: $1.shippingRules,
         startsAt: $1.startsAt,
         title: $1.title
       ) }
@@ -165,6 +172,7 @@ extension Reward {
         remaining: $1.remaining,
         rewardsItems: $1.rewardsItems,
         shipping: $1.shipping,
+        shippingRules: $1.shippingRules,
         startsAt: $1.startsAt,
         title: $1.title
       ) }
@@ -186,6 +194,7 @@ extension Reward {
         remaining: $1.remaining,
         rewardsItems: $1.rewardsItems,
         shipping: $1.shipping,
+        shippingRules: $1.shippingRules,
         startsAt: $1.startsAt,
         title: $1.title
       ) }
@@ -207,6 +216,7 @@ extension Reward {
         remaining: $1.remaining,
         rewardsItems: $1.rewardsItems,
         shipping: $1.shipping,
+        shippingRules: $1.shippingRules,
         startsAt: $1.startsAt,
         title: $1.title
       ) }
@@ -228,6 +238,7 @@ extension Reward {
         remaining: $0,
         rewardsItems: $1.rewardsItems,
         shipping: $1.shipping,
+        shippingRules: $1.shippingRules,
         startsAt: $1.startsAt,
         title: $1.title
       ) }
@@ -249,6 +260,7 @@ extension Reward {
         remaining: $1.remaining,
         rewardsItems: $0,
         shipping: $1.shipping,
+        shippingRules: $1.shippingRules,
         startsAt: $1.startsAt,
         title: $1.title
       ) }
@@ -270,6 +282,29 @@ extension Reward {
         remaining: $1.remaining,
         rewardsItems: $1.rewardsItems,
         shipping: $0,
+        shippingRules: $1.shippingRules,
+        startsAt: $1.startsAt,
+        title: $1.title
+      ) }
+    )
+
+    public static let shippingRules = Lens<Reward, [ShippingRule]?>(
+      view: { $0.shippingRules },
+      set: { Reward(
+        addOnData: $1.addOnData,
+        backersCount: $1.backersCount,
+        convertedMinimum: $1.convertedMinimum,
+        description: $1.description,
+        endsAt: $1.endsAt,
+        estimatedDeliveryOn: $1.estimatedDeliveryOn,
+        hasAddOns: $1.hasAddOns,
+        id: $1.id,
+        limit: $1.limit,
+        minimum: $1.minimum,
+        remaining: $1.remaining,
+        rewardsItems: $1.rewardsItems,
+        shipping: $1.shipping,
+        shippingRules: $0,
         startsAt: $1.startsAt,
         title: $1.title
       ) }
@@ -291,6 +326,7 @@ extension Reward {
         remaining: $1.remaining,
         rewardsItems: $1.rewardsItems,
         shipping: $1.shipping,
+        shippingRules: $1.shippingRules,
         startsAt: $0,
         title: $1.title
       ) }
@@ -312,6 +348,7 @@ extension Reward {
         remaining: $1.remaining,
         rewardsItems: $1.rewardsItems,
         shipping: $1.shipping,
+        shippingRules: $1.shippingRules,
         startsAt: $1.startsAt,
         title: $0
       ) }

--- a/KsApi/models/templates/RewardAddOnSelectionViewEnvelopeTemplate.swift
+++ b/KsApi/models/templates/RewardAddOnSelectionViewEnvelopeTemplate.swift
@@ -39,9 +39,20 @@ extension RewardAddOnSelectionViewEnvelope.Project.Reward {
   )
 }
 
+extension RewardAddOnSelectionViewEnvelope.Project.Reward.ShippingRule.Location {
+  static let template = RewardAddOnSelectionViewEnvelope.Project.Reward.ShippingRule.Location(
+    country: "CA",
+    countryName: "Canada",
+    displayableName: "Canada",
+    id: "TG9jYXRpb24tMjM0MjQ3NzU=",
+    name: "Canada"
+  )
+}
+
 extension RewardAddOnSelectionViewEnvelope.Project.Reward.ShippingRule {
   static let template = RewardAddOnSelectionViewEnvelope.Project.Reward.ShippingRule(
+    cost: Money(amount: 10, currency: .usd, symbol: "$"),
     id: "U2hpcHBpbmdSdWxlLTEwMzc5NTgz",
-    location: Location(id: "TG9jYXRpb24tMjM0MjQ5Nzc=")
+    location: .template
   )
 }

--- a/KsApi/models/templates/RewardTemplates.swift
+++ b/KsApi/models/templates/RewardTemplates.swift
@@ -23,6 +23,7 @@ extension Reward {
       summary: nil,
       type: nil
     ),
+    shippingRules: nil,
     startsAt: nil,
     title: nil
   )
@@ -47,6 +48,7 @@ extension Reward {
       summary: nil,
       type: nil
     ),
+    shippingRules: nil,
     startsAt: nil,
     title: nil
   )
@@ -71,6 +73,7 @@ extension Reward {
       summary: nil,
       type: nil
     ),
+    shippingRules: nil,
     startsAt: nil,
     title: nil
   )

--- a/KsApi/queries/RewardAddOnSelectionViewQueries.swift
+++ b/KsApi/queries/RewardAddOnSelectionViewQueries.swift
@@ -35,7 +35,19 @@ public func rewardAddOnSelectionViewAddOnsQuery(withProjectSlug slug: String) ->
               .remainingQuantity,
               .shippingPreference,
               .shippingRules(.id +| [
-                .location(.id +| [])
+                .cost(
+                  .amount +| [
+                    .currency,
+                    .symbol
+                  ]
+                ),
+                .location(
+                  .name +| [
+                    .country,
+                    .countryName,
+                    .displayableName,
+                    .id
+                  ])
               ]),
               .startsAt
             ]

--- a/KsApi/queries/RewardAddOnSelectionViewQueriesTests.swift
+++ b/KsApi/queries/RewardAddOnSelectionViewQueriesTests.swift
@@ -7,7 +7,7 @@ final class RewardAddOnSelectionViewQueriesTests: XCTestCase {
 
     // swiftformat:disable wrap
     let expected = """
-    { project(slug: "project-slug") { actions { displayConvertAmount } addOns { nodes { amount { amount currency symbol } backersCount convertedAmount { amount currency symbol } description displayName estimatedDeliveryOn id isMaxPledge items { nodes { id name } } limit limitPerBacker name remainingQuantity shippingPreference shippingRules { id location { id } } startsAt } } fxRate pid } }
+    { project(slug: "project-slug") { actions { displayConvertAmount } addOns { nodes { amount { amount currency symbol } backersCount convertedAmount { amount currency symbol } description displayName estimatedDeliveryOn id isMaxPledge items { nodes { id name } } limit limitPerBacker name remainingQuantity shippingPreference shippingRules { cost { amount currency symbol } id location { country countryName displayableName id name } } startsAt } } fxRate pid } }
     """
     // swiftformat:enable wrap
 

--- a/Library/ViewModels/PledgeAmountViewModel.swift
+++ b/Library/ViewModels/PledgeAmountViewModel.swift
@@ -19,10 +19,10 @@ public enum PledgeAmountStepperConstants {
 public protocol PledgeAmountViewModelInputs {
   func configureWith(data: PledgeAmountViewConfigData)
   func doneButtonTapped()
-  func selectedShippingAmountChanged(to amount: Double)
   func stepperValueChanged(_ value: Double)
   func textFieldDidEndEditing(_ value: String?)
   func textFieldValueChanged(_ value: String?)
+  func unavailableAmountChanged(to amount: Double)
 }
 
 public protocol PledgeAmountViewModelOutputs {
@@ -79,14 +79,14 @@ public final class PledgeAmountViewModel: PledgeAmountViewModelType,
     let minValue = minAndMax
       .map(first)
 
-    let shippingAmount = Signal.merge(
+    let unavailableAmount = Signal.merge(
       self.projectAndRewardProperty.signal.mapConst(0),
-      self.selectedShippingAmountChangedProperty.signal
+      self.unavailableAmountChangedProperty.signal
     )
 
     let maxValue = minAndMax
       .map(second)
-      .combineLatest(with: shippingAmount)
+      .combineLatest(with: unavailableAmount)
       .map(-)
 
     let textFieldInputValue = self.textFieldDidEndEditingProperty.signal
@@ -234,9 +234,9 @@ public final class PledgeAmountViewModel: PledgeAmountViewModelType,
     self.textFieldValueProperty.value = value
   }
 
-  private let selectedShippingAmountChangedProperty = MutableProperty<Double>(0)
-  public func selectedShippingAmountChanged(to amount: Double) {
-    self.selectedShippingAmountChangedProperty.value = amount
+  private let unavailableAmountChangedProperty = MutableProperty<Double>(0)
+  public func unavailableAmountChanged(to amount: Double) {
+    self.unavailableAmountChangedProperty.value = amount
   }
 
   public let currency: Signal<String, Never>

--- a/Library/ViewModels/PledgeAmountViewModelTests.swift
+++ b/Library/ViewModels/PledgeAmountViewModelTests.swift
@@ -91,7 +91,7 @@ internal final class PledgeAmountViewModelTests: TestCase {
 
     self.amountMax.assertValues([10_000])
 
-    self.vm.inputs.selectedShippingAmountChanged(to: 20)
+    self.vm.inputs.unavailableAmountChanged(to: 20)
 
     self.amountMax.assertValues([10_000, 9_980])
   }
@@ -251,12 +251,12 @@ internal final class PledgeAmountViewModelTests: TestCase {
 
     self.doneButtonIsEnabled.assertValues([true])
 
-    self.vm.inputs.selectedShippingAmountChanged(to: 10)
+    self.vm.inputs.unavailableAmountChanged(to: 10)
 
     self.amountMax.assertValues([10_000, 10_000, 9_990])
     self.doneButtonIsEnabled.assertValues([true, false])
 
-    self.vm.inputs.selectedShippingAmountChanged(to: 0)
+    self.vm.inputs.unavailableAmountChanged(to: 0)
 
     self.amountMax.assertValues([10_000, 10_000, 9_990, 10_000])
     self.doneButtonIsEnabled.assertValues([true, false, true])
@@ -868,7 +868,7 @@ internal final class PledgeAmountViewModelTests: TestCase {
     self.vm.inputs.stepperValueChanged(10_000)
     self.labelTextColor.assertValues([green])
 
-    self.vm.inputs.selectedShippingAmountChanged(to: 30)
+    self.vm.inputs.unavailableAmountChanged(to: 30)
     self.labelTextColor.assertValues([green, red])
 
     self.vm.inputs.stepperValueChanged(9_970)
@@ -890,7 +890,7 @@ internal final class PledgeAmountViewModelTests: TestCase {
     self.maxPledgeAmountErrorLabelIsHidden.assertValues([true, false, true])
 
     let shippingAmount = 30.0
-    self.vm.inputs.selectedShippingAmountChanged(to: shippingAmount)
+    self.vm.inputs.unavailableAmountChanged(to: shippingAmount)
     self.maxPledgeAmountErrorLabelIsHidden.assertValues([true, false, true, false])
   }
 
@@ -906,7 +906,7 @@ internal final class PledgeAmountViewModelTests: TestCase {
       "The maximum pledge is US$ 10,000."
     ])
 
-    self.vm.inputs.selectedShippingAmountChanged(to: 30.0)
+    self.vm.inputs.unavailableAmountChanged(to: 30.0)
 
     self.maxPledgeAmountErrorLabelText.assertValues([
       "The maximum pledge is US$ 10,000.",

--- a/Library/ViewModels/RewardAddOnSelectionViewModel.swift
+++ b/Library/ViewModels/RewardAddOnSelectionViewModel.swift
@@ -251,7 +251,9 @@ private func rewardsData(
       project: project,
       reward: reward,
       context: context == .pledge ? .pledge : .manage,
-      shippingRule: reward.shipping.enabled ? shippingRule : nil
+      shippingRule: reward.shipping.enabled
+        ? reward.shippingRule(matching: shippingRule)
+        : nil
     )
   }
 }

--- a/Library/ViewModels/RewardAddOnSelectionViewModelTests.swift
+++ b/Library/ViewModels/RewardAddOnSelectionViewModelTests.swift
@@ -186,7 +186,7 @@ final class RewardAddOnSelectionViewModelTests: TestCase {
     self.loadAddOnRewardsIntoDataSourceAndReloadTableView.assertDidNotEmitValue()
 
     let shippingRule = ShippingRule.template
-      |> ShippingRule.lens.location .~ (.template |> Location.lens.id .~ 99)
+      |> ShippingRule.lens.location .~ (.template |> Location.lens.id .~ 8)
 
     let reward = Reward.template
       |> Reward.lens.shipping.enabled .~ true
@@ -201,14 +201,16 @@ final class RewardAddOnSelectionViewModelTests: TestCase {
       |> \.id .~ "Reward-2".toBase64()
       |> \.shippingPreference .~ .restricted
       |> \.shippingRules .~ [
-        .template |> (\.location.id .~ "Location-99".toBase64())
+        .template |> (\.location.id .~ "Location-99".toBase64()),
+        .template |> (\.location.id .~ "Location-8".toBase64())
       ]
 
     let shippingAddOn2 = RewardAddOnSelectionViewEnvelope.Project.Reward.template
       |> \.id .~ "Reward-3".toBase64()
       |> \.shippingPreference .~ .restricted
       |> \.shippingRules .~ [
-        .template |> (\.location.id .~ "Location-99".toBase64())
+        .template |> (\.location.id .~ "Location-99".toBase64()),
+        .template |> (\.location.id .~ "Location-8".toBase64())
       ]
 
     let shippingAddOn3 = RewardAddOnSelectionViewEnvelope.Project.Reward.template


### PR DESCRIPTION
# 📲 What

Allows the selected base reward and its add-ons to have dissimilar shipping costs.

# 🤔 Why

Previously the assumption was made that the shipping cost would be the same across the base reward and all of its add-ons. This is not the case and this PR addresses that.

# 🛠 How

- Update logic in `PledgeViewModel` and `RewardAddOnSelectionViewModel`.
- Display individual add-on shipping cost in `RewardAddOnCardView`.
- Add an optional `shippingRules` array to our `Reward` model.
  - This data is only deserialized from GraphQL.
- Included some fixes to `PledgeAmountViewModel` to ensure pledges are within the max amount.

# ✅ Acceptance criteria

- [ ] When selecting add-ons with shipping, note that the shipping amount displayed is specific to that add-on.
- [ ] Entering a bonus support amount greater than the country maximum should display a message in the pledge view. The allowed amount should be the country maximum minus the total of the rewards + shipping. In the case of US pledged this is $10,000.