### PR TITLE
[NT-1543][NT-1544] Update Pledge and Change Payment Method stackview behavior updates

### DIFF
--- a/KsApi/models/graphql/adapters/Backing+GraphBacking.swift
+++ b/KsApi/models/graphql/adapters/Backing+GraphBacking.swift
@@ -50,7 +50,7 @@ private func backingStatus(from graphBacking: GraphBacking) -> Backing.Status? {
 }
 
 private func backingReward(from graphBacking: GraphBacking, projectId: Int) -> Reward? {
-  guard let graphReward = graphBacking.reward else { return nil }
+  guard let graphReward = graphBacking.reward else { return .noReward }
 
   return Reward.reward(from: graphReward, projectId: projectId)
 }

--- a/KsApi/models/graphql/adapters/Backing+GraphBackingTests.swift
+++ b/KsApi/models/graphql/adapters/Backing+GraphBackingTests.swift
@@ -1,9 +1,21 @@
 @testable import KsApi
+import Prelude
 import XCTest
 
 final class Backing_GraphBackingTests: XCTestCase {
   func test() {
     // TODO: consider testing more variations
     XCTAssertNotNil(Backing.backing(from: .template))
+  }
+
+  func test_noReward() {
+    let graphBacking = GraphBacking.template
+      |> \.reward .~ nil
+
+    let backing = Backing.backing(from: graphBacking)
+
+    XCTAssertNotNil(backing)
+
+    XCTAssertEqual(backing?.reward?.isNoReward, true)
   }
 }

--- a/Library/ViewModels/PledgeViewModel.swift
+++ b/Library/ViewModels/PledgeViewModel.swift
@@ -130,7 +130,9 @@ public class PledgeViewModel: PledgeViewModelType, PledgeViewModelInputs, Pledge
 
     self.pledgeAmountViewHidden = context.map { $0.pledgeAmountViewHidden }
     self.summarySectionSeparatorHidden = self.pledgeAmountViewHidden
-    self.pledgeAmountSummaryViewHidden = context.map { $0.pledgeAmountSummaryViewHidden }
+    self.pledgeAmountSummaryViewHidden = Signal.zip(baseReward, context).map { baseReward, context in
+      (baseReward.isNoReward && context == .update) || context.pledgeAmountSummaryViewHidden
+    }
 
     self.descriptionSectionSeparatorHidden = Signal.combineLatest(context, baseReward)
       .map { context, reward in

--- a/Library/ViewModels/PledgeViewModelTests.swift
+++ b/Library/ViewModels/PledgeViewModelTests.swift
@@ -5163,6 +5163,50 @@ final class PledgeViewModelTests: TestCase {
     ])
   }
 
+  func testPledgeAmountSummaryViewHidden_UpdateContext_NoReward_IsHidden() {
+    self.pledgeAmountSummaryViewHidden.assertDidNotEmitValue()
+
+    let project = Project.template
+    let reward = Reward.noReward
+
+    let data = PledgeViewData(
+      project: project,
+      rewards: [reward],
+      selectedQuantities: [reward.id: 1],
+      selectedLocationId: nil,
+      refTag: .projectPage,
+      context: .update
+    )
+
+    self.vm.inputs.configure(with: data)
+    self.vm.inputs.viewDidLoad()
+
+    self.pledgeAmountSummaryViewHidden.assertValues([true])
+  }
+
+  func testPledgeAmountSummaryViewHidden_UpdateContext_RegularReward_IsNotHidden() {
+    self.pledgeAmountSummaryViewHidden.assertDidNotEmitValue()
+
+    let project = Project.template
+    let reward = Reward.template
+
+    let data = PledgeViewData(
+      project: project,
+      rewards: [reward],
+      selectedQuantities: [reward.id: 1],
+      selectedLocationId: nil,
+      refTag: .projectPage,
+      context: .update
+    )
+
+    self.vm.inputs.configure(with: data)
+    self.vm.inputs.viewDidLoad()
+
+    self.pledgeAmountSummaryViewHidden.assertValues([false])
+  }
+
+  // MARK: - Tracking
+
   func testTrackingEvents_CheckoutPaymentPageViewed() {
     let project = Project.template
     let reward = Reward.template


### PR DESCRIPTION
# 📲 What

On the "Update Pledge" screen, when the user has pledged for no reward, the "Pledge" line item will be hidden. Similarly, on the "Change Payment Method" screen, when the user has pledged for no reward, the "Pledge" line item will be hidden.

# 🤔 Why

When a user pledges for no reward, there was previously redundancy in the way we present the pledge amount.

# 🛠 How

Added some logic to a couple of our view models that determine whether there is a reward before determining the set up of their respective view controllers.