### PR TITLE
[NT-1760] Adding feature flag for segment

### DIFF
--- a/Library/Extensions/Feature+Helpers.swift
+++ b/Library/Extensions/Feature+Helpers.swift
@@ -13,6 +13,10 @@ public func featureEmailVerificationSkipIsEnabled() -> Bool {
   return Feature.emailVerificationSkip.isEnabled()
 }
 
+public func featureSegmentIsEnabled() -> Bool {
+  return Feature.segment.isEnabled()
+}
+
 extension Feature {
   fileprivate func isEnabled(in environment: Environment = AppEnvironment.current) -> Bool {
     guard let features = environment.config?.features, !features.isEmpty else { return false }

--- a/Library/Extensions/Feature+HelpersTests.swift
+++ b/Library/Extensions/Feature+HelpersTests.swift
@@ -82,4 +82,30 @@ final class FeatureHelpersTests: TestCase {
       XCTAssertFalse(featureEmailVerificationSkipIsEnabled())
     }
   }
+
+  // MARK: - Segment
+
+  func testFeatureSegment_isTrue() {
+    let config = Config.template
+      |> \.features .~ [Feature.segment.rawValue: true]
+
+    withEnvironment(config: config) {
+      XCTAssertTrue(featureSegmentIsEnabled())
+    }
+  }
+
+  func testFeatureSegment_isFalse() {
+    let config = Config.template
+      |> \.features .~ [Feature.segment.rawValue: false]
+
+    withEnvironment(config: config) {
+      XCTAssertFalse(featureSegmentIsEnabled())
+    }
+  }
+
+  func testFeatureSegment_isFalse_whenNil() {
+    withEnvironment(config: .template) {
+      XCTAssertFalse(featureSegmentIsEnabled())
+    }
+  }
 }

--- a/Library/Feature.swift
+++ b/Library/Feature.swift
@@ -4,6 +4,7 @@ public enum Feature: String {
   case qualtrics = "ios_qualtrics"
   case emailVerificationFlow = "ios_email_verification_flow"
   case emailVerificationSkip = "ios_email_verification_skip"
+  case segment = "ios_segment"
 }
 
 extension Feature: CustomStringConvertible {
@@ -12,6 +13,7 @@ extension Feature: CustomStringConvertible {
     case .qualtrics: return "Qualtrics"
     case .emailVerificationFlow: return "Email Verification Flow"
     case .emailVerificationSkip: return "Email Verification Skip"
+    case .segment: return "Segment"
     }
   }
 }

--- a/Library/Tracking/Segment.swift
+++ b/Library/Tracking/Segment.swift
@@ -30,13 +30,15 @@ public extension Analytics {
 
 extension Analytics: IdentifyingTrackingClient {
   public func identify(userId: String?, traits: [String: Any]?) {
-    guard AppEnvironment.current.environmentVariables.isTrackingEnabled else { return }
+    guard AppEnvironment.current.environmentVariables.isTrackingEnabled,
+      featureSegmentIsEnabled() else { return }
 
     self.identify(userId, traits: traits)
   }
 
   public func resetIdentity() {
-    guard AppEnvironment.current.environmentVariables.isTrackingEnabled else { return }
+    guard AppEnvironment.current.environmentVariables.isTrackingEnabled,
+      featureSegmentIsEnabled() else { return }
 
     self.reset()
   }
@@ -44,7 +46,8 @@ extension Analytics: IdentifyingTrackingClient {
 
 extension Analytics: TrackingClientType {
   public func track(event: String, properties: [String: Any]) {
-    guard AppEnvironment.current.environmentVariables.isTrackingEnabled else { return }
+    guard AppEnvironment.current.environmentVariables.isTrackingEnabled,
+      featureSegmentIsEnabled() else { return }
 
     self.track(event, properties: properties)
   }

--- a/Library/ViewModels/FeatureFlagToolsViewModelTests.swift
+++ b/Library/ViewModels/FeatureFlagToolsViewModelTests.swift
@@ -103,7 +103,8 @@ final class FeatureFlagToolsViewModelTests: TestCase {
     let featureEnabled = featureEnabledFromDictionaries([[
       "ios_qualtrics": false,
       "ios_email_verification_flow": false,
-      "ios_email_verification_skip": false
+      "ios_email_verification_skip": false,
+      "ios_segment": false
     ]])
 
     XCTAssertFalse(featureEnabled.isEmpty, "Known features produce Feature enums")


### PR DESCRIPTION
# 📲 What

Adding a feature flag for Segment and implementing it within out Analytics client.

# 🤔 Why

This is simply an additional layer of control on the clients behavior in our environments.

# 🛠 How

- Added the flag on Flipper
- Decoding it on iOS
- Implementing it into the `Segment` client