### PR TITLE
[NT-1858] Remove PerimeterXWrapper workaround

### DIFF
--- a/Kickstarter-iOS/AppDelegate.swift
+++ b/Kickstarter-iOS/AppDelegate.swift
@@ -11,7 +11,6 @@ import Foundation
 import Kickstarter_Framework
 import Library
 import Optimizely
-import PerimeterX
 import Prelude
 import ReactiveExtensions
 import ReactiveSwift
@@ -269,8 +268,8 @@ internal final class AppDelegate: UIResponder, UIApplicationDelegate {
         object: nil,
         queue: nil
       ) { [weak self] note in
-        guard let response = note.object as? PerimeterXBlockWrapper else { return }
-        self?.viewModel.inputs.perimeterXCaptchaTriggered(response: response.originalBlockResponse)
+        guard let response = note.object as? PerimeterXBlockResponseType else { return }
+        self?.viewModel.inputs.perimeterXCaptchaTriggered(response: response)
       }
 
     self.window?.tintColor = .ksr_create_700
@@ -420,10 +419,8 @@ internal final class AppDelegate: UIResponder, UIApplicationDelegate {
     self.rootTabBarController?.switchToMessageThread(messageThread)
   }
 
-  private func goToPerimeterXCaptcha(_ response: PXBlockResponse) {
-    PXManager.sharedInstance().handle(response, with: self.window?.rootViewController) {
-      print("❎ Perimeter X CAPTCHA was successful.")
-    }
+  private func goToPerimeterXCaptcha(_ response: PerimeterXBlockResponseType) {
+    response.displayCaptcha(on: self.window?.rootViewController)
   }
 
   private func goToCreatorMessageThread(_ projectId: Param, _ messageThread: MessageThread) {

--- a/Kickstarter-iOS/ViewModels/AppDelegateViewModel.swift
+++ b/Kickstarter-iOS/ViewModels/AppDelegateViewModel.swift
@@ -1,6 +1,5 @@
 import KsApi
 import Library
-import PerimeterX
 import Prelude
 import ReactiveSwift
 import UserNotifications
@@ -74,7 +73,7 @@ public protocol AppDelegateViewModelInputs {
   func optimizelyClientConfigurationFailed()
 
   /// Call when Perimeter X Captcha is triggered
-  func perimeterXCaptchaTriggered(response: PXBlockResponse)
+  func perimeterXCaptchaTriggered(response: PerimeterXBlockResponseType)
 
   /// Call when the contextual PushNotification dialog should be presented.
   func showNotificationDialog(notification: Notification)
@@ -142,7 +141,7 @@ public protocol AppDelegateViewModelOutputs {
   var goToMessageThread: Signal<MessageThread, Never> { get }
 
   /// Emits when we should display the Perimeter X Captcha view.
-  var goToPerimeterXCaptcha: Signal<PXBlockResponse, Never> { get }
+  var goToPerimeterXCaptcha: Signal<PerimeterXBlockResponseType, Never> { get }
 
   /// Emits when the root view controller should navigate to the user's profile.
   var goToProfile: Signal<(), Never> { get }
@@ -784,8 +783,8 @@ public final class AppDelegateViewModel: AppDelegateViewModelType, AppDelegateVi
     self.optimizelyClientConfigurationFailedProperty.value = ()
   }
 
-  private let perimeterXCaptchaTriggeredProperty = MutableProperty<PXBlockResponse?>(nil)
-  public func perimeterXCaptchaTriggered(response: PXBlockResponse) {
+  private let perimeterXCaptchaTriggeredProperty = MutableProperty<PerimeterXBlockResponseType?>(nil)
+  public func perimeterXCaptchaTriggered(response: PerimeterXBlockResponseType) {
     self.perimeterXCaptchaTriggeredProperty.value = response
   }
 
@@ -806,7 +805,7 @@ public final class AppDelegateViewModel: AppDelegateViewModelType, AppDelegateVi
   public let goToLandingPage: Signal<(), Never>
   public let goToLoginWithIntent: Signal<LoginIntent, Never>
   public let goToMessageThread: Signal<MessageThread, Never>
-  public let goToPerimeterXCaptcha: Signal<PXBlockResponse, Never>
+  public let goToPerimeterXCaptcha: Signal<PerimeterXBlockResponseType, Never>
   public let goToProfile: Signal<(), Never>
   public let goToProjectActivities: Signal<Param, Never>
   public let goToMobileSafari: Signal<URL, Never>

--- a/Kickstarter-iOS/ViewModels/AppDelegateViewModelTests.swift
+++ b/Kickstarter-iOS/ViewModels/AppDelegateViewModelTests.swift
@@ -2470,7 +2470,7 @@ final class AppDelegateViewModelTests: TestCase {
     }
   }
 
-  func testGoToPerimeterXCaptcha() {
+  func testGoToPerimeterXCaptcha_Captcha() {
     self.goToPerimeterXCaptcha.assertDidNotEmitValue()
 
     let response = MockPerimeterXBlockResponse(blockType: .Captcha)
@@ -2479,6 +2479,17 @@ final class AppDelegateViewModelTests: TestCase {
 
     self.goToPerimeterXCaptcha.assertValueCount(1)
     XCTAssertEqual(self.goToPerimeterXCaptcha.values.last?.type, .Captcha)
+  }
+
+  func testGoToPerimeterXCaptcha_Blocked() {
+    self.goToPerimeterXCaptcha.assertDidNotEmitValue()
+
+    let response = MockPerimeterXBlockResponse(blockType: .Block)
+
+    self.vm.inputs.perimeterXCaptchaTriggered(response: response)
+
+    self.goToPerimeterXCaptcha.assertValueCount(1)
+    XCTAssertEqual(self.goToPerimeterXCaptcha.values.last?.type, .Block)
   }
 
   func testFeatureFlagsRetainedInConfig_NotRelease() {

--- a/Kickstarter-iOS/ViewModels/AppDelegateViewModelTests.swift
+++ b/Kickstarter-iOS/ViewModels/AppDelegateViewModelTests.swift
@@ -1,7 +1,6 @@
 @testable import Kickstarter_Framework
 @testable import KsApi
 @testable import Library
-import PerimeterX
 import Prelude
 import ReactiveExtensions
 import ReactiveExtensions_TestHelpers
@@ -31,7 +30,7 @@ final class AppDelegateViewModelTests: TestCase {
   private let goToLandingPage = TestObserver<(), Never>()
   private let goToProjectActivities = TestObserver<Param, Never>()
   private let goToLoginWithIntent = TestObserver<LoginIntent, Never>()
-  private let goToPerimeterXCaptcha = TestObserver<PXBlockResponse, Never>()
+  private let goToPerimeterXCaptcha = TestObserver<PerimeterXBlockResponseType, Never>()
   private let goToProfile = TestObserver<(), Never>()
   private let goToMobileSafari = TestObserver<URL, Never>()
   private let goToSearch = TestObserver<(), Never>()
@@ -2474,9 +2473,12 @@ final class AppDelegateViewModelTests: TestCase {
   func testGoToPerimeterXCaptcha() {
     self.goToPerimeterXCaptcha.assertDidNotEmitValue()
 
-    self.vm.inputs.perimeterXCaptchaTriggered(response: PXBlockResponse())
+    let response = MockPerimeterXBlockResponse(blockType: .Captcha)
+
+    self.vm.inputs.perimeterXCaptchaTriggered(response: response)
 
     self.goToPerimeterXCaptcha.assertValueCount(1)
+    XCTAssertEqual(self.goToPerimeterXCaptcha.values.last?.type, .Captcha)
   }
 
   func testFeatureFlagsRetainedInConfig_NotRelease() {

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -546,8 +546,6 @@
 		8ACF36E22627481C0026E74D /* ApiDateProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A1F66022627300900A28E74 /* ApiDateProtocol.swift */; };
 		8ACF36EA2627486D0026E74D /* KsApiNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ACF36E92627486D0026E74D /* KsApiNotification.swift */; };
 		8ACF36F7262763960026E74D /* MockPerimeterXTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A1F65EA262660DB00A28E74 /* MockPerimeterXTypes.swift */; };
-		8ACF36FF262769420026E74D /* PerimeterX.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8ACF36FE262769420026E74D /* PerimeterX.framework */; };
-		8ACF3703262769640026E74D /* PerimeterX.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8ACF36FE262769420026E74D /* PerimeterX.framework */; };
 		8ACF558923E8D467001654A2 /* TryDecodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ACF558823E8D467001654A2 /* TryDecodable.swift */; };
 		8ACF95AE248957B10064FC4C /* ManagePledgeDataSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ACF95AD248957B10064FC4C /* ManagePledgeDataSourceTests.swift */; };
 		8AD48633235939AF00A1463E /* StripeTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD48632235939AF00A1463E /* StripeTypes.swift */; };
@@ -2069,7 +2067,6 @@
 		8ACB32A724ABC2DB00A03968 /* RewardAddOnSelectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RewardAddOnSelectionViewController.swift; sourceTree = "<group>"; };
 		8ACD29F6243E48260044BC17 /* PledgePaymentMethodsDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PledgePaymentMethodsDataSource.swift; sourceTree = "<group>"; };
 		8ACF36E92627486D0026E74D /* KsApiNotification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KsApiNotification.swift; sourceTree = "<group>"; };
-		8ACF36FE262769420026E74D /* PerimeterX.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = PerimeterX.framework; path = Carthage/Build/iOS/PerimeterX.framework; sourceTree = "<group>"; };
 		8ACF558823E8D467001654A2 /* TryDecodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TryDecodable.swift; sourceTree = "<group>"; };
 		8ACF95AD248957B10064FC4C /* ManagePledgeDataSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManagePledgeDataSourceTests.swift; sourceTree = "<group>"; };
 		8AD48632235939AF00A1463E /* StripeTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StripeTypes.swift; sourceTree = "<group>"; };
@@ -2977,7 +2974,6 @@
 				774D98DA23A9795100FC81C2 /* Optimizely.framework in Frameworks */,
 				4748C19125B7A2F80098E89E /* FirebaseCore.framework in Frameworks */,
 				D0B45B6B1EF858C00020A8DA /* KsApi.framework in Frameworks */,
-				8ACF36FF262769420026E74D /* PerimeterX.framework in Frameworks */,
 				D0D58D862257FAE000532AC1 /* Prelude.framework in Frameworks */,
 				D0D58D8E2257FAE000532AC1 /* Prelude_UIKit.framework in Frameworks */,
 				477731BA25C4E7CF00AF3273 /* FirebaseRemoteConfig.framework in Frameworks */,
@@ -3012,7 +3008,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				D0BE6F1E228634C700D05A10 /* Prelude.framework in Frameworks */,
-				8ACF3703262769640026E74D /* PerimeterX.framework in Frameworks */,
 				D0BE6F1F228634C700D05A10 /* ReactiveExtensions.framework in Frameworks */,
 				D0BE6F20228634C700D05A10 /* ReactiveSwift.framework in Frameworks */,
 			);
@@ -3904,7 +3899,6 @@
 		A7E06DBC1C5C027800EBDCC2 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				8ACF36FE262769420026E74D /* PerimeterX.framework */,
 				8AA5B061235E253B0022F5F0 /* AppCenterDistributeResources.bundle */,
 				D00A373E2258270600F46F47 /* Alamofire.framework */,
 				D00A371F225815FA00F46F47 /* AlamofireImage.framework */,

--- a/KsApi/px/MockPerimeterXTypes.swift
+++ b/KsApi/px/MockPerimeterXTypes.swift
@@ -14,6 +14,8 @@ struct MockPerimeterXBlockResponse: PerimeterXBlockResponseType {
   var type: PXBlockType {
     return self.blockType
   }
+
+  func displayCaptcha(on _: UIViewController?) {}
 }
 
 final class MockPerimeterXManager: PerimeterXManagerType {

--- a/KsApi/px/PerimeterXClient.swift
+++ b/KsApi/px/PerimeterXClient.swift
@@ -44,26 +44,13 @@ public class PerimeterXClient: NSObject, PerimeterXClientType {
       [.Block, .Captcha].contains(response.type)
     else { return false }
 
-    let object = PerimeterXBlockWrapper.wrapper(with: response)
-
-    NotificationCenter.default.post(name: Notification.Name.ksr_perimeterXCaptcha, object: object)
+    NotificationCenter.default.post(name: Notification.Name.ksr_perimeterXCaptcha, object: response)
 
     return true
   }
 
   public func headers() -> [String: String] {
     return (self.manager.httpHeaders() as? [String: String]) ?? [:]
-  }
-}
-
-/// Works around a Swift bug - https://bugs.swift.org/browse/SR-3871
-public struct PerimeterXBlockWrapper {
-  public let originalBlockResponse: PXBlockResponse
-
-  static func wrapper(with response: PerimeterXBlockResponseType) -> PerimeterXBlockWrapper? {
-    guard let response = response as? PXBlockResponse else { return nil }
-
-    return PerimeterXBlockWrapper(originalBlockResponse: response)
   }
 }
 

--- a/KsApi/px/PerimeterXTypes.swift
+++ b/KsApi/px/PerimeterXTypes.swift
@@ -29,6 +29,14 @@ extension PXManager: PerimeterXManagerType {
 
 public protocol PerimeterXBlockResponseType {
   var type: PXBlockType { get }
+
+  func displayCaptcha(on vc: UIViewController?)
 }
 
-extension PXBlockResponse: PerimeterXBlockResponseType {}
+extension PXBlockResponse: PerimeterXBlockResponseType {
+  public func displayCaptcha(on vc: UIViewController?) {
+    PXManager.sharedInstance()?.handle(self, with: vc) {
+      print("❎ Perimeter X CAPTCHA was successful.")
+    }
+  }
+}


### PR DESCRIPTION
# 📲 What

In a previous refactor (#1427) we encountered a Swift bug and implemented a workaround for that. Thinking about this more I think this would be a better approach and coincidentally noticed that it also helps to reduce noise in our console logs.

# 🤔 Why

Although sometimes necessary it's preferred to avoid awkward workarounds for language/platform bugs as far as possible.

Also, upon investigating I discovered that the earlier refactor had also caused duplicate symbol warnings in the console log which, while somewhat innocuous in this case, is also preferable to avoid:

<img width="1083" alt="image" src="https://user-images.githubusercontent.com/3735375/115423931-d76ef580-a1c3-11eb-9ffe-f50deeb942f2.png">

# 🛠 How

- Moved target membership around so that only KsApi imports `PerimeterX`.
- Updated the `PerimeterXBlockResponseType` to have a simple function which receives a `UIViewController` on which to display the captcha.

# ✅ Acceptance criteria

- [ ] Run the app on device, use the PerimeterX developer console to trigger a captcha. Solving the captcha should dismiss it and it shouldn't be shown again.