### PR TITLE
[NT-1889] Add Domains For Universal Links From Emails

### DIFF
--- a/Kickstarter-iOS/Alpha.entitlements
+++ b/Kickstarter-iOS/Alpha.entitlements
@@ -15,6 +15,9 @@
       <string>applinks:emails.kickstarter.com</string>
       <string>applinks:e2.kickstarter.com</string>
       <string>applinks:e3.kickstarter.com</string>
+      <string>applinks:clicks.kickstarter.com</string>
+      <string>applinks:ea.kickstarter.com</string>
+      <string>applinks:me.kickstarter.com</string>
       <string>webcredentials:kickstarter.com</string>
     </array>
     <key>com.apple.developer.ubiquity-kvstore-identifier</key>

--- a/Kickstarter-iOS/Beta.entitlements
+++ b/Kickstarter-iOS/Beta.entitlements
@@ -15,6 +15,9 @@
       <string>applinks:emails.kickstarter.com</string>
       <string>applinks:e2.kickstarter.com</string>
       <string>applinks:e3.kickstarter.com</string>
+      <string>applinks:clicks.kickstarter.com</string>
+      <string>applinks:ea.kickstarter.com</string>
+      <string>applinks:me.kickstarter.com</string>
       <string>webcredentials:kickstarter.com</string>
     </array>
     <key>com.apple.developer.ubiquity-kvstore-identifier</key>

--- a/Kickstarter-iOS/Debug.entitlements
+++ b/Kickstarter-iOS/Debug.entitlements
@@ -1,33 +1,36 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
-	<key>aps-environment</key>
-	<string>development</string>
-	<key>com.apple.developer.applesignin</key>
-	<array>
-		<string>Default</string>
-	</array>
-	<key>com.apple.developer.associated-domains</key>
-	<array>
-		<string>applinks:staging.kickstarter.com</string>
-		<string>applinks:native.dev.kickstarter.com</string>
-		<string>applinks:www.kickstarter.com</string>
-		<string>applinks:click.e.kickstarter.com</string>
-		<string>applinks:click.em.kickstarter.com</string>
-		<string>applinks:email.kickstarter.com</string>
-		<string>applinks:emails.kickstarter.com</string>
-		<string>applinks:e2.kickstarter.com</string>
-		<string>applinks:e3.kickstarter.com</string>
-		<string>webcredentials:kickstarter.com</string>
-	</array>
-	<key>com.apple.developer.icloud-container-identifiers</key>
-	<array/>
-	<key>com.apple.developer.in-app-payments</key>
-	<array>
-		<string>merchant.com.kickstarter</string>
-	</array>
-	<key>com.apple.developer.ubiquity-kvstore-identifier</key>
-	<string>$(TeamIdentifierPrefix)$(CFBundleIdentifier)</string>
-</dict>
+  <dict>
+    <key>aps-environment</key>
+    <string>development</string>
+    <key>com.apple.developer.applesignin</key>
+    <array>
+      <string>Default</string>
+    </array>
+    <key>com.apple.developer.associated-domains</key>
+    <array>
+      <string>applinks:staging.kickstarter.com</string>
+      <string>applinks:native.dev.kickstarter.com</string>
+      <string>applinks:www.kickstarter.com</string>
+      <string>applinks:click.e.kickstarter.com</string>
+      <string>applinks:click.em.kickstarter.com</string>
+      <string>applinks:email.kickstarter.com</string>
+      <string>applinks:emails.kickstarter.com</string>
+      <string>applinks:e2.kickstarter.com</string>
+      <string>applinks:e3.kickstarter.com</string>
+      <string>applinks:clicks.kickstarter.com</string>
+      <string>applinks:ea.kickstarter.com</string>
+      <string>applinks:me.kickstarter.com</string>
+      <string>webcredentials:kickstarter.com</string>
+    </array>
+    <key>com.apple.developer.icloud-container-identifiers</key>
+    <array/>
+    <key>com.apple.developer.in-app-payments</key>
+    <array>
+      <string>merchant.com.kickstarter</string>
+    </array>
+    <key>com.apple.developer.ubiquity-kvstore-identifier</key>
+    <string>$(TeamIdentifierPrefix)$(CFBundleIdentifier)</string>
+  </dict>
 </plist>

--- a/Kickstarter-iOS/Release.entitlements
+++ b/Kickstarter-iOS/Release.entitlements
@@ -1,31 +1,34 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
-	<key>aps-environment</key>
-	<string>production</string>
-	<key>com.apple.developer.applesignin</key>
-	<array>
-		<string>Default</string>
-	</array>
-	<key>com.apple.developer.associated-domains</key>
-	<array>
-		<string>applinks:www.kickstarter.com</string>
-		<string>applinks:click.e.kickstarter.com</string>
-		<string>applinks:click.em.kickstarter.com</string>
-		<string>applinks:email.kickstarter.com</string>
-		<string>applinks:emails.kickstarter.com</string>
-		<string>applinks:e2.kickstarter.com</string>
-		<string>applinks:e3.kickstarter.com</string>
-		<string>webcredentials:kickstarter.com</string>
-	</array>
-	<key>com.apple.developer.icloud-container-identifiers</key>
-	<array/>
-	<key>com.apple.developer.in-app-payments</key>
-	<array>
-		<string>merchant.com.kickstarter</string>
-	</array>
-	<key>com.apple.developer.ubiquity-kvstore-identifier</key>
-	<string>$(TeamIdentifierPrefix)$(CFBundleIdentifier)</string>
-</dict>
+  <dict>
+    <key>aps-environment</key>
+    <string>production</string>
+    <key>com.apple.developer.applesignin</key>
+    <array>
+      <string>Default</string>
+    </array>
+    <key>com.apple.developer.associated-domains</key>
+    <array>
+      <string>applinks:www.kickstarter.com</string>
+      <string>applinks:click.e.kickstarter.com</string>
+      <string>applinks:click.em.kickstarter.com</string>
+      <string>applinks:email.kickstarter.com</string>
+      <string>applinks:emails.kickstarter.com</string>
+      <string>applinks:e2.kickstarter.com</string>
+      <string>applinks:e3.kickstarter.com</string>
+      <string>applinks:clicks.kickstarter.com</string>
+      <string>applinks:ea.kickstarter.com</string>
+      <string>applinks:me.kickstarter.com</string>
+      <string>webcredentials:kickstarter.com</string>
+    </array>
+    <key>com.apple.developer.icloud-container-identifiers</key>
+    <array/>
+    <key>com.apple.developer.in-app-payments</key>
+    <array>
+      <string>merchant.com.kickstarter</string>
+    </array>
+    <key>com.apple.developer.ubiquity-kvstore-identifier</key>
+    <string>$(TeamIdentifierPrefix)$(CFBundleIdentifier)</string>
+  </dict>
 </plist>

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -6402,7 +6402,6 @@
 				8AA407CE24DB5316008C5FB0 /* GraphCategoryTemplates.swift in Sources */,
 				D01588A91EEB2ED7006E7684 /* Project.PersonalizationLenses.swift in Sources */,
 				D015888B1EEB2ED7006E7684 /* DeprecatedCommentLenses.swift in Sources */,
-				D015888B1EEB2ED7006E7684 /* DeprecatedCommentLenses.swift in Sources */,
 				8A1F65E6262660CB00A28E74 /* PerimeterXClient.swift in Sources */,
 				D0158A281EEB30A2006E7684 /* StarEnvelopeTemplates.swift in Sources */,
 				D0158A221EEB30A2006E7684 /* ProjectStatsEnvelopeTemplates.swift in Sources */,

--- a/Library/Navigation.swift
+++ b/Library/Navigation.swift
@@ -494,6 +494,9 @@ private func settingsNotifications(_ params: RouteParamsDecoded) -> Navigation? 
 
 private func parsedParams(url: URL, fromTemplate template: String) -> RouteParamsDecoded? {
   let recognizedEmailHosts = [
+    "me.kickstarter.com",
+    "ea.kickstarter.com",
+    "clicks.kickstarter.com",
     "click.e.kickstarter.com",
     "click.em.kickstarter.com",
     "emails.kickstarter.com",

--- a/Library/NavigationTests.swift
+++ b/Library/NavigationTests.swift
@@ -230,6 +230,11 @@ public final class NavigationTests: XCTestCase {
 
     XCTAssertEqual(
       .emailClick,
+      Navigation.match(URL(string: "https://click.e.kickstarter.com/wf/click?upn=deadbeef")!)
+    )
+
+    XCTAssertEqual(
+      .emailClick,
       Navigation.match(URL(string: "https://clicks.kickstarter.com/wf/click?upn=deadbeef")!)
     )
 

--- a/Library/NavigationTests.swift
+++ b/Library/NavigationTests.swift
@@ -220,6 +220,21 @@ public final class NavigationTests: XCTestCase {
 
     XCTAssertEqual(
       .emailClick,
+      Navigation.match(URL(string: "https://me.kickstarter.com/wf/click?upn=deadbeef")!)
+    )
+
+    XCTAssertEqual(
+      .emailClick,
+      Navigation.match(URL(string: "https://ea.kickstarter.com/wf/click?upn=deadbeef")!)
+    )
+
+    XCTAssertEqual(
+      .emailClick,
+      Navigation.match(URL(string: "https://clicks.kickstarter.com/wf/click?upn=deadbeef")!)
+    )
+
+    XCTAssertEqual(
+      .emailClick,
       Navigation.match(URL(string: "https://click.em.kickstarter.com/wf/click?upn=deadbeef")!)
     )
 


### PR DESCRIPTION
# 📲 What

Adds new domains that we will use for universal links in emails.

**Note:** Blocked until the domains are correctly configured.

# 🤔 Why

We're using these new domains when sending emails from Braze.

# 🛠 How

Added the 3 new domains to our entitlements and `Navigation.swift` and updated tests.

# ✅ Acceptance criteria

Once these domains have been configured with the `apple-app-site-association` file then we should be able to tap links in emails that have any of the following domains.

- [ ] `ea.kickstarter.com`
- [ ] `me.kickstarter.com`
- [ ] `clicks.kickstarter.com`