### PR TITLE
[NT-1416] Navigation bugfix

### DIFF
--- a/Library/ViewModels/RewardsCollectionViewModel.swift
+++ b/Library/ViewModels/RewardsCollectionViewModel.swift
@@ -145,17 +145,15 @@ public final class RewardsCollectionViewModel: RewardsCollectionViewModelType,
       )
     }
 
-    let goToAddOnSelectionBackedConfirmed = Signal.zip(
-      goToAddOnSelectionBackedWithAddOns,
-      self.confirmedEditRewardProperty.signal
-    )
-    .map(first)
+    let goToAddOnSelectionBackedConfirmed = goToPledge
+      .takeWhen(self.confirmedEditRewardProperty.signal)
+      .filter(second >>> isTrue)
+      .map(first)
 
-    let goToPledgeBackedConfirmed = Signal.zip(
-      goToPledgeBackedWithAddOns,
-      self.confirmedEditRewardProperty.signal
-    )
-    .map(first)
+    let goToPledgeBackedConfirmed = goToPledge
+      .takeWhen(self.confirmedEditRewardProperty.signal)
+      .filter(second >>> isFalse)
+      .map(first)
 
     self.goToAddOnSelection = Signal.merge(
       goToAddOnSelectionNotBackedWithAddOns,

--- a/Library/ViewModels/RewardsCollectionViewModel.swift
+++ b/Library/ViewModels/RewardsCollectionViewModel.swift
@@ -271,7 +271,9 @@ private func titleForContext(_ context: RewardsCollectionViewContext, project: P
 }
 
 private func shouldNavigateToReward(project: Project, reward: Reward, refTag _: RefTag?) -> Bool {
-  project.state == .live && (!userIsBacking(reward: reward, inProject: project) || reward.hasAddOns)
+  guard !currentUserIsCreator(of: project) else { return false }
+
+  return project.state == .live && (!userIsBacking(reward: reward, inProject: project) || reward.hasAddOns)
 }
 
 private func shouldTriggerEditRewardPrompt(_ data: PledgeViewData) -> Bool {

--- a/Library/ViewModels/RewardsCollectionViewModelTests.swift
+++ b/Library/ViewModels/RewardsCollectionViewModelTests.swift
@@ -99,6 +99,22 @@ final class RewardsCollectionViewModelTests: TestCase {
     }
   }
 
+  func testGoToPledge_DoesNotEmitIfCreatorOfProject() {
+    let user = User.template
+    let project = Project.cosmicSurgery
+      |> Project.lens.creator .~ user
+
+    withEnvironment(config: .template, currentUser: user) {
+      self.vm.inputs.configure(with: project, refTag: .activity, context: .createPledge)
+      self.vm.inputs.viewDidLoad()
+
+      self.vm.inputs.rewardSelected(with: project.rewards[0].id)
+
+      self.goToAddOnSelection.assertDidNotEmitValue()
+      self.goToPledge.assertDidNotEmitValue()
+    }
+  }
+
   func testGoToPledge_NotBacked() {
     withEnvironment(config: .template) {
       let project = Project.cosmicSurgery


### PR DESCRIPTION
# 📲 What

Fixes a bug which would sometimes caused navigation to not work correctly when a backer edits their reward and selected a new reward.

# 🤔 Why

This bug was caused by the behaviour of `Signal.zip`. `zip` emits when all of its signals have emitted at least once and then emits each time all of the signals have emitted again. In the situation where the user dismissed the alert by cancelling the last selected reward ID would remain in the buffer and the following time that they tapped _yes_ to continue it would incorrectly navigate to the wrong reward.

# 🛠 How

Rearranged the signals to make use of `takeWhen` instead of `zip`.

# 👀 See

# ✅ Acceptance criteria

The ACs from #1269:

- [ ] Back a reward with add-ons, edit the reward, select the same reward - no prompt is shown.
- [ ] Back a reward with add-ons, edit the reward, select a new reward - prompt is shown.
- [ ] Back a reward without add-ons, edit the reward, select a new reward - no prompt is shown.
- [ ] Back a reward without add-ons, edit the reward, should not be able to select the same reward.

Also:

- [ ] When shown the alert, select _no_ to cancel and then select a different reward. You should not be shown the previously selected reward.