### PR TITLE
[EP-245] CTA Clicked (watch_project)

### DIFF
--- a/Library/Tracking/KSRAnalytics.swift
+++ b/Library/Tracking/KSRAnalytics.swift
@@ -370,7 +370,6 @@ public final class KSRAnalytics {
     case tag
     case unwatch
     case watch
-    case watched
 
     public enum PledgeContext {
       case fixErroredPledge
@@ -410,7 +409,6 @@ public final class KSRAnalytics {
       case .tag: return "tag"
       case .unwatch: return "unwatch"
       case .watch: return "watch"
-      case .watched: return "watched"
       }
     }
   }
@@ -1202,7 +1200,7 @@ public final class KSRAnalytics {
    - parameter project: The project being watched
    - parameter location: The location context of where the project is being watched from
    - parameter params: The optional Discover params if the project is being watched from Discover
-   - parameter watchContext: The context of the watch/saved project
+   - parameter typeContext: The context of the watch/saved project
    */
 
   public func trackWatchProjectButtonClicked(

--- a/Library/Tracking/KSRAnalytics.swift
+++ b/Library/Tracking/KSRAnalytics.swift
@@ -368,7 +368,9 @@ public final class KSRAnalytics {
     case subscriptionFalse
     case subscriptionTrue
     case tag
-    case watchContext(WatchContext)
+    case unwatch
+    case watch
+    case watched
 
     public enum PledgeContext {
       case fixErroredPledge
@@ -380,20 +382,6 @@ public final class KSRAnalytics {
         case .fixErroredPledge: return "fix_errored_pledge"
         case .newPledge: return "new_pledge"
         case .managePledge: return "manage_pledge"
-        }
-      }
-    }
-
-    public enum WatchContext {
-      case unwatch
-      case watch
-      case watched
-
-      var trackingString: String {
-        switch self {
-        case .unwatch: return "unwatch"
-        case .watch: return "watch"
-        case .watched: return "watched"
         }
       }
     }
@@ -420,7 +408,9 @@ public final class KSRAnalytics {
       case .subscriptionFalse: return "subscription_false"
       case .subscriptionTrue: return "subscription_true"
       case .tag: return "tag"
-      case let .watchContext(watchContext): return watchContext.trackingString
+      case .unwatch: return "unwatch"
+      case .watch: return "watch"
+      case .watched: return "watched"
       }
     }
   }
@@ -1219,12 +1209,12 @@ public final class KSRAnalytics {
     project: Project,
     location: PageContext,
     params: DiscoveryParams? = nil,
-    watchContext: TypeContext.WatchContext
+    typeContext: TypeContext
   ) {
     var props = projectProperties(from: project, loggedInUser: self.loggedInUser)
       .withAllValuesFrom(contextProperties(
         ctaContext: .watchProject,
-        typeContext: .watchContext(watchContext)
+        typeContext: typeContext
       ))
 
     if let discoveryParams = params {

--- a/Library/Tracking/KSRAnalyticsTests.swift
+++ b/Library/Tracking/KSRAnalyticsTests.swift
@@ -885,7 +885,7 @@ final class KSRAnalyticsTests: TestCase {
     self.assertProjectProperties(segmentClient.properties.last)
   }
 
-  func testUnWatchProjectButtonClicked_ContextProperties() {
+  func testUnWatchProjectButtonClicked_ProjectPageLocationContext() {
     let dataLakeClient = MockTrackingClient()
     let segmentClient = MockTrackingClient()
     let ksrAnalytics = KSRAnalytics(dataLakeClient: dataLakeClient, segmentClient: segmentClient)
@@ -1684,7 +1684,6 @@ final class KSRAnalyticsTests: TestCase {
     XCTAssertEqual(KSRAnalytics.TypeContext.tag.trackingString, "tag")
     XCTAssertEqual(KSRAnalytics.TypeContext.unwatch.trackingString, "unwatch")
     XCTAssertEqual(KSRAnalytics.TypeContext.watch.trackingString, "watch")
-    XCTAssertEqual(KSRAnalytics.TypeContext.watched.trackingString, "watched")
   }
 
   /*

--- a/Library/Tracking/KSRAnalyticsTests.swift
+++ b/Library/Tracking/KSRAnalyticsTests.swift
@@ -810,7 +810,7 @@ final class KSRAnalyticsTests: TestCase {
       project: .template,
       location: .discovery,
       params: DiscoveryParams.recommendedDefaults,
-      watchContext: .watch
+      typeContext: .watch
     )
 
     XCTAssertEqual(["CTA Clicked"], dataLakeClient.events)
@@ -839,7 +839,7 @@ final class KSRAnalyticsTests: TestCase {
       project: .template,
       location: .discovery,
       params: DiscoveryParams.recommendedDefaults,
-      watchContext: .unwatch
+      typeContext: .unwatch
     )
 
     XCTAssertEqual(["CTA Clicked"], dataLakeClient.events)
@@ -867,7 +867,7 @@ final class KSRAnalyticsTests: TestCase {
     ksrAnalytics.trackWatchProjectButtonClicked(
       project: .template,
       location: .projectPage,
-      watchContext: .watch
+      typeContext: .watch
     )
 
     XCTAssertEqual(["CTA Clicked"], dataLakeClient.events)
@@ -885,7 +885,7 @@ final class KSRAnalyticsTests: TestCase {
     self.assertProjectProperties(segmentClient.properties.last)
   }
 
-  func testUnWatchProjectButtonClicked_ProjectPageLocationContext() {
+  func testUnWatchProjectButtonClicked_ContextProperties() {
     let dataLakeClient = MockTrackingClient()
     let segmentClient = MockTrackingClient()
     let ksrAnalytics = KSRAnalytics(dataLakeClient: dataLakeClient, segmentClient: segmentClient)
@@ -893,7 +893,7 @@ final class KSRAnalyticsTests: TestCase {
     ksrAnalytics.trackWatchProjectButtonClicked(
       project: .template,
       location: .projectPage,
-      watchContext: .unwatch
+      typeContext: .unwatch
     )
 
     XCTAssertEqual(["CTA Clicked"], dataLakeClient.events)
@@ -1682,9 +1682,9 @@ final class KSRAnalyticsTests: TestCase {
     XCTAssertEqual(KSRAnalytics.TypeContext.subscriptionFalse.trackingString, "subscription_false")
     XCTAssertEqual(KSRAnalytics.TypeContext.subscriptionTrue.trackingString, "subscription_true")
     XCTAssertEqual(KSRAnalytics.TypeContext.tag.trackingString, "tag")
-    XCTAssertEqual(KSRAnalytics.TypeContext.watchContext(.unwatch).trackingString, "unwatch")
-    XCTAssertEqual(KSRAnalytics.TypeContext.watchContext(.watch).trackingString, "watch")
-    XCTAssertEqual(KSRAnalytics.TypeContext.watchContext(.watched).trackingString, "watched")
+    XCTAssertEqual(KSRAnalytics.TypeContext.unwatch.trackingString, "unwatch")
+    XCTAssertEqual(KSRAnalytics.TypeContext.watch.trackingString, "watch")
+    XCTAssertEqual(KSRAnalytics.TypeContext.watched.trackingString, "watched")
   }
 
   /*

--- a/Library/Tracking/KSRAnalyticsTests.swift
+++ b/Library/Tracking/KSRAnalyticsTests.swift
@@ -809,17 +809,51 @@ final class KSRAnalyticsTests: TestCase {
     ksrAnalytics.trackWatchProjectButtonClicked(
       project: .template,
       location: .discovery,
-      params: DiscoveryParams.recommendedDefaults
+      params: DiscoveryParams.recommendedDefaults,
+      watchContext: .watch
     )
 
-    XCTAssertEqual(["Watch Project Button Clicked"], dataLakeClient.events)
+    XCTAssertEqual(["CTA Clicked"], dataLakeClient.events)
     XCTAssertEqual("discover", dataLakeClient.properties.last?["context_page"] as? String)
+    XCTAssertEqual("watch_project", dataLakeClient.properties.last?["context_cta"] as? String)
+    XCTAssertEqual("watch", dataLakeClient.properties.last?["context_type"] as? String)
 
     self.assertProjectProperties(dataLakeClient.properties.last)
     self.assertDiscoveryProperties(dataLakeClient.properties.last)
 
-    XCTAssertEqual(["Watch Project Button Clicked"], segmentClient.events)
+    XCTAssertEqual(["CTA Clicked"], segmentClient.events)
     XCTAssertEqual("discover", segmentClient.properties.last?["context_page"] as? String)
+    XCTAssertEqual("watch_project", segmentClient.properties.last?["context_cta"] as? String)
+    XCTAssertEqual("watch", segmentClient.properties.last?["context_type"] as? String)
+
+    self.assertProjectProperties(segmentClient.properties.last)
+    self.assertDiscoveryProperties(segmentClient.properties.last)
+  }
+
+  func testUnWatchProjectButtonClicked_DiscoveryLocationContext() {
+    let dataLakeClient = MockTrackingClient()
+    let segmentClient = MockTrackingClient()
+    let ksrAnalytics = KSRAnalytics(dataLakeClient: dataLakeClient, segmentClient: segmentClient)
+
+    ksrAnalytics.trackWatchProjectButtonClicked(
+      project: .template,
+      location: .discovery,
+      params: DiscoveryParams.recommendedDefaults,
+      watchContext: .unwatch
+    )
+
+    XCTAssertEqual(["CTA Clicked"], dataLakeClient.events)
+    XCTAssertEqual("discover", dataLakeClient.properties.last?["context_page"] as? String)
+    XCTAssertEqual("watch_project", dataLakeClient.properties.last?["context_cta"] as? String)
+    XCTAssertEqual("unwatch", dataLakeClient.properties.last?["context_type"] as? String)
+
+    self.assertProjectProperties(dataLakeClient.properties.last)
+    self.assertDiscoveryProperties(dataLakeClient.properties.last)
+
+    XCTAssertEqual(["CTA Clicked"], segmentClient.events)
+    XCTAssertEqual("discover", segmentClient.properties.last?["context_page"] as? String)
+    XCTAssertEqual("watch_project", segmentClient.properties.last?["context_cta"] as? String)
+    XCTAssertEqual("unwatch", segmentClient.properties.last?["context_type"] as? String)
 
     self.assertProjectProperties(segmentClient.properties.last)
     self.assertDiscoveryProperties(segmentClient.properties.last)
@@ -832,16 +866,47 @@ final class KSRAnalyticsTests: TestCase {
 
     ksrAnalytics.trackWatchProjectButtonClicked(
       project: .template,
-      location: .projectPage
+      location: .projectPage,
+      watchContext: .watch
     )
 
-    XCTAssertEqual(["Watch Project Button Clicked"], dataLakeClient.events)
+    XCTAssertEqual(["CTA Clicked"], dataLakeClient.events)
     XCTAssertEqual("project", dataLakeClient.properties.last?["context_page"] as? String)
+    XCTAssertEqual("watch_project", dataLakeClient.properties.last?["context_cta"] as? String)
+    XCTAssertEqual("watch", dataLakeClient.properties.last?["context_type"] as? String)
 
     self.assertProjectProperties(dataLakeClient.properties.last)
 
-    XCTAssertEqual(["Watch Project Button Clicked"], segmentClient.events)
+    XCTAssertEqual(["CTA Clicked"], segmentClient.events)
     XCTAssertEqual("project", segmentClient.properties.last?["context_page"] as? String)
+    XCTAssertEqual("watch_project", segmentClient.properties.last?["context_cta"] as? String)
+    XCTAssertEqual("watch", segmentClient.properties.last?["context_type"] as? String)
+
+    self.assertProjectProperties(segmentClient.properties.last)
+  }
+
+  func testUnWatchProjectButtonClicked_ProjectPageLocationContext() {
+    let dataLakeClient = MockTrackingClient()
+    let segmentClient = MockTrackingClient()
+    let ksrAnalytics = KSRAnalytics(dataLakeClient: dataLakeClient, segmentClient: segmentClient)
+
+    ksrAnalytics.trackWatchProjectButtonClicked(
+      project: .template,
+      location: .projectPage,
+      watchContext: .unwatch
+    )
+
+    XCTAssertEqual(["CTA Clicked"], dataLakeClient.events)
+    XCTAssertEqual("project", dataLakeClient.properties.last?["context_page"] as? String)
+    XCTAssertEqual("watch_project", dataLakeClient.properties.last?["context_cta"] as? String)
+    XCTAssertEqual("unwatch", dataLakeClient.properties.last?["context_type"] as? String)
+
+    self.assertProjectProperties(dataLakeClient.properties.last)
+
+    XCTAssertEqual(["CTA Clicked"], segmentClient.events)
+    XCTAssertEqual("project", segmentClient.properties.last?["context_page"] as? String)
+    XCTAssertEqual("watch_project", segmentClient.properties.last?["context_cta"] as? String)
+    XCTAssertEqual("unwatch", segmentClient.properties.last?["context_type"] as? String)
 
     self.assertProjectProperties(segmentClient.properties.last)
   }
@@ -1617,9 +1682,9 @@ final class KSRAnalyticsTests: TestCase {
     XCTAssertEqual(KSRAnalytics.TypeContext.subscriptionFalse.trackingString, "subscription_false")
     XCTAssertEqual(KSRAnalytics.TypeContext.subscriptionTrue.trackingString, "subscription_true")
     XCTAssertEqual(KSRAnalytics.TypeContext.tag.trackingString, "tag")
-    XCTAssertEqual(KSRAnalytics.TypeContext.unwatch.trackingString, "unwatch")
-    XCTAssertEqual(KSRAnalytics.TypeContext.watch.trackingString, "watch")
-    XCTAssertEqual(KSRAnalytics.TypeContext.watched.trackingString, "watched")
+    XCTAssertEqual(KSRAnalytics.TypeContext.watchContext(.unwatch).trackingString, "unwatch")
+    XCTAssertEqual(KSRAnalytics.TypeContext.watchContext(.watch).trackingString, "watch")
+    XCTAssertEqual(KSRAnalytics.TypeContext.watchContext(.watched).trackingString, "watched")
   }
 
   /*

--- a/Library/ViewModels/WatchProjectViewModel.swift
+++ b/Library/ViewModels/WatchProjectViewModel.swift
@@ -183,7 +183,8 @@ public final class WatchProjectViewModel: WatchProjectViewModelType,
         AppEnvironment.current.ksrAnalytics.trackWatchProjectButtonClicked(
           project: project,
           location: context,
-          params: discoveryParams
+          params: discoveryParams,
+          watchContext: self.saveButtonTappedProperty.value ? .unwatch : .watch
         )
       }
   }

--- a/Library/ViewModels/WatchProjectViewModel.swift
+++ b/Library/ViewModels/WatchProjectViewModel.swift
@@ -184,7 +184,7 @@ public final class WatchProjectViewModel: WatchProjectViewModelType,
           project: project,
           location: context,
           params: discoveryParams,
-          watchContext: self.saveButtonTappedProperty.value ? .unwatch : .watch
+          typeContext: self.saveButtonTappedProperty.value ? .unwatch : .watch
         )
       }
   }

--- a/Library/ViewModels/WatchProjectViewModelTests.swift
+++ b/Library/ViewModels/WatchProjectViewModelTests.swift
@@ -292,7 +292,7 @@ internal final class WatchProjectViewModelTests: TestCase {
       )
       XCTAssertEqual(["project"], self.dataLakeTrackingClient.properties(forKey: "context_page"))
       XCTAssertEqual(["watch_project"], self.dataLakeTrackingClient.properties(forKey: "context_cta"))
-      XCTAssertEqual(["unwatch"], self.dataLakeTrackingClient.properties(forKey: "context_type"))
+      XCTAssertEqual(["watch"], self.dataLakeTrackingClient.properties(forKey: "context_type"))
 
       XCTAssertEqual(
         ["CTA Clicked"],
@@ -300,7 +300,7 @@ internal final class WatchProjectViewModelTests: TestCase {
       )
       XCTAssertEqual(["project"], self.segmentTrackingClient.properties(forKey: "context_page"))
       XCTAssertEqual(["watch_project"], self.segmentTrackingClient.properties(forKey: "context_cta"))
-      XCTAssertEqual(["unwatch"], self.segmentTrackingClient.properties(forKey: "context_type"))
+      XCTAssertEqual(["watch"], self.segmentTrackingClient.properties(forKey: "context_type"))
 
       self.saveButtonSelected.assertValues([false, true], "Save button selects immediately.")
       self.saveButtonAccessibilityValue.assertValues(["Unsaved", "Saved"])
@@ -330,7 +330,7 @@ internal final class WatchProjectViewModelTests: TestCase {
           self.dataLakeTrackingClient.properties(forKey: "context_cta")
         )
         XCTAssertEqual(
-          ["unwatch", "watch"],
+          ["watch", "unwatch"],
           self.dataLakeTrackingClient.properties(forKey: "context_type")
         )
 
@@ -347,7 +347,7 @@ internal final class WatchProjectViewModelTests: TestCase {
           self.segmentTrackingClient.properties(forKey: "context_cta")
         )
         XCTAssertEqual(
-          ["unwatch", "watch"],
+          ["watch", "unwatch"],
           self.segmentTrackingClient.properties(forKey: "context_type")
         )
 
@@ -389,7 +389,7 @@ internal final class WatchProjectViewModelTests: TestCase {
       )
       XCTAssertEqual(["project"], self.dataLakeTrackingClient.properties(forKey: "context_page"))
       XCTAssertEqual(["watch_project"], self.dataLakeTrackingClient.properties(forKey: "context_cta"))
-      XCTAssertEqual(["unwatch"], self.dataLakeTrackingClient.properties(forKey: "context_type"))
+      XCTAssertEqual(["watch"], self.dataLakeTrackingClient.properties(forKey: "context_type"))
 
       XCTAssertEqual(
         ["CTA Clicked"],
@@ -397,7 +397,7 @@ internal final class WatchProjectViewModelTests: TestCase {
       )
       XCTAssertEqual(["project"], self.segmentTrackingClient.properties(forKey: "context_page"))
       XCTAssertEqual(["watch_project"], self.segmentTrackingClient.properties(forKey: "context_cta"))
-      XCTAssertEqual(["unwatch"], self.segmentTrackingClient.properties(forKey: "context_type"))
+      XCTAssertEqual(["watch"], self.segmentTrackingClient.properties(forKey: "context_type"))
 
       self.scheduler.advance(by: .milliseconds(500))
 
@@ -439,7 +439,7 @@ internal final class WatchProjectViewModelTests: TestCase {
       )
       XCTAssertEqual(["discover"], self.dataLakeTrackingClient.properties(forKey: "context_page"))
       XCTAssertEqual(["watch_project"], self.dataLakeTrackingClient.properties(forKey: "context_cta"))
-      XCTAssertEqual(["unwatch"], self.dataLakeTrackingClient.properties(forKey: "context_type"))
+      XCTAssertEqual(["watch"], self.dataLakeTrackingClient.properties(forKey: "context_type"))
 
       XCTAssertEqual(
         ["CTA Clicked"],
@@ -447,7 +447,7 @@ internal final class WatchProjectViewModelTests: TestCase {
       )
       XCTAssertEqual(["discover"], self.segmentTrackingClient.properties(forKey: "context_page"))
       XCTAssertEqual(["watch_project"], self.segmentTrackingClient.properties(forKey: "context_cta"))
-      XCTAssertEqual(["unwatch"], self.segmentTrackingClient.properties(forKey: "context_type"))
+      XCTAssertEqual(["watch"], self.segmentTrackingClient.properties(forKey: "context_type"))
     }
   }
 }

--- a/Library/ViewModels/WatchProjectViewModelTests.swift
+++ b/Library/ViewModels/WatchProjectViewModelTests.swift
@@ -287,16 +287,20 @@ internal final class WatchProjectViewModelTests: TestCase {
       self.vm.inputs.saveButtonTapped(selected: false)
 
       XCTAssertEqual(
-        ["Watch Project Button Clicked"],
+        ["CTA Clicked"],
         self.dataLakeTrackingClient.events
       )
       XCTAssertEqual(["project"], self.dataLakeTrackingClient.properties(forKey: "context_page"))
+      XCTAssertEqual(["watch_project"], self.dataLakeTrackingClient.properties(forKey: "context_cta"))
+      XCTAssertEqual(["unwatch"], self.dataLakeTrackingClient.properties(forKey: "context_type"))
 
       XCTAssertEqual(
-        ["Watch Project Button Clicked"],
+        ["CTA Clicked"],
         self.segmentTrackingClient.events
       )
       XCTAssertEqual(["project"], self.segmentTrackingClient.properties(forKey: "context_page"))
+      XCTAssertEqual(["watch_project"], self.segmentTrackingClient.properties(forKey: "context_cta"))
+      XCTAssertEqual(["unwatch"], self.segmentTrackingClient.properties(forKey: "context_type"))
 
       self.saveButtonSelected.assertValues([false, true], "Save button selects immediately.")
       self.saveButtonAccessibilityValue.assertValues(["Unsaved", "Saved"])
@@ -314,21 +318,37 @@ internal final class WatchProjectViewModelTests: TestCase {
         self.vm.inputs.saveButtonTapped(selected: true)
 
         XCTAssertEqual(
-          ["Watch Project Button Clicked", "Watch Project Button Clicked"],
+          ["CTA Clicked", "CTA Clicked"],
           self.dataLakeTrackingClient.events
         )
         XCTAssertEqual(
           ["project", "project"],
           self.dataLakeTrackingClient.properties(forKey: "context_page")
         )
+        XCTAssertEqual(
+          ["watch_project", "watch_project"],
+          self.dataLakeTrackingClient.properties(forKey: "context_cta")
+        )
+        XCTAssertEqual(
+          ["unwatch", "watch"],
+          self.dataLakeTrackingClient.properties(forKey: "context_type")
+        )
 
         XCTAssertEqual(
-          ["Watch Project Button Clicked", "Watch Project Button Clicked"],
+          ["CTA Clicked", "CTA Clicked"],
           self.segmentTrackingClient.events
         )
         XCTAssertEqual(
           ["project", "project"],
           self.segmentTrackingClient.properties(forKey: "context_page")
+        )
+        XCTAssertEqual(
+          ["watch_project", "watch_project"],
+          self.segmentTrackingClient.properties(forKey: "context_cta")
+        )
+        XCTAssertEqual(
+          ["unwatch", "watch"],
+          self.segmentTrackingClient.properties(forKey: "context_type")
         )
 
         self.saveButtonSelected.assertValues(
@@ -364,16 +384,20 @@ internal final class WatchProjectViewModelTests: TestCase {
       self.vm.inputs.saveButtonTapped(selected: false)
 
       XCTAssertEqual(
-        ["Watch Project Button Clicked"],
+        ["CTA Clicked"],
         self.dataLakeTrackingClient.events
       )
       XCTAssertEqual(["project"], self.dataLakeTrackingClient.properties(forKey: "context_page"))
+      XCTAssertEqual(["watch_project"], self.dataLakeTrackingClient.properties(forKey: "context_cta"))
+      XCTAssertEqual(["unwatch"], self.dataLakeTrackingClient.properties(forKey: "context_type"))
 
       XCTAssertEqual(
-        ["Watch Project Button Clicked"],
+        ["CTA Clicked"],
         self.segmentTrackingClient.events
       )
       XCTAssertEqual(["project"], self.segmentTrackingClient.properties(forKey: "context_page"))
+      XCTAssertEqual(["watch_project"], self.segmentTrackingClient.properties(forKey: "context_cta"))
+      XCTAssertEqual(["unwatch"], self.segmentTrackingClient.properties(forKey: "context_type"))
 
       self.scheduler.advance(by: .milliseconds(500))
 
@@ -410,16 +434,20 @@ internal final class WatchProjectViewModelTests: TestCase {
       self.vm.inputs.saveButtonTapped(selected: false)
 
       XCTAssertEqual(
-        ["Watch Project Button Clicked"],
+        ["CTA Clicked"],
         self.dataLakeTrackingClient.events
       )
       XCTAssertEqual(["discover"], self.dataLakeTrackingClient.properties(forKey: "context_page"))
+      XCTAssertEqual(["watch_project"], self.dataLakeTrackingClient.properties(forKey: "context_cta"))
+      XCTAssertEqual(["unwatch"], self.dataLakeTrackingClient.properties(forKey: "context_type"))
 
       XCTAssertEqual(
-        ["Watch Project Button Clicked"],
+        ["CTA Clicked"],
         self.segmentTrackingClient.events
       )
       XCTAssertEqual(["discover"], self.segmentTrackingClient.properties(forKey: "context_page"))
+      XCTAssertEqual(["watch_project"], self.segmentTrackingClient.properties(forKey: "context_cta"))
+      XCTAssertEqual(["unwatch"], self.segmentTrackingClient.properties(forKey: "context_type"))
     }
   }
 }


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

CTA Clicked (watch_project)

# 🤔 Why

Segment Integration

# 🛠 How

More in-depth discussion of the change or implementation.

1. Move related Watch context to a new Enum `WatchContext`
2. Added a new parameter to `trackWatchProjectButtonClicked` (`watchContext`). This allows tracking for watch and unwatch project.
3. More tests to include `unwatch` context.
