### PR TITLE
[NT-2073] Don't Fetch Expanded Shipping Rules For Digital-Only Rewards

### DIFF
--- a/KsApi/MockService.swift
+++ b/KsApi/MockService.swift
@@ -896,7 +896,7 @@
       return producer(for: self.fetchRewardAddOnsSelectionViewRewardsResult)
     }
 
-    func fetchRewardAddOnsSelectionViewRewards(slug _: String, locationId _: String?)
+    func fetchRewardAddOnsSelectionViewRewards(slug _: String, shippingEnabled: Bool, locationId _: String?)
       -> SignalProducer<Project, ErrorEnvelope> {
       return producer(for: self.fetchRewardAddOnsSelectionViewRewardsResult)
     }

--- a/KsApi/Service.swift
+++ b/KsApi/Service.swift
@@ -354,10 +354,17 @@ public struct Service: ServiceType {
 
   public func fetchRewardAddOnsSelectionViewRewards(
     slug: String,
+    shippingEnabled: Bool,
     locationId: String?
   ) -> SignalProducer<Project, ErrorEnvelope> {
+    let query = GraphAPI.FetchAddOnsQuery(
+      projectSlug: slug,
+      shippingEnabled: shippingEnabled,
+      locationId: locationId
+    )
+
     return GraphQL.shared.client
-      .fetch(query: GraphAPI.FetchAddOnsQuery(projectSlug: slug, locationId: locationId))
+      .fetch(query: query)
       .flatMap(Project.projectProducer(from:))
   }
 

--- a/KsApi/ServiceType.swift
+++ b/KsApi/ServiceType.swift
@@ -217,7 +217,7 @@ public protocol ServiceType {
     -> SignalProducer<Project, ErrorEnvelope>
 
   /// Fetch the add-on rewards for the add-on selection view with a `Project` slug and optional `Location` ID.
-  func fetchRewardAddOnsSelectionViewRewards(slug: String, locationId: String?)
+  func fetchRewardAddOnsSelectionViewRewards(slug: String, shippingEnabled: Bool, locationId: String?)
     -> SignalProducer<Project, ErrorEnvelope>
 
   /// Fetches a reward for a project and reward id.

--- a/KsApi/queries/FetchAddOnsQuery.graphql
+++ b/KsApi/queries/FetchAddOnsQuery.graphql
@@ -1,10 +1,10 @@
-query FetchAddOns($projectSlug: String!, $locationId: ID) {
+query FetchAddOns($projectSlug: String!, $shippingEnabled: Boolean!, $locationId: ID) {
   project(slug: $projectSlug) {
     ...ProjectFragment
     addOns {
       nodes {
         ...RewardFragment
-        shippingRulesExpanded(forLocation: $locationId) {
+        shippingRulesExpanded(forLocation: $locationId) @include(if: $shippingEnabled) {
           nodes {
             ...ShippingRuleFragment
           }

--- a/Library/ViewModels/RewardAddOnSelectionViewModel.swift
+++ b/Library/ViewModels/RewardAddOnSelectionViewModel.swift
@@ -97,6 +97,7 @@ public final class RewardAddOnSelectionViewModel: RewardAddOnSelectionViewModelT
     let projectEvent = slugAndShippingRule.switchMap { slug, shippingRule in
       AppEnvironment.current.apiService.fetchRewardAddOnsSelectionViewRewards(
         slug: slug,
+        shippingEnabled: shippingRule?.location.graphID != nil,
         locationId: shippingRule?.location.graphID
       )
       .ksr_delay(AppEnvironment.current.apiDelayInterval, on: AppEnvironment.current.scheduler)


### PR DESCRIPTION
# 📲 What

Excludes expanded shipping rules for digital-only rewards.

# 🤔 Why

When fetching add-ons, if we pass in a `nil` location ID, all possible locations are returned. This returns all possible shipping locations in the known universe and can cause the response to time out.

# 🛠 How

Added a [directive](https://graphql.org/learn/queries/#directives) to our query to make this property conditional.

# ✅ Acceptance criteria

- [x] No regression on reward add-on selection.
- [x] Digital-only add-ons load fine.