### PR TITLE
[NT-1670] Deeplink users when selecting a remote notification

### DIFF
--- a/Kickstarter-iOS/AppDelegate.swift
+++ b/Kickstarter-iOS/AppDelegate.swift
@@ -445,9 +445,15 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
 
   public func userNotificationCenter(
     _: UNUserNotificationCenter,
-    didReceive _: UNNotificationResponse,
+    didReceive response: UNNotificationResponse,
     withCompletionHandler completion: @escaping () -> Void
   ) {
+    guard let rootTabBarController = self.rootTabBarController else {
+      completion()
+      return
+    }
+    self.viewModel.inputs.didReceive(remoteNotification: response.notification.request.content.userInfo)
+    rootTabBarController.didReceiveBadgeValue(response.notification.request.content.badge as? Int)
     completion()
   }
 }


### PR DESCRIPTION
# 📲 What

We noticed an influx of reports from Support Dev that suggested deeplinking was no longer working for users. It appears we introduced a regression recently and this PR provides the fix.

# 🤔 Why

The push notifications are designed to take the user directly into the relevant point in the application. When deeplinking doesn't work as expected, the user is simply taken into the app and loses context of what the notification was meant for.

# 🛠 How

In the `userNotificationCenter: didReceive` delegate method we were not handling the response. It looks like when we [removed the Qualtrics SDK](https://github.com/kickstarter/ios-oss/commit/f6a6d8dec8890d29b8b291750be8fa19624d6494#diff-2b5cc9e2481b28948ced1e33f97217f053db9fd9c2de5070819b45ff03463369L483) we introduced a regression and removed the view model handling in there. Adding that line back results in the deeplinks working as expected again. 