### PR TITLE
[NT-2046] Allow multiple identify calls for logged in users

### DIFF
--- a/Library/AppEnvironment.swift
+++ b/Library/AppEnvironment.swift
@@ -64,8 +64,6 @@ public struct AppEnvironment: AppEnvironmentType {
   }
 
   public static func updateConfig(_ config: Config) {
-    AppEnvironment.current.userDefaults.analyticsIdentityData = nil
-
     let debugConfigOrConfig = self.current.debugData?.config ?? config
     
     self.replaceCurrentEnvironment(
@@ -83,8 +81,6 @@ public struct AppEnvironment: AppEnvironmentType {
   public static func logout() {
     let storage = AppEnvironment.current.cookieStorage
     storage.cookies?.forEach(storage.deleteCookie)
-
-    AppEnvironment.current.userDefaults.analyticsIdentityData = nil
 
     self.replaceCurrentEnvironment(
       apiService: AppEnvironment.current.apiService.logout(),

--- a/Library/AppEnvironment.swift
+++ b/Library/AppEnvironment.swift
@@ -64,8 +64,10 @@ public struct AppEnvironment: AppEnvironmentType {
   }
 
   public static func updateConfig(_ config: Config) {
-    let debugConfigOrConfig = self.current.debugData?.config ?? config
+    AppEnvironment.current.userDefaults.analyticsIdentityData = nil
 
+    let debugConfigOrConfig = self.current.debugData?.config ?? config
+    
     self.replaceCurrentEnvironment(
       config: debugConfigOrConfig,
       countryCode: debugConfigOrConfig.countryCode,

--- a/Library/AppEnvironment.swift
+++ b/Library/AppEnvironment.swift
@@ -65,7 +65,7 @@ public struct AppEnvironment: AppEnvironmentType {
 
   public static func updateConfig(_ config: Config) {
     let debugConfigOrConfig = self.current.debugData?.config ?? config
-    
+
     self.replaceCurrentEnvironment(
       config: debugConfigOrConfig,
       countryCode: debugConfigOrConfig.countryCode,

--- a/Library/AppEnvironmentTests.swift
+++ b/Library/AppEnvironmentTests.swift
@@ -58,26 +58,21 @@ final class AppEnvironmentTests: XCTestCase {
 
     XCTAssertNil(AppEnvironment.current.apiService.oauthToken)
     XCTAssertNil(AppEnvironment.current.currentUser)
-    XCTAssertNil(AppEnvironment.current.userDefaults.analyticsIdentityData)
 
     AppEnvironment.login(AccessTokenEnvelope(accessToken: "deadbeef", user: User.template))
-    AppEnvironment.current.userDefaults.analyticsIdentityData = KSRAnalyticsIdentityData(.template)
 
     XCTAssertEqual("deadbeef", AppEnvironment.current.apiService.oauthToken?.token)
     XCTAssertEqual(User.template, AppEnvironment.current.currentUser)
-    XCTAssertNotNil(AppEnvironment.current.userDefaults.analyticsIdentityData)
 
     AppEnvironment.updateCurrentUser(User.template)
 
     XCTAssertEqual("deadbeef", AppEnvironment.current.apiService.oauthToken?.token)
     XCTAssertEqual(User.template, AppEnvironment.current.currentUser)
-    XCTAssertNotNil(AppEnvironment.current.userDefaults.analyticsIdentityData)
 
     AppEnvironment.logout()
 
     XCTAssertNil(AppEnvironment.current.apiService.oauthToken)
     XCTAssertNil(AppEnvironment.current.currentUser)
-    XCTAssertNil(AppEnvironment.current.userDefaults.analyticsIdentityData)
 
     AppEnvironment.popEnvironment()
   }

--- a/Library/KeyValueStoreType.swift
+++ b/Library/KeyValueStoreType.swift
@@ -2,7 +2,6 @@ import Foundation
 
 public enum AppKeys: String {
   // swiftformat:disable wrap
-  case analyticsIdentityData = "com.kickstarter.KeyValueStoreType.analyticsIdentityData"
   case closedFacebookConnectInActivity = "com.kickstarter.KeyValueStoreType.closedFacebookConnectInActivity"
   case closedFindFriendsInActivity = "com.kickstarter.KeyValueStoreType.closedFindFriendsInActivity"
   case deniedNotificationContexts = "com.kickstarter.KeyValueStoreType.deniedNotificationContexts"
@@ -34,7 +33,6 @@ public protocol KeyValueStoreType: AnyObject {
   func synchronize() -> Bool
 
   func removeObject(forKey defaultName: String)
-  var analyticsIdentityData: KSRAnalyticsIdentityData? { get set }
   var deniedNotificationContexts: [String] { get set }
   var favoriteCategoryIds: [Int] { get set }
   var hasClosedFacebookConnectInActivity: Bool { get set }
@@ -52,17 +50,6 @@ public protocol KeyValueStoreType: AnyObject {
 }
 
 extension KeyValueStoreType {
-  public var analyticsIdentityData: KSRAnalyticsIdentityData? {
-    get {
-      guard let data = self.data(forKey: AppKeys.analyticsIdentityData.rawValue) else { return nil }
-      return try? JSONDecoder().decode(KSRAnalyticsIdentityData.self, from: data)
-    }
-    set {
-      let data = try? JSONEncoder().encode(newValue)
-      self.set(data, forKey: AppKeys.analyticsIdentityData.rawValue)
-    }
-  }
-
   public var favoriteCategoryIds: [Int] {
     get {
       return self.object(forKey: AppKeys.favoriteCategoryIds.rawValue) as? [Int] ?? []

--- a/Library/Tracking/KSRAnalytics.swift
+++ b/Library/Tracking/KSRAnalytics.swift
@@ -9,8 +9,8 @@ public final class KSRAnalytics {
   internal private(set) var config: Config?
   private let device: UIDeviceType
   internal private(set) var loggedInUser: User? {
-    didSet {
-      self.identify(self.loggedInUser)
+    willSet {
+      self.identify(oldUser: loggedInUser, newUser: newValue)
     }
   }
 
@@ -533,24 +533,19 @@ public final class KSRAnalytics {
   }
 
   /// Configure Tracking Client's supporting user identity
-  private func identify(_ user: User?) {
-    guard let user = user else {
+  private func identify(oldUser: User?, newUser: User?) {
+    guard let newUser = newUser else {
       self.segmentClient?.reset()
       return
     }
 
-    let previousIdentityData = AppEnvironment.current.userDefaults.analyticsIdentityData
+    guard newUser != oldUser else { return }
 
-    let newData = KSRAnalyticsIdentityData(user)
-
-    guard newData != previousIdentityData else { return }
-
+    let newData = KSRAnalyticsIdentityData(newUser)
     self.segmentClient?.identify(
       "\(newData.userId)",
       traits: newData.allTraits
     )
-
-    AppEnvironment.current.userDefaults.analyticsIdentityData = newData
   }
 
   // MARK: - Activity

--- a/Library/Tracking/KSRAnalytics.swift
+++ b/Library/Tracking/KSRAnalytics.swift
@@ -10,7 +10,7 @@ public final class KSRAnalytics {
   private let device: UIDeviceType
   internal private(set) var loggedInUser: User? {
     willSet {
-      self.identify(oldUser: loggedInUser, newUser: newValue)
+      self.identify(oldUser: self.loggedInUser, newUser: newValue)
     }
   }
 
@@ -538,7 +538,7 @@ public final class KSRAnalytics {
       self.segmentClient?.reset()
       return
     }
-    
+
     let newData = KSRAnalyticsIdentityData(newUser)
     if let oldUser = oldUser, newData == KSRAnalyticsIdentityData(oldUser) {
       return

--- a/Library/Tracking/KSRAnalytics.swift
+++ b/Library/Tracking/KSRAnalytics.swift
@@ -538,10 +538,12 @@ public final class KSRAnalytics {
       self.segmentClient?.reset()
       return
     }
-
-    guard newUser != oldUser else { return }
-
+    
     let newData = KSRAnalyticsIdentityData(newUser)
+    if let oldUser = oldUser, newData == KSRAnalyticsIdentityData(oldUser) {
+      return
+    }
+
     self.segmentClient?.identify(
       "\(newData.userId)",
       traits: newData.allTraits

--- a/Library/Tracking/KSRAnalyticsTests.swift
+++ b/Library/Tracking/KSRAnalyticsTests.swift
@@ -1565,6 +1565,25 @@ final class KSRAnalyticsTests: TestCase {
     }
   }
 
+  func testIdentifyingTrackingClient_RepeatsIfAnalyticsIdentityDataChanges() {
+    let user = User.template
+      |> User.lens.notifications.follower .~ false
+    let updatedUser = user
+      |> User.lens.notifications.follower .~ true
+
+    withEnvironment {
+      AppEnvironment.updateCurrentUser(user)
+
+      self.segmentTrackingClient.userId = nil
+      self.segmentTrackingClient.traits = nil
+
+      AppEnvironment.updateCurrentUser(updatedUser)
+
+      XCTAssertNotNil(self.segmentTrackingClient.userId)
+      XCTAssertNotNil(self.segmentTrackingClient.traits)
+    }
+  }
+
   func testIdentifyingTrackingClient_RepeatAllIfAnyChanges() {
     let mockKeyValueStore = MockKeyValueStore()
 

--- a/Library/Tracking/KSRAnalyticsTests.swift
+++ b/Library/Tracking/KSRAnalyticsTests.swift
@@ -1550,7 +1550,7 @@ final class KSRAnalyticsTests: TestCase {
       XCTAssertEqual(self.segmentTrackingClient.traits?["name"] as? String, user.name)
     }
   }
-  
+
   func testIdentifyingTrackingClient_DoesNotRepeatAfterInitialUserSet() {
     let user = User.template
 

--- a/Library/Tracking/KSRAnalyticsTests.swift
+++ b/Library/Tracking/KSRAnalyticsTests.swift
@@ -1547,8 +1547,6 @@ final class KSRAnalyticsTests: TestCase {
 
     let data = KSRAnalyticsIdentityData(user)
 
-    mockKeyValueStore.analyticsIdentityData = data
-
     withEnvironment(userDefaults: mockKeyValueStore) {
       AppEnvironment.updateCurrentUser(user)
 
@@ -1565,8 +1563,6 @@ final class KSRAnalyticsTests: TestCase {
       |> User.lens.notifications.messages .~ true
 
     let data = KSRAnalyticsIdentityData(user)
-
-    mockKeyValueStore.analyticsIdentityData = data
 
     withEnvironment(userDefaults: mockKeyValueStore) {
       let updatedUser = User.template

--- a/Library/Tracking/KSRAnalyticsTests.swift
+++ b/Library/Tracking/KSRAnalyticsTests.swift
@@ -1540,14 +1540,24 @@ final class KSRAnalyticsTests: TestCase {
     XCTAssertNil(self.segmentTrackingClient.traits)
   }
 
-  func testIdentifyingTrackingClient_DoesNotRepeat() {
-    let mockKeyValueStore = MockKeyValueStore()
-
+  func testIdentifyingTrackingClient_OnInitialUserSet() {
     let user = User.template
 
-    let data = KSRAnalyticsIdentityData(user)
+    withEnvironment {
+      AppEnvironment.updateCurrentUser(user)
 
-    withEnvironment(userDefaults: mockKeyValueStore) {
+      XCTAssertEqual(self.segmentTrackingClient.userId, "\(1)")
+      XCTAssertEqual(self.segmentTrackingClient.traits?["name"] as? String, user.name)
+    }
+  }
+  
+  func testIdentifyingTrackingClient_DoesNotRepeatAfterInitialUserSet() {
+    let user = User.template
+
+    withEnvironment {
+      AppEnvironment.updateCurrentUser(user)
+      self.segmentTrackingClient.userId = nil
+      self.segmentTrackingClient.traits = nil
       AppEnvironment.updateCurrentUser(user)
 
       XCTAssertNil(self.segmentTrackingClient.userId)
@@ -1561,8 +1571,6 @@ final class KSRAnalyticsTests: TestCase {
     let user = User.template
       |> User.lens.notifications.mobileUpdates .~ true
       |> User.lens.notifications.messages .~ true
-
-    let data = KSRAnalyticsIdentityData(user)
 
     withEnvironment(userDefaults: mockKeyValueStore) {
       let updatedUser = User.template


### PR DESCRIPTION
# 📲 What

We noticed that when opening the app when the user is logged in, the app does not identify the user. This is due to the app identifying the user while the segment feature is disabled. We store the identify data even if the identify calls fail due to the feature flag disabling the integration. When the feature flag is then enabled, the app does not identify users because it had values stored in user defaults when in reality it has never identified the user. 

After syncing with Paulo, we've decided to allow multiple identify calls if we can be sure that the user is identified when the app opens. 

# 🛠 How

The stored analytics identify data is removed in favor of comparing old and new user values. This will force the app to identify on app open since the old user value is nil and the new user value is the stored user. 

[NT-2046](https://kickstarter.atlassian.net/browse/NT-2046)