### PR TITLE
[NT-2040] Enable Segment By Default

### DIFF
--- a/Library/Tracking/Segment.swift
+++ b/Library/Tracking/Segment.swift
@@ -20,9 +20,6 @@ public extension Analytics {
 
     Analytics.setup(with: configuration)
 
-    // Disabled when initialized and enabled by our feature-flag configuration.
-    Analytics.shared().disable()
-
     return Analytics.shared()
   }
 }


### PR DESCRIPTION
# 📲 What

Enables Segment by default.

# 🤔 Why

We discovered that push notifications that were received while the app was backgrounded would open and follow their deep-links. However, when the app was freshly launched from a push notification, those deep-links would just do nothing.

It turns out that this is because we call run this line in our `application(_:didFinishLaunchingWithOptions:)`:

```swift
SEGAppboyIntegrationFactory.instance()?.saveLaunchOptions(launchOptions)
```

This causes Segment to save the `launchOptions` dictionary for processing later on by Braze.

However, during our configuration of Segment and Braze, we also immediately _disable_ Segment. We do this so that it can later be enabled by our feature flag configuration and immediately disabling it also ensures that we don't track any app lifecycle events in between the launch and receipt of our app's feature flags. It turns out that disabling Segment directly after having it save the launch options appears to cause it to discard them and not have them processed by Braze at a later time.

Removing the line that disables Segment fixes this and also seems like a reasonable solution. As it stands we _do_ want Segment enabled by default for everyone. In the unlikely scenario that we turned this feature flag off the worst outcome would be that we'd track "App Opened" type of events in between the setup of Segment and the disabling of it via our feature flag configuration.

This seems like a reasonable trade-off to make to ensure that our deep-links from app launch work correctly.

# 🛠 How

Removed the line that disables Segment by default.

# ✅ Acceptance criteria

Difficult to test before this merges. Once merged, install KickBeta, swipe up on the app card to ensure it is not running and not backgrounded. Send yourself a push from the Braze console with a deep link URL.

- [ ] The app opens and the deep-link is followed.