### PR TITLE
[NT-1480] Tracking for Add-ons

### DIFF
--- a/Library/Tracking/Koala.swift
+++ b/Library/Tracking/Koala.swift
@@ -23,6 +23,8 @@ public final class Koala {
   private enum DataLakeApprovedEvent: String, CaseIterable {
     case activityFeedViewed = "Activity Feed Viewed"
     case addNewCardButtonClicked = "Add New Card Button Clicked"
+    case addOnsContinueButtonClicked = "Add-Ons Continue Button Clicked"
+    case addOnsPageViewed = "Add-Ons Page Viewed"
     case campaignDetailsButtonClicked = "Campaign Details Button Clicked"
     case campaignDetailsPledgeButtonClicked = "Campaign Details Pledge Button Clicked"
     case creatorDetailsClicked = "Creator Details Clicked"
@@ -68,6 +70,7 @@ public final class Koala {
   /// Determines the screen from which the event is sent.
   public enum LocationContext: String {
     case activities = "activity_feed_screen" // ActivitiesViewController
+    case addOnsSelection = "add_ons_selection" // RewardAddOnSelectionViewController
     case campaign = "campaign_screen" // ProjectDescriptionViewController
     case discovery = "explore_screen" // DiscoveryViewController
     case editorialProjects = "editorial_collection_screen" // EditorialProjectsViewController
@@ -340,6 +343,9 @@ public final class Koala {
   }
 
   public struct CheckoutPropertiesData: Equatable {
+    let addOnsCountTotal: Int?
+    let addOnsCountUnique: Int?
+    let addOnsMinimumUsd: String?
     let amount: String
     let bonusAmount: String
     let bonusAmountInUsd: String
@@ -348,9 +354,11 @@ public final class Koala {
     let paymentType: String?
     let revenueInUsdCents: Int
     let rewardId: Int
+    let rewardMinimumUsd: String
     let rewardTitle: String?
     let shippingEnabled: Bool
     let shippingAmount: Double?
+    let shippingAmountUsd: String?
     let userHasStoredApplePayCard: Bool
   }
 
@@ -613,6 +621,42 @@ public final class Koala {
   }
 
   // MARK: - Pledge Events
+
+  public func trackAddOnsContinueButtonClicked(
+    project: Project,
+    reward: Reward,
+    context: PledgeContext,
+    refTag: RefTag?
+  ) {
+    let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
+      .withAllValuesFrom(pledgeProperties(from: reward))
+      .withAllValuesFrom(contextProperties(pledgeFlowContext: context))
+
+    self.track(
+      event: DataLakeApprovedEvent.addOnsContinueButtonClicked.rawValue,
+      location: .addOnsSelection,
+      properties: props,
+      refTag: refTag?.stringTag
+    )
+  }
+
+  public func trackAddOnsPageViewed(
+    project: Project,
+    reward: Reward,
+    context: PledgeContext,
+    refTag: RefTag?
+  ) {
+    let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
+      .withAllValuesFrom(pledgeProperties(from: reward))
+      .withAllValuesFrom(contextProperties(pledgeFlowContext: context))
+
+    self.track(
+      event: DataLakeApprovedEvent.addOnsPageViewed.rawValue,
+      location: .addOnsSelection,
+      properties: props,
+      refTag: refTag?.stringTag
+    )
+  }
 
   public func trackPledgeCTAButtonClicked(
     stateType: PledgeStateCTAType,
@@ -2306,16 +2350,23 @@ private func checkoutProperties(from data: Koala.CheckoutPropertiesData, prefix:
   var result: [String: Any] = [:]
 
   result["amount"] = data.amount
+  result["add_ons_count_total"] = data.addOnsCountTotal
+  result["add_ons_count_unique"] = data.addOnsCountUnique
+  result["add_ons_minimum_usd"] = data.addOnsMinimumUsd
   result["bonus_amount"] = data.bonusAmount
   result["bonus_amount_usd"] = data.bonusAmountInUsd
   result["id"] = data.checkoutId
   result["payment_type"] = data.paymentType
   result["reward_id"] = data.rewardId
   result["reward_title"] = data.rewardTitle
+  result["reward_minimum_usd"] = data.rewardMinimumUsd
   result["shipping_amount"] = data.shippingAmount
   result["revenue_in_usd_cents"] = data.revenueInUsdCents
   result["reward_estimated_delivery_on"] = data.estimatedDelivery
   result["reward_shipping_enabled"] = data.shippingEnabled
+  result["shipping_amount"] = data.shippingAmount
+  result["shipping_amount_usd"] = data.shippingAmountUsd
+  result["reward_estimated_delivery_on"] = data.estimatedDelivery
   result["user_has_eligible_stored_apple_pay_card"] = data.userHasStoredApplePayCard
 
   return result.prefixedKeys(prefix)

--- a/Library/Tracking/KoalaTests.swift
+++ b/Library/Tracking/KoalaTests.swift
@@ -905,7 +905,8 @@ final class KoalaTests: TestCase {
     koala.trackPledgeSubmitButtonClicked(
       project: .template,
       reward: .template,
-      checkoutData: .template, refTag: nil
+      checkoutData: .template,
+      refTag: nil
     )
 
     let props = client.properties.last
@@ -1347,33 +1348,43 @@ final class KoalaTests: TestCase {
    Helper for testing checkoutProperties from a template Koala.CheckoutPropertiesData
    */
   private func assertCheckoutProperties(_ props: [String: Any]?) {
-    XCTAssertEqual("20.00", props?["checkout_amount"] as? String)
+    XCTAssertEqual(2, props?["checkout_add_ons_count_total"] as? Int)
+    XCTAssertEqual(1, props?["checkout_add_ons_count_unique"] as? Int)
+    XCTAssertEqual("8.00", props?["checkout_add_ons_minimum_usd"] as? String)
+    XCTAssertEqual("43.00", props?["checkout_amount"] as? String)
     XCTAssertEqual("10.00", props?["checkout_bonus_amount"] as? String)
     XCTAssertEqual("10.00", props?["checkout_bonus_amount_usd"] as? String)
     XCTAssertEqual("CREDIT_CARD", props?["checkout_payment_type"] as? String)
     XCTAssertEqual("SUPER reward", props?["checkout_reward_title"] as? String)
+    XCTAssertEqual("5.00", props?["checkout_reward_minimum_usd"] as? String)
     XCTAssertEqual(2, props?["checkout_reward_id"] as? Int)
     XCTAssertEqual(2_000, props?["checkout_revenue_in_usd_cents"] as? Int)
-    XCTAssertEqual(false, props?["checkout_reward_shipping_enabled"] as? Bool)
+    XCTAssertEqual(true, props?["checkout_reward_shipping_enabled"] as? Bool)
     XCTAssertEqual(true, props?["checkout_user_has_eligible_stored_apple_pay_card"] as? Bool)
-    XCTAssertNil(props?["checkout_shipping_amount"] as? Double)
-    XCTAssertNil(props?["checkout_reward_estimated_delivery_on"] as? TimeInterval)
+    XCTAssertEqual(10.00, props?["checkout_shipping_amount"] as? Double)
+    XCTAssertEqual("10.00", props?["checkout_shipping_amount_usd"] as? String)
+    XCTAssertEqual(12_345_678, props?["checkout_reward_estimated_delivery_on"] as? TimeInterval)
   }
 }
 
 extension Koala.CheckoutPropertiesData {
   static let template = Koala.CheckoutPropertiesData(
-    amount: "20.00",
+    addOnsCountTotal: 2,
+    addOnsCountUnique: 1,
+    addOnsMinimumUsd: "8.00",
+    amount: "43.00",
     bonusAmount: "10.00",
     bonusAmountInUsd: "10.00",
     checkoutId: 1,
-    estimatedDelivery: nil,
+    estimatedDelivery: 12_345_678,
     paymentType: "CREDIT_CARD",
     revenueInUsdCents: 2_000,
     rewardId: 2,
+    rewardMinimumUsd: "5.00",
     rewardTitle: "SUPER reward",
-    shippingEnabled: false,
-    shippingAmount: nil,
+    shippingEnabled: true,
+    shippingAmount: 10,
+    shippingAmountUsd: "10.00",
     userHasStoredApplePayCard: true
   )
 }

--- a/Library/Tracking/MockTrackingClient.swift
+++ b/Library/Tracking/MockTrackingClient.swift
@@ -22,4 +22,10 @@ internal final class MockTrackingClient: TrackingClientType {
   internal func properties<A>(forKey key: String, as _: A.Type) -> [A?] {
     return self.tracks.map { $0.properties[key] as? A }
   }
+
+  internal func containsKeyPrefix(_ prefix: String) -> Bool {
+    for key in self.properties.map(\.keys).flatMap({ $0 }) where key.hasPrefix(prefix) { return true }
+
+    return false
+  }
 }

--- a/Library/ViewModels/RewardAddOnSelectionViewModel.swift
+++ b/Library/ViewModels/RewardAddOnSelectionViewModel.swift
@@ -245,6 +245,32 @@ public final class RewardAddOnSelectionViewModel: RewardAddOnSelectionViewModelT
     )
     .map(PledgeViewData.init)
     .takeWhen(self.continueButtonTappedProperty.signal)
+
+    // MARK: - Tracking
+
+    Signal.zip(project, baseReward, context, refTag)
+      .take(first: 1)
+      .observeForUI()
+      .observeValues { project, baseReward, context, refTag in
+        AppEnvironment.current.koala.trackAddOnsPageViewed(
+          project: project,
+          reward: baseReward,
+          context: TrackingHelpers.pledgeContext(for: context),
+          refTag: refTag
+        )
+      }
+
+    Signal.zip(project, baseReward, context, refTag)
+      .takeWhen(self.continueButtonTappedProperty.signal)
+      .observeForUI()
+      .observeValues { project, baseReward, context, refTag in
+        AppEnvironment.current.koala.trackAddOnsContinueButtonClicked(
+          project: project,
+          reward: baseReward,
+          context: TrackingHelpers.pledgeContext(for: context),
+          refTag: refTag
+        )
+      }
   }
 
   private let (beginRefreshSignal, beginRefreshObserver) = Signal<Void, Never>.pipe()

--- a/Library/ViewModels/ThanksViewModelTests.swift
+++ b/Library/ViewModels/ThanksViewModelTests.swift
@@ -326,17 +326,22 @@ final class ThanksViewModelTests: TestCase {
 
   func testThanksPageViewed_Properties() {
     let checkoutData = Koala.CheckoutPropertiesData(
-      amount: "10.00",
-      bonusAmount: "20.00",
-      bonusAmountInUsd: "20.00",
+      addOnsCountTotal: 2,
+      addOnsCountUnique: 1,
+      addOnsMinimumUsd: "8.00",
+      amount: "43.00",
+      bonusAmount: "10.00",
+      bonusAmountInUsd: "10.00",
       checkoutId: 1,
-      estimatedDelivery: nil,
+      estimatedDelivery: 12_345_678,
       paymentType: "CREDIT_CARD",
-      revenueInUsdCents: 500,
+      revenueInUsdCents: 2_000,
       rewardId: 2,
+      rewardMinimumUsd: "5.00",
       rewardTitle: "SUPER reward",
-      shippingEnabled: false,
-      shippingAmount: nil,
+      shippingEnabled: true,
+      shippingAmount: 10,
+      shippingAmountUsd: "10.00",
       userHasStoredApplePayCard: true
     )
 
@@ -348,17 +353,22 @@ final class ThanksViewModelTests: TestCase {
     XCTAssertEqual(["Triggered App Store Rating Dialog", "Thanks Page Viewed"], self.trackingClient.events)
 
     // Checkout properties
-    XCTAssertEqual("10.00", props?["checkout_amount"] as? String)
-    XCTAssertEqual("20.00", props?["checkout_bonus_amount"] as? String)
-    XCTAssertEqual("20.00", props?["checkout_bonus_amount_usd"] as? String)
+    XCTAssertEqual(2, props?["checkout_add_ons_count_total"] as? Int)
+    XCTAssertEqual(1, props?["checkout_add_ons_count_unique"] as? Int)
+    XCTAssertEqual("8.00", props?["checkout_add_ons_minimum_usd"] as? String)
+    XCTAssertEqual("43.00", props?["checkout_amount"] as? String)
+    XCTAssertEqual("10.00", props?["checkout_bonus_amount"] as? String)
+    XCTAssertEqual("10.00", props?["checkout_bonus_amount_usd"] as? String)
     XCTAssertEqual("CREDIT_CARD", props?["checkout_payment_type"] as? String)
     XCTAssertEqual("SUPER reward", props?["checkout_reward_title"] as? String)
+    XCTAssertEqual("5.00", props?["checkout_reward_minimum_usd"] as? String)
     XCTAssertEqual(2, props?["checkout_reward_id"] as? Int)
-    XCTAssertEqual(500, props?["checkout_revenue_in_usd_cents"] as? Int)
-    XCTAssertEqual(false, props?["checkout_reward_shipping_enabled"] as? Bool)
+    XCTAssertEqual(2_000, props?["checkout_revenue_in_usd_cents"] as? Int)
+    XCTAssertEqual(true, props?["checkout_reward_shipping_enabled"] as? Bool)
     XCTAssertEqual(true, props?["checkout_user_has_eligible_stored_apple_pay_card"] as? Bool)
-    XCTAssertNil(props?["checkout_shipping_amount"] as? Double)
-    XCTAssertNil(props?["checkout_reward_estimated_delivery_on"] as? TimeInterval)
+    XCTAssertEqual(10.00, props?["checkout_shipping_amount"] as? Double)
+    XCTAssertEqual("10.00", props?["checkout_shipping_amount_usd"] as? String)
+    XCTAssertEqual(12_345_678, props?["checkout_reward_estimated_delivery_on"] as? TimeInterval)
 
     // Pledge properties
     XCTAssertEqual(true, props?["pledge_backer_reward_has_items"] as? Bool)


### PR DESCRIPTION
# 📲 What

Adds some required tracking for add-ons.

# 🤔 Why

This will allow us to learn more about how backers use this feature and hopefully inform some of our decisions moving forward.

# 🛠 How

Added two tracking events:

`Add-Ons Continue Button Clicked`
`Add-Ons Page Viewed`

Added several checkout properties:

`checkout_add_ons_count_total`
`checkout_add_ons_count_unique`
`checkout_add_ons_minimum_usd`
`checkout_bonus_amount_usd`
`checkout_reward_minimum_usd`
`checkout_shipping_amount_usd`

# ✅ Acceptance criteria

- [ ] When navigating to the add-on selection view, the event `Add-Ons Page Viewed` should be tracked.
- [ ] When tapping to skip add-ons or continue to the pledge view, the event `Add-Ons Continue Button Clicked` should be tracked.
- [ ] After completing checkout the additional properties listed above should be included.