### PR TITLE
[EP-450] context_page = other

### DIFF
--- a/Library/Tracking/KSRAnalytics.swift
+++ b/Library/Tracking/KSRAnalytics.swift
@@ -980,7 +980,8 @@ public final class KSRAnalytics {
     case .pledge:
       let allProps = props
         .withAllValuesFrom(optimizelyProperties() ?? [:])
-        .withAllValuesFrom(contextProperties(ctaContext: .pledgeInitiate, page: .projectPage))
+        .withAllValuesFrom(contextProperties(ctaContext: .pledgeInitiate))
+        .withAllValuesFrom(props)
 
       self.track(
         event: NewApprovedEvent.ctaClicked.rawValue,
@@ -1153,14 +1154,14 @@ public final class KSRAnalytics {
    */
 
   public func trackAddNewCardButtonClicked(
-    location: KSRAnalytics.PageContext? = nil,
+    page: KSRAnalytics.PageContext? = nil,
     project: Project,
     refTag: RefTag?,
     reward: Reward
   ) {
     let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
       .withAllValuesFrom(pledgeProperties(from: reward))
-      .withAllValuesFrom(contextProperties(page: location))
+      .withAllValuesFrom(contextProperties(page: page))
 
     self.track(
       event: ApprovedEvent.addNewCardButtonClicked.rawValue,
@@ -1462,14 +1463,14 @@ public final class KSRAnalytics {
 
   public func trackWatchProjectButtonClicked(
     project: Project,
-    location: PageContext,
+    page: PageContext,
     params: DiscoveryParams? = nil,
     typeContext: TypeContext
   ) {
     var props = projectProperties(from: project, loggedInUser: self.loggedInUser)
       .withAllValuesFrom(contextProperties(
         ctaContext: .watchProject,
-        page: location,
+        page: page,
         typeContext: typeContext
       ))
 
@@ -1815,7 +1816,9 @@ private func contextProperties(
 
   result["cta"] = ctaContext?.trackingString
   result["location"] = locationContext?.trackingString
-  result["page"] = page?.rawValue ?? "other"
+  result["page"] = page?
+    .rawValue ??
+    "other" // Product/Insight want some event with no `context_page` to be defaulted as `other` until a context_page is defined for them.
   result["section"] = sectionContext?.trackingString
   result["tab_bar_label"] = tabBarLabel?.trackingString
   result["type"] = typeContext?.trackingString

--- a/Library/Tracking/KSRAnalytics.swift
+++ b/Library/Tracking/KSRAnalytics.swift
@@ -615,10 +615,13 @@ public final class KSRAnalytics {
 
   /// Call when the activities screen is shown.
   public func trackActivities(count: Int) {
+    let properties = contextProperties(page: .activities)
+      .withAllValuesFrom(
+        ["activities_count": count]
+      )
     self.track(
       event: ApprovedEvent.activityFeedViewed.rawValue,
-      page: .activities,
-      properties: ["activities_count": count]
+      properties: properties
     )
   }
 
@@ -688,34 +691,38 @@ public final class KSRAnalytics {
   // MARK: - Onboarding Events
 
   public func trackOnboardingCarouselSwiped(optimizelyProperties: [String: Any] = [:]) {
+    let properties = contextProperties(page: .landingPage)
+      .withAllValuesFrom(optimizelyProperties)
     self.track(
       event: ApprovedEvent.onboardingCarouselSwiped.rawValue,
-      page: .landingPage,
-      properties: optimizelyProperties
+      properties: properties
     )
   }
 
   public func trackOnboardingGetStartedButtonClicked(optimizelyProperties: [String: Any] = [:]) {
+    let properties = contextProperties(page: .landingPage)
+      .withAllValuesFrom(optimizelyProperties)
     self.track(
       event: ApprovedEvent.onboardingGetStartedButtonClicked.rawValue,
-      page: .landingPage,
-      properties: optimizelyProperties
+      properties: properties
     )
   }
 
   public func trackOnboardingSkipButtonClicked(optimizelyProperties: [String: Any] = [:]) {
+    let properties = contextProperties(page: .onboarding)
+      .withAllValuesFrom(optimizelyProperties)
     self.track(
       event: ApprovedEvent.onboardingSkipButtonClicked.rawValue,
-      page: .onboarding,
-      properties: optimizelyProperties
+      properties: properties
     )
   }
 
   public func trackOnboardingContinueButtonClicked(optimizelyProperties: [String: Any] = [:]) {
+    let properties = contextProperties(page: .onboarding)
+      .withAllValuesFrom(optimizelyProperties)
     self.track(
       event: ApprovedEvent.onboardingContinueButtonClicked.rawValue,
-      page: .onboarding,
-      properties: optimizelyProperties
+      properties: properties
     )
   }
 
@@ -728,12 +735,12 @@ public final class KSRAnalytics {
    */
 
   public func trackDiscovery(params: DiscoveryParams) {
-    let props = discoveryProperties(from: params)
+    let properties = contextProperties(page: .discovery)
+      .withAllValuesFrom(discoveryProperties(from: params))
 
     self.track(
       event: NewApprovedEvent.pageViewed.rawValue,
-      page: .discovery,
-      properties: props
+      properties: properties
     )
   }
 
@@ -809,6 +816,7 @@ public final class KSRAnalytics {
       .withAllValuesFrom(
         contextProperties(
           ctaContext: .discoverSort,
+          page: .discovery,
           typeContext: .discovery(discoverySortContext),
           locationContext: .discoverAdvanced
         )
@@ -816,7 +824,6 @@ public final class KSRAnalytics {
 
     self.track(
       event: NewApprovedEvent.ctaClicked.rawValue,
-      page: .discovery,
       properties: props
     )
   }
@@ -846,10 +853,11 @@ public final class KSRAnalytics {
    - parameter params: The DiscoveryParams associated with the collection
    */
   public func trackCollectionViewed(params: DiscoveryParams) {
+    let properties = contextProperties(page: .editorialProjects)
+      .withAllValuesFrom(discoveryProperties(from: params))
     self.track(
       event: ApprovedEvent.collectionViewed.rawValue,
-      page: .editorialProjects,
-      properties: discoveryProperties(from: params)
+      properties: properties
     )
   }
 
@@ -878,6 +886,7 @@ public final class KSRAnalytics {
     var props = projectProperties(from: project, loggedInUser: self.loggedInUser)
       .withAllValuesFrom(contextProperties(
         ctaContext: .project,
+        page: page,
         sectionContext: section,
         typeContext: typeContext,
         locationContext: location
@@ -893,7 +902,6 @@ public final class KSRAnalytics {
 
     self.track(
       event: NewApprovedEvent.ctaClicked.rawValue,
-      page: page,
       properties: props
     )
   }
@@ -913,10 +921,10 @@ public final class KSRAnalytics {
   ) {
     let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
       .withAllValuesFrom(videoProperties(videoLength: videoLength, videoPosition: videoPosition))
+      .withAllValuesFrom(contextProperties(page: .projectPage))
 
     self.track(
       event: NewApprovedEvent.videoPlaybackStarted.rawValue,
-      page: .projectPage,
       properties: props
     )
   }
@@ -947,10 +955,10 @@ public final class KSRAnalytics {
   ) {
     let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
       .withAllValuesFrom(checkoutProperties(from: checkoutData, and: reward))
+      .withAllValuesFrom(contextProperties(page: .addOnsSelection))
 
     self.track(
       event: NewApprovedEvent.pageViewed.rawValue,
-      page: .addOnsSelection,
       properties: props,
       refTag: refTag?.stringTag
     )
@@ -962,12 +970,12 @@ public final class KSRAnalytics {
     optimizelyProperties _: [String: Any] = [:]
   ) {
     let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
+      .withAllValuesFrom(contextProperties(page: .projectPage))
 
     switch stateType {
     case .fix:
       self.track(
         event: ApprovedEvent.managePledgeButtonClicked.rawValue,
-        page: .projectPage,
         properties: props.withAllValuesFrom(contextProperties()) // .fixErroredPledge
       )
     case .pledge:
@@ -977,13 +985,11 @@ public final class KSRAnalytics {
 
       self.track(
         event: NewApprovedEvent.ctaClicked.rawValue,
-        page: .projectPage,
         properties: allProps
       )
     case .manage:
       self.track(
         event: ApprovedEvent.managePledgeButtonClicked.rawValue,
-        page: .projectPage,
         properties: props.withAllValuesFrom(contextProperties()) // .manageReward
       )
     default:
@@ -993,11 +999,10 @@ public final class KSRAnalytics {
 
   public func trackFixPledgeButtonClicked(project: Project) {
     let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
-      .withAllValuesFrom(contextProperties())
+      .withAllValuesFrom(contextProperties(page: .managePledgeScreen))
 
     self.track(
       event: ApprovedEvent.fixPledgeButtonClicked.rawValue,
-      page: .managePledgeScreen,
       properties: props
     )
   }
@@ -1009,10 +1014,10 @@ public final class KSRAnalytics {
   ) {
     let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
       .withAllValuesFrom(checkoutProperties(from: checkoutData, and: reward))
+      .withAllValuesFrom(contextProperties(page: .managePledgeScreen))
 
     self.track(
       event: NewApprovedEvent.pageViewed.rawValue,
-      page: .managePledgeScreen,
       properties: props
     )
   }
@@ -1033,12 +1038,11 @@ public final class KSRAnalytics {
     refTag: RefTag?
   ) {
     let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
-      .withAllValuesFrom(contextProperties(ctaContext: .rewardContinue))
+      .withAllValuesFrom(contextProperties(ctaContext: .rewardContinue, page: .rewards))
       .withAllValuesFrom(checkoutProperties(from: checkoutPropertiesData, and: reward))
 
     self.track(
       event: NewApprovedEvent.ctaClicked.rawValue,
-      page: .rewards,
       properties: props,
       refTag: refTag?.stringTag
     )
@@ -1059,10 +1063,10 @@ public final class KSRAnalytics {
   ) {
     let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
       .withAllValuesFrom(checkoutProperties(from: checkoutPropertiesData))
+      .withAllValuesFrom(contextProperties(page: .rewards))
 
     self.track(
       event: NewApprovedEvent.pageViewed.rawValue,
-      page: .rewards,
       properties: props,
       refTag: refTag?.stringTag
     )
@@ -1128,11 +1132,14 @@ public final class KSRAnalytics {
     let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
       .withAllValuesFrom(checkoutProperties(from: checkoutData, and: reward))
       // the context is always "newPledge" for this event
-      .withAllValuesFrom(contextProperties(ctaContext: .pledgeSubmit, typeContext: typeContext))
+      .withAllValuesFrom(contextProperties(
+        ctaContext: .pledgeSubmit,
+        page: .checkout,
+        typeContext: typeContext
+      ))
 
     self.track(
       event: NewApprovedEvent.ctaClicked.rawValue,
-      page: .checkout,
       properties: props,
       refTag: refTag?.stringTag
     )
@@ -1154,11 +1161,10 @@ public final class KSRAnalytics {
   ) {
     let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
       .withAllValuesFrom(pledgeProperties(from: reward))
-      .withAllValuesFrom(contextProperties())
+      .withAllValuesFrom(contextProperties(page: location))
 
     self.track(
       event: ApprovedEvent.addNewCardButtonClicked.rawValue,
-      page: location,
       properties: props,
       refTag: refTag?.stringTag
     )
@@ -1180,7 +1186,7 @@ public final class KSRAnalytics {
     var props = projectProperties(from: project, isBacker: true)
       .withAllValuesFrom(pledgeProperties(from: reward))
       // the context is always "newPledge" for this event
-      .withAllValuesFrom(contextProperties(typeContext: TypeContext.pledge(.newPledge)))
+      .withAllValuesFrom(contextProperties(page: .thanks, typeContext: TypeContext.pledge(.newPledge)))
 
     if let checkoutData = checkoutData {
       props = props.withAllValuesFrom(checkoutProperties(from: checkoutData, and: reward))
@@ -1188,7 +1194,6 @@ public final class KSRAnalytics {
 
     self.track(
       event: NewApprovedEvent.pageViewed.rawValue,
-      page: .thanks,
       properties: props
     )
   }
@@ -1200,10 +1205,9 @@ public final class KSRAnalytics {
   public func trackActivitiesManagePledgeButtonClicked(project: Project) {
     let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
       // the context is always "fixErroredPledge" for this event
-      .withAllValuesFrom(contextProperties())
+      .withAllValuesFrom(contextProperties(page: .activities))
     self.track(
       event: ApprovedEvent.managePledgeButtonClicked.rawValue,
-      page: .activities,
       properties: props
     )
   }
@@ -1224,10 +1228,10 @@ public final class KSRAnalytics {
     reward: Reward? = nil
   ) {
     let props = self.loginEventProperties(for: intent, project: project, reward: reward)
+      .withAllValuesFrom(contextProperties(page: .discovery))
 
     self.track(
       event: ApprovedEvent.loginOrSignupButtonClicked.rawValue,
-      page: .discovery,
       properties: props
     )
   }
@@ -1245,10 +1249,10 @@ public final class KSRAnalytics {
     reward: Reward? = nil
   ) {
     let props = self.loginEventProperties(for: intent, project: project, reward: reward)
+      .withAllValuesFrom(contextProperties(page: .loginTout))
 
     self.track(
       event: ApprovedEvent.loginOrSignupPageViewed.rawValue,
-      page: .loginTout,
       properties: props
     )
   }
@@ -1267,10 +1271,10 @@ public final class KSRAnalytics {
     reward: Reward? = nil
   ) {
     let props = self.loginEventProperties(for: intent, project: project, reward: reward)
+      .withAllValuesFrom(contextProperties(page: .loginTout))
 
     self.track(
       event: ApprovedEvent.loginButtonClicked.rawValue,
-      page: .loginTout,
       properties: props
     )
   }
@@ -1289,10 +1293,10 @@ public final class KSRAnalytics {
     reward: Reward? = nil
   ) {
     let props = self.loginEventProperties(for: intent, project: project, reward: reward)
+      .withAllValuesFrom(contextProperties(page: .loginTout))
 
     self.track(
       event: ApprovedEvent.fbLoginOrSignupButtonClicked.rawValue,
-      page: .loginTout,
       properties: props
     )
   }
@@ -1311,10 +1315,10 @@ public final class KSRAnalytics {
     reward: Reward? = nil
   ) {
     let props = self.loginEventProperties(for: intent, project: project, reward: reward)
+      .withAllValuesFrom(contextProperties(page: .loginTout))
 
     self.track(
       event: ApprovedEvent.continueWithAppleButtonClicked.rawValue,
-      page: .loginTout,
       properties: props
     )
   }
@@ -1333,33 +1337,44 @@ public final class KSRAnalytics {
     reward: Reward? = nil
   ) {
     let props = self.loginEventProperties(for: intent, project: project, reward: reward)
+      .withAllValuesFrom(contextProperties(page: .loginTout))
 
     self.track(
       event: ApprovedEvent.signupButtonClicked.rawValue,
-      page: .loginTout,
       properties: props
     )
   }
 
   public func trackSignupSubmitButtonClicked() {
-    self.track(event: ApprovedEvent.signupSubmitButtonClicked.rawValue, page: .signup)
+    let properties = contextProperties(page: .signup)
+    self.track(
+      event: ApprovedEvent.signupSubmitButtonClicked.rawValue,
+      properties: properties
+    )
   }
 
   public func trackLoginSubmitButtonClicked() {
-    let props = contextProperties(ctaContext: .logInSubmit)
+    let props = contextProperties(ctaContext: .logInSubmit, page: .login)
     self.track(
       event: NewApprovedEvent.ctaClicked.rawValue,
-      page: .login,
       properties: props
     )
   }
 
   public func trackForgotPasswordViewed() {
-    self.track(event: ApprovedEvent.forgotPasswordViewed.rawValue, page: .forgotPassword)
+    let properties = contextProperties(page: .forgotPassword)
+    self.track(
+      event: ApprovedEvent.forgotPasswordViewed.rawValue,
+      properties: properties
+    )
   }
 
   public func track2FAViewed() {
-    self.track(event: ApprovedEvent.twoFactorConfirmationViewed.rawValue, page: .twoFactorAuth)
+    let properties = contextProperties(page: .twoFactorAuth)
+    self.track(
+      event: ApprovedEvent.twoFactorConfirmationViewed.rawValue,
+      properties: properties
+    )
   }
 
   private func loginEventProperties(for intent: LoginIntent, project: Project?, reward: Reward?)
@@ -1385,10 +1400,10 @@ public final class KSRAnalytics {
     results: Int? = nil
   ) {
     let props = discoveryProperties(from: params, results: results)
+      .withAllValuesFrom(contextProperties(page: .search))
 
     self.track(
       event: NewApprovedEvent.pageViewed.rawValue,
-      page: .search,
       properties: props
     )
   }
@@ -1408,11 +1423,10 @@ public final class KSRAnalytics {
     sectionContext: KSRAnalytics.SectionContext
   ) {
     let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
-      .withAllValuesFrom(contextProperties(sectionContext: sectionContext))
+      .withAllValuesFrom(contextProperties(page: .projectPage, sectionContext: sectionContext))
 
     self.track(
       event: NewApprovedEvent.pageViewed.rawValue,
-      page: .projectPage,
       properties: props,
       refTag: refTag?.stringTag
     )
@@ -1425,10 +1439,10 @@ public final class KSRAnalytics {
    */
   public func trackSwipedProject(_ project: Project, refTag: RefTag?) {
     let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
+      .withAllValuesFrom(contextProperties(page: .projectPage))
 
     self.track(
       event: ApprovedEvent.projectSwiped.rawValue,
-      page: .projectPage,
       properties: props, refTag: refTag?.stringTag
     )
   }
@@ -1450,6 +1464,7 @@ public final class KSRAnalytics {
     var props = projectProperties(from: project, loggedInUser: self.loggedInUser)
       .withAllValuesFrom(contextProperties(
         ctaContext: .watchProject,
+        page: location,
         typeContext: typeContext
       ))
 
@@ -1459,7 +1474,6 @@ public final class KSRAnalytics {
 
     self.track(
       event: NewApprovedEvent.ctaClicked.rawValue,
-      page: location,
       properties: props
     )
   }
@@ -1497,16 +1511,18 @@ public final class KSRAnalytics {
   // MARK: - Email Verification
 
   public func trackEmailVerificationScreenViewed() {
+    let properties = contextProperties(page: .emailVerification)
     self.track(
       event: ApprovedEvent.verificationScreenViewed.rawValue,
-      page: .emailVerification
+      properties: properties
     )
   }
 
   public func trackSkipEmailVerificationButtonClicked() {
+    let properties = contextProperties(page: .emailVerification)
     self.track(
       event: ApprovedEvent.skipVerificationButtonClicked.rawValue,
-      page: .emailVerification
+      properties: properties
     )
   }
 
@@ -1515,13 +1531,11 @@ public final class KSRAnalytics {
   // Private tracking method that merges in default properties.
   private func track(
     event: String,
-    page: KSRAnalytics.PageContext? = nil,
     properties: [String: Any] = [:],
     refTag: String? = nil
   ) {
     let props = self.sessionProperties(refTag: refTag)
       .withAllValuesFrom(userProperties(for: self.loggedInUser))
-      .withAllValuesFrom(contextProperties(page: page))
       .withAllValuesFrom(properties)
 
     self.logEventCallback?(event, props)

--- a/Library/Tracking/KSRAnalytics.swift
+++ b/Library/Tracking/KSRAnalytics.swift
@@ -976,12 +976,12 @@ public final class KSRAnalytics {
     case .fix:
       self.track(
         event: ApprovedEvent.managePledgeButtonClicked.rawValue,
-        properties: props.withAllValuesFrom(contextProperties()) // .fixErroredPledge
+        properties: props // .fixErroredPledge
       )
     case .pledge:
       let allProps = props
         .withAllValuesFrom(optimizelyProperties() ?? [:])
-        .withAllValuesFrom(contextProperties(ctaContext: .pledgeInitiate))
+        .withAllValuesFrom(contextProperties(ctaContext: .pledgeInitiate, page: .projectPage))
 
       self.track(
         event: NewApprovedEvent.ctaClicked.rawValue,
@@ -990,7 +990,7 @@ public final class KSRAnalytics {
     case .manage:
       self.track(
         event: ApprovedEvent.managePledgeButtonClicked.rawValue,
-        properties: props.withAllValuesFrom(contextProperties()) // .manageReward
+        properties: props // .manageReward
       )
     default:
       return
@@ -1810,7 +1810,7 @@ private func contextProperties(
 
   result["cta"] = ctaContext?.trackingString
   result["location"] = locationContext?.trackingString
-  result["page"] = page?.rawValue
+  result["page"] = page?.rawValue ?? "other"
   result["section"] = sectionContext?.trackingString
   result["tab_bar_label"] = tabBarLabel?.trackingString
   result["type"] = typeContext?.trackingString

--- a/Library/Tracking/KSRAnalytics.swift
+++ b/Library/Tracking/KSRAnalytics.swift
@@ -1346,10 +1346,9 @@ public final class KSRAnalytics {
 
   public func trackSignupSubmitButtonClicked(isSubscribed: Bool) {
     let typeContext: TypeContext = isSubscribed ? .subscriptionTrue : .subscriptionFalse
-    let props = contextProperties(ctaContext: .signUpSubmit, typeContext: typeContext)
+    let props = contextProperties(ctaContext: .signUpSubmit, page: .signup, typeContext: typeContext)
     self.track(
       event: NewApprovedEvent.ctaClicked.rawValue,
-      page: .signup,
       properties: props
     )
   }
@@ -1358,15 +1357,7 @@ public final class KSRAnalytics {
     let props = contextProperties(page: .signup)
     self.track(event: NewApprovedEvent.pageViewed.rawValue, properties: props)
   }
-  
-  public func trackSignupSubmitButtonClicked() {
-    let properties = contextProperties(page: .signup)
-    self.track(
-      event: ApprovedEvent.signupSubmitButtonClicked.rawValue,
-      properties: properties
-    )
-  }
-  
+
   public func trackLoginSubmitButtonClicked() {
     let props = contextProperties(ctaContext: .logInSubmit, page: .login)
     self.track(

--- a/Library/Tracking/KSRAnalyticsTests.swift
+++ b/Library/Tracking/KSRAnalyticsTests.swift
@@ -1325,7 +1325,7 @@ final class KSRAnalyticsTests: TestCase {
 
     ksrAnalytics.trackWatchProjectButtonClicked(
       project: .template,
-      location: .discovery,
+      page: .discovery,
       params: DiscoveryParams.recommendedDefaults,
       typeContext: .watch
     )
@@ -1354,7 +1354,7 @@ final class KSRAnalyticsTests: TestCase {
 
     ksrAnalytics.trackWatchProjectButtonClicked(
       project: .template,
-      location: .discovery,
+      page: .discovery,
       params: DiscoveryParams.recommendedDefaults,
       typeContext: .unwatch
     )
@@ -1383,7 +1383,7 @@ final class KSRAnalyticsTests: TestCase {
 
     ksrAnalytics.trackWatchProjectButtonClicked(
       project: .template,
-      location: .projectPage,
+      page: .projectPage,
       typeContext: .watch
     )
 
@@ -1409,7 +1409,7 @@ final class KSRAnalyticsTests: TestCase {
 
     ksrAnalytics.trackWatchProjectButtonClicked(
       project: .template,
-      location: .projectPage,
+      page: .projectPage,
       typeContext: .unwatch
     )
 
@@ -2430,7 +2430,7 @@ final class KSRAnalyticsTests: TestCase {
     )
 
     ksrAnalytics.trackAddNewCardButtonClicked(
-      location: .pledgeAddNewCard,
+      page: .pledgeAddNewCard,
       project: .template,
       refTag: nil,
       reward: .template
@@ -2445,7 +2445,7 @@ final class KSRAnalyticsTests: TestCase {
     )
 
     ksrAnalytics.trackAddNewCardButtonClicked(
-      location: .settingsAddNewCard,
+      page: .settingsAddNewCard,
       project: .template,
       refTag: nil,
       reward: .template

--- a/Library/ViewModels/PledgePaymentMethodsViewModel.swift
+++ b/Library/ViewModels/PledgePaymentMethodsViewModel.swift
@@ -186,7 +186,7 @@ public final class PledgePaymentMethodsViewModel: PledgePaymentMethodsViewModelT
       .takeWhen(self.goToAddCardScreen)
       .observeValues { project, reward, refTag in
         AppEnvironment.current.ksrAnalytics.trackAddNewCardButtonClicked(
-          location: .pledgeAddNewCard,
+          page: .pledgeAddNewCard,
           project: project,
           refTag: refTag,
           reward: reward

--- a/Library/ViewModels/RootViewModelTests.swift
+++ b/Library/ViewModels/RootViewModelTests.swift
@@ -510,7 +510,7 @@ final class RootViewModelTests: TestCase {
       self.dataLakeTrackingClient.properties(forKey: "context_tab_bar_label")
     )
     XCTAssertEqual(
-      [nil, nil, "discover"],
+      ["other", "other", "discover"],
       self.dataLakeTrackingClient.properties(forKey: "context_page")
     )
     XCTAssertEqual(
@@ -523,7 +523,7 @@ final class RootViewModelTests: TestCase {
       self.segmentTrackingClient.properties(forKey: "context_tab_bar_label")
     )
     XCTAssertEqual(
-      [nil, nil, "discover"],
+      ["other", "other", "discover"],
       self.segmentTrackingClient.properties(forKey: "context_page")
     )
     XCTAssertEqual(

--- a/Library/ViewModels/WatchProjectViewModel.swift
+++ b/Library/ViewModels/WatchProjectViewModel.swift
@@ -182,7 +182,7 @@ public final class WatchProjectViewModel: WatchProjectViewModelType,
       .observeValues { project, context, discoveryParams in
         AppEnvironment.current.ksrAnalytics.trackWatchProjectButtonClicked(
           project: project,
-          location: context,
+          page: context,
           params: discoveryParams,
           typeContext: self.saveButtonTappedProperty.value ? .unwatch : .watch
         )


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

- Remove `page` parameter in `track` function inside KSRAnalytics.
- default `page` in `contextProperties()` function to `other` for some events that Product/Insight hasn't defined `page_context` for.

# 🤔 Why

We previously had `page` as a parameter in our `track` function as well as `contextProperties()` function. This is not necessary as we need all of our `Context Properties` to be in on function called `contextProperties()`
