### PR TITLE
[NT-2070] UX – Comment cell shouldn't be tappable

### DIFF
--- a/Kickstarter-iOS/Views/Controllers/CommentsViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/CommentsViewController.swift
@@ -179,9 +179,8 @@ internal final class CommentsViewController: UITableViewController {
 
 extension CommentsViewController {
   override func tableView(_: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
-    if let commentRemovedCell = cell as? CommentRemovedCell {
-      commentRemovedCell.delegate = self
-    }
+    (cell as? CommentCell)?.delegate = self
+    (cell as? CommentRemovedCell)?.delegate = self
 
     self.viewModel.inputs.willDisplayRow(
       self.dataSource.itemIndexAt(indexPath),
@@ -209,6 +208,14 @@ extension CommentsViewController: CommentComposerViewDelegate {
 extension CommentsViewController: CommentTableViewFooterViewDelegate {
   func commentTableViewFooterViewDidTapRetry(_: CommentTableViewFooterView) {
     self.viewModel.inputs.commentTableViewFooterViewDidTapRetry()
+  }
+}
+
+// MARK: - CommentCellDelegate
+
+extension CommentsViewController: CommentCellDelegate {
+  func commentCellDidTapViewReplies(_: CommentCell, comment: Comment) {
+    self.viewModel.inputs.commentCellDidTapViewReplies(comment)
   }
 }
 

--- a/Library/ViewModels/CommentCellViewModel.swift
+++ b/Library/ViewModels/CommentCellViewModel.swift
@@ -11,6 +11,9 @@ public protocol CommentCellViewModelInputs {
 
   /// Call when the textView delegate method for shouldInteractWith url is called
   func linkTapped(url: URL)
+
+  /// Call when the view replies button  is tapped
+  func viewRepliesButtonTapped()
 }
 
 public protocol CommentCellViewModelOutputs {
@@ -46,6 +49,9 @@ public protocol CommentCellViewModelOutputs {
 
   /// Emits a Bool determining if the reply button in the bottomRowStackView are hidden.
   var replyButtonIsHidden: Signal<Bool, Never> { get }
+
+  /// Emits current `Comment` view replies button is clicked for
+  var viewCommentReplies: Signal<Comment, Never> { get }
 
   /// Emits whether or not the view replies stack view is hidden.
   var viewRepliesViewHidden: Signal<Bool, Never> { get }
@@ -129,6 +135,8 @@ public final class CommentCellViewModel:
     // If there are no replies or if the feature flag returns false, hide the stack view.
     self.viewRepliesViewHidden = comment.map(\.replyCount)
       .map(viewRepliesStackViewHidden)
+
+    self.viewCommentReplies = comment.takeWhen(self.viewRepliesButtonTappedProperty.signal)
   }
 
   private var bindStylesProperty = MutableProperty(())
@@ -146,6 +154,11 @@ public final class CommentCellViewModel:
     self.linkTappedProperty.value = url
   }
 
+  fileprivate let viewRepliesButtonTappedProperty = MutableProperty(())
+  public func viewRepliesButtonTapped() {
+    self.viewRepliesButtonTappedProperty.value = ()
+  }
+
   public let authorBadge: Signal<Comment.AuthorBadge, Never>
   public var authorImageURL: Signal<URL, Never>
   public let authorName: Signal<String, Never>
@@ -157,6 +170,7 @@ public final class CommentCellViewModel:
   public let postTime: Signal<String, Never>
   public let postedButtonIsHidden: Signal<Bool, Never>
   public let replyButtonIsHidden: Signal<Bool, Never>
+  public let viewCommentReplies: Signal<Comment, Never>
   public let viewRepliesViewHidden: Signal<Bool, Never>
 
   public var inputs: CommentCellViewModelInputs { self }

--- a/Library/ViewModels/CommentCellViewModel.swift
+++ b/Library/ViewModels/CommentCellViewModel.swift
@@ -12,7 +12,7 @@ public protocol CommentCellViewModelInputs {
   /// Call when the textView delegate method for shouldInteractWith url is called
   func linkTapped(url: URL)
 
-  /// Call when the view replies button  is tapped
+  /// Call when the view replies button is tapped
   func viewRepliesButtonTapped()
 }
 
@@ -50,7 +50,7 @@ public protocol CommentCellViewModelOutputs {
   /// Emits a Bool determining if the reply button in the bottomRowStackView are hidden.
   var replyButtonIsHidden: Signal<Bool, Never> { get }
 
-  /// Emits current `Comment` view replies button is clicked for
+  /// Emits a `Comment` for the cell that view replies button is clicked for.
   var viewCommentReplies: Signal<Comment, Never> { get }
 
   /// Emits whether or not the view replies stack view is hidden.

--- a/Library/ViewModels/CommentCellViewModelTests.swift
+++ b/Library/ViewModels/CommentCellViewModelTests.swift
@@ -291,7 +291,8 @@ internal final class CommentCellViewModelTests: TestCase {
 
       self.vm.inputs.viewRepliesButtonTapped()
 
-      self.viewCommentReplies.assertValue(comment, "The comment user want to view replies for was emmited")
+      self.viewCommentReplies
+        .assertValue(comment, "A Comment was emitted after the view replies button was tapped.")
     }
   }
 

--- a/Library/ViewModels/CommentCellViewModelTests.swift
+++ b/Library/ViewModels/CommentCellViewModelTests.swift
@@ -19,6 +19,7 @@ internal final class CommentCellViewModelTests: TestCase {
   private let postTime = TestObserver<String, Never>()
   private let postedButtonIsHidden = TestObserver<Bool, Never>()
   private let replyButtonIsHidden = TestObserver<Bool, Never>()
+  private let viewCommentReplies = TestObserver<Comment, Never>()
   private let viewRepliesStackViewIsHidden = TestObserver<Bool, Never>()
 
   override func setUp() {
@@ -34,6 +35,7 @@ internal final class CommentCellViewModelTests: TestCase {
     self.vm.outputs.postTime.observe(self.postTime.observer)
     self.vm.outputs.postedButtonIsHidden.observe(self.postedButtonIsHidden.observer)
     self.vm.outputs.replyButtonIsHidden.observe(self.replyButtonIsHidden.observer)
+    self.vm.outputs.viewCommentReplies.observe(self.viewCommentReplies.observer)
     self.vm.outputs.viewRepliesViewHidden.observe(self.viewRepliesStackViewIsHidden.observer)
   }
 
@@ -279,6 +281,18 @@ internal final class CommentCellViewModelTests: TestCase {
     self.body.assertValues([comment.body], "The comment body is emitted.")
     self.postTime.assertValueCount(1, "The relative time of the comment is emitted.")
     self.replyButtonIsHidden.assertValue(true, "User is not logged in.")
+  }
+
+  func testOutput_ViewCommentReplies() {
+    let comment = Comment.template
+    withEnvironment(currentUser: .template) {
+      self.vm.inputs.configureWith(comment: comment, project: .template)
+      self.viewCommentReplies.assertDidNotEmitValue()
+
+      self.vm.inputs.viewRepliesButtonTapped()
+
+      self.viewCommentReplies.assertValue(comment, "The comment user want to view replies for was emmited")
+    }
   }
 
   func testPersonalizedLabels_UserIs_Creator_Author() {

--- a/Library/ViewModels/CommentsViewModel.swift
+++ b/Library/ViewModels/CommentsViewModel.swift
@@ -6,6 +6,9 @@ import ReactiveSwift
 private let concurrentCommentLimit: UInt = 5
 
 public protocol CommentsViewModelInputs {
+  /// Call when the delegate method for the CommentCellDelegate is called.
+  func commentCellDidTapViewReplies(_ comment: Comment)
+
   /// Call when the User is posting a comment or reply.
   func commentComposerDidSubmitText(_ text: String)
 
@@ -205,13 +208,11 @@ public final class CommentsViewModel: CommentsViewModelType,
     self.beginOrEndRefreshing = isLoading
     self.cellSeparatorHidden = commentsAndProject.map(first).map { $0.count == .zero }
 
-    let commentTapped = self.viewRepliesProperty.signal.skipNil()
-    let regularCommentTapped = commentTapped.filter { comment in
-      [comment.status == .success, comment.isDeleted == false].allSatisfy(isTrue)
-    }
-    let erroredCommentTapped = commentTapped.filter { comment in comment.status == .failed }
+    let commentCellTapped = self.didSelectCommentProperty.signal.skipNil()
+    let erroredCommentTapped = commentCellTapped.filter { comment in comment.status == .failed }
 
-    self.goToCommentReplies = regularCommentTapped
+    self.goToCommentReplies = self.commentCellDidTapViewRepliesProperty.signal
+      .skipNil()
       .filter { comment in comment.replyCount > 0 }
 
     let commentComposerDidSubmitText = self.commentComposerDidSubmitTextProperty.signal.skipNil()
@@ -290,9 +291,14 @@ public final class CommentsViewModel: CommentsViewModelType,
   private let retryingComment = MutableProperty<(Comment, String)?>(nil)
   private let failableOrComment = MutableProperty<(Comment, String)?>(nil)
 
-  private let viewRepliesProperty = MutableProperty<Comment?>(nil)
+  private let commentCellDidTapViewRepliesProperty = MutableProperty<Comment?>(nil)
+  public func commentCellDidTapViewReplies(_ comment: Comment) {
+    self.commentCellDidTapViewRepliesProperty.value = comment
+  }
+
+  private let didSelectCommentProperty = MutableProperty<Comment?>(nil)
   public func didSelectComment(_ comment: Comment) {
-    self.viewRepliesProperty.value = comment
+    self.didSelectCommentProperty.value = comment
   }
 
   fileprivate let commentComposerDidSubmitTextProperty = MutableProperty<String?>(nil)

--- a/Library/ViewModels/CommentsViewModelTests.swift
+++ b/Library/ViewModels/CommentsViewModelTests.swift
@@ -174,7 +174,7 @@ internal final class CommentsViewModelTests: TestCase {
 
     self.goToCommentRepliesComment.assertDidNotEmitValue()
 
-    self.vm.inputs.didSelectComment(comment)
+    self.vm.inputs.commentCellDidTapViewReplies(comment)
 
     self.goToCommentRepliesComment
       .assertValues([comment])


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Fix a bug where tapping the comment cell goes to a comment thread.

# 🤔 Why

Only the View replies and Reply buttons should allow a user to navigate to a thread – not tapping anywhere on the comment cell

# 👀 See
![CommentUpdate](https://user-images.githubusercontent.com/4386218/123283247-21958f80-d503-11eb-9d96-7420437355c4.gif)

# ✅ Acceptance criteria

- [x] Confirm tapping the Comment cell doesn't go to comment thread.
- [x] When a post comment fails, confirm tapping the cell retries the post.