### PR TITLE
[NT-1513] Reduce Optimizely Configuration Timeout

### DIFF
--- a/Kickstarter-iOS/AppDelegate.swift
+++ b/Kickstarter-iOS/AppDelegate.swift
@@ -364,7 +364,7 @@ internal final class AppDelegate: UIResponder, UIApplicationDelegate {
       defaultLogLevel: logLevel.logLevel
     )
 
-    optimizelyClient.start { [weak self] result in
+    optimizelyClient.start(resourceTimeout: 3) { [weak self] result in
       guard let self = self else { return }
 
       let optimizelyConfigurationError = self.viewModel.inputs.optimizelyConfigured(with: result)


### PR DESCRIPTION
# 📲 What

Causes Optimizely configuration to timeout after 3 secs.

# 🤔 Why

We have received some user reviews mentioning a blank Explore view when they launch the app. We're also noticing a very high number of errors being logged for Optimizely failing to initialize. We believe this may be timing out and causing the Explore view to take very long to load because of the way that we wait for Optimizely to be configured before activating the experiment needed to show the correct project cards in Explore.

# 🛠 How

Added a timeout interval of 3 seconds to `OptimizelyClient`'s `start(resourceTimeout:completion:)` function.

# 👀 See

Optimizely [docs](https://docs.developers.optimizely.com/full-stack/docs/initialize-sdk-objective-c#section-asynchronous-initialization).

# ✅ Acceptance criteria

- [ ] Try to emulate a slow connection, if Optimizely takes longer than 3 secs to load, the Explore feed should show the default project cards or attempt to fetch them (likely observable in Charles).