### PR TITLE
[NT-1401] Reward Card UI updates

### DIFF
--- a/Kickstarter-iOS/Views/Cells/RewardCell.swift
+++ b/Kickstarter-iOS/Views/Cells/RewardCell.swift
@@ -73,7 +73,7 @@ final class RewardCell: UICollectionViewCell, ValueCell {
       |> ksr_addSubviewToParent()
       |> ksr_constrainViewToMarginsInParent()
 
-    _ = (self.backerLabelContainer, self.contentView)
+    _ = (self.backerLabelContainer, self.rewardCardContainerView)
       |> ksr_addSubviewToParent()
 
     _ = (self.rewardCardContainerView, self.scrollView)

--- a/Kickstarter-iOS/Views/Cells/RewardCell.swift
+++ b/Kickstarter-iOS/Views/Cells/RewardCell.swift
@@ -12,6 +12,16 @@ protocol RewardCellDelegate: AnyObject {
 final class RewardCell: UICollectionViewCell, ValueCell {
   // MARK: - Properties
 
+  private lazy var backerLabelContainer: UIView = {
+    UIView(frame: .zero)
+      |> \.translatesAutoresizingMaskIntoConstraints .~ false
+  }()
+
+  private lazy var backerLabel: UILabel = {
+    UILabel(frame: .zero)
+      |> \.translatesAutoresizingMaskIntoConstraints .~ false
+  }()
+
   internal weak var delegate: RewardCellDelegate?
   private let viewModel: RewardCellViewModelType = RewardCellViewModel()
 
@@ -35,6 +45,8 @@ final class RewardCell: UICollectionViewCell, ValueCell {
   override func bindViewModel() {
     super.bindViewModel()
 
+    self.backerLabelContainer.rac.hidden = self.viewModel.outputs.backerLabelHidden
+
     self.viewModel.outputs.scrollScrollViewToTop
       .observeForUI()
       .observeValues { [weak self] in
@@ -57,6 +69,13 @@ final class RewardCell: UICollectionViewCell, ValueCell {
       |> ksr_addSubviewToParent()
       |> ksr_constrainViewToEdgesInParent()
 
+    _ = (self.backerLabel, self.backerLabelContainer)
+      |> ksr_addSubviewToParent()
+      |> ksr_constrainViewToMarginsInParent()
+
+    _ = (self.backerLabelContainer, self.contentView)
+      |> ksr_addSubviewToParent()
+
     _ = (self.rewardCardContainerView, self.scrollView)
       |> ksr_addSubviewToParent()
       |> ksr_constrainViewToEdgesInParent()
@@ -69,7 +88,21 @@ final class RewardCell: UICollectionViewCell, ValueCell {
   private func setupConstraints() {
     self.rewardCardContainerView.pinBottomViews(to: self.contentView.layoutMarginsGuide)
 
+    let backerLabelContainerYConstraint = NSLayoutConstraint(
+      item: self.backerLabelContainer,
+      attribute: .centerY,
+      relatedBy: .equal,
+      toItem: self.rewardCardContainerView,
+      attribute: .top,
+      multiplier: 0.9,
+      constant: 0
+    )
+
     NSLayoutConstraint.activate([
+      backerLabelContainerYConstraint,
+      self.backerLabelContainer.leftAnchor.constraint(
+        equalTo: self.rewardCardContainerView.leftAnchor, constant: Styles.grid(3)
+      ),
       self.rewardCardContainerView.widthAnchor.constraint(equalTo: self.contentView.widthAnchor)
     ])
   }
@@ -81,11 +114,22 @@ final class RewardCell: UICollectionViewCell, ValueCell {
       |> contentViewStyle
       |> checkoutBackgroundStyle
 
+    _ = self.backerLabelContainer
+      |> \.backgroundColor .~ .ksr_cobalt_500
+      |> roundedStyle(cornerRadius: Styles.grid(1))
+      |> \.layoutMargins .~ .init(topBottom: Styles.grid(1), leftRight: Styles.grid(2))
+
+    _ = self.backerLabel
+      |> \.text %~ { _ in localizedString(key: "You_backed", defaultValue: "You backed") }
+      |> \.font .~ UIFont.ksr_footnote().weighted(.medium)
+      |> \.textColor .~ .white
+
     _ = self.scrollView
       |> scrollViewStyle
   }
 
   internal func configureWith(value: RewardCardViewData) {
+    self.viewModel.inputs.configure(with: value)
     self.rewardCardContainerView.configure(with: value)
   }
 

--- a/Kickstarter-iOS/Views/RewardCardContainerView.swift
+++ b/Kickstarter-iOS/Views/RewardCardContainerView.swift
@@ -24,6 +24,11 @@ public final class RewardCardContainerView: UIView {
   private var pledgeButtonMarginConstraints: [NSLayoutConstraint]?
   private var pledgeButtonShownConstraints: [NSLayoutConstraint] = []
   private var pledgeButtonHiddenConstraints: [NSLayoutConstraint] = []
+  private let rewardCardMaskView = {
+    UIView(frame: .zero)
+      |> \.translatesAutoresizingMaskIntoConstraints .~ false
+  }()
+
   private let rewardCardView: RewardCardView = {
     RewardCardView(frame: .zero)
       |> \.translatesAutoresizingMaskIntoConstraints .~ false
@@ -46,9 +51,12 @@ public final class RewardCardContainerView: UIView {
     super.bindStyles()
 
     _ = self
+      |> checkoutBackgroundStyle
+
+    _ = self.rewardCardMaskView
       |> checkoutWhiteBackgroundStyle
-      |> roundedStyle(cornerRadius: Styles.grid(3))
       |> \.layoutMargins .~ .init(all: Styles.grid(3))
+      |> roundedStyle(cornerRadius: Styles.grid(3))
   }
 
   public override func bindViewModel() {
@@ -97,7 +105,11 @@ public final class RewardCardContainerView: UIView {
   // MARK: - Functions
 
   private func configureViews() {
-    _ = (self.rewardCardView, self)
+    _ = (self.rewardCardMaskView, self)
+      |> ksr_addSubviewToParent()
+      |> ksr_constrainViewToEdgesInParent()
+
+    _ = (self.rewardCardView, self.rewardCardMaskView)
       |> ksr_addSubviewToParent()
 
     _ = (self.pledgeButtonLayoutGuide, self)
@@ -117,7 +129,7 @@ public final class RewardCardContainerView: UIView {
   }
 
   private func hiddenPledgeHiddenConstraints() -> [NSLayoutConstraint] {
-    let containerMargins = self.layoutMarginsGuide
+    let containerMargins = self.rewardCardMaskView.layoutMarginsGuide
 
     let rewardCardViewConstraints = [
       self.rewardCardView.leftAnchor.constraint(equalTo: containerMargins.leftAnchor),
@@ -130,7 +142,7 @@ public final class RewardCardContainerView: UIView {
   }
 
   private func shownPledgeButtonConstraints() -> [NSLayoutConstraint] {
-    let containerMargins = self.layoutMarginsGuide
+    let containerMargins = self.rewardCardMaskView.layoutMarginsGuide
 
     let rewardCardViewConstraints = [
       self.rewardCardView.leftAnchor.constraint(equalTo: containerMargins.leftAnchor),
@@ -143,7 +155,7 @@ public final class RewardCardContainerView: UIView {
       |> \.priority .~ .defaultLow
 
     // sometimes this is provided by the parent cell for pinning of the button
-    self.addBottomViewsMarginConstraints(with: self.layoutMarginsGuide)
+    self.addBottomViewsMarginConstraints(with: self.rewardCardMaskView.layoutMarginsGuide)
 
     let pledgeButtonLayoutGuideConstraints = [
       self.pledgeButtonLayoutGuide.bottomAnchor.constraint(equalTo: containerMargins.bottomAnchor),

--- a/Library/ViewModels/RewardCardViewModel.swift
+++ b/Library/ViewModels/RewardCardViewModel.swift
@@ -218,9 +218,16 @@ private func pillValues(project: Project, reward: Reward) -> [String] {
   return [
     timeLeftString(project: project, reward: reward),
     backerCountOrRemainingString(project: project, reward: reward),
-    shippingSummaryString(project: project, reward: reward)
+    shippingSummaryString(project: project, reward: reward),
+    addOnsString(reward: reward)
   ]
   .compact()
+}
+
+private func addOnsString(reward: Reward) -> String? {
+  guard reward.hasAddOns else { return nil }
+
+  return localizedString(key: "Add_ons", defaultValue: "Add-ons")
 }
 
 private func timeLeftString(project: Project, reward: Reward) -> String? {

--- a/Library/ViewModels/RewardCardViewModelTests.swift
+++ b/Library/ViewModels/RewardCardViewModelTests.swift
@@ -484,6 +484,24 @@ final class RewardCardViewModelTests: TestCase {
 
   // MARK: - Pills
 
+  func testPillsRewardHasAddOns() {
+    self.pillCollectionViewHidden.assertValueCount(0)
+    self.reloadPills.assertValueCount(0)
+
+    let reward = Reward.postcards
+      |> Reward.lens.backersCount .~ nil
+      |> Reward.lens.limit .~ nil
+      |> Reward.lens.remaining .~ nil
+      |> Reward.lens.hasAddOns .~ true
+
+    self.vm.inputs.configure(with: (.template, reward, .pledge))
+
+    self.pillCollectionViewHidden.assertValues([false])
+    self.reloadPills.assertValues([
+      ["Add-ons"]
+    ])
+  }
+
   func testPillsLimitedReward() {
     self.pillCollectionViewHidden.assertValueCount(0)
     self.reloadPills.assertValueCount(0)

--- a/Library/ViewModels/RewardCellViewModel.swift
+++ b/Library/ViewModels/RewardCellViewModel.swift
@@ -1,12 +1,14 @@
 import Foundation
 import ReactiveSwift
 
-public protocol RewardCellViewModelOutputs {
-  var scrollScrollViewToTop: Signal<Void, Never> { get }
+public protocol RewardCellViewModelInputs {
+  func configure(with data: RewardCardViewData)
+  func prepareForReuse()
 }
 
-public protocol RewardCellViewModelInputs {
-  func prepareForReuse()
+public protocol RewardCellViewModelOutputs {
+  var backerLabelHidden: Signal<Bool, Never> { get }
+  var scrollScrollViewToTop: Signal<Void, Never> { get }
 }
 
 public protocol RewardCellViewModelType {
@@ -18,6 +20,16 @@ public final class RewardCellViewModel: RewardCellViewModelType, RewardCellViewM
   RewardCellViewModelOutputs {
   public init() {
     self.scrollScrollViewToTop = self.prepareForReuseProperty.signal
+    self.backerLabelHidden = self.configDataProperty.signal.skipNil()
+      .map { project, reward, _ in
+        userIsBacking(reward: reward, inProject: project)
+      }
+      .negate()
+  }
+
+  private let configDataProperty = MutableProperty<RewardCardViewData?>(nil)
+  public func configure(with data: RewardCardViewData) {
+    self.configDataProperty.value = data
   }
 
   private let prepareForReuseProperty = MutableProperty(())
@@ -25,6 +37,7 @@ public final class RewardCellViewModel: RewardCellViewModelType, RewardCellViewM
     self.prepareForReuseProperty.value = ()
   }
 
+  public let backerLabelHidden: Signal<Bool, Never>
   public let scrollScrollViewToTop: Signal<Void, Never>
 
   public var inputs: RewardCellViewModelInputs { return self }

--- a/Library/ViewModels/RewardCellViewModelTests.swift
+++ b/Library/ViewModels/RewardCellViewModelTests.swift
@@ -1,16 +1,20 @@
 import Foundation
+@testable import KsApi
 import Library
+import Prelude
 import ReactiveExtensions
 import ReactiveExtensions_TestHelpers
 
 final class RewardCellViewModelTests: TestCase {
   private let vm = RewardCellViewModel()
 
+  private let backerLabelHidden = TestObserver<Bool, Never>()
   private let scrollScrollViewToTop = TestObserver<Void, Never>()
 
   override func setUp() {
     super.setUp()
 
+    self.vm.outputs.backerLabelHidden.observe(self.backerLabelHidden.observer)
     self.vm.outputs.scrollScrollViewToTop.observe(self.scrollScrollViewToTop.observer)
   }
 
@@ -24,5 +28,47 @@ final class RewardCellViewModelTests: TestCase {
     self.vm.inputs.prepareForReuse()
 
     self.scrollScrollViewToTop.assertValueCount(2)
+  }
+
+  func testBackerLabelHidden_IsBacked() {
+    self.backerLabelHidden.assertDidNotEmitValue()
+
+    let reward = Reward.template
+
+    let project = Project.cosmicSurgery
+      |> Project.lens.state .~ .live
+      |> Project.lens.personalization.isBacking .~ true
+      |> Project.lens.personalization.backing .~ (
+        .template
+          |> Backing.lens.reward .~ reward
+          |> Backing.lens.rewardId .~ reward.id
+          |> Backing.lens.shippingAmount .~ 10
+          |> Backing.lens.amount .~ 700.0
+      )
+
+    self.vm.inputs.configure(with: (project, reward, .manage))
+
+    self.backerLabelHidden.assertValues([false])
+  }
+
+  func testBackerLabelHidden_IsNotBacked() {
+    self.backerLabelHidden.assertDidNotEmitValue()
+
+    let reward = Reward.template
+
+    let project = Project.cosmicSurgery
+      |> Project.lens.state .~ .live
+      |> Project.lens.personalization.isBacking .~ true
+      |> Project.lens.personalization.backing .~ (
+        .template
+          |> Backing.lens.reward .~ Reward.noReward
+          |> Backing.lens.rewardId .~ Reward.noReward.id
+          |> Backing.lens.shippingAmount .~ 10
+          |> Backing.lens.amount .~ 700.0
+      )
+
+    self.vm.inputs.configure(with: (project, reward, .manage))
+
+    self.backerLabelHidden.assertValues([true])
   }
 }


### PR DESCRIPTION
# 📲 What

- Adds the "You backed" label to the currently backed reward card.
- Adds the "Add-ons" tag to rewards that have add-ons.

# 🤔 Why

This better surfaces information to backers that they have backed a particular reward and whether a reward had add-ons.

# 🛠 How

Added the UI elements and behaviour to hide/show the information with tests.

# 👀 See

| Before 🐛 | After 🦋 |
| --- | --- |
| <img width="545" alt="image" src="https://user-images.githubusercontent.com/3735375/88740033-f3d87880-d0f0-11ea-8a55-37c5e124eee2.png"> | <img width="545" alt="image" src="https://user-images.githubusercontent.com/3735375/88739929-a52ade80-d0f0-11ea-9729-d0ac19d51c0d.png"> |

# ✅ Acceptance criteria

- [ ] Navigate to the rewards carousel for a project that you have backed. The backed reward should have the blue _You backed_ label.
- [ ] Navigate to the rewards carousel for a project that has rewards with add-ons. That reward should include the _Add-ons_ tag.