### PR TITLE
[EP-491] QA CTA Clicked Search

### DIFF
--- a/Kickstarter.xcodeproj/xcshareddata/xcschemes/Kickstarter-iOS.xcscheme
+++ b/Kickstarter.xcodeproj/xcshareddata/xcschemes/Kickstarter-iOS.xcscheme
@@ -129,7 +129,7 @@
          <EnvironmentVariable
             key = "TRACKING_ENABLED"
             value = "true"
-            isEnabled = "NO">
+            isEnabled = "YES">
          </EnvironmentVariable>
          <EnvironmentVariable
             key = "OS_ACTIVITY_MODE"

--- a/Kickstarter.xcodeproj/xcshareddata/xcschemes/Kickstarter-iOS.xcscheme
+++ b/Kickstarter.xcodeproj/xcshareddata/xcschemes/Kickstarter-iOS.xcscheme
@@ -129,7 +129,7 @@
          <EnvironmentVariable
             key = "TRACKING_ENABLED"
             value = "true"
-            isEnabled = "YES">
+            isEnabled = "NO">
          </EnvironmentVariable>
          <EnvironmentVariable
             key = "OS_ACTIVITY_MODE"

--- a/Library/Tracking/KSRAnalytics.swift
+++ b/Library/Tracking/KSRAnalytics.swift
@@ -665,7 +665,7 @@ public final class KSRAnalytics {
    */
 
   public func trackSearchTabBarClicked(prevTabBarItemLabel: TabBarItemLabel) {
-    let pageContext: PageContext
+    let pageContext: PageContext?
     switch prevTabBarItemLabel {
     case .activity:
       pageContext = .activities
@@ -673,8 +673,10 @@ public final class KSRAnalytics {
       pageContext = .discovery
     case .profile:
       pageContext = .profile
-    default:
+    case .search:
       pageContext = .search
+    default:
+      pageContext = nil
     }
     let properties = contextProperties(
       ctaContext: .search,

--- a/Library/Tracking/KSRAnalyticsTests.swift
+++ b/Library/Tracking/KSRAnalyticsTests.swift
@@ -2063,6 +2063,24 @@ final class KSRAnalyticsTests: TestCase {
     XCTAssertEqual("search", segmentClient.properties.last?["context_cta"] as? String)
     XCTAssertEqual("global_nav", segmentClient.properties.last?["context_location"] as? String)
     XCTAssertEqual("profile", segmentClient.properties.last?["context_page"] as? String)
+
+    ksrAnalytics.trackSearchTabBarClicked(prevTabBarItemLabel: .dashboard)
+
+    XCTAssertEqual([
+      "CTA Clicked",
+      "CTA Clicked"
+    ], dataLakeClient.events)
+    XCTAssertEqual("search", dataLakeClient.properties.last?["context_cta"] as? String)
+    XCTAssertEqual("global_nav", dataLakeClient.properties.last?["context_location"] as? String)
+    XCTAssertEqual("other", dataLakeClient.properties.last?["context_page"] as? String)
+
+    XCTAssertEqual([
+      "CTA Clicked",
+      "CTA Clicked"
+    ], segmentClient.events)
+    XCTAssertEqual("search", segmentClient.properties.last?["context_cta"] as? String)
+    XCTAssertEqual("global_nav", segmentClient.properties.last?["context_location"] as? String)
+    XCTAssertEqual("other", segmentClient.properties.last?["context_page"] as? String)
   }
 
   func testTrackDiscoverySortProperties() {


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Add `context_page` = `other` when user clicks on Search Tab from Creator Dashboard Tab

# 🤔 Why

This is a continuation of our Segment Integration.


# 👀 See
<img width="524" alt="Screenshot 2021-04-27 at 23 15 29" src="https://user-images.githubusercontent.com/4386218/116320112-907a9480-a7af-11eb-88bd-7c5717526c7f.png">

# ✅ Acceptance criteria

- Navigate to Creator's Dashboard Tab
- Switch to Search Tab 
- Verify on Segment debugger that 

> `context_page` = `other`
> `context_cta` = `search`
> `context_location` = `global_nav`
