### PR TITLE
[NT-542] Replace UIButton on CancelPledgeViewController with LoadingButton

### DIFF
--- a/Kickstarter-iOS/Views/Controllers/CancelPledgeViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/CancelPledgeViewController.swift
@@ -17,8 +17,9 @@ final class CancelPledgeViewController: UIViewController, MessageBannerViewContr
 
   // MARK: - Properties
 
-  private lazy var cancelPledgeButton = { UIButton(type: .custom)
-    |> \.translatesAutoresizingMaskIntoConstraints .~ false
+  private lazy var cancelPledgeButton: LoadingButton = {
+    LoadingButton(type: .custom)
+      |> \.translatesAutoresizingMaskIntoConstraints .~ false
   }()
 
   private lazy var cancellationDetailsTextLabel = { UILabel(frame: .zero) }()
@@ -168,6 +169,12 @@ final class CancelPledgeViewController: UIViewController, MessageBannerViewContr
       .observeForControllerAction()
       .observeValues { [weak self] in
         self?.navigationController?.popViewController(animated: true)
+      }
+
+    self.viewModel.outputs.isLoading
+      .observeForUI()
+      .observeValues { [weak self] isLoading in
+        self?.cancelPledgeButton.isLoading = isLoading
       }
 
     self.cancellationDetailsTextLabel.rac.attributedText = self.viewModel.outputs

--- a/Library/ViewModels/CancelPledgeViewModel.swift
+++ b/Library/ViewModels/CancelPledgeViewModel.swift
@@ -28,6 +28,7 @@ public protocol CancelPledgeViewModelOutputs {
   var cancelPledgeButtonEnabled: Signal<Bool, Never> { get }
   var cancelPledgeError: Signal<String, Never> { get }
   var dismissKeyboard: Signal<Void, Never> { get }
+  var isLoading: Signal<Bool, Never> { get }
   var notifyDelegateCancelPledgeSuccess: Signal<String, Never> { get }
   var popCancelPledgeViewController: Signal<Void, Never> { get }
 }
@@ -85,6 +86,11 @@ public final class CancelPledgeViewModel: CancelPledgeViewModelType, CancelPledg
           .ksr_delay(AppEnvironment.current.apiDelayInterval, on: AppEnvironment.current.scheduler)
           .materialize()
       }
+
+    self.isLoading = Signal.merge(
+      self.cancelPledgeButtonTappedProperty.signal.mapConst(true),
+      cancelPledgeEvent.filter { $0.isTerminating }.mapConst(false)
+    )
 
     self.notifyDelegateCancelPledgeSuccess = cancelPledgeEvent.values()
       .map { _ in Strings.Youve_canceled_your_pledge() }
@@ -156,6 +162,7 @@ public final class CancelPledgeViewModel: CancelPledgeViewModelType, CancelPledg
   public let cancelPledgeButtonEnabled: Signal<Bool, Never>
   public let cancelPledgeError: Signal<String, Never>
   public let dismissKeyboard: Signal<Void, Never>
+  public let isLoading: Signal<Bool, Never>
   public let notifyDelegateCancelPledgeSuccess: Signal<String, Never>
   public let popCancelPledgeViewController: Signal<Void, Never>
 


### PR DESCRIPTION
# 📲 What

We are displaying a loading spinner within the Cancel pledge button while the API call is processing. 

# 🤔 Why

This behavior is currently implemented on the `Pledge` and `Confirm` buttons.

# 🛠 How

We replace the `UIButton` with a `LoadingButton` within the `CancelPledgeViewController`, provide functionality within the view model to observe the cancellation event and appropriately render either the buttons title or loading spinner.

# ✅ Acceptance criteria

- [x] A loading spinner is shown on Cancel pledge buttons while the API call is processing