### PR TITLE
[NT-1850] Retain Debug Feature Flag Values For Non-Release Builds

### DIFF
--- a/Kickstarter-iOS/ViewModels/AppDelegateViewModel.swift
+++ b/Kickstarter-iOS/ViewModels/AppDelegateViewModel.swift
@@ -1134,5 +1134,5 @@ private func configRetainingDebugFeatureFlags(_ config: Config) -> Config {
   let storedFeatures = (AppEnvironment.current.config?.features ?? [:])
     .filter { key, _ in currentFeatureKeys.contains(key) }
 
-  return config |> Config.lens.features .~ (currentFeatures.withAllValuesFrom(storedFeatures))
+  return config |> Config.lens.features .~ currentFeatures.withAllValuesFrom(storedFeatures)
 }

--- a/Kickstarter-iOS/ViewModels/AppDelegateViewModel.swift
+++ b/Kickstarter-iOS/ViewModels/AppDelegateViewModel.swift
@@ -231,6 +231,7 @@ public final class AppDelegateViewModel: AppDelegateViewModelType, AppDelegateVi
 
       return AppEnvironment.current.apiService.fetchConfig().demoteErrors()
     }
+    .map(configRetainingDebugFeatureFlags)
 
     let currentUserUpdatedNotification = self.currentUserUpdatedInEnvironmentProperty.signal
       .mapConst(Notification(name: .ksr_userUpdated, object: nil))
@@ -1122,4 +1123,16 @@ private func emailVerificationCompletionData(
   }
 
   return (message, true)
+}
+
+private func configRetainingDebugFeatureFlags(_ config: Config) -> Config {
+  guard AppEnvironment.current.mainBundle.isRelease == false else { return config }
+
+  let currentFeatures = config.features
+  let currentFeatureKeys = Set(currentFeatures.keys)
+
+  let storedFeatures = (AppEnvironment.current.config?.features ?? [:])
+    .filter { key, _ in currentFeatureKeys.contains(key) }
+
+  return config |> Config.lens.features .~ (currentFeatures.withAllValuesFrom(storedFeatures))
 }

--- a/Kickstarter-iOS/ViewModels/AppDelegateViewModelTests.swift
+++ b/Kickstarter-iOS/ViewModels/AppDelegateViewModelTests.swift
@@ -2461,7 +2461,11 @@ final class AppDelegateViewModelTests: TestCase {
     self.goToPerimeterXCaptcha.assertValueCount(1)
   }
 
-  func testFeatureFlagsRetainedInConfig() {
+  func testFeatureFlagsRetainedInConfig_NotRelease() {
+    let mockBundle = MockBundle(
+      bundleIdentifier: KickstarterBundleIdentifier.beta.rawValue
+    )
+
     let config = Config.template
       |> Config.lens.features .~ [
         "my_enabled_feature": true,
@@ -2479,7 +2483,7 @@ final class AppDelegateViewModelTests: TestCase {
 
     self.updateConfigInEnvironment.assertDidNotEmitValue()
 
-    withEnvironment(apiService: service, config: config) {
+    withEnvironment(apiService: service, config: config, mainBundle: mockBundle) {
       self.vm.inputs.applicationDidFinishLaunching(
         application: .shared,
         launchOptions: [:]
@@ -2491,6 +2495,44 @@ final class AppDelegateViewModelTests: TestCase {
 
       XCTAssertEqual(updatedFeatures?["my_enabled_feature"], true, "Retains stored value")
       XCTAssertEqual(updatedFeatures?["my_disabled_feature"], false, "Retains stored value")
+      XCTAssertEqual(updatedFeatures?["my_new_feature"], true, "Uses incoming value")
+    }
+  }
+
+  func testFeatureFlagsRetainedInConfig_Release() {
+    let mockBundle = MockBundle(
+      bundleIdentifier: KickstarterBundleIdentifier.release.rawValue
+    )
+
+    let config = Config.template
+      |> Config.lens.features .~ [
+        "my_enabled_feature": true,
+        "my_disabled_feature": false
+      ]
+
+    let incomingConfig = Config.template
+      |> Config.lens.features .~ [
+        "my_enabled_feature": false,
+        "my_disabled_feature": true,
+        "my_new_feature": true
+      ]
+
+    let service = MockService(fetchConfigResponse: incomingConfig)
+
+    self.updateConfigInEnvironment.assertDidNotEmitValue()
+
+    withEnvironment(apiService: service, config: config, mainBundle: mockBundle) {
+      self.vm.inputs.applicationDidFinishLaunching(
+        application: .shared,
+        launchOptions: [:]
+      )
+
+      self.updateConfigInEnvironment.assertValueCount(1)
+
+      let updatedFeatures = self.updateConfigInEnvironment.lastValue?.features
+
+      XCTAssertEqual(updatedFeatures?["my_enabled_feature"], false, "Uses incoming value")
+      XCTAssertEqual(updatedFeatures?["my_disabled_feature"], true, "Uses incoming value")
       XCTAssertEqual(updatedFeatures?["my_new_feature"], true, "Uses incoming value")
     }
   }

--- a/Kickstarter-iOS/ViewModels/AppDelegateViewModelTests.swift
+++ b/Kickstarter-iOS/ViewModels/AppDelegateViewModelTests.swift
@@ -2460,6 +2460,40 @@ final class AppDelegateViewModelTests: TestCase {
 
     self.goToPerimeterXCaptcha.assertValueCount(1)
   }
+
+  func testFeatureFlagsRetainedInConfig() {
+    let config = Config.template
+      |> Config.lens.features .~ [
+        "my_enabled_feature": true,
+        "my_disabled_feature": false
+      ]
+
+    let incomingConfig = Config.template
+      |> Config.lens.features .~ [
+        "my_enabled_feature": false,
+        "my_disabled_feature": true,
+        "my_new_feature": true
+      ]
+
+    let service = MockService(fetchConfigResponse: incomingConfig)
+
+    self.updateConfigInEnvironment.assertDidNotEmitValue()
+
+    withEnvironment(apiService: service, config: config) {
+      self.vm.inputs.applicationDidFinishLaunching(
+        application: .shared,
+        launchOptions: [:]
+      )
+
+      self.updateConfigInEnvironment.assertValueCount(1)
+
+      let updatedFeatures = self.updateConfigInEnvironment.lastValue?.features
+
+      XCTAssertEqual(updatedFeatures?["my_enabled_feature"], true, "Retains stored value")
+      XCTAssertEqual(updatedFeatures?["my_disabled_feature"], false, "Retains stored value")
+      XCTAssertEqual(updatedFeatures?["my_new_feature"], true, "Uses incoming value")
+    }
+  }
 }
 
 private let backingForCreatorPushData: [String: Any] = [


### PR DESCRIPTION
# 📲 What

Retains the feature flag toggles that we set in our debug menu between app launches.

# 🤔 Why

This makes our development workflow easier so that we don't have to remember to enable feature flags each time the app launches while we're testing.

# 🛠 How

When the app starts up it restores its config from storage, I've added a function to give the values retrieved from storage precedence over the incoming values.

Note that this means the toggles that we have in the app will always override those that are coming in from the back-end. In order to reset the debug toggles and receive the values from the back-end we will need to delete the app and install it again.

# ✅ Acceptance criteria

- [ ] Launch the app in alpha, beta or debug, toggle feature flags in the debug menu. Re-launch the app and navigate back to this menu, your flags should be configured as they were before you re-launched.