### PR TITLE
[NT-1416] Edit Add-Ons Reward Alert

### DIFF
--- a/Kickstarter-iOS/Views/Controllers/RewardsCollectionViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/RewardsCollectionViewController.swift
@@ -180,6 +180,12 @@ final class RewardsCollectionViewController: UICollectionViewController {
           ? UIImage()
           : self.navigationBarShadowImage
       }
+
+    self.viewModel.outputs.showEditRewardConfirmationPrompt
+      .observeForControllerAction()
+      .observeValues { [weak self] message in
+        self?.showEditRewardConfirmationPrompt(message: message)
+      }
   }
 
   // MARK: - Functions
@@ -247,6 +253,28 @@ final class RewardsCollectionViewController: UICollectionViewController {
     pledgeViewController.configure(with: data)
 
     self.navigationController?.pushViewController(pledgeViewController, animated: true)
+  }
+
+  private func showEditRewardConfirmationPrompt(message: String) {
+    let alert = UIAlertController(
+      title: message,
+      message: nil,
+      preferredStyle: .alert
+    )
+
+    // FIXME: replace once translations are generated.
+    let yes = localizedString(key: "Yes_continue", defaultValue: "Yes, continue")
+    let no = localizedString(key: "No_go_back", defaultValue: "No, go back")
+
+    let continueAction = UIAlertAction(title: yes, style: .default) { [weak self] _ in
+      self?.viewModel.inputs.confirmedEditReward()
+    }
+
+    alert.addAction(continueAction)
+    alert.addAction(UIAlertAction(title: no, style: .cancel))
+    alert.preferredAction = continueAction
+
+    self.present(alert, animated: true)
   }
 
   // MARK: - Actions

--- a/Library/ViewModels/RewardsCollectionViewModel.swift
+++ b/Library/ViewModels/RewardsCollectionViewModel.swift
@@ -285,7 +285,7 @@ private func shouldTriggerEditRewardPrompt(_ data: PledgeViewData) -> Bool {
 
   let rewardChanged = data.rewards.first?.id != backing.reward?.id
 
-  // We show the prompt if they have previously backed with add-ons and they selecting a new reward.
+  // We show the prompt if they have previously backed with add-ons and they are selecting a new reward.
   return backing.addOns?.isEmpty == false && rewardChanged
 }
 

--- a/Library/ViewModels/RewardsCollectionViewModel.swift
+++ b/Library/ViewModels/RewardsCollectionViewModel.swift
@@ -10,6 +10,7 @@ public enum RewardsCollectionViewContext {
 
 public protocol RewardsCollectionViewModelInputs {
   func configure(with project: Project, refTag: RefTag?, context: RewardsCollectionViewContext)
+  func confirmedEditReward()
   func rewardCellShouldShowDividerLine(_ show: Bool)
   func rewardSelected(with rewardId: Int)
   func traitCollectionDidChange(_ traitCollection: UITraitCollection)
@@ -28,6 +29,7 @@ public protocol RewardsCollectionViewModelOutputs {
   var reloadDataWithValues: Signal<[RewardCardViewData], Never> { get }
   var rewardsCollectionViewFooterIsHidden: Signal<Bool, Never> { get }
   var scrollToBackedRewardIndexPath: Signal<IndexPath, Never> { get }
+  var showEditRewardConfirmationPrompt: Signal<String, Never> { get }
   var title: Signal<String, Never> { get }
 
   func selectedReward() -> Reward?
@@ -108,8 +110,61 @@ public final class RewardsCollectionViewModel: RewardsCollectionViewModelType,
       return (data, reward.hasAddOns)
     }
 
-    self.goToAddOnSelection = goToPledge.filter(second >>> isTrue).map(first)
-    self.goToPledge = goToPledge.filter(second >>> isFalse).map(first)
+    // Reward has add-ons, project is not backed, navigates to add-on selection without prompt.
+    let goToAddOnSelectionNotBackedWithAddOns = goToPledge
+      .filter(second >>> isTrue)
+      .map(first)
+      .filter(shouldTriggerEditRewardPrompt >>> isFalse)
+
+    // Reward has add-ons, project is backed with add-ons, triggers prompt before add-on selection.
+    let goToAddOnSelectionBackedWithAddOns = goToPledge
+      .filter(second >>> isTrue)
+      .map(first)
+      .filter(shouldTriggerEditRewardPrompt >>> isTrue)
+
+    // Reward does not have add-ons, project is not backed, navigates to pledge without prompt.
+    let goToPledgeNotBackedWithAddOns = goToPledge
+      .filter(second >>> isFalse)
+      .map(first)
+      .filter(shouldTriggerEditRewardPrompt >>> isFalse)
+
+    // Reward does not have add-ons, project is backed with add-ons, triggers prompt before pledge.
+    let goToPledgeBackedWithAddOns = goToPledge
+      .filter(second >>> isFalse)
+      .map(first)
+      .filter(shouldTriggerEditRewardPrompt >>> isTrue)
+
+    self.showEditRewardConfirmationPrompt = Signal.merge(
+      goToAddOnSelectionBackedWithAddOns,
+      goToPledgeBackedWithAddOns
+    )
+    .map { _ in
+      localizedString(
+        key: "Continue_with_this_reward_It_may_not_offer_some_or_all_of_your_add_ons",
+        defaultValue: "Continue with this reward? It may not offer some or all of your add-ons."
+      )
+    }
+
+    let goToAddOnSelectionBackedConfirmed = Signal.zip(
+      goToAddOnSelectionBackedWithAddOns,
+      self.confirmedEditRewardProperty.signal
+    )
+    .map(first)
+
+    let goToPledgeBackedConfirmed = Signal.zip(
+      goToPledgeBackedWithAddOns,
+      self.confirmedEditRewardProperty.signal
+    )
+    .map(first)
+
+    self.goToAddOnSelection = Signal.merge(
+      goToAddOnSelectionNotBackedWithAddOns,
+      goToAddOnSelectionBackedConfirmed
+    )
+    self.goToPledge = Signal.merge(
+      goToPledgeNotBackedWithAddOns,
+      goToPledgeBackedConfirmed
+    )
 
     self.rewardsCollectionViewFooterIsHidden = self.traitCollectionChangedProperty.signal
       .skipNil()
@@ -141,6 +196,11 @@ public final class RewardsCollectionViewModel: RewardsCollectionViewModelType,
   private let configDataProperty = MutableProperty<(Project, RefTag?, RewardsCollectionViewContext)?>(nil)
   public func configure(with project: Project, refTag: RefTag?, context: RewardsCollectionViewContext) {
     self.configDataProperty.value = (project, refTag, context)
+  }
+
+  private let confirmedEditRewardProperty = MutableProperty(())
+  public func confirmedEditReward() {
+    self.confirmedEditRewardProperty.value = ()
   }
 
   private let rewardCellShouldShowDividerLineProperty = MutableProperty<Bool>(false)
@@ -186,6 +246,7 @@ public final class RewardsCollectionViewModel: RewardsCollectionViewModelType,
   public let reloadDataWithValues: Signal<[RewardCardViewData], Never>
   public let rewardsCollectionViewFooterIsHidden: Signal<Bool, Never>
   public let scrollToBackedRewardIndexPath: Signal<IndexPath, Never>
+  public let showEditRewardConfirmationPrompt: Signal<String, Never>
   public let title: Signal<String, Never>
 
   private let selectedRewardProperty = MutableProperty<Reward?>(nil)
@@ -213,6 +274,19 @@ private func titleForContext(_ context: RewardsCollectionViewContext, project: P
 
 private func shouldNavigateToReward(project: Project, reward: Reward, refTag _: RefTag?) -> Bool {
   project.state == .live && (!userIsBacking(reward: reward, inProject: project) || reward.hasAddOns)
+}
+
+private func shouldTriggerEditRewardPrompt(_ data: PledgeViewData) -> Bool {
+  // If the user is not backing the project then there is no need to show the prompt.
+  guard
+    userIsBackingProject(data.project),
+    let backing = data.project.personalization.backing
+  else { return false }
+
+  let rewardUnchanged = data.rewards.first?.id == backing.reward?.id
+
+  // We show the prompt if they have previously backed with add-ons and they selecting a new reward.
+  return backing.addOns?.isEmpty == false && !rewardUnchanged
 }
 
 private func backedReward(_ project: Project, rewards: [Reward]) -> IndexPath? {

--- a/Library/ViewModels/RewardsCollectionViewModel.swift
+++ b/Library/ViewModels/RewardsCollectionViewModel.swift
@@ -283,10 +283,10 @@ private func shouldTriggerEditRewardPrompt(_ data: PledgeViewData) -> Bool {
     let backing = data.project.personalization.backing
   else { return false }
 
-  let rewardUnchanged = data.rewards.first?.id == backing.reward?.id
+  let rewardChanged = data.rewards.first?.id != backing.reward?.id
 
   // We show the prompt if they have previously backed with add-ons and they selecting a new reward.
-  return backing.addOns?.isEmpty == false && !rewardUnchanged
+  return backing.addOns?.isEmpty == false && rewardChanged
 }
 
 private func backedReward(_ project: Project, rewards: [Reward]) -> IndexPath? {


### PR DESCRIPTION
# 📲 What

Displays a prompt when editing a reward that previously had add-ons selected.

# 🤔 Why

Selecting a new reward might affect the add-ons that a backer selected before and we would like to inform them of this during the edit flow.

# 🛠 How

Updated `RewardsCollectionViewModel` to display a prompt when selecting a reward under these circumstances:
- Reward has add-ons, project is not backed, navigates to add-on selection without prompt.
- Reward has add-ons, project is backed with add-ons, triggers prompt before add-on selection.
- Reward does not have add-ons, project is not backed, navigates to pledge without prompt.
- Reward does not have add-ons, project is backed with add-ons, triggers prompt before pledge.

# 👀 See

<img width="50%" alt="image" src="https://user-images.githubusercontent.com/3735375/91235869-540c0b80-e6eb-11ea-8e10-285a382a590e.png">

# ✅ Acceptance criteria

- [ ] Back a reward with add-ons, edit the reward, select the same reward - no prompt is shown.
- [ ] Back a reward with add-ons, edit the reward, select a new reward - prompt is shown.
- [ ] Back a reward without add-ons, edit the reward, select a new reward - no prompt is shown.
- [ ] Back a reward without add-ons, edit the reward, should not be able to select the same reward.