### PR TITLE
[NTV-13] Supporting deep links to a specific reply.

### DIFF
--- a/Kickstarter-iOS/DataSources/CommentRepliesDataSource.swift
+++ b/Kickstarter-iOS/DataSources/CommentRepliesDataSource.swift
@@ -228,6 +228,28 @@ internal final class CommentRepliesDataSource: ValueCellDataSource {
   }
 
   /**
+   Returns an `IndexPath?` if the given replyId exists in the dataSource
+
+   - parameter for: The replyId of a `Comment`.
+
+   - returns: The `IndexPath?`with the matching replyId.
+
+   */
+  public func index(for replyId: String) -> IndexPath? {
+    let commentIndex = self.items(in: Section.replies.rawValue).firstIndex { value in
+      let foundAsCommentCell = (value as? (value: (Comment, Project), reusableId: String))?.value.0
+        .id == replyId
+      return foundAsCommentCell
+    }
+
+    if let commentIndex = commentIndex {
+      return IndexPath(row: commentIndex, section: Section.replies.rawValue)
+    }
+
+    return nil
+  }
+
+  /**
    Returns `true` when  the `replies`section of the data source is empty.
 
    - parameter in: `UITableView` object that we need the number of sections from.

--- a/Kickstarter-iOS/DataSources/CommentRepliesDataSourceTests.swift
+++ b/Kickstarter-iOS/DataSources/CommentRepliesDataSourceTests.swift
@@ -57,6 +57,30 @@ class CommentRepliesDataSourceTests: XCTestCase {
     )
   }
 
+  func testIndexForReplyId_ReplyIdExists() {
+    let commentsAndReplyCount = ([
+      Comment.replyTemplate |> \.id .~ "1",
+      Comment.replyTemplate |> \.id .~ "2",
+      Comment.replyTemplate |> \.id .~ "3"
+    ], 3)
+    self.dataSource.load(repliesAndTotalCount: commentsAndReplyCount, project: .template)
+
+    XCTAssertEqual(self.dataSource.index(for: "1"), IndexPath(row: 0, section: self.repliesSection))
+    XCTAssertEqual(self.dataSource.index(for: "2"), IndexPath(row: 1, section: self.repliesSection))
+    XCTAssertEqual(self.dataSource.index(for: "3"), IndexPath(row: 2, section: self.repliesSection))
+  }
+
+  func testIndexForReplyId_ReplyIdDoesNotExist() {
+    let commentsAndReplyCount = ([
+      Comment.replyTemplate |> \.id .~ "1",
+      Comment.replyTemplate |> \.id .~ "2",
+      Comment.replyTemplate |> \.id .~ "3"
+    ], 3)
+    self.dataSource.load(repliesAndTotalCount: commentsAndReplyCount, project: .template)
+
+    XCTAssertNil(self.dataSource.index(for: "99"))
+  }
+
   func testIsRepliesSectionEmpty_False() {
     self.dataSource.load(repliesAndTotalCount: self.templateRepliesAndTotalCount, project: .template)
 

--- a/Kickstarter-iOS/ViewModels/AppDelegateViewModel.swift
+++ b/Kickstarter-iOS/ViewModels/AppDelegateViewModel.swift
@@ -565,10 +565,11 @@ public final class AppDelegateViewModel: AppDelegateViewModelType, AppDelegateVi
     let projectCommentThreadLink = projectLink
       .observeForUI()
       .switchMap { project, subpage, vcs, _ -> SignalProducer<[UIViewController], Never> in
-        guard case let .commentThread(commentId) = subpage,
+        guard case let .commentThread(commentId, replyId) = subpage,
           let commentId = commentId else {
           return .empty
         }
+
         return AppEnvironment.current.apiService
           .fetchCommentReplies(query: commentRepliesQuery(withCommentId: commentId))
           .demoteErrors()
@@ -579,7 +580,8 @@ public final class AppDelegateViewModel: AppDelegateViewModelType, AppDelegateVi
               CommentRepliesViewController.configuredWith(
                 comment: envelope.comment,
                 project: project,
-                inputAreaBecomeFirstResponder: false
+                inputAreaBecomeFirstResponder: false,
+                replyId: replyId
               )
             ]
           }
@@ -652,7 +654,7 @@ public final class AppDelegateViewModel: AppDelegateViewModelType, AppDelegateVi
     let updateCommentThreadLink = updateLink
       .observeForUI()
       .switchMap { project, update, subpage, vcs -> SignalProducer<[UIViewController], Never> in
-        guard case let .commentThread(commentId) = subpage,
+        guard case let .commentThread(commentId, replyId) = subpage,
           let commentId = commentId else {
           return .empty
         }
@@ -666,7 +668,8 @@ public final class AppDelegateViewModel: AppDelegateViewModelType, AppDelegateVi
               CommentRepliesViewController.configuredWith(
                 comment: envelope.comment,
                 project: project,
-                inputAreaBecomeFirstResponder: false
+                inputAreaBecomeFirstResponder: false,
+                replyId: replyId
               )
             ]
           }
@@ -1039,7 +1042,7 @@ private func navigation(fromPushEnvelope envelope: PushEnvelope) -> Navigation? 
       if let commentId = activity.commentId {
         return .project(
           .id(projectId),
-          .update(updateId, .commentThread(commentId)),
+          .update(updateId, .commentThread(commentId, activity.replyId)),
           refTag: .push
         )
       }
@@ -1049,7 +1052,7 @@ private func navigation(fromPushEnvelope envelope: PushEnvelope) -> Navigation? 
       guard let projectId = activity.projectId else { return nil }
 
       if let commentId = activity.commentId {
-        return .project(.id(projectId), .commentThread(commentId), refTag: .push)
+        return .project(.id(projectId), .commentThread(commentId, activity.replyId), refTag: .push)
       }
       return .project(.id(projectId), .comments, refTag: .push)
 

--- a/Kickstarter-iOS/ViewModels/AppDelegateViewModelTests.swift
+++ b/Kickstarter-iOS/ViewModels/AppDelegateViewModelTests.swift
@@ -739,6 +739,28 @@ final class AppDelegateViewModelTests: TestCase {
     }
   }
 
+  func testPresentViewController_ProjectCommentThread_Reply_Success() {
+    self.vm.inputs.applicationDidFinishLaunching(
+      application: UIApplication.shared,
+      launchOptions: [:]
+    )
+
+    withEnvironment(apiService: MockService(fetchCommentRepliesEnvelopeResult: .success(CommentRepliesEnvelope
+        .successfulRepliesTemplate), fetchProjectResponse: .template)) {
+      let url =
+        "https://\(AppEnvironment.current.apiService.serverConfig.webBaseUrl.host ?? "")/projects/fjorden/fjorden-iphone-photography-reinvented/comments?comment=Q29tbWVudC0zMzY0OTg0MQ%3D%3D&reply=deadbeef"
+
+      let result = self.vm.inputs.applicationOpenUrl(
+        application: UIApplication.shared,
+        url: URL(string: url)!,
+        options: [:]
+      )
+      XCTAssertTrue(result)
+
+      self.presentViewController.assertValues([3])
+    }
+  }
+
   func testPresentViewController_UpdateCommentThread_Success() {
     self.vm.inputs.applicationDidFinishLaunching(
       application: UIApplication.shared,
@@ -749,6 +771,28 @@ final class AppDelegateViewModelTests: TestCase {
         .successfulRepliesTemplate), fetchProjectResponse: .template)) {
       let url =
         "https://\(AppEnvironment.current.apiService.serverConfig.webBaseUrl.host ?? "")/projects/fjorden/fjorden-iphone-photography-reinvented/posts/3254626/comments?comment=Q29tbWVudC0zMzY0OTg0MQ%3D%3D"
+
+      let result = self.vm.inputs.applicationOpenUrl(
+        application: UIApplication.shared,
+        url: URL(string: url)!,
+        options: [:]
+      )
+      XCTAssertTrue(result)
+
+      self.presentViewController.assertValues([4])
+    }
+  }
+
+  func testPresentViewController_UpdateCommentThread_Reply_Success() {
+    self.vm.inputs.applicationDidFinishLaunching(
+      application: UIApplication.shared,
+      launchOptions: [:]
+    )
+
+    withEnvironment(apiService: MockService(fetchCommentRepliesEnvelopeResult: .success(CommentRepliesEnvelope
+        .successfulRepliesTemplate), fetchProjectResponse: .template)) {
+      let url =
+        "https://\(AppEnvironment.current.apiService.serverConfig.webBaseUrl.host ?? "")/projects/fjorden/fjorden-iphone-photography-reinvented/posts/3254626/comments?comment=Q29tbWVudC0zMzY0OTg0MQ%3D%3D&reply=deadbeef"
 
       let result = self.vm.inputs.applicationOpenUrl(
         application: UIApplication.shared,

--- a/Kickstarter-iOS/Views/Controllers/CommentRepliesViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/CommentRepliesViewController.swift
@@ -27,13 +27,15 @@ final class CommentRepliesViewController: UITableViewController {
   internal static func configuredWith(
     comment: Comment,
     project: Project,
-    inputAreaBecomeFirstResponder: Bool
+    inputAreaBecomeFirstResponder: Bool,
+    replyId: String?
   ) -> CommentRepliesViewController {
     let vc = CommentRepliesViewController.instantiate()
     vc.viewModel.inputs.configureWith(
       comment: comment,
       project: project,
-      inputAreaBecomeFirstResponder: inputAreaBecomeFirstResponder
+      inputAreaBecomeFirstResponder: inputAreaBecomeFirstResponder,
+      replyId: replyId
     )
 
     return vc
@@ -114,6 +116,7 @@ final class CommentRepliesViewController: UITableViewController {
         guard let self = self else { return }
         self.dataSource.load(repliesAndTotalCount: repliesAndTotalCount, project: project)
         self.tableView.reloadData()
+        self.viewModel.inputs.loadRepliesAndProjectIntoDataSourceComplete()
       }
 
     self.viewModel.outputs.loadFailableReplyIntoDataSource
@@ -145,6 +148,14 @@ final class CommentRepliesViewController: UITableViewController {
         guard let self = self else { return }
         self.dataSource.showPaginationErrorState()
         self.tableView.reloadData()
+      }
+
+    self.viewModel.outputs.scrollToReply
+      .observeForUI()
+      .observeValues { [weak self] replyId in
+        if let indexPath = self?.dataSource.index(for: replyId) {
+          self?.tableView.scrollToRow(at: indexPath, at: .top, animated: false)
+        }
       }
   }
 }

--- a/Kickstarter-iOS/Views/Controllers/CommentRepliesViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/CommentRepliesViewController.swift
@@ -116,7 +116,7 @@ final class CommentRepliesViewController: UITableViewController {
         guard let self = self else { return }
         self.dataSource.load(repliesAndTotalCount: repliesAndTotalCount, project: project)
         self.tableView.reloadData()
-        self.viewModel.inputs.loadRepliesAndProjectIntoDataSourceComplete()
+        self.viewModel.inputs.dataSourceLoaded()
       }
 
     self.viewModel.outputs.loadFailableReplyIntoDataSource

--- a/Kickstarter-iOS/Views/Controllers/CommentRepliesViewControllerTests.swift
+++ b/Kickstarter-iOS/Views/Controllers/CommentRepliesViewControllerTests.swift
@@ -22,7 +22,12 @@ final class CommentRepliesViewControllerTests: TestCase {
     combos(Language.allLanguages, devices).forEach { language, device in
       withEnvironment(currentUser: .template, language: language) {
         let controller = CommentRepliesViewController
-          .configuredWith(comment: .template, project: .template, inputAreaBecomeFirstResponder: true)
+          .configuredWith(
+            comment: .template,
+            project: .template,
+            inputAreaBecomeFirstResponder: true,
+            replyId: nil
+          )
 
         let (parent, _) = traitControllers(
           device: device,
@@ -47,7 +52,12 @@ final class CommentRepliesViewControllerTests: TestCase {
     combos(Language.allLanguages, devices).forEach { language, device in
       withEnvironment(apiService: mockService, currentUser: .template, language: language) {
         let controller = CommentRepliesViewController
-          .configuredWith(comment: .template, project: .template, inputAreaBecomeFirstResponder: true)
+          .configuredWith(
+            comment: .template,
+            project: .template,
+            inputAreaBecomeFirstResponder: true,
+            replyId: nil
+          )
 
         let (parent, _) = traitControllers(
           device: device,
@@ -71,7 +81,12 @@ final class CommentRepliesViewControllerTests: TestCase {
     combos(Language.allLanguages, devices).forEach { language, device in
       withEnvironment(apiService: mockService, currentUser: .template, language: language) {
         let controller = CommentRepliesViewController
-          .configuredWith(comment: .template, project: .template, inputAreaBecomeFirstResponder: true)
+          .configuredWith(
+            comment: .template,
+            project: .template,
+            inputAreaBecomeFirstResponder: true,
+            replyId: nil
+          )
 
         let (parent, _) = traitControllers(
           device: device,
@@ -96,7 +111,12 @@ final class CommentRepliesViewControllerTests: TestCase {
       language, device in
       withEnvironment(apiService: mockService, currentUser: .template, language: language) {
         let controller = CommentRepliesViewController
-          .configuredWith(comment: .template, project: .template, inputAreaBecomeFirstResponder: true)
+          .configuredWith(
+            comment: .template,
+            project: .template,
+            inputAreaBecomeFirstResponder: true,
+            replyId: nil
+          )
 
         let (parent, _) = traitControllers(
           device: device,
@@ -120,7 +140,12 @@ final class CommentRepliesViewControllerTests: TestCase {
     combos(Language.allLanguages, devices).forEach { language, device in
       withEnvironment(apiService: mockService, currentUser: .template, language: language) {
         let controller = CommentRepliesViewController
-          .configuredWith(comment: .template, project: .template, inputAreaBecomeFirstResponder: true)
+          .configuredWith(
+            comment: .template,
+            project: .template,
+            inputAreaBecomeFirstResponder: true,
+            replyId: nil
+          )
 
         let (parent, _) = traitControllers(
           device: device,
@@ -149,7 +174,12 @@ final class CommentRepliesViewControllerTests: TestCase {
     combos(Language.allLanguages, devices).forEach { language, device in
       withEnvironment(apiService: mockService, currentUser: .template, language: language) {
         let controller = CommentRepliesViewController
-          .configuredWith(comment: .template, project: .template, inputAreaBecomeFirstResponder: true)
+          .configuredWith(
+            comment: .template,
+            project: .template,
+            inputAreaBecomeFirstResponder: true,
+            replyId: nil
+          )
 
         let (parent, _) = traitControllers(
           device: device,

--- a/Kickstarter-iOS/Views/Controllers/CommentsViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/CommentsViewController.swift
@@ -141,7 +141,8 @@ internal final class CommentsViewController: UITableViewController {
         let vc = CommentRepliesViewController.configuredWith(
           comment: comment,
           project: project,
-          inputAreaBecomeFirstResponder: becomeFirstResponder
+          inputAreaBecomeFirstResponder: becomeFirstResponder,
+          replyId: nil
         )
         self?.navigationController?.pushViewController(vc, animated: true)
       }

--- a/KsApi/models/PushEnvelope.swift
+++ b/KsApi/models/PushEnvelope.swift
@@ -16,6 +16,7 @@ public struct PushEnvelope {
     public let id: Int
     public let projectId: Int?
     public let projectPhoto: String?
+    public let replyId: String?
     public let updateId: Int?
     public let userPhoto: String?
   }
@@ -86,6 +87,7 @@ extension PushEnvelope.Activity: Decodable {
     case id
     case projectId = "project_id"
     case projectPhoto = "project_photo"
+    case replyId = "reply"
     case updateId = "update_id"
     case userPhoto = "user_photo"
   }

--- a/KsApi/models/PushEnvelopeTests.swift
+++ b/KsApi/models/PushEnvelopeTests.swift
@@ -31,6 +31,7 @@ final class PushEnvelopeTests: XCTestCase {
       "activity": [
         "category": "comment-post",
         "comment": "Q29ij3oij234",
+        "reply": "Qn123!@",
         "id": 1,
         "project_id": 2
       ]
@@ -39,6 +40,7 @@ final class PushEnvelopeTests: XCTestCase {
     XCTAssertNotNil(decodedEnvelope.activity)
     XCTAssertEqual(.commentPost, decodedEnvelope.activity?.category)
     XCTAssertEqual("Q29ij3oij234", decodedEnvelope.activity?.commentId)
+    XCTAssertEqual("Qn123!@", decodedEnvelope.activity?.replyId)
     XCTAssertEqual(1, decodedEnvelope.activity?.id)
     XCTAssertEqual(2, decodedEnvelope.activity?.projectId)
   }

--- a/KsApi/models/lenses/PushEnvelopeLenses.swift
+++ b/KsApi/models/lenses/PushEnvelopeLenses.swift
@@ -74,7 +74,7 @@ extension PushEnvelope.Activity {
       view: { $0.category },
       set: { .init(
         category: $0, commentId: $1.commentId, id: $1.id, projectId: $1.projectId,
-        projectPhoto: $1.projectPhoto, updateId: $1.updateId, userPhoto: $1.userPhoto
+        projectPhoto: $1.projectPhoto, replyId: $1.replyId, updateId: $1.updateId, userPhoto: $1.userPhoto
       ) }
     )
 
@@ -82,7 +82,7 @@ extension PushEnvelope.Activity {
       view: { $0.commentId },
       set: { .init(
         category: $1.category, commentId: $0, id: $1.id, projectId: $1.projectId,
-        projectPhoto: $1.projectPhoto, updateId: $1.updateId, userPhoto: $1.userPhoto
+        projectPhoto: $1.projectPhoto, replyId: $1.replyId, updateId: $1.updateId, userPhoto: $1.userPhoto
       ) }
     )
 
@@ -90,7 +90,7 @@ extension PushEnvelope.Activity {
       view: { $0.id },
       set: { .init(
         category: $1.category, commentId: $1.commentId, id: $0, projectId: $1.projectId,
-        projectPhoto: $1.projectPhoto, updateId: $1.updateId, userPhoto: $1.userPhoto
+        projectPhoto: $1.projectPhoto, replyId: $1.replyId, updateId: $1.updateId, userPhoto: $1.userPhoto
       ) }
     )
 
@@ -98,7 +98,7 @@ extension PushEnvelope.Activity {
       view: { $0.projectId },
       set: { .init(
         category: $1.category, commentId: $1.commentId, id: $1.id, projectId: $0,
-        projectPhoto: $1.projectPhoto, updateId: $1.updateId, userPhoto: $1.userPhoto
+        projectPhoto: $1.projectPhoto, replyId: $1.replyId, updateId: $1.updateId, userPhoto: $1.userPhoto
       ) }
     )
 
@@ -106,7 +106,15 @@ extension PushEnvelope.Activity {
       view: { $0.projectPhoto },
       set: { .init(
         category: $1.category, commentId: $1.commentId, id: $1.id, projectId: $1.projectId,
-        projectPhoto: $0, updateId: $1.updateId, userPhoto: $1.userPhoto
+        projectPhoto: $0, replyId: $1.replyId, updateId: $1.updateId, userPhoto: $1.userPhoto
+      ) }
+    )
+
+    public static let replyId = Lens<PushEnvelope.Activity, String?>(
+      view: { $0.replyId },
+      set: { .init(
+        category: $1.category, commentId: $1.commentId, id: $1.id, projectId: $1.projectId,
+        projectPhoto: $1.projectPhoto, replyId: $0, updateId: $1.updateId, userPhoto: $1.userPhoto
       ) }
     )
 
@@ -114,7 +122,7 @@ extension PushEnvelope.Activity {
       view: { $0.updateId },
       set: { .init(
         category: $1.category, commentId: $1.commentId, id: $1.id, projectId: $1.projectId,
-        projectPhoto: $1.projectPhoto, updateId: $0, userPhoto: $1.userPhoto
+        projectPhoto: $1.projectPhoto, replyId: $1.replyId, updateId: $0, userPhoto: $1.userPhoto
       ) }
     )
 
@@ -122,7 +130,7 @@ extension PushEnvelope.Activity {
       view: { $0.userPhoto },
       set: { .init(
         category: $1.category, commentId: $1.commentId, id: $1.id, projectId: $1.projectId,
-        projectPhoto: $1.projectPhoto, updateId: $1.updateId, userPhoto: $0
+        projectPhoto: $1.projectPhoto, replyId: $1.replyId, updateId: $1.updateId, userPhoto: $0
       ) }
     )
   }

--- a/Library/Navigation.swift
+++ b/Library/Navigation.swift
@@ -43,7 +43,7 @@ public enum Navigation: Equatable {
     case checkout(Int, Navigation.Project.Checkout)
     case root
     case comments
-    case commentThread(String?)
+    case commentThread(String?, String?)
     case creatorBio
     case faqs
     case friends
@@ -70,7 +70,7 @@ public enum Navigation: Equatable {
     public enum Update: Equatable {
       case root
       case comments
-      case commentThread(String?)
+      case commentThread(String?, String?)
     }
   }
 
@@ -90,8 +90,8 @@ public func == (lhs: Navigation.Project.Update, rhs: Navigation.Project.Update) 
     return true
   case (.comments, .comments):
     return true
-  case let (.commentThread(commentId), .commentThread(otherCommentId)):
-    return commentId == otherCommentId
+  case let (.commentThread(commentId, replyId), .commentThread(otherCommentId, otherReplyId)):
+    return commentId == otherCommentId && replyId == otherReplyId
   default:
     return false
   }
@@ -320,7 +320,7 @@ private func projectComments(_ params: RouteParamsDecoded) -> Navigation? {
       return .project(projectParam, .comments, refTag: refTag)
     }
 
-    return .project(projectParam, .commentThread(commentId), refTag: refTag)
+    return .project(projectParam, .commentThread(commentId, params.reply()), refTag: refTag)
   }
 
   return nil
@@ -475,7 +475,7 @@ private func updateComments(_ params: RouteParamsDecoded) -> Navigation? {
 
     return .project(
       projectParam,
-      .update(updateParam, .commentThread(commentId)),
+      .update(updateParam, .commentThread(commentId, params.reply())),
       refTag: refTag
     )
   }
@@ -610,6 +610,7 @@ extension RouteParamsDecoded {
     case ref
     case token
     case racing
+    case reply
     case updateParam = "update_param"
     case surveyParam = "survey_param"
     case userParam = "user_param"
@@ -629,6 +630,11 @@ extension RouteParamsDecoded {
   public func refTag() -> RefTag? {
     let key = CodingKeys.ref.rawValue
     return self[key].flatMap { RefTag.init(code: $0) }
+  }
+
+  public func reply() -> String? {
+    let key = CodingKeys.reply.rawValue
+    return self[key].flatMap { String($0) }
   }
 
   public func token() -> String? {

--- a/Library/NavigationTests.swift
+++ b/Library/NavigationTests.swift
@@ -70,8 +70,13 @@ public final class NavigationTests: XCTestCase {
     )
 
     KSRAssertMatch(
-      .project(.slug("project"), .commentThread("dead-b33f"), refTag: nil),
-      "/projects/creator/project/comments?comment=dead-b33f"
+      .project(.slug("project"), .commentThread("dead", nil), refTag: nil),
+      "/projects/creator/project/comments?comment=dead"
+    )
+
+    KSRAssertMatch(
+      .project(.slug("project"), .commentThread("dead", "beef"), refTag: nil),
+      "/projects/creator/project/comments?comment=dead&reply=beef"
     )
 
     KSRAssertMatch(
@@ -145,8 +150,13 @@ public final class NavigationTests: XCTestCase {
     )
 
     KSRAssertMatch(
-      .project(.slug("project"), .update(2, .commentThread("dead-b33f")), refTag: nil),
-      "/projects/creator/project/posts/2/comments?comment=dead-b33f"
+      .project(.slug("project"), .update(2, .commentThread("dead", nil)), refTag: nil),
+      "/projects/creator/project/posts/2/comments?comment=dead"
+    )
+
+    KSRAssertMatch(
+      .project(.slug("project"), .update(2, .commentThread("dead", "beef")), refTag: nil),
+      "/projects/creator/project/posts/2/comments?comment=dead&reply=beef"
     )
 
     KSRAssertMatch(

--- a/Library/ViewModels/CommentRepliesViewModel.swift
+++ b/Library/ViewModels/CommentRepliesViewModel.swift
@@ -26,7 +26,7 @@ public protocol CommentRepliesViewModelInputs {
   func paginateOrErrorCellWasTapped()
 
   /// Call after the data source is loaded and the tableView reloads.
-  func loadRepliesAndProjectIntoDataSourceComplete()
+  func dataSourceLoaded()
 
   /// Call when there is a failure in requesting the first page of the data and the `CommentViewMoreRepliesFailedCell` is tapped.
   func retryFirstPage()
@@ -223,7 +223,7 @@ public final class CommentRepliesViewModel: CommentRepliesViewModelType,
 
     self.scrollToReply = self.replyIdProperty.signal
       .skipNil()
-      .takeWhen(self.loadRepliesAndProjectIntoDataSourceCompleteProperty.signal)
+      .takeWhen(self.dataSourceLoadedProperty.signal)
   }
 
   private let didSelectCommentProperty = MutableProperty<Comment?>(nil)
@@ -258,9 +258,9 @@ public final class CommentRepliesViewModel: CommentRepliesViewModelType,
     self.retryFirstPageProperty.value = ()
   }
 
-  fileprivate let loadRepliesAndProjectIntoDataSourceCompleteProperty = MutableProperty(())
-  public func loadRepliesAndProjectIntoDataSourceComplete() {
-    self.loadRepliesAndProjectIntoDataSourceCompleteProperty.value = ()
+  fileprivate let dataSourceLoadedProperty = MutableProperty(())
+  public func dataSourceLoaded() {
+    self.dataSourceLoadedProperty.value = ()
   }
 
   fileprivate let viewDidAppearProperty = MutableProperty(())

--- a/Library/ViewModels/CommentRepliesViewModel.swift
+++ b/Library/ViewModels/CommentRepliesViewModel.swift
@@ -11,8 +11,10 @@ public protocol CommentRepliesViewModelInputs {
      - parameter comment: The `Comment` we are viewing the replies.
      - parameter project: The `Project` the comment replies are for.
      - parameter inputAreaBecomeFirstResponder: A Bool that determines if the composer should become first responder.
+     - parameter replyId: A `String?` that determines which cell to scroll to, if visible on the first page.
    **/
-  func configureWith(comment: Comment, project: Project, inputAreaBecomeFirstResponder: Bool)
+  func configureWith(comment: Comment, project: Project, inputAreaBecomeFirstResponder: Bool,
+                     replyId: String?)
 
   /// Call when the User is posting a comment or reply.
   func commentComposerDidSubmitText(_ text: String)
@@ -22,6 +24,9 @@ public protocol CommentRepliesViewModelInputs {
 
   /// Call in `didSelectRow` when either a `ViewMoreRepliesCell` or `CommentViewMoreRepliesFailedCell` is tapped.
   func paginateOrErrorCellWasTapped()
+
+  /// Call after the data source is loaded and the tableView reloads.
+  func loadRepliesAndProjectIntoDataSourceComplete()
 
   /// Call when there is a failure in requesting the first page of the data and the `CommentViewMoreRepliesFailedCell` is tapped.
   func retryFirstPage()
@@ -48,6 +53,9 @@ public protocol CommentRepliesViewModelOutputs {
 
   /// Emits when a comment has been posted reset the composer.
   var resetCommentComposer: Signal<(), Never> { get }
+
+  /// Emits when a replyId is supplied to the view controller configuration and we want to scroll to a specific index.
+  var scrollToReply: Signal<String, Never> { get }
 
   /// Emits when a pagination error has occurred.
   var showPaginationErrorState: Signal<(), Never> { get }
@@ -212,6 +220,10 @@ public final class CommentRepliesViewModel: CommentRepliesViewModelType,
       .map(unpack)
 
     self.showPaginationErrorState = error.ignoreValues()
+
+    self.scrollToReply = self.replyIdProperty.signal
+      .skipNil()
+      .takeWhen(self.loadRepliesAndProjectIntoDataSourceCompleteProperty.signal)
   }
 
   private let didSelectCommentProperty = MutableProperty<Comment?>(nil)
@@ -225,8 +237,15 @@ public final class CommentRepliesViewModel: CommentRepliesViewModelType,
   }
 
   fileprivate let commentProjectProperty = MutableProperty<(Comment, Project, Bool)?>(nil)
-  public func configureWith(comment: Comment, project: Project, inputAreaBecomeFirstResponder: Bool) {
+  fileprivate let replyIdProperty = MutableProperty<String?>(nil)
+  public func configureWith(
+    comment: Comment,
+    project: Project,
+    inputAreaBecomeFirstResponder: Bool,
+    replyId: String?
+  ) {
     self.commentProjectProperty.value = (comment, project, inputAreaBecomeFirstResponder)
+    self.replyIdProperty.value = replyId
   }
 
   fileprivate let paginateOrErrorCellWasTappedProperty = MutableProperty(())
@@ -237,6 +256,11 @@ public final class CommentRepliesViewModel: CommentRepliesViewModelType,
   fileprivate let retryFirstPageProperty = MutableProperty(())
   public func retryFirstPage() {
     self.retryFirstPageProperty.value = ()
+  }
+
+  fileprivate let loadRepliesAndProjectIntoDataSourceCompleteProperty = MutableProperty(())
+  public func loadRepliesAndProjectIntoDataSourceComplete() {
+    self.loadRepliesAndProjectIntoDataSourceCompleteProperty.value = ()
   }
 
   fileprivate let viewDidAppearProperty = MutableProperty(())
@@ -254,6 +278,7 @@ public final class CommentRepliesViewModel: CommentRepliesViewModelType,
   public var loadRepliesAndProjectIntoDataSource: Signal<(([Comment], Int), Project), Never>
   public let loadFailableReplyIntoDataSource: Signal<(Comment, String, Project), Never>
   public let resetCommentComposer: Signal<(), Never>
+  public let scrollToReply: Signal<String, Never>
   public let showPaginationErrorState: Signal<(), Never>
 
   public var inputs: CommentRepliesViewModelInputs { return self }

--- a/Library/ViewModels/CommentRepliesViewModelTests.swift
+++ b/Library/ViewModels/CommentRepliesViewModelTests.swift
@@ -400,7 +400,7 @@ internal final class CommentRepliesViewModelTests: TestCase {
       self.scheduler.advance()
 
       self.loadRepliesAndProjectIntoDataSourceReplies.assertValues([envelope.replies])
-      self.vm.inputs.loadRepliesAndProjectIntoDataSourceComplete()
+      self.vm.inputs.dataSourceLoaded()
 
       self.scheduler.advance()
 
@@ -430,7 +430,7 @@ internal final class CommentRepliesViewModelTests: TestCase {
       self.scheduler.advance()
 
       self.loadRepliesAndProjectIntoDataSourceReplies.assertValues([envelope.replies])
-      self.vm.inputs.loadRepliesAndProjectIntoDataSourceComplete()
+      self.vm.inputs.dataSourceLoaded()
 
       self.scheduler.advance()
 

--- a/Library/ViewModels/CommentRepliesViewModelTests.swift
+++ b/Library/ViewModels/CommentRepliesViewModelTests.swift
@@ -20,6 +20,7 @@ internal final class CommentRepliesViewModelTests: TestCase {
   private let loadRepliesAndProjectIntoDataSourceReplies = TestObserver<[Comment], Never>()
   private let loadRepliesAndProjectIntoDataSourceTotalCount = TestObserver<Int, Never>()
   private let resetCommentComposer = TestObserver<(), Never>()
+  private let scrollToReply = TestObserver<String, Never>()
   private let showPaginationErrorState = TestObserver<(), Never>()
 
   override func setUp() {
@@ -53,6 +54,7 @@ internal final class CommentRepliesViewModelTests: TestCase {
       .map { _, totalCount in totalCount }
       .observe(self.loadRepliesAndProjectIntoDataSourceTotalCount.observer)
     self.vm.outputs.resetCommentComposer.observe(self.resetCommentComposer.observer)
+    self.vm.outputs.scrollToReply.observe(self.scrollToReply.observer)
     self.vm.outputs.showPaginationErrorState.observe(self.showPaginationErrorState.observer)
   }
 
@@ -65,7 +67,8 @@ internal final class CommentRepliesViewModelTests: TestCase {
       self.vm.inputs.configureWith(
         comment: rootComment,
         project: .template,
-        inputAreaBecomeFirstResponder: false
+        inputAreaBecomeFirstResponder: false,
+        replyId: nil
       )
 
       self.loadCommentIntoDataSourceComment.assertDidNotEmitValue()
@@ -83,7 +86,12 @@ internal final class CommentRepliesViewModelTests: TestCase {
 
     withEnvironment(currentUser: nil) {
       self.vm.inputs
-        .configureWith(comment: .template, project: .template, inputAreaBecomeFirstResponder: false)
+        .configureWith(
+          comment: .template,
+          project: .template,
+          inputAreaBecomeFirstResponder: false,
+          replyId: nil
+        )
       self.vm.inputs.viewDidLoad()
       self.vm.inputs.viewDidAppear()
 
@@ -106,7 +114,12 @@ internal final class CommentRepliesViewModelTests: TestCase {
 
     withEnvironment(currentUser: user) {
       self.vm.inputs
-        .configureWith(comment: .template, project: .template, inputAreaBecomeFirstResponder: false)
+        .configureWith(
+          comment: .template,
+          project: .template,
+          inputAreaBecomeFirstResponder: false,
+          replyId: nil
+        )
       self.vm.inputs.viewDidLoad()
       self.vm.inputs.viewDidAppear()
 
@@ -130,7 +143,13 @@ internal final class CommentRepliesViewModelTests: TestCase {
     self.configureCommentComposerViewCanPostComment.assertDidNotEmitValue()
 
     withEnvironment(currentUser: user) {
-      self.vm.inputs.configureWith(comment: .template, project: project, inputAreaBecomeFirstResponder: true)
+      self.vm.inputs
+        .configureWith(
+          comment: .template,
+          project: project,
+          inputAreaBecomeFirstResponder: true,
+          replyId: nil
+        )
       self.vm.inputs.viewDidLoad()
 
       self.configureCommentComposerViewURL
@@ -152,7 +171,13 @@ internal final class CommentRepliesViewModelTests: TestCase {
     self.configureCommentComposerViewCanPostComment.assertDidNotEmitValue()
 
     withEnvironment(currentUser: .template) {
-      self.vm.inputs.configureWith(comment: .template, project: project, inputAreaBecomeFirstResponder: true)
+      self.vm.inputs
+        .configureWith(
+          comment: .template,
+          project: project,
+          inputAreaBecomeFirstResponder: true,
+          replyId: nil
+        )
       self.vm.inputs.viewDidLoad()
 
       self.configureCommentComposerViewURL
@@ -174,7 +199,13 @@ internal final class CommentRepliesViewModelTests: TestCase {
     self.configureCommentComposerViewCanPostComment.assertDidNotEmitValue()
 
     withEnvironment(currentUser: .template) {
-      self.vm.inputs.configureWith(comment: .template, project: project, inputAreaBecomeFirstResponder: true)
+      self.vm.inputs
+        .configureWith(
+          comment: .template,
+          project: project,
+          inputAreaBecomeFirstResponder: true,
+          replyId: nil
+        )
       self.vm.inputs.viewDidLoad()
       self.vm.inputs.viewDidAppear()
 
@@ -200,7 +231,13 @@ internal final class CommentRepliesViewModelTests: TestCase {
     self.configureCommentComposerViewCanPostComment.assertDidNotEmitValue()
 
     withEnvironment(currentUser: .template) {
-      self.vm.inputs.configureWith(comment: .template, project: project, inputAreaBecomeFirstResponder: false)
+      self.vm.inputs
+        .configureWith(
+          comment: .template,
+          project: project,
+          inputAreaBecomeFirstResponder: false,
+          replyId: nil
+        )
       self.vm.inputs.viewDidLoad()
       self.vm.inputs.viewDidAppear()
 
@@ -240,7 +277,8 @@ internal final class CommentRepliesViewModelTests: TestCase {
       self.vm.inputs.configureWith(
         comment: .template,
         project: project,
-        inputAreaBecomeFirstResponder: false
+        inputAreaBecomeFirstResponder: false,
+        replyId: nil
       )
 
       self.vm.inputs.viewDidLoad()
@@ -292,7 +330,8 @@ internal final class CommentRepliesViewModelTests: TestCase {
       self.vm.inputs.configureWith(
         comment: .template,
         project: project,
-        inputAreaBecomeFirstResponder: false
+        inputAreaBecomeFirstResponder: false,
+        replyId: nil
       )
 
       self.vm.inputs.viewDidLoad()
@@ -339,6 +378,66 @@ internal final class CommentRepliesViewModelTests: TestCase {
     }
   }
 
+  func testOutput_ScrollToReply_Emits() {
+    let envelope = CommentRepliesEnvelope.singleReplyTemplate
+    let mockService = MockService(fetchCommentRepliesEnvelopeResult: .success(envelope))
+    let project = Project.template
+      |> \.personalization.isBacking .~ false
+      |> Project.lens.memberData.permissions .~ [.post, .viewPledges, .comment]
+
+    withEnvironment(apiService: mockService, currentUser: .template) {
+      self.scrollToReply.assertDidNotEmitValue()
+
+      self.vm.inputs
+        .configureWith(
+          comment: .template,
+          project: project,
+          inputAreaBecomeFirstResponder: true,
+          replyId: envelope.replies[0].id
+        )
+      self.vm.inputs.viewDidLoad()
+
+      self.scheduler.advance()
+
+      self.loadRepliesAndProjectIntoDataSourceReplies.assertValues([envelope.replies])
+      self.vm.inputs.loadRepliesAndProjectIntoDataSourceComplete()
+
+      self.scheduler.advance()
+
+      self.scrollToReply.assertValue(envelope.replies[0].id)
+    }
+  }
+
+  func testOutput_ScrollToReply_DoesNotEmit() {
+    let envelope = CommentRepliesEnvelope.singleReplyTemplate
+    let mockService = MockService(fetchCommentRepliesEnvelopeResult: .success(envelope))
+    let project = Project.template
+      |> \.personalization.isBacking .~ false
+      |> Project.lens.memberData.permissions .~ [.post, .viewPledges, .comment]
+
+    withEnvironment(apiService: mockService, currentUser: .template) {
+      self.scrollToReply.assertDidNotEmitValue()
+
+      self.vm.inputs
+        .configureWith(
+          comment: .template,
+          project: project,
+          inputAreaBecomeFirstResponder: true,
+          replyId: nil
+        )
+      self.vm.inputs.viewDidLoad()
+
+      self.scheduler.advance()
+
+      self.loadRepliesAndProjectIntoDataSourceReplies.assertValues([envelope.replies])
+      self.vm.inputs.loadRepliesAndProjectIntoDataSourceComplete()
+
+      self.scheduler.advance()
+
+      self.scrollToReply.assertDidNotEmitValue()
+    }
+  }
+
   func testOutput_SubmitText_FromCommentComposer_ResetsCommentComposerTextInput() {
     let project = Project.template
       |> \.personalization.isBacking .~ false
@@ -347,7 +446,13 @@ internal final class CommentRepliesViewModelTests: TestCase {
     self.resetCommentComposer.assertDidNotEmitValue()
 
     withEnvironment(currentUser: .template) {
-      self.vm.inputs.configureWith(comment: .template, project: project, inputAreaBecomeFirstResponder: true)
+      self.vm.inputs
+        .configureWith(
+          comment: .template,
+          project: project,
+          inputAreaBecomeFirstResponder: true,
+          replyId: nil
+        )
       self.vm.inputs.viewDidLoad()
 
       self.resetCommentComposer.assertDidNotEmitValue()
@@ -375,7 +480,8 @@ internal final class CommentRepliesViewModelTests: TestCase {
       self.vm.inputs.configureWith(
         comment: .replyRootCommentTemplate,
         project: project,
-        inputAreaBecomeFirstResponder: true
+        inputAreaBecomeFirstResponder: true,
+        replyId: nil
       )
       self.vm.inputs.viewDidLoad()
 
@@ -415,7 +521,12 @@ internal final class CommentRepliesViewModelTests: TestCase {
 
     withEnvironment(apiService: mockService1, currentUser: .template) {
       self.vm.inputs
-        .configureWith(comment: .template, project: .template, inputAreaBecomeFirstResponder: true)
+        .configureWith(
+          comment: .template,
+          project: .template,
+          inputAreaBecomeFirstResponder: true,
+          replyId: nil
+        )
       self.vm.inputs.viewDidLoad()
 
       self.scheduler.advance(by: .seconds(1))
@@ -514,7 +625,12 @@ internal final class CommentRepliesViewModelTests: TestCase {
 
     withEnvironment(apiService: mockService1, currentUser: .template) {
       self.vm.inputs
-        .configureWith(comment: .template, project: .template, inputAreaBecomeFirstResponder: true)
+        .configureWith(
+          comment: .template,
+          project: .template,
+          inputAreaBecomeFirstResponder: true,
+          replyId: nil
+        )
       self.vm.inputs.viewDidLoad()
 
       self.scheduler.advance(by: .seconds(1))
@@ -593,7 +709,12 @@ internal final class CommentRepliesViewModelTests: TestCase {
 
     withEnvironment(apiService: mockService1, currentUser: .template) {
       self.vm.inputs
-        .configureWith(comment: .template, project: .template, inputAreaBecomeFirstResponder: true)
+        .configureWith(
+          comment: .template,
+          project: .template,
+          inputAreaBecomeFirstResponder: true,
+          replyId: nil
+        )
       self.vm.inputs.viewDidLoad()
 
       self.scheduler.advance()


### PR DESCRIPTION
# 📲 What

One of the final pieces to our deep link integration with comment threading is the ability to take a user to a specific reply. We're using the replyId as a query parameter and scrolling the table view to a particular index, if the replyId matches.

# 🤔 Why

This is part of our larger goal to drive engagement with deeplinks. This should be something we incorporate into all new feature releases. A good gameplan would probably be to release the feature, add analytics support and then finish it off with a supporting deeplink.

# 🛠 How

Most of the work involving deeplinks is done in two files: `AppDelegateViewModel.swift` and `Navigation.swift`. It's in these two files that we parse the route, determine the relevant query parameters and subsequently navigate the user to the correct point in the stack.

# ✅ Acceptance criteria

I used the following links to test:
Update: https://staging.kickstarter.com/projects/fjorden/fjorden-iphone-photography-reinvented/posts/3254626/comments?comment=Q29tbWVudC0zMzU2MTY4Ng%3D%3D&reply=Q29tbWVudC0zMzY1NTUxMQ%3D%3D
Comments: https://staging.kickstarter.com/projects/fjorden/fjorden-iphone-photography-reinvented/comments?comment=Q29tbWVudC0zMzYzMzAyOA%3D%3D&reply=Q29tbWVudC0zMzY0Nzg3Nw%3D%3D

- [x] Check while the app is backgrounded, terminated and in the foreground that a deeplink for both URLs responds appropriately.
- [x] Check while the app is backgrounded, terminated and in the foreground that a push notification for both URLs responds appropriately.