### PR TITLE
[EP-402] QA phase 1 fix time properties

### DIFF
--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -558,6 +558,8 @@
 		8AFB8C99233E9A1F006779B5 /* CreatePaymentSourceInput+ConstructorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AFB8C98233E9A1F006779B5 /* CreatePaymentSourceInput+ConstructorTests.swift */; };
 		94BE15C225E857C4007CD9A4 /* TrackingHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94BE15C125E857C4007CD9A4 /* TrackingHelpers.swift */; };
 		94BE15CE25E970A3007CD9A4 /* TrackingHelpersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94BE15C925E96F06007CD9A4 /* TrackingHelpersTests.swift */; };
+		94F4A95A26125C8C000C21F9 /* TimeInterval+ISO8601Date.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94F4A95926125C8C000C21F9 /* TimeInterval+ISO8601Date.swift */; };
+		94F4A96926125EE8000C21F9 /* TimeInterval+ISO8601DateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94F4A96126125EA0000C21F9 /* TimeInterval+ISO8601DateTests.swift */; };
 		9D10B91B1D35407C008B8045 /* String+Truncate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D10B91A1D35407C008B8045 /* String+Truncate.swift */; };
 		9D14FF8D1D133351005F4ABB /* ProjectActivityBackingCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D9F57CB1D131AF200CE81DE /* ProjectActivityBackingCell.swift */; };
 		9D14FF8E1D133351005F4ABB /* ProjectActivityEmptyStateCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D9F57CC1D131AF200CE81DE /* ProjectActivityEmptyStateCell.swift */; };
@@ -2065,6 +2067,8 @@
 		8AFB8C98233E9A1F006779B5 /* CreatePaymentSourceInput+ConstructorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CreatePaymentSourceInput+ConstructorTests.swift"; sourceTree = "<group>"; };
 		94BE15C125E857C4007CD9A4 /* TrackingHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackingHelpers.swift; sourceTree = "<group>"; };
 		94BE15C925E96F06007CD9A4 /* TrackingHelpersTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackingHelpersTests.swift; sourceTree = "<group>"; };
+		94F4A95926125C8C000C21F9 /* TimeInterval+ISO8601Date.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TimeInterval+ISO8601Date.swift"; sourceTree = "<group>"; };
+		94F4A96126125EA0000C21F9 /* TimeInterval+ISO8601DateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TimeInterval+ISO8601DateTests.swift"; sourceTree = "<group>"; };
 		9D10B91A1D35407C008B8045 /* String+Truncate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+Truncate.swift"; sourceTree = "<group>"; };
 		9D14FFC51D135C12005F4ABB /* ProjectActivityUpdateCellViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProjectActivityUpdateCellViewModel.swift; sourceTree = "<group>"; };
 		9D2546F71D23101E0053844D /* ProjectActivityCommentCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProjectActivityCommentCell.swift; sourceTree = "<group>"; };
@@ -3711,6 +3715,8 @@
 				A7ED1F221E830FDC00BFFA01 /* String+WhitespaceTests.swift */,
 				A79BF81E1D11F6AF004C0445 /* Strings.swift */,
 				8AD48632235939AF00A1463E /* StripeTypes.swift */,
+				94F4A95926125C8C000C21F9 /* TimeInterval+ISO8601Date.swift */,
+				94F4A96126125EA0000C21F9 /* TimeInterval+ISO8601DateTests.swift */,
 				0156B4181D10B419000C4252 /* UIAlertController.swift */,
 				D69BACEF21C856F2006EAA00 /* UIAlertControllerTests.swift */,
 				370F52B2225426C700F159B9 /* UIApplication.swift */,
@@ -5259,6 +5265,7 @@
 				771E630C23426B27005967E8 /* CancelPledgeViewModel.swift in Sources */,
 				A7CA8C0E1D8F241A0086A3E9 /* ProjectNavBarViewModel.swift in Sources */,
 				A7F441C51D005A9400FE6FC5 /* LoginToutViewModel.swift in Sources */,
+				94F4A95A26125C8C000C21F9 /* TimeInterval+ISO8601Date.swift in Sources */,
 				D7E20EA7228B4B7D00BA61A0 /* PledgeCTAContainerViewViewModel.swift in Sources */,
 				A75C811E1D210C4700B5AD03 /* ProjectActivityItemProvider.swift in Sources */,
 				370C8B6623590CA500DE75DD /* LoadingButtonViewModel.swift in Sources */,
@@ -5636,6 +5643,7 @@
 				3705CF48222EE77F0025D37E /* EnvironmentVariablesTests.swift in Sources */,
 				D710ADFD2441172100DC7199 /* PledgeViewCTAContainerViewModelTests.swift in Sources */,
 				D6B4D9BF209B88F3002C7B68 /* PushNotificationDialogTests.swift in Sources */,
+				94F4A96926125EE8000C21F9 /* TimeInterval+ISO8601DateTests.swift in Sources */,
 				8AE8D86823466EDB005860C6 /* UpdateBackingInput+ConstructorTests.swift in Sources */,
 				D04AACAD218BB72100CF713E /* SettingsNotificationPickerViewModelTests.swift in Sources */,
 				A7ED1FBF1E831C5C00BFFA01 /* SortPagerViewModelTests.swift in Sources */,

--- a/Library/TimeInterval+ISO8601Date.swift
+++ b/Library/TimeInterval+ISO8601Date.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+public extension TimeInterval {
+  func toISO8601DateTimeString() -> String {
+    return ISO8601DateFormatter().string(from: Date(timeIntervalSince1970: self))
+  }
+}

--- a/Library/TimeInterval+ISO8601DateTests.swift
+++ b/Library/TimeInterval+ISO8601DateTests.swift
@@ -1,0 +1,11 @@
+@testable import Library
+import XCTest
+
+class TimeInterval_ISO8601DateTests: XCTestCase {
+  func testConvertToISO8601DateTimeString_FromTimeInterval() {
+    let timeInterval = 1_506_897_315.0
+
+    let iSO8601DateTimeString = timeInterval.toISO8601DateTimeString()
+    XCTAssertEqual(iSO8601DateTimeString, "2017-10-01T22:35:15Z")
+  }
+}

--- a/Library/TimeInterval+ISO8601DateTests.swift
+++ b/Library/TimeInterval+ISO8601DateTests.swift
@@ -8,11 +8,11 @@ class TimeInterval_ISO8601DateTests: XCTestCase {
     let iSO8601DateTimeString = timeInterval.toISO8601DateTimeString()
     XCTAssertEqual(iSO8601DateTimeString, "2017-10-01T22:35:15Z")
   }
-  
+
   func testToISO8601DateTimeString_Future() {
-    let timeInterval = 1_680_048_000.0
+    let timeInterval = 1_680_078_655.0
 
     let iSO8601DateTimeString = timeInterval.toISO8601DateTimeString()
-    XCTAssertEqual(iSO8601DateTimeString, "2023-03-29T00:00:00Z")
+    XCTAssertEqual(iSO8601DateTimeString, "2023-03-29T08:30:55Z")
   }
 }

--- a/Library/TimeInterval+ISO8601DateTests.swift
+++ b/Library/TimeInterval+ISO8601DateTests.swift
@@ -5,14 +5,12 @@ class TimeInterval_ISO8601DateTests: XCTestCase {
   func testToISO8601DateTimeString() {
     let timeInterval = 1_506_897_315.0
 
-    let iSO8601DateTimeString = timeInterval.toISO8601DateTimeString()
-    XCTAssertEqual(iSO8601DateTimeString, "2017-10-01T22:35:15Z")
+    XCTAssertEqual(timeInterval.toISO8601DateTimeString(), "2017-10-01T22:35:15Z")
   }
 
   func testToISO8601DateTimeString_Future() {
     let timeInterval = 1_680_078_655.0
 
-    let iSO8601DateTimeString = timeInterval.toISO8601DateTimeString()
-    XCTAssertEqual(iSO8601DateTimeString, "2023-03-29T08:30:55Z")
+    XCTAssertEqual(timeInterval.toISO8601DateTimeString(), "2023-03-29T08:30:55Z")
   }
 }

--- a/Library/TimeInterval+ISO8601DateTests.swift
+++ b/Library/TimeInterval+ISO8601DateTests.swift
@@ -2,10 +2,17 @@
 import XCTest
 
 class TimeInterval_ISO8601DateTests: XCTestCase {
-  func testConvertToISO8601DateTimeString_FromTimeInterval() {
+  func testToISO8601DateTimeString() {
     let timeInterval = 1_506_897_315.0
 
     let iSO8601DateTimeString = timeInterval.toISO8601DateTimeString()
     XCTAssertEqual(iSO8601DateTimeString, "2017-10-01T22:35:15Z")
+  }
+  
+  func testToISO8601DateTimeString_Future() {
+    let timeInterval = 1_680_048_000.0
+
+    let iSO8601DateTimeString = timeInterval.toISO8601DateTimeString()
+    XCTAssertEqual(iSO8601DateTimeString, "2023-03-29T00:00:00Z")
   }
 }

--- a/Library/Tracking/KSRAnalytics.swift
+++ b/Library/Tracking/KSRAnalytics.swift
@@ -1564,7 +1564,7 @@ private func projectProperties(
   props["comments_count"] = project.stats.commentsCount ?? 0
   props["currency"] = project.country.currencyCode
   props["creator_uid"] = project.creator.id
-  props["deadline"] = project.dates.deadline
+  props["deadline"] = ISO8601DateFormatter().string(from: Date(timeIntervalSince1970: project.dates.deadline))
   props["has_add_ons"] = project.hasAddOns
   props["launched_at"] = project.dates.launchedAt
   props["name"] = project.name

--- a/Library/Tracking/KSRAnalytics.swift
+++ b/Library/Tracking/KSRAnalytics.swift
@@ -1578,9 +1578,9 @@ private func projectProperties(
   props["comments_count"] = project.stats.commentsCount ?? 0
   props["currency"] = project.country.currencyCode
   props["creator_uid"] = project.creator.id
-  props["deadline"] = ISO8601DateFormatter().string(from: Date(timeIntervalSince1970: project.dates.deadline))
+  props["deadline"] = project.dates.deadline.toISO8601DateTimeString()
   props["has_add_ons"] = project.hasAddOns
-  props["launched_at"] = project.dates.launchedAt
+  props["launched_at"] = project.dates.launchedAt.toISO8601DateTimeString()
   props["name"] = project.name
   props["pid"] = project.id
   props["category"] = project.category.parentName
@@ -1670,7 +1670,7 @@ private func checkoutProperties(from data: KSRAnalytics.CheckoutPropertiesData, 
   result["bonus_amount_usd"] = data.bonusAmountInUsd
   result["id"] = data.checkoutId
   result["payment_type"] = data.paymentType
-  result["reward_estimated_delivery_on"] = data.estimatedDelivery
+  result["reward_estimated_delivery_on"] = data.estimatedDelivery?.toISO8601DateTimeString()
   result["reward_id"] = data.rewardId
   result["reward_is_limited_quantity"] = reward?.isLimitedQuantity
   result["reward_is_limited_time"] = reward?.isLimitedTime

--- a/Library/Tracking/KSRAnalyticsTests.swift
+++ b/Library/Tracking/KSRAnalyticsTests.swift
@@ -262,8 +262,14 @@ final class KSRAnalyticsTests: TestCase {
     XCTAssertEqual(project.creator.id, dataLakeClientProperties?["project_creator_uid"] as? Int)
     XCTAssertEqual(24 * 15, dataLakeClientProperties?["project_hours_remaining"] as? Int)
     XCTAssertEqual(30, dataLakeClientProperties?["project_duration"] as? Int)
-    XCTAssertEqual(1_476_657_315, dataLakeClientProperties?["project_deadline"] as? Double)
-    XCTAssertEqual(1_474_065_315, dataLakeClientProperties?["project_launched_at"] as? Double)
+    XCTAssertEqual(
+      1_476_657_315.toISO8601DateTimeString(),
+      dataLakeClientProperties?["project_deadline"] as? String
+    )
+    XCTAssertEqual(
+      1_474_065_315.toISO8601DateTimeString(),
+      dataLakeClientProperties?["project_launched_at"] as? String
+    )
     XCTAssertEqual("live", dataLakeClientProperties?["project_state"] as? String)
     XCTAssertEqual(project.stats.pledged, dataLakeClientProperties?["project_current_pledge_amount"] as? Int)
     XCTAssertEqual(2_000, dataLakeClientProperties?["project_current_amount_pledged_usd"] as? Float)
@@ -301,8 +307,14 @@ final class KSRAnalyticsTests: TestCase {
     XCTAssertEqual(project.creator.id, segmentClientProperties?["project_creator_uid"] as? Int)
     XCTAssertEqual(24 * 15, segmentClientProperties?["project_hours_remaining"] as? Int)
     XCTAssertEqual(30, segmentClientProperties?["project_duration"] as? Int)
-    XCTAssertEqual(1_476_657_315, segmentClientProperties?["project_deadline"] as? Double)
-    XCTAssertEqual(1_474_065_315, segmentClientProperties?["project_launched_at"] as? Double)
+    XCTAssertEqual(
+      1_476_657_315.toISO8601DateTimeString(),
+      segmentClientProperties?["project_deadline"] as? String
+    )
+    XCTAssertEqual(
+      1_474_065_315.toISO8601DateTimeString(),
+      segmentClientProperties?["project_launched_at"] as? String
+    )
     XCTAssertEqual("live", segmentClientProperties?["project_state"] as? String)
     XCTAssertEqual(project.stats.pledged, segmentClientProperties?["project_current_pledge_amount"] as? Int)
     XCTAssertEqual(2_000, segmentClientProperties?["project_current_amount_pledged_usd"] as? Float)
@@ -2309,8 +2321,8 @@ final class KSRAnalyticsTests: TestCase {
     XCTAssertEqual(1, props?["project_creator_uid"] as? Int)
     XCTAssertEqual(24 * 15, props?["project_hours_remaining"] as? Int)
     XCTAssertEqual(30, props?["project_duration"] as? Int)
-    XCTAssertEqual(1_476_657_315, props?["project_deadline"] as? Double)
-    XCTAssertEqual(1_474_065_315, props?["project_launched_at"] as? Double)
+    XCTAssertEqual(1_476_657_315.toISO8601DateTimeString(), props?["project_deadline"] as? String)
+    XCTAssertEqual(1_474_065_315.toISO8601DateTimeString(), props?["project_launched_at"] as? String)
     XCTAssertEqual("live", props?["project_state"] as? String)
     XCTAssertEqual(1_000, props?["project_current_pledge_amount"] as? Int)
     XCTAssertEqual(1_000, props?["project_current_amount_pledged_usd"] as? Float)
@@ -2356,7 +2368,10 @@ final class KSRAnalyticsTests: TestCase {
     XCTAssertEqual("restricted", props?["checkout_reward_shipping_preference"] as? String)
     XCTAssertEqual(true, props?["checkout_user_has_eligible_stored_apple_pay_card"] as? Bool)
     XCTAssertEqual("10.00", props?["checkout_shipping_amount_usd"] as? String)
-    XCTAssertEqual(12_345_678, props?["checkout_reward_estimated_delivery_on"] as? TimeInterval)
+    XCTAssertEqual(
+      12_345_678.toISO8601DateTimeString(),
+      props?["checkout_reward_estimated_delivery_on"] as? String
+    )
   }
 
   /*

--- a/Library/Tracking/KSRAnalyticsTests.swift
+++ b/Library/Tracking/KSRAnalyticsTests.swift
@@ -263,11 +263,11 @@ final class KSRAnalyticsTests: TestCase {
     XCTAssertEqual(24 * 15, dataLakeClientProperties?["project_hours_remaining"] as? Int)
     XCTAssertEqual(30, dataLakeClientProperties?["project_duration"] as? Int)
     XCTAssertEqual(
-      1_476_657_315.toISO8601DateTimeString(),
+      "2016-10-16T22:35:15Z",
       dataLakeClientProperties?["project_deadline"] as? String
     )
     XCTAssertEqual(
-      1_474_065_315.toISO8601DateTimeString(),
+      "2016-09-16T22:35:15Z",
       dataLakeClientProperties?["project_launched_at"] as? String
     )
     XCTAssertEqual("live", dataLakeClientProperties?["project_state"] as? String)
@@ -308,11 +308,11 @@ final class KSRAnalyticsTests: TestCase {
     XCTAssertEqual(24 * 15, segmentClientProperties?["project_hours_remaining"] as? Int)
     XCTAssertEqual(30, segmentClientProperties?["project_duration"] as? Int)
     XCTAssertEqual(
-      1_476_657_315.toISO8601DateTimeString(),
+      "2016-10-16T22:35:15Z",
       segmentClientProperties?["project_deadline"] as? String
     )
     XCTAssertEqual(
-      1_474_065_315.toISO8601DateTimeString(),
+      "2016-09-16T22:35:15Z",
       segmentClientProperties?["project_launched_at"] as? String
     )
     XCTAssertEqual("live", segmentClientProperties?["project_state"] as? String)
@@ -2321,8 +2321,8 @@ final class KSRAnalyticsTests: TestCase {
     XCTAssertEqual(1, props?["project_creator_uid"] as? Int)
     XCTAssertEqual(24 * 15, props?["project_hours_remaining"] as? Int)
     XCTAssertEqual(30, props?["project_duration"] as? Int)
-    XCTAssertEqual(1_476_657_315.toISO8601DateTimeString(), props?["project_deadline"] as? String)
-    XCTAssertEqual(1_474_065_315.toISO8601DateTimeString(), props?["project_launched_at"] as? String)
+    XCTAssertEqual("2016-10-16T22:35:15Z", props?["project_deadline"] as? String)
+    XCTAssertEqual("2016-09-16T22:35:15Z", props?["project_launched_at"] as? String)
     XCTAssertEqual("live", props?["project_state"] as? String)
     XCTAssertEqual(1_000, props?["project_current_pledge_amount"] as? Int)
     XCTAssertEqual(1_000, props?["project_current_amount_pledged_usd"] as? Float)
@@ -2369,7 +2369,7 @@ final class KSRAnalyticsTests: TestCase {
     XCTAssertEqual(true, props?["checkout_user_has_eligible_stored_apple_pay_card"] as? Bool)
     XCTAssertEqual("10.00", props?["checkout_shipping_amount_usd"] as? String)
     XCTAssertEqual(
-      12_345_678.toISO8601DateTimeString(),
+      "1970-05-23T21:21:18Z",
       props?["checkout_reward_estimated_delivery_on"] as? String
     )
   }

--- a/Library/ViewModels/PledgeViewModelTests.swift
+++ b/Library/ViewModels/PledgeViewModelTests.swift
@@ -5862,7 +5862,7 @@ final class PledgeViewModelTests: TestCase {
       dataLakeTrackingClientProps?["checkout_user_has_eligible_stored_apple_pay_card"] as? Bool
     )
     XCTAssertEqual(
-      1_506_897_315.0.toISO8601DateTimeString(),
+      "2017-10-01T22:35:15Z",
       dataLakeTrackingClientProps?["checkout_reward_estimated_delivery_on"] as? String
     )
     XCTAssertEqual("My Reward", dataLakeTrackingClientProps?["checkout_reward_title"] as? String)
@@ -5873,7 +5873,7 @@ final class PledgeViewModelTests: TestCase {
     XCTAssertEqual(true, segmentClientProps?["checkout_reward_shipping_enabled"] as? Bool)
     XCTAssertEqual(true, segmentClientProps?["checkout_user_has_eligible_stored_apple_pay_card"] as? Bool)
     XCTAssertEqual(
-      1_506_897_315.0.toISO8601DateTimeString(),
+      "2017-10-01T22:35:15Z",
       segmentClientProps?["checkout_reward_estimated_delivery_on"] as? String
     )
     XCTAssertEqual("My Reward", segmentClientProps?["checkout_reward_title"] as? String)

--- a/Library/ViewModels/PledgeViewModelTests.swift
+++ b/Library/ViewModels/PledgeViewModelTests.swift
@@ -5862,8 +5862,8 @@ final class PledgeViewModelTests: TestCase {
       dataLakeTrackingClientProps?["checkout_user_has_eligible_stored_apple_pay_card"] as? Bool
     )
     XCTAssertEqual(
-      1_506_897_315.0,
-      dataLakeTrackingClientProps?["checkout_reward_estimated_delivery_on"] as? TimeInterval
+      1_506_897_315.0.toISO8601DateTimeString(),
+      dataLakeTrackingClientProps?["checkout_reward_estimated_delivery_on"] as? String
     )
     XCTAssertEqual("My Reward", dataLakeTrackingClientProps?["checkout_reward_title"] as? String)
     XCTAssertEqual("CREDIT_CARD", segmentClientProps?["checkout_payment_type"] as? String)
@@ -5873,8 +5873,8 @@ final class PledgeViewModelTests: TestCase {
     XCTAssertEqual(true, segmentClientProps?["checkout_reward_shipping_enabled"] as? Bool)
     XCTAssertEqual(true, segmentClientProps?["checkout_user_has_eligible_stored_apple_pay_card"] as? Bool)
     XCTAssertEqual(
-      1_506_897_315.0,
-      segmentClientProps?["checkout_reward_estimated_delivery_on"] as? TimeInterval
+      1_506_897_315.0.toISO8601DateTimeString(),
+      segmentClientProps?["checkout_reward_estimated_delivery_on"] as? String
     )
     XCTAssertEqual("My Reward", segmentClientProps?["checkout_reward_title"] as? String)
 

--- a/Library/ViewModels/ThanksViewModelTests.swift
+++ b/Library/ViewModels/ThanksViewModelTests.swift
@@ -408,8 +408,8 @@ final class ThanksViewModelTests: TestCase {
     )
     XCTAssertEqual("10.00", dataLakeTrackingClientProps?["checkout_shipping_amount_usd"] as? String)
     XCTAssertEqual(
-      12_345_678,
-      dataLakeTrackingClientProps?["checkout_reward_estimated_delivery_on"] as? TimeInterval
+      12_345_678.toISO8601DateTimeString(),
+      dataLakeTrackingClientProps?["checkout_reward_estimated_delivery_on"] as? String
     )
 
     XCTAssertEqual(2, segmentClientProps?["checkout_add_ons_count_total"] as? Int)
@@ -425,7 +425,10 @@ final class ThanksViewModelTests: TestCase {
     XCTAssertEqual(true, segmentClientProps?["checkout_reward_shipping_enabled"] as? Bool)
     XCTAssertEqual(true, segmentClientProps?["checkout_user_has_eligible_stored_apple_pay_card"] as? Bool)
     XCTAssertEqual("10.00", segmentClientProps?["checkout_shipping_amount_usd"] as? String)
-    XCTAssertEqual(12_345_678, segmentClientProps?["checkout_reward_estimated_delivery_on"] as? TimeInterval)
+    XCTAssertEqual(
+      12_345_678.toISO8601DateTimeString(),
+      segmentClientProps?["checkout_reward_estimated_delivery_on"] as? String
+    )
 
     // Pledge properties
     XCTAssertEqual(true, dataLakeTrackingClientProps?["pledge_backer_reward_has_items"] as? Bool)

--- a/Library/ViewModels/ThanksViewModelTests.swift
+++ b/Library/ViewModels/ThanksViewModelTests.swift
@@ -408,7 +408,7 @@ final class ThanksViewModelTests: TestCase {
     )
     XCTAssertEqual("10.00", dataLakeTrackingClientProps?["checkout_shipping_amount_usd"] as? String)
     XCTAssertEqual(
-      12_345_678.toISO8601DateTimeString(),
+      "1970-05-23T21:21:18Z",
       dataLakeTrackingClientProps?["checkout_reward_estimated_delivery_on"] as? String
     )
 
@@ -426,7 +426,7 @@ final class ThanksViewModelTests: TestCase {
     XCTAssertEqual(true, segmentClientProps?["checkout_user_has_eligible_stored_apple_pay_card"] as? Bool)
     XCTAssertEqual("10.00", segmentClientProps?["checkout_shipping_amount_usd"] as? String)
     XCTAssertEqual(
-      12_345_678.toISO8601DateTimeString(),
+      "1970-05-23T21:21:18Z",
       segmentClientProps?["checkout_reward_estimated_delivery_on"] as? String
     )
 


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Add a new extension that converts TimeInterval to ISO 8601 Date and Time  Format.
Update `checkout_reward_estimated_delivery_on `, `project_deadline `, and `project_launched_at ` to send ISO 8601 Date Time format to Segment. 

# 🤔 Why

Based on the feedback from QA Phase 1 event tasks, `checkout_reward_estimated_delivery_on `, `project_deadline `, and `project_launched_at ` are sending their values as `TimeInterval` .