### PR TITLE
[NT-2186] Upgrading dependency version for Braze.

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -19,7 +19,7 @@ github "appboy/appboy-segment-ios" == 4.0.0
 
 ### Binaries
 
-binary "https://raw.githubusercontent.com/Appboy/appboy-ios-sdk/master/appboy_ios_sdk_full.json" == 4.1.0
+binary "https://raw.githubusercontent.com/Appboy/appboy-ios-sdk/master/appboy_ios_sdk_full.json" == 4.3.2
 binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseAnalyticsBinary.json" == 7.4.0
 binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseCrashlyticsBinary.json" == 7.4.0
 binary "https://dl.google.com/dl/firebase/ios/carthage/FirebasePerformanceBinary.json" == 7.4.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -3,7 +3,7 @@ binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseCrashlyticsBinary
 binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseInAppMessagingBinary.json" "7.4.0"
 binary "https://dl.google.com/dl/firebase/ios/carthage/FirebasePerformanceBinary.json" "7.4.0"
 binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseProtobufBinary.json" "7.4.0"
-binary "https://raw.githubusercontent.com/Appboy/appboy-ios-sdk/master/appboy_ios_sdk_full.json" "4.1.0"
+binary "https://raw.githubusercontent.com/Appboy/appboy-ios-sdk/master/appboy_ios_sdk_full.json" "4.3.2"
 binary "https://raw.githubusercontent.com/PerimeterX/px-iOS-Framework/master/PerimeterX.json" "1.13.9"
 github "Alamofire/Alamofire" "5.4.3"
 github "Alamofire/AlamofireImage" "4.1.0"


### PR DESCRIPTION
# 📲 What

iOS 15 is introducing new breaking changes for Braze and push notifications. Braze has emailed us that we should upgrade to their latest SDK to make sure we are able to support the new iOS 15 features.

# 🛠 How

Updated `Cartfile` and `Cartfile.resolved`.

# ✅ Acceptance criteria

- [x] Run `carthage bootstrap --platform iOS` and run the app.