### PR TITLE
[NT-1443] Choose another Reward -> Edit Reward

### DIFF
--- a/Kickstarter-iOS/Views/Controllers/ManagePledgeViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/ManagePledgeViewController.swift
@@ -471,7 +471,7 @@ final class ManagePledgeViewController: UIViewController, MessageBannerViewContr
       case .changePaymentMethod:
         title = Strings.Change_payment_method()
       case .chooseAnotherReward:
-        title = Strings.Choose_another_reward()
+        title = localizedString(key: "Edit_reward", defaultValue: "Edit reward")
       case .contactCreator:
         title = Strings.Contact_creator()
       case .cancelPledge:

--- a/Library/ViewModels/RewardsCollectionViewModel.swift
+++ b/Library/ViewModels/RewardsCollectionViewModel.swift
@@ -208,7 +208,9 @@ private func titleForContext(_ context: RewardsCollectionViewContext, project: P
     return Strings.View_rewards()
   }
 
-  return context == .createPledge ? Strings.Back_this_project() : Strings.Choose_another_reward()
+  return context == .createPledge
+    ? Strings.Back_this_project()
+    : localizedString(key: "Edit_reward", defaultValue: "Edit reward")
 }
 
 private func backedReward(_ project: Project, rewards: [Reward]) -> IndexPath? {

--- a/Library/ViewModels/RewardsCollectionViewModelTests.swift
+++ b/Library/ViewModels/RewardsCollectionViewModelTests.swift
@@ -297,7 +297,7 @@ final class RewardsCollectionViewModelTests: TestCase {
     self.vm.inputs.configure(with: Project.cosmicSurgery, refTag: .activity, context: .managePledge)
     self.vm.inputs.viewDidLoad()
 
-    self.title.assertValue("Choose another reward")
+    self.title.assertValue("Edit reward")
   }
 
   func testTitle_CreatePledgeContext_IsCreator() {
@@ -360,7 +360,7 @@ final class RewardsCollectionViewModelTests: TestCase {
       self.vm.inputs.configure(with: project, refTag: .activity, context: .managePledge)
       self.vm.inputs.viewDidLoad()
 
-      self.title.assertValue("Choose another reward")
+      self.title.assertValue("Edit reward")
     }
   }
 


### PR DESCRIPTION
# 📲 What

Updates the string `Choose another reward` to `Edit reward`. This is seen in the Manage Pledge context menu as well as the rewards carousel title when navigating from the manage pledge context.

**Note:** This string has been added for translation and will be update along with other strings once translations have come back.

**Also note:** Editing the reward for a backing that has add-ons will be supported in an upcoming PR.

# 🤔 Why

We're improving our nomenclature around this with the introduction of add-ons.

# 🛠 How

Updated the strings and added them for translation.

# 👀 See

Trello, screenshots, external resources?

| Before 🐛 | After 🦋 |
| --- | --- |
| <img width="545" alt="image" src="https://user-images.githubusercontent.com/3735375/88850764-a87da300-d1a0-11ea-8d7e-2d19e6c510db.png"> | <img width="545" alt="image" src="https://user-images.githubusercontent.com/3735375/88850618-7ff5a900-d1a0-11ea-94f3-a1ef66e244b1.png"> |

# ✅ Acceptance criteria

- [ ] The updated string is observed in the context menu and as the title for the rewards carousel when editing a reward.