### PR TITLE
[NTV-287] Updating PerimeterX to 1.16.2

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -25,4 +25,4 @@ binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseCrashlyticsBinary
 binary "https://dl.google.com/dl/firebase/ios/carthage/FirebasePerformanceBinary.json" == 7.4.0
 binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseProtobufBinary.json" == 7.4.0
 binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseInAppMessagingBinary.json" == 7.4.0
-binary "https://raw.githubusercontent.com/PerimeterX/px-iOS-Framework/master/PerimeterX.json" == 1.13.9
+binary "https://raw.githubusercontent.com/PerimeterX/px-iOS-Framework/master/PerimeterX.json" == 1.16.2

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -4,7 +4,7 @@ binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseInAppMessagingBin
 binary "https://dl.google.com/dl/firebase/ios/carthage/FirebasePerformanceBinary.json" "7.4.0"
 binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseProtobufBinary.json" "7.4.0"
 binary "https://raw.githubusercontent.com/Appboy/appboy-ios-sdk/master/appboy_ios_sdk_full.json" "4.3.2"
-binary "https://raw.githubusercontent.com/PerimeterX/px-iOS-Framework/master/PerimeterX.json" "1.13.9"
+binary "https://raw.githubusercontent.com/PerimeterX/px-iOS-Framework/master/PerimeterX.json" "1.16.2"
 github "Alamofire/Alamofire" "5.4.3"
 github "Alamofire/AlamofireImage" "4.1.0"
 github "ReactiveCocoa/ReactiveSwift" "6.5.0"


### PR DESCRIPTION
# 📲 What

Updating our PerimeterX iOS SDK dependency to version 1.16.2. We're using carthage and our script to do this and did not run into anything unusual in the process.

# ✅ Acceptance criteria

- [ ] Run `bin/carthage.sh bootstrap --platform iOS` and verify your dependency updated + the project builds.
