### PR TITLE
[NTV-156] Adding Segment analytics events for Risk Messaging confirm button

### DIFF
--- a/Library/Tracking/KSRAnalytics.swift
+++ b/Library/Tracking/KSRAnalytics.swift
@@ -952,7 +952,6 @@ public final class KSRAnalytics {
   ) {
     let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
       .withAllValuesFrom(checkoutProperties(from: checkoutData, and: reward))
-      // the context is always "newPledge" for this event
       .withAllValuesFrom(contextProperties(
         ctaContext: .pledgeConfirm,
         page: .checkout,

--- a/Library/Tracking/KSRAnalytics.swift
+++ b/Library/Tracking/KSRAnalytics.swift
@@ -147,6 +147,7 @@ public final class KSRAnalytics {
     case logInInitiate
     case logInOrSignUp
     case logInSubmit
+    case pledgeConfirm
     case pledgeInitiate
     case pledgeSubmit
     case project
@@ -166,6 +167,7 @@ public final class KSRAnalytics {
       case .discoverSort: return "discover_sort"
       case .forgotPassword: return "forgot_password"
       case .pledgeInitiate: return "pledge_initiate"
+      case .pledgeConfirm: return "pledge_confirm"
       case .pledgeSubmit: return "pledge_submit"
       case .project: return "project"
       case .logInInitiate: return "log_in_initiate"
@@ -919,6 +921,40 @@ public final class KSRAnalytics {
       // the context is always "newPledge" for this event
       .withAllValuesFrom(contextProperties(
         ctaContext: .pledgeSubmit,
+        page: .checkout,
+        typeContext: typeContext
+      ))
+
+    self.track(
+      event: SegmentEvent.ctaClicked.rawValue,
+      properties: props,
+      refTag: refTag?.stringTag
+    )
+  }
+
+  /* Call when the Confirm button on the Risk Messaging modal is clicked
+
+   parameters:
+   - project: the project being pledged to
+   - reward: the chosen reward
+   - typeContext: The context of the pledge submit button for a project.
+   - checkoutData: all the checkout data associated with the pledge
+   - refTag: the associated RefTag for the pledge
+
+   */
+
+  public func trackPledgeConfirmButtonClicked(
+    project: Project,
+    reward: Reward,
+    typeContext: TypeContext,
+    checkoutData: CheckoutPropertiesData,
+    refTag: RefTag?
+  ) {
+    let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
+      .withAllValuesFrom(checkoutProperties(from: checkoutData, and: reward))
+      // the context is always "newPledge" for this event
+      .withAllValuesFrom(contextProperties(
+        ctaContext: .pledgeConfirm,
         page: .checkout,
         typeContext: typeContext
       ))

--- a/Library/Tracking/KSRAnalyticsTests.swift
+++ b/Library/Tracking/KSRAnalyticsTests.swift
@@ -1075,6 +1075,42 @@ final class KSRAnalyticsTests: TestCase {
     XCTAssertEqual("rewards", segmentClientProperties?["context_page"] as? String)
   }
 
+  func testTrackPledgeConfirmButtonClicked() {
+    let segmentClient = MockTrackingClient()
+    let ksrAnalytics = KSRAnalytics(segmentClient: segmentClient)
+    let reward = Reward.template
+      |> Reward.lens.endsAt .~ 5.0
+      |> Reward.lens.shipping.preference .~ .restricted
+
+    ksrAnalytics.trackPledgeConfirmButtonClicked(
+      project: .template,
+      reward: reward,
+      typeContext: .creditCard,
+      checkoutData: .template,
+      refTag: nil
+    )
+
+    let segmentClientProps = segmentClient.properties.last
+
+    XCTAssertEqual(["CTA Clicked"], segmentClient.events)
+
+    self.assertProjectProperties(segmentClientProps)
+    self.assertCheckoutProperties(segmentClientProps)
+
+    XCTAssertEqual(
+      KSRAnalytics.CTAContext.pledgeConfirm.trackingString,
+      segmentClientProps?["context_cta"] as? String
+    )
+    XCTAssertEqual(
+      KSRAnalytics.TypeContext.creditCard.trackingString,
+      segmentClientProps?["context_type"] as? String
+    )
+    XCTAssertEqual(
+      "checkout",
+      segmentClientProps?["context_page"] as? String
+    )
+  }
+
   func testTrackPledgeSubmitButtonClicked_Pledge() {
     let segmentClient = MockTrackingClient()
     let ksrAnalytics = KSRAnalytics(segmentClient: segmentClient)
@@ -1732,6 +1768,7 @@ final class KSRAnalyticsTests: TestCase {
 
   func testCTAContextTrackingStrings() {
     XCTAssertEqual(KSRAnalytics.CTAContext.addOnsContinue.trackingString, "add_ons_continue")
+    XCTAssertEqual(KSRAnalytics.CTAContext.pledgeConfirm.trackingString, "pledge_confirm")
     XCTAssertEqual(KSRAnalytics.CTAContext.pledgeInitiate.trackingString, "pledge_initiate")
     XCTAssertEqual(KSRAnalytics.CTAContext.pledgeSubmit.trackingString, "pledge_submit")
     XCTAssertEqual(KSRAnalytics.CTAContext.project.trackingString, "project")


### PR DESCRIPTION
# 📲 What

Adding a `CTA Clicked` analytics event for whenever the "I Understand" button is tapped in the `RiskMessagingViewController`.

# 🤔 Why

It's important for us to monitor the effectiveness of our experiment. Given the proximity to the point of checkout, the analytics will give us an understanding if the risk messaging is leading to revenue drops or anything else unexpected.

# 🛠 How

- Adding a new event to `KSRAnalytics`
- Updating the `PledgeViewModel` to account for the `RiskMessagingViewController`s `confirmButton` being tapped.
- Updating some older events to respond specifically to the `submitButtonTappedSignal` and `applePayButtonTappedSignal`.

# ✅ Acceptance criteria

- [x] On staging, while you have the Segment debugger open, go through the checkout flow for a given project.
- [x] When the `RiskMessagingViewController` has been presented, before moving forward, verify that when you tap either `Pledge` or `Pay With Apple` that a `CTA Clicked` event with a `context_cta` of `pledge_submit` has emitted.
- [x] After tapping `I Understand`, verify a `CTA Clicked` event with a `context_cta` of `pledge_confirm` has emitted.