### PR TITLE
[NT-1425] Hide Shipping Amount Shimmer During Add-ons Selection

### DIFF
--- a/Kickstarter-iOS/Views/Controllers/PledgeShippingLocationViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/PledgeShippingLocationViewController.swift
@@ -115,6 +115,12 @@ final class PledgeShippingLocationViewController: UIViewController {
     self.shimmerLoadingView.rac.hidden = self.viewModel.outputs.shimmerLoadingViewIsHidden
     self.shippingLocationButton.rac.title = self.viewModel.outputs.shippingLocationButtonTitle
 
+    self.viewModel.outputs.amountLabelIsHidden
+      .observeForUI()
+      .observeValues { [weak self] isHidden in
+        self?.shimmerLoadingView.amountPlaceholder.alpha = isHidden ? 0 : 1
+    }
+
     /**
      When any layout updates occur we need to notify the delegate. This is only necessary when
      this view is contained within a view that is not fully supported by Auto Layout,

--- a/Kickstarter-iOS/Views/ShimmerLoadingViews/PledgeShippingLocationShimmerLoadingView.swift
+++ b/Kickstarter-iOS/Views/ShimmerLoadingViews/PledgeShippingLocationShimmerLoadingView.swift
@@ -6,7 +6,7 @@ import UIKit
 final class PledgeShippingLocationShimmerLoadingView: UIView {
   // MARK: - Properties
 
-  private lazy var amountPlaceholder: UIView = { UIView(frame: .zero) }()
+  internal lazy var amountPlaceholder: UIView = { UIView(frame: .zero) }()
   private lazy var buttonPlaceholder: UIView = { UIView(frame: .zero) }()
   private lazy var rootStackView: UIStackView = { UIStackView(frame: .zero) }()
 


### PR DESCRIPTION
# 📲 What

Hides the shimmer loading effect for the shipping amount during add-ons selection.

# 🤔 Why

We do not display an amount on this view so the shimmer creates the expectation that a value will be shown there.

# 🛠 How

Exposed the property for the placeholder and set its `alpha` to `0` when the amount label is hidden.

# 👀 See

| Before 🐛 | After 🦋 |
| --- | --- |
| <img width="545" alt="image" src="https://user-images.githubusercontent.com/3735375/92290115-d48af300-eec7-11ea-89d3-ab9cd832aac3.png"> | <img width="545" alt="image" src="https://user-images.githubusercontent.com/3735375/92290033-8970e000-eec7-11ea-86f4-2503eedce621.png"> |

# ✅ Acceptance criteria

- [ ] Navigate to add-on selection for a reward that has shipping enabled. Observe that no shimmer is shown to the right where the amount label would appear.
- [ ] Navigate to the pledge view for a regular reward with shipping. Observe that the shimmer is still shown to the right where the amount appears.