### PR TITLE
[NT-1870] Enable Notification Setting From In-App Message

### DIFF
--- a/Kickstarter-iOS/AppDelegate.swift
+++ b/Kickstarter-iOS/AppDelegate.swift
@@ -40,6 +40,10 @@ internal final class AppDelegate: UIResponder, UIApplicationDelegate {
 
     // Braze initialization
     SEGAppboyIntegrationFactory.instance()?.saveLaunchOptions(launchOptions)
+    SEGAppboyIntegrationFactory.instance()?.appboyOptions = [
+      ABKInAppMessageControllerDelegateKey: self,
+      ABKURLDelegateKey: self
+    ]
 
     UIView.doBadSwizzleStuff()
     UIViewController.doBadSwizzleStuff()
@@ -528,5 +532,17 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
 extension AppDelegate: ABKInAppMessageControllerDelegate {
   func before(inAppMessageDisplayed inAppMessage: ABKInAppMessage) -> ABKInAppMessageDisplayChoice {
     return self.viewModel.inputs.brazeWillDisplayInAppMessage(inAppMessage)
+  }
+}
+
+// MARK: - ABKURLDelegate
+
+extension AppDelegate: ABKURLDelegate {
+  func handleAppboyURL(
+    _ url: URL?,
+    from _: ABKChannel,
+    withExtras extras: [AnyHashable: Any]?
+  ) -> Bool {
+    return self.viewModel.inputs.brazeDidHandleURL(url, extras: extras)
   }
 }

--- a/Kickstarter-iOS/ViewModels/AppDelegateViewModelTests.swift
+++ b/Kickstarter-iOS/ViewModels/AppDelegateViewModelTests.swift
@@ -2653,6 +2653,84 @@ final class AppDelegateViewModelTests: TestCase {
       XCTAssertTrue(self.vm.inputs.brazeWillDisplayInAppMessage(message) == .discardInAppMessage)
     }
   }
+
+  func testBrazeDidHandleURL_AppDidNotHandleNilUrl() {
+    XCTAssertFalse(self.vm.inputs.brazeDidHandleURL(nil, extras: nil))
+  }
+
+  func testBrazeDidHandleURL_AppDidNotHandleInvalidUrl() {
+    XCTAssertFalse(self.vm.inputs.brazeDidHandleURL(URL(string: "https://www.google.com"), extras: [:]))
+  }
+
+  func testBrazeDidHandleURL_AppDidHandleValidUrl() {
+    let url =
+      "https://\(AppEnvironment.current.apiService.serverConfig.webBaseUrl.host ?? "")/settings/notify_mobile_of_marketing_update/true"
+
+    XCTAssertTrue(self.vm.inputs.brazeDidHandleURL(URL(string: url), extras: [:]))
+  }
+
+  func testBrazeDidHandleURL_UserDidNotUpdateWithInvalidUrl() {
+    self.updateCurrentUserInEnvironment.assertDidNotEmitValue()
+
+    withEnvironment(apiService: MockService()) {
+      let user = User.template
+
+      let env = AccessTokenEnvelope(accessToken: "deadbeef", user: user)
+      AppEnvironment.login(env)
+
+      self.vm.inputs.applicationDidFinishLaunching(
+        application: UIApplication.shared,
+        launchOptions: [:]
+      )
+
+      self.scheduler.advance(by: .seconds(5))
+
+      self.updateCurrentUserInEnvironment.assertValues([env.user])
+
+      XCTAssertFalse(self.vm.inputs.brazeDidHandleURL(URL(string: "https://www.google.com"), extras: [:]))
+
+      self.updateCurrentUserInEnvironment.assertValues([env.user])
+
+      self.scheduler.advance()
+
+      self.updateCurrentUserInEnvironment.assertValues([env.user])
+    }
+  }
+
+  func testBrazeDidHandleURL_UserDidUpdateWithValidUrl() {
+    self.updateCurrentUserInEnvironment.assertDidNotEmitValue()
+
+    withEnvironment(apiService: MockService()) {
+      let user = User.template
+        |> User.lens.notifications.mobileMessages .~ false
+
+      let env = AccessTokenEnvelope(accessToken: "deadbeef", user: user)
+      AppEnvironment.login(env)
+
+      self.vm.inputs.applicationDidFinishLaunching(
+        application: UIApplication.shared,
+        launchOptions: [:]
+      )
+
+      self.scheduler.advance(by: .seconds(5))
+
+      self.updateCurrentUserInEnvironment.assertValues([user])
+
+      let updatedUser = user
+        |> User.lens.notifications.mobileMessages .~ true
+
+      let url =
+        "https://\(AppEnvironment.current.apiService.serverConfig.webBaseUrl.host ?? "")/settings/notify_mobile_of_messages/true"
+
+      XCTAssertTrue(self.vm.inputs.brazeDidHandleURL(URL(string: url), extras: [:]))
+
+      self.updateCurrentUserInEnvironment.assertValues([user])
+
+      self.scheduler.advance()
+
+      self.updateCurrentUserInEnvironment.assertValues([user, updatedUser])
+    }
+  }
 }
 
 private let backingForCreatorPushData: [String: Any] = [

--- a/Library/NavigationTests.swift
+++ b/Library/NavigationTests.swift
@@ -202,6 +202,16 @@ public final class NavigationTests: XCTestCase {
       .profile(.verifyEmail),
       "/profile/verify_email"
     )
+
+    KSRAssertMatch(
+      .settings(.notifications("notify_mobile_of_marketing_update", true)),
+      "/settings/notify_mobile_of_marketing_update/true"
+    )
+
+    KSRAssertMatch(
+      .settings(.notifications("notify_mobile_of_messages", false)),
+      "/settings/notify_mobile_of_messages/false"
+    )
   }
 
   func testRecognizesEmailClickUrls() {


### PR DESCRIPTION
# 📲 What

Allows us to enable a push notification setting from an in-app message dialogue sent from Braze.

# 🤔 Why

We are making use of in-app messages from Braze to inform users of new notifications that they may wish to subscribe to.

# 🛠 How

- Implement the `ABKURLDelegate` `handleAppboyURL(_:from:withExtras)` function which receives the URL from the in-app message button tap.
- Parse the URL through a `Navigation` deep-link.
- Update the currently logged in user and send a `PUT` request to the `/v1/users/self` endpoint.

# 👀 See

https://www.braze.com/docs/developer_guide/platform_integration_guides/ios/in-app_messaging/customization

# ✅ Acceptance criteria

Go to your user's notification settings, disable the push notification for mobile marketing updates (top of the list). Enable the Braze feature flag in the debug menu.

- [x] Send yourself a test IAM from Braze with a button configured to deep link with the expected URL structure (see `NavigationTests.swift`) Be sure to use the staging base URL when testing on simulator/beta. Launch the app (IAMs were only shown to me upon app-launch). You should see the IAM, tapping the button that the URL was assigned to should dismiss the modal and the notification option should be enabled for your user.
- [ ] Using any other valid URL replacing the notification option should also work for that option.
- [x] Using an invalid URL should do nothing (or cause Braze to handle it using its default behaviour).