### PR TITLE
[NT-2137] Upload dSYMs During App Store Delivery

### DIFF
--- a/.fastlane/Fastfile
+++ b/.fastlane/Fastfile
@@ -138,6 +138,12 @@ platform :ios do
       precheck_include_in_app_purchases: false
     )
 
+    upload_symbols_to_crashlytics(
+      gsp_path: "./Frameworks/native-secrets/ios/Firebase-Production/GoogleService-Info.plist",
+      binary_path: "./bin/upload-symbols",
+      dsym_path: "#{gym_dir}/Kickstarter.app.dSYM.zip"
+    )
+
     slack(
       slack_url: ENV["SLACK_WEBHOOK"],
       message: slack_message(
@@ -200,10 +206,6 @@ platform :ios do
       version: "latest"
     )
 
-    upload_symbols_to_crashlytics(
-      gsp_path: "./Frameworks/native-secrets/ios/Firebase-Production/GoogleService-Info.plist",
-      binary_path: "./bin/upload-symbols"
-    )
     clean_build_artifacts
 
     slack(


### PR DESCRIPTION
# 📲 What

Adds a step to our Fastlane configuration to upload dSYMs to Firebase after delivering builds to the App Store.

# 🤔 Why

A regression was introduced in #1432 which caused dSYMs to stop being automatically uploaded to Firebase Crashlytics during our CI builds. Instead of splitting this part out into its own lane, we prevented the entire lane from executing which was not the correct approach.

By not having these dSYMs on Firebase we are unable to see resymbolicated crashes.

# 🛠 How

Moved the `upload_symbols_to_crashlytics` command to run just after the `deliver` command. This ensures that any builds uploaded to the App Store also have their dSYMs uploaded to Firebase Crashlytics.

# ✅ Acceptance criteria

- [ ] Push a build (that we later discard) to the App Store to test this.