### PR TITLE
[NTV-284] - Currency Display Differences Between Android and iOS

### DIFF
--- a/KsApi/GraphAPI.swift
+++ b/KsApi/GraphAPI.swift
@@ -9255,6 +9255,7 @@ public enum GraphAPI {
           __typename
           ...LocationFragment
         }
+        maxPledge
         minPledge
         name
         pid
@@ -9322,6 +9323,7 @@ public enum GraphAPI {
         GraphQLField("isLaunched", type: .nonNull(.scalar(Bool.self))),
         GraphQLField("launchedAt", type: .scalar(String.self)),
         GraphQLField("location", type: .object(Location.selections)),
+        GraphQLField("maxPledge", type: .nonNull(.scalar(Int.self))),
         GraphQLField("minPledge", type: .nonNull(.scalar(Int.self))),
         GraphQLField("name", type: .nonNull(.scalar(String.self))),
         GraphQLField("pid", type: .nonNull(.scalar(Int.self))),
@@ -9345,8 +9347,8 @@ public enum GraphAPI {
       self.resultMap = unsafeResultMap
     }
 
-    public init(availableCardTypes: [CreditCardTypes], backersCount: Int, category: Category? = nil, canComment: Bool, commentsCount: Int, country: Country, creator: Creator? = nil, currency: CurrencyCode, deadlineAt: String? = nil, description: String, environmentalCommitments: [EnvironmentalCommitment?]? = nil, faqs: Faq? = nil, finalCollectionDate: String? = nil, fxRate: Double, goal: Goal? = nil, image: Image? = nil, isProjectWeLove: Bool, isProjectOfTheDay: Bool? = nil, isWatched: Bool, isLaunched: Bool, launchedAt: String? = nil, location: Location? = nil, minPledge: Int, name: String, pid: Int, pledged: Pledged, posts: Post? = nil, prelaunchActivated: Bool, risks: String, slug: String, state: ProjectState, stateChangedAt: String, tags: [Tag?], url: String, usdExchangeRate: Double? = nil, video: Video? = nil) {
-      self.init(unsafeResultMap: ["__typename": "Project", "availableCardTypes": availableCardTypes, "backersCount": backersCount, "category": category.flatMap { (value: Category) -> ResultMap in value.resultMap }, "canComment": canComment, "commentsCount": commentsCount, "country": country.resultMap, "creator": creator.flatMap { (value: Creator) -> ResultMap in value.resultMap }, "currency": currency, "deadlineAt": deadlineAt, "description": description, "environmentalCommitments": environmentalCommitments.flatMap { (value: [EnvironmentalCommitment?]) -> [ResultMap?] in value.map { (value: EnvironmentalCommitment?) -> ResultMap? in value.flatMap { (value: EnvironmentalCommitment) -> ResultMap in value.resultMap } } }, "faqs": faqs.flatMap { (value: Faq) -> ResultMap in value.resultMap }, "finalCollectionDate": finalCollectionDate, "fxRate": fxRate, "goal": goal.flatMap { (value: Goal) -> ResultMap in value.resultMap }, "image": image.flatMap { (value: Image) -> ResultMap in value.resultMap }, "isProjectWeLove": isProjectWeLove, "isProjectOfTheDay": isProjectOfTheDay, "isWatched": isWatched, "isLaunched": isLaunched, "launchedAt": launchedAt, "location": location.flatMap { (value: Location) -> ResultMap in value.resultMap }, "minPledge": minPledge, "name": name, "pid": pid, "pledged": pledged.resultMap, "posts": posts.flatMap { (value: Post) -> ResultMap in value.resultMap }, "prelaunchActivated": prelaunchActivated, "risks": risks, "slug": slug, "state": state, "stateChangedAt": stateChangedAt, "tags": tags.map { (value: Tag?) -> ResultMap? in value.flatMap { (value: Tag) -> ResultMap in value.resultMap } }, "url": url, "usdExchangeRate": usdExchangeRate, "video": video.flatMap { (value: Video) -> ResultMap in value.resultMap }])
+    public init(availableCardTypes: [CreditCardTypes], backersCount: Int, category: Category? = nil, canComment: Bool, commentsCount: Int, country: Country, creator: Creator? = nil, currency: CurrencyCode, deadlineAt: String? = nil, description: String, environmentalCommitments: [EnvironmentalCommitment?]? = nil, faqs: Faq? = nil, finalCollectionDate: String? = nil, fxRate: Double, goal: Goal? = nil, image: Image? = nil, isProjectWeLove: Bool, isProjectOfTheDay: Bool? = nil, isWatched: Bool, isLaunched: Bool, launchedAt: String? = nil, location: Location? = nil, maxPledge: Int, minPledge: Int, name: String, pid: Int, pledged: Pledged, posts: Post? = nil, prelaunchActivated: Bool, risks: String, slug: String, state: ProjectState, stateChangedAt: String, tags: [Tag?], url: String, usdExchangeRate: Double? = nil, video: Video? = nil) {
+      self.init(unsafeResultMap: ["__typename": "Project", "availableCardTypes": availableCardTypes, "backersCount": backersCount, "category": category.flatMap { (value: Category) -> ResultMap in value.resultMap }, "canComment": canComment, "commentsCount": commentsCount, "country": country.resultMap, "creator": creator.flatMap { (value: Creator) -> ResultMap in value.resultMap }, "currency": currency, "deadlineAt": deadlineAt, "description": description, "environmentalCommitments": environmentalCommitments.flatMap { (value: [EnvironmentalCommitment?]) -> [ResultMap?] in value.map { (value: EnvironmentalCommitment?) -> ResultMap? in value.flatMap { (value: EnvironmentalCommitment) -> ResultMap in value.resultMap } } }, "faqs": faqs.flatMap { (value: Faq) -> ResultMap in value.resultMap }, "finalCollectionDate": finalCollectionDate, "fxRate": fxRate, "goal": goal.flatMap { (value: Goal) -> ResultMap in value.resultMap }, "image": image.flatMap { (value: Image) -> ResultMap in value.resultMap }, "isProjectWeLove": isProjectWeLove, "isProjectOfTheDay": isProjectOfTheDay, "isWatched": isWatched, "isLaunched": isLaunched, "launchedAt": launchedAt, "location": location.flatMap { (value: Location) -> ResultMap in value.resultMap }, "maxPledge": maxPledge, "minPledge": minPledge, "name": name, "pid": pid, "pledged": pledged.resultMap, "posts": posts.flatMap { (value: Post) -> ResultMap in value.resultMap }, "prelaunchActivated": prelaunchActivated, "risks": risks, "slug": slug, "state": state, "stateChangedAt": stateChangedAt, "tags": tags.map { (value: Tag?) -> ResultMap? in value.flatMap { (value: Tag) -> ResultMap in value.resultMap } }, "url": url, "usdExchangeRate": usdExchangeRate, "video": video.flatMap { (value: Video) -> ResultMap in value.resultMap }])
     }
 
     public var __typename: String {
@@ -9575,6 +9577,16 @@ public enum GraphAPI {
       }
       set {
         resultMap.updateValue(newValue?.resultMap, forKey: "location")
+      }
+    }
+
+    /// The max pledge amount for a single reward tier.
+    public var maxPledge: Int {
+      get {
+        return resultMap["maxPledge"]! as! Int
+      }
+      set {
+        resultMap.updateValue(newValue, forKey: "maxPledge")
       }
     }
 

--- a/KsApi/MockService.swift
+++ b/KsApi/MockService.swift
@@ -949,7 +949,7 @@
       }
     }
 
-    internal func fetchProject(projectParam: Param)
+    internal func fetchProject(projectParam: Param, configCurrency _: String?)
       -> SignalProducer<Project.ProjectPamphletData, ErrorEnvelope> {
       guard let client = self.apolloClient else {
         return .empty

--- a/KsApi/Service.swift
+++ b/KsApi/Service.swift
@@ -340,10 +340,11 @@ public struct Service: ServiceType {
   /**
     Use case:
    - `ProjectPamphletViewModel`
+   - `ProjectPageViewModel`
 
-   This is the only use case at the moment as it effects the `ProjectPamphletViewController` directly.
+   This is the only use case at the moment as it effects the `ProjectPamphletViewController`, `ProjectPageViewController` directly.
    */
-  public func fetchProject(projectParam: Param)
+  public func fetchProject(projectParam: Param, configCurrency: String?)
     -> SignalProducer<Project.ProjectPamphletData, ErrorEnvelope> {
     switch (projectParam.id, projectParam.slug) {
     case let (.some(projectId), _):
@@ -352,14 +353,14 @@ public struct Service: ServiceType {
 
       return GraphQL.shared.client
         .fetch(query: query)
-        .flatMap(Project.projectProducer(from:))
+        .flatMap { Project.projectProducer(from: $0, configCurrency: configCurrency) }
     case let (_, .some(projectSlug)):
       let query = GraphAPI
         .FetchProjectBySlugQuery(slug: projectSlug, withStoredCards: false)
 
       return GraphQL.shared.client
         .fetch(query: query)
-        .flatMap(Project.projectProducer(from:))
+        .flatMap { Project.projectProducer(from: $0, configCurrency: configCurrency) }
     default:
       return .empty
     }

--- a/KsApi/ServiceType.swift
+++ b/KsApi/ServiceType.swift
@@ -175,8 +175,9 @@ public protocol ServiceType {
   func fetchProject(param: Param) -> SignalProducer<Project, ErrorEnvelope>
 
   /// Fetch the newest data for a particular project from its id or slug, including an optional backing id if current user is backing project
-  /// (currently only used on `ProjectPamphetViewModel` because it's a GQL query)
-  func fetchProject(projectParam: Param) -> SignalProducer<Project.ProjectPamphletData, ErrorEnvelope>
+  /// (currently only used on `ProjectPamphetViewModel`and `ProjectPageViewModel`  because it's a GQL query)
+  func fetchProject(projectParam: Param, configCurrency: String?)
+    -> SignalProducer<Project.ProjectPamphletData, ErrorEnvelope>
 
   /// Fetch the project's rewards only, without shipping rules
   func fetchProjectRewards(projectId: Int) -> SignalProducer<[Reward], ErrorEnvelope>

--- a/KsApi/fragments/ProjectFragment.graphql
+++ b/KsApi/fragments/ProjectFragment.graphql
@@ -45,6 +45,7 @@ fragment ProjectFragment on Project {
   location {
     ...LocationFragment
   }
+  maxPledge
   minPledge
   name
   pid

--- a/KsApi/models/graphql/adapters/Backing+BackingFragment.swift
+++ b/KsApi/models/graphql/adapters/Backing+BackingFragment.swift
@@ -1,4 +1,4 @@
-import Foundation
+import Prelude
 import ReactiveSwift
 
 extension Backing {
@@ -56,7 +56,18 @@ private func backingStatus(from backingFragment: GraphAPI.BackingFragment) -> Ba
 }
 
 private func backingReward(from backingFragment: GraphAPI.BackingFragment) -> Reward? {
-  guard let reward = backingFragment.reward?.fragments.rewardFragment else { return .noReward }
+  guard let reward = backingFragment.reward?.fragments.rewardFragment else {
+    let projectMinimumPledgeAmount: Int = backingFragment.project?.fragments.projectFragment.minPledge ?? 1
+    let projectFXRate: Double = backingFragment.project?.fragments.projectFragment.fxRate ?? 1.0
+
+    let convertedMinimumAmount = projectFXRate * Double(projectMinimumPledgeAmount)
+
+    let emptyReward = Reward.noReward
+      |> Reward.lens.minimum .~ Double(projectMinimumPledgeAmount)
+      |> Reward.lens.convertedMinimum .~ convertedMinimumAmount
+
+    return emptyReward
+  }
 
   return Reward.reward(from: reward)
 }

--- a/KsApi/models/graphql/adapters/Backing+BackingFragmentTests.swift
+++ b/KsApi/models/graphql/adapters/Backing+BackingFragmentTests.swift
@@ -66,6 +66,8 @@ final class Backing_BackingFragmentTests: XCTestCase {
       let backing = Backing.backing(from: fragment)
       XCTAssertNotNil(backing)
       XCTAssertEqual(backing?.reward?.isNoReward, true)
+      XCTAssertEqual(backing?.reward?.convertedMinimum, 1.23244501)
+      XCTAssertEqual(backing?.reward?.minimum, 1.0)
     } catch {
       XCTFail(error.localizedDescription)
     }
@@ -683,6 +685,7 @@ private func backingDictionary() -> [String: Any] {
         "id": "TG9jYXRpb24tMjQxOTk0NA==",
         "name": "Henderson"
       },
+      "maxPledge": 8500,
       "minPledge": 1,
       "name": "WEE WILLIAM WITCHLING",
       "pid": 1596594463,

--- a/KsApi/models/graphql/adapters/Project+FetchProjectQueryData.swift
+++ b/KsApi/models/graphql/adapters/Project+FetchProjectQueryData.swift
@@ -4,37 +4,53 @@ import Prelude
 import ReactiveSwift
 
 extension Project {
-  public typealias ProjectPamphletData = (project: Project, backingId: Int?)
+  public typealias ProjectPamphletData = (
+    project: Project,
+    backingId: Int?
+  )
 
   static func projectProducer(
-    from data: GraphAPI.FetchProjectByIdQuery.Data
+    from data: GraphAPI.FetchProjectByIdQuery.Data,
+    configCurrency: String?
   ) -> SignalProducer<ProjectPamphletData, ErrorEnvelope> {
-    let projectAndBackingId = Project.project(from: data)
+    let projectAndBackingId = Project.project(
+      from: data,
+      configCurrency: configCurrency
+    )
 
     guard let project = projectAndBackingId.0 else {
       return SignalProducer(error: ErrorEnvelope.couldNotParseJSON)
     }
 
-    let data = ProjectPamphletData(project: project, backingId: projectAndBackingId.1)
+    let data = ProjectPamphletData(
+      project: project,
+      backingId: projectAndBackingId.1
+    )
 
     return SignalProducer(value: data)
   }
 
-  static func projectProducer(
-    from data: GraphAPI.FetchProjectBySlugQuery.Data
-  ) -> SignalProducer<ProjectPamphletData, ErrorEnvelope> {
-    let projectAndBackingId = Project.project(from: data)
+  static func projectProducer(from data: GraphAPI.FetchProjectBySlugQuery.Data,
+                              configCurrency: String?) -> SignalProducer<ProjectPamphletData, ErrorEnvelope> {
+    let projectAndBackingId = Project.project(
+      from: data,
+      configCurrency: configCurrency
+    )
 
     guard let project = projectAndBackingId.0 else {
       return SignalProducer(error: ErrorEnvelope.couldNotParseJSON)
     }
 
-    let data = ProjectPamphletData(project: project, backingId: projectAndBackingId.1)
+    let data = ProjectPamphletData(
+      project: project,
+      backingId: projectAndBackingId.1
+    )
 
     return SignalProducer(value: data)
   }
 
-  static func project(from data: GraphAPI.FetchProjectByIdQuery.Data) -> (Project?, Int?) {
+  static func project(from data: GraphAPI.FetchProjectByIdQuery.Data,
+                      configCurrency: String?) -> (Project?, Int?) {
     var projectBackingId: Int?
 
     if let backingId = data.project?.backing?.id {
@@ -48,14 +64,15 @@ extension Project {
         rewards: [noRewardReward(from: fragment)],
         addOns: nil,
         backing: nil,
-        currentUserChosenCurrency: data.me?.chosenCurrency
+        currentUserChosenCurrency: data.me?.chosenCurrency ?? configCurrency
       )
     else { return (nil, nil) }
 
     return (project, projectBackingId)
   }
 
-  static func project(from data: GraphAPI.FetchProjectBySlugQuery.Data) -> (Project?, Int?) {
+  static func project(from data: GraphAPI.FetchProjectBySlugQuery.Data,
+                      configCurrency: String?) -> (Project?, Int?) {
     var projectBackingId: Int?
 
     if let backingId = data.project?.backing?.id {
@@ -69,7 +86,7 @@ extension Project {
         rewards: [noRewardReward(from: fragment)],
         addOns: nil,
         backing: nil,
-        currentUserChosenCurrency: data.me?.chosenCurrency
+        currentUserChosenCurrency: data.me?.chosenCurrency ?? configCurrency
       )
     else { return (nil, nil) }
 

--- a/KsApi/models/graphql/adapters/Project+FetchProjectQueryDataTests.swift
+++ b/KsApi/models/graphql/adapters/Project+FetchProjectQueryDataTests.swift
@@ -6,7 +6,10 @@ import XCTest
 final class Project_FetchProjectQueryDataTests: XCTestCase {
   /// `FetchProjectQueryBySlug` returns identical data.
   func testFetchProjectQueryData_Success() {
-    let producer = Project.projectProducer(from: FetchProjectQueryTemplate.valid.data)
+    let producer = Project.projectProducer(
+      from: FetchProjectQueryTemplate.valid.data,
+      configCurrency: Project.Country.de.currencyCode
+    )
 
     let projectProducer = producer
       .switchMap { projectPamphletData -> SignalProducer<Project, ErrorEnvelope> in
@@ -64,7 +67,7 @@ final class Project_FetchProjectQueryDataTests: XCTestCase {
       "https://staging.kickstarter.com/projects/theaschneider/thequiet/posts"
     )
 
-    /// Project Statshttps://staging.kickstarter.com/projects/theaschneider/thequiet/posts
+    /// Project Stats
     XCTAssertEqual(project.stats.backersCount, 148)
     XCTAssertEqual(project.stats.currency, "EUR")
     XCTAssertEqual(project.stats.goal, 2_000)
@@ -116,7 +119,11 @@ final class Project_FetchProjectQueryDataTests: XCTestCase {
     XCTAssertEqual(project.category.parentName, "Photography")
 
     /// Project Country
-    XCTAssertEqual(project.country, .de)
+    XCTAssertEqual(project.country.countryCode, "CA")
+    XCTAssertEqual(project.country.currencySymbol, "€")
+    XCTAssertEqual(project.country.maxPledge, 8_500)
+    XCTAssertEqual(project.country.minPledge, 1)
+    XCTAssertEqual(project.country.trailingCode, true)
 
     /// Project User
     XCTAssertEqual(

--- a/KsApi/models/graphql/adapters/Project+ProjectFragment.swift
+++ b/KsApi/models/graphql/adapters/Project+ProjectFragment.swift
@@ -56,12 +56,21 @@ extension Project {
       .last
 
     let extendedProjectProperties = extendedProject(from: projectFragment)
+    
+    //Trial and error, because it seems like the project's country currencyCode can be different from the official ISO standard country currency code.
+    var updatedCountry = country
+    
+    if country.currencyCode != projectFragment.currency.rawValue {
+      updatedCountry = Project.Country(countryCode: country.countryCode,
+                                           currencyCode: projectFragment.currency.rawValue,
+                                           currencySymbol: country.currencySymbol,/*symbol here is wrong */ maxPledge: country.maxPledge, minPledge: country.minPledge, trailingCode: country.trailingCode)
+    }
 
     return Project(
       availableCardTypes: availableCardTypes,
       blurb: projectFragment.description,
       category: category,
-      country: country,
+      country: updatedCountry,
       creator: creator,
       extendedProjectProperties: extendedProjectProperties,
       memberData: memberData,

--- a/KsApi/models/graphql/adapters/Project+ProjectFragment.swift
+++ b/KsApi/models/graphql/adapters/Project+ProjectFragment.swift
@@ -12,7 +12,12 @@ extension Project {
     currentUserChosenCurrency: String?
   ) -> Project? {
     guard
-      let country = Country.country(from: projectFragment.country.fragments.countryFragment),
+      let country = Country.country(
+        from: projectFragment.country.fragments.countryFragment,
+        minPledge: projectFragment.minPledge,
+        maxPledge: projectFragment.maxPledge,
+        currency: projectFragment.currency
+      ),
       let categoryFragment = projectFragment.category?.fragments.categoryFragment,
       let category = Project.Category.category(from: categoryFragment),
       let dates = projectDates(from: projectFragment),
@@ -56,21 +61,12 @@ extension Project {
       .last
 
     let extendedProjectProperties = extendedProject(from: projectFragment)
-    
-    //Trial and error, because it seems like the project's country currencyCode can be different from the official ISO standard country currency code.
-    var updatedCountry = country
-    
-    if country.currencyCode != projectFragment.currency.rawValue {
-      updatedCountry = Project.Country(countryCode: country.countryCode,
-                                           currencyCode: projectFragment.currency.rawValue,
-                                           currencySymbol: country.currencySymbol,/*symbol here is wrong */ maxPledge: country.maxPledge, minPledge: country.minPledge, trailingCode: country.trailingCode)
-    }
 
     return Project(
       availableCardTypes: availableCardTypes,
       blurb: projectFragment.description,
       category: category,
-      country: updatedCountry,
+      country: country,
       creator: creator,
       extendedProjectProperties: extendedProjectProperties,
       memberData: memberData,

--- a/KsApi/models/graphql/adapters/Project+ProjectFragment.swift
+++ b/KsApi/models/graphql/adapters/Project+ProjectFragment.swift
@@ -105,12 +105,6 @@ private func projectPersonalization(isStarred: Bool,
   )
 }
 
-private func projectRewards(from rewardFragments: [GraphAPI.RewardFragment]?) -> [Reward]? {
-  return rewardFragments?.compactMap { rewardFragment in
-    Reward.reward(from: rewardFragment)
-  }
-}
-
 /**
  Returns a minimal `Project.Dates` from a `ProjectFragment`
  */

--- a/KsApi/models/graphql/adapters/Project+ProjectFragmentTests.swift
+++ b/KsApi/models/graphql/adapters/Project+ProjectFragmentTests.swift
@@ -20,7 +20,12 @@ final class Project_ProjectFragmentTests: XCTestCase {
         return
       }
 
-      XCTAssertEqual(project.country, .us)
+      XCTAssertEqual(project.country.countryCode, Project.Country.us.countryCode)
+      XCTAssertEqual(project.country.currencySymbol, Project.Country.us.currencySymbol)
+      XCTAssertEqual(project.country.currencyCode, Project.Country.us.currencyCode)
+      XCTAssertEqual(project.country.maxPledge, 8_500)
+      XCTAssertEqual(project.country.minPledge, 23)
+      XCTAssertEqual(project.country.trailingCode, true)
       XCTAssertEqual(project.availableCardTypes?.count, 7)
       XCTAssertEqual(
         project.blurb,
@@ -323,6 +328,7 @@ final class Project_ProjectFragmentTests: XCTestCase {
           "id":"TG9jYXRpb24tMjM3MTQ2NA==",
           "name":"Buffalo"
        },
+       "maxPledge": 8500,
        "minPledge": 23,
        "name":"FINAL GAMBLE Issue #1",
        "pid":1841936784,

--- a/KsApi/models/graphql/adapters/Project.Country+CountryFragment.swift
+++ b/KsApi/models/graphql/adapters/Project.Country+CountryFragment.swift
@@ -1,10 +1,26 @@
-import Foundation
+import Prelude
 
 extension Project.Country {
-  static func country(from countryFragment: GraphAPI.CountryFragment) -> Project.Country? {
-    guard let country = Project.Country.all
-      .first(where: { $0.countryCode == countryFragment.code.rawValue }) else { return nil }
+  static func country(from countryFragment: GraphAPI.CountryFragment,
+                      minPledge: Int,
+                      maxPledge: Int,
+                      currency: GraphAPI.CurrencyCode) -> Project.Country? {
+    guard let countryWithCurrencyDefault = Project.Country.all
+      .first(where: { $0.countryCode == countryFragment.code.rawValue }) else {
+      return nil
+    }
 
-    return country
+    var updatedCountryWithProjectCurrency = countryWithCurrencyDefault
+      |> Project.Country.lens.minPledge .~ minPledge
+      |> Project.Country.lens.maxPledge .~ maxPledge
+      |> Project.Country.lens.currencyCode .~ currency.rawValue
+
+    if let matchingCurrencySymbol = Project.Country.all
+      .first(where: { $0.currencyCode.lowercased() == currency.rawValue.lowercased() })?.currencySymbol {
+      updatedCountryWithProjectCurrency = updatedCountryWithProjectCurrency
+        |> Project.Country.lens.currencySymbol .~ matchingCurrencySymbol
+    }
+
+    return updatedCountryWithProjectCurrency
   }
 }

--- a/KsApi/models/graphql/adapters/Project.Country+CountryFragmentTests.swift
+++ b/KsApi/models/graphql/adapters/Project.Country+CountryFragmentTests.swift
@@ -3,14 +3,38 @@ import Foundation
 import XCTest
 
 final class Country_CountryFragmentTests: XCTestCase {
-  func test() {
-    let countryFragment = GraphAPI.CountryFragment(
-      code: .us,
-      name: "United States"
+  private let countryFragment = GraphAPI.CountryFragment(
+    code: .us,
+    name: "United States"
+  )
+
+  func testCurrency_WhenItsTheSameAsCountrysCurrency_Success() {
+    let country = Project.Country.country(
+      from: self.countryFragment,
+      minPledge: 1,
+      maxPledge: 8_500,
+      currency: .usd
     )
 
-    let country = Project.Country.country(from: countryFragment)
+    XCTAssertEqual(country?.countryCode, "US")
+    XCTAssertEqual(country?.currencySymbol, "$")
+    XCTAssertEqual(country?.maxPledge, 8_500)
+    XCTAssertEqual(country?.minPledge, 1)
+    XCTAssertEqual(country?.trailingCode, true)
+  }
 
-    XCTAssertEqual(country, .us)
+  func testCurrency_WhenItsNotTheSameAsCountrysCurrency_Success() {
+    let country = Project.Country.country(
+      from: self.countryFragment,
+      minPledge: 1,
+      maxPledge: 8_500,
+      currency: .jpy
+    )
+
+    XCTAssertEqual(country?.countryCode, "US")
+    XCTAssertEqual(country?.currencySymbol, "¥")
+    XCTAssertEqual(country?.maxPledge, 8_500)
+    XCTAssertEqual(country?.minPledge, 1)
+    XCTAssertEqual(country?.trailingCode, true)
   }
 }

--- a/KsApi/models/lenses/CountryLenses.swift
+++ b/KsApi/models/lenses/CountryLenses.swift
@@ -25,5 +25,29 @@ extension Project.Country {
         trailingCode: $1.trailingCode
       ) }
     )
+
+    public static let currencyCode = Lens<Project.Country, String>(
+      view: { $0.currencyCode },
+      set: { Project.Country(
+        countryCode: $1.countryCode,
+        currencyCode: $0,
+        currencySymbol: $1.currencySymbol,
+        maxPledge: $1.maxPledge,
+        minPledge: $1.minPledge,
+        trailingCode: $1.trailingCode
+      ) }
+    )
+
+    public static let currencySymbol = Lens<Project.Country, String>(
+      view: { $0.currencySymbol },
+      set: { Project.Country(
+        countryCode: $1.countryCode,
+        currencyCode: $1.currencyCode,
+        currencySymbol: $0,
+        maxPledge: $1.maxPledge,
+        minPledge: $1.minPledge,
+        trailingCode: $1.trailingCode
+      ) }
+    )
   }
 }

--- a/KsApi/mutations/templates/query/FetchAddOnsQueryTemplate.swift
+++ b/KsApi/mutations/templates/query/FetchAddOnsQueryTemplate.swift
@@ -548,6 +548,7 @@ public enum FetchAddsOnsQueryTemplate {
             "id": "TG9jYXRpb24tMTEwMzM2OA==",
             "name": "Launceston"
           },
+          "maxPledge": 8500,
           "minPledge": 1,
           "name": "Peppermint Fox Press: Notebooks & Stationery",
           "pid": 1606532881,

--- a/KsApi/mutations/templates/query/FetchProjectQueryTemplate.swift
+++ b/KsApi/mutations/templates/query/FetchProjectQueryTemplate.swift
@@ -49,8 +49,8 @@ public enum FetchProjectQueryTemplate {
           "commentsCount":0,
           "country":{
              "__typename":"Country",
-             "code":"DE",
-             "name":"Germany"
+             "code":"CA",
+             "name":"Canada"
           },
           "creator":{
              "__typename":"User",
@@ -220,6 +220,7 @@ public enum FetchProjectQueryTemplate {
              "id":"TG9jYXRpb24tNjc2NzU2",
              "name":"München"
           },
+          "maxPledge": 8500,
           "minPledge": 1,
           "name":"The Quiet",
           "pid":904702116,
@@ -294,7 +295,7 @@ public enum FetchProjectQueryTemplate {
 
     var updatedCountryResultMap = countryResultMap
     var updatedCreatorResultMap = creatorResultMap
-    updatedCountryResultMap["code"] = KsApi.GraphAPI.CountryCode.de
+    updatedCountryResultMap["code"] = KsApi.GraphAPI.CountryCode.ca
     projectResultMap["country"] = updatedCountryResultMap
     projectResultMap["deadlineAt"] = "1628622000"
     projectResultMap["launchedAt"] = "1625118948"

--- a/Library/ViewModels/ProjectPamphletMainCellViewModel.swift
+++ b/Library/ViewModels/ProjectPamphletMainCellViewModel.swift
@@ -418,6 +418,11 @@ private func pledgedText(for project: Project, _ needsConversion: Bool) -> Strin
 }
 
 private func conversionText(for project: Project) -> String {
+  // Displays SEK instead of EUR here, because the text is using the project country's currency symbol which is hardcoded. Not the Project's currency.
+  // Try this on Monday to update the country with the `project.stats.currency`
+  // var updatedProjectCountry = Project.Country(currencyCode: project.country.currencyCode)
+  // updatedProjectCountry.currencyCode = project.stats.currency
+  
   return Strings.discovery_baseball_card_stats_convert_from_pledged_of_goal(
     pledged: Format.currency(
       project.stats.pledged,

--- a/Library/ViewModels/ProjectPamphletMainCellViewModel.swift
+++ b/Library/ViewModels/ProjectPamphletMainCellViewModel.swift
@@ -418,11 +418,6 @@ private func pledgedText(for project: Project, _ needsConversion: Bool) -> Strin
 }
 
 private func conversionText(for project: Project) -> String {
-  // Displays SEK instead of EUR here, because the text is using the project country's currency symbol which is hardcoded. Not the Project's currency.
-  // Try this on Monday to update the country with the `project.stats.currency`
-  // var updatedProjectCountry = Project.Country(currencyCode: project.country.currencyCode)
-  // updatedProjectCountry.currencyCode = project.stats.currency
-  
   return Strings.discovery_baseball_card_stats_convert_from_pledged_of_goal(
     pledged: Format.currency(
       project.stats.pledged,

--- a/Library/ViewModels/ProjectPamphletViewModel.swift
+++ b/Library/ViewModels/ProjectPamphletViewModel.swift
@@ -300,9 +300,14 @@ private func fetchProjectFriends(projectOrParam: Either<Project, Param>)
 private func fetchProject(projectOrParam: Either<Project, Param>, shouldPrefix: Bool)
   -> SignalProducer<Project, ErrorEnvelope> {
   let param = projectOrParam.ifLeft({ Param.id($0.id) }, ifRight: id)
+  let configCurrency = AppEnvironment.current.launchedCountries.countries
+    .first(where: { $0.countryCode == AppEnvironment.current.countryCode })?.currencyCode
 
-  let projectAndBackingIdProducer = AppEnvironment.current.apiService.fetchProject(projectParam: param)
-    .ksr_delay(AppEnvironment.current.apiDelayInterval, on: AppEnvironment.current.scheduler)
+  let projectAndBackingIdProducer = AppEnvironment.current.apiService.fetchProject(
+    projectParam: param,
+    configCurrency: configCurrency
+  )
+  .ksr_delay(AppEnvironment.current.apiDelayInterval, on: AppEnvironment.current.scheduler)
 
   let projectAndBackingProducer = projectAndBackingIdProducer
     .switchMap { projectPamphletData -> SignalProducer<Project, ErrorEnvelope> in


### PR DESCRIPTION
# 📲 What

Earlier last week it was brought to our attention that projects created in countries that set their project currency to something different than their country's currency.

# 🤔 Why

Obviously this is a big issue and effects pledging volume as evidenced in this large [project](https://www.kickstarter.com/projects/shortcutlabs/flic-twist-the-wireless-dial-for-your-smart-home?ref=bgtrbl&token=e1d08d69).

https://kickstarter.atlassian.net/browse/NTV-284 contains the exact problem and this [document](https://kickstarter.atlassian.net/wiki/spaces/~294637594/pages/1840840709/Price+Display+Errors+on+iOS.) investigates the full scope of the issue.

# 🛠 How

**Part 1**
In the first part of this fix, noticed that we were simply getting the project's country code, looking it up in our `Project.Country` enum's `all` and mapping it to the `project`'s `country` object we returned to be displayed.
However, this breaks down when the creator specifies a project currency _different_ from the hard coded currencies returned from within the app. Like in the example project above, the project's country is Sweden, but its' built to accept pledges in "EUR". 

So updated the `Project.Country` adapter to take in the project fragment's currency and update the hardcoded country's currency if it's different.

This solved the currency symbol display issues on project, rewards selection, add-ons and checkout screens. (Both logged in and logged out)

**Part 2**
Thanks @Arkariang for showing us where the users' currency is [populated](https://kickstarter.slack.com/archives/C02LY6LM0CU/p1637087305018100).

Basically there is a `fetchConfig` endpoint called on `AppDelegate`, which is what Android uses' to populate the default currency for conversions if the user is not logged in. Previously iOS was just using `USD` if it wasn't there, which causes incorrect conversions to show up for example in the rewards (because each reward uses' the configs' currency to display its converted amount.)

**Part 3**
Another [issue](https://kickstarter.atlassian.net/browse/SD-1061?atlOrigin=eyJpIjoiNGUzMzRhMTQzNjQ4NGJjNmI1NGUzN2E5YzYwYjcwNmEiLCJwIjoiamlyYS1zbGFjay1pbnQifQ) noticed was on the manage pledge screen, no reward rewards on iOS were displaying an incorrect currency conersion (ie. "About $0"), Android was displaying correctly (ie. About $1). That was corrected by adding the `minPledge` and `fxRate` properties from the backing's project fragment. (`Backing+BackingFragment.swift`)

| Before 🦋 | After 🐛 |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/4282741/142240170-e742282a-c5d4-4061-9a1f-2f97b8691202.png" width="300"> | <img src="https://user-images.githubusercontent.com/4282741/142240304-e88a7742-3e6c-4483-8cbd-500ac8555283.png" width="300"> |

# 👀 See

| Before 🦋 | After 🐛 |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/4282741/142240470-074e09fd-15b0-41b2-b5f1-b2b49bebcd40.gif" width="300"> | <img src="https://user-images.githubusercontent.com/4282741/142240416-a4a41716-6bb7-47f3-a0be-7cf3d50e55b0.gif" width="300"> |

# ✅ Acceptance criteria
- [x] Investigate all screens in the app listed in the document. Check that there are no differences between the Android or iOS app for _any_ project, not just the one above.

# ⏰ TODO

**Follow up**
- [x] Write tests
- [x] Go through follow up scenarios in document and note any follow up issues.