### PR TITLE
[NT-1661][NT-1662] Connect Login and Signup Flow to Interstitial UI

### DIFF
--- a/Kickstarter-iOS/Library/SharedFunctions.swift
+++ b/Kickstarter-iOS/Library/SharedFunctions.swift
@@ -47,3 +47,13 @@ public func logoutAndDismiss(
 
   viewController.dismiss(animated: true, completion: nil)
 }
+
+// MARK: - Email Verification workflow
+
+public func pushEmailVerificationViewController(
+  viewController: UIViewController
+) {
+  viewController.navigationController?
+    .pushViewController(EmailVerificationViewController.instantiate(), animated: true)
+  viewController.navigationController?.setNavigationBarHidden(true, animated: true)
+}

--- a/Kickstarter-iOS/Library/SharedFunctions.swift
+++ b/Kickstarter-iOS/Library/SharedFunctions.swift
@@ -47,13 +47,3 @@ public func logoutAndDismiss(
 
   viewController.dismiss(animated: true, completion: nil)
 }
-
-// MARK: - Email Verification workflow
-
-public func pushEmailVerificationViewController(
-  viewController: UIViewController
-) {
-  viewController.navigationController?
-    .pushViewController(EmailVerificationViewController.instantiate(), animated: true)
-  viewController.navigationController?.setNavigationBarHidden(true, animated: true)
-}

--- a/Kickstarter-iOS/Views/Controllers/EmailVerificationViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/EmailVerificationViewController.swift
@@ -3,6 +3,10 @@ import Library
 import Prelude
 import UIKit
 
+protocol EmailVerificationViewControllerDelegate: AnyObject {
+  func emailVerificationViewControllerDidComplete(_ viewController: EmailVerificationViewController)
+}
+
 final class EmailVerificationViewController: UIViewController {
   // MARK: - Properties
 
@@ -18,6 +22,7 @@ final class EmailVerificationViewController: UIViewController {
   private lazy var skipButton: UIButton = { UIButton(type: .custom) }()
   private lazy var titleLabel: UILabel = { UILabel(frame: .zero) }()
 
+  private weak var delegate: EmailVerificationViewControllerDelegate?
   private let viewModel: EmailVerificationViewModelType = EmailVerificationViewModel()
 
   // MARK: - Lifecycle
@@ -206,4 +211,15 @@ private let titleLabelStyle: LabelStyle = { (label: UILabel) in
       )
     }
     |> \.numberOfLines .~ 0
+}
+
+// MARK: - Presentation
+
+extension EmailVerificationViewController {
+  static func push(on otherVC: UIViewController & EmailVerificationViewControllerDelegate) {
+    let vc = EmailVerificationViewController.instantiate()
+    vc.delegate = otherVC
+    otherVC.navigationController?.pushViewController(vc, animated: true)
+    otherVC.navigationController?.setNavigationBarHidden(true, animated: true)
+  }
 }

--- a/Kickstarter-iOS/Views/Controllers/LoginViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/LoginViewController.swift
@@ -229,8 +229,7 @@ internal final class LoginViewController: UIViewController {
 // MARK: - EmailVerificationViewControllerDelegate
 
 extension LoginViewController: EmailVerificationViewControllerDelegate {
-  func emailVerificationViewControllerDidComplete(_ viewController: EmailVerificationViewController) {
-    // create another input called emailVerificationViewControllerDidComplete() which does exactly the same as environmentLoggedIn()
-    self.viewModel.inputs.environmentLoggedIn()
+  func emailVerificationViewControllerDidComplete(_: EmailVerificationViewController) {
+    self.viewModel.inputs.emailVerificationViewControllerDidComplete()
   }
 }

--- a/Kickstarter-iOS/Views/Controllers/LoginViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/LoginViewController.swift
@@ -133,17 +133,16 @@ internal final class LoginViewController: UIViewController {
 
     self.viewModel.outputs.logIntoEnvironment
       .observeValues { [weak self] env in
-        guard let env = env else { return }
         AppEnvironment.login(env)
         self?.viewModel.inputs.environmentLoggedIn()
       }
 
-    self.viewModel.outputs.showEmailVerification
+    self.viewModel.outputs.logIntoEnvironmentAndShowEmailVerification
       .observeForControllerAction()
       .observeValues { [weak self] env in
         guard let self = self else { return }
         AppEnvironment.login(env)
-        pushEmailVerificationViewController(viewController: self)
+        EmailVerificationViewController.push(on: self)
       }
 
     self.viewModel.outputs.showResetPassword
@@ -224,5 +223,14 @@ internal final class LoginViewController: UIViewController {
 
   @objc func showHidePasswordButtonTapped() {
     self.viewModel.inputs.showHidePasswordButtonTapped()
+  }
+}
+
+// MARK: - EmailVerificationViewControllerDelegate
+
+extension LoginViewController: EmailVerificationViewControllerDelegate {
+  func emailVerificationViewControllerDidComplete(_ viewController: EmailVerificationViewController) {
+    // create another input called emailVerificationViewControllerDidComplete() which does exactly the same as environmentLoggedIn()
+    self.viewModel.inputs.environmentLoggedIn()
   }
 }

--- a/Kickstarter-iOS/Views/Controllers/LoginViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/LoginViewController.swift
@@ -133,8 +133,17 @@ internal final class LoginViewController: UIViewController {
 
     self.viewModel.outputs.logIntoEnvironment
       .observeValues { [weak self] env in
+        guard let env = env else { return }
         AppEnvironment.login(env)
         self?.viewModel.inputs.environmentLoggedIn()
+      }
+
+    self.viewModel.outputs.showEmailVerification
+      .observeForControllerAction()
+      .observeValues { [weak self] env in
+        guard let self = self else { return }
+        AppEnvironment.login(env)
+        pushEmailVerificationViewController(viewController: self)
       }
 
     self.viewModel.outputs.showResetPassword

--- a/Kickstarter-iOS/Views/Controllers/SignupViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/SignupViewController.swift
@@ -119,14 +119,23 @@ internal final class SignupViewController: UIViewController, MFMailComposeViewCo
     self.signupButton.rac.enabled = self.viewModel.outputs.isSignupButtonEnabled
 
     self.viewModel.outputs.logIntoEnvironment
-      .observeValues { [weak self] in
-        AppEnvironment.login($0)
+      .observeValues { [weak self] env in
+        guard let env = env else { return }
+        AppEnvironment.login(env)
         self?.viewModel.inputs.environmentLoggedIn()
       }
 
     self.viewModel.outputs.postNotification
       .observeForUI()
       .observeValues(NotificationCenter.default.post)
+
+    self.viewModel.outputs.showEmailVerification
+      .observeForControllerAction()
+      .observeValues { [weak self] env in
+        guard let self = self else { return }
+        AppEnvironment.login(env)
+        pushEmailVerificationViewController(viewController: self)
+      }
 
     self.viewModel.outputs.showError
       .observeForControllerAction()

--- a/Kickstarter-iOS/Views/Controllers/SignupViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/SignupViewController.swift
@@ -134,7 +134,7 @@ internal final class SignupViewController: UIViewController, MFMailComposeViewCo
       .observeValues { [weak self] env in
         guard let self = self else { return }
         AppEnvironment.login(env)
-        pushEmailVerificationViewController(viewController: self)
+        EmailVerificationViewController.push(on: self)
       }
 
     self.viewModel.outputs.showError
@@ -260,5 +260,13 @@ internal final class SignupViewController: UIViewController, MFMailComposeViewCo
     helpSheet.popoverPresentationController?.barButtonItem = self.navigationItem.rightBarButtonItem
 
     self.present(helpSheet, animated: true, completion: nil)
+  }
+}
+
+// MARK: - EmailVerificationViewControllerDelegate
+
+extension SignupViewController: EmailVerificationViewControllerDelegate {
+  func emailVerificationViewControllerDidComplete(_ viewController: EmailVerificationViewController) {
+
   }
 }

--- a/Kickstarter-iOS/Views/Controllers/SignupViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/SignupViewController.swift
@@ -120,22 +120,21 @@ internal final class SignupViewController: UIViewController, MFMailComposeViewCo
 
     self.viewModel.outputs.logIntoEnvironment
       .observeValues { [weak self] env in
-        guard let env = env else { return }
         AppEnvironment.login(env)
         self?.viewModel.inputs.environmentLoggedIn()
       }
 
-    self.viewModel.outputs.postNotification
-      .observeForUI()
-      .observeValues(NotificationCenter.default.post)
-
-    self.viewModel.outputs.showEmailVerification
+    self.viewModel.outputs.logIntoEnvironmentAndShowEmailVerification
       .observeForControllerAction()
       .observeValues { [weak self] env in
         guard let self = self else { return }
         AppEnvironment.login(env)
         EmailVerificationViewController.push(on: self)
       }
+
+    self.viewModel.outputs.postNotification
+      .observeForUI()
+      .observeValues(NotificationCenter.default.post)
 
     self.viewModel.outputs.showError
       .observeForControllerAction()
@@ -266,7 +265,7 @@ internal final class SignupViewController: UIViewController, MFMailComposeViewCo
 // MARK: - EmailVerificationViewControllerDelegate
 
 extension SignupViewController: EmailVerificationViewControllerDelegate {
-  func emailVerificationViewControllerDidComplete(_ viewController: EmailVerificationViewController) {
-
+  func emailVerificationViewControllerDidComplete(_: EmailVerificationViewController) {
+    self.viewModel.inputs.emailVerificationViewControllerDidComplete()
   }
 }

--- a/Library/SharedFunctions.swift
+++ b/Library/SharedFunctions.swift
@@ -396,6 +396,7 @@ public func isEndDateAfterToday(for reward: Reward) -> Bool {
 
  - returns: A Bool representing whether the email is verified.
  */
-public func isAccessTokenEnvelopeEmailVerified(_ env: AccessTokenEnvelope) -> Bool {
-  return featureEmailVerificationFlowIsEnabled() ? (env.user.isEmailVerified ?? false) : true
+public func showEmailVerificationForAccessTokenEnvelope(_ env: AccessTokenEnvelope) -> Bool {
+  guard featureEmailVerificationFlowIsEnabled() else { return false }
+  return env.user.isEmailVerified == nil || env.user.isEmailVerified == false
 }

--- a/Library/SharedFunctions.swift
+++ b/Library/SharedFunctions.swift
@@ -397,6 +397,5 @@ public func isEndDateAfterToday(for reward: Reward) -> Bool {
  - returns: A Bool representing whether the email is verified.
  */
 public func isAccessTokenEnvelopeEmailVerified(_ env: AccessTokenEnvelope) -> Bool {
-  return false
   return env.user.isEmailVerified ?? false
 }

--- a/Library/SharedFunctions.swift
+++ b/Library/SharedFunctions.swift
@@ -388,3 +388,15 @@ public func isEndDateAfterToday(for reward: Reward) -> Bool {
   return (reward.endsAt == nil || (reward.endsAt ?? 0) >= AppEnvironment.current.dateType.init()
     .timeIntervalSince1970)
 }
+
+/**
+ Determines if a given `AccessTokenEnvelope`'s `User`'s email is verified.
+
+ - parameter env: The access token envelope.
+
+ - returns: A Bool representing whether the email is verified.
+ */
+public func isAccessTokenEnvelopeEmailVerified(_ env: AccessTokenEnvelope) -> Bool {
+  return false
+  return env.user.isEmailVerified ?? false
+}

--- a/Library/SharedFunctions.swift
+++ b/Library/SharedFunctions.swift
@@ -397,5 +397,5 @@ public func isEndDateAfterToday(for reward: Reward) -> Bool {
  - returns: A Bool representing whether the email is verified.
  */
 public func isAccessTokenEnvelopeEmailVerified(_ env: AccessTokenEnvelope) -> Bool {
-  return env.user.isEmailVerified ?? false
+  return featureEmailVerificationFlowIsEnabled() ? (env.user.isEmailVerified ?? false) : true
 }

--- a/Library/SharedFunctionsTests.swift
+++ b/Library/SharedFunctionsTests.swift
@@ -346,20 +346,20 @@ final class SharedFunctionsTests: TestCase {
 
     XCTAssertTrue(isEndDateAfterToday(for: reward))
   }
-  
+
   func testIsAccessTokenEnvelopeEmailVerified_IsEmailVerified_True() {
     let user = .template
       |> User.lens.isEmailVerified .~ true
     let env = AccessTokenEnvelope(accessToken: "deadbeef", user: user)
-    
+
     XCTAssertTrue(isAccessTokenEnvelopeEmailVerified(env))
   }
-  
+
   func testIsAccessTokenEnvelopeEmailVerified_IsEmailVerified_False() {
     let user = .template
       |> User.lens.isEmailVerified .~ false
     let env = AccessTokenEnvelope(accessToken: "deadbeef", user: user)
-    
+
     XCTAssertFalse(isAccessTokenEnvelopeEmailVerified(env))
   }
 }

--- a/Library/SharedFunctionsTests.swift
+++ b/Library/SharedFunctionsTests.swift
@@ -347,19 +347,51 @@ final class SharedFunctionsTests: TestCase {
     XCTAssertTrue(isEndDateAfterToday(for: reward))
   }
 
-  func testIsAccessTokenEnvelopeEmailVerified_IsEmailVerified_True() {
+  func testIsAccessTokenEnvelopeEmailVerified_IsEmailVerified_True_FeatureFlag_True() {
+    let config = .template
+      |> Config.lens.features .~ [Feature.emailVerificationFlow.rawValue: true]
     let user = .template
       |> User.lens.isEmailVerified .~ true
     let env = AccessTokenEnvelope(accessToken: "deadbeef", user: user)
 
-    XCTAssertTrue(isAccessTokenEnvelopeEmailVerified(env))
+    withEnvironment(apiService: MockService(loginResponse: env), config: config) {
+      XCTAssertTrue(isAccessTokenEnvelopeEmailVerified(env))
+    }
   }
 
-  func testIsAccessTokenEnvelopeEmailVerified_IsEmailVerified_False() {
+  func testIsAccessTokenEnvelopeEmailVerified_IsEmailVerified_True_FeatureFlag_False() {
+    let config = .template
+      |> Config.lens.features .~ [Feature.emailVerificationFlow.rawValue: false]
+    let user = .template
+      |> User.lens.isEmailVerified .~ true
+    let env = AccessTokenEnvelope(accessToken: "deadbeef", user: user)
+
+    withEnvironment(apiService: MockService(loginResponse: env), config: config) {
+      XCTAssertTrue(isAccessTokenEnvelopeEmailVerified(env))
+    }
+  }
+
+  func testIsAccessTokenEnvelopeEmailVerified_IsEmailVerified_False_FeatureFlag_True() {
+    let config = .template
+      |> Config.lens.features .~ [Feature.emailVerificationFlow.rawValue: true]
     let user = .template
       |> User.lens.isEmailVerified .~ false
     let env = AccessTokenEnvelope(accessToken: "deadbeef", user: user)
 
-    XCTAssertFalse(isAccessTokenEnvelopeEmailVerified(env))
+    withEnvironment(apiService: MockService(loginResponse: env), config: config) {
+      XCTAssertFalse(isAccessTokenEnvelopeEmailVerified(env))
+    }
+  }
+
+  func testIsAccessTokenEnvelopeEmailVerified_IsEmailVerified_False_FeatureFlag_False() {
+    let config = .template
+      |> Config.lens.features .~ [Feature.emailVerificationFlow.rawValue: false]
+    let user = .template
+      |> User.lens.isEmailVerified .~ false
+    let env = AccessTokenEnvelope(accessToken: "deadbeef", user: user)
+
+    withEnvironment(apiService: MockService(loginResponse: env), config: config) {
+      XCTAssertTrue(isAccessTokenEnvelopeEmailVerified(env))
+    }
   }
 }

--- a/Library/SharedFunctionsTests.swift
+++ b/Library/SharedFunctionsTests.swift
@@ -355,7 +355,7 @@ final class SharedFunctionsTests: TestCase {
     let env = AccessTokenEnvelope(accessToken: "deadbeef", user: user)
 
     withEnvironment(apiService: MockService(loginResponse: env), config: config) {
-      XCTAssertTrue(isAccessTokenEnvelopeEmailVerified(env))
+      XCTAssertFalse(showEmailVerificationForAccessTokenEnvelope(env))
     }
   }
 
@@ -367,7 +367,7 @@ final class SharedFunctionsTests: TestCase {
     let env = AccessTokenEnvelope(accessToken: "deadbeef", user: user)
 
     withEnvironment(apiService: MockService(loginResponse: env), config: config) {
-      XCTAssertTrue(isAccessTokenEnvelopeEmailVerified(env))
+      XCTAssertFalse(showEmailVerificationForAccessTokenEnvelope(env))
     }
   }
 
@@ -379,7 +379,7 @@ final class SharedFunctionsTests: TestCase {
     let env = AccessTokenEnvelope(accessToken: "deadbeef", user: user)
 
     withEnvironment(apiService: MockService(loginResponse: env), config: config) {
-      XCTAssertFalse(isAccessTokenEnvelopeEmailVerified(env))
+      XCTAssertTrue(showEmailVerificationForAccessTokenEnvelope(env))
     }
   }
 
@@ -391,7 +391,7 @@ final class SharedFunctionsTests: TestCase {
     let env = AccessTokenEnvelope(accessToken: "deadbeef", user: user)
 
     withEnvironment(apiService: MockService(loginResponse: env), config: config) {
-      XCTAssertTrue(isAccessTokenEnvelopeEmailVerified(env))
+      XCTAssertFalse(showEmailVerificationForAccessTokenEnvelope(env))
     }
   }
 }

--- a/Library/SharedFunctionsTests.swift
+++ b/Library/SharedFunctionsTests.swift
@@ -346,4 +346,20 @@ final class SharedFunctionsTests: TestCase {
 
     XCTAssertTrue(isEndDateAfterToday(for: reward))
   }
+  
+  func testIsAccessTokenEnvelopeEmailVerified_IsEmailVerified_True() {
+    let user = .template
+      |> User.lens.isEmailVerified .~ true
+    let env = AccessTokenEnvelope(accessToken: "deadbeef", user: user)
+    
+    XCTAssertTrue(isAccessTokenEnvelopeEmailVerified(env))
+  }
+  
+  func testIsAccessTokenEnvelopeEmailVerified_IsEmailVerified_False() {
+    let user = .template
+      |> User.lens.isEmailVerified .~ false
+    let env = AccessTokenEnvelope(accessToken: "deadbeef", user: user)
+    
+    XCTAssertFalse(isAccessTokenEnvelopeEmailVerified(env))
+  }
 }

--- a/Library/ViewModels/LoginViewModel.swift
+++ b/Library/ViewModels/LoginViewModel.swift
@@ -109,11 +109,11 @@ public final class LoginViewModel: LoginViewModelType, LoginViewModelInputs, Log
 
     /// If user's email is verified, log into environment.
     self.logIntoEnvironment = loginEventValues
-      .filter(isAccessTokenEnvelopeEmailVerified)
+      .filter(showEmailVerificationForAccessTokenEnvelope >>> isFalse)
 
     /// If user's email is not verified, show email verification prompt.
     self.logIntoEnvironmentAndShowEmailVerification = loginEventValues
-      .filter(isAccessTokenEnvelopeEmailVerified >>> isFalse)
+      .filter(showEmailVerificationForAccessTokenEnvelope >>> isTrue)
 
     let tfaError = loginEvent.errors()
       .filter { $0.ksrCode == .TfaRequired }

--- a/Library/ViewModels/LoginViewModel.swift
+++ b/Library/ViewModels/LoginViewModel.swift
@@ -13,6 +13,9 @@ public protocol LoginViewModelInputs {
   /// Call when the environment has been logged into.
   func environmentLoggedIn()
 
+  /// Call when the skip button on the  email verification view controller is tapped.
+  func emailVerificationViewControllerDidComplete()
+
   /// Call when login button is pressed.
   func loginButtonPressed()
 
@@ -120,16 +123,19 @@ public final class LoginViewModel: LoginViewModelType, LoginViewModelInputs, Log
       .takeWhen(tfaError)
       .map { (email: $0, password: $1) }
 
-    self.postNotification = self.environmentLoggedInProperty.signal
-      .mapConst(
-        (
-          Notification(name: .ksr_sessionStarted),
-          Notification(
-            name: .ksr_showNotificationsDialog,
-            userInfo: [UserInfoKeys.context: PushNotificationDialog.Context.login]
-          )
+    self.postNotification = Signal.merge(
+      self.environmentLoggedInProperty.signal,
+      self.emailVerificationViewControllerDidCompleteProperty.signal
+    )
+    .mapConst(
+      (
+        Notification(name: .ksr_sessionStarted),
+        Notification(
+          name: .ksr_showNotificationsDialog,
+          userInfo: [UserInfoKeys.context: PushNotificationDialog.Context.login]
         )
       )
+    )
 
     self.dismissKeyboard = self.passwordTextFieldDoneEditingProperty.signal
     self.passwordTextFieldBecomeFirstResponder = self.emailTextFieldDoneEditingProperty.signal
@@ -187,6 +193,11 @@ public final class LoginViewModel: LoginViewModelType, LoginViewModelInputs, Log
   fileprivate let environmentLoggedInProperty = MutableProperty(())
   public func environmentLoggedIn() {
     self.environmentLoggedInProperty.value = ()
+  }
+
+  fileprivate let emailVerificationViewControllerDidCompleteProperty = MutableProperty(())
+  public func emailVerificationViewControllerDidComplete() {
+    self.emailVerificationViewControllerDidCompleteProperty.value = ()
   }
 
   fileprivate let resetPasswordPressedProperty = MutableProperty(())

--- a/Library/ViewModels/LoginViewModelTests.swift
+++ b/Library/ViewModels/LoginViewModelTests.swift
@@ -13,8 +13,8 @@ final class LoginViewModelTests: TestCase {
   fileprivate let isFormValid = TestObserver<Bool, Never>()
   fileprivate let dismissKeyboard = TestObserver<(), Never>()
   fileprivate let postNotificationName = TestObserver<(Notification.Name, Notification.Name), Never>()
-  fileprivate let logIntoEnvironment = TestObserver<AccessTokenEnvelope?, Never>()
-  fileprivate let showEmailVerification = TestObserver<AccessTokenEnvelope, Never>()
+  fileprivate let logIntoEnvironment = TestObserver<AccessTokenEnvelope, Never>()
+  fileprivate let logIntoEnvironmentAndShowEmailVerification = TestObserver<AccessTokenEnvelope, Never>()
   fileprivate let showError = TestObserver<String, Never>()
   fileprivate let tfaChallenge = TestObserver<String, Never>()
   fileprivate let tfaChallengePasswordText = TestObserver<String, Never>()
@@ -32,7 +32,8 @@ final class LoginViewModelTests: TestCase {
     self.vm.outputs.postNotification.map { ($0.0.name, $0.1.name) }
       .observe(self.postNotificationName.observer)
     self.vm.outputs.logIntoEnvironment.observe(self.logIntoEnvironment.observer)
-    self.vm.outputs.showEmailVerification.observe(self.showEmailVerification.observer)
+    self.vm.outputs.logIntoEnvironmentAndShowEmailVerification
+      .observe(self.logIntoEnvironmentAndShowEmailVerification.observer)
     self.vm.outputs.showError.observe(self.showError.observer)
     self.vm.outputs.tfaChallenge.map { $0.email }.observe(self.tfaChallenge.observer)
     self.vm.outputs.tfaChallenge.map { $0.password }.observe(self.tfaChallengePasswordText.observer)
@@ -65,7 +66,8 @@ final class LoginViewModelTests: TestCase {
     XCTAssertEqual(["Log In Submit Button Clicked"], self.trackingClient.events)
 
     self.dismissKeyboard.assertValueCount(1, "Keyboard is dismissed")
-    self.logIntoEnvironment.assertValueCount(1, "Log into environment.")
+    self.logIntoEnvironmentAndShowEmailVerification
+      .assertValueCount(1, "Log into environment and show email verification since User Lens is not applied with isEmailVerified set to true.")
 
     self.vm.inputs.environmentLoggedIn()
     XCTAssertEqual(
@@ -97,7 +99,7 @@ final class LoginViewModelTests: TestCase {
 
       self.showError.assertDidNotEmitValue()
       self.logIntoEnvironment.assertValueCount(1, "Logged into environment.")
-      self.showEmailVerification.assertValueCount(0, "Did not show email verification.")
+      self.logIntoEnvironmentAndShowEmailVerification.assertValueCount(0, "Did not show email verification.")
       self.tfaChallenge.assertValueCount(0, "TFA challenge did not happen.")
       self.showError.assertValueCount(0, "Login error did not happen.")
     }
@@ -118,8 +120,8 @@ final class LoginViewModelTests: TestCase {
       self.vm.inputs.loginButtonPressed()
 
       self.showError.assertDidNotEmitValue()
-      self.logIntoEnvironment.assertValueCount(1, "Logged into environment.")
-      self.showEmailVerification.assertValueCount(1, "Showed email verification.")
+      self.logIntoEnvironment.assertValueCount(0, "Did not log into environment.")
+      self.logIntoEnvironmentAndShowEmailVerification.assertValueCount(1, "Logged into environment and showed email verification.")
       self.tfaChallenge.assertValueCount(0, "Should not show TFA challenge.")
       self.showError.assertValueCount(0, "Should not show login error.")
     }

--- a/Library/ViewModels/LoginViewModelTests.swift
+++ b/Library/ViewModels/LoginViewModelTests.swift
@@ -67,7 +67,10 @@ final class LoginViewModelTests: TestCase {
 
     self.dismissKeyboard.assertValueCount(1, "Keyboard is dismissed")
     self.logIntoEnvironmentAndShowEmailVerification
-      .assertValueCount(1, "Log into environment and show email verification since User Lens is not applied with isEmailVerified set to true.")
+      .assertValueCount(
+        1,
+        "Log into environment and show email verification since User Lens is not applied with isEmailVerified set to true."
+      )
 
     self.vm.inputs.environmentLoggedIn()
     XCTAssertEqual(
@@ -121,7 +124,8 @@ final class LoginViewModelTests: TestCase {
 
       self.showError.assertDidNotEmitValue()
       self.logIntoEnvironment.assertValueCount(0, "Did not log into environment.")
-      self.logIntoEnvironmentAndShowEmailVerification.assertValueCount(1, "Logged into environment and showed email verification.")
+      self.logIntoEnvironmentAndShowEmailVerification
+        .assertValueCount(1, "Logged into environment and showed email verification.")
       self.tfaChallenge.assertValueCount(0, "Should not show TFA challenge.")
       self.showError.assertValueCount(0, "Should not show login error.")
     }

--- a/Library/ViewModels/SignupViewModel.swift
+++ b/Library/ViewModels/SignupViewModel.swift
@@ -137,11 +137,11 @@ public final class SignupViewModel: SignupViewModelType, SignupViewModelInputs, 
 
     /// If user's email is verified, log into environment.
     self.logIntoEnvironment = signupEventValues
-      .filter(isAccessTokenEnvelopeEmailVerified)
+      .filter(showEmailVerificationForAccessTokenEnvelope >>> isFalse)
 
     /// If user's email is not verified, show email verification prompt.
     self.logIntoEnvironmentAndShowEmailVerification = signupEventValues
-      .filter(isAccessTokenEnvelopeEmailVerified >>> isFalse)
+      .filter(showEmailVerificationForAccessTokenEnvelope >>> isTrue)
 
     self.postNotification = Signal.merge(
       self.environmentLoggedInProperty.signal,

--- a/Library/ViewModels/SignupViewModelTests.swift
+++ b/Library/ViewModels/SignupViewModelTests.swift
@@ -9,13 +9,13 @@ internal final class SignupViewModelTests: TestCase {
   fileprivate let vm: SignupViewModelType = SignupViewModel()
   fileprivate let emailTextFieldBecomeFirstResponder = TestObserver<(), Never>()
   fileprivate let isSignupButtonEnabled = TestObserver<Bool, Never>()
-  fileprivate let logIntoEnvironment = TestObserver<AccessTokenEnvelope?, Never>()
+  fileprivate let logIntoEnvironment = TestObserver<AccessTokenEnvelope, Never>()
+  fileprivate let logIntoEnvironmentAndShowEmailVerification = TestObserver<AccessTokenEnvelope, Never>()
   fileprivate let nameTextFieldBecomeFirstResponder = TestObserver<(), Never>()
   fileprivate let passwordTextFieldBecomeFirstResponder = TestObserver<(), Never>()
   fileprivate let postNotification = TestObserver<Notification.Name, Never>()
   fileprivate let setWeeklyNewsletterState = TestObserver<Bool, Never>()
   fileprivate let showError = TestObserver<String, Never>()
-  fileprivate let showEmailVerification = TestObserver<AccessTokenEnvelope, Never>()
 
   override func setUp() {
     super.setUp()
@@ -24,13 +24,14 @@ internal final class SignupViewModelTests: TestCase {
       .observe(self.emailTextFieldBecomeFirstResponder.observer)
     self.vm.outputs.isSignupButtonEnabled.observe(self.isSignupButtonEnabled.observer)
     self.vm.outputs.logIntoEnvironment.observe(self.logIntoEnvironment.observer)
+    self.vm.outputs.logIntoEnvironmentAndShowEmailVerification
+      .observe(self.logIntoEnvironmentAndShowEmailVerification.observer)
     self.vm.outputs.nameTextFieldBecomeFirstResponder.observe(self.nameTextFieldBecomeFirstResponder.observer)
     self.vm.outputs.passwordTextFieldBecomeFirstResponder
       .observe(self.passwordTextFieldBecomeFirstResponder.observer)
     self.vm.outputs.postNotification.map { $0.name }.observe(self.postNotification.observer)
     self.vm.outputs.setWeeklyNewsletterState.observe(self.setWeeklyNewsletterState.observer)
     self.vm.outputs.showError.observe(self.showError.observer)
-    self.vm.outputs.showEmailVerification.observe(self.showEmailVerification.observer)
   }
 
   // Tests a standard flow for signing up.
@@ -73,7 +74,7 @@ internal final class SignupViewModelTests: TestCase {
 
     self.scheduler.advance()
 
-    self.logIntoEnvironment.assertValueCount(1, "Login after scheduler advances.")
+    self.logIntoEnvironmentAndShowEmailVerification.assertValueCount(1, "Login and show email verification since User Lens is not applied with isEmailVerified set to true.")
     self.postNotification.assertDidNotEmitValue("Does not emit until environment logged in.")
 
     self.vm.inputs.environmentLoggedIn()
@@ -105,7 +106,8 @@ internal final class SignupViewModelTests: TestCase {
       self.scheduler.advance()
 
       self.logIntoEnvironment.assertValueCount(1, "Logged into environment.")
-      self.showEmailVerification.assertValueCount(0, "Should not show email verificaton.")
+      self.logIntoEnvironmentAndShowEmailVerification
+        .assertValueCount(0, "Should not show email verificaton.")
       self.vm.inputs.passwordTextFieldReturn()
       self.showError.assertValueCount(0, "Should not show error.")
     }
@@ -129,8 +131,8 @@ internal final class SignupViewModelTests: TestCase {
 
       self.scheduler.advance()
 
-      self.logIntoEnvironment.assertValueCount(1, "Logged into environment.")
-      self.showEmailVerification.assertValueCount(1, "Showed email verification.")
+      self.logIntoEnvironment.assertValueCount(0, "Did not log into environment.")
+      self.logIntoEnvironmentAndShowEmailVerification.assertValueCount(1, "Logged into environment and showed email verification.")
       self.vm.inputs.passwordTextFieldReturn()
       self.showError.assertValueCount(0, "Should not show error.")
     }

--- a/Library/ViewModels/SignupViewModelTests.swift
+++ b/Library/ViewModels/SignupViewModelTests.swift
@@ -1,5 +1,6 @@
 @testable import KsApi
 @testable import Library
+import Prelude
 import ReactiveExtensions_TestHelpers
 import ReactiveSwift
 import XCTest
@@ -8,12 +9,13 @@ internal final class SignupViewModelTests: TestCase {
   fileprivate let vm: SignupViewModelType = SignupViewModel()
   fileprivate let emailTextFieldBecomeFirstResponder = TestObserver<(), Never>()
   fileprivate let isSignupButtonEnabled = TestObserver<Bool, Never>()
-  fileprivate let logIntoEnvironment = TestObserver<AccessTokenEnvelope, Never>()
+  fileprivate let logIntoEnvironment = TestObserver<AccessTokenEnvelope?, Never>()
   fileprivate let nameTextFieldBecomeFirstResponder = TestObserver<(), Never>()
   fileprivate let passwordTextFieldBecomeFirstResponder = TestObserver<(), Never>()
   fileprivate let postNotification = TestObserver<Notification.Name, Never>()
   fileprivate let setWeeklyNewsletterState = TestObserver<Bool, Never>()
   fileprivate let showError = TestObserver<String, Never>()
+  fileprivate let showEmailVerification = TestObserver<AccessTokenEnvelope, Never>()
 
   override func setUp() {
     super.setUp()
@@ -28,6 +30,7 @@ internal final class SignupViewModelTests: TestCase {
     self.vm.outputs.postNotification.map { $0.name }.observe(self.postNotification.observer)
     self.vm.outputs.setWeeklyNewsletterState.observe(self.setWeeklyNewsletterState.observer)
     self.vm.outputs.showError.observe(self.showError.observer)
+    self.vm.outputs.showEmailVerification.observe(self.showEmailVerification.observer)
   }
 
   // Tests a standard flow for signing up.
@@ -81,6 +84,56 @@ internal final class SignupViewModelTests: TestCase {
       [.ksr_sessionStarted],
       "Notification posted after scheduler advances."
     )
+  }
+
+  func testSignupFlow_IsEmailVerifiedTrue_EmailVerificationFeatureFlagEnabled() {
+    let config = .template
+      |> Config.lens.features .~ ["ios_email_verification_flow": true]
+    let user = .template
+      |> User.lens.isEmailVerified .~ true
+    let signupResponse = AccessTokenEnvelope(accessToken: "deadbeef", user: user)
+
+    withEnvironment(apiService: MockService(signupResponse: signupResponse), config: config) {
+      self.vm.inputs.viewDidLoad()
+      self.vm.inputs.emailChanged("nativesquad@kickstarter.com")
+      self.vm.inputs.nameChanged("Native Squad")
+      self.vm.inputs.passwordChanged("0773rw473rm3l0n")
+      self.vm.inputs.signupButtonPressed()
+
+      self.showError.assertDidNotEmitValue()
+
+      self.scheduler.advance()
+
+      self.logIntoEnvironment.assertValueCount(1, "Logged into environment.")
+      self.showEmailVerification.assertValueCount(0, "Should not show email verificaton.")
+      self.vm.inputs.passwordTextFieldReturn()
+      self.showError.assertValueCount(0, "Should not show error.")
+    }
+  }
+
+  func testSignupFlow_IsEmailVerifiedFalse_EmailVerificationFeatureFlagEnabled() {
+    let config = .template
+      |> Config.lens.features .~ ["ios_email_verification_flow": true]
+    let user = .template
+      |> User.lens.isEmailVerified .~ false
+    let signupResponse = AccessTokenEnvelope(accessToken: "deadbeef", user: user)
+
+    withEnvironment(apiService: MockService(signupResponse: signupResponse), config: config) {
+      self.vm.inputs.viewDidLoad()
+      self.vm.inputs.emailChanged("nativesquad@kickstarter.com")
+      self.vm.inputs.nameChanged("Native Squad")
+      self.vm.inputs.passwordChanged("0773rw473rm3l0n")
+      self.vm.inputs.signupButtonPressed()
+
+      self.showError.assertDidNotEmitValue()
+
+      self.scheduler.advance()
+
+      self.logIntoEnvironment.assertValueCount(1, "Logged into environment.")
+      self.showEmailVerification.assertValueCount(1, "Showed email verification.")
+      self.vm.inputs.passwordTextFieldReturn()
+      self.showError.assertValueCount(0, "Should not show error.")
+    }
   }
 
   func testBecomeFirstResponder() {

--- a/Library/ViewModels/SignupViewModelTests.swift
+++ b/Library/ViewModels/SignupViewModelTests.swift
@@ -74,7 +74,11 @@ internal final class SignupViewModelTests: TestCase {
 
     self.scheduler.advance()
 
-    self.logIntoEnvironmentAndShowEmailVerification.assertValueCount(1, "Login and show email verification since User Lens is not applied with isEmailVerified set to true.")
+    self.logIntoEnvironmentAndShowEmailVerification
+      .assertValueCount(
+        1,
+        "Login and show email verification since User Lens is not applied with isEmailVerified set to true."
+      )
     self.postNotification.assertDidNotEmitValue("Does not emit until environment logged in.")
 
     self.vm.inputs.environmentLoggedIn()
@@ -132,7 +136,8 @@ internal final class SignupViewModelTests: TestCase {
       self.scheduler.advance()
 
       self.logIntoEnvironment.assertValueCount(0, "Did not log into environment.")
-      self.logIntoEnvironmentAndShowEmailVerification.assertValueCount(1, "Logged into environment and showed email verification.")
+      self.logIntoEnvironmentAndShowEmailVerification
+        .assertValueCount(1, "Logged into environment and showed email verification.")
       self.vm.inputs.passwordTextFieldReturn()
       self.showError.assertValueCount(0, "Should not show error.")
     }


### PR DESCRIPTION
# 📲 What

Before dismissing the login or sign up view controllers we need to push an interstitial UI for email verification onto the navigation stack. The work is behind a feature flag and given the user successfully logs in (within the context of login or account creation) we should show the email verification UI before the tab bar is rendered.

# 🤔 Why

This PR continues the work for our email verification flow. It represents the connection between our `User` and UI/UX interactions.

# 🛠 How

Login and account creation rely on `NotificationCenter` to dismiss the view controllers after the user has successfully logged in. In between login and view controller dismissal, the email verification work is plugged in. Specifically in the `LoginViewController` and `SignUpViewController`.

# ⏰ TODO

- [ ] Got planned refactors to come
- [ ] Will add tests
