### PR TITLE
[NT-1495] Update logic for quantity attributed text in RewardCardView

### DIFF
--- a/Library/ViewModels/RewardCardViewModel.swift
+++ b/Library/ViewModels/RewardCardViewModel.swift
@@ -214,6 +214,7 @@ private func rewardTitle(project: Project, reward: Reward) -> NSAttributedString
     attributes: attributes,
     bolding: [title]
   )
+  
   return qtyAttributed + titleAttributed
 }
 

--- a/Library/ViewModels/RewardCardViewModel.swift
+++ b/Library/ViewModels/RewardCardViewModel.swift
@@ -203,7 +203,7 @@ private func rewardTitle(project: Project, reward: Reward) -> NSAttributedString
     // Not the base reward, for that we just return the title without quantity.
     reward.id != backing.reward?.id,
     let selectedQuantity = selectedRewardQuantities(in: backing)[reward.id],
-    selectedQuantity > 0 else {
+    selectedQuantity > 1 else {
     return titleAttributed
   }
 
@@ -214,7 +214,6 @@ private func rewardTitle(project: Project, reward: Reward) -> NSAttributedString
     attributes: attributes,
     bolding: [title]
   )
-
   return qtyAttributed + titleAttributed
 }
 

--- a/Library/ViewModels/RewardCardViewModel.swift
+++ b/Library/ViewModels/RewardCardViewModel.swift
@@ -214,7 +214,6 @@ private func rewardTitle(project: Project, reward: Reward) -> NSAttributedString
     attributes: attributes,
     bolding: [title]
   )
-  
   return qtyAttributed + titleAttributed
 }
 

--- a/Library/ViewModels/RewardCardViewModelTests.swift
+++ b/Library/ViewModels/RewardCardViewModelTests.swift
@@ -118,6 +118,24 @@ final class RewardCardViewModelTests: TestCase {
     XCTAssertEqual(self.rewardTitleLabelAttributedText.values.map { $0.string }, ["2 x The thing"])
   }
 
+  func testTitleLabel_Backed_AddOn_Single() {
+    let reward = .template
+      |> Reward.lens.id .~ 99
+      |> Reward.lens.title .~ "The thing"
+      |> Reward.lens.remaining .~ nil
+
+    let backing = Backing.template
+      |> Backing.lens.addOns .~ [reward]
+
+    let project = Project.template
+      |> Project.lens.personalization.isBacking .~ true
+      |> Project.lens.personalization.backing .~ backing
+
+    self.vm.inputs.configure(with: (project, reward, .pledge))
+
+    XCTAssertEqual(self.rewardTitleLabelAttributedText.values.map { $0.string }, ["The thing"])
+  }
+
   // MARK: - Reward Minimum
 
   func testMinimumLabel_US_Project_US_UserLocation() {


### PR DESCRIPTION
# 📲 What

When specifying a quantity of add-ons, we use `# x add-on name` on both the Pledge screen and the View/Manage Pledge screen. On the Pledge screen, we hide `# x` when # is > 1, but we don’t do that on the View/Manage screen

# 🤔 Why

Consistency within view controllers that display similar information.

# 🛠 How

All of the work is done in the `RewardCardViewModel`. We're doing a check on the quantity of the add-on which was updated.