### PR TITLE
NT-1631: Blank Screen on Discover

### DIFF
--- a/Kickstarter-iOS/AppDelegate.swift
+++ b/Kickstarter-iOS/AppDelegate.swift
@@ -356,6 +356,7 @@ internal final class AppDelegate: UIResponder, UIApplicationDelegate {
       print("🔴 Optimizely SDK Configuration Failed with Error: \(optimizelyError.localizedDescription)")
 
       Crashlytics.crashlytics().record(error: optimizelyError)
+      self.viewModel.inputs.optimizelyClientConfigurationFailed()
     }
   }
 

--- a/Library/ViewModels/DiscoveryViewModel.swift
+++ b/Library/ViewModels/DiscoveryViewModel.swift
@@ -86,7 +86,6 @@ public final class DiscoveryViewModel: DiscoveryViewModelType, DiscoveryViewMode
     let optimizelyReadyOrContinue = Signal.merge(
       self.optimizelyClientConfiguredProperty.signal,
       self.viewDidLoadProperty.signal.map { _ in AppEnvironment.current.optimizelyClient }
-        .skipNil()
         .ignoreValues(),
       self.optimizelyClientConfigurationFailedProperty.signal
     ).take(first: 1)

--- a/Library/ViewModels/DiscoveryViewModelTests.swift
+++ b/Library/ViewModels/DiscoveryViewModelTests.swift
@@ -44,21 +44,16 @@ internal final class DiscoveryViewModelTests: TestCase {
   }
 
   func testConfigureDataSourceOptimizelyConfiguration() {
-    withEnvironment(optimizelyClient: nil) {
+    let mockOptimizelyClient = MockOptimizelyClient()
+
+    withEnvironment(optimizelyClient: mockOptimizelyClient) {
       self.vm.inputs.viewDidLoad()
       self.vm.inputs.viewWillAppear(animated: false)
+      self.vm.inputs.optimizelyClientConfigured()
 
-      self.configureDataSource.assertDidNotEmitValue("Waits for Optimizely configuration")
+      XCTAssertTrue(mockOptimizelyClient.activatePathCalled)
 
-      let mockOptimizelyClient = MockOptimizelyClient()
-
-      withEnvironment(optimizelyClient: mockOptimizelyClient) {
-        self.vm.inputs.optimizelyClientConfigured()
-
-        XCTAssertTrue(mockOptimizelyClient.activatePathCalled)
-
-        self.configureDataSource.assertValueCount(1)
-      }
+      self.configureDataSource.assertValueCount(1)
     }
   }
 
@@ -66,8 +61,6 @@ internal final class DiscoveryViewModelTests: TestCase {
     withEnvironment(optimizelyClient: nil) {
       self.vm.inputs.viewDidLoad()
       self.vm.inputs.viewWillAppear(animated: false)
-
-      self.configureDataSource.assertDidNotEmitValue("Waits for Optimizely configuration")
 
       self.vm.inputs.optimizelyClientConfigurationFailed()
 


### PR DESCRIPTION
# 📲 What

There have been reports that user's are seeing blank screens on discover. We've tracked down this issue to an issue with Optimizely. The fix was to reduce the amount of time the app will wait for Optimizely to initialize. After the fix we were still noticing issues with discover.

# 🤔 Why

User's are unable to access the discover page to view projects. Reproducing this was difficult until a user mentioned that their NextDNS VPN was causing it to not work. Testing on a physical device indicated that it was indeed causing blank screens on iOS. 

# 🛠 How

Another way to test for this is by setting the optimizely key to an empty string. When this happens the sdk is unable to download the datafile and thus cannot configure the sdk. The fix is to call the failed to configure sdk signal when this happens and also to enable nil sdk values in the discover view model. 

# Test
- Run branch on device
- Visit nextdns.io on device
- Download the NextDNS app
- Follow the instructions to setup a vpn
- Ensure that the discover screen does not show a blank screen