### PR TITLE
[NT-1473] Reload Shipping Selector on Error

### DIFF
--- a/Kickstarter-iOS/Views/Controllers/PledgeShippingLocationViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/PledgeShippingLocationViewController.swift
@@ -12,6 +12,9 @@ protocol PledgeShippingLocationViewControllerDelegate: AnyObject {
   func pledgeShippingLocationViewControllerLayoutDidUpdate(
     _ viewController: PledgeShippingLocationViewController
   )
+  func pledgeShippingLocationViewControllerFailedToLoad(
+    _ viewController: PledgeShippingLocationViewController
+  )
 }
 
 final class PledgeShippingLocationViewController: UIViewController {
@@ -150,6 +153,14 @@ final class PledgeShippingLocationViewController: UIViewController {
       .observeForUI()
       .observeValues { [weak self] in
         self?.dismiss(animated: true)
+      }
+
+    self.viewModel.outputs.shippingRulesError
+      .observeForUI()
+      .observeValues { [weak self] _ in
+        guard let self = self else { return }
+
+        self.delegate?.pledgeShippingLocationViewControllerFailedToLoad(self)
       }
   }
 

--- a/Kickstarter-iOS/Views/Controllers/PledgeViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/PledgeViewController.swift
@@ -606,6 +606,7 @@ extension PledgeViewController: PledgeShippingLocationViewControllerDelegate {
   }
 
   func pledgeShippingLocationViewControllerLayoutDidUpdate(_: PledgeShippingLocationViewController) {}
+  func pledgeShippingLocationViewControllerFailedToLoad(_: PledgeShippingLocationViewController) {}
 }
 
 // MARK: - PledgeViewControllerMessageDisplaying

--- a/Kickstarter-iOS/Views/Controllers/RewardAddOnSelectionViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/RewardAddOnSelectionViewController.swift
@@ -221,6 +221,10 @@ extension RewardAddOnSelectionViewController: PledgeShippingLocationViewControll
   func pledgeShippingLocationViewControllerLayoutDidUpdate(_: PledgeShippingLocationViewController) {
     self.tableView.ksr_sizeHeaderFooterViewsToFit()
   }
+
+  func pledgeShippingLocationViewControllerFailedToLoad(_: PledgeShippingLocationViewController) {
+    self.viewModel.inputs.shippingLocationViewDidFailToLoad()
+  }
 }
 
 // MARK: - RewardAddOnCardViewDelegate

--- a/Library/ViewModels/RewardAddOnSelectionViewModelTests.swift
+++ b/Library/ViewModels/RewardAddOnSelectionViewModelTests.swift
@@ -48,12 +48,15 @@ final class RewardAddOnSelectionViewModelTests: TestCase {
     self.vm.outputs.startRefreshing.observe(self.startRefreshing.observer)
   }
 
-  func testConfigurePledgeShippingLocationViewControllerWithData() {
+  func testConfigurePledgeShippingLocationViewControllerWithData_ShippingEnabled() {
     self.configurePledgeShippingLocationViewControllerWithDataProject.assertDidNotEmitValue()
     self.configurePledgeShippingLocationViewControllerWithDataReward.assertDidNotEmitValue()
     self.configurePledgeShippingLocationViewControllerWithDataShowAmount.assertDidNotEmitValue()
+    self.configurePledgeShippingLocationViewControllerWithDataSelectedLocationId.assertDidNotEmitValue()
 
     let reward = Reward.template
+      |> Reward.lens.shipping.enabled .~ true
+
     let project = Project.template
 
     let data = PledgeViewData(
@@ -72,6 +75,82 @@ final class RewardAddOnSelectionViewModelTests: TestCase {
     self.configurePledgeShippingLocationViewControllerWithDataReward.assertValues([reward])
     self.configurePledgeShippingLocationViewControllerWithDataShowAmount.assertValues([false])
     self.configurePledgeShippingLocationViewControllerWithDataSelectedLocationId.assertValues([2])
+  }
+
+  func testConfigurePledgeShippingLocationViewControllerWithData_ShippingDisabled() {
+    self.configurePledgeShippingLocationViewControllerWithDataProject.assertDidNotEmitValue()
+    self.configurePledgeShippingLocationViewControllerWithDataReward.assertDidNotEmitValue()
+    self.configurePledgeShippingLocationViewControllerWithDataShowAmount.assertDidNotEmitValue()
+    self.configurePledgeShippingLocationViewControllerWithDataSelectedLocationId.assertDidNotEmitValue()
+
+    let reward = Reward.template
+      |> Reward.lens.shipping.enabled .~ false
+
+    let project = Project.template
+
+    let data = PledgeViewData(
+      project: project,
+      rewards: [reward],
+      selectedQuantities: [:],
+      selectedLocationId: 2,
+      refTag: nil,
+      context: .pledge
+    )
+
+    self.vm.inputs.configure(with: data)
+    self.vm.inputs.viewDidLoad()
+
+    self.configurePledgeShippingLocationViewControllerWithDataProject.assertDidNotEmitValue()
+    self.configurePledgeShippingLocationViewControllerWithDataReward.assertDidNotEmitValue()
+    self.configurePledgeShippingLocationViewControllerWithDataShowAmount.assertDidNotEmitValue()
+    self.configurePledgeShippingLocationViewControllerWithDataSelectedLocationId.assertDidNotEmitValue()
+  }
+
+  func testConfigurePledgeShippingLocationViewControllerWithData_ShippingEnabled_FailedThenRefreshed() {
+    self.configurePledgeShippingLocationViewControllerWithDataProject.assertDidNotEmitValue()
+    self.configurePledgeShippingLocationViewControllerWithDataReward.assertDidNotEmitValue()
+    self.configurePledgeShippingLocationViewControllerWithDataShowAmount.assertDidNotEmitValue()
+    self.configurePledgeShippingLocationViewControllerWithDataSelectedLocationId.assertDidNotEmitValue()
+    self.shippingLocationViewIsHidden.assertDidNotEmitValue()
+
+    let reward = Reward.template
+      |> Reward.lens.shipping.enabled .~ true
+
+    let project = Project.template
+
+    let data = PledgeViewData(
+      project: project,
+      rewards: [reward],
+      selectedQuantities: [:],
+      selectedLocationId: 2,
+      refTag: nil,
+      context: .pledge
+    )
+
+    self.vm.inputs.configure(with: data)
+    self.vm.inputs.viewDidLoad()
+
+    self.configurePledgeShippingLocationViewControllerWithDataProject.assertValues([project])
+    self.configurePledgeShippingLocationViewControllerWithDataReward.assertValues([reward])
+    self.configurePledgeShippingLocationViewControllerWithDataShowAmount.assertValues([false])
+    self.configurePledgeShippingLocationViewControllerWithDataSelectedLocationId.assertValues([2])
+    self.shippingLocationViewIsHidden.assertValues([false])
+
+    self.vm.inputs.shippingLocationViewDidFailToLoad()
+
+    self.configurePledgeShippingLocationViewControllerWithDataProject.assertValues([project])
+    self.configurePledgeShippingLocationViewControllerWithDataReward.assertValues([reward])
+    self.configurePledgeShippingLocationViewControllerWithDataShowAmount.assertValues([false])
+    self.configurePledgeShippingLocationViewControllerWithDataSelectedLocationId.assertValues([2])
+    self.shippingLocationViewIsHidden.assertValues([false, true])
+
+    self.vm.inputs.beginRefresh()
+
+    self.configurePledgeShippingLocationViewControllerWithDataProject.assertValues([project, project])
+    self.configurePledgeShippingLocationViewControllerWithDataReward.assertValues([reward, reward])
+    self.configurePledgeShippingLocationViewControllerWithDataShowAmount.assertValues([false, false])
+    self.configurePledgeShippingLocationViewControllerWithDataSelectedLocationId.assertValues([2, 2])
+    self.shippingLocationViewIsHidden.assertValues([false, true, false])
   }
 
   func testLoadAddOnRewardsIntoDataSource() {
@@ -647,9 +726,7 @@ final class RewardAddOnSelectionViewModelTests: TestCase {
     self.shippingLocationViewIsHidden.assertDidNotEmitValue()
 
     let reward = Reward.template
-      |> Reward.lens.shipping .~ (
-        .template |> Reward.Shipping.lens.enabled .~ true
-      )
+      |> Reward.lens.shipping.enabled .~ true
     let project = Project.template
 
     let data = PledgeViewData(


### PR DESCRIPTION
# 📲 What

Refreshes the shipping location selector on `RewardAddOnSelectionViewController` when the user pulls to refresh.

# 🤔 Why

The shipping locations are fetched in a separate call to the reward add-ons so if one of these calls fail the user should have the opportunity to recover from that.

# 🛠 How

- Updated `RewardAddOnSelectionViewModel` to reconfigure the `PledgeShippingLocationViewController` when the user pulls to refresh.
- The `PledgeShippingLocationViewController` is now also hidden when it is in an errored state.

# 👀 See

<img src="https://user-images.githubusercontent.com/3735375/91353883-bb37c780-e7a0-11ea-80d7-47020cf57cf1.gif" width="35%" />

# ✅ Acceptance criteria

Turn on airplane mode or use Charles proxy to cause the shipping locations to fail.

- [ ] If the calls fail the error should be displayed.
- [ ] Pulling to refresh should refresh both the shipping location selector and the add-ons.