### PR TITLE
Fix refreshing of dSYMs on CircleCI

### DIFF
--- a/.fastlane/Fastfile
+++ b/.fastlane/Fastfile
@@ -200,7 +200,10 @@ platform :ios do
       version: "latest"
     )
 
-    upload_dsyms # Paths are taken from lane_context[SharedValues::DSYM_PATHS] automatically
+    upload_symbols_to_crashlytics(
+      gsp_path: "./Frameworks/native-secrets/ios/Firebase-Production/GoogleService-Info.plist",
+      binary_path: "./bin/upload-symbols"
+    )
     clean_build_artifacts
 
     slack(


### PR DESCRIPTION
# 📲 What

Fixes a regression introduced in #1279 which caused our App Store dSYMs refreshing to stop working on CI.

# 🤔 Why

Each time that we merge to master, when our beta app is distributed, we refresh the latest dSYMs from the App Store to ensure that Crashlytics always has them for re-symbolicating crashes.

The changes that were made in the above-mentioned PR caused this to stop working.

# 🛠 How

Added the necessary Fastlane action back to upload the dSYMs to Firebase Crashlytics.

# 👀 See

https://docs.fastlane.tools/actions/download_dsyms/
http://docs.fastlane.tools/actions/upload_symbols_to_crashlytics