### PR TITLE
[Unticketed] No Rewards Reward Added To Rewards Selection Screen

### DIFF
--- a/KsApi/GraphAPI.swift
+++ b/KsApi/GraphAPI.swift
@@ -9493,6 +9493,7 @@ public enum GraphAPI {
           __typename
           ...LocationFragment
         }
+        minPledge
         name
         pid
         pledged {
@@ -9561,6 +9562,7 @@ public enum GraphAPI {
         GraphQLField("isLaunched", type: .nonNull(.scalar(Bool.self))),
         GraphQLField("launchedAt", type: .scalar(String.self)),
         GraphQLField("location", type: .object(Location.selections)),
+        GraphQLField("minPledge", type: .nonNull(.scalar(Int.self))),
         GraphQLField("name", type: .nonNull(.scalar(String.self))),
         GraphQLField("pid", type: .nonNull(.scalar(Int.self))),
         GraphQLField("pledged", type: .nonNull(.object(Pledged.selections))),
@@ -9584,8 +9586,8 @@ public enum GraphAPI {
       self.resultMap = unsafeResultMap
     }
 
-    public init(actions: Action, availableCardTypes: [CreditCardTypes], backersCount: Int, category: Category? = nil, canComment: Bool, commentsCount: Int, country: Country, creator: Creator? = nil, currency: CurrencyCode, deadlineAt: String? = nil, description: String, environmentalCommitments: [EnvironmentalCommitment?]? = nil, faqs: Faq? = nil, finalCollectionDate: String? = nil, fxRate: Double, goal: Goal? = nil, image: Image? = nil, isProjectWeLove: Bool, isProjectOfTheDay: Bool? = nil, isWatched: Bool, isLaunched: Bool, launchedAt: String? = nil, location: Location? = nil, name: String, pid: Int, pledged: Pledged, posts: Post? = nil, prelaunchActivated: Bool, risks: String, slug: String, state: ProjectState, stateChangedAt: String, story: String, tags: [Tag?], url: String, usdExchangeRate: Double? = nil, video: Video? = nil) {
-      self.init(unsafeResultMap: ["__typename": "Project", "actions": actions.resultMap, "availableCardTypes": availableCardTypes, "backersCount": backersCount, "category": category.flatMap { (value: Category) -> ResultMap in value.resultMap }, "canComment": canComment, "commentsCount": commentsCount, "country": country.resultMap, "creator": creator.flatMap { (value: Creator) -> ResultMap in value.resultMap }, "currency": currency, "deadlineAt": deadlineAt, "description": description, "environmentalCommitments": environmentalCommitments.flatMap { (value: [EnvironmentalCommitment?]) -> [ResultMap?] in value.map { (value: EnvironmentalCommitment?) -> ResultMap? in value.flatMap { (value: EnvironmentalCommitment) -> ResultMap in value.resultMap } } }, "faqs": faqs.flatMap { (value: Faq) -> ResultMap in value.resultMap }, "finalCollectionDate": finalCollectionDate, "fxRate": fxRate, "goal": goal.flatMap { (value: Goal) -> ResultMap in value.resultMap }, "image": image.flatMap { (value: Image) -> ResultMap in value.resultMap }, "isProjectWeLove": isProjectWeLove, "isProjectOfTheDay": isProjectOfTheDay, "isWatched": isWatched, "isLaunched": isLaunched, "launchedAt": launchedAt, "location": location.flatMap { (value: Location) -> ResultMap in value.resultMap }, "name": name, "pid": pid, "pledged": pledged.resultMap, "posts": posts.flatMap { (value: Post) -> ResultMap in value.resultMap }, "prelaunchActivated": prelaunchActivated, "risks": risks, "slug": slug, "state": state, "stateChangedAt": stateChangedAt, "story": story, "tags": tags.map { (value: Tag?) -> ResultMap? in value.flatMap { (value: Tag) -> ResultMap in value.resultMap } }, "url": url, "usdExchangeRate": usdExchangeRate, "video": video.flatMap { (value: Video) -> ResultMap in value.resultMap }])
+    public init(actions: Action, availableCardTypes: [CreditCardTypes], backersCount: Int, category: Category? = nil, canComment: Bool, commentsCount: Int, country: Country, creator: Creator? = nil, currency: CurrencyCode, deadlineAt: String? = nil, description: String, environmentalCommitments: [EnvironmentalCommitment?]? = nil, faqs: Faq? = nil, finalCollectionDate: String? = nil, fxRate: Double, goal: Goal? = nil, image: Image? = nil, isProjectWeLove: Bool, isProjectOfTheDay: Bool? = nil, isWatched: Bool, isLaunched: Bool, launchedAt: String? = nil, location: Location? = nil, minPledge: Int, name: String, pid: Int, pledged: Pledged, posts: Post? = nil, prelaunchActivated: Bool, risks: String, slug: String, state: ProjectState, stateChangedAt: String, story: String, tags: [Tag?], url: String, usdExchangeRate: Double? = nil, video: Video? = nil) {
+      self.init(unsafeResultMap: ["__typename": "Project", "actions": actions.resultMap, "availableCardTypes": availableCardTypes, "backersCount": backersCount, "category": category.flatMap { (value: Category) -> ResultMap in value.resultMap }, "canComment": canComment, "commentsCount": commentsCount, "country": country.resultMap, "creator": creator.flatMap { (value: Creator) -> ResultMap in value.resultMap }, "currency": currency, "deadlineAt": deadlineAt, "description": description, "environmentalCommitments": environmentalCommitments.flatMap { (value: [EnvironmentalCommitment?]) -> [ResultMap?] in value.map { (value: EnvironmentalCommitment?) -> ResultMap? in value.flatMap { (value: EnvironmentalCommitment) -> ResultMap in value.resultMap } } }, "faqs": faqs.flatMap { (value: Faq) -> ResultMap in value.resultMap }, "finalCollectionDate": finalCollectionDate, "fxRate": fxRate, "goal": goal.flatMap { (value: Goal) -> ResultMap in value.resultMap }, "image": image.flatMap { (value: Image) -> ResultMap in value.resultMap }, "isProjectWeLove": isProjectWeLove, "isProjectOfTheDay": isProjectOfTheDay, "isWatched": isWatched, "isLaunched": isLaunched, "launchedAt": launchedAt, "location": location.flatMap { (value: Location) -> ResultMap in value.resultMap }, "minPledge": minPledge, "name": name, "pid": pid, "pledged": pledged.resultMap, "posts": posts.flatMap { (value: Post) -> ResultMap in value.resultMap }, "prelaunchActivated": prelaunchActivated, "risks": risks, "slug": slug, "state": state, "stateChangedAt": stateChangedAt, "story": story, "tags": tags.map { (value: Tag?) -> ResultMap? in value.flatMap { (value: Tag) -> ResultMap in value.resultMap } }, "url": url, "usdExchangeRate": usdExchangeRate, "video": video.flatMap { (value: Video) -> ResultMap in value.resultMap }])
     }
 
     public var __typename: String {
@@ -9824,6 +9826,16 @@ public enum GraphAPI {
       }
       set {
         resultMap.updateValue(newValue?.resultMap, forKey: "location")
+      }
+    }
+
+    /// The min pledge amount for a single reward tier.
+    public var minPledge: Int {
+      get {
+        return resultMap["minPledge"]! as! Int
+      }
+      set {
+        resultMap.updateValue(newValue, forKey: "minPledge")
       }
     }
 

--- a/KsApi/fragments/ProjectFragment.graphql
+++ b/KsApi/fragments/ProjectFragment.graphql
@@ -48,6 +48,7 @@ fragment ProjectFragment on Project {
   location {
     ...LocationFragment
   }
+  minPledge
   name
   pid
   pledged {

--- a/KsApi/models/ExtendedProjectProperties.swift
+++ b/KsApi/models/ExtendedProjectProperties.swift
@@ -15,6 +15,7 @@ public struct ExtendedProjectProperties: Decodable {
   public var faqs: [ProjectFAQ]
   public var risks: String
   public var story: String
+  public var minimumPledgeAmount: Int
 
   public struct ProjectFAQ: Decodable {
     public var answer: String

--- a/KsApi/models/graphql/adapters/Backing+BackingFragmentTests.swift
+++ b/KsApi/models/graphql/adapters/Backing+BackingFragmentTests.swift
@@ -665,6 +665,7 @@ private func backingDictionary() -> [String: Any] {
         "id": "TG9jYXRpb24tMjQxOTk0NA==",
         "name": "Henderson"
       },
+      "minPledge": 1,
       "name": "WEE WILLIAM WITCHLING",
       "pid": 1596594463,
       "pledged": {

--- a/KsApi/models/graphql/adapters/Project+FetchProjectQueryData.swift
+++ b/KsApi/models/graphql/adapters/Project+FetchProjectQueryData.swift
@@ -55,27 +55,8 @@ extension Project {
         Reward.reward(from: fragment)
       } ?? []
 
-    /** FIXME: This is unfortunately a consequence of the no-reward reward being returned on v1 but not in GQL. Eventually we'll want to talk with backend about the possibility of returning a no-reward reward as part of the project query, just as they did with v1. The benefit of that is no reward reward doesn't have to be maintained locally. We want to show the rewards that the backend returns without modification to the raw data.
-     */
-
-    var projectMinimumPledgeAmount = 1.0
-    var currentUsersCurrencyFXRate = 1.0
-
-    if let fxRateValue = data.project?.fragments.projectFragment.fxRate {
-      currentUsersCurrencyFXRate = Double(fxRateValue)
-    }
-
-    if let projectMinPledgeSingleTierRawValue = data.project?.fragments.projectFragment.minPledge {
-      projectMinimumPledgeAmount = Double(projectMinPledgeSingleTierRawValue)
-    }
-
-    let convertedMinimumAmount = currentUsersCurrencyFXRate * projectMinimumPledgeAmount
-
-    let emptyReward = Reward.noReward
-      |> Reward.lens.minimum .~ projectMinimumPledgeAmount
-      |> Reward.lens.convertedMinimum .~ convertedMinimumAmount
-
-    let updatedRewardsWithNoReward = [emptyReward] + rewards
+    let emptyRewards = [noRewardReward(from: data.project?.fragments.projectFragment)]
+    let updatedRewardsWithNoReward = emptyRewards + rewards
 
     var projectBackingId: Int?
 
@@ -118,27 +99,8 @@ extension Project {
         Reward.reward(from: fragment)
       } ?? []
 
-    /** FIXME: This is unfortunately a consequence of the no-reward reward being returned on v1 but not in GQL. Eventually we'll want to talk with backend about the possibility of returning a no-reward reward as part of the project query, just as they did with v1. The benefit of that is no reward reward doesn't have to be maintained locally. We want to show the rewards that the backend returns without modification to the raw data.
-     */
-
-    var projectMinimumPledgeAmount = 1.0
-    var currentUsersCurrencyFXRate = 1.0
-
-    if let fxRateValue = data.project?.fragments.projectFragment.fxRate {
-      currentUsersCurrencyFXRate = Double(fxRateValue)
-    }
-
-    if let projectMinPledgeSingleTierRawValue = data.project?.fragments.projectFragment.minPledge {
-      projectMinimumPledgeAmount = Double(projectMinPledgeSingleTierRawValue)
-    }
-
-    let convertedMinimumAmount = currentUsersCurrencyFXRate * projectMinimumPledgeAmount
-
-    let emptyReward = Reward.noReward
-      |> Reward.lens.minimum .~ projectMinimumPledgeAmount
-      |> Reward.lens.convertedMinimum .~ convertedMinimumAmount
-
-    let updatedRewardsWithNoReward = [emptyReward] + rewards
+    let emptyRewards = [noRewardReward(from: data.project?.fragments.projectFragment)]
+    let updatedRewardsWithNoReward = emptyRewards + rewards
 
     var projectBackingId: Int?
 
@@ -158,5 +120,29 @@ extension Project {
     else { return (nil, nil) }
 
     return (project, projectBackingId)
+  }
+
+  /** FIXME: This is unfortunately a consequence of the no-reward reward being returned on v1 but not in GQL. Eventually we'll want to talk with backend about the possibility of returning a no-reward reward as part of the project query, just as they did with v1. The benefit of that is no reward reward doesn't have to be maintained locally. We want to show the rewards that the backend returns without modification to the raw data.
+   */
+
+  private static func noRewardReward(from fragment: GraphAPI.ProjectFragment?) -> Reward {
+    var projectMinimumPledgeAmount = 1.0
+    var currentUsersCurrencyFXRate = 1.0
+
+    if let fxRateValue = fragment?.fxRate {
+      currentUsersCurrencyFXRate = Double(fxRateValue)
+    }
+
+    if let projectMinPledgeSingleTierRawValue = fragment?.minPledge {
+      projectMinimumPledgeAmount = Double(projectMinPledgeSingleTierRawValue)
+    }
+
+    let convertedMinimumAmount = currentUsersCurrencyFXRate * projectMinimumPledgeAmount
+
+    let emptyReward = Reward.noReward
+      |> Reward.lens.minimum .~ projectMinimumPledgeAmount
+      |> Reward.lens.convertedMinimum .~ convertedMinimumAmount
+
+    return emptyReward
   }
 }

--- a/KsApi/models/graphql/adapters/Project+FetchProjectQueryData.swift
+++ b/KsApi/models/graphql/adapters/Project+FetchProjectQueryData.swift
@@ -56,7 +56,7 @@ extension Project {
       } ?? []
 
     let emptyRewards = [noRewardReward(from: data.project?.fragments.projectFragment)]
-    let updatedRewardsWithNoReward = emptyRewards + rewards
+    let allRewards = emptyRewards + rewards
 
     var projectBackingId: Int?
 
@@ -68,7 +68,7 @@ extension Project {
       let fragment = data.project?.fragments.projectFragment,
       let project = Project.project(
         from: fragment,
-        rewards: updatedRewardsWithNoReward,
+        rewards: allRewards,
         addOns: addOns,
         backing: nil,
         currentUserChosenCurrency: data.me?.chosenCurrency
@@ -100,7 +100,7 @@ extension Project {
       } ?? []
 
     let emptyRewards = [noRewardReward(from: data.project?.fragments.projectFragment)]
-    let updatedRewardsWithNoReward = emptyRewards + rewards
+    let allRewards = emptyRewards + rewards
 
     var projectBackingId: Int?
 
@@ -112,7 +112,7 @@ extension Project {
       let fragment = data.project?.fragments.projectFragment,
       let project = Project.project(
         from: fragment,
-        rewards: updatedRewardsWithNoReward,
+        rewards: allRewards,
         addOns: addOns,
         backing: nil,
         currentUserChosenCurrency: data.me?.chosenCurrency
@@ -126,21 +126,13 @@ extension Project {
    */
 
   private static func noRewardReward(from fragment: GraphAPI.ProjectFragment?) -> Reward {
-    var projectMinimumPledgeAmount = 1.0
-    var currentUsersCurrencyFXRate = 1.0
+    let projectMinimumPledgeAmount: Int = fragment?.minPledge ?? 1
+    let currentUsersCurrencyFXRate: Double = fragment?.fxRate ?? 1.0
 
-    if let fxRateValue = fragment?.fxRate {
-      currentUsersCurrencyFXRate = Double(fxRateValue)
-    }
-
-    if let projectMinPledgeSingleTierRawValue = fragment?.minPledge {
-      projectMinimumPledgeAmount = Double(projectMinPledgeSingleTierRawValue)
-    }
-
-    let convertedMinimumAmount = currentUsersCurrencyFXRate * projectMinimumPledgeAmount
+    let convertedMinimumAmount = currentUsersCurrencyFXRate * Double(projectMinimumPledgeAmount)
 
     let emptyReward = Reward.noReward
-      |> Reward.lens.minimum .~ projectMinimumPledgeAmount
+      |> Reward.lens.minimum .~ Double(projectMinimumPledgeAmount)
       |> Reward.lens.convertedMinimum .~ convertedMinimumAmount
 
     return emptyReward

--- a/KsApi/models/graphql/adapters/Project+FetchProjectQueryData.swift
+++ b/KsApi/models/graphql/adapters/Project+FetchProjectQueryData.swift
@@ -1,5 +1,6 @@
 import Apollo
 import Foundation
+import Prelude
 import ReactiveSwift
 
 extension Project {
@@ -54,6 +55,28 @@ extension Project {
         Reward.reward(from: fragment)
       } ?? []
 
+    /** FIXME: This is unfortunately a consequence of the no-reward reward being returned on v1 but not in GQL. Eventually we'll want to talk with backend about the possibility of returning a no-reward reward as part of the project query, just as they did with v1. The benefit of that is no reward reward doesn't have to be maintained locally. We want to show the rewards that the backend returns without modification to the raw data.
+     */
+    
+    var projectMinimumPledgeAmount = 1.0
+    var currentUsersCurrencyFXRate = 1.0
+    
+    if let fxRateValue = data.project?.fragments.projectFragment.fxRate {
+      currentUsersCurrencyFXRate = Double(fxRateValue)
+    }
+    
+    if let projectMinPledgeSingleTierRawValue = data.project?.fragments.projectFragment.minPledge {
+      projectMinimumPledgeAmount = Double(projectMinPledgeSingleTierRawValue)
+    }
+    
+    let convertedMinimumAmount = currentUsersCurrencyFXRate * projectMinimumPledgeAmount
+    
+    let emptyReward = Reward.noReward
+      |> Reward.lens.minimum .~ projectMinimumPledgeAmount
+      |> Reward.lens.convertedMinimum .~ convertedMinimumAmount
+    
+    let updatedRewardsWithNoReward = [emptyReward] + rewards
+    
     var projectBackingId: Int?
 
     if let backingId = data.project?.backing?.id {
@@ -64,7 +87,7 @@ extension Project {
       let fragment = data.project?.fragments.projectFragment,
       let project = Project.project(
         from: fragment,
-        rewards: rewards,
+        rewards: updatedRewardsWithNoReward,
         addOns: addOns,
         backing: nil,
         currentUserChosenCurrency: data.me?.chosenCurrency
@@ -95,6 +118,28 @@ extension Project {
         Reward.reward(from: fragment)
       } ?? []
 
+    /** FIXME: This is unfortunately a consequence of the no-reward reward being returned on v1 but not in GQL. Eventually we'll want to talk with backend about the possibility of returning a no-reward reward as part of the project query, just as they did with v1. The benefit of that is no reward reward doesn't have to be maintained locally. We want to show the rewards that the backend returns without modification to the raw data.
+     */
+    
+    var projectMinimumPledgeAmount = 1.0
+    var currentUsersCurrencyFXRate = 1.0
+    
+    if let fxRateValue = data.project?.fragments.projectFragment.fxRate {
+      currentUsersCurrencyFXRate = Double(fxRateValue)
+    }
+    
+    if let projectMinPledgeSingleTierRawValue = data.project?.fragments.projectFragment.minPledge {
+      projectMinimumPledgeAmount = Double(projectMinPledgeSingleTierRawValue)
+    }
+    
+    let convertedMinimumAmount = currentUsersCurrencyFXRate * projectMinimumPledgeAmount
+    
+    let emptyReward = Reward.noReward
+      |> Reward.lens.minimum .~ projectMinimumPledgeAmount
+      |> Reward.lens.convertedMinimum .~ convertedMinimumAmount
+    
+    let updatedRewardsWithNoReward = [emptyReward] + rewards
+    
     var projectBackingId: Int?
 
     if let backingId = data.project?.backing?.id {
@@ -105,7 +150,7 @@ extension Project {
       let fragment = data.project?.fragments.projectFragment,
       let project = Project.project(
         from: fragment,
-        rewards: rewards,
+        rewards: updatedRewardsWithNoReward,
         addOns: addOns,
         backing: nil,
         currentUserChosenCurrency: data.me?.chosenCurrency

--- a/KsApi/models/graphql/adapters/Project+FetchProjectQueryData.swift
+++ b/KsApi/models/graphql/adapters/Project+FetchProjectQueryData.swift
@@ -57,26 +57,26 @@ extension Project {
 
     /** FIXME: This is unfortunately a consequence of the no-reward reward being returned on v1 but not in GQL. Eventually we'll want to talk with backend about the possibility of returning a no-reward reward as part of the project query, just as they did with v1. The benefit of that is no reward reward doesn't have to be maintained locally. We want to show the rewards that the backend returns without modification to the raw data.
      */
-    
+
     var projectMinimumPledgeAmount = 1.0
     var currentUsersCurrencyFXRate = 1.0
-    
+
     if let fxRateValue = data.project?.fragments.projectFragment.fxRate {
       currentUsersCurrencyFXRate = Double(fxRateValue)
     }
-    
+
     if let projectMinPledgeSingleTierRawValue = data.project?.fragments.projectFragment.minPledge {
       projectMinimumPledgeAmount = Double(projectMinPledgeSingleTierRawValue)
     }
-    
+
     let convertedMinimumAmount = currentUsersCurrencyFXRate * projectMinimumPledgeAmount
-    
+
     let emptyReward = Reward.noReward
       |> Reward.lens.minimum .~ projectMinimumPledgeAmount
       |> Reward.lens.convertedMinimum .~ convertedMinimumAmount
-    
+
     let updatedRewardsWithNoReward = [emptyReward] + rewards
-    
+
     var projectBackingId: Int?
 
     if let backingId = data.project?.backing?.id {
@@ -120,26 +120,26 @@ extension Project {
 
     /** FIXME: This is unfortunately a consequence of the no-reward reward being returned on v1 but not in GQL. Eventually we'll want to talk with backend about the possibility of returning a no-reward reward as part of the project query, just as they did with v1. The benefit of that is no reward reward doesn't have to be maintained locally. We want to show the rewards that the backend returns without modification to the raw data.
      */
-    
+
     var projectMinimumPledgeAmount = 1.0
     var currentUsersCurrencyFXRate = 1.0
-    
+
     if let fxRateValue = data.project?.fragments.projectFragment.fxRate {
       currentUsersCurrencyFXRate = Double(fxRateValue)
     }
-    
+
     if let projectMinPledgeSingleTierRawValue = data.project?.fragments.projectFragment.minPledge {
       projectMinimumPledgeAmount = Double(projectMinPledgeSingleTierRawValue)
     }
-    
+
     let convertedMinimumAmount = currentUsersCurrencyFXRate * projectMinimumPledgeAmount
-    
+
     let emptyReward = Reward.noReward
       |> Reward.lens.minimum .~ projectMinimumPledgeAmount
       |> Reward.lens.convertedMinimum .~ convertedMinimumAmount
-    
+
     let updatedRewardsWithNoReward = [emptyReward] + rewards
-    
+
     var projectBackingId: Int?
 
     if let backingId = data.project?.backing?.id {

--- a/KsApi/models/graphql/adapters/Project+FetchProjectQueryDataTests.swift
+++ b/KsApi/models/graphql/adapters/Project+FetchProjectQueryDataTests.swift
@@ -237,7 +237,7 @@ final class Project_FetchProjectQueryDataTests: XCTestCase {
     XCTAssertNil(lastAddOn.shipping.type)
 
     /// Project rewards data -- rewards
-    XCTAssertEqual(project.rewards.count, 14)
+    XCTAssertEqual(project.rewards.count, 15)
 
     guard let lastReward = project.rewards.last else {
       XCTFail()
@@ -260,7 +260,17 @@ final class Project_FetchProjectQueryDataTests: XCTestCase {
       return
     }
 
-    XCTAssertTrue(firstReward.hasAddOns)
+    XCTAssertTrue(firstReward.isNoReward)
+
+    guard project.rewards.count > 1 else {
+      XCTFail("project should have at least two rewards.")
+
+      return
+    }
+
+    let secondReward = project.rewards[1]
+
+    XCTAssertTrue(secondReward.hasAddOns)
 
     let date2: String? = "2021-11-01"
     let formattedDate2 = date2.flatMap(DateFormatter.isoDateFormatter.date(from:))

--- a/KsApi/models/graphql/adapters/Project+ProjectFragment.swift
+++ b/KsApi/models/graphql/adapters/Project+ProjectFragment.swift
@@ -228,12 +228,14 @@ private func extendedProject(from projectFragment: GraphAPI.ProjectFragment) -> 
   let risks = projectFragment.risks
   let environmentalCommitments = extendedProjectEnvironmentalCommitments(from: projectFragment)
   let faqs = extendedProjectFAQs(from: projectFragment)
-
+  let minimumSingleTierPledgeAmount = projectFragment.minPledge
+  
   let extendedProjectProperties = ExtendedProjectProperties(
     environmentalCommitments: environmentalCommitments,
     faqs: faqs,
     risks: risks,
-    story: story
+    story: story,
+    minimumPledgeAmount: minimumSingleTierPledgeAmount
   )
 
   return extendedProjectProperties

--- a/KsApi/models/graphql/adapters/Project+ProjectFragment.swift
+++ b/KsApi/models/graphql/adapters/Project+ProjectFragment.swift
@@ -229,7 +229,7 @@ private func extendedProject(from projectFragment: GraphAPI.ProjectFragment) -> 
   let environmentalCommitments = extendedProjectEnvironmentalCommitments(from: projectFragment)
   let faqs = extendedProjectFAQs(from: projectFragment)
   let minimumSingleTierPledgeAmount = projectFragment.minPledge
-  
+
   let extendedProjectProperties = ExtendedProjectProperties(
     environmentalCommitments: environmentalCommitments,
     faqs: faqs,

--- a/KsApi/models/graphql/adapters/Project+ProjectFragmentTests.swift
+++ b/KsApi/models/graphql/adapters/Project+ProjectFragmentTests.swift
@@ -55,35 +55,43 @@ final class Project_ProjectFragmentTests: XCTestCase {
       XCTAssertFalse(project.displayPrelaunch!)
       XCTAssertNil(project.personalization.backing)
       XCTAssertNil(project.rewardData.addOns)
-      XCTAssertNotNil(project.extendedProjectProperties?.story)
-      XCTAssertNotNil(project.extendedProjectProperties?.risks)
-      XCTAssertEqual(project.extendedProjectProperties?.environmentalCommitments.count, 1)
+
+      guard let extendedProjectProperties = project.extendedProjectProperties else {
+        XCTFail()
+
+        return
+      }
+
+      XCTAssertNotNil(extendedProjectProperties.story)
+      XCTAssertNotNil(extendedProjectProperties.risks)
+      XCTAssertEqual(extendedProjectProperties.environmentalCommitments.count, 1)
       XCTAssertEqual(
-        project.extendedProjectProperties?.environmentalCommitments.last?.category,
+        extendedProjectProperties.environmentalCommitments.last?.category,
         .longLastingDesign
       )
       XCTAssertEqual(
-        project.extendedProjectProperties?.environmentalCommitments.last?.description,
+        extendedProjectProperties.environmentalCommitments.last?.description,
         "High quality materials and cards - there is nothing design or tech-wise that would render Dustbiters obsolete besides losing the cards."
       )
       XCTAssertEqual(
-        project.extendedProjectProperties?.environmentalCommitments.last?.id,
+        extendedProjectProperties.environmentalCommitments.last?.id,
         decompose(id: "RW52aXJvbm1lbnRhbENvbW1pdG1lbnQtMTI2NTA2")
       )
-      XCTAssertEqual(project.extendedProjectProperties?.faqs.count, 1)
+      XCTAssertEqual(extendedProjectProperties.faqs.count, 1)
       XCTAssertEqual(
-        project.extendedProjectProperties?.faqs.last!.question,
+        extendedProjectProperties.faqs.last!.question,
         "Are you planning any expansions for Dustbiters?"
       )
       XCTAssertEqual(
-        project.extendedProjectProperties?.faqs.last!.answer,
+        extendedProjectProperties.faqs.last!.answer,
         "This may sound weird in the world of big game boxes with hundreds of tokens, cards and thick manuals, but through years of playtesting and refinement we found our ideal experience is these 21 unique cards we have now. Dustbiters is balanced for quick and furious games with different strategies every time you jump back in, and we currently have no plans to mess with that."
       )
       XCTAssertEqual(
-        project.extendedProjectProperties?.faqs.last!.id,
+        extendedProjectProperties.faqs.last!.id,
         decompose(id: "UHJvamVjdEZhcS0zNzA4MDM=")
       )
-      XCTAssertEqual(project.extendedProjectProperties?.faqs.last!.createdAt!, TimeInterval(1_628_103_400))
+      XCTAssertEqual(extendedProjectProperties.faqs.last!.createdAt!, TimeInterval(1_628_103_400))
+      XCTAssertEqual(extendedProjectProperties.minimumPledgeAmount, 23)
     } catch {
       XCTFail(error.localizedDescription)
     }
@@ -319,6 +327,7 @@ final class Project_ProjectFragmentTests: XCTestCase {
           "id":"TG9jYXRpb24tMjM3MTQ2NA==",
           "name":"Buffalo"
        },
+       "minPledge": 23,
        "name":"FINAL GAMBLE Issue #1",
        "pid":1841936784,
        "pledged":{

--- a/KsApi/mutations/templates/query/FetchAddOnsQueryTemplate.swift
+++ b/KsApi/mutations/templates/query/FetchAddOnsQueryTemplate.swift
@@ -538,6 +538,7 @@ public enum FetchAddsOnsQueryTemplate {
             "id": "TG9jYXRpb24tMTEwMzM2OA==",
             "name": "Launceston"
           },
+          "minPledge": 1,
           "name": "Peppermint Fox Press: Notebooks & Stationery",
           "pid": 1606532881,
           "pledged": {

--- a/KsApi/mutations/templates/query/FetchProjectQueryTemplate.swift
+++ b/KsApi/mutations/templates/query/FetchProjectQueryTemplate.swift
@@ -1651,6 +1651,7 @@ public enum FetchProjectQueryTemplate {
              "id":"TG9jYXRpb24tNjc2NzU2",
              "name":"München"
           },
+          "minPledge": 1,
           "name":"The Quiet",
           "pid":904702116,
           "pledged":{


### PR DESCRIPTION
# 📲 What

Last minute bug fix for release `4.15.0`.

# 🤔 Why

With 3/4 % of pledges coming from this reward tier, its' important we support it in every release.

# 🛠 How

Pretty straightforward, thanks @Arkariang for the tip of making the project minimum pledge the minimum of the no-reward pledge. 
- Added `minPledge` to `ProjectFragment` under `extendedProjectProperties` because it wasn't in the v1 model.

Also updated the `Project+FetchProjectQueryData.swift` file to include the `minimum` and `convertedMinimum` fields of the no reward reward.

# 👀 See

Trello, screenshots, external resources?

| Before 🐛 | After 🦋 |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/4282741/135334660-f157dc11-5f36-4b7b-b244-e50fcc938347.png" width="300"> | <img src="https://user-images.githubusercontent.com/4282741/135333604-09dbb061-96de-43b1-8e75-87b34108ddc9.png" width="300"> |

# ✅ Acceptance criteria

- [ ] Adds no rewards reward to reward selection screen.
