### PR TITLE
[EP-399] QA Phase 1 Remove Properties

### DIFF
--- a/Library/SharedFunctions.swift
+++ b/Library/SharedFunctions.swift
@@ -543,9 +543,6 @@ public func checkoutProperties(
 
   let shippingAmount: Double? = baseReward.shipping.enabled ? shippingTotal : nil
 
-  let amount = Format.decimalCurrency(for: pledgeTotal)
-
-  let bonusAmount = Format.decimalCurrency(for: additionalPledgeAmount)
   let bonusAmountInUsd = Format.decimalCurrency(for: bonusAmountUsd)
 
   let rewardId = baseReward.id
@@ -572,8 +569,6 @@ public func checkoutProperties(
     addOnsCountTotal: addOnsCountTotal,
     addOnsCountUnique: addOnsCountUnique,
     addOnsMinimumUsd: addOnsMinimumUsd,
-    amount: amount,
-    bonusAmount: bonusAmount,
     bonusAmountInUsd: bonusAmountInUsd,
     checkoutId: checkoutId,
     estimatedDelivery: estimatedDelivery,
@@ -583,7 +578,6 @@ public func checkoutProperties(
     rewardMinimumUsd: rewardMinimumUsd,
     rewardTitle: rewardTitle,
     shippingEnabled: shippingEnabled,
-    shippingAmount: shippingAmount,
     shippingAmountUsd: shippingAmountUsd,
     userHasStoredApplePayCard: userHasEligibleStoredApplePayCard
   )

--- a/Library/SharedFunctionsTests.swift
+++ b/Library/SharedFunctionsTests.swift
@@ -305,6 +305,32 @@ final class SharedFunctionsTests: TestCase {
     XCTAssertTrue(rewardsCarouselCanNavigateToReward(reward, in: project))
   }
 
+  func testSelectedRewardQuanties_With_Addons() {
+    let reward = Reward.template
+      |> Reward.lens.id .~ 99
+    let addOn1 = Reward.template
+      |> Reward.lens.id .~ 5
+    let addOn2 = Reward.template
+      |> Reward.lens.id .~ 10
+
+    let backing = Backing.template
+      |> Backing.lens.addOns .~ [addOn1, addOn2]
+      |> Backing.lens.reward .~ reward
+
+    let selectedQuantities = selectedRewardQuantities(in: backing)
+
+    XCTAssertEqual(selectedQuantities, [10: 1, 99: 1, 5: 1])
+  }
+
+  func testSelectedRewardQuanties_No_Addons() {
+    let backing = Backing.template
+      |> Backing.lens.addOns .~ nil
+
+    let selectedQuantities = selectedRewardQuantities(in: backing)
+
+    XCTAssertEqual(selectedQuantities, [1: 1])
+  }
+
   func testIsStartDateBeforeToday_Reward_StartsAt_Nil() {
     let reward = Reward.template
       |> Reward.lens.startsAt .~ nil

--- a/Library/SharedFunctionsTests.swift
+++ b/Library/SharedFunctionsTests.swift
@@ -305,32 +305,6 @@ final class SharedFunctionsTests: TestCase {
     XCTAssertTrue(rewardsCarouselCanNavigateToReward(reward, in: project))
   }
 
-  func testSelectedRewardQuanties_With_Addons() {
-    let reward = Reward.template
-      |> Reward.lens.id .~ 99
-    let addOn1 = Reward.template
-      |> Reward.lens.id .~ 5
-    let addOn2 = Reward.template
-      |> Reward.lens.id .~ 10
-
-    let backing = Backing.template
-      |> Backing.lens.addOns .~ [addOn1, addOn2]
-      |> Backing.lens.reward .~ reward
-
-    let selectedQuantities = selectedRewardQuantities(in: backing)
-
-    XCTAssertEqual(selectedQuantities, [10: 1, 99: 1, 5: 1])
-  }
-
-  func testSelectedRewardQuanties_No_Addons() {
-    let backing = Backing.template
-      |> Backing.lens.addOns .~ nil
-
-    let selectedQuantities = selectedRewardQuantities(in: backing)
-
-    XCTAssertEqual(selectedQuantities, [1: 1])
-  }
-
   func testIsStartDateBeforeToday_Reward_StartsAt_Nil() {
     let reward = Reward.template
       |> Reward.lens.startsAt .~ nil

--- a/Library/SharedFunctionsTests.swift
+++ b/Library/SharedFunctionsTests.swift
@@ -383,8 +383,6 @@ final class SharedFunctionsTests: TestCase {
     XCTAssertEqual(0, checkoutPropertiesData.addOnsCountTotal)
     XCTAssertEqual(0, checkoutPropertiesData.addOnsCountUnique)
     XCTAssertEqual("0.00", checkoutPropertiesData.addOnsMinimumUsd)
-    XCTAssertEqual("100.00", checkoutPropertiesData.amount)
-    XCTAssertEqual("10.00", checkoutPropertiesData.bonusAmount)
     XCTAssertEqual("10.00", checkoutPropertiesData.bonusAmountInUsd)
     XCTAssertEqual(nil, checkoutPropertiesData.checkoutId)
     XCTAssertEqual(
@@ -397,7 +395,6 @@ final class SharedFunctionsTests: TestCase {
     XCTAssertEqual("10.00", checkoutPropertiesData.rewardMinimumUsd)
     XCTAssertEqual("My Reward", checkoutPropertiesData.rewardTitle)
     XCTAssertEqual(true, checkoutPropertiesData.shippingEnabled)
-    XCTAssertEqual(10.0, checkoutPropertiesData.shippingAmount)
     XCTAssertEqual("10.00", checkoutPropertiesData.shippingAmountUsd)
     XCTAssertEqual(
       true,

--- a/Library/Tracking/KSRAnalytics.swift
+++ b/Library/Tracking/KSRAnalytics.swift
@@ -507,8 +507,6 @@ public final class KSRAnalytics {
     let addOnsCountTotal: Int?
     let addOnsCountUnique: Int?
     let addOnsMinimumUsd: String?
-    let amount: String
-    let bonusAmount: String
     let bonusAmountInUsd: String
     let checkoutId: Int?
     let estimatedDelivery: TimeInterval?
@@ -518,7 +516,6 @@ public final class KSRAnalytics {
     let rewardMinimumUsd: String
     let rewardTitle: String?
     let shippingEnabled: Bool
-    let shippingAmount: Double?
     let shippingAmountUsd: String?
     let userHasStoredApplePayCard: Bool
   }
@@ -1489,20 +1486,12 @@ public final class KSRAnalytics {
 
   private func sessionProperties(
     refTag: String?,
-    referrerCredit: String?,
+    referrerCredit _: String?,
     prefix: String = "session_"
   ) -> [String: Any] {
     var props: [String: Any] = [:]
 
-    let enabledFeatureFlags = self.config?.features
-      .filter { key, value in key.starts(with: "ios_") && value }
-      .keys
-      .sorted()
-
     props["apple_pay_capable"] = AppEnvironment.current.applePayCapabilities.applePayCapable()
-    props["apple_pay_device"] = AppEnvironment.current.applePayCapabilities.applePayDevice()
-    props["cellular_connection"] = AppEnvironment.current.coreTelephonyNetworkInfo
-      .serviceCurrentRadioAccessTechnology
     props["client"] = "native"
     props["current_variants"] = self.config?.abExperimentsArray.sorted()
     props["display_language"] = AppEnvironment.current.language.rawValue
@@ -1515,19 +1504,15 @@ public final class KSRAnalytics {
 
     props["app_build_number"] = self.bundle.infoDictionary?["CFBundleVersion"]
     props["app_release_version"] = self.bundle.infoDictionary?["CFBundleShortVersionString"]
-    props["enabled_features"] = enabledFeatureFlags
     props["is_voiceover_running"] = AppEnvironment.current.isVoiceOverRunning()
-    props["mp_lib"] = "kickstarter_ios"
     props["os"] = self.device.systemName
     props["os_version"] = self.device.systemVersion
     props["platform"] = self.clientPlatform
     props["screen_width"] = UInt(self.screen.bounds.width)
     props["user_agent"] = Service.userAgent
     props["user_logged_in"] = self.loggedInUser != nil
-    props["wifi_connection"] = Reachability.current == .wifi
 
     props["ref_tag"] = refTag
-    props["referrer_credit"] = referrerCredit
 
     return props.prefixedKeys(prefix)
   }
@@ -1583,23 +1568,18 @@ private func projectProperties(
 
   props["backers_count"] = project.stats.backersCount
   props["subcategory"] = project.category.name
-  props["subcategory_id"] = project.category.id
-  props["country"] = project.country.countryCode
   props["comments_count"] = project.stats.commentsCount ?? 0
   props["currency"] = project.country.currencyCode
   props["creator_uid"] = project.creator.id
   props["deadline"] = project.dates.deadline
-  props["goal"] = project.stats.goal
   props["has_add_ons"] = project.hasAddOns
   props["launched_at"] = project.dates.launchedAt
-  props["location"] = project.location.name
   props["name"] = project.name
   props["pid"] = project.id
   props["category"] = project.category.parentName
   props["category_id"] = project.category.parentId
   props["percent_raised"] = project.stats.fundingProgress
   props["state"] = project.state.rawValue
-  props["static_usd_rate"] = project.stats.staticUsdRate
   props["current_pledge_amount"] = project.stats.pledged
   props["current_amount_pledged_usd"] = project.stats.pledgedUsd
   props["goal_usd"] = project.stats.goalUsd
@@ -1676,12 +1656,10 @@ private func checkoutProperties(from data: KSRAnalytics.CheckoutPropertiesData, 
   -> [String: Any] {
   var result: [String: Any] = [:]
 
-  result["amount"] = data.amount
   result["amount_total_usd"] = data.revenueInUsd
   result["add_ons_count_total"] = data.addOnsCountTotal
   result["add_ons_count_unique"] = data.addOnsCountUnique
   result["add_ons_minimum_usd"] = data.addOnsMinimumUsd
-  result["bonus_amount"] = data.bonusAmount
   result["bonus_amount_usd"] = data.bonusAmountInUsd
   result["id"] = data.checkoutId
   result["payment_type"] = data.paymentType
@@ -1693,7 +1671,6 @@ private func checkoutProperties(from data: KSRAnalytics.CheckoutPropertiesData, 
   result["reward_shipping_enabled"] = data.shippingEnabled
   result["reward_shipping_preference"] = reward?.shipping.preference?.trackingString
   result["reward_title"] = data.rewardTitle
-  result["shipping_amount"] = data.shippingAmount
   result["shipping_amount_usd"] = data.shippingAmountUsd
   result["user_has_eligible_stored_apple_pay_card"] = data.userHasStoredApplePayCard
 
@@ -1757,7 +1734,6 @@ private func contextProperties(
   result["location"] = locationContext?.trackingString
   result["page"] = page?.rawValue
   result["section"] = sectionContext?.trackingString
-  result["timestamp"] = AppEnvironment.current.dateType.init().timeIntervalSince1970
   result["tab_bar_label"] = tabBarLabel?.trackingString
   result["type"] = typeContext?.trackingString
 

--- a/Library/Tracking/KSRAnalytics.swift
+++ b/Library/Tracking/KSRAnalytics.swift
@@ -1791,11 +1791,10 @@ private func shareTypeProperty(_ shareType: UIActivity.ActivityType?) -> String?
 
 // MARK: - User Properties
 
-private func userProperties(for user: User?, config: Config?, _ prefix: String = "user_") -> [String: Any] {
+private func userProperties(for user: User?, config _: Config?, _ prefix: String = "user_") -> [String: Any] {
   var props: [String: Any] = [:]
 
   props["backed_projects_count"] = user?.stats.backedProjectsCount
-  props["country"] = user?.location?.country ?? config?.countryCode
   props["created_projects_count"] = user?.stats.createdProjectsCount
   props["is_admin"] = user?.isAdmin
   props["launched_projects_count"] = user?.stats.memberProjectsCount

--- a/Library/Tracking/KSRAnalytics.swift
+++ b/Library/Tracking/KSRAnalytics.swift
@@ -1013,7 +1013,6 @@ public final class KSRAnalytics {
    - pledgeViewContext: The specific context applicable to the PledgeViewModel
    - checkoutData: the `CheckoutPropertiesData` associated with the given project and reward
    - refTag: the associated RefTag for the pledge
-   - cookieRefTag: The ref tag pulled from cookie storage when this project was shown.
 
    */
 
@@ -1022,8 +1021,7 @@ public final class KSRAnalytics {
     reward: Reward,
     pledgeViewContext: PledgeViewContext,
     checkoutData: CheckoutPropertiesData,
-    refTag: RefTag?,
-    cookieRefTag _: RefTag?
+    refTag: RefTag?
   ) {
     var props = projectProperties(from: project, loggedInUser: self.loggedInUser)
       .withAllValuesFrom(checkoutProperties(from: checkoutData, and: reward))
@@ -1354,7 +1352,6 @@ public final class KSRAnalytics {
    - parameter project: The project being viewed.
    - parameter refTag: The ref tag used when opening the project.
    - parameter sectionContext: The context referring to the section of the screen being interacted with.
-   - parameter cookieRefTag: The ref tag pulled from cookie storage when this project was shown.
    */
   public func trackProjectViewed(
     _ project: Project,
@@ -1563,6 +1560,7 @@ private func projectProperties(
 
   props["backers_count"] = project.stats.backersCount
   props["subcategory"] = project.category.name
+  props["country"] = project.country.countryCode
   props["comments_count"] = project.stats.commentsCount ?? 0
   props["currency"] = project.country.currencyCode
   props["creator_uid"] = project.creator.id

--- a/Library/Tracking/KSRAnalytics.swift
+++ b/Library/Tracking/KSRAnalytics.swift
@@ -1023,7 +1023,7 @@ public final class KSRAnalytics {
     pledgeViewContext: PledgeViewContext,
     checkoutData: CheckoutPropertiesData,
     refTag: RefTag?,
-    cookieRefTag: RefTag?
+    cookieRefTag _: RefTag?
   ) {
     var props = projectProperties(from: project, loggedInUser: self.loggedInUser)
       .withAllValuesFrom(checkoutProperties(from: checkoutData, and: reward))
@@ -1042,8 +1042,7 @@ public final class KSRAnalytics {
     self.track(
       event: NewApprovedEvent.pageViewed.rawValue,
       properties: props,
-      refTag: refTag?.stringTag,
-      referrerCredit: cookieRefTag?.stringTag
+      refTag: refTag?.stringTag
     )
   }
 
@@ -1360,8 +1359,7 @@ public final class KSRAnalytics {
   public func trackProjectViewed(
     _ project: Project,
     refTag: RefTag? = nil,
-    sectionContext: KSRAnalytics.SectionContext,
-    cookieRefTag: RefTag? = nil
+    sectionContext: KSRAnalytics.SectionContext
   ) {
     let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
       .withAllValuesFrom(contextProperties(sectionContext: sectionContext))
@@ -1370,8 +1368,7 @@ public final class KSRAnalytics {
       event: NewApprovedEvent.pageViewed.rawValue,
       page: .projectPage,
       properties: props,
-      refTag: refTag?.stringTag,
-      referrerCredit: cookieRefTag?.stringTag
+      refTag: refTag?.stringTag
     )
   }
 
@@ -1460,10 +1457,9 @@ public final class KSRAnalytics {
     event: String,
     page: KSRAnalytics.PageContext? = nil,
     properties: [String: Any] = [:],
-    refTag: String? = nil,
-    referrerCredit: String? = nil
+    refTag: String? = nil
   ) {
-    let props = self.sessionProperties(refTag: refTag, referrerCredit: referrerCredit)
+    let props = self.sessionProperties(refTag: refTag)
       .withAllValuesFrom(userProperties(for: self.loggedInUser, config: self.config))
       .withAllValuesFrom(contextProperties(page: page))
       .withAllValuesFrom(properties)
@@ -1486,7 +1482,6 @@ public final class KSRAnalytics {
 
   private func sessionProperties(
     refTag: String?,
-    referrerCredit _: String?,
     prefix: String = "session_"
   ) -> [String: Any] {
     var props: [String: Any] = [:]

--- a/Library/Tracking/KSRAnalyticsTests.swift
+++ b/Library/Tracking/KSRAnalyticsTests.swift
@@ -1599,10 +1599,8 @@ final class KSRAnalyticsTests: TestCase {
     let dataLakeClientProps = dataLakeClient.properties.last
     let segmentClientProps = segmentClient.properties.last
 
-    XCTAssertEqual("US", dataLakeClientProps?["user_country"] as? String)
     XCTAssertNil(dataLakeClientProps?["user_uid"])
 
-    XCTAssertEqual("US", segmentClientProps?["user_country"] as? String)
     XCTAssertNil(segmentClientProps?["user_uid"])
   }
 
@@ -1630,10 +1628,8 @@ final class KSRAnalyticsTests: TestCase {
     let dataLakeClientProps = dataLakeClient.properties.last
     let segmentClientProps = segmentClient.properties.last
 
-    XCTAssertEqual("US", dataLakeClientProps?["user_country"] as? String)
     XCTAssertEqual(10, dataLakeClientProps?["user_uid"] as? Int)
 
-    XCTAssertEqual("US", segmentClientProps?["user_country"] as? String)
     XCTAssertEqual(10, segmentClientProps?["user_uid"] as? Int)
   }
 

--- a/Library/Tracking/KSRAnalyticsTests.swift
+++ b/Library/Tracking/KSRAnalyticsTests.swift
@@ -709,8 +709,7 @@ final class KSRAnalyticsTests: TestCase {
       reward: reward,
       pledgeViewContext: .pledge,
       checkoutData: .template,
-      refTag: .activity,
-      cookieRefTag: .activity
+      refTag: .activity
     )
 
     let dataLakeClientProps = dataLakeClient.properties.last
@@ -744,8 +743,7 @@ final class KSRAnalyticsTests: TestCase {
       reward: reward,
       pledgeViewContext: .update,
       checkoutData: .template,
-      refTag: .activity,
-      cookieRefTag: .activity
+      refTag: .activity
     )
 
     let dataLakeClientProps = dataLakeClient.properties.last
@@ -779,8 +777,7 @@ final class KSRAnalyticsTests: TestCase {
       reward: reward,
       pledgeViewContext: .updateReward,
       checkoutData: .template,
-      refTag: .activity,
-      cookieRefTag: .activity
+      refTag: .activity
     )
 
     let dataLakeClientProps = dataLakeClient.properties.last
@@ -814,8 +811,7 @@ final class KSRAnalyticsTests: TestCase {
       reward: reward,
       pledgeViewContext: .changePaymentMethod,
       checkoutData: .template,
-      refTag: .activity,
-      cookieRefTag: .activity
+      refTag: .activity
     )
 
     let dataLakeClientProps = dataLakeClient.properties.last

--- a/Library/Tracking/KSRAnalyticsTests.swift
+++ b/Library/Tracking/KSRAnalyticsTests.swift
@@ -240,7 +240,7 @@ final class KSRAnalyticsTests: TestCase {
       |> Project.lens.prelaunchActivated .~ true
 
     ksrAnalytics
-      .trackProjectViewed(project, refTag: .discovery, sectionContext: .overview, cookieRefTag: .recommended)
+      .trackProjectViewed(project, refTag: .discovery, sectionContext: .overview)
 
     XCTAssertEqual(1, dataLakeClient.properties.count)
     XCTAssertEqual(1, segmentClient.properties.count)
@@ -337,7 +337,7 @@ final class KSRAnalyticsTests: TestCase {
       segmentClient: segmentClient
     )
 
-    ksrAnalytics.trackProjectViewed(project, refTag: nil, sectionContext: .overview, cookieRefTag: nil)
+    ksrAnalytics.trackProjectViewed(project, refTag: nil, sectionContext: .overview)
 
     XCTAssertEqual(1, dataLakeClient.properties.count)
     XCTAssertEqual(1, segmentClient.properties.count)
@@ -376,7 +376,7 @@ final class KSRAnalyticsTests: TestCase {
       segmentClient: segmentClient
     )
 
-    ksrAnalytics.trackProjectViewed(project, refTag: nil, sectionContext: .overview, cookieRefTag: nil)
+    ksrAnalytics.trackProjectViewed(project, refTag: nil, sectionContext: .overview)
     XCTAssertEqual(1, dataLakeClient.properties.count)
     XCTAssertEqual(1, segmentClient.properties.count)
 
@@ -414,7 +414,7 @@ final class KSRAnalyticsTests: TestCase {
       segmentClient: segmentClient
     )
 
-    ksrAnalytics.trackProjectViewed(project, refTag: nil, sectionContext: .overview, cookieRefTag: nil)
+    ksrAnalytics.trackProjectViewed(project, refTag: nil, sectionContext: .overview)
     XCTAssertEqual(1, dataLakeClient.properties.count)
     XCTAssertEqual(1, segmentClient.properties.count)
 
@@ -452,7 +452,7 @@ final class KSRAnalyticsTests: TestCase {
       segmentClient: segmentClient
     )
 
-    ksrAnalytics.trackProjectViewed(project, refTag: nil, sectionContext: .overview, cookieRefTag: nil)
+    ksrAnalytics.trackProjectViewed(project, refTag: nil, sectionContext: .overview)
     XCTAssertEqual(1, dataLakeClient.properties.count)
     XCTAssertEqual(1, segmentClient.properties.count)
 
@@ -679,7 +679,7 @@ final class KSRAnalyticsTests: TestCase {
     let ksrAnalytics = KSRAnalytics(dataLakeClient: dataLakeClient, segmentClient: segmentClient)
 
     ksrAnalytics
-      .trackProjectViewed(project, refTag: .discovery, sectionContext: .campaign, cookieRefTag: .discovery)
+      .trackProjectViewed(project, refTag: .discovery, sectionContext: .campaign)
 
     XCTAssertEqual(["Page Viewed"], dataLakeClient.events)
     XCTAssertEqual(["project"], dataLakeClient.properties(forKey: "context_page"))

--- a/Library/Tracking/KSRAnalyticsTests.swift
+++ b/Library/Tracking/KSRAnalyticsTests.swift
@@ -45,22 +45,10 @@ final class KSRAnalyticsTests: TestCase {
       ["native_checkout[experimental]", "other_experiment[control]"],
       dataLakeClientProperties?["session_current_variants"] as? [String]
     )
-    XCTAssertEqual(
-      [
-        "ios_enabled_feature"
-      ],
-      dataLakeClientProperties?["session_enabled_features"] as? [String]
-    )
 
     XCTAssertEqual(
       ["native_checkout[experimental]", "other_experiment[control]"],
       segmentClientProperties?["session_current_variants"] as? [String]
-    )
-    XCTAssertEqual(
-      [
-        "ios_enabled_feature"
-      ],
-      segmentClientProperties?["session_enabled_features"] as? [String]
     )
 
     XCTAssertEqual("native", dataLakeClientProperties?["session_client"] as? String)
@@ -70,20 +58,15 @@ final class KSRAnalyticsTests: TestCase {
     XCTAssertEqual("Apple", dataLakeClientProperties?["session_device_manufacturer"] as? String)
     XCTAssertEqual("Portrait", dataLakeClientProperties?["session_device_orientation"] as? String)
     XCTAssertEqual("abc-123", dataLakeClientProperties?["session_device_distinct_id"] as? String)
-    XCTAssertEqual(
-      ["service": "wifi"],
-      dataLakeClientProperties?["session_cellular_connection"] as? [String: String]?
-    )
 
     XCTAssertEqual("MockSystemName", dataLakeClientProperties?["session_os"] as? String)
     XCTAssertEqual("MockSystemVersion", dataLakeClientProperties?["session_os_version"] as? String)
     XCTAssertEqual(UInt(screen.bounds.width), dataLakeClientProperties?["session_screen_width"] as? UInt)
-    XCTAssertEqual("kickstarter_ios", dataLakeClientProperties?["session_mp_lib"] as? String)
     XCTAssertEqual(false, dataLakeClientProperties?["session_user_logged_in"] as? Bool)
     XCTAssertEqual("ios", dataLakeClientProperties?["session_platform"] as? String)
     XCTAssertEqual("en", dataLakeClientProperties?["session_display_language"] as? String)
 
-    XCTAssertEqual(23, dataLakeClientProperties?.keys.filter { $0.hasPrefix("session_") }.count)
+    XCTAssertEqual(18, dataLakeClientProperties?.keys.filter { $0.hasPrefix("session_") }.count)
 
     XCTAssertEqual("native", segmentClientProperties?["session_client"] as? String)
     XCTAssertEqual("1234567890", segmentClientProperties?["session_app_build_number"] as? String)
@@ -92,20 +75,15 @@ final class KSRAnalyticsTests: TestCase {
     XCTAssertEqual("Apple", segmentClientProperties?["session_device_manufacturer"] as? String)
     XCTAssertEqual("Portrait", segmentClientProperties?["session_device_orientation"] as? String)
     XCTAssertEqual("abc-123", segmentClientProperties?["session_device_distinct_id"] as? String)
-    XCTAssertEqual(
-      ["service": "wifi"],
-      segmentClientProperties?["session_cellular_connection"] as? [String: String]?
-    )
 
     XCTAssertEqual("MockSystemName", segmentClientProperties?["session_os"] as? String)
     XCTAssertEqual("MockSystemVersion", segmentClientProperties?["session_os_version"] as? String)
     XCTAssertEqual(UInt(screen.bounds.width), segmentClientProperties?["session_screen_width"] as? UInt)
-    XCTAssertEqual("kickstarter_ios", segmentClientProperties?["session_mp_lib"] as? String)
     XCTAssertEqual(false, segmentClientProperties?["session_user_logged_in"] as? Bool)
     XCTAssertEqual("ios", segmentClientProperties?["session_platform"] as? String)
     XCTAssertEqual("en", segmentClientProperties?["session_display_language"] as? String)
 
-    XCTAssertEqual(23, segmentClientProperties?.keys.filter { $0.hasPrefix("session_") }.count)
+    XCTAssertEqual(18, segmentClientProperties?.keys.filter { $0.hasPrefix("session_") }.count)
   }
 
   func testSessionProperties_Language() {
@@ -272,26 +250,20 @@ final class KSRAnalyticsTests: TestCase {
 
     XCTAssertEqual("Page Viewed", dataLakeClient.events.last)
     XCTAssertEqual(project.stats.backersCount, dataLakeClientProperties?["project_backers_count"] as? Int)
-    XCTAssertEqual(project.country.countryCode, dataLakeClientProperties?["project_country"] as? String)
     XCTAssertEqual(project.country.currencyCode, dataLakeClientProperties?["project_currency"] as? String)
-    XCTAssertEqual(project.stats.goal, dataLakeClientProperties?["project_goal"] as? Int)
     XCTAssertEqual(project.id, dataLakeClientProperties?["project_pid"] as? Int)
     XCTAssertEqual(
       project.stats.fundingProgress,
       dataLakeClientProperties?["project_percent_raised"] as? Float
     )
     XCTAssertEqual(project.category.name, dataLakeClientProperties?["project_subcategory"] as? String)
-    XCTAssertEqual(123, dataLakeClientProperties?["project_subcategory_id"] as? Int)
     XCTAssertEqual("Art", dataLakeClientProperties?["project_category"] as? String)
-    XCTAssertEqual(321, dataLakeClientProperties?["project_category_id"] as? Int)
-    XCTAssertEqual(project.location.name, dataLakeClientProperties?["project_location"] as? String)
     XCTAssertEqual(project.stats.commentsCount, dataLakeClientProperties?["project_comments_count"] as? Int)
     XCTAssertEqual(project.creator.id, dataLakeClientProperties?["project_creator_uid"] as? Int)
     XCTAssertEqual(24 * 15, dataLakeClientProperties?["project_hours_remaining"] as? Int)
     XCTAssertEqual(30, dataLakeClientProperties?["project_duration"] as? Int)
     XCTAssertEqual(1_476_657_315, dataLakeClientProperties?["project_deadline"] as? Double)
     XCTAssertEqual(1_474_065_315, dataLakeClientProperties?["project_launched_at"] as? Double)
-    XCTAssertEqual(2, dataLakeClientProperties?["project_static_usd_rate"] as? Float)
     XCTAssertEqual("live", dataLakeClientProperties?["project_state"] as? String)
     XCTAssertEqual(project.stats.pledged, dataLakeClientProperties?["project_current_pledge_amount"] as? Int)
     XCTAssertEqual(2_000, dataLakeClientProperties?["project_current_amount_pledged_usd"] as? Float)
@@ -311,33 +283,26 @@ final class KSRAnalyticsTests: TestCase {
     XCTAssertNil(dataLakeClientProperties?["project_user_is_backer"])
     XCTAssertNil(dataLakeClientProperties?["project_user_has_starred"])
 
-    XCTAssertEqual(30, dataLakeClientProperties?.keys.filter { $0.hasPrefix("project_") }.count)
+    XCTAssertEqual(25, dataLakeClientProperties?.keys.filter { $0.hasPrefix("project_") }.count)
 
     XCTAssertEqual("discovery", dataLakeClientProperties?["session_ref_tag"] as? String)
-    XCTAssertEqual("recommended", dataLakeClientProperties?["session_referrer_credit"] as? String)
 
     XCTAssertEqual("Page Viewed", segmentClient.events.last)
     XCTAssertEqual(project.stats.backersCount, segmentClientProperties?["project_backers_count"] as? Int)
-    XCTAssertEqual(project.country.countryCode, segmentClientProperties?["project_country"] as? String)
     XCTAssertEqual(project.country.currencyCode, segmentClientProperties?["project_currency"] as? String)
-    XCTAssertEqual(project.stats.goal, segmentClientProperties?["project_goal"] as? Int)
     XCTAssertEqual(project.id, segmentClientProperties?["project_pid"] as? Int)
     XCTAssertEqual(
       project.stats.fundingProgress,
       segmentClientProperties?["project_percent_raised"] as? Float
     )
     XCTAssertEqual(project.category.name, segmentClientProperties?["project_subcategory"] as? String)
-    XCTAssertEqual(123, segmentClientProperties?["project_subcategory_id"] as? Int)
     XCTAssertEqual("Art", segmentClientProperties?["project_category"] as? String)
-    XCTAssertEqual(321, segmentClientProperties?["project_category_id"] as? Int)
-    XCTAssertEqual(project.location.name, segmentClientProperties?["project_location"] as? String)
     XCTAssertEqual(project.stats.commentsCount, dataLakeClientProperties?["project_comments_count"] as? Int)
     XCTAssertEqual(project.creator.id, segmentClientProperties?["project_creator_uid"] as? Int)
     XCTAssertEqual(24 * 15, segmentClientProperties?["project_hours_remaining"] as? Int)
     XCTAssertEqual(30, segmentClientProperties?["project_duration"] as? Int)
     XCTAssertEqual(1_476_657_315, segmentClientProperties?["project_deadline"] as? Double)
     XCTAssertEqual(1_474_065_315, segmentClientProperties?["project_launched_at"] as? Double)
-    XCTAssertEqual(2, segmentClientProperties?["project_static_usd_rate"] as? Float)
     XCTAssertEqual("live", segmentClientProperties?["project_state"] as? String)
     XCTAssertEqual(project.stats.pledged, segmentClientProperties?["project_current_pledge_amount"] as? Int)
     XCTAssertEqual(2_000, segmentClientProperties?["project_current_amount_pledged_usd"] as? Float)
@@ -354,10 +319,9 @@ final class KSRAnalyticsTests: TestCase {
     XCTAssertNil(segmentClientProperties?["project_user_is_backer"])
     XCTAssertNil(segmentClientProperties?["project_user_has_starred"])
 
-    XCTAssertEqual(30, segmentClientProperties?.keys.filter { $0.hasPrefix("project_") }.count)
+    XCTAssertEqual(25, segmentClientProperties?.keys.filter { $0.hasPrefix("project_") }.count)
 
     XCTAssertEqual("discovery", segmentClientProperties?["session_ref_tag"] as? String)
-    XCTAssertEqual("recommended", segmentClientProperties?["session_referrer_credit"] as? String)
   }
 
   func testProjectProperties_LoggedInUser() {
@@ -389,14 +353,14 @@ final class KSRAnalyticsTests: TestCase {
       dataLakeClientProperties?["project_tags"] as? String
     )
 
-    XCTAssertEqual(29, dataLakeClientProperties?.keys.filter { $0.hasPrefix("project_") }.count)
+    XCTAssertEqual(24, dataLakeClientProperties?.keys.filter { $0.hasPrefix("project_") }.count)
 
     XCTAssertEqual(false, segmentClientProperties?["project_user_is_project_creator"] as? Bool)
     XCTAssertEqual(false, segmentClientProperties?["project_user_is_backer"] as? Bool)
     XCTAssertEqual(false, segmentClientProperties?["project_user_has_watched"] as? Bool)
     XCTAssertEqual(project.tags?.joined(separator: ", "), segmentClientProperties?["project_tags"] as? String)
 
-    XCTAssertEqual(29, segmentClientProperties?.keys.filter { $0.hasPrefix("project_") }.count)
+    XCTAssertEqual(24, segmentClientProperties?.keys.filter { $0.hasPrefix("project_") }.count)
   }
 
   func testProjectProperties_LoggedInBacker() {
@@ -427,14 +391,14 @@ final class KSRAnalyticsTests: TestCase {
       dataLakeClientProperties?["project_tags"] as? String
     )
 
-    XCTAssertEqual(29, dataLakeClientProperties?.keys.filter { $0.hasPrefix("project_") }.count)
+    XCTAssertEqual(24, dataLakeClientProperties?.keys.filter { $0.hasPrefix("project_") }.count)
 
     XCTAssertEqual(false, segmentClientProperties?["project_user_is_project_creator"] as? Bool)
     XCTAssertEqual(true, segmentClientProperties?["project_user_is_backer"] as? Bool)
     XCTAssertEqual(false, segmentClientProperties?["project_user_has_watched"] as? Bool)
     XCTAssertEqual(project.tags?.joined(separator: ", "), segmentClientProperties?["project_tags"] as? String)
 
-    XCTAssertEqual(29, segmentClientProperties?.keys.filter { $0.hasPrefix("project_") }.count)
+    XCTAssertEqual(24, segmentClientProperties?.keys.filter { $0.hasPrefix("project_") }.count)
   }
 
   func testProjectProperties_LoggedInStarrer() {
@@ -465,14 +429,14 @@ final class KSRAnalyticsTests: TestCase {
       dataLakeClientProperties?["project_tags"] as? String
     )
 
-    XCTAssertEqual(29, dataLakeClientProperties?.keys.filter { $0.hasPrefix("project_") }.count)
+    XCTAssertEqual(24, dataLakeClientProperties?.keys.filter { $0.hasPrefix("project_") }.count)
 
     XCTAssertEqual(false, segmentClientProperties?["project_user_is_project_creator"] as? Bool)
     XCTAssertEqual(false, segmentClientProperties?["project_user_is_backer"] as? Bool)
     XCTAssertEqual(true, segmentClientProperties?["project_user_has_watched"] as? Bool)
     XCTAssertEqual(project.tags?.joined(separator: ", "), segmentClientProperties?["project_tags"] as? String)
 
-    XCTAssertEqual(29, segmentClientProperties?.keys.filter { $0.hasPrefix("project_") }.count)
+    XCTAssertEqual(24, segmentClientProperties?.keys.filter { $0.hasPrefix("project_") }.count)
   }
 
   func testProjectProperties_LoggedInCreator() {
@@ -503,14 +467,14 @@ final class KSRAnalyticsTests: TestCase {
       dataLakeClientProperties?["project_tags"] as? String
     )
 
-    XCTAssertEqual(29, dataLakeClientProperties?.keys.filter { $0.hasPrefix("project_") }.count)
+    XCTAssertEqual(24, dataLakeClientProperties?.keys.filter { $0.hasPrefix("project_") }.count)
 
     XCTAssertEqual(true, segmentClientProperties?["project_user_is_project_creator"] as? Bool)
     XCTAssertEqual(false, segmentClientProperties?["project_user_is_backer"] as? Bool)
     XCTAssertEqual(false, segmentClientProperties?["project_user_has_watched"] as? Bool)
     XCTAssertEqual(project.tags?.joined(separator: ", "), segmentClientProperties?["project_tags"] as? String)
 
-    XCTAssertEqual(29, segmentClientProperties?.keys.filter { $0.hasPrefix("project_") }.count)
+    XCTAssertEqual(24, segmentClientProperties?.keys.filter { $0.hasPrefix("project_") }.count)
   }
 
   // MARK: - Discovery Properties Tests
@@ -721,7 +685,6 @@ final class KSRAnalyticsTests: TestCase {
     XCTAssertEqual(["project"], dataLakeClient.properties(forKey: "context_page"))
     XCTAssertEqual(["campaign"], dataLakeClient.properties(forKey: "context_section"))
     XCTAssertEqual(["discovery"], dataLakeClient.properties(forKey: "session_ref_tag"))
-    XCTAssertEqual(["discovery"], dataLakeClient.properties(forKey: "session_referrer_credit"))
 
     self.assertProjectProperties(dataLakeClient.properties.last)
 
@@ -729,7 +692,6 @@ final class KSRAnalyticsTests: TestCase {
     XCTAssertEqual(["project"], segmentClient.properties(forKey: "context_page"))
     XCTAssertEqual(["campaign"], segmentClient.properties(forKey: "context_section"))
     XCTAssertEqual(["discovery"], segmentClient.properties(forKey: "session_ref_tag"))
-    XCTAssertEqual(["discovery"], segmentClient.properties(forKey: "session_referrer_credit"))
 
     self.assertProjectProperties(segmentClient.properties.last)
   }
@@ -2320,21 +2282,15 @@ final class KSRAnalyticsTests: TestCase {
    */
   private func assertProjectProperties(_ props: [String: Any]?) {
     XCTAssertEqual(10, props?["project_backers_count"] as? Int)
-    XCTAssertEqual("US", props?["project_country"] as? String)
     XCTAssertEqual("USD", props?["project_currency"] as? String)
-    XCTAssertEqual(2_000, props?["project_goal"] as? Int)
     XCTAssertEqual(1, props?["project_pid"] as? Int)
     XCTAssertEqual(0.50, props?["project_percent_raised"] as? Float)
     XCTAssertEqual("Art", props?["project_subcategory"] as? String)
-    XCTAssertEqual(1, props?["project_subcategory_id"] as? Int)
-
-    XCTAssertEqual("Brooklyn", props?["project_location"] as? String)
     XCTAssertEqual(1, props?["project_creator_uid"] as? Int)
     XCTAssertEqual(24 * 15, props?["project_hours_remaining"] as? Int)
     XCTAssertEqual(30, props?["project_duration"] as? Int)
     XCTAssertEqual(1_476_657_315, props?["project_deadline"] as? Double)
     XCTAssertEqual(1_474_065_315, props?["project_launched_at"] as? Double)
-    XCTAssertEqual(1, props?["project_static_usd_rate"] as? Float)
     XCTAssertEqual("live", props?["project_state"] as? String)
     XCTAssertEqual(1_000, props?["project_current_pledge_amount"] as? Int)
     XCTAssertEqual(1_000, props?["project_current_amount_pledged_usd"] as? Float)
@@ -2349,7 +2305,6 @@ final class KSRAnalyticsTests: TestCase {
     XCTAssertNil(props?["project_user_is_backer"])
     XCTAssertNil(props?["project_user_has_starred"])
     XCTAssertNil(props?["project_category"] as? String)
-    XCTAssertNil(props?["project_category_id"] as? String)
     XCTAssertNil(props?["project_prelaunch_activated"] as? Bool)
   }
 
@@ -2369,8 +2324,6 @@ final class KSRAnalyticsTests: TestCase {
     XCTAssertEqual(2, props?["checkout_add_ons_count_total"] as? Int)
     XCTAssertEqual(1, props?["checkout_add_ons_count_unique"] as? Int)
     XCTAssertEqual("8.00", props?["checkout_add_ons_minimum_usd"] as? String)
-    XCTAssertEqual("43.00", props?["checkout_amount"] as? String)
-    XCTAssertEqual("10.00", props?["checkout_bonus_amount"] as? String)
     XCTAssertEqual("10.00", props?["checkout_bonus_amount_usd"] as? String)
     XCTAssertEqual("CREDIT_CARD", props?["checkout_payment_type"] as? String)
     XCTAssertEqual("SUPER reward", props?["checkout_reward_title"] as? String)
@@ -2382,7 +2335,6 @@ final class KSRAnalyticsTests: TestCase {
     XCTAssertEqual(true, props?["checkout_reward_shipping_enabled"] as? Bool)
     XCTAssertEqual("restricted", props?["checkout_reward_shipping_preference"] as? String)
     XCTAssertEqual(true, props?["checkout_user_has_eligible_stored_apple_pay_card"] as? Bool)
-    XCTAssertEqual(10.00, props?["checkout_shipping_amount"] as? Double)
     XCTAssertEqual("10.00", props?["checkout_shipping_amount_usd"] as? String)
     XCTAssertEqual(12_345_678, props?["checkout_reward_estimated_delivery_on"] as? TimeInterval)
   }
@@ -2411,8 +2363,6 @@ extension KSRAnalytics.CheckoutPropertiesData {
     addOnsCountTotal: 2,
     addOnsCountUnique: 1,
     addOnsMinimumUsd: "8.00",
-    amount: "43.00",
-    bonusAmount: "10.00",
     bonusAmountInUsd: "10.00",
     checkoutId: 1,
     estimatedDelivery: 12_345_678,
@@ -2422,7 +2372,6 @@ extension KSRAnalytics.CheckoutPropertiesData {
     rewardMinimumUsd: "5.00",
     rewardTitle: "SUPER reward",
     shippingEnabled: true,
-    shippingAmount: 10,
     shippingAmountUsd: "10.00",
     userHasStoredApplePayCard: true
   )

--- a/Library/Tracking/KSRAnalyticsTests.swift
+++ b/Library/Tracking/KSRAnalyticsTests.swift
@@ -283,7 +283,7 @@ final class KSRAnalyticsTests: TestCase {
     XCTAssertNil(dataLakeClientProperties?["project_user_is_backer"])
     XCTAssertNil(dataLakeClientProperties?["project_user_has_starred"])
 
-    XCTAssertEqual(25, dataLakeClientProperties?.keys.filter { $0.hasPrefix("project_") }.count)
+    XCTAssertEqual(26, dataLakeClientProperties?.keys.filter { $0.hasPrefix("project_") }.count)
 
     XCTAssertEqual("discovery", dataLakeClientProperties?["session_ref_tag"] as? String)
 
@@ -319,7 +319,7 @@ final class KSRAnalyticsTests: TestCase {
     XCTAssertNil(segmentClientProperties?["project_user_is_backer"])
     XCTAssertNil(segmentClientProperties?["project_user_has_starred"])
 
-    XCTAssertEqual(25, segmentClientProperties?.keys.filter { $0.hasPrefix("project_") }.count)
+    XCTAssertEqual(26, segmentClientProperties?.keys.filter { $0.hasPrefix("project_") }.count)
 
     XCTAssertEqual("discovery", segmentClientProperties?["session_ref_tag"] as? String)
   }
@@ -353,14 +353,14 @@ final class KSRAnalyticsTests: TestCase {
       dataLakeClientProperties?["project_tags"] as? String
     )
 
-    XCTAssertEqual(24, dataLakeClientProperties?.keys.filter { $0.hasPrefix("project_") }.count)
+    XCTAssertEqual(25, dataLakeClientProperties?.keys.filter { $0.hasPrefix("project_") }.count)
 
     XCTAssertEqual(false, segmentClientProperties?["project_user_is_project_creator"] as? Bool)
     XCTAssertEqual(false, segmentClientProperties?["project_user_is_backer"] as? Bool)
     XCTAssertEqual(false, segmentClientProperties?["project_user_has_watched"] as? Bool)
     XCTAssertEqual(project.tags?.joined(separator: ", "), segmentClientProperties?["project_tags"] as? String)
 
-    XCTAssertEqual(24, segmentClientProperties?.keys.filter { $0.hasPrefix("project_") }.count)
+    XCTAssertEqual(25, segmentClientProperties?.keys.filter { $0.hasPrefix("project_") }.count)
   }
 
   func testProjectProperties_LoggedInBacker() {
@@ -391,14 +391,14 @@ final class KSRAnalyticsTests: TestCase {
       dataLakeClientProperties?["project_tags"] as? String
     )
 
-    XCTAssertEqual(24, dataLakeClientProperties?.keys.filter { $0.hasPrefix("project_") }.count)
+    XCTAssertEqual(25, dataLakeClientProperties?.keys.filter { $0.hasPrefix("project_") }.count)
 
     XCTAssertEqual(false, segmentClientProperties?["project_user_is_project_creator"] as? Bool)
     XCTAssertEqual(true, segmentClientProperties?["project_user_is_backer"] as? Bool)
     XCTAssertEqual(false, segmentClientProperties?["project_user_has_watched"] as? Bool)
     XCTAssertEqual(project.tags?.joined(separator: ", "), segmentClientProperties?["project_tags"] as? String)
 
-    XCTAssertEqual(24, segmentClientProperties?.keys.filter { $0.hasPrefix("project_") }.count)
+    XCTAssertEqual(25, segmentClientProperties?.keys.filter { $0.hasPrefix("project_") }.count)
   }
 
   func testProjectProperties_LoggedInStarrer() {
@@ -429,14 +429,14 @@ final class KSRAnalyticsTests: TestCase {
       dataLakeClientProperties?["project_tags"] as? String
     )
 
-    XCTAssertEqual(24, dataLakeClientProperties?.keys.filter { $0.hasPrefix("project_") }.count)
+    XCTAssertEqual(25, dataLakeClientProperties?.keys.filter { $0.hasPrefix("project_") }.count)
 
     XCTAssertEqual(false, segmentClientProperties?["project_user_is_project_creator"] as? Bool)
     XCTAssertEqual(false, segmentClientProperties?["project_user_is_backer"] as? Bool)
     XCTAssertEqual(true, segmentClientProperties?["project_user_has_watched"] as? Bool)
     XCTAssertEqual(project.tags?.joined(separator: ", "), segmentClientProperties?["project_tags"] as? String)
 
-    XCTAssertEqual(24, segmentClientProperties?.keys.filter { $0.hasPrefix("project_") }.count)
+    XCTAssertEqual(25, segmentClientProperties?.keys.filter { $0.hasPrefix("project_") }.count)
   }
 
   func testProjectProperties_LoggedInCreator() {
@@ -467,14 +467,14 @@ final class KSRAnalyticsTests: TestCase {
       dataLakeClientProperties?["project_tags"] as? String
     )
 
-    XCTAssertEqual(24, dataLakeClientProperties?.keys.filter { $0.hasPrefix("project_") }.count)
+    XCTAssertEqual(25, dataLakeClientProperties?.keys.filter { $0.hasPrefix("project_") }.count)
 
     XCTAssertEqual(true, segmentClientProperties?["project_user_is_project_creator"] as? Bool)
     XCTAssertEqual(false, segmentClientProperties?["project_user_is_backer"] as? Bool)
     XCTAssertEqual(false, segmentClientProperties?["project_user_has_watched"] as? Bool)
     XCTAssertEqual(project.tags?.joined(separator: ", "), segmentClientProperties?["project_tags"] as? String)
 
-    XCTAssertEqual(24, segmentClientProperties?.keys.filter { $0.hasPrefix("project_") }.count)
+    XCTAssertEqual(25, segmentClientProperties?.keys.filter { $0.hasPrefix("project_") }.count)
   }
 
   // MARK: - Discovery Properties Tests

--- a/Library/ViewModels/PledgeViewModel.swift
+++ b/Library/ViewModels/PledgeViewModel.swift
@@ -849,8 +849,7 @@ public class PledgeViewModel: PledgeViewModelType, PledgeViewModelInputs, Pledge
           reward: baseReward,
           pledgeViewContext: pledgeViewContext,
           checkoutData: checkoutData,
-          refTag: refTag,
-          cookieRefTag: cookieRefTag
+          refTag: refTag
         )
       }
 

--- a/Library/ViewModels/PledgeViewModel.swift
+++ b/Library/ViewModels/PledgeViewModel.swift
@@ -828,8 +828,6 @@ public class PledgeViewModel: PledgeViewModelType, PledgeViewModelInputs, Pledge
     trackCheckoutPageViewData
       .observeValues { project, baseReward, rewards, selectedQuantities, refTag, additionalPledgeAmount, pledgeTotal, shippingTotal, pledgeViewContext in
 
-        let cookieRefTag = cookieRefTagFor(project: project) ?? refTag
-
         AppEnvironment.current.optimizelyClient?.track(eventName: "Pledge Screen Viewed")
 
         let checkoutData = checkoutProperties(

--- a/Library/ViewModels/PledgeViewModelTests.swift
+++ b/Library/ViewModels/PledgeViewModelTests.swift
@@ -5700,6 +5700,7 @@ final class PledgeViewModelTests: TestCase {
 
       XCTAssertEqual(dataLakeTrackingClient.properties(forKey: "project_subcategory"), ["Illustration"])
       XCTAssertEqual(dataLakeTrackingClient.properties(forKey: "project_category"), ["Art"])
+      XCTAssertEqual(dataLakeTrackingClient.properties(forKey: "project_country"), ["US"])
       XCTAssertEqual(
         dataLakeTrackingClient.properties(forKey: "project_user_has_watched", as: Bool.self),
         [true]
@@ -5712,6 +5713,7 @@ final class PledgeViewModelTests: TestCase {
 
       XCTAssertEqual(segmentClient.properties(forKey: "project_subcategory"), ["Illustration"])
       XCTAssertEqual(segmentClient.properties(forKey: "project_category"), ["Art"])
+      XCTAssertEqual(segmentClient.properties(forKey: "project_country"), ["US"])
       XCTAssertEqual(
         segmentClient.properties(forKey: "project_user_has_watched", as: Bool.self),
         [true]

--- a/Library/ViewModels/PledgeViewModelTests.swift
+++ b/Library/ViewModels/PledgeViewModelTests.swift
@@ -5528,10 +5528,8 @@ final class PledgeViewModelTests: TestCase {
       XCTAssertEqual(segmentClient.properties(forKey: "session_ref_tag"), ["discovery"])
 
       XCTAssertEqual(dataLakeClient.properties(forKey: "session_user_logged_in", as: Bool.self), [false])
-      XCTAssertEqual(dataLakeClient.properties(forKey: "user_country"), ["US"])
       XCTAssertEqual(dataLakeClient.properties(forKey: "user_uid", as: Int.self), [nil])
       XCTAssertEqual(segmentClient.properties(forKey: "session_user_logged_in", as: Bool.self), [false])
-      XCTAssertEqual(segmentClient.properties(forKey: "user_country"), ["US"])
       XCTAssertEqual(segmentClient.properties(forKey: "user_uid", as: Int.self), [nil])
 
       XCTAssertEqual(dataLakeClient.properties(forKey: "project_subcategory"), ["Illustration"])
@@ -5698,7 +5696,6 @@ final class PledgeViewModelTests: TestCase {
         dataLakeTrackingClient.properties(forKey: "session_user_logged_in", as: Bool.self),
         [true]
       )
-      XCTAssertEqual(dataLakeTrackingClient.properties(forKey: "user_country"), ["US"])
       XCTAssertEqual(dataLakeTrackingClient.properties(forKey: "user_uid", as: Int.self), [1])
 
       XCTAssertEqual(dataLakeTrackingClient.properties(forKey: "project_subcategory"), ["Illustration"])
@@ -5711,7 +5708,6 @@ final class PledgeViewModelTests: TestCase {
         segmentClient.properties(forKey: "session_user_logged_in", as: Bool.self),
         [true]
       )
-      XCTAssertEqual(segmentClient.properties(forKey: "user_country"), ["US"])
       XCTAssertEqual(segmentClient.properties(forKey: "user_uid", as: Int.self), [1])
 
       XCTAssertEqual(segmentClient.properties(forKey: "project_subcategory"), ["Illustration"])

--- a/Library/ViewModels/PledgeViewModelTests.swift
+++ b/Library/ViewModels/PledgeViewModelTests.swift
@@ -5576,7 +5576,6 @@ final class PledgeViewModelTests: TestCase {
     XCTAssertEqual(self.optimizelyClient.trackedAttributes?["user_display_language"] as? String, "en")
 
     XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_ref_tag"] as? String, nil)
-    XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_referrer_credit"] as? String, nil)
     XCTAssertEqual(
       self.optimizelyClient.trackedAttributes?["session_os_version"] as? String,
       "MockSystemVersion"
@@ -5692,15 +5691,8 @@ final class PledgeViewModelTests: TestCase {
       XCTAssertEqual(["Page Viewed"], segmentClient.events)
 
       XCTAssertEqual(dataLakeTrackingClient.properties(forKey: "session_ref_tag"), ["discovery"])
-      XCTAssertEqual(
-        dataLakeTrackingClient.properties(forKey: "session_referrer_credit"),
-        ["discovery"]
-      )
+
       XCTAssertEqual(segmentClient.properties(forKey: "session_ref_tag"), ["discovery"])
-      XCTAssertEqual(
-        segmentClient.properties(forKey: "session_referrer_credit"),
-        ["discovery"]
-      )
 
       XCTAssertEqual(
         dataLakeTrackingClient.properties(forKey: "session_user_logged_in", as: Bool.self),
@@ -5711,7 +5703,6 @@ final class PledgeViewModelTests: TestCase {
 
       XCTAssertEqual(dataLakeTrackingClient.properties(forKey: "project_subcategory"), ["Illustration"])
       XCTAssertEqual(dataLakeTrackingClient.properties(forKey: "project_category"), ["Art"])
-      XCTAssertEqual(dataLakeTrackingClient.properties(forKey: "project_country"), ["US"])
       XCTAssertEqual(
         dataLakeTrackingClient.properties(forKey: "project_user_has_watched", as: Bool.self),
         [true]
@@ -5725,7 +5716,6 @@ final class PledgeViewModelTests: TestCase {
 
       XCTAssertEqual(segmentClient.properties(forKey: "project_subcategory"), ["Illustration"])
       XCTAssertEqual(segmentClient.properties(forKey: "project_category"), ["Art"])
-      XCTAssertEqual(segmentClient.properties(forKey: "project_country"), ["US"])
       XCTAssertEqual(
         segmentClient.properties(forKey: "project_user_has_watched", as: Bool.self),
         [true]

--- a/Library/ViewModels/PledgeViewModelTests.swift
+++ b/Library/ViewModels/PledgeViewModelTests.swift
@@ -1628,8 +1628,6 @@ final class PledgeViewModelTests: TestCase {
         addOnsCountTotal: 0,
         addOnsCountUnique: 0,
         addOnsMinimumUsd: "0.00",
-        amount: "15.00",
-        bonusAmount: "10.00",
         bonusAmountInUsd: "10.00",
         checkoutId: 1,
         estimatedDelivery: 1_506_897_315.0,
@@ -1639,7 +1637,6 @@ final class PledgeViewModelTests: TestCase {
         rewardMinimumUsd: "5.00",
         rewardTitle: "My Reward",
         shippingEnabled: false,
-        shippingAmount: nil,
         shippingAmountUsd: nil,
         userHasStoredApplePayCard: true
       )
@@ -1725,8 +1722,6 @@ final class PledgeViewModelTests: TestCase {
         addOnsCountTotal: 0,
         addOnsCountUnique: 0,
         addOnsMinimumUsd: "0.00",
-        amount: "15.00",
-        bonusAmount: "10.00",
         bonusAmountInUsd: "13.09",
         checkoutId: 1,
         estimatedDelivery: 1_506_897_315.0,
@@ -1736,7 +1731,6 @@ final class PledgeViewModelTests: TestCase {
         rewardMinimumUsd: "6.54",
         rewardTitle: "My Reward",
         shippingEnabled: false,
-        shippingAmount: nil,
         shippingAmountUsd: nil,
         userHasStoredApplePayCard: true
       )
@@ -1910,8 +1904,6 @@ final class PledgeViewModelTests: TestCase {
         addOnsCountTotal: 0,
         addOnsCountUnique: 0,
         addOnsMinimumUsd: "0.00",
-        amount: "10.00",
-        bonusAmount: "0.00",
         bonusAmountInUsd: "0.00",
         checkoutId: 1,
         estimatedDelivery: 1_506_897_315.0,
@@ -1921,7 +1913,6 @@ final class PledgeViewModelTests: TestCase {
         rewardMinimumUsd: "5.00",
         rewardTitle: "My Reward",
         shippingEnabled: true,
-        shippingAmount: 5.0,
         shippingAmountUsd: "5.00",
         userHasStoredApplePayCard: true
       )
@@ -2139,8 +2130,6 @@ final class PledgeViewModelTests: TestCase {
         addOnsCountTotal: 3,
         addOnsCountUnique: 2,
         addOnsMinimumUsd: "18.00",
-        amount: "58.00",
-        bonusAmount: "15.00",
         bonusAmountInUsd: "15.00",
         checkoutId: 1,
         estimatedDelivery: reward.estimatedDeliveryOn,
@@ -2150,7 +2139,6 @@ final class PledgeViewModelTests: TestCase {
         rewardMinimumUsd: "10.00",
         rewardTitle: reward.title,
         shippingEnabled: true,
-        shippingAmount: 15.0,
         shippingAmountUsd: "15.00",
         userHasStoredApplePayCard: true
       )
@@ -2240,8 +2228,6 @@ final class PledgeViewModelTests: TestCase {
         addOnsCountTotal: 0,
         addOnsCountUnique: 0,
         addOnsMinimumUsd: "0.00",
-        amount: "35.00",
-        bonusAmount: "25.00",
         bonusAmountInUsd: "25.00",
         checkoutId: 1,
         estimatedDelivery: reward.estimatedDeliveryOn,
@@ -2251,7 +2237,6 @@ final class PledgeViewModelTests: TestCase {
         rewardMinimumUsd: "10.00",
         rewardTitle: reward.title,
         shippingEnabled: reward.shipping.enabled,
-        shippingAmount: nil,
         shippingAmountUsd: nil,
         userHasStoredApplePayCard: true
       )
@@ -4480,8 +4465,6 @@ final class PledgeViewModelTests: TestCase {
         addOnsCountTotal: 0,
         addOnsCountUnique: 0,
         addOnsMinimumUsd: "0.00",
-        amount: "35.00",
-        bonusAmount: "15.00",
         bonusAmountInUsd: "15.00",
         checkoutId: 1,
         estimatedDelivery: Reward.template.estimatedDeliveryOn,
@@ -4491,7 +4474,6 @@ final class PledgeViewModelTests: TestCase {
         rewardMinimumUsd: "10.00",
         rewardTitle: reward.title,
         shippingEnabled: reward.shipping.enabled,
-        shippingAmount: 10,
         shippingAmountUsd: "10.00",
         userHasStoredApplePayCard: true
       )
@@ -5329,7 +5311,6 @@ final class PledgeViewModelTests: TestCase {
 
     // Checkout properties
 
-    XCTAssertEqual("10.00", dataLakeTrackingClientProps?["checkout_amount"] as? String)
     XCTAssertEqual("CREDIT_CARD", dataLakeTrackingClientProps?["checkout_payment_type"] as? String)
     XCTAssertEqual("My Reward", dataLakeTrackingClientProps?["checkout_reward_title"] as? String)
     XCTAssertEqual("10.00", dataLakeTrackingClientProps?["checkout_reward_minimum_usd"] as? String)
@@ -5343,7 +5324,6 @@ final class PledgeViewModelTests: TestCase {
       dataLakeTrackingClientProps?["checkout_user_has_eligible_stored_apple_pay_card"] as? Bool
     )
 
-    XCTAssertEqual("10.00", segmentTrackingClientProps?["checkout_amount"] as? String)
     XCTAssertEqual("CREDIT_CARD", segmentTrackingClientProps?["checkout_payment_type"] as? String)
     XCTAssertEqual("My Reward", segmentTrackingClientProps?["checkout_reward_title"] as? String)
     XCTAssertEqual("10.00", segmentTrackingClientProps?["checkout_reward_minimum_usd"] as? String)
@@ -5414,7 +5394,6 @@ final class PledgeViewModelTests: TestCase {
 
     // Checkout properties
 
-    XCTAssertEqual("10.00", dataLakeTrackingClientProps?["checkout_amount"] as? String)
     XCTAssertEqual("CREDIT_CARD", dataLakeTrackingClientProps?["checkout_payment_type"] as? String)
     XCTAssertEqual("My Reward", dataLakeTrackingClientProps?["checkout_reward_title"] as? String)
     XCTAssertEqual("10.00", dataLakeTrackingClientProps?["checkout_reward_minimum_usd"] as? String)
@@ -5426,7 +5405,6 @@ final class PledgeViewModelTests: TestCase {
       dataLakeTrackingClientProps?["checkout_user_has_eligible_stored_apple_pay_card"] as? Bool
     )
 
-    XCTAssertEqual("10.00", segmentTrackingClientProps?["checkout_amount"] as? String)
     XCTAssertEqual("CREDIT_CARD", segmentTrackingClientProps?["checkout_payment_type"] as? String)
     XCTAssertEqual("My Reward", segmentTrackingClientProps?["checkout_reward_title"] as? String)
     XCTAssertEqual("10.00", segmentTrackingClientProps?["checkout_reward_minimum_usd"] as? String)
@@ -5476,7 +5454,6 @@ final class PledgeViewModelTests: TestCase {
 
     // Checkout properties
 
-    XCTAssertEqual("10.00", dataLakeTrackingClientProps?["checkout_amount"] as? String)
     XCTAssertEqual("CREDIT_CARD", dataLakeTrackingClientProps?["checkout_payment_type"] as? String)
     XCTAssertEqual("My Reward", dataLakeTrackingClientProps?["checkout_reward_title"] as? String)
     XCTAssertEqual("10.00", dataLakeTrackingClientProps?["checkout_reward_minimum_usd"] as? String)
@@ -5488,7 +5465,6 @@ final class PledgeViewModelTests: TestCase {
       dataLakeTrackingClientProps?["checkout_user_has_eligible_stored_apple_pay_card"] as? Bool
     )
 
-    XCTAssertEqual("10.00", segmentTrackingClientProps?["checkout_amount"] as? String)
     XCTAssertEqual("CREDIT_CARD", segmentTrackingClientProps?["checkout_payment_type"] as? String)
     XCTAssertEqual("My Reward", segmentTrackingClientProps?["checkout_reward_title"] as? String)
     XCTAssertEqual("10.00", segmentTrackingClientProps?["checkout_reward_minimum_usd"] as? String)
@@ -5888,7 +5864,6 @@ final class PledgeViewModelTests: TestCase {
     let segmentClientProps = self.dataLakeTrackingClient.properties.last
 
     // Checkout properties
-    XCTAssertEqual("55.00", dataLakeTrackingClientProps?["checkout_amount"] as? String)
     XCTAssertEqual("CREDIT_CARD", dataLakeTrackingClientProps?["checkout_payment_type"] as? String)
     XCTAssertEqual(1, dataLakeTrackingClientProps?["checkout_reward_id"] as? Int)
     XCTAssertEqual(55.00, dataLakeTrackingClientProps?["checkout_amount_total_usd"] as? Double)
@@ -5898,20 +5873,17 @@ final class PledgeViewModelTests: TestCase {
       true,
       dataLakeTrackingClientProps?["checkout_user_has_eligible_stored_apple_pay_card"] as? Bool
     )
-    XCTAssertEqual(5.0, dataLakeTrackingClientProps?["checkout_shipping_amount"] as? Double)
     XCTAssertEqual(
       1_506_897_315.0,
       dataLakeTrackingClientProps?["checkout_reward_estimated_delivery_on"] as? TimeInterval
     )
     XCTAssertEqual("My Reward", dataLakeTrackingClientProps?["checkout_reward_title"] as? String)
-    XCTAssertEqual("55.00", segmentClientProps?["checkout_amount"] as? String)
     XCTAssertEqual("CREDIT_CARD", segmentClientProps?["checkout_payment_type"] as? String)
     XCTAssertEqual(1, segmentClientProps?["checkout_reward_id"] as? Int)
     XCTAssertEqual(55.00, segmentClientProps?["checkout_amount_total_usd"] as? Double)
     XCTAssertEqual(true, segmentClientProps?["checkout_reward_is_limited_quantity"] as? Bool)
     XCTAssertEqual(true, segmentClientProps?["checkout_reward_shipping_enabled"] as? Bool)
     XCTAssertEqual(true, segmentClientProps?["checkout_user_has_eligible_stored_apple_pay_card"] as? Bool)
-    XCTAssertEqual(5.0, segmentClientProps?["checkout_shipping_amount"] as? Double)
     XCTAssertEqual(
       1_506_897_315.0,
       segmentClientProps?["checkout_reward_estimated_delivery_on"] as? TimeInterval

--- a/Library/ViewModels/ProjectPamphletMainCellViewModel.swift
+++ b/Library/ViewModels/ProjectPamphletMainCellViewModel.swift
@@ -244,13 +244,11 @@ public final class ProjectPamphletMainCellViewModel: ProjectPamphletMainCellView
       .takeWhen(self.readMoreButtonTappedProperty.signal)
       .observeValues { projectAndRefTag in
         let (project, refTag) = projectAndRefTag
-        let cookieRefTag = cookieRefTagFor(project: project) ?? refTag
 
         AppEnvironment.current.ksrAnalytics.trackProjectViewed(
           project,
           refTag: refTag,
-          sectionContext: .campaign,
-          cookieRefTag: cookieRefTag
+          sectionContext: .campaign
         )
 
         AppEnvironment.current.optimizelyClient?.track(eventName: "Campaign Details Button Clicked")

--- a/Library/ViewModels/ProjectPamphletMainCellViewModelTests.swift
+++ b/Library/ViewModels/ProjectPamphletMainCellViewModelTests.swift
@@ -681,12 +681,14 @@ final class ProjectPamphletMainCellViewModelTests: TestCase {
 
       XCTAssertEqual(self.dataLakeTrackingClient.properties(forKey: "project_subcategory"), ["Art"])
       XCTAssertEqual(self.dataLakeTrackingClient.properties(forKey: "project_category"), [nil])
+      XCTAssertEqual(self.dataLakeTrackingClient.properties(forKey: "project_country"), ["US"])
       XCTAssertEqual(
         self.dataLakeTrackingClient.properties(forKey: "project_user_has_watched", as: Bool.self),
         [nil]
       )
       XCTAssertEqual(self.segmentTrackingClient.properties(forKey: "project_subcategory"), ["Art"])
       XCTAssertEqual(self.segmentTrackingClient.properties(forKey: "project_category"), [nil])
+      XCTAssertEqual(self.segmentTrackingClient.properties(forKey: "project_country"), ["US"])
       XCTAssertEqual(
         self.segmentTrackingClient.properties(forKey: "project_user_has_watched", as: Bool.self),
         [nil]

--- a/Library/ViewModels/ProjectPamphletMainCellViewModelTests.swift
+++ b/Library/ViewModels/ProjectPamphletMainCellViewModelTests.swift
@@ -675,22 +675,18 @@ final class ProjectPamphletMainCellViewModelTests: TestCase {
       XCTAssertEqual(self.dataLakeTrackingClient.properties(forKey: "context_page"), ["project"])
       XCTAssertEqual(self.dataLakeTrackingClient.properties(forKey: "context_section"), ["campaign"])
       XCTAssertEqual(self.dataLakeTrackingClient.properties(forKey: "session_ref_tag"), ["discovery"])
-      XCTAssertEqual(self.dataLakeTrackingClient.properties(forKey: "session_referrer_credit"), ["discovery"])
       XCTAssertEqual(self.segmentTrackingClient.properties(forKey: "context_page"), ["project"])
       XCTAssertEqual(self.segmentTrackingClient.properties(forKey: "context_section"), ["campaign"])
       XCTAssertEqual(self.segmentTrackingClient.properties(forKey: "session_ref_tag"), ["discovery"])
-      XCTAssertEqual(self.segmentTrackingClient.properties(forKey: "session_referrer_credit"), ["discovery"])
 
       XCTAssertEqual(self.dataLakeTrackingClient.properties(forKey: "project_subcategory"), ["Art"])
       XCTAssertEqual(self.dataLakeTrackingClient.properties(forKey: "project_category"), [nil])
-      XCTAssertEqual(self.dataLakeTrackingClient.properties(forKey: "project_country"), ["US"])
       XCTAssertEqual(
         self.dataLakeTrackingClient.properties(forKey: "project_user_has_watched", as: Bool.self),
         [nil]
       )
       XCTAssertEqual(self.segmentTrackingClient.properties(forKey: "project_subcategory"), ["Art"])
       XCTAssertEqual(self.segmentTrackingClient.properties(forKey: "project_category"), [nil])
-      XCTAssertEqual(self.segmentTrackingClient.properties(forKey: "project_country"), ["US"])
       XCTAssertEqual(
         self.segmentTrackingClient.properties(forKey: "project_user_has_watched", as: Bool.self),
         [nil]

--- a/Library/ViewModels/ProjectPamphletViewModel.swift
+++ b/Library/ViewModels/ProjectPamphletViewModel.swift
@@ -174,7 +174,7 @@ public final class ProjectPamphletViewModel: ProjectPamphletViewModelType, Proje
       }
       .take(first: 1)
 
-    let freshProjectRefTagAndCookieRefTag: Signal<(Project, RefTag?), Never> = Signal.zip(
+    let freshProjectRefTag: Signal<(Project, RefTag?), Never> = Signal.zip(
       freshProjectAndRefTag.skip(first: 1),
       self.viewDidAppearAnimated.signal.ignoreValues()
     )

--- a/Library/ViewModels/ProjectPamphletViewModel.swift
+++ b/Library/ViewModels/ProjectPamphletViewModel.swift
@@ -174,19 +174,17 @@ public final class ProjectPamphletViewModel: ProjectPamphletViewModelType, Proje
       }
       .take(first: 1)
 
-    let freshProjectRefTagAndCookieRefTag: Signal<(Project, RefTag?, RefTag?), Never> = Signal.zip(
+    let freshProjectRefTagAndCookieRefTag: Signal<(Project, RefTag?), Never> = Signal.zip(
       freshProjectAndRefTag.skip(first: 1),
       self.viewDidAppearAnimated.signal.ignoreValues()
     )
     .map(unpack)
     .map { project, refTag, _ in
-      let cookieRefTag = cookieRefTagFor(project: project) ?? refTag
-
-      return (project: project, refTag: refTag, cookieRefTag: cookieRefTag)
+      (project: project, refTag: refTag)
     }
 
     freshProjectRefTagAndCookieRefTag
-      .observeValues { project, refTag, _ in
+      .observeValues { project, refTag in
         AppEnvironment.current.ksrAnalytics.trackProjectViewed(
           project,
           refTag: refTag,

--- a/Library/ViewModels/ProjectPamphletViewModel.swift
+++ b/Library/ViewModels/ProjectPamphletViewModel.swift
@@ -186,12 +186,11 @@ public final class ProjectPamphletViewModel: ProjectPamphletViewModelType, Proje
     }
 
     freshProjectRefTagAndCookieRefTag
-      .observeValues { project, refTag, cookieRefTag in
+      .observeValues { project, refTag, _ in
         AppEnvironment.current.ksrAnalytics.trackProjectViewed(
           project,
           refTag: refTag,
-          sectionContext: .overview,
-          cookieRefTag: cookieRefTag
+          sectionContext: .overview
         )
         AppEnvironment.current.optimizelyClient?.track(eventName: "Project Page Viewed")
       }

--- a/Library/ViewModels/ProjectPamphletViewModel.swift
+++ b/Library/ViewModels/ProjectPamphletViewModel.swift
@@ -183,7 +183,7 @@ public final class ProjectPamphletViewModel: ProjectPamphletViewModelType, Proje
       (project: project, refTag: refTag)
     }
 
-    freshProjectRefTagAndCookieRefTag
+    freshProjectRefTag
       .observeValues { project, refTag in
         AppEnvironment.current.ksrAnalytics.trackProjectViewed(
           project,

--- a/Library/ViewModels/ProjectPamphletViewModelTests.swift
+++ b/Library/ViewModels/ProjectPamphletViewModelTests.swift
@@ -872,11 +872,9 @@ final class ProjectPamphletViewModelTests: TestCase {
       XCTAssertEqual(dataLakeClient.properties(forKey: "session_ref_tag"), ["discovery"])
 
       XCTAssertEqual(dataLakeClient.properties(forKey: "session_user_logged_in", as: Bool.self), [true])
-      XCTAssertEqual(dataLakeClient.properties(forKey: "user_country"), ["US"])
       XCTAssertEqual(dataLakeClient.properties(forKey: "user_uid", as: Int.self), [1])
 
       XCTAssertEqual(segmentClient.properties(forKey: "session_user_logged_in", as: Bool.self), [true])
-      XCTAssertEqual(segmentClient.properties(forKey: "user_country"), ["US"])
       XCTAssertEqual(segmentClient.properties(forKey: "user_uid", as: Int.self), [1])
 
       XCTAssertEqual(dataLakeClient.properties(forKey: "project_subcategory"), ["Art"])
@@ -916,10 +914,8 @@ final class ProjectPamphletViewModelTests: TestCase {
       XCTAssertEqual(segmentClient.properties(forKey: "session_ref_tag"), ["discovery"])
 
       XCTAssertEqual(dataLakeClient.properties(forKey: "session_user_logged_in", as: Bool.self), [false])
-      XCTAssertEqual(dataLakeClient.properties(forKey: "user_country"), ["GB"])
       XCTAssertEqual(dataLakeClient.properties(forKey: "user_uid", as: Int.self), [nil])
       XCTAssertEqual(segmentClient.properties(forKey: "session_user_logged_in", as: Bool.self), [false])
-      XCTAssertEqual(segmentClient.properties(forKey: "user_country"), ["GB"])
       XCTAssertEqual(segmentClient.properties(forKey: "user_uid", as: Int.self), [nil])
 
       XCTAssertEqual(dataLakeClient.properties(forKey: "project_subcategory"), ["Art"])

--- a/Library/ViewModels/ProjectPamphletViewModelTests.swift
+++ b/Library/ViewModels/ProjectPamphletViewModelTests.swift
@@ -193,16 +193,6 @@ final class ProjectPamphletViewModelTests: TestCase {
       "The ref tag is tracked in the event."
     )
     XCTAssertEqual(
-      [RefTag.category.stringTag],
-      self.dataLakeTrackingClient.properties.compactMap { $0["session_referrer_credit"] as? String },
-      "The referral credit is tracked in the event."
-    )
-    XCTAssertEqual(
-      [RefTag.category.stringTag],
-      self.segmentTrackingClient.properties.compactMap { $0["session_referrer_credit"] as? String },
-      "The referral credit is tracked in the event."
-    )
-    XCTAssertEqual(
       1, self.cookieStorage.cookies?.count,
       "A single cookie is set"
     )
@@ -252,22 +242,6 @@ final class ProjectPamphletViewModelTests: TestCase {
       ],
       self.segmentTrackingClient.properties.compactMap { $0["session_ref_tag"] as? String },
       "The new ref tag is tracked in an event."
-    )
-    XCTAssertEqual(
-      [
-        RefTag.category.stringTag,
-        RefTag.category.stringTag
-      ],
-      self.dataLakeTrackingClient.properties.compactMap { $0["session_referrer_credit"] as? String },
-      "The referrer credit did not change, and is still category."
-    )
-    XCTAssertEqual(
-      [
-        RefTag.category.stringTag,
-        RefTag.category.stringTag
-      ],
-      self.segmentTrackingClient.properties.compactMap { $0["session_referrer_credit"] as? String },
-      "The referrer credit did not change, and is still category."
     )
     XCTAssertEqual(
       1, self.cookieStorage.cookies?.count,
@@ -409,16 +383,6 @@ final class ProjectPamphletViewModelTests: TestCase {
       "The ref tag is tracked in the event."
     )
     XCTAssertEqual(
-      [RefTag.category.stringTag],
-      self.dataLakeTrackingClient.properties.compactMap { $0["session_referrer_credit"] as? String },
-      "The referral credit is tracked in the event."
-    )
-    XCTAssertEqual(
-      [RefTag.category.stringTag],
-      self.segmentTrackingClient.properties.compactMap { $0["session_referrer_credit"] as? String },
-      "The referral credit is tracked in the event."
-    )
-    XCTAssertEqual(
       1, self.cookieStorage.cookies?.count,
       "A single cookie is set"
     )
@@ -468,20 +432,6 @@ final class ProjectPamphletViewModelTests: TestCase {
       ],
       self.segmentTrackingClient.properties.compactMap { $0["session_ref_tag"] as? String },
       "The new ref tag is tracked in an event."
-    )
-    XCTAssertEqual(
-      [
-        RefTag.category.stringTag, RefTag.category.stringTag
-      ],
-      self.dataLakeTrackingClient.properties.compactMap { $0["session_referrer_credit"] as? String },
-      "The referrer credit did not change, and is still category."
-    )
-    XCTAssertEqual(
-      [
-        RefTag.category.stringTag, RefTag.category.stringTag
-      ],
-      self.segmentTrackingClient.properties.compactMap { $0["session_referrer_credit"] as? String },
-      "The referrer credit did not change, and is still category."
     )
     XCTAssertEqual(
       1, self.cookieStorage.cookies?.count,
@@ -920,15 +870,6 @@ final class ProjectPamphletViewModelTests: TestCase {
       XCTAssertEqual(segmentClient.events, ["Page Viewed"])
 
       XCTAssertEqual(dataLakeClient.properties(forKey: "session_ref_tag"), ["discovery"])
-      XCTAssertEqual(
-        dataLakeClient.properties(forKey: "session_referrer_credit"),
-        ["discovery"]
-      )
-      XCTAssertEqual(segmentClient.properties(forKey: "session_ref_tag"), ["discovery"])
-      XCTAssertEqual(
-        segmentClient.properties(forKey: "session_referrer_credit"),
-        ["discovery"]
-      )
 
       XCTAssertEqual(dataLakeClient.properties(forKey: "session_user_logged_in", as: Bool.self), [true])
       XCTAssertEqual(dataLakeClient.properties(forKey: "user_country"), ["US"])
@@ -940,12 +881,10 @@ final class ProjectPamphletViewModelTests: TestCase {
 
       XCTAssertEqual(dataLakeClient.properties(forKey: "project_subcategory"), ["Art"])
       XCTAssertEqual(dataLakeClient.properties(forKey: "project_category"), [nil])
-      XCTAssertEqual(dataLakeClient.properties(forKey: "project_country"), ["US"])
       XCTAssertEqual(dataLakeClient.properties(forKey: "project_user_has_watched", as: Bool.self), [nil])
 
       XCTAssertEqual(segmentClient.properties(forKey: "project_subcategory"), ["Art"])
       XCTAssertEqual(segmentClient.properties(forKey: "project_category"), [nil])
-      XCTAssertEqual(segmentClient.properties(forKey: "project_country"), ["US"])
       XCTAssertEqual(segmentClient.properties(forKey: "project_user_has_watched", as: Bool.self), [nil])
     }
   }
@@ -974,15 +913,7 @@ final class ProjectPamphletViewModelTests: TestCase {
       XCTAssertEqual(segmentClient.events, ["Page Viewed"])
 
       XCTAssertEqual(dataLakeClient.properties(forKey: "session_ref_tag"), ["discovery"])
-      XCTAssertEqual(
-        dataLakeClient.properties(forKey: "session_referrer_credit"),
-        ["discovery"]
-      )
       XCTAssertEqual(segmentClient.properties(forKey: "session_ref_tag"), ["discovery"])
-      XCTAssertEqual(
-        segmentClient.properties(forKey: "session_referrer_credit"),
-        ["discovery"]
-      )
 
       XCTAssertEqual(dataLakeClient.properties(forKey: "session_user_logged_in", as: Bool.self), [false])
       XCTAssertEqual(dataLakeClient.properties(forKey: "user_country"), ["GB"])
@@ -993,11 +924,9 @@ final class ProjectPamphletViewModelTests: TestCase {
 
       XCTAssertEqual(dataLakeClient.properties(forKey: "project_subcategory"), ["Art"])
       XCTAssertEqual(dataLakeClient.properties(forKey: "project_category"), [nil])
-      XCTAssertEqual(dataLakeClient.properties(forKey: "project_country"), ["US"])
       XCTAssertEqual(dataLakeClient.properties(forKey: "project_user_has_watched", as: Bool.self), [nil])
       XCTAssertEqual(segmentClient.properties(forKey: "project_subcategory"), ["Art"])
       XCTAssertEqual(segmentClient.properties(forKey: "project_category"), [nil])
-      XCTAssertEqual(segmentClient.properties(forKey: "project_country"), ["US"])
       XCTAssertEqual(segmentClient.properties(forKey: "project_user_has_watched", as: Bool.self), [nil])
     }
   }

--- a/Library/ViewModels/ProjectPamphletViewModelTests.swift
+++ b/Library/ViewModels/ProjectPamphletViewModelTests.swift
@@ -879,10 +879,12 @@ final class ProjectPamphletViewModelTests: TestCase {
 
       XCTAssertEqual(dataLakeClient.properties(forKey: "project_subcategory"), ["Art"])
       XCTAssertEqual(dataLakeClient.properties(forKey: "project_category"), [nil])
+      XCTAssertEqual(dataLakeClient.properties(forKey: "project_country"), ["US"])
       XCTAssertEqual(dataLakeClient.properties(forKey: "project_user_has_watched", as: Bool.self), [nil])
 
       XCTAssertEqual(segmentClient.properties(forKey: "project_subcategory"), ["Art"])
       XCTAssertEqual(segmentClient.properties(forKey: "project_category"), [nil])
+      XCTAssertEqual(segmentClient.properties(forKey: "project_country"), ["US"])
       XCTAssertEqual(segmentClient.properties(forKey: "project_user_has_watched", as: Bool.self), [nil])
     }
   }
@@ -920,9 +922,11 @@ final class ProjectPamphletViewModelTests: TestCase {
 
       XCTAssertEqual(dataLakeClient.properties(forKey: "project_subcategory"), ["Art"])
       XCTAssertEqual(dataLakeClient.properties(forKey: "project_category"), [nil])
+      XCTAssertEqual(dataLakeClient.properties(forKey: "project_country"), ["US"])
       XCTAssertEqual(dataLakeClient.properties(forKey: "project_user_has_watched", as: Bool.self), [nil])
       XCTAssertEqual(segmentClient.properties(forKey: "project_subcategory"), ["Art"])
       XCTAssertEqual(segmentClient.properties(forKey: "project_category"), [nil])
+      XCTAssertEqual(segmentClient.properties(forKey: "project_country"), ["US"])
       XCTAssertEqual(segmentClient.properties(forKey: "project_user_has_watched", as: Bool.self), [nil])
     }
   }

--- a/Library/ViewModels/RewardsCollectionViewModelTests.swift
+++ b/Library/ViewModels/RewardsCollectionViewModelTests.swift
@@ -780,11 +780,15 @@ final class RewardsCollectionViewModelTests: TestCase {
     XCTAssertEqual("rewards", self.segmentTrackingClient.properties.last?["context_page"] as? String)
     XCTAssertEqual("reward_continue", self.segmentTrackingClient.properties.last?["context_cta"] as? String)
 
-    XCTAssertEqual("10.00", self.dataLakeTrackingClient.properties.last?["checkout_amount"] as? String)
-    XCTAssertEqual("0.00", self.dataLakeTrackingClient.properties.last?["checkout_bonus_amount"] as? String)
+    XCTAssertEqual(
+      "0.00",
+      self.dataLakeTrackingClient.properties.last?["checkout_bonus_amount_usd"] as? String
+    )
     XCTAssertEqual(0, self.dataLakeTrackingClient.properties.last?["checkout_add_ons_count_total"] as? Int)
-    XCTAssertEqual("10.00", self.segmentTrackingClient.properties.last?["checkout_amount"] as? String)
-    XCTAssertEqual("0.00", self.segmentTrackingClient.properties.last?["checkout_bonus_amount"] as? String)
+    XCTAssertEqual(
+      "0.00",
+      self.segmentTrackingClient.properties.last?["checkout_bonus_amount_usd"] as? String
+    )
     XCTAssertEqual(0, self.segmentTrackingClient.properties.last?["checkout_add_ons_count_total"] as? Int)
   }
 
@@ -822,10 +826,14 @@ final class RewardsCollectionViewModelTests: TestCase {
     XCTAssertEqual("rewards", self.segmentTrackingClient.properties.last?["context_page"] as? String)
     XCTAssertEqual("reward_continue", self.segmentTrackingClient.properties.last?["context_cta"] as? String)
 
-    XCTAssertEqual("20.00", self.dataLakeTrackingClient.properties.last?["checkout_amount"] as? String)
-    XCTAssertEqual("20.00", self.segmentTrackingClient.properties.last?["checkout_amount"] as? String)
-    XCTAssertEqual("100.00", self.dataLakeTrackingClient.properties.last?["checkout_bonus_amount"] as? String)
-    XCTAssertEqual("100.00", self.segmentTrackingClient.properties.last?["checkout_bonus_amount"] as? String)
+    XCTAssertEqual(
+      "100.00",
+      self.dataLakeTrackingClient.properties.last?["checkout_bonus_amount_usd"] as? String
+    )
+    XCTAssertEqual(
+      "100.00",
+      self.segmentTrackingClient.properties.last?["checkout_bonus_amount_usd"] as? String
+    )
 
     // Even though there is an addOn on the Backing, we don't calculate that as a total in the Rewards carousel
     XCTAssertEqual(0, self.dataLakeTrackingClient.properties.last?["checkout_add_ons_count_total"] as? Int)
@@ -866,8 +874,5 @@ final class RewardsCollectionViewModelTests: TestCase {
 
     XCTAssertEqual([nil, "reward_continue"], self.dataLakeTrackingClient.properties(forKey: "context_cta"))
     XCTAssertEqual([nil, "reward_continue"], self.segmentTrackingClient.properties(forKey: "context_cta"))
-
-    XCTAssertEqual(["0.00", "10.00"], self.dataLakeTrackingClient.properties(forKey: "checkout_amount"))
-    XCTAssertEqual(["0.00", "10.00"], self.segmentTrackingClient.properties(forKey: "checkout_amount"))
   }
 }

--- a/Library/ViewModels/ThanksViewModelTests.swift
+++ b/Library/ViewModels/ThanksViewModelTests.swift
@@ -362,8 +362,6 @@ final class ThanksViewModelTests: TestCase {
       addOnsCountTotal: 2,
       addOnsCountUnique: 1,
       addOnsMinimumUsd: "8.00",
-      amount: "43.00",
-      bonusAmount: "10.00",
       bonusAmountInUsd: "10.00",
       checkoutId: 1,
       estimatedDelivery: 12_345_678,
@@ -373,7 +371,6 @@ final class ThanksViewModelTests: TestCase {
       rewardMinimumUsd: "5.00",
       rewardTitle: "SUPER reward",
       shippingEnabled: true,
-      shippingAmount: 10,
       shippingAmountUsd: "10.00",
       userHasStoredApplePayCard: true
     )
@@ -397,8 +394,6 @@ final class ThanksViewModelTests: TestCase {
     XCTAssertEqual(2, dataLakeTrackingClientProps?["checkout_add_ons_count_total"] as? Int)
     XCTAssertEqual(1, dataLakeTrackingClientProps?["checkout_add_ons_count_unique"] as? Int)
     XCTAssertEqual("8.00", dataLakeTrackingClientProps?["checkout_add_ons_minimum_usd"] as? String)
-    XCTAssertEqual("43.00", dataLakeTrackingClientProps?["checkout_amount"] as? String)
-    XCTAssertEqual("10.00", dataLakeTrackingClientProps?["checkout_bonus_amount"] as? String)
     XCTAssertEqual("10.00", dataLakeTrackingClientProps?["checkout_bonus_amount_usd"] as? String)
     XCTAssertEqual("CREDIT_CARD", dataLakeTrackingClientProps?["checkout_payment_type"] as? String)
     XCTAssertEqual("SUPER reward", dataLakeTrackingClientProps?["checkout_reward_title"] as? String)
@@ -411,7 +406,6 @@ final class ThanksViewModelTests: TestCase {
       true,
       dataLakeTrackingClientProps?["checkout_user_has_eligible_stored_apple_pay_card"] as? Bool
     )
-    XCTAssertEqual(10.00, dataLakeTrackingClientProps?["checkout_shipping_amount"] as? Double)
     XCTAssertEqual("10.00", dataLakeTrackingClientProps?["checkout_shipping_amount_usd"] as? String)
     XCTAssertEqual(
       12_345_678,
@@ -421,8 +415,6 @@ final class ThanksViewModelTests: TestCase {
     XCTAssertEqual(2, segmentClientProps?["checkout_add_ons_count_total"] as? Int)
     XCTAssertEqual(1, segmentClientProps?["checkout_add_ons_count_unique"] as? Int)
     XCTAssertEqual("8.00", segmentClientProps?["checkout_add_ons_minimum_usd"] as? String)
-    XCTAssertEqual("43.00", segmentClientProps?["checkout_amount"] as? String)
-    XCTAssertEqual("10.00", segmentClientProps?["checkout_bonus_amount"] as? String)
     XCTAssertEqual("10.00", segmentClientProps?["checkout_bonus_amount_usd"] as? String)
     XCTAssertEqual("CREDIT_CARD", segmentClientProps?["checkout_payment_type"] as? String)
     XCTAssertEqual("SUPER reward", segmentClientProps?["checkout_reward_title"] as? String)
@@ -432,7 +424,6 @@ final class ThanksViewModelTests: TestCase {
     XCTAssertEqual(true, segmentClientProps?["checkout_reward_is_limited_quantity"] as? Bool)
     XCTAssertEqual(true, segmentClientProps?["checkout_reward_shipping_enabled"] as? Bool)
     XCTAssertEqual(true, segmentClientProps?["checkout_user_has_eligible_stored_apple_pay_card"] as? Bool)
-    XCTAssertEqual(10.00, segmentClientProps?["checkout_shipping_amount"] as? Double)
     XCTAssertEqual("10.00", segmentClientProps?["checkout_shipping_amount_usd"] as? String)
     XCTAssertEqual(12_345_678, segmentClientProps?["checkout_reward_estimated_delivery_on"] as? TimeInterval)
 


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Remove the following event properties and their related tests.

- checkout_amount
- checkout_bonus_amount
- checkout_shipping_amount
- context_timestamp
- project_category_id
- project_goal
- project_location
- project_static_usd_rate
- project_subcategory_id
- session_apple_pay_device
- session_cellular_connection
- session_enabled_features
- session_mp_lib
- session_referrer_credit
- session_wifi_connection
- user_country



# 🤔 Why

Base on the feedback from QA for Phase 1 event tracking, some of the event  properties sent to Segment are not needed.