### PR TITLE
[NT-1486] Add-on Selection Card Haptics

### DIFF
--- a/Kickstarter-iOS/Views/RewardAddOnCardView.swift
+++ b/Kickstarter-iOS/Views/RewardAddOnCardView.swift
@@ -176,6 +176,14 @@ public final class RewardAddOnCardView: UIView {
       .observeValues { [weak self] values in
         self?.configurePillsView(values)
       }
+
+    self.viewModel.outputs.generateSelectionFeedback
+      .observeForUI()
+      .observeValues { generateSelectionFeedback() }
+
+    self.viewModel.outputs.generateNotificationWarningFeedback
+      .observeForUI()
+      .observeValues { generateNotificationWarningFeedback() }
   }
 
   // MARK: - Private Helpers

--- a/Library/ViewModels/RewardAddOnCardViewModel.swift
+++ b/Library/ViewModels/RewardAddOnCardViewModel.swift
@@ -23,6 +23,8 @@ public protocol RewardAddOnCardViewModelOutputs {
   var amountConversionLabelText: Signal<String, Never> { get }
   var amountLabelAttributedText: Signal<NSAttributedString, Never> { get }
   var descriptionLabelText: Signal<String, Never> { get }
+  var generateSelectionFeedback: Signal<Void, Never> { get }
+  var generateNotificationWarningFeedback: Signal<Void, Never> { get }
   var includedItemsLabelAttributedText: Signal<NSAttributedString, Never> { get }
   var includedItemsStackViewHidden: Signal<Bool, Never> { get }
   var notifiyDelegateDidSelectQuantity: Signal<(SelectedRewardQuantity, SelectedRewardId), Never> { get }
@@ -134,6 +136,20 @@ public final class RewardAddOnCardViewModel: RewardAddOnCardViewModelType, Rewar
 
     self.stepperValue = initialOrUpdatedSelectedQuantity
       .map(Double.init)
+
+    self.generateSelectionFeedback = Signal.combineLatest(
+      updatedSelectedQuantity.map(Double.init),
+      self.stepperMaxValue
+    )
+    .filter { value, max in value > 0 && value < max }
+    .ignoreValues()
+
+    self.generateNotificationWarningFeedback = Signal.combineLatest(
+      updatedSelectedQuantity.map(Double.init),
+      self.stepperMaxValue
+    )
+    .filter { value, max in value == 0 || value >= max }
+    .ignoreValues()
   }
 
   private let addButtonTappedProperty = MutableProperty(())
@@ -161,6 +177,8 @@ public final class RewardAddOnCardViewModel: RewardAddOnCardViewModelType, Rewar
   public let amountConversionLabelText: Signal<String, Never>
   public let amountLabelAttributedText: Signal<NSAttributedString, Never>
   public let descriptionLabelText: Signal<String, Never>
+  public let generateSelectionFeedback: Signal<Void, Never>
+  public let generateNotificationWarningFeedback: Signal<Void, Never>
   public let includedItemsLabelAttributedText: Signal<NSAttributedString, Never>
   public let includedItemsStackViewHidden: Signal<Bool, Never>
   public let notifiyDelegateDidSelectQuantity: Signal<(SelectedRewardQuantity, SelectedRewardId), Never>


### PR DESCRIPTION
# 📲 What

Adds haptics to the `UIStepper` control on `RewardAddOnSelectionView`.

# 🤔 Why

This is in keeping with the haptics that we have for the similar `UIStepper` control on our `PledgeViewController` and helps to communicate minimum, selection and maximum to the user while they are interacting with the control.

# 🛠 How

Updated `RewardAddOnSelectionViewModel` to generate the necessary signals when the stepper is at zero, within the selectable range or at the maximum.

# ✅ Acceptance criteria

During add-on selection, Iincrement and decrement the quantity stepper:

- [ ] At zero it should trigger the haptic 'warning feedback' (two taps).
- [ ] Above zero and below the maximum it should trigger the haptic 'selection feedback' (single tap).
- [ ] At the maximum it should trigger the haptic 'warning feedback' (two taps).