### PR TITLE
[NT-1599] Survey Response Bugfix

### DIFF
--- a/Library/ViewModels/SurveyResponseViewModel.swift
+++ b/Library/ViewModels/SurveyResponseViewModel.swift
@@ -109,6 +109,7 @@ public final class SurveyResponseViewModel: SurveyResponseViewModelType {
     self.title = self.viewDidLoadProperty.signal
       .mapConst(Strings.Survey())
 
+    // Required for `WKWebView` bug prior to iOS 14
     self.extractFormDataWithJavaScript = surveyResponse
       .takeWhen(surveyPostRequest.filter { $0.httpBody == nil })
       .map { surveyResponse in
@@ -123,6 +124,7 @@ public final class SurveyResponseViewModel: SurveyResponseViewModelType {
 
     self.webViewLoadRequest = Signal.merge(
       initialRequest,
+      surveyPostRequest.filter { $0.httpBody != nil }, // iOS 14 and up uses this path
       newRequest
     )
     .map { request in AppEnvironment.current.apiService.preparedRequest(forRequest: request) }
@@ -141,6 +143,7 @@ public final class SurveyResponseViewModel: SurveyResponseViewModelType {
     return self.policyDecisionProperty.value
   }
 
+  // Required for `WKWebView` bug prior to iOS 14
   private let didEvaluateJavaScriptWithResultProperty = MutableProperty<Any?>(nil)
   public func didEvaluateJavaScriptWithResult(_ result: Any?) {
     self.didEvaluateJavaScriptWithResultProperty.value = result


### PR DESCRIPTION
# 📲 What

Fixes a bug in `SurveyResponseViewModel` which was causing survey response submission to fail on iOS 14.

# 🤔 Why

In the time of iOS 12 and iOS 13, a bug existed in `WKWebView` which would produce a `nil` `httpBody` property on `URLRequest`. This was problematic for us because we would intercept these requests in order to inject our authentication headers before submitting the form data in the web view. A workaround was introduced in #975 to do this which thus expected the `httpBody` to be `nil` however it no longer is on iOS 14 as it seems Apple or the WebKit team have fixed this bug (although I can't find a source to confirm this).

# 🛠 How

Added another path to handle the request which does not require the `httpBody` to be `nil` and in this case does not evaluate the JavaScript as a workaround.

# 👀 See

Some discussion of the original `WKWebView` bug:

https://bugs.webkit.org/show_bug.cgi?id=145410
https://bugs.webkit.org/show_bug.cgi?id=167131

# ✅ Acceptance criteria

- [ ] Navigate to a survey on iOS 13, submission should be successful.
- [ ] Navigate to a survey on iOS 14, submission should be successful.