### PR TITLE
[NT-1559] Reward Availability Bugfixes

### DIFF
--- a/Library/SharedFunctions.swift
+++ b/Library/SharedFunctions.swift
@@ -270,7 +270,15 @@ public func rewardIsAvailable(project: Project, reward: Reward) -> Bool {
   let endsAt = reward.endsAt.coalesceWith(now)
   let timeLimitNotReached = endsAt > now
 
-  return (isLimited && isRemaining) || (isTimebased && timeLimitNotReached)
+  // Limited availability is valid if the reward is limited and remaining > 0 OR this reward is not limited.
+  let limitedAvailabilityValid = (isLimited && isRemaining) || !isLimited
+
+  // Timebased availability is valid if the reward is timebased and the time limit has not been reached
+  // OR the reward is not timebased.
+  let timebasedAvailabilityValid = (isTimebased && timeLimitNotReached) || !isTimebased
+
+  // Both type of availability must be valid in order for this reward to be considered available.
+  return limitedAvailabilityValid && timebasedAvailabilityValid
 }
 
 public func rewardLimitRemainingForBacker(project: Project, reward: Reward) -> Int? {

--- a/Library/SharedFunctions.swift
+++ b/Library/SharedFunctions.swift
@@ -277,7 +277,7 @@ public func rewardIsAvailable(project: Project, reward: Reward) -> Bool {
   // OR the reward is not timebased.
   let timebasedAvailabilityValid = (isTimebased && timeLimitNotReached) || !isTimebased
 
-  // Both type of availability must be valid in order for this reward to be considered available.
+  // Both types of availability must be valid in order for this reward to be considered available.
   return limitedAvailabilityValid && timebasedAvailabilityValid
 }
 

--- a/Library/ViewModels/RewardCardContainerViewModel.swift
+++ b/Library/ViewModels/RewardCardContainerViewModel.swift
@@ -52,7 +52,9 @@ public final class RewardCardContainerViewModel: RewardCardContainerViewModelTyp
       .map(buttonStyleType(project:reward:))
 
     self.pledgeButtonEnabled = projectAndReward
-      .map(pledgeButtonIsEnabled(project:reward:))
+      .map { project, reward in
+        RewardsCollectionViewModel.rewardsCarouselCanNavigateToReward(reward, in: project)
+      }
 
     self.pledgeButtonHidden = pledgeButtonTitleText.map(isNil)
 
@@ -147,18 +149,4 @@ private func buttonStyleType(project: Project, reward: Reward) -> ButtonStyleTyp
   }
 
   return .green
-}
-
-private func pledgeButtonIsEnabled(project: Project, reward: Reward) -> Bool {
-  if currentUserIsCreator(of: project) { return false }
-
-  let isAvailable = rewardIsAvailable(project: project, reward: reward)
-  let isBacking = userIsBacking(reward: reward, inProject: project)
-
-  return [
-    project.state == .live,
-    isAvailable,
-    !isBacking || reward.hasAddOns
-  ]
-  .allSatisfy(isTrue)
 }

--- a/Library/ViewModels/RewardCardContainerViewModelTests.swift
+++ b/Library/ViewModels/RewardCardContainerViewModelTests.swift
@@ -20,6 +20,7 @@ final class RewardCardContainerViewModelTests: TestCase {
   let availableLimitedReward = Reward.postcards
     |> Reward.lens.limit .~ 100
     |> Reward.lens.remaining .~ 25
+    |> Reward.lens.endsAt .~ nil
   let availableTimebasedReward = Reward.postcards
     |> Reward.lens.limit .~ nil
     |> Reward.lens.remaining .~ nil
@@ -36,6 +37,7 @@ final class RewardCardContainerViewModelTests: TestCase {
   let unavailableLimitedReward = Reward.postcards
     |> Reward.lens.limit .~ 100
     |> Reward.lens.remaining .~ 0
+    |> Reward.lens.endsAt .~ nil
   let unavailableTimebasedReward = Reward.postcards
     |> Reward.lens.limit .~ nil
     |> Reward.lens.remaining .~ nil
@@ -43,6 +45,10 @@ final class RewardCardContainerViewModelTests: TestCase {
   let unavailableLimitedTimebasedReward = Reward.postcards
     |> Reward.lens.limit .~ 100
     |> Reward.lens.remaining .~ 0
+    |> Reward.lens.endsAt .~ (MockDate().date.timeIntervalSince1970 - 1)
+  let availableLimitedUnavailableTimebasedReward = Reward.postcards
+    |> Reward.lens.limit .~ 100
+    |> Reward.lens.remaining .~ 25
     |> Reward.lens.endsAt .~ (MockDate().date.timeIntervalSince1970 - 1)
 
   private var allRewards: [Reward] {
@@ -55,6 +61,7 @@ final class RewardCardContainerViewModelTests: TestCase {
       unavailableLimitedReward,
       unavailableTimebasedReward,
       unavailableLimitedTimebasedReward,
+      availableLimitedUnavailableTimebasedReward,
       Reward.noReward
     ]
   }
@@ -103,13 +110,17 @@ final class RewardCardContainerViewModelTests: TestCase {
     self.pledgeButtonTitleText.assertValueCount(self.allRewards.count)
 
     self.pledgeButtonStyleType.assertValues([
-      .green, .black, .black, .black, .black, .black, .black, .black, .black
-    ]
+      .green, .black, .black, .black, .black, .black, .black, .black, .black, .black
+    ])
+    self.pledgeButtonEnabled.assertValues(
+      [true, false, false, false, false, false, false, false, false, false]
     )
-    self.pledgeButtonEnabled.assertValues([true, false, false, false, false, false, false, false, false])
-    self.pledgeButtonHidden.assertValues([false, false, false, false, false, false, false, false, false])
+    self.pledgeButtonHidden.assertValues(
+      [false, false, false, false, false, false, false, false, false, false]
+    )
     self.pledgeButtonTitleText.assertValues([
       "Continue",
+      "Selected",
       "Selected",
       "Selected",
       "Selected",
@@ -155,16 +166,20 @@ final class RewardCardContainerViewModelTests: TestCase {
     self.pledgeButtonTitleText.assertValueCount(self.allRewards.count)
 
     self.pledgeButtonStyleType.assertValues(
-      [.green, .green, .green, .green, .green, .green, .green, .green, .green]
+      [.green, .green, .green, .green, .green, .green, .green, .green, .green, .green]
     )
-    self.pledgeButtonEnabled.assertValues([true, true, true, true, true, false, false, false, true])
-    self.pledgeButtonHidden.assertValues([false, false, false, false, false, false, false, false, false])
+
+    self.pledgeButtonEnabled.assertValues([true, true, true, true, true, false, false, false, false, true])
+    self.pledgeButtonHidden.assertValues(
+      [false, false, false, false, false, false, false, false, false, false]
+    )
     self.pledgeButtonTitleText.assertValues([
       "Select",
       "Select",
       "Select",
       "Select",
       "Select",
+      "No longer available",
       "No longer available",
       "No longer available",
       "No longer available",
@@ -200,16 +215,19 @@ final class RewardCardContainerViewModelTests: TestCase {
       self.pledgeButtonTitleText.assertValueCount(self.allRewards.count)
 
       self.pledgeButtonStyleType.assertValues(
-        [.green, .green, .green, .green, .green, .green, .green, .green, .green]
+        [.green, .green, .green, .green, .green, .green, .green, .green, .green, .green]
       )
-      self.pledgeButtonEnabled.assertValues([true, true, true, true, true, false, false, false, true])
-      self.pledgeButtonHidden.assertValues([false, false, false, false, false, false, false, false, false])
+      self.pledgeButtonEnabled.assertValues([true, true, true, true, true, false, false, false, false, true])
+      self.pledgeButtonHidden.assertValues(
+        [false, false, false, false, false, false, false, false, false, false]
+      )
       self.pledgeButtonTitleText.assertValues([
         "Select",
         "Select",
         "Select",
         "Select",
         "Select",
+        "No longer available",
         "No longer available",
         "No longer available",
         "No longer available",
@@ -247,16 +265,19 @@ final class RewardCardContainerViewModelTests: TestCase {
       self.pledgeButtonTitleText.assertValueCount(self.allRewards.count)
 
       self.pledgeButtonStyleType.assertValues(
-        [.green, .green, .green, .green, .green, .green, .green, .green, .green]
+        [.green, .green, .green, .green, .green, .green, .green, .green, .green, .green]
       )
-      self.pledgeButtonEnabled.assertValues([true, true, true, true, true, false, false, false, true])
-      self.pledgeButtonHidden.assertValues([false, false, false, false, false, false, false, false, false])
+      self.pledgeButtonEnabled.assertValues([true, true, true, true, true, false, false, false, false, true])
+      self.pledgeButtonHidden.assertValues(
+        [false, false, false, false, false, false, false, false, false, false]
+      )
       self.pledgeButtonTitleText.assertValues([
         "Select",
         "Select",
         "Select",
         "Select",
         "Select",
+        "No longer available",
         "No longer available",
         "No longer available",
         "No longer available",
@@ -299,11 +320,16 @@ final class RewardCardContainerViewModelTests: TestCase {
     self.pledgeButtonTitleText.assertValueCount(self.allRewards.count)
 
     self.pledgeButtonStyleType.assertValues(
-      [.black, .black, .black, .black, .black, .black, .black, .black, .black]
+      [.black, .black, .black, .black, .black, .black, .black, .black, .black, .black]
     )
-    self.pledgeButtonEnabled.assertValues([false, false, false, false, false, false, false, false, false])
-    self.pledgeButtonHidden.assertValues([false, false, false, false, false, false, false, false, false])
+    self.pledgeButtonEnabled.assertValues(
+      [false, false, false, false, false, false, false, false, false, false]
+    )
+    self.pledgeButtonHidden.assertValues(
+      [false, false, false, false, false, false, false, false, false, false]
+    )
     self.pledgeButtonTitleText.assertValues([
+      "Selected",
       "Selected",
       "Selected",
       "Selected",
@@ -350,11 +376,13 @@ final class RewardCardContainerViewModelTests: TestCase {
     self.pledgeButtonTitleText.assertValueCount(self.allRewards.count)
 
     self.pledgeButtonStyleType.assertValues([
-      .none, .none, .none, .none, .none, .none, .none, .none, .none
+      .none, .none, .none, .none, .none, .none, .none, .none, .none, .none
     ])
-    self.pledgeButtonEnabled.assertValues([false, false, false, false, false, false, false, false, false])
-    self.pledgeButtonHidden.assertValues([true, true, true, true, true, true, true, true, true])
-    self.pledgeButtonTitleText.assertValues([nil, nil, nil, nil, nil, nil, nil, nil, nil])
+    self.pledgeButtonEnabled.assertValues(
+      [false, false, false, false, false, false, false, false, false, false]
+    )
+    self.pledgeButtonHidden.assertValues([true, true, true, true, true, true, true, true, true, true])
+    self.pledgeButtonTitleText.assertValues([nil, nil, nil, nil, nil, nil, nil, nil, nil, nil])
   }
 
   func testNonLive_NonBackedProject() {
@@ -384,11 +412,17 @@ final class RewardCardContainerViewModelTests: TestCase {
     self.pledgeButtonTitleText.assertValueCount(self.allRewards.count)
 
     self.pledgeButtonStyleType.assertValues([
-      .none, .none, .none, .none, .none, .none, .none, .none, .none
+      .none, .none, .none, .none, .none, .none, .none, .none, .none, .none
     ])
-    self.pledgeButtonEnabled.assertValues([false, false, false, false, false, false, false, false, false])
-    self.pledgeButtonHidden.assertValues([true, true, true, true, true, true, true, true, true])
-    self.pledgeButtonTitleText.assertValues([nil, nil, nil, nil, nil, nil, nil, nil, nil])
+    self.pledgeButtonEnabled.assertValues(
+      [false, false, false, false, false, false, false, false, false, false]
+    )
+    self.pledgeButtonHidden.assertValues(
+      [true, true, true, true, true, true, true, true, true, true]
+    )
+    self.pledgeButtonTitleText.assertValues(
+      [nil, nil, nil, nil, nil, nil, nil, nil, nil, nil]
+    )
   }
 
   func testLive_BackedProject_BackedReward_Errored() {
@@ -532,11 +566,15 @@ final class RewardCardContainerViewModelTests: TestCase {
       self.pledgeButtonTitleText.assertValueCount(self.allRewards.count)
 
       self.pledgeButtonStyleType.assertValues(
-        [.none, .none, .none, .none, .none, .none, .none, .none, .none]
+        [.none, .none, .none, .none, .none, .none, .none, .none, .none, .none]
       )
-      self.pledgeButtonEnabled.assertValues([false, false, false, false, false, false, false, false, false])
-      self.pledgeButtonHidden.assertValues([true, true, true, true, true, true, true, true, true])
-      self.pledgeButtonTitleText.assertValues([nil, nil, nil, nil, nil, nil, nil, nil, nil])
+      self.pledgeButtonEnabled.assertValues(
+        [false, false, false, false, false, false, false, false, false, false]
+      )
+      self.pledgeButtonHidden.assertValues(
+        [true, true, true, true, true, true, true, true, true, true]
+      )
+      self.pledgeButtonTitleText.assertValues([nil, nil, nil, nil, nil, nil, nil, nil, nil, nil])
     }
   }
 
@@ -572,11 +610,17 @@ final class RewardCardContainerViewModelTests: TestCase {
       self.pledgeButtonTitleText.assertValueCount(self.allRewards.count)
 
       self.pledgeButtonStyleType.assertValues(
-        [.none, .none, .none, .none, .none, .none, .none, .none, .none]
+        [.none, .none, .none, .none, .none, .none, .none, .none, .none, .none]
       )
-      self.pledgeButtonEnabled.assertValues([false, false, false, false, false, false, false, false, false])
-      self.pledgeButtonHidden.assertValues([true, true, true, true, true, true, true, true, true])
-      self.pledgeButtonTitleText.assertValues([nil, nil, nil, nil, nil, nil, nil, nil, nil])
+      self.pledgeButtonEnabled.assertValues(
+        [false, false, false, false, false, false, false, false, false, false]
+      )
+      self.pledgeButtonHidden.assertValues(
+        [true, true, true, true, true, true, true, true, true, true]
+      )
+      self.pledgeButtonTitleText.assertValues(
+        [nil, nil, nil, nil, nil, nil, nil, nil, nil, nil]
+      )
     }
   }
 

--- a/Library/ViewModels/RewardsCollectionViewModel.swift
+++ b/Library/ViewModels/RewardsCollectionViewModel.swift
@@ -268,7 +268,15 @@ private func titleForContext(_ context: RewardsCollectionViewContext, project: P
 private func shouldNavigateToReward(project: Project, reward: Reward, refTag _: RefTag?) -> Bool {
   guard !currentUserIsCreator(of: project) else { return false }
 
-  return project.state == .live && (!userIsBacking(reward: reward, inProject: project) || reward.hasAddOns)
+  let isAvailable = rewardIsAvailable(project: project, reward: reward)
+  let isBacking = userIsBacking(reward: reward, inProject: project)
+
+  return [
+    project.state == .live,
+    isAvailable,
+    !isBacking || reward.hasAddOns
+  ]
+  .allSatisfy(isTrue)
 }
 
 private func shouldTriggerEditRewardPrompt(_ data: PledgeViewData) -> Bool {

--- a/Library/ViewModels/RewardsCollectionViewModel.swift
+++ b/Library/ViewModels/RewardsCollectionViewModel.swift
@@ -96,7 +96,9 @@ public final class RewardsCollectionViewModel: RewardsCollectionViewModelType,
       selectedRewardFromId,
       refTag
     )
-    .filter(shouldNavigateToReward)
+    .filter { project, reward, _ in
+      RewardsCollectionViewModel.rewardsCarouselCanNavigateToReward(reward, in: project)
+    }
     .map { project, reward, refTag -> (PledgeViewData, Bool) in
       let data = PledgeViewData(
         project: project,
@@ -265,20 +267,6 @@ private func titleForContext(_ context: RewardsCollectionViewContext, project: P
   return context == .createPledge ? Strings.Back_this_project() : Strings.Edit_reward()
 }
 
-private func shouldNavigateToReward(project: Project, reward: Reward, refTag _: RefTag?) -> Bool {
-  guard !currentUserIsCreator(of: project) else { return false }
-
-  let isAvailable = rewardIsAvailable(project: project, reward: reward)
-  let isBacking = userIsBacking(reward: reward, inProject: project)
-
-  return [
-    project.state == .live,
-    isAvailable,
-    !isBacking || reward.hasAddOns
-  ]
-  .allSatisfy(isTrue)
-}
-
 private func shouldTriggerEditRewardPrompt(_ data: PledgeViewData) -> Bool {
   // If the user is not backing the project then there is no need to show the prompt.
   guard
@@ -309,5 +297,21 @@ private func trackingPledgeContext(for rewardsContext: RewardsCollectionViewCont
     return Koala.PledgeContext.newPledge
   case .managePledge:
     return Koala.PledgeContext.changeReward
+  }
+}
+
+extension RewardsCollectionViewModel {
+  public static func rewardsCarouselCanNavigateToReward(_ reward: Reward, in project: Project) -> Bool {
+    guard !currentUserIsCreator(of: project) else { return false }
+
+    let isAvailable = rewardIsAvailable(project: project, reward: reward)
+    let isBacking = userIsBacking(reward: reward, inProject: project)
+
+    return [
+      project.state == .live,
+      isAvailable,
+      !isBacking || reward.hasAddOns
+    ]
+    .allSatisfy(isTrue)
   }
 }


### PR DESCRIPTION
# 📲 What

Fixes two bugs with regards to the availability of rewards:

1. If a reward is both timebased and limited we were allowing users to back rewards if either of these conditions passed, for example someone could back a timebased reward, that was also limited, that had expired but had a remaining positive quantity.
2. We were allowing users to tap through on reward cards even when unavailable under certain conditions.

# 🤔 Why

Users should not be able to back rewards in these situations and we also did not have sufficient back-end fail-safes to prevent this.

# 🛠 How

1. Fixed the logic that determines the availability of rewards.
2. Shared the rewards carousel navigation filtering behaviour.
3. Updated tests.

# ✅ Acceptance criteria

- [ ] A reward that is both timebased and limited should not be backable if either the timelimit is reached or the remaining quantity drops to zero.