### PR TITLE
Fix User Settings Regression

### DIFF
--- a/KsApi/queries/UserQueries.swift
+++ b/KsApi/queries/UserQueries.swift
@@ -21,66 +21,69 @@ public enum UserQueries: Queryable {
 }
 
 public func accountQueryFields() -> NonEmptySet<Query.User> {
-  return .chosenCurrency +|
-    [
-      .isAppleConnected,
-      .isEmailVerified,
-      .isEmailDeliverable,
-      .id,
-      .imageUrl(alias: "imageUrl", blur: false, width: Constants.imageWidth),
-      .name,
-      .hasPassword,
-      .email
-    ]
+  return GraphUser.baseQueryProperties
+    .op(
+      .chosenCurrency +| [
+        .isAppleConnected,
+        .isEmailVerified,
+        .isEmailDeliverable,
+        .hasPassword,
+        .email
+      ]
+    )
 }
 
 public func storedCardsQueryFields() -> NonEmptySet<Query.User> {
-  return .id +| [
-    .storedCards(
-      [],
-      .totalCount +| [
-        .nodes(
-          .id +| [
-            .expirationDate,
-            .lastFour,
-            .type
-          ]
-        )
-      ]
-    )
-  ]
-}
-
-public func changeEmailQueryFields() -> NonEmptySet<Query.User> {
-  return .email +| [
-    .isEmailVerified,
-    .isEmailDeliverable,
-    .id,
-    .imageUrl(alias: "imageUrl", blur: false, width: Constants.imageWidth),
-    .name
-  ]
-}
-
-public func backingsQueryFields(status: String) -> NonEmptySet<Query.User> {
-  return .id +| [
-    .backings(
-      status: status,
-      [],
-      .totalCount +| [
-        .nodes(
-          .status +| [
-            .id,
-            .errorReason,
-            .project(
-              .pid +| [
-                .name,
-                .slug,
-                .finalCollectionDate
+  return GraphUser.baseQueryProperties
+    .op(
+      .chosenCurrency +| [
+        .storedCards(
+          [],
+          .totalCount +| [
+            .nodes(
+              .id +| [
+                .expirationDate,
+                .lastFour,
+                .type
               ]
             )
           ]
         )
       ]
     )
-  ]
+}
+
+public func changeEmailQueryFields() -> NonEmptySet<Query.User> {
+  return GraphUser.baseQueryProperties
+    .op(
+      .email +| [
+        .isEmailVerified,
+        .isEmailDeliverable
+      ]
+    )
+}
+
+public func backingsQueryFields(status: String) -> NonEmptySet<Query.User> {
+  return GraphUser.baseQueryProperties
+    .op(
+      Query.User.backings(
+        status: status,
+        [],
+        .totalCount +| [
+          .nodes(
+            .status +| [
+              .id,
+              .errorReason,
+              .project(
+                .pid +| [
+                  .name,
+                  .slug,
+                  .finalCollectionDate
+                ]
+              )
+            ]
+          )
+        ]
+      ) +| []
+    )
 }

--- a/KsApi/queries/UserQueries.swift
+++ b/KsApi/queries/UserQueries.swift
@@ -36,20 +36,18 @@ public func accountQueryFields() -> NonEmptySet<Query.User> {
 public func storedCardsQueryFields() -> NonEmptySet<Query.User> {
   return GraphUser.baseQueryProperties
     .op(
-      .chosenCurrency +| [
-        .storedCards(
-          [],
-          .totalCount +| [
-            .nodes(
-              .id +| [
-                .expirationDate,
-                .lastFour,
-                .type
-              ]
-            )
-          ]
-        )
-      ]
+      Query.User.storedCards(
+        [],
+        .totalCount +| [
+          .nodes(
+            .id +| [
+              .expirationDate,
+              .lastFour,
+              .type
+            ]
+          )
+        ]
+      ) +| []
     )
 }
 

--- a/KsApi/queries/UserQueriesTests.swift
+++ b/KsApi/queries/UserQueriesTests.swift
@@ -7,11 +7,11 @@ final class UserQueriesTests: XCTestCase {
     let query = Query.user(accountQueryFields())
 
     XCTAssertEqual(
-      "me { chosenCurrency email hasPassword id imageUrl: imageUrl(blur: false, width: 1024) isAppleConnected isDeliverable isEmailVerified name }",
+      "me { chosenCurrency email hasPassword id imageUrl: imageUrl(blur: false, width: 1024) isAppleConnected isDeliverable isEmailVerified name uid }",
       query.description
     )
     XCTAssertEqual(
-      "{ me { chosenCurrency email hasPassword id imageUrl: imageUrl(blur: false, width: 1024) isAppleConnected isDeliverable isEmailVerified name } }",
+      "{ me { chosenCurrency email hasPassword id imageUrl: imageUrl(blur: false, width: 1024) isAppleConnected isDeliverable isEmailVerified name uid } }",
       Query.build(NonEmptySet(query))
     )
   }
@@ -20,11 +20,11 @@ final class UserQueriesTests: XCTestCase {
     let query = Query.user(changeEmailQueryFields())
 
     XCTAssertEqual(
-      "me { email id imageUrl: imageUrl(blur: false, width: 1024) isDeliverable isEmailVerified name }",
+      "me { email id imageUrl: imageUrl(blur: false, width: 1024) isDeliverable isEmailVerified name uid }",
       query.description
     )
     XCTAssertEqual(
-      "{ me { email id imageUrl: imageUrl(blur: false, width: 1024) isDeliverable isEmailVerified name } }",
+      "{ me { email id imageUrl: imageUrl(blur: false, width: 1024) isDeliverable isEmailVerified name uid } }",
       Query.build(NonEmptySet(query))
     )
   }
@@ -33,11 +33,11 @@ final class UserQueriesTests: XCTestCase {
     let query = Query.user(storedCardsQueryFields())
 
     XCTAssertEqual(
-      "me { id storedCards { nodes { expirationDate id lastFour type } totalCount } }",
+      "me { chosenCurrency id imageUrl: imageUrl(blur: false, width: 1024) name storedCards { nodes { expirationDate id lastFour type } totalCount } uid }",
       query.description
     )
     XCTAssertEqual(
-      "{ me { id storedCards { nodes { expirationDate id lastFour type } totalCount } } }",
+      "{ me { chosenCurrency id imageUrl: imageUrl(blur: false, width: 1024) name storedCards { nodes { expirationDate id lastFour type } totalCount } uid } }",
       Query.build(NonEmptySet(query))
     )
   }
@@ -45,11 +45,11 @@ final class UserQueriesTests: XCTestCase {
   func testBackingsQuery() {
     let query = Query.user(backingsQueryFields(status: BackingState.errored.rawValue))
     XCTAssertEqual(
-      "me { backings(status: errored) { nodes { errorReason id project { finalCollectionDate name pid slug } status } totalCount } id }",
+      "me { backings(status: errored) { nodes { errorReason id project { finalCollectionDate name pid slug } status } totalCount } id imageUrl: imageUrl(blur: false, width: 1024) name uid }",
       query.description
     )
     XCTAssertEqual(
-      "{ me { backings(status: errored) { nodes { errorReason id project { finalCollectionDate name pid slug } status } totalCount } id } }",
+      "{ me { backings(status: errored) { nodes { errorReason id project { finalCollectionDate name pid slug } status } totalCount } id imageUrl: imageUrl(blur: false, width: 1024) name uid } }",
       Query.build(NonEmptySet(query))
     )
   }

--- a/KsApi/queries/UserQueriesTests.swift
+++ b/KsApi/queries/UserQueriesTests.swift
@@ -33,11 +33,11 @@ final class UserQueriesTests: XCTestCase {
     let query = Query.user(storedCardsQueryFields())
 
     XCTAssertEqual(
-      "me { chosenCurrency id imageUrl: imageUrl(blur: false, width: 1024) name storedCards { nodes { expirationDate id lastFour type } totalCount } uid }",
+      "me { id imageUrl: imageUrl(blur: false, width: 1024) name storedCards { nodes { expirationDate id lastFour type } totalCount } uid }",
       query.description
     )
     XCTAssertEqual(
-      "{ me { chosenCurrency id imageUrl: imageUrl(blur: false, width: 1024) name storedCards { nodes { expirationDate id lastFour type } totalCount } uid } }",
+      "{ me { id imageUrl: imageUrl(blur: false, width: 1024) name storedCards { nodes { expirationDate id lastFour type } totalCount } uid } }",
       Query.build(NonEmptySet(query))
     )
   }


### PR DESCRIPTION
# 📲 What

Fixes a regression in our user account settings which caused changing user settings to error.

# 🤔 Why

Why indeed. The refactor in #1263 introduced some changes that added a non-nil property `uid` to `GraphUser`. The various queries we have that fetch data for our user settings views make use of `GraphUser` but those queries unfortunately hadn't been updated to include the `uid` property resulting in `GraphUser` in those contexts failing to deserialize.

# 🛠 How

Added `GraphUser.baseQueryProperties` to `UserQueries`.

# ✅ Acceptance criteria

- [ ] All user settings views should be available and functioning.