### PR TITLE
[NT-1577] BAsic FP operators implementation for Argo models added  to project

### DIFF
--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -358,6 +358,26 @@
 		80D73AF61D50F1A60099231F /* Navigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80E26A121D500C6A007B3022 /* Navigation.swift */; };
 		80E8EAC81D3EC65A007BDA4B /* Image.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80E8EAC71D3EC65A007BDA4B /* Image.swift */; };
 		80EAEF051D243C4E008C2353 /* Backing.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 80EAEF031D243C4E008C2353 /* Backing.storyboard */; };
+		84264EEC25387B0500D8DF81 /* Param.swift in Sources */ = {isa = PBXBuildFile; fileRef = D01587D41EEB2ED7006E7684 /* Param.swift */; };
+		84264F0F25387BB500D8DF81 /* JSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84264ECB2538793900D8DF81 /* JSON.swift */; };
+		84264F1025387BB500D8DF81 /* decode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84264EC82538793800D8DF81 /* decode.swift */; };
+		84264F1125387BB500D8DF81 /* Dictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84264ECF2538793900D8DF81 /* Dictionary.swift */; };
+		84264F1225387BB500D8DF81 /* sequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84264ECE2538793900D8DF81 /* sequence.swift */; };
+		84264F1325387BB500D8DF81 /* DecodeOperators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84264EC92538793900D8DF81 /* DecodeOperators.swift */; };
+		84264F1425387BB500D8DF81 /* ArgoDecodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84264ECA2538793900D8DF81 /* ArgoDecodable.swift */; };
+		84264F1525387BB500D8DF81 /* flatReduce.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84264EC72538793800D8DF81 /* flatReduce.swift */; };
+		84264F1625387BB500D8DF81 /* StandardTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84264ECC2538793900D8DF81 /* StandardTypes.swift */; };
+		84264F1725387BB500D8DF81 /* Alternative.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84264EB8253877C100D8DF81 /* Alternative.swift */; };
+		84264F1825387BB500D8DF81 /* Applicative.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84264EB7253877C100D8DF81 /* Applicative.swift */; };
+		84264F1925387BB500D8DF81 /* DecodeError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84264EC2253877E500D8DF81 /* DecodeError.swift */; };
+		84264F1A25387BB500D8DF81 /* NSNumber.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84264ECD2538793900D8DF81 /* NSNumber.swift */; };
+		84264F1B25387BB500D8DF81 /* Decoded.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84264EB3253877C100D8DF81 /* Decoded.swift */; };
+		84264F1C25387BB500D8DF81 /* Functor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84264EB5253877C100D8DF81 /* Functor.swift */; };
+		84264F1D25387BB500D8DF81 /* Monad.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84264EB6253877C100D8DF81 /* Monad.swift */; };
+		84264F1E25387BB500D8DF81 /* Argo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84264ED12538793900D8DF81 /* Argo.swift */; };
+		84264F1F25387BB500D8DF81 /* catDecoded.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84264ED22538793900D8DF81 /* catDecoded.swift */; };
+		84264F2025387BB500D8DF81 /* FailureCoalescing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84264EB4253877C100D8DF81 /* FailureCoalescing.swift */; };
+		84264F2125387BB500D8DF81 /* RawRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84264ED02538793900D8DF81 /* RawRepresentable.swift */; };
 		8479CF2C2530A5D700FD13F1 /* Service+DecodeHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8479CF2B2530A5D700FD13F1 /* Service+DecodeHelpers.swift */; };
 		84F3C492251C87B400AEF24D /* UpdateActivityItemProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84F3C491251C87A400AEF24D /* UpdateActivityItemProviderTests.swift */; };
 		8A00CCFF24BD439E00E12D49 /* RewardAddOnCardViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A00CCFE24BD439E00E12D49 /* RewardAddOnCardViewModelTests.swift */; };
@@ -991,7 +1011,6 @@
 		D01588EF1EEB2ED7006E7684 /* MessageThread.swift in Sources */ = {isa = PBXBuildFile; fileRef = D01587D01EEB2ED7006E7684 /* MessageThread.swift */; };
 		D01588F11EEB2ED7006E7684 /* MessageThreadEnvelope.swift in Sources */ = {isa = PBXBuildFile; fileRef = D01587D11EEB2ED7006E7684 /* MessageThreadEnvelope.swift */; };
 		D01588F31EEB2ED7006E7684 /* MessageThreadsEnvelope.swift in Sources */ = {isa = PBXBuildFile; fileRef = D01587D21EEB2ED7006E7684 /* MessageThreadsEnvelope.swift */; };
-		D01588F71EEB2ED7006E7684 /* Param.swift in Sources */ = {isa = PBXBuildFile; fileRef = D01587D41EEB2ED7006E7684 /* Param.swift */; };
 		D01588F91EEB2ED7006E7684 /* Project.Country.swift in Sources */ = {isa = PBXBuildFile; fileRef = D01587D51EEB2ED7006E7684 /* Project.Country.swift */; };
 		D01588FF1EEB2ED7006E7684 /* Project.swift in Sources */ = {isa = PBXBuildFile; fileRef = D01587D81EEB2ED7006E7684 /* Project.swift */; };
 		D01589011EEB2ED7006E7684 /* Project.Video.swift in Sources */ = {isa = PBXBuildFile; fileRef = D01587D91EEB2ED7006E7684 /* Project.Video.swift */; };
@@ -1895,6 +1914,25 @@
 		80E26A121D500C6A007B3022 /* Navigation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Navigation.swift; sourceTree = "<group>"; };
 		80E8EAC71D3EC65A007BDA4B /* Image.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Image.swift; sourceTree = "<group>"; };
 		80EAEF031D243C4E008C2353 /* Backing.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Backing.storyboard; sourceTree = "<group>"; };
+		84264EB3253877C100D8DF81 /* Decoded.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Decoded.swift; sourceTree = "<group>"; };
+		84264EB4253877C100D8DF81 /* FailureCoalescing.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FailureCoalescing.swift; sourceTree = "<group>"; };
+		84264EB5253877C100D8DF81 /* Functor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Functor.swift; sourceTree = "<group>"; };
+		84264EB6253877C100D8DF81 /* Monad.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Monad.swift; sourceTree = "<group>"; };
+		84264EB7253877C100D8DF81 /* Applicative.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Applicative.swift; sourceTree = "<group>"; };
+		84264EB8253877C100D8DF81 /* Alternative.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Alternative.swift; sourceTree = "<group>"; };
+		84264EC2253877E500D8DF81 /* DecodeError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DecodeError.swift; sourceTree = "<group>"; };
+		84264EC72538793800D8DF81 /* flatReduce.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = flatReduce.swift; sourceTree = "<group>"; };
+		84264EC82538793800D8DF81 /* decode.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = decode.swift; sourceTree = "<group>"; };
+		84264EC92538793900D8DF81 /* DecodeOperators.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DecodeOperators.swift; sourceTree = "<group>"; };
+		84264ECA2538793900D8DF81 /* ArgoDecodable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ArgoDecodable.swift; sourceTree = "<group>"; };
+		84264ECB2538793900D8DF81 /* JSON.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSON.swift; sourceTree = "<group>"; };
+		84264ECC2538793900D8DF81 /* StandardTypes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StandardTypes.swift; sourceTree = "<group>"; };
+		84264ECD2538793900D8DF81 /* NSNumber.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSNumber.swift; sourceTree = "<group>"; };
+		84264ECE2538793900D8DF81 /* sequence.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = sequence.swift; sourceTree = "<group>"; };
+		84264ECF2538793900D8DF81 /* Dictionary.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Dictionary.swift; sourceTree = "<group>"; };
+		84264ED02538793900D8DF81 /* RawRepresentable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RawRepresentable.swift; sourceTree = "<group>"; };
+		84264ED12538793900D8DF81 /* Argo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Argo.swift; sourceTree = "<group>"; };
+		84264ED22538793900D8DF81 /* catDecoded.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = catDecoded.swift; sourceTree = "<group>"; };
 		8479CF2B2530A5D700FD13F1 /* Service+DecodeHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Service+DecodeHelpers.swift"; sourceTree = "<group>"; };
 		84F3C491251C87A400AEF24D /* UpdateActivityItemProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateActivityItemProviderTests.swift; sourceTree = "<group>"; };
 		8A00CCFE24BD439E00E12D49 /* RewardAddOnCardViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RewardAddOnCardViewModelTests.swift; sourceTree = "<group>"; };
@@ -3093,6 +3131,32 @@
 			name = Configs;
 			sourceTree = "<group>";
 		};
+		84264EB22538776600D8DF81 /* ArgoDecoded */ = {
+			isa = PBXGroup;
+			children = (
+				84264ED12538793900D8DF81 /* Argo.swift */,
+				84264ED22538793900D8DF81 /* catDecoded.swift */,
+				84264ECA2538793900D8DF81 /* ArgoDecodable.swift */,
+				84264EC82538793800D8DF81 /* decode.swift */,
+				84264EC92538793900D8DF81 /* DecodeOperators.swift */,
+				84264ECF2538793900D8DF81 /* Dictionary.swift */,
+				84264EC72538793800D8DF81 /* flatReduce.swift */,
+				84264ECB2538793900D8DF81 /* JSON.swift */,
+				84264ECD2538793900D8DF81 /* NSNumber.swift */,
+				84264ED02538793900D8DF81 /* RawRepresentable.swift */,
+				84264ECE2538793900D8DF81 /* sequence.swift */,
+				84264ECC2538793900D8DF81 /* StandardTypes.swift */,
+				84264EC2253877E500D8DF81 /* DecodeError.swift */,
+				84264EB8253877C100D8DF81 /* Alternative.swift */,
+				84264EB7253877C100D8DF81 /* Applicative.swift */,
+				84264EB3253877C100D8DF81 /* Decoded.swift */,
+				84264EB4253877C100D8DF81 /* FailureCoalescing.swift */,
+				84264EB5253877C100D8DF81 /* Functor.swift */,
+				84264EB6253877C100D8DF81 /* Monad.swift */,
+			);
+			path = ArgoDecoded;
+			sourceTree = "<group>";
+		};
 		8A0B1E2824DA1048009E90C0 /* graphql */ = {
 			isa = PBXGroup;
 			children = (
@@ -3582,6 +3646,7 @@
 		A7C725771C85D36D005A016B /* Library */ = {
 			isa = PBXGroup;
 			children = (
+				84264EB22538776600D8DF81 /* ArgoDecoded */,
 				8A142EBC23354BFD00FB43AB /* AddNewCardIntent.swift */,
 				A709697D1D143D1300DB39D3 /* AlertError.swift */,
 				A7C725781C85D36D005A016B /* AppEnvironment.swift */,
@@ -6067,6 +6132,8 @@
 				D01588991EEB2ED7006E7684 /* FriendStatsEnvelopeLenses.swift in Sources */,
 				D6B9F943220358D1003282A5 /* AuthorTemplates.swift in Sources */,
 				D7417D0E20BF4833004DABA6 /* ExportStateEnvelopeTemplates.swift in Sources */,
+				84264F1A25387BB500D8DF81 /* NSNumber.swift in Sources */,
+				84264F1725387BB500D8DF81 /* Alternative.swift in Sources */,
 				8AE3F72C24DA1D2A002B03C3 /* GraphProjectTemplates.swift in Sources */,
 				7798B56521750041008BC50D /* GraphUser.swift in Sources */,
 				D08CD20321922025009F89F0 /* GraphMutationWatchProjectResponseEnvelopeTemplates.swift in Sources */,
@@ -6089,6 +6156,7 @@
 				D0158A231EEB30A2006E7684 /* ProjectTemplates.swift in Sources */,
 				D6B9DF3F1F72E25A0064A4D8 /* Category.swift in Sources */,
 				D01589051EEB2ED7006E7684 /* ProjectActivityEnvelope.swift in Sources */,
+				84264F1525387BB500D8DF81 /* flatReduce.swift in Sources */,
 				D015899F1EEB2ED7006E7684 /* ServiceType.swift in Sources */,
 				D7774466217A345D008D679F /* UpdateUserProfileMutation .swift in Sources */,
 				D67B6C9D221F458700B63A6B /* Config+Argo.swift in Sources */,
@@ -6097,6 +6165,7 @@
 				D01588D91EEB2ED7006E7684 /* User.AvatarLenses.swift in Sources */,
 				D015882F1EEB2ED7006E7684 /* ClientAuth.swift in Sources */,
 				D01588371EEB2ED7006E7684 /* EncodableType.swift in Sources */,
+				84264F1025387BB500D8DF81 /* decode.swift in Sources */,
 				D0158A301EEB30A2006E7684 /* User.NewsletterSubscriptionsTemplates.swift in Sources */,
 				D01588DB1EEB2ED7006E7684 /* User.NewsletterSubscriptionsLenses.swift in Sources */,
 				D01588691EEB2ED7006E7684 /* DiscoveryEnvelope.swift in Sources */,
@@ -6114,11 +6183,13 @@
 				D01588AF1EEB2ED7006E7684 /* Project.VideoLenses.swift in Sources */,
 				D0158A091EEB30A2006E7684 /* ActivityTemplates.swift in Sources */,
 				D01589811EEB2ED7006E7684 /* Update.swift in Sources */,
+				84264F1D25387BB500D8DF81 /* Monad.swift in Sources */,
 				378CA24622C4449F004E3C86 /* CountryLenses.swift in Sources */,
 				D0158A161EEB30A2006E7684 /* ItemTemplates.swift in Sources */,
 				D63BBD33217F9CDE007E01F0 /* GraphCreditCardTemplate.swift in Sources */,
 				D01588D71EEB2ED7006E7684 /* UpdateLenses.swift in Sources */,
 				8A30C6B12491683C00EE12E4 /* ManagePledgeViewQueries.swift in Sources */,
+				84264F2025387BB500D8DF81 /* FailureCoalescing.swift in Sources */,
 				D01588FF1EEB2ED7006E7684 /* Project.swift in Sources */,
 				D002CAE1218CF8F1009783F2 /* WatchProjectMutation.swift in Sources */,
 				D0158A1D1EEB30A2006E7684 /* ProjectStatsEnvelope.CumulativeStatsTemplates.swift in Sources */,
@@ -6133,6 +6204,7 @@
 				D01588B91EEB2ED7006E7684 /* ProjectStatsEnvelope.FundingDateStatsLenses.swift in Sources */,
 				D0158A101EEB30A2006E7684 /* CommentTemplates.swift in Sources */,
 				D01588B31EEB2ED7006E7684 /* ProjectNotification.ProjectLenses.swift in Sources */,
+				84264F1E25387BB500D8DF81 /* Argo.swift in Sources */,
 				D01588811EEB2ED7006E7684 /* ActivityLenses.swift in Sources */,
 				D01588971EEB2ED7006E7684 /* FriendStatsEnvelope.StatsLenses.swift in Sources */,
 				8A41CC6A2458A0360095B15E /* GraphBacking.swift in Sources */,
@@ -6142,16 +6214,19 @@
 				8A8831C324DA2B27002BCA5E /* Backing+GraphBacking.swift in Sources */,
 				D79440902208970E00D0A747 /* CreatePaymentSourceTemplate.swift in Sources */,
 				D01589991EEB2ED7006E7684 /* ServerConfig.swift in Sources */,
+				84264F1125387BB500D8DF81 /* Dictionary.swift in Sources */,
 				D01588931EEB2ED7006E7684 /* DiscoveryParamsLenses.swift in Sources */,
 				D01588AB1EEB2ED7006E7684 /* Project.PhotoLenses.swift in Sources */,
 				D0158A0A1EEB30A2006E7684 /* BackingTemplates.swift in Sources */,
 				D67F29361F68333800E399A6 /* GraphSchema.swift in Sources */,
+				84264F1F25387BB500D8DF81 /* catDecoded.swift in Sources */,
 				D6B686E92191FE5E005F5DA7 /* EmptyInput.swift in Sources */,
 				D0158A2A1EEB30A2006E7684 /* SurveyResponseTemplates.swift in Sources */,
 				8AE3F73124DA29FC002B03C3 /* Project+GraphProject.swift in Sources */,
 				D6ED38A21F796FE5006CAAE9 /* GraphCategoriesEnvelopeTemplate.swift in Sources */,
 				D01588911EEB2ED7006E7684 /* DiscoveryEnvelopeLenses.swift in Sources */,
 				D01588DF1EEB2ED7006E7684 /* User.StatsLenses.swift in Sources */,
+				84264F1825387BB500D8DF81 /* Applicative.swift in Sources */,
 				8A0B1E2324D4C486009E90C0 /* GraphProject.swift in Sources */,
 				D7417CD620BF12F4004DABA6 /* ExportDataEnvelope.swift in Sources */,
 				D6DC65522178CDDD008CF69C /* GraphUserEmailTemplate.swift in Sources */,
@@ -6193,6 +6268,7 @@
 				D63BBD31217F7212007E01F0 /* GraphUserCreditCard.swift in Sources */,
 				D79CF32E219CE51A00ECB73A /* CreatePaymentSourceInput.swift in Sources */,
 				D01588A51EEB2ED7006E7684 /* Project.DatesLenses.swift in Sources */,
+				84264EEC25387B0500D8DF81 /* Param.swift in Sources */,
 				D01588EB1EEB2ED7006E7684 /* MessageSubject.swift in Sources */,
 				D770DDE8217D729300B5319A /* GraphUserTemplates.swift in Sources */,
 				D01589171EEB2ED7006E7684 /* RewardsItem.swift in Sources */,
@@ -6213,12 +6289,12 @@
 				D01589071EEB2ED7006E7684 /* ProjectNotification.swift in Sources */,
 				D01588D31EEB2ED7006E7684 /* SurveyResponseLenses.swift in Sources */,
 				8AA407CE24DB5316008C5FB0 /* GraphCategoryTemplates.swift in Sources */,
-				D01588F71EEB2ED7006E7684 /* Param.swift in Sources */,
 				D01588A91EEB2ED7006E7684 /* Project.PersonalizationLenses.swift in Sources */,
 				D015888B1EEB2ED7006E7684 /* CommentLenses.swift in Sources */,
 				D0158A281EEB30A2006E7684 /* StarEnvelopeTemplates.swift in Sources */,
 				D0158A221EEB30A2006E7684 /* ProjectStatsEnvelopeTemplates.swift in Sources */,
 				D01588B71EEB2ED7006E7684 /* ProjectStatsEnvelope.CumulativeStatsLenses.swift in Sources */,
+				84264F1325387BB500D8DF81 /* DecodeOperators.swift in Sources */,
 				D01589271EEB2ED7006E7684 /* SurveyResponse.swift in Sources */,
 				D75DACA8221DC4340027F478 /* CreatePasswordInput.swift in Sources */,
 				D0158A0D1EEB30A2006E7684 /* ChangePaymentMethodEnvelopeTemplates.swift in Sources */,
@@ -6241,6 +6317,7 @@
 				D64DDCE123564D3700DE0EA9 /* PaymentSourceTemplates.swift in Sources */,
 				D002CAE5218CF951009783F2 /* GraphMutationWatchProjectResponseEnvelope.swift in Sources */,
 				D0158A1C1EEB30A2006E7684 /* ProjectNotificationTemplates.swift in Sources */,
+				84264F0F25387BB500D8DF81 /* JSON.swift in Sources */,
 				D01588F91EEB2ED7006E7684 /* Project.Country.swift in Sources */,
 				D01588311EEB2ED7006E7684 /* OauthToken.swift in Sources */,
 				77776BC8234BA76400A42388 /* CancelBackingInput.swift in Sources */,
@@ -6262,6 +6339,7 @@
 				D01589931EEB2ED7006E7684 /* User.swift in Sources */,
 				8A49396924B690E000C3C3CE /* RewardAddOnSelectionViewEnvelopeTemplate.swift in Sources */,
 				D0158A271EEB30A2006E7684 /* ShippingRuleTemplates.swift in Sources */,
+				84264F1925387BB500D8DF81 /* DecodeError.swift in Sources */,
 				D6B9F90A22035840003282A5 /* Author.swift in Sources */,
 				8A0B1E2724DA0DC3009E90C0 /* GraphLocation.swift in Sources */,
 				8AF34C782342D6A5000B211D /* Encodable+Dictionary.swift in Sources */,
@@ -6279,8 +6357,12 @@
 				D015889D1EEB2ED7006E7684 /* LocationLenses.swift in Sources */,
 				D01589011EEB2ED7006E7684 /* Project.Video.swift in Sources */,
 				D0E78C3622A980A600AAB645 /* ClearUserUnseenActivityEnvelope.swift in Sources */,
+				84264F1425387BB500D8DF81 /* ArgoDecodable.swift in Sources */,
 				D0158A1A1EEB30A2006E7684 /* Project.PhotoTemplates.swift in Sources */,
 				8AF34C722342CBAD000B211D /* UpdateBackingMutation.swift in Sources */,
+				84264F1B25387BB500D8DF81 /* Decoded.swift in Sources */,
+				84264F1225387BB500D8DF81 /* sequence.swift in Sources */,
+				84264F2125387BB500D8DF81 /* RawRepresentable.swift in Sources */,
 				D01588B51EEB2ED7006E7684 /* ProjectNotificationLenses.swift in Sources */,
 				8A1F155624DB609D00E0C000 /* DateFormatter+ISOFormatter.swift in Sources */,
 				D015882B1EEB2ED7006E7684 /* NSURLSession.swift in Sources */,
@@ -6299,12 +6381,14 @@
 				D68F0B16243CFF3F009FC948 /* SignInWithAppleEnvelope.swift in Sources */,
 				D6B686EB2191FEEE005F5DA7 /* UserSendEmailVerificationMutation.swift in Sources */,
 				8AA407CC24DB49CE008C5FB0 /* Location+GraphLocation.swift in Sources */,
+				84264F1C25387BB500D8DF81 /* Functor.swift in Sources */,
 				D6F5C60F2437DD2A00C1A79D /* SignInWithAppleMutation.swift in Sources */,
 				D67B6CD8221F46D700B63A6B /* Project.Country+Argo.swift in Sources */,
 				8AA8A38424EC6DA400085282 /* ProjectAndBackingEnvelopeTemplates.swift in Sources */,
 				D01589871EEB2ED7006E7684 /* UpdatePledgeEnvelope.swift in Sources */,
 				D01588DD1EEB2ED7006E7684 /* User.NotificationsLenses.swift in Sources */,
 				D015886B1EEB2ED7006E7684 /* DiscoveryParams.swift in Sources */,
+				84264F1625387BB500D8DF81 /* StandardTypes.swift in Sources */,
 				8A4E954B245268F100A578CF /* ManagePledgeViewBackingEnvelopeTemplate.swift in Sources */,
 				D755ECAB232005A70096F189 /* Checkout.swift in Sources */,
 				8A4E953B2450FE1500A578CF /* Money.swift in Sources */,

--- a/KsApi/GraphMutation.swift
+++ b/KsApi/GraphMutation.swift
@@ -10,7 +10,7 @@ protocol GraphMutation: CustomStringConvertible {
   var input: Input { get }
 }
 
-public struct GraphMutationEmptyResponseEnvelope: Decodable {}
+public struct GraphMutationEmptyResponseEnvelope: Swift.Decodable {}
 
 extension GraphMutationInput where Self: Encodable {
   public func toInputDictionary() -> [String: Any] {

--- a/KsApi/GraphSchema.swift
+++ b/KsApi/GraphSchema.swift
@@ -2,11 +2,11 @@ import Prelude
 
 // MARK: - Graph Response
 
-public struct GraphResponse<T: Decodable>: Decodable {
+public struct GraphResponse<T: Swift.Decodable>: Swift.Decodable {
   let data: T
 }
 
-public struct GraphResponseErrorEnvelope: Decodable {
+public struct GraphResponseErrorEnvelope: Swift.Decodable {
   let errors: [GraphResponseError]?
 }
 
@@ -100,7 +100,7 @@ public enum Nodes<Q: QueryType> {
   case nodes(NonEmptySet<Q>)
 }
 
-public struct GraphResponseError: Decodable {
+public struct GraphResponseError: Swift.Decodable {
   public let message: String
 }
 

--- a/KsApi/Service+DecodeHelpers.swift
+++ b/KsApi/Service+DecodeHelpers.swift
@@ -1,11 +1,10 @@
-import Argo
 import Foundation
 import Prelude
 import ReactiveExtensions
 import ReactiveSwift
 
 extension Service {
-  func decodeModel<M: Argo.Decodable>(_ json: Any) ->
+  func decodeModel<M: Decodable>(_ json: Any) ->
     SignalProducer<M, ErrorEnvelope> where M == M.DecodedType {
     return SignalProducer(value: json)
       .map { json in decode(json) as Decoded<M> }
@@ -20,7 +19,7 @@ extension Service {
       }
   }
 
-  func decodeModels<M: Argo.Decodable>(_ json: Any)
+  func decodeModels<M: Decodable>(_ json: Any)
     -> SignalProducer<[M], ErrorEnvelope> where M == M.DecodedType {
     return SignalProducer(value: json)
       .map { json in decode(json) as Decoded<[M]> }
@@ -35,7 +34,7 @@ extension Service {
       }
   }
 
-  func decodeModel<M: Argo.Decodable>(_ json: Any) ->
+  func decodeModel<M: Decodable>(_ json: Any) ->
     SignalProducer<M?, ErrorEnvelope> where M == M.DecodedType {
     return SignalProducer(value: json)
       .map { json in decode(json) as M? }

--- a/KsApi/Service+RequestHelpers.swift
+++ b/KsApi/Service+RequestHelpers.swift
@@ -1,4 +1,3 @@
-import Argo
 import Foundation
 import Prelude
 import ReactiveExtensions
@@ -37,7 +36,7 @@ extension Service {
     }
   }
 
-  func requestPagination<M: Argo.Decodable>(_ paginationUrl: String)
+  func requestPagination<M: Decodable>(_ paginationUrl: String)
     -> SignalProducer<M, ErrorEnvelope> where M == M.DecodedType {
     guard let paginationUrl = URL(string: paginationUrl) else {
       return .init(error: .invalidPaginationUrl)
@@ -47,7 +46,7 @@ extension Service {
       .flatMap(self.decodeModel)
   }
 
-  func request<M: Argo.Decodable>(_ route: Route)
+  func request<M: Decodable>(_ route: Route)
     -> SignalProducer<M, ErrorEnvelope> where M == M.DecodedType {
     let properties = route.requestProperties
 
@@ -64,7 +63,7 @@ extension Service {
     .flatMap(self.decodeModel)
   }
 
-  func request<M: Argo.Decodable>(_ route: Route)
+  func request<M: Decodable>(_ route: Route)
     -> SignalProducer<[M], ErrorEnvelope> where M == M.DecodedType {
     let properties = route.requestProperties
 
@@ -77,7 +76,7 @@ extension Service {
     .flatMap(self.decodeModels)
   }
 
-  func request<M: Argo.Decodable>(_ route: Route)
+  func request<M: Decodable>(_ route: Route)
     -> SignalProducer<M?, ErrorEnvelope> where M == M.DecodedType {
     let properties = route.requestProperties
 

--- a/KsApi/extensions/Argo+ToPrimitive.swift
+++ b/KsApi/extensions/Argo+ToPrimitive.swift
@@ -1,7 +1,6 @@
-import Argo
 import Foundation
 
-extension Argo.JSON {
+extension JSON {
   func toPrimitive() -> Any? {
     switch self {
     case let .array(json):

--- a/KsApi/lib/Decodable.swift
+++ b/KsApi/lib/Decodable.swift
@@ -1,6 +1,4 @@
-import Argo
-
-public extension Argo.Decodable {
+public extension Decodable {
   /**
    Decode a JSON dictionary into a `Decoded` type.
 

--- a/KsApi/lib/TryDecodable.swift
+++ b/KsApi/lib/TryDecodable.swift
@@ -1,7 +1,6 @@
-import Argo
 import Foundation
 
-public func tryDecodable<T: Swift.Decodable>(_ json: JSON) -> Argo.Decoded<T> {
+public func tryDecodable<T: Swift.Decodable>(_ json: JSON) -> Decoded<T> {
   guard
     // Convert Argo.JSON to primitive types, e.g. [String: Any].
     let primitive = json.toPrimitive(),

--- a/KsApi/lib/TryDecodableTests.swift
+++ b/KsApi/lib/TryDecodableTests.swift
@@ -1,11 +1,10 @@
-import Argo
 import Curry
 import Foundation
 import KsApi
 import Runes
 import XCTest
 
-struct MyArgoModel: Argo.Decodable, Equatable {
+struct MyArgoModel: Decodable, Equatable {
   public let id: Int
   public let name: String
   public let model: MySwiftModel
@@ -26,7 +25,7 @@ struct MySwiftModel: Swift.Decodable, Equatable {
   public let name: String
 }
 
-struct SingleValueArgoModel: Argo.Decodable, Equatable {
+struct SingleValueArgoModel: Decodable, Equatable {
   public let id: Int
   public let name: String
   public let model: SingleValueSwiftModel

--- a/KsApi/models/AccessTokenEnvelope.swift
+++ b/KsApi/models/AccessTokenEnvelope.swift
@@ -1,4 +1,3 @@
-import Argo
 import Curry
 import Runes
 
@@ -12,7 +11,7 @@ public struct AccessTokenEnvelope {
   }
 }
 
-extension AccessTokenEnvelope: Argo.Decodable {
+extension AccessTokenEnvelope: Decodable {
   public static func decode(_ json: JSON) -> Decoded<AccessTokenEnvelope> {
     return curry(AccessTokenEnvelope.init)
       <^> json <| "access_token"

--- a/KsApi/models/Activity.swift
+++ b/KsApi/models/Activity.swift
@@ -1,4 +1,3 @@
-import Argo
 import Curry
 import Foundation
 import Runes
@@ -50,7 +49,7 @@ public func == (lhs: Activity, rhs: Activity) -> Bool {
   return lhs.id == rhs.id
 }
 
-extension Activity: Argo.Decodable {
+extension Activity: Decodable {
   public static func decode(_ json: JSON) -> Decoded<Activity> {
     let tmp = curry(Activity.init)
       <^> json <| "category"
@@ -65,7 +64,7 @@ extension Activity: Argo.Decodable {
   }
 }
 
-extension Activity.Category: Argo.Decodable {
+extension Activity.Category: Decodable {
   public static func decode(_ json: JSON) -> Decoded<Activity.Category> {
     switch json {
     case let .string(category):
@@ -76,7 +75,7 @@ extension Activity.Category: Argo.Decodable {
   }
 }
 
-extension Activity.MemberData: Argo.Decodable {
+extension Activity.MemberData: Decodable {
   public static func decode(_ json: JSON) -> Decoded<Activity.MemberData> {
     let tmp = curry(Activity.MemberData.init)
       <^> json <|? "amount"

--- a/KsApi/models/ActivityEnvelope.swift
+++ b/KsApi/models/ActivityEnvelope.swift
@@ -1,4 +1,3 @@
-import Argo
 import Curry
 import Runes
 
@@ -15,7 +14,7 @@ public struct ActivityEnvelope {
   }
 }
 
-extension ActivityEnvelope: Argo.Decodable {
+extension ActivityEnvelope: Decodable {
   public static func decode(_ json: JSON) -> Decoded<ActivityEnvelope> {
     return curry(ActivityEnvelope.init)
       <^> json <|| "activities"
@@ -23,14 +22,14 @@ extension ActivityEnvelope: Argo.Decodable {
   }
 }
 
-extension ActivityEnvelope.UrlsEnvelope: Argo.Decodable {
+extension ActivityEnvelope.UrlsEnvelope: Decodable {
   public static func decode(_ json: JSON) -> Decoded<ActivityEnvelope.UrlsEnvelope> {
     return curry(ActivityEnvelope.UrlsEnvelope.init)
       <^> json <| "api"
   }
 }
 
-extension ActivityEnvelope.UrlsEnvelope.ApiEnvelope: Argo.Decodable {
+extension ActivityEnvelope.UrlsEnvelope.ApiEnvelope: Decodable {
   public static func decode(_ json: JSON) -> Decoded<ActivityEnvelope.UrlsEnvelope.ApiEnvelope> {
     return curry(ActivityEnvelope.UrlsEnvelope.ApiEnvelope.init)
       <^> (json <| "more_activities" <|> .success(""))

--- a/KsApi/models/Author.swift
+++ b/KsApi/models/Author.swift
@@ -1,4 +1,3 @@
-import Argo
 import Curry
 import Foundation
 import Runes
@@ -37,7 +36,7 @@ extension Author.Url: Swift.Decodable {
   }
 }
 
-extension Author: Argo.Decodable {
+extension Author: Decodable {
   public static func decode(_ json: JSON) -> Decoded<Author> {
     return curry(Author.init)
       <^> json <| "avatar"
@@ -47,7 +46,7 @@ extension Author: Argo.Decodable {
   }
 }
 
-extension Author.Avatar: Argo.Decodable {
+extension Author.Avatar: Decodable {
   public static func decode(_ json: JSON) -> Decoded<Author.Avatar> {
     return curry(Author.Avatar.init)
       <^> json <|? "medium"
@@ -56,7 +55,7 @@ extension Author.Avatar: Argo.Decodable {
   }
 }
 
-extension Author.Url: Argo.Decodable {
+extension Author.Url: Decodable {
   public static func decode(_ json: JSON) -> Decoded<Author.Url> {
     return curry(Author.Url.init)
       <^> json <| ["api", "user"]

--- a/KsApi/models/Backing.swift
+++ b/KsApi/models/Backing.swift
@@ -1,4 +1,3 @@
-import Argo
 import Curry
 import Runes
 
@@ -48,7 +47,7 @@ public func == (lhs: Backing, rhs: Backing) -> Bool {
   return lhs.id == rhs.id
 }
 
-extension Backing: Argo.Decodable {
+extension Backing: Decodable {
   public static func decode(_ json: JSON) -> Decoded<Backing> {
     let tmp1 = curry(Backing.init)
       <^> json <||? "add_ons"
@@ -104,7 +103,7 @@ extension Backing: EncodableType {
   }
 }
 
-extension Backing.PaymentSource: Argo.Decodable {
+extension Backing.PaymentSource: Decodable {
   public static func decode(_ json: JSON) -> Decoded<Backing.PaymentSource?> {
     return curry(Backing.PaymentSource.init)
       <^> json <|? "expiration_date"
@@ -116,7 +115,7 @@ extension Backing.PaymentSource: Argo.Decodable {
   }
 }
 
-extension Backing.Status: Argo.Decodable {}
+extension Backing.Status: Decodable {}
 
 extension Backing.PaymentSource: Equatable {}
 public func == (lhs: Backing.PaymentSource, rhs: Backing.PaymentSource) -> Bool {

--- a/KsApi/models/BackingsEnvelope.swift
+++ b/KsApi/models/BackingsEnvelope.swift
@@ -1,4 +1,3 @@
-import Argo
 import Foundation
 import ReactiveSwift
 
@@ -12,9 +11,9 @@ public struct BackingsEnvelope {
   public let projectsAndBackings: [ProjectAndBackingEnvelope]
 }
 
-extension BackingsEnvelope: Argo.Decodable {
+extension BackingsEnvelope: Decodable {
   public static func decode(_: JSON) -> Decoded<BackingsEnvelope> {
-    fatalError("Conformance is to satisfy the compiler, do not create this model using Argo.")
+    fatalError("Conformance is to satisfy the compiler, do not create this model using ")
   }
 }
 

--- a/KsApi/models/ChangePaymentMethodEnvelope.swift
+++ b/KsApi/models/ChangePaymentMethodEnvelope.swift
@@ -1,4 +1,3 @@
-import Argo
 import Curry
 import Runes
 
@@ -7,7 +6,7 @@ public struct ChangePaymentMethodEnvelope {
   public let status: Int
 }
 
-extension ChangePaymentMethodEnvelope: Argo.Decodable {
+extension ChangePaymentMethodEnvelope: Decodable {
   public static func decode(_ json: JSON) -> Decoded<ChangePaymentMethodEnvelope> {
     return curry(ChangePaymentMethodEnvelope.init)
       <^> json <|? ["data", "new_checkout_url"]

--- a/KsApi/models/Checkout.swift
+++ b/KsApi/models/Checkout.swift
@@ -1,19 +1,19 @@
 import Foundation
 
 // This model is used in multiple queries, if modified update UpdateBacking and CreateBacking mutations.
-public struct Checkout: Decodable {
+public struct Checkout: Swift.Decodable {
   public var id: String
   public var state: State
   public var backing: Backing
 
-  public enum State: String, Decodable, CaseIterable {
+  public enum State: String, Swift.Decodable, CaseIterable {
     case authorizing = "AUTHORIZING"
     case verifying = "VERIFYING"
     case successful = "SUCCESSFUL"
     case failed = "FAILED"
   }
 
-  public struct Backing: Decodable {
+  public struct Backing: Swift.Decodable {
     public let clientSecret: String?
     public let requiresAction: Bool
   }

--- a/KsApi/models/ClearUserUnseenActivityEnvelope.swift
+++ b/KsApi/models/ClearUserUnseenActivityEnvelope.swift
@@ -4,7 +4,7 @@ public struct ClearUserUnseenActivityEnvelope {
   public var activityIndicatorCount: Int
 }
 
-extension ClearUserUnseenActivityEnvelope: Decodable {
+extension ClearUserUnseenActivityEnvelope: Swift.Decodable {
   enum CodingKeys: String, CodingKey {
     case clearUserUnseenActivity
     case activityIndicatorCount

--- a/KsApi/models/Comment.swift
+++ b/KsApi/models/Comment.swift
@@ -1,4 +1,3 @@
-import Argo
 import Curry
 import Runes
 
@@ -29,7 +28,7 @@ extension Comment: Swift.Decodable {
   }
 }
 
-extension Comment: Argo.Decodable {
+extension Comment: Decodable {
   public static func decode(_ json: JSON) -> Decoded<Comment> {
     let tmp = curry(Comment.init)
       <^> json <| "author"

--- a/KsApi/models/CommentsEnvelope.swift
+++ b/KsApi/models/CommentsEnvelope.swift
@@ -1,4 +1,3 @@
-import Argo
 import Curry
 import Runes
 
@@ -33,7 +32,7 @@ extension CommentsEnvelope.UrlsEnvelope {
   }
 }
 
-extension CommentsEnvelope: Argo.Decodable {
+extension CommentsEnvelope: Decodable {
   public static func decode(_ json: JSON) -> Decoded<CommentsEnvelope> {
     return curry(CommentsEnvelope.init)
       <^> json <|| "comments"
@@ -41,14 +40,14 @@ extension CommentsEnvelope: Argo.Decodable {
   }
 }
 
-extension CommentsEnvelope.UrlsEnvelope: Argo.Decodable {
+extension CommentsEnvelope.UrlsEnvelope: Decodable {
   public static func decode(_ json: JSON) -> Decoded<CommentsEnvelope.UrlsEnvelope> {
     return curry(CommentsEnvelope.UrlsEnvelope.init)
       <^> json <| "api"
   }
 }
 
-extension CommentsEnvelope.UrlsEnvelope.ApiEnvelope: Argo.Decodable {
+extension CommentsEnvelope.UrlsEnvelope.ApiEnvelope: Decodable {
   public static func decode(_ json: JSON) -> Decoded<CommentsEnvelope.UrlsEnvelope.ApiEnvelope> {
     return curry(CommentsEnvelope.UrlsEnvelope.ApiEnvelope.init)
       <^> (json <| "more_comments" <|> .success(""))

--- a/KsApi/models/Config+Argo.swift
+++ b/KsApi/models/Config+Argo.swift
@@ -1,8 +1,7 @@
-import Argo
 import Curry
 import Runes
 
-extension Config: Argo.Decodable {
+extension Config: Decodable {
   public static func decode(_ json: JSON) -> Decoded<Config> {
     let tmp = curry(Config.init)
       <^> decodeDictionary(json <| "ab_experiments")
@@ -37,7 +36,7 @@ extension Config: EncodableType {
 // Useful for getting around swift optimization bug: https://github.com/thoughtbot/Argo/issues/363
 // Turns out using `>>-` or `flatMap` on a `Decoded` fails to compile with optimizations on, so this
 // function does it manually.
-private func decodeDictionary<T: Argo.Decodable>(_ j: Decoded<JSON>)
+private func decodeDictionary<T: Decodable>(_ j: Decoded<JSON>)
   -> Decoded<[String: T]> where T.DecodedType == T {
   switch j {
   case let .success(json): return [String: T].decode(json)

--- a/KsApi/models/CreateBackingEnvelope.swift
+++ b/KsApi/models/CreateBackingEnvelope.swift
@@ -1,9 +1,9 @@
 import Foundation
 
-public struct CreateBackingEnvelope: Decodable {
+public struct CreateBackingEnvelope: Swift.Decodable {
   public var createBacking: CreateBacking
 
-  public struct CreateBacking: Decodable {
+  public struct CreateBacking: Swift.Decodable {
     public var checkout: Checkout
   }
 }

--- a/KsApi/models/CreatePaymentSourceEnvelope.swift
+++ b/KsApi/models/CreatePaymentSourceEnvelope.swift
@@ -1,9 +1,9 @@
 import Foundation
 
-public struct CreatePaymentSourceEnvelope: Decodable {
+public struct CreatePaymentSourceEnvelope: Swift.Decodable {
   public var createPaymentSource: CreatePaymentSource
 
-  public struct CreatePaymentSource: Decodable {
+  public struct CreatePaymentSource: Swift.Decodable {
     public var errorMessage: String?
     public var isSuccessful: Bool
     public var paymentSource: GraphUserCreditCard.CreditCard

--- a/KsApi/models/CreditCardType.swift
+++ b/KsApi/models/CreditCardType.swift
@@ -1,4 +1,3 @@
-import Argo
 import Foundation
 
 public enum CreditCardType: String, Swift.Decodable, CaseIterable {
@@ -31,4 +30,4 @@ public enum CreditCardType: String, Swift.Decodable, CaseIterable {
   }
 }
 
-extension CreditCardType: Argo.Decodable {}
+extension CreditCardType: Decodable {}

--- a/KsApi/models/DiscoveryEnvelope.swift
+++ b/KsApi/models/DiscoveryEnvelope.swift
@@ -1,4 +1,3 @@
-import Argo
 import Curry
 import Runes
 
@@ -24,7 +23,7 @@ public struct DiscoveryEnvelope {
   }
 }
 
-extension DiscoveryEnvelope: Argo.Decodable {
+extension DiscoveryEnvelope: Decodable {
   public static func decode(_ json: JSON) -> Decoded<DiscoveryEnvelope> {
     return curry(DiscoveryEnvelope.init)
       <^> json <|| "projects"
@@ -33,21 +32,21 @@ extension DiscoveryEnvelope: Argo.Decodable {
   }
 }
 
-extension DiscoveryEnvelope.UrlsEnvelope: Argo.Decodable {
+extension DiscoveryEnvelope.UrlsEnvelope: Decodable {
   public static func decode(_ json: JSON) -> Decoded<DiscoveryEnvelope.UrlsEnvelope> {
     return curry(DiscoveryEnvelope.UrlsEnvelope.init)
       <^> json <| "api"
   }
 }
 
-extension DiscoveryEnvelope.UrlsEnvelope.ApiEnvelope: Argo.Decodable {
+extension DiscoveryEnvelope.UrlsEnvelope.ApiEnvelope: Decodable {
   public static func decode(_ json: JSON) -> Decoded<DiscoveryEnvelope.UrlsEnvelope.ApiEnvelope> {
     return curry(DiscoveryEnvelope.UrlsEnvelope.ApiEnvelope.init)
       <^> json <| "more_projects"
   }
 }
 
-extension DiscoveryEnvelope.StatsEnvelope: Argo.Decodable {
+extension DiscoveryEnvelope.StatsEnvelope: Decodable {
   public static func decode(_ json: JSON) -> Decoded<DiscoveryEnvelope.StatsEnvelope> {
     return curry(DiscoveryEnvelope.StatsEnvelope.init)
       <^> json <| "count"

--- a/KsApi/models/DiscoveryParams.swift
+++ b/KsApi/models/DiscoveryParams.swift
@@ -1,4 +1,3 @@
-import Argo
 import Curry
 import Prelude
 import Runes
@@ -23,13 +22,13 @@ public struct DiscoveryParams {
   public var state: State?
   public var tagId: TagID?
 
-  public enum State: String, Argo.Decodable {
+  public enum State: String, Decodable {
     case all
     case live
     case successful
   }
 
-  public enum Sort: String, Argo.Decodable {
+  public enum Sort: String, Decodable {
     case endingSoon = "end_date"
     case magic
     case newest
@@ -37,7 +36,7 @@ public struct DiscoveryParams {
     case distance
   }
 
-  public enum TagID: String, Argo.Decodable {
+  public enum TagID: String, Decodable {
     case lightsOn = "557"
   }
 
@@ -99,7 +98,7 @@ extension DiscoveryParams: CustomStringConvertible, CustomDebugStringConvertible
   }
 }
 
-extension DiscoveryParams: Argo.Decodable {
+extension DiscoveryParams: Decodable {
   public static func decode(_ json: JSON) -> Decoded<DiscoveryParams> {
     let tmp1 = curry(DiscoveryParams.init)
       <^> ((json <|? "backed" >>- stringIntToBool) as Decoded<Bool?>)

--- a/KsApi/models/ErrorEnvelope.swift
+++ b/KsApi/models/ErrorEnvelope.swift
@@ -1,4 +1,3 @@
-import Argo
 import Curry
 import Runes
 
@@ -138,7 +137,7 @@ public struct ErrorEnvelope {
 
 extension ErrorEnvelope: Error {}
 
-extension ErrorEnvelope: Argo.Decodable {
+extension ErrorEnvelope: Decodable {
   public static func decode(_ json: JSON) -> Decoded<ErrorEnvelope> {
     // Typically API errors come back in this form...
     let standardErrorEnvelope = curry(ErrorEnvelope.init)
@@ -167,7 +166,7 @@ extension ErrorEnvelope: Argo.Decodable {
   }
 }
 
-extension ErrorEnvelope.Exception: Argo.Decodable {
+extension ErrorEnvelope.Exception: Decodable {
   public static func decode(_ json: JSON) -> Decoded<ErrorEnvelope.Exception> {
     return curry(ErrorEnvelope.Exception.init)
       <^> json <||? "backtrace"
@@ -175,7 +174,7 @@ extension ErrorEnvelope.Exception: Argo.Decodable {
   }
 }
 
-extension ErrorEnvelope.KsrCode: Argo.Decodable {
+extension ErrorEnvelope.KsrCode: Decodable {
   public static func decode(_ j: JSON) -> Decoded<ErrorEnvelope.KsrCode> {
     switch j {
     case let .string(s):
@@ -186,7 +185,7 @@ extension ErrorEnvelope.KsrCode: Argo.Decodable {
   }
 }
 
-extension ErrorEnvelope.FacebookUser: Argo.Decodable {
+extension ErrorEnvelope.FacebookUser: Decodable {
   public static func decode(_ json: JSON) -> Decoded<ErrorEnvelope.FacebookUser> {
     return curry(ErrorEnvelope.FacebookUser.init)
       <^> json <| "id"

--- a/KsApi/models/ExportDataEnvelope.swift
+++ b/KsApi/models/ExportDataEnvelope.swift
@@ -1,4 +1,3 @@
-import Argo
 import Curry
 import Runes
 
@@ -15,7 +14,7 @@ public struct ExportDataEnvelope {
   }
 }
 
-extension ExportDataEnvelope: Argo.Decodable {
+extension ExportDataEnvelope: Decodable {
   public static func decode(_ json: JSON) -> Decoded<ExportDataEnvelope> {
     return curry(ExportDataEnvelope.init)
       <^> json <|? "expires_at"
@@ -24,4 +23,4 @@ extension ExportDataEnvelope: Argo.Decodable {
   }
 }
 
-extension ExportDataEnvelope.State: Argo.Decodable {}
+extension ExportDataEnvelope.State: Decodable {}

--- a/KsApi/models/FindFriendsEnvelope.swift
+++ b/KsApi/models/FindFriendsEnvelope.swift
@@ -1,4 +1,3 @@
-import Argo
 import Curry
 import Runes
 
@@ -16,7 +15,7 @@ public struct FindFriendsEnvelope {
   }
 }
 
-extension FindFriendsEnvelope: Argo.Decodable {
+extension FindFriendsEnvelope: Decodable {
   public static func decode(_ json: JSON) -> Decoded<FindFriendsEnvelope> {
     return curry(FindFriendsEnvelope.init)
       <^> json <| "contacts_imported"
@@ -25,14 +24,14 @@ extension FindFriendsEnvelope: Argo.Decodable {
   }
 }
 
-extension FindFriendsEnvelope.UrlsEnvelope: Argo.Decodable {
+extension FindFriendsEnvelope.UrlsEnvelope: Decodable {
   public static func decode(_ json: JSON) -> Decoded<FindFriendsEnvelope.UrlsEnvelope> {
     return curry(FindFriendsEnvelope.UrlsEnvelope.init)
       <^> json <| "api"
   }
 }
 
-extension FindFriendsEnvelope.UrlsEnvelope.ApiEnvelope: Argo.Decodable {
+extension FindFriendsEnvelope.UrlsEnvelope.ApiEnvelope: Decodable {
   public static func decode(_ json: JSON) -> Decoded<FindFriendsEnvelope.UrlsEnvelope.ApiEnvelope> {
     return curry(FindFriendsEnvelope.UrlsEnvelope.ApiEnvelope.init)
       <^> json <|? "more_users"

--- a/KsApi/models/FriendStatsEnvelope.swift
+++ b/KsApi/models/FriendStatsEnvelope.swift
@@ -1,4 +1,3 @@
-import Argo
 import Curry
 import Runes
 
@@ -11,14 +10,14 @@ public struct FriendStatsEnvelope {
   }
 }
 
-extension FriendStatsEnvelope: Argo.Decodable {
+extension FriendStatsEnvelope: Decodable {
   public static func decode(_ json: JSON) -> Decoded<FriendStatsEnvelope> {
     return curry(FriendStatsEnvelope.init)
       <^> json <| "stats"
   }
 }
 
-extension FriendStatsEnvelope.Stats: Argo.Decodable {
+extension FriendStatsEnvelope.Stats: Decodable {
   public static func decode(_ json: JSON) -> Decoded<FriendStatsEnvelope.Stats> {
     return curry(FriendStatsEnvelope.Stats.init)
       <^> json <| "friend_projects_count"

--- a/KsApi/models/Item.swift
+++ b/KsApi/models/Item.swift
@@ -1,4 +1,3 @@
-import Argo
 import Curry
 import Runes
 
@@ -9,7 +8,7 @@ public struct Item {
   public let projectId: Int
 }
 
-extension Item: Argo.Decodable {
+extension Item: Decodable {
   public static func decode(_ json: JSON) -> Decoded<Item> {
     return curry(Item.init)
       <^> json <|? "description"

--- a/KsApi/models/Location+Argo.swift
+++ b/KsApi/models/Location+Argo.swift
@@ -1,8 +1,7 @@
-import Argo
 import Curry
 import Runes
 
-extension Location: Argo.Decodable {
+extension Location: Decodable {
   public static func decode(_ json: JSON) -> Decoded<Location> {
     return curry(Location.init)
       <^> json <| "country"

--- a/KsApi/models/Message.swift
+++ b/KsApi/models/Message.swift
@@ -1,4 +1,3 @@
-import Argo
 import Curry
 import Foundation
 import Runes
@@ -11,7 +10,7 @@ public struct Message {
   public let sender: User
 }
 
-extension Message: Argo.Decodable {
+extension Message: Decodable {
   public static func decode(_ json: JSON) -> Decoded<Message> {
     return curry(Message.init)
       <^> json <| "body"

--- a/KsApi/models/MessageThread.swift
+++ b/KsApi/models/MessageThread.swift
@@ -1,4 +1,3 @@
-import Argo
 import Curry
 import Runes
 
@@ -12,7 +11,7 @@ public struct MessageThread {
   public let unreadMessagesCount: Int
 }
 
-extension MessageThread: Argo.Decodable {
+extension MessageThread: Decodable {
   public static func decode(_ json: JSON) -> Decoded<MessageThread> {
     let tmp = curry(MessageThread.init)
       <^> json <|? "backing"

--- a/KsApi/models/MessageThreadEnvelope.swift
+++ b/KsApi/models/MessageThreadEnvelope.swift
@@ -1,4 +1,3 @@
-import Argo
 import Curry
 import Runes
 
@@ -8,7 +7,7 @@ public struct MessageThreadEnvelope {
   public let messageThread: MessageThread
 }
 
-extension MessageThreadEnvelope: Argo.Decodable {
+extension MessageThreadEnvelope: Decodable {
   public static func decode(_ json: JSON) -> Decoded<MessageThreadEnvelope> {
     return curry(MessageThreadEnvelope.init)
       <^> json <|| "participants"

--- a/KsApi/models/MessageThreadsEnvelope.swift
+++ b/KsApi/models/MessageThreadsEnvelope.swift
@@ -1,4 +1,3 @@
-import Argo
 import Curry
 import Runes
 
@@ -15,7 +14,7 @@ public struct MessageThreadsEnvelope {
   }
 }
 
-extension MessageThreadsEnvelope: Argo.Decodable {
+extension MessageThreadsEnvelope: Decodable {
   public static func decode(_ json: JSON) -> Decoded<MessageThreadsEnvelope> {
     return curry(MessageThreadsEnvelope.init)
       <^> json <|| "message_threads"
@@ -23,14 +22,14 @@ extension MessageThreadsEnvelope: Argo.Decodable {
   }
 }
 
-extension MessageThreadsEnvelope.UrlsEnvelope: Argo.Decodable {
+extension MessageThreadsEnvelope.UrlsEnvelope: Decodable {
   public static func decode(_ json: JSON) -> Decoded<MessageThreadsEnvelope.UrlsEnvelope> {
     return curry(MessageThreadsEnvelope.UrlsEnvelope.init)
       <^> json <| "api"
   }
 }
 
-extension MessageThreadsEnvelope.UrlsEnvelope.ApiEnvelope: Argo.Decodable {
+extension MessageThreadsEnvelope.UrlsEnvelope.ApiEnvelope: Decodable {
   public static func decode(_ json: JSON) -> Decoded<MessageThreadsEnvelope.UrlsEnvelope.ApiEnvelope> {
     return curry(MessageThreadsEnvelope.UrlsEnvelope.ApiEnvelope.init)
       <^> json <| "more_message_threads"

--- a/KsApi/models/Param.swift
+++ b/KsApi/models/Param.swift
@@ -1,4 +1,4 @@
-import Argo
+import Foundation
 
 /// Represents a way to paramterize a model by either an `id` integer or `slug` string.
 public enum Param {
@@ -55,7 +55,7 @@ public func == (lhs: Param, rhs: Param) -> Bool {
   }
 }
 
-extension Param: Argo.Decodable {
+extension Param: Decodable {
   public static func decode(_ json: JSON) -> Decoded<Param> {
     switch json {
     case let .string(slug):

--- a/KsApi/models/PaymentType.swift
+++ b/KsApi/models/PaymentType.swift
@@ -1,4 +1,3 @@
-import Argo
 import Foundation
 
 public enum PaymentType: String, Swift.Decodable {
@@ -18,4 +17,4 @@ public enum PaymentType: String, Swift.Decodable {
   }
 }
 
-extension PaymentType: Argo.Decodable {}
+extension PaymentType: Decodable {}

--- a/KsApi/models/Project.Country+Argo.swift
+++ b/KsApi/models/Project.Country+Argo.swift
@@ -1,8 +1,7 @@
-import Argo
 import Curry
 import Runes
 
-extension Project.Country: Argo.Decodable {
+extension Project.Country: Decodable {
   public static func decode(_ json: JSON) -> Decoded<Project.Country> {
     let tmp = curry(Project.Country.init)
       <^> (json <| "country" <|> json <| "name")

--- a/KsApi/models/Project.Video.swift
+++ b/KsApi/models/Project.Video.swift
@@ -1,8 +1,7 @@
-import Argo
 import Curry
 import Runes
 
-extension Project.Video: Argo.Decodable {
+extension Project.Video: Decodable {
   public static func decode(_ json: JSON) -> Decoded<Project.Video> {
     return curry(Project.Video.init)
       <^> json <| "id"

--- a/KsApi/models/Project.swift
+++ b/KsApi/models/Project.swift
@@ -1,4 +1,3 @@
-import Argo
 import Curry
 import Prelude
 import ReactiveSwift
@@ -52,7 +51,7 @@ public struct Project {
     public var hls: String?
   }
 
-  public enum State: String, Argo.Decodable, CaseIterable {
+  public enum State: String, Decodable, CaseIterable {
     case canceled
     case failed
     case live
@@ -236,7 +235,7 @@ extension Project: CustomDebugStringConvertible {
   }
 }
 
-extension Project: Argo.Decodable {
+extension Project: Decodable {
   public static func decode(_ json: JSON) -> Decoded<Project> {
     let tmp1 = curry(Project.init)
       <^> json <||? "available_card_types"
@@ -265,14 +264,14 @@ extension Project: Argo.Decodable {
   }
 }
 
-extension Project.UrlsEnvelope: Argo.Decodable {
+extension Project.UrlsEnvelope: Decodable {
   public static func decode(_ json: JSON) -> Decoded<Project.UrlsEnvelope> {
     return curry(Project.UrlsEnvelope.init)
       <^> json <| "web"
   }
 }
 
-extension Project.UrlsEnvelope.WebEnvelope: Argo.Decodable {
+extension Project.UrlsEnvelope.WebEnvelope: Decodable {
   public static func decode(_ json: JSON) -> Decoded<Project.UrlsEnvelope.WebEnvelope> {
     return curry(Project.UrlsEnvelope.WebEnvelope.init)
       <^> json <| "project"
@@ -280,7 +279,7 @@ extension Project.UrlsEnvelope.WebEnvelope: Argo.Decodable {
   }
 }
 
-extension Project.Stats: Argo.Decodable {
+extension Project.Stats: Decodable {
   public static func decode(_ json: JSON) -> Decoded<Project.Stats> {
     let tmp1 = curry(Project.Stats.init)
       <^> json <| "backers_count"
@@ -297,7 +296,7 @@ extension Project.Stats: Argo.Decodable {
   }
 }
 
-extension Project.MemberData: Argo.Decodable {
+extension Project.MemberData: Decodable {
   public static func decode(_ json: JSON) -> Decoded<Project.MemberData> {
     return curry(Project.MemberData.init)
       <^> json <|? "last_update_published_at"
@@ -307,7 +306,7 @@ extension Project.MemberData: Argo.Decodable {
   }
 }
 
-extension Project.Dates: Argo.Decodable {
+extension Project.Dates: Decodable {
   public static func decode(_ json: JSON) -> Decoded<Project.Dates> {
     return curry(Project.Dates.init)
       <^> json <| "deadline"
@@ -318,7 +317,7 @@ extension Project.Dates: Argo.Decodable {
   }
 }
 
-extension Project.Personalization: Argo.Decodable {
+extension Project.Personalization: Decodable {
   public static func decode(_ json: JSON) -> Decoded<Project.Personalization> {
     return curry(Project.Personalization.init)
       <^> json <|? "backing"
@@ -328,7 +327,7 @@ extension Project.Personalization: Argo.Decodable {
   }
 }
 
-extension Project.RewardData: Argo.Decodable {
+extension Project.RewardData: Decodable {
   public static func decode(_ json: JSON) -> Decoded<Project.RewardData> {
     return curry(Project.RewardData.init)
       <^> json <||? "add_ons"
@@ -336,7 +335,7 @@ extension Project.RewardData: Argo.Decodable {
   }
 }
 
-extension Project.Category: Argo.Decodable {
+extension Project.Category: Decodable {
   public static func decode(_ json: JSON) -> Decoded<Project.Category> {
     return curry(Project.Category.init)
       <^> json <| "id"
@@ -346,7 +345,7 @@ extension Project.Category: Argo.Decodable {
   }
 }
 
-extension Project.Photo: Argo.Decodable {
+extension Project.Photo: Decodable {
   public static func decode(_ json: JSON) -> Decoded<Project.Photo> {
     let url1024: Decoded<String?> = ((json <| "1024x768") <|> (json <| "1024x576"))
       .map(Optional<String>.init)
@@ -360,7 +359,7 @@ extension Project.Photo: Argo.Decodable {
   }
 }
 
-extension Project.MemberData.Permission: Argo.Decodable {
+extension Project.MemberData.Permission: Decodable {
   public static func decode(_ json: JSON) -> Decoded<Project.MemberData.Permission> {
     if case let .string(permission) = json {
       return self.init(rawValue: permission).map(pure) ?? .success(.unknown)

--- a/KsApi/models/ProjectActivityEnvelope.swift
+++ b/KsApi/models/ProjectActivityEnvelope.swift
@@ -1,4 +1,3 @@
-import Argo
 import Curry
 import Runes
 
@@ -15,7 +14,7 @@ public struct ProjectActivityEnvelope {
   }
 }
 
-extension ProjectActivityEnvelope: Argo.Decodable {
+extension ProjectActivityEnvelope: Decodable {
   public static func decode(_ json: JSON) -> Decoded<ProjectActivityEnvelope> {
     return curry(ProjectActivityEnvelope.init)
       <^> json <|| "activities"
@@ -23,14 +22,14 @@ extension ProjectActivityEnvelope: Argo.Decodable {
   }
 }
 
-extension ProjectActivityEnvelope.UrlsEnvelope: Argo.Decodable {
+extension ProjectActivityEnvelope.UrlsEnvelope: Decodable {
   public static func decode(_ json: JSON) -> Decoded<ProjectActivityEnvelope.UrlsEnvelope> {
     return curry(ProjectActivityEnvelope.UrlsEnvelope.init)
       <^> json <| "api"
   }
 }
 
-extension ProjectActivityEnvelope.UrlsEnvelope.ApiEnvelope: Argo.Decodable {
+extension ProjectActivityEnvelope.UrlsEnvelope.ApiEnvelope: Decodable {
   public static func decode(_ json: JSON) -> Decoded<ProjectActivityEnvelope.UrlsEnvelope.ApiEnvelope> {
     return curry(ProjectActivityEnvelope.UrlsEnvelope.ApiEnvelope.init)
       <^> (json <| "more_activities" <|> .success(""))

--- a/KsApi/models/ProjectAndBackingEnvelope.swift
+++ b/KsApi/models/ProjectAndBackingEnvelope.swift
@@ -1,4 +1,3 @@
-import Argo
 import Foundation
 import ReactiveSwift
 
@@ -7,9 +6,9 @@ public struct ProjectAndBackingEnvelope: Equatable {
   public var backing: Backing
 }
 
-extension ProjectAndBackingEnvelope: Argo.Decodable {
+extension ProjectAndBackingEnvelope: Decodable {
   public static func decode(_: JSON) -> Decoded<ProjectAndBackingEnvelope> {
-    fatalError("Conformance is to satisfy the compiler, do not create this model using Argo.")
+    fatalError("Conformance is to satisfy the compiler, do not create this model using Argo")
   }
 }
 

--- a/KsApi/models/ProjectNotification.swift
+++ b/KsApi/models/ProjectNotification.swift
@@ -1,4 +1,3 @@
-import Argo
 import Curry
 import Foundation
 import Runes
@@ -15,7 +14,7 @@ public struct ProjectNotification {
   }
 }
 
-extension ProjectNotification: Argo.Decodable {
+extension ProjectNotification: Decodable {
   public static func decode(_ json: JSON) -> Decoded<ProjectNotification> {
     return curry(ProjectNotification.init)
       <^> json <| "email"
@@ -25,7 +24,7 @@ extension ProjectNotification: Argo.Decodable {
   }
 }
 
-extension ProjectNotification.Project: Argo.Decodable {
+extension ProjectNotification.Project: Decodable {
   public static func decode(_ json: JSON) -> Decoded<ProjectNotification.Project> {
     return curry(ProjectNotification.Project.init)
       <^> json <| "id"

--- a/KsApi/models/ProjectStatsEnvelope.swift
+++ b/KsApi/models/ProjectStatsEnvelope.swift
@@ -1,4 +1,3 @@
-import Argo
 import Curry
 import Runes
 
@@ -65,7 +64,7 @@ public struct ProjectStatsEnvelope {
   }
 }
 
-extension ProjectStatsEnvelope: Argo.Decodable {
+extension ProjectStatsEnvelope: Decodable {
   public static func decode(_ json: JSON) -> Decoded<ProjectStatsEnvelope> {
     return curry(ProjectStatsEnvelope.init)
       <^> json <| "cumulative"
@@ -77,7 +76,7 @@ extension ProjectStatsEnvelope: Argo.Decodable {
   }
 }
 
-extension ProjectStatsEnvelope.CumulativeStats: Argo.Decodable {
+extension ProjectStatsEnvelope.CumulativeStats: Decodable {
   public static func decode(_ json: JSON) -> Decoded<ProjectStatsEnvelope.CumulativeStats> {
     return curry(ProjectStatsEnvelope.CumulativeStats.init)
       <^> json <| "average_pledge"
@@ -94,7 +93,7 @@ public func == (lhs: ProjectStatsEnvelope.CumulativeStats, rhs: ProjectStatsEnve
   return lhs.averagePledge == rhs.averagePledge
 }
 
-extension ProjectStatsEnvelope.FundingDateStats: Argo.Decodable {
+extension ProjectStatsEnvelope.FundingDateStats: Decodable {
   public static func decode(_ json: JSON) -> Decoded<ProjectStatsEnvelope.FundingDateStats> {
     return curry(ProjectStatsEnvelope.FundingDateStats.init)
       <^> (json <| "backers_count" <|> .success(0))
@@ -111,7 +110,7 @@ public func == (lhs: ProjectStatsEnvelope.FundingDateStats, rhs: ProjectStatsEnv
   return lhs.date == rhs.date
 }
 
-extension ProjectStatsEnvelope.ReferralAggregateStats: Argo.Decodable {
+extension ProjectStatsEnvelope.ReferralAggregateStats: Decodable {
   public static func decode(_ json: JSON) -> Decoded<ProjectStatsEnvelope.ReferralAggregateStats> {
     return curry(ProjectStatsEnvelope.ReferralAggregateStats.init)
       <^> json <| "custom"
@@ -130,7 +129,7 @@ public func == (
     lhs.kickstarter == rhs.kickstarter
 }
 
-extension ProjectStatsEnvelope.ReferrerStats: Argo.Decodable {
+extension ProjectStatsEnvelope.ReferrerStats: Decodable {
   public static func decode(_ json: JSON) -> Decoded<ProjectStatsEnvelope.ReferrerStats> {
     let tmp = curry(ProjectStatsEnvelope.ReferrerStats.init)
       <^> json <| "backers_count"
@@ -148,7 +147,7 @@ public func == (lhs: ProjectStatsEnvelope.ReferrerStats, rhs: ProjectStatsEnvelo
   return lhs.code == rhs.code
 }
 
-extension ProjectStatsEnvelope.ReferrerStats.ReferrerType: Argo.Decodable {
+extension ProjectStatsEnvelope.ReferrerStats.ReferrerType: Decodable {
   public static func decode(_ json: JSON) -> Decoded<ProjectStatsEnvelope.ReferrerStats.ReferrerType> {
     if case let .string(referrerType) = json {
       switch referrerType.lowercased() {
@@ -166,7 +165,7 @@ extension ProjectStatsEnvelope.ReferrerStats.ReferrerType: Argo.Decodable {
   }
 }
 
-extension ProjectStatsEnvelope.RewardStats: Argo.Decodable {
+extension ProjectStatsEnvelope.RewardStats: Decodable {
   public static func decode(_ json: JSON) -> Decoded<ProjectStatsEnvelope.RewardStats> {
     return curry(ProjectStatsEnvelope.RewardStats.init)
       <^> json <| "backers_count"
@@ -182,7 +181,7 @@ public func == (lhs: ProjectStatsEnvelope.RewardStats, rhs: ProjectStatsEnvelope
   return lhs.rewardId == rhs.rewardId
 }
 
-extension ProjectStatsEnvelope.VideoStats: Argo.Decodable {
+extension ProjectStatsEnvelope.VideoStats: Decodable {
   public static func decode(_ json: JSON) -> Decoded<ProjectStatsEnvelope.VideoStats> {
     return curry(ProjectStatsEnvelope.VideoStats.init)
       <^> json <| "external_completions"

--- a/KsApi/models/ProjectsEnvelope.swift
+++ b/KsApi/models/ProjectsEnvelope.swift
@@ -1,4 +1,3 @@
-import Argo
 import Curry
 import Runes
 
@@ -15,7 +14,7 @@ public struct ProjectsEnvelope {
   }
 }
 
-extension ProjectsEnvelope: Argo.Decodable {
+extension ProjectsEnvelope: Decodable {
   public static func decode(_ json: JSON) -> Decoded<ProjectsEnvelope> {
     return curry(ProjectsEnvelope.init)
       <^> json <|| "projects"
@@ -23,14 +22,14 @@ extension ProjectsEnvelope: Argo.Decodable {
   }
 }
 
-extension ProjectsEnvelope.UrlsEnvelope: Argo.Decodable {
+extension ProjectsEnvelope.UrlsEnvelope: Decodable {
   public static func decode(_ json: JSON) -> Decoded<ProjectsEnvelope.UrlsEnvelope> {
     return curry(ProjectsEnvelope.UrlsEnvelope.init)
       <^> json <| "api"
   }
 }
 
-extension ProjectsEnvelope.UrlsEnvelope.ApiEnvelope: Argo.Decodable {
+extension ProjectsEnvelope.UrlsEnvelope.ApiEnvelope: Decodable {
   public static func decode(_ json: JSON) -> Decoded<ProjectsEnvelope.UrlsEnvelope.ApiEnvelope> {
     return curry(ProjectsEnvelope.UrlsEnvelope.ApiEnvelope.init)
       <^> (json <| "more_projects" <|> .success(""))

--- a/KsApi/models/PushEnvelope.swift
+++ b/KsApi/models/PushEnvelope.swift
@@ -1,4 +1,3 @@
-import Argo
 import Curry
 import Runes
 
@@ -51,7 +50,7 @@ public struct PushEnvelope {
   }
 }
 
-extension PushEnvelope: Argo.Decodable {
+extension PushEnvelope: Decodable {
   public static func decode(_ json: JSON) -> Decoded<PushEnvelope> {
     let update: Decoded<Update> = json <| "update" <|> json <| "post"
     let optionalUpdate: Decoded<Update?> = update.map(Optional.some) <|> .success(nil)
@@ -70,7 +69,7 @@ extension PushEnvelope: Argo.Decodable {
   }
 }
 
-extension PushEnvelope.Activity: Argo.Decodable {
+extension PushEnvelope.Activity: Decodable {
   public static func decode(_ json: JSON) -> Decoded<PushEnvelope.Activity> {
     let tmp = curry(PushEnvelope.Activity.init)
       <^> json <| "category"
@@ -84,21 +83,21 @@ extension PushEnvelope.Activity: Argo.Decodable {
   }
 }
 
-extension PushEnvelope.ApsEnvelope: Argo.Decodable {
+extension PushEnvelope.ApsEnvelope: Decodable {
   public static func decode(_ json: JSON) -> Decoded<PushEnvelope.ApsEnvelope> {
     return curry(PushEnvelope.ApsEnvelope.init)
       <^> json <| "alert"
   }
 }
 
-extension PushEnvelope.ErroredPledge: Argo.Decodable {
+extension PushEnvelope.ErroredPledge: Decodable {
   public static func decode(_ json: JSON) -> Decoded<PushEnvelope.ErroredPledge> {
     return curry(PushEnvelope.ErroredPledge.init)
       <^> json <| "project_id"
   }
 }
 
-extension PushEnvelope.Message: Argo.Decodable {
+extension PushEnvelope.Message: Decodable {
   public static func decode(_ json: JSON) -> Decoded<PushEnvelope.Message> {
     return curry(PushEnvelope.Message.init)
       <^> json <| "message_thread_id"
@@ -106,7 +105,7 @@ extension PushEnvelope.Message: Argo.Decodable {
   }
 }
 
-extension PushEnvelope.Project: Argo.Decodable {
+extension PushEnvelope.Project: Decodable {
   public static func decode(_ json: JSON) -> Decoded<PushEnvelope.Project> {
     return curry(PushEnvelope.Project.init)
       <^> json <| "id"
@@ -114,7 +113,7 @@ extension PushEnvelope.Project: Argo.Decodable {
   }
 }
 
-extension PushEnvelope.Survey: Argo.Decodable {
+extension PushEnvelope.Survey: Decodable {
   public static func decode(_ json: JSON) -> Decoded<PushEnvelope.Survey> {
     return curry(PushEnvelope.Survey.init)
       <^> json <| "id"
@@ -122,7 +121,7 @@ extension PushEnvelope.Survey: Argo.Decodable {
   }
 }
 
-extension PushEnvelope.Update: Argo.Decodable {
+extension PushEnvelope.Update: Decodable {
   public static func decode(_ json: JSON) -> Decoded<PushEnvelope.Update> {
     return curry(PushEnvelope.Update.init)
       <^> json <| "id"

--- a/KsApi/models/Reward.swift
+++ b/KsApi/models/Reward.swift
@@ -1,4 +1,3 @@
-import Argo
 import Curry
 import Prelude
 import Runes
@@ -81,7 +80,7 @@ public func < (lhs: Reward, rhs: Reward) -> Bool {
   return minimumAndIdComparator.isOrdered(lhs, rhs)
 }
 
-extension Reward: Argo.Decodable {
+extension Reward: Decodable {
   public static func decode(_ json: JSON) -> Decoded<Reward> {
     let tmp1 = curry(Reward.init)
       <^> json <|? "backers_count"

--- a/KsApi/models/RewardsItem.swift
+++ b/KsApi/models/RewardsItem.swift
@@ -1,4 +1,3 @@
-import Argo
 import Curry
 import Runes
 
@@ -9,7 +8,7 @@ public struct RewardsItem {
   public let rewardId: Int
 }
 
-extension RewardsItem: Argo.Decodable {
+extension RewardsItem: Decodable {
   public static func decode(_ json: JSON) -> Decoded<RewardsItem> {
     return curry(RewardsItem.init)
       <^> json <| "id"

--- a/KsApi/models/ShippingRule.swift
+++ b/KsApi/models/ShippingRule.swift
@@ -1,4 +1,3 @@
-import Argo
 import Curry
 import Runes
 
@@ -8,7 +7,7 @@ public struct ShippingRule {
   public let location: Location
 }
 
-extension ShippingRule: Argo.Decodable {
+extension ShippingRule: Decodable {
   public static func decode(_ json: JSON) -> Decoded<ShippingRule> {
     return curry(ShippingRule.init)
       <^> (json <| "cost" >>- stringToDouble)

--- a/KsApi/models/ShippingRulesEnvelope.swift
+++ b/KsApi/models/ShippingRulesEnvelope.swift
@@ -1,4 +1,3 @@
-import Argo
 import Curry
 import Runes
 
@@ -6,7 +5,7 @@ public struct ShippingRulesEnvelope {
   public let shippingRules: [ShippingRule]
 }
 
-extension ShippingRulesEnvelope: Argo.Decodable {
+extension ShippingRulesEnvelope: Decodable {
   public static func decode(_ json: JSON) -> Decoded<ShippingRulesEnvelope> {
     return curry(ShippingRulesEnvelope.init)
       <^> json <|| "shipping_rules"

--- a/KsApi/models/SignInWithAppleEnvelope.swift
+++ b/KsApi/models/SignInWithAppleEnvelope.swift
@@ -1,14 +1,14 @@
 import Foundation
 
-public struct SignInWithAppleEnvelope: Decodable {
+public struct SignInWithAppleEnvelope: Swift.Decodable {
   public var signInWithApple: SignInWithApple
 
-  public struct SignInWithApple: Decodable {
+  public struct SignInWithApple: Swift.Decodable {
     public var apiAccessToken: String
     public var user: SignInWithAppleEnvelope.User
   }
 
-  public struct User: Decodable {
+  public struct User: Swift.Decodable {
     public var uid: String
   }
 }

--- a/KsApi/models/StarEnvelope.swift
+++ b/KsApi/models/StarEnvelope.swift
@@ -1,4 +1,3 @@
-import Argo
 import Curry
 import Runes
 
@@ -7,7 +6,7 @@ public struct StarEnvelope {
   public let project: Project
 }
 
-extension StarEnvelope: Argo.Decodable {
+extension StarEnvelope: Decodable {
   public static func decode(_ json: JSON) -> Decoded<StarEnvelope> {
     return curry(StarEnvelope.init)
       <^> json <| "user"

--- a/KsApi/models/SurveyResponse.swift
+++ b/KsApi/models/SurveyResponse.swift
@@ -1,4 +1,3 @@
-import Argo
 import Curry
 import Runes
 
@@ -22,7 +21,7 @@ public func == (lhs: SurveyResponse, rhs: SurveyResponse) -> Bool {
   return lhs.id == rhs.id
 }
 
-extension SurveyResponse: Argo.Decodable {
+extension SurveyResponse: Decodable {
   public static func decode(_ json: JSON) -> Decoded<SurveyResponse> {
     return curry(SurveyResponse.init)
       <^> json <|? "answered_at"
@@ -32,14 +31,14 @@ extension SurveyResponse: Argo.Decodable {
   }
 }
 
-extension SurveyResponse.UrlsEnvelope: Argo.Decodable {
+extension SurveyResponse.UrlsEnvelope: Decodable {
   public static func decode(_ json: JSON) -> Decoded<SurveyResponse.UrlsEnvelope> {
     return curry(SurveyResponse.UrlsEnvelope.init)
       <^> json <| "web"
   }
 }
 
-extension SurveyResponse.UrlsEnvelope.WebEnvelope: Argo.Decodable {
+extension SurveyResponse.UrlsEnvelope.WebEnvelope: Decodable {
   public static func decode(_ json: JSON) -> Decoded<SurveyResponse.UrlsEnvelope.WebEnvelope> {
     return curry(SurveyResponse.UrlsEnvelope.WebEnvelope.init)
       <^> json <| "survey"

--- a/KsApi/models/Update.swift
+++ b/KsApi/models/Update.swift
@@ -1,4 +1,3 @@
-import Argo
 import Curry
 import Foundation
 import Runes
@@ -33,7 +32,7 @@ public func == (lhs: Update, rhs: Update) -> Bool {
   return lhs.id == rhs.id
 }
 
-extension Update: Argo.Decodable {
+extension Update: Decodable {
   public static func decode(_ json: JSON) -> Decoded<Update> {
     let tmp1 = curry(Update.init)
       <^> json <|? "body"
@@ -55,14 +54,14 @@ extension Update: Argo.Decodable {
   }
 }
 
-extension Update.UrlsEnvelope: Argo.Decodable {
+extension Update.UrlsEnvelope: Decodable {
   public static func decode(_ json: JSON) -> Decoded<Update.UrlsEnvelope> {
     return curry(Update.UrlsEnvelope.init)
       <^> json <| "web"
   }
 }
 
-extension Update.UrlsEnvelope.WebEnvelope: Argo.Decodable {
+extension Update.UrlsEnvelope.WebEnvelope: Decodable {
   public static func decode(_ json: JSON) -> Decoded<Update.UrlsEnvelope.WebEnvelope> {
     return curry(Update.UrlsEnvelope.WebEnvelope.init)
       <^> json <| "update"

--- a/KsApi/models/UpdateBackingEnvelope.swift
+++ b/KsApi/models/UpdateBackingEnvelope.swift
@@ -1,9 +1,9 @@
 import Foundation
 
-public struct UpdateBackingEnvelope: Decodable {
+public struct UpdateBackingEnvelope: Swift.Decodable {
   public var updateBacking: UpdateBacking
 
-  public struct UpdateBacking: Decodable {
+  public struct UpdateBacking: Swift.Decodable {
     public var checkout: Checkout
   }
 }

--- a/KsApi/models/UpdateDraft.swift
+++ b/KsApi/models/UpdateDraft.swift
@@ -1,4 +1,3 @@
-import Argo
 import Curry
 import Runes
 
@@ -61,7 +60,7 @@ public func == (lhs: UpdateDraft.Attachment, rhs: UpdateDraft.Attachment) -> Boo
   return lhs.id == rhs.id
 }
 
-extension UpdateDraft: Argo.Decodable {
+extension UpdateDraft: Decodable {
   public static func decode(_ json: JSON) -> Decoded<UpdateDraft> {
     return curry(UpdateDraft.init)
       <^> Update.decode(json)
@@ -70,7 +69,7 @@ extension UpdateDraft: Argo.Decodable {
   }
 }
 
-extension UpdateDraft.Image: Argo.Decodable {
+extension UpdateDraft.Image: Decodable {
   public static func decode(_ json: JSON) -> Decoded<UpdateDraft.Image> {
     return curry(UpdateDraft.Image.init)
       <^> json <| "id"
@@ -79,7 +78,7 @@ extension UpdateDraft.Image: Argo.Decodable {
   }
 }
 
-extension UpdateDraft.Video: Argo.Decodable {
+extension UpdateDraft.Video: Decodable {
   public static func decode(_ json: JSON) -> Decoded<UpdateDraft.Video> {
     return curry(UpdateDraft.Video.init)
       <^> json <| "id"
@@ -88,4 +87,4 @@ extension UpdateDraft.Video: Argo.Decodable {
   }
 }
 
-extension UpdateDraft.Video.Status: Argo.Decodable {}
+extension UpdateDraft.Video.Status: Decodable {}

--- a/KsApi/models/UpdatePledgeEnvelope.swift
+++ b/KsApi/models/UpdatePledgeEnvelope.swift
@@ -1,4 +1,3 @@
-import Argo
 import Curry
 import Runes
 
@@ -7,7 +6,7 @@ public struct UpdatePledgeEnvelope {
   public let status: Int
 }
 
-extension UpdatePledgeEnvelope: Argo.Decodable {
+extension UpdatePledgeEnvelope: Decodable {
   public static func decode(_ json: JSON) -> Decoded<UpdatePledgeEnvelope> {
     return curry(UpdatePledgeEnvelope.init)
       <^> json <|? ["data", "new_checkout_url"]

--- a/KsApi/models/User.swift
+++ b/KsApi/models/User.swift
@@ -1,4 +1,3 @@
-import Argo
 import Curry
 import Runes
 
@@ -107,7 +106,7 @@ extension User: CustomDebugStringConvertible {
   }
 }
 
-extension User: Argo.Decodable {
+extension User: Decodable {
   public static func decode(_ json: JSON) -> Decoded<User> {
     let tmp1 = pure(curry(User.init))
       <*> json <| "avatar"
@@ -153,7 +152,7 @@ extension User: EncodableType {
   }
 }
 
-extension User.Avatar: Argo.Decodable {
+extension User.Avatar: Decodable {
   public static func decode(_ json: JSON) -> Decoded<User.Avatar> {
     return curry(User.Avatar.init)
       <^> json <|? "large"
@@ -175,7 +174,7 @@ extension User.Avatar: EncodableType {
   }
 }
 
-extension User.NewsletterSubscriptions: Argo.Decodable {
+extension User.NewsletterSubscriptions: Decodable {
   public static func decode(_ json: JSON) -> Decoded<User.NewsletterSubscriptions> {
     return curry(User.NewsletterSubscriptions.init)
       <^> json <|? "arts_culture_newsletter"
@@ -221,7 +220,7 @@ public func == (lhs: User.NewsletterSubscriptions, rhs: User.NewsletterSubscript
     lhs.alumni == rhs.alumni
 }
 
-extension User.Notifications: Argo.Decodable {
+extension User.Notifications: Decodable {
   public static func decode(_ json: JSON) -> Decoded<User.Notifications> {
     let tmp1 = curry(User.Notifications.init)
       <^> json <|? "notify_of_backings"
@@ -291,7 +290,7 @@ public func == (lhs: User.Notifications, rhs: User.Notifications) -> Bool {
     lhs.updates == rhs.updates
 }
 
-extension User.Stats: Argo.Decodable {
+extension User.Stats: Decodable {
   public static func decode(_ json: JSON) -> Decoded<User.Stats> {
     return curry(User.Stats.init)
       <^> json <|? "backed_projects_count"

--- a/KsApi/models/VoidEnvelope.swift
+++ b/KsApi/models/VoidEnvelope.swift
@@ -1,8 +1,7 @@
-import Argo
 
 public struct VoidEnvelope {}
 
-extension VoidEnvelope: Argo.Decodable {
+extension VoidEnvelope: Decodable {
   public static func decode(_: JSON) -> Decoded<VoidEnvelope> {
     return .success(VoidEnvelope())
   }

--- a/KsApi/models/graphql/GraphMutationWatchProjectResponseEnvelope.swift
+++ b/KsApi/models/graphql/GraphMutationWatchProjectResponseEnvelope.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-public struct GraphMutationWatchProjectResponseEnvelope: Decodable {
+public struct GraphMutationWatchProjectResponseEnvelope: Swift.Decodable {
   public var watchProject: WatchProject
 
-  public struct WatchProject: Decodable {
+  public struct WatchProject: Swift.Decodable {
     public var project: Project
 
-    public struct Project: Decodable {
+    public struct Project: Swift.Decodable {
       public var id: String
       public var isWatched: Bool
     }

--- a/Library/ArgoDecoded/Alternative.swift
+++ b/Library/ArgoDecoded/Alternative.swift
@@ -1,0 +1,39 @@
+import Runes
+
+/**
+  Return the left `Decoded` value if it is `.Success`, otherwise return the
+  default value on the right.
+
+  - If the left hand side is `.Success`, this will return the argument on the
+    left hand side.
+  - If the left hand side is `.Failure`, this will return the argument on the
+    right hand side.
+
+  - parameter lhs: A value of type `Decoded<T>`
+  - parameter rhs: A value of type `Decoded<T>`
+
+  - returns: A value of type `Decoded<T>`
+*/
+public func <|> <T>(lhs: Decoded<T>, rhs: @autoclosure () -> Decoded<T>) -> Decoded<T> {
+  return lhs.or(rhs())
+}
+
+public extension Decoded {
+  /**
+    Return `self` if it is `.Success`, otherwise return the provided default
+    value.
+
+    - If `self` is `.Success`, this will return `self`.
+    - If `self` is `.Failure`, this will return the default.
+
+    - parameter other: A value of type `Decoded<T>`
+
+    - returns: A value of type `Decoded<T>`
+  */
+  func or(_ other: @autoclosure () -> Decoded<T>) -> Decoded<T> {
+    switch self {
+      case .success: return self
+      case .failure: return other()
+    }
+  }
+}

--- a/Library/ArgoDecoded/Alternative.swift
+++ b/Library/ArgoDecoded/Alternative.swift
@@ -1,39 +1,39 @@
 import Runes
 
 /**
-  Return the left `Decoded` value if it is `.Success`, otherwise return the
-  default value on the right.
+ Return the left `Decoded` value if it is `.Success`, otherwise return the
+ default value on the right.
 
-  - If the left hand side is `.Success`, this will return the argument on the
-    left hand side.
-  - If the left hand side is `.Failure`, this will return the argument on the
-    right hand side.
+ - If the left hand side is `.Success`, this will return the argument on the
+   left hand side.
+ - If the left hand side is `.Failure`, this will return the argument on the
+   right hand side.
 
-  - parameter lhs: A value of type `Decoded<T>`
-  - parameter rhs: A value of type `Decoded<T>`
+ - parameter lhs: A value of type `Decoded<T>`
+ - parameter rhs: A value of type `Decoded<T>`
 
-  - returns: A value of type `Decoded<T>`
-*/
+ - returns: A value of type `Decoded<T>`
+ */
 public func <|> <T>(lhs: Decoded<T>, rhs: @autoclosure () -> Decoded<T>) -> Decoded<T> {
   return lhs.or(rhs())
 }
 
 public extension Decoded {
   /**
-    Return `self` if it is `.Success`, otherwise return the provided default
-    value.
+   Return `self` if it is `.Success`, otherwise return the provided default
+   value.
 
-    - If `self` is `.Success`, this will return `self`.
-    - If `self` is `.Failure`, this will return the default.
+   - If `self` is `.Success`, this will return `self`.
+   - If `self` is `.Failure`, this will return the default.
 
-    - parameter other: A value of type `Decoded<T>`
+   - parameter other: A value of type `Decoded<T>`
 
-    - returns: A value of type `Decoded<T>`
-  */
+   - returns: A value of type `Decoded<T>`
+   */
   func or(_ other: @autoclosure () -> Decoded<T>) -> Decoded<T> {
     switch self {
-      case .success: return self
-      case .failure: return other()
+    case .success: return self
+    case .failure: return other()
     }
   }
 }

--- a/Library/ArgoDecoded/Applicative.swift
+++ b/Library/ArgoDecoded/Applicative.swift
@@ -1,0 +1,56 @@
+import Runes
+
+/**
+  Conditionally apply a `Decoded` function to a `Decoded` value.
+
+  - If either the function or value arguments are `.Failure`, this will return
+    `.Failure`. The function's `.Failure` takes precedence here, and will be
+    returned first. If the function is `.Success` and the value is `.Failure`,
+    then the value's `.Failure` will be returned.
+  - If both the function and value arguments are `.Success`, this will return
+    the result of the function applied to the unwrapped value.
+
+  - parameter f: A `Decoded` transformation function from type `T` to type `U`
+  - parameter x: A value of type `Decoded<T>`
+
+  - returns: A value of type `Decoded<U>`
+*/
+public func <*> <T, U>(f: Decoded<(T) -> U>, x: Decoded<T>) -> Decoded<U> {
+  return x.apply(f)
+}
+
+/**
+  Wrap a value in the minimal context of `.Success`.
+
+  - parameter x: Any value
+
+  - returns: The provided value wrapped in `.Success`
+*/
+public func pure<T>(_ x: T) -> Decoded<T> {
+  return .success(x)
+}
+
+public extension Decoded {
+  /**
+    Conditionally apply a `Decoded` function to `self`.
+
+    - If either the function or `self` are `.Failure`, this will return
+      `.Failure`. The function's `.Failure` takes precedence here, and will be
+      returned first. If the function is `.Success` and `self` is `.Failure`,
+      then `self`'s `.Failure` will be returned.
+    - If both the function and `self` are `.Success`, this will return
+      the result of the function applied to the unwrapped value.
+
+    - parameter f: A `Decoded` transformation function from type `T` to type
+      `U`
+
+    - returns: A value of type `Decoded<U>`
+  */
+  func apply<U>(_ f: Decoded<(T) -> U>) -> Decoded<U> {
+    switch (f, self) {
+    case let (.success(function), _): return self.map(function)
+    case let (.failure(le), .failure(re)): return .failure(le + re)
+    case let (.failure(f), _): return .failure(f)
+    }
+  }
+}

--- a/Library/ArgoDecoded/Applicative.swift
+++ b/Library/ArgoDecoded/Applicative.swift
@@ -1,51 +1,51 @@
 import Runes
 
 /**
-  Conditionally apply a `Decoded` function to a `Decoded` value.
+ Conditionally apply a `Decoded` function to a `Decoded` value.
 
-  - If either the function or value arguments are `.Failure`, this will return
-    `.Failure`. The function's `.Failure` takes precedence here, and will be
-    returned first. If the function is `.Success` and the value is `.Failure`,
-    then the value's `.Failure` will be returned.
-  - If both the function and value arguments are `.Success`, this will return
-    the result of the function applied to the unwrapped value.
+ - If either the function or value arguments are `.Failure`, this will return
+   `.Failure`. The function's `.Failure` takes precedence here, and will be
+   returned first. If the function is `.Success` and the value is `.Failure`,
+   then the value's `.Failure` will be returned.
+ - If both the function and value arguments are `.Success`, this will return
+   the result of the function applied to the unwrapped value.
 
-  - parameter f: A `Decoded` transformation function from type `T` to type `U`
-  - parameter x: A value of type `Decoded<T>`
+ - parameter f: A `Decoded` transformation function from type `T` to type `U`
+ - parameter x: A value of type `Decoded<T>`
 
-  - returns: A value of type `Decoded<U>`
-*/
+ - returns: A value of type `Decoded<U>`
+ */
 public func <*> <T, U>(f: Decoded<(T) -> U>, x: Decoded<T>) -> Decoded<U> {
   return x.apply(f)
 }
 
 /**
-  Wrap a value in the minimal context of `.Success`.
+ Wrap a value in the minimal context of `.Success`.
 
-  - parameter x: Any value
+ - parameter x: Any value
 
-  - returns: The provided value wrapped in `.Success`
-*/
+ - returns: The provided value wrapped in `.Success`
+ */
 public func pure<T>(_ x: T) -> Decoded<T> {
   return .success(x)
 }
 
 public extension Decoded {
   /**
-    Conditionally apply a `Decoded` function to `self`.
+   Conditionally apply a `Decoded` function to `self`.
 
-    - If either the function or `self` are `.Failure`, this will return
-      `.Failure`. The function's `.Failure` takes precedence here, and will be
-      returned first. If the function is `.Success` and `self` is `.Failure`,
-      then `self`'s `.Failure` will be returned.
-    - If both the function and `self` are `.Success`, this will return
-      the result of the function applied to the unwrapped value.
+   - If either the function or `self` are `.Failure`, this will return
+     `.Failure`. The function's `.Failure` takes precedence here, and will be
+     returned first. If the function is `.Success` and `self` is `.Failure`,
+     then `self`'s `.Failure` will be returned.
+   - If both the function and `self` are `.Success`, this will return
+     the result of the function applied to the unwrapped value.
 
-    - parameter f: A `Decoded` transformation function from type `T` to type
-      `U`
+   - parameter f: A `Decoded` transformation function from type `T` to type
+     `U`
 
-    - returns: A value of type `Decoded<U>`
-  */
+   - returns: A value of type `Decoded<U>`
+   */
   func apply<U>(_ f: Decoded<(T) -> U>) -> Decoded<U> {
     switch (f, self) {
     case let (.success(function), _): return self.map(function)

--- a/Library/ArgoDecoded/Argo.swift
+++ b/Library/ArgoDecoded/Argo.swift
@@ -1,0 +1,12 @@
+import Runes
+
+precedencegroup ArgoDecodePrecedence {
+  associativity: left
+  higherThan: RunesApplicativeSequencePrecedence
+  lowerThan: NilCoalescingPrecedence
+}
+
+infix operator <| : ArgoDecodePrecedence
+infix operator <|? : ArgoDecodePrecedence
+infix operator <|| : ArgoDecodePrecedence
+infix operator <||? : ArgoDecodePrecedence

--- a/Library/ArgoDecoded/Argo.swift
+++ b/Library/ArgoDecoded/Argo.swift
@@ -6,7 +6,7 @@ precedencegroup ArgoDecodePrecedence {
   lowerThan: NilCoalescingPrecedence
 }
 
-infix operator <| : ArgoDecodePrecedence
-infix operator <|? : ArgoDecodePrecedence
-infix operator <|| : ArgoDecodePrecedence
-infix operator <||? : ArgoDecodePrecedence
+infix operator <|: ArgoDecodePrecedence
+infix operator <|?: ArgoDecodePrecedence
+infix operator <||: ArgoDecodePrecedence
+infix operator <||?: ArgoDecodePrecedence

--- a/Library/ArgoDecoded/ArgoDecodable.swift
+++ b/Library/ArgoDecoded/ArgoDecodable.swift
@@ -1,0 +1,34 @@
+public protocol Decodable {
+  /**
+    The type of object that will be decoded.
+
+    In order to work with the rest of Argo, this needs to be the same as `Self`.
+
+    You will only need to worry about this if the object conforming to
+    `Decodable` is a reference type (i.e. a `class`), and one of the following
+    is true:
+
+     - Your type is not marked as `final`
+     - Your `decode` function is not marked as either `final` or `static`
+
+    In that case, you will need to explicitly set `DecodedType` to the type you
+    are returning in order for the compiler to be able to guarantee that this
+    protocol is being fully conformed to.
+
+    We expect the need for this typealias to be removed in a later version of Swift.
+  */
+  associatedtype DecodedType = Self
+
+  /**
+    Decode an object from JSON.
+
+    This is the main entry point for Argo. This function declares how the
+    conforming type should be decoded from JSON. Since this is a failable
+    operation, we need to return a `Decoded` type from this function.
+
+    - parameter json: The `JSON` representation of this object
+
+    - returns: A decoded instance of the `DecodedType`
+  */
+  static func decode(_ json: JSON) -> Decoded<DecodedType>
+}

--- a/Library/ArgoDecoded/ArgoDecodable.swift
+++ b/Library/ArgoDecoded/ArgoDecodable.swift
@@ -1,34 +1,34 @@
 public protocol Decodable {
   /**
-    The type of object that will be decoded.
+   The type of object that will be decoded.
 
-    In order to work with the rest of Argo, this needs to be the same as `Self`.
+   In order to work with the rest of Argo, this needs to be the same as `Self`.
 
-    You will only need to worry about this if the object conforming to
-    `Decodable` is a reference type (i.e. a `class`), and one of the following
-    is true:
+   You will only need to worry about this if the object conforming to
+   `Decodable` is a reference type (i.e. a `class`), and one of the following
+   is true:
 
-     - Your type is not marked as `final`
-     - Your `decode` function is not marked as either `final` or `static`
+    - Your type is not marked as `final`
+    - Your `decode` function is not marked as either `final` or `static`
 
-    In that case, you will need to explicitly set `DecodedType` to the type you
-    are returning in order for the compiler to be able to guarantee that this
-    protocol is being fully conformed to.
+   In that case, you will need to explicitly set `DecodedType` to the type you
+   are returning in order for the compiler to be able to guarantee that this
+   protocol is being fully conformed to.
 
-    We expect the need for this typealias to be removed in a later version of Swift.
-  */
+   We expect the need for this typealias to be removed in a later version of Swift.
+   */
   associatedtype DecodedType = Self
 
   /**
-    Decode an object from JSON.
+   Decode an object from JSON.
 
-    This is the main entry point for Argo. This function declares how the
-    conforming type should be decoded from JSON. Since this is a failable
-    operation, we need to return a `Decoded` type from this function.
+   This is the main entry point for Argo. This function declares how the
+   conforming type should be decoded from JSON. Since this is a failable
+   operation, we need to return a `Decoded` type from this function.
 
-    - parameter json: The `JSON` representation of this object
+   - parameter json: The `JSON` representation of this object
 
-    - returns: A decoded instance of the `DecodedType`
-  */
+   - returns: A decoded instance of the `DecodedType`
+   */
   static func decode(_ json: JSON) -> Decoded<DecodedType>
 }

--- a/Library/ArgoDecoded/DecodeError.swift
+++ b/Library/ArgoDecoded/DecodeError.swift
@@ -1,0 +1,67 @@
+/// Possible decoding failure reasons.
+public enum DecodeError: Error {
+  /// The type existing at the key didn't match the type being requested.
+  case typeMismatch(expected: String, actual: String)
+
+  /// The key did not exist in the JSON.
+  case missingKey(String)
+
+  /// A custom error case for adding explicit failure info.
+  case custom(String)
+
+  /// There were multiple errors in the JSON.
+  case multiple([DecodeError])
+}
+
+extension DecodeError: CustomStringConvertible {
+  public var description: String {
+    switch self {
+    case let .typeMismatch(expected, actual): return "TypeMismatch(Expected \(expected), got \(actual))"
+    case let .missingKey(s): return "MissingKey(\(s))"
+    case let .custom(s): return "Custom(\(s))"
+    case let .multiple(es): return "Multiple(\(es.map { $0.description }.joined(separator: ", ")))"
+    }
+  }
+}
+
+extension DecodeError: Hashable {
+  public var hashValue: Int {
+    switch self {
+    case let .typeMismatch(expected: expected, actual: actual):
+      return expected.hashValue ^ actual.hashValue
+    case let .missingKey(string):
+      return string.hashValue
+    case let .custom(string):
+      return string.hashValue
+    case let .multiple(es):
+      return es.reduce(0) { $0 ^ $1.hashValue }
+    }
+  }
+}
+
+public func == (lhs: DecodeError, rhs: DecodeError) -> Bool {
+  switch (lhs, rhs) {
+  case let (.typeMismatch(expected: expected1, actual: actual1), .typeMismatch(expected: expected2, actual: actual2)):
+    return expected1 == expected2 && actual1 == actual2
+
+  case let (.missingKey(string1), .missingKey(string2)):
+    return string1 == string2
+
+  case let (.custom(string1), .custom(string2)):
+    return string1 == string2
+
+  case let (.multiple(lhs), .multiple(rhs)):
+    return lhs == rhs
+
+  default:
+    return false
+  }
+}
+
+public func + (lhs: DecodeError, rhs: DecodeError) -> DecodeError {
+  switch (lhs, rhs) {
+  case let (.multiple(es), e): return .multiple(es + [e])
+  case let (e, .multiple(es)): return .multiple([e] + es)
+  case let (le, re): return .multiple([le, re])
+  }
+}

--- a/Library/ArgoDecoded/DecodeError.swift
+++ b/Library/ArgoDecoded/DecodeError.swift
@@ -41,7 +41,10 @@ extension DecodeError: Hashable {
 
 public func == (lhs: DecodeError, rhs: DecodeError) -> Bool {
   switch (lhs, rhs) {
-  case let (.typeMismatch(expected: expected1, actual: actual1), .typeMismatch(expected: expected2, actual: actual2)):
+  case let (
+    .typeMismatch(expected: expected1, actual: actual1),
+    .typeMismatch(expected: expected2, actual: actual2)
+  ):
     return expected1 == expected2 && actual1 == actual2
 
   case let (.missingKey(string1), .missingKey(string2)):

--- a/Library/ArgoDecoded/DecodeOperators.swift
+++ b/Library/ArgoDecoded/DecodeOperators.swift
@@ -1,0 +1,158 @@
+import Runes
+
+/**
+  Attempt to decode a value at the specified key into the requested type.
+
+  This operator is used to decode a mandatory value from the `JSON`. If the
+  decoding fails for any reason, this will result in a `.Failure` being
+  returned.
+
+  - parameter json: The `JSON` object containing the key
+  - parameter key: The key for the object to decode
+
+  - returns: A `Decoded` value representing the success or failure of the
+             decode operation
+*/
+public func <| <A: Decodable>(json: JSON, key: String) -> Decoded<A> where A == A.DecodedType {
+  return json <| [key]
+}
+
+/**
+  Attempt to decode an optional value at the specified key into the requested
+  type.
+
+  This operator is used to decode an optional value from the `JSON`. If the key
+  isn't present in the `JSON`, this will still return `.Success`. However, if
+  the key exists but the object assigned to that key is unable to be decoded
+  into the requested type, this will return `.Failure`.
+
+  - parameter json: The `JSON` object containing the key
+  - parameter key: The key for the object to decode
+
+  - returns: A `Decoded` optional value representing the success or failure of
+             the decode operation
+*/
+public func <|? <A: Decodable>(json: JSON, key: String) -> Decoded<A?> where A == A.DecodedType {
+  return json <|? [key]
+}
+
+/**
+  Attempt to decode a value at the specified key path into the requested type.
+
+  This operator is used to decode a mandatory value from the `JSON`. If the
+  decoding fails for any reason, this will result in a `.Failure` being
+  returned.
+
+  - parameter json: The `JSON` object containing the key
+  - parameter keys: The key path for the object to decode, represented by an
+                    array of strings
+
+  - returns: A `Decoded` value representing the success or failure of the
+             decode operation
+*/
+public func <| <A: Decodable>(json: JSON, keys: [String]) -> Decoded<A> where A == A.DecodedType {
+  return flatReduce(keys, initial: json, combine: decodedJSON) >>- A.decode
+}
+
+/**
+  Attempt to decode an optional value at the specified key path into the
+  requested type.
+
+  This operator is used to decode an optional value from the `JSON`. If any of
+  the keys in the key path aren't present in the `JSON`, this will still return
+  `.Success`. However, if the key path exists but the object assigned to the
+  final key is unable to be decoded into the requested type, this will return
+  `.Failure`.
+
+  - parameter json: The `JSON` object containing the key
+  - parameter keys: The key path for the object to decode, represented by an
+                    array of strings
+  - returns: A `Decoded` optional value representing the success or failure of
+             the decode operation
+*/
+public func <|? <A: Decodable>(json: JSON, keys: [String]) -> Decoded<A?> where A == A.DecodedType {
+  switch flatReduce(keys, initial: json, combine: decodedJSON) {
+  case .failure: return .success(.none)
+  case .success(let x): return A.decode(x) >>- { .success(.some($0)) }
+  }
+}
+
+/**
+  Attempt to decode an array of values at the specified key into the requested
+  type.
+
+  This operator is used to decode a mandatory array of values from the `JSON`.
+  If the decoding of any of the objects fail for any reason, this will result
+  in a `.Failure` being returned.
+
+  - parameter json: The `JSON` object containing the key
+  - parameter key: The key for the array of objects to decode
+
+  - returns: A `Decoded` array of values representing the success or failure of
+             the decode operation
+*/
+public func <|| <A: Decodable>(json: JSON, key: String) -> Decoded<[A]> where A == A.DecodedType {
+  return json <|| [key]
+}
+
+/**
+  Attempt to decode an optional array of values at the specified key into the
+  requested type.
+
+  This operator is used to decode an optional array of values from the `JSON`.
+  If the key isn't present in the `JSON`, this will still return `.Success`.
+  However, if the key exists but the objects assigned to that key are unable to
+  be decoded into the requested type, this will return `.Failure`.
+
+  - parameter json: The `JSON` object containing the key
+  - parameter key: The key for the object to decode
+
+  - returns: A `Decoded` optional array of values representing the success or
+             failure of the decode operation
+*/
+public func <||? <A: Decodable>(json: JSON, key: String) -> Decoded<[A]?> where A == A.DecodedType {
+  return json <||? [key]
+}
+
+/**
+  Attempt to decode an array of values at the specified key path into the
+  requested type.
+
+  This operator is used to decode a mandatory array of values from the `JSON`.
+  If the decoding fails for any reason, this will result in a `.Failure` being
+  returned.
+
+  - parameter json: The `JSON` object containing the key
+  - parameter keys: The key path for the object to decode, represented by an
+                    array of strings
+
+  - returns: A `Decoded` array of values representing the success or failure of
+             the decode operation
+*/
+public func <|| <A: Decodable>(json: JSON, keys: [String]) -> Decoded<[A]> where A == A.DecodedType {
+  return flatReduce(keys, initial: json, combine: decodedJSON) >>- Array<A>.decode
+}
+
+/**
+  Attempt to decode an optional array of values at the specified key path into
+  the requested type.
+
+  This operator is used to decode an optional array of values from the `JSON`.
+  If any of the keys in the key path aren't present in the `JSON`, this will
+  still return `.Success`. However, if the key path exists but the objects
+  assigned to the final key are unable to be decoded into the requested type,
+  this will return `.Failure`.
+
+  - parameter json: The `JSON` object containing the key
+  - parameter keys: The key path for the object to decode, represented by an
+                    array of strings
+
+  - returns: A `Decoded` optional array of values representing the success or
+             failure of the decode operation
+*/
+public func <||? <A: Decodable>(json: JSON, keys: [String]) -> Decoded<[A]?> where A == A.DecodedType {
+  switch flatReduce(keys, initial: json, combine: decodedJSON) {
+  case .failure: return .success(.none)
+  case .success(let value): return Array<A>.decode(value) >>- { .success(.some($0)) }
+  }
+}

--- a/Library/ArgoDecoded/DecodeOperators.swift
+++ b/Library/ArgoDecoded/DecodeOperators.swift
@@ -1,158 +1,158 @@
 import Runes
 
 /**
-  Attempt to decode a value at the specified key into the requested type.
+ Attempt to decode a value at the specified key into the requested type.
 
-  This operator is used to decode a mandatory value from the `JSON`. If the
-  decoding fails for any reason, this will result in a `.Failure` being
-  returned.
+ This operator is used to decode a mandatory value from the `JSON`. If the
+ decoding fails for any reason, this will result in a `.Failure` being
+ returned.
 
-  - parameter json: The `JSON` object containing the key
-  - parameter key: The key for the object to decode
+ - parameter json: The `JSON` object containing the key
+ - parameter key: The key for the object to decode
 
-  - returns: A `Decoded` value representing the success or failure of the
-             decode operation
-*/
+ - returns: A `Decoded` value representing the success or failure of the
+            decode operation
+ */
 public func <| <A: Decodable>(json: JSON, key: String) -> Decoded<A> where A == A.DecodedType {
   return json <| [key]
 }
 
 /**
-  Attempt to decode an optional value at the specified key into the requested
-  type.
+ Attempt to decode an optional value at the specified key into the requested
+ type.
 
-  This operator is used to decode an optional value from the `JSON`. If the key
-  isn't present in the `JSON`, this will still return `.Success`. However, if
-  the key exists but the object assigned to that key is unable to be decoded
-  into the requested type, this will return `.Failure`.
+ This operator is used to decode an optional value from the `JSON`. If the key
+ isn't present in the `JSON`, this will still return `.Success`. However, if
+ the key exists but the object assigned to that key is unable to be decoded
+ into the requested type, this will return `.Failure`.
 
-  - parameter json: The `JSON` object containing the key
-  - parameter key: The key for the object to decode
+ - parameter json: The `JSON` object containing the key
+ - parameter key: The key for the object to decode
 
-  - returns: A `Decoded` optional value representing the success or failure of
-             the decode operation
-*/
+ - returns: A `Decoded` optional value representing the success or failure of
+            the decode operation
+ */
 public func <|? <A: Decodable>(json: JSON, key: String) -> Decoded<A?> where A == A.DecodedType {
   return json <|? [key]
 }
 
 /**
-  Attempt to decode a value at the specified key path into the requested type.
+ Attempt to decode a value at the specified key path into the requested type.
 
-  This operator is used to decode a mandatory value from the `JSON`. If the
-  decoding fails for any reason, this will result in a `.Failure` being
-  returned.
+ This operator is used to decode a mandatory value from the `JSON`. If the
+ decoding fails for any reason, this will result in a `.Failure` being
+ returned.
 
-  - parameter json: The `JSON` object containing the key
-  - parameter keys: The key path for the object to decode, represented by an
-                    array of strings
+ - parameter json: The `JSON` object containing the key
+ - parameter keys: The key path for the object to decode, represented by an
+                   array of strings
 
-  - returns: A `Decoded` value representing the success or failure of the
-             decode operation
-*/
+ - returns: A `Decoded` value representing the success or failure of the
+            decode operation
+ */
 public func <| <A: Decodable>(json: JSON, keys: [String]) -> Decoded<A> where A == A.DecodedType {
   return flatReduce(keys, initial: json, combine: decodedJSON) >>- A.decode
 }
 
 /**
-  Attempt to decode an optional value at the specified key path into the
-  requested type.
+ Attempt to decode an optional value at the specified key path into the
+ requested type.
 
-  This operator is used to decode an optional value from the `JSON`. If any of
-  the keys in the key path aren't present in the `JSON`, this will still return
-  `.Success`. However, if the key path exists but the object assigned to the
-  final key is unable to be decoded into the requested type, this will return
-  `.Failure`.
+ This operator is used to decode an optional value from the `JSON`. If any of
+ the keys in the key path aren't present in the `JSON`, this will still return
+ `.Success`. However, if the key path exists but the object assigned to the
+ final key is unable to be decoded into the requested type, this will return
+ `.Failure`.
 
-  - parameter json: The `JSON` object containing the key
-  - parameter keys: The key path for the object to decode, represented by an
-                    array of strings
-  - returns: A `Decoded` optional value representing the success or failure of
-             the decode operation
-*/
+ - parameter json: The `JSON` object containing the key
+ - parameter keys: The key path for the object to decode, represented by an
+                   array of strings
+ - returns: A `Decoded` optional value representing the success or failure of
+            the decode operation
+ */
 public func <|? <A: Decodable>(json: JSON, keys: [String]) -> Decoded<A?> where A == A.DecodedType {
   switch flatReduce(keys, initial: json, combine: decodedJSON) {
   case .failure: return .success(.none)
-  case .success(let x): return A.decode(x) >>- { .success(.some($0)) }
+  case let .success(x): return A.decode(x) >>- { .success(.some($0)) }
   }
 }
 
 /**
-  Attempt to decode an array of values at the specified key into the requested
-  type.
+ Attempt to decode an array of values at the specified key into the requested
+ type.
 
-  This operator is used to decode a mandatory array of values from the `JSON`.
-  If the decoding of any of the objects fail for any reason, this will result
-  in a `.Failure` being returned.
+ This operator is used to decode a mandatory array of values from the `JSON`.
+ If the decoding of any of the objects fail for any reason, this will result
+ in a `.Failure` being returned.
 
-  - parameter json: The `JSON` object containing the key
-  - parameter key: The key for the array of objects to decode
+ - parameter json: The `JSON` object containing the key
+ - parameter key: The key for the array of objects to decode
 
-  - returns: A `Decoded` array of values representing the success or failure of
-             the decode operation
-*/
+ - returns: A `Decoded` array of values representing the success or failure of
+            the decode operation
+ */
 public func <|| <A: Decodable>(json: JSON, key: String) -> Decoded<[A]> where A == A.DecodedType {
   return json <|| [key]
 }
 
 /**
-  Attempt to decode an optional array of values at the specified key into the
-  requested type.
+ Attempt to decode an optional array of values at the specified key into the
+ requested type.
 
-  This operator is used to decode an optional array of values from the `JSON`.
-  If the key isn't present in the `JSON`, this will still return `.Success`.
-  However, if the key exists but the objects assigned to that key are unable to
-  be decoded into the requested type, this will return `.Failure`.
+ This operator is used to decode an optional array of values from the `JSON`.
+ If the key isn't present in the `JSON`, this will still return `.Success`.
+ However, if the key exists but the objects assigned to that key are unable to
+ be decoded into the requested type, this will return `.Failure`.
 
-  - parameter json: The `JSON` object containing the key
-  - parameter key: The key for the object to decode
+ - parameter json: The `JSON` object containing the key
+ - parameter key: The key for the object to decode
 
-  - returns: A `Decoded` optional array of values representing the success or
-             failure of the decode operation
-*/
+ - returns: A `Decoded` optional array of values representing the success or
+            failure of the decode operation
+ */
 public func <||? <A: Decodable>(json: JSON, key: String) -> Decoded<[A]?> where A == A.DecodedType {
   return json <||? [key]
 }
 
 /**
-  Attempt to decode an array of values at the specified key path into the
-  requested type.
+ Attempt to decode an array of values at the specified key path into the
+ requested type.
 
-  This operator is used to decode a mandatory array of values from the `JSON`.
-  If the decoding fails for any reason, this will result in a `.Failure` being
-  returned.
+ This operator is used to decode a mandatory array of values from the `JSON`.
+ If the decoding fails for any reason, this will result in a `.Failure` being
+ returned.
 
-  - parameter json: The `JSON` object containing the key
-  - parameter keys: The key path for the object to decode, represented by an
-                    array of strings
+ - parameter json: The `JSON` object containing the key
+ - parameter keys: The key path for the object to decode, represented by an
+                   array of strings
 
-  - returns: A `Decoded` array of values representing the success or failure of
-             the decode operation
-*/
+ - returns: A `Decoded` array of values representing the success or failure of
+            the decode operation
+ */
 public func <|| <A: Decodable>(json: JSON, keys: [String]) -> Decoded<[A]> where A == A.DecodedType {
   return flatReduce(keys, initial: json, combine: decodedJSON) >>- Array<A>.decode
 }
 
 /**
-  Attempt to decode an optional array of values at the specified key path into
-  the requested type.
+ Attempt to decode an optional array of values at the specified key path into
+ the requested type.
 
-  This operator is used to decode an optional array of values from the `JSON`.
-  If any of the keys in the key path aren't present in the `JSON`, this will
-  still return `.Success`. However, if the key path exists but the objects
-  assigned to the final key are unable to be decoded into the requested type,
-  this will return `.Failure`.
+ This operator is used to decode an optional array of values from the `JSON`.
+ If any of the keys in the key path aren't present in the `JSON`, this will
+ still return `.Success`. However, if the key path exists but the objects
+ assigned to the final key are unable to be decoded into the requested type,
+ this will return `.Failure`.
 
-  - parameter json: The `JSON` object containing the key
-  - parameter keys: The key path for the object to decode, represented by an
-                    array of strings
+ - parameter json: The `JSON` object containing the key
+ - parameter keys: The key path for the object to decode, represented by an
+                   array of strings
 
-  - returns: A `Decoded` optional array of values representing the success or
-             failure of the decode operation
-*/
+ - returns: A `Decoded` optional array of values representing the success or
+            failure of the decode operation
+ */
 public func <||? <A: Decodable>(json: JSON, keys: [String]) -> Decoded<[A]?> where A == A.DecodedType {
   switch flatReduce(keys, initial: json, combine: decodedJSON) {
   case .failure: return .success(.none)
-  case .success(let value): return Array<A>.decode(value) >>- { .success(.some($0)) }
+  case let .success(value): return Array<A>.decode(value) >>- { .success(.some($0)) }
   }
 }

--- a/Library/ArgoDecoded/Decoded.swift
+++ b/Library/ArgoDecoded/Decoded.swift
@@ -1,0 +1,162 @@
+/// The result of a failable decoding operation.
+public enum Decoded<T> {
+  case success(T)
+  case failure(DecodeError)
+}
+
+public extension Decoded {
+  /**
+    Get the unwrapped value as an `Optional`.
+
+    - returns: The unwrapped value if it exists, otherwise `.None`
+  */
+  var value: T? {
+    switch self {
+    case let .success(value): return value
+    case .failure: return .none
+    }
+  }
+
+  /**
+    Get the error value as an `Optional`.
+
+    - returns: The unwrapped error if it exists, otherwise `.None`
+  */
+  var error: DecodeError? {
+    switch self {
+    case .success: return .none
+    case let .failure(error): return error
+    }
+  }
+}
+
+public extension Decoded {
+  /**
+    Convert a `Decoded` type into a `Decoded` `Optional` type.
+
+    This is useful for when a decode operation should be allowed to fail, such
+    as when decoding an optional property.
+
+    - parameter x: A `Decoded` type
+
+    - returns: The `Decoded` type with any failure converted to `.success(.none)`
+  */
+  static func optional<T>(_ x: Decoded<T>) -> Decoded<T?> {
+    return .success(x.value)
+  }
+
+  /**
+    Convert an `Optional` into a `Decoded` value.
+
+    If the provided optional is `.Some`, this method extracts the value and
+    wraps it in `.Success`. Otherwise, it returns a `.TypeMismatch` error.
+
+    - returns: The provided `Optional` value transformed into a `Decoded` value
+  */
+  static func fromOptional<T>(_ x: T?) -> Decoded<T> {
+    switch x {
+    case let .some(value): return .success(value)
+    case .none: return .typeMismatch(expected: ".Some(\(T.self))", actual: ".None")
+    }
+  }
+}
+
+public extension Decoded {
+  /**
+    Convenience function for creating `.TypeMismatch` errors.
+
+    - parameter expected: A string describing the expected type
+    - parameter actual: A string describing the actual type
+
+    - returns: A `Decoded.Failure` with a `.TypeMismatch` error constructed
+               from the provided `expected` and `actual` values
+  */
+  static func typeMismatch<T, U>(expected: String, actual: U) -> Decoded<T> {
+    return .failure(.typeMismatch(expected: expected, actual: String(describing: actual)))
+  }
+
+  /**
+    Convenience function for creating `.MissingKey` errors.
+
+    - parameter name: The name of the missing key
+
+    - returns: A `Decoded.Failure` with a `.MissingKey` error constructed from
+               the provided `name` value
+  */
+  static func missingKey<T>(_ name: String) -> Decoded<T> {
+    return .failure(.missingKey(name))
+  }
+
+  /**
+    Convenience function for creating `.Custom` errors
+
+    - parameter message: The custom error message
+
+    - returns: A `Decoded.Failure` with a `.Custom` error constructed from the
+               provided `message` value
+  */
+  static func customError<T>(_ message: String) -> Decoded<T> {
+    return .failure(.custom(message))
+  }
+
+  /**
+   Convenience function for creating `.Multiple` errors
+
+   - parameter errors: The errors
+
+   - returns: A `Decoded.Failure` with a `.Multiple` error constructed from the
+   provided `errors` value
+   */
+  static func multipleErrors<T>(errors: [DecodeError]) -> Decoded<T> {
+    return .failure(.multiple(errors))
+  }
+}
+
+extension Decoded: CustomStringConvertible {
+  public var description: String {
+    switch self {
+    case let .success(value): return "Success(\(value))"
+    case let .failure(error): return "Failure(\(error))"
+    }
+  }
+}
+
+public extension Decoded {
+  /**
+    Extract the `.Success` value or throw an error.
+
+    This can be used to move from `Decoded` types into the world of `throws`.
+    If the value exists, this will return it. Otherwise, it will throw the error
+    information.
+
+    - throws: `DecodeError` if `self` is `.Failure`
+
+    - returns: The unwrapped value
+  */
+  func dematerialize() throws -> T {
+    switch self {
+    case let .success(value): return value
+    case let .failure(error): throw error
+    }
+  }
+}
+
+/**
+  Construct a `Decoded` type from a throwing function.
+
+  This can be used to move from the world of `throws` into a `Decoded` type. If
+  the function succeeds, it will wrap the returned value in a minimal context of
+  `.Success`. Otherwise, it will return a custom error with the thrown error from
+  the function.
+
+  - parameter f: A function from `Void` to `T` that can `throw` an error
+
+  - returns: A `Decoded` type representing the success or failure of the function
+*/
+public func materialize<T>(_ f: () throws -> T) -> Decoded<T> {
+  do {
+    return .success(try f())
+  } catch {
+    return .customError("\(error)")
+  }
+}

--- a/Library/ArgoDecoded/Decoded.swift
+++ b/Library/ArgoDecoded/Decoded.swift
@@ -6,10 +6,10 @@ public enum Decoded<T> {
 
 public extension Decoded {
   /**
-    Get the unwrapped value as an `Optional`.
+   Get the unwrapped value as an `Optional`.
 
-    - returns: The unwrapped value if it exists, otherwise `.None`
-  */
+   - returns: The unwrapped value if it exists, otherwise `.None`
+   */
   var value: T? {
     switch self {
     case let .success(value): return value
@@ -18,10 +18,10 @@ public extension Decoded {
   }
 
   /**
-    Get the error value as an `Optional`.
+   Get the error value as an `Optional`.
 
-    - returns: The unwrapped error if it exists, otherwise `.None`
-  */
+   - returns: The unwrapped error if it exists, otherwise `.None`
+   */
   var error: DecodeError? {
     switch self {
     case .success: return .none
@@ -32,27 +32,27 @@ public extension Decoded {
 
 public extension Decoded {
   /**
-    Convert a `Decoded` type into a `Decoded` `Optional` type.
+   Convert a `Decoded` type into a `Decoded` `Optional` type.
 
-    This is useful for when a decode operation should be allowed to fail, such
-    as when decoding an optional property.
+   This is useful for when a decode operation should be allowed to fail, such
+   as when decoding an optional property.
 
-    - parameter x: A `Decoded` type
+   - parameter x: A `Decoded` type
 
-    - returns: The `Decoded` type with any failure converted to `.success(.none)`
-  */
+   - returns: The `Decoded` type with any failure converted to `.success(.none)`
+   */
   static func optional<T>(_ x: Decoded<T>) -> Decoded<T?> {
     return .success(x.value)
   }
 
   /**
-    Convert an `Optional` into a `Decoded` value.
+   Convert an `Optional` into a `Decoded` value.
 
-    If the provided optional is `.Some`, this method extracts the value and
-    wraps it in `.Success`. Otherwise, it returns a `.TypeMismatch` error.
+   If the provided optional is `.Some`, this method extracts the value and
+   wraps it in `.Success`. Otherwise, it returns a `.TypeMismatch` error.
 
-    - returns: The provided `Optional` value transformed into a `Decoded` value
-  */
+   - returns: The provided `Optional` value transformed into a `Decoded` value
+   */
   static func fromOptional<T>(_ x: T?) -> Decoded<T> {
     switch x {
     case let .some(value): return .success(value)
@@ -63,38 +63,38 @@ public extension Decoded {
 
 public extension Decoded {
   /**
-    Convenience function for creating `.TypeMismatch` errors.
+   Convenience function for creating `.TypeMismatch` errors.
 
-    - parameter expected: A string describing the expected type
-    - parameter actual: A string describing the actual type
+   - parameter expected: A string describing the expected type
+   - parameter actual: A string describing the actual type
 
-    - returns: A `Decoded.Failure` with a `.TypeMismatch` error constructed
-               from the provided `expected` and `actual` values
-  */
+   - returns: A `Decoded.Failure` with a `.TypeMismatch` error constructed
+              from the provided `expected` and `actual` values
+   */
   static func typeMismatch<T, U>(expected: String, actual: U) -> Decoded<T> {
     return .failure(.typeMismatch(expected: expected, actual: String(describing: actual)))
   }
 
   /**
-    Convenience function for creating `.MissingKey` errors.
+   Convenience function for creating `.MissingKey` errors.
 
-    - parameter name: The name of the missing key
+   - parameter name: The name of the missing key
 
-    - returns: A `Decoded.Failure` with a `.MissingKey` error constructed from
-               the provided `name` value
-  */
+   - returns: A `Decoded.Failure` with a `.MissingKey` error constructed from
+              the provided `name` value
+   */
   static func missingKey<T>(_ name: String) -> Decoded<T> {
     return .failure(.missingKey(name))
   }
 
   /**
-    Convenience function for creating `.Custom` errors
+   Convenience function for creating `.Custom` errors
 
-    - parameter message: The custom error message
+   - parameter message: The custom error message
 
-    - returns: A `Decoded.Failure` with a `.Custom` error constructed from the
-               provided `message` value
-  */
+   - returns: A `Decoded.Failure` with a `.Custom` error constructed from the
+              provided `message` value
+   */
   static func customError<T>(_ message: String) -> Decoded<T> {
     return .failure(.custom(message))
   }
@@ -123,16 +123,16 @@ extension Decoded: CustomStringConvertible {
 
 public extension Decoded {
   /**
-    Extract the `.Success` value or throw an error.
+   Extract the `.Success` value or throw an error.
 
-    This can be used to move from `Decoded` types into the world of `throws`.
-    If the value exists, this will return it. Otherwise, it will throw the error
-    information.
+   This can be used to move from `Decoded` types into the world of `throws`.
+   If the value exists, this will return it. Otherwise, it will throw the error
+   information.
 
-    - throws: `DecodeError` if `self` is `.Failure`
+   - throws: `DecodeError` if `self` is `.Failure`
 
-    - returns: The unwrapped value
-  */
+   - returns: The unwrapped value
+   */
   func dematerialize() throws -> T {
     switch self {
     case let .success(value): return value
@@ -142,17 +142,17 @@ public extension Decoded {
 }
 
 /**
-  Construct a `Decoded` type from a throwing function.
+ Construct a `Decoded` type from a throwing function.
 
-  This can be used to move from the world of `throws` into a `Decoded` type. If
-  the function succeeds, it will wrap the returned value in a minimal context of
-  `.Success`. Otherwise, it will return a custom error with the thrown error from
-  the function.
+ This can be used to move from the world of `throws` into a `Decoded` type. If
+ the function succeeds, it will wrap the returned value in a minimal context of
+ `.Success`. Otherwise, it will return a custom error with the thrown error from
+ the function.
 
-  - parameter f: A function from `Void` to `T` that can `throw` an error
+ - parameter f: A function from `Void` to `T` that can `throw` an error
 
-  - returns: A `Decoded` type representing the success or failure of the function
-*/
+ - returns: A `Decoded` type representing the success or failure of the function
+ */
 public func materialize<T>(_ f: () throws -> T) -> Decoded<T> {
   do {
     return .success(try f())

--- a/Library/ArgoDecoded/Dictionary.swift
+++ b/Library/ArgoDecoded/Dictionary.swift
@@ -1,0 +1,27 @@
+import Runes
+
+// pure merge for Dictionaries
+func + <T, U>(lhs: [T: U], rhs: [T: U]) -> [T: U] {
+  var merged = lhs
+  for (key, val) in rhs {
+    merged[key] = val
+  }
+
+  return merged
+}
+
+extension Dictionary {
+  func map<T>(_ f: (Value) -> T) -> [Key: T] {
+    var accum = Dictionary<Key, T>(minimumCapacity: self.count)
+
+    for (key, value) in self {
+      accum[key] = f(value)
+    }
+
+    return accum
+  }
+}
+
+func <^> <T, U, V>(f: (T) -> U, x: [V: T]) -> [V: U] {
+  return x.map(f)
+}

--- a/Library/ArgoDecoded/Dictionary.swift
+++ b/Library/ArgoDecoded/Dictionary.swift
@@ -12,7 +12,7 @@ func + <T, U>(lhs: [T: U], rhs: [T: U]) -> [T: U] {
 
 extension Dictionary {
   func map<T>(_ f: (Value) -> T) -> [Key: T] {
-    var accum = Dictionary<Key, T>(minimumCapacity: self.count)
+    var accum = [Key: T](minimumCapacity: self.count)
 
     for (key, value) in self {
       accum[key] = f(value)

--- a/Library/ArgoDecoded/FailureCoalescing.swift
+++ b/Library/ArgoDecoded/FailureCoalescing.swift
@@ -1,0 +1,20 @@
+/**
+  Return the unwrapped value of the `Decoded` value on the left if it is
+  `.Success`, otherwise return the default on the right.
+
+  - If the left hand side is `.Success`, this will return the unwrapped value
+    from the left hand side argument.
+  - If the left hand side is `.Failure`, this will return the default value on
+    the right hand side.
+
+  - parameter lhs: A value of type `Decoded<T>`
+  - parameter rhs: An autoclosure returning a value of type `T`
+
+  - returns: A value of type `T`
+*/
+public func ?? <T>(lhs: Decoded<T>, rhs: @autoclosure () -> T) -> T {
+  switch lhs {
+  case let .success(x): return x
+  case .failure: return rhs()
+  }
+}

--- a/Library/ArgoDecoded/FailureCoalescing.swift
+++ b/Library/ArgoDecoded/FailureCoalescing.swift
@@ -1,17 +1,17 @@
 /**
-  Return the unwrapped value of the `Decoded` value on the left if it is
-  `.Success`, otherwise return the default on the right.
+ Return the unwrapped value of the `Decoded` value on the left if it is
+ `.Success`, otherwise return the default on the right.
 
-  - If the left hand side is `.Success`, this will return the unwrapped value
-    from the left hand side argument.
-  - If the left hand side is `.Failure`, this will return the default value on
-    the right hand side.
+ - If the left hand side is `.Success`, this will return the unwrapped value
+   from the left hand side argument.
+ - If the left hand side is `.Failure`, this will return the default value on
+   the right hand side.
 
-  - parameter lhs: A value of type `Decoded<T>`
-  - parameter rhs: An autoclosure returning a value of type `T`
+ - parameter lhs: A value of type `Decoded<T>`
+ - parameter rhs: An autoclosure returning a value of type `T`
 
-  - returns: A value of type `T`
-*/
+ - returns: A value of type `T`
+ */
 public func ?? <T>(lhs: Decoded<T>, rhs: @autoclosure () -> T) -> T {
   switch lhs {
   case let .success(x): return x

--- a/Library/ArgoDecoded/Functor.swift
+++ b/Library/ArgoDecoded/Functor.swift
@@ -1,0 +1,39 @@
+import Runes
+
+/**
+  Conditionally map a function over a `Decoded` value.
+
+  - If the value is `.Failure`, the function will not be evaluated and this
+    will return `.Failure`.
+  - If the value is `.Success`, the function will be applied to the unwrapped
+    value.
+
+  - parameter f: A transformation function from type `T` to type `U`
+  - parameter x: A value of type `Decoded<T>`
+
+  - returns: A value of type `Decoded<U>`
+*/
+public func <^> <T, U>(f: (T) -> U, x: Decoded<T>) -> Decoded<U> {
+  return x.map(f)
+}
+
+public extension Decoded {
+  /**
+    Conditionally map a function over `self`.
+
+    - If `self` is `.Failure`, the function will not be evaluated and this will
+      return `.Failure`.
+    - If `self` is `.Success`, the function will be applied to the unwrapped
+      value.
+
+    - parameter f: A transformation function from type `T` to type `U`
+
+    - returns: A value of type `Decoded<U>`
+  */
+  func map<U>(_ f: (T) -> U) -> Decoded<U> {
+    switch self {
+    case let .success(value): return .success(f(value))
+    case let .failure(error): return .failure(error)
+    }
+  }
+}

--- a/Library/ArgoDecoded/Functor.swift
+++ b/Library/ArgoDecoded/Functor.swift
@@ -1,35 +1,35 @@
 import Runes
 
 /**
-  Conditionally map a function over a `Decoded` value.
+ Conditionally map a function over a `Decoded` value.
 
-  - If the value is `.Failure`, the function will not be evaluated and this
-    will return `.Failure`.
-  - If the value is `.Success`, the function will be applied to the unwrapped
-    value.
+ - If the value is `.Failure`, the function will not be evaluated and this
+   will return `.Failure`.
+ - If the value is `.Success`, the function will be applied to the unwrapped
+   value.
 
-  - parameter f: A transformation function from type `T` to type `U`
-  - parameter x: A value of type `Decoded<T>`
+ - parameter f: A transformation function from type `T` to type `U`
+ - parameter x: A value of type `Decoded<T>`
 
-  - returns: A value of type `Decoded<U>`
-*/
+ - returns: A value of type `Decoded<U>`
+ */
 public func <^> <T, U>(f: (T) -> U, x: Decoded<T>) -> Decoded<U> {
   return x.map(f)
 }
 
 public extension Decoded {
   /**
-    Conditionally map a function over `self`.
+   Conditionally map a function over `self`.
 
-    - If `self` is `.Failure`, the function will not be evaluated and this will
-      return `.Failure`.
-    - If `self` is `.Success`, the function will be applied to the unwrapped
-      value.
+   - If `self` is `.Failure`, the function will not be evaluated and this will
+     return `.Failure`.
+   - If `self` is `.Success`, the function will be applied to the unwrapped
+     value.
 
-    - parameter f: A transformation function from type `T` to type `U`
+   - parameter f: A transformation function from type `T` to type `U`
 
-    - returns: A value of type `Decoded<U>`
-  */
+   - returns: A value of type `Decoded<U>`
+   */
   func map<U>(_ f: (T) -> U) -> Decoded<U> {
     switch self {
     case let .success(value): return .success(f(value))

--- a/Library/ArgoDecoded/JSON.swift
+++ b/Library/ArgoDecoded/JSON.swift
@@ -1,0 +1,98 @@
+import Foundation
+
+/// A type safe representation of JSON.
+public enum JSON {
+  case object([String: JSON])
+  case array([JSON])
+  case string(String)
+  case number(NSNumber)
+  case bool(Bool)
+  case null
+}
+
+public extension JSON {
+  /**
+    Transform an `Any` instance into `JSON`.
+
+    This is used to move from a loosely typed object (like those returned from
+    `NSJSONSerialization`) to the strongly typed `JSON` tree structure.
+
+    - parameter json: A loosely typed object
+  */
+  init(_ json: Any) {
+    switch json {
+
+    case let v as [Any]:
+      self = .array(v.map(JSON.init))
+
+    case let v as [String: Any]:
+      self = .object(v.map(JSON.init))
+
+    case let v as String:
+      self = .string(v)
+
+    case let v as NSNumber:
+      if v.isBool {
+        self = .bool(v.boolValue)
+      } else {
+        self = .number(v)
+      }
+
+    default:
+      self = .null
+    }
+  }
+}
+
+extension JSON: Decodable {
+  /**
+    Decode `JSON` into `Decoded<JSON>`.
+
+    This simply wraps the provided `JSON` in `.Success`. This is useful because
+    it means we can use `JSON` values with the `<|` family of operators to pull
+    out sub-keys.
+
+    - parameter json: The `JSON` value to decode
+
+    - returns: The provided `JSON` wrapped in `.Success`
+  */
+  public static func decode(_ json: JSON) -> Decoded<JSON> {
+    return pure(json)
+  }
+}
+
+extension JSON: CustomStringConvertible {
+  public var description: String {
+    switch self {
+    case let .string(v): return "String(\(v))"
+    case let .number(v): return "Number(\(v))"
+    case let .bool(v): return "Bool(\(v))"
+    case let .array(a): return "Array(\(a.description))"
+    case let .object(o): return "Object(\(o.description))"
+    case .null: return "Null"
+    }
+  }
+}
+
+extension JSON: Equatable { }
+
+public func == (lhs: JSON, rhs: JSON) -> Bool {
+  switch (lhs, rhs) {
+  case let (.string(l), .string(r)): return l == r
+  case let (.number(l), .number(r)): return l == r
+  case let (.bool(l), .bool(r)): return l == r
+  case let (.array(l), .array(r)): return l == r
+  case let (.object(l), .object(r)): return l == r
+  case (.null, .null): return true
+  default: return false
+  }
+}
+
+/// MARK: Deprecations
+
+extension JSON {
+  @available(*, deprecated: 3.0, renamed: "init")
+  static func parse(_ json: Any) -> JSON {
+    return JSON(json)
+  }
+}

--- a/Library/ArgoDecoded/JSON.swift
+++ b/Library/ArgoDecoded/JSON.swift
@@ -12,16 +12,15 @@ public enum JSON {
 
 public extension JSON {
   /**
-    Transform an `Any` instance into `JSON`.
+   Transform an `Any` instance into `JSON`.
 
-    This is used to move from a loosely typed object (like those returned from
-    `NSJSONSerialization`) to the strongly typed `JSON` tree structure.
+   This is used to move from a loosely typed object (like those returned from
+   `NSJSONSerialization`) to the strongly typed `JSON` tree structure.
 
-    - parameter json: A loosely typed object
-  */
+   - parameter json: A loosely typed object
+   */
   init(_ json: Any) {
     switch json {
-
     case let v as [Any]:
       self = .array(v.map(JSON.init))
 
@@ -46,16 +45,16 @@ public extension JSON {
 
 extension JSON: Decodable {
   /**
-    Decode `JSON` into `Decoded<JSON>`.
+   Decode `JSON` into `Decoded<JSON>`.
 
-    This simply wraps the provided `JSON` in `.Success`. This is useful because
-    it means we can use `JSON` values with the `<|` family of operators to pull
-    out sub-keys.
+   This simply wraps the provided `JSON` in `.Success`. This is useful because
+   it means we can use `JSON` values with the `<|` family of operators to pull
+   out sub-keys.
 
-    - parameter json: The `JSON` value to decode
+   - parameter json: The `JSON` value to decode
 
-    - returns: The provided `JSON` wrapped in `.Success`
-  */
+   - returns: The provided `JSON` wrapped in `.Success`
+   */
   public static func decode(_ json: JSON) -> Decoded<JSON> {
     return pure(json)
   }
@@ -74,7 +73,7 @@ extension JSON: CustomStringConvertible {
   }
 }
 
-extension JSON: Equatable { }
+extension JSON: Equatable {}
 
 public func == (lhs: JSON, rhs: JSON) -> Bool {
   switch (lhs, rhs) {
@@ -88,7 +87,7 @@ public func == (lhs: JSON, rhs: JSON) -> Bool {
   }
 }
 
-/// MARK: Deprecations
+// MARK: Deprecations
 
 extension JSON {
   @available(*, deprecated: 3.0, renamed: "init")

--- a/Library/ArgoDecoded/Monad.swift
+++ b/Library/ArgoDecoded/Monad.swift
@@ -1,0 +1,56 @@
+import Runes
+
+/**
+  Conditionally map a function over a `Decoded` value, flattening the result.
+
+  - If the value is `.Failure`, the function will not be evaluated and this
+    will return `.Failure`.
+  - If the value is `.Success`, the function will be applied to the unwrapped
+    value.
+
+  - parameter x: A value of type `Decoded<T>`
+  - parameter f: A transformation function from type `T` to type `Decoded<U>`
+
+  - returns: A value of type `Decoded<U>`
+*/
+public func >>- <T, U>(x: Decoded<T>, f: (T) -> Decoded<U>) -> Decoded<U> {
+  return x.flatMap(f)
+}
+
+/**
+  Conditionally map a function over a `Decoded` value, flattening the result.
+
+  - If the value is `.Failure`, the function will not be evaluated and this
+    will return `.Failure`.
+  - If the value is `.Success`, the function will be applied to the unwrapped
+    value.
+
+  - parameter f: A transformation function from type `T` to type `Decoded<U>`
+  - parameter x: A value of type `Decoded<T>`
+
+  - returns: A value of type `Decoded<U>`
+*/
+public func -<< <T, U>(f: (T) -> Decoded<U>, x: Decoded<T>) -> Decoded<U> {
+  return x.flatMap(f)
+}
+
+public extension Decoded {
+  /**
+    Conditionally map a function over `self`, flattening the result.
+
+    - If `self` is `.Failure`, the function will not be evaluated and this will
+      return `.Failure`.
+    - If `self` is `.Success`, the function will be applied to the unwrapped
+      value.
+
+    - parameter f: A transformation function from type `T` to type `Decoded<U>`
+
+    - returns: A value of type `Decoded<U>`
+  */
+  func flatMap<U>(_ f: (T) -> Decoded<U>) -> Decoded<U> {
+    switch self {
+    case let .success(value): return f(value)
+    case let .failure(error): return .failure(error)
+    }
+  }
+}

--- a/Library/ArgoDecoded/Monad.swift
+++ b/Library/ArgoDecoded/Monad.swift
@@ -1,52 +1,52 @@
 import Runes
 
 /**
-  Conditionally map a function over a `Decoded` value, flattening the result.
+ Conditionally map a function over a `Decoded` value, flattening the result.
 
-  - If the value is `.Failure`, the function will not be evaluated and this
-    will return `.Failure`.
-  - If the value is `.Success`, the function will be applied to the unwrapped
-    value.
+ - If the value is `.Failure`, the function will not be evaluated and this
+   will return `.Failure`.
+ - If the value is `.Success`, the function will be applied to the unwrapped
+   value.
 
-  - parameter x: A value of type `Decoded<T>`
-  - parameter f: A transformation function from type `T` to type `Decoded<U>`
+ - parameter x: A value of type `Decoded<T>`
+ - parameter f: A transformation function from type `T` to type `Decoded<U>`
 
-  - returns: A value of type `Decoded<U>`
-*/
+ - returns: A value of type `Decoded<U>`
+ */
 public func >>- <T, U>(x: Decoded<T>, f: (T) -> Decoded<U>) -> Decoded<U> {
   return x.flatMap(f)
 }
 
 /**
-  Conditionally map a function over a `Decoded` value, flattening the result.
+ Conditionally map a function over a `Decoded` value, flattening the result.
 
-  - If the value is `.Failure`, the function will not be evaluated and this
-    will return `.Failure`.
-  - If the value is `.Success`, the function will be applied to the unwrapped
-    value.
+ - If the value is `.Failure`, the function will not be evaluated and this
+   will return `.Failure`.
+ - If the value is `.Success`, the function will be applied to the unwrapped
+   value.
 
-  - parameter f: A transformation function from type `T` to type `Decoded<U>`
-  - parameter x: A value of type `Decoded<T>`
+ - parameter f: A transformation function from type `T` to type `Decoded<U>`
+ - parameter x: A value of type `Decoded<T>`
 
-  - returns: A value of type `Decoded<U>`
-*/
+ - returns: A value of type `Decoded<U>`
+ */
 public func -<< <T, U>(f: (T) -> Decoded<U>, x: Decoded<T>) -> Decoded<U> {
   return x.flatMap(f)
 }
 
 public extension Decoded {
   /**
-    Conditionally map a function over `self`, flattening the result.
+   Conditionally map a function over `self`, flattening the result.
 
-    - If `self` is `.Failure`, the function will not be evaluated and this will
-      return `.Failure`.
-    - If `self` is `.Success`, the function will be applied to the unwrapped
-      value.
+   - If `self` is `.Failure`, the function will not be evaluated and this will
+     return `.Failure`.
+   - If `self` is `.Success`, the function will be applied to the unwrapped
+     value.
 
-    - parameter f: A transformation function from type `T` to type `Decoded<U>`
+   - parameter f: A transformation function from type `T` to type `Decoded<U>`
 
-    - returns: A value of type `Decoded<U>`
-  */
+   - returns: A value of type `Decoded<U>`
+   */
   func flatMap<U>(_ f: (T) -> Decoded<U>) -> Decoded<U> {
     switch self {
     case let .success(value): return f(value)

--- a/Library/ArgoDecoded/NSNumber.swift
+++ b/Library/ArgoDecoded/NSNumber.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+extension NSNumber {
+  var isBool: Bool {
+    return type(of: self) == type(of: NSNumber(value: true))
+  }
+}

--- a/Library/ArgoDecoded/RawRepresentable.swift
+++ b/Library/ArgoDecoded/RawRepresentable.swift
@@ -1,0 +1,31 @@
+/**
+  Default implementation of `Decodable` for `RawRepresentable` types using
+  `String` as the raw value.
+*/
+public extension Decodable where Self.DecodedType == Self, Self: RawRepresentable, Self.RawValue == String {
+  static func decode(_ json: JSON) -> Decoded<Self> {
+    switch json {
+    case let .string(s):
+      return self.init(rawValue: s)
+        .map(pure) ?? .typeMismatch(expected: "rawValue for \(self)", actual: json)
+    default:
+      return .typeMismatch(expected: "String", actual: json)
+    }
+  }
+}
+
+/**
+  Default implementation of `Decodable` for `RawRepresentable` types using
+  `Int` as the raw value.
+*/
+public extension Decodable where Self.DecodedType == Self, Self: RawRepresentable, Self.RawValue == Int {
+  static func decode(_ json: JSON) -> Decoded<Self> {
+    switch json {
+    case let .number(n):
+      return self.init(rawValue: n.intValue)
+        .map(pure) ?? .typeMismatch(expected: "rawValue for \(self)", actual: json)
+    default:
+      return .typeMismatch(expected: "Int", actual: json)
+    }
+  }
+}

--- a/Library/ArgoDecoded/RawRepresentable.swift
+++ b/Library/ArgoDecoded/RawRepresentable.swift
@@ -1,7 +1,7 @@
 /**
-  Default implementation of `Decodable` for `RawRepresentable` types using
-  `String` as the raw value.
-*/
+ Default implementation of `Decodable` for `RawRepresentable` types using
+ `String` as the raw value.
+ */
 public extension Decodable where Self.DecodedType == Self, Self: RawRepresentable, Self.RawValue == String {
   static func decode(_ json: JSON) -> Decoded<Self> {
     switch json {
@@ -15,9 +15,9 @@ public extension Decodable where Self.DecodedType == Self, Self: RawRepresentabl
 }
 
 /**
-  Default implementation of `Decodable` for `RawRepresentable` types using
-  `Int` as the raw value.
-*/
+ Default implementation of `Decodable` for `RawRepresentable` types using
+ `Int` as the raw value.
+ */
 public extension Decodable where Self.DecodedType == Self, Self: RawRepresentable, Self.RawValue == Int {
   static func decode(_ json: JSON) -> Decoded<Self> {
     switch json {

--- a/Library/ArgoDecoded/StandardTypes.swift
+++ b/Library/ArgoDecoded/StandardTypes.swift
@@ -1,0 +1,309 @@
+import Foundation
+import Runes
+
+extension String: Decodable {
+  /**
+    Decode `JSON` into `Decoded<String>`.
+
+    Succeeds if the value is a string, otherwise it returns a type mismatch.
+
+    - parameter json: The `JSON` value to decode
+
+    - returns: A decoded `String` value
+  */
+  public static func decode(_ json: JSON) -> Decoded<String> {
+    switch json {
+    case let .string(s): return pure(s)
+    default: return .typeMismatch(expected: "String", actual: json)
+    }
+  }
+}
+
+extension Int: Decodable {
+  /**
+    Decode `JSON` into `Decoded<Int>`.
+
+    Succeeds if the value is a number that can be converted to an `Int`,
+    otherwise it returns a type mismatch.
+
+    - parameter json: The `JSON` value to decode
+
+    - returns: A decoded `Int` value
+  */
+  public static func decode(_ json: JSON) -> Decoded<Int> {
+    switch json {
+    case let .number(n): return pure(n.intValue)
+    default: return .typeMismatch(expected: "Int", actual: json)
+    }
+  }
+}
+
+extension UInt: Decodable {
+  /**
+    Decode `JSON` into `Decoded<UInt>`.
+
+    Succeeds if the value is a number that can be converted to a `UInt`,
+    otherwise it returns a type mismatch.
+
+    - parameter json: The `JSON` value to decode
+
+    - returns: A decoded `UInt` value
+  */
+  public static func decode(_ json: JSON) -> Decoded<UInt> {
+    switch json {
+    case let .number(n): return pure(n.uintValue)
+    default: return .typeMismatch(expected: "UInt", actual: json)
+    }
+  }
+}
+
+extension Int64: Decodable {
+  /**
+    Decode `JSON` into `Decoded<Int64>`.
+
+    Succeeds if the value is a number that can be converted to an `Int64` or a
+    string that represents a large number, otherwise it returns a type
+    mismatch.
+
+    - parameter json: The `JSON` value to decode
+
+    - returns: A decoded `Int64` value
+  */
+  public static func decode(_ json: JSON) -> Decoded<Int64> {
+    switch json {
+    case let .number(n): return pure(n.int64Value)
+    case let .string(s):
+      guard let i = Int64(s) else { fallthrough }
+      return pure(i)
+    default: return .typeMismatch(expected: "Int64", actual: json)
+    }
+  }
+}
+
+extension UInt64: Decodable {
+  /**
+    Decode `JSON` into `Decoded<UInt64>`.
+
+    Succeeds if the value is a number that can be converted to an `UInt64` or a
+    string that represents a large number, otherwise it returns a type
+    mismatch.
+
+    - parameter json: The `JSON` value to decode
+
+    - returns: A decoded `UInt` value
+  */
+  public static func decode(_ json: JSON) -> Decoded<UInt64> {
+    switch json {
+    case let .number(n): return pure(n.uint64Value)
+    case let .string(s):
+      guard let i = UInt64(s) else { fallthrough }
+      return pure(i)
+    default: return .typeMismatch(expected: "UInt64", actual: json)
+    }
+  }
+}
+
+extension Double: Decodable {
+  /**
+    Decode `JSON` into `Decoded<Double>`.
+
+    Succeeds if the value is a number that can be converted to a `Double`,
+    otherwise it returns a type mismatch.
+
+    - parameter json: The `JSON` value to decode
+
+    - returns: A decoded `Double` value
+  */
+  public static func decode(_ json: JSON) -> Decoded<Double> {
+    switch json {
+    case let .number(n): return pure(n.doubleValue)
+    default: return .typeMismatch(expected: "Double", actual: json)
+    }
+  }
+}
+
+extension Float: Decodable {
+  /**
+    Decode `JSON` into `Decoded<Float>`.
+
+    Succeeds if the value is a number that can be converted to a `Float`,
+    otherwise it returns a type mismatch.
+
+    - parameter json: The `JSON` value to decode
+
+    - returns: A decoded `Float` value
+  */
+  public static func decode(_ json: JSON) -> Decoded<Float> {
+    switch json {
+    case let .number(n): return pure(n.floatValue)
+    default: return .typeMismatch(expected: "Float", actual: json)
+    }
+  }
+}
+
+extension Bool: Decodable {
+  /**
+    Decode `JSON` into `Decoded<Bool>`.
+
+    Succeeds if the value is a boolean or if the value is a number that is able
+    to be converted to a boolean, otherwise it returns a type mismatch.
+
+    - parameter json: The `JSON` value to decode
+
+    - returns: A decoded `Bool` value
+  */
+  public static func decode(_ json: JSON) -> Decoded<Bool> {
+    switch json {
+    case let .bool(n): return pure(n)
+    case let .number(n): return pure(n.boolValue)
+    default: return .typeMismatch(expected: "Bool", actual: json)
+    }
+  }
+}
+
+public extension Optional where Wrapped: Decodable, Wrapped == Wrapped.DecodedType {
+  /**
+    Decode `JSON` into an `Optional<Wrapped>` value where `Wrapped` is `Decodable`.
+
+    Returns a decoded optional value from the result of performing `decode` on
+    the internal wrapped type.
+
+    - parameter json: The `JSON` value to decode
+
+    - returns: A decoded optional `Wrapped` value
+  */
+  static func decode(_ json: JSON) -> Decoded<Wrapped?> {
+    return Wrapped.decode(json) >>- { .success(.some($0)) }
+  }
+}
+
+public extension Collection where Iterator.Element: Decodable, Iterator.Element == Iterator.Element.DecodedType {
+  /**
+    Decode `JSON` into an array of values where the elements of the array are
+    `Decodable`.
+
+    If the `JSON` is an array of `JSON` objects, this returns a decoded array
+    of values by mapping the element's `decode` function over the `JSON` and
+    then applying `sequence` to the result. This makes this `decode` function
+    an all-or-nothing operation (See the documentation for `sequence` for more
+    info).
+
+    If the `JSON` is not an array, this returns a type mismatch.
+
+    - parameter json: The `JSON` value to decode
+
+    - returns: A decoded array of values
+  */
+  static func decode(_ json: JSON) -> Decoded<[Iterator.Element]> {
+    switch json {
+    case let .array(a): return sequence(a.map(Iterator.Element.decode))
+    default: return .typeMismatch(expected: "Array", actual: json)
+    }
+  }
+}
+
+/**
+  Decode `JSON` into an array of values where the elements of the array are
+  `Decodable`.
+
+  If the `JSON` is an array of `JSON` objects, this returns a decoded array
+  of values by mapping the element's `decode` function over the `JSON` and
+  then applying `sequence` to the result. This makes `decodeArray` an
+  all-or-nothing operation (See the documentation for `sequence` for more
+  info).
+
+  If the `JSON` is not an array, this returns a type mismatch.
+
+  This is a convenience function that is the same as `[T].decode(json)` (where `T`
+  is `Decodable`) and only exists to ease some pain around needing to use the
+  full type of the array when calling `decode`. We expect this function to be
+  removed in a future version.
+
+  - parameter json: The `JSON` value to decode
+
+  - returns: A decoded array of values
+*/
+public func decodeArray<T: Decodable>(_ json: JSON) -> Decoded<[T]> where T.DecodedType == T {
+  return [T].decode(json)
+}
+
+public extension ExpressibleByDictionaryLiteral where Value: Decodable, Value == Value.DecodedType {
+  /**
+    Decode `JSON` into a dictionary of keys and values where the keys are
+    `String`s and the values are `Decodable`.
+
+    If the `JSON` is a dictionary of `String`/`JSON` pairs, this returns a decoded dictionary
+    of key/value pairs by mapping the value's `decode` function over the `JSON` and
+    then applying `sequence` to the result. This makes this `decode` function
+    an all-or-nothing operation (See the documentation for `sequence` for more
+    info).
+
+    If the `JSON` is not a dictionary, this returns a type mismatch.
+
+    - parameter json: The `JSON` value to decode
+
+    - returns: A decoded dictionary of key/value pairs
+  */
+  static func decode(_ json: JSON) -> Decoded<[String: Value]> {
+    switch json {
+    case let .object(o): return sequence(Value.decode <^> o)
+    default: return .typeMismatch(expected: "Object", actual: json)
+    }
+  }
+}
+
+/**
+  Decode `JSON` into a dictionary of keys and values where the keys are
+  `String`s and the values are `Decodable`.
+
+  If the `JSON` is a dictionary of `String`/`JSON` pairs, this returns a
+  decoded dictionary of key/value pairs by mapping the value's `decode`
+  function over the `JSON` and then applying `sequence` to the result. This
+  makes `decodeObject` an all-or-nothing operation (See the documentation for
+  `sequence` for more info).
+
+  If the `JSON` is not a dictionary, this returns a type mismatch.
+
+  This is a convenience function that is the same as `[String: T].decode(json)`
+  (where `T` is `Decodable`) and only exists to ease some pain around needing to
+  use the full type of the dictionary when calling `decode`. We expect this
+  function to be removed in a future version.
+
+  - parameter json: The `JSON` value to decode
+
+  - returns: A decoded dictionary of key/value pairs
+*/
+public func decodeObject<T: Decodable>(_ json: JSON) -> Decoded<[String: T]> where T.DecodedType == T {
+  return [String: T].decode(json)
+}
+
+/**
+  Pull an embedded `JSON` value from a specified key.
+
+  If the `JSON` value is an object, it will attempt to return the embedded
+  `JSON` value at the specified key, failing if the key doesn't exist.
+
+  If the `JSON` value is not an object, this will return a type mismatch.
+
+  This is similar to adding a subscript to `JSON`, except that it returns a
+  `Decoded` type.
+
+  - parameter json: The `JSON` value that contains the key
+  - parameter key: The key containing the embedded `JSON` object
+
+  - returns: A decoded `JSON` value representing the success or failure of
+             extracting the value from the object
+*/
+public func decodedJSON(_ json: JSON, forKey key: String) -> Decoded<JSON> {
+  switch json {
+  case let .object(o): return guardNull(key, o[key] ?? .null)
+  default: return .typeMismatch(expected: "Object", actual: json)
+  }
+}
+
+private func guardNull(_ key: String, _ json: JSON) -> Decoded<JSON> {
+  switch json {
+  case .null: return .missingKey(key)
+  default: return pure(json)
+  }
+}

--- a/Library/ArgoDecoded/StandardTypes.swift
+++ b/Library/ArgoDecoded/StandardTypes.swift
@@ -3,14 +3,14 @@ import Runes
 
 extension String: Decodable {
   /**
-    Decode `JSON` into `Decoded<String>`.
+   Decode `JSON` into `Decoded<String>`.
 
-    Succeeds if the value is a string, otherwise it returns a type mismatch.
+   Succeeds if the value is a string, otherwise it returns a type mismatch.
 
-    - parameter json: The `JSON` value to decode
+   - parameter json: The `JSON` value to decode
 
-    - returns: A decoded `String` value
-  */
+   - returns: A decoded `String` value
+   */
   public static func decode(_ json: JSON) -> Decoded<String> {
     switch json {
     case let .string(s): return pure(s)
@@ -21,15 +21,15 @@ extension String: Decodable {
 
 extension Int: Decodable {
   /**
-    Decode `JSON` into `Decoded<Int>`.
+   Decode `JSON` into `Decoded<Int>`.
 
-    Succeeds if the value is a number that can be converted to an `Int`,
-    otherwise it returns a type mismatch.
+   Succeeds if the value is a number that can be converted to an `Int`,
+   otherwise it returns a type mismatch.
 
-    - parameter json: The `JSON` value to decode
+   - parameter json: The `JSON` value to decode
 
-    - returns: A decoded `Int` value
-  */
+   - returns: A decoded `Int` value
+   */
   public static func decode(_ json: JSON) -> Decoded<Int> {
     switch json {
     case let .number(n): return pure(n.intValue)
@@ -40,15 +40,15 @@ extension Int: Decodable {
 
 extension UInt: Decodable {
   /**
-    Decode `JSON` into `Decoded<UInt>`.
+   Decode `JSON` into `Decoded<UInt>`.
 
-    Succeeds if the value is a number that can be converted to a `UInt`,
-    otherwise it returns a type mismatch.
+   Succeeds if the value is a number that can be converted to a `UInt`,
+   otherwise it returns a type mismatch.
 
-    - parameter json: The `JSON` value to decode
+   - parameter json: The `JSON` value to decode
 
-    - returns: A decoded `UInt` value
-  */
+   - returns: A decoded `UInt` value
+   */
   public static func decode(_ json: JSON) -> Decoded<UInt> {
     switch json {
     case let .number(n): return pure(n.uintValue)
@@ -59,16 +59,16 @@ extension UInt: Decodable {
 
 extension Int64: Decodable {
   /**
-    Decode `JSON` into `Decoded<Int64>`.
+   Decode `JSON` into `Decoded<Int64>`.
 
-    Succeeds if the value is a number that can be converted to an `Int64` or a
-    string that represents a large number, otherwise it returns a type
-    mismatch.
+   Succeeds if the value is a number that can be converted to an `Int64` or a
+   string that represents a large number, otherwise it returns a type
+   mismatch.
 
-    - parameter json: The `JSON` value to decode
+   - parameter json: The `JSON` value to decode
 
-    - returns: A decoded `Int64` value
-  */
+   - returns: A decoded `Int64` value
+   */
   public static func decode(_ json: JSON) -> Decoded<Int64> {
     switch json {
     case let .number(n): return pure(n.int64Value)
@@ -82,16 +82,16 @@ extension Int64: Decodable {
 
 extension UInt64: Decodable {
   /**
-    Decode `JSON` into `Decoded<UInt64>`.
+   Decode `JSON` into `Decoded<UInt64>`.
 
-    Succeeds if the value is a number that can be converted to an `UInt64` or a
-    string that represents a large number, otherwise it returns a type
-    mismatch.
+   Succeeds if the value is a number that can be converted to an `UInt64` or a
+   string that represents a large number, otherwise it returns a type
+   mismatch.
 
-    - parameter json: The `JSON` value to decode
+   - parameter json: The `JSON` value to decode
 
-    - returns: A decoded `UInt` value
-  */
+   - returns: A decoded `UInt` value
+   */
   public static func decode(_ json: JSON) -> Decoded<UInt64> {
     switch json {
     case let .number(n): return pure(n.uint64Value)
@@ -105,15 +105,15 @@ extension UInt64: Decodable {
 
 extension Double: Decodable {
   /**
-    Decode `JSON` into `Decoded<Double>`.
+   Decode `JSON` into `Decoded<Double>`.
 
-    Succeeds if the value is a number that can be converted to a `Double`,
-    otherwise it returns a type mismatch.
+   Succeeds if the value is a number that can be converted to a `Double`,
+   otherwise it returns a type mismatch.
 
-    - parameter json: The `JSON` value to decode
+   - parameter json: The `JSON` value to decode
 
-    - returns: A decoded `Double` value
-  */
+   - returns: A decoded `Double` value
+   */
   public static func decode(_ json: JSON) -> Decoded<Double> {
     switch json {
     case let .number(n): return pure(n.doubleValue)
@@ -124,15 +124,15 @@ extension Double: Decodable {
 
 extension Float: Decodable {
   /**
-    Decode `JSON` into `Decoded<Float>`.
+   Decode `JSON` into `Decoded<Float>`.
 
-    Succeeds if the value is a number that can be converted to a `Float`,
-    otherwise it returns a type mismatch.
+   Succeeds if the value is a number that can be converted to a `Float`,
+   otherwise it returns a type mismatch.
 
-    - parameter json: The `JSON` value to decode
+   - parameter json: The `JSON` value to decode
 
-    - returns: A decoded `Float` value
-  */
+   - returns: A decoded `Float` value
+   */
   public static func decode(_ json: JSON) -> Decoded<Float> {
     switch json {
     case let .number(n): return pure(n.floatValue)
@@ -143,15 +143,15 @@ extension Float: Decodable {
 
 extension Bool: Decodable {
   /**
-    Decode `JSON` into `Decoded<Bool>`.
+   Decode `JSON` into `Decoded<Bool>`.
 
-    Succeeds if the value is a boolean or if the value is a number that is able
-    to be converted to a boolean, otherwise it returns a type mismatch.
+   Succeeds if the value is a boolean or if the value is a number that is able
+   to be converted to a boolean, otherwise it returns a type mismatch.
 
-    - parameter json: The `JSON` value to decode
+   - parameter json: The `JSON` value to decode
 
-    - returns: A decoded `Bool` value
-  */
+   - returns: A decoded `Bool` value
+   */
   public static func decode(_ json: JSON) -> Decoded<Bool> {
     switch json {
     case let .bool(n): return pure(n)
@@ -163,37 +163,38 @@ extension Bool: Decodable {
 
 public extension Optional where Wrapped: Decodable, Wrapped == Wrapped.DecodedType {
   /**
-    Decode `JSON` into an `Optional<Wrapped>` value where `Wrapped` is `Decodable`.
+   Decode `JSON` into an `Optional<Wrapped>` value where `Wrapped` is `Decodable`.
 
-    Returns a decoded optional value from the result of performing `decode` on
-    the internal wrapped type.
+   Returns a decoded optional value from the result of performing `decode` on
+   the internal wrapped type.
 
-    - parameter json: The `JSON` value to decode
+   - parameter json: The `JSON` value to decode
 
-    - returns: A decoded optional `Wrapped` value
-  */
+   - returns: A decoded optional `Wrapped` value
+   */
   static func decode(_ json: JSON) -> Decoded<Wrapped?> {
     return Wrapped.decode(json) >>- { .success(.some($0)) }
   }
 }
 
-public extension Collection where Iterator.Element: Decodable, Iterator.Element == Iterator.Element.DecodedType {
+public extension Collection where Iterator.Element: Decodable,
+  Iterator.Element == Iterator.Element.DecodedType {
   /**
-    Decode `JSON` into an array of values where the elements of the array are
-    `Decodable`.
+   Decode `JSON` into an array of values where the elements of the array are
+   `Decodable`.
 
-    If the `JSON` is an array of `JSON` objects, this returns a decoded array
-    of values by mapping the element's `decode` function over the `JSON` and
-    then applying `sequence` to the result. This makes this `decode` function
-    an all-or-nothing operation (See the documentation for `sequence` for more
-    info).
+   If the `JSON` is an array of `JSON` objects, this returns a decoded array
+   of values by mapping the element's `decode` function over the `JSON` and
+   then applying `sequence` to the result. This makes this `decode` function
+   an all-or-nothing operation (See the documentation for `sequence` for more
+   info).
 
-    If the `JSON` is not an array, this returns a type mismatch.
+   If the `JSON` is not an array, this returns a type mismatch.
 
-    - parameter json: The `JSON` value to decode
+   - parameter json: The `JSON` value to decode
 
-    - returns: A decoded array of values
-  */
+   - returns: A decoded array of values
+   */
   static func decode(_ json: JSON) -> Decoded<[Iterator.Element]> {
     switch json {
     case let .array(a): return sequence(a.map(Iterator.Element.decode))
@@ -203,47 +204,47 @@ public extension Collection where Iterator.Element: Decodable, Iterator.Element 
 }
 
 /**
-  Decode `JSON` into an array of values where the elements of the array are
-  `Decodable`.
+ Decode `JSON` into an array of values where the elements of the array are
+ `Decodable`.
 
-  If the `JSON` is an array of `JSON` objects, this returns a decoded array
-  of values by mapping the element's `decode` function over the `JSON` and
-  then applying `sequence` to the result. This makes `decodeArray` an
-  all-or-nothing operation (See the documentation for `sequence` for more
-  info).
+ If the `JSON` is an array of `JSON` objects, this returns a decoded array
+ of values by mapping the element's `decode` function over the `JSON` and
+ then applying `sequence` to the result. This makes `decodeArray` an
+ all-or-nothing operation (See the documentation for `sequence` for more
+ info).
 
-  If the `JSON` is not an array, this returns a type mismatch.
+ If the `JSON` is not an array, this returns a type mismatch.
 
-  This is a convenience function that is the same as `[T].decode(json)` (where `T`
-  is `Decodable`) and only exists to ease some pain around needing to use the
-  full type of the array when calling `decode`. We expect this function to be
-  removed in a future version.
+ This is a convenience function that is the same as `[T].decode(json)` (where `T`
+ is `Decodable`) and only exists to ease some pain around needing to use the
+ full type of the array when calling `decode`. We expect this function to be
+ removed in a future version.
 
-  - parameter json: The `JSON` value to decode
+ - parameter json: The `JSON` value to decode
 
-  - returns: A decoded array of values
-*/
+ - returns: A decoded array of values
+ */
 public func decodeArray<T: Decodable>(_ json: JSON) -> Decoded<[T]> where T.DecodedType == T {
   return [T].decode(json)
 }
 
 public extension ExpressibleByDictionaryLiteral where Value: Decodable, Value == Value.DecodedType {
   /**
-    Decode `JSON` into a dictionary of keys and values where the keys are
-    `String`s and the values are `Decodable`.
+   Decode `JSON` into a dictionary of keys and values where the keys are
+   `String`s and the values are `Decodable`.
 
-    If the `JSON` is a dictionary of `String`/`JSON` pairs, this returns a decoded dictionary
-    of key/value pairs by mapping the value's `decode` function over the `JSON` and
-    then applying `sequence` to the result. This makes this `decode` function
-    an all-or-nothing operation (See the documentation for `sequence` for more
-    info).
+   If the `JSON` is a dictionary of `String`/`JSON` pairs, this returns a decoded dictionary
+   of key/value pairs by mapping the value's `decode` function over the `JSON` and
+   then applying `sequence` to the result. This makes this `decode` function
+   an all-or-nothing operation (See the documentation for `sequence` for more
+   info).
 
-    If the `JSON` is not a dictionary, this returns a type mismatch.
+   If the `JSON` is not a dictionary, this returns a type mismatch.
 
-    - parameter json: The `JSON` value to decode
+   - parameter json: The `JSON` value to decode
 
-    - returns: A decoded dictionary of key/value pairs
-  */
+   - returns: A decoded dictionary of key/value pairs
+   */
   static func decode(_ json: JSON) -> Decoded<[String: Value]> {
     switch json {
     case let .object(o): return sequence(Value.decode <^> o)
@@ -253,47 +254,47 @@ public extension ExpressibleByDictionaryLiteral where Value: Decodable, Value ==
 }
 
 /**
-  Decode `JSON` into a dictionary of keys and values where the keys are
-  `String`s and the values are `Decodable`.
+ Decode `JSON` into a dictionary of keys and values where the keys are
+ `String`s and the values are `Decodable`.
 
-  If the `JSON` is a dictionary of `String`/`JSON` pairs, this returns a
-  decoded dictionary of key/value pairs by mapping the value's `decode`
-  function over the `JSON` and then applying `sequence` to the result. This
-  makes `decodeObject` an all-or-nothing operation (See the documentation for
-  `sequence` for more info).
+ If the `JSON` is a dictionary of `String`/`JSON` pairs, this returns a
+ decoded dictionary of key/value pairs by mapping the value's `decode`
+ function over the `JSON` and then applying `sequence` to the result. This
+ makes `decodeObject` an all-or-nothing operation (See the documentation for
+ `sequence` for more info).
 
-  If the `JSON` is not a dictionary, this returns a type mismatch.
+ If the `JSON` is not a dictionary, this returns a type mismatch.
 
-  This is a convenience function that is the same as `[String: T].decode(json)`
-  (where `T` is `Decodable`) and only exists to ease some pain around needing to
-  use the full type of the dictionary when calling `decode`. We expect this
-  function to be removed in a future version.
+ This is a convenience function that is the same as `[String: T].decode(json)`
+ (where `T` is `Decodable`) and only exists to ease some pain around needing to
+ use the full type of the dictionary when calling `decode`. We expect this
+ function to be removed in a future version.
 
-  - parameter json: The `JSON` value to decode
+ - parameter json: The `JSON` value to decode
 
-  - returns: A decoded dictionary of key/value pairs
-*/
+ - returns: A decoded dictionary of key/value pairs
+ */
 public func decodeObject<T: Decodable>(_ json: JSON) -> Decoded<[String: T]> where T.DecodedType == T {
   return [String: T].decode(json)
 }
 
 /**
-  Pull an embedded `JSON` value from a specified key.
+ Pull an embedded `JSON` value from a specified key.
 
-  If the `JSON` value is an object, it will attempt to return the embedded
-  `JSON` value at the specified key, failing if the key doesn't exist.
+ If the `JSON` value is an object, it will attempt to return the embedded
+ `JSON` value at the specified key, failing if the key doesn't exist.
 
-  If the `JSON` value is not an object, this will return a type mismatch.
+ If the `JSON` value is not an object, this will return a type mismatch.
 
-  This is similar to adding a subscript to `JSON`, except that it returns a
-  `Decoded` type.
+ This is similar to adding a subscript to `JSON`, except that it returns a
+ `Decoded` type.
 
-  - parameter json: The `JSON` value that contains the key
-  - parameter key: The key containing the embedded `JSON` object
+ - parameter json: The `JSON` value that contains the key
+ - parameter key: The key containing the embedded `JSON` object
 
-  - returns: A decoded `JSON` value representing the success or failure of
-             extracting the value from the object
-*/
+ - returns: A decoded `JSON` value representing the success or failure of
+            extracting the value from the object
+ */
 public func decodedJSON(_ json: JSON, forKey key: String) -> Decoded<JSON> {
   switch json {
   case let .object(o): return guardNull(key, o[key] ?? .null)

--- a/Library/ArgoDecoded/catDecoded.swift
+++ b/Library/ArgoDecoded/catDecoded.swift
@@ -1,0 +1,57 @@
+/**
+  Create a new array of unwrapped `.Success` values, filtering out `.Failure`s.
+
+  This will iterate through the array of `Decoded<T>` elements and safely
+  unwrap the values.
+
+  If the element is `.Success(T)`, it will unwrap the value and add it into the
+  array.
+
+  If the element is `.Failure`, it will not be added to the new array.
+
+  - parameter xs: An array of `Decoded<T>` values
+
+  - returns: An array of unwrapped values of type `T`
+*/
+public func catDecoded<T>(_ xs: [Decoded<T>]) -> [T] {
+  var accum: [T] = []
+  accum.reserveCapacity(xs.count)
+
+  for x in xs {
+    switch x {
+    case let .success(value): accum.append(value)
+    case .failure: continue
+    }
+  }
+
+  return accum
+}
+
+/**
+  Create a new dictionary of unwrapped `.Success` values, filtering out
+  `.Failure`s.
+
+  This will iterate through the dictionary of `Decoded<T>` elements and safely
+  unwrap the values.
+
+  If the element is `.Success(T)`, it will unwrap the value and assign it to
+  the existing key in the new dictionary.
+
+  If the element is `.Failure`, it will not be added to the new dictionary.
+
+  - parameter xs: A dictionary of `Decoded<T>` values assigned to `String` keys
+
+  - returns: A dictionary of unwrapped values of type `T` assigned to `String` keys
+*/
+public func catDecoded<T>(_ xs: [String: Decoded<T>]) -> [String: T] {
+  var accum = Dictionary<String, T>(minimumCapacity: xs.count)
+
+  for (key, x) in xs {
+    switch x {
+    case let .success(value): accum[key] = value
+    case .failure: continue
+    }
+  }
+
+  return accum
+}

--- a/Library/ArgoDecoded/catDecoded.swift
+++ b/Library/ArgoDecoded/catDecoded.swift
@@ -1,18 +1,18 @@
 /**
-  Create a new array of unwrapped `.Success` values, filtering out `.Failure`s.
+ Create a new array of unwrapped `.Success` values, filtering out `.Failure`s.
 
-  This will iterate through the array of `Decoded<T>` elements and safely
-  unwrap the values.
+ This will iterate through the array of `Decoded<T>` elements and safely
+ unwrap the values.
 
-  If the element is `.Success(T)`, it will unwrap the value and add it into the
-  array.
+ If the element is `.Success(T)`, it will unwrap the value and add it into the
+ array.
 
-  If the element is `.Failure`, it will not be added to the new array.
+ If the element is `.Failure`, it will not be added to the new array.
 
-  - parameter xs: An array of `Decoded<T>` values
+ - parameter xs: An array of `Decoded<T>` values
 
-  - returns: An array of unwrapped values of type `T`
-*/
+ - returns: An array of unwrapped values of type `T`
+ */
 public func catDecoded<T>(_ xs: [Decoded<T>]) -> [T] {
   var accum: [T] = []
   accum.reserveCapacity(xs.count)
@@ -28,23 +28,23 @@ public func catDecoded<T>(_ xs: [Decoded<T>]) -> [T] {
 }
 
 /**
-  Create a new dictionary of unwrapped `.Success` values, filtering out
-  `.Failure`s.
+ Create a new dictionary of unwrapped `.Success` values, filtering out
+ `.Failure`s.
 
-  This will iterate through the dictionary of `Decoded<T>` elements and safely
-  unwrap the values.
+ This will iterate through the dictionary of `Decoded<T>` elements and safely
+ unwrap the values.
 
-  If the element is `.Success(T)`, it will unwrap the value and assign it to
-  the existing key in the new dictionary.
+ If the element is `.Success(T)`, it will unwrap the value and assign it to
+ the existing key in the new dictionary.
 
-  If the element is `.Failure`, it will not be added to the new dictionary.
+ If the element is `.Failure`, it will not be added to the new dictionary.
 
-  - parameter xs: A dictionary of `Decoded<T>` values assigned to `String` keys
+ - parameter xs: A dictionary of `Decoded<T>` values assigned to `String` keys
 
-  - returns: A dictionary of unwrapped values of type `T` assigned to `String` keys
-*/
+ - returns: A dictionary of unwrapped values of type `T` assigned to `String` keys
+ */
 public func catDecoded<T>(_ xs: [String: Decoded<T>]) -> [String: T] {
-  var accum = Dictionary<String, T>(minimumCapacity: xs.count)
+  var accum = [String: T](minimumCapacity: xs.count)
 
   for (key, x) in xs {
     switch x {

--- a/Library/ArgoDecoded/decode.swift
+++ b/Library/ArgoDecoded/decode.swift
@@ -1,0 +1,232 @@
+/**
+  Attempt to transform `Any` into a `Decodable` value.
+
+  This function takes `Any` (usually the output from
+  `NSJSONSerialization`) and attempts to transform it into a `Decodable` value.
+  This works based on the type you ask for.
+
+  For example, the following code attempts to decode to `Decoded<String>`,
+  because that's what we have explicitly stated is the return type:
+
+  ```
+  do {
+    let object = try NSJSONSerialization.JSONObjectWithData(data, options: nil)
+    let str: Decoded<String> = decode(object)
+  } catch {
+    // handle error
+  }
+  ```
+
+  - parameter object: The `Any` instance to attempt to decode
+
+  - returns: A `Decoded<T>` value where `T` is `Decodable`
+*/
+public func decode<T: Decodable>(_ object: Any) -> Decoded<T> where T == T.DecodedType {
+  return T.decode(JSON(object))
+}
+
+/**
+  Attempt to transform `Any` into an `Array` of `Decodable` values.
+
+  This function takes `Any` (usually the output from
+  `NSJSONSerialization`) and attempts to transform it into an `Array` of
+  `Decodable` values. This works based on the type you ask for.
+
+  For example, the following code attempts to decode to
+  `Decoded<[String]>`, because that's what we have explicitly stated is
+  the return type:
+
+  ```
+  do {
+    let object = try NSJSONSerialization.JSONObjectWithData(data, options: nil)
+    let str: Decoded<[String]> = decode(object)
+  } catch {
+    // handle error
+  }
+  ```
+
+  - parameter object: The `Any` instance to attempt to decode
+
+  - returns: A `Decoded<[T]>` value where `T` is `Decodable`
+*/
+public func decode<T: Decodable>(_ object: Any) -> Decoded<[T]> where T == T.DecodedType {
+  return Array<T>.decode(JSON(object))
+}
+
+/**
+  Attempt to transform `Any` into a `Decodable` value and return an `Optional`.
+
+  This function takes `Any` (usually the output from
+  `NSJSONSerialization`) and attempts to transform it into a `Decodable` value,
+  returning an `Optional`. This works based on the type you ask for.
+
+  For example, the following code attempts to decode to `Optional<String>`,
+  because that's what we have explicitly stated is the return type:
+
+  ```
+  do {
+    let object = try NSJSONSerialization.JSONObjectWithData(data, options: nil)
+    let str: String? = decode(object)
+  } catch {
+    // handle error
+  }
+  ```
+
+  - parameter object: The `Any` instance to attempt to decode
+
+  - returns: An `Optional<T>` value where `T` is `Decodable`
+*/
+public func decode<T: Decodable>(_ object: Any) -> T? where T == T.DecodedType {
+  return decode(object).value
+}
+
+/**
+  Attempt to transform `Any` into an `Array` of `Decodable` values and
+  return an `Optional`.
+
+  This function takes `Any` (usually the output from
+  `NSJSONSerialization`) and attempts to transform it into an `Array` of
+  `Decodable` values, returning an `Optional`. This works based on the type you
+  ask for.
+
+  For example, the following code attempts to decode to
+  `Optional<[String]>`, because that's what we have explicitly stated is
+  the return type:
+
+  ```
+  do {
+    let object = try NSJSONSerialization.JSONObjectWithData(data, options: nil)
+    let str: [String]? = decode(object)
+  } catch {
+    // handle error
+  }
+  ```
+
+  - parameter object: The `Any` instance to attempt to decode
+
+  - returns: An `Optional<[T]>` value where `T` is `Decodable`
+*/
+public func decode<T: Decodable>(_ object: Any) -> [T]? where T == T.DecodedType {
+  return decode(object).value
+}
+
+/**
+  Attempt to transform `Any` into a `Decodable` value using a specified
+  root key.
+
+  This function attempts to extract the embedded `JSON` object from the
+  dictionary at the specified key and transform it into a `Decodable` value.
+  This works based on the type you ask for.
+
+  For example, the following code attempts to decode to `Decoded<String>`,
+  because that's what we have explicitly stated is the return type:
+
+  ```
+  do {
+    let dict = try NSJSONSerialization.JSONObjectWithData(data, options: nil) as? [String: Any] ?? [:]
+    let str: Decoded<String> = decode(dict, rootKey: "value")
+  } catch {
+    // handle error
+  }
+  ```
+
+  - parameter dict: The dictionary containing the `Any` instance to
+                    attempt to decode
+  - parameter rootKey: The root key that contains the object to decode
+
+  - returns: A `Decoded<T>` value where `T` is `Decodable`
+*/
+public func decode<T: Decodable>(_ dict: [String: Any], rootKey: String) -> Decoded<T> where T == T.DecodedType {
+  return JSON(dict as Any) <| rootKey
+}
+
+/**
+  Attempt to transform `Any` into an `Array` of `Decodable` value using a
+  specified root key.
+
+  This function attempts to extract the embedded `JSON` object from the
+  dictionary at the specified key and transform it into an `Array` of
+  `Decodable` values. This works based on the type you ask for.
+
+  For example, the following code attempts to decode to `Decoded<[String]>`,
+  because that's what we have explicitly stated is the return type:
+
+  ```
+  do {
+    let dict = try NSJSONSerialization.JSONObjectWithData(data, options: nil) as? [String: Any] ?? [:]
+    let str: Decoded<[String]> = decode(dict, rootKey: "value")
+  } catch {
+    // handle error
+  }
+  ```
+
+  - parameter dict: The dictionary containing the `Any` instance to
+                    attempt to decode
+  - parameter rootKey: The root key that contains the object to decode
+
+  - returns: A `Decoded<[T]>` value where `T` is `Decodable`
+*/
+public func decode<T: Decodable>(_ dict: [String: Any], rootKey: String) -> Decoded<[T]> where T == T.DecodedType {
+  return JSON(dict as Any) <|| rootKey
+}
+
+/**
+  Attempt to transform `Any` into a `Decodable` value using a specified
+  root key and return an `Optional`.
+
+  This function attempts to extract the embedded `JSON` object from the
+  dictionary at the specified key and transform it into a `Decodable` value,
+  returning an `Optional`. This works based on the type you ask for.
+
+  For example, the following code attempts to decode to `Optional<String>`,
+  because that's what we have explicitly stated is the return type:
+
+  ```
+  do {
+    let dict = try NSJSONSerialization.JSONObjectWithData(data, options: nil) as? [String: Any] ?? [:]
+    let str: String? = decode(dict, rootKey: "value")
+  } catch {
+    // handle error
+  }
+  ```
+
+  - parameter dict: The dictionary containing the `Any` instance to
+                    attempt to decode
+  - parameter rootKey: The root key that contains the object to decode
+
+  - returns: A `Decoded<T>` value where `T` is `Decodable`
+*/
+public func decode<T: Decodable>(_ dict: [String: Any], rootKey: String) -> T? where T == T.DecodedType {
+  return decode(dict, rootKey: rootKey).value
+}
+
+/**
+  Attempt to transform `Any` into an `Array` of `Decodable` value using a
+  specified root key and return an `Optional`
+
+  This function attempts to extract the embedded `JSON` object from the
+  dictionary at the specified key and transform it into an `Array` of
+  `Decodable` values, returning an `Optional`. This works based on the type you
+  ask for.
+
+  For example, the following code attempts to decode to `Optional<[String]>`,
+  because that's what we have explicitly stated is the return type:
+
+  ```
+  do {
+    let dict = try NSJSONSerialization.JSONObjectWithData(data, options: nil) as? [String: Any] ?? [:]
+    let str: [String]? = decode(dict, rootKey: "value")
+  } catch {
+    // handle error
+  }
+  ```
+
+  - parameter dict: The dictionary containing the `Any` instance to
+                    attempt to decode
+  - parameter rootKey: The root key that contains the object to decode
+
+  - returns: A `Decoded<[T]>` value where `T` is `Decodable`
+*/
+public func decode<T: Decodable>(_ dict: [String: Any], rootKey: String) -> [T]? where T == T.DecodedType {
+  return decode(dict, rootKey: rootKey).value
+}

--- a/Library/ArgoDecoded/decode.swift
+++ b/Library/ArgoDecoded/decode.swift
@@ -1,232 +1,234 @@
 /**
-  Attempt to transform `Any` into a `Decodable` value.
+ Attempt to transform `Any` into a `Decodable` value.
 
-  This function takes `Any` (usually the output from
-  `NSJSONSerialization`) and attempts to transform it into a `Decodable` value.
-  This works based on the type you ask for.
+ This function takes `Any` (usually the output from
+ `NSJSONSerialization`) and attempts to transform it into a `Decodable` value.
+ This works based on the type you ask for.
 
-  For example, the following code attempts to decode to `Decoded<String>`,
-  because that's what we have explicitly stated is the return type:
+ For example, the following code attempts to decode to `Decoded<String>`,
+ because that's what we have explicitly stated is the return type:
 
-  ```
-  do {
-    let object = try NSJSONSerialization.JSONObjectWithData(data, options: nil)
-    let str: Decoded<String> = decode(object)
-  } catch {
-    // handle error
-  }
-  ```
+ ```
+ do {
+   let object = try NSJSONSerialization.JSONObjectWithData(data, options: nil)
+   let str: Decoded<String> = decode(object)
+ } catch {
+   // handle error
+ }
+ ```
 
-  - parameter object: The `Any` instance to attempt to decode
+ - parameter object: The `Any` instance to attempt to decode
 
-  - returns: A `Decoded<T>` value where `T` is `Decodable`
-*/
+ - returns: A `Decoded<T>` value where `T` is `Decodable`
+ */
 public func decode<T: Decodable>(_ object: Any) -> Decoded<T> where T == T.DecodedType {
   return T.decode(JSON(object))
 }
 
 /**
-  Attempt to transform `Any` into an `Array` of `Decodable` values.
+ Attempt to transform `Any` into an `Array` of `Decodable` values.
 
-  This function takes `Any` (usually the output from
-  `NSJSONSerialization`) and attempts to transform it into an `Array` of
-  `Decodable` values. This works based on the type you ask for.
+ This function takes `Any` (usually the output from
+ `NSJSONSerialization`) and attempts to transform it into an `Array` of
+ `Decodable` values. This works based on the type you ask for.
 
-  For example, the following code attempts to decode to
-  `Decoded<[String]>`, because that's what we have explicitly stated is
-  the return type:
+ For example, the following code attempts to decode to
+ `Decoded<[String]>`, because that's what we have explicitly stated is
+ the return type:
 
-  ```
-  do {
-    let object = try NSJSONSerialization.JSONObjectWithData(data, options: nil)
-    let str: Decoded<[String]> = decode(object)
-  } catch {
-    // handle error
-  }
-  ```
+ ```
+ do {
+   let object = try NSJSONSerialization.JSONObjectWithData(data, options: nil)
+   let str: Decoded<[String]> = decode(object)
+ } catch {
+   // handle error
+ }
+ ```
 
-  - parameter object: The `Any` instance to attempt to decode
+ - parameter object: The `Any` instance to attempt to decode
 
-  - returns: A `Decoded<[T]>` value where `T` is `Decodable`
-*/
+ - returns: A `Decoded<[T]>` value where `T` is `Decodable`
+ */
 public func decode<T: Decodable>(_ object: Any) -> Decoded<[T]> where T == T.DecodedType {
   return Array<T>.decode(JSON(object))
 }
 
 /**
-  Attempt to transform `Any` into a `Decodable` value and return an `Optional`.
+ Attempt to transform `Any` into a `Decodable` value and return an `Optional`.
 
-  This function takes `Any` (usually the output from
-  `NSJSONSerialization`) and attempts to transform it into a `Decodable` value,
-  returning an `Optional`. This works based on the type you ask for.
+ This function takes `Any` (usually the output from
+ `NSJSONSerialization`) and attempts to transform it into a `Decodable` value,
+ returning an `Optional`. This works based on the type you ask for.
 
-  For example, the following code attempts to decode to `Optional<String>`,
-  because that's what we have explicitly stated is the return type:
+ For example, the following code attempts to decode to `Optional<String>`,
+ because that's what we have explicitly stated is the return type:
 
-  ```
-  do {
-    let object = try NSJSONSerialization.JSONObjectWithData(data, options: nil)
-    let str: String? = decode(object)
-  } catch {
-    // handle error
-  }
-  ```
+ ```
+ do {
+   let object = try NSJSONSerialization.JSONObjectWithData(data, options: nil)
+   let str: String? = decode(object)
+ } catch {
+   // handle error
+ }
+ ```
 
-  - parameter object: The `Any` instance to attempt to decode
+ - parameter object: The `Any` instance to attempt to decode
 
-  - returns: An `Optional<T>` value where `T` is `Decodable`
-*/
+ - returns: An `Optional<T>` value where `T` is `Decodable`
+ */
 public func decode<T: Decodable>(_ object: Any) -> T? where T == T.DecodedType {
   return decode(object).value
 }
 
 /**
-  Attempt to transform `Any` into an `Array` of `Decodable` values and
-  return an `Optional`.
+ Attempt to transform `Any` into an `Array` of `Decodable` values and
+ return an `Optional`.
 
-  This function takes `Any` (usually the output from
-  `NSJSONSerialization`) and attempts to transform it into an `Array` of
-  `Decodable` values, returning an `Optional`. This works based on the type you
-  ask for.
+ This function takes `Any` (usually the output from
+ `NSJSONSerialization`) and attempts to transform it into an `Array` of
+ `Decodable` values, returning an `Optional`. This works based on the type you
+ ask for.
 
-  For example, the following code attempts to decode to
-  `Optional<[String]>`, because that's what we have explicitly stated is
-  the return type:
+ For example, the following code attempts to decode to
+ `Optional<[String]>`, because that's what we have explicitly stated is
+ the return type:
 
-  ```
-  do {
-    let object = try NSJSONSerialization.JSONObjectWithData(data, options: nil)
-    let str: [String]? = decode(object)
-  } catch {
-    // handle error
-  }
-  ```
+ ```
+ do {
+   let object = try NSJSONSerialization.JSONObjectWithData(data, options: nil)
+   let str: [String]? = decode(object)
+ } catch {
+   // handle error
+ }
+ ```
 
-  - parameter object: The `Any` instance to attempt to decode
+ - parameter object: The `Any` instance to attempt to decode
 
-  - returns: An `Optional<[T]>` value where `T` is `Decodable`
-*/
+ - returns: An `Optional<[T]>` value where `T` is `Decodable`
+ */
 public func decode<T: Decodable>(_ object: Any) -> [T]? where T == T.DecodedType {
   return decode(object).value
 }
 
 /**
-  Attempt to transform `Any` into a `Decodable` value using a specified
-  root key.
+ Attempt to transform `Any` into a `Decodable` value using a specified
+ root key.
 
-  This function attempts to extract the embedded `JSON` object from the
-  dictionary at the specified key and transform it into a `Decodable` value.
-  This works based on the type you ask for.
+ This function attempts to extract the embedded `JSON` object from the
+ dictionary at the specified key and transform it into a `Decodable` value.
+ This works based on the type you ask for.
 
-  For example, the following code attempts to decode to `Decoded<String>`,
-  because that's what we have explicitly stated is the return type:
+ For example, the following code attempts to decode to `Decoded<String>`,
+ because that's what we have explicitly stated is the return type:
 
-  ```
-  do {
-    let dict = try NSJSONSerialization.JSONObjectWithData(data, options: nil) as? [String: Any] ?? [:]
-    let str: Decoded<String> = decode(dict, rootKey: "value")
-  } catch {
-    // handle error
-  }
-  ```
+ ```
+ do {
+   let dict = try NSJSONSerialization.JSONObjectWithData(data, options: nil) as? [String: Any] ?? [:]
+   let str: Decoded<String> = decode(dict, rootKey: "value")
+ } catch {
+   // handle error
+ }
+ ```
 
-  - parameter dict: The dictionary containing the `Any` instance to
-                    attempt to decode
-  - parameter rootKey: The root key that contains the object to decode
+ - parameter dict: The dictionary containing the `Any` instance to
+                   attempt to decode
+ - parameter rootKey: The root key that contains the object to decode
 
-  - returns: A `Decoded<T>` value where `T` is `Decodable`
-*/
-public func decode<T: Decodable>(_ dict: [String: Any], rootKey: String) -> Decoded<T> where T == T.DecodedType {
+ - returns: A `Decoded<T>` value where `T` is `Decodable`
+ */
+public func decode<T: Decodable>(_ dict: [String: Any], rootKey: String) -> Decoded<T>
+  where T == T.DecodedType {
   return JSON(dict as Any) <| rootKey
 }
 
 /**
-  Attempt to transform `Any` into an `Array` of `Decodable` value using a
-  specified root key.
+ Attempt to transform `Any` into an `Array` of `Decodable` value using a
+ specified root key.
 
-  This function attempts to extract the embedded `JSON` object from the
-  dictionary at the specified key and transform it into an `Array` of
-  `Decodable` values. This works based on the type you ask for.
+ This function attempts to extract the embedded `JSON` object from the
+ dictionary at the specified key and transform it into an `Array` of
+ `Decodable` values. This works based on the type you ask for.
 
-  For example, the following code attempts to decode to `Decoded<[String]>`,
-  because that's what we have explicitly stated is the return type:
+ For example, the following code attempts to decode to `Decoded<[String]>`,
+ because that's what we have explicitly stated is the return type:
 
-  ```
-  do {
-    let dict = try NSJSONSerialization.JSONObjectWithData(data, options: nil) as? [String: Any] ?? [:]
-    let str: Decoded<[String]> = decode(dict, rootKey: "value")
-  } catch {
-    // handle error
-  }
-  ```
+ ```
+ do {
+   let dict = try NSJSONSerialization.JSONObjectWithData(data, options: nil) as? [String: Any] ?? [:]
+   let str: Decoded<[String]> = decode(dict, rootKey: "value")
+ } catch {
+   // handle error
+ }
+ ```
 
-  - parameter dict: The dictionary containing the `Any` instance to
-                    attempt to decode
-  - parameter rootKey: The root key that contains the object to decode
+ - parameter dict: The dictionary containing the `Any` instance to
+                   attempt to decode
+ - parameter rootKey: The root key that contains the object to decode
 
-  - returns: A `Decoded<[T]>` value where `T` is `Decodable`
-*/
-public func decode<T: Decodable>(_ dict: [String: Any], rootKey: String) -> Decoded<[T]> where T == T.DecodedType {
+ - returns: A `Decoded<[T]>` value where `T` is `Decodable`
+ */
+public func decode<T: Decodable>(_ dict: [String: Any], rootKey: String) -> Decoded<[T]>
+  where T == T.DecodedType {
   return JSON(dict as Any) <|| rootKey
 }
 
 /**
-  Attempt to transform `Any` into a `Decodable` value using a specified
-  root key and return an `Optional`.
+ Attempt to transform `Any` into a `Decodable` value using a specified
+ root key and return an `Optional`.
 
-  This function attempts to extract the embedded `JSON` object from the
-  dictionary at the specified key and transform it into a `Decodable` value,
-  returning an `Optional`. This works based on the type you ask for.
+ This function attempts to extract the embedded `JSON` object from the
+ dictionary at the specified key and transform it into a `Decodable` value,
+ returning an `Optional`. This works based on the type you ask for.
 
-  For example, the following code attempts to decode to `Optional<String>`,
-  because that's what we have explicitly stated is the return type:
+ For example, the following code attempts to decode to `Optional<String>`,
+ because that's what we have explicitly stated is the return type:
 
-  ```
-  do {
-    let dict = try NSJSONSerialization.JSONObjectWithData(data, options: nil) as? [String: Any] ?? [:]
-    let str: String? = decode(dict, rootKey: "value")
-  } catch {
-    // handle error
-  }
-  ```
+ ```
+ do {
+   let dict = try NSJSONSerialization.JSONObjectWithData(data, options: nil) as? [String: Any] ?? [:]
+   let str: String? = decode(dict, rootKey: "value")
+ } catch {
+   // handle error
+ }
+ ```
 
-  - parameter dict: The dictionary containing the `Any` instance to
-                    attempt to decode
-  - parameter rootKey: The root key that contains the object to decode
+ - parameter dict: The dictionary containing the `Any` instance to
+                   attempt to decode
+ - parameter rootKey: The root key that contains the object to decode
 
-  - returns: A `Decoded<T>` value where `T` is `Decodable`
-*/
+ - returns: A `Decoded<T>` value where `T` is `Decodable`
+ */
 public func decode<T: Decodable>(_ dict: [String: Any], rootKey: String) -> T? where T == T.DecodedType {
   return decode(dict, rootKey: rootKey).value
 }
 
 /**
-  Attempt to transform `Any` into an `Array` of `Decodable` value using a
-  specified root key and return an `Optional`
+ Attempt to transform `Any` into an `Array` of `Decodable` value using a
+ specified root key and return an `Optional`
 
-  This function attempts to extract the embedded `JSON` object from the
-  dictionary at the specified key and transform it into an `Array` of
-  `Decodable` values, returning an `Optional`. This works based on the type you
-  ask for.
+ This function attempts to extract the embedded `JSON` object from the
+ dictionary at the specified key and transform it into an `Array` of
+ `Decodable` values, returning an `Optional`. This works based on the type you
+ ask for.
 
-  For example, the following code attempts to decode to `Optional<[String]>`,
-  because that's what we have explicitly stated is the return type:
+ For example, the following code attempts to decode to `Optional<[String]>`,
+ because that's what we have explicitly stated is the return type:
 
-  ```
-  do {
-    let dict = try NSJSONSerialization.JSONObjectWithData(data, options: nil) as? [String: Any] ?? [:]
-    let str: [String]? = decode(dict, rootKey: "value")
-  } catch {
-    // handle error
-  }
-  ```
+ ```
+ do {
+   let dict = try NSJSONSerialization.JSONObjectWithData(data, options: nil) as? [String: Any] ?? [:]
+   let str: [String]? = decode(dict, rootKey: "value")
+ } catch {
+   // handle error
+ }
+ ```
 
-  - parameter dict: The dictionary containing the `Any` instance to
-                    attempt to decode
-  - parameter rootKey: The root key that contains the object to decode
+ - parameter dict: The dictionary containing the `Any` instance to
+                   attempt to decode
+ - parameter rootKey: The root key that contains the object to decode
 
-  - returns: A `Decoded<[T]>` value where `T` is `Decodable`
-*/
+ - returns: A `Decoded<[T]>` value where `T` is `Decodable`
+ */
 public func decode<T: Decodable>(_ dict: [String: Any], rootKey: String) -> [T]? where T == T.DecodedType {
   return decode(dict, rootKey: rootKey).value
 }

--- a/Library/ArgoDecoded/flatReduce.swift
+++ b/Library/ArgoDecoded/flatReduce.swift
@@ -1,0 +1,26 @@
+import Runes
+
+/**
+  Reduce a sequence with a combinator that returns a `Decoded` type, flattening
+  the result.
+
+  This function is a helper function to make it easier to deal with combinators
+  that return `Decoded` types without ending up with multiple levels of nested
+  `Decoded` values.
+
+  For example, it can be used to traverse a JSON structure with an array of
+  keys. See the implementations of `<|` and `<||` that take an array of keys for
+  a real-world example of this use case.
+
+  - parameter sequence: Any `SequenceType` of values
+  - parameter initial: The initial value for the accumulator
+  - parameter combine: The combinator, which returns a `Decoded` type
+
+  - returns: The result of iterating the combinator over every element of the
+             sequence and flattening the result
+*/
+public func flatReduce<S: Sequence, U>(_ sequence: S, initial: U, combine: (U, S.Iterator.Element) -> Decoded<U>) -> Decoded<U> {
+  return sequence.reduce(pure(initial)) { accum, x in
+    accum >>- { combine($0, x) }
+  }
+}

--- a/Library/ArgoDecoded/flatReduce.swift
+++ b/Library/ArgoDecoded/flatReduce.swift
@@ -1,25 +1,26 @@
 import Runes
 
 /**
-  Reduce a sequence with a combinator that returns a `Decoded` type, flattening
-  the result.
+ Reduce a sequence with a combinator that returns a `Decoded` type, flattening
+ the result.
 
-  This function is a helper function to make it easier to deal with combinators
-  that return `Decoded` types without ending up with multiple levels of nested
-  `Decoded` values.
+ This function is a helper function to make it easier to deal with combinators
+ that return `Decoded` types without ending up with multiple levels of nested
+ `Decoded` values.
 
-  For example, it can be used to traverse a JSON structure with an array of
-  keys. See the implementations of `<|` and `<||` that take an array of keys for
-  a real-world example of this use case.
+ For example, it can be used to traverse a JSON structure with an array of
+ keys. See the implementations of `<|` and `<||` that take an array of keys for
+ a real-world example of this use case.
 
-  - parameter sequence: Any `SequenceType` of values
-  - parameter initial: The initial value for the accumulator
-  - parameter combine: The combinator, which returns a `Decoded` type
+ - parameter sequence: Any `SequenceType` of values
+ - parameter initial: The initial value for the accumulator
+ - parameter combine: The combinator, which returns a `Decoded` type
 
-  - returns: The result of iterating the combinator over every element of the
-             sequence and flattening the result
-*/
-public func flatReduce<S: Sequence, U>(_ sequence: S, initial: U, combine: (U, S.Iterator.Element) -> Decoded<U>) -> Decoded<U> {
+ - returns: The result of iterating the combinator over every element of the
+            sequence and flattening the result
+ */
+public func flatReduce<S: Sequence, U>(_ sequence: S, initial: U,
+                                       combine: (U, S.Iterator.Element) -> Decoded<U>) -> Decoded<U> {
   return sequence.reduce(pure(initial)) { accum, x in
     accum >>- { combine($0, x) }
   }

--- a/Library/ArgoDecoded/sequence.swift
+++ b/Library/ArgoDecoded/sequence.swift
@@ -1,0 +1,56 @@
+/**
+  Convert an `Array` of `Decoded<T>` values to a `Decoded` `Array` of unwrapped
+  `T` values.
+
+  This performs an all-or-nothing transformation on the array. If every element
+  is `.Success`, then this function will return `.Success` along with the array
+  of unwrapped `T` values.
+
+  However, if _any_ of the elements are `.Failure`, this function will also
+  return `.Failure`, and no array will be returned.
+
+  - parameter xs: An `Array` of `Decoded<T>` values
+  - returns: A `Decoded` `Array` of unwrapped `T` values
+*/
+public func sequence<T>(_ xs: [Decoded<T>]) -> Decoded<[T]> {
+  var accum: [T] = []
+  accum.reserveCapacity(xs.count)
+
+  for x in xs {
+    switch x {
+    case let .success(value): accum.append(value)
+    case let .failure(error): return .failure(error)
+    }
+  }
+
+  return pure(accum)
+}
+
+/**
+  Convert a `Dictionary` with `Decoded<T>` values to a `Decoded` `Dictionary`
+  with unwrapped `T` values.
+
+  This performs an all-or-nothing transformation on the dictionary. If every
+  key is associated with a `.Success` value, then this function will return
+  `.Success` along with the dictionary of unwrapped `T` values associated with
+  their original keys.
+
+  However, if _any_ of the keys are associated with a `.Failure` value, this
+  function will also return `.Failure`, and no dictionary will be returned.
+
+  - parameter xs: A `Dictionary` of arbitrary keys and `Decoded<T>` values
+  - returns: A `Decoded` `Dictionary` of unwrapped `T` values assigned to their
+             original keys
+*/
+public func sequence<Key, Value>(_ xs: [Key: Decoded<Value>]) -> Decoded<[Key: Value]> {
+  var accum = Dictionary<Key, Value>(minimumCapacity: xs.count)
+
+  for (key, x) in xs {
+    switch x {
+    case let .success(value): accum[key] = value
+    case let .failure(error): return .failure(error)
+    }
+  }
+
+  return pure(accum)
+}

--- a/Library/ArgoDecoded/sequence.swift
+++ b/Library/ArgoDecoded/sequence.swift
@@ -1,17 +1,17 @@
 /**
-  Convert an `Array` of `Decoded<T>` values to a `Decoded` `Array` of unwrapped
-  `T` values.
+ Convert an `Array` of `Decoded<T>` values to a `Decoded` `Array` of unwrapped
+ `T` values.
 
-  This performs an all-or-nothing transformation on the array. If every element
-  is `.Success`, then this function will return `.Success` along with the array
-  of unwrapped `T` values.
+ This performs an all-or-nothing transformation on the array. If every element
+ is `.Success`, then this function will return `.Success` along with the array
+ of unwrapped `T` values.
 
-  However, if _any_ of the elements are `.Failure`, this function will also
-  return `.Failure`, and no array will be returned.
+ However, if _any_ of the elements are `.Failure`, this function will also
+ return `.Failure`, and no array will be returned.
 
-  - parameter xs: An `Array` of `Decoded<T>` values
-  - returns: A `Decoded` `Array` of unwrapped `T` values
-*/
+ - parameter xs: An `Array` of `Decoded<T>` values
+ - returns: A `Decoded` `Array` of unwrapped `T` values
+ */
 public func sequence<T>(_ xs: [Decoded<T>]) -> Decoded<[T]> {
   var accum: [T] = []
   accum.reserveCapacity(xs.count)
@@ -27,23 +27,23 @@ public func sequence<T>(_ xs: [Decoded<T>]) -> Decoded<[T]> {
 }
 
 /**
-  Convert a `Dictionary` with `Decoded<T>` values to a `Decoded` `Dictionary`
-  with unwrapped `T` values.
+ Convert a `Dictionary` with `Decoded<T>` values to a `Decoded` `Dictionary`
+ with unwrapped `T` values.
 
-  This performs an all-or-nothing transformation on the dictionary. If every
-  key is associated with a `.Success` value, then this function will return
-  `.Success` along with the dictionary of unwrapped `T` values associated with
-  their original keys.
+ This performs an all-or-nothing transformation on the dictionary. If every
+ key is associated with a `.Success` value, then this function will return
+ `.Success` along with the dictionary of unwrapped `T` values associated with
+ their original keys.
 
-  However, if _any_ of the keys are associated with a `.Failure` value, this
-  function will also return `.Failure`, and no dictionary will be returned.
+ However, if _any_ of the keys are associated with a `.Failure` value, this
+ function will also return `.Failure`, and no dictionary will be returned.
 
-  - parameter xs: A `Dictionary` of arbitrary keys and `Decoded<T>` values
-  - returns: A `Decoded` `Dictionary` of unwrapped `T` values assigned to their
-             original keys
-*/
+ - parameter xs: A `Dictionary` of arbitrary keys and `Decoded<T>` values
+ - returns: A `Decoded` `Dictionary` of unwrapped `T` values assigned to their
+            original keys
+ */
 public func sequence<Key, Value>(_ xs: [Key: Decoded<Value>]) -> Decoded<[Key: Value]> {
-  var accum = Dictionary<Key, Value>(minimumCapacity: xs.count)
+  var accum = [Key: Value](minimumCapacity: xs.count)
 
   for (key, x) in xs {
     switch x {

--- a/Library/Navigation.swift
+++ b/Library/Navigation.swift
@@ -1,4 +1,3 @@
-import Argo
 import Curry
 import Foundation
 import KsApi

--- a/Library/OptimizelyClientType.swift
+++ b/Library/OptimizelyClientType.swift
@@ -139,12 +139,12 @@ public func optimizelyUserAttributes(
   refTag: RefTag? = nil
 ) -> [String: Any] {
   let user = AppEnvironment.current.currentUser
-
+  let user_country = user?.location?.country
   let properties: [String: Any] = [
     "user_distinct_id": debugDeviceIdentifier(),
     "user_backed_projects_count": user?.stats.backedProjectsCount,
     "user_launched_projects_count": user?.stats.createdProjectsCount,
-    "user_country": (user?.location?.country ?? AppEnvironment.current.config?.countryCode)?.lowercased(),
+    "user_country": (user_country ?? AppEnvironment.current.config?.countryCode)?.lowercased(),
     "user_facebook_account": user?.facebookConnected,
     "user_display_language": AppEnvironment.current.language.rawValue,
     "session_os_version": AppEnvironment.current.device.systemVersion,

--- a/Library/RefTag.swift
+++ b/Library/RefTag.swift
@@ -1,4 +1,3 @@
-import Argo
 import KsApi
 import Runes
 
@@ -197,7 +196,7 @@ private func sortRefTagSuffix(_ sort: DiscoveryParams.Sort) -> String {
   }
 }
 
-extension RefTag: Argo.Decodable {
+extension RefTag: Decodable {
   public static func decode(_ json: JSON) -> Decoded<RefTag> {
     switch json {
     case let .string(code):


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

As a part of Argo removal implementations for functor, monad, and additional FP operations implementations for Argo classes were added to the project. 

# 🤔 Why

`Navigation` enum uses FP operations Argo overloads extensively. As well as many other classes. Re-implementing them for `Swift.Codable` and model conversion to a `Swift.Codable` is a bit of chicken and egg problem. To avoid that i've added to project implementations of functor, monad, etc. And went through the project to make sure all our model use new implementations. 

And fixed some failing test cases
i had very strange
`Left side of nil coalescing operator '??' has non-optional type 'String? ` warning and some tests failing due to it in `OptimizelyClientType.swift`

When I’ve added local `let user_country = user?.location?.country`  and used it instead `user?.location?.country`  my tests went back to green



# ✅ Acceptance criteria

- [ ] All tests should pass

# Summary

It's provisional PR to allow finish model conversion to `Swift.Codable`
