### PR TITLE
[NT-1692] "Mark as received" causes View Pledge to error

### DIFF
--- a/KsApi/models/Backing.swift
+++ b/KsApi/models/Backing.swift
@@ -75,8 +75,7 @@ extension Backing: Decodable {
     self.amount = try values.decode(Double.self, forKey: .amount)
     self.backer = try values.decodeIfPresent(User.self, forKey: .backer)
     self.backerId = try values.decode(Int.self, forKey: .backerId)
-    self.backerCompleted = try values
-      .decodeIfPresent(Int.self, forKey: .backerCompleted) != nil ? true : false
+    self.backerCompleted = try values.decodeIfPresent(Int.self, forKey: .backerCompleted) != nil
     self.bonusAmount = try values.decodeIfPresent(Double.self, forKey: .bonusAmount) ?? 0.0
     self.cancelable = try values.decode(Bool.self, forKey: .cancelable)
     self.id = try values.decode(Int.self, forKey: .id)

--- a/KsApi/models/Backing.swift
+++ b/KsApi/models/Backing.swift
@@ -75,7 +75,8 @@ extension Backing: Decodable {
     self.amount = try values.decode(Double.self, forKey: .amount)
     self.backer = try values.decodeIfPresent(User.self, forKey: .backer)
     self.backerId = try values.decode(Int.self, forKey: .backerId)
-    self.backerCompleted = try values.decodeIfPresent(Bool.self, forKey: .backerCompleted)
+    self.backerCompleted = try values
+      .decodeIfPresent(Int.self, forKey: .backerCompleted) != nil ? true : false
     self.bonusAmount = try values.decodeIfPresent(Double.self, forKey: .bonusAmount) ?? 0.0
     self.cancelable = try values.decode(Bool.self, forKey: .cancelable)
     self.id = try values.decode(Int.self, forKey: .id)

--- a/KsApi/models/BackingTests.swift
+++ b/KsApi/models/BackingTests.swift
@@ -7,6 +7,7 @@ final class BackingTests: XCTestCase {
     let backing: Backing? = Backing.decodeJSONDictionary([
       "amount": 1.0,
       "backer_id": 1,
+      "backer_completed_at": 1,
       "cancelable": true,
       "id": 1,
       "location_id": 1,
@@ -28,6 +29,7 @@ final class BackingTests: XCTestCase {
 
     XCTAssertEqual(1.0, backing?.amount)
     XCTAssertEqual(1, backing?.backerId)
+    XCTAssertEqual(true, backing?.backerCompleted)
     XCTAssertEqual(true, backing?.cancelable)
     XCTAssertEqual(1, backing?.id)
     XCTAssertEqual("2019-09-23", backing?.paymentSource?.expirationDate)
@@ -49,6 +51,7 @@ final class BackingTests: XCTestCase {
     let backing: Backing = try! Backing.decodeJSONDictionary([
       "amount": 1.0,
       "backer_id": 1,
+      "backer_completed_at": nil,
       "cancelable": true,
       "id": 1,
       "location_id": 1,
@@ -63,6 +66,7 @@ final class BackingTests: XCTestCase {
 
     XCTAssertEqual(1.0, backing.amount)
     XCTAssertEqual(1, backing.backerId)
+    XCTAssertEqual(false, backing.backerCompleted)
     XCTAssertEqual(1, backing.id)
 
     XCTAssertNil(backing.paymentSource)


### PR DESCRIPTION
# 📲 What

There is a decoding error within our `Backing` model object that is causing an error in our pledge view. We are currently expecting a `Bool` to be returned for our `backer_completed_at` key but the server is actually providing an `Int`. This PR includes a bit of logic to map these different types.

# 🤔 Why

This bug is preventing backers from viewing their pledge/reward. The footer will show an error and a Retry button because of the decoding failure. 
The expected behavior is a button that says `View Your Pledge` and once the user selects it they can view the details of their pledge/reward.

# 🛠 How

In our `Backing` object, we included a line to map the value of an existing timestamp to a boolean.