### PR TITLE
[NT-1504] Remove Project Page Campaign Details Experiment

### DIFF
--- a/Kickstarter-iOS/ViewModels/AppDelegateViewModel.swift
+++ b/Kickstarter-iOS/ViewModels/AppDelegateViewModel.swift
@@ -539,8 +539,8 @@ public final class AppDelegateViewModel: AppDelegateViewModelType, AppDelegateVi
 
     let campaignFaqLink = projectLink
       .filter { _, subpage, _, _ in subpage == .faqs }
-      .map { project, _, vcs, refTag in
-        vcs + [ProjectDescriptionViewController.configuredWith(value: (project, refTag))]
+      .map { project, _, vcs, _ in
+        vcs + [ProjectDescriptionViewController.configuredWith(value: project)]
       }
 
     let updatesLink = projectLink

--- a/Kickstarter-iOS/Views/Cells/ProjectPamphletMainCell.swift
+++ b/Kickstarter-iOS/Views/Cells/ProjectPamphletMainCell.swift
@@ -3,17 +3,11 @@ import Library
 import Prelude
 import UIKit
 
-private enum Layout {
-  enum Button {
-    static let height: CGFloat = 48
-  }
-}
-
 internal protocol ProjectPamphletMainCellDelegate: VideoViewControllerDelegate {
   func projectPamphletMainCell(_ cell: ProjectPamphletMainCell, addChildController child: UIViewController)
   func projectPamphletMainCell(
     _ cell: ProjectPamphletMainCell,
-    goToCampaignForProjectWith projectAndRefTag: (project: Project, refTag: RefTag?)
+    goToCampaignForProjectWith project: Project
   )
   func projectPamphletMainCell(_ cell: ProjectPamphletMainCell, goToCreatorForProject project: Project)
 }
@@ -58,10 +52,6 @@ internal final class ProjectPamphletMainCell: UITableViewCell, ValueCell {
   @IBOutlet fileprivate var projectNameLabel: UILabel!
   @IBOutlet fileprivate var progressBarAndStatsStackView: UIStackView!
   @IBOutlet fileprivate var readMoreButton: UIButton!
-  fileprivate lazy var readMoreButtonLarge: LoadingButton = {
-    LoadingButton(type: .custom)
-  }()
-
   @IBOutlet fileprivate var readMoreStackView: UIStackView!
   @IBOutlet fileprivate var stateLabel: UILabel!
   @IBOutlet fileprivate var statsStackView: UIStackView!
@@ -82,16 +72,6 @@ internal final class ProjectPamphletMainCell: UITableViewCell, ValueCell {
       action: #selector(self.readMoreButtonTapped),
       for: .touchUpInside
     )
-    self.readMoreButtonLarge.addTarget(
-      self,
-      action: #selector(self.readMoreButtonTapped),
-      for: .touchUpInside
-    )
-
-    self.readMoreButtonLarge.heightAnchor
-      .constraint(greaterThanOrEqualToConstant: Layout.Button.height).isActive = true
-
-    self.readMoreStackView.addArrangedSubview(self.readMoreButtonLarge)
 
     self.viewModel.inputs.awakeFromNib()
   }
@@ -286,11 +266,6 @@ internal final class ProjectPamphletMainCell: UITableViewCell, ValueCell {
     _ = self.readMoreButton
       |> readMoreButtonStyle
       |> UIButton.lens.title(for: .normal) %~ { _ in Strings.Read_more_about_the_campaign_arrow() }
-
-    _ = self.readMoreButtonLarge
-      |> \.activityIndicatorStyle .~ .gray
-      |> greyReadMoreButtonStyle
-      |> UIButton.lens.title(for: .normal) %~ { _ in Strings.Read_more_about_the_campaign() }
   }
 
   internal override func bindViewModel() {
@@ -316,19 +291,11 @@ internal final class ProjectPamphletMainCell: UITableViewCell, ValueCell {
     self.pledgedTitleLabel.rac.textColor = self.viewModel.outputs.pledgedTitleLabelTextColor
     self.projectBlurbLabel.rac.text = self.viewModel.outputs.projectBlurbLabelText
     self.projectNameLabel.rac.text = self.viewModel.outputs.projectNameLabelText
-    self.readMoreButton.rac.hidden = self.viewModel.outputs.readMoreButtonIsHidden
-    self.readMoreButtonLarge.rac.hidden = self.viewModel.outputs.readMoreButtonLargeIsHidden
     self.stateLabel.rac.text = self.viewModel.outputs.projectStateLabelText
     self.stateLabel.rac.textColor = self.viewModel.outputs.projectStateLabelTextColor
     self.stateLabel.rac.hidden = self.viewModel.outputs.stateLabelHidden
     self.statsStackView.rac.accessibilityLabel = self.viewModel.outputs.statsStackViewAccessibilityLabel
     self.youreABackerContainerView.rac.hidden = self.viewModel.outputs.youreABackerLabelHidden
-
-    self.viewModel.outputs.readMoreButtonIsLoading
-      .observeForUI()
-      .observeValues { [weak self] isLoading in
-        self?.readMoreButtonLarge.isLoading = isLoading
-      }
 
     self.viewModel.outputs.configureVideoPlayerController
       .observeForUI()
@@ -340,7 +307,7 @@ internal final class ProjectPamphletMainCell: UITableViewCell, ValueCell {
       .skipNil()
       .observeValues { [weak self] in self?.creatorImageView.af.setImage(withURL: $0) }
 
-    self.viewModel.outputs.notifyDelegateToGoToCampaignWithProjectAndRefTag
+    self.viewModel.outputs.notifyDelegateToGoToCampaignWithProject
       .observeForControllerAction()
       .observeValues { [weak self] in
         guard let self = self else { return }

--- a/Kickstarter-iOS/Views/Controllers/ProjectPamphletContentViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/ProjectPamphletContentViewController.swift
@@ -185,9 +185,9 @@ public final class ProjectPamphletContentViewController: UITableViewController {
 extension ProjectPamphletContentViewController: ProjectPamphletMainCellDelegate {
   internal func projectPamphletMainCell(
     _: ProjectPamphletMainCell,
-    goToCampaignForProjectWith projectAndRefTag: (project: Project, refTag: RefTag?)
+    goToCampaignForProjectWith project: Project
   ) {
-    let vc = ProjectDescriptionViewController.configuredWith(value: projectAndRefTag)
+    let vc = ProjectDescriptionViewController.configuredWith(value: project)
     self.navigationController?.pushViewController(vc, animated: true)
   }
 

--- a/Library/OptimizelyExperiment.swift
+++ b/Library/OptimizelyExperiment.swift
@@ -7,7 +7,6 @@ public enum OptimizelyExperiment {
     case pledgeCTACopy = "pledge_cta_copy"
     case onboardingCategoryPersonalizationFlow = "onboarding_category_personalization_flow"
     case nativeProjectCards = "native_project_cards"
-    case nativeProjectPageCampaignDetails = "native_project_page_campaign_details"
   }
 
   public enum Variant: String, Equatable {
@@ -18,17 +17,6 @@ public enum OptimizelyExperiment {
 }
 
 extension OptimizelyExperiment {
-  static func projectCampaignExperiment(
-    project: Project,
-    refTag: RefTag?
-  ) -> OptimizelyExperiment.Variant {
-    return AppEnvironment.current.optimizelyClient?
-      .variant(
-        for: OptimizelyExperiment.Key.nativeProjectPageCampaignDetails,
-        userAttributes: optimizelyUserAttributes(with: project, refTag: refTag)
-      ) ?? .control
-  }
-
   // Returns variation via getVariation for native_project_cards experiment
   static func nativeProjectCardsExperimentVariant() -> OptimizelyExperiment.Variant {
     guard let optimizelyClient = AppEnvironment.current.optimizelyClient else {

--- a/Library/ViewModels/ProjectDescriptionViewModel.swift
+++ b/Library/ViewModels/ProjectDescriptionViewModel.swift
@@ -4,14 +4,11 @@ import ReactiveSwift
 import WebKit
 
 public protocol ProjectDescriptionViewModelInputs {
-  /// Call with the project and reftag given to the view.
-  func configureWith(value: (Project, RefTag?))
+  /// Call with the project given to the view.
+  func configureWith(value: Project)
 
   /// Call when the webview needs to decide a policy for a navigation action. Returns the decision policy.
   func decidePolicyFor(navigationAction: WKNavigationActionData)
-
-  /// Call when the pledge CTA button is tapped.
-  func pledgeCTAButtonTapped(with state: PledgeStateCTAType)
 
   /// Call when the view loads.
   func viewDidLoad()
@@ -27,9 +24,6 @@ public protocol ProjectDescriptionViewModelInputs {
 }
 
 public protocol ProjectDescriptionViewModelOutputs {
-  /// Emits PledgeCTAContainerViewData to configure the PledgeCTAContainerView
-  var configurePledgeCTAContainerView: Signal<PledgeCTAContainerViewData, Never> { get }
-
   /// Can be returned from the web view's policy decision delegate method.
   var decidedPolicyForNavigationAction: WKNavigationActionPolicy { get }
 
@@ -39,9 +33,6 @@ public protocol ProjectDescriptionViewModelOutputs {
   /// Emits when we should navigate to the message dialog.
   var goToMessageDialog: Signal<(MessageSubject, Koala.MessageDialogContext), Never> { get }
 
-  /// Emits when we should navigate to the rewards
-  var goToRewards: Signal<(Project, RefTag?), Never> { get }
-
   /// Emits when we should open a safari browser with the URL.
   var goToSafariBrowser: Signal<URL, Never> { get }
 
@@ -50,9 +41,6 @@ public protocol ProjectDescriptionViewModelOutputs {
 
   /// Emits a url request that should be loaded into the webview.
   var loadWebViewRequest: Signal<URLRequest, Never> { get }
-
-  /// Emits whether the pledgeCTAContainerView is hidden.
-  var pledgeCTAContainerViewIsHidden: Signal<Bool, Never> { get }
 
   /// Emits when an error should be displayed.
   var showErrorAlert: Signal<Error, Never> { get }
@@ -66,13 +54,11 @@ public protocol ProjectDescriptionViewModelType {
 public final class ProjectDescriptionViewModel: ProjectDescriptionViewModelType,
   ProjectDescriptionViewModelInputs, ProjectDescriptionViewModelOutputs {
   public init() {
-    let projectAndRefTag = Signal.combineLatest(
-      self.projectAndRefTagProperty.signal.skipNil(),
+    let project = Signal.combineLatest(
+      self.projectProperty.signal.skipNil(),
       self.viewDidLoadProperty.signal
     )
     .map(first)
-
-    let project = projectAndRefTag.map(first)
 
     let navigationAction = self.policyForNavigationActionProperty.signal.skipNil()
     let navigationActionLink = navigationAction
@@ -133,36 +119,6 @@ public final class ProjectDescriptionViewModel: ProjectDescriptionViewModelType,
     .map { navigationAction, _, _ in navigationAction.request.url }
     .skipNil()
 
-    self.pledgeCTAContainerViewIsHidden = projectAndRefTag
-      .map(shouldShowPledgeButton)
-      .negate()
-
-    self.configurePledgeCTAContainerView = projectAndRefTag
-      .combineLatest(with: self.pledgeCTAContainerViewIsHidden)
-      .filter(second >>> isFalse)
-      .map(first)
-      .map(Either.left)
-      .map { ($0, false, .projectDescription) }
-
-    self.goToRewards = projectAndRefTag
-      .takeWhen(self.pledgeCTAButtonTappedProperty.signal)
-
-    projectAndRefTag
-      .takeWhen(self.pledgeCTAButtonTappedProperty.signal)
-      .observeValues { project, refTag in
-        let cookieRefTag = cookieRefTagFor(project: project) ?? refTag
-        let optimizelyProps = optimizelyProperties() ?? [:]
-
-        AppEnvironment.current.koala.trackCampaignDetailsPledgeButtonClicked(
-          project: project,
-          location: .campaign,
-          refTag: refTag,
-          cookieRefTag: cookieRefTag,
-          optimizelyProperties: optimizelyProps
-        )
-        AppEnvironment.current.optimizelyClient?.track(eventName: "Campaign Details Pledge Button Clicked")
-      }
-
     project
       .takeWhen(self.goToSafariBrowser)
       .observeValues {
@@ -170,14 +126,9 @@ public final class ProjectDescriptionViewModel: ProjectDescriptionViewModelType,
       }
   }
 
-  private let pledgeCTAButtonTappedProperty = MutableProperty<PledgeStateCTAType?>(nil)
-  public func pledgeCTAButtonTapped(with state: PledgeStateCTAType) {
-    self.pledgeCTAButtonTappedProperty.value = state
-  }
-
-  fileprivate let projectAndRefTagProperty = MutableProperty<(Project, RefTag?)?>(nil)
-  public func configureWith(value: (Project, RefTag?)) {
-    self.projectAndRefTagProperty.value = value
+  fileprivate let projectProperty = MutableProperty<Project?>(nil)
+  public func configureWith(value: Project) {
+    self.projectProperty.value = value
   }
 
   fileprivate let policyForNavigationActionProperty = MutableProperty<WKNavigationActionData?>(nil)
@@ -210,14 +161,11 @@ public final class ProjectDescriptionViewModel: ProjectDescriptionViewModelType,
     self.webViewDidStartProvisionalNavigationProperty.value = ()
   }
 
-  public let configurePledgeCTAContainerView: Signal<PledgeCTAContainerViewData, Never>
   public let goBackToProject: Signal<(), Never>
   public let goToMessageDialog: Signal<(MessageSubject, Koala.MessageDialogContext), Never>
-  public let goToRewards: Signal<(Project, RefTag?), Never>
   public let goToSafariBrowser: Signal<URL, Never>
   public let isLoading: Signal<Bool, Never>
   public let loadWebViewRequest: Signal<URLRequest, Never>
-  public let pledgeCTAContainerViewIsHidden: Signal<Bool, Never>
   public let showErrorAlert: Signal<Error, Never>
 
   public var inputs: ProjectDescriptionViewModelInputs { return self }
@@ -232,14 +180,4 @@ private func isMessageCreator(navigation: Navigation) -> Bool {
 private func allowed(navigationAction action: WKNavigationActionData) -> Bool {
   return action.request.url?.path.contains("/description") == .some(true)
     || action.targetFrame?.mainFrame == .some(false)
-}
-
-private func shouldShowPledgeButton(project: Project, refTag: RefTag?) -> Bool {
-  let isLive = project.state == .live
-  let notBacking = project.personalization.backing == nil
-  let isVariant2 = OptimizelyExperiment
-    .projectCampaignExperiment(project: project, refTag: refTag) == .variant2
-  let isNotCreator = currentUserIsCreator(of: project) == false
-
-  return [isLive, notBacking, isVariant2, isNotCreator].allSatisfy(isTrue)
 }

--- a/Library/ViewModels/ProjectDescriptionViewModelTests.swift
+++ b/Library/ViewModels/ProjectDescriptionViewModelTests.swift
@@ -9,17 +9,9 @@ import XCTest
 final class ProjectDescriptionViewModelTests: TestCase {
   private let vm: ProjectDescriptionViewModelType = ProjectDescriptionViewModel()
 
-  private let configurePledgeCTAViewContext = TestObserver<PledgeCTAContainerViewContext, Never>()
-  private let configurePledgeCTAViewErrorEnvelope = TestObserver<ErrorEnvelope, Never>()
-  private let configurePledgeCTAViewProject = TestObserver<Project, Never>()
-  private let configurePledgeCTAViewIsLoading = TestObserver<Bool, Never>()
-  private let configurePledgeCTAViewRefTag = TestObserver<RefTag?, Never>()
   private let goBackToProject = TestObserver<(), Never>()
   private let goToMessageDialog = TestObserver<(MessageSubject, Koala.MessageDialogContext), Never>()
-  private let goToRewardsProject = TestObserver<Project, Never>()
-  private let goToRewardsRefTag = TestObserver<RefTag?, Never>()
   private let goToSafariBrowser = TestObserver<URL, Never>()
-
   private let isLoading = TestObserver<Bool, Never>()
   private let loadWebViewRequest = TestObserver<URLRequest, Never>()
   private let pledgeCTAContainerViewIsHidden = TestObserver<Bool, Never>()
@@ -28,39 +20,11 @@ final class ProjectDescriptionViewModelTests: TestCase {
   override func setUp() {
     super.setUp()
 
-    self.vm.outputs.configurePledgeCTAContainerView
-      .map(first)
-      .map(\.left)
-      .skipNil()
-      .map(first)
-      .observe(self.configurePledgeCTAViewProject.observer)
-
-    self.vm.outputs.configurePledgeCTAContainerView
-      .map(first)
-      .map(\.left)
-      .skipNil()
-      .map(second)
-      .observe(self.configurePledgeCTAViewRefTag.observer)
-
-    self.vm.outputs.configurePledgeCTAContainerView
-      .map(first)
-      .map(\.right)
-      .skipNil()
-      .observe(self.configurePledgeCTAViewErrorEnvelope.observer)
-
-    self.vm.outputs.configurePledgeCTAContainerView.map(second)
-      .observe(self.configurePledgeCTAViewIsLoading.observer)
-    self.vm.outputs.configurePledgeCTAContainerView.map(third)
-      .observe(self.configurePledgeCTAViewContext.observer)
-
     self.vm.outputs.goBackToProject.observe(self.goBackToProject.observer)
     self.vm.outputs.goToMessageDialog.observe(self.goToMessageDialog.observer)
     self.vm.outputs.goToSafariBrowser.observe(self.goToSafariBrowser.observer)
-    self.vm.outputs.goToRewards.map(first).observe(self.goToRewardsProject.observer)
-    self.vm.outputs.goToRewards.map(second).observe(self.goToRewardsRefTag.observer)
     self.vm.outputs.isLoading.observe(self.isLoading.observer)
     self.vm.outputs.loadWebViewRequest.observe(self.loadWebViewRequest.observer)
-    self.vm.outputs.pledgeCTAContainerViewIsHidden.observe(self.pledgeCTAContainerViewIsHidden.observer)
     self.vm.outputs.showErrorAlert.map { $0 as NSError }.observe(self.showErrorAlert.observer)
   }
 
@@ -69,7 +33,7 @@ final class ProjectDescriptionViewModelTests: TestCase {
       |> Project.lens.id .~ 42
       |> Project.lens.urls.web.project .~ "https://www.kickstarter.com/projects/1/42"
 
-    self.vm.inputs.configureWith(value: (project, nil))
+    self.vm.inputs.configureWith(value: project)
     self.vm.inputs.viewDidLoad()
 
     self.isLoading.assertValues([true])
@@ -108,7 +72,7 @@ final class ProjectDescriptionViewModelTests: TestCase {
       |> Project.lens.id .~ 42
       |> Project.lens.urls.web.project .~ "https://www.kickstarter.com/projects/1/42"
 
-    self.vm.inputs.configureWith(value: (project, nil))
+    self.vm.inputs.configureWith(value: project)
     self.vm.inputs.viewDidLoad()
 
     self.loadWebViewRequest.assertValueCount(1)
@@ -139,25 +103,12 @@ final class ProjectDescriptionViewModelTests: TestCase {
     self.goToSafariBrowser.assertValueCount(0)
   }
 
-  func testGoToRewards() {
-    self.vm.inputs.configureWith(value: (.template, .discovery))
-    self.vm.inputs.viewDidLoad()
-
-    self.goToRewardsProject.assertDidNotEmitValue()
-    self.goToRewardsRefTag.assertDidNotEmitValue()
-
-    self.vm.inputs.pledgeCTAButtonTapped(with: .viewRewards)
-
-    self.goToRewardsProject.assertValues([.template])
-    self.goToRewardsRefTag.assertValues([.discovery])
-  }
-
   func testGoToSafari() {
     let project = .template
       |> Project.lens.id .~ 42
       |> Project.lens.urls.web.project .~ "https://www.kickstarter.com/projects/1/42"
 
-    self.vm.inputs.configureWith(value: (project, nil))
+    self.vm.inputs.configureWith(value: project)
     self.vm.inputs.viewDidLoad()
 
     self.loadWebViewRequest.assertValueCount(1)
@@ -193,7 +144,7 @@ final class ProjectDescriptionViewModelTests: TestCase {
   func testDescriptionRequest() {
     let project = Project.template
 
-    self.vm.inputs.configureWith(value: (project, nil))
+    self.vm.inputs.configureWith(value: project)
     self.vm.inputs.viewDidLoad()
 
     self.loadWebViewRequest.assertValueCount(1)
@@ -227,7 +178,7 @@ final class ProjectDescriptionViewModelTests: TestCase {
   func testIFrameRequest() {
     let project = Project.template
 
-    self.vm.inputs.configureWith(value: (project, nil))
+    self.vm.inputs.configureWith(value: project)
     self.vm.inputs.viewDidLoad()
 
     self.loadWebViewRequest.assertValueCount(1)
@@ -262,7 +213,7 @@ final class ProjectDescriptionViewModelTests: TestCase {
   func testError() {
     let project = Project.template
 
-    self.vm.inputs.configureWith(value: (project, nil))
+    self.vm.inputs.configureWith(value: project)
     self.vm.inputs.viewDidLoad()
 
     let request = URLRequest(url: URL(string: project.urls.web.project)!)
@@ -283,299 +234,5 @@ final class ProjectDescriptionViewModelTests: TestCase {
     self.vm.inputs.webViewDidFailProvisionalNavigation(withError: error)
 
     self.showErrorAlert.assertValues([error])
-  }
-
-  func testConfigurePledgeCTAContainerView_LiveProject_NonBacker_Control() {
-    let project = Project.template
-      |> Project.lens.state .~ .live
-      |> Project.lens.personalization.backing .~ nil
-      |> Project.lens.personalization.isBacking .~ false
-
-    let optimizelyClient = MockOptimizelyClient()
-      |> \.experiments .~ [
-        OptimizelyExperiment.Key.nativeProjectPageCampaignDetails.rawValue: OptimizelyExperiment.Variant
-          .control.rawValue
-      ]
-
-    withEnvironment(optimizelyClient: optimizelyClient) {
-      self.pledgeCTAContainerViewIsHidden.assertDidNotEmitValue()
-
-      self.vm.inputs.configureWith(value: (project, .discovery))
-      self.vm.inputs.viewDidLoad()
-
-      self.pledgeCTAContainerViewIsHidden.assertValues([true])
-    }
-  }
-
-  func testConfigurePledgeCTAContainerView_Backer_Control() {
-    let project = Project.template
-      |> Project.lens.state .~ .live
-      |> Project.lens.personalization.isBacking .~ true
-      |> Project.lens.personalization.backing .~ (
-        .template
-          |> Backing.lens.reward .~ Reward.noReward
-          |> Backing.lens.rewardId .~ Reward.noReward.id
-          |> Backing.lens.shippingAmount .~ 10
-          |> Backing.lens.amount .~ 700.0
-      )
-
-    let optimizelyClient = MockOptimizelyClient()
-      |> \.experiments .~ [
-        OptimizelyExperiment.Key.nativeProjectPageCampaignDetails.rawValue: OptimizelyExperiment.Variant
-          .control.rawValue
-      ]
-
-    withEnvironment(optimizelyClient: optimizelyClient) {
-      self.pledgeCTAContainerViewIsHidden.assertDidNotEmitValue()
-
-      self.vm.inputs.configureWith(value: (project, .discovery))
-      self.vm.inputs.viewDidLoad()
-
-      self.pledgeCTAContainerViewIsHidden.assertValues([true])
-    }
-  }
-
-  func testConfigurePledgeCTAContainerView_LiveProject_NonBacker_Variant1() {
-    let project = Project.template
-      |> Project.lens.state .~ .live
-      |> Project.lens.personalization.backing .~ nil
-      |> Project.lens.personalization.isBacking .~ false
-
-    let optimizelyClient = MockOptimizelyClient()
-      |> \.experiments .~ [
-        OptimizelyExperiment.Key.nativeProjectPageCampaignDetails.rawValue: OptimizelyExperiment.Variant
-          .variant1.rawValue
-      ]
-
-    withEnvironment(optimizelyClient: optimizelyClient) {
-      self.pledgeCTAContainerViewIsHidden.assertDidNotEmitValue()
-
-      self.vm.inputs.configureWith(value: (project, .discovery))
-      self.vm.inputs.viewDidLoad()
-
-      self.pledgeCTAContainerViewIsHidden.assertValues([true])
-    }
-  }
-
-  func testConfigurePledgeCTAContainerView_LiveProject_Backer_Variant1() {
-    let project = Project.template
-      |> Project.lens.state .~ .live
-      |> Project.lens.personalization.isBacking .~ true
-      |> Project.lens.personalization.backing .~ (
-        .template
-          |> Backing.lens.reward .~ Reward.noReward
-          |> Backing.lens.rewardId .~ Reward.noReward.id
-          |> Backing.lens.shippingAmount .~ 10
-          |> Backing.lens.amount .~ 700.0
-      )
-
-    let optimizelyClient = MockOptimizelyClient()
-      |> \.experiments .~ [
-        OptimizelyExperiment.Key.nativeProjectPageCampaignDetails.rawValue: OptimizelyExperiment.Variant
-          .variant1.rawValue
-      ]
-
-    withEnvironment(optimizelyClient: optimizelyClient) {
-      self.pledgeCTAContainerViewIsHidden.assertDidNotEmitValue()
-
-      self.vm.inputs.configureWith(value: (project, .discovery))
-      self.vm.inputs.viewDidLoad()
-
-      self.pledgeCTAContainerViewIsHidden.assertValues([true])
-    }
-  }
-
-  func testConfigurePledgeCTAContainerView_LiveProject_NonBacker_Variant2() {
-    let project = Project.template
-      |> Project.lens.state .~ .live
-      |> Project.lens.personalization.backing .~ nil
-      |> Project.lens.personalization.isBacking .~ false
-
-    let optimizelyClient = MockOptimizelyClient()
-      |> \.experiments .~ [
-        OptimizelyExperiment.Key.nativeProjectPageCampaignDetails.rawValue: OptimizelyExperiment.Variant
-          .variant2.rawValue
-      ]
-
-    withEnvironment(optimizelyClient: optimizelyClient) {
-      self.pledgeCTAContainerViewIsHidden.assertDidNotEmitValue()
-      self.goToRewardsProject.assertDidNotEmitValue()
-      self.goToRewardsRefTag.assertDidNotEmitValue()
-
-      self.vm.inputs.configureWith(value: (project, .discovery))
-      self.vm.inputs.viewDidLoad()
-
-      self.pledgeCTAContainerViewIsHidden.assertValues([false])
-      self.goToRewardsProject.assertDidNotEmitValue()
-      self.goToRewardsRefTag.assertDidNotEmitValue()
-
-      self.vm.inputs.pledgeCTAButtonTapped(with: .viewRewards)
-
-      self.goToRewardsProject.assertValues([project])
-      self.goToRewardsRefTag.assertValues([.discovery])
-    }
-  }
-
-  func testConfigurePledgeCTAContainerView_NonLiveProject_NonBacker_Variant2() {
-    let project = Project.template
-      |> Project.lens.state .~ .successful
-      |> Project.lens.personalization.backing .~ nil
-      |> Project.lens.personalization.isBacking .~ false
-
-    let optimizelyClient = MockOptimizelyClient()
-      |> \.experiments .~ [
-        OptimizelyExperiment.Key.nativeProjectPageCampaignDetails.rawValue: OptimizelyExperiment.Variant
-          .variant2.rawValue
-      ]
-
-    withEnvironment(optimizelyClient: optimizelyClient) {
-      self.pledgeCTAContainerViewIsHidden.assertDidNotEmitValue()
-
-      self.vm.inputs.configureWith(value: (project, .discovery))
-      self.vm.inputs.viewDidLoad()
-
-      self.pledgeCTAContainerViewIsHidden.assertValues([true])
-    }
-  }
-
-  func testConfigurePledgeCTAContainerView_LiveProject_Backer_Variant2() {
-    let project = Project.template
-      |> Project.lens.state .~ .live
-      |> Project.lens.personalization.isBacking .~ true
-      |> Project.lens.personalization.backing .~ (
-        .template
-          |> Backing.lens.reward .~ Reward.noReward
-          |> Backing.lens.rewardId .~ Reward.noReward.id
-          |> Backing.lens.shippingAmount .~ 10
-          |> Backing.lens.amount .~ 700.0
-      )
-
-    let optimizelyClient = MockOptimizelyClient()
-      |> \.experiments .~ [
-        OptimizelyExperiment.Key.nativeProjectPageCampaignDetails.rawValue: OptimizelyExperiment.Variant
-          .variant2.rawValue
-      ]
-
-    withEnvironment(optimizelyClient: optimizelyClient) {
-      self.pledgeCTAContainerViewIsHidden.assertDidNotEmitValue()
-
-      self.vm.inputs.configureWith(value: (project, .discovery))
-      self.vm.inputs.viewDidLoad()
-
-      self.pledgeCTAContainerViewIsHidden.assertValues([true])
-    }
-  }
-
-  func testOptimizelyTrackingCampaignDetailsPledgeButtonTapped_LiveProject_LoggedIn_NonBacked_Variant1() {
-    let user = User.template
-      |> \.location .~ Location.template
-      |> \.stats.backedProjectsCount .~ 50
-
-    let project = Project.template
-      |> Project.lens.creator .~ user
-      |> Project.lens.state .~ .live
-      |> Project.lens.personalization.backing .~ nil
-      |> Project.lens.personalization.isBacking .~ false
-
-    let optimizelyClient = MockOptimizelyClient()
-      |> \.experiments .~ [
-        OptimizelyExperiment.Key.nativeProjectPageCampaignDetails.rawValue: OptimizelyExperiment.Variant
-          .variant1.rawValue
-      ]
-
-    withEnvironment(currentUser: user, optimizelyClient: optimizelyClient) {
-      self.vm.inputs.configureWith(value: (project, .discovery))
-      self.vm.inputs.viewDidLoad()
-
-      XCTAssertEqual(optimizelyClient.trackedUserId, nil)
-      XCTAssertEqual(optimizelyClient.trackedEventKey, nil)
-      XCTAssertNil(optimizelyClient.trackedAttributes)
-      self.pledgeCTAContainerViewIsHidden.assertValues([true])
-    }
-  }
-
-  func testOptimizelyTrackingCampaignDetailsPledgeButtonTapped_LiveProject_LoggedIn_Backed_Variant2() {
-    let user = User.template
-      |> \.location .~ Location.template
-      |> \.stats.backedProjectsCount .~ 50
-
-    let project = Project.template
-      |> Project.lens.state .~ .live
-      |> Project.lens.personalization.backing .~ Backing.template
-
-    let optimizelyClient = MockOptimizelyClient()
-      |> \.experiments .~ [
-        OptimizelyExperiment.Key.nativeProjectPageCampaignDetails.rawValue: OptimizelyExperiment.Variant
-          .variant2.rawValue
-      ]
-
-    withEnvironment(currentUser: user, optimizelyClient: optimizelyClient) {
-      self.vm.inputs.configureWith(value: (project, .discovery))
-      self.vm.inputs.viewDidLoad()
-
-      XCTAssertEqual(optimizelyClient.trackedUserId, nil)
-      XCTAssertEqual(optimizelyClient.trackedEventKey, nil)
-      XCTAssertNil(optimizelyClient.trackedAttributes)
-
-      self.pledgeCTAContainerViewIsHidden.assertValues([true])
-    }
-  }
-
-  func testTrackingCampaignDetailsPledgeButtonTapped_LiveProject_LoggedIn_NonBacked_Variant2() {
-    let project = Project.template
-      |> Project.lens.state .~ .live
-      |> Project.lens.personalization.backing .~ nil
-
-    let optimizelyClient = MockOptimizelyClient()
-      |> \.experiments .~ [
-        OptimizelyExperiment.Key.nativeProjectPageCampaignDetails.rawValue: OptimizelyExperiment.Variant
-          .variant2.rawValue
-      ]
-
-    withEnvironment(config: .template, currentUser: .template, optimizelyClient: optimizelyClient) {
-      self.vm.inputs.configureWith(value: (project, .discovery))
-      self.vm.inputs.viewDidLoad()
-
-      XCTAssertEqual(self.trackingClient.events, [])
-
-      // Optimizely Client
-      XCTAssertEqual(optimizelyClient.trackedUserId, nil)
-      XCTAssertEqual(optimizelyClient.trackedEventKey, nil)
-      XCTAssertNil(optimizelyClient.trackedAttributes)
-
-      self.pledgeCTAContainerViewIsHidden.assertValues([true])
-      self.vm.inputs.pledgeCTAButtonTapped(with: .pledge)
-
-      XCTAssertEqual(self.trackingClient.events, ["Campaign Details Pledge Button Clicked"])
-
-      XCTAssertEqual(self.trackingClient.properties(forKey: "context_location"), ["campaign_screen"])
-      XCTAssertEqual(self.trackingClient.properties(forKey: "session_ref_tag"), ["discovery"])
-      XCTAssertEqual(self.trackingClient.properties(forKey: "session_referrer_credit"), ["discovery"])
-
-      XCTAssertEqual(self.trackingClient.properties(forKey: "project_subcategory"), ["Art"])
-      XCTAssertEqual(self.trackingClient.properties(forKey: "project_category"), [nil])
-      XCTAssertEqual(self.trackingClient.properties(forKey: "project_country"), ["US"])
-      XCTAssertEqual(self.trackingClient.properties(forKey: "project_user_has_watched"), [nil])
-
-      let properties = self.trackingClient.properties.last
-
-      XCTAssertNotNil(properties?["optimizely_api_key"], "Event includes Optimizely properties")
-      XCTAssertNotNil(properties?["optimizely_environment"], "Event includes Optimizely properties")
-      XCTAssertNotNil(properties?["optimizely_experiments"], "Event includes Optimizely properties")
-
-      // Optimizely Client
-      XCTAssertEqual(optimizelyClient.trackedEventKey, "Campaign Details Pledge Button Clicked")
-      XCTAssertEqual(
-        optimizelyClient.trackedAttributes?["session_os_version"] as? String,
-        "MockSystemVersion"
-      )
-      XCTAssertEqual(optimizelyClient.trackedAttributes?["session_user_is_logged_in"] as? Bool, true)
-      XCTAssertEqual(
-        optimizelyClient.trackedAttributes?["session_app_release_version"] as? String,
-        "1.2.3.4.5.6.7.8.9.0"
-      )
-      XCTAssertEqual(optimizelyClient.trackedAttributes?["session_apple_pay_device"] as? Bool, true)
-      XCTAssertEqual(optimizelyClient.trackedAttributes?["session_device_format"] as? String, "phone")
-    }
   }
 }

--- a/Library/ViewModels/ProjectPamphletMainCellViewModel.swift
+++ b/Library/ViewModels/ProjectPamphletMainCellViewModel.swift
@@ -64,8 +64,8 @@ public protocol ProjectPamphletMainCellViewModelOutputs {
   /// Emits a string to use for the location name label.
   var locationNameLabelText: Signal<String, Never> { get }
 
-  /// Emits the project and refTag when we should go to the campaign view for the project.
-  var notifyDelegateToGoToCampaignWithProjectAndRefTag: Signal<(Project, RefTag?), Never> { get }
+  /// Emits the project when we should go to the campaign view for the project.
+  var notifyDelegateToGoToCampaignWithProject: Signal<Project, Never> { get }
 
   /// Emits the project when we should go to the creator's view for the project.
   var notifyDelegateToGoToCreator: Signal<Project, Never> { get }
@@ -103,15 +103,6 @@ public protocol ProjectPamphletMainCellViewModelOutputs {
   /// Emits the text color of the backer and deadline title label.
   var projectUnsuccessfulLabelTextColor: Signal<UIColor, Never> { get }
 
-  /// Emits when the read more button should be hidden.
-  var readMoreButtonIsHidden: Signal<Bool, Never> { get }
-
-  /// Emits when the read more button is loading.
-  var readMoreButtonIsLoading: Signal<Bool, Never> { get }
-
-  /// Emits when the large read more button should be hidden.
-  var readMoreButtonLargeIsHidden: Signal<Bool, Never> { get }
-
   /// Emits a boolean that determines if the project state label should be hidden.
   var stateLabelHidden: Signal<Bool, Never> { get }
 
@@ -148,14 +139,6 @@ public final class ProjectPamphletMainCellViewModel: ProjectPamphletMainCellView
     self.creatorImageUrl = project.map { URL(string: $0.creator.avatar.small) }
 
     self.stateLabelHidden = project.map { $0.state == .live }
-
-    let projectCampaignExperimentVariant = data
-      .map(OptimizelyExperiment.projectCampaignExperiment)
-
-    let isProjectCampaignExperimentVariant = projectCampaignExperimentVariant.map { $0 != .control }
-
-    self.readMoreButtonIsHidden = isProjectCampaignExperimentVariant
-    self.readMoreButtonLargeIsHidden = isProjectCampaignExperimentVariant.negate()
 
     self.projectStateLabelText = project
       .filter { $0.state != .live }
@@ -240,7 +223,7 @@ public final class ProjectPamphletMainCellViewModel: ProjectPamphletMainCellView
       .map(Project.lens.stats.fundingProgress.view)
       .map(clamp(0, 1))
 
-    self.notifyDelegateToGoToCampaignWithProjectAndRefTag = data.map { $0 as (Project, RefTag?) }
+    self.notifyDelegateToGoToCampaignWithProject = project
       .takeWhen(self.readMoreButtonTappedProperty.signal)
 
     self.notifyDelegateToGoToCreator = project
@@ -254,17 +237,6 @@ public final class ProjectPamphletMainCellViewModel: ProjectPamphletMainCellView
       self.dataProperty.signal.skipNil().mapConst(1.0),
       self.awakeFromNibProperty.signal.mapConst(0.0)
     )
-
-    /* Read more button has initial loading state in second experiment variant
-     * while rewards are being loaded.
-     */
-    self.readMoreButtonIsLoading = Signal.combineLatest(
-      project,
-      projectCampaignExperimentVariant
-    )
-    .map { project, variant in
-      project.rewards.isEmpty && variant == .variant2
-    }
 
     // Tracking
 
@@ -336,7 +308,7 @@ public final class ProjectPamphletMainCellViewModel: ProjectPamphletMainCellView
   public let deadlineTitleLabelText: Signal<String, Never>
   public let fundingProgressBarViewBackgroundColor: Signal<UIColor, Never>
   public let locationNameLabelText: Signal<String, Never>
-  public let notifyDelegateToGoToCampaignWithProjectAndRefTag: Signal<(Project, RefTag?), Never>
+  public let notifyDelegateToGoToCampaignWithProject: Signal<Project, Never>
   public let notifyDelegateToGoToCreator: Signal<Project, Never>
   public let opacityForViews: Signal<CGFloat, Never>
   public let pledgedSubtitleLabelText: Signal<String, Never>
@@ -349,9 +321,6 @@ public final class ProjectPamphletMainCellViewModel: ProjectPamphletMainCellView
   public let projectStateLabelText: Signal<String, Never>
   public let projectStateLabelTextColor: Signal<UIColor, Never>
   public let projectUnsuccessfulLabelTextColor: Signal<UIColor, Never>
-  public let readMoreButtonIsHidden: Signal<Bool, Never>
-  public let readMoreButtonIsLoading: Signal<Bool, Never>
-  public let readMoreButtonLargeIsHidden: Signal<Bool, Never>
   public let stateLabelHidden: Signal<Bool, Never>
   public let statsStackViewAccessibilityLabel: Signal<String, Never>
   public let youreABackerLabelHidden: Signal<Bool, Never>

--- a/Library/ViewModels/ProjectPamphletMainCellViewModelTests.swift
+++ b/Library/ViewModels/ProjectPamphletMainCellViewModelTests.swift
@@ -19,7 +19,6 @@ final class ProjectPamphletMainCellViewModelTests: TestCase {
   private let deadlineTitleLabelText = TestObserver<String, Never>()
   private let fundingProgressBarViewBackgroundColor = TestObserver<UIColor, Never>()
   private let notifyDelegateToGoToCampaignWithProject = TestObserver<Project, Never>()
-  private let notifyDelegateToGoToCampaignWithRefTag = TestObserver<RefTag?, Never>()
   private let notifyDelegateToGoToCreator = TestObserver<Project, Never>()
   private let opacityForViews = TestObserver<CGFloat, Never>()
   private let pledgedSubtitleLabelText = TestObserver<String, Never>()
@@ -52,10 +51,8 @@ final class ProjectPamphletMainCellViewModelTests: TestCase {
     self.vm.outputs.deadlineTitleLabelText.observe(self.deadlineTitleLabelText.observer)
     self.vm.outputs.fundingProgressBarViewBackgroundColor
       .observe(self.fundingProgressBarViewBackgroundColor.observer)
-    self.vm.outputs.notifyDelegateToGoToCampaignWithProjectAndRefTag.map(first)
+    self.vm.outputs.notifyDelegateToGoToCampaignWithProject
       .observe(self.notifyDelegateToGoToCampaignWithProject.observer)
-    self.vm.outputs.notifyDelegateToGoToCampaignWithProjectAndRefTag.map(second)
-      .observe(self.notifyDelegateToGoToCampaignWithRefTag.observer)
     self.vm.outputs.notifyDelegateToGoToCreator.observe(self.notifyDelegateToGoToCreator.observer)
     self.vm.outputs.opacityForViews.observe(self.opacityForViews.observer)
     self.vm.outputs.pledgedSubtitleLabelText.observe(self.pledgedSubtitleLabelText.observer)
@@ -485,18 +482,15 @@ final class ProjectPamphletMainCellViewModelTests: TestCase {
     let refTag = RefTag.discovery
 
     self.notifyDelegateToGoToCampaignWithProject.assertValues([])
-    self.notifyDelegateToGoToCampaignWithRefTag.assertValues([])
 
     self.vm.inputs.configureWith(value: (project, refTag))
     self.vm.inputs.awakeFromNib()
 
     self.notifyDelegateToGoToCampaignWithProject.assertValues([])
-    self.notifyDelegateToGoToCampaignWithRefTag.assertValues([])
 
     self.vm.inputs.readMoreButtonTapped()
 
     self.notifyDelegateToGoToCampaignWithProject.assertValues([project])
-    self.notifyDelegateToGoToCampaignWithRefTag.assertValues([refTag])
   }
 
   func testNotifyDelegateToGoToCreator() {
@@ -601,7 +595,6 @@ final class ProjectPamphletMainCellViewModelTests: TestCase {
       self.vm.inputs.readMoreButtonTapped()
 
       self.notifyDelegateToGoToCampaignWithProject.assertValues([project])
-      self.notifyDelegateToGoToCampaignWithRefTag.assertValues([.discovery])
 
       XCTAssertEqual(self.optimizelyClient.trackedUserId, "DEADBEEF-DEAD-BEEF-DEAD-DEADBEEFBEEF")
       XCTAssertEqual(self.optimizelyClient.trackedEventKey, "Campaign Details Button Clicked")
@@ -643,7 +636,6 @@ final class ProjectPamphletMainCellViewModelTests: TestCase {
       self.vm.inputs.readMoreButtonTapped()
 
       self.notifyDelegateToGoToCampaignWithProject.assertValues([project])
-      self.notifyDelegateToGoToCampaignWithRefTag.assertValues([.discovery])
 
       XCTAssertEqual(self.trackingClient.events, ["Campaign Details Button Clicked"])
 

--- a/Library/ViewModels/ProjectPamphletMainCellViewModelTests.swift
+++ b/Library/ViewModels/ProjectPamphletMainCellViewModelTests.swift
@@ -68,9 +68,6 @@ final class ProjectPamphletMainCellViewModelTests: TestCase {
     self.vm.outputs.projectStateLabelText.observe(self.projectStateLabelText.observer)
     self.vm.outputs.projectStateLabelTextColor.observe(self.projectStateLabelTextColor.observer)
     self.vm.outputs.projectUnsuccessfulLabelTextColor.observe(self.projectUnsuccessfulLabelTextColor.observer)
-    self.vm.outputs.readMoreButtonIsLoading.observe(self.readMoreButtonIsLoading.observer)
-    self.vm.outputs.readMoreButtonIsHidden.observe(self.readMoreButtonIsHidden.observer)
-    self.vm.outputs.readMoreButtonLargeIsHidden.observe(self.readMoreButtonLargeIsHidden.observer)
     self.vm.outputs.stateLabelHidden.observe(self.stateLabelHidden.observer)
     self.vm.outputs.youreABackerLabelHidden.observe(self.youreABackerLabelHidden.observer)
   }
@@ -483,73 +480,6 @@ final class ProjectPamphletMainCellViewModelTests: TestCase {
     self.opacityForViews.assertValues([0.0, 1.0], "Fade in views after project comes in.")
   }
 
-  func testProjectCampaignCTA_OptimizelyControl() {
-    let optimizelyClient = MockOptimizelyClient()
-      |> \.experiments .~ [
-        OptimizelyExperiment.Key.nativeProjectPageCampaignDetails.rawValue:
-          OptimizelyExperiment.Variant.control.rawValue
-      ]
-
-    self.readMoreButtonIsHidden.assertDidNotEmitValue()
-    self.readMoreButtonLargeIsHidden.assertDidNotEmitValue()
-
-    withEnvironment(optimizelyClient: optimizelyClient) {
-      self.vm.inputs.configureWith(value: (.template, nil))
-      self.vm.inputs.awakeFromNib()
-
-      self.readMoreButtonIsHidden.assertValues([false])
-      self.readMoreButtonLargeIsHidden.assertValues([true])
-    }
-  }
-
-  func testProjectCampaignCTA_OptimizelyControl_OptimizelyClientNotConfigured() {
-    self.readMoreButtonIsHidden.assertDidNotEmitValue()
-    self.readMoreButtonLargeIsHidden.assertDidNotEmitValue()
-
-    withEnvironment(optimizelyClient: nil) {
-      self.vm.inputs.configureWith(value: (.template, nil))
-      self.vm.inputs.awakeFromNib()
-
-      self.readMoreButtonIsHidden.assertValues([false])
-      self.readMoreButtonLargeIsHidden.assertValues([true])
-    }
-  }
-
-  func testProjectCampaignCTA_OptimizelyExperimental_Variant1() {
-    let optimizelyClient = MockOptimizelyClient()
-      |> \.experiments .~ [
-        OptimizelyExperiment.Key.nativeProjectPageCampaignDetails.rawValue:
-          OptimizelyExperiment.Variant.variant1.rawValue
-      ]
-
-    self.readMoreButtonIsHidden.assertDidNotEmitValue()
-    self.readMoreButtonLargeIsHidden.assertDidNotEmitValue()
-
-    withEnvironment(optimizelyClient: optimizelyClient) {
-      self.vm.inputs.configureWith(value: (.template, nil))
-      self.vm.inputs.awakeFromNib()
-
-      self.readMoreButtonIsHidden.assertValues([true])
-      self.readMoreButtonLargeIsHidden.assertValues([false])
-    }
-  }
-
-  func testProjectCampaignCTA_OptimizelyExperimental_Variant2() {
-    let optimizelyClient = MockOptimizelyClient()
-      |> \.experiments .~ [
-        OptimizelyExperiment.Key.nativeProjectPageCampaignDetails.rawValue:
-          OptimizelyExperiment.Variant.variant2.rawValue
-      ]
-
-    withEnvironment(optimizelyClient: optimizelyClient) {
-      self.vm.inputs.configureWith(value: (.template, nil))
-      self.vm.inputs.awakeFromNib()
-
-      self.readMoreButtonIsHidden.assertValues([true])
-      self.readMoreButtonLargeIsHidden.assertValues([false])
-    }
-  }
-
   func testNotifyDelegateToGoToCampaign() {
     let project = Project.template
     let refTag = RefTag.discovery
@@ -740,88 +670,6 @@ final class ProjectPamphletMainCellViewModelTests: TestCase {
         properties?["optimizely_experiments"],
         "Event includes Optimizely properties"
       )
-    }
-  }
-
-  func testReadMoreButtonIsLoading_Control() {
-    let project = Project.template
-
-    self.readMoreButtonIsLoading.assertDidNotEmitValue()
-
-    let optimizelyClient = MockOptimizelyClient()
-      |> \.experiments .~ [
-        OptimizelyExperiment.Key.nativeProjectPageCampaignDetails.rawValue: OptimizelyExperiment.Variant
-          .control.rawValue
-      ]
-
-    withEnvironment(optimizelyClient: optimizelyClient) {
-      self.vm.inputs.configureWith(value: (project, nil))
-      self.vm.inputs.awakeFromNib()
-
-      self.readMoreButtonIsLoading.assertValues([false])
-    }
-  }
-
-  func testReadMoreButtonIsLoading_Variant1() {
-    let project = Project.template
-
-    self.readMoreButtonIsLoading.assertDidNotEmitValue()
-
-    let optimizelyClient = MockOptimizelyClient()
-      |> \.experiments .~ [
-        OptimizelyExperiment.Key.nativeProjectPageCampaignDetails.rawValue: OptimizelyExperiment.Variant
-          .variant1.rawValue
-      ]
-
-    withEnvironment(optimizelyClient: optimizelyClient) {
-      self.vm.inputs.configureWith(value: (project, nil))
-      self.vm.inputs.awakeFromNib()
-
-      self.readMoreButtonIsLoading.assertValues([false])
-    }
-  }
-
-  func testReadMoreButtonIsLoading_Variant2_NoRewards() {
-    let project = Project.template
-
-    self.readMoreButtonIsLoading.assertDidNotEmitValue()
-
-    let optimizelyClient = MockOptimizelyClient()
-      |> \.experiments .~ [
-        OptimizelyExperiment.Key.nativeProjectPageCampaignDetails.rawValue: OptimizelyExperiment.Variant
-          .variant2.rawValue
-      ]
-
-    withEnvironment(optimizelyClient: optimizelyClient) {
-      self.vm.inputs.configureWith(value: (project, nil))
-      self.vm.inputs.awakeFromNib()
-
-      self.readMoreButtonIsLoading.assertValues([true])
-
-      let projectWithRewards = Project.cosmicSurgery
-
-      self.vm.inputs.configureWith(value: (projectWithRewards, nil))
-
-      self.readMoreButtonIsLoading.assertValues([true, false, false])
-    }
-  }
-
-  func testReadMoreButtonIsLoading_Variant2_HasRewards() {
-    let project = Project.cosmicSurgery
-
-    self.readMoreButtonIsLoading.assertDidNotEmitValue()
-
-    let optimizelyClient = MockOptimizelyClient()
-      |> \.experiments .~ [
-        OptimizelyExperiment.Key.nativeProjectPageCampaignDetails.rawValue: OptimizelyExperiment.Variant
-          .variant2.rawValue
-      ]
-
-    withEnvironment(optimizelyClient: optimizelyClient) {
-      self.vm.inputs.configureWith(value: (project, nil))
-      self.vm.inputs.awakeFromNib()
-
-      self.readMoreButtonIsLoading.assertValues([false])
     }
   }
 }


### PR DESCRIPTION
# 📲 What

Removes the `native_project_page_campaign_details` A/B experiment that we were running with Optimizely.

# 🤔 Why

We're no longer running this experiment and have reverted to the `control` experience.

# 🛠 How

- Removed the experiment.
- Removed any code affected by this experiment.

# 👀 See

Original PR for this experiment:

#1081 

# ✅ Acceptance criteria

- [ ] There should be no regressions on the project page and the CTA button should be removed from the project description view.