### PR TITLE
[NT-2020] Update Paginate Function To Emit Errors

### DIFF
--- a/Library/ViewModels/SearchViewModel.swift
+++ b/Library/ViewModels/SearchViewModel.swift
@@ -146,7 +146,11 @@ public final class SearchViewModel: SearchViewModelType, SearchViewModelInputs, 
       valuesFromEnvelope: { [SearchPageData(projects: $0.projects, statsCount: $0.stats.count)] },
       cursorFromEnvelope: { $0.urls.api.moreProjects },
       requestFromParams: requestFromParamsWithDebounce,
-      requestFromCursor: { AppEnvironment.current.apiService.fetchDiscovery(paginationUrl: $0) }
+      requestFromCursor: { AppEnvironment.current.apiService.fetchDiscovery(paginationUrl: $0) },
+      concater: { (accum, data) -> [SearchPageData] in
+        let currentProjects = !accum.isEmpty ? accum[0].projects : []
+        return [SearchPageData(projects: currentProjects + data[0].projects, statsCount: data[0].statsCount)]
+      }
     )
 
     let paginatedProjects = paginatedValues.map { $0[0].projects }

--- a/Library/ViewModels/SearchViewModelTests.swift
+++ b/Library/ViewModels/SearchViewModelTests.swift
@@ -684,7 +684,7 @@ internal final class SearchViewModelTests: TestCase {
 
         self.scrollToProjectRow.assertValues([5, 6, 7, 8])
 
-        self.hasAddedProjects.assertValues([true, false, true], "Paginated projects are loaded.")
+        self.hasAddedProjects.assertValues([true, false, true, true], "Paginated projects are loaded.")
 
         self.vm.inputs.transitionedToProject(at: 7, outOf: playlist2.count)
 

--- a/Library/ViewModels/SearchViewModelTests.swift
+++ b/Library/ViewModels/SearchViewModelTests.swift
@@ -684,7 +684,7 @@ internal final class SearchViewModelTests: TestCase {
 
         self.scrollToProjectRow.assertValues([5, 6, 7, 8])
 
-        self.hasAddedProjects.assertValues([true, false, true, true], "Paginated projects are loaded.")
+        self.hasAddedProjects.assertValues([true, false, true], "Paginated projects are loaded.")
 
         self.vm.inputs.transitionedToProject(at: 7, outOf: playlist2.count)
 


### PR DESCRIPTION
# 📲 What

Updates our pagination function to emit errors in anticipation of needing this for handling paging errors for comments.

**Note:** This just modifies the `paginate` function, we will make use of this in an upcoming PR for comments paging.

# 🤔 Why

We have historically not done any error handling for pagination and we've decided to bring this improvement to threaded comments.

# 🛠 How

Modified `paginate` to return an additional `Signal` that can emit an `Error` without causing the existing value signal to error.

# ✅ Acceptance criteria

- [ ] No regressions on existing behaviour (tests pass).
- [x] New functionality and tests that were added make sense.
