### PR TITLE
[NT-1493] Hide Shipping in Manage View Based on Base Reward

### DIFF
--- a/KsApi/models/graphql/adapters/Backing+GraphBacking.swift
+++ b/KsApi/models/graphql/adapters/Backing+GraphBacking.swift
@@ -35,7 +35,7 @@ extension Backing {
       reward: reward,
       rewardId: reward?.id,
       sequence: graphBacking.sequence ?? 0,
-      shippingAmount: Int(graphBacking.shippingAmount?.amount ?? 0),
+      shippingAmount: graphBacking.shippingAmount.map(\.amount).flatMap(Int.init),
       status: backingStatus
     )
   }

--- a/Library/ViewModels/ManagePledgeSummaryViewModel.swift
+++ b/Library/ViewModels/ManagePledgeSummaryViewModel.swift
@@ -21,6 +21,7 @@ public struct ManagePledgeSummaryViewData: Equatable {
   public let projectState: Project.State
   public let rewardMinimum: Double
   public let shippingAmount: Double?
+  public let shippingAmountHidden: Bool
 }
 
 public protocol ManagePledgeSummaryViewModelInputs {
@@ -138,7 +139,7 @@ private func pledgeAmountSummaryViewData(
     pledgedOn: data.pledgedOn,
     rewardMinimum: data.rewardMinimum,
     shippingAmount: data.shippingAmount,
-    shippingAmountHidden: false
+    shippingAmountHidden: data.shippingAmountHidden
   )
 }
 

--- a/Library/ViewModels/ManagePledgeSummaryViewModelTests.swift
+++ b/Library/ViewModels/ManagePledgeSummaryViewModelTests.swift
@@ -50,7 +50,8 @@ final class ManagePledgeSummaryViewModelTests: TestCase {
       projectDeadline: 1_572_626_213.0,
       projectState: Project.State.live,
       rewardMinimum: 30,
-      shippingAmount: nil
+      shippingAmount: nil,
+      shippingAmountHidden: true
     )
 
     self.vm.inputs.configureWith(data)
@@ -83,7 +84,8 @@ final class ManagePledgeSummaryViewModelTests: TestCase {
       projectDeadline: 1_572_626_213.0,
       projectState: Project.State.live,
       rewardMinimum: 30,
-      shippingAmount: nil
+      shippingAmount: nil,
+      shippingAmountHidden: true
     )
 
     withEnvironment(currentUser: user) {
@@ -119,7 +121,8 @@ final class ManagePledgeSummaryViewModelTests: TestCase {
       projectDeadline: 1_572_626_213.0,
       projectState: Project.State.live,
       rewardMinimum: 30,
-      shippingAmount: nil
+      shippingAmount: nil,
+      shippingAmountHidden: true
     )
 
     withEnvironment(currentUser: user) {

--- a/Library/ViewModels/ManagePledgeViewModel.swift
+++ b/Library/ViewModels/ManagePledgeViewModel.swift
@@ -520,7 +520,8 @@ private func managePledgeSummaryViewData(
     projectDeadline: project.dates.deadline,
     projectState: project.state,
     rewardMinimum: allRewardsTotal(for: backing),
-    shippingAmount: backing.shippingAmount.flatMap(Double.init)
+    shippingAmount: backing.shippingAmount.flatMap(Double.init),
+    shippingAmountHidden: backing.reward?.shipping.enabled == false
   )
 }
 

--- a/Library/ViewModels/ManagePledgeViewModelTests.swift
+++ b/Library/ViewModels/ManagePledgeViewModelTests.swift
@@ -188,7 +188,8 @@ internal final class ManagePledgeViewModelTests: TestCase {
       projectDeadline: 1_476_657_315.0,
       projectState: Project.State.live,
       rewardMinimum: 10.0,
-      shippingAmount: envelope.backing.shippingAmount.flatMap(Double.init)
+      shippingAmount: envelope.backing.shippingAmount.flatMap(Double.init),
+      shippingAmountHidden: true
     )
 
     withEnvironment(apiService: mockService) {
@@ -781,7 +782,8 @@ internal final class ManagePledgeViewModelTests: TestCase {
       projectDeadline: 1_476_657_315.0,
       projectState: Project.State.live,
       rewardMinimum: 0,
-      shippingAmount: envelope.backing.shippingAmount.flatMap(Double.init)
+      shippingAmount: envelope.backing.shippingAmount.flatMap(Double.init),
+      shippingAmountHidden: true
     )
 
     // Pledge amount 50
@@ -802,7 +804,8 @@ internal final class ManagePledgeViewModelTests: TestCase {
       projectDeadline: 1_476_657_315.0,
       projectState: Project.State.live,
       rewardMinimum: 0,
-      shippingAmount: envelope.backing.shippingAmount.flatMap(Double.init)
+      shippingAmount: envelope.backing.shippingAmount.flatMap(Double.init),
+      shippingAmountHidden: true
     )
 
     let pledgePaymentMethodViewData = ManagePledgePaymentMethodViewData(


### PR DESCRIPTION
# 📲 What

Hides the shipping line item displayed on the Manage Pledge View based on the base reward's shipping preference.

# 🤔 Why

When editing a reward from one that has shipping to one without the back-end erroneously sends back shipping information for the backing which we were displaying at the client. This is a workaround to prevent that from happening.

# 🛠 How

We are now inspecting whether shipping is enabled for the backing's base reward before displaying the shipping line item.

# 👀 See

| Before 🐛 | After 🦋 |
| --- | --- |
| <img width="545" alt="image" src="https://user-images.githubusercontent.com/3735375/92177852-2a8f6600-edf6-11ea-86e9-aca24bf05220.png"> | <img width="545" alt="image" src="https://user-images.githubusercontent.com/3735375/92177474-6d9d0980-edf5-11ea-94c4-fcebd0ecec0c.png"> |

# ✅ Acceptance criteria

- [ ] Back a reward with shipping enabled, observe the shipping amount is displayed in the manage view.
- [ ] Edit the reward and change to a reward without shipping. There should be no shipping amount shown on the manage view.