### PR TITLE
[Unticketed] Put Back Add Ons Selection To Checkout

### DIFF
--- a/KsApi/GraphAPI.swift
+++ b/KsApi/GraphAPI.swift
@@ -10830,6 +10830,13 @@ public enum GraphAPI {
           __typename
           ...MoneyFragment
         }
+        allowedAddons {
+          __typename
+          nodes {
+            __typename
+            id
+          }
+        }
         description
         displayName
         endsAt
@@ -10869,6 +10876,7 @@ public enum GraphAPI {
         GraphQLField("amount", type: .nonNull(.object(Amount.selections))),
         GraphQLField("backersCount", type: .scalar(Int.self)),
         GraphQLField("convertedAmount", type: .nonNull(.object(ConvertedAmount.selections))),
+        GraphQLField("allowedAddons", type: .nonNull(.object(AllowedAddon.selections))),
         GraphQLField("description", type: .nonNull(.scalar(String.self))),
         GraphQLField("displayName", type: .nonNull(.scalar(String.self))),
         GraphQLField("endsAt", type: .scalar(String.self)),
@@ -10893,8 +10901,8 @@ public enum GraphAPI {
       self.resultMap = unsafeResultMap
     }
 
-    public init(amount: Amount, backersCount: Int? = nil, convertedAmount: ConvertedAmount, description: String, displayName: String, endsAt: String? = nil, estimatedDeliveryOn: String? = nil, id: GraphQLID, isMaxPledge: Bool, items: Item? = nil, limit: Int? = nil, limitPerBacker: Int? = nil, name: String? = nil, project: Project? = nil, remainingQuantity: Int? = nil, shippingPreference: ShippingPreference? = nil, shippingRules: [ShippingRule?], startsAt: String? = nil) {
-      self.init(unsafeResultMap: ["__typename": "Reward", "amount": amount.resultMap, "backersCount": backersCount, "convertedAmount": convertedAmount.resultMap, "description": description, "displayName": displayName, "endsAt": endsAt, "estimatedDeliveryOn": estimatedDeliveryOn, "id": id, "isMaxPledge": isMaxPledge, "items": items.flatMap { (value: Item) -> ResultMap in value.resultMap }, "limit": limit, "limitPerBacker": limitPerBacker, "name": name, "project": project.flatMap { (value: Project) -> ResultMap in value.resultMap }, "remainingQuantity": remainingQuantity, "shippingPreference": shippingPreference, "shippingRules": shippingRules.map { (value: ShippingRule?) -> ResultMap? in value.flatMap { (value: ShippingRule) -> ResultMap in value.resultMap } }, "startsAt": startsAt])
+    public init(amount: Amount, backersCount: Int? = nil, convertedAmount: ConvertedAmount, allowedAddons: AllowedAddon, description: String, displayName: String, endsAt: String? = nil, estimatedDeliveryOn: String? = nil, id: GraphQLID, isMaxPledge: Bool, items: Item? = nil, limit: Int? = nil, limitPerBacker: Int? = nil, name: String? = nil, project: Project? = nil, remainingQuantity: Int? = nil, shippingPreference: ShippingPreference? = nil, shippingRules: [ShippingRule?], startsAt: String? = nil) {
+      self.init(unsafeResultMap: ["__typename": "Reward", "amount": amount.resultMap, "backersCount": backersCount, "convertedAmount": convertedAmount.resultMap, "allowedAddons": allowedAddons.resultMap, "description": description, "displayName": displayName, "endsAt": endsAt, "estimatedDeliveryOn": estimatedDeliveryOn, "id": id, "isMaxPledge": isMaxPledge, "items": items.flatMap { (value: Item) -> ResultMap in value.resultMap }, "limit": limit, "limitPerBacker": limitPerBacker, "name": name, "project": project.flatMap { (value: Project) -> ResultMap in value.resultMap }, "remainingQuantity": remainingQuantity, "shippingPreference": shippingPreference, "shippingRules": shippingRules.map { (value: ShippingRule?) -> ResultMap? in value.flatMap { (value: ShippingRule) -> ResultMap in value.resultMap } }, "startsAt": startsAt])
     }
 
     public var __typename: String {
@@ -10933,6 +10941,18 @@ public enum GraphAPI {
       }
       set {
         resultMap.updateValue(newValue.resultMap, forKey: "convertedAmount")
+      }
+    }
+
+    /// Add-ons which can be combined with this reward.
+    /// Uses creator preferences and shipping rules to determine allow-ability.
+    /// Inclusion in this list does not necessarily indicate that the add-on is available for backing.
+    public var allowedAddons: AllowedAddon {
+      get {
+        return AllowedAddon(unsafeResultMap: resultMap["allowedAddons"]! as! ResultMap)
+      }
+      set {
+        resultMap.updateValue(newValue.resultMap, forKey: "allowedAddons")
       }
     }
 
@@ -11192,6 +11212,85 @@ public enum GraphAPI {
           }
           set {
             resultMap += newValue.resultMap
+          }
+        }
+      }
+    }
+
+    public struct AllowedAddon: GraphQLSelectionSet {
+      public static let possibleTypes: [String] = ["RewardConnection"]
+
+      public static var selections: [GraphQLSelection] {
+        return [
+          GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+          GraphQLField("nodes", type: .list(.object(Node.selections))),
+        ]
+      }
+
+      public private(set) var resultMap: ResultMap
+
+      public init(unsafeResultMap: ResultMap) {
+        self.resultMap = unsafeResultMap
+      }
+
+      public init(nodes: [Node?]? = nil) {
+        self.init(unsafeResultMap: ["__typename": "RewardConnection", "nodes": nodes.flatMap { (value: [Node?]) -> [ResultMap?] in value.map { (value: Node?) -> ResultMap? in value.flatMap { (value: Node) -> ResultMap in value.resultMap } } }])
+      }
+
+      public var __typename: String {
+        get {
+          return resultMap["__typename"]! as! String
+        }
+        set {
+          resultMap.updateValue(newValue, forKey: "__typename")
+        }
+      }
+
+      /// A list of nodes.
+      public var nodes: [Node?]? {
+        get {
+          return (resultMap["nodes"] as? [ResultMap?]).flatMap { (value: [ResultMap?]) -> [Node?] in value.map { (value: ResultMap?) -> Node? in value.flatMap { (value: ResultMap) -> Node in Node(unsafeResultMap: value) } } }
+        }
+        set {
+          resultMap.updateValue(newValue.flatMap { (value: [Node?]) -> [ResultMap?] in value.map { (value: Node?) -> ResultMap? in value.flatMap { (value: Node) -> ResultMap in value.resultMap } } }, forKey: "nodes")
+        }
+      }
+
+      public struct Node: GraphQLSelectionSet {
+        public static let possibleTypes: [String] = ["Reward"]
+
+        public static var selections: [GraphQLSelection] {
+          return [
+            GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+            GraphQLField("id", type: .nonNull(.scalar(GraphQLID.self))),
+          ]
+        }
+
+        public private(set) var resultMap: ResultMap
+
+        public init(unsafeResultMap: ResultMap) {
+          self.resultMap = unsafeResultMap
+        }
+
+        public init(id: GraphQLID) {
+          self.init(unsafeResultMap: ["__typename": "Reward", "id": id])
+        }
+
+        public var __typename: String {
+          get {
+            return resultMap["__typename"]! as! String
+          }
+          set {
+            resultMap.updateValue(newValue, forKey: "__typename")
+          }
+        }
+
+        public var id: GraphQLID {
+          get {
+            return resultMap["id"]! as! GraphQLID
+          }
+          set {
+            resultMap.updateValue(newValue, forKey: "id")
           }
         }
       }

--- a/KsApi/fragments/RewardFragment.graphql
+++ b/KsApi/fragments/RewardFragment.graphql
@@ -6,6 +6,11 @@ fragment RewardFragment on Reward {
   convertedAmount {
     ...MoneyFragment
   }
+  allowedAddons {
+    nodes {
+      id
+    }
+  }
   description
   displayName
   endsAt

--- a/KsApi/models/graphql/adapters/Backing+BackingFragmentTests.swift
+++ b/KsApi/models/graphql/adapters/Backing+BackingFragmentTests.swift
@@ -25,6 +25,7 @@ final class Backing_BackingFragmentTests: XCTestCase {
       XCTAssertEqual(backing?.projectCountry, "US")
       XCTAssertEqual(backing?.projectId, 1_596_594_463)
       XCTAssertNotNil(backing?.reward)
+      XCTAssertTrue(backing!.reward!.hasAddOns)
       XCTAssertEqual(backing?.rewardId, decompose(id: "UmV3YXJkLTgxNzM5MDE="))
       XCTAssertEqual(backing?.sequence, 148)
       XCTAssertEqual(backing?.shippingAmount, 10.0)
@@ -67,6 +68,10 @@ private func backingDictionary() -> [String: Any] {
             "amount": "30.0",
             "currency": "USD",
             "symbol": "$"
+          },
+          "allowedAddons": {
+             "__typename": "RewardConnection",
+             "nodes": []
           },
           "backersCount": 2,
           "convertedAmount": {
@@ -144,6 +149,10 @@ private func backingDictionary() -> [String: Any] {
             "currency": "USD",
             "symbol": "$"
           },
+          "allowedAddons": {
+            "__typename": "RewardConnection",
+            "nodes": []
+          },
           "backersCount": 23,
           "convertedAmount": {
             "__typename": "Money",
@@ -214,6 +223,10 @@ private func backingDictionary() -> [String: Any] {
             "currency": "USD",
             "symbol": "$"
           },
+          "allowedAddons": {
+            "__typename": "RewardConnection",
+            "nodes": []
+          },
           "backersCount": 23,
           "convertedAmount": {
             "__typename": "Money",
@@ -283,6 +296,10 @@ private func backingDictionary() -> [String: Any] {
             "amount": "10.0",
             "currency": "USD",
             "symbol": "$"
+          },
+          "allowedAddons": {
+            "__typename": "RewardConnection",
+            "nodes": []
           },
           "backersCount": 23,
           "convertedAmount": {
@@ -683,6 +700,22 @@ private func backingDictionary() -> [String: Any] {
         "amount": "25.0",
         "currency": "USD",
         "symbol": "$"
+      },
+      "allowedAddons": {
+        "__typename": "RewardConnection",
+        "nodes": [{
+            "__typename": "Reward",
+            "id": "UmV3YXJkLTgzODEyNDk="
+          },
+          {
+            "__typename": "Reward",
+            "id": "UmV3YXJkLTgzODEyNTE="
+          },
+          {
+            "__typename": "Reward",
+            "id": "UmV3YXJkLTgzODEyNTE="
+          }
+        ]
       },
       "backersCount": 13,
       "convertedAmount": {

--- a/KsApi/models/graphql/adapters/Backing+BackingFragmentTests.swift
+++ b/KsApi/models/graphql/adapters/Backing+BackingFragmentTests.swift
@@ -9,27 +9,39 @@ final class Backing_BackingFragmentTests: XCTestCase {
       let fragment = try GraphAPI.BackingFragment(jsonObject: backingDictionary(), variables: variables)
       XCTAssertNotNil(fragment)
 
-      let backing = Backing.backing(from: fragment)
+      guard let backing = Backing.backing(from: fragment) else {
+        XCTFail("Backing should created from fragment")
+
+        return
+      }
+
       XCTAssertNotNil(backing)
-      XCTAssertEqual(backing?.amount, 90.0)
-      XCTAssertNotNil(backing?.backer)
-      XCTAssertNotNil(backing?.backerId)
-      XCTAssertEqual(backing?.backerCompleted, false)
-      XCTAssertEqual(backing?.bonusAmount, 5.0)
-      XCTAssertEqual(backing?.cancelable, true)
-      XCTAssertEqual(backing?.id, decompose(id: "QmFja2luZy0xNDQ5NTI3MTc="))
-      XCTAssertEqual(backing?.locationId, decompose(id: "TG9jYXRpb24tMjM0MjQ3NzU="))
-      XCTAssertEqual(backing?.locationName, "Canada")
-      XCTAssertEqual(backing?.paymentSource?.type, .visa)
-      XCTAssertEqual(backing?.pledgedAt, 1_625_613_342.0)
-      XCTAssertEqual(backing?.projectCountry, "US")
-      XCTAssertEqual(backing?.projectId, 1_596_594_463)
-      XCTAssertNotNil(backing?.reward)
-      XCTAssertTrue(backing!.reward!.hasAddOns)
-      XCTAssertEqual(backing?.rewardId, decompose(id: "UmV3YXJkLTgxNzM5MDE="))
-      XCTAssertEqual(backing?.sequence, 148)
-      XCTAssertEqual(backing?.shippingAmount, 10.0)
-      XCTAssertEqual(backing?.status, .pledged)
+      XCTAssertEqual(backing.amount, 90.0)
+      XCTAssertNotNil(backing.backer)
+      XCTAssertNotNil(backing.backerId)
+      XCTAssertEqual(backing.backerCompleted, false)
+      XCTAssertEqual(backing.bonusAmount, 5.0)
+      XCTAssertEqual(backing.cancelable, true)
+      XCTAssertEqual(backing.id, decompose(id: "QmFja2luZy0xNDQ5NTI3MTc="))
+      XCTAssertEqual(backing.locationId, decompose(id: "TG9jYXRpb24tMjM0MjQ3NzU="))
+      XCTAssertEqual(backing.locationName, "Canada")
+      XCTAssertEqual(backing.paymentSource?.type, .visa)
+      XCTAssertEqual(backing.pledgedAt, 1_625_613_342.0)
+      XCTAssertEqual(backing.projectCountry, "US")
+      XCTAssertEqual(backing.projectId, 1_596_594_463)
+      XCTAssertNotNil(backing.reward)
+      XCTAssertEqual(backing.rewardId, decompose(id: "UmV3YXJkLTgxNzM5MDE="))
+      XCTAssertEqual(backing.sequence, 148)
+      XCTAssertEqual(backing.shippingAmount, 10.0)
+      XCTAssertEqual(backing.status, .pledged)
+
+      guard let reward = backing.reward else {
+        XCTFail("reward should exist")
+
+        return
+      }
+
+      XCTAssertTrue(reward.hasAddOns)
     } catch {
       XCTFail(error.localizedDescription)
     }

--- a/KsApi/models/graphql/adapters/Project+FetchProjectQueryDataTests.swift
+++ b/KsApi/models/graphql/adapters/Project+FetchProjectQueryDataTests.swift
@@ -253,6 +253,8 @@ final class Project_FetchProjectQueryDataTests: XCTestCase {
     )
     XCTAssertNil(lastReward.endsAt)
     XCTAssertFalse(lastReward.hasAddOns)
+    XCTAssertTrue(project.rewards.first!.hasAddOns)
+    
     let date2: String? = "2021-11-01"
     let formattedDate2 = date2.flatMap(DateFormatter.isoDateFormatter.date(from:))
     let timeInterval2 = formattedDate2?.timeIntervalSince1970

--- a/KsApi/models/graphql/adapters/Project+FetchProjectQueryDataTests.swift
+++ b/KsApi/models/graphql/adapters/Project+FetchProjectQueryDataTests.swift
@@ -253,7 +253,14 @@ final class Project_FetchProjectQueryDataTests: XCTestCase {
     )
     XCTAssertNil(lastReward.endsAt)
     XCTAssertFalse(lastReward.hasAddOns)
-    XCTAssertTrue(project.rewards.first!.hasAddOns)
+
+    guard let firstReward = project.rewards.first else {
+      XCTFail("project should have at least one reward.")
+
+      return
+    }
+
+    XCTAssertTrue(firstReward.hasAddOns)
 
     let date2: String? = "2021-11-01"
     let formattedDate2 = date2.flatMap(DateFormatter.isoDateFormatter.date(from:))

--- a/KsApi/models/graphql/adapters/Project+FetchProjectQueryDataTests.swift
+++ b/KsApi/models/graphql/adapters/Project+FetchProjectQueryDataTests.swift
@@ -254,7 +254,7 @@ final class Project_FetchProjectQueryDataTests: XCTestCase {
     XCTAssertNil(lastReward.endsAt)
     XCTAssertFalse(lastReward.hasAddOns)
     XCTAssertTrue(project.rewards.first!.hasAddOns)
-    
+
     let date2: String? = "2021-11-01"
     let formattedDate2 = date2.flatMap(DateFormatter.isoDateFormatter.date(from:))
     let timeInterval2 = formattedDate2?.timeIntervalSince1970

--- a/KsApi/models/graphql/adapters/Reward+RewardFragment.swift
+++ b/KsApi/models/graphql/adapters/Reward+RewardFragment.swift
@@ -26,7 +26,11 @@ extension Reward {
     let estimatedDeliveryOn = rewardFragment.estimatedDeliveryOn
       .flatMap(dateFormatter.date(from:))?.timeIntervalSince1970
 
-    let rewardHasNoAddons = rewardFragment.allowedAddons.nodes?.isEmpty ?? true
+    var rewardHasAddons = false
+
+    if let addOnsAvailable = rewardFragment.allowedAddons.nodes {
+      rewardHasAddons = !addOnsAvailable.isEmpty
+    }
 
     return Reward(
       backersCount: rewardFragment.backersCount,
@@ -35,7 +39,7 @@ extension Reward {
       description: rewardFragment.description,
       endsAt: rewardFragment.endsAt.flatMap(TimeInterval.init),
       estimatedDeliveryOn: estimatedDeliveryOn,
-      hasAddOns: !rewardHasNoAddons,
+      hasAddOns: rewardHasAddons,
       id: rewardId,
       limit: rewardFragment.limit,
       limitPerBacker: rewardFragment.limitPerBacker,

--- a/KsApi/models/graphql/adapters/Reward+RewardFragment.swift
+++ b/KsApi/models/graphql/adapters/Reward+RewardFragment.swift
@@ -26,6 +26,8 @@ extension Reward {
     let estimatedDeliveryOn = rewardFragment.estimatedDeliveryOn
       .flatMap(dateFormatter.date(from:))?.timeIntervalSince1970
 
+    let rewardHasNoAddons = rewardFragment.allowedAddons.nodes?.isEmpty ?? true
+    
     return Reward(
       backersCount: rewardFragment.backersCount,
       convertedMinimum: rewardFragment.convertedAmount.fragments.moneyFragment.amount
@@ -33,7 +35,7 @@ extension Reward {
       description: rewardFragment.description,
       endsAt: rewardFragment.endsAt.flatMap(TimeInterval.init),
       estimatedDeliveryOn: estimatedDeliveryOn,
-      hasAddOns: false, // This value is only sent via the v1 API to indicate that a base reward has add-ons
+      hasAddOns: !rewardHasNoAddons,
       id: rewardId,
       limit: rewardFragment.limit,
       limitPerBacker: rewardFragment.limitPerBacker,

--- a/KsApi/models/graphql/adapters/Reward+RewardFragment.swift
+++ b/KsApi/models/graphql/adapters/Reward+RewardFragment.swift
@@ -27,7 +27,7 @@ extension Reward {
       .flatMap(dateFormatter.date(from:))?.timeIntervalSince1970
 
     let rewardHasNoAddons = rewardFragment.allowedAddons.nodes?.isEmpty ?? true
-    
+
     return Reward(
       backersCount: rewardFragment.backersCount,
       convertedMinimum: rewardFragment.convertedAmount.fragments.moneyFragment.amount

--- a/KsApi/models/graphql/adapters/Reward+RewardFragmentTests.swift
+++ b/KsApi/models/graphql/adapters/Reward+RewardFragmentTests.swift
@@ -27,6 +27,7 @@ final class Reward_RewardFragmentTests: XCTestCase {
       XCTAssertEqual(v1Reward?.limit, nil)
       XCTAssertEqual(v1Reward?.limitPerBacker, 1)
       XCTAssertEqual(v1Reward?.minimum, 25.0)
+      XCTAssertTrue(v1Reward!.hasAddOns)
       XCTAssertEqual(v1Reward?.remaining, nil)
       XCTAssertEqual(v1Reward?.rewardsItems[0].item.id, 1_170_799)
       XCTAssertEqual(v1Reward?.rewardsItems[0].item.name, "Soft-Cover Book (Signed)")
@@ -51,6 +52,18 @@ private func rewardDictionary() -> [String: Any] {
   let json = """
   {
     "__typename": "Reward",
+    "allowedAddons": {
+      "__typename": "RewardConnection",
+      "nodes": [{
+          "__typename": "Reward",
+          "id": "UmV3YXJkLTgzODEyNDk="
+        },
+        {
+          "__typename": "Reward",
+          "id": "UmV3YXJkLTgzODEyNTE="
+        }
+      ]
+    },
     "amount": {
       "__typename": "Money",
       "amount": "25.0",
@@ -72,8 +85,7 @@ private func rewardDictionary() -> [String: Any] {
     "isMaxPledge": false,
     "items": {
       "__typename": "RewardItemsConnection",
-      "nodes": [
-        {
+      "nodes": [{
           "__typename": "RewardItem",
           "id": "UmV3YXJkSXRlbS0xMTcwNzk5",
           "name": "Soft-Cover Book (Signed)"
@@ -94,8 +106,7 @@ private func rewardDictionary() -> [String: Any] {
     },
     "remainingQuantity": null,
     "shippingPreference": "unrestricted",
-    "shippingRules": [
-      {
+    "shippingRules": [{
         "__typename": "ShippingRule",
         "cost": {
           "__typename": "Money",

--- a/KsApi/models/graphql/adapters/Reward+RewardFragmentTests.swift
+++ b/KsApi/models/graphql/adapters/Reward+RewardFragmentTests.swift
@@ -12,36 +12,39 @@ final class Reward_RewardFragmentTests: XCTestCase {
       dateFormatter.timeZone = TimeZone(secondsFromGMT: 0)
       dateFormatter.dateFormat = "yyyy-MM-dd"
 
-      let v1Reward = Reward.reward(
+      guard let v1Reward = Reward.reward(
         from: fragment,
         dateFormatter: dateFormatter
-      )
+      ) else {
+        XCTFail("reward should be created from fragment")
 
-      XCTAssertNotNil(v1Reward)
-      XCTAssertEqual(v1Reward?.backersCount, 13)
-      XCTAssertEqual(v1Reward?.convertedMinimum, 31.0)
-      XCTAssertEqual(v1Reward?.description, "Description")
-      XCTAssertEqual(v1Reward?.endsAt, nil)
-      XCTAssertEqual(v1Reward?.estimatedDeliveryOn, 1_638_316_800.0)
-      XCTAssertEqual(v1Reward?.id, 8_173_901)
-      XCTAssertEqual(v1Reward?.limit, nil)
-      XCTAssertEqual(v1Reward?.limitPerBacker, 1)
-      XCTAssertEqual(v1Reward?.minimum, 25.0)
-      XCTAssertTrue(v1Reward!.hasAddOns)
-      XCTAssertEqual(v1Reward?.remaining, nil)
-      XCTAssertEqual(v1Reward?.rewardsItems[0].item.id, 1_170_799)
-      XCTAssertEqual(v1Reward?.rewardsItems[0].item.name, "Soft-Cover Book (Signed)")
-      XCTAssertEqual(v1Reward?.rewardsItems[1].item.id, 1_170_813)
-      XCTAssertEqual(v1Reward?.rewardsItems[1].item.name, "Custom Bookmark")
+        return
+      }
 
-      XCTAssertEqual(v1Reward?.shipping.enabled, true)
-      XCTAssertEqual(v1Reward?.shipping.preference, .unrestricted)
-      XCTAssertEqual(v1Reward?.shippingRules?.count, 2)
-      XCTAssertEqual(v1Reward?.startsAt, nil)
-      XCTAssertEqual(v1Reward?.title, "Soft Cover Book (Signed)")
+      XCTAssertEqual(v1Reward.backersCount, 13)
+      XCTAssertEqual(v1Reward.convertedMinimum, 31.0)
+      XCTAssertEqual(v1Reward.description, "Description")
+      XCTAssertEqual(v1Reward.endsAt, nil)
+      XCTAssertEqual(v1Reward.estimatedDeliveryOn, 1_638_316_800.0)
+      XCTAssertEqual(v1Reward.id, 8_173_901)
+      XCTAssertEqual(v1Reward.limit, nil)
+      XCTAssertEqual(v1Reward.limitPerBacker, 1)
+      XCTAssertEqual(v1Reward.minimum, 25.0)
+      XCTAssertTrue(v1Reward.hasAddOns)
+      XCTAssertEqual(v1Reward.remaining, nil)
+      XCTAssertEqual(v1Reward.rewardsItems[0].item.id, 1_170_799)
+      XCTAssertEqual(v1Reward.rewardsItems[0].item.name, "Soft-Cover Book (Signed)")
+      XCTAssertEqual(v1Reward.rewardsItems[1].item.id, 1_170_813)
+      XCTAssertEqual(v1Reward.rewardsItems[1].item.name, "Custom Bookmark")
 
-      XCTAssertEqual(v1Reward?.isLimitedQuantity, false)
-      XCTAssertEqual(v1Reward?.isLimitedTime, false)
+      XCTAssertEqual(v1Reward.shipping.enabled, true)
+      XCTAssertEqual(v1Reward.shipping.preference, .unrestricted)
+      XCTAssertEqual(v1Reward.shippingRules?.count, 2)
+      XCTAssertEqual(v1Reward.startsAt, nil)
+      XCTAssertEqual(v1Reward.title, "Soft Cover Book (Signed)")
+
+      XCTAssertEqual(v1Reward.isLimitedQuantity, false)
+      XCTAssertEqual(v1Reward.isLimitedTime, false)
     } catch {
       XCTFail(error.localizedDescription)
     }

--- a/KsApi/mutations/templates/query/FetchAddOnsQueryTemplate.swift
+++ b/KsApi/mutations/templates/query/FetchAddOnsQueryTemplate.swift
@@ -26,6 +26,10 @@ public enum FetchAddsOnsQueryTemplate {
             "nodes": [
               {
                 "__typename": "Reward",
+                "allowedAddons": {
+                  "__typename": "RewardConnection",
+                  "nodes": []
+                },
                 "shippingRulesExpanded": {
                   "__typename": "RewardShippingRulesConnection",
                   "nodes": [
@@ -129,6 +133,10 @@ public enum FetchAddsOnsQueryTemplate {
               },
               {
                 "__typename": "Reward",
+                "allowedAddons": {
+                  "__typename": "RewardConnection",
+                  "nodes": []
+                },
                 "shippingRulesExpanded": {
                   "__typename": "RewardShippingRulesConnection",
                   "nodes": [

--- a/KsApi/mutations/templates/query/FetchProjectQueryTemplate.swift
+++ b/KsApi/mutations/templates/query/FetchProjectQueryTemplate.swift
@@ -32,6 +32,10 @@ public enum FetchProjectQueryTemplate {
                       "currency":"EUR",
                       "symbol":"€"
                    },
+                   "allowedAddons": {
+                     "__typename": "RewardConnection",
+                     "nodes": []
+                   },
                    "backersCount":68,
                    "convertedAmount":{
                       "amount":"3.0",
@@ -107,6 +111,10 @@ public enum FetchProjectQueryTemplate {
                       "currency":"EUR",
                       "symbol":"€"
                    },
+                   "allowedAddons": {
+                     "__typename": "RewardConnection",
+                     "nodes": []
+                   },
                    "backersCount":17,
                    "convertedAmount":{
                       "amount":"8.0",
@@ -181,6 +189,10 @@ public enum FetchProjectQueryTemplate {
                       "amount":"24.0",
                       "currency":"EUR",
                       "symbol":"€"
+                   },
+                   "allowedAddons": {
+                     "__typename": "RewardConnection",
+                     "nodes": []
                    },
                    "backersCount":6,
                    "convertedAmount":{
@@ -264,6 +276,16 @@ public enum FetchProjectQueryTemplate {
                       "currency":"EUR",
                       "symbol":"€"
                    },
+                   "allowedAddons": {
+                     "__typename": "RewardConnection",
+                     "nodes": [{
+                         "id": "UmV3YXJkLTgzODEyNDk="
+                       },
+                       {
+                         "id": "UmV3YXJkLTgzODEyNTE="
+                       }
+                     ]
+                   },
                    "backersCount":3,
                    "convertedAmount":{
                       "amount":"8.0",
@@ -304,6 +326,13 @@ public enum FetchProjectQueryTemplate {
                       "amount":"10.0",
                       "currency":"EUR",
                       "symbol":"€"
+                   },
+                   "allowedAddons": {
+                     "__typename": "RewardConnection",
+                     "nodes": [{
+                         "id": "UmV3YXJkLTgzODEyNDk="
+                       }
+                     ]
                    },
                    "backersCount":6,
                    "convertedAmount":{
@@ -395,6 +424,10 @@ public enum FetchProjectQueryTemplate {
                       "currency":"EUR",
                       "symbol":"€"
                    },
+                   "allowedAddons": {
+                     "__typename": "RewardConnection",
+                     "nodes": []
+                   },
                    "backersCount":10,
                    "convertedAmount":{
                       "amount":"24.0",
@@ -469,6 +502,19 @@ public enum FetchProjectQueryTemplate {
                       "amount":"24.0",
                       "currency":"EUR",
                       "symbol":"€"
+                   },
+                   "allowedAddons": {
+                     "__typename": "RewardConnection",
+                     "nodes": [{
+                         "id": "UmV3YXJkLTgzODEyNDk="
+                       },
+                       {
+                         "id": "UmV3YXJkLTgzODEyNTE="
+                       },
+                       {
+                         "id": "UmV3YXJkLTgzODEyNTE="
+                       }
+                     ]
                    },
                    "backersCount":56,
                    "convertedAmount":{
@@ -560,6 +606,10 @@ public enum FetchProjectQueryTemplate {
                       "currency":"EUR",
                       "symbol":"€"
                    },
+                   "allowedAddons": {
+                     "__typename": "RewardConnection",
+                     "nodes": []
+                   },
                    "backersCount":10,
                    "convertedAmount":{
                       "amount":"48.0",
@@ -635,6 +685,10 @@ public enum FetchProjectQueryTemplate {
                       "currency":"EUR",
                       "symbol":"€"
                    },
+                   "allowedAddons": {
+                     "__typename": "RewardConnection",
+                     "nodes": []
+                   },
                    "backersCount":21,
                    "convertedAmount":{
                       "amount":"66.0",
@@ -709,6 +763,10 @@ public enum FetchProjectQueryTemplate {
                       "amount":"50.0",
                       "currency":"EUR",
                       "symbol":"€"
+                   },
+                   "allowedAddons": {
+                     "__typename": "RewardConnection",
+                     "nodes": []
                    },
                    "backersCount":9,
                    "convertedAmount":{
@@ -789,6 +847,10 @@ public enum FetchProjectQueryTemplate {
                       "currency":"EUR",
                       "symbol":"€"
                    },
+                   "allowedAddons": {
+                     "__typename": "RewardConnection",
+                     "nodes": []
+                   },
                    "backersCount":10,
                    "convertedAmount":{
                       "amount":"75.0",
@@ -867,6 +929,10 @@ public enum FetchProjectQueryTemplate {
                       "amount":"50.0",
                       "currency":"EUR",
                       "symbol":"€"
+                   },
+                   "allowedAddons": {
+                     "__typename": "RewardConnection",
+                     "nodes": []
                    },
                    "backersCount":3,
                    "convertedAmount":{
@@ -947,6 +1013,10 @@ public enum FetchProjectQueryTemplate {
                       "currency":"EUR",
                       "symbol":"€"
                    },
+                   "allowedAddons": {
+                     "__typename": "RewardConnection",
+                     "nodes": []
+                   },
                    "backersCount":4,
                    "convertedAmount":{
                       "amount":"150.0",
@@ -1025,6 +1095,10 @@ public enum FetchProjectQueryTemplate {
                       "amount":"100.0",
                       "currency":"EUR",
                       "symbol":"€"
+                   },
+                   "allowedAddons": {
+                     "__typename": "RewardConnection",
+                     "nodes": []
                    },
                    "backersCount":6,
                    "convertedAmount":{
@@ -1105,6 +1179,10 @@ public enum FetchProjectQueryTemplate {
                       "currency":"EUR",
                       "symbol":"€"
                    },
+                   "allowedAddons": {
+                     "__typename": "RewardConnection",
+                     "nodes": []
+                   },
                    "backersCount":3,
                    "convertedAmount":{
                       "amount":"374.0",
@@ -1184,6 +1262,10 @@ public enum FetchProjectQueryTemplate {
                       "currency":"EUR",
                       "symbol":"€"
                    },
+                   "allowedAddons": {
+                     "__typename": "RewardConnection",
+                     "nodes": []
+                   },
                    "backersCount":1,
                    "convertedAmount":{
                       "amount":"374.0",
@@ -1262,6 +1344,10 @@ public enum FetchProjectQueryTemplate {
                       "amount":"400.0",
                       "currency":"EUR",
                       "symbol":"€"
+                   },
+                   "allowedAddons": {
+                     "__typename": "RewardConnection",
+                     "nodes": []
                    },
                    "backersCount":1,
                    "convertedAmount":{


### PR DESCRIPTION
# 📲 What  and 🤔 Why

While testing, @paulomcg found that we are missing the add-ons selection step in the checkout process. This is because the `Reward` object was always passing in `false` to the `hasAddons` property of `Reward` model.

It wasn't completely within the scope of `Project` model, but due to relationships created previously through `v1/projects` endpoint, this flag is now important to both show the **Addons** pill and guide the user through the **Addons** step if the reward has addons.

# 🛠 How

Added this property to the `RewardFragment` and adjusted the `Rewards+RewardsFragment` to check if there are nodes and `hasAddons` will be `true` if its not empty.

```
allowedAddons {
  __typename
      nodes {
         __typename
         id
   }
}
```

# 👀 See

Trello, screenshots, external resources?

| Before 🐛 | After 🦋 |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/4282741/134724650-23f605a8-d025-4f97-b18a-1c6f38c34cc0.gif" width="300"> | <img src="https://user-images.githubusercontent.com/4282741/134725113-d5d01719-4ec1-4a26-9d27-29ac3f1f7acf.gif" width="300">  |


# ✅ Acceptance criteria

- [x] Ensure a project with addons ([example](https://www.kickstarter.com/projects/fjorden/fjorden-iphone-photography-reinvented)) allows the user to checkout with addons on a reward.
