### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,6 @@ A collection of operators we like to add to ReactiveCocoa.
 ### 3rd party
 
 * [AlamofireImage](https://github.com/Alamofire/AlamofireImage)
-* [Argo](https://github.com/thoughtbot/Argo)
 * [FBSnapshotTestCase](https://github.com/facebook/ios-snapshot-test-case)
 * [ReactiveSwift](https://github.com/ReactiveCocoa/ReactiveSwift)
 


### PR DESCRIPTION
# 📲 What

We're no longer using `Argo` as a dependency, so we've removed it from our README.

# 🤔 Why

We're now relying on Swift's `Codable`protocol to do this work for us.