### PR TITLE
[NT-1822] Switch prelaunch display logic to use display_prelaunch field from v1 API

### DIFF
--- a/Kickstarter-iOS/ViewModels/AppDelegateViewModel.swift
+++ b/Kickstarter-iOS/ViewModels/AppDelegateViewModel.swift
@@ -432,10 +432,10 @@ public final class AppDelegateViewModel: AppDelegateViewModelType, AppDelegateVi
       }
 
     let projectLink = projectLinkValues
-      .filter { project, _, _, _ in project.prelaunchActivated != true }
+      .filter { project, _, _, _ in project.displayPrelaunch != true }
 
     let projectPreviewLink = projectLinkValues
-      .filter { project, _, _, _ in project.prelaunchActivated == true }
+      .filter { project, _, _, _ in project.displayPrelaunch == true }
 
     let fixErroredPledgeLinkAndIsLoggedIn = projectLink
       .filter { _, subpage, _, _ in subpage == .pledge(.manage) }

--- a/Kickstarter-iOS/ViewModels/AppDelegateViewModelTests.swift
+++ b/Kickstarter-iOS/ViewModels/AppDelegateViewModelTests.swift
@@ -647,7 +647,7 @@ final class AppDelegateViewModelTests: TestCase {
 
   func testPresentViewController_ProjectPreviewLink_PrelaunchActivated_True() {
     let project = Project.template
-      |> Project.lens.prelaunchActivated .~ true
+      |> Project.lens.displayPrelaunch .~ true
 
     let apiService = MockService(fetchProjectResponse: project)
     withEnvironment(apiService: apiService) {
@@ -675,7 +675,7 @@ final class AppDelegateViewModelTests: TestCase {
 
   func testPresentViewController_ProjectPreviewLink_PrelaunchActivated_False() {
     let project = Project.template
-      |> Project.lens.prelaunchActivated .~ false
+      |> Project.lens.displayPrelaunch .~ false
 
     let apiService = MockService(fetchProjectResponse: project)
     withEnvironment(apiService: apiService) {
@@ -703,7 +703,7 @@ final class AppDelegateViewModelTests: TestCase {
 
   func testPresentViewController_ProjectPreviewLink_PrelaunchActivated_Nil() {
     let project = Project.template
-      |> Project.lens.prelaunchActivated .~ nil
+      |> Project.lens.displayPrelaunch .~ nil
 
     let apiService = MockService(fetchProjectResponse: project)
     withEnvironment(apiService: apiService) {

--- a/Kickstarter-iOS/ViewModels/AppDelegateViewModelTests.swift
+++ b/Kickstarter-iOS/ViewModels/AppDelegateViewModelTests.swift
@@ -645,7 +645,7 @@ final class AppDelegateViewModelTests: TestCase {
     }
   }
 
-  func testPresentViewController_ProjectPreviewLink_PrelaunchActivated_True() {
+  func testPresentViewController_ProjectPreviewLink_DisplayPrelaunch_True() {
     let project = Project.template
       |> Project.lens.displayPrelaunch .~ true
 
@@ -673,7 +673,7 @@ final class AppDelegateViewModelTests: TestCase {
     }
   }
 
-  func testPresentViewController_ProjectPreviewLink_PrelaunchActivated_False() {
+  func testPresentViewController_ProjectPreviewLink_DisplayPrelaunch_False() {
     let project = Project.template
       |> Project.lens.displayPrelaunch .~ false
 
@@ -701,7 +701,7 @@ final class AppDelegateViewModelTests: TestCase {
     }
   }
 
-  func testPresentViewController_ProjectPreviewLink_PrelaunchActivated_Nil() {
+  func testPresentViewController_ProjectPreviewLink_DisplayPrelaunch_Nil() {
     let project = Project.template
       |> Project.lens.displayPrelaunch .~ nil
 

--- a/Kickstarter-iOS/ViewModels/UpdateViewModel.swift
+++ b/Kickstarter-iOS/ViewModels/UpdateViewModel.swift
@@ -132,11 +132,11 @@ internal final class UpdateViewModel: UpdateViewModelType, UpdateViewModelInputs
       }
 
     self.goToComments = goToComments
-    self.goToProject = projectAndRefTag.filter { _, project, _ in project.prelaunchActivated != .some(true) }
+    self.goToProject = projectAndRefTag.filter { _, project, _ in project.displayPrelaunch != .some(true) }
       .map { _, project, refTag in (project, refTag) }
 
     let goToPrelaunchPage = projectAndRefTag
-      .filter { _, project, _ in project.prelaunchActivated == true }
+      .filter { _, project, _ in project.displayPrelaunch == true }
       .map(first)
 
     self.goToSafariBrowser = Signal.merge(externalNavigationAction, goToPrelaunchPage)

--- a/Kickstarter-iOS/ViewModels/UpdateViewModelTests.swift
+++ b/Kickstarter-iOS/ViewModels/UpdateViewModelTests.swift
@@ -195,7 +195,7 @@ final class UpdateViewModelTests: TestCase {
   func testGoToSafariBrowser_PrelaunchProject() {
     let prelaunchProject = Project.template
       |> Project.lens.id .~ 10
-      |> Project.lens.prelaunchActivated .~ true
+      |> Project.lens.displayPrelaunch .~ true
     let prelaunchProjectURL = URL(string: prelaunchProject.urls.web.project)
       .flatMap { $0.deletingLastPathComponent() }
       .map { $0.appendingPathComponent(String(prelaunchProject.id)) }!

--- a/KsApi/models/Project.swift
+++ b/KsApi/models/Project.swift
@@ -10,6 +10,7 @@ public struct Project {
   public var creator: User
   public var memberData: MemberData
   public var dates: Dates
+  public var displayPrelaunch: Bool?
   public var id: Int
   public var location: Location
   public var name: String
@@ -241,6 +242,7 @@ extension Project: Decodable {
     case blurb
     case category
     case creator
+    case displayPrelaunch = "display_prelaunch"
     case id
     case location
     case name
@@ -263,6 +265,7 @@ extension Project: Decodable {
     self.creator = try values.decode(User.self, forKey: .creator)
     self.memberData = try Project.MemberData(from: decoder)
     self.dates = try Project.Dates(from: decoder)
+    self.displayPrelaunch = try values.decodeIfPresent(Bool.self, forKey: .displayPrelaunch)
     self.id = try values.decode(Int.self, forKey: .id)
     self.location = (try? values.decodeIfPresent(Location.self, forKey: .location)) ?? Location.none
     self.name = try values.decode(String.self, forKey: .name)

--- a/KsApi/models/graphql/GraphBackingTests.swift
+++ b/KsApi/models/graphql/GraphBackingTests.swift
@@ -53,6 +53,7 @@ final class GraphBackingTests: XCTestCase {
                 "name": "Canada"
               ],
               "isProjectWeLove": true,
+              "displayPrelaunch": false,
               "prelaunchActivated": false,
               "deadlineAt": 158_750_211,
               "launchedAt": 158_740_211,

--- a/KsApi/models/graphql/GraphProject.swift
+++ b/KsApi/models/graphql/GraphProject.swift
@@ -10,6 +10,7 @@ struct GraphProject: Decodable {
   var creator: GraphUser
   var currency: String
   var deadlineAt: TimeInterval?
+  var displayPrelaunch: Bool?
   var description: String
   var finalCollectionDate: String?
   var fxRate: Double

--- a/KsApi/models/graphql/ManagePledgeViewBackingEnvelopeTests.swift
+++ b/KsApi/models/graphql/ManagePledgeViewBackingEnvelopeTests.swift
@@ -197,6 +197,7 @@ final class ManagePledgeViewBackingEnvelopeTests: XCTestCase {
       XCTAssertEqual(value.project.actions.displayConvertAmount, true)
       XCTAssertEqual(value.project.fxRate, 1.082342)
       XCTAssertEqual(value.project.deadlineAt, 158_750_211.0)
+      XCTAssertEqual(value.project.displayPrelaunch, false)
       XCTAssertEqual(value.project.launchedAt, 158_740_211)
       XCTAssertEqual(value.project.stateChangedAt, 1_587_502_131.0)
       XCTAssertEqual(value.project.description, "Project description")

--- a/KsApi/models/graphql/ManagePledgeViewBackingEnvelopeTests.swift
+++ b/KsApi/models/graphql/ManagePledgeViewBackingEnvelopeTests.swift
@@ -31,6 +31,7 @@ final class ManagePledgeViewBackingEnvelopeTests: XCTestCase {
             "name": "Canada"
           ],
           "isProjectWeLove": true,
+          "displayPrelaunch": false,
           "prelaunchActivated": false,
           "deadlineAt": 158_750_211,
           "launchedAt": 158_740_211,

--- a/KsApi/models/graphql/RewardAddOnSelectionViewEnvelopeTests.swift
+++ b/KsApi/models/graphql/RewardAddOnSelectionViewEnvelopeTests.swift
@@ -133,6 +133,7 @@ final class RewardAddOnSelectionViewEnvelopeTests: XCTestCase {
       XCTAssertEqual(value.project.launchedAt, 158_740_211)
       XCTAssertEqual(value.project.stateChangedAt, 1_587_502_131.0)
       XCTAssertEqual(value.project.description, "Project description")
+      XCTAssertEqual(value.project.displayPrelaunch, false)
       XCTAssertEqual(value.project.finalCollectionDate, "2020-07-01")
       XCTAssertEqual(value.project.isProjectWeLove, true)
       XCTAssertEqual(value.project.prelaunchActivated, false)

--- a/KsApi/models/graphql/RewardAddOnSelectionViewEnvelopeTests.swift
+++ b/KsApi/models/graphql/RewardAddOnSelectionViewEnvelopeTests.swift
@@ -29,6 +29,7 @@ final class RewardAddOnSelectionViewEnvelopeTests: XCTestCase {
           "name": "Canada"
         ],
         "isProjectWeLove": true,
+        "displayPrelaunch": false,
         "prelaunchActivated": false,
         "deadlineAt": 158_750_211,
         "launchedAt": 158_740_211,

--- a/KsApi/models/lenses/ProjectLenses.swift
+++ b/KsApi/models/lenses/ProjectLenses.swift
@@ -6,7 +6,8 @@ extension Project {
       view: { $0.availableCardTypes },
       set: { Project(
         availableCardTypes: $0, blurb: $1.blurb, category: $1.category, country: $1.country,
-        creator: $1.creator, memberData: $1.memberData, dates: $1.dates, id: $1.id,
+        creator: $1.creator, memberData: $1.memberData, dates: $1.dates,
+        displayPrelaunch: $1.displayPrelaunch, id: $1.id,
         location: $1.location, name: $1.name, personalization: $1.personalization, photo: $1.photo,
         prelaunchActivated: $1.prelaunchActivated, rewardData: $1.rewardData, slug: $1.slug,
         staffPick: $1.staffPick, state: $1.state, stats: $1.stats, tags: $1.tags, urls: $1.urls,
@@ -18,7 +19,8 @@ extension Project {
       view: { $0.blurb },
       set: { Project(
         availableCardTypes: $1.availableCardTypes, blurb: $0, category: $1.category, country: $1.country,
-        creator: $1.creator, memberData: $1.memberData, dates: $1.dates, id: $1.id,
+        creator: $1.creator, memberData: $1.memberData, dates: $1.dates,
+        displayPrelaunch: $1.displayPrelaunch, id: $1.id,
         location: $1.location, name: $1.name, personalization: $1.personalization, photo: $1.photo,
         prelaunchActivated: $1.prelaunchActivated, rewardData: $1.rewardData, slug: $1.slug, staffPick:
         $1.staffPick, state: $1.state, stats: $1.stats, tags: $1.tags, urls: $1.urls, video: $1.video
@@ -29,7 +31,8 @@ extension Project {
       view: { $0.staffPick },
       set: { Project(
         availableCardTypes: $1.availableCardTypes, blurb: $1.blurb, category: $1.category,
-        country: $1.country, creator: $1.creator, memberData: $1.memberData, dates: $1.dates, id: $1.id,
+        country: $1.country, creator: $1.creator, memberData: $1.memberData, dates: $1.dates,
+        displayPrelaunch: $1.displayPrelaunch, id: $1.id,
         location: $1.location, name: $1.name, personalization: $1.personalization,
         photo: $1.photo, prelaunchActivated: $1.prelaunchActivated, rewardData: $1.rewardData, slug: $1.slug,
         staffPick: $0, state: $1.state, stats: $1.stats, tags: $1.tags, urls: $1.urls, video: $1.video
@@ -40,7 +43,8 @@ extension Project {
       view: { $0.category },
       set: { Project(
         availableCardTypes: $1.availableCardTypes, blurb: $1.blurb, category: $0, country: $1.country,
-        creator: $1.creator, memberData: $1.memberData, dates: $1.dates, id: $1.id,
+        creator: $1.creator, memberData: $1.memberData, dates: $1.dates,
+        displayPrelaunch: $1.displayPrelaunch, id: $1.id,
         location: $1.location, name: $1.name, personalization: $1.personalization, photo: $1.photo,
         prelaunchActivated: $1.prelaunchActivated, rewardData: $1.rewardData, slug: $1.slug,
         staffPick: $1.staffPick, state: $1.state, stats: $1.stats, tags: $1.tags, urls: $1.urls,
@@ -52,7 +56,8 @@ extension Project {
       view: { $0.country },
       set: { Project(
         availableCardTypes: $1.availableCardTypes, blurb: $1.blurb, category: $1.category, country: $0,
-        creator: $1.creator, memberData: $1.memberData, dates: $1.dates, id: $1.id,
+        creator: $1.creator, memberData: $1.memberData, dates: $1.dates,
+        displayPrelaunch: $1.displayPrelaunch, id: $1.id,
         location: $1.location, name: $1.name, personalization: $1.personalization, photo: $1.photo,
         prelaunchActivated: $1.prelaunchActivated, rewardData: $1.rewardData, slug: $1.slug,
         staffPick: $1.staffPick, state: $1.state, stats: $1.stats, tags: $1.tags, urls: $1.urls,
@@ -64,7 +69,8 @@ extension Project {
       view: { $0.creator },
       set: { Project(
         availableCardTypes: $1.availableCardTypes, blurb: $1.blurb, category: $1.category,
-        country: $1.country, creator: $0, memberData: $1.memberData, dates: $1.dates, id: $1.id,
+        country: $1.country, creator: $0, memberData: $1.memberData, dates: $1.dates,
+        displayPrelaunch: $1.displayPrelaunch, id: $1.id,
         location: $1.location, name: $1.name, personalization: $1.personalization, photo: $1.photo,
         prelaunchActivated: $1.prelaunchActivated, rewardData: $1.rewardData, slug: $1.slug,
         staffPick: $1.staffPick, state: $1.state, stats: $1.stats, tags: $1.tags, urls: $1.urls,
@@ -76,7 +82,21 @@ extension Project {
       view: { $0.dates },
       set: { Project(
         availableCardTypes: $1.availableCardTypes, blurb: $1.blurb, category: $1.category,
-        country: $1.country, creator: $1.creator, memberData: $1.memberData, dates: $0, id: $1.id,
+        country: $1.country, creator: $1.creator, memberData: $1.memberData, dates: $0,
+        displayPrelaunch: $1.displayPrelaunch, id: $1.id,
+        location: $1.location, name: $1.name, personalization: $1.personalization, photo: $1.photo,
+        prelaunchActivated: $1.prelaunchActivated, rewardData: $1.rewardData, slug: $1.slug,
+        staffPick: $1.staffPick, state: $1.state, stats: $1.stats, tags: $1.tags, urls: $1.urls,
+        video: $1.video
+      ) }
+    )
+
+    public static let displayPrelaunch = Lens<Project, Bool?>(
+      view: { $0.displayPrelaunch },
+      set: { Project(
+        availableCardTypes: $1.availableCardTypes, blurb: $1.blurb, category: $1.category,
+        country: $1.country, creator: $1.creator, memberData: $1.memberData, dates: $1.dates,
+        displayPrelaunch: $0, id: $1.id,
         location: $1.location, name: $1.name, personalization: $1.personalization, photo: $1.photo,
         prelaunchActivated: $1.prelaunchActivated, rewardData: $1.rewardData, slug: $1.slug,
         staffPick: $1.staffPick, state: $1.state, stats: $1.stats, tags: $1.tags, urls: $1.urls,
@@ -88,7 +108,8 @@ extension Project {
       view: { $0.id },
       set: { Project(
         availableCardTypes: $1.availableCardTypes, blurb: $1.blurb, category: $1.category,
-        country: $1.country, creator: $1.creator, memberData: $1.memberData, dates: $1.dates, id: $0,
+        country: $1.country, creator: $1.creator, memberData: $1.memberData, dates: $1.dates,
+        displayPrelaunch: $1.displayPrelaunch, id: $0,
         location: $1.location, name: $1.name, personalization: $1.personalization, photo: $1.photo,
         prelaunchActivated: $1.prelaunchActivated, rewardData: $1.rewardData, slug: $1.slug,
         staffPick: $1.staffPick, state: $1.state, stats: $1.stats, tags: $1.tags, urls: $1.urls,
@@ -100,7 +121,8 @@ extension Project {
       view: { $0.location },
       set: { Project(
         availableCardTypes: $1.availableCardTypes, blurb: $1.blurb, category: $1.category,
-        country: $1.country, creator: $1.creator, memberData: $1.memberData, dates: $1.dates, id: $1.id,
+        country: $1.country, creator: $1.creator, memberData: $1.memberData, dates: $1.dates,
+        displayPrelaunch: $1.displayPrelaunch, id: $1.id,
         location: $0, name: $1.name, personalization: $1.personalization, photo: $1.photo,
         prelaunchActivated: $1.prelaunchActivated, rewardData: $1.rewardData, slug: $1.slug,
         staffPick: $1.staffPick, state: $1.state, stats: $1.stats, tags: $1.tags, urls: $1.urls,
@@ -112,7 +134,8 @@ extension Project {
       view: { $0.memberData },
       set: { Project(
         availableCardTypes: $1.availableCardTypes, blurb: $1.blurb, category: $1.category,
-        country: $1.country, creator: $1.creator, memberData: $0, dates: $1.dates, id: $1.id,
+        country: $1.country, creator: $1.creator, memberData: $0, dates: $1.dates,
+        displayPrelaunch: $1.displayPrelaunch, id: $1.id,
         location: $1.location, name: $1.name, personalization: $1.personalization, photo: $1.photo,
         prelaunchActivated: $1.prelaunchActivated, rewardData: $1.rewardData, slug: $1.slug,
         staffPick: $1.staffPick, state: $1.state, stats: $1.stats, tags: $1.tags, urls: $1.urls,
@@ -124,7 +147,8 @@ extension Project {
       view: { $0.name },
       set: { Project(
         availableCardTypes: $1.availableCardTypes, blurb: $1.blurb, category: $1.category,
-        country: $1.country, creator: $1.creator, memberData: $1.memberData, dates: $1.dates, id: $1.id,
+        country: $1.country, creator: $1.creator, memberData: $1.memberData, dates: $1.dates,
+        displayPrelaunch: $1.displayPrelaunch, id: $1.id,
         location: $1.location, name: $0, personalization: $1.personalization, photo: $1.photo,
         prelaunchActivated: $1.prelaunchActivated, rewardData: $1.rewardData, slug: $1.slug,
         staffPick: $1.staffPick, state: $1.state, stats: $1.stats, tags: $1.tags, urls: $1.urls,
@@ -136,7 +160,8 @@ extension Project {
       view: { $0.personalization },
       set: { Project(
         availableCardTypes: $1.availableCardTypes, blurb: $1.blurb, category: $1.category,
-        country: $1.country, creator: $1.creator, memberData: $1.memberData, dates: $1.dates, id: $1.id,
+        country: $1.country, creator: $1.creator, memberData: $1.memberData, dates: $1.dates,
+        displayPrelaunch: $1.displayPrelaunch, id: $1.id,
         location: $1.location, name: $1.name, personalization: $0, photo: $1.photo,
         prelaunchActivated: $1.prelaunchActivated, rewardData: $1.rewardData, slug: $1.slug,
         staffPick: $1.staffPick, state: $1.state, stats: $1.stats, tags: $1.tags, urls: $1.urls,
@@ -148,7 +173,8 @@ extension Project {
       view: { $0.photo },
       set: { Project(
         availableCardTypes: $1.availableCardTypes, blurb: $1.blurb, category: $1.category,
-        country: $1.country, creator: $1.creator, memberData: $1.memberData, dates: $1.dates, id: $1.id,
+        country: $1.country, creator: $1.creator, memberData: $1.memberData, dates: $1.dates,
+        displayPrelaunch: $1.displayPrelaunch, id: $1.id,
         location: $1.location, name: $1.name, personalization: $1.personalization, photo: $0,
         prelaunchActivated: $1.prelaunchActivated, rewardData: $1.rewardData, slug: $1.slug,
         staffPick: $1.staffPick, state: $1.state, stats: $1.stats, tags: $1.tags, urls: $1.urls,
@@ -160,7 +186,8 @@ extension Project {
       view: { $0.prelaunchActivated },
       set: { Project(
         availableCardTypes: $1.availableCardTypes, blurb: $1.blurb, category: $1.category,
-        country: $1.country, creator: $1.creator, memberData: $1.memberData, dates: $1.dates, id: $1.id,
+        country: $1.country, creator: $1.creator, memberData: $1.memberData, dates: $1.dates,
+        displayPrelaunch: $1.displayPrelaunch, id: $1.id,
         location: $1.location, name: $1.name, personalization: $1.personalization, photo: $1.photo,
         prelaunchActivated: $0, rewardData: $1.rewardData, slug: $1.slug,
         staffPick: $1.staffPick, state: $1.state, stats: $1.stats, tags: $1.tags, urls: $1.urls,
@@ -172,7 +199,8 @@ extension Project {
       view: { $0.rewardData },
       set: { Project(
         availableCardTypes: $1.availableCardTypes, blurb: $1.blurb, category: $1.category,
-        country: $1.country, creator: $1.creator, memberData: $1.memberData, dates: $1.dates, id: $1.id,
+        country: $1.country, creator: $1.creator, memberData: $1.memberData, dates: $1.dates,
+        displayPrelaunch: $1.displayPrelaunch, id: $1.id,
         location: $1.location, name: $1.name, personalization: $1.personalization, photo: $1.photo,
         prelaunchActivated: $1.prelaunchActivated, rewardData: $0, slug: $1.slug, staffPick: $1.staffPick,
         state: $1.state, stats: $1.stats, tags: $1.tags, urls: $1.urls, video: $1.video
@@ -183,7 +211,8 @@ extension Project {
       view: { $0.slug },
       set: { Project(
         availableCardTypes: $1.availableCardTypes, blurb: $1.blurb, category: $1.category,
-        country: $1.country, creator: $1.creator, memberData: $1.memberData, dates: $1.dates, id: $1.id,
+        country: $1.country, creator: $1.creator, memberData: $1.memberData, dates: $1.dates,
+        displayPrelaunch: $1.displayPrelaunch, id: $1.id,
         location: $1.location, name: $1.name, personalization: $1.personalization, photo: $1.photo,
         prelaunchActivated: $1.prelaunchActivated, rewardData: $1.rewardData, slug: $0,
         staffPick: $1.staffPick,
@@ -195,7 +224,8 @@ extension Project {
       view: { $0.state },
       set: { Project(
         availableCardTypes: $1.availableCardTypes, blurb: $1.blurb, category: $1.category,
-        country: $1.country, creator: $1.creator, memberData: $1.memberData, dates: $1.dates, id: $1.id,
+        country: $1.country, creator: $1.creator, memberData: $1.memberData, dates: $1.dates,
+        displayPrelaunch: $1.displayPrelaunch, id: $1.id,
         location: $1.location, name: $1.name, personalization: $1.personalization, photo: $1.photo,
         prelaunchActivated: $1.prelaunchActivated, rewardData: $1.rewardData, slug: $1.slug,
         staffPick: $1.staffPick, state: $0, stats: $1.stats, tags: $1.tags, urls: $1.urls, video: $1.video
@@ -206,7 +236,8 @@ extension Project {
       view: { $0.stats },
       set: { Project(
         availableCardTypes: $1.availableCardTypes, blurb: $1.blurb, category: $1.category,
-        country: $1.country, creator: $1.creator, memberData: $1.memberData, dates: $1.dates, id: $1.id,
+        country: $1.country, creator: $1.creator, memberData: $1.memberData, dates: $1.dates,
+        displayPrelaunch: $1.displayPrelaunch, id: $1.id,
         location: $1.location, name: $1.name, personalization: $1.personalization, photo: $1.photo,
         prelaunchActivated: $1.prelaunchActivated, rewardData: $1.rewardData, slug: $1.slug,
         staffPick: $1.staffPick, state: $1.state, stats: $0, tags: $1.tags, urls: $1.urls, video: $1.video
@@ -217,7 +248,8 @@ extension Project {
       view: { $0.tags },
       set: { Project(
         availableCardTypes: $1.availableCardTypes, blurb: $1.blurb, category: $1.category,
-        country: $1.country, creator: $1.creator, memberData: $1.memberData, dates: $1.dates, id: $1.id,
+        country: $1.country, creator: $1.creator, memberData: $1.memberData, dates: $1.dates,
+        displayPrelaunch: $1.displayPrelaunch, id: $1.id,
         location: $1.location, name: $1.name, personalization: $1.personalization, photo: $1.photo,
         prelaunchActivated: $1.prelaunchActivated, rewardData: $1.rewardData, slug: $1.slug,
         staffPick: $1.staffPick, state: $1.state, stats: $1.stats, tags: $0, urls: $1.urls, video: $1.video
@@ -228,7 +260,8 @@ extension Project {
       view: { $0.urls },
       set: { Project(
         availableCardTypes: $1.availableCardTypes, blurb: $1.blurb, category: $1.category,
-        country: $1.country, creator: $1.creator, memberData: $1.memberData, dates: $1.dates, id: $1.id,
+        country: $1.country, creator: $1.creator, memberData: $1.memberData, dates: $1.dates,
+        displayPrelaunch: $1.displayPrelaunch, id: $1.id,
         location: $1.location, name: $1.name, personalization: $1.personalization, photo: $1.photo,
         prelaunchActivated: $1.prelaunchActivated, rewardData: $1.rewardData, slug: $1.slug,
         staffPick: $1.staffPick, state: $1.state, stats: $1.stats, tags: $1.tags, urls: $0, video: $1.video
@@ -239,7 +272,8 @@ extension Project {
       view: { $0.video },
       set: { Project(
         availableCardTypes: $1.availableCardTypes, blurb: $1.blurb, category: $1.category,
-        country: $1.country, creator: $1.creator, memberData: $1.memberData, dates: $1.dates, id: $1.id,
+        country: $1.country, creator: $1.creator, memberData: $1.memberData, dates: $1.dates,
+        displayPrelaunch: $1.displayPrelaunch, id: $1.id,
         location: $1.location, name: $1.name, personalization: $1.personalization, photo: $1.photo,
         prelaunchActivated: $1.prelaunchActivated, rewardData: $1.rewardData, slug: $1.slug,
         staffPick: $1.staffPick, state: $1.state, stats: $1.stats, tags: $1.tags, urls: $1.urls, video: $0

--- a/KsApi/models/templates/ProjectTemplates.swift
+++ b/KsApi/models/templates/ProjectTemplates.swift
@@ -30,6 +30,7 @@ extension Project {
         timeIntervalSince1970: 1_475_361_315
       ).timeIntervalSince1970 - 60.0 * 60.0 * 24.0 * 15.0
     ),
+    displayPrelaunch: nil,
     id: 1,
     location: .template,
     name: "The Project",

--- a/KsApi/models/templates/graphql/GraphProjectTemplates.swift
+++ b/KsApi/models/templates/graphql/GraphProjectTemplates.swift
@@ -10,6 +10,7 @@ extension GraphProject {
     creator: .template,
     currency: "USD",
     deadlineAt: 12_342_342_343,
+    displayPrelaunch: false,
     description: "Project description",
     finalCollectionDate: "2020-04-08T15:15:05Z",
     fxRate: 1,

--- a/Library/Tracking/KSRAnalyticsTests.swift
+++ b/Library/Tracking/KSRAnalyticsTests.swift
@@ -369,6 +369,7 @@ final class KSRAnalyticsTests: TestCase {
       |> Project.lens.stats.staticUsdRate .~ 2.0
       |> Project.lens.stats.commentsCount .~ 10
       |> Project.lens.prelaunchActivated .~ true
+      |> Project.lens.displayPrelaunch .~ true
 
     ksrAnalytics
       .trackProjectViewed(project, refTag: .discovery, sectionContext: .overview)


### PR DESCRIPTION
# 📲 What

Currently, we're using the field `prelaunch_activated` to determine the display logic of prelaunch deeplinks. We want to change this logic to check `display_prelaunch` instead. 

We will need to add a new field `displayPrelaunch` to capture this field from the project payload.

Any instances using `prelaunch_activated` for display logic will need to be updated to use `display_prelaunch` instead.

# 🤔 Why

We're making this change after noticing some discrepancies with the response from the web. This, paired with some changes to the backend logic, should ensure we're all on the same page.
