### PR TITLE
[NT-1492] Bonus Amount Editing Bugfix

### DIFF
--- a/Library/ViewModels/PledgeAmountViewModel.swift
+++ b/Library/ViewModels/PledgeAmountViewModel.swift
@@ -98,7 +98,6 @@ public final class PledgeAmountViewModel: PledgeAmountViewModelType,
 
     let initialValue = Signal.combineLatest(
       project,
-      reward,
       currentAmount,
       minValue
     )
@@ -272,11 +271,10 @@ private func rounded(_ value: Double) -> Double {
 
 private func initialPledgeAmount(
   from project: Project,
-  reward: Reward,
   currentAmount: Double,
   minValue: Double
 ) -> Double {
-  guard userIsBacking(reward: reward, inProject: project) else { return minValue }
+  guard userIsBackingProject(project) else { return minValue }
 
   return currentAmount
 }

--- a/Library/ViewModels/PledgeAmountViewModelTests.swift
+++ b/Library/ViewModels/PledgeAmountViewModelTests.swift
@@ -1308,7 +1308,7 @@ internal final class PledgeAmountViewModelTests: TestCase {
     self.titleLabelText.assertValues(["Bonus support"])
   }
 
-  func testCurrentAmount_BackedReward() {
+  func testCurrentAmount_BackedReward_EditingSameReward() {
     let reward = Reward.template
 
     let project = Project.cosmicSurgery
@@ -1334,6 +1334,46 @@ internal final class PledgeAmountViewModelTests: TestCase {
     self.textFieldValue.assertDidNotEmitValue()
 
     self.vm.inputs.configureWith(data: (project, reward: reward, 50))
+
+    self.amountIsValid.assertValues([true])
+    self.amountMin.assertValues([0])
+    self.amountMax.assertValues([8_000])
+    self.amountValue.assertValues([50])
+    self.currency.assertValues(["£"])
+    self.stepperMinValue.assertValue(0)
+    self.stepperMaxValue.assertValue(PledgeAmountStepperConstants.max)
+    self.stepperValue.assertValues([50.0])
+    self.textFieldValue.assertValues(["50"])
+  }
+
+  func testCurrentAmount_BackedReward_EditingDifferentReward() {
+    let reward = Reward.template
+    let otherReward = Reward.template
+      |> Reward.lens.id .~ 5
+
+    let project = Project.cosmicSurgery
+      |> Project.lens.state .~ .live
+      |> Project.lens.personalization.isBacking .~ true
+      |> Project.lens.personalization.backing .~ (
+        .template
+          |> Backing.lens.reward .~ reward
+          |> Backing.lens.rewardId .~ reward.id
+          |> Backing.lens.shippingAmount .~ 10
+          |> Backing.lens.amount .~ 700.0
+          |> Backing.lens.status .~ .pledged
+      )
+
+    self.amountIsValid.assertDidNotEmitValue()
+    self.amountMin.assertDidNotEmitValue()
+    self.amountMax.assertDidNotEmitValue()
+    self.amountValue.assertDidNotEmitValue()
+    self.currency.assertDidNotEmitValue()
+    self.stepperMinValue.assertDidNotEmitValue()
+    self.stepperMaxValue.assertDidNotEmitValue()
+    self.stepperValue.assertDidNotEmitValue()
+    self.textFieldValue.assertDidNotEmitValue()
+
+    self.vm.inputs.configureWith(data: (project, reward: otherReward, 50))
 
     self.amountIsValid.assertValues([true])
     self.amountMin.assertValues([0])


### PR DESCRIPTION
# 📲 What

Fixes a bug that resulted in the bonus amount when editing a reward not being passed through correctly when editing to back a new reward.

# 🤔 Why

Our check was too specific, we were checking to see that the reward was backed but we in fact only care that the project has been backed.

# 🛠 How

Updated the `guard` statement and added a test.

# ✅ Acceptance criteria

- [ ] When editing a reward with add-ons and selecting the same reward the previous bonus amount should be set initially.
- [ ] When editing a reward with add-ons and selecting a new reward the previous bonus amount should be set initially.