### PR TITLE
[EP-334] Page Viewed (sign_up)

### DIFF
--- a/Library/Tracking/KSRAnalytics.swift
+++ b/Library/Tracking/KSRAnalytics.swift
@@ -1341,6 +1341,11 @@ public final class KSRAnalytics {
     )
   }
 
+  public func trackSignupPageViewed() {
+    let props = contextProperties(page: .signup)
+    self.track(event: NewApprovedEvent.pageViewed.rawValue, properties: props)
+  }
+
   public func trackSignupSubmitButtonClicked() {
     self.track(event: ApprovedEvent.signupSubmitButtonClicked.rawValue, page: .signup)
   }

--- a/Library/Tracking/KSRAnalyticsTests.swift
+++ b/Library/Tracking/KSRAnalyticsTests.swift
@@ -373,6 +373,24 @@ final class KSRAnalyticsTests: TestCase {
     XCTAssertEqual("log_in_submit", segmentClient.properties.last?["context_cta"] as? String)
   }
 
+  func testTrackSignupPageViewed() {
+    let dataLakeClient = MockTrackingClient()
+    let segmentClient = MockTrackingClient()
+    let ksrAnalytics = KSRAnalytics(
+      dataLakeClient: dataLakeClient,
+      loggedInUser: nil,
+      segmentClient: segmentClient
+    )
+
+    ksrAnalytics.trackSignupPageViewed()
+
+    XCTAssertEqual(["Page Viewed"], dataLakeClient.events)
+    XCTAssertEqual(["Page Viewed"], segmentClient.events)
+
+    XCTAssertEqual("sign_up", dataLakeClient.properties.last?["context_page"] as? String)
+    XCTAssertEqual("sign_up", segmentClient.properties.last?["context_page"] as? String)
+  }
+
   // MARK: - Project Properties Tests
 
   func testProjectProperties() {
@@ -2527,6 +2545,10 @@ final class KSRAnalyticsTests: TestCase {
     ksrAnalytics.trackSwipedProject(.template, refTag: nil)
     XCTAssertEqual("project", dataLakeClient.properties.last?["context_page"] as? String)
     XCTAssertEqual("project", segmentClient.properties.last?["context_page"] as? String)
+
+    ksrAnalytics.trackSignupPageViewed()
+    XCTAssertEqual("sign_up", dataLakeClient.properties.last?["context_page"] as? String)
+    XCTAssertEqual("sign_up", segmentClient.properties.last?["context_page"] as? String)
 
     ksrAnalytics.trackSignupSubmitButtonClicked()
     XCTAssertEqual("sign_up", dataLakeClient.properties.last?["context_page"] as? String)

--- a/Library/ViewModels/SignupViewModel.swift
+++ b/Library/ViewModels/SignupViewModel.swift
@@ -132,8 +132,13 @@ public final class SignupViewModel: SignupViewModelType, SignupViewModelInputs, 
     self.postNotification = self.environmentLoggedInProperty.signal
       .mapConst(Notification(name: .ksr_sessionStarted))
 
+    // Tracking
+
     attemptSignup
       .observeValues { AppEnvironment.current.ksrAnalytics.trackSignupSubmitButtonClicked() }
+
+    self.viewDidLoadProperty.signal
+      .observeValues { AppEnvironment.current.ksrAnalytics.trackSignupPageViewed() }
   }
 
   fileprivate let emailChangedProperty = MutableProperty("")

--- a/Library/ViewModels/SignupViewModelTests.swift
+++ b/Library/ViewModels/SignupViewModelTests.swift
@@ -39,6 +39,9 @@ internal final class SignupViewModelTests: TestCase {
 
     self.vm.inputs.viewDidLoad()
 
+    XCTAssertEqual(["Page Viewed"], self.dataLakeTrackingClient.events)
+    XCTAssertEqual(["Page Viewed"], self.segmentTrackingClient.events)
+
     self.setWeeklyNewsletterState.assertValues([false], "Unselected when view loads.")
     self.isSignupButtonEnabled.assertValues([false], "Disabled when view loads.")
     self.nameTextFieldBecomeFirstResponder
@@ -67,8 +70,8 @@ internal final class SignupViewModelTests: TestCase {
     self.vm.inputs.signupButtonPressed()
     self.logIntoEnvironment.assertDidNotEmitValue("Does not immediately emit after signup button is pressed.")
 
-    XCTAssertEqual(["Signup Submit Button Clicked"], self.dataLakeTrackingClient.events)
-    XCTAssertEqual(["Signup Submit Button Clicked"], self.segmentTrackingClient.events)
+    XCTAssertEqual(["Page Viewed", "Signup Submit Button Clicked"], self.dataLakeTrackingClient.events)
+    XCTAssertEqual(["Page Viewed", "Signup Submit Button Clicked"], self.segmentTrackingClient.events)
 
     self.scheduler.advance()
 


### PR DESCRIPTION
# 📲 What

Adding a new `Page Viewed` event with a `context_page` property of `sign_up` in the `SignUpViewModel`.

# 🤔 Why

This is part of our ongoing implementation of Segment on the native apps.

# 👀 See

<img width="483" alt="Screen Shot 2021-04-26 at 1 06 07 PM" src="https://user-images.githubusercontent.com/15615702/116122840-477fee80-a690-11eb-98c5-4268219c7cd1.png">

# ✅ Acceptance criteria

- [ ] Navigate to the `SignUpViewController`
- [ ] Verify in the Segment debugger that a `Page Viewed` event was fired with a `context_page` property of `sign_up`.
