### PR TITLE
[NT-1844] Register Push Tokens With Segment/Braze

### DIFF
--- a/Kickstarter-iOS/AppDelegate.swift
+++ b/Kickstarter-iOS/AppDelegate.swift
@@ -161,6 +161,12 @@ internal final class AppDelegate: UIResponder, UIApplicationDelegate {
         print("📲 [Push Registration] Push token successfully registered (\(token)) ✨")
       }
 
+    self.viewModel.outputs.registerPushTokenInSegment
+      .observeForUI()
+      .observeValues { token in
+        Analytics.shared().registeredForRemoteNotifications(withDeviceToken: token)
+      }
+
     self.viewModel.outputs.showAlert
       .observeForUI()
       .observeValues { [weak self] in

--- a/Kickstarter-iOS/ViewModels/AppDelegateViewModel.swift
+++ b/Kickstarter-iOS/ViewModels/AppDelegateViewModel.swift
@@ -168,6 +168,9 @@ public protocol AppDelegateViewModelOutputs {
   /// Emits the push token that has been successfully registered on the server.
   var pushTokenSuccessfullyRegistered: Signal<String, Never> { get }
 
+  /// Emits when we should register the device push token in Segment Analytics.
+  var registerPushTokenInSegment: Signal<Data, Never> { get }
+
   /// Emits an array of short cut items to put into the shared application.
   var setApplicationShortcutItems: Signal<[ShortcutItem], Never> { get }
 
@@ -297,6 +300,8 @@ public final class AppDelegateViewModel: AppDelegateViewModelType, AppDelegateVi
           .demoteErrors()
           .map { _ in token }
       }
+
+    self.registerPushTokenInSegment = self.deviceTokenDataProperty.signal
 
     // Onboarding
 
@@ -809,6 +814,7 @@ public final class AppDelegateViewModel: AppDelegateViewModelType, AppDelegateVi
   public let presentViewController: Signal<UIViewController, Never>
   public let pushTokenRegistrationStarted: Signal<(), Never>
   public let pushTokenSuccessfullyRegistered: Signal<String, Never>
+  public let registerPushTokenInSegment: Signal<Data, Never>
   public let setApplicationShortcutItems: Signal<[ShortcutItem], Never>
   public let showAlert: Signal<Notification, Never>
   public let synchronizeUbiquitousStore: Signal<(), Never>

--- a/Kickstarter-iOS/ViewModels/AppDelegateViewModelTests.swift
+++ b/Kickstarter-iOS/ViewModels/AppDelegateViewModelTests.swift
@@ -41,6 +41,7 @@ final class AppDelegateViewModelTests: TestCase {
   private let presentViewController = TestObserver<Int, Never>()
   private let pushRegistrationStarted = TestObserver<(), Never>()
   private let pushTokenSuccessfullyRegistered = TestObserver<String, Never>()
+  private let registerPushTokenInSegment = TestObserver<Data, Never>()
   private let setApplicationShortcutItems = TestObserver<[ShortcutItem], Never>()
   private let showAlert = TestObserver<Notification, Never>()
   private let unregisterForRemoteNotifications = TestObserver<(), Never>()
@@ -82,6 +83,7 @@ final class AppDelegateViewModelTests: TestCase {
       .observe(self.presentViewController.observer)
     self.vm.outputs.pushTokenRegistrationStarted.observe(self.pushRegistrationStarted.observer)
     self.vm.outputs.pushTokenSuccessfullyRegistered.observe(self.pushTokenSuccessfullyRegistered.observer)
+    self.vm.outputs.registerPushTokenInSegment.observe(self.registerPushTokenInSegment.observer)
     self.vm.outputs.setApplicationShortcutItems.observe(self.setApplicationShortcutItems.observer)
     self.vm.outputs.showAlert.observe(self.showAlert.observer)
     self.vm.outputs.unregisterForRemoteNotifications.observe(self.unregisterForRemoteNotifications.observer)
@@ -987,6 +989,22 @@ final class AppDelegateViewModelTests: TestCase {
       self.scheduler.advance(by: .seconds(5))
 
       self.pushTokenSuccessfullyRegistered.assertValueCount(1)
+    }
+  }
+
+  func testRegisterPushTokenInSegment() {
+    let data = Data("deadbeef".utf8)
+
+    self.registerPushTokenInSegment.assertDidNotEmitValue()
+
+    withEnvironment(currentUser: .template) {
+      self.vm.inputs.applicationDidFinishLaunching(
+        application: UIApplication.shared,
+        launchOptions: [:]
+      )
+      self.vm.inputs.didRegisterForRemoteNotifications(withDeviceTokenData: data)
+
+      self.registerPushTokenInSegment.assertValueCount(1)
     }
   }
 


### PR DESCRIPTION
# 📲 What

Registers push tokens with Braze via Segment.

# 🤔 Why

This allows us to send pushes using Braze.

# 🛠 How

Passing the device token upon registration to the Segment library which is in a side-by-side configuration with the Braze SDK.

# 👀 See

https://segment.com/docs/connections/destinations/catalog/braze/#ios
https://www.braze.com/docs/user_guide/message_building_by_channel/push/push_registration/

# ✅ Acceptance criteria

Run the app on device using the KickBeta scheme and register for pushes.

- [ ] You should be able to send a push to your user ID from the Braze console for iOS Staging.