### PR TITLE
[NT-1981] Post PX Notification On Main Thread

### DIFF
--- a/Kickstarter-iOS/AppDelegate.swift
+++ b/Kickstarter-iOS/AppDelegate.swift
@@ -294,8 +294,7 @@ internal final class AppDelegate: UIResponder, UIApplicationDelegate {
         object: nil,
         queue: nil
       ) { [weak self] note in
-        guard let response = note.object as? PerimeterXBlockResponseType else { return }
-        self?.viewModel.inputs.perimeterXCaptchaTriggered(response: response)
+        self?.viewModel.inputs.perimeterXCaptchaTriggeredWithUserInfo(note.userInfo)
       }
 
     self.window?.tintColor = .ksr_create_700

--- a/Kickstarter-iOS/ViewModels/AppDelegateViewModel.swift
+++ b/Kickstarter-iOS/ViewModels/AppDelegateViewModel.swift
@@ -80,7 +80,7 @@ public protocol AppDelegateViewModelInputs {
   func optimizelyClientConfigurationFailed()
 
   /// Call when Perimeter X Captcha is triggered
-  func perimeterXCaptchaTriggered(response: PerimeterXBlockResponseType)
+  func perimeterXCaptchaTriggeredWithUserInfo(_ userInfo: [AnyHashable: Any]?)
 
   /// Call when the contextual PushNotification dialog should be presented.
   func showNotificationDialog(notification: Notification)
@@ -677,7 +677,12 @@ public final class AppDelegateViewModel: AppDelegateViewModelType, AppDelegateVi
       .skipNil()
       .map { $0.hasError }
 
-    self.goToPerimeterXCaptcha = self.perimeterXCaptchaTriggeredProperty.signal.skipNil()
+    self.goToPerimeterXCaptcha = self.perimeterXCaptchaTriggeredWithUserInfoProperty.signal.skipNil()
+      .map { userInfo -> PerimeterXBlockResponseType? in
+        guard let response = userInfo["response"] as? PerimeterXBlockResponseType else { return nil }
+        return response
+      }
+      .skipNil()
 
     self.configureSegment = self.applicationLaunchOptionsProperty.signal
       .skipNil()
@@ -835,9 +840,9 @@ public final class AppDelegateViewModel: AppDelegateViewModelType, AppDelegateVi
     self.optimizelyClientConfigurationFailedProperty.value = ()
   }
 
-  private let perimeterXCaptchaTriggeredProperty = MutableProperty<PerimeterXBlockResponseType?>(nil)
-  public func perimeterXCaptchaTriggered(response: PerimeterXBlockResponseType) {
-    self.perimeterXCaptchaTriggeredProperty.value = response
+  private let perimeterXCaptchaTriggeredWithUserInfoProperty = MutableProperty<[AnyHashable: Any]?>(nil)
+  public func perimeterXCaptchaTriggeredWithUserInfo(_ userInfo: [AnyHashable: Any]?) {
+    self.perimeterXCaptchaTriggeredWithUserInfoProperty.value = userInfo
   }
 
   public let applicationIconBadgeNumber: Signal<Int, Never>

--- a/Kickstarter-iOS/ViewModels/AppDelegateViewModelTests.swift
+++ b/Kickstarter-iOS/ViewModels/AppDelegateViewModelTests.swift
@@ -2471,7 +2471,7 @@ final class AppDelegateViewModelTests: TestCase {
 
     let response = MockPerimeterXBlockResponse(blockType: .Captcha)
 
-    self.vm.inputs.perimeterXCaptchaTriggered(response: response)
+    self.vm.inputs.perimeterXCaptchaTriggeredWithUserInfo(["response": response])
 
     self.goToPerimeterXCaptcha.assertValueCount(1)
     XCTAssertEqual(self.goToPerimeterXCaptcha.values.last?.type, .Captcha)
@@ -2482,7 +2482,7 @@ final class AppDelegateViewModelTests: TestCase {
 
     let response = MockPerimeterXBlockResponse(blockType: .Block)
 
-    self.vm.inputs.perimeterXCaptchaTriggered(response: response)
+    self.vm.inputs.perimeterXCaptchaTriggeredWithUserInfo(["response": response])
 
     self.goToPerimeterXCaptcha.assertValueCount(1)
     XCTAssertEqual(self.goToPerimeterXCaptcha.values.last?.type, .Block)

--- a/KsApi/px/PerimeterXClient.swift
+++ b/KsApi/px/PerimeterXClient.swift
@@ -44,7 +44,13 @@ public class PerimeterXClient: NSObject, PerimeterXClientType {
       [.Block, .Captcha].contains(response.type)
     else { return false }
 
-    NotificationCenter.default.post(name: Notification.Name.ksr_perimeterXCaptcha, object: response)
+    DispatchQueue.main.async {
+      NotificationCenter.default.post(
+        name: Notification.Name.ksr_perimeterXCaptcha,
+        object: nil,
+        userInfo: ["response": response]
+      )
+    }
 
     return true
   }

--- a/KsApi/px/PerimeterXClientTests.swift
+++ b/KsApi/px/PerimeterXClientTests.swift
@@ -50,20 +50,13 @@ final class PerimeterXClientTests: XCTestCase {
       return
     }
 
-    var notification: Notification?
+    XCTAssertTrue(client.handleError(response: response, and: data!))
 
-    let token = NotificationCenter.default.addObserver(
-      forName: Notification.Name.ksr_perimeterXCaptcha,
-      object: nil,
-      queue: nil
-    ) { note in
-      notification = note
+    expectation(forNotification: Notification.Name.ksr_perimeterXCaptcha, object: nil) { note in
+      Thread.isMainThread && (note.userInfo?["response"] as? PerimeterXBlockResponseType)?.type == .Captcha
     }
 
-    XCTAssertTrue(client.handleError(response: response, and: data!))
-    XCTAssertNotNil(notification)
-
-    NotificationCenter.default.removeObserver(token)
+    waitForExpectations(timeout: 0.01, handler: nil)
   }
 
   func testHandleError_StatusCode_403_Block() {
@@ -82,20 +75,13 @@ final class PerimeterXClientTests: XCTestCase {
       return
     }
 
-    var notification: Notification?
+    XCTAssertTrue(client.handleError(response: response, and: data!))
 
-    let token = NotificationCenter.default.addObserver(
-      forName: Notification.Name.ksr_perimeterXCaptcha,
-      object: nil,
-      queue: nil
-    ) { note in
-      notification = note
+    expectation(forNotification: Notification.Name.ksr_perimeterXCaptcha, object: nil) { note in
+      Thread.isMainThread && (note.userInfo?["response"] as? PerimeterXBlockResponseType)?.type == .Block
     }
 
-    XCTAssertTrue(client.handleError(response: response, and: data!))
-    XCTAssertNotNil(notification)
-
-    NotificationCenter.default.removeObserver(token)
+    waitForExpectations(timeout: 0.01, handler: nil)
   }
 
   func testHandleError_StatusCode_200() {


### PR DESCRIPTION
# 📲 What

Ensures that the notification that triggers the PerimeterX dialogue is always posted on the main thread.

# 🤔 Why

In #1427 we made some changes which triggers the PerimeterX Captcha using a `Notification` rather than reaching out directly to the app's `Window` for display purposes. It's possible that this wasn't implemented quite correctly and may be causing some intermittent crashes due to the response object being passed across threads.

# 🛠 How

Ensure that the notification is always posted and handled on the main thread.

# ✅ Acceptance criteria

- [ ] Navigate to PerimeterX's developer console and ensure that the captcha flow still works as before.