### PR TITLE
[NT-2183] Enabling identify calls from our analytics client.

### DIFF
--- a/Library/Tracking/KSRAnalytics.swift
+++ b/Library/Tracking/KSRAnalytics.swift
@@ -10,7 +10,7 @@ public final class KSRAnalytics {
   private let device: UIDeviceType
   internal private(set) var loggedInUser: User? {
     willSet {
-      self.identify(oldUser: self.loggedInUser, newUser: newValue)
+      self.identify(newUser: newValue)
     }
   }
 
@@ -495,17 +495,13 @@ public final class KSRAnalytics {
   }
 
   /// Configure Tracking Client's supporting user identity
-  private func identify(oldUser: User?, newUser: User?) {
+  private func identify(newUser: User?) {
     guard let newUser = newUser else {
       self.segmentClient?.reset()
       return
     }
 
     let newData = KSRAnalyticsIdentityData(newUser)
-    if let oldUser = oldUser, newData == KSRAnalyticsIdentityData(oldUser) {
-      return
-    }
-
     self.segmentClient?.identify(
       "\(newData.userId)",
       traits: newData.allTraits

--- a/Library/Tracking/KSRAnalyticsTests.swift
+++ b/Library/Tracking/KSRAnalyticsTests.swift
@@ -1550,20 +1550,6 @@ final class KSRAnalyticsTests: TestCase {
     }
   }
 
-  func testIdentifyingTrackingClient_DoesNotRepeatAfterInitialUserSet() {
-    let user = User.template
-
-    withEnvironment {
-      AppEnvironment.updateCurrentUser(user)
-      self.segmentTrackingClient.userId = nil
-      self.segmentTrackingClient.traits = nil
-      AppEnvironment.updateCurrentUser(user)
-
-      XCTAssertNil(self.segmentTrackingClient.userId)
-      XCTAssertNil(self.segmentTrackingClient.traits)
-    }
-  }
-
   func testIdentifyingTrackingClient_RepeatsIfAnalyticsIdentityDataChanges() {
     let user = User.template
       |> User.lens.notifications.follower .~ false


### PR DESCRIPTION
# 📲 What

We've been encountering some issues with the `identify` method of the Segment client. In particular, the events don't seem to be propagating to Segment, resulting in some gaps in our events. It appears that in [this PR](https://github.com/kickstarter/ios-oss/pull/1515) we were patching an issue with multiple identify calls by determining if the user has changed in between calls but that resulted in a newer bug. What seems to be occurring, now, is the `identify` method being called successfully and subsequently returning early, resulting in the event not occurring at all. It's tough to determine what specifically is occurring but debugging suggests the SDK is doing some work behind the scenes to cancel an event from firing if it's called in succession twice (and returning early the second time?).

# 🤔 Why

It's most important for us to call `identify` so we can be certain our users events are tracked and provide meaningful insights into their behavior. The `identify` method will be called multiple times in a given session but also provide a "map" of user behavior within an application session.

# 🛠 How

Deleting a condiitonal block in the implementation for `identify`. We are no longer concerned about an older user or a newer user but rather anytime we set the logged in user we will call identify.

# ✅ Acceptance criteria

- [x] Open up the Segment close for staging and prepare to monitor incoming identify calls.
- [x] Erase all contents and settings from your simulator, run the branch and log in with your user on staging.
- [x] Verify the identify call is occurring for a log in.
- [x] Minimize the app to the background, open it back up in the foreground and verify identify is being called on Segments developer console.
- [x] Change your notification settings and verify identify is called in this case as well.
- [x] Verify there is no strange behavior in the `identify` calls. In particular, that we aren't calling it more times than needed. There are a handful of places in the app where we set the logged in user to render specific details on a screen, so keep in mind these locations are fine.
