### PR TITLE
[NT-1567] Fix CircleCI Configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -238,7 +238,7 @@ jobs:
     <<: *distribute_job
     environment:
       - *default_environment
-      - LANE=alpha_match_gym_appcenter_s3
+      - LANE=alpha_match_gym_appcenter
       - FIREBASE_DIR=Firebase-Alpha
       - DSYMS_FILE=KickAlpha.app.dSYM.zip
 
@@ -274,7 +274,7 @@ jobs:
     <<: *distribute_job
     environment:
       - *default_environment
-      - LANE=itunes_match_gym_appcenter_s3
+      - LANE=itunes_match_gym_deliver
       - FIREBASE_DIR=Firebase-Production
       - DSYMS_FILE=Kickstarter.app.dSYM.zip
 

--- a/.fastlane/Fastfile
+++ b/.fastlane/Fastfile
@@ -20,7 +20,8 @@ platform :ios do
       git_url: "https://github.com/kickstarter/ios-certificates",
       team_id: "48YBP49Y5N",
       git_branch: "ksr",
-      username: ENV["ITUNES_CONNECT_ACCOUNT"]
+      username: ENV["ITUNES_CONNECT_ACCOUNT"],
+      readonly: is_ci
     )
   end
 
@@ -36,7 +37,8 @@ platform :ios do
       team_id: "48YBP49Y5N",
       git_branch: "ksr",
       username: ENV["ITUNES_CONNECT_ACCOUNT"],
-      force_for_new_devices: true
+      force_for_new_devices: true,
+      readonly: is_ci
     )
   end
 
@@ -52,7 +54,8 @@ platform :ios do
       team_id: "5DAN4UM3NC",
       git_branch: "ksr-enterprise",
       username: ENV["ITUNES_CONNECT_ACCOUNT"],
-      force_for_new_devices: true
+      force_for_new_devices: true,
+      readonly: is_ci
     )
   end
 
@@ -126,7 +129,6 @@ platform :ios do
 
   desc "Upload to the App Store"
   lane :itunes_deliver do
-
     deliver(
       force: true,
       username: ENV["ITUNES_CONNECT_ACCOUNT"],


### PR DESCRIPTION
# 📲 What

- Fixes some copy-paste typos introduced in #1296.
- Sets `match` to run in read-only mode on CI.

# 🤔 Why

- We had copy-pasted some lane names when making those changes and our alpha and app store lane names were incorrect.
- `match` should run in read-only mode when running on CI. It's faster and ensures we don't make any changes without knowing about it.

# 🛠 How

- Fixed the lane names.
- Set `match` to run in read-only mode on CI using the built-in `is_ci` Fastlane function.