### PR TITLE
[NT-1655] Email Verification Event Tracking

### DIFF
--- a/Library/Tracking/Koala.swift
+++ b/Library/Tracking/Koala.swift
@@ -56,9 +56,11 @@ public final class Koala {
     case selectRewardButtonClicked = "Select Reward Button Clicked"
     case signupButtonClicked = "Signup Button Clicked"
     case signupSubmitButtonClicked = "Signup Submit Button Clicked"
+    case skipVerificationButtonClicked = "Skip Verification Button Clicked"
     case tabBarClicked = "Tab Bar Clicked"
     case thanksPageViewed = "Thanks Page Viewed"
     case twoFactorConfirmationViewed = "Two-Factor Confirmation Viewed"
+    case verificationScreenViewed = "Verification Screen Viewed"
     case watchProjectButtonClicked = "Watch Project Button Clicked"
 
     static func allApprovedEvents() -> [String] {
@@ -73,6 +75,7 @@ public final class Koala {
     case campaign = "campaign_screen" // ProjectDescriptionViewController
     case discovery = "explore_screen" // DiscoveryViewController
     case editorialProjects = "editorial_collection_screen" // EditorialProjectsViewController
+    case emailVerification = "email_verification" // EmailVerificationViewController
     case forgotPassword = "forgot_password_screen" // ResetPasswordViewController
     case landingPage = "landing_page" // LandingViewController
     case login = "login_screen" // LoginViewController
@@ -2060,6 +2063,22 @@ public final class Koala {
     self.track(
       event: "Started Project Video",
       properties: projectProperties(from: project, loggedInUser: self.loggedInUser)
+    )
+  }
+
+  // MARK: - Email Verification
+
+  public func trackEmailVerificationScreenViewed() {
+    self.track(
+      event: DataLakeApprovedEvent.verificationScreenViewed.rawValue,
+      location: .emailVerification
+    )
+  }
+
+  public func trackSkipEmailVerificationButtonClicked() {
+    self.track(
+      event: DataLakeApprovedEvent.skipVerificationButtonClicked.rawValue,
+      location: .emailVerification
     )
   }
 

--- a/Library/Tracking/KoalaTests.swift
+++ b/Library/Tracking/KoalaTests.swift
@@ -1227,6 +1227,29 @@ final class KoalaTests: TestCase {
 
     koala.track2FAViewed()
     XCTAssertEqual("two_factor_auth_verify_screen", client.properties.last?["context_location"] as? String)
+
+    koala.trackEmailVerificationScreenViewed()
+    XCTAssertEqual("email_verification", client.properties.last?["context_location"] as? String)
+  }
+
+  // MARK: - Email Verification
+
+  func testTrackEmailVerificationScreenViewed() {
+    let client = MockTrackingClient()
+    let koala = Koala(client: client)
+
+    koala.trackEmailVerificationScreenViewed()
+
+    XCTAssertEqual(["Verification Screen Viewed"], client.events, "Event is tracked by koala client")
+  }
+
+  func testTrackSkipEmailVerificationButtonClicked() {
+    let client = MockTrackingClient()
+    let koala = Koala(client: client)
+
+    koala.trackSkipEmailVerificationButtonClicked()
+
+    XCTAssertEqual(["Skip Verification Button Clicked"], client.events, "Event is tracked by koala client")
   }
 
   /*

--- a/Library/ViewModels/EmailVerificationViewModel.swift
+++ b/Library/ViewModels/EmailVerificationViewModel.swift
@@ -52,6 +52,16 @@ public final class EmailVerificationViewModel: EmailVerificationViewModelType,
 
     self.showSuccessBannerWithMessage = didSendVerificationEmail
       .mapConst(Strings.Verification_email_sent())
+
+    // MARK: - Tracking
+
+    self.viewDidLoadProperty.signal.observeValues { _ in
+      AppEnvironment.current.koala.trackEmailVerificationScreenViewed()
+    }
+
+    self.skipButtonTappedProperty.signal.observeValues { _ in
+      AppEnvironment.current.koala.trackSkipEmailVerificationButtonClicked()
+    }
   }
 
   private let resendButtonTappedProperty = MutableProperty(())

--- a/Library/ViewModels/EmailVerificationViewModelTests.swift
+++ b/Library/ViewModels/EmailVerificationViewModelTests.swift
@@ -59,6 +59,31 @@ final class EmailVerificationViewModelTests: TestCase {
     self.notifyDelegateDidComplete.assertValueCount(1)
   }
 
+  func testTrackVerificationScreenViewed() {
+    XCTAssertEqual(self.trackingClient.events, [])
+
+    self.vm.inputs.viewDidLoad()
+
+    XCTAssertEqual(self.trackingClient.events, ["Verification Screen Viewed"])
+
+    XCTAssertTrue(self.trackingClient.containsKeyPrefix("context_"))
+    XCTAssertTrue(self.trackingClient.containsKeyPrefix("session_"))
+  }
+
+  func testTrackSkipEmailVerificationButtonClicked() {
+    XCTAssertEqual(self.trackingClient.events, [])
+
+    AppEnvironment.login(.init(accessToken: "deadbeef", user: .template))
+
+    self.vm.inputs.skipButtonTapped()
+
+    XCTAssertEqual(self.trackingClient.events, ["Skip Verification Button Clicked"])
+
+    XCTAssertTrue(self.trackingClient.containsKeyPrefix("context_"))
+    XCTAssertTrue(self.trackingClient.containsKeyPrefix("session_"))
+    XCTAssertTrue(self.trackingClient.containsKeyPrefix("user_"))
+  }
+
   func testResend_Success() {
     let mockService = MockService(sendEmailVerificationResponse: GraphMutationEmptyResponseEnvelope())
 


### PR DESCRIPTION
# 📲 What

Adds event tracking for `EmailVerificationViewController`.

# 🤔 Why

This will help us to gain insights into how this feature is being used when the app is live.

# 🛠 How

Added two new events:

`Verification Screen Viewed`
`Skip Verification Button Clicked`

# ✅ Acceptance criteria

- [ ] When `EmailVerificationViewController` is shown, `Verification Screen Viewed` should be tracked.
- [ ] When the skip/I'll do this later button is tapped, `Skip Verification Button Clicked` should be tracked.