### PR TITLE
Handling target = blank for webview URL navigation in WKUIDelegate.

### DIFF
--- a/Kickstarter-iOS/Library/WebViewController.swift
+++ b/Kickstarter-iOS/Library/WebViewController.swift
@@ -62,7 +62,19 @@ internal class WebViewController: UIViewController {
   }
 }
 
-extension WebViewController: WKUIDelegate {}
+extension WebViewController: WKUIDelegate {
+  func webView(
+    _ webView: WKWebView,
+    createWebViewWith _: WKWebViewConfiguration,
+    for navigationAction: WKNavigationAction,
+    windowFeatures _: WKWindowFeatures
+  ) -> WKWebView? {
+    if navigationAction.targetFrame == nil {
+      webView.load(navigationAction.request)
+    }
+    return nil
+  }
+}
 
 extension WebViewController: WKNavigationDelegate {}
 


### PR DESCRIPTION
# 📲 What

While debugging an issue regarding the accountability webview not rendering, @DeMarko discovered that URL navigation was not working as expected within our webviews. In particular, iOS does not respond to a tapped URL when the target frame is blank. This PR addresses that issue by implementing a `WKUIDelegate` method on the `WebViewController` class.

# 🤔 Why

An unresponsive UI is a poor user experience and so is not throwing an explicit error when something is not working. In this case, we are tackling the root cause of the unresponsiveness by enabling a webview to open another link within itself.

# 🛠 How

Implement the `WKUIDelegate` method with the following signature: `webView(webView, createWebViewWith, for, windowFeatures)`. We are specifically checking if the `targetFrame` is nil (blank on web) and instructing the webView to load the request, if so.

# ✅ Acceptance criteria

- [ ] On prod, load the accountability webview (at the checkout step).
- [ ] Scroll down a bit to the point where a hyperlink to Terms of Use is shown.
- [ ] Tap on the URL and verify navigation to the appropriate webpage occurs.
