### PR TITLE
[NT-1966] Fixing empty state cell Storyboard identifier

### DIFF
--- a/Kickstarter-iOS/Views/Storyboards/DeprecatedComments.storyboard
+++ b/Kickstarter-iOS/Views/Storyboards/DeprecatedComments.storyboard
@@ -171,7 +171,7 @@
                                     <outlet property="youView" destination="3ET-R2-24I" id="ExL-bE-Za6"/>
                                 </connections>
                             </tableViewCell>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="CommentsEmptyStateCell" id="AgR-zW-Trc" customClass="DeprecatedCommentsEmptyStateCell" customModule="Kickstarter_Framework" customModuleProvider="target">
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="DeprecatedCommentsEmptyStateCell" id="AgR-zW-Trc" customClass="DeprecatedCommentsEmptyStateCell" customModule="Kickstarter_Framework" customModuleProvider="target">
                                 <rect key="frame" x="0.0" y="268" width="450" height="198"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="AgR-zW-Trc" id="GhZ-I8-Uys">


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

While deprecating our old `Comment` namespace there were some old Storyboard identifiers that were not automatically updated with Xcodes renaming tool. This is leading to an unfortunate crash on launch of the empty state of our comments.

# 🤔 Why

It appears the rename tool will only rename file, class and struct names/references. Storyboard identifiers need to be manually updated.


# ✅ Acceptance criteria

- [ ] While logged out, go to a projects comment section that has 0 comments. Verify no crash.
- [ ] While logged in, go to a projects comment section that has 0 comments. Verify no crash.