### PR TITLE
[NT-2072] Update Manage Pledge View To Use Apollo Query

### DIFF
--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -598,6 +598,13 @@
 		8AC3E00C26961E8A00168BF8 /* Reward+RewardFragmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AC3E00B26961E8A00168BF8 /* Reward+RewardFragmentTests.swift */; };
 		8AC3E017269626A400168BF8 /* Location+LocationFragment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AC3E016269626A400168BF8 /* Location+LocationFragment.swift */; };
 		8AC3E01F2696368B00168BF8 /* Location+LocationFragmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AC3E01E2696368A00168BF8 /* Location+LocationFragmentTests.swift */; };
+		8AC3E03926977C0200168BF8 /* Project+ProjectFragment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AC3E03826977C0200168BF8 /* Project+ProjectFragment.swift */; };
+		8AC3E041269791C300168BF8 /* Project.Country+CountryFragment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AC3E040269791C300168BF8 /* Project.Country+CountryFragment.swift */; };
+		8AC3E046269791D400168BF8 /* Project.Category+CategoryFragment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AC3E045269791D400168BF8 /* Project.Category+CategoryFragment.swift */; };
+		8AC3E05126979F8600168BF8 /* Project+ProjectFragmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AC3E05026979F8600168BF8 /* Project+ProjectFragmentTests.swift */; };
+		8AC3E0592697ABD900168BF8 /* Project.Category+CategoryFragmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AC3E0582697ABD900168BF8 /* Project.Category+CategoryFragmentTests.swift */; };
+		8AC3E05E2697ABEF00168BF8 /* Project.Country+CountryFragmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AC3E05D2697ABEF00168BF8 /* Project.Country+CountryFragmentTests.swift */; };
+		8AC3E0662697AC0400168BF8 /* User+UserFragmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AC3E0652697AC0400168BF8 /* User+UserFragmentTests.swift */; };
 		8ACB32A824ABC2DB00A03968 /* RewardAddOnSelectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ACB32A724ABC2DB00A03968 /* RewardAddOnSelectionViewController.swift */; };
 		8ACD29F7243E48260044BC17 /* PledgePaymentMethodsDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ACD29F6243E48260044BC17 /* PledgePaymentMethodsDataSource.swift */; };
 		8ACF36D1262745520026E74D /* MockService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D01587761EEB2ED6006E7684 /* MockService.swift */; };
@@ -2216,6 +2223,13 @@
 		8AC3E00B26961E8A00168BF8 /* Reward+RewardFragmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Reward+RewardFragmentTests.swift"; sourceTree = "<group>"; };
 		8AC3E016269626A400168BF8 /* Location+LocationFragment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Location+LocationFragment.swift"; sourceTree = "<group>"; };
 		8AC3E01E2696368A00168BF8 /* Location+LocationFragmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Location+LocationFragmentTests.swift"; sourceTree = "<group>"; };
+		8AC3E03826977C0200168BF8 /* Project+ProjectFragment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Project+ProjectFragment.swift"; sourceTree = "<group>"; };
+		8AC3E040269791C300168BF8 /* Project.Country+CountryFragment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Project.Country+CountryFragment.swift"; sourceTree = "<group>"; };
+		8AC3E045269791D400168BF8 /* Project.Category+CategoryFragment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Project.Category+CategoryFragment.swift"; sourceTree = "<group>"; };
+		8AC3E05026979F8600168BF8 /* Project+ProjectFragmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Project+ProjectFragmentTests.swift"; sourceTree = "<group>"; };
+		8AC3E0582697ABD900168BF8 /* Project.Category+CategoryFragmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Project.Category+CategoryFragmentTests.swift"; sourceTree = "<group>"; };
+		8AC3E05D2697ABEF00168BF8 /* Project.Country+CountryFragmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Project.Country+CountryFragmentTests.swift"; sourceTree = "<group>"; };
+		8AC3E0652697AC0400168BF8 /* User+UserFragmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "User+UserFragmentTests.swift"; sourceTree = "<group>"; };
 		8ACB32A724ABC2DB00A03968 /* RewardAddOnSelectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RewardAddOnSelectionViewController.swift; sourceTree = "<group>"; };
 		8ACD29F6243E48260044BC17 /* PledgePaymentMethodsDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PledgePaymentMethodsDataSource.swift; sourceTree = "<group>"; };
 		8ACF36E92627486D0026E74D /* KsApiNotification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KsApiNotification.swift; sourceTree = "<group>"; };
@@ -3466,10 +3480,16 @@
 				8AA407CB24DB49CE008C5FB0 /* Location+GraphLocation.swift */,
 				8AC3E016269626A400168BF8 /* Location+LocationFragment.swift */,
 				8AC3E01E2696368A00168BF8 /* Location+LocationFragmentTests.swift */,
+				8AC3E045269791D400168BF8 /* Project.Category+CategoryFragment.swift */,
+				8AC3E0582697ABD900168BF8 /* Project.Category+CategoryFragmentTests.swift */,
 				8AA407C924DB453C008C5FB0 /* Project.Category+GraphCategory.swift */,
+				8AC3E040269791C300168BF8 /* Project.Country+CountryFragment.swift */,
+				8AC3E05D2697ABEF00168BF8 /* Project.Country+CountryFragmentTests.swift */,
 				8AA407C524DB36E8008C5FB0 /* Project.Country+GraphCountry.swift */,
 				8AE3F73024DA29FC002B03C3 /* Project+GraphProject.swift */,
 				8AE3F73224DA2A53002B03C3 /* Project+GraphProjectTests.swift */,
+				8AC3E03826977C0200168BF8 /* Project+ProjectFragment.swift */,
+				8AC3E05026979F8600168BF8 /* Project+ProjectFragmentTests.swift */,
 				8A49396424B54F9B00C3C3CE /* Reward+GraphReward.swift */,
 				8A49396624B68FA500C3C3CE /* Reward+GraphRewardTests.swift */,
 				8AC3E00626961E6400168BF8 /* Reward+RewardFragment.swift */,
@@ -3477,6 +3497,7 @@
 				8AA407C724DB4399008C5FB0 /* User+GraphUser.swift */,
 				8A67DDB324DCA41400B4AB10 /* User+GraphUserTests.swift */,
 				8A1557142693B28300017845 /* User+UserFragment.swift */,
+				8AC3E0652697AC0400168BF8 /* User+UserFragmentTests.swift */,
 			);
 			path = adapters;
 			sourceTree = "<group>";
@@ -6537,6 +6558,7 @@
 				D0158A251EEB30A2006E7684 /* RewardTemplates.swift in Sources */,
 				D0158A241EEB30A2006E7684 /* RewardsItemTemplates.swift in Sources */,
 				D0158A171EEB30A2006E7684 /* LocationTemplates.swift in Sources */,
+				8AC3E03926977C0200168BF8 /* Project+ProjectFragment.swift in Sources */,
 				D6AE52251FD1B3F600BEC788 /* RootCategoriesEnvelope.swift in Sources */,
 				D002CAE3218CF91D009783F2 /* WatchProjectInput.swift in Sources */,
 				D0158A2D1EEB30A2006E7684 /* UpdateTemplates.swift in Sources */,
@@ -6635,6 +6657,7 @@
 				D015899B1EEB2ED7006E7684 /* Service.swift in Sources */,
 				D6ED1B39216D50BE007F7547 /* UserEmailFields.swift in Sources */,
 				D01588731EEB2ED7006E7684 /* FindFriendsEnvelope.swift in Sources */,
+				8AC3E041269791C300168BF8 /* Project.Country+CountryFragment.swift in Sources */,
 				D6F5C6112437E12300C1A79D /* SignInWithAppleInput.swift in Sources */,
 				8AA407C224DB0C8D008C5FB0 /* GraphCountry.swift in Sources */,
 				D63BBD31217F7212007E01F0 /* GraphUserCreditCard.swift in Sources */,
@@ -6743,6 +6766,7 @@
 				8AF34C722342CBAD000B211D /* UpdateBackingMutation.swift in Sources */,
 				D01588B51EEB2ED7006E7684 /* ProjectNotificationLenses.swift in Sources */,
 				8A1F155624DB609D00E0C000 /* DateFormatter+ISOFormatter.swift in Sources */,
+				8AC3E046269791D400168BF8 /* Project.Category+CategoryFragment.swift in Sources */,
 				D015882B1EEB2ED7006E7684 /* NSURLSession.swift in Sources */,
 				47613FC62652CD11006F09FF /* CommentTemplates.swift in Sources */,
 				D79440572203A63300D0A747 /* CreatePaymentSourceEnvelope.swift in Sources */,
@@ -6795,6 +6819,7 @@
 				8A1F65F2262660EF00A28E74 /* PerimeterXClientTests.swift in Sources */,
 				77272D382370AB8E003B7A9C /* BackingPaymentSourceTests.swift in Sources */,
 				8A15574326951A4B00017845 /* Backing+BackingFragmentTests.swift in Sources */,
+				8AC3E0592697ABD900168BF8 /* Project.Category+CategoryFragmentTests.swift in Sources */,
 				D0E78C3822A981EE00AAB645 /* ClearUserUnseenActivityEnvelopeTests.swift in Sources */,
 				D0D10C1E1EEB4550005EBAD0 /* UpdateTests.swift in Sources */,
 				D0D10C211EEB4550005EBAD0 /* User.NotificationsTests.swift in Sources */,
@@ -6817,8 +6842,10 @@
 				D0D10C0C1EEB4550005EBAD0 /* FindFriendsEnvelopeTests.swift in Sources */,
 				D0D10C141EEB4550005EBAD0 /* Project.VideoTests.swift in Sources */,
 				D0D10C181EEB4550005EBAD0 /* RewardsItemTests.swift in Sources */,
+				8AC3E05126979F8600168BF8 /* Project+ProjectFragmentTests.swift in Sources */,
 				8A30C6B32491689300EE12E4 /* ManagePledgeViewQueriesTests.swift in Sources */,
 				8AF34C7F2343C3EF000B211D /* UpdateBackingEnvelopeTests.swift in Sources */,
+				8AC3E05E2697ABEF00168BF8 /* Project.Country+CountryFragmentTests.swift in Sources */,
 				D0D10C131EEB4550005EBAD0 /* Project.PhotoTests.swift in Sources */,
 				D0D10C071EEB4550005EBAD0 /* DeprecatedCommentTests.swift in Sources */,
 				8AF34C762342D1D2000B211D /* UpdateBackingInputTests.swift in Sources */,
@@ -6838,6 +6865,7 @@
 				8A55587C264C567F00C2C30D /* CommentsQueriesTests.swift in Sources */,
 				8ADCCC87264C6E4A0079D308 /* GraphCommentTests.swift in Sources */,
 				D755ECAE23216C290096F189 /* CreateBackingInputTests.swift in Sources */,
+				8AC3E0662697AC0400168BF8 /* User+UserFragmentTests.swift in Sources */,
 				D755ECB123217D5B0096F189 /* CreateBackingEnvelopeTests.swift in Sources */,
 				8ADCCD912655D4030079D308 /* ApolloInterceptorsTests.swift in Sources */,
 				8A07CFE92665785000426B1C /* GraphCommentRepliesEnvelopeTests.swift in Sources */,

--- a/KsApi/GraphAPI.swift
+++ b/KsApi/GraphAPI.swift
@@ -4219,6 +4219,7 @@ public enum GraphAPI {
         currency
         deadlineAt
         description
+        finalCollectionDate
         fxRate
         goal {
           __typename
@@ -4262,6 +4263,7 @@ public enum GraphAPI {
         GraphQLField("currency", type: .nonNull(.scalar(CurrencyCode.self))),
         GraphQLField("deadlineAt", type: .scalar(String.self)),
         GraphQLField("description", type: .nonNull(.scalar(String.self))),
+        GraphQLField("finalCollectionDate", type: .scalar(String.self)),
         GraphQLField("fxRate", type: .nonNull(.scalar(Double.self))),
         GraphQLField("goal", type: .object(Goal.selections)),
         GraphQLField("image", type: .object(Image.selections)),
@@ -4285,8 +4287,8 @@ public enum GraphAPI {
       self.resultMap = unsafeResultMap
     }
 
-    public init(actions: Action, backersCount: Int, category: Category? = nil, country: Country, creator: Creator? = nil, currency: CurrencyCode, deadlineAt: String? = nil, description: String, fxRate: Double, goal: Goal? = nil, image: Image? = nil, isProjectWeLove: Bool, launchedAt: String? = nil, location: Location? = nil, name: String, pid: Int, pledged: Pledged, slug: String, state: ProjectState, stateChangedAt: String, url: String, usdExchangeRate: Double? = nil) {
-      self.init(unsafeResultMap: ["__typename": "Project", "actions": actions.resultMap, "backersCount": backersCount, "category": category.flatMap { (value: Category) -> ResultMap in value.resultMap }, "country": country.resultMap, "creator": creator.flatMap { (value: Creator) -> ResultMap in value.resultMap }, "currency": currency, "deadlineAt": deadlineAt, "description": description, "fxRate": fxRate, "goal": goal.flatMap { (value: Goal) -> ResultMap in value.resultMap }, "image": image.flatMap { (value: Image) -> ResultMap in value.resultMap }, "isProjectWeLove": isProjectWeLove, "launchedAt": launchedAt, "location": location.flatMap { (value: Location) -> ResultMap in value.resultMap }, "name": name, "pid": pid, "pledged": pledged.resultMap, "slug": slug, "state": state, "stateChangedAt": stateChangedAt, "url": url, "usdExchangeRate": usdExchangeRate])
+    public init(actions: Action, backersCount: Int, category: Category? = nil, country: Country, creator: Creator? = nil, currency: CurrencyCode, deadlineAt: String? = nil, description: String, finalCollectionDate: String? = nil, fxRate: Double, goal: Goal? = nil, image: Image? = nil, isProjectWeLove: Bool, launchedAt: String? = nil, location: Location? = nil, name: String, pid: Int, pledged: Pledged, slug: String, state: ProjectState, stateChangedAt: String, url: String, usdExchangeRate: Double? = nil) {
+      self.init(unsafeResultMap: ["__typename": "Project", "actions": actions.resultMap, "backersCount": backersCount, "category": category.flatMap { (value: Category) -> ResultMap in value.resultMap }, "country": country.resultMap, "creator": creator.flatMap { (value: Creator) -> ResultMap in value.resultMap }, "currency": currency, "deadlineAt": deadlineAt, "description": description, "finalCollectionDate": finalCollectionDate, "fxRate": fxRate, "goal": goal.flatMap { (value: Goal) -> ResultMap in value.resultMap }, "image": image.flatMap { (value: Image) -> ResultMap in value.resultMap }, "isProjectWeLove": isProjectWeLove, "launchedAt": launchedAt, "location": location.flatMap { (value: Location) -> ResultMap in value.resultMap }, "name": name, "pid": pid, "pledged": pledged.resultMap, "slug": slug, "state": state, "stateChangedAt": stateChangedAt, "url": url, "usdExchangeRate": usdExchangeRate])
     }
 
     public var __typename: String {
@@ -4375,6 +4377,16 @@ public enum GraphAPI {
       }
       set {
         resultMap.updateValue(newValue, forKey: "description")
+      }
+    }
+
+    /// The date at which pledge collections will end
+    public var finalCollectionDate: String? {
+      get {
+        return resultMap["finalCollectionDate"] as? String
+      }
+      set {
+        resultMap.updateValue(newValue, forKey: "finalCollectionDate")
       }
     }
 
@@ -4973,6 +4985,10 @@ public enum GraphAPI {
         limit
         limitPerBacker
         name
+        project {
+          __typename
+          id
+        }
         remainingQuantity
         shippingPreference
         shippingRules {
@@ -5009,6 +5025,7 @@ public enum GraphAPI {
         GraphQLField("limit", type: .scalar(Int.self)),
         GraphQLField("limitPerBacker", type: .scalar(Int.self)),
         GraphQLField("name", type: .scalar(String.self)),
+        GraphQLField("project", type: .object(Project.selections)),
         GraphQLField("remainingQuantity", type: .scalar(Int.self)),
         GraphQLField("shippingPreference", type: .scalar(ShippingPreference.self)),
         GraphQLField("shippingRules", type: .nonNull(.list(.object(ShippingRule.selections)))),
@@ -5022,8 +5039,8 @@ public enum GraphAPI {
       self.resultMap = unsafeResultMap
     }
 
-    public init(amount: Amount, backersCount: Int? = nil, convertedAmount: ConvertedAmount, description: String, displayName: String, endsAt: String? = nil, estimatedDeliveryOn: String? = nil, id: GraphQLID, isMaxPledge: Bool, items: Item? = nil, limit: Int? = nil, limitPerBacker: Int? = nil, name: String? = nil, remainingQuantity: Int? = nil, shippingPreference: ShippingPreference? = nil, shippingRules: [ShippingRule?], startsAt: String? = nil) {
-      self.init(unsafeResultMap: ["__typename": "Reward", "amount": amount.resultMap, "backersCount": backersCount, "convertedAmount": convertedAmount.resultMap, "description": description, "displayName": displayName, "endsAt": endsAt, "estimatedDeliveryOn": estimatedDeliveryOn, "id": id, "isMaxPledge": isMaxPledge, "items": items.flatMap { (value: Item) -> ResultMap in value.resultMap }, "limit": limit, "limitPerBacker": limitPerBacker, "name": name, "remainingQuantity": remainingQuantity, "shippingPreference": shippingPreference, "shippingRules": shippingRules.map { (value: ShippingRule?) -> ResultMap? in value.flatMap { (value: ShippingRule) -> ResultMap in value.resultMap } }, "startsAt": startsAt])
+    public init(amount: Amount, backersCount: Int? = nil, convertedAmount: ConvertedAmount, description: String, displayName: String, endsAt: String? = nil, estimatedDeliveryOn: String? = nil, id: GraphQLID, isMaxPledge: Bool, items: Item? = nil, limit: Int? = nil, limitPerBacker: Int? = nil, name: String? = nil, project: Project? = nil, remainingQuantity: Int? = nil, shippingPreference: ShippingPreference? = nil, shippingRules: [ShippingRule?], startsAt: String? = nil) {
+      self.init(unsafeResultMap: ["__typename": "Reward", "amount": amount.resultMap, "backersCount": backersCount, "convertedAmount": convertedAmount.resultMap, "description": description, "displayName": displayName, "endsAt": endsAt, "estimatedDeliveryOn": estimatedDeliveryOn, "id": id, "isMaxPledge": isMaxPledge, "items": items.flatMap { (value: Item) -> ResultMap in value.resultMap }, "limit": limit, "limitPerBacker": limitPerBacker, "name": name, "project": project.flatMap { (value: Project) -> ResultMap in value.resultMap }, "remainingQuantity": remainingQuantity, "shippingPreference": shippingPreference, "shippingRules": shippingRules.map { (value: ShippingRule?) -> ResultMap? in value.flatMap { (value: ShippingRule) -> ResultMap in value.resultMap } }, "startsAt": startsAt])
     }
 
     public var __typename: String {
@@ -5161,6 +5178,16 @@ public enum GraphAPI {
       }
       set {
         resultMap.updateValue(newValue, forKey: "name")
+      }
+    }
+
+    /// The project
+    public var project: Project? {
+      get {
+        return (resultMap["project"] as? ResultMap).flatMap { Project(unsafeResultMap: $0) }
+      }
+      set {
+        resultMap.updateValue(newValue?.resultMap, forKey: "project")
       }
     }
 
@@ -5402,6 +5429,45 @@ public enum GraphAPI {
           set {
             resultMap.updateValue(newValue, forKey: "name")
           }
+        }
+      }
+    }
+
+    public struct Project: GraphQLSelectionSet {
+      public static let possibleTypes: [String] = ["Project"]
+
+      public static var selections: [GraphQLSelection] {
+        return [
+          GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+          GraphQLField("id", type: .nonNull(.scalar(GraphQLID.self))),
+        ]
+      }
+
+      public private(set) var resultMap: ResultMap
+
+      public init(unsafeResultMap: ResultMap) {
+        self.resultMap = unsafeResultMap
+      }
+
+      public init(id: GraphQLID) {
+        self.init(unsafeResultMap: ["__typename": "Project", "id": id])
+      }
+
+      public var __typename: String {
+        get {
+          return resultMap["__typename"]! as! String
+        }
+        set {
+          resultMap.updateValue(newValue, forKey: "__typename")
+        }
+      }
+
+      public var id: GraphQLID {
+        get {
+          return resultMap["id"]! as! GraphQLID
+        }
+        set {
+          resultMap.updateValue(newValue, forKey: "id")
         }
       }
     }

--- a/KsApi/MockService.swift
+++ b/KsApi/MockService.swift
@@ -887,6 +887,10 @@
       return producer(for: self.fetchManagePledgeViewBackingResult)
     }
 
+    func fetchManagePledgeViewBacking(id _: Int) -> SignalProducer<ProjectAndBackingEnvelope, ErrorEnvelope> {
+      return producer(for: self.fetchManagePledgeViewBackingResult)
+    }
+
     func fetchRewardAddOnsSelectionViewRewards(query _: NonEmptySet<Query>)
       -> SignalProducer<Project, ErrorEnvelope> {
       return producer(for: self.fetchRewardAddOnsSelectionViewRewardsResult)

--- a/KsApi/Service.swift
+++ b/KsApi/Service.swift
@@ -279,6 +279,13 @@ public struct Service: ServiceType {
       .flatMap(ProjectAndBackingEnvelope.envelopeProducer(from:))
   }
 
+  public func fetchManagePledgeViewBacking(id: Int)
+    -> SignalProducer<ProjectAndBackingEnvelope, ErrorEnvelope> {
+    return GraphQL.shared.client
+      .fetch(query: GraphAPI.FetchBackingQuery(id: "\(id)"))
+      .flatMap(ProjectAndBackingEnvelope.envelopeProducer(from:))
+  }
+
   public func fetchMessageThread(messageThreadId: Int)
     -> SignalProducer<MessageThreadEnvelope, ErrorEnvelope> {
     return request(.messagesForThread(messageThreadId: messageThreadId))

--- a/KsApi/ServiceType.swift
+++ b/KsApi/ServiceType.swift
@@ -160,8 +160,12 @@ public protocol ServiceType {
   func fetchGraphUserEmailFields(query: NonEmptySet<Query>)
     -> SignalProducer<UserEnvelope<UserEmailFields>, GraphError>
 
-  /// Fetch Backing data for ManagePledgeViewController
+  /// Fetch `Backing` data for ManagePledgeViewController with a query.
   func fetchManagePledgeViewBacking(query: NonEmptySet<Query>)
+    -> SignalProducer<ProjectAndBackingEnvelope, ErrorEnvelope>
+
+  /// Fetch `Backing` data for ManagePledgeViewController with a `Backing` ID.
+  func fetchManagePledgeViewBacking(id: Int)
     -> SignalProducer<ProjectAndBackingEnvelope, ErrorEnvelope>
 
   /// Fetches all of the messages in a particular message thread.

--- a/KsApi/fragments/ProjectFragment.graphql
+++ b/KsApi/fragments/ProjectFragment.graphql
@@ -15,6 +15,7 @@ fragment ProjectFragment on Project {
   currency
   deadlineAt
   description
+  finalCollectionDate
   fxRate
   goal {
     ...MoneyFragment

--- a/KsApi/fragments/RewardFragment.graphql
+++ b/KsApi/fragments/RewardFragment.graphql
@@ -21,6 +21,9 @@ fragment RewardFragment on Reward {
   limit
   limitPerBacker
   name
+  project {
+    id
+  }
   remainingQuantity
   shippingPreference
   shippingRules {

--- a/KsApi/models/graphql/adapters/Backing+BackingFragment.swift
+++ b/KsApi/models/graphql/adapters/Backing+BackingFragment.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ReactiveSwift
 
 extension Backing {
   /**
@@ -19,7 +20,7 @@ extension Backing {
       let user = backingFragment.backer?.fragments.userFragment
     else { return nil }
 
-    let reward = backingReward(from: backingFragment, projectId: projectId)
+    let reward = backingReward(from: backingFragment)
     let backer = User.user(from: user)
     var locationId: Int?
     if let locationGraphId = backingFragment.location?.fragments.locationFragment.id {
@@ -54,10 +55,10 @@ private func backingStatus(from backingFragment: GraphAPI.BackingFragment) -> Ba
   return Backing.Status(rawValue: backingFragment.status.rawValue)
 }
 
-private func backingReward(from backingFragment: GraphAPI.BackingFragment, projectId: Int) -> Reward? {
+private func backingReward(from backingFragment: GraphAPI.BackingFragment) -> Reward? {
   guard let reward = backingFragment.reward?.fragments.rewardFragment else { return .noReward }
 
-  return Reward.reward(from: reward, projectId: projectId)
+  return Reward.reward(from: reward)
 }
 
 private func backingPaymentSource(from backingFragment: GraphAPI.BackingFragment) -> Backing.PaymentSource? {

--- a/KsApi/models/graphql/adapters/Backing+BackingFragmentTests.swift
+++ b/KsApi/models/graphql/adapters/Backing+BackingFragmentTests.swift
@@ -402,6 +402,7 @@ private func backingDictionary() -> [String: Any] {
       "currency": "USD",
       "deadlineAt": 1620478771,
       "description": "Dark Fantasy Novel & Tarot Cards",
+      "finalCollectionDate": null,
       "fxRate": 1.23244501,
       "goal": {
         "__typename": "Money",
@@ -477,6 +478,10 @@ private func backingDictionary() -> [String: Any] {
       "limit": null,
       "limitPerBacker": 1,
       "name": "Soft Cover Book (Signed)",
+      "project": {
+        "__typename": "Project",
+        "id": "UHJvamVjdC0xNTk2NTk0NDYz"
+      },
       "remainingQuantity": null,
       "shippingPreference": "unrestricted",
       "shippingRules": [

--- a/KsApi/models/graphql/adapters/Project+ProjectFragment.swift
+++ b/KsApi/models/graphql/adapters/Project+ProjectFragment.swift
@@ -1,0 +1,119 @@
+import Foundation
+
+extension Project {
+  /**
+   Returns a minimal `Project` from a `ProjectFragment`
+   */
+  static func project(
+    from projectFragment: GraphAPI.ProjectFragment,
+    rewards: [Reward] = [],
+    addOns: [Reward]? = nil
+  ) -> Project? {
+    guard
+      let country = Country.country(from: projectFragment.country.fragments.countryFragment),
+      let categoryFragment = projectFragment.category?.fragments.categoryFragment,
+      let category = Project.Category.category(from: categoryFragment),
+      let dates = projectDates(from: projectFragment),
+      let locationFragment = projectFragment.location?.fragments.locationFragment,
+      let location = Location.location(from: locationFragment),
+      let photo = projectPhoto(from: projectFragment),
+      let state = projectState(from: projectFragment.state),
+      let userFragment = projectFragment.creator?.fragments.userFragment,
+      let creator = User.user(from: userFragment)
+    else { return nil }
+
+    let urls = Project.UrlsEnvelope(
+      web: UrlsEnvelope.WebEnvelope(project: projectFragment.url, updates: nil)
+    )
+
+    return Project(
+      blurb: projectFragment.description,
+      category: category,
+      country: country,
+      creator: creator,
+      memberData: MemberData(permissions: []),
+      dates: dates,
+      id: projectFragment.pid,
+      location: location,
+      name: projectFragment.name,
+      personalization: Personalization(),
+      photo: photo,
+      rewardData: RewardData(addOns: addOns, rewards: rewards),
+      slug: projectFragment.slug,
+      staffPick: projectFragment.isProjectWeLove,
+      state: state,
+      stats: projectStats(from: projectFragment),
+      urls: urls
+    )
+  }
+}
+
+private func projectRewards(from rewardFragments: [GraphAPI.RewardFragment]?) -> [Reward]? {
+  return rewardFragments?.compactMap { rewardFragment in
+    Reward.reward(from: rewardFragment)
+  }
+}
+
+/**
+ Returns a minimal `Project.Dates` from a `ProjectFragment`
+ */
+private func projectDates(from projectFragment: GraphAPI.ProjectFragment) -> Project.Dates? {
+  guard
+    let deadline = projectFragment.deadlineAt.flatMap(TimeInterval.init),
+    let launchedAt = projectFragment.launchedAt.flatMap(TimeInterval.init),
+    let stateChangedAt = TimeInterval(projectFragment.stateChangedAt)
+  else { return nil }
+
+  return Project.Dates(
+    deadline: deadline,
+    featuredAt: nil,
+    finalCollectionDate: finalCollectionDateTimeInterval(from: projectFragment.finalCollectionDate),
+    launchedAt: launchedAt,
+    stateChangedAt: stateChangedAt
+  )
+}
+
+private func finalCollectionDateTimeInterval(
+  from string: String?,
+  dateFormatter: ISO8601DateFormatter = ISO8601DateFormatter()
+) -> TimeInterval? {
+  guard let string = string else { return nil }
+
+  return dateFormatter.date(from: string)?.timeIntervalSince1970
+}
+
+/**
+ Returns a minimal `Project.Stats` from a `ProjectFragment`
+ */
+private func projectStats(from projectFragment: GraphAPI.ProjectFragment) -> Project.Stats {
+  return Project.Stats(
+    backersCount: projectFragment.backersCount,
+    commentsCount: nil,
+    convertedPledgedAmount: nil,
+    currency: projectFragment.currency.rawValue,
+    currentCurrency: nil,
+    currentCurrencyRate: nil,
+    goal: projectFragment.goal?.fragments.moneyFragment.amount.flatMap(Int.init) ?? 0,
+    pledged: projectFragment.pledged.fragments.moneyFragment.amount.flatMap(Int.init) ?? 0,
+    staticUsdRate: projectFragment.usdExchangeRate.flatMap(Float.init) ?? 0,
+    updatesCount: nil
+  )
+}
+
+/**
+ Returns a minimal `Project.Photo` from a `ProjectFragment`
+ */
+private func projectPhoto(from projectFragment: GraphAPI.ProjectFragment) -> Project.Photo? {
+  guard let url = projectFragment.image?.url else { return nil }
+
+  return Project.Photo(
+    full: url,
+    med: url,
+    size1024x768: url,
+    small: url
+  )
+}
+
+private func projectState(from projectState: GraphAPI.ProjectState) -> Project.State? {
+  return Project.State(rawValue: projectState.rawValue.lowercased())
+}

--- a/KsApi/models/graphql/adapters/Project+ProjectFragmentTests.swift
+++ b/KsApi/models/graphql/adapters/Project+ProjectFragmentTests.swift
@@ -1,0 +1,396 @@
+@testable import KsApi
+import XCTest
+
+final class Project_ProjectFragmentTests: XCTestCase {
+  func test() {
+    do {
+      let dict = self.projectDictionary()
+
+      let addOns = (dict["addOns"] as? [String: [[String: Any]]])?["nodes"]?
+        .compactMap { try? GraphAPI.RewardFragment(jsonObject: $0) }
+        .compactMap { Reward.reward(from: $0) }
+      let rewards = (dict["rewards"] as? [String: [[String: Any]]])?["nodes"]?
+        .compactMap { try? GraphAPI.RewardFragment(jsonObject: $0) }
+        .compactMap { Reward.reward(from: $0) } ?? []
+
+      let fragment = try GraphAPI.ProjectFragment(jsonObject: self.projectDictionary())
+      XCTAssertNotNil(fragment)
+
+      let project = Project.project(
+        from: fragment,
+        rewards: rewards,
+        addOns: addOns
+      )
+
+      XCTAssertNotNil(project)
+      XCTAssertEqual(project?.addOns?.count, 2)
+      XCTAssertEqual(project?.rewards.count, 2)
+    } catch {
+      XCTFail(error.localizedDescription)
+    }
+
+    XCTAssertNotNil(Project.project(from: .template))
+  }
+
+  private func projectDictionary() -> [String: Any] {
+    let json = """
+    {
+      "__typename": "Project",
+      "actions": {
+        "__typename": "ProjectActions",
+        "displayConvertAmount": false
+      },
+      "backersCount": 136,
+      "category": {
+        "__typename": "Category",
+        "id": "Q2F0ZWdvcnktNDc=",
+        "name": "Fiction",
+        "parentCategory": {
+          "__typename": "Category",
+          "id": "Q2F0ZWdvcnktMTg=",
+          "name": "Publishing"
+        }
+      },
+      "country": {
+        "__typename": "Country",
+        "code": "US",
+        "name": "the United States"
+      },
+      "creator": {
+        "__typename": "User",
+        "id": "VXNlci02MzE4MTEzODc=",
+        "imageUrl": "https://ksr-qa-ugc.imgix.net/assets/026/582/411/0064c9eba577b99cbb09d9bb197e215a_original.jpeg?ixlib=rb-4.0.2&blur=false&w=1024&h=1024&fit=crop&v=1617736562&auto=format&frame=1&q=92&s=085218a7258d22c455492bed76f5433a",
+        "isCreator": null,
+        "name": "Hugh Alan Samples",
+        "uid": "631811387"
+      },
+      "currency": "USD",
+      "deadlineAt": 1620478771,
+      "description": "Dark Fantasy Novel & Tarot Cards",
+      "finalCollectionDate": null,
+      "fxRate": 1.25195501,
+      "goal": {
+        "__typename": "Money",
+        "amount": "3000.0",
+        "currency": "USD",
+        "symbol": "$"
+      },
+      "image": {
+        "__typename": "Photo",
+        "id": "UGhvdG8tMzI0NTYxMDE=",
+        "url": "https://ksr-qa-ugc.imgix.net/assets/032/456/101/d32b5e2097301e5ccf4aa1e4f0be9086_original.tiff?ixlib=rb-4.0.2&crop=faces&w=1024&h=576&fit=crop&v=1613880671&auto=format&frame=1&q=92&s=617def65783295f2dabdff1b39005eca"
+      },
+      "isProjectWeLove": true,
+      "launchedAt": 1617886771,
+      "location": {
+        "__typename": "Location",
+        "country": "US",
+        "countryName": "United States",
+        "displayableName": "Henderson, KY",
+        "id": "TG9jYXRpb24tMjQxOTk0NA==",
+        "name": "Henderson"
+      },
+      "name": "WEE WILLIAM WITCHLING",
+      "pid": 1596594463,
+      "pledged": {
+        "__typename": "Money",
+        "amount": "9893.0",
+        "currency": "USD",
+        "symbol": "$"
+      },
+      "addOns": {
+        "nodes": [
+          {
+            "__typename": "Reward",
+            "amount": {
+              "__typename": "Money",
+              "amount": "10.0",
+              "currency": "USD",
+              "symbol": "$"
+            },
+            "backersCount": 26,
+            "convertedAmount": {
+              "__typename": "Money",
+              "amount": "13.0",
+              "currency": "CAD",
+              "symbol": "$"
+            },
+            "description": "A 160 page coloring book and tarot journal with all 78 cards available for your enjoyment!",
+            "displayName": "Wee William Journal & Coloring Book ($10)",
+            "endsAt": null,
+            "estimatedDeliveryOn": "2021-12-01",
+            "id": "UmV3YXJkLTgyNDgxOTM=",
+            "isMaxPledge": false,
+            "items": {
+              "__typename": "RewardItemsConnection",
+              "nodes": []
+            },
+            "limit": null,
+            "limitPerBacker": 10,
+            "name": "Wee William Journal & Coloring Book",
+            "project": {
+            "__typename": "Project",
+              "id": "UHJvamVjdC0xNTk2NTk0NDYz"
+            },
+            "remainingQuantity": null,
+            "shippingPreference": "unrestricted",
+            "shippingRules": [
+              {
+                "__typename": "ShippingRule",
+                "cost": {
+                  "__typename": "Money",
+                  "amount": "0.0",
+                  "currency": "USD",
+                  "symbol": "$"
+                },
+                "id": "U2hpcHBpbmdSdWxlLTExNDY2NTM4",
+                "location": {
+                  "__typename": "Location",
+                  "country": "ZZ",
+                  "countryName": null,
+                  "displayableName": "Earth",
+                  "id": "TG9jYXRpb24tMQ==",
+                  "name": "Rest of World"
+                }
+              },
+              {
+                "__typename": "ShippingRule",
+                "cost": {
+                  "__typename": "Money",
+                  "amount": "0.0",
+                  "currency": "USD",
+                  "symbol": "$"
+                },
+                "id": "U2hpcHBpbmdSdWxlLTExNDY2NTM5",
+                "location": {
+                  "__typename": "Location",
+                  "country": "US",
+                  "countryName": "United States",
+                  "displayableName": "United States",
+                  "id": "TG9jYXRpb24tMjM0MjQ5Nzc=",
+                  "name": "United States"
+                }
+              }
+            ],
+            "startsAt": null
+          },
+          {
+            "__typename": "Reward",
+            "amount": {
+              "__typename": "Money",
+              "amount": "25.0",
+              "currency": "USD",
+              "symbol": "$"
+            },
+            "backersCount": 21,
+            "convertedAmount": {
+              "__typename": "Money",
+              "amount": "32.0",
+              "currency": "CAD",
+              "symbol": "$"
+            },
+            "description": "Add the soft bound edition to an existing reward tier!",
+            "displayName": "Soft-cover signed Book ($25)",
+            "endsAt": null,
+            "estimatedDeliveryOn": "2021-12-01",
+            "id": "UmV3YXJkLTgyMjcyOTM=",
+            "isMaxPledge": false,
+            "items": {
+              "__typename": "RewardItemsConnection",
+              "nodes": []
+            },
+            "limit": null,
+            "limitPerBacker": 10,
+            "name": "Soft-cover signed Book",
+            "project": {
+            "__typename": "Project",
+              "id": "UHJvamVjdC0xNTk2NTk0NDYz"
+            },
+            "remainingQuantity": null,
+            "shippingPreference": "unrestricted",
+            "shippingRules": [
+              {
+                "__typename": "ShippingRule",
+                "cost": {
+                  "__typename": "Money",
+                  "amount": "0.0",
+                  "currency": "USD",
+                  "symbol": "$"
+                },
+                "id": "U2hpcHBpbmdSdWxlLTExNDEzMzgz",
+                "location": {
+                  "__typename": "Location",
+                  "country": "ZZ",
+                  "countryName": null,
+                  "displayableName": "Earth",
+                  "id": "TG9jYXRpb24tMQ==",
+                  "name": "Rest of World"
+                }
+              },
+              {
+                "__typename": "ShippingRule",
+                "cost": {
+                  "__typename": "Money",
+                  "amount": "0.0",
+                  "currency": "USD",
+                  "symbol": "$"
+                },
+                "id": "U2hpcHBpbmdSdWxlLTExNDA2OTkz",
+                "location": {
+                  "__typename": "Location",
+                  "country": "US",
+                  "countryName": "United States",
+                  "displayableName": "United States",
+                  "id": "TG9jYXRpb24tMjM0MjQ5Nzc=",
+                  "name": "United States"
+                }
+              }
+            ],
+            "startsAt": null
+          }
+        ]
+      },
+      "rewards": {
+        "nodes": [
+          {
+            "__typename": "Reward",
+            "amount": {
+              "__typename": "Money",
+              "amount": "10.0",
+              "currency": "USD",
+              "symbol": "$"
+            },
+            "backersCount": 7,
+            "convertedAmount": {
+              "__typename": "Money",
+              "amount": "13.0",
+              "currency": "CAD",
+              "symbol": "$"
+            },
+            "description": "",
+            "displayName": "Digital Copy ($10)",
+            "endsAt": null,
+            "estimatedDeliveryOn": "2021-12-01",
+            "id": "UmV3YXJkLTgxNzM4OTk=",
+            "isMaxPledge": false,
+            "items": {
+              "__typename": "RewardItemsConnection",
+              "nodes": [
+                {
+                  "__typename": "RewardItem",
+                  "id": "UmV3YXJkSXRlbS0xMTcwNzk2",
+                  "name": "Wee William Witchling (PDF) Digital Copy"
+                }
+              ]
+            },
+            "limit": null,
+            "limitPerBacker": 1,
+            "name": "Digital Copy",
+            "project": {
+            "__typename": "Project",
+              "id": "UHJvamVjdC0xNTk2NTk0NDYz"
+            },
+            "remainingQuantity": null,
+            "shippingPreference": "none",
+            "shippingRules": [],
+            "startsAt": null
+          },
+          {
+            "__typename": "Reward",
+            "amount": {
+              "__typename": "Money",
+              "amount": "25.0",
+              "currency": "USD",
+              "symbol": "$"
+            },
+            "backersCount": 13,
+            "convertedAmount": {
+              "__typename": "Money",
+              "amount": "32.0",
+              "currency": "CAD",
+              "symbol": "$"
+            },
+            "description": "",
+            "displayName": "Soft Cover Book (Signed) ($25)",
+            "endsAt": null,
+            "estimatedDeliveryOn": "2021-12-01",
+            "id": "UmV3YXJkLTgxNzM5MDE=",
+            "isMaxPledge": false,
+            "items": {
+              "__typename": "RewardItemsConnection",
+              "nodes": [
+                {
+                  "__typename": "RewardItem",
+                  "id": "UmV3YXJkSXRlbS0xMTcwNzk5",
+                  "name": "Soft-Cover Book (Signed)"
+                },
+                {
+                  "__typename": "RewardItem",
+                  "id": "UmV3YXJkSXRlbS0xMTcwODEz",
+                  "name": "Custom Bookmark"
+                }
+              ]
+            },
+            "limit": null,
+            "limitPerBacker": 1,
+            "name": "Soft Cover Book (Signed)",
+            "project": {
+            "__typename": "Project",
+              "id": "UHJvamVjdC0xNTk2NTk0NDYz"
+            },
+            "remainingQuantity": null,
+            "shippingPreference": "unrestricted",
+            "shippingRules": [
+              {
+                "__typename": "ShippingRule",
+                "cost": {
+                  "__typename": "Money",
+                  "amount": "0.0",
+                  "currency": "USD",
+                  "symbol": "$"
+                },
+                "id": "U2hpcHBpbmdSdWxlLTExNDEzMzc5",
+                "location": {
+                  "__typename": "Location",
+                  "country": "ZZ",
+                  "countryName": null,
+                  "displayableName": "Earth",
+                  "id": "TG9jYXRpb24tMQ==",
+                  "name": "Rest of World"
+                }
+              },
+              {
+                "__typename": "ShippingRule",
+                "cost": {
+                  "__typename": "Money",
+                  "amount": "0.0",
+                  "currency": "USD",
+                  "symbol": "$"
+                },
+                "id": "U2hpcHBpbmdSdWxlLTExMjc4NzUy",
+                "location": {
+                  "__typename": "Location",
+                  "country": "US",
+                  "countryName": "United States",
+                  "displayableName": "United States",
+                  "id": "TG9jYXRpb24tMjM0MjQ5Nzc=",
+                  "name": "United States"
+                }
+              }
+            ],
+            "startsAt": null
+          }
+        ]
+      },
+      "slug": "parliament-of-rooks/wee-william-witchling",
+      "state": "LIVE",
+      "stateChangedAt": 1617886773,
+      "url": "https://staging.kickstarter.com/projects/parliament-of-rooks/wee-william-witchling",
+      "usdExchangeRate": 1
+    }
+    """
+
+    let data = Data(json.utf8)
+    return (try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any]) ?? [:]
+  }
+}

--- a/KsApi/models/graphql/adapters/Project.Category+CategoryFragment.swift
+++ b/KsApi/models/graphql/adapters/Project.Category+CategoryFragment.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+extension Project.Category {
+  /**
+   Returns a minimal `Project.Category` from a `CategoryFragment`
+   */
+  static func category(from categoryFragment: GraphAPI.CategoryFragment) -> Project.Category? {
+    guard let id = decompose(id: categoryFragment.id) else { return nil }
+
+    return Project.Category(
+      id: id,
+      name: categoryFragment.name,
+      parentId: categoryFragment.parentCategory.map(\.id).flatMap(decompose(id:)),
+      parentName: categoryFragment.parentCategory?.name
+    )
+  }
+}

--- a/KsApi/models/graphql/adapters/Project.Category+CategoryFragmentTests.swift
+++ b/KsApi/models/graphql/adapters/Project.Category+CategoryFragmentTests.swift
@@ -1,0 +1,23 @@
+import Foundation
+@testable import KsApi
+import XCTest
+
+final class Category_CategoryFragmentTests: XCTestCase {
+  func test() {
+    let categoryFragment = GraphAPI.CategoryFragment(
+      id: "Q2F0ZWdvcnktNDc=",
+      name: "My Category",
+      parentCategory: .init(
+        id: "Q2F0ZWdvcnktMTg=",
+        name: "My Parent Category"
+      )
+    )
+
+    let category = Project.Category.category(from: categoryFragment)
+
+    XCTAssertEqual(category?.id, 47)
+    XCTAssertEqual(category?.name, "My Category")
+    XCTAssertEqual(category?.parentId, 18)
+    XCTAssertEqual(category?.parentName, "My Parent Category")
+  }
+}

--- a/KsApi/models/graphql/adapters/Project.Country+CountryFragment.swift
+++ b/KsApi/models/graphql/adapters/Project.Country+CountryFragment.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+extension Project.Country {
+  static func country(from countryFragment: GraphAPI.CountryFragment) -> Project.Country? {
+    guard let country = Project.Country.all
+      .first(where: { $0.countryCode == countryFragment.code.rawValue }) else { return nil }
+
+    return country
+  }
+}

--- a/KsApi/models/graphql/adapters/Project.Country+CountryFragmentTests.swift
+++ b/KsApi/models/graphql/adapters/Project.Country+CountryFragmentTests.swift
@@ -1,0 +1,16 @@
+import Foundation
+@testable import KsApi
+import XCTest
+
+final class Country_CountryFragmentTests: XCTestCase {
+  func test() {
+    let countryFragment = GraphAPI.CountryFragment(
+      code: .us,
+      name: "United States"
+    )
+
+    let country = Project.Country.country(from: countryFragment)
+
+    XCTAssertEqual(country, .us)
+  }
+}

--- a/KsApi/models/graphql/adapters/Reward+RewardFragment.swift
+++ b/KsApi/models/graphql/adapters/Reward+RewardFragment.swift
@@ -14,11 +14,14 @@ extension Reward {
 
   static func reward(
     from rewardFragment: GraphAPI.RewardFragment,
-    projectId: Int,
     dateFormatter: DateFormatter = DateFormatter.isoDateFormatter,
     expandedShippingRules: [ShippingRule]? = nil
   ) -> Reward? {
-    guard let rewardId = decompose(id: rewardFragment.id) else { return nil }
+    guard
+      let rewardId = decompose(id: rewardFragment.id),
+      let projectRelayId = rewardFragment.project?.id,
+      let projectId = decompose(id: projectRelayId)
+    else { return nil }
 
     let estimatedDeliveryOn = rewardFragment.estimatedDeliveryOn
       .flatMap(dateFormatter.date(from:))?.timeIntervalSince1970

--- a/KsApi/models/graphql/adapters/Reward+RewardFragmentTests.swift
+++ b/KsApi/models/graphql/adapters/Reward+RewardFragmentTests.swift
@@ -14,7 +14,6 @@ final class Reward_RewardFragmentTests: XCTestCase {
 
       let v1Reward = Reward.reward(
         from: fragment,
-        projectId: Project.template.id,
         dateFormatter: dateFormatter
       )
 
@@ -89,6 +88,10 @@ private func rewardDictionary() -> [String: Any] {
     "limit": null,
     "limitPerBacker": 1,
     "name": "Soft Cover Book (Signed)",
+    "project": {
+      "__typename": "Project",
+      "id": "UHJvamVjdC0xNTk2NTk0NDYz"
+    },
     "remainingQuantity": null,
     "shippingPreference": "unrestricted",
     "shippingRules": [

--- a/KsApi/models/graphql/adapters/User+UserFragment.swift
+++ b/KsApi/models/graphql/adapters/User+UserFragment.swift
@@ -4,7 +4,6 @@ extension User {
   /**
    Returns a minimal `User` from a `GraphUser`
    */
-  // TODO: Add test
   static func user(from userFragment: GraphAPI.UserFragment) -> User? {
     guard let id = decompose(id: userFragment.id) else { return nil }
 

--- a/KsApi/models/graphql/adapters/User+UserFragmentTests.swift
+++ b/KsApi/models/graphql/adapters/User+UserFragmentTests.swift
@@ -1,0 +1,24 @@
+import Foundation
+@testable import KsApi
+import XCTest
+
+final class User_UserFragmentTests: XCTestCase {
+  func test() {
+    let userFragment = GraphAPI.UserFragment(
+      id: "Q2F0ZWdvcnktNDc=",
+      imageUrl: "http://www.kickstarter.com/image.jpg",
+      isCreator: false,
+      name: "Billy Bob",
+      uid: "47"
+    )
+
+    let user = User.user(from: userFragment)
+
+    XCTAssertEqual(user?.id, 47)
+    XCTAssertEqual(user?.avatar.large, "http://www.kickstarter.com/image.jpg")
+    XCTAssertEqual(user?.avatar.medium, "http://www.kickstarter.com/image.jpg")
+    XCTAssertEqual(user?.avatar.small, "http://www.kickstarter.com/image.jpg")
+    XCTAssertEqual(user?.isCreator, false)
+    XCTAssertEqual(user?.name, "Billy Bob")
+  }
+}

--- a/Library/ViewModels/ManagePledgeViewModel.swift
+++ b/Library/ViewModels/ManagePledgeViewModel.swift
@@ -122,10 +122,9 @@ public final class ManagePledgeViewModel:
     let graphBackingEvent = shouldFetchGraphBackingWithParam
       .map { param in param.id }
       .skipNil()
-      .map(String.init)
       .switchMap { backingId in
         AppEnvironment.current.apiService
-          .fetchManagePledgeViewBacking(query: managePledgeViewProjectBackingQuery(withBackingId: backingId))
+          .fetchManagePledgeViewBacking(id: backingId)
           .ksr_delay(AppEnvironment.current.apiDelayInterval, on: AppEnvironment.current.scheduler)
           .materialize()
       }


### PR DESCRIPTION
# 📲 What

Continues the migration of fetching the data for the Manage Pledge View from our legacy GraphQL queries to Apollo using fragments.

# 🤔 Why

We are using Apollo for GraphQL moving forward.

# 🛠 How

Added the remaining required fragments, adapters and tests.

# ✅ Acceptance criteria

- [ ] `Project` can be created from `ProjectFragment`.
- [ ] No regression in the behaviour of `ManagePledgeViewController`.