### PR TITLE
[NT-1565] Backers Can Edit an Expired Reward with Add-Ons

### DIFF
--- a/Library/SharedFunctions.swift
+++ b/Library/SharedFunctions.swift
@@ -350,3 +350,17 @@ public func selectedRewardQuantities(in backing: Backing) -> SelectedRewardQuant
 
   return quantities
 }
+
+public func rewardsCarouselCanNavigateToReward(_ reward: Reward, in project: Project) -> Bool {
+  guard !currentUserIsCreator(of: project) else { return false }
+
+  let isBacking = userIsBacking(reward: reward, inProject: project)
+  let isAvailableForNewBacker = rewardIsAvailable(project: project, reward: reward) && !isBacking
+  let isAvailableForExistingBackerToEdit = (isBacking && reward.hasAddOns)
+
+  return [
+    project.state == .live,
+    isAvailableForNewBacker || isAvailableForExistingBackerToEdit
+  ]
+  .allSatisfy(isTrue)
+}

--- a/Library/SharedFunctionsTests.swift
+++ b/Library/SharedFunctionsTests.swift
@@ -115,4 +115,194 @@ final class SharedFunctionsTests: TestCase {
       XCTAssertEqual("CZ", shippingRule?.location.country)
     }
   }
+
+  func testRewardsCarouselCanNavigateToReward_RegularReward_Available_NotBacked_IsCreator() {
+    let creator = User.template
+      |> User.lens.id .~ 5
+
+    withEnvironment(currentUser: creator) {
+      let reward = Reward.template
+        |> Reward.lens.limit .~ 5
+        |> Reward.lens.remaining .~ 5
+        |> Reward.lens.endsAt .~ (MockDate().timeIntervalSince1970 + 60)
+
+      let project = Project.template
+        |> Project.lens.creator .~ creator
+        |> Project.lens.rewardData.rewards .~ [reward]
+        |> Project.lens.rewardData.addOns .~ nil
+
+      XCTAssertFalse(rewardsCarouselCanNavigateToReward(reward, in: project))
+    }
+  }
+
+  func testRewardsCarouselCanNavigateToReward_RegularReward_Available_NotBacked() {
+    let reward = Reward.template
+      |> Reward.lens.limit .~ 5
+      |> Reward.lens.remaining .~ 5
+      |> Reward.lens.endsAt .~ (MockDate().timeIntervalSince1970 + 60)
+
+    let project = Project.template
+      |> Project.lens.rewardData.rewards .~ [reward]
+      |> Project.lens.rewardData.addOns .~ nil
+
+    XCTAssertTrue(rewardsCarouselCanNavigateToReward(reward, in: project))
+  }
+
+  func testRewardsCarouselCanNavigateToReward_RegularReward_Available_Backed() {
+    let reward = Reward.template
+      |> Reward.lens.limit .~ 5
+      |> Reward.lens.remaining .~ 5
+      |> Reward.lens.endsAt .~ (MockDate().timeIntervalSince1970 + 60)
+
+    let project = Project.cosmicSurgery
+      |> Project.lens.rewardData.rewards .~ [reward]
+      |> Project.lens.personalization.backing .~ (
+        .template
+          |> Backing.lens.reward .~ reward
+          |> Backing.lens.rewardId .~ reward.id
+      )
+
+    XCTAssertFalse(rewardsCarouselCanNavigateToReward(reward, in: project))
+  }
+
+  func testRewardsCarouselCanNavigateToReward_RegularReward_Unavailable_Backed() {
+    let reward = Reward.template
+      |> Reward.lens.limit .~ 5
+      |> Reward.lens.remaining .~ 0
+      |> Reward.lens.endsAt .~ (MockDate().timeIntervalSince1970 + 60)
+
+    let project = Project.cosmicSurgery
+      |> Project.lens.rewardData.rewards .~ [reward]
+      |> Project.lens.personalization.backing .~ (
+        .template
+          |> Backing.lens.reward .~ reward
+          |> Backing.lens.rewardId .~ reward.id
+      )
+
+    XCTAssertFalse(rewardsCarouselCanNavigateToReward(reward, in: project))
+  }
+
+  func testRewardsCarouselCanNavigateToReward_RegularReward_Expired_Backed() {
+    let reward = Reward.template
+      |> Reward.lens.limit .~ 5
+      |> Reward.lens.remaining .~ 2
+      |> Reward.lens.endsAt .~ (MockDate().timeIntervalSince1970 - 1)
+
+    let project = Project.cosmicSurgery
+      |> Project.lens.rewardData.rewards .~ [reward]
+      |> Project.lens.personalization.backing .~ (
+        .template
+          |> Backing.lens.reward .~ reward
+          |> Backing.lens.rewardId .~ reward.id
+      )
+
+    XCTAssertFalse(rewardsCarouselCanNavigateToReward(reward, in: project))
+  }
+
+  func testRewardsCarouselCanNavigateToReward_RegularReward_Unavailable_NotBacked() {
+    let reward = Reward.template
+      |> Reward.lens.limit .~ 5
+      |> Reward.lens.remaining .~ 0
+      |> Reward.lens.endsAt .~ (MockDate().timeIntervalSince1970 + 60)
+
+    let project = Project.template
+      |> Project.lens.rewardData.rewards .~ [reward]
+      |> Project.lens.rewardData.addOns .~ nil
+
+    XCTAssertFalse(rewardsCarouselCanNavigateToReward(reward, in: project))
+  }
+
+  func testRewardsCarouselCanNavigateToReward_RegularReward_Expired_NotBacked() {
+    let reward = Reward.template
+      |> Reward.lens.limit .~ 5
+      |> Reward.lens.remaining .~ 2
+      |> Reward.lens.endsAt .~ (MockDate().timeIntervalSince1970 - 1)
+
+    let project = Project.template
+      |> Project.lens.rewardData.rewards .~ [reward]
+      |> Project.lens.rewardData.addOns .~ nil
+
+    XCTAssertFalse(rewardsCarouselCanNavigateToReward(reward, in: project))
+  }
+
+  func testRewardsCarouselCanNavigateToReward_Reward_Available_NotBacked_HasAddOns() {
+    let reward = Reward.template
+      |> Reward.lens.limit .~ 5
+      |> Reward.lens.remaining .~ 5
+      |> Reward.lens.endsAt .~ (MockDate().timeIntervalSince1970 + 60)
+      |> Reward.lens.hasAddOns .~ true
+
+    let project = Project.template
+      |> Project.lens.rewardData.rewards .~ [reward]
+      |> Project.lens.rewardData.addOns .~ [reward]
+
+    XCTAssertTrue(rewardsCarouselCanNavigateToReward(reward, in: project))
+  }
+
+
+  func testRewardsCarouselCanNavigateToReward_Reward_Unavailable_NotBacked_HasAddOns() {
+    let reward = Reward.template
+      |> Reward.lens.limit .~ 5
+      |> Reward.lens.remaining .~ 0
+      |> Reward.lens.endsAt .~ (MockDate().timeIntervalSince1970 + 60)
+      |> Reward.lens.hasAddOns .~ true
+
+    let project = Project.template
+      |> Project.lens.rewardData.rewards .~ [reward]
+      |> Project.lens.rewardData.addOns .~ [reward]
+
+    XCTAssertFalse(rewardsCarouselCanNavigateToReward(reward, in: project))
+  }
+
+  func testRewardsCarouselCanNavigateToReward_Reward_Expired_NotBacked_HasAddOns() {
+    let reward = Reward.template
+      |> Reward.lens.limit .~ 5
+      |> Reward.lens.remaining .~ 2
+      |> Reward.lens.endsAt .~ (MockDate().timeIntervalSince1970 - 1)
+      |> Reward.lens.hasAddOns .~ true
+
+    let project = Project.template
+      |> Project.lens.rewardData.rewards .~ [reward]
+      |> Project.lens.rewardData.addOns .~ [reward]
+
+    XCTAssertFalse(rewardsCarouselCanNavigateToReward(reward, in: project))
+  }
+
+  func testRewardsCarouselCanNavigateToReward_Reward_Unavailable_Backed_HasAddOns() {
+    let reward = Reward.template
+      |> Reward.lens.limit .~ 5
+      |> Reward.lens.remaining .~ 0
+      |> Reward.lens.endsAt .~ (MockDate().timeIntervalSince1970 + 60)
+      |> Reward.lens.hasAddOns .~ true
+
+    let project = Project.template
+      |> Project.lens.rewardData.rewards .~ [reward]
+      |> Project.lens.rewardData.addOns .~ [reward]
+      |> Project.lens.personalization.backing .~ (
+        .template
+          |> Backing.lens.reward .~ reward
+          |> Backing.lens.rewardId .~ reward.id
+      )
+
+    XCTAssertTrue(rewardsCarouselCanNavigateToReward(reward, in: project))
+  }
+
+  func testRewardsCarouselCanNavigateToReward_Reward_Expired_Backed_HasAddOns() {
+    let reward = Reward.template
+      |> Reward.lens.limit .~ 5
+      |> Reward.lens.remaining .~ 2
+      |> Reward.lens.endsAt .~ (MockDate().timeIntervalSince1970 - 1)
+      |> Reward.lens.hasAddOns .~ true
+
+    let project = Project.template
+      |> Project.lens.rewardData.rewards .~ [reward]
+      |> Project.lens.rewardData.addOns .~ [reward]
+      |> Project.lens.personalization.backing .~ (
+        .template
+          |> Backing.lens.reward .~ reward
+          |> Backing.lens.rewardId .~ reward.id
+      )
+
+    XCTAssertTrue(rewardsCarouselCanNavigateToReward(reward, in: project))
+  }
 }

--- a/Library/ViewModels/RewardCardContainerViewModel.swift
+++ b/Library/ViewModels/RewardCardContainerViewModel.swift
@@ -53,7 +53,7 @@ public final class RewardCardContainerViewModel: RewardCardContainerViewModelTyp
 
     self.pledgeButtonEnabled = projectAndReward
       .map { project, reward in
-        RewardsCollectionViewModel.rewardsCarouselCanNavigateToReward(reward, in: project)
+        rewardsCarouselCanNavigateToReward(reward, in: project)
       }
 
     self.pledgeButtonHidden = pledgeButtonTitleText.map(isNil)

--- a/Library/ViewModels/RewardCardViewModel.swift
+++ b/Library/ViewModels/RewardCardViewModel.swift
@@ -82,9 +82,6 @@ public final class RewardCardViewModel: RewardCardViewModelType, RewardCardViewM
     let rewardItemsIsEmpty = reward
       .map { $0.rewardsItems.isEmpty }
 
-    let rewardAvailable = reward
-      .map { $0.remaining == 0 }.negate()
-
     self.includedItemsStackViewHidden = rewardItemsIsEmpty.skipRepeats()
 
     self.items = reward
@@ -103,7 +100,9 @@ public final class RewardCardViewModel: RewardCardViewModelType, RewardCardViewM
       .takeWhen(self.rewardCardTappedProperty.signal)
       .map { $0.id }
 
-    self.cardUserInteractionIsEnabled = rewardAvailable
+    self.cardUserInteractionIsEnabled = projectAndReward.map { project, reward in
+      rewardsCarouselCanNavigateToReward(reward, in: project)
+    }
 
     self.estimatedDeliveryDateLabelHidden = context.combineLatest(with: reward)
       .map { context, reward in

--- a/Library/ViewModels/RewardsCollectionViewModel.swift
+++ b/Library/ViewModels/RewardsCollectionViewModel.swift
@@ -97,7 +97,7 @@ public final class RewardsCollectionViewModel: RewardsCollectionViewModelType,
       refTag
     )
     .filter { project, reward, _ in
-      RewardsCollectionViewModel.rewardsCarouselCanNavigateToReward(reward, in: project)
+      rewardsCarouselCanNavigateToReward(reward, in: project)
     }
     .map { project, reward, refTag -> (PledgeViewData, Bool) in
       let data = PledgeViewData(
@@ -297,21 +297,5 @@ private func trackingPledgeContext(for rewardsContext: RewardsCollectionViewCont
     return Koala.PledgeContext.newPledge
   case .managePledge:
     return Koala.PledgeContext.changeReward
-  }
-}
-
-extension RewardsCollectionViewModel {
-  public static func rewardsCarouselCanNavigateToReward(_ reward: Reward, in project: Project) -> Bool {
-    guard !currentUserIsCreator(of: project) else { return false }
-
-    let isBacking = userIsBacking(reward: reward, inProject: project)
-    let isAvailableForNewBacker = rewardIsAvailable(project: project, reward: reward) && !isBacking
-    let isAvailableForExistingBackerToEdit = (isBacking && reward.hasAddOns)
-
-    return [
-      project.state == .live,
-      isAvailableForNewBacker || isAvailableForExistingBackerToEdit
-    ]
-    .allSatisfy(isTrue)
   }
 }

--- a/Library/ViewModels/RewardsCollectionViewModel.swift
+++ b/Library/ViewModels/RewardsCollectionViewModel.swift
@@ -304,13 +304,13 @@ extension RewardsCollectionViewModel {
   public static func rewardsCarouselCanNavigateToReward(_ reward: Reward, in project: Project) -> Bool {
     guard !currentUserIsCreator(of: project) else { return false }
 
-    let isAvailable = rewardIsAvailable(project: project, reward: reward)
     let isBacking = userIsBacking(reward: reward, inProject: project)
+    let isAvailableForNewBacker = rewardIsAvailable(project: project, reward: reward) && !isBacking
+    let isAvailableForExistingBackerToEdit = (isBacking && reward.hasAddOns)
 
     return [
       project.state == .live,
-      isAvailable,
-      !isBacking || reward.hasAddOns
+      isAvailableForNewBacker || isAvailableForExistingBackerToEdit
     ]
     .allSatisfy(isTrue)
   }


### PR DESCRIPTION
# 📲 What

Allows backers to edit an expired reward with add-ons.

# 🤔 Why

Fixes a bug from #1309. Rewards should be editable if they've expired and have add-ons.

# 🛠 How

Fixed the logic for this and added tests.

# 👀 See

# ✅ Acceptance criteria

- [ ] Back a reward with add-ons that will expire soon. Once it has expired you should be able to edit it.
- [ ] There should be no regressions to other reward editing behaviour (see tests).