### PR TITLE
[NT-2034] UI – Reply button not showing for creators/collaborators

### DIFF
--- a/Library/ViewModels/CommentCellViewModel.swift
+++ b/Library/ViewModels/CommentCellViewModel.swift
@@ -117,15 +117,15 @@ public final class CommentCellViewModel:
       .map { _ in AppEnvironment.current.currentUser }
       .map(isNil)
 
-    let isNotABacker = self.commentAndProject.signal
+    let isNotABackerCreatorOrCollaborator = self.commentAndProject.signal
       .skipNil()
       .map { _, project in project }
       .skipNil()
-      .map(userIsBackingProject)
+      .map(userIsBackingCreatorOrCollaborator)
       .negate()
 
     // If the user is either logged out, not backing or the flag is disabled, hide replyButton.
-    self.replyButtonIsHidden = Signal.combineLatest(isLoggedOut, isNotABacker)
+    self.replyButtonIsHidden = Signal.combineLatest(isLoggedOut, isNotABackerCreatorOrCollaborator)
       .map(replyButtonHidden)
 
     // If both the replyButton and flagButton should be hidden, the entire stackview will be hidden too.
@@ -190,9 +190,14 @@ public final class CommentCellViewModel:
   public var outputs: CommentCellViewModelOutputs { self }
 }
 
-private func replyButtonHidden(isLoggedOut: Bool, isNotABacker: Bool) -> Bool {
+private func userIsBackingCreatorOrCollaborator(_ project: Project) -> Bool {
+  return (project.personalization.backing != nil || project.personalization.isBacking == .some(true)) ||
+    !project.memberData.permissions.isEmpty
+}
+
+private func replyButtonHidden(isLoggedOut: Bool, isNotABackerCreatorOrCollaborator: Bool) -> Bool {
   guard featureCommentThreadingRepliesIsEnabled() else { return true }
-  return isLoggedOut || isNotABacker
+  return isLoggedOut || isNotABackerCreatorOrCollaborator
 }
 
 private func viewRepliesStackViewHidden(_ replyCount: Int) -> Bool {

--- a/Library/ViewModels/CommentCellViewModelTests.swift
+++ b/Library/ViewModels/CommentCellViewModelTests.swift
@@ -213,7 +213,7 @@ internal final class CommentCellViewModelTests: TestCase {
     }
   }
 
-  func testOutputs_replyButtonIsHidden_FeatureFlag_True_IsCreatorOrCollaborator_False() {
+  func testOutputs_replyButtonIsHidden_FeatureFlag_True_IsNotBacker_IsNotCreatorOrCollaborator_False() {
     let user = User.template |> \.id .~ 12_345
 
     let project = Project.template

--- a/Library/ViewModels/CommentCellViewModelTests.swift
+++ b/Library/ViewModels/CommentCellViewModelTests.swift
@@ -213,6 +213,40 @@ internal final class CommentCellViewModelTests: TestCase {
     }
   }
 
+  func testOutputs_replyButtonIsHidden_FeatureFlag_True_IsCreatorOrCollaborator_False() {
+    let user = User.template |> \.id .~ 12_345
+
+    let project = Project.template
+      |> \.memberData.permissions .~ [.post, .comment]
+
+    let mockOptimizelyClient = MockOptimizelyClient()
+      |> \.features .~ [OptimizelyFeature.commentThreadingRepliesEnabled.rawValue: true]
+
+    withEnvironment(currentUser: user, optimizelyClient: mockOptimizelyClient) {
+      self.vm.inputs.configureWith(comment: .template, project: project)
+
+      self.replyButtonIsHidden
+        .assertValue(false, "The replyButton is not hidden because the user is a creator collaborator.")
+    }
+  }
+
+  func testOutputs_replyButtonIsHidden_FeatureFlag_True_IsNotBacker_IsNotCreatorOrCollaborator_True() {
+    let user = User.template |> \.id .~ 12_345
+
+    let mockOptimizelyClient = MockOptimizelyClient()
+      |> \.features .~ [OptimizelyFeature.commentThreadingRepliesEnabled.rawValue: true]
+
+    withEnvironment(currentUser: user, optimizelyClient: mockOptimizelyClient) {
+      self.vm.inputs.configureWith(comment: .template, project: .template)
+
+      self.replyButtonIsHidden
+        .assertValue(
+          true,
+          "The replyButton is hidden because the user is not backing, and not a creator or collaborator."
+        )
+    }
+  }
+
   func testOutputs_replyButtonIsHidden_viewRepliesStackViewIsHidden_IsBacker_True_IsLoggedIn_FeatureFlag_True() {
     let mockOptimizelyClient = MockOptimizelyClient()
       |> \.features .~ [OptimizelyFeature.commentThreadingRepliesEnabled.rawValue: true]


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Reply button not showing on comments the user is the creator or a collaborator of the project.

# 🤔 Why

* Creators and Collaborators should be able to reply to comments on their projects even if they are not backing. Currently that's not happening as the reply button is hidden for creators and collaborators until they back.

# 👀 See

Trello, screenshots, external resources?

| Before 🐛 | After 🦋 |
| --- | --- |
| <img width="560" src="https://user-images.githubusercontent.com/4386218/123863346-65343300-d921-11eb-9307-41128bc39002.png"> | <img width="560" src="https://user-images.githubusercontent.com/4386218/123863493-93b20e00-d921-11eb-9ae9-2c48f21434ce.png"> |

# ✅ Acceptance criteria

- [ ] Steps to test this feature

    1. Log in with paulomcg@icloud.com / KSR2021
    2.  Go to the dashboard tab
    3. View THE project
    4. Go to comments
    5. Reply button should show because the user is a collaborator.

- [ ] Projects where user is not logged in, not a backing or  not a creator/collaborator should not have reply button.
