### PR TITLE
[NT-1734] Remove unused REST API references

### DIFF
--- a/KsApi/MockService.swift
+++ b/KsApi/MockService.swift
@@ -1040,24 +1040,6 @@
       return SignalProducer(value: .init(shippingRules: self.fetchShippingRulesResult?.value ?? [.template]))
     }
 
-    internal func fetchUserProjectsBacked() -> SignalProducer<ProjectsEnvelope, ErrorEnvelope> {
-      if let error = fetchUserProjectsBackedError {
-        return SignalProducer(error: error)
-      } else if let projects = fetchUserProjectsBackedResponse {
-        return SignalProducer(
-          value: ProjectsEnvelope(
-            projects: projects,
-            urls: ProjectsEnvelope.UrlsEnvelope(
-              api: ProjectsEnvelope.UrlsEnvelope.ApiEnvelope(
-                moreProjects: ""
-              )
-            )
-          )
-        )
-      }
-      return .empty
-    }
-
     internal func fetchUserProjectsBacked(paginationUrl _: String)
       -> SignalProducer<ProjectsEnvelope, ErrorEnvelope> {
       if let error = fetchUserProjectsBackedError {
@@ -1341,20 +1323,6 @@
       return producer(for: self.updateBackingResult)
     }
 
-    internal func updatePledge(
-      project _: Project,
-      amount _: Double,
-      reward _: Reward?,
-      shippingLocation _: Location?,
-      tappedReward _: Bool
-    ) -> SignalProducer<UpdatePledgeEnvelope, ErrorEnvelope> {
-      if let error = self.updatePledgeResult?.error {
-        return SignalProducer(error: error)
-      }
-
-      return SignalProducer(value: self.updatePledgeResult?.value ?? .template)
-    }
-
     internal func unwatchProject(input _: WatchProjectInput)
       -> SignalProducer<GraphMutationWatchProjectResponseEnvelope, GraphError> {
       return producer(for: self.unwatchProjectMutationResult)
@@ -1388,29 +1356,10 @@
       return SignalProducer(value: self.removeAttachmentResponse ?? .template)
     }
 
-    internal func addVideo(file _: URL, toDraft _: UpdateDraft)
-      -> SignalProducer<UpdateDraft.Video, ErrorEnvelope> {
-      return .empty
-    }
-
-    internal func changePaymentMethod(project _: Project)
-      -> SignalProducer<ChangePaymentMethodEnvelope, ErrorEnvelope> {
-      if let error = self.changePaymentMethodResult?.error {
-        return SignalProducer(error: error)
-      }
-
-      return SignalProducer(value: self.changePaymentMethodResult?.value ?? .template)
-    }
-
     internal func deletePaymentMethod(input _: PaymentSourceDeleteInput) -> SignalProducer<
       DeletePaymentMethodEnvelope, GraphError
     > {
       return producer(for: self.deletePaymentMethodResult)
-    }
-
-    internal func delete(video _: UpdateDraft.Video, fromDraft _: UpdateDraft)
-      -> SignalProducer<UpdateDraft.Video, ErrorEnvelope> {
-      return .empty
     }
 
     internal func publish(draft _: UpdateDraft) -> SignalProducer<Update, ErrorEnvelope> {

--- a/KsApi/Service.swift
+++ b/KsApi/Service.swift
@@ -76,11 +76,6 @@ public struct Service: ServiceType {
     return applyMutation(mutation: CreatePaymentSourceMutation(input: input))
   }
 
-  public func addVideo(file fileURL: URL, toDraft draft: UpdateDraft)
-    -> SignalProducer<UpdateDraft.Video, ErrorEnvelope> {
-    return request(Route.addVideo(fileUrl: fileURL, toDraft: draft))
-  }
-
   public func cancelBacking(input: CancelBackingInput)
     -> SignalProducer<GraphMutationEmptyResponseEnvelope, GraphError> {
     return applyMutation(mutation: CancelBackingMutation(input: input))
@@ -106,11 +101,6 @@ public struct Service: ServiceType {
     return applyMutation(mutation: UpdateUserAccountMutation(input: input))
   }
 
-  public func changePaymentMethod(project: Project)
-    -> SignalProducer<ChangePaymentMethodEnvelope, ErrorEnvelope> {
-    return request(.changePaymentMethod(project: project))
-  }
-
   public func clearUserUnseenActivity(input: EmptyInput)
     -> SignalProducer<ClearUserUnseenActivityEnvelope, GraphError> {
     return applyMutation(mutation: ClearUserUnseenActivityMutation(input: input))
@@ -129,11 +119,6 @@ public struct Service: ServiceType {
   public func delete(image: UpdateDraft.Image, fromDraft draft: UpdateDraft)
     -> SignalProducer<UpdateDraft.Image, ErrorEnvelope> {
     return request(.deleteImage(image, fromDraft: draft))
-  }
-
-  public func delete(video: UpdateDraft.Video, fromDraft draft: UpdateDraft)
-    -> SignalProducer<UpdateDraft.Video, ErrorEnvelope> {
-    return request(.deleteVideo(video, fromDraft: draft))
   }
 
   public func exportData() -> SignalProducer<VoidEnvelope, ErrorEnvelope> {
@@ -326,10 +311,6 @@ public struct Service: ServiceType {
     return request(.surveyResponse(surveyResponseId: id))
   }
 
-  public func fetchUserProjectsBacked() -> SignalProducer<ProjectsEnvelope, ErrorEnvelope> {
-    return request(.userProjectsBacked)
-  }
-
   public func fetchUserProjectsBacked(paginationUrl url: String)
     -> SignalProducer<ProjectsEnvelope, ErrorEnvelope> {
     return requestPaginationDecodable(url)
@@ -488,24 +469,6 @@ public struct Service: ServiceType {
   public func update(draft: UpdateDraft, title: String, body: String, isPublic: Bool)
     -> SignalProducer<UpdateDraft, ErrorEnvelope> {
     return request(.updateUpdateDraft(draft, title: title, body: body, isPublic: isPublic))
-  }
-
-  public func updatePledge(
-    project: Project,
-    amount: Double,
-    reward: Reward?,
-    shippingLocation: Location?,
-    tappedReward: Bool
-  ) -> SignalProducer<UpdatePledgeEnvelope, ErrorEnvelope> {
-    return request(
-      .updatePledge(
-        project: project,
-        amount: amount,
-        reward: reward,
-        shippingLocation: shippingLocation,
-        tappedReward: tappedReward
-      )
-    )
   }
 
   public func updateProjectNotification(_ notification: ProjectNotification)

--- a/KsApi/ServiceType.swift
+++ b/KsApi/ServiceType.swift
@@ -43,10 +43,6 @@ public protocol ServiceType {
   func addImage(file fileURL: URL, toDraft draft: UpdateDraft)
     -> SignalProducer<UpdateDraft.Image, ErrorEnvelope>
 
-  /// Uploads and attaches a video to the draft of a project update.
-  func addVideo(file fileURL: URL, toDraft draft: UpdateDraft)
-    -> SignalProducer<UpdateDraft.Video, ErrorEnvelope>
-
   /// Cancels a backing
   func cancelBacking(input: CancelBackingInput)
     -> SignalProducer<GraphMutationEmptyResponseEnvelope, GraphError>
@@ -73,9 +69,6 @@ public protocol ServiceType {
   func addNewCreditCard(input: CreatePaymentSourceInput) ->
     SignalProducer<CreatePaymentSourceEnvelope, GraphError>
 
-  func changePaymentMethod(project: Project)
-    -> SignalProducer<ChangePaymentMethodEnvelope, ErrorEnvelope>
-
   /// Deletes a payment method
   func deletePaymentMethod(input: PaymentSourceDeleteInput) ->
     SignalProducer<DeletePaymentMethodEnvelope, GraphError>
@@ -83,10 +76,6 @@ public protocol ServiceType {
   /// Removes an image from a project update draft.
   func delete(image: UpdateDraft.Image, fromDraft draft: UpdateDraft)
     -> SignalProducer<UpdateDraft.Image, ErrorEnvelope>
-
-  /// Removes a video from a project update draft.
-  func delete(video: UpdateDraft.Video, fromDraft draft: UpdateDraft)
-    -> SignalProducer<UpdateDraft.Video, ErrorEnvelope>
 
   func exportData() -> SignalProducer<VoidEnvelope, ErrorEnvelope>
 
@@ -221,9 +210,6 @@ public protocol ServiceType {
   /// Fetches a project update draft.
   func fetchUpdateDraft(forProject project: Project) -> SignalProducer<UpdateDraft, ErrorEnvelope>
 
-  /// Fetches the current user's backed projects.
-  func fetchUserProjectsBacked() -> SignalProducer<ProjectsEnvelope, ErrorEnvelope>
-
   /// Fetches more user backed projects.
   func fetchUserProjectsBacked(paginationUrl url: String) -> SignalProducer<ProjectsEnvelope, ErrorEnvelope>
 
@@ -312,15 +298,6 @@ public protocol ServiceType {
 
   /// Updates a backing
   func updateBacking(input: UpdateBackingInput) -> SignalProducer<UpdateBackingEnvelope, GraphError>
-
-  /// Performs the first step of checkout by creating a pledge on the server.
-  func updatePledge(
-    project: Project,
-    amount: Double,
-    reward: Reward?,
-    shippingLocation: Location?,
-    tappedReward: Bool
-  ) -> SignalProducer<UpdatePledgeEnvelope, ErrorEnvelope>
 
   /// Update the project notification setting.
   func updateProjectNotification(_ notification: ProjectNotification)


### PR DESCRIPTION
# 📲 What

While documenting [a list of the API requests](https://kickstarter.atlassian.net/wiki/spaces/NT/pages/908525614/Native+API+Documentation) currently being made in the project, we determined a few of our REST API methods were no longer in use. It's presumable that during the shift from REST to GraphQL they may have been left behind. 

# 🤔 Why

This is the first step in an eventual update of how we're handling our API interactions on iOS. Ideally, sometime later in 2021 we can add on to this work by investigating further re-factoring of some REST endpoints to GraphQL.

# 🛠 How

Updated the following files:

- `Route.swift`
- `Service.swift`
- `ServiceType.swift`
- `MockService.swift`