### PR TITLE
[NT-2073] Migrate Reward Add-On Selection Query To Apollo

### DIFF
--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -606,6 +606,12 @@
 		8AC3E0592697ABD900168BF8 /* Project.Category+CategoryFragmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AC3E0582697ABD900168BF8 /* Project.Category+CategoryFragmentTests.swift */; };
 		8AC3E05E2697ABEF00168BF8 /* Project.Country+CountryFragmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AC3E05D2697ABEF00168BF8 /* Project.Country+CountryFragmentTests.swift */; };
 		8AC3E0662697AC0400168BF8 /* User+UserFragmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AC3E0652697AC0400168BF8 /* User+UserFragmentTests.swift */; };
+		8AC3E0892698CC1A00168BF8 /* FetchAddOnsQuery.graphql in Resources */ = {isa = PBXBuildFile; fileRef = 8AC3E0882698CC1900168BF8 /* FetchAddOnsQuery.graphql */; };
+		8AC3E08E2698CE8200168BF8 /* ShippingRuleFragment.graphql in Resources */ = {isa = PBXBuildFile; fileRef = 8AC3E08D2698CE8200168BF8 /* ShippingRuleFragment.graphql */; };
+		8AC3E0962698CF0600168BF8 /* ShippingRule+ShippingRuleFragment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AC3E0952698CF0500168BF8 /* ShippingRule+ShippingRuleFragment.swift */; };
+		8AC3E0A42698EE9500168BF8 /* ShippingRule+ShippingRuleFragmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AC3E0A32698EE9500168BF8 /* ShippingRule+ShippingRuleFragmentTests.swift */; };
+		8AC3E0AC2698EFAA00168BF8 /* Project+FetchAddOnsQueryData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AC3E0AB2698EFAA00168BF8 /* Project+FetchAddOnsQueryData.swift */; };
+		8AC3E0B42698F03200168BF8 /* Project+FetchAddOnsQueryDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AC3E0B32698F03200168BF8 /* Project+FetchAddOnsQueryDataTests.swift */; };
 		8ACB32A824ABC2DB00A03968 /* RewardAddOnSelectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ACB32A724ABC2DB00A03968 /* RewardAddOnSelectionViewController.swift */; };
 		8ACD29F7243E48260044BC17 /* PledgePaymentMethodsDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ACD29F6243E48260044BC17 /* PledgePaymentMethodsDataSource.swift */; };
 		8ACF36D1262745520026E74D /* MockService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D01587761EEB2ED6006E7684 /* MockService.swift */; };
@@ -2232,6 +2238,12 @@
 		8AC3E0582697ABD900168BF8 /* Project.Category+CategoryFragmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Project.Category+CategoryFragmentTests.swift"; sourceTree = "<group>"; };
 		8AC3E05D2697ABEF00168BF8 /* Project.Country+CountryFragmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Project.Country+CountryFragmentTests.swift"; sourceTree = "<group>"; };
 		8AC3E0652697AC0400168BF8 /* User+UserFragmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "User+UserFragmentTests.swift"; sourceTree = "<group>"; };
+		8AC3E0882698CC1900168BF8 /* FetchAddOnsQuery.graphql */ = {isa = PBXFileReference; lastKnownFileType = text; path = FetchAddOnsQuery.graphql; sourceTree = "<group>"; };
+		8AC3E08D2698CE8200168BF8 /* ShippingRuleFragment.graphql */ = {isa = PBXFileReference; lastKnownFileType = text; path = ShippingRuleFragment.graphql; sourceTree = "<group>"; };
+		8AC3E0952698CF0500168BF8 /* ShippingRule+ShippingRuleFragment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ShippingRule+ShippingRuleFragment.swift"; sourceTree = "<group>"; };
+		8AC3E0A32698EE9500168BF8 /* ShippingRule+ShippingRuleFragmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ShippingRule+ShippingRuleFragmentTests.swift"; sourceTree = "<group>"; };
+		8AC3E0AB2698EFAA00168BF8 /* Project+FetchAddOnsQueryData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Project+FetchAddOnsQueryData.swift"; sourceTree = "<group>"; };
+		8AC3E0B32698F03200168BF8 /* Project+FetchAddOnsQueryDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Project+FetchAddOnsQueryDataTests.swift"; sourceTree = "<group>"; };
 		8ACB32A724ABC2DB00A03968 /* RewardAddOnSelectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RewardAddOnSelectionViewController.swift; sourceTree = "<group>"; };
 		8ACD29F6243E48260044BC17 /* PledgePaymentMethodsDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PledgePaymentMethodsDataSource.swift; sourceTree = "<group>"; };
 		8ACF36E92627486D0026E74D /* KsApiNotification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KsApiNotification.swift; sourceTree = "<group>"; };
@@ -3312,6 +3324,7 @@
 		7798B5292174F3BC008BC50D /* queries */ = {
 			isa = PBXGroup;
 			children = (
+				8AC3E0882698CC1900168BF8 /* FetchAddOnsQuery.graphql */,
 				8A1556FE26939F4B00017845 /* FetchBackingQuery.graphql */,
 				8ADCCD3D26532D730079D308 /* FetchProjectComments.graphql */,
 				8A1556AF268CE6A500017845 /* FetchUpdateComments.graphql */,
@@ -3460,6 +3473,7 @@
 				8A1556F0269398CB00017845 /* MoneyFragment.graphql */,
 				8A1556EF269398CB00017845 /* ProjectFragment.graphql */,
 				8A1556DF269394B600017845 /* RewardFragment.graphql */,
+				8AC3E08D2698CE8200168BF8 /* ShippingRuleFragment.graphql */,
 				8A1556F1269398CB00017845 /* UserFragment.graphql */,
 			);
 			path = fragments;
@@ -3488,6 +3502,8 @@
 				8AC3E040269791C300168BF8 /* Project.Country+CountryFragment.swift */,
 				8AC3E05D2697ABEF00168BF8 /* Project.Country+CountryFragmentTests.swift */,
 				8AA407C524DB36E8008C5FB0 /* Project.Country+GraphCountry.swift */,
+				8AC3E0AB2698EFAA00168BF8 /* Project+FetchAddOnsQueryData.swift */,
+				8AC3E0B32698F03200168BF8 /* Project+FetchAddOnsQueryDataTests.swift */,
 				8AE3F73024DA29FC002B03C3 /* Project+GraphProject.swift */,
 				8AE3F73224DA2A53002B03C3 /* Project+GraphProjectTests.swift */,
 				8AC3E03826977C0200168BF8 /* Project+ProjectFragment.swift */,
@@ -3496,6 +3512,8 @@
 				8A49396624B68FA500C3C3CE /* Reward+GraphRewardTests.swift */,
 				8AC3E00626961E6400168BF8 /* Reward+RewardFragment.swift */,
 				8AC3E00B26961E8A00168BF8 /* Reward+RewardFragmentTests.swift */,
+				8AC3E0952698CF0500168BF8 /* ShippingRule+ShippingRuleFragment.swift */,
+				8AC3E0A32698EE9500168BF8 /* ShippingRule+ShippingRuleFragmentTests.swift */,
 				8AA407C724DB4399008C5FB0 /* User+GraphUser.swift */,
 				8A67DDB324DCA41400B4AB10 /* User+GraphUserTests.swift */,
 				8A1557142693B28300017845 /* User+UserFragment.swift */,
@@ -5383,7 +5401,9 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				8AC3E0892698CC1A00168BF8 /* FetchAddOnsQuery.graphql in Resources */,
 				8A1556FF26939F4B00017845 /* FetchBackingQuery.graphql in Resources */,
+				8AC3E08E2698CE8200168BF8 /* ShippingRuleFragment.graphql in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -6575,6 +6595,7 @@
 				D01588AF1EEB2ED7006E7684 /* Project.VideoLenses.swift in Sources */,
 				D0158A091EEB30A2006E7684 /* ActivityTemplates.swift in Sources */,
 				8A1557152693B28300017845 /* User+UserFragment.swift in Sources */,
+				8AC3E0AC2698EFAA00168BF8 /* Project+FetchAddOnsQueryData.swift in Sources */,
 				D01589811EEB2ED7006E7684 /* Update.swift in Sources */,
 				8AC3E00726961E6400168BF8 /* Reward+RewardFragment.swift in Sources */,
 				378CA24622C4449F004E3C86 /* CountryLenses.swift in Sources */,
@@ -6741,6 +6762,7 @@
 				D015882D1EEB2ED7006E7684 /* BasicHTTPAuth.swift in Sources */,
 				D0851010219500F200BC418B /* PaymentSourceDeleteMutation.swift in Sources */,
 				D01589091EEB2ED7006E7684 /* ProjectsEnvelope.swift in Sources */,
+				8AC3E0962698CF0600168BF8 /* ShippingRule+ShippingRuleFragment.swift in Sources */,
 				4753C78A264ED44100BB10B6 /* GraphMutationPostCommentEnvelopeTemplate.swift in Sources */,
 				D6C9A2541F758C7900981E64 /* GraphCategoryLenses.swift in Sources */,
 				D015883B1EEB2ED7006E7684 /* MimeType.swift in Sources */,
@@ -6874,6 +6896,7 @@
 				8ADCCD912655D4030079D308 /* ApolloInterceptorsTests.swift in Sources */,
 				8A07CFE92665785000426B1C /* GraphCommentRepliesEnvelopeTests.swift in Sources */,
 				8AC3E01F2696368B00168BF8 /* Location+LocationFragmentTests.swift in Sources */,
+				8AC3E0B42698F03200168BF8 /* Project+FetchAddOnsQueryDataTests.swift in Sources */,
 				47613FBE2652C66A006F09FF /* PostCommentMutationTests.swift in Sources */,
 				D0D10C1B1EEB4550005EBAD0 /* SurveyResponseTests.swift in Sources */,
 				D0D10C1F1EEB4550005EBAD0 /* User.AvatarTests.swift in Sources */,
@@ -6884,6 +6907,7 @@
 				8A49396724B68FA500C3C3CE /* Reward+GraphRewardTests.swift in Sources */,
 				8AE3F73324DA2A53002B03C3 /* Project+GraphProjectTests.swift in Sources */,
 				8A4E953D2451058F00A578CF /* ManagePledgeViewBackingEnvelopeTests.swift in Sources */,
+				8AC3E0A42698EE9500168BF8 /* ShippingRule+ShippingRuleFragmentTests.swift in Sources */,
 				D0D10C161EEB4550005EBAD0 /* ProjectTests.swift in Sources */,
 				777B88E522BD911F0027640F /* CategoryTests.swift in Sources */,
 			);

--- a/KsApi/GraphAPI.swift
+++ b/KsApi/GraphAPI.swift
@@ -1806,6 +1806,348 @@ public enum GraphAPI {
     }
   }
 
+  public final class FetchAddOnsQuery: GraphQLQuery {
+    /// The raw GraphQL definition of this operation.
+    public let operationDefinition: String =
+      """
+      query FetchAddOns($projectSlug: String!, $locationId: ID) {
+        project(slug: $projectSlug) {
+          __typename
+          ...ProjectFragment
+          addOns {
+            __typename
+            nodes {
+              __typename
+              ...RewardFragment
+              shippingRulesExpanded(forLocation: $locationId) {
+                __typename
+                nodes {
+                  __typename
+                  ...ShippingRuleFragment
+                }
+              }
+            }
+          }
+        }
+      }
+      """
+
+    public let operationName: String = "FetchAddOns"
+
+    public var queryDocument: String {
+      var document: String = operationDefinition
+      document.append("\n" + ProjectFragment.fragmentDefinition)
+      document.append("\n" + CategoryFragment.fragmentDefinition)
+      document.append("\n" + CountryFragment.fragmentDefinition)
+      document.append("\n" + UserFragment.fragmentDefinition)
+      document.append("\n" + MoneyFragment.fragmentDefinition)
+      document.append("\n" + LocationFragment.fragmentDefinition)
+      document.append("\n" + RewardFragment.fragmentDefinition)
+      document.append("\n" + ShippingRuleFragment.fragmentDefinition)
+      return document
+    }
+
+    public var projectSlug: String
+    public var locationId: GraphQLID?
+
+    public init(projectSlug: String, locationId: GraphQLID? = nil) {
+      self.projectSlug = projectSlug
+      self.locationId = locationId
+    }
+
+    public var variables: GraphQLMap? {
+      return ["projectSlug": projectSlug, "locationId": locationId]
+    }
+
+    public struct Data: GraphQLSelectionSet {
+      public static let possibleTypes: [String] = ["Query"]
+
+      public static var selections: [GraphQLSelection] {
+        return [
+          GraphQLField("project", arguments: ["slug": GraphQLVariable("projectSlug")], type: .object(Project.selections)),
+        ]
+      }
+
+      public private(set) var resultMap: ResultMap
+
+      public init(unsafeResultMap: ResultMap) {
+        self.resultMap = unsafeResultMap
+      }
+
+      public init(project: Project? = nil) {
+        self.init(unsafeResultMap: ["__typename": "Query", "project": project.flatMap { (value: Project) -> ResultMap in value.resultMap }])
+      }
+
+      /// Fetches a project given its slug or pid.
+      public var project: Project? {
+        get {
+          return (resultMap["project"] as? ResultMap).flatMap { Project(unsafeResultMap: $0) }
+        }
+        set {
+          resultMap.updateValue(newValue?.resultMap, forKey: "project")
+        }
+      }
+
+      public struct Project: GraphQLSelectionSet {
+        public static let possibleTypes: [String] = ["Project"]
+
+        public static var selections: [GraphQLSelection] {
+          return [
+            GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+            GraphQLFragmentSpread(ProjectFragment.self),
+            GraphQLField("addOns", type: .object(AddOn.selections)),
+          ]
+        }
+
+        public private(set) var resultMap: ResultMap
+
+        public init(unsafeResultMap: ResultMap) {
+          self.resultMap = unsafeResultMap
+        }
+
+        public var __typename: String {
+          get {
+            return resultMap["__typename"]! as! String
+          }
+          set {
+            resultMap.updateValue(newValue, forKey: "__typename")
+          }
+        }
+
+        /// Backing Add-ons
+        public var addOns: AddOn? {
+          get {
+            return (resultMap["addOns"] as? ResultMap).flatMap { AddOn(unsafeResultMap: $0) }
+          }
+          set {
+            resultMap.updateValue(newValue?.resultMap, forKey: "addOns")
+          }
+        }
+
+        public var fragments: Fragments {
+          get {
+            return Fragments(unsafeResultMap: resultMap)
+          }
+          set {
+            resultMap += newValue.resultMap
+          }
+        }
+
+        public struct Fragments {
+          public private(set) var resultMap: ResultMap
+
+          public init(unsafeResultMap: ResultMap) {
+            self.resultMap = unsafeResultMap
+          }
+
+          public var projectFragment: ProjectFragment {
+            get {
+              return ProjectFragment(unsafeResultMap: resultMap)
+            }
+            set {
+              resultMap += newValue.resultMap
+            }
+          }
+        }
+
+        public struct AddOn: GraphQLSelectionSet {
+          public static let possibleTypes: [String] = ["ProjectRewardConnection"]
+
+          public static var selections: [GraphQLSelection] {
+            return [
+              GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+              GraphQLField("nodes", type: .list(.object(Node.selections))),
+            ]
+          }
+
+          public private(set) var resultMap: ResultMap
+
+          public init(unsafeResultMap: ResultMap) {
+            self.resultMap = unsafeResultMap
+          }
+
+          public init(nodes: [Node?]? = nil) {
+            self.init(unsafeResultMap: ["__typename": "ProjectRewardConnection", "nodes": nodes.flatMap { (value: [Node?]) -> [ResultMap?] in value.map { (value: Node?) -> ResultMap? in value.flatMap { (value: Node) -> ResultMap in value.resultMap } } }])
+          }
+
+          public var __typename: String {
+            get {
+              return resultMap["__typename"]! as! String
+            }
+            set {
+              resultMap.updateValue(newValue, forKey: "__typename")
+            }
+          }
+
+          /// A list of nodes.
+          public var nodes: [Node?]? {
+            get {
+              return (resultMap["nodes"] as? [ResultMap?]).flatMap { (value: [ResultMap?]) -> [Node?] in value.map { (value: ResultMap?) -> Node? in value.flatMap { (value: ResultMap) -> Node in Node(unsafeResultMap: value) } } }
+            }
+            set {
+              resultMap.updateValue(newValue.flatMap { (value: [Node?]) -> [ResultMap?] in value.map { (value: Node?) -> ResultMap? in value.flatMap { (value: Node) -> ResultMap in value.resultMap } } }, forKey: "nodes")
+            }
+          }
+
+          public struct Node: GraphQLSelectionSet {
+            public static let possibleTypes: [String] = ["Reward"]
+
+            public static var selections: [GraphQLSelection] {
+              return [
+                GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                GraphQLFragmentSpread(RewardFragment.self),
+                GraphQLField("shippingRulesExpanded", arguments: ["forLocation": GraphQLVariable("locationId")], type: .object(ShippingRulesExpanded.selections)),
+              ]
+            }
+
+            public private(set) var resultMap: ResultMap
+
+            public init(unsafeResultMap: ResultMap) {
+              self.resultMap = unsafeResultMap
+            }
+
+            public var __typename: String {
+              get {
+                return resultMap["__typename"]! as! String
+              }
+              set {
+                resultMap.updateValue(newValue, forKey: "__typename")
+              }
+            }
+
+            /// Shipping rules for all shippable countries.
+            public var shippingRulesExpanded: ShippingRulesExpanded? {
+              get {
+                return (resultMap["shippingRulesExpanded"] as? ResultMap).flatMap { ShippingRulesExpanded(unsafeResultMap: $0) }
+              }
+              set {
+                resultMap.updateValue(newValue?.resultMap, forKey: "shippingRulesExpanded")
+              }
+            }
+
+            public var fragments: Fragments {
+              get {
+                return Fragments(unsafeResultMap: resultMap)
+              }
+              set {
+                resultMap += newValue.resultMap
+              }
+            }
+
+            public struct Fragments {
+              public private(set) var resultMap: ResultMap
+
+              public init(unsafeResultMap: ResultMap) {
+                self.resultMap = unsafeResultMap
+              }
+
+              public var rewardFragment: RewardFragment {
+                get {
+                  return RewardFragment(unsafeResultMap: resultMap)
+                }
+                set {
+                  resultMap += newValue.resultMap
+                }
+              }
+            }
+
+            public struct ShippingRulesExpanded: GraphQLSelectionSet {
+              public static let possibleTypes: [String] = ["RewardShippingRulesConnection"]
+
+              public static var selections: [GraphQLSelection] {
+                return [
+                  GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                  GraphQLField("nodes", type: .list(.object(Node.selections))),
+                ]
+              }
+
+              public private(set) var resultMap: ResultMap
+
+              public init(unsafeResultMap: ResultMap) {
+                self.resultMap = unsafeResultMap
+              }
+
+              public init(nodes: [Node?]? = nil) {
+                self.init(unsafeResultMap: ["__typename": "RewardShippingRulesConnection", "nodes": nodes.flatMap { (value: [Node?]) -> [ResultMap?] in value.map { (value: Node?) -> ResultMap? in value.flatMap { (value: Node) -> ResultMap in value.resultMap } } }])
+              }
+
+              public var __typename: String {
+                get {
+                  return resultMap["__typename"]! as! String
+                }
+                set {
+                  resultMap.updateValue(newValue, forKey: "__typename")
+                }
+              }
+
+              /// A list of nodes.
+              public var nodes: [Node?]? {
+                get {
+                  return (resultMap["nodes"] as? [ResultMap?]).flatMap { (value: [ResultMap?]) -> [Node?] in value.map { (value: ResultMap?) -> Node? in value.flatMap { (value: ResultMap) -> Node in Node(unsafeResultMap: value) } } }
+                }
+                set {
+                  resultMap.updateValue(newValue.flatMap { (value: [Node?]) -> [ResultMap?] in value.map { (value: Node?) -> ResultMap? in value.flatMap { (value: Node) -> ResultMap in value.resultMap } } }, forKey: "nodes")
+                }
+              }
+
+              public struct Node: GraphQLSelectionSet {
+                public static let possibleTypes: [String] = ["ShippingRule"]
+
+                public static var selections: [GraphQLSelection] {
+                  return [
+                    GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                    GraphQLFragmentSpread(ShippingRuleFragment.self),
+                  ]
+                }
+
+                public private(set) var resultMap: ResultMap
+
+                public init(unsafeResultMap: ResultMap) {
+                  self.resultMap = unsafeResultMap
+                }
+
+                public var __typename: String {
+                  get {
+                    return resultMap["__typename"]! as! String
+                  }
+                  set {
+                    resultMap.updateValue(newValue, forKey: "__typename")
+                  }
+                }
+
+                public var fragments: Fragments {
+                  get {
+                    return Fragments(unsafeResultMap: resultMap)
+                  }
+                  set {
+                    resultMap += newValue.resultMap
+                  }
+                }
+
+                public struct Fragments {
+                  public private(set) var resultMap: ResultMap
+
+                  public init(unsafeResultMap: ResultMap) {
+                    self.resultMap = unsafeResultMap
+                  }
+
+                  public var shippingRuleFragment: ShippingRuleFragment {
+                    get {
+                      return ShippingRuleFragment(unsafeResultMap: resultMap)
+                    }
+                    set {
+                      resultMap += newValue.resultMap
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
   public final class FetchBackingQuery: GraphQLQuery {
     /// The raw GraphQL definition of this operation.
     public let operationDefinition: String =
@@ -1831,6 +2173,7 @@ public enum GraphAPI {
       var document: String = operationDefinition
       document.append("\n" + RewardFragment.fragmentDefinition)
       document.append("\n" + MoneyFragment.fragmentDefinition)
+      document.append("\n" + ShippingRuleFragment.fragmentDefinition)
       document.append("\n" + LocationFragment.fragmentDefinition)
       document.append("\n" + BackingFragment.fragmentDefinition)
       document.append("\n" + UserFragment.fragmentDefinition)
@@ -4993,15 +5336,7 @@ public enum GraphAPI {
         shippingPreference
         shippingRules {
           __typename
-          cost {
-            __typename
-            ...MoneyFragment
-          }
-          id
-          location {
-            __typename
-            ...LocationFragment
-          }
+          ...ShippingRuleFragment
         }
         startsAt
       }
@@ -5478,9 +5813,7 @@ public enum GraphAPI {
       public static var selections: [GraphQLSelection] {
         return [
           GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-          GraphQLField("cost", type: .object(Cost.selections)),
-          GraphQLField("id", type: .nonNull(.scalar(GraphQLID.self))),
-          GraphQLField("location", type: .object(Location.selections)),
+          GraphQLFragmentSpread(ShippingRuleFragment.self),
         ]
       }
 
@@ -5488,10 +5821,6 @@ public enum GraphAPI {
 
       public init(unsafeResultMap: ResultMap) {
         self.resultMap = unsafeResultMap
-      }
-
-      public init(cost: Cost? = nil, id: GraphQLID, location: Location? = nil) {
-        self.init(unsafeResultMap: ["__typename": "ShippingRule", "cost": cost.flatMap { (value: Cost) -> ResultMap in value.resultMap }, "id": id, "location": location.flatMap { (value: Location) -> ResultMap in value.resultMap }])
       }
 
       public var __typename: String {
@@ -5503,143 +5832,218 @@ public enum GraphAPI {
         }
       }
 
-      /// The shipping cost for this location.
-      public var cost: Cost? {
+      public var fragments: Fragments {
         get {
-          return (resultMap["cost"] as? ResultMap).flatMap { Cost(unsafeResultMap: $0) }
+          return Fragments(unsafeResultMap: resultMap)
         }
         set {
-          resultMap.updateValue(newValue?.resultMap, forKey: "cost")
+          resultMap += newValue.resultMap
         }
       }
 
-      public var id: GraphQLID {
-        get {
-          return resultMap["id"]! as! GraphQLID
-        }
-        set {
-          resultMap.updateValue(newValue, forKey: "id")
-        }
-      }
-
-      /// The shipping location to which the rule pertains.
-      public var location: Location? {
-        get {
-          return (resultMap["location"] as? ResultMap).flatMap { Location(unsafeResultMap: $0) }
-        }
-        set {
-          resultMap.updateValue(newValue?.resultMap, forKey: "location")
-        }
-      }
-
-      public struct Cost: GraphQLSelectionSet {
-        public static let possibleTypes: [String] = ["Money"]
-
-        public static var selections: [GraphQLSelection] {
-          return [
-            GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-            GraphQLFragmentSpread(MoneyFragment.self),
-          ]
-        }
-
+      public struct Fragments {
         public private(set) var resultMap: ResultMap
 
         public init(unsafeResultMap: ResultMap) {
           self.resultMap = unsafeResultMap
         }
 
-        public init(amount: String? = nil, currency: CurrencyCode? = nil, symbol: String? = nil) {
-          self.init(unsafeResultMap: ["__typename": "Money", "amount": amount, "currency": currency, "symbol": symbol])
-        }
-
-        public var __typename: String {
+        public var shippingRuleFragment: ShippingRuleFragment {
           get {
-            return resultMap["__typename"]! as! String
-          }
-          set {
-            resultMap.updateValue(newValue, forKey: "__typename")
-          }
-        }
-
-        public var fragments: Fragments {
-          get {
-            return Fragments(unsafeResultMap: resultMap)
+            return ShippingRuleFragment(unsafeResultMap: resultMap)
           }
           set {
             resultMap += newValue.resultMap
           }
         }
+      }
+    }
+  }
 
-        public struct Fragments {
-          public private(set) var resultMap: ResultMap
+  public struct ShippingRuleFragment: GraphQLFragment {
+    /// The raw GraphQL definition of this fragment.
+    public static let fragmentDefinition: String =
+      """
+      fragment ShippingRuleFragment on ShippingRule {
+        __typename
+        cost {
+          __typename
+          ...MoneyFragment
+        }
+        id
+        location {
+          __typename
+          ...LocationFragment
+        }
+      }
+      """
 
-          public init(unsafeResultMap: ResultMap) {
-            self.resultMap = unsafeResultMap
-          }
+    public static let possibleTypes: [String] = ["ShippingRule"]
 
-          public var moneyFragment: MoneyFragment {
-            get {
-              return MoneyFragment(unsafeResultMap: resultMap)
-            }
-            set {
-              resultMap += newValue.resultMap
-            }
-          }
+    public static var selections: [GraphQLSelection] {
+      return [
+        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+        GraphQLField("cost", type: .object(Cost.selections)),
+        GraphQLField("id", type: .nonNull(.scalar(GraphQLID.self))),
+        GraphQLField("location", type: .object(Location.selections)),
+      ]
+    }
+
+    public private(set) var resultMap: ResultMap
+
+    public init(unsafeResultMap: ResultMap) {
+      self.resultMap = unsafeResultMap
+    }
+
+    public init(cost: Cost? = nil, id: GraphQLID, location: Location? = nil) {
+      self.init(unsafeResultMap: ["__typename": "ShippingRule", "cost": cost.flatMap { (value: Cost) -> ResultMap in value.resultMap }, "id": id, "location": location.flatMap { (value: Location) -> ResultMap in value.resultMap }])
+    }
+
+    public var __typename: String {
+      get {
+        return resultMap["__typename"]! as! String
+      }
+      set {
+        resultMap.updateValue(newValue, forKey: "__typename")
+      }
+    }
+
+    /// The shipping cost for this location.
+    public var cost: Cost? {
+      get {
+        return (resultMap["cost"] as? ResultMap).flatMap { Cost(unsafeResultMap: $0) }
+      }
+      set {
+        resultMap.updateValue(newValue?.resultMap, forKey: "cost")
+      }
+    }
+
+    public var id: GraphQLID {
+      get {
+        return resultMap["id"]! as! GraphQLID
+      }
+      set {
+        resultMap.updateValue(newValue, forKey: "id")
+      }
+    }
+
+    /// The shipping location to which the rule pertains.
+    public var location: Location? {
+      get {
+        return (resultMap["location"] as? ResultMap).flatMap { Location(unsafeResultMap: $0) }
+      }
+      set {
+        resultMap.updateValue(newValue?.resultMap, forKey: "location")
+      }
+    }
+
+    public struct Cost: GraphQLSelectionSet {
+      public static let possibleTypes: [String] = ["Money"]
+
+      public static var selections: [GraphQLSelection] {
+        return [
+          GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+          GraphQLFragmentSpread(MoneyFragment.self),
+        ]
+      }
+
+      public private(set) var resultMap: ResultMap
+
+      public init(unsafeResultMap: ResultMap) {
+        self.resultMap = unsafeResultMap
+      }
+
+      public init(amount: String? = nil, currency: CurrencyCode? = nil, symbol: String? = nil) {
+        self.init(unsafeResultMap: ["__typename": "Money", "amount": amount, "currency": currency, "symbol": symbol])
+      }
+
+      public var __typename: String {
+        get {
+          return resultMap["__typename"]! as! String
+        }
+        set {
+          resultMap.updateValue(newValue, forKey: "__typename")
         }
       }
 
-      public struct Location: GraphQLSelectionSet {
-        public static let possibleTypes: [String] = ["Location"]
-
-        public static var selections: [GraphQLSelection] {
-          return [
-            GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-            GraphQLFragmentSpread(LocationFragment.self),
-          ]
+      public var fragments: Fragments {
+        get {
+          return Fragments(unsafeResultMap: resultMap)
         }
+        set {
+          resultMap += newValue.resultMap
+        }
+      }
 
+      public struct Fragments {
         public private(set) var resultMap: ResultMap
 
         public init(unsafeResultMap: ResultMap) {
           self.resultMap = unsafeResultMap
         }
 
-        public init(country: String, countryName: String? = nil, displayableName: String, id: GraphQLID, name: String) {
-          self.init(unsafeResultMap: ["__typename": "Location", "country": country, "countryName": countryName, "displayableName": displayableName, "id": id, "name": name])
-        }
-
-        public var __typename: String {
+        public var moneyFragment: MoneyFragment {
           get {
-            return resultMap["__typename"]! as! String
-          }
-          set {
-            resultMap.updateValue(newValue, forKey: "__typename")
-          }
-        }
-
-        public var fragments: Fragments {
-          get {
-            return Fragments(unsafeResultMap: resultMap)
+            return MoneyFragment(unsafeResultMap: resultMap)
           }
           set {
             resultMap += newValue.resultMap
           }
         }
+      }
+    }
 
-        public struct Fragments {
-          public private(set) var resultMap: ResultMap
+    public struct Location: GraphQLSelectionSet {
+      public static let possibleTypes: [String] = ["Location"]
 
-          public init(unsafeResultMap: ResultMap) {
-            self.resultMap = unsafeResultMap
+      public static var selections: [GraphQLSelection] {
+        return [
+          GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+          GraphQLFragmentSpread(LocationFragment.self),
+        ]
+      }
+
+      public private(set) var resultMap: ResultMap
+
+      public init(unsafeResultMap: ResultMap) {
+        self.resultMap = unsafeResultMap
+      }
+
+      public init(country: String, countryName: String? = nil, displayableName: String, id: GraphQLID, name: String) {
+        self.init(unsafeResultMap: ["__typename": "Location", "country": country, "countryName": countryName, "displayableName": displayableName, "id": id, "name": name])
+      }
+
+      public var __typename: String {
+        get {
+          return resultMap["__typename"]! as! String
+        }
+        set {
+          resultMap.updateValue(newValue, forKey: "__typename")
+        }
+      }
+
+      public var fragments: Fragments {
+        get {
+          return Fragments(unsafeResultMap: resultMap)
+        }
+        set {
+          resultMap += newValue.resultMap
+        }
+      }
+
+      public struct Fragments {
+        public private(set) var resultMap: ResultMap
+
+        public init(unsafeResultMap: ResultMap) {
+          self.resultMap = unsafeResultMap
+        }
+
+        public var locationFragment: LocationFragment {
+          get {
+            return LocationFragment(unsafeResultMap: resultMap)
           }
-
-          public var locationFragment: LocationFragment {
-            get {
-              return LocationFragment(unsafeResultMap: resultMap)
-            }
-            set {
-              resultMap += newValue.resultMap
-            }
+          set {
+            resultMap += newValue.resultMap
           }
         }
       }

--- a/KsApi/MockService.swift
+++ b/KsApi/MockService.swift
@@ -896,6 +896,11 @@
       return producer(for: self.fetchRewardAddOnsSelectionViewRewardsResult)
     }
 
+    func fetchRewardAddOnsSelectionViewRewards(slug _: String, locationId _: String?)
+      -> SignalProducer<Project, ErrorEnvelope> {
+      return producer(for: self.fetchRewardAddOnsSelectionViewRewardsResult)
+    }
+
     internal func fetchMessageThread(messageThreadId _: Int)
       -> SignalProducer<MessageThreadEnvelope, ErrorEnvelope> {
       if let error = self.fetchMessageThreadResult?.error {

--- a/KsApi/Service.swift
+++ b/KsApi/Service.swift
@@ -352,6 +352,15 @@ public struct Service: ServiceType {
       .flatMap(Project.projectProducer(from:))
   }
 
+  public func fetchRewardAddOnsSelectionViewRewards(
+    slug: String,
+    locationId: String?
+  ) -> SignalProducer<Project, ErrorEnvelope> {
+    return GraphQL.shared.client
+      .fetch(query: GraphAPI.FetchAddOnsQuery(projectSlug: slug, locationId: locationId))
+      .flatMap(Project.projectProducer(from:))
+  }
+
   public func fetchRewardShippingRules(projectId: Int, rewardId: Int)
     -> SignalProducer<ShippingRulesEnvelope, ErrorEnvelope> {
     return request(.shippingRules(projectId: projectId, rewardId: rewardId))

--- a/KsApi/ServiceType.swift
+++ b/KsApi/ServiceType.swift
@@ -216,6 +216,10 @@ public protocol ServiceType {
   func fetchRewardAddOnsSelectionViewRewards(query: NonEmptySet<Query>)
     -> SignalProducer<Project, ErrorEnvelope>
 
+  /// Fetch the add-on rewards for the add-on selection view with a `Project` slug and optional `Location` ID.
+  func fetchRewardAddOnsSelectionViewRewards(slug: String, locationId: String?)
+    -> SignalProducer<Project, ErrorEnvelope>
+
   /// Fetches a reward for a project and reward id.
   func fetchRewardShippingRules(projectId: Int, rewardId: Int)
     -> SignalProducer<ShippingRulesEnvelope, ErrorEnvelope>

--- a/KsApi/fragments/RewardFragment.graphql
+++ b/KsApi/fragments/RewardFragment.graphql
@@ -27,13 +27,7 @@ fragment RewardFragment on Reward {
   remainingQuantity
   shippingPreference
   shippingRules {
-    cost {
-      ...MoneyFragment
-    }
-    id
-    location {
-      ...LocationFragment
-    }
+    ...ShippingRuleFragment
   }
   startsAt
 }

--- a/KsApi/fragments/ShippingRuleFragment.graphql
+++ b/KsApi/fragments/ShippingRuleFragment.graphql
@@ -1,0 +1,9 @@
+fragment ShippingRuleFragment on ShippingRule {
+  cost {
+    ...MoneyFragment
+  }
+  id
+  location {
+    ...LocationFragment
+  }
+}

--- a/KsApi/models/graphql/adapters/Project+FetchAddOnsQueryData.swift
+++ b/KsApi/models/graphql/adapters/Project+FetchAddOnsQueryData.swift
@@ -1,0 +1,37 @@
+import Foundation
+import ReactiveSwift
+
+extension Project {
+  static func projectProducer(
+    from data: GraphAPI.FetchAddOnsQuery.Data
+  ) -> SignalProducer<Project, ErrorEnvelope> {
+    guard let project = Project.project(from: data) else {
+      return SignalProducer(error: ErrorEnvelope.couldNotParseJSON)
+    }
+
+    return SignalProducer(value: project)
+  }
+
+  static func project(from data: GraphAPI.FetchAddOnsQuery.Data) -> Project? {
+    let addOns = data.project?.addOns?.nodes?
+      .compactMap { node -> (GraphAPI.RewardFragment, [ShippingRule]?)? in
+        guard let rewardFragment = node?.fragments.rewardFragment else { return nil }
+
+        let expandedShippingRules = node?.shippingRulesExpanded?.nodes?
+          .compactMap { node in node?.fragments.shippingRuleFragment }
+          .compactMap(ShippingRule.shippingRule(from:))
+
+        return (rewardFragment, expandedShippingRules)
+      }
+      .compactMap { fragment, expandedShippingRules in
+        Reward.reward(from: fragment, expandedShippingRules: expandedShippingRules)
+      }
+
+    guard
+      let fragment = data.project?.fragments.projectFragment,
+      let project = Project.project(from: fragment, addOns: addOns)
+    else { return nil }
+
+    return project
+  }
+}

--- a/KsApi/models/graphql/adapters/Project+FetchAddOnsQueryDataTests.swift
+++ b/KsApi/models/graphql/adapters/Project+FetchAddOnsQueryDataTests.swift
@@ -1,0 +1,504 @@
+import Apollo
+@testable import KsApi
+import XCTest
+
+final class Project_FetchAddOnsQueryDataTests: XCTestCase {
+  func test() {
+    do {
+      let fragment = try GraphAPI.ProjectFragment(jsonObject: self.projectDictionary())
+      XCTAssertNotNil(fragment)
+
+      let project = Project.project(from: fragment)
+      XCTAssertNotNil(project)
+    } catch {
+      XCTFail(error.localizedDescription)
+    }
+  }
+
+  private func projectDictionary() -> [String: Any] {
+    let json = """
+    {
+      "__typename": "Project",
+      "addOns": {
+        "__typename": "ProjectRewardConnection",
+        "nodes": [
+          {
+            "__typename": "Reward",
+            "shippingRulesExpanded": {
+              "__typename": "RewardShippingRulesConnection",
+              "nodes": [
+                {
+                  "__typename": "ShippingRule",
+                  "cost": {
+                    "__typename": "Money",
+                    "amount": "0.0",
+                    "currency": null,
+                    "symbol": null
+                  },
+                  "id": "U2hpcHBpbmdSdWxlLQ==",
+                  "location": {
+                    "__typename": "Location",
+                    "country": "EE",
+                    "countryName": "Estonia",
+                    "displayableName": "Estonia",
+                    "id": "TG9jYXRpb24tMjM0MjQ4MDU=",
+                    "name": "Estonia"
+                  }
+                }
+              ]
+            },
+            "amount": {
+              "__typename": "Money",
+              "amount": "4.0",
+              "currency": "AUD",
+              "symbol": "$"
+            },
+            "backersCount": 9,
+            "convertedAmount": {
+              "__typename": "Money",
+              "amount": "4.0",
+              "currency": "CAD",
+              "symbol": "$"
+            },
+            "description": "Translucent Sticker Sheet",
+            "displayName": "Paper Sticker Sheet (AU$ 4)",
+            "endsAt": null,
+            "estimatedDeliveryOn": "2021-06-01",
+            "id": "UmV3YXJkLTgxOTAzMjA=",
+            "isMaxPledge": false,
+            "items": {
+              "__typename": "RewardItemsConnection",
+              "nodes": [
+                {
+                  "__typename": "RewardItem",
+                  "id": "UmV3YXJkSXRlbS0xMTc5OTgz",
+                  "name": "Paper Sticker Sheet"
+                }
+              ]
+            },
+            "limit": null,
+            "limitPerBacker": 10,
+            "name": "Paper Sticker Sheet",
+            "project": {
+              "__typename": "Project",
+              "id": "UHJvamVjdC0xNjA2NTMyODgx"
+            },
+            "remainingQuantity": null,
+            "shippingPreference": "unrestricted",
+            "shippingRules": [
+              {
+                "__typename": "ShippingRule",
+                "cost": {
+                  "__typename": "Money",
+                  "amount": "0.0",
+                  "currency": "AUD",
+                  "symbol": "$"
+                },
+                "id": "U2hpcHBpbmdSdWxlLTExMzIxNDA2",
+                "location": {
+                  "__typename": "Location",
+                  "country": "ZZ",
+                  "countryName": null,
+                  "displayableName": "Earth",
+                  "id": "TG9jYXRpb24tMQ==",
+                  "name": "Rest of World"
+                }
+              },
+              {
+                "__typename": "ShippingRule",
+                "cost": {
+                  "__typename": "Money",
+                  "amount": "0.0",
+                  "currency": "AUD",
+                  "symbol": "$"
+                },
+                "id": "U2hpcHBpbmdSdWxlLTExMzIxNDA3",
+                "location": {
+                  "__typename": "Location",
+                  "country": "AU",
+                  "countryName": "Australia",
+                  "displayableName": "Australia",
+                  "id": "TG9jYXRpb24tMjM0MjQ3NDg=",
+                  "name": "Australia"
+                }
+              }
+            ],
+            "startsAt": null
+          },
+          {
+            "__typename": "Reward",
+            "shippingRulesExpanded": {
+              "__typename": "RewardShippingRulesConnection",
+              "nodes": [
+                {
+                  "__typename": "ShippingRule",
+                  "cost": {
+                    "__typename": "Money",
+                    "amount": "0.0",
+                    "currency": null,
+                    "symbol": null
+                  },
+                  "id": "U2hpcHBpbmdSdWxlLQ==",
+                  "location": {
+                    "__typename": "Location",
+                    "country": "EE",
+                    "countryName": "Estonia",
+                    "displayableName": "Estonia",
+                    "id": "TG9jYXRpb24tMjM0MjQ4MDU=",
+                    "name": "Estonia"
+                  }
+                }
+              ]
+            },
+            "amount": {
+              "__typename": "Money",
+              "amount": "8.0",
+              "currency": "AUD",
+              "symbol": "$"
+            },
+            "backersCount": 2,
+            "convertedAmount": {
+              "__typename": "Money",
+              "amount": "8.0",
+              "currency": "CAD",
+              "symbol": "$"
+            },
+            "description": "Boxed paper tape of 1x 20mm deco tape.",
+            "displayName": "Hedgerow Paper Tape (20mm) (AU$ 8)",
+            "endsAt": null,
+            "estimatedDeliveryOn": "2021-06-01",
+            "id": "UmV3YXJkLTgxOTc0NDQ=",
+            "isMaxPledge": false,
+            "items": {
+              "__typename": "RewardItemsConnection",
+              "nodes": [
+                {
+                  "__typename": "RewardItem",
+                  "id": "UmV3YXJkSXRlbS0xMTc5OTgx",
+                  "name": "Paper Tape Boxed Set"
+                }
+              ]
+            },
+            "limit": null,
+            "limitPerBacker": 10,
+            "name": "Hedgerow Paper Tape (20mm)",
+            "project": {
+              "__typename": "Project",
+              "id": "UHJvamVjdC0xNjA2NTMyODgx"
+            },
+            "remainingQuantity": null,
+            "shippingPreference": "restricted",
+            "shippingRules": [
+              {
+                "__typename": "ShippingRule",
+                "cost": {
+                  "__typename": "Money",
+                  "amount": "0.0",
+                  "currency": "AUD",
+                  "symbol": "$"
+                },
+                "id": "U2hpcHBpbmdSdWxlLTExMzM3OTE1",
+                "location": {
+                  "__typename": "Location",
+                  "country": "AU",
+                  "countryName": "Australia",
+                  "displayableName": "Australia",
+                  "id": "TG9jYXRpb24tMjM0MjQ3NDg=",
+                  "name": "Australia"
+                }
+              },
+              {
+                "__typename": "ShippingRule",
+                "cost": {
+                  "__typename": "Money",
+                  "amount": "0.0",
+                  "currency": "AUD",
+                  "symbol": "$"
+                },
+                "id": "U2hpcHBpbmdSdWxlLTExMzM3OTIx",
+                "location": {
+                  "__typename": "Location",
+                  "country": "CA",
+                  "countryName": "Canada",
+                  "displayableName": "Canada",
+                  "id": "TG9jYXRpb24tMjM0MjQ3NzU=",
+                  "name": "Canada"
+                }
+              },
+              {
+                "__typename": "ShippingRule",
+                "cost": {
+                  "__typename": "Money",
+                  "amount": "0.0",
+                  "currency": "AUD",
+                  "symbol": "$"
+                },
+                "id": "U2hpcHBpbmdSdWxlLTExMzM3OTE3",
+                "location": {
+                  "__typename": "Location",
+                  "country": "CN",
+                  "countryName": "China",
+                  "displayableName": "China",
+                  "id": "TG9jYXRpb24tMjM0MjQ3ODE=",
+                  "name": "China"
+                }
+              },
+              {
+                "__typename": "ShippingRule",
+                "cost": {
+                  "__typename": "Money",
+                  "amount": "0.0",
+                  "currency": "AUD",
+                  "symbol": "$"
+                },
+                "id": "U2hpcHBpbmdSdWxlLTExMzM3OTE4",
+                "location": {
+                  "__typename": "Location",
+                  "country": "JP",
+                  "countryName": "Japan",
+                  "displayableName": "Japan",
+                  "id": "TG9jYXRpb24tMjM0MjQ4NTY=",
+                  "name": "Japan"
+                }
+              },
+              {
+                "__typename": "ShippingRule",
+                "cost": {
+                  "__typename": "Money",
+                  "amount": "0.0",
+                  "currency": "AUD",
+                  "symbol": "$"
+                },
+                "id": "U2hpcHBpbmdSdWxlLTExMzM3OTE5",
+                "location": {
+                  "__typename": "Location",
+                  "country": "KR",
+                  "countryName": "Korea, Republic of",
+                  "displayableName": "South Korea",
+                  "id": "TG9jYXRpb24tMjM0MjQ4Njg=",
+                  "name": "South Korea"
+                }
+              },
+              {
+                "__typename": "ShippingRule",
+                "cost": {
+                  "__typename": "Money",
+                  "amount": "0.0",
+                  "currency": "AUD",
+                  "symbol": "$"
+                },
+                "id": "U2hpcHBpbmdSdWxlLTExMzM3OTIz",
+                "location": {
+                  "__typename": "Location",
+                  "country": "MY",
+                  "countryName": "Malaysia",
+                  "displayableName": "Malaysia",
+                  "id": "TG9jYXRpb24tMjM0MjQ5MDE=",
+                  "name": "Malaysia"
+                }
+              },
+              {
+                "__typename": "ShippingRule",
+                "cost": {
+                  "__typename": "Money",
+                  "amount": "0.0",
+                  "currency": "AUD",
+                  "symbol": "$"
+                },
+                "id": "U2hpcHBpbmdSdWxlLTExMzM3OTI1",
+                "location": {
+                  "__typename": "Location",
+                  "country": "NZ",
+                  "countryName": "New Zealand",
+                  "displayableName": "New Zealand",
+                  "id": "TG9jYXRpb24tMjM0MjQ5MTY=",
+                  "name": "New Zealand"
+                }
+              },
+              {
+                "__typename": "ShippingRule",
+                "cost": {
+                  "__typename": "Money",
+                  "amount": "0.0",
+                  "currency": "AUD",
+                  "symbol": "$"
+                },
+                "id": "U2hpcHBpbmdSdWxlLTExMzM3OTIw",
+                "location": {
+                  "__typename": "Location",
+                  "country": "PH",
+                  "countryName": "Philippines",
+                  "displayableName": "Philippines",
+                  "id": "TG9jYXRpb24tMjM0MjQ5MzQ=",
+                  "name": "Philippines"
+                }
+              },
+              {
+                "__typename": "ShippingRule",
+                "cost": {
+                  "__typename": "Money",
+                  "amount": "0.0",
+                  "currency": "AUD",
+                  "symbol": "$"
+                },
+                "id": "U2hpcHBpbmdSdWxlLTExMzM3OTI3",
+                "location": {
+                  "__typename": "Location",
+                  "country": "RU",
+                  "countryName": "Russia",
+                  "displayableName": "Russia",
+                  "id": "TG9jYXRpb24tMjM0MjQ5MzY=",
+                  "name": "Russia"
+                }
+              },
+              {
+                "__typename": "ShippingRule",
+                "cost": {
+                  "__typename": "Money",
+                  "amount": "0.0",
+                  "currency": "AUD",
+                  "symbol": "$"
+                },
+                "id": "U2hpcHBpbmdSdWxlLTExMzM3OTI0",
+                "location": {
+                  "__typename": "Location",
+                  "country": "SG",
+                  "countryName": "Singapore",
+                  "displayableName": "Singapore",
+                  "id": "TG9jYXRpb24tMjM0MjQ5NDg=",
+                  "name": "Singapore"
+                }
+              },
+              {
+                "__typename": "ShippingRule",
+                "cost": {
+                  "__typename": "Money",
+                  "amount": "0.0",
+                  "currency": "AUD",
+                  "symbol": "$"
+                },
+                "id": "U2hpcHBpbmdSdWxlLTExMzM3OTI2",
+                "location": {
+                  "__typename": "Location",
+                  "country": "US",
+                  "countryName": "United States",
+                  "displayableName": "United States",
+                  "id": "TG9jYXRpb24tMjM0MjQ5Nzc=",
+                  "name": "United States"
+                }
+              },
+              {
+                "__typename": "ShippingRule",
+                "cost": {
+                  "__typename": "Money",
+                  "amount": "0.0",
+                  "currency": "AUD",
+                  "symbol": "$"
+                },
+                "id": "U2hpcHBpbmdSdWxlLTExMzM3OTIy",
+                "location": {
+                  "__typename": "Location",
+                  "country": "HK",
+                  "countryName": "Hong Kong",
+                  "displayableName": "Hong Kong",
+                  "id": "TG9jYXRpb24tMjQ4NjU2OTg=",
+                  "name": "Hong Kong"
+                }
+              },
+              {
+                "__typename": "ShippingRule",
+                "cost": {
+                  "__typename": "Money",
+                  "amount": "0.0",
+                  "currency": "AUD",
+                  "symbol": "$"
+                },
+                "id": "U2hpcHBpbmdSdWxlLTExMzM3OTE2",
+                "location": {
+                  "__typename": "Location",
+                  "country": "ZZ",
+                  "countryName": null,
+                  "displayableName": "European Union",
+                  "id": "TG9jYXRpb24tNTU5NDkwNjg=",
+                  "name": "European Union"
+                }
+              }
+            ],
+            "startsAt": null
+          }
+        ]
+      },
+      "actions": {
+        "__typename": "ProjectActions",
+        "displayConvertAmount": false
+      },
+      "backersCount": 46,
+      "category": {
+        "__typename": "Category",
+        "id": "Q2F0ZWdvcnktMjI=",
+        "name": "Illustration",
+        "parentCategory": {
+          "__typename": "Category",
+          "id": "Q2F0ZWdvcnktMQ==",
+          "name": "Art"
+        }
+      },
+      "country": {
+        "__typename": "Country",
+        "code": "AU",
+        "name": "Australia"
+      },
+      "creator": {
+        "__typename": "User",
+        "id": "VXNlci0xNzA1MzA0MDA2",
+        "imageUrl": "https://ksr-qa-ugc.imgix.net/assets/033/090/101/8667751e512228a62d426c77f6eb8a0b_original.jpg?ixlib=rb-4.0.2&blur=false&w=1024&h=1024&fit=crop&v=1618227451&auto=format&frame=1&q=92&s=36de925b6797139e096d7b6219f743d0",
+        "isCreator": null,
+        "name": "Peppermint Fox",
+        "uid": "1705304006"
+      },
+      "currency": "AUD",
+      "deadlineAt": 1622195758,
+      "description": "Notebooks, paper tape and sticker sets from the Peppermint Fox Press, inspired by vintage books. For poets, planners, and storytellers.",
+      "finalCollectionDate": null,
+      "fxRate": 0.93110152,
+      "goal": {
+        "__typename": "Money",
+        "amount": "1500.0",
+        "currency": "AUD",
+        "symbol": "$"
+      },
+      "image": {
+        "__typename": "Photo",
+        "id": "UGhvdG8tMzMzOTU0MTI=",
+        "url": "https://ksr-qa-ugc.imgix.net/assets/033/395/412/618ee8bdcfcfd731cc0404270a79d98c_original.jpg?ixlib=rb-4.0.2&crop=faces&w=1024&h=576&fit=crop&v=1620193138&auto=format&frame=1&q=92&s=518067d52053dd4f523b5ced0bb1487d"
+      },
+      "isProjectWeLove": true,
+      "launchedAt": 1619603758,
+      "location": {
+        "__typename": "Location",
+        "country": "AU",
+        "countryName": "Australia",
+        "displayableName": "Launceston, AU",
+        "id": "TG9jYXRpb24tMTEwMzM2OA==",
+        "name": "Launceston"
+      },
+      "name": "Peppermint Fox Press: Notebooks & Stationery",
+      "pid": 1606532881,
+      "pledged": {
+        "__typename": "Money",
+        "amount": "6054.32",
+        "currency": "AUD",
+        "symbol": "$"
+      },
+      "slug": "peppermintfox/peppermint-fox-press-notebooks-and-stationery",
+      "state": "LIVE",
+      "stateChangedAt": 1619603760,
+      "url": "https://staging.kickstarter.com/projects/peppermintfox/peppermint-fox-press-notebooks-and-stationery",
+      "usdExchangeRate": 0.74641181
+    }
+    """
+
+    let data = Data(json.utf8)
+    return (try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any]) ?? [:]
+  }
+}

--- a/KsApi/models/graphql/adapters/Reward+RewardFragment.swift
+++ b/KsApi/models/graphql/adapters/Reward+RewardFragment.swift
@@ -31,7 +31,7 @@ extension Reward {
       convertedMinimum: rewardFragment.convertedAmount.fragments.moneyFragment.amount
         .flatMap(Double.init) ?? 0,
       description: rewardFragment.description,
-      endsAt: rewardFragment.endsAt.flatMap(TimeInterval.init) ?? 0,
+      endsAt: rewardFragment.endsAt.flatMap(TimeInterval.init),
       estimatedDeliveryOn: estimatedDeliveryOn,
       hasAddOns: false, // This value is only sent via the v1 API to indicate that a base reward has add-ons
       id: rewardId,
@@ -43,7 +43,7 @@ extension Reward {
       shipping: shippingData(from: rewardFragment),
       shippingRules: shippingRulesData(from: rewardFragment),
       shippingRulesExpanded: expandedShippingRules,
-      startsAt: rewardFragment.startsAt.flatMap(TimeInterval.init) ?? 0,
+      startsAt: rewardFragment.startsAt.flatMap(TimeInterval.init),
       title: rewardFragment.name
     )
   }
@@ -100,19 +100,10 @@ private func shippingPreference(from rewardFragment: GraphAPI.RewardFragment) ->
 }
 
 private func shippingRulesData(
-  from graphReward: GraphAPI.RewardFragment
+  from rewardFragment: GraphAPI.RewardFragment
 ) -> [ShippingRule]? {
-  return graphReward.shippingRules.compactMap { shippingRule -> ShippingRule? in
-    guard
-      let shippingRule = shippingRule,
-      let locationFragment = shippingRule.location?.fragments.locationFragment,
-      let location = Location.location(from: locationFragment)
-    else { return nil }
-
-    return ShippingRule(
-      cost: shippingRule.cost?.fragments.moneyFragment.amount.flatMap(Double.init) ?? 0,
-      id: decompose(id: shippingRule.id),
-      location: location
-    )
+  return rewardFragment.shippingRules.compactMap { shippingRule -> ShippingRule? in
+    guard let fragment = shippingRule?.fragments.shippingRuleFragment else { return nil }
+    return ShippingRule.shippingRule(from: fragment)
   }
 }

--- a/KsApi/models/graphql/adapters/Reward+RewardFragmentTests.swift
+++ b/KsApi/models/graphql/adapters/Reward+RewardFragmentTests.swift
@@ -21,7 +21,7 @@ final class Reward_RewardFragmentTests: XCTestCase {
       XCTAssertEqual(v1Reward?.backersCount, 13)
       XCTAssertEqual(v1Reward?.convertedMinimum, 31.0)
       XCTAssertEqual(v1Reward?.description, "Description")
-      XCTAssertEqual(v1Reward?.endsAt, 0)
+      XCTAssertEqual(v1Reward?.endsAt, nil)
       XCTAssertEqual(v1Reward?.estimatedDeliveryOn, 1_638_316_800.0)
       XCTAssertEqual(v1Reward?.id, 8_173_901)
       XCTAssertEqual(v1Reward?.limit, nil)
@@ -36,11 +36,11 @@ final class Reward_RewardFragmentTests: XCTestCase {
       XCTAssertEqual(v1Reward?.shipping.enabled, true)
       XCTAssertEqual(v1Reward?.shipping.preference, .unrestricted)
       XCTAssertEqual(v1Reward?.shippingRules?.count, 2)
-      XCTAssertEqual(v1Reward?.startsAt, 0)
+      XCTAssertEqual(v1Reward?.startsAt, nil)
       XCTAssertEqual(v1Reward?.title, "Soft Cover Book (Signed)")
 
       XCTAssertEqual(v1Reward?.isLimitedQuantity, false)
-      XCTAssertEqual(v1Reward?.isLimitedTime, true)
+      XCTAssertEqual(v1Reward?.isLimitedTime, false)
     } catch {
       XCTFail(error.localizedDescription)
     }

--- a/KsApi/models/graphql/adapters/ShippingRule+ShippingRuleFragment.swift
+++ b/KsApi/models/graphql/adapters/ShippingRule+ShippingRuleFragment.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+extension ShippingRule {
+  /**
+   Returns a minimal `ShippingRule` from a `ShippingRuleFragment`
+   */
+  static func shippingRule(from shippingRuleFragment: GraphAPI.ShippingRuleFragment) -> ShippingRule? {
+    guard
+      let locationFragment = shippingRuleFragment.location?.fragments.locationFragment,
+      let location = Location.location(from: locationFragment)
+    else { return nil }
+
+    return ShippingRule(
+      cost: shippingRuleFragment.cost?.fragments.moneyFragment.amount.flatMap(Double.init) ?? 0,
+      id: decompose(id: shippingRuleFragment.id),
+      location: location
+    )
+  }
+}

--- a/KsApi/models/graphql/adapters/ShippingRule+ShippingRuleFragmentTests.swift
+++ b/KsApi/models/graphql/adapters/ShippingRule+ShippingRuleFragmentTests.swift
@@ -1,0 +1,25 @@
+import Foundation
+@testable import KsApi
+import XCTest
+
+final class ShippingRule_ShippingRuleFragmentTests: XCTestCase {
+  func test() {
+    let shippingRuleFragment = GraphAPI.ShippingRuleFragment(
+      cost: GraphAPI.ShippingRuleFragment.Cost(
+        amount: "50",
+        currency: .usd,
+        symbol: "$"
+      ),
+      id: "TG9jYXRpb24tMjM0MjQ3NzU=",
+      location: GraphAPI.ShippingRuleFragment.Location(
+        country: "CA",
+        countryName: "Canada",
+        displayableName: "Canada",
+        id: "TG9jYXRpb24tMjM0MjQ3NzU=",
+        name: "Canada"
+      )
+    )
+
+    XCTAssertNotNil(ShippingRule.shippingRule(from: shippingRuleFragment))
+  }
+}

--- a/KsApi/queries/FetchAddOnsQuery.graphql
+++ b/KsApi/queries/FetchAddOnsQuery.graphql
@@ -1,0 +1,15 @@
+query FetchAddOns($projectSlug: String!, $locationId: ID) {
+  project(slug: $projectSlug) {
+    ...ProjectFragment
+    addOns {
+      nodes {
+        ...RewardFragment
+        shippingRulesExpanded(forLocation: $locationId) {
+          nodes {
+            ...ShippingRuleFragment
+          }
+        }
+      }
+    }
+  }
+}

--- a/Library/ViewModels/RewardAddOnSelectionViewModel.swift
+++ b/Library/ViewModels/RewardAddOnSelectionViewModel.swift
@@ -96,10 +96,8 @@ public final class RewardAddOnSelectionViewModel: RewardAddOnSelectionViewModelT
 
     let projectEvent = slugAndShippingRule.switchMap { slug, shippingRule in
       AppEnvironment.current.apiService.fetchRewardAddOnsSelectionViewRewards(
-        query: rewardAddOnSelectionViewAddOnsQuery(
-          withProjectSlug: slug,
-          andGraphId: shippingRule?.location.graphID
-        )
+        slug: slug,
+        locationId: shippingRule?.location.graphID
       )
       .ksr_delay(AppEnvironment.current.apiDelayInterval, on: AppEnvironment.current.scheduler)
       .materialize()


### PR DESCRIPTION
# 📲 What

Updates the data being fetched in `RewardAddOnSelectionViewModel` to use Apollo.

# 🤔 Why

Continuation of our migration to Apollo.

# 🛠 How

- Added the `FetchAddOns` query.
- Adapted the data returned to `Project`.

# ✅ Acceptance criteria

- [ ] A `Project` with add-ons can be created from `GraphAPI.FetchAddOnsQuery.Data`.
- [ ] No regression in RewardAddOnSelectionViewController.