### PR TITLE
[NT-2006][NT-2013] Update Carthage Bootstrap to use XCFrameworks

### DIFF
--- a/bin/carthage.sh
+++ b/bin/carthage.sh
@@ -31,6 +31,6 @@ elif ! cmp -s Cartfile.resolved Carthage/Cartfile.resolved; then
   # Related: https://discuss.circleci.com/t/homebrew-stopped-to-download-openssl-1-1/39828
   HOMEBREW_BOTTLE_DOMAIN=https://ghcr.io/v2/Homebrew/core brew upgrade carthage
   echo "Resolving dependencies"
-  carthage bootstrap --platform iOS
+  carthage bootstrap --xc-frameworks --platform iOS
   cp Cartfile.resolved Carthage
 fi

--- a/bin/carthage.sh
+++ b/bin/carthage.sh
@@ -31,6 +31,6 @@ elif ! cmp -s Cartfile.resolved Carthage/Cartfile.resolved; then
   # Related: https://discuss.circleci.com/t/homebrew-stopped-to-download-openssl-1-1/39828
   HOMEBREW_BOTTLE_DOMAIN=https://ghcr.io/v2/Homebrew/core brew upgrade carthage
   echo "Resolving dependencies"
-  carthage bootstrap --xc-frameworks --platform iOS
+  carthage bootstrap --use-xcframeworks --platform iOS
   cp Cartfile.resolved Carthage
 fi


### PR DESCRIPTION
In order to avoid this error on [the xc-frameworks pr](https://github.com/kickstarter/ios-oss/pull/1520)
which is a CI failure, we need to add this flag to the ci before running the tests.
<img src="https://user-images.githubusercontent.com/4282741/122847302-6cca5b00-d2d5-11eb-8dcf-8d6b27028f45.png" width="300">

