### PR TITLE
[NT-1575] Argo Decodable Function

### DIFF
--- a/KsApi/lib/TryDecodable.swift
+++ b/KsApi/lib/TryDecodable.swift
@@ -6,6 +6,7 @@ public func tryDecodable<T: Swift.Decodable>(_ json: JSON) -> Argo.Decoded<T> {
     // Convert Argo.JSON to primitive types, e.g. [String: Any].
     let primitive = json.toPrimitive(),
     // Convert the [String: Any] dictionary into `Data` for de-serialization by Swift.Decodable.
+
     let data = try? JSONSerialization.data(withJSONObject: primitive, options: [])
   // Any failure at this point is considered a de-serialization failure and will fail up to Argo.
   else { return .failure(.custom("Invalid JSON data")) }

--- a/KsApi/lib/TryDecodableTests.swift
+++ b/KsApi/lib/TryDecodableTests.swift
@@ -137,4 +137,40 @@ final class TryDecodableTests: XCTestCase {
 
     XCTAssertEqual(argoDecoded.value, expected)
   }
+
+  func testTryDecodableMissingKeyError() {
+    let data: [String: Any?] = [
+      "id": 3,
+      "name": "Missing Key"
+    ]
+
+    let argoDecoded = SingleValueArgoModel.decodeJSONDictionary(data as [String: Any])
+
+    XCTAssertNil(argoDecoded.value, "decoded value should be nil")
+    XCTAssert(argoDecoded.error == DecodeError.missingKey("model"))
+  }
+
+  func testTryDecodableTypeMismatchError() {
+    let data: [String: Any?] = [
+      "id": 4,
+      "name": "value",
+      "model": [
+        "array": ["string1", "string2"],
+        "bool": true,
+        "dict": ["key1": "value1", "key2": "value2"],
+        "id": "wrong type",
+        "name": "Swift Name"
+      ]
+    ]
+
+    let argoDecoded = MyArgoModel.decodeJSONDictionary(data as [String: Any])
+
+    XCTAssertNil(argoDecoded.value, "decoded value should be nil")
+    switch argoDecoded.error! {
+    case DecodeError.custom:
+      XCTAssertTrue(true, "custom error type expected")
+    default:
+      XCTAssertTrue(false, "custom error type expected")
+    }
+  }
 }

--- a/KsApi/lib/TryDecodableTests.swift
+++ b/KsApi/lib/TryDecodableTests.swift
@@ -26,6 +26,37 @@ struct MySwiftModel: Swift.Decodable, Equatable {
   public let name: String
 }
 
+struct SingleValueArgoModel: Argo.Decodable, Equatable {
+  public let id: Int
+  public let name: String
+  public let model: SingleValueSwiftModel
+
+  static func decode(_ json: JSON) -> Decoded<SingleValueArgoModel> {
+    return curry(SingleValueArgoModel.init)
+      <^> json <| "id"
+      <*> json <| "name"
+      <*> ((json <| "model" >>- tryDecodable) as Decoded<SingleValueSwiftModel>)
+  }
+}
+
+struct SingleValueSwiftModel: Codable, Equatable {
+  public let k_bool: Bool
+  public let k_int: Int
+  public let k_int8: Int8
+  public let k_int16: Int16
+  public let k_int32: Int32
+  public let k_int64: Int64
+  public let k_uint: UInt
+  public let k_uint8: UInt8
+  public let k_uint16: UInt16
+  public let k_uint32: UInt32
+  public let k_uint64: UInt64
+  public let k_string: String
+  public let k_double: Double
+  public let k_float: Float
+  public let k_nil: String?
+}
+
 final class TryDecodableTests: XCTestCase {
   func testTryDecodable() {
     let data: [String: Any] = [
@@ -51,6 +82,56 @@ final class TryDecodableTests: XCTestCase {
         dict: ["key1": "value1", "key2": "value2"],
         id: 5,
         name: "Swift Name"
+      )
+    )
+
+    XCTAssertEqual(argoDecoded.value, expected)
+  }
+
+  func testTryDecodablePrimitiveTypes() {
+    let data: [String: Any?] = [
+      "id": 2,
+      "name": "Argo Name",
+      "model": [
+        "k_bool": true,
+        "k_int": Int(1),
+        "k_int8": Int8(8),
+        "k_int16": Int16(16),
+        "k_int32": Int32(32),
+        "k_int64": Int64(64),
+        "k_uint": UInt(1),
+        "k_uint8": UInt8(8),
+        "k_uint16": UInt16(16),
+        "k_uint32": UInt32(32),
+        "k_uint64": UInt64(64),
+        "k_string": "string",
+        "k_double": Double(1.1),
+        "k_float": Float(1.2),
+        "k_nil": nil
+      ]
+    ]
+
+    let argoDecoded = SingleValueArgoModel.decodeJSONDictionary(data as [String: Any])
+
+    let expected = SingleValueArgoModel(
+      id: 2,
+      name: "Argo Name",
+      model: SingleValueSwiftModel(
+        k_bool: true,
+        k_int: Int(1),
+        k_int8: Int8(8),
+        k_int16: Int16(16),
+        k_int32: Int32(32),
+        k_int64: Int64(64),
+        k_uint: UInt(1),
+        k_uint8: UInt8(8),
+        k_uint16: UInt16(16),
+        k_uint32: UInt32(32),
+        k_uint64: UInt64(64),
+        k_string: "string",
+        k_double: Double(1.1),
+        k_float: Float(1.2),
+        k_nil: nil
       )
     )
 

--- a/KsApi/models/Update.swift
+++ b/KsApi/models/Update.swift
@@ -49,7 +49,7 @@ extension Update: Argo.Decodable {
       <*> json <| "sequence"
       <*> (json <| "title" <|> .success(""))
     return tmp3
-      <*> json <| "urls"
+      <*> ((json <| "urls" >>- tryDecodable) as Decoded<Update.UrlsEnvelope>)
       <*> json <|? "user"
       <*> json <|? "visible"
   }
@@ -68,3 +68,7 @@ extension Update.UrlsEnvelope.WebEnvelope: Argo.Decodable {
       <^> json <| "update"
   }
 }
+
+extension Update.UrlsEnvelope.WebEnvelope: Swift.Codable {}
+
+extension Update.UrlsEnvelope: Swift.Codable {}

--- a/KsApi/models/UpdateTests.swift
+++ b/KsApi/models/UpdateTests.swift
@@ -71,7 +71,7 @@ internal final class UpdateTests: XCTestCase {
     )
   }
 
-  func testJSONDecoding_WithBadUrlsWebData() {
+  func testJSONDecoding_WithBadUrls_WebData_WrongType() {
     let update = Update.decodeJSONDictionary([
       "body": "world",
       "id": 1,
@@ -90,7 +90,7 @@ internal final class UpdateTests: XCTestCase {
     XCTAssertNotNil(update.error)
   }
 
-  func testJSONDecoding_WithBadUrlsWebWrongKeyData() {
+  func testJSONDecoding_WithBadUrls_WebData_WrongKey() {
     let update = Update.decodeJSONDictionary([
       "body": "world",
       "id": 1,

--- a/KsApi/models/UpdateTests.swift
+++ b/KsApi/models/UpdateTests.swift
@@ -70,4 +70,40 @@ internal final class UpdateTests: XCTestCase {
       update.value?.urls.web.update
     )
   }
+
+  func testJSONDecoding_WithBadUrlsWebData() {
+    let update = Update.decodeJSONDictionary([
+      "body": "world",
+      "id": 1,
+      "public": true,
+      "project_id": 2,
+      "sequence": 3,
+      "title": "hello",
+      "visible": true,
+      "urls": [
+        "web": [
+          "update": 0xBAAAAAAD
+        ]
+      ]
+    ])
+
+    XCTAssertNotNil(update.error)
+  }
+
+  func testJSONDecoding_WithBadUrlsWebWrongKeyData() {
+    let update = Update.decodeJSONDictionary([
+      "body": "world",
+      "id": 1,
+      "public": true,
+      "project_id": 2,
+      "sequence": 3,
+      "title": "hello",
+      "visible": true,
+      "urls": [
+        "wrong_key": "data"
+      ]
+    ])
+
+    XCTAssertNotNil(update.error)
+  }
 }

--- a/Library/SharedFunctionsTests.swift
+++ b/Library/SharedFunctionsTests.swift
@@ -239,7 +239,6 @@ final class SharedFunctionsTests: TestCase {
     XCTAssertTrue(rewardsCarouselCanNavigateToReward(reward, in: project))
   }
 
-
   func testRewardsCarouselCanNavigateToReward_Reward_Unavailable_NotBacked_HasAddOns() {
     let reward = Reward.template
       |> Reward.lens.limit .~ 5


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

First step to remove Argo dependency

# 🤔 Why

With **Swift.Codable** introduction there is no need to carry around **Argo** lib for JSON parsing 

[RFC](https://github.com/kickstarter/rfcs/blob/master/rfcs/0069-native-deprecate-argo.md)

# 🛠 How

**tryDecodable** function

Extended test coverage for tryDecodable function

- Added tests for primitive data types
- Added tests for missing key and key type mismatch

**Update.UrlsEnvelope** and **Update.UrlsEnvelope.WebEnvelope** converted to **Swift.Codable** 

- added test cases for missing key and key type mismatch

# ✅ Acceptance criteria

- [ ] Pass **UpdateTests**
- [ ] Pass **TryDecodableTests**

# ⏰ TODO

- [ ] Get an idea of how regression testing is going to take place
