### PR TITLE
[NT-1679] Re-send Verification Email on View Loading

### DIFF
--- a/Kickstarter-iOS/Views/Controllers/EmailVerificationViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/EmailVerificationViewController.swift
@@ -143,10 +143,10 @@ final class EmailVerificationViewController: UIViewController, MessageBannerView
         self.delegate?.emailVerificationViewControllerDidComplete(self)
       }
 
-    self.viewModel.outputs.showSuccessBannerWithMessageAndShouldShow
+    self.viewModel.outputs.showSuccessBannerWithMessageAndShowBanner
       .observeForUI()
-      .observeValues { [weak self] message, shouldShow in
-        guard shouldShow else { return }
+      .observeValues { [weak self] message, showBanner in
+        guard showBanner else { return }
         self?.messageBannerViewController?.showBanner(with: .success, message: message)
       }
 

--- a/Kickstarter-iOS/Views/Controllers/EmailVerificationViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/EmailVerificationViewController.swift
@@ -143,9 +143,10 @@ final class EmailVerificationViewController: UIViewController, MessageBannerView
         self.delegate?.emailVerificationViewControllerDidComplete(self)
       }
 
-    self.viewModel.outputs.showSuccessBannerWithMessage
+    self.viewModel.outputs.showSuccessBannerWithMessageAndShouldShow
       .observeForUI()
-      .observeValues { [weak self] message in
+      .observeValues { [weak self] message, shouldShow in
+        guard shouldShow else { return }
         self?.messageBannerViewController?.showBanner(with: .success, message: message)
       }
 

--- a/Library/ViewModels/EmailVerificationViewModel.swift
+++ b/Library/ViewModels/EmailVerificationViewModel.swift
@@ -13,7 +13,7 @@ public protocol EmailVerificationViewModelOutputs {
   var activityIndicatorIsHidden: Signal<Bool, Never> { get }
   var notifyDelegateDidComplete: Signal<(), Never> { get }
   var showErrorBannerWithMessage: Signal<String, Never> { get }
-  var showSuccessBannerWithMessageAndShouldShow: Signal<(String, Bool), Never> { get }
+  var showSuccessBannerWithMessageAndShowBanner: Signal<(String, Bool), Never> { get }
   var skipButtonHidden: Signal<Bool, Never> { get }
 }
 
@@ -55,7 +55,7 @@ public final class EmailVerificationViewModel: EmailVerificationViewModelType,
 
     self.showErrorBannerWithMessage = didFailToSendVerificationEmail
 
-    self.showSuccessBannerWithMessageAndShouldShow = didSendVerificationEmail
+    self.showSuccessBannerWithMessageAndShowBanner = didSendVerificationEmail
       .map { (Strings.Verification_email_sent(), $1) }
 
     // MARK: - Tracking
@@ -87,7 +87,7 @@ public final class EmailVerificationViewModel: EmailVerificationViewModelType,
   public let activityIndicatorIsHidden: Signal<Bool, Never>
   public let notifyDelegateDidComplete: Signal<(), Never>
   public let showErrorBannerWithMessage: Signal<String, Never>
-  public let showSuccessBannerWithMessageAndShouldShow: Signal<(String, Bool), Never>
+  public let showSuccessBannerWithMessageAndShowBanner: Signal<(String, Bool), Never>
   public let skipButtonHidden: Signal<Bool, Never>
 
   public var inputs: EmailVerificationViewModelInputs { return self }

--- a/Library/ViewModels/EmailVerificationViewModelTests.swift
+++ b/Library/ViewModels/EmailVerificationViewModelTests.swift
@@ -13,7 +13,7 @@ final class EmailVerificationViewModelTests: TestCase {
   private let notifyDelegateDidComplete = TestObserver<(), Never>()
   private let showErrorBannerWithMessage = TestObserver<String, Never>()
   private let showSuccessBannerWithMessage = TestObserver<String, Never>()
-  private let showSuccessBannerShouldShow = TestObserver<Bool, Never>()
+  private let showSuccessBannerShowBanner = TestObserver<Bool, Never>()
   private let skipButtonHidden = TestObserver<Bool, Never>()
 
   override func setUp() {
@@ -22,12 +22,12 @@ final class EmailVerificationViewModelTests: TestCase {
     self.vm.outputs.activityIndicatorIsHidden.observe(self.activityIndicatorIsHidden.observer)
     self.vm.outputs.notifyDelegateDidComplete.observe(self.notifyDelegateDidComplete.observer)
     self.vm.outputs.showErrorBannerWithMessage.observe(self.showErrorBannerWithMessage.observer)
-    self.vm.outputs.showSuccessBannerWithMessageAndShouldShow
+    self.vm.outputs.showSuccessBannerWithMessageAndShowBanner
       .map(first)
       .observe(self.showSuccessBannerWithMessage.observer)
-    self.vm.outputs.showSuccessBannerWithMessageAndShouldShow
+    self.vm.outputs.showSuccessBannerWithMessageAndShowBanner
       .map(second)
-      .observe(self.showSuccessBannerShouldShow.observer)
+      .observe(self.showSuccessBannerShowBanner.observer)
     self.vm.outputs.skipButtonHidden.observe(self.skipButtonHidden.observer)
   }
 
@@ -94,7 +94,7 @@ final class EmailVerificationViewModelTests: TestCase {
     let mockService = MockService(sendEmailVerificationResponse: GraphMutationEmptyResponseEnvelope())
 
     self.showSuccessBannerWithMessage.assertDidNotEmitValue()
-    self.showSuccessBannerShouldShow.assertDidNotEmitValue()
+    self.showSuccessBannerShowBanner.assertDidNotEmitValue()
     self.showErrorBannerWithMessage.assertDidNotEmitValue()
     self.activityIndicatorIsHidden.assertDidNotEmitValue()
 
@@ -102,7 +102,7 @@ final class EmailVerificationViewModelTests: TestCase {
       self.vm.inputs.viewDidLoad()
 
       self.showSuccessBannerWithMessage.assertDidNotEmitValue()
-      self.showSuccessBannerShouldShow.assertDidNotEmitValue()
+      self.showSuccessBannerShowBanner.assertDidNotEmitValue()
       self.showErrorBannerWithMessage.assertDidNotEmitValue()
       self.activityIndicatorIsHidden.assertValues([true])
 
@@ -111,7 +111,7 @@ final class EmailVerificationViewModelTests: TestCase {
       self.showSuccessBannerWithMessage.assertValues([
         "We\'ve just sent you a verification email. Click the link in it and your address will be verified."
       ])
-      self.showSuccessBannerShouldShow.assertValues([false])
+      self.showSuccessBannerShowBanner.assertValues([false])
       self.showErrorBannerWithMessage.assertDidNotEmitValue()
       self.activityIndicatorIsHidden.assertValues([true])
 
@@ -120,7 +120,7 @@ final class EmailVerificationViewModelTests: TestCase {
       self.showSuccessBannerWithMessage.assertValues([
         "We\'ve just sent you a verification email. Click the link in it and your address will be verified."
       ])
-      self.showSuccessBannerShouldShow.assertValues([false])
+      self.showSuccessBannerShowBanner.assertValues([false])
       self.showErrorBannerWithMessage.assertDidNotEmitValue()
       self.activityIndicatorIsHidden.assertValues([true, false])
 
@@ -130,7 +130,7 @@ final class EmailVerificationViewModelTests: TestCase {
         "We\'ve just sent you a verification email. Click the link in it and your address will be verified.",
         "We\'ve just sent you a verification email. Click the link in it and your address will be verified."
       ])
-      self.showSuccessBannerShouldShow.assertValues([false, true])
+      self.showSuccessBannerShowBanner.assertValues([false, true])
       self.showErrorBannerWithMessage.assertDidNotEmitValue()
       self.activityIndicatorIsHidden.assertValues([true, false, true])
     }
@@ -141,28 +141,28 @@ final class EmailVerificationViewModelTests: TestCase {
 
     self.showSuccessBannerWithMessage.assertDidNotEmitValue()
     self.showErrorBannerWithMessage.assertDidNotEmitValue()
-    self.showSuccessBannerShouldShow.assertDidNotEmitValue()
+    self.showSuccessBannerShowBanner.assertDidNotEmitValue()
     self.activityIndicatorIsHidden.assertDidNotEmitValue()
 
     withEnvironment(apiService: MockService(sendEmailVerificationError: error)) {
       self.vm.inputs.viewDidLoad()
 
       self.showSuccessBannerWithMessage.assertDidNotEmitValue()
-      self.showSuccessBannerShouldShow.assertDidNotEmitValue()
+      self.showSuccessBannerShowBanner.assertDidNotEmitValue()
       self.showErrorBannerWithMessage.assertDidNotEmitValue()
       self.activityIndicatorIsHidden.assertValues([true])
 
       self.vm.inputs.resendButtonTapped()
 
       self.showSuccessBannerWithMessage.assertDidNotEmitValue()
-      self.showSuccessBannerShouldShow.assertDidNotEmitValue()
+      self.showSuccessBannerShowBanner.assertDidNotEmitValue()
       self.showErrorBannerWithMessage.assertDidNotEmitValue()
       self.activityIndicatorIsHidden.assertValues([true, false])
 
       self.scheduler.advance()
 
       self.showSuccessBannerWithMessage.assertDidNotEmitValue()
-      self.showSuccessBannerShouldShow.assertDidNotEmitValue()
+      self.showSuccessBannerShowBanner.assertDidNotEmitValue()
       self.showErrorBannerWithMessage.assertValues([
         GraphError.invalidInput.localizedDescription,
         GraphError.invalidInput.localizedDescription

--- a/Library/ViewModels/EmailVerificationViewModelTests.swift
+++ b/Library/ViewModels/EmailVerificationViewModelTests.swift
@@ -13,6 +13,7 @@ final class EmailVerificationViewModelTests: TestCase {
   private let notifyDelegateDidComplete = TestObserver<(), Never>()
   private let showErrorBannerWithMessage = TestObserver<String, Never>()
   private let showSuccessBannerWithMessage = TestObserver<String, Never>()
+  private let showSuccessBannerShouldShow = TestObserver<Bool, Never>()
   private let skipButtonHidden = TestObserver<Bool, Never>()
 
   override func setUp() {
@@ -21,7 +22,12 @@ final class EmailVerificationViewModelTests: TestCase {
     self.vm.outputs.activityIndicatorIsHidden.observe(self.activityIndicatorIsHidden.observer)
     self.vm.outputs.notifyDelegateDidComplete.observe(self.notifyDelegateDidComplete.observer)
     self.vm.outputs.showErrorBannerWithMessage.observe(self.showErrorBannerWithMessage.observer)
-    self.vm.outputs.showSuccessBannerWithMessage.observe(self.showSuccessBannerWithMessage.observer)
+    self.vm.outputs.showSuccessBannerWithMessageAndShouldShow
+      .map(first)
+      .observe(self.showSuccessBannerWithMessage.observer)
+    self.vm.outputs.showSuccessBannerWithMessageAndShouldShow
+      .map(second)
+      .observe(self.showSuccessBannerShouldShow.observer)
     self.vm.outputs.skipButtonHidden.observe(self.skipButtonHidden.observer)
   }
 
@@ -88,6 +94,7 @@ final class EmailVerificationViewModelTests: TestCase {
     let mockService = MockService(sendEmailVerificationResponse: GraphMutationEmptyResponseEnvelope())
 
     self.showSuccessBannerWithMessage.assertDidNotEmitValue()
+    self.showSuccessBannerShouldShow.assertDidNotEmitValue()
     self.showErrorBannerWithMessage.assertDidNotEmitValue()
     self.activityIndicatorIsHidden.assertDidNotEmitValue()
 
@@ -95,20 +102,35 @@ final class EmailVerificationViewModelTests: TestCase {
       self.vm.inputs.viewDidLoad()
 
       self.showSuccessBannerWithMessage.assertDidNotEmitValue()
+      self.showSuccessBannerShouldShow.assertDidNotEmitValue()
       self.showErrorBannerWithMessage.assertDidNotEmitValue()
       self.activityIndicatorIsHidden.assertValues([true])
-
-      self.vm.inputs.resendButtonTapped()
-
-      self.showSuccessBannerWithMessage.assertDidNotEmitValue()
-      self.showErrorBannerWithMessage.assertDidNotEmitValue()
-      self.activityIndicatorIsHidden.assertValues([true, false])
 
       self.scheduler.advance()
 
       self.showSuccessBannerWithMessage.assertValues([
         "We\'ve just sent you a verification email. Click the link in it and your address will be verified."
       ])
+      self.showSuccessBannerShouldShow.assertValues([false])
+      self.showErrorBannerWithMessage.assertDidNotEmitValue()
+      self.activityIndicatorIsHidden.assertValues([true])
+
+      self.vm.inputs.resendButtonTapped()
+
+      self.showSuccessBannerWithMessage.assertValues([
+        "We\'ve just sent you a verification email. Click the link in it and your address will be verified."
+      ])
+      self.showSuccessBannerShouldShow.assertValues([false])
+      self.showErrorBannerWithMessage.assertDidNotEmitValue()
+      self.activityIndicatorIsHidden.assertValues([true, false])
+
+      self.scheduler.advance()
+
+      self.showSuccessBannerWithMessage.assertValues([
+        "We\'ve just sent you a verification email. Click the link in it and your address will be verified.",
+        "We\'ve just sent you a verification email. Click the link in it and your address will be verified."
+      ])
+      self.showSuccessBannerShouldShow.assertValues([false, true])
       self.showErrorBannerWithMessage.assertDidNotEmitValue()
       self.activityIndicatorIsHidden.assertValues([true, false, true])
     }
@@ -119,25 +141,32 @@ final class EmailVerificationViewModelTests: TestCase {
 
     self.showSuccessBannerWithMessage.assertDidNotEmitValue()
     self.showErrorBannerWithMessage.assertDidNotEmitValue()
+    self.showSuccessBannerShouldShow.assertDidNotEmitValue()
     self.activityIndicatorIsHidden.assertDidNotEmitValue()
 
     withEnvironment(apiService: MockService(sendEmailVerificationError: error)) {
       self.vm.inputs.viewDidLoad()
 
       self.showSuccessBannerWithMessage.assertDidNotEmitValue()
+      self.showSuccessBannerShouldShow.assertDidNotEmitValue()
       self.showErrorBannerWithMessage.assertDidNotEmitValue()
       self.activityIndicatorIsHidden.assertValues([true])
 
       self.vm.inputs.resendButtonTapped()
 
       self.showSuccessBannerWithMessage.assertDidNotEmitValue()
+      self.showSuccessBannerShouldShow.assertDidNotEmitValue()
       self.showErrorBannerWithMessage.assertDidNotEmitValue()
       self.activityIndicatorIsHidden.assertValues([true, false])
 
       self.scheduler.advance()
 
       self.showSuccessBannerWithMessage.assertDidNotEmitValue()
-      self.showErrorBannerWithMessage.assertValue(GraphError.invalidInput.localizedDescription)
+      self.showSuccessBannerShouldShow.assertDidNotEmitValue()
+      self.showErrorBannerWithMessage.assertValues([
+        GraphError.invalidInput.localizedDescription,
+        GraphError.invalidInput.localizedDescription
+      ])
       self.activityIndicatorIsHidden.assertValues([true, false, true])
     }
   }


### PR DESCRIPTION
# 📲 What

Requests that the verification email is re-sent upon `EmailVerificationViewController`'s view loading.

# 🤔 Why

When users are shown this view we want to ensure that they have a fresh verification email in their inbox.

# 🛠 How

Wired up the `viewDidLoad` signal to the same code as the re-send button and added in a boolean to decide whether or not to show the success message.

# ✅ Acceptance criteria

- [ ] Log-in as a user that is unverified and is shown the `EmailVerificationViewController`. Check your inbox, a verification email should have been re-sent.
- [ ] No success banner or activity indicator is shown.