### PR TITLE
[NT-1843] Add Subscriptions To Identify Call

### DIFF
--- a/Library/Tracking/KSRAnalytics.swift
+++ b/Library/Tracking/KSRAnalytics.swift
@@ -584,6 +584,7 @@ public final class KSRAnalytics {
         "backed_projects_count": user.stats.backedProjectsCount ?? 0,
         "created_projects_count": user.stats.createdProjectsCount ?? 0
       ]
+      .withAllValuesFrom(user.notifications.encode())
     )
   }
 

--- a/Library/Tracking/KSRAnalyticsTests.swift
+++ b/Library/Tracking/KSRAnalyticsTests.swift
@@ -2150,6 +2150,12 @@ final class KSRAnalyticsTests: TestCase {
       user.stats.createdProjectsCount
     )
 
+    let notifications1 = user.notifications.encode()
+
+    for (key, _) in notifications1 {
+      XCTAssertEqual(notifications1[key] as? Bool, self.segmentTrackingClient.traits?[key] as? Bool)
+    }
+
     let user2 = user
       |> User.lens.id .~ 9_999
       |> User.lens.name .~ "Another User"
@@ -2169,6 +2175,12 @@ final class KSRAnalyticsTests: TestCase {
       self.segmentTrackingClient.traits?["created_projects_count"] as? Int,
       user2.stats.createdProjectsCount
     )
+
+    let notifications2 = user.notifications.encode()
+
+    for (key, _) in notifications2 {
+      XCTAssertEqual(notifications2[key] as? Bool, self.segmentTrackingClient.traits?[key] as? Bool)
+    }
 
     AppEnvironment.logout()
 


### PR DESCRIPTION
# 📲 What

Adds the user subscriptions to our analytics `identify` call.

# 🤔 Why

We will carry these properties through to Segment and Braze so that we can manage push/email subscriptions based on these values.

# 🛠 How

Added the subscriptions to the traits dictionary that's passed to `identify`.

# 👀 See

```json
{
  "traits": {
    "anonymousId": "70A0938F-99E2-4C29-9A32-12C4999B0E64",
    "backed_projects_count": 43,
    "created_projects_count": 0,
    "is_creator": false,
    "name": "Justin Swart",
    "notify_mobile_of_backings": true,
    "notify_mobile_of_comments": true,
    "notify_mobile_of_follower": true,
    "notify_mobile_of_friend_activity": true,
    "notify_mobile_of_messages": true,
    "notify_mobile_of_post_likes": true,
    "notify_mobile_of_updates": true,
    "notify_of_backings": false,
    "notify_of_comment_replies": true,
    "notify_of_comments": true,
    "notify_of_creator_digest": false,
    "notify_of_creator_edu": true,
    "notify_of_follower": true,
    "notify_of_friend_activity": true,
    "notify_of_messages": true,
    "notify_of_post_likes": false,
    "notify_of_updates": true,
    "userId": "<redacted>"
  }
}
```

# ✅ Acceptance criteria

- [x] Run the app, check the segment debugger for the most recent identify call for your user, these properties should be seen there.
- [ ] Toggle some of your user's subscriptions, identify should be called again and reflected in Segment's debugger.