### PR TITLE
[EP-282] CTA Clicked (sign_up_submit)

### DIFF
--- a/Library/Tracking/KSRAnalytics.swift
+++ b/Library/Tracking/KSRAnalytics.swift
@@ -48,7 +48,6 @@ public final class KSRAnalytics {
     case projectPagePledgeButtonClicked = "Project Page Pledge Button Clicked"
     case projectSwiped = "Project Swiped"
     case signupButtonClicked = "Signup Button Clicked"
-    case signupSubmitButtonClicked = "Signup Submit Button Clicked"
     case skipVerificationButtonClicked = "Skip Verification Button Clicked"
     case tabBarClicked = "Tab Bar Clicked"
     case twoFactorConfirmationViewed = "Two-Factor Confirmation Viewed"
@@ -1342,8 +1341,14 @@ public final class KSRAnalytics {
     )
   }
 
-  public func trackSignupSubmitButtonClicked() {
-    self.track(event: ApprovedEvent.signupSubmitButtonClicked.rawValue, page: .signup)
+  public func trackSignupSubmitButtonClicked(subscription: Bool) {
+    let typeContext = subscription ? TypeContext.subscriptionTrue : .subscriptionFalse
+    let props = contextProperties(ctaContext: .signUpSubmit, typeContext: typeContext)
+    self.track(
+      event: NewApprovedEvent.ctaClicked.rawValue,
+      page: .signup,
+      properties: props
+    )
   }
 
   public func trackLoginSubmitButtonClicked() {

--- a/Library/Tracking/KSRAnalytics.swift
+++ b/Library/Tracking/KSRAnalytics.swift
@@ -1340,8 +1340,8 @@ public final class KSRAnalytics {
     )
   }
 
-  public func trackSignupSubmitButtonClicked(subscription: Bool) {
-    let typeContext = subscription ? TypeContext.subscriptionTrue : .subscriptionFalse
+  public func trackSignupSubmitButtonClicked(isSubscribed: Bool) {
+    let typeContext: TypeContext = isSubscribed ? .subscriptionTrue : .subscriptionFalse
     let props = contextProperties(ctaContext: .signUpSubmit, typeContext: typeContext)
     self.track(
       event: NewApprovedEvent.ctaClicked.rawValue,

--- a/Library/Tracking/KSRAnalyticsTests.swift
+++ b/Library/Tracking/KSRAnalyticsTests.swift
@@ -350,6 +350,31 @@ final class KSRAnalyticsTests: TestCase {
     XCTAssertEqual("unknown", segmentProps?["session_device_orientation"] as? String)
   }
 
+  // MARK: - Login & Signup Tests
+
+  func testTrackSignupSubmitButtonClicked() {
+    let dataLakeClient = MockTrackingClient()
+    let segmentClient = MockTrackingClient()
+    let ksrAnalytics = KSRAnalytics(
+      dataLakeClient: dataLakeClient,
+      loggedInUser: nil,
+      segmentClient: segmentClient
+    )
+
+    ksrAnalytics.trackSignupSubmitButtonClicked(subscription: true)
+
+    XCTAssertEqual(["CTA Clicked"], dataLakeClient.events)
+    XCTAssertEqual(["CTA Clicked"], segmentClient.events)
+
+    XCTAssertEqual("sign_up", dataLakeClient.properties.last?["context_page"] as? String)
+    XCTAssertEqual("sign_up_submit", dataLakeClient.properties.last?["context_cta"] as? String)
+    XCTAssertEqual("subscription_true", dataLakeClient.properties.last?["context_type"] as? String)
+
+    XCTAssertEqual("sign_up", segmentClient.properties.last?["context_page"] as? String)
+    XCTAssertEqual("sign_up_submit", segmentClient.properties.last?["context_cta"] as? String)
+    XCTAssertEqual("subscription_true", segmentClient.properties.last?["context_type"] as? String)
+  }
+
   // MARK: - Project Properties Tests
 
   func testProjectProperties() {
@@ -2505,7 +2530,7 @@ final class KSRAnalyticsTests: TestCase {
     XCTAssertEqual("project", dataLakeClient.properties.last?["context_page"] as? String)
     XCTAssertEqual("project", segmentClient.properties.last?["context_page"] as? String)
 
-    ksrAnalytics.trackSignupSubmitButtonClicked()
+    ksrAnalytics.trackSignupSubmitButtonClicked(subscription: false)
     XCTAssertEqual("sign_up", dataLakeClient.properties.last?["context_page"] as? String)
     XCTAssertEqual("sign_up", segmentClient.properties.last?["context_page"] as? String)
 

--- a/Library/Tracking/KSRAnalyticsTests.swift
+++ b/Library/Tracking/KSRAnalyticsTests.swift
@@ -382,7 +382,7 @@ final class KSRAnalyticsTests: TestCase {
       segmentClient: segmentClient
     )
 
-    ksrAnalytics.trackSignupSubmitButtonClicked(subscription: true)
+    ksrAnalytics.trackSignupSubmitButtonClicked(isSubscribed: true)
 
     XCTAssertEqual(["CTA Clicked"], dataLakeClient.events)
     XCTAssertEqual(["CTA Clicked"], segmentClient.events)
@@ -2579,7 +2579,7 @@ final class KSRAnalyticsTests: TestCase {
     XCTAssertEqual("project", dataLakeClient.properties.last?["context_page"] as? String)
     XCTAssertEqual("project", segmentClient.properties.last?["context_page"] as? String)
 
-    ksrAnalytics.trackSignupSubmitButtonClicked(subscription: false)
+    ksrAnalytics.trackSignupSubmitButtonClicked(isSubscribed: false)
     XCTAssertEqual("sign_up", dataLakeClient.properties.last?["context_page"] as? String)
     XCTAssertEqual("sign_up", segmentClient.properties.last?["context_page"] as? String)
 

--- a/Library/ViewModels/SignupViewModel.swift
+++ b/Library/ViewModels/SignupViewModel.swift
@@ -82,7 +82,7 @@ public final class SignupViewModel: SignupViewModelType, SignupViewModelInputs, 
       initialText
     )
 
-    let newsletter = Signal.merge(
+    let isSubscribed = Signal.merge(
       self.viewDidLoadProperty.signal.mapConst(false),
       self.weeklyNewsletterChangedProperty.signal.skipNil()
     )
@@ -99,14 +99,14 @@ public final class SignupViewModel: SignupViewModelType, SignupViewModelInputs, 
       .map { $0 && $1 && $2 }
       .skipRepeats()
 
-    self.setWeeklyNewsletterState = newsletter.take(first: 1)
+    self.setWeeklyNewsletterState = isSubscribed.take(first: 1)
 
     let attemptSignup = Signal.merge(
       self.passwordTextFieldReturnProperty.signal,
       self.signupButtonPressedProperty.signal
     )
 
-    let signupEvent = Signal.combineLatest(name, email, password, newsletter)
+    let signupEvent = Signal.combineLatest(name, email, password, isSubscribed)
       .takeWhen(attemptSignup)
       .switchMap { name, email, password, newsletter in
         AppEnvironment.current.apiService.signup(
@@ -132,9 +132,9 @@ public final class SignupViewModel: SignupViewModelType, SignupViewModelInputs, 
     self.postNotification = self.environmentLoggedInProperty.signal
       .mapConst(Notification(name: .ksr_sessionStarted))
 
-    newsletter.takeWhen(attemptSignup)
-      .observeValues { newsletter in
-        AppEnvironment.current.ksrAnalytics.trackSignupSubmitButtonClicked(subscription: newsletter)
+    isSubscribed.takeWhen(attemptSignup)
+      .observeValues { isSubscribed in
+        AppEnvironment.current.ksrAnalytics.trackSignupSubmitButtonClicked(isSubscribed: isSubscribed)
       }
   }
 

--- a/Library/ViewModels/SignupViewModel.swift
+++ b/Library/ViewModels/SignupViewModel.swift
@@ -132,8 +132,10 @@ public final class SignupViewModel: SignupViewModelType, SignupViewModelInputs, 
     self.postNotification = self.environmentLoggedInProperty.signal
       .mapConst(Notification(name: .ksr_sessionStarted))
 
-    attemptSignup
-      .observeValues { AppEnvironment.current.ksrAnalytics.trackSignupSubmitButtonClicked() }
+    newsletter.takeWhen(attemptSignup)
+      .observeValues { newsletter in
+        AppEnvironment.current.ksrAnalytics.trackSignupSubmitButtonClicked(subscription: newsletter)
+      }
   }
 
   fileprivate let emailChangedProperty = MutableProperty("")

--- a/Library/ViewModels/SignupViewModelTests.swift
+++ b/Library/ViewModels/SignupViewModelTests.swift
@@ -67,8 +67,8 @@ internal final class SignupViewModelTests: TestCase {
     self.vm.inputs.signupButtonPressed()
     self.logIntoEnvironment.assertDidNotEmitValue("Does not immediately emit after signup button is pressed.")
 
-    XCTAssertEqual(["Signup Submit Button Clicked"], self.dataLakeTrackingClient.events)
-    XCTAssertEqual(["Signup Submit Button Clicked"], self.segmentTrackingClient.events)
+    XCTAssertEqual(["CTA Clicked"], self.dataLakeTrackingClient.events)
+    XCTAssertEqual(["CTA Clicked"], self.segmentTrackingClient.events)
 
     self.scheduler.advance()
 


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

- Convert `Sign up Submit Button Clicked` Event to a CTA Clicked event
- Supply a `TypeContext` based on newsletter subscription to the the CTA event.
- Add a test for the analytics event method that tracks signup submit button clicked.

# 🤔 Why

This is part of phase 6 of Segment event tracking.

# 👀 See

<img width="544" alt="Screenshot 2021-04-26 at 15 57 12" src="https://user-images.githubusercontent.com/8595853/116125928-f8e94900-a6bd-11eb-97c4-0bcce9b2b598.png">


# ✅ Acceptance criteria

1. Launch and App and navigate to Sign up screen, that's if you're not already logged in.
2. Enter a name, email address and a password so that the Sign up button is enabled
3. You can also toggle the newsletter switch
3. Once the Sign up button it's enabled, tap it
4. Verify that a CTA event shows up in Segment debugger with these properties
```
"event": "CTA Clicked"
"context_cta": "sign_up_submit"
"context_page": "sign_up",
"context_type": "subscription_true" or "subscription_false" (depending on newsletter subscription)
```