### PR TITLE
[EP-459] QA CTA Clicked (discover) phase two

### DIFF
--- a/Library/Tracking/KSRAnalytics.swift
+++ b/Library/Tracking/KSRAnalytics.swift
@@ -594,7 +594,7 @@ public final class KSRAnalytics {
 
   /// Call when the user is logged out, on the `Activity` tab and taps the `Explore Projects`button.
   public func trackExploreButtonClicked() {
-    let properties = contextProperties(ctaContext: .discover, locationContext: .globalNav)
+    let properties = contextProperties(ctaContext: .discover, page: .activities)
     self.track(
       event: NewApprovedEvent.ctaClicked.rawValue,
       properties: properties
@@ -605,6 +605,15 @@ public final class KSRAnalytics {
 
   public func trackTabBarClicked(_ tabBarItemLabel: TabBarItemLabel) {
     switch tabBarItemLabel {
+    case .discovery:
+      let properties = contextProperties(
+        ctaContext: .discover,
+        locationContext: .globalNav
+      )
+      self.track(
+        event: NewApprovedEvent.ctaClicked.rawValue,
+        properties: properties
+      )
     case .search:
       let properties = contextProperties(
         ctaContext: .search,

--- a/Library/Tracking/KSRAnalyticsTests.swift
+++ b/Library/Tracking/KSRAnalyticsTests.swift
@@ -1749,11 +1749,11 @@ final class KSRAnalyticsTests: TestCase {
     XCTAssertEqual(["CTA Clicked"], dataLakeClient.events)
     XCTAssertEqual(["CTA Clicked"], segmentClient.events)
 
-    XCTAssertEqual(dataLakeClient.properties(forKey: "context_location"), ["global_nav"])
-    XCTAssertEqual(segmentClient.properties(forKey: "context_location"), ["global_nav"])
-
     XCTAssertEqual(dataLakeClient.properties(forKey: "context_cta"), ["discover"])
     XCTAssertEqual(segmentClient.properties(forKey: "context_cta"), ["discover"])
+
+    XCTAssertEqual(dataLakeClient.properties(forKey: "context_page"), ["activity_feed"])
+    XCTAssertEqual(segmentClient.properties(forKey: "context_page"), ["activity_feed"])
   }
 
   // MARK: - Search Tracking
@@ -1905,22 +1905,24 @@ final class KSRAnalyticsTests: TestCase {
 
     ksrAnalytics.trackTabBarClicked(tabBarHome)
 
-    XCTAssertEqual(["Tab Bar Clicked", "Tab Bar Clicked", "Tab Bar Clicked"], dataLakeClient.events)
-    XCTAssertEqual("discovery", dataLakeClient.properties.last?["context_tab_bar_label"] as? String)
+    XCTAssertEqual(["Tab Bar Clicked", "Tab Bar Clicked", "CTA Clicked"], dataLakeClient.events)
+    XCTAssertEqual(["Tab Bar Clicked", "Tab Bar Clicked", "CTA Clicked"], segmentClient.events)
 
-    XCTAssertEqual(["Tab Bar Clicked", "Tab Bar Clicked", "Tab Bar Clicked"], segmentClient.events)
-    XCTAssertEqual("discovery", segmentClient.properties.last?["context_tab_bar_label"] as? String)
+    XCTAssertEqual("discover", dataLakeClient.properties.last?["context_cta"] as? String)
+    XCTAssertEqual("discover", segmentClient.properties.last?["context_cta"] as? String)
+    XCTAssertEqual("global_nav", dataLakeClient.properties.last?["context_location"] as? String)
+    XCTAssertEqual("global_nav", segmentClient.properties.last?["context_location"] as? String)
 
     ksrAnalytics.trackTabBarClicked(tabBarProfile)
 
     XCTAssertEqual(
-      ["Tab Bar Clicked", "Tab Bar Clicked", "Tab Bar Clicked", "Tab Bar Clicked"],
+      ["Tab Bar Clicked", "Tab Bar Clicked", "CTA Clicked", "Tab Bar Clicked"],
       dataLakeClient.events
     )
     XCTAssertEqual("profile", dataLakeClient.properties.last?["context_tab_bar_label"] as? String)
 
     XCTAssertEqual(
-      ["Tab Bar Clicked", "Tab Bar Clicked", "Tab Bar Clicked", "Tab Bar Clicked"],
+      ["Tab Bar Clicked", "Tab Bar Clicked", "CTA Clicked", "Tab Bar Clicked"],
       segmentClient.events
     )
     XCTAssertEqual("profile", segmentClient.properties.last?["context_tab_bar_label"] as? String)
@@ -1930,7 +1932,7 @@ final class KSRAnalyticsTests: TestCase {
     XCTAssertEqual([
       "Tab Bar Clicked",
       "Tab Bar Clicked",
-      "Tab Bar Clicked",
+      "CTA Clicked",
       "Tab Bar Clicked",
       "CTA Clicked"
     ], dataLakeClient.events)
@@ -1940,7 +1942,7 @@ final class KSRAnalyticsTests: TestCase {
     XCTAssertEqual([
       "Tab Bar Clicked",
       "Tab Bar Clicked",
-      "Tab Bar Clicked",
+      "CTA Clicked",
       "Tab Bar Clicked",
       "CTA Clicked"
     ], segmentClient.events)
@@ -2297,8 +2299,8 @@ final class KSRAnalyticsTests: TestCase {
     XCTAssertEqual("discover", segmentClient.properties.last?["context_page"] as? String)
 
     ksrAnalytics.trackExploreButtonClicked()
-    XCTAssertEqual(nil, dataLakeClient.properties.last?["context_page"] as? String)
-    XCTAssertEqual(nil, segmentClient.properties.last?["context_page"] as? String)
+    XCTAssertEqual("activity_feed", dataLakeClient.properties.last?["context_page"] as? String)
+    XCTAssertEqual("activity_feed", segmentClient.properties.last?["context_page"] as? String)
 
     ksrAnalytics.trackFacebookLoginOrSignupButtonClicked(intent: .generic)
     XCTAssertEqual("log_in_sign_up", dataLakeClient.properties.last?["context_page"] as? String)

--- a/Library/ViewModels/EmptyStatesViewModelTests.swift
+++ b/Library/ViewModels/EmptyStatesViewModelTests.swift
@@ -61,8 +61,8 @@ internal final class EmptyStatesViewModelTests: TestCase {
     XCTAssertEqual(["CTA Clicked"], self.dataLakeTrackingClient.events)
     XCTAssertEqual(["CTA Clicked"], self.segmentTrackingClient.events)
 
-    XCTAssertEqual(self.dataLakeTrackingClient.properties(forKey: "context_location"), ["global_nav"])
-    XCTAssertEqual(self.segmentTrackingClient.properties(forKey: "context_location"), ["global_nav"])
+    XCTAssertEqual(self.dataLakeTrackingClient.properties(forKey: "context_page"), ["activity_feed"])
+    XCTAssertEqual(self.segmentTrackingClient.properties(forKey: "context_page"), ["activity_feed"])
 
     XCTAssertEqual(self.dataLakeTrackingClient.properties(forKey: "context_cta"), ["discover"])
     XCTAssertEqual(self.segmentTrackingClient.properties(forKey: "context_cta"), ["discover"])

--- a/Library/ViewModels/RootViewModelTests.swift
+++ b/Library/ViewModels/RootViewModelTests.swift
@@ -490,28 +490,28 @@ final class RootViewModelTests: TestCase {
     self.vm.inputs.didSelect(index: 0)
 
     self.selectedIndex.assertValues([0, 1, 0], "Selects index immediately.")
-    XCTAssertEqual(["Tab Bar Clicked", "Tab Bar Clicked"], self.dataLakeTrackingClient.events)
+    XCTAssertEqual(["Tab Bar Clicked", "CTA Clicked"], self.dataLakeTrackingClient.events)
     XCTAssertEqual(
-      ["activity", "discovery"],
+      ["activity", nil],
       self.dataLakeTrackingClient.properties(forKey: "context_tab_bar_label")
     )
-    XCTAssertEqual(["Tab Bar Clicked", "Tab Bar Clicked"], self.segmentTrackingClient.events)
+    XCTAssertEqual(["Tab Bar Clicked", "CTA Clicked"], self.segmentTrackingClient.events)
     XCTAssertEqual(
-      ["activity", "discovery"],
+      ["activity", nil],
       self.segmentTrackingClient.properties(forKey: "context_tab_bar_label")
     )
 
     self.vm.inputs.didSelect(index: 10)
 
     self.selectedIndex.assertValues([0, 1, 0, 3], "Selects index immediately.")
-    XCTAssertEqual(["Tab Bar Clicked", "Tab Bar Clicked"], self.dataLakeTrackingClient.events)
+    XCTAssertEqual(["Tab Bar Clicked", "CTA Clicked"], self.dataLakeTrackingClient.events)
     XCTAssertEqual(
-      ["activity", "discovery"],
+      ["activity", nil],
       self.dataLakeTrackingClient.properties(forKey: "context_tab_bar_label")
     )
-    XCTAssertEqual(["Tab Bar Clicked", "Tab Bar Clicked"], self.segmentTrackingClient.events)
+    XCTAssertEqual(["Tab Bar Clicked", "CTA Clicked"], self.segmentTrackingClient.events)
     XCTAssertEqual(
-      ["activity", "discovery"],
+      ["activity", nil],
       self.segmentTrackingClient.properties(forKey: "context_tab_bar_label")
     )
   }


### PR DESCRIPTION
# 📲 What

- Updating some properties related to the `Explore projects` button on the activity tab.
- Sending an event for when the `Home` tab is selected from the tab bar navigation.

## Action: On the Activity screen, tap the "Explore projects" button.
## Expected Result:
Event: CTA Clicked
Property Groups: Context Properties, Session Properties, User Properties
context_cta = discover
context_page = activity_feed
context_location = [null]

## Action: From the Search screen, tap "Explore" in the global nav.
## Expected Result:
Event: CTA Clicked
Property Groups: Context Properties, Session Properties, User Properties
context_cta = discover
context_location = global_nav

# 🤔 Why

This is a refinement based on QA feedback from our insights team. The point of these properties is to draw a very specific context to each event. This PR includes updates to the context properties, specifically.
<img width="575" alt="Screen Shot 2021-04-12 at 5 10 28 PM" src="https://user-images.githubusercontent.com/15615702/114466881-0d561d80-9bb7-11eb-9e60-f8cf528e2772.png">
<img width="525" alt="Screen Shot 2021-04-12 at 5 09 33 PM" src="https://user-images.githubusercontent.com/15615702/114466883-0deeb400-9bb7-11eb-80b2-9fa93c1ac51d.png">