### PR TITLE
Upload screenshots to Screenshotbot!

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,7 +155,27 @@ jobs:
   # Kickstarter tests
   kickstarter-tests:
     <<: *base_job
-    <<: *test_job
+    steps:
+      - when:
+          condition: true
+          <<: *test_job
+      - run:
+          name: Install Screenshotbot SDK
+          command: curl https://screenshotbot.io/recorder.sh | sh
+          when: always
+      - run:
+          name: Upload Screenshots to Screenshotbot
+          command: >
+            cd ~/kickstarter && ~/screenshotbot/recorder --channel ios-oss \
+              --api-key "${SCREENSHOTBOT_API_KEY}" \
+              --api-secret "${SCREENSHOTBOT_API_SECRET}" \
+              --directory Screenshots/_64/ \
+              --ios-multi-dir \
+              --verbose \
+              --production \
+              --repo-url ${CIRCLE_REPOSITORY_URL} \
+              --ios-diff-dir Screenshots/FailureDiffs/
+          when: always
     environment:
       - *default_environment
       - SCHEME=Kickstarter-Framework-iOS


### PR DESCRIPTION
# 📲 What

Hi @justinswart, @singhhari 

Once this PR is merged (plus some extra stuff, which I'll explain in a second), you'll get Screenshotbot reports on your PRs!

Here's an example PR: https://github.com/tdrhq/ios-oss/pull/90.

At this point it does not change the behavior with your tests, a screenshot change will always fail your tests, and you still have to manually record any changes for the test to pass. We'll make that final change once you're confident with the Screenshotbot workflow. i.e. In a few weeks time you'll never have to record screenshots again, just trust Screenshotbot to notify you on PRs. (I realized I might need some tweaks to FBSnapshotTestCase for this too.)

Few changes needed on your end: you'll have to add the Screenshotbot marketplace app: https://github.com/marketplace/screenshotbot (you don't have to grant permissions for the entire Kickstarter organization, just the ios-oss repo, which is open source anyway) Second, you'll need to set up the SCREENSHOTBOT_API_KEY and SCREENSHOTBOT_API_SECRET environment variables in your CircleCI builds. I'll send that over email.

PS. It's possible there are bugs in the circle config. I tested this on a heavily modified version of the config so that I could test it with my limited CircleCI capacity. I'm sure it's all fixable though.

cc @Arkariang 

