### PR TITLE
[NTV-180] Sending commentableId based on value of updateProperty in CommentRepliesViewModel

### DIFF
--- a/Kickstarter-iOS/ViewModels/AppDelegateViewModel.swift
+++ b/Kickstarter-iOS/ViewModels/AppDelegateViewModel.swift
@@ -580,6 +580,7 @@ public final class AppDelegateViewModel: AppDelegateViewModelType, AppDelegateVi
               CommentRepliesViewController.configuredWith(
                 comment: envelope.comment,
                 project: project,
+                update: nil,
                 inputAreaBecomeFirstResponder: false,
                 replyId: replyId
               )
@@ -668,6 +669,7 @@ public final class AppDelegateViewModel: AppDelegateViewModelType, AppDelegateVi
               CommentRepliesViewController.configuredWith(
                 comment: envelope.comment,
                 project: project,
+                update: update,
                 inputAreaBecomeFirstResponder: false,
                 replyId: replyId
               )

--- a/Kickstarter-iOS/Views/Controllers/CommentRepliesViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/CommentRepliesViewController.swift
@@ -27,6 +27,7 @@ final class CommentRepliesViewController: UITableViewController {
   internal static func configuredWith(
     comment: Comment,
     project: Project,
+    update: Update?,
     inputAreaBecomeFirstResponder: Bool,
     replyId: String?
   ) -> CommentRepliesViewController {
@@ -34,6 +35,7 @@ final class CommentRepliesViewController: UITableViewController {
     vc.viewModel.inputs.configureWith(
       comment: comment,
       project: project,
+      update: update,
       inputAreaBecomeFirstResponder: inputAreaBecomeFirstResponder,
       replyId: replyId
     )

--- a/Kickstarter-iOS/Views/Controllers/CommentRepliesViewControllerTests.swift
+++ b/Kickstarter-iOS/Views/Controllers/CommentRepliesViewControllerTests.swift
@@ -25,7 +25,7 @@ final class CommentRepliesViewControllerTests: TestCase {
           .configuredWith(
             comment: .template,
             project: .template,
-            update: .template,
+            update: nil,
             inputAreaBecomeFirstResponder: true,
             replyId: nil
           )

--- a/Kickstarter-iOS/Views/Controllers/CommentRepliesViewControllerTests.swift
+++ b/Kickstarter-iOS/Views/Controllers/CommentRepliesViewControllerTests.swift
@@ -25,6 +25,7 @@ final class CommentRepliesViewControllerTests: TestCase {
           .configuredWith(
             comment: .template,
             project: .template,
+            update: .template,
             inputAreaBecomeFirstResponder: true,
             replyId: nil
           )
@@ -55,6 +56,7 @@ final class CommentRepliesViewControllerTests: TestCase {
           .configuredWith(
             comment: .template,
             project: .template,
+            update: nil,
             inputAreaBecomeFirstResponder: true,
             replyId: nil
           )
@@ -84,6 +86,7 @@ final class CommentRepliesViewControllerTests: TestCase {
           .configuredWith(
             comment: .template,
             project: .template,
+            update: nil,
             inputAreaBecomeFirstResponder: true,
             replyId: nil
           )
@@ -114,6 +117,7 @@ final class CommentRepliesViewControllerTests: TestCase {
           .configuredWith(
             comment: .template,
             project: .template,
+            update: nil,
             inputAreaBecomeFirstResponder: true,
             replyId: nil
           )
@@ -143,6 +147,7 @@ final class CommentRepliesViewControllerTests: TestCase {
           .configuredWith(
             comment: .template,
             project: .template,
+            update: nil,
             inputAreaBecomeFirstResponder: true,
             replyId: nil
           )
@@ -177,6 +182,7 @@ final class CommentRepliesViewControllerTests: TestCase {
           .configuredWith(
             comment: .template,
             project: .template,
+            update: nil,
             inputAreaBecomeFirstResponder: true,
             replyId: nil
           )

--- a/Kickstarter-iOS/Views/Controllers/CommentsViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/CommentsViewController.swift
@@ -135,12 +135,13 @@ internal final class CommentsViewController: UITableViewController {
         self?.tableView.reloadData()
       }
 
-    self.viewModel.outputs.goToRepliesWithCommentProjectAndBecomeFirstResponder
+    self.viewModel.outputs.goToRepliesWithCommentProjectUpdateAndBecomeFirstResponder
       .observeForControllerAction()
-      .observeValues { [weak self] comment, project, becomeFirstResponder in
+      .observeValues { [weak self] comment, project, update, becomeFirstResponder in
         let vc = CommentRepliesViewController.configuredWith(
           comment: comment,
           project: project,
+          update: update,
           inputAreaBecomeFirstResponder: becomeFirstResponder,
           replyId: nil
         )

--- a/Library/ViewModels/CommentRepliesViewModel.swift
+++ b/Library/ViewModels/CommentRepliesViewModel.swift
@@ -158,6 +158,7 @@ public final class CommentRepliesViewModel: CommentRepliesViewModelType,
 
     let commentComposerDidSubmitText = self.commentComposerDidSubmitTextProperty.signal.skipNil()
 
+    // If the Update is non-nil we send the FreeformPost format, otherwise we send the Project graphID
     let commentableId = self.updateProperty.signal.combineLatest(with: project)
       .map { update, project -> String in
         guard let update = update else {

--- a/Library/ViewModels/CommentRepliesViewModelTests.swift
+++ b/Library/ViewModels/CommentRepliesViewModelTests.swift
@@ -90,7 +90,7 @@ internal final class CommentRepliesViewModelTests: TestCase {
         .configureWith(
           comment: .template,
           project: .template,
-          update: .template,
+          update: nil,
           inputAreaBecomeFirstResponder: false,
           replyId: nil
         )

--- a/Library/ViewModels/CommentRepliesViewModelTests.swift
+++ b/Library/ViewModels/CommentRepliesViewModelTests.swift
@@ -67,6 +67,7 @@ internal final class CommentRepliesViewModelTests: TestCase {
       self.vm.inputs.configureWith(
         comment: rootComment,
         project: .template,
+        update: nil,
         inputAreaBecomeFirstResponder: false,
         replyId: nil
       )
@@ -89,6 +90,7 @@ internal final class CommentRepliesViewModelTests: TestCase {
         .configureWith(
           comment: .template,
           project: .template,
+          update: .template,
           inputAreaBecomeFirstResponder: false,
           replyId: nil
         )
@@ -117,6 +119,7 @@ internal final class CommentRepliesViewModelTests: TestCase {
         .configureWith(
           comment: .template,
           project: .template,
+          update: nil,
           inputAreaBecomeFirstResponder: false,
           replyId: nil
         )
@@ -147,6 +150,7 @@ internal final class CommentRepliesViewModelTests: TestCase {
         .configureWith(
           comment: .template,
           project: project,
+          update: nil,
           inputAreaBecomeFirstResponder: true,
           replyId: nil
         )
@@ -175,6 +179,7 @@ internal final class CommentRepliesViewModelTests: TestCase {
         .configureWith(
           comment: .template,
           project: project,
+          update: nil,
           inputAreaBecomeFirstResponder: true,
           replyId: nil
         )
@@ -203,6 +208,7 @@ internal final class CommentRepliesViewModelTests: TestCase {
         .configureWith(
           comment: .template,
           project: project,
+          update: nil,
           inputAreaBecomeFirstResponder: true,
           replyId: nil
         )
@@ -235,6 +241,7 @@ internal final class CommentRepliesViewModelTests: TestCase {
         .configureWith(
           comment: .template,
           project: project,
+          update: nil,
           inputAreaBecomeFirstResponder: false,
           replyId: nil
         )
@@ -277,6 +284,7 @@ internal final class CommentRepliesViewModelTests: TestCase {
       self.vm.inputs.configureWith(
         comment: .template,
         project: project,
+        update: nil,
         inputAreaBecomeFirstResponder: false,
         replyId: nil
       )
@@ -330,6 +338,7 @@ internal final class CommentRepliesViewModelTests: TestCase {
       self.vm.inputs.configureWith(
         comment: .template,
         project: project,
+        update: nil,
         inputAreaBecomeFirstResponder: false,
         replyId: nil
       )
@@ -392,6 +401,7 @@ internal final class CommentRepliesViewModelTests: TestCase {
         .configureWith(
           comment: .template,
           project: project,
+          update: nil,
           inputAreaBecomeFirstResponder: true,
           replyId: envelope.replies[0].id
         )
@@ -422,6 +432,7 @@ internal final class CommentRepliesViewModelTests: TestCase {
         .configureWith(
           comment: .template,
           project: project,
+          update: nil,
           inputAreaBecomeFirstResponder: true,
           replyId: nil
         )
@@ -450,6 +461,7 @@ internal final class CommentRepliesViewModelTests: TestCase {
         .configureWith(
           comment: .template,
           project: project,
+          update: nil,
           inputAreaBecomeFirstResponder: true,
           replyId: nil
         )
@@ -480,6 +492,7 @@ internal final class CommentRepliesViewModelTests: TestCase {
       self.vm.inputs.configureWith(
         comment: .replyRootCommentTemplate,
         project: project,
+        update: nil,
         inputAreaBecomeFirstResponder: true,
         replyId: nil
       )
@@ -524,6 +537,7 @@ internal final class CommentRepliesViewModelTests: TestCase {
         .configureWith(
           comment: .template,
           project: .template,
+          update: nil,
           inputAreaBecomeFirstResponder: true,
           replyId: nil
         )
@@ -628,6 +642,7 @@ internal final class CommentRepliesViewModelTests: TestCase {
         .configureWith(
           comment: .template,
           project: .template,
+          update: nil,
           inputAreaBecomeFirstResponder: true,
           replyId: nil
         )
@@ -712,6 +727,7 @@ internal final class CommentRepliesViewModelTests: TestCase {
         .configureWith(
           comment: .template,
           project: .template,
+          update: nil,
           inputAreaBecomeFirstResponder: true,
           replyId: nil
         )

--- a/Library/ViewModels/CommentsViewModel.swift
+++ b/Library/ViewModels/CommentsViewModel.swift
@@ -50,7 +50,12 @@ public protocol CommentsViewModelOutputs {
   var configureFooterViewWithState: Signal<CommentTableViewFooterViewState, Never> { get }
 
   /// Emits the selected `Comment`, `Project` and a `Bool` to determine if keyboard should show when user to navigate to replies.
-  var goToRepliesWithCommentProjectAndBecomeFirstResponder: Signal<(Comment, Project, Bool), Never> { get }
+  var goToRepliesWithCommentProjectUpdateAndBecomeFirstResponder: Signal<
+    (Comment, Project, Update?, Bool),
+    Never
+  > {
+    get
+  }
 
   /// Emits a list of `Comments`, the `Project` to load into the data source and whether an error state should be displayed.
   var loadCommentsAndProjectIntoDataSource: Signal<([Comment], Project, Bool), Never> { get }
@@ -235,19 +240,24 @@ public final class CommentsViewModel: CommentsViewModelType,
       .skipNil()
       .filter { comment in comment.replyCount > 0 }
 
+    let update = self.projectAndUpdateProperty.signal
+      .skipNil()
+      .map(second)
+
     let commentsWithRepliesAndProject = Signal.combineLatest(
-      viewCommentReplies, initialProject
+      viewCommentReplies, initialProject, update
     )
 
     let replyCommentWithProject = Signal.combineLatest(
       self.commentCellDidTapReplyProperty.signal.skipNil(),
-      initialProject
+      initialProject,
+      update
     )
 
-    self.goToRepliesWithCommentProjectAndBecomeFirstResponder =
+    self.goToRepliesWithCommentProjectUpdateAndBecomeFirstResponder =
       Signal.merge(
-        commentsWithRepliesAndProject.map { ($0, $1, false) },
-        replyCommentWithProject.map { ($0, $1, true) }
+        commentsWithRepliesAndProject.map { ($0, $1, $2, false) },
+        replyCommentWithProject.map { ($0, $1, $2, true) }
       )
 
     let commentComposerDidSubmitText = self.commentComposerDidSubmitTextProperty.signal.skipNil()
@@ -402,7 +412,10 @@ public final class CommentsViewModel: CommentsViewModelType,
   public let cellSeparatorHidden: Signal<Bool, Never>
   public let configureCommentComposerViewWithData: Signal<CommentComposerViewData, Never>
   public let configureFooterViewWithState: Signal<CommentTableViewFooterViewState, Never>
-  public let goToRepliesWithCommentProjectAndBecomeFirstResponder: Signal<(Comment, Project, Bool), Never>
+  public let goToRepliesWithCommentProjectUpdateAndBecomeFirstResponder: Signal<
+    (Comment, Project, Update?, Bool),
+    Never
+  >
   public let loadCommentsAndProjectIntoDataSource: Signal<([Comment], Project, Bool), Never>
   public let showHelpWebViewController: Signal<HelpType, Never>
   public let resetCommentComposerAndScrollToTop: Signal<(), Never>

--- a/Library/ViewModels/CommentsViewModel.swift
+++ b/Library/ViewModels/CommentsViewModel.swift
@@ -49,13 +49,11 @@ public protocol CommentsViewModelOutputs {
   /// Configures the footer view with the current state.
   var configureFooterViewWithState: Signal<CommentTableViewFooterViewState, Never> { get }
 
-  /// Emits the selected `Comment`, `Project` and a `Bool` to determine if keyboard should show when user to navigate to replies.
+  /// Emits the selected `Comment`, `Project`, `Update?` and a `Bool` to determine if keyboard should show when user to navigate to replies.
   var goToRepliesWithCommentProjectUpdateAndBecomeFirstResponder: Signal<
     (Comment, Project, Update?, Bool),
     Never
-  > {
-    get
-  }
+  > { get }
 
   /// Emits a list of `Comments`, the `Project` to load into the data source and whether an error state should be displayed.
   var loadCommentsAndProjectIntoDataSource: Signal<([Comment], Project, Bool), Never> { get }


### PR DESCRIPTION
# 📲 What

We were made aware of a bug that was introduced to our comment threading feature which is being corrected in this PR. In particular, we were sending the wrong relayId when posting replies. Until the web team informed us recently, we were sending `Project-{id}` for all new replies even if they were Updates. An Update should be sending a relayId of `Freeform-Post-{id}`. Now we are checking if this reply is occurring in a Update or not before dynamically sending the commentableId.

# 🤔 Why

 Because we are setting the reply comments commentable type to Project, it's triggering errors everyday in our "new reply notiification" emails which only support project comment replies at the moment.

# 🛠 How

Passing the `Update` when we set up the `CommentRepliesViewController` and `CommentRepliesViewModel`. We then unwrap the update property and if it is not nil we send the Freeform-Post relay id.

# ✅ Acceptance criteria

- [x] Post a reply to a comment in the `Comments` section, take the commentableId and decode it. Verify it is prefixed by `Project`
- [x] Post a reply to a comment in the `Updates` section, take the commentableId and decode it. Verify it is prefixed by `Freeform-Post`