### PR TITLE
Default UITableViewCell labels are used to show estimated delivery date

### DIFF
--- a/Kickstarter-iOS/Views/Cells/PledgeExpandableHeaderRewardHeaderCell.swift
+++ b/Kickstarter-iOS/Views/Cells/PledgeExpandableHeaderRewardHeaderCell.swift
@@ -20,6 +20,7 @@ final class PledgeExpandableHeaderRewardHeaderCell: UITableViewCell, ValueCell {
     super.init(style: style, reuseIdentifier: reuseIdentifier)
 
     self.configureViews()
+    self.setupConstraints()
     self.bindViewModel()
   }
 
@@ -38,19 +39,25 @@ final class PledgeExpandableHeaderRewardHeaderCell: UITableViewCell, ValueCell {
 
     _ = self.amountLabel
       |> \.adjustsFontForContentSizeCategory .~ true
+      |> UIView.lens.contentCompressionResistancePriority(for: .vertical) .~ UILayoutPriority.required
+    
 
     _ = self.rootStackView
       |> rootStackViewStyle(self.traitCollection.preferredContentSizeCategory > .accessibilityLarge)
 
     _ = self.titleLabel
       |> titleLabelStyle
+      |> UILabel.lens.contentCompressionResistancePriority(for: .vertical) .~ UILayoutPriority.required
 
     _ = self.subtitleLabel
       |> subtitleLabelStyle
+      |> UILabel.lens.contentCompressionResistancePriority(for: .vertical) .~ UILayoutPriority.required
 
     _ = self.leftColumnStackView
       |> verticalStackViewStyle
+      |> UIStackView.lens.contentCompressionResistancePriority(for: .vertical) .~ UILayoutPriority.required
       |> \.spacing .~ Styles.grid(1)
+      
   }
 
   // MARK: - View model
@@ -64,13 +71,22 @@ final class PledgeExpandableHeaderRewardHeaderCell: UITableViewCell, ValueCell {
       .observeForUI()
       .observeValues { [weak self] titleText in
         self?.subtitleLabel.text = titleText
+        self?.subtitleLabel.setNeedsLayout()
       }
   }
 
   // MARK: - Configuration
+  
+  private func setupConstraints() {
+    NSLayoutConstraint.activate([
+      self.leftColumnStackView.heightAnchor.constraint(greaterThanOrEqualToConstant: 40),
+    ])
+  }
 
   func configureWith(value: PledgeExpandableHeaderRewardCellData) {
     self.viewModel.inputs.configure(with: value)
+    
+    self.contentView.layoutIfNeeded()
   }
 
   private func configureViews() {
@@ -83,6 +99,7 @@ final class PledgeExpandableHeaderRewardHeaderCell: UITableViewCell, ValueCell {
 
     _ = ([self.leftColumnStackView, UIView(), self.amountLabel], self.rootStackView)
       |> ksr_addArrangedSubviewsToStackView()
+  
   }
 }
 

--- a/Kickstarter-iOS/Views/Cells/PledgeExpandableHeaderRewardHeaderCell.swift
+++ b/Kickstarter-iOS/Views/Cells/PledgeExpandableHeaderRewardHeaderCell.swift
@@ -12,7 +12,7 @@ final class PledgeExpandableHeaderRewardHeaderCell: UITableViewCell, ValueCell {
 
   // MARK: - Lifecycle
 
-  override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+  override init(style _: UITableViewCell.CellStyle, reuseIdentifier: String?) {
     super.init(style: .subtitle, reuseIdentifier: reuseIdentifier)
 
     self.configureViews()
@@ -35,13 +35,12 @@ final class PledgeExpandableHeaderRewardHeaderCell: UITableViewCell, ValueCell {
     _ = self.amountLabel
       |> \.adjustsFontForContentSizeCategory .~ true
       |> UIView.lens.contentCompressionResistancePriority(for: .vertical) .~ UILayoutPriority.required
-    
+
     _ = self.textLabel!
       |> titleLabelStyle
 
     _ = self.detailTextLabel!
       |> subtitleLabelStyle
-    
   }
 
   // MARK: - View model
@@ -67,8 +66,8 @@ final class PledgeExpandableHeaderRewardHeaderCell: UITableViewCell, ValueCell {
 
   private func configureViews() {
     _ = (self.amountLabel, self.contentView)
-     |> ksr_addSubviewToParent()
-     |> ksr_constrainViewToTrailingMarginInParent()
+      |> ksr_addSubviewToParent()
+      |> ksr_constrainViewToTrailingMarginInParent()
   }
 }
 

--- a/Kickstarter-iOS/Views/Cells/PledgeExpandableHeaderRewardHeaderCell.swift
+++ b/Kickstarter-iOS/Views/Cells/PledgeExpandableHeaderRewardHeaderCell.swift
@@ -6,10 +6,6 @@ final class PledgeExpandableHeaderRewardHeaderCell: UITableViewCell, ValueCell {
   // MARK: - Properties
 
   private lazy var amountLabel: UILabel = UILabel(frame: .zero)
-  private lazy var leftColumnStackView: UIStackView = UIStackView(frame: .zero)
-  private lazy var rootStackView: UIStackView = UIStackView(frame: .zero)
-  private lazy var subtitleLabel: UILabel = UILabel(frame: .zero)
-  private lazy var titleLabel: UILabel = UILabel(frame: .zero)
 
   private let viewModel: PledgeExpandableHeaderRewardCellViewModelType
     = PledgeExpandableHeaderRewardCellViewModel()
@@ -17,10 +13,9 @@ final class PledgeExpandableHeaderRewardHeaderCell: UITableViewCell, ValueCell {
   // MARK: - Lifecycle
 
   override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
-    super.init(style: style, reuseIdentifier: reuseIdentifier)
+    super.init(style: .subtitle, reuseIdentifier: reuseIdentifier)
 
     self.configureViews()
-    self.setupConstraints()
     self.bindViewModel()
   }
 
@@ -41,23 +36,12 @@ final class PledgeExpandableHeaderRewardHeaderCell: UITableViewCell, ValueCell {
       |> \.adjustsFontForContentSizeCategory .~ true
       |> UIView.lens.contentCompressionResistancePriority(for: .vertical) .~ UILayoutPriority.required
     
-
-    _ = self.rootStackView
-      |> rootStackViewStyle(self.traitCollection.preferredContentSizeCategory > .accessibilityLarge)
-
-    _ = self.titleLabel
+    _ = self.textLabel!
       |> titleLabelStyle
-      |> UILabel.lens.contentCompressionResistancePriority(for: .vertical) .~ UILayoutPriority.required
 
-    _ = self.subtitleLabel
+    _ = self.detailTextLabel!
       |> subtitleLabelStyle
-      |> UILabel.lens.contentCompressionResistancePriority(for: .vertical) .~ UILayoutPriority.required
-
-    _ = self.leftColumnStackView
-      |> verticalStackViewStyle
-      |> UIStackView.lens.contentCompressionResistancePriority(for: .vertical) .~ UILayoutPriority.required
-      |> \.spacing .~ Styles.grid(1)
-      
+    
   }
 
   // MARK: - View model
@@ -70,36 +54,21 @@ final class PledgeExpandableHeaderRewardHeaderCell: UITableViewCell, ValueCell {
     self.viewModel.outputs.labelText
       .observeForUI()
       .observeValues { [weak self] titleText in
-        self?.subtitleLabel.text = titleText
-        self?.subtitleLabel.setNeedsLayout()
+        self?.detailTextLabel?.text = titleText
       }
   }
 
   // MARK: - Configuration
-  
-  private func setupConstraints() {
-    NSLayoutConstraint.activate([
-      self.leftColumnStackView.heightAnchor.constraint(greaterThanOrEqualToConstant: 40),
-    ])
-  }
 
   func configureWith(value: PledgeExpandableHeaderRewardCellData) {
     self.viewModel.inputs.configure(with: value)
-    
     self.contentView.layoutIfNeeded()
   }
 
   private func configureViews() {
-    _ = (self.rootStackView, self.contentView)
-      |> ksr_addSubviewToParent()
-      |> ksr_constrainViewToEdgesInParent()
-
-    _ = ([self.titleLabel, self.subtitleLabel], self.leftColumnStackView)
-      |> ksr_addArrangedSubviewsToStackView()
-
-    _ = ([self.leftColumnStackView, UIView(), self.amountLabel], self.rootStackView)
-      |> ksr_addArrangedSubviewsToStackView()
-  
+    _ = (self.amountLabel, self.contentView)
+     |> ksr_addSubviewToParent()
+     |> ksr_constrainViewToTrailingMarginInParent()
   }
 }
 
@@ -118,24 +87,4 @@ private let titleLabelStyle: LabelStyle = { label in
     |> \.textColor .~ .ksr_text_black
     |> \.numberOfLines .~ 0
     |> \.text .~ Strings.Your_reward()
-}
-
-private func rootStackViewStyle(_ isAccessibilityCategory: Bool) -> (StackViewStyle) {
-  let alignment: UIStackView.Alignment = (isAccessibilityCategory ? .leading : .top)
-  let axis: NSLayoutConstraint.Axis = (isAccessibilityCategory ? .vertical : .horizontal)
-  let distribution: UIStackView.Distribution = (isAccessibilityCategory ? .equalSpacing : .fill)
-  let spacing: CGFloat = (isAccessibilityCategory ? Styles.grid(1) : 0)
-
-  return { (stackView: UIStackView) in
-    stackView
-      |> \.alignment .~ alignment
-      |> \.axis .~ axis
-      |> \.distribution .~ distribution
-      |> \.spacing .~ spacing
-      |> \.isLayoutMarginsRelativeArrangement .~ true
-      |> \.layoutMargins .~ .init(
-        topBottom: Styles.grid(3),
-        leftRight: CheckoutConstants.PledgeView.Inset.leftRight
-      )
-  }
 }

--- a/Library/UIView+AutoLayout.swift
+++ b/Library/UIView+AutoLayout.swift
@@ -38,6 +38,21 @@ public func ksr_constrainViewToCenterInParent() -> ((UIView, UIView) -> (UIView,
   }
 }
 
+public func ksr_constrainViewToTrailingMarginInParent() -> ((UIView, UIView) -> (UIView, UIView)) {
+  return { subview, parent in
+    subview.translatesAutoresizingMaskIntoConstraints = false
+
+    let constraints = [
+      subview.trailingAnchor.constraint(equalTo: parent.layoutMarginsGuide.trailingAnchor),
+      subview.centerYAnchor.constraint(equalTo: parent.centerYAnchor),
+    ]
+
+    NSLayoutConstraint.activate(constraints)
+
+    return (subview, parent)
+  }
+}
+
 public func ksr_addLayoutGuideToView() -> ((UILayoutGuide, UIView) -> (UILayoutGuide, UIView)) {
   return { layoutGuide, view in
     view.addLayoutGuide(layoutGuide)

--- a/Library/UIView+AutoLayout.swift
+++ b/Library/UIView+AutoLayout.swift
@@ -44,7 +44,7 @@ public func ksr_constrainViewToTrailingMarginInParent() -> ((UIView, UIView) -> 
 
     let constraints = [
       subview.trailingAnchor.constraint(equalTo: parent.layoutMarginsGuide.trailingAnchor),
-      subview.centerYAnchor.constraint(equalTo: parent.centerYAnchor),
+      subview.centerYAnchor.constraint(equalTo: parent.centerYAnchor)
     ]
 
     NSLayoutConstraint.activate(constraints)


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

**PledgeExpandableHeaderRewardHeaderCell** cell style set to **subtitle** to show title and estimated delivery date with default **UITableViewCell** title and subtitle labels to avoid nested **UIStackView** layout issues

**amountLabel** is added as a subview to contentView

# 🤔 Why

UIKit default behavior for **UIStackView**


    - Apple automatically creates 1000 priority constraints for you when you add managed subviews to a stack view.
    - Apple automatically creates a 0-height constraint for you when you hide a subview of a stack view.

This creates layout issue for the cell content. Like clipping of the estimated delivery label.
Or plasing the hole content of the stack view much lover relative to parent than it should be.

[here](https://stackoverflow.com/questions/32428210/uistackview-unable-to-simultaneously-satisfy-constraints-on-squished-hidden/38064687#38064687) you can find more derails.

With wrapper **UIView** approach i was able to resolve issue with label clipping. But issue with Y axis  misplacement on view scroll of the entire **rootStackView** persisted.

So i've decided to use default cell properties. It fixed the issue with layout. And reduce amount of code in **PledgeExpandableHeaderRewardHeaderCell**

# ✅ Acceptance criteria

- [ ] Navigate to back this project screen
- [ ] Scroll up and down

