### PR TITLE
[NT-2007] Update Comment State Delays

### DIFF
--- a/Library/ViewModels/CommentsViewModelTests.swift
+++ b/Library/ViewModels/CommentsViewModelTests.swift
@@ -668,7 +668,7 @@ internal final class CommentsViewModelTests: TestCase {
           "Comment is replaced with one with a retrying status."
         )
 
-        self.scheduler.advance()
+        self.scheduler.advance(by: .seconds(1))
 
         let expectedRetryingSuccessComment = expectedFailedComment
           |> \.body .~ bodyText
@@ -677,10 +677,10 @@ internal final class CommentsViewModelTests: TestCase {
         XCTAssertEqual(
           self.loadCommentsAndProjectIntoDataSourceComments.values.last?.first,
           expectedRetryingSuccessComment,
-          "Comment is replaced with one with a retrySuccess status."
+          "Comment is replaced with one with a retrySuccess status after elapsed time."
         )
 
-        self.scheduler.advance(by: .seconds(1))
+        self.scheduler.advance(by: .seconds(3))
 
         XCTAssertEqual(
           self.loadCommentsAndProjectIntoDataSourceComments.values.last?.first,
@@ -760,7 +760,7 @@ internal final class CommentsViewModelTests: TestCase {
           "Comment is replaced with one with a retrying status."
         )
 
-        self.scheduler.advance()
+        self.scheduler.advance(by: .seconds(1))
 
         XCTAssertEqual(
           self.loadCommentsAndProjectIntoDataSourceComments.values.last?.first,


### PR DESCRIPTION
# 📲 What

Updates the delays for emitting comments in `retrying`, `retrySuccess` and `successful` states during retrying. This will be implemented in a separate PR by @moderateepheezy.

# 🤔 Why

We want to delay these transitions in order to show the visual indicator to users.

# 🛠 How

Updated the delay values and related tests.

# ✅ Acceptance criteria

- [ ] Delays are correct.