### PR TITLE
[NT-1508] Round Up Converted Amount On Add-on Card

### DIFF
--- a/Library/ViewModels/RewardAddOnCardViewModel.swift
+++ b/Library/ViewModels/RewardAddOnCardViewModel.swift
@@ -75,7 +75,8 @@ public final class RewardAddOnCardViewModel: RewardAddOnCardViewModelType, Rewar
         Format.currency(
           amount,
           country: project.stats.currentCountry ?? .us,
-          omitCurrencyCode: project.stats.omitUSCurrencyCode
+          omitCurrencyCode: project.stats.omitUSCurrencyCode,
+          roundingMode: .up
         )
       }
       .map(Strings.About_reward_amount(reward_amount:))

--- a/Library/ViewModels/RewardAddOnCardViewModelTests.swift
+++ b/Library/ViewModels/RewardAddOnCardViewModelTests.swift
@@ -452,6 +452,34 @@ final class RewardAddOnCardViewModelTests: TestCase {
     }
   }
 
+  func testConversionLabel_US_Currency_NonUS_Location_NonUS_Project_ConversionRoundedUp() {
+    let project = .template
+      |> Project.lens.country .~ .mx
+      |> Project.lens.stats.currency .~ Project.Country.mx.currencyCode
+      |> Project.lens.stats.currentCurrency .~ Project.Country.us.currencyCode
+      |> Project.lens.stats.currentCurrencyRate .~ 0.05
+    let reward = .template |> Reward.lens.minimum .~ 10
+
+    withEnvironment(countryCode: "CA") {
+      self.vm.inputs
+        .configure(with: .init(
+          project: project,
+          reward: reward,
+          context: .pledge,
+          shippingRule: nil,
+          selectedQuantities: [:]
+        ))
+
+      self.amountConversionLabelHidden.assertValues(
+        [false],
+        """
+        User with US currency preferences, non-US location, viewing non-US project sees conversion rounded up.
+        """
+      )
+      self.amountConversionLabelText.assertValues(["About US$ 1"], "Conversion label shows US symbol.")
+    }
+  }
+
   func testConversionLabel_Unknown_Location_US_Project_ConfiguredWithReward_WithoutUserCurrency() {
     let project = .template
       |> Project.lens.country .~ .us


### PR DESCRIPTION
# 📲 What

Rounds up the converted amount displayed on add-on cards.

# 🤔 Why

This is rounded up on the regular reward card shown in the rewards carousel and we were seeing `$0` values in some cases where the converted amount was below `$1`, for example `MX$10` is currently less than `US$1`.

# 🛠 How

Added rounding _up_ for this value without decimals.

# 👀 See

| Before 🐛 | After 🦋 |
| --- | --- |
| <img width="545" alt="image" src="https://user-images.githubusercontent.com/3735375/92665102-89535480-f2ba-11ea-8d8c-5ff0337022d6.png"> | <img width="545" alt="image" src="https://user-images.githubusercontent.com/3735375/92664274-61fb8800-f2b8-11ea-94bb-6f478fd451d3.png"> |

# ✅ Acceptance criteria

- [ ] Navigate to add-on selection for a project in which the converted amount would be less than `1` in any currency. It should be shown, rounded up to `1`.