### PR TITLE
[NT-1533] Filter Add-Ons From List When Unavailable

### DIFF
--- a/Kickstarter-iOS/Views/Controllers/PledgeShippingLocationViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/PledgeShippingLocationViewController.swift
@@ -119,7 +119,7 @@ final class PledgeShippingLocationViewController: UIViewController {
       .observeForUI()
       .observeValues { [weak self] isHidden in
         self?.shimmerLoadingView.amountPlaceholder.alpha = isHidden ? 0 : 1
-    }
+      }
 
     /**
      When any layout updates occur we need to notify the delegate. This is only necessary when

--- a/Library/ViewModels/RewardAddOnCardViewModel.swift
+++ b/Library/ViewModels/RewardAddOnCardViewModel.swift
@@ -138,19 +138,16 @@ public final class RewardAddOnCardViewModel: RewardAddOnCardViewModelType, Rewar
     self.stepperValue = initialOrUpdatedSelectedQuantity
       .map(Double.init)
 
-    self.generateSelectionFeedback = Signal.combineLatest(
-      updatedSelectedQuantity.map(Double.init),
-      self.stepperMaxValue
-    )
-    .filter { value, max in value > 0 && value < max }
-    .ignoreValues()
+    let generateFeedbackWithValues = updatedSelectedQuantity.map(Double.init)
+      .withLatestFrom(self.stepperMaxValue)
 
-    self.generateNotificationWarningFeedback = Signal.combineLatest(
-      updatedSelectedQuantity.map(Double.init),
-      self.stepperMaxValue
-    )
-    .filter { value, max in value == 0 || value >= max }
-    .ignoreValues()
+    self.generateSelectionFeedback = generateFeedbackWithValues
+      .filter { value, max in value > 0 && value < max }
+      .ignoreValues()
+
+    self.generateNotificationWarningFeedback = generateFeedbackWithValues
+      .filter { value, max in value == 0 || value >= max }
+      .ignoreValues()
   }
 
   private let addButtonTappedProperty = MutableProperty(())

--- a/Library/ViewModels/RewardAddOnCardViewModelTests.swift
+++ b/Library/ViewModels/RewardAddOnCardViewModelTests.swift
@@ -996,5 +996,18 @@ final class RewardAddOnCardViewModelTests: TestCase {
     self.vm.inputs.stepperValueChanged(0)
     self.generateSelectionFeedback.assertValueCount(3)
     self.generateNotificationWarningFeedback.assertValueCount(2)
+
+    self.vm.inputs
+      .configure(with: .init(
+        project: .template,
+        reward: reward,
+        context: .pledge,
+        shippingRule: nil,
+        selectedQuantities: [:]
+      ))
+
+    // Does not generate feedback when reconfigured for cell re-use.
+    self.generateSelectionFeedback.assertValueCount(3)
+    self.generateNotificationWarningFeedback.assertValueCount(2)
   }
 }

--- a/Library/ViewModels/RewardAddOnSelectionViewModel.swift
+++ b/Library/ViewModels/RewardAddOnSelectionViewModel.swift
@@ -373,9 +373,7 @@ private func rewardsData(
 
 private func addOnIsAvailable(_ addOn: Reward, in project: Project) -> Bool {
   // If the user is backing this addOn, it's available for editing
-  if
-    let backedAddOns = project.personalization.backing?.addOns,
-    backedAddOns.map(\.id).contains(addOn.id) {
+  if let backedAddOns = project.personalization.backing?.addOns, backedAddOns.map(\.id).contains(addOn.id) {
     return true
   }
 

--- a/Library/ViewModels/RewardAddOnSelectionViewModel.swift
+++ b/Library/ViewModels/RewardAddOnSelectionViewModel.swift
@@ -344,8 +344,10 @@ private func rewardsData(
   shippingRule: ShippingRule?,
   selectedQuantities: SelectedRewardQuantities
 ) -> [RewardAddOnSelectionDataSourceItem] {
+  let addOnsFilteredByAvailability = addOns.filter { addOnIsAvailable($0, in: project) }
+
   let addOnsFilteredByShippingRule = filteredAddOns(
-    addOns,
+    addOnsFilteredByAvailability,
     filteredBy: shippingRule,
     baseReward: baseReward
   )
@@ -367,6 +369,28 @@ private func rewardsData(
       )
     }
     .map(RewardAddOnSelectionDataSourceItem.rewardAddOn)
+}
+
+private func addOnIsAvailable(_ addOn: Reward, in project: Project) -> Bool {
+  // If the user is backing this addOn, it's available for editing
+  if
+    let backedAddOns = project.personalization.backing?.addOns,
+    backedAddOns.map(\.id).contains(addOn.id) {
+    return true
+  }
+
+  let isUnlimitedOrAvailable = addOn.limit == nil || addOn.remaining ?? 0 > 0
+  let hasNoTimeLimitOrHasNotEnded = (
+    addOn.endsAt == nil ||
+      (addOn.endsAt ?? 0) >= AppEnvironment.current.dateType.init().timeIntervalSince1970
+  )
+
+  return [
+    project.state == .live,
+    hasNoTimeLimitOrHasNotEnded,
+    isUnlimitedOrAvailable
+  ]
+  .allSatisfy(isTrue)
 }
 
 private func filteredAddOns(


### PR DESCRIPTION
# 📲 What

- Filters add-ons from the list for selection when they are unavailable either by way of a timebased or quantity limit. Add-ons are always shown during editing when previously backed.
- Adds a small fix for haptics on the stepper.

# 🤔 Why

- During UAT we found that we were able to select add-ons for backing even though they might be unavailable. This resulted in unexpected behaviour.
- Haptics were being triggered on cell configuration but should only emit when adjusting the stepper.

# 🛠 How

- Added availability checking and tests.
- Updated the logic for haptics and updated the test.

# ✅ Acceptance criteria

- [ ] When backing a project that had unavailable add-ons, those add-ons should not appear in the list.
- [ ] When editing a backing that contains add-ons that have since become unavailable, those add-ons should appear in the list for editing.
- [ ] Haptics should only emit when adjusting the stepper, not when the cell is reconfigured while scrolling up and down the list.