### PR TITLE
[EP-323] Page Viewed (update_pledge)

### DIFF
--- a/Library/Tracking/KSRAnalytics.swift
+++ b/Library/Tracking/KSRAnalytics.swift
@@ -84,6 +84,7 @@ public final class KSRAnalytics {
     case signup = "sign_up" // SignupViewController
     case thanks // ThanksViewController
     case twoFactorAuth = "two_factor_auth" // TwoFactorViewController
+    case updatePledgeScreen = "update_pledge" // PledgeViewController
   }
 
   /// Determines the authentication type for login or signup events.
@@ -971,11 +972,12 @@ public final class KSRAnalytics {
     )
   }
 
-  /* Call when the pledge screen is shown
+  /* Call when the pledge screen is shown, and pageContext = pledge, update, or updateReward.
 
    parameters:
    - project: the project being pledged to
    - reward: the chosen reward
+   - pageContext: The screen that's been tracked.
    - checkoutData: the `CheckoutPropertiesData` associated with the given project and reward
    - refTag: the associated RefTag for the pledge
    - cookieRefTag: The ref tag pulled from cookie storage when this project was shown.
@@ -985,6 +987,7 @@ public final class KSRAnalytics {
   public func trackCheckoutPaymentPageViewed(
     project: Project,
     reward: Reward,
+    pageContext: PageContext,
     checkoutData: CheckoutPropertiesData,
     refTag: RefTag?,
     cookieRefTag: RefTag?
@@ -994,7 +997,7 @@ public final class KSRAnalytics {
 
     self.track(
       event: NewApprovedEvent.pageViewed.rawValue,
-      page: .checkout,
+      page: pageContext,
       properties: props,
       refTag: refTag?.stringTag,
       referrerCredit: cookieRefTag?.stringTag

--- a/Library/Tracking/KSRAnalytics.swift
+++ b/Library/Tracking/KSRAnalytics.swift
@@ -84,7 +84,7 @@ public final class KSRAnalytics {
     case signup = "sign_up" // SignupViewController
     case thanks // ThanksViewController
     case twoFactorAuth = "two_factor_auth" // TwoFactorViewController
-    case updatePledgeScreen = "update_pledge" // PledgeViewController
+    case updatePledge = "update_pledge" // PledgeViewController
   }
 
   /// Determines the authentication type for login or signup events.

--- a/Library/Tracking/KSRAnalyticsTests.swift
+++ b/Library/Tracking/KSRAnalyticsTests.swift
@@ -746,6 +746,7 @@ final class KSRAnalyticsTests: TestCase {
     ksrAnalytics.trackCheckoutPaymentPageViewed(
       project: .template,
       reward: reward,
+      pageContext: .checkout,
       checkoutData: KSRAnalytics.CheckoutPropertiesData.template,
       refTag: RefTag.activity,
       cookieRefTag: RefTag.activity
@@ -758,6 +759,42 @@ final class KSRAnalyticsTests: TestCase {
     XCTAssertEqual(["Page Viewed"], segmentClient.events)
     XCTAssertEqual("checkout", dataLakeClientProps?["context_page"] as? String)
     XCTAssertEqual("checkout", segmentClientProps?["context_page"] as? String)
+
+    self.assertProjectProperties(dataLakeClientProps)
+    self.assertProjectProperties(segmentClientProps)
+
+    self.assertCheckoutProperties(dataLakeClientProps)
+    self.assertCheckoutProperties(segmentClientProps)
+
+    XCTAssertEqual("activity", dataLakeClientProps?["session_ref_tag"] as? String)
+    XCTAssertEqual("activity", segmentClientProps?["session_ref_tag"] as? String)
+  }
+
+  func testTrackUpdatePledgeViewed() {
+    let dataLakeClient = MockTrackingClient()
+    let segmentClient = MockTrackingClient()
+    let ksrAnalytics = KSRAnalytics(dataLakeClient: dataLakeClient, segmentClient: segmentClient)
+
+    let reward = Reward.template
+      |> Reward.lens.shipping.preference .~ .restricted
+      |> Reward.lens.endsAt .~ MockDate().addingTimeInterval(5).timeIntervalSince1970
+
+    ksrAnalytics.trackCheckoutPaymentPageViewed(
+      project: .template,
+      reward: reward,
+      pageContext: .updatePledgeScreen,
+      checkoutData: KSRAnalytics.CheckoutPropertiesData.template,
+      refTag: RefTag.activity,
+      cookieRefTag: RefTag.activity
+    )
+
+    let dataLakeClientProps = dataLakeClient.properties.last
+    let segmentClientProps = segmentClient.properties.last
+
+    XCTAssertEqual(["Page Viewed"], dataLakeClient.events)
+    XCTAssertEqual(["Page Viewed"], segmentClient.events)
+    XCTAssertEqual("update_pledge", dataLakeClientProps?["context_page"] as? String)
+    XCTAssertEqual("update_pledge", segmentClientProps?["context_page"] as? String)
 
     self.assertProjectProperties(dataLakeClientProps)
     self.assertProjectProperties(segmentClientProps)
@@ -1794,6 +1831,7 @@ final class KSRAnalyticsTests: TestCase {
     ksrAnalytics.trackCheckoutPaymentPageViewed(
       project: .template,
       reward: reward,
+      pageContext: .checkout,
       checkoutData: KSRAnalytics.CheckoutPropertiesData.template,
       refTag: nil,
       cookieRefTag: nil
@@ -1804,6 +1842,21 @@ final class KSRAnalyticsTests: TestCase {
 
     XCTAssertEqual("checkout", dataLakeClientProps?["context_page"] as? String)
     XCTAssertEqual("checkout", segmentClientProps?["context_page"] as? String)
+
+    self.assertCheckoutProperties(dataLakeClientProps)
+    self.assertCheckoutProperties(segmentClientProps)
+
+    ksrAnalytics.trackCheckoutPaymentPageViewed(
+      project: .template,
+      reward: reward,
+      pageContext: .updatePledgeScreen,
+      checkoutData: KSRAnalytics.CheckoutPropertiesData.template,
+      refTag: nil,
+      cookieRefTag: nil
+    )
+
+    XCTAssertEqual("update_pledge", dataLakeClient.properties.last?["context_page"] as? String)
+    XCTAssertEqual("update_pledge", dataLakeClient.properties.last?["context_page"] as? String)
 
     self.assertCheckoutProperties(dataLakeClientProps)
     self.assertCheckoutProperties(segmentClientProps)

--- a/Library/Tracking/KSRAnalyticsTests.swift
+++ b/Library/Tracking/KSRAnalyticsTests.swift
@@ -782,7 +782,7 @@ final class KSRAnalyticsTests: TestCase {
     ksrAnalytics.trackCheckoutPaymentPageViewed(
       project: .template,
       reward: reward,
-      pageContext: .updatePledgeScreen,
+      pageContext: .updatePledge,
       checkoutData: KSRAnalytics.CheckoutPropertiesData.template,
       refTag: RefTag.activity,
       cookieRefTag: RefTag.activity
@@ -1832,7 +1832,7 @@ final class KSRAnalyticsTests: TestCase {
       project: .template,
       reward: reward,
       pageContext: .checkout,
-      checkoutData: KSRAnalytics.CheckoutPropertiesData.template,
+      checkoutData: .template,
       refTag: nil,
       cookieRefTag: nil
     )
@@ -1849,8 +1849,8 @@ final class KSRAnalyticsTests: TestCase {
     ksrAnalytics.trackCheckoutPaymentPageViewed(
       project: .template,
       reward: reward,
-      pageContext: .updatePledgeScreen,
-      checkoutData: KSRAnalytics.CheckoutPropertiesData.template,
+      pageContext: .updatePledge,
+      checkoutData: .template,
       refTag: nil,
       cookieRefTag: nil
     )

--- a/Library/Tracking/KSRAnalyticsTests.swift
+++ b/Library/Tracking/KSRAnalyticsTests.swift
@@ -770,7 +770,7 @@ final class KSRAnalyticsTests: TestCase {
     XCTAssertEqual("activity", segmentClientProps?["session_ref_tag"] as? String)
   }
 
-  func testTrackUpdatePledgeViewed() {
+  func testTrackUpdatePledgeScreenViewed() {
     let dataLakeClient = MockTrackingClient()
     let segmentClient = MockTrackingClient()
     let ksrAnalytics = KSRAnalytics(dataLakeClient: dataLakeClient, segmentClient: segmentClient)

--- a/Library/ViewModels/PledgeViewModel.swift
+++ b/Library/ViewModels/PledgeViewModel.swift
@@ -827,7 +827,8 @@ public class PledgeViewModel: PledgeViewModelType, PledgeViewModelInputs, Pledge
 
     trackCheckoutPageViewData
       .observeValues { project, baseReward, rewards, selectedQuantities, refTag, additionalPledgeAmount, pledgeTotal, shippingTotal, context in
-        guard context == .pledge else { return }
+        let allowedPageContexts: [PledgeViewContext] = [.pledge, .update, .updateReward]
+        guard allowedPageContexts.contains(context) else { return }
 
         let cookieRefTag = cookieRefTagFor(project: project) ?? refTag
 
@@ -848,6 +849,7 @@ public class PledgeViewModel: PledgeViewModelType, PledgeViewModelInputs, Pledge
         AppEnvironment.current.ksrAnalytics.trackCheckoutPaymentPageViewed(
           project: project,
           reward: baseReward,
+          pageContext: context == .pledge ? .checkout : .updatePledgeScreen,
           checkoutData: checkoutData,
           refTag: refTag,
           cookieRefTag: cookieRefTag

--- a/Library/ViewModels/PledgeViewModel.swift
+++ b/Library/ViewModels/PledgeViewModel.swift
@@ -827,8 +827,8 @@ public class PledgeViewModel: PledgeViewModelType, PledgeViewModelInputs, Pledge
 
     trackCheckoutPageViewData
       .observeValues { project, baseReward, rewards, selectedQuantities, refTag, additionalPledgeAmount, pledgeTotal, shippingTotal, context in
-        let allowedPageContexts: [PledgeViewContext] = [.pledge, .update, .updateReward]
-        guard allowedPageContexts.contains(context) else { return }
+        
+        guard context.isAny(of: .pledge, .update, .updateReward) else { return }
 
         let cookieRefTag = cookieRefTagFor(project: project) ?? refTag
 

--- a/Library/ViewModels/PledgeViewModel.swift
+++ b/Library/ViewModels/PledgeViewModel.swift
@@ -827,7 +827,7 @@ public class PledgeViewModel: PledgeViewModelType, PledgeViewModelInputs, Pledge
 
     trackCheckoutPageViewData
       .observeValues { project, baseReward, rewards, selectedQuantities, refTag, additionalPledgeAmount, pledgeTotal, shippingTotal, context in
-        
+
         guard context.isAny(of: .pledge, .update, .updateReward) else { return }
 
         let cookieRefTag = cookieRefTagFor(project: project) ?? refTag

--- a/Library/ViewModels/PledgeViewModel.swift
+++ b/Library/ViewModels/PledgeViewModel.swift
@@ -849,7 +849,7 @@ public class PledgeViewModel: PledgeViewModelType, PledgeViewModelInputs, Pledge
         AppEnvironment.current.ksrAnalytics.trackCheckoutPaymentPageViewed(
           project: project,
           reward: baseReward,
-          pageContext: context == .pledge ? .checkout : .updatePledgeScreen,
+          pageContext: context == .pledge ? .checkout : .updatePledge,
           checkoutData: checkoutData,
           refTag: refTag,
           cookieRefTag: cookieRefTag

--- a/Library/ViewModels/PledgeViewModelTests.swift
+++ b/Library/ViewModels/PledgeViewModelTests.swift
@@ -5402,17 +5402,48 @@ final class PledgeViewModelTests: TestCase {
     self.vm.inputs.configure(with: data)
     self.vm.inputs.viewDidLoad()
 
-    XCTAssertEqual([], self.dataLakeTrackingClient.events)
-    XCTAssertEqual([], self.segmentTrackingClient.events)
+    let dataLakeTrackingClientProps = self.dataLakeTrackingClient.properties.last
+    let segmentTrackingClientProps = self.dataLakeTrackingClient.properties.last
+
+    XCTAssertEqual(["Page Viewed"], self.dataLakeTrackingClient.events)
+    XCTAssertEqual(["Page Viewed"], self.segmentTrackingClient.events)
+    XCTAssertEqual("update_pledge", segmentTrackingClientProps?["context_page"] as? String)
+    XCTAssertEqual("update_pledge", segmentTrackingClient.properties.last?["context_page"] as? String)
+
+    // Checkout properties
+
+    XCTAssertEqual("10.00", dataLakeTrackingClientProps?["checkout_amount"] as? String)
+    XCTAssertEqual("CREDIT_CARD", dataLakeTrackingClientProps?["checkout_payment_type"] as? String)
+    XCTAssertEqual("My Reward", dataLakeTrackingClientProps?["checkout_reward_title"] as? String)
+    XCTAssertEqual("10.00", dataLakeTrackingClientProps?["checkout_reward_minimum_usd"] as? String)
+    XCTAssertEqual(1, dataLakeTrackingClientProps?["checkout_reward_id"] as? Int)
+    XCTAssertEqual(10.00, dataLakeTrackingClientProps?["checkout_amount_total_usd"] as? Double)
+    XCTAssertEqual(true, dataLakeTrackingClientProps?["checkout_reward_is_limited_quantity"] as? Bool)
+    XCTAssertEqual(
+      true,
+      dataLakeTrackingClientProps?["checkout_user_has_eligible_stored_apple_pay_card"] as? Bool
+    )
+
+    XCTAssertEqual("10.00", segmentTrackingClientProps?["checkout_amount"] as? String)
+    XCTAssertEqual("CREDIT_CARD", segmentTrackingClientProps?["checkout_payment_type"] as? String)
+    XCTAssertEqual("My Reward", segmentTrackingClientProps?["checkout_reward_title"] as? String)
+    XCTAssertEqual("10.00", segmentTrackingClientProps?["checkout_reward_minimum_usd"] as? String)
+    XCTAssertEqual(1, segmentTrackingClientProps?["checkout_reward_id"] as? Int)
+    XCTAssertEqual(10.00, segmentTrackingClientProps?["checkout_amount_total_usd"] as? Double)
+    XCTAssertEqual(true, segmentTrackingClientProps?["checkout_reward_is_limited_quantity"] as? Bool)
+    XCTAssertEqual(
+      true,
+      segmentTrackingClientProps?["checkout_user_has_eligible_stored_apple_pay_card"] as? Bool
+    )
 
     self.vm.inputs.submitButtonTapped()
 
     XCTAssertEqual(
-      [],
+      ["Page Viewed"],
       self.dataLakeTrackingClient.events
     )
     XCTAssertEqual(
-      [],
+      ["Page Viewed"],
       self.segmentTrackingClient.events
     )
   }
@@ -5433,17 +5464,48 @@ final class PledgeViewModelTests: TestCase {
     self.vm.inputs.configure(with: data)
     self.vm.inputs.viewDidLoad()
 
-    XCTAssertEqual([], self.dataLakeTrackingClient.events)
-    XCTAssertEqual([], self.segmentTrackingClient.events)
+    let dataLakeTrackingClientProps = self.dataLakeTrackingClient.properties.last
+    let segmentTrackingClientProps = self.dataLakeTrackingClient.properties.last
+
+    XCTAssertEqual(["Page Viewed"], self.dataLakeTrackingClient.events)
+    XCTAssertEqual(["Page Viewed"], self.segmentTrackingClient.events)
+    XCTAssertEqual("update_pledge", segmentTrackingClientProps?["context_page"] as? String)
+    XCTAssertEqual("update_pledge", segmentTrackingClient.properties.last?["context_page"] as? String)
+
+    // Checkout properties
+
+    XCTAssertEqual("10.00", dataLakeTrackingClientProps?["checkout_amount"] as? String)
+    XCTAssertEqual("CREDIT_CARD", dataLakeTrackingClientProps?["checkout_payment_type"] as? String)
+    XCTAssertEqual("My Reward", dataLakeTrackingClientProps?["checkout_reward_title"] as? String)
+    XCTAssertEqual("10.00", dataLakeTrackingClientProps?["checkout_reward_minimum_usd"] as? String)
+    XCTAssertEqual(1, dataLakeTrackingClientProps?["checkout_reward_id"] as? Int)
+    XCTAssertEqual(10.00, dataLakeTrackingClientProps?["checkout_amount_total_usd"] as? Double)
+    XCTAssertEqual(true, dataLakeTrackingClientProps?["checkout_reward_is_limited_quantity"] as? Bool)
+    XCTAssertEqual(
+      true,
+      dataLakeTrackingClientProps?["checkout_user_has_eligible_stored_apple_pay_card"] as? Bool
+    )
+
+    XCTAssertEqual("10.00", segmentTrackingClientProps?["checkout_amount"] as? String)
+    XCTAssertEqual("CREDIT_CARD", segmentTrackingClientProps?["checkout_payment_type"] as? String)
+    XCTAssertEqual("My Reward", segmentTrackingClientProps?["checkout_reward_title"] as? String)
+    XCTAssertEqual("10.00", segmentTrackingClientProps?["checkout_reward_minimum_usd"] as? String)
+    XCTAssertEqual(1, segmentTrackingClientProps?["checkout_reward_id"] as? Int)
+    XCTAssertEqual(10.00, segmentTrackingClientProps?["checkout_amount_total_usd"] as? Double)
+    XCTAssertEqual(true, segmentTrackingClientProps?["checkout_reward_is_limited_quantity"] as? Bool)
+    XCTAssertEqual(
+      true,
+      segmentTrackingClientProps?["checkout_user_has_eligible_stored_apple_pay_card"] as? Bool
+    )
 
     self.vm.inputs.submitButtonTapped()
 
     XCTAssertEqual(
-      [],
+      ["Page Viewed"],
       self.dataLakeTrackingClient.events
     )
     XCTAssertEqual(
-      [],
+      ["Page Viewed"],
       self.segmentTrackingClient.events
     )
   }


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Added a track event for when update pledge screen is viewed.
There are two ways to get to `Update Pledge Screen`, either from `Manage Pledge` or `Update Reward`.

# 🤔 Why

Phase 3 of segment implementation
