### PR TITLE
[NT-2183] Segment identify call fix

### DIFF
--- a/Kickstarter-iOS/AppDelegate.swift
+++ b/Kickstarter-iOS/AppDelegate.swift
@@ -65,6 +65,7 @@ internal final class AppDelegate: UIResponder, UIApplicationDelegate {
       .observeForUI()
       .observeValues { [weak self] user in
         AppEnvironment.updateCurrentUser(user)
+        AppEnvironment.current.ksrAnalytics.identify(newUser: user)
         self?.viewModel.inputs.currentUserUpdatedInEnvironment()
       }
 

--- a/Kickstarter-iOS/Views/Controllers/SettingsNotificationsViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/SettingsNotificationsViewController.swift
@@ -77,8 +77,6 @@ internal final class SettingsNotificationsViewController: UIViewController {
       .observeForUI()
       .observeValues { [weak self] user in
         AppEnvironment.updateCurrentUser(user)
-        AppEnvironment.current.ksrAnalytics.identify(newUser: user)
-
         self?.dataSource.load(user: user)
         self?.tableView.reloadData()
       }

--- a/Kickstarter-iOS/Views/Controllers/SettingsNotificationsViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/SettingsNotificationsViewController.swift
@@ -77,6 +77,7 @@ internal final class SettingsNotificationsViewController: UIViewController {
       .observeForUI()
       .observeValues { [weak self] user in
         AppEnvironment.updateCurrentUser(user)
+        AppEnvironment.current.ksrAnalytics.identify(newUser: user)
 
         self?.dataSource.load(user: user)
         self?.tableView.reloadData()

--- a/Kickstarter-iOS/Views/Controllers/SettingsViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/SettingsViewController.swift
@@ -117,9 +117,6 @@ final class SettingsViewController: UIViewController {
 
   private func logout(params: DiscoveryParams) {
     AppEnvironment.logout()
-
-    // Resetting the segment client
-    AppEnvironment.current.ksrAnalytics.identify(newUser: nil)
     PushNotificationDialog.resetAllContexts()
 
     self.view.window?.rootViewController

--- a/Kickstarter-iOS/Views/Controllers/SettingsViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/SettingsViewController.swift
@@ -117,6 +117,9 @@ final class SettingsViewController: UIViewController {
 
   private func logout(params: DiscoveryParams) {
     AppEnvironment.logout()
+
+    // Resetting the segment client
+    AppEnvironment.current.ksrAnalytics.identify(newUser: nil)
     PushNotificationDialog.resetAllContexts()
 
     self.view.window?.rootViewController

--- a/Library/AppEnvironment.swift
+++ b/Library/AppEnvironment.swift
@@ -82,6 +82,8 @@ public struct AppEnvironment: AppEnvironmentType {
     let storage = AppEnvironment.current.cookieStorage
     storage.cookies?.forEach(storage.deleteCookie)
 
+    // Resetting the segment client
+    AppEnvironment.current.ksrAnalytics.identify(newUser: nil)
     self.replaceCurrentEnvironment(
       apiService: AppEnvironment.current.apiService.logout(),
       cache: type(of: AppEnvironment.current.cache).init(),

--- a/Library/Tracking/KSRAnalytics.swift
+++ b/Library/Tracking/KSRAnalytics.swift
@@ -8,11 +8,7 @@ public final class KSRAnalytics {
   private let bundle: NSBundleType
   internal private(set) var config: Config?
   private let device: UIDeviceType
-  internal private(set) var loggedInUser: User? {
-    willSet {
-      self.identify(newUser: newValue)
-    }
-  }
+  private(set) var loggedInUser: User?
 
   public var logEventCallback: ((String, [String: Any]) -> Void)?
   private let screen: UIScreenType
@@ -495,7 +491,7 @@ public final class KSRAnalytics {
   }
 
   /// Configure Tracking Client's supporting user identity
-  private func identify(newUser: User?) {
+  public func identify(newUser: User?) {
     guard let newUser = newUser else {
       self.segmentClient?.reset()
       return

--- a/Library/Tracking/KSRAnalyticsTests.swift
+++ b/Library/Tracking/KSRAnalyticsTests.swift
@@ -1522,7 +1522,7 @@ final class KSRAnalyticsTests: TestCase {
   func testIdentifyingTrackingClient() {
     let user = User.template
 
-    AppEnvironment.updateCurrentUser(user)
+    AppEnvironment.current.ksrAnalytics.identify(newUser: user)
 
     XCTAssertEqual(self.segmentTrackingClient.userId, "\(user.id)")
     XCTAssertEqual(self.segmentTrackingClient.traits?["name"] as? String, user.name)
@@ -1543,7 +1543,7 @@ final class KSRAnalyticsTests: TestCase {
     let user = User.template
 
     withEnvironment {
-      AppEnvironment.updateCurrentUser(user)
+      AppEnvironment.current.ksrAnalytics.identify(newUser: user)
 
       XCTAssertEqual(self.segmentTrackingClient.userId, "\(1)")
       XCTAssertEqual(self.segmentTrackingClient.traits?["name"] as? String, user.name)
@@ -1557,12 +1557,17 @@ final class KSRAnalyticsTests: TestCase {
       |> User.lens.notifications.follower .~ true
 
     withEnvironment {
-      AppEnvironment.updateCurrentUser(user)
+      AppEnvironment.current.ksrAnalytics.identify(newUser: user)
 
-      self.segmentTrackingClient.userId = nil
-      self.segmentTrackingClient.traits = nil
+      XCTAssertNotNil(self.segmentTrackingClient.userId)
+      XCTAssertNotNil(self.segmentTrackingClient.traits)
 
-      AppEnvironment.updateCurrentUser(updatedUser)
+      AppEnvironment.logout()
+
+      XCTAssertNil(self.segmentTrackingClient.userId)
+      XCTAssertNil(self.segmentTrackingClient.traits)
+
+      AppEnvironment.current.ksrAnalytics.identify(newUser: updatedUser)
 
       XCTAssertNotNil(self.segmentTrackingClient.userId)
       XCTAssertNotNil(self.segmentTrackingClient.traits)
@@ -1581,7 +1586,7 @@ final class KSRAnalyticsTests: TestCase {
         |> User.lens.notifications.mobileUpdates .~ true
         |> User.lens.notifications.messages .~ false
 
-      AppEnvironment.updateCurrentUser(updatedUser)
+      AppEnvironment.current.ksrAnalytics.identify(newUser: updatedUser)
 
       XCTAssertEqual(self.segmentTrackingClient.userId, "\(1)")
       XCTAssertEqual(self.segmentTrackingClient.traits?["name"] as? String, user.name)

--- a/Library/ViewModels/SettingsNotificationsViewModel.swift
+++ b/Library/ViewModels/SettingsNotificationsViewModel.swift
@@ -106,6 +106,12 @@ public final class SettingsNotificationsViewModel: SettingsNotificationsViewMode
 
     self.goToManageProjectNotifications = manageProjectNotificationsSelected.signal
       .ignoreValues()
+
+    // MARK: - Tracking
+
+    self.updatedUserProperty.signal.observeValues { user in
+      AppEnvironment.current.ksrAnalytics.identify(newUser: user)
+    }
   }
 
   fileprivate let viewDidLoadProperty = MutableProperty(())


### PR DESCRIPTION
# 📲 What

A previously introduced bug resulted in Segments identify method being called too many times. This was a result of our use of a `willSet` that fired each time `loggedInUser` was set. The fix wasn't as simple as checking if the older user == new user because of what appears to be a specific limitation of the SDK. We've re-factored where we call identify into specific locations in the application within this PR.

# 🤔 Why

The identify call is one of the core methods in the Segment SDK and we want to ensure we are not spamming the method and introducing noise into our analytics. By specifically calling identify in choice locations we are ensuring a more refined set of results being sent to Segment.

# 🛠 How

- Resetting the segmentClient in `AppEnvironment.logout`
- Calling `identify` in when the current user is updated in the `AppDelegate`
- Calling `identify` in when the current user is updated in the `SettingsNotificationsViewModel`

# ✅ Acceptance criteria

- [x] On staging, log in and verify `identify` is being sent to Segment.
- [x] On staging, while already logged in, launch the app and verify `identify` is being sent to Segment.
- [x] On staging, change your notifications within the settings and verify `identify` is being sent to Segment.
- [x] On staging, background the app, foreground it and verify `identify` is being sent to Segment.