### PR TITLE
[Ep-458] QA Page Viewed (Project) Phase 1

### DIFF
--- a/Kickstarter-iOS/ViewModels/AppDelegateViewModel.swift
+++ b/Kickstarter-iOS/ViewModels/AppDelegateViewModel.swift
@@ -554,8 +554,8 @@ public final class AppDelegateViewModel: AppDelegateViewModelType, AppDelegateVi
 
     let campaignFaqLink = projectLink
       .filter { _, subpage, _, _ in subpage == .faqs }
-      .map { project, _, vcs, _ in
-        vcs + [ProjectDescriptionViewController.configuredWith(value: project)]
+      .map { project, _, vcs, refTag in
+        vcs + [ProjectDescriptionViewController.configuredWith(data: (project, refTag))]
       }
 
     let updatesLink = projectLink

--- a/Kickstarter-iOS/ViewModels/AppDelegateViewModelTests.swift
+++ b/Kickstarter-iOS/ViewModels/AppDelegateViewModelTests.swift
@@ -642,7 +642,7 @@ final class AppDelegateViewModelTests: TestCase {
       XCTAssertTrue(result)
 
       self.presentViewController.assertValues([1, 2, 2, 2, 3])
-      
+
       let faqUrl = projectUrl + "/faqs"
       result = self.vm.inputs.applicationOpenUrl(
         application: UIApplication.shared,
@@ -650,7 +650,7 @@ final class AppDelegateViewModelTests: TestCase {
         options: [:]
       )
       XCTAssertTrue(result)
-      
+
       self.presentViewController.assertValues([1, 2, 2, 2, 3, 2])
     }
   }

--- a/Kickstarter-iOS/ViewModels/AppDelegateViewModelTests.swift
+++ b/Kickstarter-iOS/ViewModels/AppDelegateViewModelTests.swift
@@ -642,6 +642,16 @@ final class AppDelegateViewModelTests: TestCase {
       XCTAssertTrue(result)
 
       self.presentViewController.assertValues([1, 2, 2, 2, 3])
+      
+      let faqUrl = projectUrl + "/faqs"
+      result = self.vm.inputs.applicationOpenUrl(
+        application: UIApplication.shared,
+        url: URL(string: faqUrl)!,
+        options: [:]
+      )
+      XCTAssertTrue(result)
+      
+      self.presentViewController.assertValues([1, 2, 2, 2, 3, 2])
     }
   }
 

--- a/Kickstarter-iOS/Views/Cells/ProjectPamphletMainCell.swift
+++ b/Kickstarter-iOS/Views/Cells/ProjectPamphletMainCell.swift
@@ -7,7 +7,7 @@ internal protocol ProjectPamphletMainCellDelegate: VideoViewControllerDelegate {
   func projectPamphletMainCell(_ cell: ProjectPamphletMainCell, addChildController child: UIViewController)
   func projectPamphletMainCell(
     _ cell: ProjectPamphletMainCell,
-    goToCampaignForProjectWith project: Project
+    goToCampaignForProjectWith data: ProjectPamphletMainCellData
   )
   func projectPamphletMainCell(_ cell: ProjectPamphletMainCell, goToCreatorForProject project: Project)
 }
@@ -307,7 +307,7 @@ internal final class ProjectPamphletMainCell: UITableViewCell, ValueCell {
       .skipNil()
       .observeValues { [weak self] in self?.creatorImageView.af.setImage(withURL: $0) }
 
-    self.viewModel.outputs.notifyDelegateToGoToCampaignWithProject
+    self.viewModel.outputs.notifyDelegateToGoToCampaignWithData
       .observeForControllerAction()
       .observeValues { [weak self] in
         guard let self = self else { return }

--- a/Kickstarter-iOS/Views/Controllers/ProjectDescriptionViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/ProjectDescriptionViewController.swift
@@ -10,9 +10,9 @@ internal final class ProjectDescriptionViewController: WebViewController {
   private let loadingIndicator = UIActivityIndicatorView()
   private let viewModel: ProjectDescriptionViewModelType = ProjectDescriptionViewModel()
 
-  internal static func configuredWith(value: Project) -> ProjectDescriptionViewController {
+  internal static func configuredWith(data: ProjectPamphletMainCellData) -> ProjectDescriptionViewController {
     let vc = ProjectDescriptionViewController()
-    vc.viewModel.inputs.configureWith(value: value)
+    vc.viewModel.inputs.configureWith(value: data)
     return vc
   }
 

--- a/Kickstarter-iOS/Views/Controllers/ProjectPamphletContentViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/ProjectPamphletContentViewController.swift
@@ -185,9 +185,9 @@ public final class ProjectPamphletContentViewController: UITableViewController {
 extension ProjectPamphletContentViewController: ProjectPamphletMainCellDelegate {
   internal func projectPamphletMainCell(
     _: ProjectPamphletMainCell,
-    goToCampaignForProjectWith project: Project
+    goToCampaignForProjectWith data: ProjectPamphletMainCellData
   ) {
-    let vc = ProjectDescriptionViewController.configuredWith(value: project)
+    let vc = ProjectDescriptionViewController.configuredWith(data: data)
     self.navigationController?.pushViewController(vc, animated: true)
   }
 

--- a/Library/ViewModels/ProjectDescriptionViewModel.swift
+++ b/Library/ViewModels/ProjectDescriptionViewModel.swift
@@ -5,7 +5,7 @@ import WebKit
 
 public protocol ProjectDescriptionViewModelInputs {
   /// Call with the project given to the view.
-  func configureWith(value: Project)
+  func configureWith(value: ProjectPamphletMainCellData)
 
   /// Call when the webview needs to decide a policy for a navigation action. Returns the decision policy.
   func decidePolicyFor(navigationAction: WKNavigationActionData)
@@ -54,8 +54,8 @@ public protocol ProjectDescriptionViewModelType {
 public final class ProjectDescriptionViewModel: ProjectDescriptionViewModelType,
   ProjectDescriptionViewModelInputs, ProjectDescriptionViewModelOutputs {
   public init() {
-    let project = Signal.combineLatest(
-      self.projectProperty.signal.skipNil(),
+    let data = Signal.combineLatest(
+      self.configureDataProperty.signal.skipNil(),
       self.viewDidLoadProperty.signal
     )
     .map(first)
@@ -65,6 +65,8 @@ public final class ProjectDescriptionViewModel: ProjectDescriptionViewModelType,
       .filter { $0.navigationType == .linkActivated }
     let navigation = navigationActionLink
       .map { Navigation.match($0.request) }
+    
+    let project = data.map(first)
 
     let projectDescriptionRequest = project
       .map {
@@ -118,11 +120,23 @@ public final class ProjectDescriptionViewModel: ProjectDescriptionViewModelType,
     .filter { navigationAction, _, _ in navigationAction.navigationType == .linkActivated }
     .map { navigationAction, _, _ in navigationAction.request.url }
     .skipNil()
+    
+    // Tracking
+    
+    data.takeWhen(self.webViewDidFinishNavigationProperty.signal)
+      .observeValues { projectAndRefTag in
+        let (project, refTag) = projectAndRefTag
+        AppEnvironment.current.ksrAnalytics.trackProjectViewed(
+          project,
+          refTag: refTag,
+          sectionContext: .campaign
+        )
+      }
   }
 
-  fileprivate let projectProperty = MutableProperty<Project?>(nil)
-  public func configureWith(value: Project) {
-    self.projectProperty.value = value
+  fileprivate let configureDataProperty = MutableProperty<ProjectPamphletMainCellData?>(nil)
+  public func configureWith(value: ProjectPamphletMainCellData) {
+    self.configureDataProperty.value = value
   }
 
   fileprivate let policyForNavigationActionProperty = MutableProperty<WKNavigationActionData?>(nil)

--- a/Library/ViewModels/ProjectDescriptionViewModel.swift
+++ b/Library/ViewModels/ProjectDescriptionViewModel.swift
@@ -65,7 +65,7 @@ public final class ProjectDescriptionViewModel: ProjectDescriptionViewModelType,
       .filter { $0.navigationType == .linkActivated }
     let navigation = navigationActionLink
       .map { Navigation.match($0.request) }
-    
+
     let project = data.map(first)
 
     let projectDescriptionRequest = project
@@ -120,9 +120,9 @@ public final class ProjectDescriptionViewModel: ProjectDescriptionViewModelType,
     .filter { navigationAction, _, _ in navigationAction.navigationType == .linkActivated }
     .map { navigationAction, _, _ in navigationAction.request.url }
     .skipNil()
-    
+
     // Tracking
-    
+
     data.takeWhen(self.webViewDidFinishNavigationProperty.signal)
       .observeValues { projectAndRefTag in
         let (project, refTag) = projectAndRefTag

--- a/Library/ViewModels/ProjectDescriptionViewModelTests.swift
+++ b/Library/ViewModels/ProjectDescriptionViewModelTests.swift
@@ -32,8 +32,8 @@ final class ProjectDescriptionViewModelTests: TestCase {
     let project = .template
       |> Project.lens.id .~ 42
       |> Project.lens.urls.web.project .~ "https://www.kickstarter.com/projects/1/42"
-
-    self.vm.inputs.configureWith(value: project)
+    
+    self.vm.inputs.configureWith(value: (project, nil))
     self.vm.inputs.viewDidLoad()
 
     self.isLoading.assertValues([true])
@@ -71,8 +71,8 @@ final class ProjectDescriptionViewModelTests: TestCase {
     let project = .template
       |> Project.lens.id .~ 42
       |> Project.lens.urls.web.project .~ "https://www.kickstarter.com/projects/1/42"
-
-    self.vm.inputs.configureWith(value: project)
+    
+    self.vm.inputs.configureWith(value: (project, nil))
     self.vm.inputs.viewDidLoad()
 
     self.loadWebViewRequest.assertValueCount(1)
@@ -108,7 +108,7 @@ final class ProjectDescriptionViewModelTests: TestCase {
       |> Project.lens.id .~ 42
       |> Project.lens.urls.web.project .~ "https://www.kickstarter.com/projects/1/42"
 
-    self.vm.inputs.configureWith(value: project)
+    self.vm.inputs.configureWith(value: (project, nil))
     self.vm.inputs.viewDidLoad()
 
     self.loadWebViewRequest.assertValueCount(1)
@@ -142,7 +142,7 @@ final class ProjectDescriptionViewModelTests: TestCase {
   func testDescriptionRequest() {
     let project = Project.template
 
-    self.vm.inputs.configureWith(value: project)
+    self.vm.inputs.configureWith(value: (project, nil))
     self.vm.inputs.viewDidLoad()
 
     self.loadWebViewRequest.assertValueCount(1)
@@ -176,7 +176,7 @@ final class ProjectDescriptionViewModelTests: TestCase {
   func testIFrameRequest() {
     let project = Project.template
 
-    self.vm.inputs.configureWith(value: project)
+    self.vm.inputs.configureWith(value: (project, nil))
     self.vm.inputs.viewDidLoad()
 
     self.loadWebViewRequest.assertValueCount(1)
@@ -211,7 +211,7 @@ final class ProjectDescriptionViewModelTests: TestCase {
   func testError() {
     let project = Project.template
 
-    self.vm.inputs.configureWith(value: project)
+    self.vm.inputs.configureWith(value: (project, nil))
     self.vm.inputs.viewDidLoad()
 
     let request = URLRequest(url: URL(string: project.urls.web.project)!)

--- a/Library/ViewModels/ProjectDescriptionViewModelTests.swift
+++ b/Library/ViewModels/ProjectDescriptionViewModelTests.swift
@@ -32,7 +32,7 @@ final class ProjectDescriptionViewModelTests: TestCase {
     let project = .template
       |> Project.lens.id .~ 42
       |> Project.lens.urls.web.project .~ "https://www.kickstarter.com/projects/1/42"
-    
+
     self.vm.inputs.configureWith(value: (project, nil))
     self.vm.inputs.viewDidLoad()
 
@@ -71,7 +71,7 @@ final class ProjectDescriptionViewModelTests: TestCase {
     let project = .template
       |> Project.lens.id .~ 42
       |> Project.lens.urls.web.project .~ "https://www.kickstarter.com/projects/1/42"
-    
+
     self.vm.inputs.configureWith(value: (project, nil))
     self.vm.inputs.viewDidLoad()
 
@@ -142,7 +142,7 @@ final class ProjectDescriptionViewModelTests: TestCase {
   func testDescriptionRequest() {
     let project = Project.template
 
-    self.vm.inputs.configureWith(value: (project, nil))
+    self.vm.inputs.configureWith(value: (project, .discovery))
     self.vm.inputs.viewDidLoad()
 
     self.loadWebViewRequest.assertValueCount(1)
@@ -171,6 +171,15 @@ final class ProjectDescriptionViewModelTests: TestCase {
     self.goBackToProject.assertValueCount(0)
     self.goToMessageDialog.assertValueCount(0)
     self.goToSafariBrowser.assertValueCount(0)
+
+    XCTAssertEqual(["Page Viewed"], self.dataLakeTrackingClient.events)
+    XCTAssertEqual(["Page Viewed"], self.segmentTrackingClient.events)
+
+    XCTAssertEqual(["campaign"], self.dataLakeTrackingClient.properties(forKey: "context_section"))
+    XCTAssertEqual(["campaign"], self.segmentTrackingClient.properties(forKey: "context_section"))
+
+    XCTAssertEqual(["discovery"], self.dataLakeTrackingClient.properties(forKey: "session_ref_tag"))
+    XCTAssertEqual(["discovery"], self.segmentTrackingClient.properties(forKey: "session_ref_tag"))
   }
 
   func testIFrameRequest() {

--- a/Library/ViewModels/ProjectPamphletMainCellViewModel.swift
+++ b/Library/ViewModels/ProjectPamphletMainCellViewModel.swift
@@ -64,8 +64,8 @@ public protocol ProjectPamphletMainCellViewModelOutputs {
   /// Emits a string to use for the location name label.
   var locationNameLabelText: Signal<String, Never> { get }
 
-  /// Emits the project when we should go to the campaign view for the project.
-  var notifyDelegateToGoToCampaignWithProject: Signal<Project, Never> { get }
+  /// Emits the project and ref tag when we should go to the campaign view for the project.
+  var notifyDelegateToGoToCampaignWithData: Signal<ProjectPamphletMainCellData, Never> { get }
 
   /// Emits the project when we should go to the creator's view for the project.
   var notifyDelegateToGoToCreator: Signal<Project, Never> { get }
@@ -223,7 +223,7 @@ public final class ProjectPamphletMainCellViewModel: ProjectPamphletMainCellView
       .map(Project.lens.stats.fundingProgress.view)
       .map(clamp(0, 1))
 
-    self.notifyDelegateToGoToCampaignWithProject = project
+    self.notifyDelegateToGoToCampaignWithData = data
       .takeWhen(self.readMoreButtonTappedProperty.signal)
 
     self.notifyDelegateToGoToCreator = project
@@ -240,19 +240,8 @@ public final class ProjectPamphletMainCellViewModel: ProjectPamphletMainCellView
 
     // Tracking
 
-    data.take(first: 1)
-      .observeValues { projectAndRefTag in
-        let (project, refTag) = projectAndRefTag
-
-        AppEnvironment.current.ksrAnalytics.trackProjectViewed(
-          project,
-          refTag: refTag,
-          sectionContext: .campaign
-        )
-      }
-
-    self.notifyDelegateToGoToCampaignWithProject
-      .observeValues { project in
+    self.notifyDelegateToGoToCampaignWithData
+      .observeValues { project, _ in
         AppEnvironment.current.optimizelyClient?.track(eventName: "Campaign Details Button Clicked")
 
         AppEnvironment.current.ksrAnalytics.trackCampaignDetailsButtonClicked(project: project)
@@ -311,7 +300,7 @@ public final class ProjectPamphletMainCellViewModel: ProjectPamphletMainCellView
   public let deadlineTitleLabelText: Signal<String, Never>
   public let fundingProgressBarViewBackgroundColor: Signal<UIColor, Never>
   public let locationNameLabelText: Signal<String, Never>
-  public let notifyDelegateToGoToCampaignWithProject: Signal<Project, Never>
+  public let notifyDelegateToGoToCampaignWithData: Signal<ProjectPamphletMainCellData, Never>
   public let notifyDelegateToGoToCreator: Signal<Project, Never>
   public let opacityForViews: Signal<CGFloat, Never>
   public let pledgedSubtitleLabelText: Signal<String, Never>

--- a/Library/ViewModels/ProjectPamphletMainCellViewModelTests.swift
+++ b/Library/ViewModels/ProjectPamphletMainCellViewModelTests.swift
@@ -490,7 +490,10 @@ final class ProjectPamphletMainCellViewModelTests: TestCase {
 
     self.vm.inputs.readMoreButtonTapped()
 
-    assertProjectRefTagEqual(actual: self.notifyDelegateToGoToCampaignWithData.lastValue!, expected: (project, refTag))
+    assertProjectRefTagEqual(
+      actual: self.notifyDelegateToGoToCampaignWithData.lastValue!,
+      expected: (project, refTag)
+    )
 
     XCTAssertEqual(["CTA Clicked"], self.dataLakeTrackingClient.events)
     XCTAssertEqual(["CTA Clicked"], self.segmentTrackingClient.events)
@@ -628,7 +631,13 @@ final class ProjectPamphletMainCellViewModelTests: TestCase {
   }
 }
 
-private func assertProjectRefTagEqual(actual: (_: Project, _: RefTag?), expected: (_: Project, _: RefTag?), _ message: String = "", file: StaticString = #file, line: UInt = #line) {
+private func assertProjectRefTagEqual(
+  actual: (_: Project, _: RefTag?),
+  expected: (_: Project, _: RefTag?),
+  _: String = "",
+  file: StaticString = #file,
+  line: UInt = #line
+) {
   if actual != expected {
     XCTFail("Expected \(expected) but was \(actual)", file: file, line: line)
   }

--- a/Library/ViewModels/ProjectPamphletMainCellViewModelTests.swift
+++ b/Library/ViewModels/ProjectPamphletMainCellViewModelTests.swift
@@ -490,8 +490,8 @@ final class ProjectPamphletMainCellViewModelTests: TestCase {
 
     self.vm.inputs.readMoreButtonTapped()
 
-    XCTAssertEqual(project, self.notifyDelegateToGoToCampaignWithData.lastValue!.project)
-    XCTAssertEqual(refTag, self.notifyDelegateToGoToCampaignWithData.lastValue!.refTag)
+    XCTAssertEqual(project, self.notifyDelegateToGoToCampaignWithData.lastValue?.project)
+    XCTAssertEqual(refTag, self.notifyDelegateToGoToCampaignWithData.lastValue?.refTag)
 
     XCTAssertEqual(["CTA Clicked"], self.dataLakeTrackingClient.events)
     XCTAssertEqual(["CTA Clicked"], self.segmentTrackingClient.events)
@@ -530,8 +530,10 @@ final class ProjectPamphletMainCellViewModelTests: TestCase {
       |> Project.lens.state .~ .successful
       |> Project.lens.personalization.isBacking .~ true
 
+    let refTag = RefTag.discovery
+
     withEnvironment(currentUser: user) {
-      self.vm.inputs.configureWith(value: (project, .discovery))
+      self.vm.inputs.configureWith(value: (project, refTag))
       self.vm.inputs.awakeFromNib()
 
       XCTAssertEqual(self.dataLakeTrackingClient.events, [])
@@ -561,8 +563,10 @@ final class ProjectPamphletMainCellViewModelTests: TestCase {
       |> Project.lens.state .~ .successful
       |> Project.lens.personalization.isBacking .~ true
 
+    let refTag = RefTag.discovery
+
     withEnvironment(currentUser: user) {
-      self.vm.inputs.configureWith(value: (project, .discovery))
+      self.vm.inputs.configureWith(value: (project, refTag))
       self.vm.inputs.awakeFromNib()
 
       XCTAssertEqual(self.optimizelyClient.trackedUserId, nil)
@@ -591,8 +595,10 @@ final class ProjectPamphletMainCellViewModelTests: TestCase {
       |> Project.lens.state .~ .live
       |> Project.lens.personalization.backing .~ nil
 
+    let refTag = RefTag.discovery
+
     withEnvironment(currentUser: user) {
-      self.vm.inputs.configureWith(value: (project, .discovery))
+      self.vm.inputs.configureWith(value: (project, refTag))
       self.vm.inputs.awakeFromNib()
 
       XCTAssertEqual(self.optimizelyClient.trackedUserId, nil)
@@ -601,8 +607,8 @@ final class ProjectPamphletMainCellViewModelTests: TestCase {
 
       self.vm.inputs.readMoreButtonTapped()
 
-      XCTAssertEqual(project, self.notifyDelegateToGoToCampaignWithData.lastValue!.project)
-      XCTAssertEqual(.discovery, self.notifyDelegateToGoToCampaignWithData.lastValue!.refTag)
+      XCTAssertEqual(project, self.notifyDelegateToGoToCampaignWithData.lastValue?.project)
+      XCTAssertEqual(refTag, self.notifyDelegateToGoToCampaignWithData.lastValue?.refTag)
 
       XCTAssertEqual(self.optimizelyClient.trackedUserId, "DEADBEEF-DEAD-BEEF-DEAD-DEADBEEFBEEF")
       XCTAssertEqual(self.optimizelyClient.trackedEventKey, "Campaign Details Button Clicked")

--- a/Library/ViewModels/ProjectPamphletMainCellViewModelTests.swift
+++ b/Library/ViewModels/ProjectPamphletMainCellViewModelTests.swift
@@ -51,7 +51,7 @@ final class ProjectPamphletMainCellViewModelTests: TestCase {
     self.vm.outputs.deadlineTitleLabelText.observe(self.deadlineTitleLabelText.observer)
     self.vm.outputs.fundingProgressBarViewBackgroundColor
       .observe(self.fundingProgressBarViewBackgroundColor.observer)
-    self.vm.outputs.notifyDelegateToGoToCampaignWithProject
+    self.vm.outputs.notifyDelegateToGoToCampaignWithData
       .observe(self.notifyDelegateToGoToCampaignWithProject.observer)
     self.vm.outputs.notifyDelegateToGoToCreator.observe(self.notifyDelegateToGoToCreator.observer)
     self.vm.outputs.opacityForViews.observe(self.opacityForViews.observer)

--- a/Library/ViewModels/ProjectPamphletMainCellViewModelTests.swift
+++ b/Library/ViewModels/ProjectPamphletMainCellViewModelTests.swift
@@ -490,10 +490,8 @@ final class ProjectPamphletMainCellViewModelTests: TestCase {
 
     self.vm.inputs.readMoreButtonTapped()
 
-    assertProjectRefTagEqual(
-      actual: self.notifyDelegateToGoToCampaignWithData.lastValue!,
-      expected: (project, refTag)
-    )
+    XCTAssertEqual(project, self.notifyDelegateToGoToCampaignWithData.lastValue!.project)
+    XCTAssertEqual(refTag, self.notifyDelegateToGoToCampaignWithData.lastValue!.refTag)
 
     XCTAssertEqual(["CTA Clicked"], self.dataLakeTrackingClient.events)
     XCTAssertEqual(["CTA Clicked"], self.segmentTrackingClient.events)
@@ -603,10 +601,8 @@ final class ProjectPamphletMainCellViewModelTests: TestCase {
 
       self.vm.inputs.readMoreButtonTapped()
 
-      assertProjectRefTagEqual(
-        actual: self.notifyDelegateToGoToCampaignWithData.lastValue!,
-        expected: (project, .discovery)
-      )
+      XCTAssertEqual(project, self.notifyDelegateToGoToCampaignWithData.lastValue!.project)
+      XCTAssertEqual(.discovery, self.notifyDelegateToGoToCampaignWithData.lastValue!.refTag)
 
       XCTAssertEqual(self.optimizelyClient.trackedUserId, "DEADBEEF-DEAD-BEEF-DEAD-DEADBEEFBEEF")
       XCTAssertEqual(self.optimizelyClient.trackedEventKey, "Campaign Details Button Clicked")
@@ -628,17 +624,5 @@ final class ProjectPamphletMainCellViewModelTests: TestCase {
       XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_apple_pay_device"] as? Bool, true)
       XCTAssertEqual(self.optimizelyClient.trackedAttributes?["session_device_type"] as? String, "phone")
     }
-  }
-}
-
-private func assertProjectRefTagEqual(
-  actual: (_: Project, _: RefTag?),
-  expected: (_: Project, _: RefTag?),
-  _: String = "",
-  file: StaticString = #file,
-  line: UInt = #line
-) {
-  if actual != expected {
-    XCTFail("Expected \(expected) but was \(actual)", file: file, line: line)
   }
 }

--- a/Library/ViewModels/ProjectPamphletViewModelTests.swift
+++ b/Library/ViewModels/ProjectPamphletViewModelTests.swift
@@ -280,6 +280,14 @@ final class ProjectPamphletViewModelTests: TestCase {
 
     XCTAssertEqual(["Page Viewed"], self.dataLakeTrackingClient.events)
     XCTAssertEqual(["Page Viewed"], self.segmentTrackingClient.events)
+
+    XCTAssertEqual(["project"], self.dataLakeTrackingClient.properties(forKey: "context_page"))
+    XCTAssertEqual(["overview"], self.dataLakeTrackingClient.properties(forKey: "context_section"))
+    XCTAssertEqual(["discovery"], self.dataLakeTrackingClient.properties(forKey: "session_ref_tag"))
+
+    XCTAssertEqual(["project"], self.segmentTrackingClient.properties(forKey: "context_page"))
+    XCTAssertEqual(["overview"], self.segmentTrackingClient.properties(forKey: "context_section"))
+    XCTAssertEqual(["discovery"], self.segmentTrackingClient.properties(forKey: "session_ref_tag"))
   }
 
   func testMockCookieStorageSet_SeparateSchedulers() {


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Page viewed for project was tracked in two places. 
Moved the one for campaign section context into Project Description screen when the content loads.
Add RefTag as part of the Config Data sent to ProjectDescription screen.

# 🤔 Why

This is part of phase 1 Events QA.

# 👀 See

<img width="531" alt="iOS-QA-Page-Viewed-(Project)-Phase-1" src="https://user-images.githubusercontent.com/8595853/114394794-83e12400-9b93-11eb-95f9-deff2b907c07.png">
