### PR TITLE
[NT-2165] Fix for incorrect type casting on shippingAmount within Backing+BackingFragment

### DIFF
--- a/KsApi/models/Backing.swift
+++ b/KsApi/models/Backing.swift
@@ -18,7 +18,7 @@ public struct Backing {
   public let reward: Reward?
   public let rewardId: Int?
   public let sequence: Int
-  public let shippingAmount: Int?
+  public let shippingAmount: Double?
   public let status: Status
 
   public struct PaymentSource {
@@ -88,7 +88,7 @@ extension Backing: Decodable {
     self.reward = try values.decodeIfPresent(Reward.self, forKey: .reward)
     self.rewardId = try values.decodeIfPresent(Int.self, forKey: .rewardId)
     self.sequence = try values.decode(Int.self, forKey: .sequence)
-    self.shippingAmount = try values.decodeIfPresent(Int.self, forKey: .shippingAmount)
+    self.shippingAmount = try values.decodeIfPresent(Double.self, forKey: .shippingAmount)
     self.status = try values.decode(Status.self, forKey: .status)
   }
 }

--- a/KsApi/models/graphql/adapters/Backing+BackingFragment.swift
+++ b/KsApi/models/graphql/adapters/Backing+BackingFragment.swift
@@ -45,7 +45,7 @@ extension Backing {
       reward: reward,
       rewardId: reward?.id,
       sequence: backingFragment.sequence ?? 0,
-      shippingAmount: backingFragment.shippingAmount?.fragments.moneyFragment.amount.flatMap(Int.init),
+      shippingAmount: backingFragment.shippingAmount?.fragments.moneyFragment.amount.flatMap(Double.init),
       status: backingStatus
     )
   }

--- a/KsApi/models/graphql/adapters/Backing+BackingFragmentTests.swift
+++ b/KsApi/models/graphql/adapters/Backing+BackingFragmentTests.swift
@@ -10,6 +10,24 @@ final class Backing_BackingFragmentTests: XCTestCase {
 
       let backing = Backing.backing(from: fragment)
       XCTAssertNotNil(backing)
+      XCTAssertEqual(backing?.amount, 90.0)
+      XCTAssertNotNil(backing?.backer)
+      XCTAssertNotNil(backing?.backerId)
+      XCTAssertEqual(backing?.backerCompleted, false)
+      XCTAssertEqual(backing?.bonusAmount, 5.0)
+      XCTAssertEqual(backing?.cancelable, true)
+      XCTAssertEqual(backing?.id, decompose(id: "QmFja2luZy0xNDQ5NTI3MTc="))
+      XCTAssertEqual(backing?.locationId, decompose(id: "TG9jYXRpb24tMjM0MjQ3NzU="))
+      XCTAssertEqual(backing?.locationName, "Canada")
+      XCTAssertEqual(backing?.paymentSource?.type, .visa)
+      XCTAssertEqual(backing?.pledgedAt, 1_625_613_342.0)
+      XCTAssertEqual(backing?.projectCountry, "US")
+      XCTAssertEqual(backing?.projectId, 1_596_594_463)
+      XCTAssertNotNil(backing?.reward)
+      XCTAssertEqual(backing?.rewardId, 8_173_901)
+      XCTAssertEqual(backing?.sequence, 148)
+      XCTAssertEqual(backing?.shippingAmount, 10.0)
+      XCTAssertEqual(backing?.status, .pledged)
     } catch {
       XCTFail(error.localizedDescription)
     }
@@ -527,7 +545,7 @@ private func backingDictionary() -> [String: Any] {
     "sequence": 148,
     "shippingAmount": {
       "__typename": "Money",
-      "amount": "0.0",
+      "amount": "10.0",
       "currency": "USD",
       "symbol": "$"
     },

--- a/KsApi/models/graphql/adapters/Backing+BackingFragmentTests.swift
+++ b/KsApi/models/graphql/adapters/Backing+BackingFragmentTests.swift
@@ -24,7 +24,7 @@ final class Backing_BackingFragmentTests: XCTestCase {
       XCTAssertEqual(backing?.projectCountry, "US")
       XCTAssertEqual(backing?.projectId, 1_596_594_463)
       XCTAssertNotNil(backing?.reward)
-      XCTAssertEqual(backing?.rewardId, 8_173_901)
+      XCTAssertEqual(backing?.rewardId, decompose(id: "UmV3YXJkLTgxNzM5MDE="))
       XCTAssertEqual(backing?.sequence, 148)
       XCTAssertEqual(backing?.shippingAmount, 10.0)
       XCTAssertEqual(backing?.status, .pledged)

--- a/KsApi/models/graphql/adapters/Backing+GraphBacking.swift
+++ b/KsApi/models/graphql/adapters/Backing+GraphBacking.swift
@@ -35,7 +35,7 @@ extension Backing {
       reward: reward,
       rewardId: reward?.id,
       sequence: graphBacking.sequence ?? 0,
-      shippingAmount: graphBacking.shippingAmount.map(\.amount).flatMap(Int.init),
+      shippingAmount: graphBacking.shippingAmount.map(\.amount).flatMap(Double.init),
       status: backingStatus
     )
   }

--- a/KsApi/models/lenses/BackingLenses.swift
+++ b/KsApi/models/lenses/BackingLenses.swift
@@ -428,7 +428,7 @@ extension Backing {
       ) }
     )
 
-    public static let shippingAmount = Lens<Backing, Int?>(
+    public static let shippingAmount = Lens<Backing, Double?>(
       view: { $0.shippingAmount },
       set: { Backing(
         addOns: $1.addOns,


### PR DESCRIPTION
# 📲 What

When updating a backing through our `Manage Pledge` flow, we rely on a GraphQL mutation to submit the update. In the situation where a payment method errors out, we flag the user within the `Activity` tab to fix their pledge. There are a number of checks that occur on the backend to ensure this process goes smoothly; one, in particular, involves verifying the amounts of the pledges are the same. We accidentally introduced a bug in a [previous PR](https://github.com/kickstarter/ios-oss/pull/1556) that casts the `shippingAmount` as an `Int` instead of a `Double` or `Float`, like the response returns. In this PR we are updating the type casting to more reflect a money type and throw in some tests for good measure.

# 🤔 Why

This bug was directly affecting our payments pipeline, which is a critical priority. We intend of pushing this work to `main` and releasing this in a release, shortly after.

# 🛠 How

- Change the decoding of `shippingAmount` from `Int` to `Double` anywhere we are using the `BackingFragment`.

# 👀 See

| Before 🐛 | After 🦋 |
| --- | --- |
| ![Simulator Screen Shot - iPhone 8 - 2021-08-03 at 13 06 19](https://user-images.githubusercontent.com/15615702/128056996-b990df85-6e60-4f6a-a6dc-a39c9110e660.png) | ![Simulator Screen Shot - Clone 1 of iPhone 8 - 2021-08-03 at 13 02 39](https://user-images.githubusercontent.com/15615702/128056468-bdffecc0-137b-413e-b64d-a2cf382b40ea.png) |

# ✅ Acceptance criteria

- [x] Pledge to a project and select a shipping location that explicitly charges an amount greater than zero.
- [x] Manage the pledge and attempt to fix the payment method.
- [x] Within the manage pledge screen, verify the summary accurately reflects the total originally pledged (specifically for `shippingAmount` but also check the others for regression).