### PR TITLE
[NT-2160] Making error response human readable in the case of request failure.

### DIFF
--- a/KsApi/extensions/ApolloClient+RAC.swift
+++ b/KsApi/extensions/ApolloClient+RAC.swift
@@ -27,6 +27,7 @@ extension ApolloClient {
           observer.send(value: data)
           observer.sendCompleted()
         case let .failure(error):
+          print("🔴 [KsApi] ApolloClient query failure - error : \((error as NSError).description)")
           observer.send(error: .couldNotDecodeJSON(error))
         }
       }
@@ -56,6 +57,7 @@ extension ApolloClient {
           observer.send(value: data)
           observer.sendCompleted()
         case let .failure(error):
+          print("🔴 [KsApi] ApolloClient mutation failure - error : \((error as NSError).description)")
           observer.send(error: .couldNotDecodeJSON(error))
         }
       }

--- a/KsApi/models/ErrorEnvelope.swift
+++ b/KsApi/models/ErrorEnvelope.swift
@@ -101,7 +101,7 @@ public struct ErrorEnvelope {
    */
   internal static func couldNotDecodeJSON(_ decodeError: Error) -> ErrorEnvelope {
     return ErrorEnvelope(
-      errorMessages: ["JSONDecoder decoding error: \(decodeError.localizedDescription)"],
+      errorMessages: [decodeError.localizedDescription],
       ksrCode: .DecodingJSONFailed,
       httpCode: 400,
       exception: nil,


### PR DESCRIPTION
# 📲 What

In the case of an outright request failure, our GraphQL client is sending an error prefixed with the string "JSONDecoder decoding error" which is useful for developers but not for a user of the application. This PR includes an update to remove that prefix and add a print statement above it in our `fetch` and `perform` method so we still keep the debugging utility of knowing what the error is specifically throwing.

# 🤔 Why + 🛠 How

GraphQL differs from a standard REST API in a number of ways including the way errors are thrown. A standard REST API will throw an http status code that suggests what the issue is, whereas GraphQL will return a `200` but include an error message, within its response. We are handling these legitimate errors in our `success` block but our `failure` block (which runs when there are network issues) was not as human readable as we liked. We removed anything other than the localized description of the error which is produced by the system and displayed when necessary.

# ✅ Acceptance criteria

- [ ] Run Charles proxy and introduce a breakpoint that aborts Graph requests. Verify the error message is human readable.
- [ ] Turn off your WiFi and attempt a Graph request on the app. Verify the error message is human readable.
- [ ] Compose a request on Charles that outputs a response structured as an error (200 http status code). e.g.:

`
{
  "errors": [
    {
      "message": "Field 'backing' doesn't exist on type 'User'",
      "locations": [
        {
          "line": 3,
          "column": 5
        }
      ],
      "fields": [
        "query FetchUserBackings",
        "me",
        "backing"
      ]
    }
}
`

Verify that error is displayed to the user.