### PR TITLE
[NT-1584][NT-1588] Handling rewards and add ons with future start dates

### DIFF
--- a/Library/SharedFunctions.swift
+++ b/Library/SharedFunctions.swift
@@ -366,7 +366,7 @@ public func rewardsCarouselCanNavigateToReward(_ reward: Reward, in project: Pro
 }
 
 /**
- Determines if a start date from a given reward predates the current date.
+ Determines if a start date from a given reward/add on predates the current date.
 
  - parameter reward:           The reward being evaluated
 
@@ -374,5 +374,17 @@ public func rewardsCarouselCanNavigateToReward(_ reward: Reward, in project: Pro
  */
 public func isStartDateBeforeToday(for reward: Reward) -> Bool {
   return (reward.startsAt == nil || (reward.startsAt ?? 0) <= AppEnvironment.current.dateType.init()
+    .timeIntervalSince1970)
+}
+
+/**
+ Determines if an end date from a given reward/add on is after the current date.
+
+ - parameter reward:           The reward being evaluated
+
+ - returns: A Bool representing whether the reward has an end date after to the current date/time.
+ */
+public func isEndDateAfterToday(for reward: Reward) -> Bool {
+  return (reward.endsAt == nil || (reward.endsAt ?? 0) >= AppEnvironment.current.dateType.init()
     .timeIntervalSince1970)
 }

--- a/Library/SharedFunctions.swift
+++ b/Library/SharedFunctions.swift
@@ -364,3 +364,15 @@ public func rewardsCarouselCanNavigateToReward(_ reward: Reward, in project: Pro
   ]
   .allSatisfy(isTrue)
 }
+
+/**
+ Determines if a start date from a given reward predates the current date.
+
+ - parameter reward:           The reward being evaluated
+
+ - returns: A Bool representing whether the reward has a start date prior to the current date/time.
+ */
+public func isStartDateBeforeToday(for reward: Reward) -> Bool {
+  return (reward.startsAt == nil || (reward.startsAt ?? 0) <= AppEnvironment.current.dateType.init()
+    .timeIntervalSince1970)
+}

--- a/Library/SharedFunctionsTests.swift
+++ b/Library/SharedFunctionsTests.swift
@@ -239,7 +239,6 @@ final class SharedFunctionsTests: TestCase {
     XCTAssertTrue(rewardsCarouselCanNavigateToReward(reward, in: project))
   }
 
-
   func testRewardsCarouselCanNavigateToReward_Reward_Unavailable_NotBacked_HasAddOns() {
     let reward = Reward.template
       |> Reward.lens.limit .~ 5
@@ -304,5 +303,26 @@ final class SharedFunctionsTests: TestCase {
       )
 
     XCTAssertTrue(rewardsCarouselCanNavigateToReward(reward, in: project))
+  }
+
+  func testIsStartDateBeforeToday_Reward_StartsAt_Nil() {
+    let reward = Reward.template
+      |> Reward.lens.startsAt .~ nil
+
+    XCTAssertTrue(isStartDateBeforeToday(for: reward))
+  }
+
+  func testIsStartDateBeforeToday_Reward_StartsAt_PastDate() {
+    let reward = Reward.template
+      |> Reward.lens.startsAt .~ (MockDate().timeIntervalSince1970 - 60)
+
+    XCTAssertTrue(isStartDateBeforeToday(for: reward))
+  }
+
+  func testIsStartDateBeforeToday_Reward_StartsAt_FutureDate() {
+    let reward = Reward.template
+      |> Reward.lens.startsAt .~ (MockDate().timeIntervalSince1970 + 60)
+
+    XCTAssertFalse(isStartDateBeforeToday(for: reward))
   }
 }

--- a/Library/SharedFunctionsTests.swift
+++ b/Library/SharedFunctionsTests.swift
@@ -325,4 +325,25 @@ final class SharedFunctionsTests: TestCase {
 
     XCTAssertFalse(isStartDateBeforeToday(for: reward))
   }
+
+  func testIsEndDateAfterToday_Reward_EndsAt_Nil() {
+    let reward = Reward.template
+      |> Reward.lens.endsAt .~ nil
+
+    XCTAssertTrue(isEndDateAfterToday(for: reward))
+  }
+
+  func testIsEndDateAfterToday_Reward_EndsAt_PastDate() {
+    let reward = Reward.template
+      |> Reward.lens.endsAt .~ (MockDate().timeIntervalSince1970 - 60)
+
+    XCTAssertFalse(isEndDateAfterToday(for: reward))
+  }
+
+  func testIsEndDateAfterToday_Reward_EndsAt_FutureDate() {
+    let reward = Reward.template
+      |> Reward.lens.endsAt .~ (MockDate().timeIntervalSince1970 + 60)
+
+    XCTAssertTrue(isEndDateAfterToday(for: reward))
+  }
 }

--- a/Library/ViewModels/RewardAddOnSelectionViewModel.swift
+++ b/Library/ViewModels/RewardAddOnSelectionViewModel.swift
@@ -378,14 +378,14 @@ private func addOnIsAvailable(_ addOn: Reward, in project: Project) -> Bool {
   }
 
   let isUnlimitedOrAvailable = addOn.limit == nil || addOn.remaining ?? 0 > 0
-  let hasNoTimeLimitOrHasNotEnded = (
-    addOn.endsAt == nil ||
-      (addOn.endsAt ?? 0) >= AppEnvironment.current.dateType.init().timeIntervalSince1970
-  )
 
+  // Assuming the user has not backed the addOn, we only display if it's within range of the start and end date
+  let hasNoTimeLimitOrIsWithinRange = isStartDateBeforeToday(for: addOn) &&
+    (addOn.endsAt == nil || (addOn.endsAt ?? 0) >= AppEnvironment.current.dateType.init()
+      .timeIntervalSince1970)
   return [
     project.state == .live,
-    hasNoTimeLimitOrHasNotEnded,
+    hasNoTimeLimitOrIsWithinRange,
     isUnlimitedOrAvailable
   ]
   .allSatisfy(isTrue)

--- a/Library/ViewModels/RewardAddOnSelectionViewModel.swift
+++ b/Library/ViewModels/RewardAddOnSelectionViewModel.swift
@@ -380,9 +380,8 @@ private func addOnIsAvailable(_ addOn: Reward, in project: Project) -> Bool {
   let isUnlimitedOrAvailable = addOn.limit == nil || addOn.remaining ?? 0 > 0
 
   // Assuming the user has not backed the addOn, we only display if it's within range of the start and end date
-  let hasNoTimeLimitOrIsWithinRange = isStartDateBeforeToday(for: addOn) &&
-    (addOn.endsAt == nil || (addOn.endsAt ?? 0) >= AppEnvironment.current.dateType.init()
-      .timeIntervalSince1970)
+  let hasNoTimeLimitOrIsWithinRange = isStartDateBeforeToday(for: addOn) && isEndDateAfterToday(for: addOn)
+
   return [
     project.state == .live,
     hasNoTimeLimitOrIsWithinRange,

--- a/Library/ViewModels/RewardAddOnSelectionViewModelTests.swift
+++ b/Library/ViewModels/RewardAddOnSelectionViewModelTests.swift
@@ -394,9 +394,40 @@ final class RewardAddOnSelectionViewModelTests: TestCase {
       |> Reward.lens.limit .~ 5
       |> Reward.lens.remaining .~ 2
 
+    // timebased add-on, starts in 60 seconds
+    let addOn7 = Reward.template
+      |> Reward.lens.id .~ 7
+      |> Reward.lens.limit .~ nil
+      |> Reward.lens.remaining .~ nil
+      |> Reward.lens.startsAt .~ (MockDate().timeIntervalSince1970 + 60)
+
+    // timebased add-on, started 60 seconds ago.
+    let addOn8 = Reward.template
+      |> Reward.lens.id .~ 8
+      |> Reward.lens.limit .~ nil
+      |> Reward.lens.remaining .~ nil
+      |> Reward.lens.startsAt .~ (MockDate().timeIntervalSince1970 - 60)
+
+    // timebased add-on, both startsAt and endsAt are within a valid range
+    let addOn9 = Reward.template
+      |> Reward.lens.id .~ 9
+      |> Reward.lens.limit .~ nil
+      |> Reward.lens.remaining .~ nil
+      |> Reward.lens.startsAt .~ (MockDate().timeIntervalSince1970 - 60)
+      |> Reward.lens.endsAt .~ (MockDate().timeIntervalSince1970 + 60)
+
+    // timebased add-on, invalid range
+    let addOn10 = Reward.template
+      |> Reward.lens.id .~ 10
+      |> Reward.lens.limit .~ nil
+      |> Reward.lens.remaining .~ nil
+      |> Reward.lens.startsAt .~ (MockDate().timeIntervalSince1970 + 30)
+      |> Reward.lens.endsAt .~ (MockDate().timeIntervalSince1970 + 60)
+
     let project = Project.template
       |> Project.lens.rewardData.rewards .~ [baseReward]
-      |> Project.lens.rewardData.addOns .~ [addOn1, addOn2, addOn3, addOn4, addOn5, addOn6]
+      |> Project.lens.rewardData
+      .addOns .~ [addOn1, addOn2, addOn3, addOn4, addOn5, addOn6, addOn7, addOn8, addOn9, addOn10]
       |> Project.lens.personalization.backing .~ (
         .template
           |> Backing.lens.addOns .~ [addOn3]
@@ -404,7 +435,7 @@ final class RewardAddOnSelectionViewModelTests: TestCase {
           |> Backing.lens.rewardId .~ baseReward.id
       )
 
-    let expectedAddOns = [addOn1, addOn3, addOn5, addOn6]
+    let expectedAddOns = [addOn1, addOn3, addOn5, addOn6, addOn8, addOn9]
 
     let expected = expectedAddOns
       .map { reward in

--- a/Library/ViewModels/RewardsCollectionViewModel.swift
+++ b/Library/ViewModels/RewardsCollectionViewModel.swift
@@ -71,7 +71,8 @@ public final class RewardsCollectionViewModel: RewardsCollectionViewModelType,
 
     self.reloadDataWithValues = Signal.combineLatest(project, rewards)
       .map { project, rewards in
-        rewards.map { reward in (project, reward, .pledge) }
+        rewards.filter { reward in isStartDateBeforeToday(for: reward) }
+          .map { reward in (project, reward, .pledge) }
       }
 
     self.configureRewardsCollectionViewFooterWithCount = self.reloadDataWithValues
@@ -254,6 +255,8 @@ public final class RewardsCollectionViewModel: RewardsCollectionViewModelType,
   public var inputs: RewardsCollectionViewModelInputs { return self }
   public var outputs: RewardsCollectionViewModelOutputs { return self }
 }
+
+// MARK: - Functions
 
 private func titleForContext(_ context: RewardsCollectionViewContext, project: Project) -> String {
   if currentUserIsCreator(of: project) {


### PR DESCRIPTION
# 📲 What

Currently, backers are able to see rewards and add-ons with future start dates and back them. We want to conditionally render these options for selection only when the appropriate time has been reached.

# 🤔 Why

Currently, rewards and add-ons with start dates in the future are being shown as available for backing. These should be hidden from view until the start date set by the creator.

# 🛠 How

We're filtering in the `RewardAddOnSelectionViewController` and `RewardCollectionViewController` based on a date check.