### PR TITLE
[NT-1457] Remove Bonus Support Amount Rounding

### DIFF
--- a/Library/ViewModels/PledgeViewModel.swift
+++ b/Library/ViewModels/PledgeViewModel.swift
@@ -1131,7 +1131,6 @@ private func checkoutPropertiesData(
 
   let bonusAmountUsd = additionalPledgeAmount
     .multiplyingCurrency(Double(createBackingData.project.stats.staticUsdRate))
-    .rounded()
 
   let amount = Format.decimalCurrency(for: pledgeTotal)
   let bonusAmount = Format.decimalCurrency(for: additionalPledgeAmount)

--- a/Library/ViewModels/PledgeViewModelTests.swift
+++ b/Library/ViewModels/PledgeViewModelTests.swift
@@ -1715,7 +1715,7 @@ final class PledgeViewModelTests: TestCase {
       let checkoutData = Koala.CheckoutPropertiesData(
         amount: "15.00",
         bonusAmount: "10.00",
-        bonusAmountInUsd: "13.00",
+        bonusAmountInUsd: "13.09",
         checkoutId: 1,
         estimatedDelivery: 1_506_897_315.0,
         paymentType: "APPLE_PAY",


### PR DESCRIPTION
# 📲 What

Removes rounding of the tracking property `checkout_bonus_amount_usd`.

# 🤔 Why

This value should not have been rounded.

# 🛠 How

Removed the rounded modifier.

# ✅ Acceptance criteria

- [x] Back a non-USD project where the converted USD pledge amount would have decimals, observe that the decimals are tracked.
- [x] Back a non-USD project where the converted USD pledge amount would be less than `$1.00`, observe that the amount is not tracked as `$0.00`.