### PR TITLE
[NT-1936] GraphQL - Post a reply

### DIFF
--- a/KsApi/mutations/PostCommentMutationTests.swift
+++ b/KsApi/mutations/PostCommentMutationTests.swift
@@ -2,11 +2,49 @@
 import XCTest
 
 final class PostCommentMutationTests: XCTestCase {
-  func testMutationProperties() {
+  func testPostRootCommentMutationProperties() {
     let input = PostCommentInput(body: "Hello World", commentableId: "a89SFHAs89hf=")
     let mutation = PostCommentMutation(input: input)
 
     XCTAssertNil(mutation.input.parentId)
+    XCTAssertEqual(mutation.input.body, "Hello World")
+    XCTAssertEqual(mutation.input.commentableId, "a89SFHAs89hf=")
+    XCTAssertEqual(
+      mutation.description,
+      """
+      mutation ($input: PostCommentInput!) {
+        createComment(input: $input) {
+          comment {
+            author {
+              id
+              imageUrl(width: 200)
+              isCreator
+              name
+            }
+            authorBadges
+            body
+            createdAt
+            deleted
+            id
+            replies {
+              totalCount
+            }
+          }
+        }
+      }
+      """
+    )
+  }
+
+  func testPostReplyMutationProperties() {
+    let input = PostCommentInput(
+      body: "Hello World",
+      commentableId: "a89SFHAs89hf=",
+      parentId: "o85hUTAXz670p="
+    )
+    let mutation = PostCommentMutation(input: input)
+
+    XCTAssertEqual(mutation.input.parentId, "o85hUTAXz670p=")
     XCTAssertEqual(mutation.input.body, "Hello World")
     XCTAssertEqual(mutation.input.commentableId, "a89SFHAs89hf=")
     XCTAssertEqual(

--- a/KsApi/mutations/inputs/PostCommentInputTests.swift
+++ b/KsApi/mutations/inputs/PostCommentInputTests.swift
@@ -2,7 +2,17 @@
 import XCTest
 
 final class PostCommentInputTests: XCTestCase {
-  func testInput() {
+  func testInputPostComment_Root() {
+    let input = PostCommentInput(body: "Hello World", commentableId: "A8S9DU98asdaQsaf6s=")
+
+    let inputDictionary = input.toInputDictionary()
+
+    XCTAssertEqual(inputDictionary["body"] as? String, "Hello World")
+    XCTAssertEqual(inputDictionary["commentableId"] as? String, "A8S9DU98asdaQsaf6s=")
+    XCTAssertNil(inputDictionary["parentId"] as? String)
+  }
+
+  func testInputPostComment_Reply() {
     let input = PostCommentInput(
       body: "Hello World",
       commentableId: "A8S9DU98asdaQsaf6s=",
@@ -14,14 +24,5 @@ final class PostCommentInputTests: XCTestCase {
     XCTAssertEqual(inputDictionary["body"] as? String, "Hello World")
     XCTAssertEqual(inputDictionary["commentableId"] as? String, "A8S9DU98asdaQsaf6s=")
     XCTAssertEqual(inputDictionary["parentId"] as? String, "a980SDH9a7gdADASD==")
-  }
-
-  func testInput_ParentID_nil() {
-    let input = PostCommentInput(body: "Hello World", commentableId: "A8S9DU98asdaQsaf6s=")
-    let inputDictionary = input.toInputDictionary()
-
-    XCTAssertEqual(inputDictionary["body"] as? String, "Hello World")
-    XCTAssertEqual(inputDictionary["commentableId"] as? String, "A8S9DU98asdaQsaf6s=")
-    XCTAssertNil(inputDictionary["parentId"] as? String)
   }
 }


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Add test for `PostCommentMutation` when replying a comment.

# 🤔 Why

Some background context on why the change is needed.

# ✅ Acceptance criteria

- [ ] Code relating to post comment mutation for reply are setup and tested.
