### PR TITLE
Fix Beta Builds

### DIFF
--- a/KsApi/px/PerimeterXClient.swift
+++ b/KsApi/px/PerimeterXClient.swift
@@ -57,8 +57,8 @@ public class PerimeterXClient: NSObject, PerimeterXClientType {
 }
 
 /// Works around a Swift bug - https://bugs.swift.org/browse/SR-3871
-struct PerimeterXBlockWrapper {
-  let originalBlockResponse: PXBlockResponse
+public struct PerimeterXBlockWrapper {
+  public let originalBlockResponse: PXBlockResponse
 
   static func wrapper(with response: PerimeterXBlockResponseType) -> PerimeterXBlockWrapper? {
     guard let response = response as? PXBlockResponse else { return nil }


### PR DESCRIPTION
# 📲 What

Fixes beta builds on CircleCI.

# 🤔 Why

This slipped through because, during development, KsApi is imported with `@testable`. The visibility of this type needed to in fact be `public`.

# 🛠 How

Updates the type's visibility.