### PR TITLE
[NT-1851] Enable/Disable Segment By Feature Flag

### DIFF
--- a/Configs/Secrets.swift.example
+++ b/Configs/Secrets.swift.example
@@ -40,8 +40,8 @@ public enum Secrets {
   }
 
   public enum Segment {
-    public static let staging = "write-key"
-    public static let production = "write-key"
+    public static let staging = "write-key-production"
+    public static let production = "write-key-staging"
   }
 
   public enum Qualtrics {

--- a/Configs/Secrets.swift.example
+++ b/Configs/Secrets.swift.example
@@ -40,8 +40,8 @@ public enum Secrets {
   }
 
   public enum Segment {
-    public static let staging = "write-key-production"
-    public static let production = "write-key-staging"
+    public static let staging = "write-key-staging"
+    public static let production = "write-key-production"
   }
 
   public enum Qualtrics {

--- a/Kickstarter-iOS/AppDelegate.swift
+++ b/Kickstarter-iOS/AppDelegate.swift
@@ -271,11 +271,7 @@ internal final class AppDelegate: UIResponder, UIApplicationDelegate {
 
     self.viewModel.outputs.segmentIsEnabled
       .observeValues { enabled in
-        if enabled {
-          Analytics.shared().enable()
-        } else {
-          Analytics.shared().disable()
-        }
+        enabled ? Analytics.shared().enable() : Analytics.shared().disable()
       }
 
     NotificationCenter.default

--- a/Kickstarter-iOS/AppDelegate.swift
+++ b/Kickstarter-iOS/AppDelegate.swift
@@ -263,6 +263,30 @@ internal final class AppDelegate: UIResponder, UIApplicationDelegate {
         self?.viewModel.inputs.userSessionEnded()
       }
 
+    self.viewModel.outputs.configureSegment
+      .observeValues { writeKey in
+        let client = Analytics.configuredClient(withWriteKey: writeKey)
+        AppEnvironment.current.ksrAnalytics.configureSegmentClient(client)
+      }
+
+    self.viewModel.outputs.segmentIsEnabled
+      .observeValues { enabled in
+        if enabled {
+          Analytics.shared().enable()
+        } else {
+          Analytics.shared().disable()
+        }
+      }
+
+    NotificationCenter.default
+      .addObserver(
+        forName: Notification.Name.ksr_configUpdated,
+        object: nil,
+        queue: nil
+      ) { [weak self] _ in
+        self?.viewModel.inputs.configUpdatedNotificationObserved()
+      }
+
     NotificationCenter.default
       .addObserver(
         forName: Notification.Name.ksr_perimeterXCaptcha,

--- a/Kickstarter-iOS/ViewModels/AppDelegateViewModel.swift
+++ b/Kickstarter-iOS/ViewModels/AppDelegateViewModel.swift
@@ -49,6 +49,9 @@ public protocol AppDelegateViewModelInputs {
   /// Call after having invoked AppEnvironment.updateCurrentUser with a fresh user.
   func currentUserUpdatedInEnvironment()
 
+  /// Call when the `ksr_configUpdated` notification is observed (config updated elsewhere, eg. debug tools).
+  func configUpdatedNotificationObserved()
+
   /// Call when the user taps "OK" from the contextual alert.
   func didAcceptReceivingRemoteNotifications()
 
@@ -104,6 +107,9 @@ public protocol AppDelegateViewModelOutputs {
 
   /// Emits when the application should configure Perimeter X
   var configurePerimeterX: Signal<(), Never> { get }
+
+  /// Emits when the application should configure Segment.
+  var configureSegment: Signal<String, Never> { get }
 
   /// Return this value in the delegate method.
   var continueUserActivityReturnValue: MutableProperty<Bool> { get }
@@ -170,6 +176,9 @@ public protocol AppDelegateViewModelOutputs {
 
   /// Emits when we should register the device push token in Segment Analytics.
   var registerPushTokenInSegment: Signal<Data, Never> { get }
+
+  /// Emits when our config updates with the enabled state for Semgent Analytics.
+  var segmentIsEnabled: Signal<Bool, Never> { get }
 
   /// Emits an array of short cut items to put into the shared application.
   var setApplicationShortcutItems: Signal<[ShortcutItem], Never> { get }
@@ -659,6 +668,21 @@ public final class AppDelegateViewModel: AppDelegateViewModelType, AppDelegateVi
       .map { $0.hasError }
 
     self.goToPerimeterXCaptcha = self.perimeterXCaptchaTriggeredProperty.signal.skipNil()
+
+    self.configureSegment = self.applicationLaunchOptionsProperty.signal
+      .skipNil()
+      .map { _ in
+        AppEnvironment.current.mainBundle.isRelease
+          ? Secrets.Segment.production
+          : Secrets.Segment.staging
+      }
+
+    self.segmentIsEnabled = Signal.merge(
+      self.didUpdateConfigProperty.signal.skipNil().ignoreValues(),
+      self.configUpdatedNotificationObservedProperty.signal
+    )
+    .map { _ in featureSegmentIsEnabled() }
+    .skipRepeats()
   }
 
   public var inputs: AppDelegateViewModelInputs { return self }
@@ -704,6 +728,11 @@ public final class AppDelegateViewModel: AppDelegateViewModelType, AppDelegateVi
   fileprivate let currentUserUpdatedInEnvironmentProperty = MutableProperty(())
   public func currentUserUpdatedInEnvironment() {
     self.currentUserUpdatedInEnvironmentProperty.value = ()
+  }
+
+  private let configUpdatedNotificationObservedProperty = MutableProperty(())
+  public func configUpdatedNotificationObserved() {
+    self.configUpdatedNotificationObservedProperty.value = ()
   }
 
   fileprivate let remoteNotificationProperty = MutableProperty<[AnyHashable: Any]?>(nil)
@@ -794,6 +823,7 @@ public final class AppDelegateViewModel: AppDelegateViewModelType, AppDelegateVi
   public let configureFirebase: Signal<(), Never>
   public let configureOptimizely: Signal<(String, OptimizelyLogLevelType, TimeInterval), Never>
   public let configurePerimeterX: Signal<(), Never>
+  public let configureSegment: Signal<String, Never>
   public let continueUserActivityReturnValue = MutableProperty(false)
   public let emailVerificationCompleted: Signal<(String, Bool), Never>
   public let findRedirectUrl: Signal<URL, Never>
@@ -816,6 +846,7 @@ public final class AppDelegateViewModel: AppDelegateViewModelType, AppDelegateVi
   public let pushTokenRegistrationStarted: Signal<(), Never>
   public let pushTokenSuccessfullyRegistered: Signal<String, Never>
   public let registerPushTokenInSegment: Signal<Data, Never>
+  public let segmentIsEnabled: Signal<Bool, Never>
   public let setApplicationShortcutItems: Signal<[ShortcutItem], Never>
   public let showAlert: Signal<Notification, Never>
   public let synchronizeUbiquitousStore: Signal<(), Never>

--- a/Library/Tracking/IdentifyingTrackingClient.swift
+++ b/Library/Tracking/IdentifyingTrackingClient.swift
@@ -1,13 +1,14 @@
-public protocol IdentifyingTrackingClient { /**
- Identifies a user for event tracking, using the Segment SDK.
+public protocol IdentifyingTrackingClient {
+  /**
+   Identifies a user for event tracking, using the Segment SDK.
 
- - parameter userId:      The userId associated with this user on Segment.
- - parameter traits: Dictionary of properties associated with event.
- */
-func identify(userId: String?, traits: [String: Any]?)
+   - parameter userId: The userId associated with this user on Segment.
+   - parameter traits: Dictionary of properties associated with event.
+   */
+  func identify(_ userId: String?, traits: [String: Any]?)
 
-/**
- Resets the identity of a user with Segment.
- */
-func resetIdentity()
+  /**
+   Resets the identity of a user with Segment.
+   */
+  func reset()
 }

--- a/Library/Tracking/KSRAnalytics.swift
+++ b/Library/Tracking/KSRAnalytics.swift
@@ -553,12 +553,12 @@ public final class KSRAnalytics {
   /// Configure Tracking Client's supporting user identity
   private func identify(_ user: User?) {
     guard let user = user else {
-      self.segmentClient?.resetIdentity()
+      self.segmentClient?.reset()
       return
     }
 
     self.segmentClient?.identify(
-      userId: "\(user.id)",
+      "\(user.id)",
       traits: [
         "name": user.name,
         "is_creator": user.isCreator,
@@ -1501,13 +1501,13 @@ public final class KSRAnalytics {
     self.logEventCallback?(event, props)
 
     self.dataLakeClient.track(
-      event: event,
+      event,
       properties: props
     )
 
     // Currently events approved for the Data Lake are good for Segment.
     self.segmentClient?.track(
-      event: event,
+      event,
       properties: props
     )
   }

--- a/Library/Tracking/MockTrackingClient.swift
+++ b/Library/Tracking/MockTrackingClient.swift
@@ -6,8 +6,8 @@ internal final class MockTrackingClient: TrackingClientType {
   internal var userId: String?
   internal var traits: [String: Any]?
 
-  func track(event: String, properties: [String: Any]) {
-    self.tracks.append((event: event, properties: properties))
+  func track(_ event: String, properties: [String: Any]?) {
+    self.tracks.append((event: event, properties: properties ?? [:]))
   }
 
   internal var events: [String] {
@@ -34,12 +34,12 @@ internal final class MockTrackingClient: TrackingClientType {
 }
 
 extension MockTrackingClient: IdentifyingTrackingClient {
-  func identify(userId: String?, traits: [String: Any]?) {
+  func identify(_ userId: String?, traits: [String: Any]?) {
     self.userId = userId
     self.traits = traits
   }
 
-  func resetIdentity() {
+  func reset() {
     self.userId = nil
     self.traits = nil
   }

--- a/Library/Tracking/Segment.swift
+++ b/Library/Tracking/Segment.swift
@@ -27,32 +27,7 @@ public extension Analytics {
 
 /**
  The `TrackingClientType` and `IdentifyingTrackingClient` protocols
- allow us to create mocks to test these code paths. The protocol exposes functions that are named similarly
- but differently so that we can perform the check to see that tracking is enabled before calling any of the
- functions on the library itself so as to not unintentionally contribute to tracking data during debugging.
+ allow us to create mocks to test these code paths.
  */
-
-extension Analytics: IdentifyingTrackingClient {
-  public func identify(userId: String?, traits: [String: Any]?) {
-    guard AppEnvironment.current.environmentVariables.isTrackingEnabled,
-      featureSegmentIsEnabled() else { return }
-
-    self.identify(userId, traits: traits)
-  }
-
-  public func resetIdentity() {
-    guard AppEnvironment.current.environmentVariables.isTrackingEnabled,
-      featureSegmentIsEnabled() else { return }
-
-    self.reset()
-  }
-}
-
-extension Analytics: TrackingClientType {
-  public func track(event: String, properties: [String: Any]) {
-    guard AppEnvironment.current.environmentVariables.isTrackingEnabled,
-      featureSegmentIsEnabled() else { return }
-
-    self.track(event, properties: properties)
-  }
-}
+extension Analytics: IdentifyingTrackingClient {}
+extension Analytics: TrackingClientType {}

--- a/Library/Tracking/Segment.swift
+++ b/Library/Tracking/Segment.swift
@@ -7,21 +7,19 @@ public extension Analytics {
   /**
    Returns an `Analytics` instance, with Segment, using an `AnalyticsConfiguration`.
    */
-  static func configuredClient() -> Analytics {
-    // Due to this being constructed at the same time as the environment we're not able to refer to the
-    // mainBundle on the environment here. We probably should if we want to test this.
-    let writeKey = Bundle.main.isRelease
-      ? Secrets.Segment.production
-      : Secrets.Segment.staging
-
+  static func configuredClient(withWriteKey writeKey: String) -> Analytics {
     let configuration = AnalyticsConfiguration(writeKey: writeKey)
     configuration
       .trackApplicationLifecycleEvents = true
 
     // Braze is always configured but feature-flagged elsewhere.
+    // Data sent to Braze is feature-flagged by the enabling/disabling Segment.
     configuration.use(SEGAppboyIntegrationFactory.instance())
 
     Analytics.setup(with: configuration)
+
+    // Disabled when initialized and enabled by our feature-flag configuration.
+    Analytics.shared().disable()
 
     return Analytics.shared()
   }

--- a/Library/Tracking/TrackingClient.swift
+++ b/Library/Tracking/TrackingClient.swift
@@ -47,7 +47,9 @@ public final class TrackingClient: TrackingClientType {
     self.startTimer()
   }
 
-  public func track(event: String, properties: [String: Any]) {
+  public func track(_ event: String, properties: [String: Any]?) {
+    let properties = properties ?? [:]
+
     if AppEnvironment.current.environmentVariables.isTrackingEnabled {
       print("\(self.config.identifier.emoji) [\(self.config.identifier) Track]: \(event), properties: \(properties)")
 

--- a/Library/Tracking/TrackingClientType.swift
+++ b/Library/Tracking/TrackingClientType.swift
@@ -5,16 +5,5 @@ public protocol TrackingClientType {
    - parameter event:      Name of the event.
    - parameter properties: Dictionary of properties associated with event.
    */
-  func track(event: String, properties: [String: Any])
-}
-
-public extension TrackingClientType {
-  /**
-   Tracks an event in our analytics system.
-
-   - parameter event: Name of the event.
-   */
-  func track(event: String) {
-    self.track(event: event, properties: [:])
-  }
+  func track(_ event: String, properties: [String: Any]?)
 }


### PR DESCRIPTION
# 📲 What

- Moves our configuration of Segment to be after the `AppEnvironment` is set up.
- Enables and disables all Segment tracking by feature flag.
- Tidies up our protocols that we were using before to mock and feature flag tracking.

# 🤔 Why

- We had a race condition in that we were instantiating Segment's `Analytics` during the instantiation of the `AppEnvironment` and therefore could not inspect the environment at the same time. Moving this makes more tests possible.
- Previously we were feature-flagging the `track`, `identify`, etc methods but Segment would still track app lifecycle events. It turns out Segment provides `disable()` and `enable()` functions to completely disable/enable tracking which we are now using instead.
  - Note: Segment is _disabled_ by default and enabled by the feature flag configuration.
- We no longer need some of the protocol functions as we don't need to test the feature flagging at those particular call-sites.

# 🛠 How

- Moved Segment initialization to be driven by an `AppDelegateViewModel` output.
- Observing configuration changes and enabling/disabling Segment.
- Tidied up these protocols.

# ✅ Acceptance criteria

Open Segment's debugger and run the app.

- [ ] Toggle the Segment feature flag in the app's debug menu, observe that events are or are not sent to Segment based on the state of the flag.
- [ ] Trigger a reload of the config and intercept it using Charles Proxy. Edit the response to enable or disable Segment using the feature flag. Observe that events are or are not sent to Segment based on the state of the flag.