### PR TITLE
[NTV-156] Fixing pledge_confirm events apple_pay/credit_card property values

### DIFF
--- a/Library/ViewModels/PledgeViewModel.swift
+++ b/Library/ViewModels/PledgeViewModel.swift
@@ -946,8 +946,7 @@ public class PledgeViewModel: PledgeViewModelType, PledgeViewModelInputs, Pledge
 
     // Risk Messaging Modal pledge_confirm event
     pledgeSubmitEventsSignal
-      .combineLatest(with: self.riskMessagingViewControllerDismissedProperty.signal.skipNil())
-      .takeWhen(self.riskMessagingViewControllerDismissedProperty.signal)
+      .takePairWhen(self.riskMessagingViewControllerDismissedProperty.signal.skipNil())
       .map { pledgeSubmitEvent, isApplePay in
         let (data, baseReward, additionalPledgeAmount, allRewardsShippingTotal) = pledgeSubmitEvent
         let checkoutData = checkoutProperties(

--- a/Library/ViewModels/PledgeViewModel.swift
+++ b/Library/ViewModels/PledgeViewModel.swift
@@ -946,8 +946,10 @@ public class PledgeViewModel: PledgeViewModelType, PledgeViewModelInputs, Pledge
 
     // Risk Messaging Modal pledge_confirm event
     pledgeSubmitEventsSignal
+      .combineLatest(with: self.riskMessagingViewControllerDismissedProperty.signal.skipNil())
       .takeWhen(self.riskMessagingViewControllerDismissedProperty.signal)
-      .map { data, baseReward, additionalPledgeAmount, allRewardsShippingTotal in
+      .map { pledgeSubmitEvent, isApplePay in
+        let (data, baseReward, additionalPledgeAmount, allRewardsShippingTotal) = pledgeSubmitEvent
         let checkoutData = checkoutProperties(
           from: data.project,
           baseReward: baseReward,
@@ -957,16 +959,16 @@ public class PledgeViewModel: PledgeViewModelType, PledgeViewModelInputs, Pledge
           pledgeTotal: data.pledgeTotal,
           shippingTotal: allRewardsShippingTotal,
           checkoutId: nil,
-          isApplePay: false
+          isApplePay: isApplePay
         )
 
-        return (data.project, baseReward, data.refTag, checkoutData)
+        return (data.project, baseReward, data.refTag, checkoutData, isApplePay)
       }
-      .observeValues { project, reward, refTag, checkoutData in
+      .observeValues { project, reward, refTag, checkoutData, isApplePay in
         AppEnvironment.current.ksrAnalytics.trackPledgeConfirmButtonClicked(
           project: project,
           reward: reward,
-          typeContext: .creditCard,
+          typeContext: isApplePay ? .applePay : .creditCard,
           checkoutData: checkoutData,
           refTag: refTag
         )


### PR DESCRIPTION
# 📲 What

This is a quick fix to correct an issue with our `pledge_confirm` event. We were previously sending a value of `credit_card` for all payment types whether is was `Pay With Apple` or not and this PR will correct that.

# 🤔 Why

Our insights team needs accurate data in order to correctly interpret and take action on our analytics data.

# 🛠 How

Combining an additional signal to the `pledgeSubmitEventsSignal` in the `PledgeViewModel`.

# ✅ Acceptance criteria

- [x] Successfully pledge a project, on Staging, using `Pay With Apple` and verify the `CTA Clicked` event that is emitted has a `context_cta` of `pledge_confirm` and a `context_type` of `apple_pay`.
- [x] - [ ] Successfully pledge a project, on Staging, using `Pledge` and verify the `CTA Clicked` event that is emitted has a `context_cta` of `pledge_confirm` and a `context_type` of `credit_card`.