### PR TITLE
[NT-1725] Fix Tests And Only Cache Frameworks on CI

### DIFF
--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -6477,6 +6477,7 @@
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
+				VALIDATE_WORKSPACE = NO;
 			};
 			name = "AppCenter Beta";
 		};
@@ -6925,6 +6926,7 @@
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_WORKSPACE = NO;
 			};
 			name = Debug;
 		};
@@ -6995,6 +6997,7 @@
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
+				VALIDATE_WORKSPACE = NO;
 			};
 			name = Release;
 		};
@@ -7367,6 +7370,7 @@
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
+				VALIDATE_WORKSPACE = NO;
 			};
 			name = "AppCenter Alpha";
 		};

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ dependencies: carthage-bootstrap configs secrets
 bootstrap: hooks dependencies
 
 carthage-bootstrap:
-	bin/carthage.sh
+	bin/carthage.sh || exit 1
 
 configs = $(basename $(wildcard Kickstarter-iOS/Configs/*.example))
 $(configs):

--- a/bin/carthage.sh
+++ b/bin/carthage.sh
@@ -24,8 +24,9 @@ export XCODE_XCCONFIG_FILE="$xcconfig"
 if [ -z "${CIRCLECI:-}" ]; then
   carthage "$@"
 # Else if running on CircleCI and no cache found, ensure latest carthage and build resolved dependencies
-elif [ ! cmp -s Cartfile.resolved Carthage/Cartfile.resolved; ]; then
+elif ! cmp -s Cartfile.resolved Carthage/Cartfile.resolved; then
   brew upgrade carthage
   echo "Resolving dependencies"
   carthage bootstrap --platform iOS
+  cp Cartfile.resolved Carthage
 fi

--- a/bin/carthage.sh
+++ b/bin/carthage.sh
@@ -23,11 +23,9 @@ export XCODE_XCCONFIG_FILE="$xcconfig"
 # If not running on CircleCI, pass args through
 if [ -z "${CIRCLECI:-}" ]; then
   carthage "$@"
-else
-  # Else if running on CircleCI and no cache found, ensure latest carthage and build resolved dependencies
-  if [ ! cmp -s Cartfile.resolved Carthage/Cartfile.resolved; ] then
-    brew upgrade carthage
-    echo "Resolving dependencies"
-    carthage bootstrap --platform iOS
-  fi
+# Else if running on CircleCI and no cache found, ensure latest carthage and build resolved dependencies
+elif [ ! cmp -s Cartfile.resolved Carthage/Cartfile.resolved; ]; then
+  brew upgrade carthage
+  echo "Resolving dependencies"
+  carthage bootstrap --platform iOS
 fi

--- a/bin/carthage.sh
+++ b/bin/carthage.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-brew upgrade carthage
-
 # Ref for below Xcode 12 workaround: https://github.com/Carthage/Carthage/issues/3019
 # Remove workaround once Carthage team have fixed this.
 
@@ -22,16 +20,14 @@ echo 'EXCLUDED_ARCHS = $(inherited) $(EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_
 
 export XCODE_XCCONFIG_FILE="$xcconfig"
 
-# Cache Cartfile
-if [ ! -z ${FORCE_CARTHAGE:-} ] || ! cmp -s Cartfile.resolved Carthage/Cartfile.resolved; then
-  # If not running on CircleCI, update dependencies
-  if [ -z "${CIRCLECI:-}" ]; then
-    echo "Updating dependencies"
-    carthage update --platform iOS
-  # Else if running on CircleCI, build resolved dependencies
-  else
+# If not running on CircleCI, pass args through
+if [ -z "${CIRCLECI:-}" ]; then
+  carthage "$@"
+else
+  # Else if running on CircleCI and no cache found, ensure latest carthage and build resolved dependencies
+  if [ ! cmp -s Cartfile.resolved Carthage/Cartfile.resolved; then
+    brew upgrade carthage
     echo "Resolving dependencies"
     carthage bootstrap --platform iOS
   fi
-  cp Cartfile.resolved Carthage
 fi

--- a/bin/carthage.sh
+++ b/bin/carthage.sh
@@ -25,7 +25,7 @@ if [ -z "${CIRCLECI:-}" ]; then
   carthage "$@"
 else
   # Else if running on CircleCI and no cache found, ensure latest carthage and build resolved dependencies
-  if [ ! cmp -s Cartfile.resolved Carthage/Cartfile.resolved; then
+  if [ ! cmp -s Cartfile.resolved Carthage/Cartfile.resolved; ] then
     brew upgrade carthage
     echo "Resolving dependencies"
     carthage bootstrap --platform iOS


### PR DESCRIPTION
# 📲 What

- Updates our `bin/carthage.sh` script so that when run locally arguments will be passed through and our `Carthage` directory won't be cached.
- Fixes the issue that the PR #1360 raised.

# 🤔 Why

- When running Carthage builds locally we typically need this behavior and it's inconvenient to have to edit the script each time.
- It turns out that Xcode 12.3 requires that our project includes the `VALIDATE_WORKSPACE` value in our project configuration, but this value does not need to be `YES` as it was set in #1360. See: https://stackoverflow.com/a/65354762/2271759

# 🛠 How

Made the changes described above.

# ✅ Acceptance criteria

- [ ] Builds pass on CI.
- [ ] Tests run locally.