### PR TITLE
[NT-1873] Implement BrazeDebounceMiddleware

### DIFF
--- a/.slather.yml
+++ b/.slather.yml
@@ -1,2 +1,3 @@
 ignore:
   - Library/Strings.swift
+  - Library/Tracking/Vendor/BrazeDebounceMiddleware.swift

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -489,6 +489,7 @@
 		8A741BC1262A358700E864E6 /* Appboy_iOS_SDK.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 8A04FE23262781240056F413 /* Appboy_iOS_SDK.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		8A741BC2262A358700E864E6 /* Segment_Appboy.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 8A04FE24262781240056F413 /* Segment_Appboy.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		8A741BC6262A35B000E864E6 /* SDWebImage.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 8A04FE25262781240056F413 /* SDWebImage.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		8A788F27263C80D600A89DAE /* BrazeDebounceMiddleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A788F26263C80D600A89DAE /* BrazeDebounceMiddleware.swift */; };
 		8A7E71F9256460C200119B49 /* EmailVerificationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A7E71F8256460C200119B49 /* EmailVerificationViewController.swift */; };
 		8A8099EB22E213F100373E66 /* RewardCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A8099E922E213F100373E66 /* RewardCardView.swift */; };
 		8A8099EC22E213F100373E66 /* RewardCardContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A8099EA22E213F100373E66 /* RewardCardContainerView.swift */; };
@@ -2025,6 +2026,7 @@
 		8A6C978F24BFCDED00C4FA71 /* RewardAddOnSelectionContinueCTAViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RewardAddOnSelectionContinueCTAViewModel.swift; sourceTree = "<group>"; };
 		8A73EACE2339528000FF9051 /* PledgePaymentMethodCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PledgePaymentMethodCellViewModel.swift; sourceTree = "<group>"; };
 		8A73EAD02339732900FF9051 /* PledgePaymentMethodCellViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PledgePaymentMethodCellViewModelTests.swift; sourceTree = "<group>"; };
+		8A788F26263C80D600A89DAE /* BrazeDebounceMiddleware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrazeDebounceMiddleware.swift; sourceTree = "<group>"; };
 		8A7E71F8256460C200119B49 /* EmailVerificationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmailVerificationViewController.swift; sourceTree = "<group>"; };
 		8A7E71FD256460DD00119B49 /* EmailVerificationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmailVerificationViewModel.swift; sourceTree = "<group>"; };
 		8A8099E922E213F100373E66 /* RewardCardView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RewardCardView.swift; sourceTree = "<group>"; };
@@ -3180,6 +3182,7 @@
 		8A213CE3239EAEA400BBB4C7 /* Tracking */ = {
 			isa = PBXGroup;
 			children = (
+				8A788F25263C80C500A89DAE /* Vendor */,
 				8A23203025B0ECF700B940C3 /* IdentifyingTrackingClient.swift */,
 				8A213CE8239EAEA400BBB4C7 /* KSRAnalytics.swift */,
 				8A4B8E812639F8C700D92E4E /* KSRAnalyticsIdentityData.swift */,
@@ -3195,6 +3198,14 @@
 				94BE15C925E96F06007CD9A4 /* TrackingHelpersTests.swift */,
 			);
 			path = Tracking;
+			sourceTree = "<group>";
+		};
+		8A788F25263C80C500A89DAE /* Vendor */ = {
+			isa = PBXGroup;
+			children = (
+				8A788F26263C80D600A89DAE /* BrazeDebounceMiddleware.swift */,
+			);
+			path = Vendor;
 			sourceTree = "<group>";
 		};
 		8ABD5B3B24CFB026002E585C /* graphql */ = {
@@ -5489,6 +5500,7 @@
 				A796A88F1D48DE79009B6EF6 /* ProjectPamphletContentViewModel.swift in Sources */,
 				77F6E73921222F4B005A5C55 /* SettingsNotificationCellType.swift in Sources */,
 				A71404391CAF215900A2795B /* KeyValueStoreType.swift in Sources */,
+				8A788F27263C80D600A89DAE /* BrazeDebounceMiddleware.swift in Sources */,
 				D093B46321A86F7F00910962 /* PushRegistrationType.swift in Sources */,
 				A7CC13D71D00E6CF00035C52 /* FindFriendsHeaderCellViewModel.swift in Sources */,
 				A709697E1D143D1300DB39D3 /* AlertError.swift in Sources */,

--- a/Library/Tracking/KSRAnalytics.swift
+++ b/Library/Tracking/KSRAnalytics.swift
@@ -582,7 +582,7 @@ public final class KSRAnalytics {
 
     self.segmentClient?.identify(
       "\(newData.userId)",
-      traits: newData.uniqueTraits(comparedTo: previousIdentityData)
+      traits: newData.allTraits
     )
 
     AppEnvironment.current.userDefaults.analyticsIdentityData = newData

--- a/Library/Tracking/KSRAnalyticsIdentityData.swift
+++ b/Library/Tracking/KSRAnalyticsIdentityData.swift
@@ -41,6 +41,10 @@ public struct KSRAnalyticsIdentityData: Equatable {
     return newTraits
   }
 
+  var allTraits: [String: Any] {
+    return self.traits.mapValues { $0.value }
+  }
+
   fileprivate var traits: [String: KSRAnalyticsIdentityTraitValue] {
     let notifications = self.notifications.encode()
       .mapValues { ($0 as? Bool).flatMap(KSRAnalyticsIdentityTraitValue.bool) }

--- a/Library/Tracking/KSRAnalyticsIdentityDataTests.swift
+++ b/Library/Tracking/KSRAnalyticsIdentityDataTests.swift
@@ -67,6 +67,22 @@ final class KSRAnalyticsIdentityDataTests: XCTestCase {
     XCTAssertNotEqual(KSRAnalyticsIdentityData(user3), KSRAnalyticsIdentityData(user4))
   }
 
+  func testAllTraits() {
+    let user = User.template
+
+    let data = KSRAnalyticsIdentityData(user)
+
+    let traits = data.allTraits
+
+    XCTAssertEqual(traits["name"] as? String, user.name)
+
+    let notifications = user.notifications.encode()
+
+    for (key, _) in notifications {
+      XCTAssertEqual(notifications[key] as? Bool, traits[key] as? Bool)
+    }
+  }
+
   func testEncodingDecoding() {
     let data1 = KSRAnalyticsIdentityData(.template)
 

--- a/Library/Tracking/KSRAnalyticsTests.swift
+++ b/Library/Tracking/KSRAnalyticsTests.swift
@@ -2353,10 +2353,10 @@ final class KSRAnalyticsTests: TestCase {
     XCTAssertEqual(self.segmentTrackingClient.userId, "\(user.id)")
     XCTAssertEqual(self.segmentTrackingClient.traits?["name"] as? String, user.name)
 
-    let notifications1 = user.notifications.encode()
+    let notifications = user.notifications.encode()
 
-    for (key, _) in notifications1 {
-      XCTAssertEqual(notifications1[key] as? Bool, self.segmentTrackingClient.traits?[key] as? Bool)
+    for (key, _) in notifications {
+      XCTAssertEqual(notifications[key] as? Bool, self.segmentTrackingClient.traits?[key] as? Bool)
     }
 
     AppEnvironment.logout()
@@ -2382,7 +2382,7 @@ final class KSRAnalyticsTests: TestCase {
     }
   }
 
-  func testIdentifyingTrackingClient_OnlySendsDeltas() {
+  func testIdentifyingTrackingClient_RepeatAllIfAnyChanges() {
     let mockKeyValueStore = MockKeyValueStore()
 
     let user = User.template
@@ -2401,7 +2401,13 @@ final class KSRAnalyticsTests: TestCase {
       AppEnvironment.updateCurrentUser(updatedUser)
 
       XCTAssertEqual(self.segmentTrackingClient.userId, "\(1)")
-      XCTAssertEqual(self.segmentTrackingClient.traits?["notify_of_messages"] as? Bool, false)
+      XCTAssertEqual(self.segmentTrackingClient.traits?["name"] as? String, user.name)
+
+      let notifications = updatedUser.notifications.encode()
+
+      for (key, _) in notifications {
+        XCTAssertEqual(notifications[key] as? Bool, self.segmentTrackingClient.traits?[key] as? Bool)
+      }
     }
   }
 

--- a/Library/Tracking/Segment.swift
+++ b/Library/Tracking/Segment.swift
@@ -16,6 +16,8 @@ public extension Analytics {
     // Data sent to Braze is feature-flagged by the enabling/disabling Segment.
     configuration.use(SEGAppboyIntegrationFactory.instance())
 
+    configuration.sourceMiddleware = [BrazeDebounceMiddleware()]
+
     Analytics.setup(with: configuration)
 
     // Disabled when initialized and enabled by our feature-flag configuration.

--- a/Library/Tracking/Vendor/BrazeDebounceMiddleware.swift
+++ b/Library/Tracking/Vendor/BrazeDebounceMiddleware.swift
@@ -1,0 +1,73 @@
+import Foundation
+import Segment
+
+private let __brazeIntegrationName = "Appboy"
+
+/// Ref: https://github.com/segmentio/segment-braze-mobile-middleware
+class BrazeDebounceMiddleware: Middleware {
+  var previousIdentifyPayload: IdentifyPayload?
+
+  func context(_ context: Context, next: @escaping SEGMiddlewareNext) {
+    var workingContext = context
+
+    // only process identify payloads.
+    guard let identify = workingContext.payload as? IdentifyPayload else {
+      next(workingContext)
+      return
+    }
+
+    if self.shouldSendToBraze(payload: identify) {
+      // we don't need to do anything, it's different content.
+    } else {
+      // append to integrations such that this will not be sent to braze.
+      var integrations = identify.integrations
+      integrations[__brazeIntegrationName] = false
+      // provide the list of integrations to a new copy of the payload to pass along.
+      workingContext = workingContext.modify { ctx in
+        ctx.payload = IdentifyPayload(
+          userId: identify.userId,
+          anonymousId: identify.anonymousId,
+          traits: identify.traits,
+          context: identify.context,
+          integrations: integrations
+        )
+      }
+    }
+
+    self.previousIdentifyPayload = identify
+    next(workingContext)
+  }
+
+  func shouldSendToBraze(payload: IdentifyPayload) -> Bool {
+    // if userID has changed, send it to braze.
+    if payload.userId != self.previousIdentifyPayload?.userId {
+      return true
+    }
+
+    // if anonymousID has changed, send it to braze.
+    if payload.anonymousId != self.previousIdentifyPayload?.anonymousId {
+      return true
+    }
+
+    // if the traits haven't changed, don't send it to braze.
+    if self.traitsEqual(lhs: payload.traits, rhs: self.previousIdentifyPayload?.traits) {
+      return false
+    }
+
+    return true
+  }
+
+  func traitsEqual(lhs: [String: Any]?, rhs: [String: Any]?) -> Bool {
+    var result = false
+
+    if lhs == nil, rhs == nil {
+      result = true
+    }
+
+    if let lhs = lhs, let rhs = rhs {
+      result = NSDictionary(dictionary: lhs).isEqual(to: rhs)
+    }
+
+    return result
+  }
+}


### PR DESCRIPTION
# 📲 What

Updates our analytics `identify` call to always send all traits to Segment while de-duping the traits send to Braze using the middleware class provided by Braze.

# 🤔 Why

In #1452 we did some work to reduce the amount of identify calls due to the nature of our billing with Segment being per API call. We initially thought that this would cause Segment to only sent the deltas on to Braze but it appears that it always sends all of the traits that it has in its cache. Adding the middleware is the intended solution for this and inserts a step between Segment's identify call and the data being sent on to Braze during which these traits are de-duped.

# 🛠 How

- Added the `BrazeDebounceMiddleware` class and configured the Segment client with it.
- Removed the de-duplication from the traits that we send to Segment's `identify` call and instead always send everything but retain the behavior of not calling `identify` at all if nothing has changed.

# 👀 See

Segment/Braze Middleware - https://github.com/segmentio/segment-braze-mobile-middleware

# ✅ Acceptance criteria

With a fresh installation of the app:

- [x] Login and observe in the Segment debugger that all traits are being sent. Also observe in the Braze developer console that all traits are being sent.
- [x] Toggle a notification option on/off. Observe in the Segment debugger that all traits are being sent. Also observe in the Braze developer console that only the delta is being sent (only the trait that you updated).