### PR TITLE
[Unticketed] Fetching Project Query Optimization

### DIFF
--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -82,6 +82,8 @@
 		062868EA26B99FB400EC5052 /* DeletePaymentSourceEnvelope+DeletePaymentSourceMutation.Data.swift in Sources */ = {isa = PBXBuildFile; fileRef = 062868E926B99FB400EC5052 /* DeletePaymentSourceEnvelope+DeletePaymentSourceMutation.Data.swift */; };
 		062868EC26B9E25F00EC5052 /* DeletePaymentSourceEnvelope+DeletePaymentSourceMutation.DataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 062868EB26B9E25F00EC5052 /* DeletePaymentSourceEnvelope+DeletePaymentSourceMutation.DataTests.swift */; };
 		062868EE26B9F4E100EC5052 /* GraphAPI.DeletePaymentSourceInput+DeletePaymentSourceInputTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 062868ED26B9F4E100EC5052 /* GraphAPI.DeletePaymentSourceInput+DeletePaymentSourceInputTests.swift */; };
+		06566373270BA8E000CE7EDF /* FetchProjectRewardsByIdQuery.graphql in Resources */ = {isa = PBXBuildFile; fileRef = 06566372270BA8E000CE7EDF /* FetchProjectRewardsByIdQuery.graphql */; };
+		06566375270BAA7C00CE7EDF /* Project+FetchProjectRewardsByIdQueryData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06566374270BAA7C00CE7EDF /* Project+FetchProjectRewardsByIdQueryData.swift */; };
 		065E6BA626B1C7FD007F67CA /* UpdateBackingEnvelope+UpdateBackingMutation.Data.swift in Sources */ = {isa = PBXBuildFile; fileRef = 065E6BA526B1C7FD007F67CA /* UpdateBackingEnvelope+UpdateBackingMutation.Data.swift */; };
 		065E6BAA26B1E5C7007F67CA /* GraphAPI.CreatePaymentSourceInput+CreatePaymentSourceInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 065E6BA926B1E5C7007F67CA /* GraphAPI.CreatePaymentSourceInput+CreatePaymentSourceInput.swift */; };
 		065E6BAC26B1F5A0007F67CA /* CreatePaymentSourceEnvelope+CreatePaymentSourceMutation.Data.swift in Sources */ = {isa = PBXBuildFile; fileRef = 065E6BAB26B1F5A0007F67CA /* CreatePaymentSourceEnvelope+CreatePaymentSourceMutation.Data.swift */; };
@@ -1827,6 +1829,8 @@
 		062868E926B99FB400EC5052 /* DeletePaymentSourceEnvelope+DeletePaymentSourceMutation.Data.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DeletePaymentSourceEnvelope+DeletePaymentSourceMutation.Data.swift"; sourceTree = "<group>"; };
 		062868EB26B9E25F00EC5052 /* DeletePaymentSourceEnvelope+DeletePaymentSourceMutation.DataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DeletePaymentSourceEnvelope+DeletePaymentSourceMutation.DataTests.swift"; sourceTree = "<group>"; };
 		062868ED26B9F4E100EC5052 /* GraphAPI.DeletePaymentSourceInput+DeletePaymentSourceInputTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GraphAPI.DeletePaymentSourceInput+DeletePaymentSourceInputTests.swift"; sourceTree = "<group>"; };
+		06566372270BA8E000CE7EDF /* FetchProjectRewardsByIdQuery.graphql */ = {isa = PBXFileReference; lastKnownFileType = text; path = FetchProjectRewardsByIdQuery.graphql; sourceTree = "<group>"; };
+		06566374270BAA7C00CE7EDF /* Project+FetchProjectRewardsByIdQueryData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Project+FetchProjectRewardsByIdQueryData.swift"; sourceTree = "<group>"; };
 		065E6BA526B1C7FD007F67CA /* UpdateBackingEnvelope+UpdateBackingMutation.Data.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UpdateBackingEnvelope+UpdateBackingMutation.Data.swift"; sourceTree = "<group>"; };
 		065E6BA926B1E5C7007F67CA /* GraphAPI.CreatePaymentSourceInput+CreatePaymentSourceInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GraphAPI.CreatePaymentSourceInput+CreatePaymentSourceInput.swift"; sourceTree = "<group>"; };
 		065E6BAB26B1F5A0007F67CA /* CreatePaymentSourceEnvelope+CreatePaymentSourceMutation.Data.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CreatePaymentSourceEnvelope+CreatePaymentSourceMutation.Data.swift"; sourceTree = "<group>"; };
@@ -3534,6 +3538,7 @@
 			isa = PBXGroup;
 			children = (
 				8AC3E0882698CC1900168BF8 /* FetchAddOnsQuery.graphql */,
+				06566372270BA8E000CE7EDF /* FetchProjectRewardsByIdQuery.graphql */,
 				8A1556FE26939F4B00017845 /* FetchBackingQuery.graphql */,
 				06B3605B26E12288006CB9E4 /* FetchProjectByIdQuery.graphql */,
 				06813BA326E2779C006BDFB2 /* FetchProjectBySlugQuery.graphql */,
@@ -3758,6 +3763,7 @@
 				0665C74826E9302100A0EDA1 /* Project+FetchProjectQueryDataTests.swift */,
 				06D23BBC26F2454700F76122 /* Project+FetchProjectFriendsQueryData.swift */,
 				06D23BBE26F2484500F76122 /* Project+FetchProjectFriendsQueryDataTests.swift */,
+				06566374270BAA7C00CE7EDF /* Project+FetchProjectRewardsByIdQueryData.swift */,
 				8AC3E03826977C0200168BF8 /* Project+ProjectFragment.swift */,
 				8AC3E05026979F8600168BF8 /* Project+ProjectFragmentTests.swift */,
 				8A49396424B54F9B00C3C3CE /* Reward+GraphReward.swift */,
@@ -5656,6 +5662,7 @@
 			files = (
 				06DAAE5826AA3CCF00194E58 /* CountryFragment.graphql in Resources */,
 				06B3605C26E12288006CB9E4 /* FetchProjectByIdQuery.graphql in Resources */,
+				06566373270BA8E000CE7EDF /* FetchProjectRewardsByIdQuery.graphql in Resources */,
 				8AC3E0892698CC1A00168BF8 /* FetchAddOnsQuery.graphql in Resources */,
 				062868E626B999EF00EC5052 /* DeletePaymentSource.graphql in Resources */,
 				06C38CB926A9D13400591CED /* UpdateUserProfile.graphql in Resources */,
@@ -7061,6 +7068,7 @@
 				D01589931EEB2ED7006E7684 /* User.swift in Sources */,
 				8A49396924B690E000C3C3CE /* RewardAddOnSelectionViewEnvelopeTemplate.swift in Sources */,
 				D0158A271EEB30A2006E7684 /* ShippingRuleTemplates.swift in Sources */,
+				06566375270BAA7C00CE7EDF /* Project+FetchProjectRewardsByIdQueryData.swift in Sources */,
 				8A0B1E2724DA0DC3009E90C0 /* GraphLocation.swift in Sources */,
 				8AF34C782342D6A5000B211D /* Encodable+Dictionary.swift in Sources */,
 				77E44B7421823A56006446B8 /* ChangePasswordInput.swift in Sources */,

--- a/KsApi/GraphAPI.swift
+++ b/KsApi/GraphAPI.swift
@@ -4468,7 +4468,7 @@ public enum GraphAPI {
     /// The raw GraphQL definition of this operation.
     public let operationDefinition: String =
       """
-      query FetchAddOns($projectSlug: String!, $shippingEnabled: Boolean!, $locationId: ID, $withStoredCards: Boolean!) {
+      query FetchAddOns($projectSlug: String!, $shippingEnabled: Boolean!, $locationId: ID, $withStoredCards: Boolean!, $includeShippingRules: Boolean!) {
         project(slug: $projectSlug) {
           __typename
           ...ProjectFragment
@@ -4510,16 +4510,18 @@ public enum GraphAPI {
     public var shippingEnabled: Bool
     public var locationId: GraphQLID?
     public var withStoredCards: Bool
+    public var includeShippingRules: Bool
 
-    public init(projectSlug: String, shippingEnabled: Bool, locationId: GraphQLID? = nil, withStoredCards: Bool) {
+    public init(projectSlug: String, shippingEnabled: Bool, locationId: GraphQLID? = nil, withStoredCards: Bool, includeShippingRules: Bool) {
       self.projectSlug = projectSlug
       self.shippingEnabled = shippingEnabled
       self.locationId = locationId
       self.withStoredCards = withStoredCards
+      self.includeShippingRules = includeShippingRules
     }
 
     public var variables: GraphQLMap? {
-      return ["projectSlug": projectSlug, "shippingEnabled": shippingEnabled, "locationId": locationId, "withStoredCards": withStoredCards]
+      return ["projectSlug": projectSlug, "shippingEnabled": shippingEnabled, "locationId": locationId, "withStoredCards": withStoredCards, "includeShippingRules": includeShippingRules]
     }
 
     public struct Data: GraphQLSelectionSet {
@@ -4817,7 +4819,7 @@ public enum GraphAPI {
     /// The raw GraphQL definition of this operation.
     public let operationDefinition: String =
       """
-      query FetchBacking($id: ID!, $withStoredCards: Boolean!) {
+      query FetchBacking($id: ID!, $withStoredCards: Boolean!, $includeShippingRules: Boolean!) {
         backing(id: $id) {
           __typename
           addOns {
@@ -4852,14 +4854,16 @@ public enum GraphAPI {
 
     public var id: GraphQLID
     public var withStoredCards: Bool
+    public var includeShippingRules: Bool
 
-    public init(id: GraphQLID, withStoredCards: Bool) {
+    public init(id: GraphQLID, withStoredCards: Bool, includeShippingRules: Bool) {
       self.id = id
       self.withStoredCards = withStoredCards
+      self.includeShippingRules = includeShippingRules
     }
 
     public var variables: GraphQLMap? {
-      return ["id": id, "withStoredCards": withStoredCards]
+      return ["id": id, "withStoredCards": withStoredCards, "includeShippingRules": includeShippingRules]
     }
 
     public struct Data: GraphQLSelectionSet {
@@ -5052,7 +5056,7 @@ public enum GraphAPI {
     /// The raw GraphQL definition of this operation.
     public let operationDefinition: String =
       """
-      query FetchProjectById($projectId: Int!, $withStoredCards: Boolean!) {
+      query FetchProjectById($projectId: Int!, $withStoredCards: Boolean!, $includeShippingRules: Boolean!) {
         me {
           __typename
           chosenCurrency
@@ -5070,13 +5074,6 @@ public enum GraphAPI {
           backing {
             __typename
             id
-          }
-          rewards {
-            __typename
-            nodes {
-              __typename
-              ...RewardFragment
-            }
           }
         }
       }
@@ -5100,14 +5097,16 @@ public enum GraphAPI {
 
     public var projectId: Int
     public var withStoredCards: Bool
+    public var includeShippingRules: Bool
 
-    public init(projectId: Int, withStoredCards: Bool) {
+    public init(projectId: Int, withStoredCards: Bool, includeShippingRules: Bool) {
       self.projectId = projectId
       self.withStoredCards = withStoredCards
+      self.includeShippingRules = includeShippingRules
     }
 
     public var variables: GraphQLMap? {
-      return ["projectId": projectId, "withStoredCards": withStoredCards]
+      return ["projectId": projectId, "withStoredCards": withStoredCards, "includeShippingRules": includeShippingRules]
     }
 
     public struct Data: GraphQLSelectionSet {
@@ -5199,7 +5198,6 @@ public enum GraphAPI {
             GraphQLFragmentSpread(ProjectFragment.self),
             GraphQLField("addOns", type: .object(AddOn.selections)),
             GraphQLField("backing", type: .object(Backing.selections)),
-            GraphQLField("rewards", type: .object(Reward.selections)),
           ]
         }
 
@@ -5235,16 +5233,6 @@ public enum GraphAPI {
           }
           set {
             resultMap.updateValue(newValue?.resultMap, forKey: "backing")
-          }
-        }
-
-        /// Project rewards.
-        public var rewards: Reward? {
-          get {
-            return (resultMap["rewards"] as? ResultMap).flatMap { Reward(unsafeResultMap: $0) }
-          }
-          set {
-            resultMap.updateValue(newValue?.resultMap, forKey: "rewards")
           }
         }
 
@@ -5404,98 +5392,6 @@ public enum GraphAPI {
             }
           }
         }
-
-        public struct Reward: GraphQLSelectionSet {
-          public static let possibleTypes: [String] = ["ProjectRewardConnection"]
-
-          public static var selections: [GraphQLSelection] {
-            return [
-              GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-              GraphQLField("nodes", type: .list(.object(Node.selections))),
-            ]
-          }
-
-          public private(set) var resultMap: ResultMap
-
-          public init(unsafeResultMap: ResultMap) {
-            self.resultMap = unsafeResultMap
-          }
-
-          public init(nodes: [Node?]? = nil) {
-            self.init(unsafeResultMap: ["__typename": "ProjectRewardConnection", "nodes": nodes.flatMap { (value: [Node?]) -> [ResultMap?] in value.map { (value: Node?) -> ResultMap? in value.flatMap { (value: Node) -> ResultMap in value.resultMap } } }])
-          }
-
-          public var __typename: String {
-            get {
-              return resultMap["__typename"]! as! String
-            }
-            set {
-              resultMap.updateValue(newValue, forKey: "__typename")
-            }
-          }
-
-          /// A list of nodes.
-          public var nodes: [Node?]? {
-            get {
-              return (resultMap["nodes"] as? [ResultMap?]).flatMap { (value: [ResultMap?]) -> [Node?] in value.map { (value: ResultMap?) -> Node? in value.flatMap { (value: ResultMap) -> Node in Node(unsafeResultMap: value) } } }
-            }
-            set {
-              resultMap.updateValue(newValue.flatMap { (value: [Node?]) -> [ResultMap?] in value.map { (value: Node?) -> ResultMap? in value.flatMap { (value: Node) -> ResultMap in value.resultMap } } }, forKey: "nodes")
-            }
-          }
-
-          public struct Node: GraphQLSelectionSet {
-            public static let possibleTypes: [String] = ["Reward"]
-
-            public static var selections: [GraphQLSelection] {
-              return [
-                GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-                GraphQLFragmentSpread(RewardFragment.self),
-              ]
-            }
-
-            public private(set) var resultMap: ResultMap
-
-            public init(unsafeResultMap: ResultMap) {
-              self.resultMap = unsafeResultMap
-            }
-
-            public var __typename: String {
-              get {
-                return resultMap["__typename"]! as! String
-              }
-              set {
-                resultMap.updateValue(newValue, forKey: "__typename")
-              }
-            }
-
-            public var fragments: Fragments {
-              get {
-                return Fragments(unsafeResultMap: resultMap)
-              }
-              set {
-                resultMap += newValue.resultMap
-              }
-            }
-
-            public struct Fragments {
-              public private(set) var resultMap: ResultMap
-
-              public init(unsafeResultMap: ResultMap) {
-                self.resultMap = unsafeResultMap
-              }
-
-              public var rewardFragment: RewardFragment {
-                get {
-                  return RewardFragment(unsafeResultMap: resultMap)
-                }
-                set {
-                  resultMap += newValue.resultMap
-                }
-              }
-            }
-          }
-        }
       }
     }
   }
@@ -5504,7 +5400,7 @@ public enum GraphAPI {
     /// The raw GraphQL definition of this operation.
     public let operationDefinition: String =
       """
-      query FetchProjectBySlug($slug: String!, $withStoredCards: Boolean!) {
+      query FetchProjectBySlug($slug: String!, $withStoredCards: Boolean!, $includeShippingRules: Boolean!) {
         me {
           __typename
           chosenCurrency
@@ -5522,13 +5418,6 @@ public enum GraphAPI {
           backing {
             __typename
             id
-          }
-          rewards {
-            __typename
-            nodes {
-              __typename
-              ...RewardFragment
-            }
           }
         }
       }
@@ -5552,14 +5441,16 @@ public enum GraphAPI {
 
     public var slug: String
     public var withStoredCards: Bool
+    public var includeShippingRules: Bool
 
-    public init(slug: String, withStoredCards: Bool) {
+    public init(slug: String, withStoredCards: Bool, includeShippingRules: Bool) {
       self.slug = slug
       self.withStoredCards = withStoredCards
+      self.includeShippingRules = includeShippingRules
     }
 
     public var variables: GraphQLMap? {
-      return ["slug": slug, "withStoredCards": withStoredCards]
+      return ["slug": slug, "withStoredCards": withStoredCards, "includeShippingRules": includeShippingRules]
     }
 
     public struct Data: GraphQLSelectionSet {
@@ -5651,7 +5542,6 @@ public enum GraphAPI {
             GraphQLFragmentSpread(ProjectFragment.self),
             GraphQLField("addOns", type: .object(AddOn.selections)),
             GraphQLField("backing", type: .object(Backing.selections)),
-            GraphQLField("rewards", type: .object(Reward.selections)),
           ]
         }
 
@@ -5687,16 +5577,6 @@ public enum GraphAPI {
           }
           set {
             resultMap.updateValue(newValue?.resultMap, forKey: "backing")
-          }
-        }
-
-        /// Project rewards.
-        public var rewards: Reward? {
-          get {
-            return (resultMap["rewards"] as? ResultMap).flatMap { Reward(unsafeResultMap: $0) }
-          }
-          set {
-            resultMap.updateValue(newValue?.resultMap, forKey: "rewards")
           }
         }
 
@@ -5853,98 +5733,6 @@ public enum GraphAPI {
             }
             set {
               resultMap.updateValue(newValue, forKey: "id")
-            }
-          }
-        }
-
-        public struct Reward: GraphQLSelectionSet {
-          public static let possibleTypes: [String] = ["ProjectRewardConnection"]
-
-          public static var selections: [GraphQLSelection] {
-            return [
-              GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-              GraphQLField("nodes", type: .list(.object(Node.selections))),
-            ]
-          }
-
-          public private(set) var resultMap: ResultMap
-
-          public init(unsafeResultMap: ResultMap) {
-            self.resultMap = unsafeResultMap
-          }
-
-          public init(nodes: [Node?]? = nil) {
-            self.init(unsafeResultMap: ["__typename": "ProjectRewardConnection", "nodes": nodes.flatMap { (value: [Node?]) -> [ResultMap?] in value.map { (value: Node?) -> ResultMap? in value.flatMap { (value: Node) -> ResultMap in value.resultMap } } }])
-          }
-
-          public var __typename: String {
-            get {
-              return resultMap["__typename"]! as! String
-            }
-            set {
-              resultMap.updateValue(newValue, forKey: "__typename")
-            }
-          }
-
-          /// A list of nodes.
-          public var nodes: [Node?]? {
-            get {
-              return (resultMap["nodes"] as? [ResultMap?]).flatMap { (value: [ResultMap?]) -> [Node?] in value.map { (value: ResultMap?) -> Node? in value.flatMap { (value: ResultMap) -> Node in Node(unsafeResultMap: value) } } }
-            }
-            set {
-              resultMap.updateValue(newValue.flatMap { (value: [Node?]) -> [ResultMap?] in value.map { (value: Node?) -> ResultMap? in value.flatMap { (value: Node) -> ResultMap in value.resultMap } } }, forKey: "nodes")
-            }
-          }
-
-          public struct Node: GraphQLSelectionSet {
-            public static let possibleTypes: [String] = ["Reward"]
-
-            public static var selections: [GraphQLSelection] {
-              return [
-                GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-                GraphQLFragmentSpread(RewardFragment.self),
-              ]
-            }
-
-            public private(set) var resultMap: ResultMap
-
-            public init(unsafeResultMap: ResultMap) {
-              self.resultMap = unsafeResultMap
-            }
-
-            public var __typename: String {
-              get {
-                return resultMap["__typename"]! as! String
-              }
-              set {
-                resultMap.updateValue(newValue, forKey: "__typename")
-              }
-            }
-
-            public var fragments: Fragments {
-              get {
-                return Fragments(unsafeResultMap: resultMap)
-              }
-              set {
-                resultMap += newValue.resultMap
-              }
-            }
-
-            public struct Fragments {
-              public private(set) var resultMap: ResultMap
-
-              public init(unsafeResultMap: ResultMap) {
-                self.resultMap = unsafeResultMap
-              }
-
-              public var rewardFragment: RewardFragment {
-                get {
-                  return RewardFragment(unsafeResultMap: resultMap)
-                }
-                set {
-                  resultMap += newValue.resultMap
-                }
-              }
             }
           }
         }
@@ -6710,6 +6498,210 @@ public enum GraphAPI {
     }
   }
 
+  public final class FetchProjectRewardsByIdQuery: GraphQLQuery {
+    /// The raw GraphQL definition of this operation.
+    public let operationDefinition: String =
+      """
+      query FetchProjectRewardsById($projectId: Int!, $includeShippingRules: Boolean!) {
+        project(pid: $projectId) {
+          __typename
+          rewards {
+            __typename
+            nodes {
+              __typename
+              ...RewardFragment
+            }
+          }
+        }
+      }
+      """
+
+    public let operationName: String = "FetchProjectRewardsById"
+
+    public var queryDocument: String {
+      var document: String = operationDefinition
+      document.append("\n" + RewardFragment.fragmentDefinition)
+      document.append("\n" + MoneyFragment.fragmentDefinition)
+      document.append("\n" + ShippingRuleFragment.fragmentDefinition)
+      document.append("\n" + LocationFragment.fragmentDefinition)
+      return document
+    }
+
+    public var projectId: Int
+    public var includeShippingRules: Bool
+
+    public init(projectId: Int, includeShippingRules: Bool) {
+      self.projectId = projectId
+      self.includeShippingRules = includeShippingRules
+    }
+
+    public var variables: GraphQLMap? {
+      return ["projectId": projectId, "includeShippingRules": includeShippingRules]
+    }
+
+    public struct Data: GraphQLSelectionSet {
+      public static let possibleTypes: [String] = ["Query"]
+
+      public static var selections: [GraphQLSelection] {
+        return [
+          GraphQLField("project", arguments: ["pid": GraphQLVariable("projectId")], type: .object(Project.selections)),
+        ]
+      }
+
+      public private(set) var resultMap: ResultMap
+
+      public init(unsafeResultMap: ResultMap) {
+        self.resultMap = unsafeResultMap
+      }
+
+      public init(project: Project? = nil) {
+        self.init(unsafeResultMap: ["__typename": "Query", "project": project.flatMap { (value: Project) -> ResultMap in value.resultMap }])
+      }
+
+      /// Fetches a project given its slug or pid.
+      public var project: Project? {
+        get {
+          return (resultMap["project"] as? ResultMap).flatMap { Project(unsafeResultMap: $0) }
+        }
+        set {
+          resultMap.updateValue(newValue?.resultMap, forKey: "project")
+        }
+      }
+
+      public struct Project: GraphQLSelectionSet {
+        public static let possibleTypes: [String] = ["Project"]
+
+        public static var selections: [GraphQLSelection] {
+          return [
+            GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+            GraphQLField("rewards", type: .object(Reward.selections)),
+          ]
+        }
+
+        public private(set) var resultMap: ResultMap
+
+        public init(unsafeResultMap: ResultMap) {
+          self.resultMap = unsafeResultMap
+        }
+
+        public init(rewards: Reward? = nil) {
+          self.init(unsafeResultMap: ["__typename": "Project", "rewards": rewards.flatMap { (value: Reward) -> ResultMap in value.resultMap }])
+        }
+
+        public var __typename: String {
+          get {
+            return resultMap["__typename"]! as! String
+          }
+          set {
+            resultMap.updateValue(newValue, forKey: "__typename")
+          }
+        }
+
+        /// Project rewards.
+        public var rewards: Reward? {
+          get {
+            return (resultMap["rewards"] as? ResultMap).flatMap { Reward(unsafeResultMap: $0) }
+          }
+          set {
+            resultMap.updateValue(newValue?.resultMap, forKey: "rewards")
+          }
+        }
+
+        public struct Reward: GraphQLSelectionSet {
+          public static let possibleTypes: [String] = ["ProjectRewardConnection"]
+
+          public static var selections: [GraphQLSelection] {
+            return [
+              GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+              GraphQLField("nodes", type: .list(.object(Node.selections))),
+            ]
+          }
+
+          public private(set) var resultMap: ResultMap
+
+          public init(unsafeResultMap: ResultMap) {
+            self.resultMap = unsafeResultMap
+          }
+
+          public init(nodes: [Node?]? = nil) {
+            self.init(unsafeResultMap: ["__typename": "ProjectRewardConnection", "nodes": nodes.flatMap { (value: [Node?]) -> [ResultMap?] in value.map { (value: Node?) -> ResultMap? in value.flatMap { (value: Node) -> ResultMap in value.resultMap } } }])
+          }
+
+          public var __typename: String {
+            get {
+              return resultMap["__typename"]! as! String
+            }
+            set {
+              resultMap.updateValue(newValue, forKey: "__typename")
+            }
+          }
+
+          /// A list of nodes.
+          public var nodes: [Node?]? {
+            get {
+              return (resultMap["nodes"] as? [ResultMap?]).flatMap { (value: [ResultMap?]) -> [Node?] in value.map { (value: ResultMap?) -> Node? in value.flatMap { (value: ResultMap) -> Node in Node(unsafeResultMap: value) } } }
+            }
+            set {
+              resultMap.updateValue(newValue.flatMap { (value: [Node?]) -> [ResultMap?] in value.map { (value: Node?) -> ResultMap? in value.flatMap { (value: Node) -> ResultMap in value.resultMap } } }, forKey: "nodes")
+            }
+          }
+
+          public struct Node: GraphQLSelectionSet {
+            public static let possibleTypes: [String] = ["Reward"]
+
+            public static var selections: [GraphQLSelection] {
+              return [
+                GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                GraphQLFragmentSpread(RewardFragment.self),
+              ]
+            }
+
+            public private(set) var resultMap: ResultMap
+
+            public init(unsafeResultMap: ResultMap) {
+              self.resultMap = unsafeResultMap
+            }
+
+            public var __typename: String {
+              get {
+                return resultMap["__typename"]! as! String
+              }
+              set {
+                resultMap.updateValue(newValue, forKey: "__typename")
+              }
+            }
+
+            public var fragments: Fragments {
+              get {
+                return Fragments(unsafeResultMap: resultMap)
+              }
+              set {
+                resultMap += newValue.resultMap
+              }
+            }
+
+            public struct Fragments {
+              public private(set) var resultMap: ResultMap
+
+              public init(unsafeResultMap: ResultMap) {
+                self.resultMap = unsafeResultMap
+              }
+
+              public var rewardFragment: RewardFragment {
+                get {
+                  return RewardFragment(unsafeResultMap: resultMap)
+                }
+                set {
+                  resultMap += newValue.resultMap
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
   public final class FetchUpdateCommentsQuery: GraphQLQuery {
     /// The raw GraphQL definition of this operation.
     public let operationDefinition: String =
@@ -7220,7 +7212,7 @@ public enum GraphAPI {
     /// The raw GraphQL definition of this operation.
     public let operationDefinition: String =
       """
-      query FetchUserBackings($status: BackingState!, $withStoredCards: Boolean!) {
+      query FetchUserBackings($status: BackingState!, $withStoredCards: Boolean!, $includeShippingRules: Boolean!) {
         me {
           __typename
           backings(status: $status) {
@@ -7267,14 +7259,16 @@ public enum GraphAPI {
 
     public var status: BackingState
     public var withStoredCards: Bool
+    public var includeShippingRules: Bool
 
-    public init(status: BackingState, withStoredCards: Bool) {
+    public init(status: BackingState, withStoredCards: Bool, includeShippingRules: Bool) {
       self.status = status
       self.withStoredCards = withStoredCards
+      self.includeShippingRules = includeShippingRules
     }
 
     public var variables: GraphQLMap? {
-      return ["status": status, "withStoredCards": withStoredCards]
+      return ["status": status, "withStoredCards": withStoredCards, "includeShippingRules": includeShippingRules]
     }
 
     public struct Data: GraphQLSelectionSet {
@@ -10872,7 +10866,7 @@ public enum GraphAPI {
         }
         remainingQuantity
         shippingPreference
-        shippingRules {
+        shippingRules @include(if: $includeShippingRules) {
           __typename
           ...ShippingRuleFragment
         }
@@ -10902,7 +10896,9 @@ public enum GraphAPI {
         GraphQLField("project", type: .object(Project.selections)),
         GraphQLField("remainingQuantity", type: .scalar(Int.self)),
         GraphQLField("shippingPreference", type: .scalar(ShippingPreference.self)),
-        GraphQLField("shippingRules", type: .nonNull(.list(.object(ShippingRule.selections)))),
+        GraphQLBooleanCondition(variableName: "includeShippingRules", inverted: false, selections: [
+          GraphQLField("shippingRules", type: .nonNull(.list(.object(ShippingRule.selections)))),
+        ]),
         GraphQLField("startsAt", type: .scalar(String.self)),
       ]
     }
@@ -10913,8 +10909,8 @@ public enum GraphAPI {
       self.resultMap = unsafeResultMap
     }
 
-    public init(amount: Amount, backersCount: Int? = nil, convertedAmount: ConvertedAmount, allowedAddons: AllowedAddon, description: String, displayName: String, endsAt: String? = nil, estimatedDeliveryOn: String? = nil, id: GraphQLID, isMaxPledge: Bool, items: Item? = nil, limit: Int? = nil, limitPerBacker: Int? = nil, name: String? = nil, project: Project? = nil, remainingQuantity: Int? = nil, shippingPreference: ShippingPreference? = nil, shippingRules: [ShippingRule?], startsAt: String? = nil) {
-      self.init(unsafeResultMap: ["__typename": "Reward", "amount": amount.resultMap, "backersCount": backersCount, "convertedAmount": convertedAmount.resultMap, "allowedAddons": allowedAddons.resultMap, "description": description, "displayName": displayName, "endsAt": endsAt, "estimatedDeliveryOn": estimatedDeliveryOn, "id": id, "isMaxPledge": isMaxPledge, "items": items.flatMap { (value: Item) -> ResultMap in value.resultMap }, "limit": limit, "limitPerBacker": limitPerBacker, "name": name, "project": project.flatMap { (value: Project) -> ResultMap in value.resultMap }, "remainingQuantity": remainingQuantity, "shippingPreference": shippingPreference, "shippingRules": shippingRules.map { (value: ShippingRule?) -> ResultMap? in value.flatMap { (value: ShippingRule) -> ResultMap in value.resultMap } }, "startsAt": startsAt])
+    public init(amount: Amount, backersCount: Int? = nil, convertedAmount: ConvertedAmount, allowedAddons: AllowedAddon, description: String, displayName: String, endsAt: String? = nil, estimatedDeliveryOn: String? = nil, id: GraphQLID, isMaxPledge: Bool, items: Item? = nil, limit: Int? = nil, limitPerBacker: Int? = nil, name: String? = nil, project: Project? = nil, remainingQuantity: Int? = nil, shippingPreference: ShippingPreference? = nil, shippingRules: [ShippingRule?]? = nil, startsAt: String? = nil) {
+      self.init(unsafeResultMap: ["__typename": "Reward", "amount": amount.resultMap, "backersCount": backersCount, "convertedAmount": convertedAmount.resultMap, "allowedAddons": allowedAddons.resultMap, "description": description, "displayName": displayName, "endsAt": endsAt, "estimatedDeliveryOn": estimatedDeliveryOn, "id": id, "isMaxPledge": isMaxPledge, "items": items.flatMap { (value: Item) -> ResultMap in value.resultMap }, "limit": limit, "limitPerBacker": limitPerBacker, "name": name, "project": project.flatMap { (value: Project) -> ResultMap in value.resultMap }, "remainingQuantity": remainingQuantity, "shippingPreference": shippingPreference, "shippingRules": shippingRules.flatMap { (value: [ShippingRule?]) -> [ResultMap?] in value.map { (value: ShippingRule?) -> ResultMap? in value.flatMap { (value: ShippingRule) -> ResultMap in value.resultMap } } }, "startsAt": startsAt])
     }
 
     public var __typename: String {
@@ -11098,12 +11094,12 @@ public enum GraphAPI {
     }
 
     /// Shipping rules defined by the creator for this reward
-    public var shippingRules: [ShippingRule?] {
+    public var shippingRules: [ShippingRule?]? {
       get {
-        return (resultMap["shippingRules"] as! [ResultMap?]).map { (value: ResultMap?) -> ShippingRule? in value.flatMap { (value: ResultMap) -> ShippingRule in ShippingRule(unsafeResultMap: value) } }
+        return (resultMap["shippingRules"] as? [ResultMap?]).flatMap { (value: [ResultMap?]) -> [ShippingRule?] in value.map { (value: ResultMap?) -> ShippingRule? in value.flatMap { (value: ResultMap) -> ShippingRule in ShippingRule(unsafeResultMap: value) } } }
       }
       set {
-        resultMap.updateValue(newValue.map { (value: ShippingRule?) -> ResultMap? in value.flatMap { (value: ShippingRule) -> ResultMap in value.resultMap } }, forKey: "shippingRules")
+        resultMap.updateValue(newValue.flatMap { (value: [ShippingRule?]) -> [ResultMap?] in value.map { (value: ShippingRule?) -> ResultMap? in value.flatMap { (value: ShippingRule) -> ResultMap in value.resultMap } } }, forKey: "shippingRules")
       }
     }
 

--- a/KsApi/Service.swift
+++ b/KsApi/Service.swift
@@ -304,14 +304,16 @@ public struct Service: ServiceType {
     { return SignalProducer(error: .couldNotParseJSON) }
 
     return GraphQL.shared.client
-      .fetch(query: GraphAPI.FetchUserBackingsQuery(status: status, withStoredCards: false))
+      .fetch(query: GraphAPI
+        .FetchUserBackingsQuery(status: status, withStoredCards: false, includeShippingRules: true))
       .flatMap(ErroredBackingsEnvelope.producer(from:))
   }
 
   public func fetchBacking(id: Int, withStoredCards: Bool)
     -> SignalProducer<ProjectAndBackingEnvelope, ErrorEnvelope> {
     return GraphQL.shared.client
-      .fetch(query: GraphAPI.FetchBackingQuery(id: "\(id)", withStoredCards: withStoredCards))
+      .fetch(query: GraphAPI
+        .FetchBackingQuery(id: "\(id)", withStoredCards: withStoredCards, includeShippingRules: true))
       .flatMap(ProjectAndBackingEnvelope.envelopeProducer(from:))
   }
 
@@ -345,13 +347,15 @@ public struct Service: ServiceType {
     -> SignalProducer<Project.ProjectPamphletData, ErrorEnvelope> {
     switch (projectParam.id, projectParam.slug) {
     case let (.some(projectId), _):
-      let query = GraphAPI.FetchProjectByIdQuery(projectId: projectId, withStoredCards: false)
+      let query = GraphAPI
+        .FetchProjectByIdQuery(projectId: projectId, withStoredCards: false, includeShippingRules: false)
 
       return GraphQL.shared.client
         .fetch(query: query)
         .flatMap(Project.projectProducer(from:))
     case let (_, .some(projectSlug)):
-      let query = GraphAPI.FetchProjectBySlugQuery(slug: projectSlug, withStoredCards: false)
+      let query = GraphAPI
+        .FetchProjectBySlugQuery(slug: projectSlug, withStoredCards: false, includeShippingRules: false)
 
       return GraphQL.shared.client
         .fetch(query: query)
@@ -373,6 +377,15 @@ public struct Service: ServiceType {
    */
   public func fetchProject(param: Param) -> SignalProducer<Project, ErrorEnvelope> {
     return request(.project(param))
+  }
+
+  public func fetchProjectRewards(projectId: Int)
+    -> SignalProducer<[Reward], ErrorEnvelope> {
+    let query = GraphAPI.FetchProjectRewardsByIdQuery(projectId: projectId, includeShippingRules: false)
+
+    return GraphQL.shared.client
+      .fetch(query: query)
+      .flatMap(Project.projectRewardsProducer(from:))
   }
 
   public func fetchProjectFriends(param: Param) -> SignalProducer<[User], ErrorEnvelope> {
@@ -438,7 +451,8 @@ public struct Service: ServiceType {
       projectSlug: slug,
       shippingEnabled: shippingEnabled,
       locationId: locationId,
-      withStoredCards: false
+      withStoredCards: false,
+      includeShippingRules: true
     )
 
     return GraphQL.shared.client

--- a/KsApi/ServiceType.swift
+++ b/KsApi/ServiceType.swift
@@ -178,6 +178,9 @@ public protocol ServiceType {
   /// (currently only used on `ProjectPamphetViewModel` because it's a GQL query)
   func fetchProject(projectParam: Param) -> SignalProducer<Project.ProjectPamphletData, ErrorEnvelope>
 
+  /// Fetch the project's rewards only, without shipping rules
+  func fetchProjectRewards(projectId: Int) -> SignalProducer<[Reward], ErrorEnvelope>
+
   /// Fetch a project's friendly backers from its id or slug.
   func fetchProjectFriends(param: Param) -> SignalProducer<[User], ErrorEnvelope>
 

--- a/KsApi/fragments/RewardFragment.graphql
+++ b/KsApi/fragments/RewardFragment.graphql
@@ -31,7 +31,7 @@ fragment RewardFragment on Reward {
   }
   remainingQuantity
   shippingPreference
-  shippingRules {
+  shippingRules @include(if: $includeShippingRules) {
     ...ShippingRuleFragment
   }
   startsAt

--- a/KsApi/models/graphql/adapters/Project+FetchProjectQueryData.swift
+++ b/KsApi/models/graphql/adapters/Project+FetchProjectQueryData.swift
@@ -45,19 +45,6 @@ extension Project {
         Reward.reward(from: fragment)
       }
 
-    let rewards = data.project?.rewards?.nodes?
-      .compactMap { node -> GraphAPI.RewardFragment? in
-        guard let rewardFragment = node?.fragments.rewardFragment else { return nil }
-
-        return rewardFragment
-      }
-      .compactMap { fragment in
-        Reward.reward(from: fragment)
-      } ?? []
-
-    let emptyRewards = [noRewardReward(from: data.project?.fragments.projectFragment)]
-    let allRewards = emptyRewards + rewards
-
     var projectBackingId: Int?
 
     if let backingId = data.project?.backing?.id {
@@ -68,7 +55,7 @@ extension Project {
       let fragment = data.project?.fragments.projectFragment,
       let project = Project.project(
         from: fragment,
-        rewards: allRewards,
+        rewards: [noRewardReward(from: fragment)],
         addOns: addOns,
         backing: nil,
         currentUserChosenCurrency: data.me?.chosenCurrency
@@ -89,19 +76,6 @@ extension Project {
         Reward.reward(from: fragment)
       }
 
-    let rewards = data.project?.rewards?.nodes?
-      .compactMap { node -> GraphAPI.RewardFragment? in
-        guard let rewardFragment = node?.fragments.rewardFragment else { return nil }
-
-        return rewardFragment
-      }
-      .compactMap { fragment in
-        Reward.reward(from: fragment)
-      } ?? []
-
-    let emptyRewards = [noRewardReward(from: data.project?.fragments.projectFragment)]
-    let allRewards = emptyRewards + rewards
-
     var projectBackingId: Int?
 
     if let backingId = data.project?.backing?.id {
@@ -112,7 +86,7 @@ extension Project {
       let fragment = data.project?.fragments.projectFragment,
       let project = Project.project(
         from: fragment,
-        rewards: allRewards,
+        rewards: [noRewardReward(from: fragment)],
         addOns: addOns,
         backing: nil,
         currentUserChosenCurrency: data.me?.chosenCurrency

--- a/KsApi/models/graphql/adapters/Project+FetchProjectRewardsByIdQueryData.swift
+++ b/KsApi/models/graphql/adapters/Project+FetchProjectRewardsByIdQueryData.swift
@@ -1,0 +1,21 @@
+import Apollo
+import Prelude
+import ReactiveSwift
+
+extension Project {
+  static func projectRewardsProducer(
+    from data: GraphAPI.FetchProjectRewardsByIdQuery.Data
+  ) -> SignalProducer<[Reward], ErrorEnvelope> {
+    let projectRewards = Project.projectRewards(from: data)
+
+    return SignalProducer(value: projectRewards)
+  }
+
+  static func projectRewards(from data: GraphAPI.FetchProjectRewardsByIdQuery.Data) -> [Reward] {
+    let projectRewards = data.project?.rewards?.nodes?
+      .compactMap { $0?.fragments.rewardFragment }
+      .compactMap { Reward.reward(from: $0) } ?? []
+
+    return projectRewards
+  }
+}

--- a/KsApi/models/graphql/adapters/Reward+RewardFragment.swift
+++ b/KsApi/models/graphql/adapters/Reward+RewardFragment.swift
@@ -108,8 +108,18 @@ private func shippingPreference(from rewardFragment: GraphAPI.RewardFragment) ->
 private func shippingRulesData(
   from rewardFragment: GraphAPI.RewardFragment
 ) -> [ShippingRule]? {
-  return rewardFragment.shippingRules.compactMap { shippingRule -> ShippingRule? in
-    guard let fragment = shippingRule?.fragments.shippingRuleFragment else { return nil }
-    return ShippingRule.shippingRule(from: fragment)
+  guard let existingShippingRules: [GraphAPI.RewardFragment.ShippingRule?] = rewardFragment.shippingRules
+  else {
+    return nil
   }
+
+  let shippingRules = existingShippingRules
+    .compactMap { shippingRule -> ShippingRule? in
+      guard let fragment = shippingRule?.fragments.shippingRuleFragment else { return nil }
+
+      return ShippingRule.shippingRule(from: fragment)
+    }
+    .flatMap { $0 }
+
+  return shippingRules
 }

--- a/KsApi/queries/FetchAddOnsQuery.graphql
+++ b/KsApi/queries/FetchAddOnsQuery.graphql
@@ -1,4 +1,4 @@
-query FetchAddOns($projectSlug: String!, $shippingEnabled: Boolean!, $locationId: ID, $withStoredCards: Boolean!) {
+query FetchAddOns($projectSlug: String!, $shippingEnabled: Boolean!, $locationId: ID, $withStoredCards: Boolean!, $includeShippingRules: Boolean!) {
   project(slug: $projectSlug) {
     ...ProjectFragment
     addOns {

--- a/KsApi/queries/FetchBackingQuery.graphql
+++ b/KsApi/queries/FetchBackingQuery.graphql
@@ -1,4 +1,4 @@
-query FetchBacking($id: ID!, $withStoredCards: Boolean!) {
+query FetchBacking($id: ID!, $withStoredCards: Boolean!, $includeShippingRules: Boolean!) {
   backing(id: $id) {
     addOns {
       nodes {

--- a/KsApi/queries/FetchProjectByIdQuery.graphql
+++ b/KsApi/queries/FetchProjectByIdQuery.graphql
@@ -1,4 +1,4 @@
-query FetchProjectById($projectId: Int!, $withStoredCards: Boolean!) {
+query FetchProjectById($projectId: Int!, $withStoredCards: Boolean!, $includeShippingRules: Boolean!) {
   me {
     chosenCurrency
   }
@@ -11,11 +11,6 @@ query FetchProjectById($projectId: Int!, $withStoredCards: Boolean!) {
     }
     backing {
       id
-    }
-    rewards {
-      nodes {
-        ...RewardFragment
-      }
     }
   }
 }

--- a/KsApi/queries/FetchProjectBySlugQuery.graphql
+++ b/KsApi/queries/FetchProjectBySlugQuery.graphql
@@ -1,4 +1,4 @@
-query FetchProjectBySlug($slug: String!, $withStoredCards: Boolean!) {
+query FetchProjectBySlug($slug: String!, $withStoredCards: Boolean!, $includeShippingRules: Boolean!) {
   me {
     chosenCurrency
   }
@@ -11,11 +11,6 @@ query FetchProjectBySlug($slug: String!, $withStoredCards: Boolean!) {
     }
     backing {
       id
-    }
-    rewards {
-      nodes {
-        ...RewardFragment
-      }
     }
   }
 }

--- a/KsApi/queries/FetchProjectRewardsByIdQuery.graphql
+++ b/KsApi/queries/FetchProjectRewardsByIdQuery.graphql
@@ -1,0 +1,9 @@
+query FetchProjectRewardsById($projectId: Int!, $includeShippingRules: Boolean!) {
+  project(pid: $projectId) {
+    rewards {
+      nodes {
+        ...RewardFragment
+      }
+    }
+  }
+}

--- a/KsApi/queries/FetchUserBackings.graphql
+++ b/KsApi/queries/FetchUserBackings.graphql
@@ -1,4 +1,4 @@
-query FetchUserBackings($status: BackingState!, $withStoredCards: Boolean!) {
+query FetchUserBackings($status: BackingState!, $withStoredCards: Boolean!, $includeShippingRules: Boolean!) {
   me {
     backings(status: $status) {
       nodes {


### PR DESCRIPTION
# 📲 What

@paulomcg found a potential optimization where projects with many rewards (and thusly many shipping rules) takes upwards of 7 seconds before the user can back the project.

This PR breaks out the shipping rules from the `RewardsFragment` to be optionally added in on previous calls that did depend on it 
- `FetchUserBackingsQuery`
- `FetchBackingQuery`
- `FetchAddOnsQuery`

but not to calls that do not need it:
- `FetchProjectByIdQuery`
- `FetchProjectBySlugQuery`
- `FetchProjectFriendsQuery`
- `FetchProjectRewardsQuery`

# 🤔 Why

Obviously 8/9 seconds to wait for a large project is not a great way to get the user to back it, and also optimizations that reduce network load, break out our models better.

# 🛠 How

Used an `@include()` directive to add `ShippingRules` property to the `RewardFragment`, so it can be disincluded in the fetching of the project.

# 👀 See

Trello, screenshots, external resources?

| Before 🐛 | After 🦋 |
| --- | --- |
|  |  | 

# 🏎 Performance

- [ ] Optimized Blended Layers (screenshots)

# ✅ Acceptance criteria

- [ ] Acceptable loading time for backing/manage, nothing else is missing (except shipping labels on rewards and addons, which is an acceptable tradeoff until we fully understand how to fetch and model the shipping rules in GQL).
- [ ] Testing around backing object and its related properties.

# ⏰ TODO

- [ ] Write tests.
