### PR TITLE
[EP-404] QA Phase 1 Fix User Properties

### DIFF
--- a/KsApi/models/User.swift
+++ b/KsApi/models/User.swift
@@ -76,6 +76,7 @@ public struct User {
   public struct Stats {
     public var backedProjectsCount: Int?
     public var createdProjectsCount: Int?
+    public var draftProjectsCount: Int?
     public var memberProjectsCount: Int?
     public var starredProjectsCount: Int?
     public var unansweredSurveysCount: Int?
@@ -303,6 +304,7 @@ extension User.Stats: Decodable {
   enum CodingKeys: String, CodingKey {
     case backedProjectsCount = "backed_projects_count"
     case createdProjectsCount = "created_projects_count"
+    case draftProjectsCount = "draft_projects_count"
     case memberProjectsCount = "member_projects_count"
     case starredProjectsCount = "starred_projects_count"
     case unansweredSurveysCount = "unanswered_surveys_count"
@@ -314,6 +316,7 @@ extension User.Stats: EncodableType {
   public func encode() -> [String: Any] {
     var result: [String: Any] = [:]
     result["backed_projects_count"] = self.backedProjectsCount
+    result["draft_projects_count"] = self.draftProjectsCount
     result["created_projects_count"] = self.createdProjectsCount
     result["member_projects_count"] = self.memberProjectsCount
     result["starred_projects_count"] = self.starredProjectsCount

--- a/KsApi/models/User.swift
+++ b/KsApi/models/User.swift
@@ -316,8 +316,8 @@ extension User.Stats: EncodableType {
   public func encode() -> [String: Any] {
     var result: [String: Any] = [:]
     result["backed_projects_count"] = self.backedProjectsCount
-    result["draft_projects_count"] = self.draftProjectsCount
     result["created_projects_count"] = self.createdProjectsCount
+    result["draft_projects_count"] = self.draftProjectsCount
     result["member_projects_count"] = self.memberProjectsCount
     result["starred_projects_count"] = self.starredProjectsCount
     result["unanswered_surveys_count"] = self.unansweredSurveysCount

--- a/KsApi/models/UserTests.swift
+++ b/KsApi/models/UserTests.swift
@@ -21,6 +21,7 @@ final class UserTests: XCTestCase {
         "small": "http://www.kickstarter.com/small.jpg"
       ],
       "backed_projects_count": 2,
+      "draft_projects_count": 4,
       "weekly_newsletter": false,
       "promo_newsletter": false,
       "happening_newsletter": false,
@@ -48,6 +49,7 @@ final class UserTests: XCTestCase {
     XCTAssertEqual(false, user?.isAdmin)
     XCTAssertEqual("http://www.kickstarter.com/small.jpg", user?.avatar.small)
     XCTAssertEqual(2, user?.stats.backedProjectsCount)
+    XCTAssertEqual(4, user?.stats.draftProjectsCount)
     XCTAssertEqual(false, user?.newsletters.weekly)
     XCTAssertEqual(false, user?.newsletters.promo)
     XCTAssertEqual(false, user?.newsletters.happening)

--- a/KsApi/models/lenses/User.StatsLenses.swift
+++ b/KsApi/models/lenses/User.StatsLenses.swift
@@ -5,18 +5,39 @@ extension User.Stats {
     public static let backedProjectsCount = Lens<User.Stats, Int?>(
       view: { $0.backedProjectsCount },
       set: { User.Stats(
-        backedProjectsCount: $0, createdProjectsCount: $1.createdProjectsCount,
-        memberProjectsCount: $1.memberProjectsCount, starredProjectsCount: $1.starredProjectsCount,
-        unansweredSurveysCount: $1.unansweredSurveysCount, unreadMessagesCount: $1.unreadMessagesCount
+        backedProjectsCount: $0,
+        createdProjectsCount: $1.createdProjectsCount,
+        draftProjectsCount: $1.draftProjectsCount,
+        memberProjectsCount: $1.memberProjectsCount,
+        starredProjectsCount: $1.starredProjectsCount,
+        unansweredSurveysCount: $1.unansweredSurveysCount,
+        unreadMessagesCount: $1.unreadMessagesCount
+      ) }
+    )
+
+    public static let draftProjectsCount = Lens<User.Stats, Int?>(
+      view: { $0.draftProjectsCount },
+      set: { User.Stats(
+        backedProjectsCount: $1.backedProjectsCount,
+        createdProjectsCount: $1.createdProjectsCount,
+        draftProjectsCount: $0,
+        memberProjectsCount: $1.memberProjectsCount,
+        starredProjectsCount: $1.starredProjectsCount,
+        unansweredSurveysCount: $1.unansweredSurveysCount,
+        unreadMessagesCount: $1.unreadMessagesCount
       ) }
     )
 
     public static let createdProjectsCount = Lens<User.Stats, Int?>(
       view: { $0.createdProjectsCount },
       set: { User.Stats(
-        backedProjectsCount: $1.backedProjectsCount, createdProjectsCount: $0,
-        memberProjectsCount: $1.memberProjectsCount, starredProjectsCount: $1.starredProjectsCount,
-        unansweredSurveysCount: $1.unansweredSurveysCount, unreadMessagesCount: $1.unreadMessagesCount
+        backedProjectsCount: $1.backedProjectsCount,
+        createdProjectsCount: $0,
+        draftProjectsCount: $1.draftProjectsCount,
+        memberProjectsCount: $1.memberProjectsCount,
+        starredProjectsCount: $1.starredProjectsCount,
+        unansweredSurveysCount: $1.unansweredSurveysCount,
+        unreadMessagesCount: $1.unreadMessagesCount
       ) }
     )
 
@@ -24,8 +45,11 @@ extension User.Stats {
       view: { $0.memberProjectsCount },
       set: { User.Stats(
         backedProjectsCount: $1.backedProjectsCount,
-        createdProjectsCount: $1.createdProjectsCount, memberProjectsCount: $0,
-        starredProjectsCount: $1.starredProjectsCount, unansweredSurveysCount: $1.unansweredSurveysCount,
+        createdProjectsCount: $1.createdProjectsCount,
+        draftProjectsCount: $1.draftProjectsCount,
+        memberProjectsCount: $0,
+        starredProjectsCount: $1.starredProjectsCount,
+        unansweredSurveysCount: $1.unansweredSurveysCount,
         unreadMessagesCount: $1.unreadMessagesCount
       ) }
     )
@@ -34,8 +58,11 @@ extension User.Stats {
       view: { $0.starredProjectsCount },
       set: { User.Stats(
         backedProjectsCount: $1.backedProjectsCount,
-        createdProjectsCount: $1.createdProjectsCount, memberProjectsCount: $1.memberProjectsCount,
-        starredProjectsCount: $0, unansweredSurveysCount: $1.unansweredSurveysCount,
+        createdProjectsCount: $1.createdProjectsCount,
+        draftProjectsCount: $1.draftProjectsCount,
+        memberProjectsCount: $1.memberProjectsCount,
+        starredProjectsCount: $0,
+        unansweredSurveysCount: $1.unansweredSurveysCount,
         unreadMessagesCount: $1.unreadMessagesCount
       ) }
     )

--- a/KsApi/models/lenses/UserLenses.swift
+++ b/KsApi/models/lenses/UserLenses.swift
@@ -519,6 +519,10 @@ extension Lens where Whole == User, Part == User.Stats {
     return User.lens.stats .. User.Stats.lens.createdProjectsCount
   }
 
+  public var draftProjectsCount: Lens<User, Int?> {
+    return User.lens.stats .. User.Stats.lens.draftProjectsCount
+  }
+
   public var memberProjectsCount: Lens<User, Int?> {
     return User.lens.stats .. User.Stats.lens.memberProjectsCount
   }

--- a/KsApi/models/templates/User.StatsTemplates.swift
+++ b/KsApi/models/templates/User.StatsTemplates.swift
@@ -2,6 +2,7 @@ extension User.Stats {
   internal static let template = User.Stats(
     backedProjectsCount: nil,
     createdProjectsCount: nil,
+    draftProjectsCount: nil,
     memberProjectsCount: nil,
     starredProjectsCount: nil,
     unansweredSurveysCount: nil,

--- a/Library/Tracking/KSRAnalytics.swift
+++ b/Library/Tracking/KSRAnalytics.swift
@@ -1810,13 +1810,14 @@ private func userProperties(for user: User?, config _: Config?, _ prefix: String
   var props: [String: Any] = [:]
 
   props["backed_projects_count"] = user?.stats.backedProjectsCount
+  // the product/insights team definition of created_projects_count is the sum of createdProjectsCount and draftProjectsCount
   props["created_projects_count"] = (user?.stats.createdProjectsCount ?? 0) +
     (user?.stats
       .draftProjectsCount ??
-      0) // Stats.createdProjectsCount is the count of projects user has lauched only, while event property `created_projects_count` includes Stats.createdProject + Stats.draftProjectsCount
+      0)
   props["is_admin"] = user?.isAdmin
   props["launched_projects_count"] = user?.stats
-    .createdProjectsCount // event property`launched_projects_count` = Stats.createdProjectsCount
+    .createdProjectsCount // product and insights defines launched_projects_count as only the createdProjectsCount
   props["uid"] = user?.id
   props["watched_projects_count"] = user?.stats.starredProjectsCount
   props["facebook_connected"] = user?.facebookConnected

--- a/Library/Tracking/KSRAnalytics.swift
+++ b/Library/Tracking/KSRAnalytics.swift
@@ -9,7 +9,6 @@ public final class KSRAnalytics {
   private let dataLakeClient: TrackingClientType
   internal private(set) var config: Config?
   private let device: UIDeviceType
-  private let distinctId: String
   internal private(set) var loggedInUser: User? {
     didSet {
       self.identify(self.loggedInUser)
@@ -528,8 +527,7 @@ public final class KSRAnalytics {
     loggedInUser: User? = nil,
     screen: UIScreenType = UIScreen.main,
     segmentClient: TrackingClientType & IdentifyingTrackingClient = Analytics
-      .configuredClient(),
-    distinctId: String = (UIDevice.current.identifierForVendor ?? UUID()).uuidString
+      .configuredClient()
   ) {
     self.bundle = bundle
     self.dataLakeClient = dataLakeClient
@@ -538,7 +536,6 @@ public final class KSRAnalytics {
     self.loggedInUser = loggedInUser
     self.screen = screen
     self.segmentClient = segmentClient
-    self.distinctId = distinctId
 
     self.updateAndObservePreferredContentSizeCategory()
   }
@@ -1503,10 +1500,7 @@ public final class KSRAnalytics {
     props["country"] = self.config?.countryCode
     props["display_language"] = AppEnvironment.current.language.rawValue
     props["device_type"] = self.device.deviceType
-    props["device_manufacturer"] = "Apple"
-    props["device_model"] = KSRAnalytics.deviceModel
     props["device_orientation"] = self.deviceOrientation
-    props["device_distinct_id"] = self.distinctId
 
     if let appBuildNumber = self.bundle.infoDictionary?["CFBundleVersion"] as? String {
       props["app_build_number"] = Int(appBuildNumber)
@@ -1515,24 +1509,13 @@ public final class KSRAnalytics {
     props["app_release_version"] = self.bundle.infoDictionary?["CFBundleShortVersionString"]
     props["is_voiceover_running"] = AppEnvironment.current.isVoiceOverRunning()
     props["os"] = "ios"
-    props["os_version"] = self.device.systemVersion
     props["platform"] = self.clientPlatform
-    props["screen_width"] = UInt(self.screen.bounds.width)
-    props["user_agent"] = Service.userAgent
     props["user_is_logged_in"] = self.loggedInUser != nil
 
     props["ref_tag"] = refTag
 
     return props.prefixedKeys(prefix)
   }
-
-  private static let deviceModel: String? = {
-    var size: Int = 0
-    sysctlbyname("hw.machine", nil, &size, nil, 0)
-    var machine = [CChar](repeating: 0, count: Int(size))
-    sysctlbyname("hw.machine", &machine, &size, nil, 0)
-    return String(cString: machine)
-  }()
 
   private var deviceOrientation: String {
     switch self.device.orientation {

--- a/Library/Tracking/KSRAnalytics.swift
+++ b/Library/Tracking/KSRAnalytics.swift
@@ -1800,9 +1800,10 @@ private func userProperties(for user: User?, config _: Config?, _ prefix: String
   var props: [String: Any] = [:]
 
   props["backed_projects_count"] = user?.stats.backedProjectsCount
-  props["created_projects_count"] = user?.stats.createdProjectsCount
+  props["created_projects_count"] = (user?.stats.createdProjectsCount ?? 0) +
+    (user?.stats.draftProjectsCount ?? 0)
   props["is_admin"] = user?.isAdmin
-  props["launched_projects_count"] = user?.stats.memberProjectsCount
+  props["launched_projects_count"] = user?.stats.createdProjectsCount
   props["uid"] = user?.id
   props["watched_projects_count"] = user?.stats.starredProjectsCount
   props["facebook_connected"] = user?.facebookConnected

--- a/Library/Tracking/KSRAnalytics.swift
+++ b/Library/Tracking/KSRAnalytics.swift
@@ -1801,9 +1801,12 @@ private func userProperties(for user: User?, config _: Config?, _ prefix: String
 
   props["backed_projects_count"] = user?.stats.backedProjectsCount
   props["created_projects_count"] = (user?.stats.createdProjectsCount ?? 0) +
-    (user?.stats.draftProjectsCount ?? 0)
+    (user?.stats
+      .draftProjectsCount ??
+      0) // Stats.createdProjectsCount is the count of projects user has lauched only, while event property `created_projects_count` includes Stats.createdProject + Stats.draftProjectsCount
   props["is_admin"] = user?.isAdmin
-  props["launched_projects_count"] = user?.stats.createdProjectsCount
+  props["launched_projects_count"] = user?.stats
+    .createdProjectsCount // event property`launched_projects_count` = Stats.createdProjectsCount
   props["uid"] = user?.id
   props["watched_projects_count"] = user?.stats.starredProjectsCount
   props["facebook_connected"] = user?.facebookConnected

--- a/Library/Tracking/KSRAnalyticsTests.swift
+++ b/Library/Tracking/KSRAnalyticsTests.swift
@@ -32,8 +32,7 @@ final class KSRAnalyticsTests: TestCase {
       device: device,
       loggedInUser: nil,
       screen: screen,
-      segmentClient: segmentClient,
-      distinctId: "abc-123"
+      segmentClient: segmentClient
     )
 
     ksrAnalytics.trackTabBarClicked(.activity)
@@ -55,37 +54,29 @@ final class KSRAnalyticsTests: TestCase {
     XCTAssertEqual(1_234_567_890, dataLakeClientProperties?["session_app_build_number"] as? Int)
     XCTAssertEqual("1.2.3.4.5.6.7.8.9.0", dataLakeClientProperties?["session_app_release_version"] as? String)
     XCTAssertEqual("phone", dataLakeClientProperties?["session_device_type"] as? String)
-    XCTAssertEqual("Apple", dataLakeClientProperties?["session_device_manufacturer"] as? String)
     XCTAssertEqual("portrait", dataLakeClientProperties?["session_device_orientation"] as? String)
-    XCTAssertEqual("abc-123", dataLakeClientProperties?["session_device_distinct_id"] as? String)
 
     XCTAssertEqual("ios", dataLakeClientProperties?["session_os"] as? String)
-    XCTAssertEqual("MockSystemVersion", dataLakeClientProperties?["session_os_version"] as? String)
-    XCTAssertEqual(UInt(screen.bounds.width), dataLakeClientProperties?["session_screen_width"] as? UInt)
     XCTAssertEqual(false, dataLakeClientProperties?["session_user_is_logged_in"] as? Bool)
     XCTAssertEqual("native_ios", dataLakeClientProperties?["session_platform"] as? String)
     XCTAssertEqual("en", dataLakeClientProperties?["session_display_language"] as? String)
     XCTAssertEqual("GB", dataLakeClientProperties?["session_country"] as? String)
 
-    XCTAssertEqual(19, dataLakeClientProperties?.keys.filter { $0.hasPrefix("session_") }.count)
+    XCTAssertEqual(13, dataLakeClientProperties?.keys.filter { $0.hasPrefix("session_") }.count)
 
     XCTAssertEqual("native", segmentClientProperties?["session_client"] as? String)
     XCTAssertEqual(1_234_567_890, segmentClientProperties?["session_app_build_number"] as? Int)
     XCTAssertEqual("1.2.3.4.5.6.7.8.9.0", segmentClientProperties?["session_app_release_version"] as? String)
     XCTAssertEqual("phone", segmentClientProperties?["session_device_type"] as? String)
-    XCTAssertEqual("Apple", segmentClientProperties?["session_device_manufacturer"] as? String)
     XCTAssertEqual("portrait", segmentClientProperties?["session_device_orientation"] as? String)
-    XCTAssertEqual("abc-123", segmentClientProperties?["session_device_distinct_id"] as? String)
 
     XCTAssertEqual("ios", segmentClientProperties?["session_os"] as? String)
-    XCTAssertEqual("MockSystemVersion", segmentClientProperties?["session_os_version"] as? String)
-    XCTAssertEqual(UInt(screen.bounds.width), segmentClientProperties?["session_screen_width"] as? UInt)
     XCTAssertEqual(false, segmentClientProperties?["session_user_is_logged_in"] as? Bool)
     XCTAssertEqual("native_ios", segmentClientProperties?["session_platform"] as? String)
     XCTAssertEqual("en", segmentClientProperties?["session_display_language"] as? String)
     XCTAssertEqual("GB", segmentClientProperties?["session_country"] as? String)
 
-    XCTAssertEqual(19, segmentClientProperties?.keys.filter { $0.hasPrefix("session_") }.count)
+    XCTAssertEqual(13, segmentClientProperties?.keys.filter { $0.hasPrefix("session_") }.count)
   }
 
   func testSessionProperties_Language() {
@@ -982,13 +973,9 @@ final class KSRAnalyticsTests: TestCase {
 
     XCTAssertEqual(["Tab Bar Clicked"], dataLakeClient.events)
     XCTAssertEqual(["Tab Bar Clicked"], callBackEvents)
-    XCTAssertEqual("Apple", dataLakeClient.properties.last?["session_device_manufacturer"] as? String)
-    XCTAssertEqual("Apple", callBackProperties?["session_device_manufacturer"] as? String)
 
     XCTAssertEqual(["Tab Bar Clicked"], segmentClient.events)
     XCTAssertEqual(["Tab Bar Clicked"], callBackEvents)
-    XCTAssertEqual("Apple", segmentClient.properties.last?["session_device_manufacturer"] as? String)
-    XCTAssertEqual("Apple", callBackProperties?["session_device_manufacturer"] as? String)
   }
 
   func testProjectCardClicked_Page_Discover() {

--- a/Library/Tracking/KSRAnalyticsTests.swift
+++ b/Library/Tracking/KSRAnalyticsTests.swift
@@ -1751,7 +1751,6 @@ final class KSRAnalyticsTests: TestCase {
       |> User.lens.facebookConnected .~ true
       |> User.lens.stats.starredProjectsCount .~ 2
       |> User.lens.stats.createdProjectsCount .~ 7
-      |> User.lens.stats.memberProjectsCount .~ 6
       |> User.lens.stats.draftProjectsCount .~ 8
       |> User.lens.id .~ 10
       |> User.lens.isAdmin .~ false

--- a/Library/Tracking/KSRAnalyticsTests.swift
+++ b/Library/Tracking/KSRAnalyticsTests.swift
@@ -1750,8 +1750,9 @@ final class KSRAnalyticsTests: TestCase {
       |> User.lens.location .~ Location.usa
       |> User.lens.facebookConnected .~ true
       |> User.lens.stats.starredProjectsCount .~ 2
-      |> User.lens.stats.createdProjectsCount .~ 3
+      |> User.lens.stats.createdProjectsCount .~ 7
       |> User.lens.stats.memberProjectsCount .~ 6
+      |> User.lens.stats.draftProjectsCount .~ 8
       |> User.lens.id .~ 10
       |> User.lens.isAdmin .~ false
 
@@ -1768,17 +1769,17 @@ final class KSRAnalyticsTests: TestCase {
 
     XCTAssertEqual(10, dataLakeClientProps?["user_uid"] as? Int)
     XCTAssertEqual(5, dataLakeClientProps?["user_backed_projects_count"] as? Int)
-    XCTAssertEqual(3, dataLakeClientProps?["user_created_projects_count"] as? Int)
+    XCTAssertEqual(15, dataLakeClientProps?["user_created_projects_count"] as? Int)
     XCTAssertEqual(false, dataLakeClientProps?["user_is_admin"] as? Bool)
-    XCTAssertEqual(6, dataLakeClientProps?["user_launched_projects_count"] as? Int)
+    XCTAssertEqual(7, dataLakeClientProps?["user_launched_projects_count"] as? Int)
     XCTAssertEqual(2, dataLakeClientProps?["user_watched_projects_count"] as? Int)
     XCTAssertEqual(true, dataLakeClientProps?["user_facebook_connected"] as? Bool)
 
     XCTAssertEqual(10, segmentClientProps?["user_uid"] as? Int)
     XCTAssertEqual(5, segmentClientProps?["user_backed_projects_count"] as? Int)
-    XCTAssertEqual(3, segmentClientProps?["user_created_projects_count"] as? Int)
+    XCTAssertEqual(15, segmentClientProps?["user_created_projects_count"] as? Int)
     XCTAssertEqual(false, segmentClientProps?["user_is_admin"] as? Bool)
-    XCTAssertEqual(6, segmentClientProps?["user_launched_projects_count"] as? Int)
+    XCTAssertEqual(7, segmentClientProps?["user_launched_projects_count"] as? Int)
     XCTAssertEqual(2, segmentClientProps?["user_watched_projects_count"] as? Int)
     XCTAssertEqual(true, segmentClientProps?["user_facebook_connected"] as? Bool)
   }


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Change how we send `launched_project_count` and `created_project_count` for User Properties to Segment.

# 🤔 Why

The api returns created_project_count, this is the count of the project that you've created, but on segment user_created_project_count  definition is different, to get the value you'll need created_project_count from api + draft_project_count  from the api, while `launched_project_count` on segment  is `created_project_count` from the api.