### PR TITLE
[NT-2160] Switching error envelope type in failure block of ApolloClient+RAC

### DIFF
--- a/KsApi/extensions/ApolloClient+RAC.swift
+++ b/KsApi/extensions/ApolloClient+RAC.swift
@@ -28,7 +28,7 @@ extension ApolloClient {
           observer.sendCompleted()
         case let .failure(error):
           print("🔴 [KsApi] ApolloClient query failure - error : \((error as NSError).description)")
-          observer.send(error: .couldNotDecodeJSON(error))
+          observer.send(error: .couldNotParseJSON)
         }
       }
     }
@@ -58,7 +58,7 @@ extension ApolloClient {
           observer.sendCompleted()
         case let .failure(error):
           print("🔴 [KsApi] ApolloClient mutation failure - error : \((error as NSError).description)")
-          observer.send(error: .couldNotDecodeJSON(error))
+          observer.send(error: .couldNotParseJSON)
         }
       }
     }


### PR DESCRIPTION
# 📲 What

We're switching the type of `ErrorEnvelope` being send in the `failure` block of our ApolloClients `perform` and `fetch` method. The reason we're switching these is so the error message the user is seeing is human readable.

# 🤔 Why

The new error type defaults to a string of "Something went wrong." when we catch an obscure error. This is far more useful to the user than what our API or system may occasionally send back.

# ✅ Acceptance criteria

- [x] Create a new account and rapidly tap "re-send verification e-mail" in the Account settings. This will invoke a 429 http status code error which should trigger the `failure` block of our ApolloClient+RAC methods. The error message should return "Something went wrong."
- [x] Try this out with a few other queries or mutations.