### PR TITLE
[SD-345] MessageThread and ProjectStatsEnvelope Decoding Bugfixes

### DIFF
--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -398,6 +398,7 @@
 		8A297910234EA8FD0039396D /* PledgeAmountSummaryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A29790F234EA8FD0039396D /* PledgeAmountSummaryViewModel.swift */; };
 		8A297912234EBAF90039396D /* PledgeAmountSummaryViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A297911234EBAF90039396D /* PledgeAmountSummaryViewModelTests.swift */; };
 		8A2A2E2E238B3CBE002C62E0 /* UIView+ShimmerLoading.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A2A2E2D238B3CBE002C62E0 /* UIView+ShimmerLoading.swift */; };
+		8A2C015F2589391D00EE11E7 /* ProjectActivityEnvelopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A2C015E2589391D00EE11E7 /* ProjectActivityEnvelopeTests.swift */; };
 		8A30C6B12491683C00EE12E4 /* ManagePledgeViewQueries.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A30C6B02491683C00EE12E4 /* ManagePledgeViewQueries.swift */; };
 		8A30C6B32491689300EE12E4 /* ManagePledgeViewQueriesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A30C6B22491689300EE12E4 /* ManagePledgeViewQueriesTests.swift */; };
 		8A32AE9623EA1DC0005CEA57 /* Project.CategoryTemplates.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A32AE9523EA1DC0005CEA57 /* Project.CategoryTemplates.swift */; };
@@ -1901,6 +1902,7 @@
 		8A29790F234EA8FD0039396D /* PledgeAmountSummaryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PledgeAmountSummaryViewModel.swift; sourceTree = "<group>"; };
 		8A297911234EBAF90039396D /* PledgeAmountSummaryViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PledgeAmountSummaryViewModelTests.swift; sourceTree = "<group>"; };
 		8A2A2E2D238B3CBE002C62E0 /* UIView+ShimmerLoading.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+ShimmerLoading.swift"; sourceTree = "<group>"; };
+		8A2C015E2589391D00EE11E7 /* ProjectActivityEnvelopeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectActivityEnvelopeTests.swift; sourceTree = "<group>"; };
 		8A30C6B02491683C00EE12E4 /* ManagePledgeViewQueries.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManagePledgeViewQueries.swift; sourceTree = "<group>"; };
 		8A30C6B22491689300EE12E4 /* ManagePledgeViewQueriesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManagePledgeViewQueriesTests.swift; sourceTree = "<group>"; };
 		8A32AE9523EA1DC0005CEA57 /* Project.CategoryTemplates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Project.CategoryTemplates.swift; sourceTree = "<group>"; };
@@ -4374,6 +4376,7 @@
 				D01587D81EEB2ED7006E7684 /* Project.swift */,
 				D01587DA1EEB2ED7006E7684 /* Project.VideoTests.swift */,
 				D01587DB1EEB2ED7006E7684 /* ProjectActivityEnvelope.swift */,
+				8A2C015E2589391D00EE11E7 /* ProjectActivityEnvelopeTests.swift */,
 				8AE3F72D24DA27BE002B03C3 /* ProjectAndBackingEnvelope.swift */,
 				D01587DC1EEB2ED7006E7684 /* ProjectNotification.swift */,
 				D01587DD1EEB2ED7006E7684 /* ProjectsEnvelope.swift */,
@@ -6313,6 +6316,7 @@
 				D0D10C101EEB4550005EBAD0 /* MessageTests.swift in Sources */,
 				77C0818E245CBA1B004ABE88 /* SignInWithAppleInputTests.swift in Sources */,
 				D0D10C151EEB4550005EBAD0 /* ProjectStatsEnvelopeTests.swift in Sources */,
+				8A2C015F2589391D00EE11E7 /* ProjectActivityEnvelopeTests.swift in Sources */,
 				D0D10C221EEB4550005EBAD0 /* UserTests.swift in Sources */,
 				8A45169124B3E2CE00D8CAEF /* RewardAddOnSelectionViewQueriesTests.swift in Sources */,
 				D0D10C171EEB4550005EBAD0 /* PushEnvelopeTests.swift in Sources */,

--- a/KsApi/models/Backing.swift
+++ b/KsApi/models/Backing.swift
@@ -71,7 +71,7 @@ extension Backing: Decodable {
 
   public init(from decoder: Decoder) throws {
     let values = try decoder.container(keyedBy: CodingKeys.self)
-    self.addOns = try values.decodeIfPresent([Reward].self, forKey: .reward)
+    self.addOns = try values.decodeIfPresent([Reward].self, forKey: .addOns)
     self.amount = try values.decode(Double.self, forKey: .amount)
     self.backer = try values.decodeIfPresent(User.self, forKey: .backer)
     self.backerId = try values.decode(Int.self, forKey: .backerId)

--- a/KsApi/models/BackingTests.swift
+++ b/KsApi/models/BackingTests.swift
@@ -5,6 +5,15 @@ import XCTest
 final class BackingTests: XCTestCase {
   func testJSONDecoding_WithCompleteData() {
     let backing: Backing? = Backing.decodeJSONDictionary([
+      "add_ons": [
+        [
+          "id": 1,
+          "description": "Some reward",
+          "minimum": 10,
+          "converted_minimum": 12,
+          "backers_count": 10
+        ]
+      ],
       "amount": 1.0,
       "backer_id": 1,
       "backer_completed_at": 1,
@@ -24,9 +33,17 @@ final class BackingTests: XCTestCase {
       "project_country": "US",
       "project_id": 1,
       "sequence": 1,
-      "status": "pledged"
+      "status": "pledged",
+      "reward": [
+        "id": 1,
+        "description": "Some reward",
+        "minimum": 10,
+        "converted_minimum": 12,
+        "backers_count": 10
+      ]
     ])
 
+    XCTAssertNotNil(backing?.addOns)
     XCTAssertEqual(1.0, backing?.amount)
     XCTAssertEqual(1, backing?.backerId)
     XCTAssertEqual(true, backing?.backerCompleted)

--- a/KsApi/models/ProjectActivityEnvelope.swift
+++ b/KsApi/models/ProjectActivityEnvelope.swift
@@ -8,6 +8,10 @@ public struct ProjectActivityEnvelope: Decodable {
     public let api: ApiEnvelope
 
     public struct ApiEnvelope: Decodable {
+      private enum CodingKeys: String, CodingKey {
+        case moreActivities = "more_activities"
+      }
+
       public let moreActivities: String
     }
   }

--- a/KsApi/models/ProjectActivityEnvelopeTests.swift
+++ b/KsApi/models/ProjectActivityEnvelopeTests.swift
@@ -1,0 +1,81 @@
+@testable import KsApi
+import XCTest
+
+final class ProjectActivityEnvelopeTests: XCTestCase {
+  func test() {
+    let dict: [String: Any] = [
+      "urls": [
+        "api": [
+          "more_activities": "https://api.kickstarter.com/v1/projects/585534558/activities?currency=USD&cursor=93896288&signature=1608143509.1808b80cca292aa6bd422a23a411be2d7e8149d8",
+          "newer_activities": "https://api.kickstarter.com/v1/projects/585534558/activities?currency=USD&signature=1608143509.37659885e6797639728dd060fa75c3ca9553251e&since=1608057109"
+        ]
+      ],
+      "activities": [
+        [
+          "id": 138_285_118,
+          "category": "update",
+          "project_id": 585_534_558,
+          "project_photo": "https://ksr-ugc.imgix.net/assets/013/633/871/f6903ec3876e23e596507f6f1839ac09_original.JPG?ixlib=rb-2.1.0&fill=crop&w=120&h=120&v=1473255769&auto=format&frame=1&q=92&s=2dc93a909b59883a6391785adadb3ff2",
+          "update_id": 1_678_113,
+          "created_at": 1_521_754_266,
+          "user": [
+            "id": 1_178_169_226,
+            "name": "Katie Mandel Bruce",
+            "slug": "katiem",
+            "is_registered": nil,
+            "is_email_verified": nil,
+            "chosen_currency": nil,
+            "is_superbacker": nil,
+            "avatar": [
+              "thumb": "https://ksr-ugc.imgix.net/assets/008/236/721/d406e60ddcc2d3bd3ed541bb915ef53e_original.jpeg?ixlib=rb-2.1.0&w=40&h=40&fit=crop&v=1461511746&auto=format&frame=1&q=92&s=4f9153ea1cb719a4842cf795820acd25",
+              "small": "https://ksr-ugc.imgix.net/assets/008/236/721/d406e60ddcc2d3bd3ed541bb915ef53e_original.jpeg?ixlib=rb-2.1.0&w=80&h=80&fit=crop&v=1461511746&auto=format&frame=1&q=92&s=89ae627aba2c664d513ab93ebbc28753",
+              "medium": "https://ksr-ugc.imgix.net/assets/008/236/721/d406e60ddcc2d3bd3ed541bb915ef53e_original.jpeg?ixlib=rb-2.1.0&w=160&h=160&fit=crop&v=1461511746&auto=format&frame=1&q=92&s=6b5d8f08ea5e27cf225bd65e85b7744a"
+            ],
+            "urls": [
+              "web": [
+                "user": "https://www.kickstarter.com/profile/katiem"
+              ],
+              "api": [
+                "user": "https://api.kickstarter.com/v1/users/1178169226?signature=1608143509.23e4f60ff06de5e28d7b37b18c1cebc352550a78"
+              ]
+            ],
+            "backed_projects": 389,
+            "join_date": "2013-12-09T01:24:28Z",
+            "location": nil
+          ],
+          "update": [
+            "id": 1_678_113,
+            "project_id": 585_534_558,
+            "type": "FreeformPost",
+            "likers": [],
+            "has_liked": false,
+            "title": "test test",
+            "sequence": 2,
+            "public": false,
+            "is_public": false,
+            "urls": [
+              "api": [
+                "update": "https://api.kickstarter.com/v1/projects/585534558/updates/1678113?signature=1608143509.b6949f108ce6fa36d312466cf649d924ef7e8a0a",
+                "comments": "https://api.kickstarter.com/v1/projects/585534558/updates/1678113/comments?signature=1608143411.5d5b1158e4404366d6d7a97624f6211d3dac23c8"
+              ],
+              "web": [
+                "update": "https://www.kickstarter.com/projects/katiem/dogs-of-new-york-city/posts/1678113"
+              ]
+            ],
+            "visible": true,
+            "published_at": 1_521_754_266,
+            "updated_at": 1_521_754_266,
+            "comments_count": 0,
+            "likes_count": 0,
+            "body": "<p>Testing again</p>"
+          ],
+          "next_activity_id": 94_020_612
+        ]
+      ]
+    ]
+
+    let env: ProjectActivityEnvelope? = ProjectActivityEnvelope.decodeJSONDictionary(dict)
+
+    XCTAssertNotNil(env)
+  }
+}


### PR DESCRIPTION
# 📲 What

Fixes two decoding bugs that were found in `MessageThread` and `ProjectStatsEnvelope`.

# 🤔 Why

These are regressions that were introduced in #1323.

# 🛠 How

- `MessageThread` was expecting an array type for the incorrect key. Updated the key and added a test.
- `ProjectStatsEnvelope` needed a `CodingKeys` `enum` in order to decode the snake_cased `more_activities` key.

# ✅ Acceptance criteria

- [ ] Navigate to messages and tap into a message - the view should load.
- [ ] As a creator, navigate to the dashboard and tap into activities. The view should load.