### PR TITLE
[Unticketed] Fix Navigation Selector On Newer iPhones with Safe Area

### DIFF
--- a/Kickstarter-iOS/Views/ProjectNavigationSelectorView.swift
+++ b/Kickstarter-iOS/Views/ProjectNavigationSelectorView.swift
@@ -201,7 +201,8 @@ final class ProjectNavigationSelectorView: UIView {
   private func pinSelectedButtonBorderView(toIndex index: Int) {
     guard let button = self.buttonsStackView.arrangedSubviews[index] as? UIButton else { return }
 
-    let leadingConstant = button.frame.origin.x - ProjectNavigationSelectorViewStyles.Layout.layoutMargins - safeAreaInsets.left
+    let leadingConstant = button.frame.origin.x - ProjectNavigationSelectorViewStyles.Layout
+      .layoutMargins - safeAreaInsets.left
 
     // The value of the constraint is originally set to the width of the first button so we have subtract this each time we want to calculate the constant
     let widthConstant = button.frame.width - self.buttonsStackView.arrangedSubviews[0].frame.width

--- a/Kickstarter-iOS/Views/ProjectNavigationSelectorView.swift
+++ b/Kickstarter-iOS/Views/ProjectNavigationSelectorView.swift
@@ -201,7 +201,7 @@ final class ProjectNavigationSelectorView: UIView {
   private func pinSelectedButtonBorderView(toIndex index: Int) {
     guard let button = self.buttonsStackView.arrangedSubviews[index] as? UIButton else { return }
 
-    let leadingConstant = button.frame.origin.x - ProjectNavigationSelectorViewStyles.Layout.layoutMargins
+    let leadingConstant = button.frame.origin.x - ProjectNavigationSelectorViewStyles.Layout.layoutMargins - safeAreaInsets.left
 
     // The value of the constraint is originally set to the width of the first button so we have subtract this each time we want to calculate the constant
     let widthConstant = button.frame.width - self.buttonsStackView.arrangedSubviews[0].frame.width


### PR DESCRIPTION
# 📲 What # 🤔 Why # 🛠 How

Found a minor bug wrt newer iPhones that have a "safe area" which should be deducted from the layout margins when relcalculating the leading and width constraint for the `selectedBorderBottomView`

# 👀 See

Trello, screenshots, external resources?

Before 🦋 

https://user-images.githubusercontent.com/4282741/143498586-53e5f854-9f2b-42d7-9480-5dc1f7f39260.mp4

After 🐛 

https://user-images.githubusercontent.com/4282741/143498292-6f63f4e2-184f-4cd4-b6c0-48bf6a67a3f5.mp4

# ✅ Acceptance criteria

- [ ] Ensure no regressions on navigation selector on existing iPhones (testing on simulators)
- [ ] Ensure newer iPhones (with notch) work as expected in landscape and portrait mode.
