### PR TITLE
[NT-2094] Fix Root Comments Regressions

### DIFF
--- a/KsApi/extensions/ApolloClient+RAC.swift
+++ b/KsApi/extensions/ApolloClient+RAC.swift
@@ -12,7 +12,7 @@ extension ApolloClient {
    */
   public func fetch<Query: GraphQLQuery>(query: Query) -> SignalProducer<Query.Data, ErrorEnvelope> {
     SignalProducer { observer, _ in
-      self.fetch(query: query) { result in
+      self.fetch(query: query, cachePolicy: .fetchIgnoringCacheCompletely) { result in
         switch result {
         case let .success(response):
           guard let data = response.data else {

--- a/KsApi/extensions/ApolloClient+Singleton.swift
+++ b/KsApi/extensions/ApolloClient+Singleton.swift
@@ -27,7 +27,7 @@ class GraphQL {
     headers: [String: String],
     additionalHeaders: @escaping () -> [String: String]
   ) {
-    let store = ApolloStore(cache: InMemoryNormalizedCache())
+    let store = ApolloStore()
     let provider = NetworkInterceptorProvider(store: store, additionalHeaders: additionalHeaders)
     let transport = RequestChainNetworkTransport(
       interceptorProvider: provider,

--- a/KsApi/models/graphql/adapters/Comment+GraphComment.swift
+++ b/KsApi/models/graphql/adapters/Comment+GraphComment.swift
@@ -29,6 +29,7 @@ extension Comment {
   static func comment(from commentFragment: CommentFragment) -> Comment? {
     guard
       let authorId = commentFragment.author?.id,
+      let decomposedAuthorId = decompose(id: authorId),
       let authorImageUrl = commentFragment.author?.imageUrl,
       let authorName = commentFragment.author?.name
     else { return nil }
@@ -39,7 +40,7 @@ extension Comment {
 
     return Comment(
       author: Author(
-        id: authorId,
+        id: "\(decomposedAuthorId)",
         imageUrl: authorImageUrl,
         isCreator: commentFragment.author?.isCreator ?? false,
         name: authorName


### PR DESCRIPTION
# 📲 What

Fixes two regressions introduced in #1538:

- Pull-to-refresh was clearing posted comments.
- Comments weren't showing the correct author badge.

# 🤔 Why

- The Apollo client uses in-memory caching by default, when we pulled to refresh it was not making a new request to the back-end to fetch the first page again but instead reading from cache.
- In our initial implementation at the point of deserialization we were decomposing the author ID, this needed to also happen for the new `CommentFragment`.

# 🛠 How

- Disabled all caching on Apollo requests for now until we decide how we want to use this.
- Added decomposition for the author ID.

# ✅ Acceptance criteria

- [x] Post a root comment, pull to refresh, the comment should not be cleared.
- [x] All `You` author badges should be shown correctly.