### PR TITLE
[NT-1891] Add GraphQL Root Comments Types and Query

### DIFF
--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -475,6 +475,10 @@
 		8A4E954724525DE400A578CF /* ProjectState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A4E954624525DE400A578CF /* ProjectState.swift */; };
 		8A4E954924525EC100A578CF /* BackingState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A4E954824525EC100A578CF /* BackingState.swift */; };
 		8A4E954B245268F100A578CF /* ManagePledgeViewBackingEnvelopeTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A4E954A245268F100A578CF /* ManagePledgeViewBackingEnvelopeTemplate.swift */; };
+		8A555864264C4AA500C2C30D /* GraphCommentsEnvelope.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A555863264C4AA500C2C30D /* GraphCommentsEnvelope.swift */; };
+		8A555869264C4AE400C2C30D /* GraphComment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A555868264C4AE400C2C30D /* GraphComment.swift */; };
+		8A555874264C4C8300C2C30D /* CommentsQueries.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A555873264C4C8300C2C30D /* CommentsQueries.swift */; };
+		8A55587C264C567F00C2C30D /* CommentsQueriesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A55587B264C567F00C2C30D /* CommentsQueriesTests.swift */; };
 		8A5CB28424C11819003113D4 /* RewardAddOnSelectionContinueCTAViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A5CB28324C11819003113D4 /* RewardAddOnSelectionContinueCTAViewModelTests.swift */; };
 		8A64F16624BE6528004917E2 /* RewardAddOnSelectionViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A64F16524BE6528004917E2 /* RewardAddOnSelectionViewControllerTests.swift */; };
 		8A65E79B25016A22006F81CC /* FirebaseInstallations.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A65E79A25016A22006F81CC /* FirebaseInstallations.framework */; };
@@ -559,6 +563,16 @@
 		8AD7952F239EBDF600998C79 /* MockTrackingClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A213CE9239EAEA400BBB4C7 /* MockTrackingClient.swift */; };
 		8AD79530239EBDF600998C79 /* MockTrackingClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A213CE9239EAEA400BBB4C7 /* MockTrackingClient.swift */; };
 		8AD9CF1424C8D46800F77223 /* PledgeShippingSummaryViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD9CF1324C8D46800F77223 /* PledgeShippingSummaryViewModelTests.swift */; };
+		8ADCCC87264C6E4A0079D308 /* GraphCommentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ADCCC86264C6E4A0079D308 /* GraphCommentTests.swift */; };
+		8ADCCC8F264C72B20079D308 /* GraphCommentsEnvelopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ADCCC8E264C72B20079D308 /* GraphCommentsEnvelopeTests.swift */; };
+		8ADCCCA6264C97940079D308 /* CommentsEnvelope.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ADCCCA5264C97940079D308 /* CommentsEnvelope.swift */; };
+		8ADCCCAE264C98A50079D308 /* Comment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ADCCCAD264C98A50079D308 /* Comment.swift */; };
+		8ADCCCB6264C9F3B0079D308 /* CommentsEnvelope+GraphCommentsEnvelope.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ADCCCB5264C9F3B0079D308 /* CommentsEnvelope+GraphCommentsEnvelope.swift */; };
+		8ADCCCBB264C9F4C0079D308 /* Comment+GraphComment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ADCCCBA264C9F4C0079D308 /* Comment+GraphComment.swift */; };
+		8ADCCCC0264CA1270079D308 /* CommentsEnvelope+GraphCommentsEnvelopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ADCCCBF264CA1270079D308 /* CommentsEnvelope+GraphCommentsEnvelopeTests.swift */; };
+		8ADCCCCB264CA13F0079D308 /* Comment+GraphCommentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ADCCCCA264CA13F0079D308 /* Comment+GraphCommentTests.swift */; };
+		8ADCCCD0264CA18E0079D308 /* GraphCommentTemplates.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ADCCCCF264CA18E0079D308 /* GraphCommentTemplates.swift */; };
+		8ADCCCD8264CA1A00079D308 /* GraphCommentsEnvelopeTemplates.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ADCCCD7264CA1A00079D308 /* GraphCommentsEnvelopeTemplates.swift */; };
 		8ADF4D7624BCCFD60018AD4B /* PillsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ADF4D7524BCCFD60018AD4B /* PillsView.swift */; };
 		8AE09C3A244537BE00036043 /* PledgeDisclaimerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE09C39244537BE00036043 /* PledgeDisclaimerView.swift */; };
 		8AE09C3C2446330100036043 /* PledgeDisclaimerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE09C3B2446330100036043 /* PledgeDisclaimerViewModel.swift */; };
@@ -2018,6 +2032,10 @@
 		8A4E954624525DE400A578CF /* ProjectState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectState.swift; sourceTree = "<group>"; };
 		8A4E954824525EC100A578CF /* BackingState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackingState.swift; sourceTree = "<group>"; };
 		8A4E954A245268F100A578CF /* ManagePledgeViewBackingEnvelopeTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManagePledgeViewBackingEnvelopeTemplate.swift; sourceTree = "<group>"; };
+		8A555863264C4AA500C2C30D /* GraphCommentsEnvelope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphCommentsEnvelope.swift; sourceTree = "<group>"; };
+		8A555868264C4AE400C2C30D /* GraphComment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphComment.swift; sourceTree = "<group>"; };
+		8A555873264C4C8300C2C30D /* CommentsQueries.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentsQueries.swift; sourceTree = "<group>"; };
+		8A55587B264C567F00C2C30D /* CommentsQueriesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentsQueriesTests.swift; sourceTree = "<group>"; };
 		8A5CB28324C11819003113D4 /* RewardAddOnSelectionContinueCTAViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RewardAddOnSelectionContinueCTAViewModelTests.swift; sourceTree = "<group>"; };
 		8A64F16524BE6528004917E2 /* RewardAddOnSelectionViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RewardAddOnSelectionViewControllerTests.swift; sourceTree = "<group>"; };
 		8A65E79A25016A22006F81CC /* FirebaseInstallations.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = FirebaseInstallations.framework; path = Carthage/Build/iOS/FirebaseInstallations.framework; sourceTree = "<group>"; };
@@ -2084,6 +2102,16 @@
 		8AD48632235939AF00A1463E /* StripeTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StripeTypes.swift; sourceTree = "<group>"; };
 		8AD486342359F34700A1463E /* STPPaymentHandler+StripePaymentHandlerActionStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "STPPaymentHandler+StripePaymentHandlerActionStatus.swift"; sourceTree = "<group>"; };
 		8AD9CF1324C8D46800F77223 /* PledgeShippingSummaryViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PledgeShippingSummaryViewModelTests.swift; sourceTree = "<group>"; };
+		8ADCCC86264C6E4A0079D308 /* GraphCommentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphCommentTests.swift; sourceTree = "<group>"; };
+		8ADCCC8E264C72B20079D308 /* GraphCommentsEnvelopeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphCommentsEnvelopeTests.swift; sourceTree = "<group>"; };
+		8ADCCCA5264C97940079D308 /* CommentsEnvelope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentsEnvelope.swift; sourceTree = "<group>"; };
+		8ADCCCAD264C98A50079D308 /* Comment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Comment.swift; sourceTree = "<group>"; };
+		8ADCCCB5264C9F3B0079D308 /* CommentsEnvelope+GraphCommentsEnvelope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CommentsEnvelope+GraphCommentsEnvelope.swift"; sourceTree = "<group>"; };
+		8ADCCCBA264C9F4C0079D308 /* Comment+GraphComment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Comment+GraphComment.swift"; sourceTree = "<group>"; };
+		8ADCCCBF264CA1270079D308 /* CommentsEnvelope+GraphCommentsEnvelopeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CommentsEnvelope+GraphCommentsEnvelopeTests.swift"; sourceTree = "<group>"; };
+		8ADCCCCA264CA13F0079D308 /* Comment+GraphCommentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Comment+GraphCommentTests.swift"; sourceTree = "<group>"; };
+		8ADCCCCF264CA18E0079D308 /* GraphCommentTemplates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphCommentTemplates.swift; sourceTree = "<group>"; };
+		8ADCCCD7264CA1A00079D308 /* GraphCommentsEnvelopeTemplates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphCommentsEnvelopeTemplates.swift; sourceTree = "<group>"; };
 		8ADF4D7524BCCFD60018AD4B /* PillsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PillsView.swift; sourceTree = "<group>"; };
 		8AE09C39244537BE00036043 /* PledgeDisclaimerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PledgeDisclaimerView.swift; sourceTree = "<group>"; };
 		8AE09C3B2446330100036043 /* PledgeDisclaimerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PledgeDisclaimerViewModel.swift; sourceTree = "<group>"; };
@@ -3115,6 +3143,8 @@
 		7798B5292174F3BC008BC50D /* queries */ = {
 			isa = PBXGroup;
 			children = (
+				8A555873264C4C8300C2C30D /* CommentsQueries.swift */,
+				8A55587B264C567F00C2C30D /* CommentsQueriesTests.swift */,
 				8A30C6B02491683C00EE12E4 /* ManagePledgeViewQueries.swift */,
 				8A30C6B22491689300EE12E4 /* ManagePledgeViewQueriesTests.swift */,
 				D6DC652E21768502008CF69C /* Queryable.swift */,
@@ -3155,6 +3185,8 @@
 				8A41CC6E2458A0610095B15E /* GraphBackingTemplates.swift */,
 				D6ED38A11F796FE5006CAAE9 /* GraphCategoriesEnvelopeTemplate.swift */,
 				8AA407CD24DB5316008C5FB0 /* GraphCategoryTemplates.swift */,
+				8ADCCCD7264CA1A00079D308 /* GraphCommentsEnvelopeTemplates.swift */,
+				8ADCCCCF264CA18E0079D308 /* GraphCommentTemplates.swift */,
 				D63BBD32217F9CDE007E01F0 /* GraphCreditCardTemplate.swift */,
 				8A0B1E2B24DA1327009E90C0 /* GraphLocationTemplates.swift */,
 				D08CD20221922025009F89F0 /* GraphMutationWatchProjectResponseEnvelopeTemplates.swift */,
@@ -3220,6 +3252,10 @@
 				8A41CC672458A0360095B15E /* GraphBackingEnvelope.swift */,
 				8A41CC6B2458A0480095B15E /* GraphBackingTests.swift */,
 				8AA407BF24DA43D8008C5FB0 /* GraphCategory.swift */,
+				8A555868264C4AE400C2C30D /* GraphComment.swift */,
+				8A555863264C4AA500C2C30D /* GraphCommentsEnvelope.swift */,
+				8ADCCC8E264C72B20079D308 /* GraphCommentsEnvelopeTests.swift */,
+				8ADCCC86264C6E4A0079D308 /* GraphCommentTests.swift */,
 				8AA407C124DB0C8D008C5FB0 /* GraphCountry.swift */,
 				8A0B1E2624DA0DC3009E90C0 /* GraphLocation.swift */,
 				D002CAE4218CF951009783F2 /* GraphMutationWatchProjectResponseEnvelope.swift */,
@@ -3243,6 +3279,10 @@
 			children = (
 				8A8831C224DA2B27002BCA5E /* Backing+GraphBacking.swift */,
 				8A8831C424DA2B9D002BCA5E /* Backing+GraphBackingTests.swift */,
+				8ADCCCBA264C9F4C0079D308 /* Comment+GraphComment.swift */,
+				8ADCCCCA264CA13F0079D308 /* Comment+GraphCommentTests.swift */,
+				8ADCCCB5264C9F3B0079D308 /* CommentsEnvelope+GraphCommentsEnvelope.swift */,
+				8ADCCCBF264CA1270079D308 /* CommentsEnvelope+GraphCommentsEnvelopeTests.swift */,
 				8AA407CB24DB49CE008C5FB0 /* Location+GraphLocation.swift */,
 				8AA407C924DB453C008C5FB0 /* Project.Category+GraphCategory.swift */,
 				8AA407C524DB36E8008C5FB0 /* Project.Country+GraphCountry.swift */,
@@ -4454,7 +4494,6 @@
 				D01587791EEB2ED6006E7684 /* Activity.swift */,
 				D015877A1EEB2ED6006E7684 /* ActivityEnvelope.swift */,
 				D015877B1EEB2ED6006E7684 /* ActivityTests.swift */,
-				D6B9F90922035840003282A5 /* DeprecatedAuthor.swift */,
 				D6B9F94422035E34003282A5 /* AuthorTests.swift */,
 				D015877C1EEB2ED6006E7684 /* Backing.swift */,
 				77272D362370AB5C003B7A9C /* BackingPaymentSourceTests.swift */,
@@ -4469,9 +4508,8 @@
 				D755ECAA232005A70096F189 /* Checkout.swift */,
 				D0E78C3522A980A600AAB645 /* ClearUserUnseenActivityEnvelope.swift */,
 				D0E78C3722A981EE00AAB645 /* ClearUserUnseenActivityEnvelopeTests.swift */,
-				D01587851EEB2ED6006E7684 /* DeprecatedComment.swift */,
-				D01587861EEB2ED6006E7684 /* DeprecatedCommentsEnvelope.swift */,
-				D01587871EEB2ED6006E7684 /* DeprecatedCommentTests.swift */,
+				8ADCCCAD264C98A50079D308 /* Comment.swift */,
+				8ADCCCA5264C97940079D308 /* CommentsEnvelope.swift */,
 				D01587881EEB2ED6006E7684 /* Config.swift */,
 				D67B6C9C221F458700B63A6B /* Config+Encode.swift */,
 				D01587891EEB2ED6006E7684 /* ConfigTests.swift */,
@@ -4481,6 +4519,10 @@
 				8A4E95382450FBB500A578CF /* CreditCardType.swift */,
 				D62B1476221216A000AC05C8 /* DeletePaymentMethodEnvelope.swift */,
 				D62B14AF2212184500AC05C8 /* DeletePaymentMethodEnvelopeTests.swift */,
+				D6B9F90922035840003282A5 /* DeprecatedAuthor.swift */,
+				D01587851EEB2ED6006E7684 /* DeprecatedComment.swift */,
+				D01587861EEB2ED6006E7684 /* DeprecatedCommentsEnvelope.swift */,
+				D01587871EEB2ED6006E7684 /* DeprecatedCommentTests.swift */,
 				D015878C1EEB2ED6006E7684 /* DiscoveryEnvelope.swift */,
 				D015878D1EEB2ED6006E7684 /* DiscoveryParams.swift */,
 				D015878E1EEB2ED6006E7684 /* DiscoveryParamsTests.swift */,
@@ -6203,10 +6245,12 @@
 				D67B6C9D221F458700B63A6B /* Config+Encode.swift in Sources */,
 				D01588391EEB2ED7006E7684 /* Method.swift in Sources */,
 				3706408A22A8B2B700889CBD /* ShippingTemplates.swift in Sources */,
+				8ADCCCB6264C9F3B0079D308 /* CommentsEnvelope+GraphCommentsEnvelope.swift in Sources */,
 				D01588D91EEB2ED7006E7684 /* User.AvatarLenses.swift in Sources */,
 				D015882F1EEB2ED7006E7684 /* ClientAuth.swift in Sources */,
 				D01588371EEB2ED7006E7684 /* EncodableType.swift in Sources */,
 				D0158A301EEB30A2006E7684 /* User.NewsletterSubscriptionsTemplates.swift in Sources */,
+				8A555864264C4AA500C2C30D /* GraphCommentsEnvelope.swift in Sources */,
 				D01588DB1EEB2ED7006E7684 /* User.NewsletterSubscriptionsLenses.swift in Sources */,
 				D01588691EEB2ED7006E7684 /* DiscoveryEnvelope.swift in Sources */,
 				D0158A251EEB30A2006E7684 /* RewardTemplates.swift in Sources */,
@@ -6274,11 +6318,13 @@
 				D01588C51EEB2ED7006E7684 /* Reward.ShippingLenses.swift in Sources */,
 				7703B42223217D4F00169EF3 /* EnvironmentType.swift in Sources */,
 				8A0B1E2A24DA12E4009E90C0 /* GraphRewardTemplates.swift in Sources */,
+				8A555869264C4AE400C2C30D /* GraphComment.swift in Sources */,
 				8ACF36D1262745520026E74D /* MockService.swift in Sources */,
 				D68F0B18243F6730009FC948 /* SignInWithAppleEnvelopeTemplates.swift in Sources */,
 				D01588D51EEB2ED7006E7684 /* UpdateDraftLenses.swift in Sources */,
 				8ACF558923E8D467001654A2 /* TryDecodable.swift in Sources */,
 				D01589211EEB2ED7006E7684 /* StarEnvelope.swift in Sources */,
+				8ADCCCBB264C9F4C0079D308 /* Comment+GraphComment.swift in Sources */,
 				D01588EF1EEB2ED7006E7684 /* MessageThread.swift in Sources */,
 				8AA407C824DB4399008C5FB0 /* User+GraphUser.swift in Sources */,
 				8A4E95392450FBB500A578CF /* CreditCardType.swift in Sources */,
@@ -6308,6 +6354,7 @@
 				D01588EB1EEB2ED7006E7684 /* MessageSubject.swift in Sources */,
 				D770DDE8217D729300B5319A /* GraphUserTemplates.swift in Sources */,
 				D01589171EEB2ED7006E7684 /* RewardsItem.swift in Sources */,
+				8A555874264C4C8300C2C30D /* CommentsQueries.swift in Sources */,
 				77950F0A231EB8C300308331 /* CreateApplePayBackingMutation.swift in Sources */,
 				D0158A1B1EEB30A2006E7684 /* Project.VideoTemplates.swift in Sources */,
 				D0158A311EEB30A2006E7684 /* User.NotificationsTemplates.swift in Sources */,
@@ -6328,6 +6375,7 @@
 				8AA407CE24DB5316008C5FB0 /* GraphCategoryTemplates.swift in Sources */,
 				D01588A91EEB2ED7006E7684 /* Project.PersonalizationLenses.swift in Sources */,
 				D015888B1EEB2ED7006E7684 /* DeprecatedCommentLenses.swift in Sources */,
+				D015888B1EEB2ED7006E7684 /* DeprecatedCommentLenses.swift in Sources */,
 				8A1F65E6262660CB00A28E74 /* PerimeterXClient.swift in Sources */,
 				D0158A281EEB30A2006E7684 /* StarEnvelopeTemplates.swift in Sources */,
 				D0158A221EEB30A2006E7684 /* ProjectStatsEnvelopeTemplates.swift in Sources */,
@@ -6335,6 +6383,7 @@
 				D01589271EEB2ED7006E7684 /* SurveyResponse.swift in Sources */,
 				D75DACA8221DC4340027F478 /* CreatePasswordInput.swift in Sources */,
 				D0158A0D1EEB30A2006E7684 /* ChangePaymentMethodEnvelopeTemplates.swift in Sources */,
+				8ADCCCD0264CA18E0079D308 /* GraphCommentTemplates.swift in Sources */,
 				D0158A201EEB30A2006E7684 /* ProjectStatsEnvelope.RewardDistributionTemplates.swift in Sources */,
 				D01588C11EEB2ED7006E7684 /* ProjectStatsEnvelopeLenses.swift in Sources */,
 				8A49396124B54C0C00C3C3CE /* RewardAddOnSelectionViewEnvelope.swift in Sources */,
@@ -6371,6 +6420,7 @@
 				D0851010219500F200BC418B /* PaymentSourceDeleteMutation.swift in Sources */,
 				D01589091EEB2ED7006E7684 /* ProjectsEnvelope.swift in Sources */,
 				D6C9A2541F758C7900981E64 /* GraphCategoryLenses.swift in Sources */,
+				8ADCCCD8264CA1A00079D308 /* GraphCommentsEnvelopeTemplates.swift in Sources */,
 				D015883B1EEB2ED7006E7684 /* MimeType.swift in Sources */,
 				D01589931EEB2ED7006E7684 /* User.swift in Sources */,
 				8A49396924B690E000C3C3CE /* RewardAddOnSelectionViewEnvelopeTemplate.swift in Sources */,
@@ -6381,6 +6431,7 @@
 				77E44B7421823A56006446B8 /* ChangePasswordInput.swift in Sources */,
 				D08C71DC22A71A0100A245B7 /* ClearUserUnseenActivityMutation.swift in Sources */,
 				8AF34C742342CBC2000B211D /* UpdateBackingInput.swift in Sources */,
+				8ADCCCAE264C98A50079D308 /* Comment.swift in Sources */,
 				D0158A2E1EEB30A2006E7684 /* User.AvatarTemplates.swift in Sources */,
 				D01588771EEB2ED7006E7684 /* FriendStatsEnvelope.swift in Sources */,
 				D015891D1EEB2ED7006E7684 /* ShippingRule.swift in Sources */,
@@ -6403,6 +6454,7 @@
 				8ACF36EA2627486D0026E74D /* KsApiNotification.swift in Sources */,
 				D6ED386A1F796C26006CAAE9 /* GraphCategoriesEnvelopeLenses.swift in Sources */,
 				8A45168F24B3E2A800D8CAEF /* RewardAddOnSelectionViewQueries.swift in Sources */,
+				8ADCCCA6264C97940079D308 /* CommentsEnvelope.swift in Sources */,
 				D755ECA92319AF4D0096F189 /* CreateBackingEnvelope.swift in Sources */,
 				D0158A131EEB30A2006E7684 /* DiscoveryEnvelopeTemplates.swift in Sources */,
 				D01588431EEB2ED7006E7684 /* Activity.swift in Sources */,
@@ -6453,6 +6505,8 @@
 				D01589A21EEB2ED7006E7684 /* ServiceTypeTests.swift in Sources */,
 				D0D10C0F1EEB4550005EBAD0 /* LocationTests.swift in Sources */,
 				D0D10C121EEB4550005EBAD0 /* Project.CountryTests.swift in Sources */,
+				8ADCCCC0264CA1270079D308 /* CommentsEnvelope+GraphCommentsEnvelopeTests.swift in Sources */,
+				8ADCCC8F264C72B20079D308 /* GraphCommentsEnvelopeTests.swift in Sources */,
 				D0D10C0B1EEB4550005EBAD0 /* ErrorEnvelopeTests.swift in Sources */,
 				D0D10C031EEB4550005EBAD0 /* BackingTests.swift in Sources */,
 				8A67DDB424DCA41400B4AB10 /* User+GraphUserTests.swift in Sources */,
@@ -6474,10 +6528,13 @@
 				D0D10C151EEB4550005EBAD0 /* ProjectStatsEnvelopeTests.swift in Sources */,
 				8A2C015F2589391D00EE11E7 /* ProjectActivityEnvelopeTests.swift in Sources */,
 				D0D10C221EEB4550005EBAD0 /* UserTests.swift in Sources */,
+				8ADCCCCB264CA13F0079D308 /* Comment+GraphCommentTests.swift in Sources */,
 				8A45169124B3E2CE00D8CAEF /* RewardAddOnSelectionViewQueriesTests.swift in Sources */,
 				D0D10C171EEB4550005EBAD0 /* PushEnvelopeTests.swift in Sources */,
 				D0D10C1D1EEB4550005EBAD0 /* UpdatePledgeEnvelopeTests.swift in Sources */,
 				D0D10C0E1EEB4550005EBAD0 /* ItemTests.swift in Sources */,
+				8A55587C264C567F00C2C30D /* CommentsQueriesTests.swift in Sources */,
+				8ADCCC87264C6E4A0079D308 /* GraphCommentTests.swift in Sources */,
 				D755ECAE23216C290096F189 /* CreateBackingInputTests.swift in Sources */,
 				D755ECB123217D5B0096F189 /* CreateBackingEnvelopeTests.swift in Sources */,
 				D0D10C1B1EEB4550005EBAD0 /* SurveyResponseTests.swift in Sources */,

--- a/KsApi/GraphSchema.swift
+++ b/KsApi/GraphSchema.swift
@@ -139,6 +139,24 @@ public enum Query {
     case url
   }
 
+  public enum Comment {
+    case authorBadges
+    case author(NonEmptySet<Author>)
+    case id
+    case body
+    case replies(NonEmptySet<CommentReplyCount>)
+
+    public enum Author: String {
+      case id
+      case name
+      case isCreator
+    }
+
+    public enum CommentReplyCount: String {
+      case totalCount
+    }
+  }
+
   public enum Conversation {
     case id
   }
@@ -176,6 +194,7 @@ public enum Query {
     case backersCount
     case backing(NonEmptySet<Backing>)
     case category(NonEmptySet<Category>)
+    case comments(Set<QueryArg<Never>>, NonEmptySet<Connection<Comment>>)
     case country(NonEmptySet<Country>)
     case creator(NonEmptySet<User>)
     case currency
@@ -482,6 +501,32 @@ extension Query.Category.ProjectsConnection.Argument: CustomStringConvertible {
   }
 }
 
+// MARK: - Comment
+
+extension Query.Comment: QueryType {
+  public var description: String {
+    switch self {
+    case .id: return "id"
+    case .authorBadges: return "authorBadges"
+    case let .author(fields): return "author { \(join(fields)) }"
+    case .body: return "body"
+    case let .replies(fields): return "replies { \(join(fields)) }"
+    }
+  }
+}
+
+extension Query.Comment.Author: QueryType {
+  public var description: String {
+    return self.rawValue
+  }
+}
+
+extension Query.Comment.CommentReplyCount: QueryType {
+  public var description: String {
+    return self.rawValue
+  }
+}
+
 // MARK: - Project
 
 extension Query.Project: QueryType {
@@ -492,6 +537,7 @@ extension Query.Project: QueryType {
     case let .backing(fields): return "backing { \(join(fields)) }"
     case .backersCount: return "backersCount"
     case let .category(fields): return "category { \(join(fields)) }"
+    case let .comments(args, fields): return "comments\(connection(args, fields))"
     case let .country(fields): return "country { \(join(fields)) }"
     case let .creator(fields): return "creator { \(join(fields)) }"
     case .currency: return "currency"
@@ -801,4 +847,10 @@ extension Query.Notifications {
   public func hash(into hasher: inout Hasher) {
     hasher.combine(self.description)
   }
+}
+
+// MARK: - Schema Constants
+
+public extension Query {
+  static let defaultPaginationCount: Int = 25
 }

--- a/KsApi/MockService.swift
+++ b/KsApi/MockService.swift
@@ -50,6 +50,8 @@
     fileprivate let fetchCommentsResponse: [DeprecatedComment]?
     fileprivate let fetchCommentsError: ErrorEnvelope?
 
+    fileprivate let fetchCommentsEnvelopeResult: Result<CommentsEnvelope, ErrorEnvelope>?
+
     fileprivate let fetchConfigResponse: Config?
 
     fileprivate let fetchDiscoveryResponse: DiscoveryEnvelope?
@@ -230,6 +232,7 @@
       fetchGraphCategoriesError: GraphError? = nil,
       fetchCommentsResponse: [DeprecatedComment]? = nil,
       fetchCommentsError: ErrorEnvelope? = nil,
+      fetchCommentsEnvelopeResult: Result<CommentsEnvelope, ErrorEnvelope>? = nil,
       fetchConfigResponse: Config? = nil,
       fetchDiscoveryResponse: DiscoveryEnvelope? = nil,
       fetchDiscoveryError: ErrorEnvelope? = nil,
@@ -376,6 +379,8 @@
       ]
 
       self.fetchCommentsError = fetchCommentsError
+
+      self.fetchCommentsEnvelopeResult = fetchCommentsEnvelopeResult
 
       self.fetchConfigResponse = fetchConfigResponse ?? .template
 
@@ -638,6 +643,10 @@
         return SignalProducer(value: comments.value ?? .template)
       }
       return .empty
+    }
+
+    func fetchComments(query _: NonEmptySet<Query>) -> SignalProducer<CommentsEnvelope, ErrorEnvelope> {
+      return producer(for: self.fetchCommentsEnvelopeResult)
     }
 
     internal func fetchConfig() -> SignalProducer<Config, ErrorEnvelope> {

--- a/KsApi/Service.swift
+++ b/KsApi/Service.swift
@@ -174,6 +174,12 @@ public struct Service: ServiceType {
     return request(.projectComments(project))
   }
 
+  public func fetchComments(query: NonEmptySet<Query>) -> SignalProducer<CommentsEnvelope, ErrorEnvelope> {
+    return fetch(query: query)
+      .mapError(ErrorEnvelope.envelope(from:))
+      .flatMap(CommentsEnvelope.envelopeProducer(from:))
+  }
+
   public func fetchComments(update: Update) -> SignalProducer<DeprecatedCommentsEnvelope, ErrorEnvelope> {
     return request(.updateComments(update))
   }

--- a/KsApi/ServiceType.swift
+++ b/KsApi/ServiceType.swift
@@ -99,6 +99,9 @@ public protocol ServiceType {
   /// Fetch comments for a project.
   func fetchComments(project: Project) -> SignalProducer<DeprecatedCommentsEnvelope, ErrorEnvelope>
 
+  /// Fetch comments for a project with a query.
+  func fetchComments(query: NonEmptySet<Query>) -> SignalProducer<CommentsEnvelope, ErrorEnvelope>
+
   /// Fetch comments for an update.
   func fetchComments(update: Update) -> SignalProducer<DeprecatedCommentsEnvelope, ErrorEnvelope>
 

--- a/KsApi/models/Comment.swift
+++ b/KsApi/models/Comment.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+public struct Comment: Decodable, Equatable {
+  public var author: Author
+  public var body: String
+  public var id: String
+  public var uid: Int
+  public var replyCount: Int?
+
+  public struct Author: Decodable, Equatable {
+    public var id: String
+    public var isCreator: Bool
+    public var name: String
+  }
+}

--- a/KsApi/models/Comment.swift
+++ b/KsApi/models/Comment.swift
@@ -5,7 +5,7 @@ public struct Comment: Decodable, Equatable {
   public var body: String
   public var id: String
   public var uid: Int
-  public var replyCount: Int?
+  public var replyCount: Int
 
   public struct Author: Decodable, Equatable {
     public var id: String

--- a/KsApi/models/CommentsEnvelope.swift
+++ b/KsApi/models/CommentsEnvelope.swift
@@ -1,8 +1,16 @@
 import Foundation
+import ReactiveSwift
 
 public struct CommentsEnvelope: Decodable {
   public var comments: [Comment]
   public var cursor: String?
   public var hasNextPage: Bool
   public var totalCount: Int
+}
+
+extension CommentsEnvelope {
+  static func envelopeProducer(from envelope: GraphCommentsEnvelope)
+    -> SignalProducer<CommentsEnvelope, ErrorEnvelope> {
+    return SignalProducer(value: CommentsEnvelope.commentsEnvelope(from: envelope))
+  }
 }

--- a/KsApi/models/CommentsEnvelope.swift
+++ b/KsApi/models/CommentsEnvelope.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+public struct CommentsEnvelope: Decodable {
+  public var comments: [Comment]
+  public var cursor: String?
+  public var hasNextPage: Bool
+  public var totalCount: Int
+}

--- a/KsApi/models/graphql/GraphComment.swift
+++ b/KsApi/models/graphql/GraphComment.swift
@@ -1,0 +1,69 @@
+import Foundation
+import Prelude
+
+struct GraphComment: Decodable {
+  var author: GraphAuthor
+  var body: String
+  var id: String
+  var replyCount: Int
+
+  struct GraphAuthor: Decodable {
+    var id: String
+    var isCreator: Bool
+    var name: String
+  }
+}
+
+extension GraphComment {
+  /// All properties required to instantiate a `Comment` via a `GraphComment`
+  static var baseQueryProperties: NonEmptySet<Query.Comment> {
+    return Query.Comment.id +| [
+      .author(
+        .id +| [
+          .isCreator,
+          .name
+        ]
+      ),
+      .body,
+      .replies(
+        .totalCount +| []
+      )
+    ]
+  }
+}
+
+extension GraphComment {
+  private enum CodingKeys: String, CodingKey {
+    case author
+    case body
+    case id
+    case totalCount
+    case replies
+  }
+
+  init(from decoder: Decoder) throws {
+    let values = try decoder.container(keyedBy: CodingKeys.self)
+
+    self.id = try values.decode(String.self, forKey: .id)
+    self.author = try values.decode(GraphComment.GraphAuthor.self, forKey: .author)
+    self.body = try values.decode(String.self, forKey: .body)
+    self.replyCount = try values.nestedContainer(keyedBy: CodingKeys.self, forKey: .replies)
+      .decode(Int.self, forKey: .totalCount)
+  }
+}
+
+extension GraphComment.GraphAuthor {
+  private enum CodingKeys: String, CodingKey {
+    case id
+    case isCreator
+    case name
+  }
+
+  init(from decoder: Decoder) throws {
+    let values = try decoder.container(keyedBy: CodingKeys.self)
+
+    self.id = try values.decode(String.self, forKey: .id)
+    self.isCreator = try values.decodeIfPresent(Bool.self, forKey: .isCreator) ?? false
+    self.name = try values.decode(String.self, forKey: .name)
+  }
+}

--- a/KsApi/models/graphql/GraphCommentTests.swift
+++ b/KsApi/models/graphql/GraphCommentTests.swift
@@ -1,0 +1,34 @@
+@testable import KsApi
+import XCTest
+
+final class GraphCommentTests: XCTestCase {
+  func testDecode() {
+    let dictionary: [String: Any] =
+      [
+        "author": [
+          "id": "VXNlci0xOTE1MDY0NDY3",
+          "isCreator": nil,
+          "name": "James Bond"
+        ],
+        "body": "I have not received a survey yet either.",
+        "id": "Q29tbWVudC0zMDQ5MDQ2NA==",
+        "replies": [
+          "totalCount": 5
+        ]
+      ]
+
+    guard let data = try? JSONSerialization.data(withJSONObject: dictionary, options: []) else {
+      XCTFail("Should have data")
+      return
+    }
+
+    let comment = try? JSONDecoder().decode(GraphComment.self, from: data)
+
+    XCTAssertEqual(comment?.body, "I have not received a survey yet either.")
+    XCTAssertEqual(comment?.id, "Q29tbWVudC0zMDQ5MDQ2NA==")
+    XCTAssertEqual(comment?.replyCount, 5)
+    XCTAssertEqual(comment?.author.id, "VXNlci0xOTE1MDY0NDY3")
+    XCTAssertEqual(comment?.author.isCreator, false)
+    XCTAssertEqual(comment?.author.name, "James Bond")
+  }
+}

--- a/KsApi/models/graphql/GraphCommentsEnvelope.swift
+++ b/KsApi/models/graphql/GraphCommentsEnvelope.swift
@@ -1,0 +1,47 @@
+import Foundation
+import ReactiveSwift
+
+struct GraphCommentsEnvelope: Decodable {
+  var comments: [GraphComment]
+  var cursor: String
+  var hasNextPage: Bool
+  var totalCount: Int
+}
+
+extension GraphCommentsEnvelope {
+  private enum CodingKeys: CodingKey {
+    case comments
+    case edges
+    case node
+    case project
+    case pageInfo
+    case endCursor
+    case hasNextPage
+    case totalCount
+  }
+
+  init(from decoder: Decoder) throws {
+    let values = try decoder.container(keyedBy: CodingKeys.self)
+
+    let commentsContainer = try values.nestedContainer(keyedBy: CodingKeys.self, forKey: .project)
+      .nestedContainer(keyedBy: CodingKeys.self, forKey: .comments)
+
+    var edges = try commentsContainer
+      .nestedUnkeyedContainer(forKey: .edges)
+
+    var comments: [GraphComment] = []
+
+    while !edges.isAtEnd {
+      let node = try edges.nestedContainer(keyedBy: CodingKeys.self)
+      comments.append(try node.decode(GraphComment.self, forKey: .node))
+    }
+
+    self.comments = comments
+
+    let pageInfoContainer = try commentsContainer.nestedContainer(keyedBy: CodingKeys.self, forKey: .pageInfo)
+
+    self.cursor = try pageInfoContainer.decode(String.self, forKey: .endCursor)
+    self.hasNextPage = try pageInfoContainer.decode(Bool.self, forKey: .hasNextPage)
+    self.totalCount = try commentsContainer.decode(Int.self, forKey: .totalCount)
+  }
+}

--- a/KsApi/models/graphql/GraphCommentsEnvelopeTests.swift
+++ b/KsApi/models/graphql/GraphCommentsEnvelopeTests.swift
@@ -1,0 +1,76 @@
+@testable import KsApi
+import XCTest
+
+final class GraphCommentsEnvelopeTests: XCTestCase {
+  func testDecode() {
+    let dictionary: [String: Any] = [
+      "project": [
+        "comments": [
+          "edges": [
+            [
+              "node": [
+                "author": [
+                  "id": "VXNlci0xOTE1MDY0NDY3",
+                  "isCreator": true,
+                  "name": "Billy Bob"
+                ],
+                "body": "I have not received a survey yet either.",
+                "id": "Q29tbWVudC0zMDQ5MDQ2NA==",
+                "replies": [
+                  "totalCount": 1
+                ]
+              ]
+            ],
+            [
+              "node": [
+                "author": [
+                  "id": "VXNlci0yMDU3OTc4MTQ2",
+                  "isCreator": nil,
+                  "name": "Kate Hudson"
+                ],
+                "body": "I hope you guys all remembered to write in Bat Boy/Bigfoot on your ballots! Bat Boy 2020!!",
+                "id": "Q29tbWVudC0zMDQ2ODc1MA==",
+                "replies": [
+                  "totalCount": 1
+                ]
+              ]
+            ],
+            [
+              "node": [
+                "author": [
+                  "id": "VXNlci0yMTA1MDg2MzA4",
+                  "isCreator": false,
+                  "name": "Joe Smith"
+                ],
+                "body": "I haven't received my survey yet. Should I have?",
+                "id": "Q29tbWVudC0zMDQ1ODg5MQ==",
+                "replies": [
+                  "totalCount": 1
+                ]
+              ]
+            ]
+          ],
+          "pageInfo": [
+            "startCursor": "WzMwNDkwNDY0XQ==",
+            "endCursor": "WzMwNDU4ODkxXQ==",
+            "hasNextPage": true
+          ],
+          "totalCount": 61
+        ]
+      ]
+    ]
+
+    guard let data = try? JSONSerialization.data(withJSONObject: dictionary, options: []) else {
+      XCTFail("Should have data")
+      return
+    }
+
+    do {
+      let envelope = try JSONDecoder().decode(GraphCommentsEnvelope.self, from: data)
+      XCTAssertNotNil(envelope)
+    } catch {
+      XCTFail()
+      print(error)
+    }
+  }
+}

--- a/KsApi/models/graphql/GraphCommentsEnvelopeTests.swift
+++ b/KsApi/models/graphql/GraphCommentsEnvelopeTests.swift
@@ -67,7 +67,18 @@ final class GraphCommentsEnvelopeTests: XCTestCase {
 
     do {
       let envelope = try JSONDecoder().decode(GraphCommentsEnvelope.self, from: data)
-      XCTAssertNotNil(envelope)
+      XCTAssertEqual(envelope.comments[0].id, "Q29tbWVudC0zMDQ5MDQ2NA==")
+      XCTAssertEqual(envelope.comments[0].body, "I have not received a survey yet either.")
+      XCTAssertEqual(envelope.comments[0].author.id, "VXNlci0xOTE1MDY0NDY3")
+      XCTAssertEqual(envelope.comments[0].author.isCreator, true)
+      XCTAssertEqual(envelope.comments[0].author.name, "Billy Bob")
+      XCTAssertEqual(envelope.comments[0].replyCount, 1)
+
+      XCTAssertEqual(envelope.comments.count, 3)
+
+      XCTAssertEqual(envelope.hasNextPage, true)
+      XCTAssertEqual(envelope.cursor, "WzMwNDU4ODkxXQ==")
+      XCTAssertEqual(envelope.totalCount, 61)
     } catch {
       XCTFail()
       print(error)

--- a/KsApi/models/graphql/adapters/Comment+GraphComment.swift
+++ b/KsApi/models/graphql/adapters/Comment+GraphComment.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+extension Comment {
+  /**
+   Returns a minimal `Comment` from a `GraphComment`
+   */
+  static func comment(from graphComment: GraphComment) -> Comment {
+    return Comment(
+      author: Author(
+        id: graphComment.author.id,
+        isCreator: graphComment.author.isCreator,
+        name: graphComment.author.name
+      ),
+      body: graphComment.body,
+      id: graphComment.id,
+      uid: decompose(id: graphComment.id) ?? -1,
+      replyCount: graphComment.replyCount
+    )
+  }
+}

--- a/KsApi/models/graphql/adapters/Comment+GraphCommentTests.swift
+++ b/KsApi/models/graphql/adapters/Comment+GraphCommentTests.swift
@@ -3,18 +3,16 @@ import XCTest
 
 final class Comment_GraphCommentTests: XCTestCase {
   func test() {
-    func test() {
-      let comment = Comment.comment(from: .template)
-
-      XCTAssertEqual(comment.id, "VXNlci0yMDU3OTc4MTQ2")
-      XCTAssertEqual(
-        comment.body,
-        "I hope you guys all remembered to write in Bat Boy/Bigfoot on your ballots! Bat Boy 2020!!"
-      )
-      XCTAssertEqual(comment.replyCount, 4)
-      XCTAssertEqual(comment.author.id, "VXNlci0xOTE1MDY0NDY3")
-      XCTAssertEqual(comment.author.name, "Author McGee")
-      XCTAssertEqual(comment.author.isCreator, false)
-    }
+    let comment = Comment.comment(from: .template)
+    
+    XCTAssertEqual(comment.id, "VXNlci0yMDU3OTc4MTQ2")
+    XCTAssertEqual(
+      comment.body,
+      "I hope you guys all remembered to write in Bat Boy/Bigfoot on your ballots! Bat Boy 2020!!"
+    )
+    XCTAssertEqual(comment.replyCount, 4)
+    XCTAssertEqual(comment.author.id, "VXNlci0xOTE1MDY0NDY3")
+    XCTAssertEqual(comment.author.name, "Author McGee")
+    XCTAssertEqual(comment.author.isCreator, false)
   }
 }

--- a/KsApi/models/graphql/adapters/Comment+GraphCommentTests.swift
+++ b/KsApi/models/graphql/adapters/Comment+GraphCommentTests.swift
@@ -1,0 +1,20 @@
+@testable import KsApi
+import XCTest
+
+final class Comment_GraphCommentTests: XCTestCase {
+  func test() {
+    func test() {
+      let comment = Comment.comment(from: .template)
+
+      XCTAssertEqual(comment.id, "VXNlci0yMDU3OTc4MTQ2")
+      XCTAssertEqual(
+        comment.body,
+        "I hope you guys all remembered to write in Bat Boy/Bigfoot on your ballots! Bat Boy 2020!!"
+      )
+      XCTAssertEqual(comment.replyCount, 4)
+      XCTAssertEqual(comment.author.id, "VXNlci0xOTE1MDY0NDY3")
+      XCTAssertEqual(comment.author.name, "Author McGee")
+      XCTAssertEqual(comment.author.isCreator, false)
+    }
+  }
+}

--- a/KsApi/models/graphql/adapters/CommentsEnvelope+GraphCommentsEnvelope.swift
+++ b/KsApi/models/graphql/adapters/CommentsEnvelope+GraphCommentsEnvelope.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+extension CommentsEnvelope {
+  /**
+   Returns a minimal `CommentsEnvelope` from a `GraphCommentsEnvelope`
+   */
+  static func commentsEnvelope(from graphCommentsEnvelope: GraphCommentsEnvelope) -> CommentsEnvelope {
+    return CommentsEnvelope(
+      comments: graphCommentsEnvelope.comments.map(Comment.comment(from:)),
+      cursor: graphCommentsEnvelope.cursor,
+      hasNextPage: graphCommentsEnvelope.hasNextPage,
+      totalCount: graphCommentsEnvelope.totalCount
+    )
+  }
+}

--- a/KsApi/models/graphql/adapters/CommentsEnvelope+GraphCommentsEnvelopeTests.swift
+++ b/KsApi/models/graphql/adapters/CommentsEnvelope+GraphCommentsEnvelopeTests.swift
@@ -1,0 +1,16 @@
+@testable import KsApi
+import XCTest
+
+final class CommentsEnvelope_GraphCommentsEnvelopeTests: XCTestCase {
+  func test() {
+    let envelope = CommentsEnvelope.commentsEnvelope(from: .template)
+
+    XCTAssertEqual(
+      envelope.comments,
+      [Comment.comment(from: .template), Comment.comment(from: .template), Comment.comment(from: .template)]
+    )
+    XCTAssertEqual(envelope.hasNextPage, true)
+    XCTAssertEqual(envelope.cursor, "WzMwNDkwNDY0XQ==")
+    XCTAssertEqual(envelope.totalCount, 100)
+  }
+}

--- a/KsApi/models/templates/graphql/GraphCommentTemplates.swift
+++ b/KsApi/models/templates/graphql/GraphCommentTemplates.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+extension GraphComment {
+  static let template = GraphComment(
+    author: GraphAuthor(
+      id: "VXNlci0xOTE1MDY0NDY3",
+      isCreator: false,
+      name: "Author McGee"
+    ),
+    body: "I hope you guys all remembered to write in Bat Boy/Bigfoot on your ballots! Bat Boy 2020!!",
+    id: "VXNlci0yMDU3OTc4MTQ2",
+    replyCount: 4
+  )
+}

--- a/KsApi/models/templates/graphql/GraphCommentsEnvelopeTemplates.swift
+++ b/KsApi/models/templates/graphql/GraphCommentsEnvelopeTemplates.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+extension GraphCommentsEnvelope {
+  static let template = GraphCommentsEnvelope(
+    comments: [.template, .template, .template],
+    cursor: "WzMwNDkwNDY0XQ==",
+    hasNextPage: true,
+    totalCount: 100
+  )
+}

--- a/KsApi/queries/CommentsQueries.swift
+++ b/KsApi/queries/CommentsQueries.swift
@@ -1,0 +1,29 @@
+import Foundation
+import Prelude
+
+public func comments(
+  withProjectSlug slug: String,
+  first: Int = Query.defaultPaginationCount,
+  after cursor: String?
+) -> NonEmptySet<Query> {
+  let args = Set([cursor.flatMap(QueryArg<Never>.after), .first(first)].compact())
+
+  return Query.project(
+    slug: slug,
+    .id +| [
+      .comments(
+        args,
+        .edges(
+          .node(GraphComment.baseQueryProperties) +| []
+        ) +| [
+          .pageInfo(
+            .endCursor +| [
+              .hasNextPage
+            ]
+          ),
+          .totalCount
+        ]
+      )
+    ]
+  ) +| []
+}

--- a/KsApi/queries/CommentsQueries.swift
+++ b/KsApi/queries/CommentsQueries.swift
@@ -4,7 +4,7 @@ import Prelude
 public func comments(
   withProjectSlug slug: String,
   first: Int = Query.defaultPaginationCount,
-  after cursor: String?
+  after cursor: String? = nil
 ) -> NonEmptySet<Query> {
   let args = Set([cursor.flatMap(QueryArg<Never>.after), .first(first)].compact())
 

--- a/KsApi/queries/CommentsQueriesTests.swift
+++ b/KsApi/queries/CommentsQueriesTests.swift
@@ -1,0 +1,15 @@
+@testable import KsApi
+import XCTest
+
+final class CommentsQueriesTests: XCTestCase {
+  func testCommentsQuery() {
+    let queryString = Query.build(comments(withProjectSlug: "project-slug", after: "end-cursor"))
+
+    XCTAssertEqual(
+      queryString,
+      """
+      { project(slug: "project-slug") { comments(after: "end-cursor" first: 25) { edges { node { author { id isCreator name } body id replies { totalCount } } } pageInfo { endCursor hasNextPage } totalCount } id } }
+      """
+    )
+  }
+}

--- a/Library/ViewModels/CommentsViewModel.swift
+++ b/Library/ViewModels/CommentsViewModel.swift
@@ -21,10 +21,12 @@ public final class CommentsViewModel: CommentsViewModelType,
   public init() {
     // FIXME: Configure this VM with a project in order to feed the slug in here to fetch comments
     // Call this again with a cursor to paginate.
-    _ = self.viewDidLoadProperty.signal.map {
-      AppEnvironment.current.apiService.fetchComments(query: comments(withProjectSlug: ""))
+    self.viewDidLoadProperty.signal.switchMap { _ in
+      return AppEnvironment.current.apiService.fetchComments(query: comments(withProjectSlug: "bring-back-weekly-world-news"))
         .ksr_delay(AppEnvironment.current.apiDelayInterval, on: AppEnvironment.current.scheduler)
+        .materialize()
     }
+    .observeValues { print($0) }
   }
 
   fileprivate let viewDidLoadProperty = MutableProperty(())

--- a/Library/ViewModels/CommentsViewModel.swift
+++ b/Library/ViewModels/CommentsViewModel.swift
@@ -18,7 +18,14 @@ public protocol CommentsViewModelType {
 public final class CommentsViewModel: CommentsViewModelType,
   CommentsViewModelInputs,
   CommentsViewModelOutputs {
-  public init() {}
+  public init() {
+    // FIXME: Configure this VM with a project in order to feed the slug in here to fetch comments
+    // Call this again with a cursor to paginate.
+    _ = self.viewDidLoadProperty.signal.map {
+      AppEnvironment.current.apiService.fetchComments(query: comments(withProjectSlug: ""))
+        .ksr_delay(AppEnvironment.current.apiDelayInterval, on: AppEnvironment.current.scheduler)
+    }
+  }
 
   fileprivate let viewDidLoadProperty = MutableProperty(())
   public func viewDidLoad() {

--- a/Library/ViewModels/CommentsViewModel.swift
+++ b/Library/ViewModels/CommentsViewModel.swift
@@ -22,7 +22,8 @@ public final class CommentsViewModel: CommentsViewModelType,
     // FIXME: Configure this VM with a project in order to feed the slug in here to fetch comments
     // Call this again with a cursor to paginate.
     self.viewDidLoadProperty.signal.switchMap { _ in
-      return AppEnvironment.current.apiService.fetchComments(query: comments(withProjectSlug: "bring-back-weekly-world-news"))
+      AppEnvironment.current.apiService
+        .fetchComments(query: comments(withProjectSlug: "bring-back-weekly-world-news"))
         .ksr_delay(AppEnvironment.current.apiDelayInterval, on: AppEnvironment.current.scheduler)
         .materialize()
     }


### PR DESCRIPTION
# 📲 What

Adds new types for fetching comments from GraphQL along with code that adapts these types for presentation in the app.

**Note:** We intend to migrate to Apollo in the near future to get away from the complexity of adding new types like this.

# 🤔 Why

We're bringing threaded comments to the app and going forward all of our networking will be done via GraphQL instead of our legacy v1 REST API.

# 🛠 How

- Added new `CommentsEnvelope` and `Comment` types along with their corresponding GraphQL types for deserialization and adapter code to transform between these types.
- Added tests.
- Added entry points in our `ServiceType` for executing this query.

# ✅ Acceptance criteria

- [ ] For now this is just for code review, confirm that things make sense and test coverage is good enough.
- [ ] Test passing a slug into the query in `CommentsViewModel`, you should get results - It should be easier to access this VC once #1473 merges.
