### PR TITLE
[NT-2042] UI – Handle URLs in comments

### DIFF
--- a/Kickstarter-iOS/Views/Controllers/CommentsViewControllerTests.swift
+++ b/Kickstarter-iOS/Views/Controllers/CommentsViewControllerTests.swift
@@ -25,7 +25,7 @@ internal final class CommentsViewControllerTests: TestCase {
     combos(Language.allLanguages, [Device.phone4_7inch, Device.pad]).forEach {
       language, _ in
       withEnvironment(apiService: mockService, currentUser: .template, language: language) {
-        let controller = CommentsViewController.configuredWith(project: Project.template)
+        let controller = CommentsViewController.configuredWith(project: .template)
 
         let (parent, _) = traitControllers(
           device: .phone4_7inch,

--- a/Library/Styles/CommentCellStyles.swift
+++ b/Library/Styles/CommentCellStyles.swift
@@ -22,7 +22,9 @@ public let commentBodyTextViewStyle: TextViewStyle = { textView in
     |> \.font .~ UIFont.ksr_callout()
     |> \.adjustsFontForContentSizeCategory .~ true
     |> \.isEditable .~ false
-    |> \.isUserInteractionEnabled .~ false
+    |> \.isSelectable .~ true
+    |> \.isUserInteractionEnabled .~ true
+    |> \.dataDetectorTypes .~ .link
 }
 
 public let creatorAuthorBadgeStyle: PaddingLabelStyle = { label in


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

This PR introduces a decoration around links in a comment, and also enables links to be tappable. 

# 🤔 Why

Currently, links in a comment are not tappable and they appear like regular text. We want a new UX where links in comments are decorated and users can tap the link and be redirected to a web browser.

# 🛠 How

Added the following modifiers to `commentBodyTextViewStyle`

 ```
    |> \.isEditable .~ false
    |> \.isSelectable .~ true
    |> \.isUserInteractionEnabled .~ true
    |> \.dataDetectorTypes .~ .link
```

# 👀 See

![TappableLink](https://user-images.githubusercontent.com/4386218/124037256-2bcdf700-d9f7-11eb-8492-72fda611ab37.gif)


# ✅ Acceptance criteria

- [x] Comments with links should be decorated and tappable.

Test with https://staging.kickstarter.com/projects/re-uprefills/help-us-build-a-community-low-waste-refill-shop-in-oakland
