### PR TITLE
[NT-2033] Allow Concurrent Retrying/Posting Of Comments

### DIFF
--- a/Library/ViewModels/CommentComposerViewModel.swift
+++ b/Library/ViewModels/CommentComposerViewModel.swift
@@ -22,7 +22,7 @@ public protocol CommentComposerViewModelInputs {
   /// Call when the input textview of the composer should be reset.
   func resetInput()
 
-  /// Call in  `textView(_:shouldChangeTextIn:replacementText:)` UITextView delegate method.
+  /// Call in `textView(_:shouldChangeTextIn:replacementText:)` `UITextViewDelegate` method.
   func textViewShouldChange(text: String?, in range: NSRange, replacementText: String) -> Bool
 }
 

--- a/Library/ViewModels/CommentsViewModel.swift
+++ b/Library/ViewModels/CommentsViewModel.swift
@@ -3,7 +3,7 @@ import Prelude
 import ReactiveExtensions
 import ReactiveSwift
 
-private let concurrentCommentLimit: UInt = 3
+private let concurrentCommentLimit: UInt = 5
 
 public protocol CommentsViewModelInputs {
   /// Call when the User is posting a comment or reply.

--- a/Library/ViewModels/CommentsViewModel.swift
+++ b/Library/ViewModels/CommentsViewModel.swift
@@ -3,6 +3,8 @@ import Prelude
 import ReactiveExtensions
 import ReactiveSwift
 
+private let concurrentCommentLimit: UInt = 3
+
 public protocol CommentsViewModelInputs {
   /// Call when the User is posting a comment or reply.
   func commentComposerDidSubmitText(_ text: String)
@@ -177,12 +179,7 @@ public final class CommentsViewModel: CommentsViewModelType,
       .map(unpack)
       .map(commentsReplacingCommentById)
 
-    self.resetCommentComposerAndScrollToTop = commentsWithFailableOrComment
-      // We only want to scroll to top for failable comments as they represent the initial
-      // comment that's inserted. We check here to see that the first comment's ID is a UUID
-      // to determine this. There may be better ways.
-      .map { UUID(uuidString: $0.first?.id ?? "") }
-      .filter(isNotNil)
+    self.resetCommentComposerAndScrollToTop = self.commentComposerDidSubmitTextProperty.signal.skipNil()
       .ignoreValues()
 
     let paginatedComments = Signal.merge(
@@ -235,12 +232,26 @@ public final class CommentsViewModel: CommentsViewModelType,
     )
     .takePairWhen(commentComposerDidSubmitText)
     .map(unpack)
-    .flatMap(postCommentProducer)
+    .flatMap(.concurrent(limit: concurrentCommentLimit), postCommentProducer)
+
+    let currentlyRetrying = MutableProperty<Set<String>>([])
+
+    let newErroredCommentTapped = erroredCommentTapped
+      // Check that we are not currently retrying this comment.
+      .filter { [currentlyRetrying] comment in !currentlyRetrying.value.contains(comment.id) }
+      // If we pass the filter add it to our set of retrying comments.
+      .on(value: { [currentlyRetrying] comment in
+        currentlyRetrying.value.insert(comment.id)
+      })
 
     self.retryingComment <~ initialProject
-      .takePairWhen(erroredCommentTapped)
+      .takePairWhen(newErroredCommentTapped)
       .map { ($1, $0) }
-      .flatMap(retryCommentProducer)
+      .flatMap(.concurrent(limit: concurrentCommentLimit), retryCommentProducer)
+      // Once we've emitted a value here the comment has been retried and can be removed.
+      .on(value: { [currentlyRetrying] _, id in
+        currentlyRetrying.value.remove(id)
+      })
 
     let footerViewActivityState = Signal
       .combineLatest(isCloseToBottom, isLoading)

--- a/Library/ViewModels/CommentsViewModelTests.swift
+++ b/Library/ViewModels/CommentsViewModelTests.swift
@@ -671,6 +671,11 @@ internal final class CommentsViewModelTests: TestCase {
         // Tap on the failed comment to retry
         self.vm.inputs.didSelectComment(expectedFailedComment)
 
+        // Tapping repeatedly is ignored (in the case where retries may be in flight).
+        self.vm.inputs.didSelectComment(expectedFailedComment)
+        self.vm.inputs.didSelectComment(expectedFailedComment)
+        self.vm.inputs.didSelectComment(expectedFailedComment)
+
         let expectedRetryingComment = expectedFailedComment
           |> \.status .~ .retrying
 


### PR DESCRIPTION
# 📲 What

Allows us to retry and post comments in a non-blocking manner (up to a reasonable limit).

# 🤔 Why

We found that if we were attempting to retry multiple comments at once, newer retries wouldn't start until older ones had completed. Also, tapping cells repeatedly while blocked in this way would result in duplicate comments being created due to post being called multiple times once the thread was unblocked.

# 🛠 How

- Changed to a `.concurrent` `flatMap` strategy allowing us to specify an amount of concurrent operations to run on the queue. 
  - I've set this to `3` which seemed like a reasonable amount to me but we could consider a higher number if necessary.
- Also added some duplication filtering to prevent against retrying the same comment while its request is already in flight.

# 👀 See

https://user-images.githubusercontent.com/3735375/121602939-e53f3b00-c9fc-11eb-9247-af8c19ee18f2.mp4

# ✅ Acceptance criteria

- [ ] Create several errored comments, tap them in quick succession. The UI should not block requests up to the limit set and each comment should transition through the necessary states.
- [ ] Try to post multiple times as quickly as possible, the dialogue should not block and you should not find yourself tapping post multiple times to post duplicate comments.