### PR TITLE
Add Apollo Schema Download CI Step Headers

### DIFF
--- a/bin/apollo-schema-download.sh
+++ b/bin/apollo-schema-download.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 npm install -D apollo
-npx apollo schema:download --endpoint=https://staging.kickstarter.com/graph KsApi/graphql-schema.json --header "Authorization: Basic Y3JlYXRpdmU6c3R1ZHlpbmdhdGV3aW50ZXJmdW5ueQ==" --header "User-Agent: Kickstarter iOS" --header "Content-Type: application/json" --header "Authorization: token ${GRAPHQL_API_AUTH_TOKEN}" --data-raw "{'query':'{\n  __schema {\n    types {\n      name\n    }\n  }\n}','variables':{}}"
+npx apollo schema:download --endpoint=https://staging.kickstarter.com/graph KsApi/graphql-schema.json --header "Authorization: Basic Y3JlYXRpdmU6c3R1ZHlpbmdhdGV3aW50ZXJmdW5ueQ==" --header "User-Agent: Kickstarter iOS" --header "Content-Type: application/json" --header "User-Agent: Kickstarter iOS" --data-raw "{'query':'{\n  __schema {\n    types {\n      name\n    }\n  }\n}','variables':{}}"

--- a/bin/apollo-schema-download.sh
+++ b/bin/apollo-schema-download.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 npm install -D apollo
-npx apollo schema:download --endpoint=https://staging.kickstarter.com/graph KsApi/graphql-schema.json --header "Authorization: token ${GRAPHQL_API_AUTH_TOKEN}"
+npx apollo schema:download --endpoint=https://staging.kickstarter.com/graph KsApi/graphql-schema.json --header "Authorization: token ${GRAPHQL_API_AUTH_TOKEN}" --header 'User-Agent: Kickstarter iOS' --header 'Content-Type: application/json' --header "Authorization: token ${GRAPHQL_API_AUTH_TOKEN}" --data-raw '{"query":"{\n  __schema {\n    types {\n      name\n    }\n  }\n}","variables":{}}'

--- a/bin/apollo-schema-download.sh
+++ b/bin/apollo-schema-download.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 npm install -D apollo
-npx apollo schema:download --endpoint=https://staging.kickstarter.com/graph KsApi/graphql-schema.json --header "Authorization: Basic Y3JlYXRpdmU6c3R1ZHlpbmdhdGV3aW50ZXJmdW5ueQ==" --header "User-Agent: Kickstarter iOS" --header "Content-Type: application/json" --header "User-Agent: Kickstarter iOS" --data-raw "{'query':'{\n  __schema {\n    types {\n      name\n    }\n  }\n}','variables':{}}"
+npx apollo schema:download --endpoint=https://staging.kickstarter.com/graph KsApi/graphql-schema.json --header "Authorization: Basic Y3JlYXRpdmU6c3R1ZHlpbmdhdGV3aW50ZXJmdW5ueQ==" --header "User-Agent: Kickstarter iOS" --header "Content-Type: application/json" --data-raw "{'query':'{\n  __schema {\n    types {\n      name\n    }\n  }\n}','variables':{}}"

--- a/bin/apollo-schema-download.sh
+++ b/bin/apollo-schema-download.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 npm install -D apollo
-npx apollo schema:download --endpoint=https://staging.kickstarter.com/graph KsApi/graphql-schema.json --header "Authorization: Basic Y3JlYXRpdmU6c3R1ZHlpbmdhdGV3aW50ZXJmdW5ueQ==" --header "User-Agent: Kickstarter iOS" --header "Content-Type: application/json" --data-raw "{'query':'{\n  __schema {\n    types {\n      name\n    }\n  }\n}','variables':{}}"
+npx apollo schema:download --endpoint=https://staging.kickstarter.com/graph KsApi/graphql-schema.json

--- a/bin/apollo-schema-download.sh
+++ b/bin/apollo-schema-download.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 npm install -D apollo
-npx apollo codegen:generate --endpoint=https://staging.kickstarter.com/graph KsApi/graphql-schema.json
+npx apollo codegen:generate --endpoint=https://staging.kickstarter.com/graph --target=swift --includes=./**/*.graphql KsApi/graphql-schema.json

--- a/bin/apollo-schema-download.sh
+++ b/bin/apollo-schema-download.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 npm install -D apollo
-npx apollo schema:download --endpoint=https://staging.kickstarter.com/graph KsApi/graphql-schema.json --header "Authorization: token ${GRAPHQL_API_AUTH_TOKEN}" --header "User-Agent: Kickstarter iOS" --header "Content-Type: application/json" --header "Authorization: token ${GRAPHQL_API_AUTH_TOKEN}" --data-raw "{'query':'{\n  __schema {\n    types {\n      name\n    }\n  }\n}','variables':{}}"
+npx apollo schema:download --endpoint=https://staging.kickstarter.com/graph KsApi/graphql-schema.json --header "Authorization: Basic Y3JlYXRpdmU6c3R1ZHlpbmdhdGV3aW50ZXJmdW5ueQ==" --header "User-Agent: Kickstarter iOS" --header "Content-Type: application/json" --header "Authorization: token ${GRAPHQL_API_AUTH_TOKEN}" --data-raw "{'query':'{\n  __schema {\n    types {\n      name\n    }\n  }\n}','variables':{}}"

--- a/bin/apollo-schema-download.sh
+++ b/bin/apollo-schema-download.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 npm install -D apollo
-npx apollo codegen:generate --endpoint=https://staging.kickstarter.com/graph KsApi/graphql-schema.json --target=swift --includes=./**/*.graphql
+npx apollo codegen:generate --endpoint=https://staging.kickstarter.com/graph KsApi/graphql-schema.json --target=swift --includes=../**/*.graphql

--- a/bin/apollo-schema-download.sh
+++ b/bin/apollo-schema-download.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 npm install -D apollo
-npx apollo codegen:generate --endpoint=https://staging.kickstarter.com/graph --target=swift --includes=./**/*.graphql KsApi/graphql-schema.json
+npx apollo codegen:generate --endpoint=https://staging.kickstarter.com/graph KsApi/graphql-schema.json --target=swift --includes=./**/*.graphql

--- a/bin/apollo-schema-download.sh
+++ b/bin/apollo-schema-download.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 npm install -D apollo
-npx apollo schema:download --endpoint=https://staging.kickstarter.com/graph KsApi/graphql-schema.json --header "Authorization: token ${GRAPHQL_API_AUTH_TOKEN}" --header 'User-Agent: Kickstarter iOS' --header 'Content-Type: application/json' --header "Authorization: token ${GRAPHQL_API_AUTH_TOKEN}" --data-raw '{"query":"{\n  __schema {\n    types {\n      name\n    }\n  }\n}","variables":{}}'
+npx apollo schema:download --endpoint=https://staging.kickstarter.com/graph KsApi/graphql-schema.json --header "Authorization: token ${GRAPHQL_API_AUTH_TOKEN}" --header "User-Agent: Kickstarter iOS" --header "Content-Type: application/json" --header "Authorization: token ${GRAPHQL_API_AUTH_TOKEN}" --data-raw "{'query':'{\n  __schema {\n    types {\n      name\n    }\n  }\n}','variables':{}}"

--- a/bin/apollo-schema-download.sh
+++ b/bin/apollo-schema-download.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 npm install -D apollo
-npx apollo schema:download --endpoint=https://staging.kickstarter.com/graph KsApi/graphql-schema.json
+npx apollo codegen:generate --endpoint=https://staging.kickstarter.com/graph KsApi/graphql-schema.json

--- a/bin/apollo-schema-download.sh
+++ b/bin/apollo-schema-download.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 npm install -D apollo
-npx apollo codegen:generate --endpoint=https://staging.kickstarter.com/graph KsApi/graphql-schema.json --target=swift --includes=../**/*.graphql
+npx apollo schema:download --header="Content-Type: application/json" --header="User-Agent: Kickstarter iOS" --endpoint=https://staging.kickstarter.com/graph KsApi/graphql-schema.json


### PR DESCRIPTION
Quick PR correcting missing headers from our schema download step.
Somehow, the changeover from production to staging (data re-seed) on Aug 5/6 2021 caused the script to fail to download the schema on CI.
This fix seems to correct the issue.