### PR TITLE
[EP-227] CTA Clicked (reward_continue)

### DIFF
--- a/Library/SharedFunctions.swift
+++ b/Library/SharedFunctions.swift
@@ -397,11 +397,26 @@ public func rounded(_ value: Double, places: Int) -> Double {
   return (value * divisor).rounded() / divisor
 }
 
+/**
+ Creates `CheckoutPropertiesData` to send with our event properties.
+
+ - parameter from: The `Project` associated with the checkout.
+ - parameter baseReward: The reward being evaluated
+ - parameter addOnRewards: An array of `Reward` objects representing the available add-ons.
+ - parameter selectedQuantities: A dictionary of reward id to quantitiy.
+ - parameter additionalPledgeAmount: The bonus amount included in the pledge.
+ - parameter pledgeTotal: The total amount of the pledge.
+ - parameter shippingTotal: The shipping cost for the pledge.
+ - parameter checkoutId: The unique ID associated with the checkout.
+ - parameter isApplePay: A `Bool` indicating if the pledge was done with Apple pay.
+
+ - returns: A `CheckoutPropertiesData` object required for checkoutProperties.
+ */
 public func checkoutProperties(
   from project: Project,
   baseReward: Reward,
-  rewards: [Reward],
-  selectedQuantities: SelectedRewardQuantities?,
+  addOnRewards: [Reward],
+  selectedQuantities: SelectedRewardQuantities,
   additionalPledgeAmount: Double,
   pledgeTotal: Double,
   shippingTotal: Double,
@@ -416,10 +431,10 @@ public func checkoutProperties(
   let bonusAmountUsd = additionalPledgeAmount
     .multiplyingCurrency(staticUsdRate)
 
-  let addOnRewards = rewards
+  let addOnRewards = addOnRewards
     .filter { reward in reward.id != baseReward.id }
     .map { reward -> [Reward] in
-      guard let selectedRewardQuantity = selectedQuantities?[reward.id] else { return [] }
+      guard let selectedRewardQuantity = selectedQuantities[reward.id] else { return [] }
       return Array(0..<selectedRewardQuantity).map { _ in reward }
     }
     .flatMap { $0 }

--- a/Library/SharedFunctionsTests.swift
+++ b/Library/SharedFunctionsTests.swift
@@ -371,7 +371,7 @@ final class SharedFunctionsTests: TestCase {
     let checkoutPropertiesData = checkoutProperties(
       from: project,
       baseReward: baseReward,
-      rewards: [reward],
+      addOnRewards: [reward],
       selectedQuantities: selectedQuantities,
       additionalPledgeAmount: 10.0,
       pledgeTotal: 100.0,

--- a/Library/Tracking/KSRAnalytics.swift
+++ b/Library/Tracking/KSRAnalytics.swift
@@ -27,7 +27,6 @@ public final class KSRAnalytics {
     case addNewCardButtonClicked = "Add New Card Button Clicked"
     case addOnsContinueButtonClicked = "Add-Ons Continue Button Clicked"
     case addOnsPageViewed = "Add-Ons Page Viewed"
-    case campaignDetailsPledgeButtonClicked = "Campaign Details Pledge Button Clicked"
     case checkoutPaymentPageViewed = "Checkout Payment Page Viewed"
     case collectionViewed = "Collection Viewed"
     case continueWithAppleButtonClicked = "Continue With Apple Button Clicked"
@@ -52,7 +51,6 @@ public final class KSRAnalytics {
     case projectSwiped = "Project Swiped"
     case searchPageViewed = "Search Page Viewed"
     case searchResultsLoaded = "Search Results Loaded"
-    case selectRewardButtonClicked = "Select Reward Button Clicked"
     case signupButtonClicked = "Signup Button Clicked"
     case signupSubmitButtonClicked = "Signup Submit Button Clicked"
     case skipVerificationButtonClicked = "Skip Verification Button Clicked"
@@ -790,21 +788,22 @@ public final class KSRAnalytics {
    parameters:
    - project: the project being pledged to
    - reward: the selected reward
-   - context: the PledgeContext from which the event was triggered
+   - checkoutPropertiesData: the `CheckoutPropertiesData` associated with the given project and reward
    - refTag: the optional RefTag associated with the pledge
    */
 
   public func trackRewardClicked(
     project: Project,
     reward: Reward,
+    checkoutPropertiesData: KSRAnalytics.CheckoutPropertiesData,
     refTag: RefTag?
   ) {
     let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
-      .withAllValuesFrom(pledgeProperties(from: reward))
-      .withAllValuesFrom(contextProperties())
+      .withAllValuesFrom(contextProperties(ctaContext: .rewardContinue))
+      .withAllValuesFrom(checkoutProperties(from: checkoutPropertiesData, and: reward))
 
     self.track(
-      event: ApprovedEvent.selectRewardButtonClicked.rawValue,
+      event: NewApprovedEvent.ctaClicked.rawValue,
       location: .rewards,
       properties: props,
       refTag: refTag?.stringTag
@@ -1199,23 +1198,6 @@ public final class KSRAnalytics {
       event: ApprovedEvent.watchProjectButtonClicked.rawValue,
       location: location,
       properties: props
-    )
-  }
-
-  public func trackCampaignDetailsPledgeButtonClicked(project: Project,
-                                                      location: PageContext,
-                                                      refTag: RefTag?,
-                                                      cookieRefTag: RefTag? = nil,
-                                                      optimizelyProperties: [String: Any] = [:]) {
-    let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
-      .withAllValuesFrom(optimizelyProperties)
-
-    self.track(
-      event: ApprovedEvent.campaignDetailsPledgeButtonClicked.rawValue,
-      location: location,
-      properties: props,
-      refTag: refTag?.stringTag,
-      referrerCredit: cookieRefTag?.stringTag
     )
   }
 

--- a/Library/Tracking/KSRAnalyticsTests.swift
+++ b/Library/Tracking/KSRAnalyticsTests.swift
@@ -710,33 +710,6 @@ final class KSRAnalyticsTests: TestCase {
     self.assertProjectProperties(segmentClient.properties.last)
   }
 
-  func testTrackCampignDetailsPledgeButtonClicked() {
-    let dataLakeClient = MockTrackingClient()
-    let segmentClient = MockTrackingClient()
-    let ksrAnalytics = KSRAnalytics(dataLakeClient: dataLakeClient, segmentClient: segmentClient)
-
-    ksrAnalytics.trackCampaignDetailsPledgeButtonClicked(
-      project: .template,
-      location: .campaign,
-      refTag: .discovery,
-      cookieRefTag: .discovery
-    )
-
-    XCTAssertEqual(["Campaign Details Pledge Button Clicked"], dataLakeClient.events)
-    XCTAssertEqual(["campaign"], dataLakeClient.properties(forKey: "context_page"))
-    XCTAssertEqual(["discovery"], dataLakeClient.properties(forKey: "session_ref_tag"))
-    XCTAssertEqual(["discovery"], dataLakeClient.properties(forKey: "session_referrer_credit"))
-
-    self.assertProjectProperties(dataLakeClient.properties.last)
-
-    XCTAssertEqual(["Campaign Details Pledge Button Clicked"], segmentClient.events)
-    XCTAssertEqual(["campaign"], segmentClient.properties(forKey: "context_page"))
-    XCTAssertEqual(["discovery"], segmentClient.properties(forKey: "session_ref_tag"))
-    XCTAssertEqual(["discovery"], segmentClient.properties(forKey: "session_referrer_credit"))
-
-    self.assertProjectProperties(segmentClient.properties.last)
-  }
-
   func testTrackCheckoutPaymentMethodViewed() {
     let dataLakeClient = MockTrackingClient()
     let segmentClient = MockTrackingClient()

--- a/Library/ViewModels/PledgeViewModel.swift
+++ b/Library/ViewModels/PledgeViewModel.swift
@@ -735,7 +735,7 @@ public class PledgeViewModel: PledgeViewModelType, PledgeViewModelInputs, Pledge
       let checkoutPropsData = checkoutProperties(
         from: data.project,
         baseReward: baseReward,
-        rewards: data.rewards,
+        addOnRewards: data.rewards,
         selectedQuantities: data.selectedQuantities,
         additionalPledgeAmount: additionalPledgeAmount,
         pledgeTotal: data.pledgeTotal,
@@ -869,7 +869,7 @@ public class PledgeViewModel: PledgeViewModelType, PledgeViewModelInputs, Pledge
         let checkoutData = checkoutProperties(
           from: data.project,
           baseReward: baseReward,
-          rewards: data.rewards,
+          addOnRewards: data.rewards,
           selectedQuantities: data.selectedQuantities,
           additionalPledgeAmount: additionalPledgeAmount,
           pledgeTotal: data.pledgeTotal,

--- a/Library/ViewModels/RewardsCollectionViewModel.swift
+++ b/Library/ViewModels/RewardsCollectionViewModel.swift
@@ -190,7 +190,7 @@ public final class RewardsCollectionViewModel: RewardsCollectionViewModelType,
           addOnRewards: backing?.addOns ?? [],
           selectedQuantities: [reward.id: 1],
           additionalPledgeAmount: backing?.bonusAmount ?? 0,
-          pledgeTotal: backing?.amount ?? 0,
+          pledgeTotal: backing?.amount ?? reward.minimum, // The total is the value of the reward
           shippingTotal: shippingTotal ?? 0,
           isApplePay: nil
         )

--- a/Library/ViewModels/RewardsCollectionViewModel.swift
+++ b/Library/ViewModels/RewardsCollectionViewModel.swift
@@ -177,9 +177,28 @@ public final class RewardsCollectionViewModel: RewardsCollectionViewModelType,
     // Tracking
     Signal.combineLatest(project, selectedRewardFromId, refTag)
       .observeValues { project, reward, refTag in
+
+        // The `Backing` is nil for a new pledge.
+        let backing = project.personalization.backing
+        let shippingTotal = reward.shipping.enabled ? backing?.shippingAmount.flatMap(Double.init) : 0.0
+
+        // Regardless of whether this is the beginning of a new pledge or we are editing our reward,
+        // we only have the base reward selected at this point
+        let checkoutPropertiesData = checkoutProperties(
+          from: project,
+          baseReward: reward,
+          addOnRewards: backing?.addOns ?? [],
+          selectedQuantities: [reward.id: 1],
+          additionalPledgeAmount: backing?.bonusAmount ?? 0,
+          pledgeTotal: backing?.amount ?? 0,
+          shippingTotal: shippingTotal ?? 0,
+          isApplePay: nil
+        )
+
         AppEnvironment.current.ksrAnalytics.trackRewardClicked(
           project: project,
           reward: reward,
+          checkoutPropertiesData: checkoutPropertiesData,
           refTag: refTag
         )
       }

--- a/Library/ViewModels/RewardsCollectionViewModelTests.swift
+++ b/Library/ViewModels/RewardsCollectionViewModelTests.swift
@@ -716,18 +716,10 @@ final class RewardsCollectionViewModelTests: TestCase {
 
     self.vm.inputs.rewardSelected(with: 2)
 
-    XCTAssertEqual(["Select Reward Button Clicked"], self.dataLakeTrackingClient.events)
-    XCTAssertEqual(["Select Reward Button Clicked"], self.segmentTrackingClient.events)
+    XCTAssertEqual(["CTA Clicked"], self.dataLakeTrackingClient.events)
+    XCTAssertEqual(["CTA Clicked"], self.segmentTrackingClient.events)
 
-    XCTAssertEqual(
-      [2],
-      self.dataLakeTrackingClient.properties(forKey: "pledge_backer_reward_id", as: Int.self)
-    )
     XCTAssertEqual(["activity"], self.dataLakeTrackingClient.properties(forKey: "session_ref_tag"))
-    XCTAssertEqual(
-      [2],
-      self.segmentTrackingClient.properties(forKey: "pledge_backer_reward_id", as: Int.self)
-    )
     XCTAssertEqual(["activity"], self.segmentTrackingClient.properties(forKey: "session_ref_tag"))
   }
 }


### PR DESCRIPTION
# 📲 What

This PR includes an update to tracking we're currently using in the Rewards carousel. When a reward is selected, we are tracking a handful of properties associated with the context.

# 🤔 Why

Continuing phase one of our Segment implementation.