### PR TITLE
[NT-1856] Disable Refreshing dSYMs on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -289,11 +289,15 @@ workflows:
       - kickstarter-ui-tests
       - library-tests
       - ksapi-tests
-      - refresh_app_store_dsyms:
-          filters:
-            branches:
-              # matches all branches that begin with 'beta-dist'
-              only: /beta-dist-.*/
+# ** Refreshing dSYMs disabled until a suitable workaround is found for App Store Connect 2FA authentication
+# or Fastlane implements API key support in this Fastlane action. Uncomment below to re-enable.
+# See: https://docs.fastlane.tools/app-store-connect-api/
+# https://docs.fastlane.tools/best-practices/continuous-integration/
+#      - refresh_app_store_dsyms:
+#          filters:
+#            branches:
+#              # matches all branches that begin with 'beta-dist'
+#              only: /beta-dist-.*/
       - deploy_alpha:
           filters:
             branches:


### PR DESCRIPTION
# 📲 What

Disables `refresh_app_store_dsyms` in our CI pipeline.

# 🤔 Why

Refreshing dSYMs in this way is something we do in the event that Apple recompiles our app using bitcode. This is not something that has happened to my knowledge and, if it were to happen, would be quite infrequent. The purpose of refreshing the dSYMs is to download the latest from App Store Connect and upload them to Crashlytics to assist with resymbolication of crash logs. Some more info here: https://github.com/kickstarter/ios-oss/pull/420

We're disabling this because Apple updated the App Store Connect API to require 2FA authentication which presents an interactive prompt during our CI builds which we're not around to respond to.

Until Fastlane provides a way for us to include an API key in the relevant Fastlane command we're disabling this and will refresh dSYMs manually should we need to.

# 🛠 How

Commented out the job in our CircleCI config for now.

# 👀 See

https://docs.fastlane.tools/app-store-connect-api/
https://docs.fastlane.tools/best-practices/continuous-integration/

# ✅ Acceptance criteria

- [ ] When this PR merges the job should not run and should therefore not fail on CircleCI.