### PR TITLE
[NT-1644][NT-1645] Adding email verification feature flags

### DIFF
--- a/Library/Extensions/Feature+Helpers.swift
+++ b/Library/Extensions/Feature+Helpers.swift
@@ -5,6 +5,14 @@ public func featureQualtricsIsEnabled() -> Bool {
   return Feature.qualtrics.isEnabled()
 }
 
+public func featureEmailVerificationFlowIsEnabled() -> Bool {
+  return Feature.emailVerificationFlow.isEnabled()
+}
+
+public func featureEmailVerificationSkipIsEnabled() -> Bool {
+  return Feature.emailVerificationSkip.isEnabled()
+}
+
 extension Feature {
   fileprivate func isEnabled(in environment: Environment = AppEnvironment.current) -> Bool {
     guard let features = environment.config?.features, !features.isEmpty else { return false }

--- a/Library/Extensions/Feature+HelpersTests.swift
+++ b/Library/Extensions/Feature+HelpersTests.swift
@@ -30,4 +30,56 @@ final class FeatureHelpersTests: TestCase {
       XCTAssertFalse(featureQualtricsIsEnabled())
     }
   }
+
+  // MARK: - Email Verification Flow
+
+  func testFeatureEmailVerificationFlow_isTrue() {
+    let config = Config.template
+      |> \.features .~ [Feature.emailVerificationFlow.rawValue: true]
+
+    withEnvironment(config: config) {
+      XCTAssertTrue(featureEmailVerificationFlowIsEnabled())
+    }
+  }
+
+  func testFeatureEmailVerificationFlow_isFalse() {
+    let config = Config.template
+      |> \.features .~ [Feature.emailVerificationFlow.rawValue: false]
+
+    withEnvironment(config: config) {
+      XCTAssertFalse(featureEmailVerificationFlowIsEnabled())
+    }
+  }
+
+  func testFeatureEmailVerificationFlow_isFalse_whenNil() {
+    withEnvironment(config: .template) {
+      XCTAssertFalse(featureEmailVerificationFlowIsEnabled())
+    }
+  }
+
+  // MARK: - Email Verification Skip
+
+  func testFeatureEmailVerificationSkip_isTrue() {
+    let config = Config.template
+      |> \.features .~ [Feature.emailVerificationSkip.rawValue: true]
+
+    withEnvironment(config: config) {
+      XCTAssertTrue(featureEmailVerificationSkipIsEnabled())
+    }
+  }
+
+  func testFeatureEmailVerificationSkip_isFalse() {
+    let config = Config.template
+      |> \.features .~ [Feature.emailVerificationSkip.rawValue: false]
+
+    withEnvironment(config: config) {
+      XCTAssertFalse(featureEmailVerificationSkipIsEnabled())
+    }
+  }
+
+  func testFeatureEmailVerificationSkip_isFalse_whenNil() {
+    withEnvironment(config: .template) {
+      XCTAssertFalse(featureEmailVerificationSkipIsEnabled())
+    }
+  }
 }

--- a/Library/Feature.swift
+++ b/Library/Feature.swift
@@ -2,12 +2,16 @@ import Foundation
 
 public enum Feature: String {
   case qualtrics = "ios_qualtrics"
+  case emailVerificationFlow = "ios_email_verification_flow"
+  case emailVerificationSkip = "ios_email_verification_skip"
 }
 
 extension Feature: CustomStringConvertible {
   public var description: String {
     switch self {
     case .qualtrics: return "Qualtrics"
+    case .emailVerificationFlow: return "Email Verification Flow"
+    case .emailVerificationSkip: return "Email Verification Skip"
     }
   }
 }

--- a/Library/ViewModels/FeatureFlagToolsViewModelTests.swift
+++ b/Library/ViewModels/FeatureFlagToolsViewModelTests.swift
@@ -93,14 +93,18 @@ final class FeatureFlagToolsViewModelTests: TestCase {
     }
   }
 
-  func testFeatureEnabledFromDictionaries_UnkownFeatures() {
+  func testFeatureEnabledFromDictionaries_UnknownFeatures() {
     let featureEnabled = featureEnabledFromDictionaries([["some_unknown_feature": false]])
 
     XCTAssertTrue(featureEnabled.isEmpty, "Unknown features do not produce Feature enums")
   }
 
   func testFeatureEnabledFromDictionaries_KnownFeatures() {
-    let featureEnabled = featureEnabledFromDictionaries([["ios_qualtrics": false]])
+    let featureEnabled = featureEnabledFromDictionaries([[
+      "ios_qualtrics": false,
+      "ios_email_verification_flow": false,
+      "ios_email_verification_skip": false
+    ]])
 
     XCTAssertFalse(featureEnabled.isEmpty, "Known features produce Feature enums")
   }


### PR DESCRIPTION
# 📲 What

Before we begin the heavy lifting for the email verification work, we'll need to put the work behind feature flags to prevent incomplete work or bugs from being exposed in any future releases. We've added two feature flags to the project after setting them up on Flipper.

# 🤔 Why

Feature flags are a commonly used paradigm in software development that allow you to modify system behavior without changing the code explicitly. The email verification feature work is split into smaller pieces that will be incrementally developed and released as they are completed. The feature flags we've added here will ensure that any new releases prior to the completion of the feature will not introduce unexpected behavior for our current users.

# 🛠 How

The following two flags were added to the project:
- `ios_email_verification_flow`
- `ios_email_verification_skip`

# 👀 See

![Simulator Screen Shot - iPhone 11 Pro - 2020-11-03 at 11 46 28](https://user-images.githubusercontent.com/15615702/98015817-36ce7a00-1dcb-11eb-9cdc-6f636d9113ed.png)
