### PR TITLE
[EP-149] Rename Properties (Phase One)

### DIFF
--- a/KsApi/models/Reward.swift
+++ b/KsApi/models/Reward.swift
@@ -25,6 +25,16 @@ public struct Reward {
     return self.id == Reward.noReward.id
   }
 
+  /// Returns `true` if the `Reward` has a value for the `limit` property.
+  public var isLimitedQuantity: Bool {
+    return self.limit != nil
+  }
+
+  /// Returns `true` if the `Reward` has a value for the `endsAt` property.
+  public var isLimitedTime: Bool {
+    return self.endsAt != nil
+  }
+
   /**
    Returns the closest matching `ShippingRule` for this `Reward` to `otherShippingRule`.
    If no match is found `otherShippingRule` is returned, this is to be backward-compatible

--- a/KsApi/models/graphql/adapters/Reward+GraphRewardTests.swift
+++ b/KsApi/models/graphql/adapters/Reward+GraphRewardTests.swift
@@ -43,6 +43,56 @@ final class Reward_GraphRewardTests: XCTestCase {
     XCTAssertEqual(v1Reward?.shipping.preference, .restricted)
     XCTAssertEqual(v1Reward?.startsAt, 1_487_502_131)
     XCTAssertEqual(v1Reward?.title, "Reward name")
+
+    XCTAssertEqual(v1Reward?.isLimitedQuantity, true)
+    XCTAssertEqual(v1Reward?.isLimitedTime, true)
+  }
+
+  func test_isLimited_False() {
+    let shippingReward = GraphReward.template
+      |> \.shippingPreference .~ .restricted
+      |> \.limit .~ nil
+      |> \.endsAt .~ nil
+    let backing = GraphBacking.template
+      |> \.reward .~ shippingReward
+
+    guard let reward = backing.reward else {
+      XCTFail("Should have a reward")
+      return
+    }
+
+    let dateFormatter = DateFormatter()
+    dateFormatter.timeZone = TimeZone(secondsFromGMT: 0)
+    dateFormatter.dateFormat = "yyyy-MM-dd"
+
+    let v1Reward = Reward.reward(
+      from: reward,
+      projectId: Project.template.id,
+      dateFormatter: dateFormatter
+    )
+
+    XCTAssertNotNil(v1Reward)
+    XCTAssertEqual(v1Reward?.backersCount, 55)
+    XCTAssertEqual(v1Reward?.convertedMinimum, 180.0)
+    XCTAssertEqual(v1Reward?.description, "Description")
+    XCTAssertEqual(v1Reward?.endsAt, nil)
+    XCTAssertEqual(v1Reward?.estimatedDeliveryOn, 1_596_240_000.0)
+    XCTAssertEqual(v1Reward?.id, 1)
+    XCTAssertEqual(v1Reward?.limit, nil)
+    XCTAssertEqual(v1Reward?.minimum, 159.0)
+    XCTAssertEqual(v1Reward?.remaining, 10)
+    XCTAssertEqual(v1Reward?.rewardsItems[0].item.id, 921_095)
+    XCTAssertEqual(v1Reward?.rewardsItems[0].item.name, "Item 1")
+    XCTAssertEqual(v1Reward?.rewardsItems[1].item.id, 921_093)
+    XCTAssertEqual(v1Reward?.rewardsItems[1].item.name, "Item 2")
+
+    XCTAssertEqual(v1Reward?.shipping.enabled, true)
+    XCTAssertEqual(v1Reward?.shipping.preference, .restricted)
+    XCTAssertEqual(v1Reward?.startsAt, 1_487_502_131)
+    XCTAssertEqual(v1Reward?.title, "Reward name")
+
+    XCTAssertEqual(v1Reward?.isLimitedQuantity, false)
+    XCTAssertEqual(v1Reward?.isLimitedTime, false)
   }
 
   func testTemplate() {

--- a/Library/OptimizelyClientType.swift
+++ b/Library/OptimizelyClientType.swift
@@ -130,7 +130,7 @@ public func optimizelyProperties(environment: Environment? = AppEnvironment.curr
   return [
     "optimizely_api_key": sdkKey,
     "optimizely_environment": environmentType.description,
-    "optimizely_experiments": allExperiments
+    "session_variants_optimizely": allExperiments
   ]
 }
 
@@ -151,7 +151,7 @@ public func optimizelyUserAttributes(
     "session_user_is_logged_in": user != nil,
     "session_app_release_version": AppEnvironment.current.mainBundle.shortVersionString,
     "session_apple_pay_device": AppEnvironment.current.applePayCapabilities.applePayDevice(),
-    "session_device_format": AppEnvironment.current.device.deviceFormat
+    "session_device_type": AppEnvironment.current.device.deviceType
   ]
   .compact()
   .withAllValuesFrom(sessionRefTagProperties(with: project, refTag: refTag))

--- a/Library/OptimizelyClientTypeTests.swift
+++ b/Library/OptimizelyClientTypeTests.swift
@@ -129,7 +129,7 @@ final class OptimizelyClientTypeTests: TestCase {
 
     withEnvironment(apiService: mockService, optimizelyClient: mockOptimizelyClient) {
       let properties = optimizelyProperties()
-      let optimizelyExperiments = properties?["optimizely_experiments"] as? [[String: String]]
+      let optimizelyExperiments = properties?["session_variants_optimizely"] as? [[String: String]]
 
       XCTAssertEqual("Staging", properties?["optimizely_environment"] as? String)
       XCTAssertEqual(Secrets.OptimizelySDKKey.staging, properties?["optimizely_api_key"] as? String)
@@ -162,7 +162,7 @@ final class OptimizelyClientTypeTests: TestCase {
     XCTAssertEqual("MockSystemVersion", userAttributes?["session_os_version"] as? String)
     XCTAssertEqual("1.2.3.4.5.6.7.8.9.0", userAttributes?["session_app_release_version"] as? String)
     XCTAssertEqual(true, userAttributes?["session_apple_pay_device"] as? Bool)
-    XCTAssertEqual("phone", userAttributes?["session_device_format"] as? String)
+    XCTAssertEqual("phone", userAttributes?["session_device_type"] as? String)
     XCTAssertEqual(true, userAttributes?["session_user_is_logged_in"] as? Bool)
 
     XCTAssertNil(userAttributes?["user_facebook_account"] as? Bool)

--- a/Library/SharedFunctions.swift
+++ b/Library/SharedFunctions.swift
@@ -258,8 +258,8 @@ public func discoveryPageBackgroundColor() -> UIColor {
 }
 
 public func rewardIsAvailable(project: Project, reward: Reward) -> Bool {
-  let isLimited = reward.limit != nil
-  let isTimebased = reward.endsAt != nil
+  let isLimited = reward.isLimitedQuantity
+  let isTimebased = reward.isLimitedTime
 
   guard isLimited || isTimebased else { return true }
 

--- a/Library/TestHelpers/MockOptimizelyClient.swift
+++ b/Library/TestHelpers/MockOptimizelyClient.swift
@@ -86,7 +86,7 @@ extension TestCase {
       "1.2.3.4.5.6.7.8.9.0"
     )
     XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_apple_pay_device"] as? Bool, true)
-    XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_device_format"] as? String, "phone")
+    XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_device_type"] as? String, "phone")
 
     XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_country"] as? String, "us")
     XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_display_language"] as? String, "en")

--- a/Library/Tracking/KSRAnalytics.swift
+++ b/Library/Tracking/KSRAnalytics.swift
@@ -1386,8 +1386,8 @@ private func checkoutProperties(from data: KSRAnalytics.CheckoutPropertiesData, 
   result["payment_type"] = data.paymentType
   result["reward_estimated_delivery_on"] = data.estimatedDelivery
   result["reward_id"] = data.rewardId
-  result["reward_is_limited_quantity"] = reward.limit != nil
-  result["reward_is_limited_time"] = reward.endsAt != nil
+  result["reward_is_limited_quantity"] = reward.isLimitedQuantity
+  result["reward_is_limited_time"] = reward.isLimitedTime
   result["reward_minimum_usd"] = data.rewardMinimumUsd
   result["reward_shipping_enabled"] = data.shippingEnabled
   result["reward_shipping_preference"] = reward.shipping.preference?.trackingString

--- a/Library/Tracking/KSRAnalytics.swift
+++ b/Library/Tracking/KSRAnalytics.swift
@@ -746,7 +746,7 @@ public final class KSRAnalytics {
   ) {
     let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
       .withAllValuesFrom(pledgeProperties(from: reward))
-      .withAllValuesFrom(checkoutProperties(from: checkoutData))
+      .withAllValuesFrom(checkoutProperties(from: checkoutData, and: reward))
       // the context is always "newPledge" for this event
       .withAllValuesFrom(contextProperties(pledgeFlowContext: .newPledge))
 
@@ -822,7 +822,7 @@ public final class KSRAnalytics {
       .withAllValuesFrom(contextProperties(pledgeFlowContext: .newPledge))
 
     if let checkoutData = checkoutData {
-      props = props.withAllValuesFrom(checkoutProperties(from: checkoutData))
+      props = props.withAllValuesFrom(checkoutProperties(from: checkoutData, and: reward))
     }
 
     self.track(
@@ -1204,28 +1204,28 @@ public final class KSRAnalytics {
     props["apple_pay_device"] = AppEnvironment.current.applePayCapabilities.applePayDevice()
     props["cellular_connection"] = AppEnvironment.current.coreTelephonyNetworkInfo
       .serviceCurrentRadioAccessTechnology
-    props["client_type"] = "native"
+    props["client"] = "native"
     props["current_variants"] = self.config?.abExperimentsArray.sorted()
     props["display_language"] = AppEnvironment.current.language.rawValue
 
-    props["device_format"] = self.device.deviceFormat
+    props["device_type"] = self.device.deviceType
     props["device_manufacturer"] = "Apple"
     props["device_model"] = KSRAnalytics.deviceModel
     props["device_orientation"] = self.deviceOrientation
     props["device_distinct_id"] = self.distinctId
 
+    props["app_build_number"] = self.bundle.infoDictionary?["CFBundleVersion"]
+    props["app_release_version"] = self.bundle.infoDictionary?["CFBundleShortVersionString"]
     props["enabled_features"] = enabledFeatureFlags
     props["is_voiceover_running"] = AppEnvironment.current.isVoiceOverRunning()
     props["mp_lib"] = "kickstarter_ios"
     props["os"] = self.device.systemName
     props["os_version"] = self.device.systemVersion
-    props["app_build_number"] = self.bundle.infoDictionary?["CFBundleVersion"]
-    props["app_release_version"] = self.bundle.infoDictionary?["CFBundleShortVersionString"]
+    props["platform"] = self.clientPlatform
     props["screen_width"] = UInt(self.screen.bounds.width)
     props["user_agent"] = Service.userAgent
     props["user_logged_in"] = self.loggedInUser != nil
     props["wifi_connection"] = Reachability.current == .wifi
-    props["client_platform"] = self.clientPlatform
 
     props["ref_tag"] = refTag
     props["referrer_credit"] = referrerCredit
@@ -1301,7 +1301,7 @@ private func projectProperties(
   props["state"] = project.state.rawValue
   props["static_usd_rate"] = project.stats.staticUsdRate
   props["current_pledge_amount"] = project.stats.pledged
-  props["current_pledge_amount_usd"] = project.stats.pledgedUsd
+  props["current_amount_pledged_usd"] = project.stats.pledgedUsd
   props["goal_usd"] = project.stats.goalUsd
   props["has_video"] = project.video != nil
   props["prelaunch_activated"] = project.prelaunchActivated
@@ -1363,22 +1363,20 @@ private func pledgeProperties(from reward: Reward, prefix: String = "pledge_back
 
   result["has_items"] = !reward.rewardsItems.isEmpty
   result["id"] = reward.id
-  result["is_limited_quantity"] = reward.limit != nil
-  result["is_limited_time"] = reward.endsAt != nil
   result["minimum"] = reward.minimum
-  result["shipping_enabled"] = reward.shipping.enabled
-  result["shipping_preference"] = reward.shipping.preference?.trackingString
 
   return result.prefixedKeys(prefix)
 }
 
 // MARK: - Checkout Properties
 
-private func checkoutProperties(from data: KSRAnalytics.CheckoutPropertiesData, prefix: String = "checkout_")
+private func checkoutProperties(from data: KSRAnalytics.CheckoutPropertiesData, and reward: Reward,
+                                prefix: String = "checkout_")
   -> [String: Any] {
   var result: [String: Any] = [:]
 
   result["amount"] = data.amount
+  result["amount_total_usd"] = data.revenueInUsdCents
   result["add_ons_count_total"] = data.addOnsCountTotal
   result["add_ons_count_unique"] = data.addOnsCountUnique
   result["add_ons_minimum_usd"] = data.addOnsMinimumUsd
@@ -1386,16 +1384,16 @@ private func checkoutProperties(from data: KSRAnalytics.CheckoutPropertiesData, 
   result["bonus_amount_usd"] = data.bonusAmountInUsd
   result["id"] = data.checkoutId
   result["payment_type"] = data.paymentType
-  result["reward_id"] = data.rewardId
-  result["reward_title"] = data.rewardTitle
-  result["reward_minimum_usd"] = data.rewardMinimumUsd
-  result["shipping_amount"] = data.shippingAmount
-  result["revenue_in_usd_cents"] = data.revenueInUsdCents
   result["reward_estimated_delivery_on"] = data.estimatedDelivery
+  result["reward_id"] = data.rewardId
+  result["reward_is_limited_quantity"] = reward.limit != nil
+  result["reward_is_limited_time"] = reward.endsAt != nil
+  result["reward_minimum_usd"] = data.rewardMinimumUsd
   result["reward_shipping_enabled"] = data.shippingEnabled
+  result["reward_shipping_preference"] = reward.shipping.preference?.trackingString
+  result["reward_title"] = data.rewardTitle
   result["shipping_amount"] = data.shippingAmount
   result["shipping_amount_usd"] = data.shippingAmountUsd
-  result["reward_estimated_delivery_on"] = data.estimatedDelivery
   result["user_has_eligible_stored_apple_pay_card"] = data.userHasStoredApplePayCard
 
   return result.prefixedKeys(prefix)

--- a/Library/Tracking/KSRAnalyticsTests.swift
+++ b/Library/Tracking/KSRAnalyticsTests.swift
@@ -63,10 +63,10 @@ final class KSRAnalyticsTests: TestCase {
       segmentClientProperties?["session_enabled_features"] as? [String]
     )
 
-    XCTAssertEqual("native", dataLakeClientProperties?["session_client_type"] as? String)
+    XCTAssertEqual("native", dataLakeClientProperties?["session_client"] as? String)
     XCTAssertEqual("1234567890", dataLakeClientProperties?["session_app_build_number"] as? String)
     XCTAssertEqual("1.2.3.4.5.6.7.8.9.0", dataLakeClientProperties?["session_app_release_version"] as? String)
-    XCTAssertEqual("phone", dataLakeClientProperties?["session_device_format"] as? String)
+    XCTAssertEqual("phone", dataLakeClientProperties?["session_device_type"] as? String)
     XCTAssertEqual("Apple", dataLakeClientProperties?["session_device_manufacturer"] as? String)
     XCTAssertEqual("Portrait", dataLakeClientProperties?["session_device_orientation"] as? String)
     XCTAssertEqual("abc-123", dataLakeClientProperties?["session_device_distinct_id"] as? String)
@@ -80,15 +80,15 @@ final class KSRAnalyticsTests: TestCase {
     XCTAssertEqual(UInt(screen.bounds.width), dataLakeClientProperties?["session_screen_width"] as? UInt)
     XCTAssertEqual("kickstarter_ios", dataLakeClientProperties?["session_mp_lib"] as? String)
     XCTAssertEqual(false, dataLakeClientProperties?["session_user_logged_in"] as? Bool)
-    XCTAssertEqual("ios", dataLakeClientProperties?["session_client_platform"] as? String)
+    XCTAssertEqual("ios", dataLakeClientProperties?["session_platform"] as? String)
     XCTAssertEqual("en", dataLakeClientProperties?["session_display_language"] as? String)
 
     XCTAssertEqual(23, dataLakeClientProperties?.keys.filter { $0.hasPrefix("session_") }.count)
 
-    XCTAssertEqual("native", segmentClientProperties?["session_client_type"] as? String)
+    XCTAssertEqual("native", segmentClientProperties?["session_client"] as? String)
     XCTAssertEqual("1234567890", segmentClientProperties?["session_app_build_number"] as? String)
     XCTAssertEqual("1.2.3.4.5.6.7.8.9.0", segmentClientProperties?["session_app_release_version"] as? String)
-    XCTAssertEqual("phone", segmentClientProperties?["session_device_format"] as? String)
+    XCTAssertEqual("phone", segmentClientProperties?["session_device_type"] as? String)
     XCTAssertEqual("Apple", segmentClientProperties?["session_device_manufacturer"] as? String)
     XCTAssertEqual("Portrait", segmentClientProperties?["session_device_orientation"] as? String)
     XCTAssertEqual("abc-123", segmentClientProperties?["session_device_distinct_id"] as? String)
@@ -102,7 +102,7 @@ final class KSRAnalyticsTests: TestCase {
     XCTAssertEqual(UInt(screen.bounds.width), segmentClientProperties?["session_screen_width"] as? UInt)
     XCTAssertEqual("kickstarter_ios", segmentClientProperties?["session_mp_lib"] as? String)
     XCTAssertEqual(false, segmentClientProperties?["session_user_logged_in"] as? Bool)
-    XCTAssertEqual("ios", segmentClientProperties?["session_client_platform"] as? String)
+    XCTAssertEqual("ios", segmentClientProperties?["session_platform"] as? String)
     XCTAssertEqual("en", segmentClientProperties?["session_display_language"] as? String)
 
     XCTAssertEqual(23, segmentClientProperties?.keys.filter { $0.hasPrefix("session_") }.count)
@@ -179,11 +179,11 @@ final class KSRAnalyticsTests: TestCase {
     )
     ksrAnalytics.trackTabBarClicked(.activity)
 
-    XCTAssertEqual("phone", dataLakeClient.properties.last?["session_device_format"] as? String)
-    XCTAssertEqual("ios", dataLakeClient.properties.last?["session_client_platform"] as? String)
+    XCTAssertEqual("phone", dataLakeClient.properties.last?["session_device_type"] as? String)
+    XCTAssertEqual("ios", dataLakeClient.properties.last?["session_platform"] as? String)
 
-    XCTAssertEqual("phone", segmentClient.properties.last?["session_device_format"] as? String)
-    XCTAssertEqual("ios", segmentClient.properties.last?["session_client_platform"] as? String)
+    XCTAssertEqual("phone", segmentClient.properties.last?["session_device_type"] as? String)
+    XCTAssertEqual("ios", segmentClient.properties.last?["session_platform"] as? String)
   }
 
   func testSessionProperties_DeviceFormatAndClientPlatform_ForIPadIdiom() {
@@ -197,11 +197,11 @@ final class KSRAnalyticsTests: TestCase {
     )
     ksrAnalytics.trackTabBarClicked(.activity)
 
-    XCTAssertEqual("tablet", dataLakeClient.properties.last?["session_device_format"] as? String)
-    XCTAssertEqual("ios", dataLakeClient.properties.last?["session_client_platform"] as? String)
+    XCTAssertEqual("tablet", dataLakeClient.properties.last?["session_device_type"] as? String)
+    XCTAssertEqual("ios", dataLakeClient.properties.last?["session_platform"] as? String)
 
-    XCTAssertEqual("tablet", segmentClient.properties.last?["session_device_format"] as? String)
-    XCTAssertEqual("ios", segmentClient.properties.last?["session_client_platform"] as? String)
+    XCTAssertEqual("tablet", segmentClient.properties.last?["session_device_type"] as? String)
+    XCTAssertEqual("ios", segmentClient.properties.last?["session_platform"] as? String)
   }
 
   func testSessionProperties_DeviceFormatAndClientPlatform_ForTvIdiom() {
@@ -215,11 +215,11 @@ final class KSRAnalyticsTests: TestCase {
     )
     ksrAnalytics.trackTabBarClicked(.activity)
 
-    XCTAssertEqual("tv", dataLakeClient.properties.last?["session_device_format"] as? String)
-    XCTAssertEqual("tvos", dataLakeClient.properties.last?["session_client_platform"] as? String)
+    XCTAssertEqual("tv", dataLakeClient.properties.last?["session_device_type"] as? String)
+    XCTAssertEqual("tvos", dataLakeClient.properties.last?["session_platform"] as? String)
 
-    XCTAssertEqual("tv", segmentClient.properties.last?["session_device_format"] as? String)
-    XCTAssertEqual("tvos", segmentClient.properties.last?["session_client_platform"] as? String)
+    XCTAssertEqual("tv", segmentClient.properties.last?["session_device_type"] as? String)
+    XCTAssertEqual("tvos", segmentClient.properties.last?["session_platform"] as? String)
   }
 
   func testSessionProperties_DeviceOrientation() {
@@ -292,7 +292,7 @@ final class KSRAnalyticsTests: TestCase {
     XCTAssertEqual(2, dataLakeClientProperties?["project_static_usd_rate"] as? Float)
     XCTAssertEqual("live", dataLakeClientProperties?["project_state"] as? String)
     XCTAssertEqual(project.stats.pledged, dataLakeClientProperties?["project_current_pledge_amount"] as? Int)
-    XCTAssertEqual(2_000, dataLakeClientProperties?["project_current_pledge_amount_usd"] as? Int)
+    XCTAssertEqual(2_000, dataLakeClientProperties?["project_current_amount_pledged_usd"] as? Int)
     XCTAssertEqual(4_000, dataLakeClientProperties?["project_goal_usd"] as? Int)
     XCTAssertEqual(true, dataLakeClientProperties?["project_has_video"] as? Bool)
     XCTAssertEqual(10, dataLakeClientProperties?["project_comments_count"] as? Int)
@@ -332,7 +332,7 @@ final class KSRAnalyticsTests: TestCase {
     XCTAssertEqual(2, segmentClientProperties?["project_static_usd_rate"] as? Float)
     XCTAssertEqual("live", segmentClientProperties?["project_state"] as? String)
     XCTAssertEqual(project.stats.pledged, segmentClientProperties?["project_current_pledge_amount"] as? Int)
-    XCTAssertEqual(2_000, segmentClientProperties?["project_current_pledge_amount_usd"] as? Int)
+    XCTAssertEqual(2_000, segmentClientProperties?["project_current_amount_pledged_usd"] as? Int)
     XCTAssertEqual(4_000, segmentClientProperties?["project_goal_usd"] as? Int)
     XCTAssertEqual(true, segmentClientProperties?["project_has_video"] as? Bool)
     XCTAssertEqual(10, segmentClientProperties?["project_comments_count"] as? Int)
@@ -643,22 +643,14 @@ final class KSRAnalyticsTests: TestCase {
 
     XCTAssertEqual(true, dataLakeClientProps?["pledge_backer_reward_has_items"] as? Bool)
     XCTAssertEqual(1, dataLakeClientProps?["pledge_backer_reward_id"] as? Int)
-    XCTAssertEqual(true, dataLakeClientProps?["pledge_backer_reward_is_limited_quantity"] as? Bool)
-    XCTAssertEqual(false, dataLakeClientProps?["pledge_backer_reward_is_limited_time"] as? Bool)
     XCTAssertEqual(10.00, dataLakeClientProps?["pledge_backer_reward_minimum"] as? Double)
-    XCTAssertEqual(false, dataLakeClientProps?["pledge_backer_reward_shipping_enabled"] as? Bool)
-    XCTAssertNil(dataLakeClientProps?["pledge_backer_reward_shipping_preference"] as? String)
 
     XCTAssertEqual("recommended", dataLakeClientProps?["session_ref_tag"] as? String)
     XCTAssertEqual("new_pledge", dataLakeClientProps?["context_pledge_flow"] as? String)
 
     XCTAssertEqual(true, segmentClientProps?["pledge_backer_reward_has_items"] as? Bool)
     XCTAssertEqual(1, segmentClientProps?["pledge_backer_reward_id"] as? Int)
-    XCTAssertEqual(true, segmentClientProps?["pledge_backer_reward_is_limited_quantity"] as? Bool)
-    XCTAssertEqual(false, segmentClientProps?["pledge_backer_reward_is_limited_time"] as? Bool)
     XCTAssertEqual(10.00, segmentClientProps?["pledge_backer_reward_minimum"] as? Double)
-    XCTAssertEqual(false, segmentClientProps?["pledge_backer_reward_shipping_enabled"] as? Bool)
-    XCTAssertNil(segmentClientProps?["pledge_backer_reward_shipping_preference"] as? String)
 
     XCTAssertEqual("recommended", segmentClientProps?["session_ref_tag"] as? String)
     XCTAssertEqual("new_pledge", segmentClientProps?["context_pledge_flow"] as? String)
@@ -680,21 +672,13 @@ final class KSRAnalyticsTests: TestCase {
 
     XCTAssertEqual(false, dataLakeClientProps?["pledge_backer_reward_has_items"] as? Bool)
     XCTAssertEqual(0, dataLakeClientProps?["pledge_backer_reward_id"] as? Int)
-    XCTAssertEqual(false, dataLakeClientProps?["pledge_backer_reward_is_limited_quantity"] as? Bool)
-    XCTAssertEqual(false, dataLakeClientProps?["pledge_backer_reward_is_limited_time"] as? Bool)
     XCTAssertEqual(5.00, dataLakeClientProps?["pledge_backer_reward_minimum"] as? Double)
-    XCTAssertEqual(false, dataLakeClientProps?["pledge_backer_reward_shipping_enabled"] as? Bool)
-    XCTAssertNil(dataLakeClientProps?["pledge_backer_reward_shipping_preference"] as? String)
 
     XCTAssertEqual("change_reward", dataLakeClientProps?["context_pledge_flow"] as? String)
 
     XCTAssertEqual(false, segmentClientProps?["pledge_backer_reward_has_items"] as? Bool)
     XCTAssertEqual(0, segmentClientProps?["pledge_backer_reward_id"] as? Int)
-    XCTAssertEqual(false, segmentClientProps?["pledge_backer_reward_is_limited_quantity"] as? Bool)
-    XCTAssertEqual(false, segmentClientProps?["pledge_backer_reward_is_limited_time"] as? Bool)
     XCTAssertEqual(5.00, segmentClientProps?["pledge_backer_reward_minimum"] as? Double)
-    XCTAssertEqual(false, segmentClientProps?["pledge_backer_reward_shipping_enabled"] as? Bool)
-    XCTAssertNil(segmentClientProps?["pledge_backer_reward_shipping_preference"] as? String)
 
     XCTAssertEqual("change_reward", segmentClientProps?["context_pledge_flow"] as? String)
   }
@@ -714,10 +698,7 @@ final class KSRAnalyticsTests: TestCase {
     let dataLakeClientProps = dataLakeClient.properties.last
     let segmentClientProps = segmentClient.properties.last
 
-    XCTAssertEqual("restricted", dataLakeClientProps?["pledge_backer_reward_shipping_preference"] as? String)
     XCTAssertEqual("manage_reward", dataLakeClientProps?["context_pledge_flow"] as? String)
-
-    XCTAssertEqual("restricted", segmentClientProps?["pledge_backer_reward_shipping_preference"] as? String)
     XCTAssertEqual("manage_reward", segmentClientProps?["context_pledge_flow"] as? String)
   }
 
@@ -1006,10 +987,13 @@ final class KSRAnalyticsTests: TestCase {
     let dataLakeClient = MockTrackingClient()
     let segmentClient = MockTrackingClient()
     let ksrAnalytics = KSRAnalytics(dataLakeClient: dataLakeClient, segmentClient: segmentClient)
+    let reward = Reward.template
+      |> Reward.lens.endsAt .~ 5.0
+      |> Reward.lens.shipping.preference .~ .restricted
 
     ksrAnalytics.trackPledgeSubmitButtonClicked(
       project: .template,
-      reward: .template,
+      reward: reward,
       checkoutData: .template,
       refTag: nil
     )
@@ -1556,7 +1540,7 @@ final class KSRAnalyticsTests: TestCase {
     XCTAssertEqual(1, props?["project_static_usd_rate"] as? Float)
     XCTAssertEqual("live", props?["project_state"] as? String)
     XCTAssertEqual(1_000, props?["project_current_pledge_amount"] as? Int)
-    XCTAssertEqual(1_000, props?["project_current_pledge_amount_usd"] as? Int)
+    XCTAssertEqual(1_000, props?["project_current_amount_pledged_usd"] as? Int)
     XCTAssertEqual(2_000, props?["project_goal_usd"] as? Int)
     XCTAssertEqual(true, props?["project_has_video"] as? Bool)
     XCTAssertEqual(10, props?["project_comments_count"] as? Int)
@@ -1577,12 +1561,7 @@ final class KSRAnalyticsTests: TestCase {
   private func assertPledgeProperties(_ props: [String: Any]?) {
     XCTAssertEqual(true, props?["pledge_backer_reward_has_items"] as? Bool)
     XCTAssertEqual(1, props?["pledge_backer_reward_id"] as? Int)
-    XCTAssertEqual(true, props?["pledge_backer_reward_is_limited_quantity"] as? Bool)
-    XCTAssertEqual(false, props?["pledge_backer_reward_is_limited_time"] as? Bool)
     XCTAssertEqual(10.00, props?["pledge_backer_reward_minimum"] as? Double)
-    XCTAssertEqual(false, props?["pledge_backer_reward_shipping_enabled"] as? Bool)
-
-    XCTAssertNil(props?["pledge_backer_reward_shipping_preference"] as? String)
   }
 
   /*
@@ -1599,8 +1578,11 @@ final class KSRAnalyticsTests: TestCase {
     XCTAssertEqual("SUPER reward", props?["checkout_reward_title"] as? String)
     XCTAssertEqual("5.00", props?["checkout_reward_minimum_usd"] as? String)
     XCTAssertEqual(2, props?["checkout_reward_id"] as? Int)
-    XCTAssertEqual(2_000, props?["checkout_revenue_in_usd_cents"] as? Int)
+    XCTAssertEqual(2_000, props?["checkout_amount_total_usd"] as? Int)
+    XCTAssertEqual(true, props?["checkout_reward_is_limited_quantity"] as? Bool)
+    XCTAssertEqual(true, props?["checkout_reward_is_limited_time"] as? Bool)
     XCTAssertEqual(true, props?["checkout_reward_shipping_enabled"] as? Bool)
+    XCTAssertEqual("restricted", props?["checkout_reward_shipping_preference"] as? String)
     XCTAssertEqual(true, props?["checkout_user_has_eligible_stored_apple_pay_card"] as? Bool)
     XCTAssertEqual(10.00, props?["checkout_shipping_amount"] as? Double)
     XCTAssertEqual("10.00", props?["checkout_shipping_amount_usd"] as? String)

--- a/Library/UIDeviceType.swift
+++ b/Library/UIDeviceType.swift
@@ -40,7 +40,7 @@ internal struct MockDevice: UIDeviceType {
 }
 
 extension UIDeviceType {
-  var deviceFormat: String {
+  var deviceType: String {
     switch self.userInterfaceIdiom {
     case .phone: return "phone"
     case .pad: return "tablet"

--- a/Library/ViewModels/DiscoveryPageViewModelTests.swift
+++ b/Library/ViewModels/DiscoveryPageViewModelTests.swift
@@ -140,13 +140,16 @@ internal final class DiscoveryPageViewModelTests: TestCase {
       "Event includes Optimizely properties"
     )
     XCTAssertNotNil(
-      dataLakeTrackingClientProps?["optimizely_experiments"],
+      dataLakeTrackingClientProps?["session_variants_optimizely"],
       "Event includes Optimizely properties"
     )
 
     XCTAssertNotNil(segmentClientProps?["optimizely_api_key"], "Event includes Optimizely properties")
     XCTAssertNotNil(segmentClientProps?["optimizely_environment"], "Event includes Optimizely properties")
-    XCTAssertNotNil(segmentClientProps?["optimizely_experiments"], "Event includes Optimizely properties")
+    XCTAssertNotNil(
+      segmentClientProps?["session_variants_optimizely"],
+      "Event includes Optimizely properties"
+    )
 
     // Scroll down a bit and advance scheduler
     self.vm.inputs.willDisplayRow(2, outOf: 10)
@@ -1632,7 +1635,7 @@ internal final class DiscoveryPageViewModelTests: TestCase {
         "Event includes Optimizely properties"
       )
       XCTAssertNotNil(
-        dataLakeTrackingClientProperties?["optimizely_experiments"],
+        dataLakeTrackingClientProperties?["session_variants_optimizely"],
         "Event includes Optimizely properties"
       )
 
@@ -1645,7 +1648,7 @@ internal final class DiscoveryPageViewModelTests: TestCase {
         "Event includes Optimizely properties"
       )
       XCTAssertNotNil(
-        segmentTrackingClientProperties?["optimizely_experiments"],
+        segmentTrackingClientProperties?["session_variants_optimizely"],
         "Event includes Optimizely properties"
       )
     }

--- a/Library/ViewModels/PledgeCTAContainerViewViewModelTests.swift
+++ b/Library/ViewModels/PledgeCTAContainerViewViewModelTests.swift
@@ -291,7 +291,7 @@ internal final class PledgeCTAContainerViewViewModelTests: TestCase {
       "Event includes Optimizely properties"
     )
     XCTAssertNotNil(
-      dataLakeTrackingClientProperties?["optimizely_experiments"],
+      dataLakeTrackingClientProperties?["session_variants_optimizely"],
       "Event includes Optimizely properties"
     )
 
@@ -304,7 +304,7 @@ internal final class PledgeCTAContainerViewViewModelTests: TestCase {
       "Event includes Optimizely properties"
     )
     XCTAssertNotNil(
-      segmentTrackingClientProperties?["optimizely_experiments"],
+      segmentTrackingClientProperties?["session_variants_optimizely"],
       "Event includes Optimizely properties"
     )
   }

--- a/Library/ViewModels/PledgeViewModelTests.swift
+++ b/Library/ViewModels/PledgeViewModelTests.swift
@@ -1829,7 +1829,7 @@ final class PledgeViewModelTests: TestCase {
         optimizelyClient.trackedAttributes?["session_app_release_version"] as? String, "1.2.3.4.5.6.7.8.9.0"
       )
       XCTAssertEqual(optimizelyClient.trackedAttributes?["session_apple_pay_device"] as? Bool, true)
-      XCTAssertEqual(optimizelyClient.trackedAttributes?["session_device_format"] as? String, "phone")
+      XCTAssertEqual(optimizelyClient.trackedAttributes?["session_device_type"] as? String, "phone")
     }
   }
 
@@ -2337,7 +2337,7 @@ final class PledgeViewModelTests: TestCase {
         optimizelyClient.trackedAttributes?["session_app_release_version"] as? String, "1.2.3.4.5.6.7.8.9.0"
       )
       XCTAssertEqual(optimizelyClient.trackedAttributes?["session_apple_pay_device"] as? Bool, true)
-      XCTAssertEqual(optimizelyClient.trackedAttributes?["session_device_format"] as? String, "phone")
+      XCTAssertEqual(optimizelyClient.trackedAttributes?["session_device_type"] as? String, "phone")
     }
   }
 
@@ -5292,7 +5292,7 @@ final class PledgeViewModelTests: TestCase {
       "Event includes Optimizely properties"
     )
     XCTAssertNotNil(
-      dataLakeTrackingClientProperties?["optimizely_experiments"],
+      dataLakeTrackingClientProperties?["session_variants_optimizely"],
       "Event includes Optimizely properties"
     )
 
@@ -5302,7 +5302,7 @@ final class PledgeViewModelTests: TestCase {
       "Event includes Optimizely properties"
     )
     XCTAssertNotNil(
-      segmentClientProperties?["optimizely_experiments"],
+      segmentClientProperties?["session_variants_optimizely"],
       "Event includes Optimizely properties"
     )
   }
@@ -5508,7 +5508,7 @@ final class PledgeViewModelTests: TestCase {
       "1.2.3.4.5.6.7.8.9.0"
     )
     XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_apple_pay_device"] as? Bool, true)
-    XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_device_format"] as? String, "phone")
+    XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_device_type"] as? String, "phone")
   }
 
   func testTrackingEvents_OptimizelyClient_PledgeScreenViewed_LoggedIn() {
@@ -5564,7 +5564,7 @@ final class PledgeViewModelTests: TestCase {
         "1.2.3.4.5.6.7.8.9.0"
       )
       XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_apple_pay_device"] as? Bool, true)
-      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_device_format"] as? String, "phone")
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_device_type"] as? String, "phone")
     }
   }
 
@@ -5788,7 +5788,8 @@ final class PledgeViewModelTests: TestCase {
     XCTAssertEqual("55.00", dataLakeTrackingClientProps?["checkout_amount"] as? String)
     XCTAssertEqual("CREDIT_CARD", dataLakeTrackingClientProps?["checkout_payment_type"] as? String)
     XCTAssertEqual(1, dataLakeTrackingClientProps?["checkout_reward_id"] as? Int)
-    XCTAssertEqual(5_500, dataLakeTrackingClientProps?["checkout_revenue_in_usd_cents"] as? Int)
+    XCTAssertEqual(5_500, dataLakeTrackingClientProps?["checkout_amount_total_usd"] as? Int)
+    XCTAssertEqual(true, dataLakeTrackingClientProps?["checkout_reward_is_limited_quantity"] as? Bool)
     XCTAssertEqual(true, dataLakeTrackingClientProps?["checkout_reward_shipping_enabled"] as? Bool)
     XCTAssertEqual(
       true,
@@ -5803,7 +5804,8 @@ final class PledgeViewModelTests: TestCase {
     XCTAssertEqual("55.00", segmentClientProps?["checkout_amount"] as? String)
     XCTAssertEqual("CREDIT_CARD", segmentClientProps?["checkout_payment_type"] as? String)
     XCTAssertEqual(1, segmentClientProps?["checkout_reward_id"] as? Int)
-    XCTAssertEqual(5_500, segmentClientProps?["checkout_revenue_in_usd_cents"] as? Int)
+    XCTAssertEqual(5_500, segmentClientProps?["checkout_amount_total_usd"] as? Int)
+    XCTAssertEqual(true, segmentClientProps?["checkout_reward_is_limited_quantity"] as? Bool)
     XCTAssertEqual(true, segmentClientProps?["checkout_reward_shipping_enabled"] as? Bool)
     XCTAssertEqual(true, segmentClientProps?["checkout_user_has_eligible_stored_apple_pay_card"] as? Bool)
     XCTAssertEqual(5.0, segmentClientProps?["checkout_shipping_amount"] as? Double)
@@ -5816,19 +5818,10 @@ final class PledgeViewModelTests: TestCase {
     // Pledge properties
     XCTAssertEqual(true, dataLakeTrackingClientProps?["pledge_backer_reward_has_items"] as? Bool)
     XCTAssertEqual(1, dataLakeTrackingClientProps?["pledge_backer_reward_id"] as? Int)
-    XCTAssertEqual(true, dataLakeTrackingClientProps?["pledge_backer_reward_is_limited_quantity"] as? Bool)
-    XCTAssertEqual(false, dataLakeTrackingClientProps?["pledge_backer_reward_is_limited_time"] as? Bool)
     XCTAssertEqual(10.00, dataLakeTrackingClientProps?["pledge_backer_reward_minimum"] as? Double)
-    XCTAssertEqual(true, segmentClientProps?["pledge_backer_reward_shipping_enabled"] as? Bool)
     XCTAssertEqual(true, segmentClientProps?["pledge_backer_reward_has_items"] as? Bool)
     XCTAssertEqual(1, segmentClientProps?["pledge_backer_reward_id"] as? Int)
-    XCTAssertEqual(true, segmentClientProps?["pledge_backer_reward_is_limited_quantity"] as? Bool)
-    XCTAssertEqual(false, segmentClientProps?["pledge_backer_reward_is_limited_time"] as? Bool)
     XCTAssertEqual(10.00, segmentClientProps?["pledge_backer_reward_minimum"] as? Double)
-    XCTAssertEqual(true, segmentClientProps?["pledge_backer_reward_shipping_enabled"] as? Bool)
-
-    XCTAssertNil(dataLakeTrackingClientProps?["pledge_backer_reward_shipping_preference"] as? String)
-    XCTAssertNil(segmentClientProps?["pledge_backer_reward_shipping_preference"] as? String)
 
     // Project properties
     XCTAssertEqual(1, dataLakeTrackingClientProps?["project_pid"] as? Int)

--- a/Library/ViewModels/ProjectPamphletMainCellViewModelTests.swift
+++ b/Library/ViewModels/ProjectPamphletMainCellViewModelTests.swift
@@ -639,7 +639,7 @@ final class ProjectPamphletMainCellViewModelTests: TestCase {
         "1.2.3.4.5.6.7.8.9.0"
       )
       XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_apple_pay_device"] as? Bool, true)
-      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_device_format"] as? String, "phone")
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_device_type"] as? String, "phone")
     }
   }
 
@@ -700,7 +700,7 @@ final class ProjectPamphletMainCellViewModelTests: TestCase {
         "Event includes Optimizely properties"
       )
       XCTAssertNotNil(
-        dataLakeTrackingClientProperties?["optimizely_experiments"],
+        dataLakeTrackingClientProperties?["session_variants_optimizely"],
         "Event includes Optimizely properties"
       )
       XCTAssertNotNil(
@@ -712,7 +712,7 @@ final class ProjectPamphletMainCellViewModelTests: TestCase {
         "Event includes Optimizely properties"
       )
       XCTAssertNotNil(
-        segmentClientProperties?["optimizely_experiments"],
+        segmentClientProperties?["session_variants_optimizely"],
         "Event includes Optimizely properties"
       )
     }

--- a/Library/ViewModels/ProjectPamphletViewModelTests.swift
+++ b/Library/ViewModels/ProjectPamphletViewModelTests.swift
@@ -957,7 +957,7 @@ final class ProjectPamphletViewModelTests: TestCase {
         "Event includes Optimizely properties"
       )
       XCTAssertNotNil(
-        dataLakeClientProperties?["optimizely_experiments"],
+        dataLakeClientProperties?["session_variants_optimizely"],
         "Event includes Optimizely properties"
       )
 
@@ -967,7 +967,7 @@ final class ProjectPamphletViewModelTests: TestCase {
         "Event includes Optimizely properties"
       )
       XCTAssertNotNil(
-        segmentClientProperties?["optimizely_experiments"],
+        segmentClientProperties?["session_variants_optimizely"],
         "Event includes Optimizely properties"
       )
     }
@@ -1032,7 +1032,7 @@ final class ProjectPamphletViewModelTests: TestCase {
         "Event includes Optimizely properties"
       )
       XCTAssertNotNil(
-        dataLakeClientProperties?["optimizely_experiments"],
+        dataLakeClientProperties?["session_variants_optimizely"],
         "Event includes Optimizely properties"
       )
       XCTAssertNotNil(segmentClientProperties?["optimizely_api_key"], "Event includes Optimizely properties")
@@ -1041,7 +1041,7 @@ final class ProjectPamphletViewModelTests: TestCase {
         "Event includes Optimizely properties"
       )
       XCTAssertNotNil(
-        segmentClientProperties?["optimizely_experiments"],
+        segmentClientProperties?["session_variants_optimizely"],
         "Event includes Optimizely properties"
       )
     }
@@ -1077,7 +1077,7 @@ final class ProjectPamphletViewModelTests: TestCase {
         "1.2.3.4.5.6.7.8.9.0"
       )
       XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_apple_pay_device"] as? Bool, true)
-      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_device_format"] as? String, "phone")
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_device_type"] as? String, "phone")
     }
   }
 
@@ -1107,7 +1107,7 @@ final class ProjectPamphletViewModelTests: TestCase {
         "1.2.3.4.5.6.7.8.9.0"
       )
       XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_apple_pay_device"] as? Bool, true)
-      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_device_format"] as? String, "phone")
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_device_type"] as? String, "phone")
     }
   }
 
@@ -1147,7 +1147,7 @@ final class ProjectPamphletViewModelTests: TestCase {
       "1.2.3.4.5.6.7.8.9.0"
     )
     XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_apple_pay_device"] as? Bool, true)
-    XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_device_format"] as? String, "phone")
+    XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_device_type"] as? String, "phone")
   }
 
   func testOptimizelyTrackingPledgeCTAButtonTapped_LoggedOut_Backed() {
@@ -1224,7 +1224,7 @@ final class ProjectPamphletViewModelTests: TestCase {
         "1.2.3.4.5.6.7.8.9.0"
       )
       XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_apple_pay_device"] as? Bool, true)
-      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_device_format"] as? String, "phone")
+      XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_device_type"] as? String, "phone")
     }
   }
 

--- a/Library/ViewModels/ThanksViewModelTests.swift
+++ b/Library/ViewModels/ThanksViewModelTests.swift
@@ -396,7 +396,8 @@ final class ThanksViewModelTests: TestCase {
     XCTAssertEqual("SUPER reward", dataLakeTrackingClientProps?["checkout_reward_title"] as? String)
     XCTAssertEqual("5.00", dataLakeTrackingClientProps?["checkout_reward_minimum_usd"] as? String)
     XCTAssertEqual(2, dataLakeTrackingClientProps?["checkout_reward_id"] as? Int)
-    XCTAssertEqual(2_000, dataLakeTrackingClientProps?["checkout_revenue_in_usd_cents"] as? Int)
+    XCTAssertEqual(2_000, dataLakeTrackingClientProps?["checkout_amount_total_usd"] as? Int)
+    XCTAssertEqual(true, dataLakeTrackingClientProps?["checkout_reward_is_limited_quantity"] as? Bool)
     XCTAssertEqual(true, dataLakeTrackingClientProps?["checkout_reward_shipping_enabled"] as? Bool)
     XCTAssertEqual(
       true,
@@ -419,7 +420,8 @@ final class ThanksViewModelTests: TestCase {
     XCTAssertEqual("SUPER reward", segmentClientProps?["checkout_reward_title"] as? String)
     XCTAssertEqual("5.00", segmentClientProps?["checkout_reward_minimum_usd"] as? String)
     XCTAssertEqual(2, segmentClientProps?["checkout_reward_id"] as? Int)
-    XCTAssertEqual(2_000, segmentClientProps?["checkout_revenue_in_usd_cents"] as? Int)
+    XCTAssertEqual(2_000, segmentClientProps?["checkout_amount_total_usd"] as? Int)
+    XCTAssertEqual(true, segmentClientProps?["checkout_reward_is_limited_quantity"] as? Bool)
     XCTAssertEqual(true, segmentClientProps?["checkout_reward_shipping_enabled"] as? Bool)
     XCTAssertEqual(true, segmentClientProps?["checkout_user_has_eligible_stored_apple_pay_card"] as? Bool)
     XCTAssertEqual(10.00, segmentClientProps?["checkout_shipping_amount"] as? Double)
@@ -429,21 +431,11 @@ final class ThanksViewModelTests: TestCase {
     // Pledge properties
     XCTAssertEqual(true, dataLakeTrackingClientProps?["pledge_backer_reward_has_items"] as? Bool)
     XCTAssertEqual(1, dataLakeTrackingClientProps?["pledge_backer_reward_id"] as? Int)
-    XCTAssertEqual(true, dataLakeTrackingClientProps?["pledge_backer_reward_is_limited_quantity"] as? Bool)
-    XCTAssertEqual(false, dataLakeTrackingClientProps?["pledge_backer_reward_is_limited_time"] as? Bool)
     XCTAssertEqual(10.00, dataLakeTrackingClientProps?["pledge_backer_reward_minimum"] as? Double)
-    XCTAssertEqual(false, dataLakeTrackingClientProps?["pledge_backer_reward_shipping_enabled"] as? Bool)
 
     XCTAssertEqual(true, segmentClientProps?["pledge_backer_reward_has_items"] as? Bool)
     XCTAssertEqual(1, segmentClientProps?["pledge_backer_reward_id"] as? Int)
-    XCTAssertEqual(true, segmentClientProps?["pledge_backer_reward_is_limited_quantity"] as? Bool)
-    XCTAssertEqual(false, segmentClientProps?["pledge_backer_reward_is_limited_time"] as? Bool)
     XCTAssertEqual(10.00, segmentClientProps?["pledge_backer_reward_minimum"] as? Double)
-    XCTAssertEqual(false, segmentClientProps?["pledge_backer_reward_shipping_enabled"] as? Bool)
-
-    XCTAssertNil(dataLakeTrackingClientProps?["pledge_backer_reward_shipping_preference"] as? String)
-
-    XCTAssertNil(segmentClientProps?["pledge_backer_reward_shipping_preference"] as? String)
 
     // Project properties
     XCTAssertEqual(1, dataLakeTrackingClientProps?["project_pid"] as? Int)


### PR DESCRIPTION
# 📲 What

As part of our ongoing initiative to implement `Segment` and replace our legacy tracking clients, we begin here with some renaming of old events. The Insights team has provided us with a set of properties and the contexts they belong to; this PR is one of many upcoming extensions to the addition of Segment.

# 🤔 Why

Our events and their respective tracking clients are present everywhere in this project. It's important that we break down all these tasks into manageable bits. Each phase of work will be represented by anywhere from one to three tickets.

# 🛠 How

A lot of the work is in our `KSRAnalytics` file and the tests that make use of it.