### PR TITLE
[NT-1391] Change Bonus Amount in USD to decimal currency

### DIFF
--- a/Library/Tracking/Koala.swift
+++ b/Library/Tracking/Koala.swift
@@ -342,7 +342,7 @@ public final class Koala {
   public struct CheckoutPropertiesData: Equatable {
     let amount: String
     let bonusAmount: String
-    let bonusAmountInUsdCents: Int
+    let bonusAmountInUsd: String
     let checkoutId: Int?
     let estimatedDelivery: TimeInterval?
     let paymentType: String?
@@ -2293,7 +2293,7 @@ private func checkoutProperties(from data: Koala.CheckoutPropertiesData, prefix:
 
   result["amount"] = data.amount
   result["bonus_amount"] = data.bonusAmount
-  result["bonus_amount_usd"] = data.bonusAmountInUsdCents
+  result["bonus_amount_usd"] = data.bonusAmountInUsd
   result["id"] = data.checkoutId
   result["payment_type"] = data.paymentType
   result["reward_id"] = data.rewardId

--- a/Library/Tracking/KoalaTests.swift
+++ b/Library/Tracking/KoalaTests.swift
@@ -1349,7 +1349,7 @@ final class KoalaTests: TestCase {
   private func assertCheckoutProperties(_ props: [String: Any]?) {
     XCTAssertEqual("20.00", props?["checkout_amount"] as? String)
     XCTAssertEqual("10.00", props?["checkout_bonus_amount"] as? String)
-    XCTAssertEqual(100, props?["checkout_bonus_amount_usd"] as? Int)
+    XCTAssertEqual("10.00", props?["checkout_bonus_amount_usd"] as? String)
     XCTAssertEqual("CREDIT_CARD", props?["checkout_payment_type"] as? String)
     XCTAssertEqual("SUPER reward", props?["checkout_reward_title"] as? String)
     XCTAssertEqual(2, props?["checkout_reward_id"] as? Int)
@@ -1365,7 +1365,7 @@ extension Koala.CheckoutPropertiesData {
   static let template = Koala.CheckoutPropertiesData(
     amount: "20.00",
     bonusAmount: "10.00",
-    bonusAmountInUsdCents: 100,
+    bonusAmountInUsd: "10.00",
     checkoutId: 1,
     estimatedDelivery: nil,
     paymentType: "CREDIT_CARD",

--- a/Library/ViewModels/PledgeViewModel.swift
+++ b/Library/ViewModels/PledgeViewModel.swift
@@ -1122,15 +1122,14 @@ private func checkoutPropertiesData(
     .multiplyingCurrency(100.0)
     .rounded()
 
-  let bonusAmountUsdCents = additionalPledgeAmount
+  let bonusAmountUsd = additionalPledgeAmount
     .multiplyingCurrency(Double(createBackingData.project.stats.staticUsdRate))
-    .multiplyingCurrency(100.0)
     .rounded()
 
   let amount = Format.decimalCurrency(for: pledgeTotal)
   let bonusAmount = Format.decimalCurrency(for: additionalPledgeAmount)
   let revenueInUsdCents = Int(pledgeTotalUsdCents)
-  let bonusAmountInUsdCents = Int(bonusAmountUsdCents)
+  let bonusAmountInUsd = Format.decimalCurrency(for: bonusAmountUsd)
   let rewardId = baseReward.id
   let estimatedDelivery = baseReward.estimatedDeliveryOn
   let paymentType = isApplePay
@@ -1146,7 +1145,7 @@ private func checkoutPropertiesData(
   return Koala.CheckoutPropertiesData(
     amount: amount,
     bonusAmount: bonusAmount,
-    bonusAmountInUsdCents: bonusAmountInUsdCents,
+    bonusAmountInUsd: bonusAmountInUsd,
     checkoutId: checkoutId,
     estimatedDelivery: estimatedDelivery,
     paymentType: paymentType,

--- a/Library/ViewModels/ThanksViewModelTests.swift
+++ b/Library/ViewModels/ThanksViewModelTests.swift
@@ -328,7 +328,7 @@ final class ThanksViewModelTests: TestCase {
     let checkoutData = Koala.CheckoutPropertiesData(
       amount: "10.00",
       bonusAmount: "20.00",
-      bonusAmountInUsdCents: 200,
+      bonusAmountInUsd: "20.00",
       checkoutId: 1,
       estimatedDelivery: nil,
       paymentType: "CREDIT_CARD",
@@ -350,7 +350,7 @@ final class ThanksViewModelTests: TestCase {
     // Checkout properties
     XCTAssertEqual("10.00", props?["checkout_amount"] as? String)
     XCTAssertEqual("20.00", props?["checkout_bonus_amount"] as? String)
-    XCTAssertEqual(200, props?["checkout_bonus_amount_usd"] as? Int)
+    XCTAssertEqual("20.00", props?["checkout_bonus_amount_usd"] as? String)
     XCTAssertEqual("CREDIT_CARD", props?["checkout_payment_type"] as? String)
     XCTAssertEqual("SUPER reward", props?["checkout_reward_title"] as? String)
     XCTAssertEqual(2, props?["checkout_reward_id"] as? Int)


### PR DESCRIPTION
# 📲 What

Updates our tracking property `checkout_bonus_amount_usd` to be a decimal currency `String` rather than an `Int` representing the amount in USD cents.

# 🤔 Why

This was the actual requirement, I implemented it in cents because I assumed it was the same as `checkout_revenue_in_usd_cents`.

# 🛠 How

Updated this to behave like the other decimal amounts in our `checkout_` tracking properties.

# ✅ Acceptance criteria

- [ ] When backing non-USD projects with a bonus support amount, that amount is tracked as a decimal currency `String` value.