### PR TITLE
[NT-1566] Fix Supported Countries List

### DIFF
--- a/KsApi/models/Project.Country.swift
+++ b/KsApi/models/Project.Country.swift
@@ -38,14 +38,14 @@ extension Project {
     public static let nl = Country(countryCode: "NL", currencyCode: "EUR", currencySymbol: "€", maxPledge: eurMaxPledge, minPledge: eurMinPledge, trailingCode: false)
     public static let no = Country(countryCode: "NO", currencyCode: "NOK", currencySymbol: "kr", maxPledge: 80_000, minPledge: 5, trailingCode: true)
     public static let nz = Country(countryCode: "NZ", currencyCode: "NZD", currencySymbol: "$", maxPledge: 14_000, minPledge: 1, trailingCode: true)
-    public static let pl = Country(countryCode: "PL", currencyCode: "PLN", currencySymbol: "zł", maxPledge: 37_250, minPledge: 5, trailingCode: true)
+    public static let pl = Country(countryCode: "PL", currencyCode: "PLN", currencySymbol: "zł", maxPledge: 37_250, minPledge: 5, trailingCode: false)
     public static let se = Country(countryCode: "SE", currencyCode: "SEK", currencySymbol: "kr", maxPledge: 85_000, minPledge: 5, trailingCode: true)
     public static let sg = Country(countryCode: "SG", currencyCode: "SGD", currencySymbol: "$", maxPledge: 13_000, minPledge: 2, trailingCode: true)
     public static let si = Country(countryCode: "SI", currencyCode: "EUR", currencySymbol: "€", maxPledge: eurMaxPledge, minPledge: eurMinPledge, trailingCode: false)
     public static let us = Country(countryCode: "US", currencyCode: "USD", currencySymbol: "$", maxPledge: 10_000, minPledge: 1, trailingCode: true)
 
     public static let all: [Country] = [
-      .au, .at, .be, .ca, .ch, .de, .dk, .es, .fr, .gb, .gr, .hk, .ie, .it, .jp, .lu, .mx, .nl, .no, .nz, .pl, .se, .sg, si, .us
+      .au, .at, .be, .ca, .ch, .de, .dk, .es, .fr, .gb, .gr, .hk, .ie, .it, .jp, .lu, .mx, .nl, .no, .nz, .pl, .se, .sg, .si, .us
     ]
     // swiftformat:enable wrap
     // swiftformat:enable wrapArguments

--- a/Library/LaunchedCountries.swift
+++ b/Library/LaunchedCountries.swift
@@ -4,10 +4,7 @@ public struct LaunchedCountries {
   public let countries: [Project.Country]
 
   public init() {
-    self.countries = [
-      .au, .at, .be, .ca, .ch, .de, .dk, .es, .fr, .gb, .hk, .ie, .it, .jp, .lu, .mx, .nl, .no, .nz, .se, .sg,
-      .us
-    ]
+    self.countries = Project.Country.all
   }
 
   /**


### PR DESCRIPTION
# 📲 What

Adds a change that was meant to be in #1300 in which we added new country support.

# 🤔 Why

The array updated in this change was meant to be updated before but we weren't aware of it. This is necessary for project country min and max pledge values to used when pledging.

# 🛠 How

For some reason this array was maintained separately from `Project.Country.all`, for simplicity I've set them to be the same list, that is - any country that we add to `Project.Country` is supported. If at a later stage it is necessary for us to have countries in `Project.Country` that aren't supported then we can simply filter those out in the launched countries list.

# ✅ Acceptance criteria

- [ ] Navigate to a project in Poland, the minimum pledge value for _No Reward_ should be zl 5.
- [ ] Navigate to a project in Mexico, the minimum pledge value for _No Reward_ should be MX$10.