### PR TITLE
[NTV-34] Deeplink to Subcategories By Name

### DIFF
--- a/Kickstarter-iOS/ViewModels/AppDelegateViewModelTests.swift
+++ b/Kickstarter-iOS/ViewModels/AppDelegateViewModelTests.swift
@@ -813,6 +813,28 @@ final class AppDelegateViewModelTests: TestCase {
     let params = .defaults |> DiscoveryParams.lens.category .~ .art
     self.goToDiscovery.assertValues([params])
   }
+  
+  func testGoToDiscoveryWithSubcategory() {
+    self.vm.inputs.applicationDidFinishLaunching(
+      application: UIApplication.shared,
+      launchOptions: [:]
+    )
+
+    self.goToDiscovery.assertValues([])
+
+    let url = URL(string: "https://www.kickstarter.com/discover/categories/games/tabletop%20games")!
+    let result = self.vm.inputs.applicationOpenUrl(
+      application: UIApplication.shared,
+      url: url,
+      options: [:]
+    )
+    XCTAssertTrue(result)
+
+    self.scheduler.advance()
+
+    let params = .defaults |> DiscoveryParams.lens.category .~ .tabletopGames
+    self.goToDiscovery.assertValues([params])
+  }
 
   func testGoToLogin() {
     self.vm.inputs.applicationDidFinishLaunching(

--- a/KsApi/MockService.swift
+++ b/KsApi/MockService.swift
@@ -352,12 +352,14 @@
 
       self.backingUpdate = backingUpdate
 
+      /// FIXME: Once converted to Apollo, remove the default value and combine the `Response` and `Error` into a `Result`
       self.fetchGraphCategoriesResponse = fetchGraphCategoriesResponse ?? (RootCategoriesEnvelope.template
         |> RootCategoriesEnvelope.lens.categories .~ [
           .art,
           .filmAndVideo,
           .illustration,
-          .documentary
+          .documentary,
+          .games
         ]
       )
 


### PR DESCRIPTION
# 📲 What

Allows users to deeplink into the app using a deeplink to either a category/subcategory. If a subcategory fails, the deeplink will route to the category. Finally if the category fails, the deeplink will route to the "All Projects" filter

# 🤔 Why

Helping Brand Marketing effectively use Braze push notifications and deeplinks.

# 🛠 How

So it turned out there was an existing route `/discover/categories/:parent_category_id/:category_id` for subcategories that wasn't being utilized correctly.

Refactored the `goToDiscovery` mapping to check both for category or subcategory.
"/discover/categories/:parent_category_id/:category_id"
"/discover/categories/:category_id"
should now both work as intended in this output.

# 👀 See

| Before 🐛 | After 🦋 |
| --- | --- |
| <img="https://user-images.githubusercontent.com/4282741/130696263-7144df76-a1a6-4fe9-8f84-a09d7c16ef70.gif" width="300"> | <img src="https://user-images.githubusercontent.com/4282741/130696539-5fbbc4c2-de7c-47be-9a95-4e6b0f3fa412.gif" width="300"> |


# ✅ Acceptance criteria

Install KickBeta on simulator:

**Deeplink to Category** `https://www.kickstarter.com/discover/categories/technology` 
- [ ] Deeplink  from a backgrounded app.
- [ ] Deeplink  from a terminated app.

**Deeplink to Subcategory** `https://www.kickstarter.com/discover/categories/technology/space%20exploration` 
- [ ] Deeplink  from a backgrounded app.
- [ ] Deeplink  from a terminated app.

**PN Testing to come**


# ⏰ TODO

- [ ] Run PN testing on backgrounded/terminated app.
