### PR TITLE
[NT-1550] Fix ISO Date Format

### DIFF
--- a/KsApi/extensions/DateFormatter+ISOFormatter.swift
+++ b/KsApi/extensions/DateFormatter+ISOFormatter.swift
@@ -3,7 +3,9 @@ import Foundation
 extension DateFormatter {
   static var isoDateFormatter: DateFormatter {
     let dateFormatter = DateFormatter()
-    dateFormatter.dateFormat = "yyyy-MM-DD"
+    dateFormatter.dateFormat = "yyyy-MM-dd"
+    dateFormatter.timeZone = TimeZone.init(secondsFromGMT: 0)
+    dateFormatter.locale = Locale(identifier: "en_US_POSIX")
     return dateFormatter
   }
 }

--- a/KsApi/models/graphql/adapters/Reward+GraphRewardTests.swift
+++ b/KsApi/models/graphql/adapters/Reward+GraphRewardTests.swift
@@ -16,7 +16,7 @@ final class Reward_GraphRewardTests: XCTestCase {
 
     let dateFormatter = DateFormatter()
     dateFormatter.timeZone = TimeZone(secondsFromGMT: 0)
-    dateFormatter.dateFormat = "yyyy-MM-DD"
+    dateFormatter.dateFormat = "yyyy-MM-dd"
 
     let v1Reward = Reward.reward(
       from: reward,
@@ -29,7 +29,7 @@ final class Reward_GraphRewardTests: XCTestCase {
     XCTAssertEqual(v1Reward?.convertedMinimum, 180.0)
     XCTAssertEqual(v1Reward?.description, "Description")
     XCTAssertEqual(v1Reward?.endsAt, 1_887_502_131)
-    XCTAssertEqual(v1Reward?.estimatedDeliveryOn, 1_577_836_800.0)
+    XCTAssertEqual(v1Reward?.estimatedDeliveryOn, 1_596_240_000.0)
     XCTAssertEqual(v1Reward?.id, 1)
     XCTAssertEqual(v1Reward?.limit, 5)
     XCTAssertEqual(v1Reward?.minimum, 159.0)
@@ -46,6 +46,8 @@ final class Reward_GraphRewardTests: XCTestCase {
   }
 
   func testTemplate() {
-    XCTAssertNotNil(Reward.reward(from: .template, projectId: 12_345))
+    let reward = Reward.reward(from: .template, projectId: 12_345)
+    XCTAssertNotNil(reward)
+    XCTAssertEqual(reward?.estimatedDeliveryOn, 1_596_240_000.0)
   }
 }


### PR DESCRIPTION
# 📲 What

Fixes an issue where the estimated delivery date was incorrect on `ManagePledgeViewController`.

# 🤔 Why

We were using the incorrect date format for our date formatter when deserializing this date from GraphQL. We have different date formats used in various places, some are timestamps, some are ISO8601, but in this particular case the date is `YYYY-MM-DD` which `NSDateFormatter` converts as `yyyy-MM-dd`.

# 🛠 How

Updated the configuration of the date formatter used to convert this date string.

# 👀 See

Trello, screenshots, external resources?

| Reward selected | Manage Pledge |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/3735375/94193183-de6b9a80-fe64-11ea-88d4-9c60acd39b67.png) | ![image](https://user-images.githubusercontent.com/3735375/94193231-f3e0c480-fe64-11ea-8802-59907b7a294b.png) |

# ✅ Acceptance criteria

- [ ] Pledge to a regular reward, observe the estimated delivery date. Manage your pledge and observe that the delivery dates match.
- [ ] Pledge to a reward with add-ons. Manage your pledge and observe that the delivery date is that of the _latest_ add-on delivery date.