### PR TITLE
[NT-1494] Fix for Pledge View Reward Title Being Cut Off

### DIFF
--- a/Kickstarter-iOS/Views/Cells/PledgeExpandableHeaderRewardCell.swift
+++ b/Kickstarter-iOS/Views/Cells/PledgeExpandableHeaderRewardCell.swift
@@ -95,6 +95,7 @@ private func rootStackViewStyle(_ isAccessibilityCategory: Bool) -> (StackViewSt
 
   return { (stackView: UIStackView) in
     stackView
+      |> \.insetsLayoutMarginsFromSafeArea .~ false
       |> \.alignment .~ alignment
       |> \.axis .~ axis
       |> \.distribution .~ distribution

--- a/Kickstarter-iOS/Views/Cells/PledgeExpandableHeaderRewardHeaderCell.swift
+++ b/Kickstarter-iOS/Views/Cells/PledgeExpandableHeaderRewardHeaderCell.swift
@@ -111,6 +111,7 @@ private func rootStackViewStyle(_ isAccessibilityCategory: Bool) -> (StackViewSt
 
   return { (stackView: UIStackView) in
     stackView
+      |> \.insetsLayoutMarginsFromSafeArea .~ false
       |> \.alignment .~ alignment
       |> \.axis .~ axis
       |> \.distribution .~ distribution


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Fixes an issue that was causing the reward title on the pledge view to sometimes be clipped.

# 🤔 Why

This is not the expected behaviour and hampers the experience.

# 🛠 How

Set the property `insetsLayoutMarginsFromSafeArea` to `false` for both of the cell's root stackviews in this table view. Sometimes when the cell is scrolled beyond the safe area of the view and performs a layout pass it does so incorrectly insetting its layout margins from the safe area. Setting this property to `false` prevents this from happening. I was not able to reproduce the issue after setting this to `false` but could consistently do so with it being `true` (default).

# 👀 See

https://developer.apple.com/documentation/uikit/uiview/2891101-insetslayoutmarginsfromsafearea

| Before 🐛 | After 🦋 |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/3735375/99319420-554a6180-281e-11eb-967a-8f9a434cfb45.png) | ![image](https://user-images.githubusercontent.com/3735375/99319568-95114900-281e-11eb-9fd9-c27a8e9d3e8d.png) |

# ✅ Acceptance criteria

- [ ] Navigate to the pledge view for a reward that has shipping. While the shipping locations are loading try to scroll the reward title out of view. This should _not_ cause the text to be cut off.