### PR TITLE
[EP-226] CTA Clicked (pledge_submit)

### DIFF
--- a/Library/Tracking/KSRAnalytics.swift
+++ b/Library/Tracking/KSRAnalytics.swift
@@ -48,7 +48,6 @@ public final class KSRAnalytics {
     case onboardingContinueButtonClicked = "Onboarding Continue Button Clicked"
     case onboardingGetStartedButtonClicked = "Onboarding Get Started Button Clicked"
     case onboardingSkipButtonClicked = "Onboarding Skip Button Clicked"
-    case pledgeSubmitButtonClicked = "Pledge Submit Button Clicked"
     case projectCardClicked = "Project Card Clicked"
     case projectPagePledgeButtonClicked = "Project Page Pledge Button Clicked"
     case projectPageViewed = "Project Page Viewed"
@@ -67,6 +66,7 @@ public final class KSRAnalytics {
 
   private enum NewApprovedEvent: String, CaseIterable {
     case pageViewed = "Page Viewed"
+    case ctaClicked = "CTA Clicked"
   }
 
   /// Determines the screen from which the event is sent.
@@ -867,30 +867,12 @@ public final class KSRAnalytics {
     refTag: RefTag?
   ) {
     let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
-      .withAllValuesFrom(pledgeProperties(from: reward))
       .withAllValuesFrom(checkoutProperties(from: checkoutData, and: reward))
       // the context is always "newPledge" for this event
-      .withAllValuesFrom(contextProperties())
+      .withAllValuesFrom(contextProperties(ctaContext: .pledgeSubmit, typeContext: .creditCard))
 
     self.track(
-      event: ApprovedEvent.pledgeSubmitButtonClicked.rawValue,
-      location: .pledgeScreen,
-      properties: props,
-      refTag: refTag?.stringTag
-    )
-  }
-
-  public func trackPledgeSubmitButtonClicked(
-    project: Project,
-    reward: Reward,
-    refTag: RefTag?
-  ) {
-    let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
-      .withAllValuesFrom(pledgeProperties(from: reward))
-      .withAllValuesFrom(contextProperties())
-
-    self.track(
-      event: ApprovedEvent.pledgeSubmitButtonClicked.rawValue,
+      event: NewApprovedEvent.ctaClicked.rawValue,
       location: .pledgeScreen,
       properties: props,
       refTag: refTag?.stringTag

--- a/Library/Tracking/KSRAnalyticsTests.swift
+++ b/Library/Tracking/KSRAnalyticsTests.swift
@@ -974,45 +974,33 @@ final class KSRAnalyticsTests: TestCase {
     let dataLakeClientProps = dataLakeClient.properties.last
     let segmentClientProps = segmentClient.properties.last
 
-    XCTAssertEqual(["Pledge Submit Button Clicked"], dataLakeClient.events)
+    XCTAssertEqual(["CTA Clicked"], dataLakeClient.events)
 
     self.assertProjectProperties(dataLakeClientProps)
-    self.assertPledgeProperties(dataLakeClientProps)
     self.assertCheckoutProperties(dataLakeClientProps)
 
-    XCTAssertEqual(["Pledge Submit Button Clicked"], segmentClient.events)
-
-    self.assertProjectProperties(segmentClientProps)
-    self.assertPledgeProperties(segmentClientProps)
-    self.assertCheckoutProperties(segmentClientProps)
-  }
-
-  func testTrackPledgeSubmitButtonClicked_Context() {
-    let dataLakeClient = MockTrackingClient()
-    let segmentClient = MockTrackingClient()
-    let ksrAnalytics = KSRAnalytics(dataLakeClient: dataLakeClient, segmentClient: segmentClient)
-    let reward = Reward.template
-      |> Reward.lens.endsAt .~ 5.0
-      |> Reward.lens.shipping.preference .~ .restricted
-
-    ksrAnalytics.trackPledgeSubmitButtonClicked(
-      project: .template,
-      reward: reward,
-      refTag: nil
+    XCTAssertEqual(
+      KSRAnalytics.CTAContext.pledgeSubmit.trackingString,
+      dataLakeClientProps?["context_cta"] as? String
+    )
+    XCTAssertEqual(
+      KSRAnalytics.TypeContext.creditCard.trackingString,
+      dataLakeClientProps?["context_type"] as? String
     )
 
-    let dataLakeClientProps = dataLakeClient.properties.last
-    let segmentClientProps = segmentClient.properties.last
-
-    XCTAssertEqual(["Pledge Submit Button Clicked"], dataLakeClient.events)
-
-    self.assertProjectProperties(dataLakeClientProps)
-    self.assertPledgeProperties(dataLakeClientProps)
-
-    XCTAssertEqual(["Pledge Submit Button Clicked"], segmentClient.events)
+    XCTAssertEqual(["CTA Clicked"], segmentClient.events)
 
     self.assertProjectProperties(segmentClientProps)
-    self.assertPledgeProperties(segmentClientProps)
+    self.assertCheckoutProperties(segmentClientProps)
+
+    XCTAssertEqual(
+      KSRAnalytics.CTAContext.pledgeSubmit.trackingString,
+      segmentClientProps?["context_cta"] as? String
+    )
+    XCTAssertEqual(
+      KSRAnalytics.TypeContext.creditCard.trackingString,
+      segmentClientProps?["context_type"] as? String
+    )
   }
 
   func testTrackAddNewCardButtonClicked() {

--- a/Library/ViewModels/PledgeViewModelTests.swift
+++ b/Library/ViewModels/PledgeViewModelTests.swift
@@ -1983,13 +1983,11 @@ final class PledgeViewModelTests: TestCase {
         ["Checkout Payment Page Viewed"],
         self.dataLakeTrackingClient.events
       )
-      XCTAssertEqual([nil], self.dataLakeTrackingClient.properties(forKey: "pledge_context"))
 
       XCTAssertEqual(
         ["Checkout Payment Page Viewed"],
         self.segmentTrackingClient.events
       )
-      XCTAssertEqual([nil], self.segmentTrackingClient.properties(forKey: "pledge_context"))
     }
   }
 
@@ -2046,13 +2044,11 @@ final class PledgeViewModelTests: TestCase {
         ["Checkout Payment Page Viewed"],
         self.dataLakeTrackingClient.events
       )
-      XCTAssertEqual([nil], self.dataLakeTrackingClient.properties(forKey: "pledge_context"))
 
       XCTAssertEqual(
         ["Checkout Payment Page Viewed"],
         self.segmentTrackingClient.events
       )
-      XCTAssertEqual([nil], self.segmentTrackingClient.properties(forKey: "pledge_context"))
     }
   }
 
@@ -2164,11 +2160,11 @@ final class PledgeViewModelTests: TestCase {
       self.goToThanksCheckoutData.assertValues([checkoutData])
 
       XCTAssertEqual(
-        ["Checkout Payment Page Viewed", "Pledge Submit Button Clicked"],
+        ["Checkout Payment Page Viewed", "CTA Clicked"],
         self.dataLakeTrackingClient.events
       )
       XCTAssertEqual(
-        ["Checkout Payment Page Viewed", "Pledge Submit Button Clicked"],
+        ["Checkout Payment Page Viewed", "CTA Clicked"],
         self.segmentTrackingClient.events
       )
     }
@@ -2265,11 +2261,11 @@ final class PledgeViewModelTests: TestCase {
       self.goToThanksCheckoutData.assertValues([checkoutData])
 
       XCTAssertEqual(
-        ["Checkout Payment Page Viewed", "Pledge Submit Button Clicked"],
+        ["Checkout Payment Page Viewed", "CTA Clicked"],
         self.dataLakeTrackingClient.events
       )
       XCTAssertEqual(
-        ["Checkout Payment Page Viewed", "Pledge Submit Button Clicked"],
+        ["Checkout Payment Page Viewed", "CTA Clicked"],
         self.segmentTrackingClient.events
       )
     }
@@ -2396,15 +2392,13 @@ final class PledgeViewModelTests: TestCase {
       self.showErrorBannerWithMessage.assertValues(["Something went wrong."])
 
       XCTAssertEqual(
-        ["Checkout Payment Page Viewed", "Pledge Submit Button Clicked"],
+        ["Checkout Payment Page Viewed", "CTA Clicked"],
         self.dataLakeTrackingClient.events
       )
-      XCTAssertEqual([nil, nil], self.dataLakeTrackingClient.properties(forKey: "pledge_context"))
       XCTAssertEqual(
-        ["Checkout Payment Page Viewed", "Pledge Submit Button Clicked"],
+        ["Checkout Payment Page Viewed", "CTA Clicked"],
         self.segmentTrackingClient.events
       )
-      XCTAssertEqual([nil, nil], self.segmentTrackingClient.properties(forKey: "pledge_context"))
     }
   }
 
@@ -4507,12 +4501,28 @@ final class PledgeViewModelTests: TestCase {
       self.goToThanksCheckoutData.assertValues([checkoutData])
 
       XCTAssertEqual(
-        ["Checkout Payment Page Viewed", "Pledge Submit Button Clicked"],
+        ["Checkout Payment Page Viewed", "CTA Clicked"],
         self.dataLakeTrackingClient.events
       )
       XCTAssertEqual(
-        ["Checkout Payment Page Viewed", "Pledge Submit Button Clicked"],
+        KSRAnalytics.CTAContext.pledgeSubmit.trackingString,
+        self.dataLakeTrackingClient.properties.last?["context_cta"] as? String
+      )
+      XCTAssertEqual(
+        KSRAnalytics.TypeContext.creditCard.trackingString,
+        self.dataLakeTrackingClient.properties.last?["context_type"] as? String
+      )
+      XCTAssertEqual(
+        ["Checkout Payment Page Viewed", "CTA Clicked"],
         self.segmentTrackingClient.events
+      )
+      XCTAssertEqual(
+        KSRAnalytics.CTAContext.pledgeSubmit.trackingString,
+        self.segmentTrackingClient.properties.last?["context_cta"] as? String
+      )
+      XCTAssertEqual(
+        KSRAnalytics.TypeContext.creditCard.trackingString,
+        self.segmentTrackingClient.properties.last?["context_type"] as? String
       )
     }
   }
@@ -4604,15 +4614,30 @@ final class PledgeViewModelTests: TestCase {
       )
 
       XCTAssertEqual(
-        ["Checkout Payment Page Viewed", "Pledge Submit Button Clicked"],
+        ["Checkout Payment Page Viewed", "CTA Clicked"],
         self.dataLakeTrackingClient.events
       )
-      XCTAssertEqual([nil, nil], self.dataLakeTrackingClient.properties(forKey: "pledge_context"))
       XCTAssertEqual(
-        ["Checkout Payment Page Viewed", "Pledge Submit Button Clicked"],
+        KSRAnalytics.CTAContext.pledgeSubmit.trackingString,
+        self.dataLakeTrackingClient.properties.last?["context_cta"] as? String
+      )
+      XCTAssertEqual(
+        KSRAnalytics.TypeContext.creditCard.trackingString,
+        self.dataLakeTrackingClient.properties.last?["context_type"] as? String
+      )
+
+      XCTAssertEqual(
+        ["Checkout Payment Page Viewed", "CTA Clicked"],
         self.segmentTrackingClient.events
       )
-      XCTAssertEqual([nil, nil], self.segmentTrackingClient.properties(forKey: "pledge_context"))
+      XCTAssertEqual(
+        KSRAnalytics.CTAContext.pledgeSubmit.trackingString,
+        self.segmentTrackingClient.properties.last?["context_cta"] as? String
+      )
+      XCTAssertEqual(
+        KSRAnalytics.TypeContext.creditCard.trackingString,
+        self.segmentTrackingClient.properties.last?["context_type"] as? String
+      )
     }
   }
 
@@ -4695,15 +4720,30 @@ final class PledgeViewModelTests: TestCase {
       self.showErrorBannerWithMessage.assertDidNotEmitValue()
 
       XCTAssertEqual(
-        ["Checkout Payment Page Viewed", "Pledge Submit Button Clicked"],
+        ["Checkout Payment Page Viewed", "CTA Clicked"],
         self.dataLakeTrackingClient.events
       )
-      XCTAssertEqual([nil, nil], self.dataLakeTrackingClient.properties(forKey: "pledge_context"))
       XCTAssertEqual(
-        ["Checkout Payment Page Viewed", "Pledge Submit Button Clicked"],
+        KSRAnalytics.CTAContext.pledgeSubmit.trackingString,
+        self.dataLakeTrackingClient.properties.last?["context_cta"] as? String
+      )
+      XCTAssertEqual(
+        KSRAnalytics.TypeContext.creditCard.trackingString,
+        self.dataLakeTrackingClient.properties.last?["context_type"] as? String
+      )
+
+      XCTAssertEqual(
+        ["Checkout Payment Page Viewed", "CTA Clicked"],
         self.segmentTrackingClient.events
       )
-      XCTAssertEqual([nil, nil], self.segmentTrackingClient.properties(forKey: "pledge_context"))
+      XCTAssertEqual(
+        KSRAnalytics.CTAContext.pledgeSubmit.trackingString,
+        self.segmentTrackingClient.properties.last?["context_cta"] as? String
+      )
+      XCTAssertEqual(
+        KSRAnalytics.TypeContext.creditCard.trackingString,
+        self.segmentTrackingClient.properties.last?["context_type"] as? String
+      )
     }
   }
 
@@ -5759,11 +5799,11 @@ final class PledgeViewModelTests: TestCase {
     self.vm.inputs.submitButtonTapped()
 
     XCTAssertEqual(
-      ["Checkout Payment Page Viewed", "Pledge Submit Button Clicked"],
+      ["Checkout Payment Page Viewed", "CTA Clicked"],
       self.dataLakeTrackingClient.events
     )
     XCTAssertEqual(
-      ["Checkout Payment Page Viewed", "Pledge Submit Button Clicked"],
+      ["Checkout Payment Page Viewed", "CTA Clicked"],
       self.segmentTrackingClient.events
     )
 
@@ -5801,20 +5841,30 @@ final class PledgeViewModelTests: TestCase {
     )
     XCTAssertEqual("My Reward", segmentClientProps?["checkout_reward_title"] as? String)
 
-    // Pledge properties
-    XCTAssertEqual(true, dataLakeTrackingClientProps?["pledge_backer_reward_has_items"] as? Bool)
-    XCTAssertEqual(1, dataLakeTrackingClientProps?["pledge_backer_reward_id"] as? Int)
-    XCTAssertEqual(10.00, dataLakeTrackingClientProps?["pledge_backer_reward_minimum"] as? Double)
-    XCTAssertEqual(true, segmentClientProps?["pledge_backer_reward_has_items"] as? Bool)
-    XCTAssertEqual(1, segmentClientProps?["pledge_backer_reward_id"] as? Int)
-    XCTAssertEqual(10.00, segmentClientProps?["pledge_backer_reward_minimum"] as? Double)
-
     // Project properties
     XCTAssertEqual(1, dataLakeTrackingClientProps?["project_pid"] as? Int)
     XCTAssertEqual(1, segmentClientProps?["project_pid"] as? Int)
 
     XCTAssertEqual("discovery", dataLakeTrackingClientProps?["session_ref_tag"] as? String)
     XCTAssertEqual("discovery", segmentClientProps?["session_ref_tag"] as? String)
+
+    // Context properties
+    XCTAssertEqual(
+      KSRAnalytics.CTAContext.pledgeSubmit.trackingString,
+      dataLakeTrackingClientProps?["context_cta"] as? String
+    )
+    XCTAssertEqual(
+      KSRAnalytics.CTAContext.pledgeSubmit.trackingString,
+      segmentClientProps?["context_cta"] as? String
+    )
+    XCTAssertEqual(
+      KSRAnalytics.TypeContext.creditCard.trackingString,
+      dataLakeTrackingClientProps?["context_type"] as? String
+    )
+    XCTAssertEqual(
+      KSRAnalytics.TypeContext.creditCard.trackingString,
+      segmentClientProps?["context_type"] as? String
+    )
   }
 
   func testTrackingEvents_UpdatePledgeButtonSubmit_ContextIsFixPayment() {


### PR DESCRIPTION
# 📲 What

When a user clicks the "Pledge" button we're currently firing an event labeled `Pledge Submit Button Clicked`. In this PR we are updating both the event name and the properties we send along with it.

# 🤔 Why

This is an addition to our ongoing initiative to move forward from our legacy tracking and over to Segment.