### PR TITLE
[NT-1884] Send User ID as String in User Properties

### DIFF
--- a/Library/Tracking/KSRAnalytics.swift
+++ b/Library/Tracking/KSRAnalytics.swift
@@ -1905,7 +1905,7 @@ private func userProperties(for user: User?, _ prefix: String = "user_") -> [Str
   props["is_admin"] = user.isAdmin
   props["launched_projects_count"] = user.stats
     .createdProjectsCount // product and insights defines launched_projects_count as only the createdProjectsCount
-  props["uid"] = user.id
+  props["uid"] = "\(user.id)"
   props["watched_projects_count"] = user.stats.starredProjectsCount
   props["facebook_connected"] = user.facebookConnected
 

--- a/Library/Tracking/KSRAnalyticsTests.swift
+++ b/Library/Tracking/KSRAnalyticsTests.swift
@@ -1972,7 +1972,7 @@ final class KSRAnalyticsTests: TestCase {
     let dataLakeClientProps = dataLakeClient.properties.last
     let segmentClientProps = segmentClient.properties.last
 
-    XCTAssertEqual(10, dataLakeClientProps?["user_uid"] as? Int)
+    XCTAssertEqual("10", dataLakeClientProps?["user_uid"] as? String)
     XCTAssertEqual(5, dataLakeClientProps?["user_backed_projects_count"] as? Int)
     XCTAssertEqual(15, dataLakeClientProps?["user_created_projects_count"] as? Int)
     XCTAssertEqual(false, dataLakeClientProps?["user_is_admin"] as? Bool)
@@ -1980,7 +1980,7 @@ final class KSRAnalyticsTests: TestCase {
     XCTAssertEqual(2, dataLakeClientProps?["user_watched_projects_count"] as? Int)
     XCTAssertEqual(true, dataLakeClientProps?["user_facebook_connected"] as? Bool)
 
-    XCTAssertEqual(10, segmentClientProps?["user_uid"] as? Int)
+    XCTAssertEqual("10", segmentClientProps?["user_uid"] as? String)
     XCTAssertEqual(5, segmentClientProps?["user_backed_projects_count"] as? Int)
     XCTAssertEqual(15, segmentClientProps?["user_created_projects_count"] as? Int)
     XCTAssertEqual(false, segmentClientProps?["user_is_admin"] as? Bool)

--- a/Library/ViewModels/PledgeViewModelTests.swift
+++ b/Library/ViewModels/PledgeViewModelTests.swift
@@ -5698,7 +5698,7 @@ final class PledgeViewModelTests: TestCase {
         dataLakeTrackingClient.properties(forKey: "session_user_is_logged_in", as: Bool.self),
         [true]
       )
-      XCTAssertEqual(dataLakeTrackingClient.properties(forKey: "user_uid", as: Int.self), [1])
+      XCTAssertEqual(dataLakeTrackingClient.properties(forKey: "user_uid", as: String.self), ["1"])
 
       XCTAssertEqual(dataLakeTrackingClient.properties(forKey: "project_subcategory"), ["Illustration"])
       XCTAssertEqual(dataLakeTrackingClient.properties(forKey: "project_category"), ["Art"])
@@ -5711,7 +5711,7 @@ final class PledgeViewModelTests: TestCase {
         segmentClient.properties(forKey: "session_user_is_logged_in", as: Bool.self),
         [true]
       )
-      XCTAssertEqual(segmentClient.properties(forKey: "user_uid", as: Int.self), [1])
+      XCTAssertEqual(segmentClient.properties(forKey: "user_uid", as: String.self), ["1"])
 
       XCTAssertEqual(segmentClient.properties(forKey: "project_subcategory"), ["Illustration"])
       XCTAssertEqual(segmentClient.properties(forKey: "project_category"), ["Art"])

--- a/Library/ViewModels/ProjectPamphletViewModelTests.swift
+++ b/Library/ViewModels/ProjectPamphletViewModelTests.swift
@@ -880,10 +880,10 @@ final class ProjectPamphletViewModelTests: TestCase {
       XCTAssertEqual(dataLakeClient.properties(forKey: "session_ref_tag"), ["discovery"])
 
       XCTAssertEqual(dataLakeClient.properties(forKey: "session_user_is_logged_in", as: Bool.self), [true])
-      XCTAssertEqual(dataLakeClient.properties(forKey: "user_uid", as: Int.self), [1])
+      XCTAssertEqual(dataLakeClient.properties(forKey: "user_uid", as: String.self), ["1"])
 
       XCTAssertEqual(segmentClient.properties(forKey: "session_user_is_logged_in", as: Bool.self), [true])
-      XCTAssertEqual(segmentClient.properties(forKey: "user_uid", as: Int.self), [1])
+      XCTAssertEqual(segmentClient.properties(forKey: "user_uid", as: String.self), ["1"])
 
       XCTAssertEqual(dataLakeClient.properties(forKey: "project_subcategory"), ["Ceramics"])
       XCTAssertEqual(dataLakeClient.properties(forKey: "project_category"), ["Art"])


### PR DESCRIPTION
# 📲 What

Sends the user ID property as a `String` instead of an `Int`.

# 🤔 Why

@lauriestark found that there were data anomalies related to the user ID property in Amplitude and upon investigation it seems that this property is being flagged as a violation for not being a `String`.

Also, we _do_ send this property as a `String` when we call `identify` because that does not accept an `Int`. It seems reasonable to assume that these data types should be the same but I've opened this PR for us to test and discuss as I have limited context of this project thus far. @singhhari should advise.

# 🛠 How

Wrapped the user ID in a `String` and updated tests.

# 👀 See

Screenshot of violation in Segment debugger:

<img width="567" alt="image" src="https://user-images.githubusercontent.com/3735375/117227346-77836c00-adcb-11eb-984a-ae2160d0f36d.png">

Source: https://app.segment.com/kickstarter/protocols/violations/ios/track

# ✅ Acceptance criteria

- [ ] Test an event through to Amplitude to confirm that the IDs shown there are correct.