### PR TITLE
[NT-1576] Added test cases for service ext decode API

### DIFF
--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -358,6 +358,7 @@
 		80D73AF61D50F1A60099231F /* Navigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80E26A121D500C6A007B3022 /* Navigation.swift */; };
 		80E8EAC81D3EC65A007BDA4B /* Image.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80E8EAC71D3EC65A007BDA4B /* Image.swift */; };
 		80EAEF051D243C4E008C2353 /* Backing.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 80EAEF031D243C4E008C2353 /* Backing.storyboard */; };
+		8479CF2C2530A5D700FD13F1 /* Service+DecodeHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8479CF2B2530A5D700FD13F1 /* Service+DecodeHelpers.swift */; };
 		84F3C492251C87B400AEF24D /* UpdateActivityItemProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84F3C491251C87A400AEF24D /* UpdateActivityItemProviderTests.swift */; };
 		8A00CCFF24BD439E00E12D49 /* RewardAddOnCardViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A00CCFE24BD439E00E12D49 /* RewardAddOnCardViewModelTests.swift */; };
 		8A05CB0E23DB82D3002B01EE /* CookieRefTagFunctions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A05CB0D23DB82D3002B01EE /* CookieRefTagFunctions.swift */; };
@@ -1894,6 +1895,7 @@
 		80E26A121D500C6A007B3022 /* Navigation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Navigation.swift; sourceTree = "<group>"; };
 		80E8EAC71D3EC65A007BDA4B /* Image.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Image.swift; sourceTree = "<group>"; };
 		80EAEF031D243C4E008C2353 /* Backing.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Backing.storyboard; sourceTree = "<group>"; };
+		8479CF2B2530A5D700FD13F1 /* Service+DecodeHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Service+DecodeHelpers.swift"; sourceTree = "<group>"; };
 		84F3C491251C87A400AEF24D /* UpdateActivityItemProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateActivityItemProviderTests.swift; sourceTree = "<group>"; };
 		8A00CCFE24BD439E00E12D49 /* RewardAddOnCardViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RewardAddOnCardViewModelTests.swift; sourceTree = "<group>"; };
 		8A05CB0D23DB82D3002B01EE /* CookieRefTagFunctions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CookieRefTagFunctions.swift; sourceTree = "<group>"; };
@@ -4299,6 +4301,7 @@
 				D01588261EEB2ED7006E7684 /* ServerConfig.swift */,
 				D01588271EEB2ED7006E7684 /* Service.swift */,
 				775DFAD4215EB2AB00620CED /* Service+RequestHelpers.swift */,
+				8479CF2B2530A5D700FD13F1 /* Service+DecodeHelpers.swift */,
 				D01588281EEB2ED7006E7684 /* ServiceTests.swift */,
 				D01588291EEB2ED7006E7684 /* ServiceType.swift */,
 				D015882A1EEB2ED7006E7684 /* ServiceTypeTests.swift */,
@@ -6292,6 +6295,7 @@
 				D01588431EEB2ED7006E7684 /* Activity.swift in Sources */,
 				D01588CD1EEB2ED7006E7684 /* ShippingRulesEnvelopeLenses.swift in Sources */,
 				8A4E954924525EC100A578CF /* BackingState.swift in Sources */,
+				8479CF2C2530A5D700FD13F1 /* Service+DecodeHelpers.swift in Sources */,
 				D68F0B16243CFF3F009FC948 /* SignInWithAppleEnvelope.swift in Sources */,
 				D6B686EB2191FEEE005F5DA7 /* UserSendEmailVerificationMutation.swift in Sources */,
 				8AA407CC24DB49CE008C5FB0 /* Location+GraphLocation.swift in Sources */,

--- a/KsApi/Service+DecodeHelpers.swift
+++ b/KsApi/Service+DecodeHelpers.swift
@@ -14,7 +14,7 @@ extension Service {
         case let .success(value):
           return .init(value: value)
         case let .failure(error):
-          print("Argo decoding model \(M.self) error: \(error)")
+          print("🔴 [KsApi] Failure - Argo decoding model \(M.self) error: \(error)")
           return .init(error: .couldNotDecodeJSON(error))
         }
       }
@@ -29,7 +29,7 @@ extension Service {
         case let .success(value):
           return .init(value: value)
         case let .failure(error):
-          print("Argo decoding model error: \(error)")
+          print("🔴 [KsApi] Failure - Argo decoding model error: \(error)")
           return .init(error: .couldNotDecodeJSON(error))
         }
       }
@@ -41,7 +41,7 @@ extension Service {
       .map { json in decode(json) as M? }
   }
 
-  // MARK: Swift.Codable
+  // MARK: - Swift.Codable
 
   func decodeGraphModel<T: Swift.Decodable>(_ jsonData: Data) -> SignalProducer<T, GraphError> {
     return SignalProducer(value: jsonData)

--- a/KsApi/Service+DecodeHelpers.swift
+++ b/KsApi/Service+DecodeHelpers.swift
@@ -1,0 +1,102 @@
+import Argo
+import Foundation
+import Prelude
+import ReactiveExtensions
+import ReactiveSwift
+
+extension Service {
+  func decodeModel<M: Argo.Decodable>(_ json: Any) ->
+    SignalProducer<M, ErrorEnvelope> where M == M.DecodedType {
+    return SignalProducer(value: json)
+      .map { json in decode(json) as Decoded<M> }
+      .flatMap(.concat) { (decoded: Decoded<M>) -> SignalProducer<M, ErrorEnvelope> in
+        switch decoded {
+        case let .success(value):
+          return .init(value: value)
+        case let .failure(error):
+          print("Argo decoding model \(M.self) error: \(error)")
+          return .init(error: .couldNotDecodeJSON(error))
+        }
+      }
+  }
+
+  func decodeModels<M: Argo.Decodable>(_ json: Any)
+    -> SignalProducer<[M], ErrorEnvelope> where M == M.DecodedType {
+    return SignalProducer(value: json)
+      .map { json in decode(json) as Decoded<[M]> }
+      .flatMap(.concat) { (decoded: Decoded<[M]>) -> SignalProducer<[M], ErrorEnvelope> in
+        switch decoded {
+        case let .success(value):
+          return .init(value: value)
+        case let .failure(error):
+          print("Argo decoding model error: \(error)")
+          return .init(error: .couldNotDecodeJSON(error))
+        }
+      }
+  }
+
+  func decodeModel<M: Argo.Decodable>(_ json: Any) ->
+    SignalProducer<M?, ErrorEnvelope> where M == M.DecodedType {
+    return SignalProducer(value: json)
+      .map { json in decode(json) as M? }
+  }
+
+  // MARK: Swift.Codable
+
+  func decodeGraphModel<T: Swift.Decodable>(_ jsonData: Data) -> SignalProducer<T, GraphError> {
+    return SignalProducer(value: jsonData)
+      .flatMap { data -> SignalProducer<T, GraphError> in
+        do {
+          let decodedObject = try JSONDecoder().decode(GraphResponse<T>.self, from: data)
+
+          print("🔵 [KsApi] Successfully Decoded Data")
+
+          return .init(value: decodedObject.data)
+        } catch {
+          print("🔴 [KsApi] Failure - Decoding error: \((error as NSError).description)")
+          return .init(error: .jsonDecodingError(
+            responseString: String(data: data, encoding: .utf8),
+            error: error
+          ))
+        }
+      }
+  }
+
+  func decodeModel<T: Swift.Decodable>(_ jsonData: Data) -> SignalProducer<T, ErrorEnvelope> {
+    return SignalProducer(value: jsonData)
+      .flatMap { data -> SignalProducer<T, ErrorEnvelope> in
+        do {
+          let decodedObject = try JSONDecoder().decode(T.self, from: data)
+
+          print("🔵 [KsApi] Successfully Decoded Data")
+
+          return .init(value: decodedObject)
+        } catch {
+          print("🔴 [KsApi] Failure - Decoding error: \(error)")
+          return .init(error: .couldNotDecodeJSON(error))
+        }
+      }
+  }
+
+  func decodeModels<T: Swift.Decodable>(_ jsonData: Data) -> SignalProducer<[T], ErrorEnvelope> {
+    return SignalProducer(value: jsonData)
+      .flatMap { data -> SignalProducer<[T], ErrorEnvelope> in
+        do {
+          let decodedObject = try JSONDecoder().decode([T].self, from: data)
+
+          print("🔵 [KsApi] Successfully Decoded Data")
+
+          return .init(value: decodedObject)
+        } catch {
+          print("🔴 [KsApi] Failure - Decoding error: \(error)")
+          return .init(error: .couldNotDecodeJSON(error))
+        }
+      }
+  }
+
+  func decodeModel<T: Swift.Decodable>(data json: Data) ->
+    SignalProducer<T?, ErrorEnvelope> {
+    return SignalProducer(value: json)
+      .map { json in try? JSONDecoder().decode(T.self, from: json) }
+  }
+}

--- a/KsApi/ServiceTests.swift
+++ b/KsApi/ServiceTests.swift
@@ -1,4 +1,6 @@
 @testable import KsApi
+import ReactiveExtensions
+import ReactiveSwift
 import XCTest
 
 final class ServiceTests: XCTestCase {
@@ -41,5 +43,208 @@ final class ServiceTests: XCTestCase {
     let loggedOut = loggedIn.logout()
 
     XCTAssertTrue(loggedOut == Service())
+  }
+
+  func testArgoDecodeModel_ValidModel() {
+    let data: [String: Any] = [
+      "id": 1,
+      "name": "Argo Name",
+      "model": [
+        "array": ["string1", "string2"],
+        "bool": true,
+        "dict": ["key1": "value1", "key2": "value2"],
+        "id": 5,
+        "name": "Swift Name"
+      ]
+    ]
+
+    let expectedResult = MyArgoModel.decodeJSONDictionary(data).value
+
+    let service = Service()
+    let model: SignalProducer<MyArgoModel, ErrorEnvelope> = service.decodeModel(data)
+    let result = try! model.single()?.get()
+    XCTAssertEqual(result, expectedResult)
+  }
+
+  func testArgoDecodeModel_WrongKeyModel() {
+    let data: [String: Any] = [
+      "id": 1,
+      "name": "Argo Name",
+      "model": [
+        "array": ["string1", "string2"],
+        "bool": true,
+        "dict": ["key1": "value1", "key2": "value2"],
+        "id": 5,
+        "wrong_key": "Swift Name"
+      ]
+    ]
+
+    let model: SignalProducer<MyArgoModel, ErrorEnvelope> = Service().decodeModel(data)
+    XCTAssertThrowsError(try model.single()?.get(), "wrong key should throw an error")
+  }
+
+  func testArgoDecodeModel_WrongTypeModel() {
+    let data: [String: Any] = [
+      "id": 1,
+      "name": "Argo Name",
+      "model": [
+        "array": ["string1", "string2"],
+        "bool": "wrong type",
+        "dict": ["key1": "value1", "key2": "value2"],
+        "id": 5,
+        "name": "Swift Name"
+      ]
+    ]
+
+    let model: SignalProducer<MyArgoModel, ErrorEnvelope> = Service().decodeModel(data)
+    XCTAssertThrowsError(try model.single()?.get(), "wrong type should throw an error")
+  }
+
+  func test_Array_ArgoDecodeModel_ValidModel() {
+    let data: [[String: Any]] = [[
+      "id": 1,
+      "name": "Argo Name",
+      "model": [
+        "array": ["string1", "string2"],
+        "bool": true,
+        "dict": ["key1": "value1", "key2": "value2"],
+        "id": 5,
+        "name": "Swift Name"
+      ]
+    ]]
+
+    let expectedResult = data.map { (dict) -> MyArgoModel in
+      MyArgoModel.decodeJSONDictionary(dict).value!
+    }
+
+    let model: SignalProducer<[MyArgoModel], ErrorEnvelope> = Service().decodeModels(data)
+    let result = try! model.single()?.get()
+    XCTAssertEqual(result, expectedResult)
+  }
+
+  func test_Array_ArgoDecodeModel_EmptyArray() {
+    let data: [[String: Any]] = [[:]]
+
+    let model: SignalProducer<[MyArgoModel], ErrorEnvelope> = Service().decodeModels(data)
+    XCTAssertThrowsError(try model.single()?.get(), "empty array should throw an error")
+  }
+
+  func testSwiftDecodeModel_ValidModel() {
+    let jsonData: String = """
+    {
+        "array": ["string1", "string2"],
+        "bool": true,
+        "dict": {"key1": "value1", "key2": "value2"},
+        "id": 5,
+        "name": "Swift Name"
+    }
+    """
+
+    let expectedResult = try! JSONDecoder().decode(MySwiftModel.self, from: jsonData.data(using: .utf8)!)
+
+    let model: SignalProducer<MySwiftModel, ErrorEnvelope> = Service()
+      .decodeModel(jsonData.data(using: .utf8)!)
+    let result = try! model.single()?.get()
+    XCTAssertEqual(result, expectedResult)
+  }
+
+  func testSwiftDecodeModel_WrongKeyModel() {
+    let jsonData: String = """
+    {
+        "array": ["string1", "string2"],
+        "bool": true,
+        "dict": {"key1": "value1", "key2": "value2"},
+        "id": 5,
+        "wrong_key": "Swift Name"
+    }
+    """
+
+    let model: SignalProducer<MySwiftModel, ErrorEnvelope> = Service()
+      .decodeModel(jsonData.data(using: .utf8)!)
+    XCTAssertThrowsError(try model.single()?.get(), "wrong key should throw an error")
+  }
+
+  func testSwiftDecodeModel_WrongTypeModel() {
+    let jsonData: String = """
+    {
+        "array": ["string1", "string2"],
+        "bool": "wrong_type",
+        "dict": {"key1": "value1", "key2": "value2"},
+        "id": 5,
+        "name": "Swift Name"
+    }
+    """
+
+    let model: SignalProducer<MySwiftModel, ErrorEnvelope> = Service()
+      .decodeModel(jsonData.data(using: .utf8)!)
+    XCTAssertThrowsError(try model.single()?.get(), "wrong key should throw an error")
+  }
+
+  func testSwiftDecodeModel_Optional_WrongTypeModel() {
+    let jsonData: String = """
+    {
+        "array": ["string1", "string2"],
+        "bool": "wrong_type",
+        "dict": {"key1": "value1", "key2": "value2"},
+        "id": 5,
+        "name": "Swift Name"
+    }
+    """
+    let data = jsonData.data(using: .utf8)!
+    let model: SignalProducer<MySwiftModel?, ErrorEnvelope> = Service().decodeModel(data: data)
+    let result = try! model.single()?.get()
+    XCTAssertNil(result)
+  }
+
+  func test_Array_SwiftDecodeModel_ValidModel() {
+    let jsonData: String = """
+    [
+       {
+          "array":[
+             "string1",
+             "string2"
+          ],
+          "bool":true,
+          "dict":{
+             "key1":"value1",
+             "key2":"value2"
+          },
+          "id":5,
+          "name":"Swift Name"
+       },
+       {
+          "array":[
+             "string1",
+             "string2"
+          ],
+          "bool":true,
+          "dict":{
+             "key1":"value1",
+             "key2":"value2"
+          },
+          "id":6,
+          "name":"Swift Name"
+       }
+    ]
+    """
+
+    let expectedResult = try! JSONDecoder().decode([MySwiftModel].self, from: jsonData.data(using: .utf8)!)
+
+    let model: SignalProducer<[MySwiftModel], ErrorEnvelope> = Service()
+      .decodeModels(jsonData.data(using: .utf8)!)
+    let result = try! model.single()?.get()
+    XCTAssertEqual(result, expectedResult)
+  }
+
+  func test_Array_SwiftDecodeModel_EmptyArray() {
+    let jsonData: String = """
+    [
+    ]
+    """
+
+    let model: SignalProducer<[MySwiftModel], ErrorEnvelope> = Service()
+      .decodeModels(jsonData.data(using: .utf8)!)
+    let result = try! model.single()?.get()
+    XCTAssertEqual(result?.count, 0)
   }
 }

--- a/KsApi/models/ErrorEnvelope.swift
+++ b/KsApi/models/ErrorEnvelope.swift
@@ -102,6 +102,24 @@ public struct ErrorEnvelope {
   }
 
   /**
+   A general error that some JSON could not be decoded.
+
+   - parameter decodeError: The JSONDecoder decoding error.
+
+   - returns: An error envelope that describes why decoding failed.
+   */
+  internal static func couldNotDecodeJSON(_ decodeError: Error) -> ErrorEnvelope {
+    return ErrorEnvelope(
+      errorMessages: ["JSONDecoder decoding error: \(decodeError.localizedDescription)"],
+      ksrCode: .DecodingJSONFailed,
+      httpCode: 400,
+      exception: nil,
+      facebookUser: nil,
+      graphError: nil
+    )
+  }
+
+  /**
    A error that the pagination URL is invalid.
 
    - parameter decodeError: The Argo decoding error.

--- a/Library/SharedFunctionsTests.swift
+++ b/Library/SharedFunctionsTests.swift
@@ -239,7 +239,6 @@ final class SharedFunctionsTests: TestCase {
     XCTAssertTrue(rewardsCarouselCanNavigateToReward(reward, in: project))
   }
 
-
   func testRewardsCarouselCanNavigateToReward_Reward_Unavailable_NotBacked_HasAddOns() {
     let reward = Reward.template
       |> Reward.lens.limit .~ 5


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

`Service+DecodeHelpers` extracted from `Service+RequestHelpers` and added `Swift.Decodable` overloads
Extended tests cases for both `Argo` and `Swift.Decodable` functions

# 🤔 Why

`Service+RequestHelpers` is a part of Argo removal process. It is required to make it work with `Swift.Decodable` models

# 🛠 How

`Service+DecodeHelpers` extracted from `Service+RequestHelpers` and added `Swift.Decodable` overloads.

# ✅ Acceptance criteria

- [ ] ServiceTests passes
