### PR TITLE
[NT-2074] Download GraphQL Schema During CI Builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ test_job: &test_job
         command: make bootstrap
     - run:
         name: Download GraphQL Schema
-        command: apollo schema:download --endpoint=https://www.kickstarter.com/graph KsApi/graphql-schema.json --header "Authorization: token $GRAPHQL_API_AUTH_TOKEN"
+        command: $(apollo schema:download --endpoint=https://www.kickstarter.com/graph KsApi/graphql-schema.json --header "Authorization: token $GRAPHQL_API_AUTH_TOKEN")
     - run:
         name: Pre-load simulator
         command: *preload_simulator

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ test_job: &test_job
         command: make bootstrap
     - run:
         name: Download GraphQL Schema
-        command: $(apollo schema:download --endpoint=https://www.kickstarter.com/graph KsApi/graphql-schema.json --header "Authorization: token $GRAPHQL_API_AUTH_TOKEN")
+        command: bin/apollo-schema-download.sh
     - run:
         name: Pre-load simulator
         command: *preload_simulator

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ test_job: &test_job
         command: make bootstrap
     - run:
         name: Download GraphQL Schema
-        command: apollo schema:download --endpoint=https://www.kickstarter.com/graph KsApi/graphql-schema.json --header "Authorization: token ${GRAPHQL_API_AUTH_TOKEN}"
+        command: apollo schema:download --endpoint=https://www.kickstarter.com/graph KsApi/graphql-schema.json --header "Authorization: token $GRAPHQL_API_AUTH_TOKEN"
     - run:
         name: Pre-load simulator
         command: *preload_simulator

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,6 +44,9 @@ test_job: &test_job
         name: Bootstrap
         command: make bootstrap
     - run:
+        name: Download GraphQL Schema
+        command: apollo schema:download --endpoint=https://www.kickstarter.com/graph KsApi/graphql-schema.json --header "Authorization: token ${GRAPHQL_API_AUTH_TOKEN}"
+    - run:
         name: Pre-load simulator
         command: *preload_simulator
     - run:

--- a/bin/apollo-schema-download.sh
+++ b/bin/apollo-schema-download.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-
+npm install -D apollo
 apollo schema:download --endpoint=https://www.kickstarter.com/graph KsApi/graphql-schema.json --header "Authorization: token ${GRAPHQL_API_AUTH_TOKEN}"

--- a/bin/apollo-schema-download.sh
+++ b/bin/apollo-schema-download.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 npm install -D apollo
-apollo schema:download --endpoint=https://www.kickstarter.com/graph KsApi/graphql-schema.json --header "Authorization: token ${GRAPHQL_API_AUTH_TOKEN}"
+npx apollo schema:download --endpoint=https://www.kickstarter.com/graph KsApi/graphql-schema.json --header "Authorization: token ${GRAPHQL_API_AUTH_TOKEN}"

--- a/bin/apollo-schema-download.sh
+++ b/bin/apollo-schema-download.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 npm install -D apollo
-npx apollo schema:download --endpoint=https://www.kickstarter.com/graph KsApi/graphql-schema.json --header "Authorization: token ${GRAPHQL_API_AUTH_TOKEN}"
+npx apollo schema:download --endpoint=https://staging.kickstarter.com/graph KsApi/graphql-schema.json --header "Authorization: token ${GRAPHQL_API_AUTH_TOKEN}"

--- a/bin/apollo-schema-download.sh
+++ b/bin/apollo-schema-download.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+apollo schema:download --endpoint=https://www.kickstarter.com/graph KsApi/graphql-schema.json --header "Authorization: token ${GRAPHQL_API_AUTH_TOKEN}"


### PR DESCRIPTION
# 📲 What

Adds a step to our builds on CircleCI so that the latest GraphQL schema on staging is downloaded.

# 🤔 Why

Downloading the schema ahead of the build will ensure that if there are breaking changes, the app will fail to compile and we'll be afforded the opportunity to catch those sorts of issues earlier.

# 🛠 How

Added a script that installs the Apollo CLI client and then runs it to download the schema from staging.

# ✅ Acceptance criteria

- [ ] Build step runs, app compiles.
- [ ] We're happy to download the schema from staging.