### PR TITLE
Feature Flag Enable Fix

### DIFF
--- a/Library/Feature.swift
+++ b/Library/Feature.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public enum Feature: String {
+public enum Feature: String, CaseIterable {
   case emailVerificationFlow = "ios_email_verification_flow"
   case emailVerificationSkip = "ios_email_verification_skip"
   case segment = "ios_segment"

--- a/Library/ViewModels/FeatureFlagToolsViewModel.swift
+++ b/Library/ViewModels/FeatureFlagToolsViewModel.swift
@@ -49,6 +49,9 @@ public final class FeatureFlagToolsViewModel: FeatureFlagToolsViewModelType, Fea
       .takePairWhen(self.setFeatureEnabledAtIndexProperty.signal.skipNil())
       .map(unpack)
       .map { features, index, enabled -> Features? in
+        guard features.count > index else {
+          return nil
+        }
         let featureEnabledPair = features[index]
 
         guard featureEnabledPair.value != enabled else {

--- a/Library/ViewModels/FeatureFlagToolsViewModel.swift
+++ b/Library/ViewModels/FeatureFlagToolsViewModel.swift
@@ -36,8 +36,11 @@ public final class FeatureFlagToolsViewModel: FeatureFlagToolsViewModelType, Fea
     .skipNil()
 
     let sortedFeatures = features
-      .map { features in Array(features).sorted(by: { $0.0 < $1.0 }) }
-
+      .map { features in Array(features)
+        .filter { Feature(rawValue: $0.0) != nil }
+        .sorted(by: { $0.0 < $1.0 })
+      }
+    
     self.reloadWithData = sortedFeatures.map { featureTuples in
       featureTuples.map { key, value in [key: value] }
     }

--- a/Library/ViewModels/FeatureFlagToolsViewModel.swift
+++ b/Library/ViewModels/FeatureFlagToolsViewModel.swift
@@ -23,7 +23,8 @@ public protocol FeatureFlagToolsViewModelType {
 }
 
 public final class FeatureFlagToolsViewModel: FeatureFlagToolsViewModelType, FeatureFlagToolsViewModelInputs,
-  FeatureFlagToolsViewModelOutputs {
+  FeatureFlagToolsViewModelOutputs
+{
   public init() {
     let didUpdateConfigAndUI = self.didUpdateConfigProperty.signal
       .ksr_debounce(.seconds(1), on: AppEnvironment.current.scheduler)
@@ -40,7 +41,7 @@ public final class FeatureFlagToolsViewModel: FeatureFlagToolsViewModelType, Fea
         .filter { Feature(rawValue: $0.0) != nil }
         .sorted(by: { $0.0 < $1.0 })
       }
-    
+
     self.reloadWithData = sortedFeatures.map { featureTuples in
       featureTuples.map { key, value in [key: value] }
     }

--- a/Library/ViewModels/FeatureFlagToolsViewModelTests.swift
+++ b/Library/ViewModels/FeatureFlagToolsViewModelTests.swift
@@ -25,13 +25,13 @@ final class FeatureFlagToolsViewModelTests: TestCase {
     let featuresArray = Feature.allCases.map { $0.rawValue }
     let sortedClientFeatures = featuresArray.sorted().map { [$0: true] }
     let configFeatures = featuresArray.reduce(into: [String: Bool]()) { $0[$1] = true }
-    
+
     let mockConfig = Config.template
       |> \.features .~ configFeatures
-    
+
     withEnvironment(config: mockConfig) {
       self.vm.inputs.viewDidLoad()
-      
+
       self.reloadWithDataFeatures.assertValue(sortedClientFeatures)
     }
   }
@@ -39,7 +39,7 @@ final class FeatureFlagToolsViewModelTests: TestCase {
   func testFeatureFlagTools_LoadsWithFeatureFlags() {
     let featureName = Feature.allCases.first?.rawValue ?? ""
     let mockConfig = Config.template
-      |> \.features .~ [featureName : true]
+      |> \.features .~ [featureName: true]
 
     withEnvironment(config: mockConfig) {
       self.vm.inputs.viewDidLoad()
@@ -80,8 +80,9 @@ final class FeatureFlagToolsViewModelTests: TestCase {
   }
 
   func testUpdateFeatureFlagEnabledValue() {
-    let originalFeatures = Feature.allCases.map { $0.rawValue }.reduce(into: [String: Bool]()) { $0[$1] = true }
-    let expectedFeatures =  Feature.allCases.map { $0.rawValue }.reduce(into: [String: Bool]()) {
+    let originalFeatures = Feature.allCases.map { $0.rawValue }
+      .reduce(into: [String: Bool]()) { $0[$1] = true }
+    let expectedFeatures = Feature.allCases.map { $0.rawValue }.reduce(into: [String: Bool]()) {
       if $1 == Feature.allCases.first?.rawValue ?? "" {
         return $0[$1] = false
       }
@@ -128,7 +129,8 @@ final class FeatureFlagToolsViewModelTests: TestCase {
   }
 
   func testPostNotification() {
-    let originalFeatures = Feature.allCases.map { $0.rawValue }.reduce(into: [String: Bool]()) { $0[$1] = true }
+    let originalFeatures = Feature.allCases.map { $0.rawValue }
+      .reduce(into: [String: Bool]()) { $0[$1] = true }
 
     let mockConfig = Config.template
       |> \.features .~ originalFeatures

--- a/Library/ViewModels/FeatureFlagToolsViewModelTests.swift
+++ b/Library/ViewModels/FeatureFlagToolsViewModelTests.swift
@@ -21,58 +21,32 @@ final class FeatureFlagToolsViewModelTests: TestCase {
     self.vm.outputs.reloadWithData.observe(self.reloadWithDataFeatures.observer)
   }
 
-  func testDataIsSortedAlphabetically_When_Sorted() {
+  func testDataIsSortedAlphabetically() {
+    let featuresArray = Feature.allCases.map { $0.rawValue }
+    let sortedClientFeatures = featuresArray.sorted().map { [$0: true] }
+    let configFeatures = featuresArray.reduce(into: [String: Bool]()) { $0[$1] = true }
+    
     let mockConfig = Config.template
-      |> \.features .~ [
-        "a": false,
-        "b": true,
-        "c": true
-      ]
-
+      |> \.features .~ configFeatures
+    
     withEnvironment(config: mockConfig) {
       self.vm.inputs.viewDidLoad()
-
-      self.reloadWithDataFeatures.assertValues([
-        [
-          ["a": false],
-          ["b": true],
-          ["c": true]
-        ]
-      ])
-    }
-  }
-
-  func testDataIsSortedAlphabetically_When_Unsorted() {
-    let mockConfig = Config.template
-      |> \.features .~ [
-        "c": true,
-        "a": false,
-        "b": true
-      ]
-
-    withEnvironment(config: mockConfig) {
-      self.vm.inputs.viewDidLoad()
-
-      self.reloadWithDataFeatures.assertValues([
-        [
-          ["a": false],
-          ["b": true],
-          ["c": true]
-        ]
-      ])
+      
+      self.reloadWithDataFeatures.assertValue(sortedClientFeatures)
     }
   }
 
   func testFeatureFlagTools_LoadsWithFeatureFlags() {
+    let featureName = Feature.allCases.first?.rawValue ?? ""
     let mockConfig = Config.template
-      |> \.features .~ ["a": true]
+      |> \.features .~ [featureName : true]
 
     withEnvironment(config: mockConfig) {
       self.vm.inputs.viewDidLoad()
 
       self.reloadWithDataFeatures.assertValues([
         [
-          ["a": true]
+          [featureName: true]
         ]
       ])
     }
@@ -85,11 +59,7 @@ final class FeatureFlagToolsViewModelTests: TestCase {
     withEnvironment(config: mockConfig) {
       self.vm.inputs.viewDidLoad()
 
-      self.reloadWithDataFeatures.assertValues([
-        [
-          ["some_unknown_feature": false]
-        ]
-      ], "Does emit unknown features")
+      self.reloadWithDataFeatures.assertValues([[]], "Does NOT emit unknown features")
     }
   }
 
@@ -110,15 +80,13 @@ final class FeatureFlagToolsViewModelTests: TestCase {
   }
 
   func testUpdateFeatureFlagEnabledValue() {
-    let originalFeatures = [
-      "a": true,
-      "b": true
-    ]
-
-    let expectedFeatures = [
-      "a": true,
-      "b": false
-    ]
+    let originalFeatures = Feature.allCases.map { $0.rawValue }.reduce(into: [String: Bool]()) { $0[$1] = true }
+    let expectedFeatures =  Feature.allCases.map { $0.rawValue }.reduce(into: [String: Bool]()) {
+      if $1 == Feature.allCases.first?.rawValue ?? "" {
+        return $0[$1] = false
+      }
+      return $0[$1] = true
+    }
 
     let mockConfig = Config.template
       |> \.features .~ originalFeatures
@@ -127,17 +95,14 @@ final class FeatureFlagToolsViewModelTests: TestCase {
       self.vm.inputs.viewDidLoad()
 
       self.reloadWithDataFeatures.assertValues([
-        [
-          ["a": true],
-          ["b": true]
-        ]
+        Feature.allCases.map { $0.rawValue }.map { [$0: true] }
       ])
 
       self.vm.inputs.setFeatureAtIndexEnabled(index: 0, isEnabled: true)
 
       self.updateConfigWithFeatures.assertValues([], "Doesn't update when the enabled value is the same.")
 
-      self.vm.inputs.setFeatureAtIndexEnabled(index: 1, isEnabled: false)
+      self.vm.inputs.setFeatureAtIndexEnabled(index: 0, isEnabled: false)
 
       self.updateConfigWithFeatures.assertValues([expectedFeatures])
     }
@@ -151,24 +116,22 @@ final class FeatureFlagToolsViewModelTests: TestCase {
       self.scheduler.run()
 
       self.reloadWithDataFeatures.assertValues([
-        [
-          ["a": true],
-          ["b": true]
-        ],
-        [
-          ["a": true],
-          ["b": false]
-        ]
+        Feature.allCases.map { $0.rawValue }.map { [$0: true] },
+        Feature.allCases.map { $0.rawValue }.map {
+          if $0 == Feature.allCases.first?.rawValue ?? "" {
+            return [$0: false]
+          }
+          return [$0: true]
+        }
       ])
     }
   }
 
   func testPostNotification() {
+    let originalFeatures = Feature.allCases.map { $0.rawValue }.reduce(into: [String: Bool]()) { $0[$1] = true }
+
     let mockConfig = Config.template
-      |> \.features .~ [
-        "a": true,
-        "b": true
-      ]
+      |> \.features .~ originalFeatures
 
     withEnvironment(config: mockConfig) {
       self.vm.inputs.viewDidLoad()
@@ -180,14 +143,6 @@ final class FeatureFlagToolsViewModelTests: TestCase {
       self.vm.inputs.didUpdateConfig()
 
       self.postNotificationName.assertValues([.ksr_configUpdated])
-
-      self.vm.inputs.setFeatureAtIndexEnabled(index: 1, isEnabled: false)
-
-      self.updateConfigWithFeatures.assertValueCount(2)
-
-      self.vm.inputs.didUpdateConfig()
-
-      self.postNotificationName.assertValues([.ksr_configUpdated, .ksr_configUpdated])
     }
   }
 }

--- a/Library/ViewModels/FeatureFlagToolsViewModelTests.swift
+++ b/Library/ViewModels/FeatureFlagToolsViewModelTests.swift
@@ -127,6 +127,25 @@ final class FeatureFlagToolsViewModelTests: TestCase {
       ])
     }
   }
+  
+  func testUpdateConfig_UnknownFeatures() {
+    let mockConfig = Config.template
+      |> \.features .~ ["some_unknown_feature": false]
+
+    withEnvironment(config: mockConfig) {
+      self.vm.inputs.viewDidLoad()
+
+      self.reloadWithDataFeatures.assertValues([[]])
+
+      self.vm.inputs.setFeatureAtIndexEnabled(index: 0, isEnabled: true)
+
+      self.updateConfigWithFeatures.assertValues([], "Doesn't update when the enabled value is the same.")
+
+      self.vm.inputs.setFeatureAtIndexEnabled(index: 0, isEnabled: false)
+
+      self.updateConfigWithFeatures.assertValues([])
+    }
+  }
 
   func testPostNotification() {
     let originalFeatures = Feature.allCases.map { $0.rawValue }


### PR DESCRIPTION
# 📲 What

When a developer would like to enable a feature flag in the app, the selection is not linked to the right feature. We filter the enabled features on the client, however do not update the filtered list but the full list

# 🛠 How

An additional step to filter the features based on the enabled client side features is added

# ✅ Acceptance criteria

- [ ] Enable `TRACKING_ENABLED` in the project's arguments
- [ ] Run the app and enable the Segment feature flag
- [ ] Tap into a project and verify on Segment's debugger that an event is sent to Segment
