### PR TITLE
[NT-2114] Adding collaboratorPermissions to ProjectFragment

### DIFF
--- a/KsApi/GraphAPI.swift
+++ b/KsApi/GraphAPI.swift
@@ -2062,6 +2062,67 @@ public enum GraphAPI {
     }
   }
 
+  /// A permission for a collaborator on a project
+  public enum CollaboratorPermission: RawRepresentable, Equatable, Hashable, CaseIterable, Apollo.JSONDecodable, Apollo.JSONEncodable {
+    public typealias RawValue = String
+    case editProject
+    case editFaq
+    case post
+    case comment
+    case viewPledges
+    case fulfillment
+    /// Auto generated constant for unknown enum values
+    case __unknown(RawValue)
+
+    public init?(rawValue: RawValue) {
+      switch rawValue {
+        case "edit_project": self = .editProject
+        case "edit_faq": self = .editFaq
+        case "post": self = .post
+        case "comment": self = .comment
+        case "view_pledges": self = .viewPledges
+        case "fulfillment": self = .fulfillment
+        default: self = .__unknown(rawValue)
+      }
+    }
+
+    public var rawValue: RawValue {
+      switch self {
+        case .editProject: return "edit_project"
+        case .editFaq: return "edit_faq"
+        case .post: return "post"
+        case .comment: return "comment"
+        case .viewPledges: return "view_pledges"
+        case .fulfillment: return "fulfillment"
+        case .__unknown(let value): return value
+      }
+    }
+
+    public static func == (lhs: CollaboratorPermission, rhs: CollaboratorPermission) -> Bool {
+      switch (lhs, rhs) {
+        case (.editProject, .editProject): return true
+        case (.editFaq, .editFaq): return true
+        case (.post, .post): return true
+        case (.comment, .comment): return true
+        case (.viewPledges, .viewPledges): return true
+        case (.fulfillment, .fulfillment): return true
+        case (.__unknown(let lhsValue), .__unknown(let rhsValue)): return lhsValue == rhsValue
+        default: return false
+      }
+    }
+
+    public static var allCases: [CollaboratorPermission] {
+      return [
+        .editProject,
+        .editFaq,
+        .post,
+        .comment,
+        .viewPledges,
+        .fulfillment,
+      ]
+    }
+  }
+
   /// Various project states.
   public enum ProjectState: RawRepresentable, Equatable, Hashable, CaseIterable, Apollo.JSONDecodable, Apollo.JSONEncodable {
     public typealias RawValue = String
@@ -5373,6 +5434,7 @@ public enum GraphAPI {
           __typename
           ...CategoryFragment
         }
+        collaboratorPermissions
         country {
           __typename
           ...CountryFragment
@@ -5423,6 +5485,7 @@ public enum GraphAPI {
         GraphQLField("actions", type: .nonNull(.object(Action.selections))),
         GraphQLField("backersCount", type: .nonNull(.scalar(Int.self))),
         GraphQLField("category", type: .object(Category.selections)),
+        GraphQLField("collaboratorPermissions", type: .nonNull(.list(.nonNull(.scalar(CollaboratorPermission.self))))),
         GraphQLField("country", type: .nonNull(.object(Country.selections))),
         GraphQLField("creator", type: .object(Creator.selections)),
         GraphQLField("currency", type: .nonNull(.scalar(CurrencyCode.self))),
@@ -5452,8 +5515,8 @@ public enum GraphAPI {
       self.resultMap = unsafeResultMap
     }
 
-    public init(actions: Action, backersCount: Int, category: Category? = nil, country: Country, creator: Creator? = nil, currency: CurrencyCode, deadlineAt: String? = nil, description: String, finalCollectionDate: String? = nil, fxRate: Double, goal: Goal? = nil, image: Image? = nil, isProjectWeLove: Bool, launchedAt: String? = nil, location: Location? = nil, name: String, pid: Int, pledged: Pledged, slug: String, state: ProjectState, stateChangedAt: String, url: String, usdExchangeRate: Double? = nil) {
-      self.init(unsafeResultMap: ["__typename": "Project", "actions": actions.resultMap, "backersCount": backersCount, "category": category.flatMap { (value: Category) -> ResultMap in value.resultMap }, "country": country.resultMap, "creator": creator.flatMap { (value: Creator) -> ResultMap in value.resultMap }, "currency": currency, "deadlineAt": deadlineAt, "description": description, "finalCollectionDate": finalCollectionDate, "fxRate": fxRate, "goal": goal.flatMap { (value: Goal) -> ResultMap in value.resultMap }, "image": image.flatMap { (value: Image) -> ResultMap in value.resultMap }, "isProjectWeLove": isProjectWeLove, "launchedAt": launchedAt, "location": location.flatMap { (value: Location) -> ResultMap in value.resultMap }, "name": name, "pid": pid, "pledged": pledged.resultMap, "slug": slug, "state": state, "stateChangedAt": stateChangedAt, "url": url, "usdExchangeRate": usdExchangeRate])
+    public init(actions: Action, backersCount: Int, category: Category? = nil, collaboratorPermissions: [CollaboratorPermission], country: Country, creator: Creator? = nil, currency: CurrencyCode, deadlineAt: String? = nil, description: String, finalCollectionDate: String? = nil, fxRate: Double, goal: Goal? = nil, image: Image? = nil, isProjectWeLove: Bool, launchedAt: String? = nil, location: Location? = nil, name: String, pid: Int, pledged: Pledged, slug: String, state: ProjectState, stateChangedAt: String, url: String, usdExchangeRate: Double? = nil) {
+      self.init(unsafeResultMap: ["__typename": "Project", "actions": actions.resultMap, "backersCount": backersCount, "category": category.flatMap { (value: Category) -> ResultMap in value.resultMap }, "collaboratorPermissions": collaboratorPermissions, "country": country.resultMap, "creator": creator.flatMap { (value: Creator) -> ResultMap in value.resultMap }, "currency": currency, "deadlineAt": deadlineAt, "description": description, "finalCollectionDate": finalCollectionDate, "fxRate": fxRate, "goal": goal.flatMap { (value: Goal) -> ResultMap in value.resultMap }, "image": image.flatMap { (value: Image) -> ResultMap in value.resultMap }, "isProjectWeLove": isProjectWeLove, "launchedAt": launchedAt, "location": location.flatMap { (value: Location) -> ResultMap in value.resultMap }, "name": name, "pid": pid, "pledged": pledged.resultMap, "slug": slug, "state": state, "stateChangedAt": stateChangedAt, "url": url, "usdExchangeRate": usdExchangeRate])
     }
 
     public var __typename: String {
@@ -5492,6 +5555,16 @@ public enum GraphAPI {
       }
       set {
         resultMap.updateValue(newValue?.resultMap, forKey: "category")
+      }
+    }
+
+    /// Permissions that can be assigned to a collaborator on a project
+    public var collaboratorPermissions: [CollaboratorPermission] {
+      get {
+        return resultMap["collaboratorPermissions"]! as! [CollaboratorPermission]
+      }
+      set {
+        resultMap.updateValue(newValue, forKey: "collaboratorPermissions")
       }
     }
 

--- a/KsApi/fragments/ProjectFragment.graphql
+++ b/KsApi/fragments/ProjectFragment.graphql
@@ -6,6 +6,7 @@ fragment ProjectFragment on Project {
   category {
     ...CategoryFragment
   }
+  collaboratorPermissions
   country {
     ...CountryFragment
   }

--- a/KsApi/models/graphql/adapters/Backing+BackingFragmentTests.swift
+++ b/KsApi/models/graphql/adapters/Backing+BackingFragmentTests.swift
@@ -386,6 +386,14 @@ private func backingDictionary() -> [String: Any] {
           "name": "Publishing"
         }
       },
+      "collaboratorPermissions": [
+        "edit_project",
+        "edit_faq",
+        "post",
+        "comment",
+        "view_pledges",
+        "fulfillment"
+      ],
       "country": {
         "__typename": "Country",
         "code": "US",

--- a/KsApi/models/graphql/adapters/Project+FetchAddOnsQueryDataTests.swift
+++ b/KsApi/models/graphql/adapters/Project+FetchAddOnsQueryDataTests.swift
@@ -9,6 +9,7 @@ final class Project_FetchAddOnsQueryDataTests: XCTestCase {
       XCTAssertNotNil(fragment)
 
       let project = Project.project(from: fragment)
+      XCTAssertEqual(project?.memberData.permissions.count, 6)
       XCTAssertNotNil(project)
     } catch {
       XCTFail(error.localizedDescription)
@@ -443,6 +444,14 @@ final class Project_FetchAddOnsQueryDataTests: XCTestCase {
           "name": "Art"
         }
       },
+      "collaboratorPermissions": [
+        "edit_project",
+        "edit_faq",
+        "post",
+        "comment",
+        "view_pledges",
+        "fulfillment"
+      ],
       "country": {
         "__typename": "Country",
         "code": "AU",

--- a/KsApi/models/graphql/adapters/Project+ProjectFragment.swift
+++ b/KsApi/models/graphql/adapters/Project+ProjectFragment.swift
@@ -16,6 +16,7 @@ extension Project {
       let dates = projectDates(from: projectFragment),
       let locationFragment = projectFragment.location?.fragments.locationFragment,
       let location = Location.location(from: locationFragment),
+      let memberData = projectMemberData(from: projectFragment),
       let photo = projectPhoto(from: projectFragment),
       let state = projectState(from: projectFragment.state),
       let userFragment = projectFragment.creator?.fragments.userFragment,
@@ -31,7 +32,7 @@ extension Project {
       category: category,
       country: country,
       creator: creator,
-      memberData: MemberData(permissions: []),
+      memberData: memberData,
       dates: dates,
       id: projectFragment.pid,
       location: location,
@@ -83,21 +84,14 @@ private func finalCollectionDateTimeInterval(
 }
 
 /**
- Returns a minimal `Project.Stats` from a `ProjectFragment`
+ Returns a minimal `Project.MemberData` from a `ProjectFragment`
  */
-private func projectStats(from projectFragment: GraphAPI.ProjectFragment) -> Project.Stats {
-  return Project.Stats(
-    backersCount: projectFragment.backersCount,
-    commentsCount: nil,
-    convertedPledgedAmount: nil,
-    currency: projectFragment.currency.rawValue,
-    currentCurrency: nil,
-    currentCurrencyRate: nil,
-    goal: projectFragment.goal?.fragments.moneyFragment.amount.flatMap(Int.init) ?? 0,
-    pledged: projectFragment.pledged.fragments.moneyFragment.amount.flatMap(Int.init) ?? 0,
-    staticUsdRate: projectFragment.usdExchangeRate.flatMap(Float.init) ?? 0,
-    updatesCount: nil
-  )
+private func projectMemberData(from projectFragment: GraphAPI.ProjectFragment) -> Project.MemberData? {
+  let collaboratorPermissions = projectFragment.collaboratorPermissions.compactMap { permission in
+    Project.MemberData.Permission(rawValue: permission.rawValue.lowercased())
+  }
+
+  return Project.MemberData(permissions: collaboratorPermissions)
 }
 
 /**
@@ -116,4 +110,22 @@ private func projectPhoto(from projectFragment: GraphAPI.ProjectFragment) -> Pro
 
 private func projectState(from projectState: GraphAPI.ProjectState) -> Project.State? {
   return Project.State(rawValue: projectState.rawValue.lowercased())
+}
+
+/**
+ Returns a minimal `Project.Stats` from a `ProjectFragment`
+ */
+private func projectStats(from projectFragment: GraphAPI.ProjectFragment) -> Project.Stats {
+  return Project.Stats(
+    backersCount: projectFragment.backersCount,
+    commentsCount: nil,
+    convertedPledgedAmount: nil,
+    currency: projectFragment.currency.rawValue,
+    currentCurrency: nil,
+    currentCurrencyRate: nil,
+    goal: projectFragment.goal?.fragments.moneyFragment.amount.flatMap(Int.init) ?? 0,
+    pledged: projectFragment.pledged.fragments.moneyFragment.amount.flatMap(Int.init) ?? 0,
+    staticUsdRate: projectFragment.usdExchangeRate.flatMap(Float.init) ?? 0,
+    updatesCount: nil
+  )
 }

--- a/KsApi/models/graphql/adapters/Project+ProjectFragment.swift
+++ b/KsApi/models/graphql/adapters/Project+ProjectFragment.swift
@@ -91,6 +91,7 @@ private func projectMemberData(from projectFragment: GraphAPI.ProjectFragment) -
     Project.MemberData.Permission(rawValue: permission.rawValue.lowercased())
   }
 
+  // TODO: - Once we are receiving the other three properties of MemberData back from a Project on Graph, extend this functionality.
   return Project.MemberData(permissions: collaboratorPermissions)
 }
 

--- a/KsApi/models/graphql/adapters/Project+ProjectFragmentTests.swift
+++ b/KsApi/models/graphql/adapters/Project+ProjectFragmentTests.swift
@@ -24,6 +24,7 @@ final class Project_ProjectFragmentTests: XCTestCase {
 
       XCTAssertNotNil(project)
       XCTAssertEqual(project?.addOns?.count, 2)
+      XCTAssertEqual(project?.memberData.permissions.count, 6)
       XCTAssertEqual(project?.rewards.count, 2)
     } catch {
       XCTFail(error.localizedDescription)
@@ -51,6 +52,14 @@ final class Project_ProjectFragmentTests: XCTestCase {
           "name": "Publishing"
         }
       },
+      "collaboratorPermissions": [
+        "edit_project",
+        "edit_faq",
+        "post",
+        "comment",
+        "view_pledges",
+        "fulfillment"
+      ],
       "country": {
         "__typename": "Country",
         "code": "US",


### PR DESCRIPTION
# 📲 What

`MemberData` is currently not being fetched from GraphQL and we need the various properties of this object for the `ProjectFragment`. It doesn't seem like our GraphQL `Project` object currently supports any of the properties other than `collaboratorPermissions` so that is what we will add in this PR.

# 🤔 Why

Part of our native comment threading feature involves the use of permissions for determining whether a collaborator can comment or not. Moreover, with the migration toward Apollos GraphQL client we are updating our fragments and ensuring they are both reusable and bug free when used elsewhere.

# 🛠 How

Added the `collaboratorPermissions` field to our `ProjectFragment` and extended our adapter to take a given `CollaboratorPermission` from GraphQL and turn it into a `Project.MemberData.Permission` type.

# ✅ Acceptance criteria

- [ ] Run the app on staging and navigate to the various places we make use of the `ProjectFragment`. That includes the query for fetching add ons and the query for backing.
- [ ] Using Charles, verify the response is not erroring and there is no regression in the behavior of the queries.

# ⏰ TODO

- [ ] Inform @paulomcg that backend support will be needed to add the following properties to the GraphQL response for a `Project`:
 - `lastUpdatePublishedAt`
 - `unreadMessagesCount`
 - `unseenActivityCount`
