### PR TITLE
[NT-1888] Improve Redundant Identify Handling

### DIFF
--- a/Library/AppEnvironment.swift
+++ b/Library/AppEnvironment.swift
@@ -82,6 +82,8 @@ public struct AppEnvironment: AppEnvironmentType {
     let storage = AppEnvironment.current.cookieStorage
     storage.cookies?.forEach(storage.deleteCookie)
 
+    AppEnvironment.current.userDefaults.analyticsIdentityData = nil
+
     self.replaceCurrentEnvironment(
       apiService: AppEnvironment.current.apiService.logout(),
       cache: type(of: AppEnvironment.current.cache).init(),

--- a/Library/AppEnvironmentTests.swift
+++ b/Library/AppEnvironmentTests.swift
@@ -60,19 +60,23 @@ final class AppEnvironmentTests: XCTestCase {
     XCTAssertNil(AppEnvironment.current.currentUser)
 
     AppEnvironment.login(AccessTokenEnvelope(accessToken: "deadbeef", user: User.template))
+    AppEnvironment.current.userDefaults.analyticsIdentityData = KSRAnalyticsIdentityData(.template)
 
     XCTAssertEqual("deadbeef", AppEnvironment.current.apiService.oauthToken?.token)
     XCTAssertEqual(User.template, AppEnvironment.current.currentUser)
+    XCTAssertNotNil(AppEnvironment.current.userDefaults.analyticsIdentityData)
 
     AppEnvironment.updateCurrentUser(User.template)
 
     XCTAssertEqual("deadbeef", AppEnvironment.current.apiService.oauthToken?.token)
     XCTAssertEqual(User.template, AppEnvironment.current.currentUser)
+    XCTAssertNotNil(AppEnvironment.current.userDefaults.analyticsIdentityData)
 
     AppEnvironment.logout()
 
     XCTAssertNil(AppEnvironment.current.apiService.oauthToken)
     XCTAssertNil(AppEnvironment.current.currentUser)
+    XCTAssertNil(AppEnvironment.current.userDefaults.analyticsIdentityData)
 
     AppEnvironment.popEnvironment()
   }

--- a/Library/Tracking/KSRAnalyticsIdentityData.swift
+++ b/Library/Tracking/KSRAnalyticsIdentityData.swift
@@ -25,6 +25,8 @@ public struct KSRAnalyticsIdentityData: Equatable {
   }
 
   public static func == (lhs: KSRAnalyticsIdentityData, rhs: KSRAnalyticsIdentityData) -> Bool {
+    guard lhs.userId == rhs.userId else { return false }
+
     let uniqueTraits = lhs.uniqueTraits(comparedTo: rhs)
 
     return uniqueTraits.isEmpty

--- a/Library/Tracking/KSRAnalyticsIdentityDataTests.swift
+++ b/Library/Tracking/KSRAnalyticsIdentityDataTests.swift
@@ -65,6 +65,14 @@ final class KSRAnalyticsIdentityDataTests: XCTestCase {
       |> User.lens.notifications.messages .~ true
 
     XCTAssertNotEqual(KSRAnalyticsIdentityData(user3), KSRAnalyticsIdentityData(user4))
+
+    let user5 = User.template
+      |> User.lens.id .~ 1
+
+    let user6 = User.template
+      |> User.lens.id .~ 2
+
+    XCTAssertNotEqual(KSRAnalyticsIdentityData(user5), KSRAnalyticsIdentityData(user6))
   }
 
   func testAllTraits() {


### PR DESCRIPTION
# 📲 What

Improves how we handle the redundant calls to Segment's `identify` API.

# 🤔 Why

During testing it was found that `identify` was not called when logging out and logging in on a device with a different user. I suspect this is because I was not checking for changes in the user ID but only in the rest of the traits. I've also ensured that we clear the persisted data at logout.

# 🛠 How

- Added a check to see if the user ID changes.
- Cleared persisted data at logout.

# ✅ Acceptance criteria

To be sure, reset your simulator completely.

- [ ] Log in and observe that identify is called in the Segment debugger.
- [ ] Log out and back in as the same user, observe that identify is called.
- [ ] Log out and log in as a different user, observe that identify is called.
- [ ] When logged in change any notification option and observe that identify is called.