### PR TITLE
[NT-1452] Maximum Pledge Amount Fix

### DIFF
--- a/Library/ViewModels/PledgeAmountViewModel.swift
+++ b/Library/ViewModels/PledgeAmountViewModel.swift
@@ -80,7 +80,8 @@ public final class PledgeAmountViewModel: PledgeAmountViewModelType,
       .map(first)
 
     let unavailableAmount = Signal.merge(
-      self.projectAndRewardProperty.signal.mapConst(0),
+      self.projectAndRewardProperty.signal.mapConst(0)
+        .take(until: self.unavailableAmountChangedProperty.signal.ignoreValues()),
       self.unavailableAmountChangedProperty.signal
     )
 


### PR DESCRIPTION
# 📲 What

Fixes the amount displayed for the maximum pledge amount validation message.

# 🤔 Why

This amount is initially set to `0` and then updated by the delegate. In some situations there was a race condition between the initial amount and the delegate causing the amount to remain at `0`.

# 🛠 How

Fixed the race condition by cancelling the initial value signal once we've received an amount from the pledge view.

- [ ] Back a USD reward without shipping, enter an amount above $10000, observe that the amount displayed is $10000 minus the reward minimum.
- [ ] Back a USD reward with shipping, enter an amount above $10000, observe that the amount displayed is $10000 minus the reward minimum and shipping amounts.