### PR TITLE
Add PerimeterX SDK

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -20,3 +20,4 @@ binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseAnalyticsBinary.j
 binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseCrashlyticsBinary.json" == 7.4.0
 binary "https://dl.google.com/dl/firebase/ios/carthage/FirebasePerformanceBinary.json" == 7.4.0
 binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseProtobufBinary.json" == 7.4.0
+binary "https://raw.githubusercontent.com/PerimeterX/px-iOS-Framework/master/PerimeterX.json"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -2,6 +2,7 @@ binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseAnalyticsBinary.j
 binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseCrashlyticsBinary.json" "7.4.0"
 binary "https://dl.google.com/dl/firebase/ios/carthage/FirebasePerformanceBinary.json" "7.4.0"
 binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseProtobufBinary.json" "7.4.0"
+binary "https://raw.githubusercontent.com/PerimeterX/px-iOS-Framework/master/PerimeterX.json" "1.13.8"
 github "Alamofire/Alamofire" "5.4.1"
 github "Alamofire/AlamofireImage" "4.1.0"
 github "ReactiveCocoa/ReactiveSwift" "6.5.0"

--- a/Configs/Secrets.swift.example
+++ b/Configs/Secrets.swift.example
@@ -1,6 +1,7 @@
 public enum Secrets {
   public static let isOSS = false
   public static let fieldReportEmail = "hello@email.com"
+  public static let perimeterxAppId = "deadbeef"
 
   public enum Api {
     public enum Client {

--- a/Kickstarter-iOS/AppDelegate.swift
+++ b/Kickstarter-iOS/AppDelegate.swift
@@ -50,11 +50,6 @@ internal final class AppDelegate: UIResponder, UIApplicationDelegate {
       )
     )
 
-    if let pxManager = PXManager.sharedInstance() {
-      pxManager.delegate = self
-      pxManager.start(with: Secrets.perimeterxAppId)
-    }
-
     #if DEBUG
       if KsApi.Secrets.isOSS {
         AppEnvironment.replaceCurrentEnvironment(apiService: MockService())
@@ -82,8 +77,6 @@ internal final class AppDelegate: UIResponder, UIApplicationDelegate {
 
         self?.viewModel.inputs.didUpdateConfig(config)
       }
-
-    // Perimeter X
 
     self.viewModel.outputs.perimeterXInitialHeaders
       .observeForUI()
@@ -282,6 +275,13 @@ internal final class AppDelegate: UIResponder, UIApplicationDelegate {
       application: application,
       launchOptions: launchOptions
     )
+
+    // Perimeter X
+
+    if let pxManager = PXManager.sharedInstance() {
+      pxManager.delegate = self
+      pxManager.start(with: Secrets.perimeterxAppId)
+    }
 
     UNUserNotificationCenter.current().delegate = self
 

--- a/Kickstarter-iOS/ViewModels/AppDelegateViewModel.swift
+++ b/Kickstarter-iOS/ViewModels/AppDelegateViewModel.swift
@@ -72,6 +72,12 @@ public protocol AppDelegateViewModelInputs {
   /// Call when Optimizely configuration has failed
   func optimizelyClientConfigurationFailed()
 
+  /// Call when the Perimeter X manager is ready
+  func perimeterXManagerReady(with headers: [AnyHashable: Any]?)
+
+  /// Call when a refresh to Perimeter X headers has occurred
+  func perimeterXNewHeaders(with headers: [AnyHashable: Any]?)
+
   /// Call when the contextual PushNotification dialog should be presented.
   func showNotificationDialog(notification: Notification)
 
@@ -145,6 +151,12 @@ public protocol AppDelegateViewModelOutputs {
 
   /// Emits when the root view controller should navigate to search.
   var goToSearch: Signal<(), Never> { get }
+
+  /// Emits when PerimeterXs first set of headers are available.
+  var perimeterXInitialHeaders: Signal<[AnyHashable: Any]?, Never> { get }
+
+  /// Emits when PerimeterXs headers have been refreshed
+  var perimeterXRefreshedHeaders: Signal<[AnyHashable: Any]?, Never> { get }
 
   /// Emits an Notification that should be immediately posted.
   var postNotification: Signal<Notification, Never> { get }
@@ -248,6 +260,11 @@ public final class AppDelegateViewModel: AppDelegateViewModelType, AppDelegateVi
     // iCloud
 
     self.synchronizeUbiquitousStore = self.applicationLaunchOptionsProperty.signal.ignoreValues()
+
+    // PerimeterX
+
+    self.perimeterXInitialHeaders = self.perimeterXManagerReadyProperty.signal
+    self.perimeterXRefreshedHeaders = self.perimeterXNewHeadersProperty.signal
 
     // Push notifications
 
@@ -764,6 +781,16 @@ public final class AppDelegateViewModel: AppDelegateViewModelType, AppDelegateVi
     self.optimizelyClientConfigurationFailedProperty.value = ()
   }
 
+  fileprivate let perimeterXManagerReadyProperty = MutableProperty<[AnyHashable: Any]?>(nil)
+  public func perimeterXManagerReady(with headers: [AnyHashable: Any]?) {
+    self.perimeterXManagerReadyProperty.value = headers
+  }
+
+  fileprivate let perimeterXNewHeadersProperty = MutableProperty<[AnyHashable: Any]?>(nil)
+  public func perimeterXNewHeaders(with headers: [AnyHashable: Any]?) {
+    self.perimeterXNewHeadersProperty.value = headers
+  }
+
   public let applicationIconBadgeNumber: Signal<Int, Never>
   public let configureAppCenterWithData: Signal<AppCenterConfigData, Never>
   public let configureFirebase: Signal<(), Never>
@@ -784,6 +811,8 @@ public final class AppDelegateViewModel: AppDelegateViewModelType, AppDelegateVi
   public let goToProjectActivities: Signal<Param, Never>
   public let goToMobileSafari: Signal<URL, Never>
   public let goToSearch: Signal<(), Never>
+  public let perimeterXInitialHeaders: Signal<[AnyHashable: Any]?, Never>
+  public let perimeterXRefreshedHeaders: Signal<[AnyHashable: Any]?, Never>
   public let postNotification: Signal<Notification, Never>
   public let presentViewController: Signal<UIViewController, Never>
   public let pushTokenRegistrationStarted: Signal<(), Never>

--- a/Kickstarter-iOS/ViewModels/AppDelegateViewModelTests.swift
+++ b/Kickstarter-iOS/ViewModels/AppDelegateViewModelTests.swift
@@ -32,6 +32,8 @@ final class AppDelegateViewModelTests: TestCase {
   private let goToProfile = TestObserver<(), Never>()
   private let goToMobileSafari = TestObserver<URL, Never>()
   private let goToSearch = TestObserver<(), Never>()
+  private let perimeterXManagerReady = TestObserver<[String: String]?, Never>()
+  private let perimeterXRefreshedHeaders = TestObserver<[String: String]?, Never>()
   private let postNotificationName = TestObserver<Notification.Name, Never>()
   private let presentViewController = TestObserver<Int, Never>()
   private let pushRegistrationStarted = TestObserver<(), Never>()
@@ -70,6 +72,10 @@ final class AppDelegateViewModelTests: TestCase {
     self.vm.outputs.goToMobileSafari.observe(self.goToMobileSafari.observer)
     self.vm.outputs.goToProjectActivities.observe(self.goToProjectActivities.observer)
     self.vm.outputs.goToSearch.observe(self.goToSearch.observer)
+    self.vm.outputs.perimeterXInitialHeaders.map { $0 as? [String: String] }
+      .observe(self.perimeterXManagerReady.observer)
+    self.vm.outputs.perimeterXRefreshedHeaders.map { $0 as? [String: String] }
+      .observe(self.perimeterXRefreshedHeaders.observer)
     self.vm.outputs.postNotification.map { $0.name }.observe(self.postNotificationName.observer)
     self.vm.outputs.presentViewController.map { ($0 as! UINavigationController).viewControllers.count }
       .observe(self.presentViewController.observer)
@@ -538,6 +544,32 @@ final class AppDelegateViewModelTests: TestCase {
         .ksr_configUpdated,
         .ksr_configUpdated
       ])
+    }
+  }
+
+  // MARK: - Perimeter X
+
+  func testPerimeterXManagerReady() {
+    let mockService = MockService(serverConfig: ServerConfig.staging)
+
+    withEnvironment(apiService: mockService) {
+      self.perimeterXManagerReady.assertDidNotEmitValue()
+
+      self.vm.inputs.perimeterXManagerReady(with: ["foo": "bar"])
+
+      self.perimeterXManagerReady.assertValue(["foo": "bar"])
+    }
+  }
+
+  func testPerimeterXNewHeaders() {
+    let mockService = MockService(serverConfig: ServerConfig.staging)
+
+    withEnvironment(apiService: mockService) {
+      self.perimeterXRefreshedHeaders.assertDidNotEmitValue()
+
+      self.vm.inputs.perimeterXNewHeaders(with: ["foo": "bar"])
+
+      self.perimeterXRefreshedHeaders.assertValue(["foo": "bar"])
     }
   }
 

--- a/KsApi/ServiceType.swift
+++ b/KsApi/ServiceType.swift
@@ -474,9 +474,6 @@ extension ServiceType {
   }
 
   fileprivate var defaultHeaders: [String: String] {
-    // PerimeterX authorization header
-    let pxHeaders = (PXManager.sharedInstance()?.httpHeaders() as! [String: String])
-
     var headers: [String: String] = [:]
     headers["Accept-Language"] = self.language
     headers["Authorization"] = self.authorizationHeader
@@ -486,7 +483,12 @@ extension ServiceType {
     headers["X-KICKSTARTER-CLIENT"] = self.serverConfig.apiClientAuth.clientId
     headers["Kickstarter-iOS-App-UUID"] = self.deviceIdentifier
 
-    return headers.withAllValuesFrom(pxHeaders)
+    return headers.withAllValuesFrom(self.pxHeaders)
+  }
+
+  // PerimeterX authorization header
+  fileprivate var pxHeaders: [String: String] {
+    return (PXManager.sharedInstance()?.httpHeaders() as! [String: String])
   }
 
   func graphMutationRequestBody(mutation: String, input: [String: Any]) -> [String: Any] {

--- a/KsApi/ServiceType.swift
+++ b/KsApi/ServiceType.swift
@@ -1,4 +1,5 @@
 import Foundation
+import PerimeterX
 import Prelude
 import ReactiveSwift
 
@@ -473,6 +474,9 @@ extension ServiceType {
   }
 
   fileprivate var defaultHeaders: [String: String] {
+    // PerimeterX authorization header
+    let pxHeaders = (PXManager.sharedInstance()?.httpHeaders() as! [String: String])
+
     var headers: [String: String] = [:]
     headers["Accept-Language"] = self.language
     headers["Authorization"] = self.authorizationHeader
@@ -482,7 +486,7 @@ extension ServiceType {
     headers["X-KICKSTARTER-CLIENT"] = self.serverConfig.apiClientAuth.clientId
     headers["Kickstarter-iOS-App-UUID"] = self.deviceIdentifier
 
-    return headers
+    return headers.withAllValuesFrom(pxHeaders)
   }
 
   func graphMutationRequestBody(mutation: String, input: [String: Any]) -> [String: Any] {

--- a/KsApi/ServiceTypeTests.swift
+++ b/KsApi/ServiceTypeTests.swift
@@ -94,6 +94,7 @@ final class ServiceTypeTests: XCTestCase {
     )
     XCTAssertEqual(
       [
+        "X-PX-AUTHORIZATION": "1",
         "Kickstarter-iOS-App": "1234567890",
         "Authorization": "token cafebeef",
         "Accept-Language": "ksr",
@@ -116,6 +117,7 @@ final class ServiceTypeTests: XCTestCase {
     )
     XCTAssertEqual(
       [
+        "X-PX-AUTHORIZATION": "1",
         "Kickstarter-iOS-App": "1234567890",
         "Authorization": "token cafebeef",
         "Accept-Language": "ksr",
@@ -139,6 +141,7 @@ final class ServiceTypeTests: XCTestCase {
     )
     XCTAssertEqual(
       [
+        "X-PX-AUTHORIZATION": "1",
         "Kickstarter-iOS-App": "1234567890",
         "Authorization": "token cafebeef",
         "Accept-Language": "ksr",
@@ -162,6 +165,7 @@ final class ServiceTypeTests: XCTestCase {
     )
     XCTAssertEqual(
       [
+        "X-PX-AUTHORIZATION": "1",
         "Kickstarter-iOS-App": "1234567890",
         "Authorization": "token cafebeef",
         "Accept-Language": "ksr",
@@ -194,6 +198,7 @@ final class ServiceTypeTests: XCTestCase {
     )
     XCTAssertEqual(
       [
+        "X-PX-AUTHORIZATION": "1",
         "Kickstarter-iOS-App": "1234567890",
         "Authorization": "token cafebeef",
         "Accept-Language": "ksr",
@@ -218,6 +223,7 @@ final class ServiceTypeTests: XCTestCase {
     )
     XCTAssertEqual(
       [
+        "X-PX-AUTHORIZATION": "1",
         "Kickstarter-iOS-App": "\(testToolBuildNumber())",
         "Authorization": "Basic dXNlcm5hbWU6cGFzc3dvcmQ=",
         "Accept-Language": "en",
@@ -257,6 +263,7 @@ final class ServiceTypeTests: XCTestCase {
     )
     XCTAssertEqual(
       [
+        "X-PX-AUTHORIZATION": "1",
         "Kickstarter-iOS-App": "\(testToolBuildNumber())",
         "Authorization": "Basic dXNlcm5hbWU6cGFzc3dvcmQ=",
         "Accept-Language": "en",
@@ -291,6 +298,7 @@ final class ServiceTypeTests: XCTestCase {
     XCTAssertEqual(request?.allHTTPHeaderFields?["Kickstarter-App-Id"], self.service.appId)
     XCTAssertEqual(request?.allHTTPHeaderFields?["Kickstarter-iOS-App"], self.service.buildVersion)
     XCTAssertEqual(request?.allHTTPHeaderFields?["X-KICKSTARTER-CLIENT"], "deadbeef")
+    XCTAssertEqual(request?.allHTTPHeaderFields?["X-PX-AUTHORIZATION"], "1")
     XCTAssertEqual(request?.allHTTPHeaderFields?["User-Agent"], userAgent())
     XCTAssertEqual(
       request?.allHTTPHeaderFields?["Kickstarter-iOS-App-UUID"],


### PR DESCRIPTION
# 📲 What

Adding Perimeter X SDK into the project.

# 🤔 Why

Due to some recent security incidents we are using `Perimeter X` to bolster the authorization info we provide in our http headers.