### PR TITLE
[NTV-358] Added External Links To Text Elements

### DIFF
--- a/Kickstarter-iOS/Views/Cells/HTML Parser/TextViewElementCell.swift
+++ b/Kickstarter-iOS/Views/Cells/HTML Parser/TextViewElementCell.swift
@@ -7,7 +7,7 @@ import UIKit
 class TextViewElementCell: UITableViewCell, ValueCell {
   // MARK: Properties
 
-  private lazy var bodyLabel: UILabel = { UILabel(frame: .zero) }()
+  private lazy var textView: UITextView = { UITextView(frame: .zero) }()
   private let viewModel = TextViewElementCellViewModel()
 
   // MARK: Initializers
@@ -31,7 +31,11 @@ class TextViewElementCell: UITableViewCell, ValueCell {
   // MARK: View Model
 
   internal override func bindViewModel() {
-    self.bodyLabel.rac.attributedText = self.viewModel.outputs.attributedText
+    self.viewModel.outputs.attributedText
+      .observeForUI()
+      .observeValues { [weak self] attributedText in
+        self?.textView.attributedText = attributedText
+      }
   }
 
   // MARK: View Styles
@@ -55,15 +59,32 @@ class TextViewElementCell: UITableViewCell, ValueCell {
         leftRight: Styles.grid(3)
       )
 
-    _ = self.bodyLabel
-      |> \.adjustsFontForContentSizeCategory .~ true
-      |> \.numberOfLines .~ 0
+    _ = self.textView
+      |> self.textViewStyle
   }
 
   // MARK: Helpers
 
+  private let textViewStyle: TextViewStyle = { textView in
+    let t = textView
+      |> UITextView.lens.isScrollEnabled .~ false
+      |> UITextView.lens.textContainerInset .~ UIEdgeInsets.zero
+      |> UITextView.lens.textContainer.lineFragmentPadding .~ 0
+      |> UITextView.lens.backgroundColor .~ UIColor.ksr_white
+      |> \.textAlignment .~ .left
+
+    let b = t
+      |> \.adjustsFontForContentSizeCategory .~ true
+      |> \.isEditable .~ false
+      |> \.isSelectable .~ true
+      |> \.isUserInteractionEnabled .~ true
+      |> \.dataDetectorTypes .~ .link
+
+    return b
+  }
+
   private func configureViews() {
-    _ = (self.bodyLabel, self.contentView)
+    _ = (self.textView, self.contentView)
       |> ksr_addSubviewToParent()
       |> ksr_constrainViewToMarginsInParent()
   }

--- a/Library/ViewModels/HTML Parser/TextViewElementCellViewModel.swift
+++ b/Library/ViewModels/HTML Parser/TextViewElementCellViewModel.swift
@@ -88,7 +88,11 @@ private func attributedText(textElement: TextViewElement) -> SignalProducer<NSAt
       case .link:
         combinedAttributes[NSAttributedString.Key.foregroundColor] = UIColor.ksr_create_700
         combinedAttributes[NSAttributedString.Key.underlineStyle] = NSUnderlineStyle.single.rawValue
-        combinedAttributes[NSAttributedString.Key.link] = NSURL(string: "https://www.kickstarter.com")
+
+        if let validURLString = textItem.link,
+          let validURL = URL(string: validURLString) {
+          combinedAttributes[NSAttributedString.Key.link] = validURL
+        }
       case .bulletStart:
         paragraphStyle.headIndent = (textItem.text as NSString).size(withAttributes: baseFontAttributes).width
         combinedAttributes[NSAttributedString.Key.paragraphStyle] = paragraphStyle

--- a/Library/ViewModels/HTML Parser/TextViewElementCellViewModel.swift
+++ b/Library/ViewModels/HTML Parser/TextViewElementCellViewModel.swift
@@ -88,6 +88,7 @@ private func attributedText(textElement: TextViewElement) -> SignalProducer<NSAt
       case .link:
         combinedAttributes[NSAttributedString.Key.foregroundColor] = UIColor.ksr_create_700
         combinedAttributes[NSAttributedString.Key.underlineStyle] = NSUnderlineStyle.single.rawValue
+        combinedAttributes[NSAttributedString.Key.link] = NSURL(string: "https://www.kickstarter.com")
       case .bulletStart:
         paragraphStyle.headIndent = (textItem.text as NSString).size(withAttributes: baseFontAttributes).width
         combinedAttributes[NSAttributedString.Key.paragraphStyle] = paragraphStyle

--- a/Library/ViewModels/HTML Parser/TextViewElementCellViewModelTests.swift
+++ b/Library/ViewModels/HTML Parser/TextViewElementCellViewModelTests.swift
@@ -116,6 +116,7 @@ internal final class TextElementCellViewModelTests: TestCase {
     expectedFontAttributes[NSAttributedString.Key.font] = self.expectedBaseFont.boldItalic
     self.expectedFontAttributes[NSAttributedString.Key.foregroundColor] = UIColor.ksr_create_700
     self.expectedFontAttributes[NSAttributedString.Key.underlineStyle] = NSUnderlineStyle.single.rawValue
+    self.expectedFontAttributes[NSAttributedString.Key.link] = NSURL(string: "https://ksr.com")!
 
     let expectedLinkWithStylesAttributedText = NSAttributedString(
       string: expectedSampleString,
@@ -136,6 +137,7 @@ internal final class TextElementCellViewModelTests: TestCase {
 
     self.expectedFontAttributes[NSAttributedString.Key.foregroundColor] = UIColor.ksr_create_700
     self.expectedFontAttributes[NSAttributedString.Key.underlineStyle] = NSUnderlineStyle.single.rawValue
+    self.expectedFontAttributes[NSAttributedString.Key.link] = NSURL(string: "https://ksr.com")!
 
     let expectedLinkWithNoStylesAttributedText = NSAttributedString(
       string: expectedSampleString,
@@ -214,6 +216,7 @@ internal final class TextElementCellViewModelTests: TestCase {
     self.expectedFontAttributes[NSAttributedString.Key.foregroundColor] = UIColor.ksr_create_700
     self.expectedFontAttributes[NSAttributedString.Key.underlineStyle] = NSUnderlineStyle.single.rawValue
     self.expectedFontAttributes[NSAttributedString.Key.paragraphStyle] = self.expectedParagraphStyle
+    self.expectedFontAttributes[NSAttributedString.Key.link] = NSURL(string: "https://ksr.com")!
 
     let expectedFirstListAttributedText = NSAttributedString(
       string: expectedFirstListValue,


### PR DESCRIPTION
# 📲 What

Up to this point, the text elements that were rendered as links we not functional.
Now they are and externally link to a Safari browser.

# 🤔 Why

Links need to work for them to be useful to the user.

# 🛠 How

Turns out setting a prelude style font (ex. `.ksr_callout`) to the TextView's font property via the style interferes with the textviews' rendering of the text on the first pass. Removing all font related styles from the `TextViewStyle` fixed this issue.

# 👀 See

| Before 🐛 | After 🦋 |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/4282741/150885858-afa16adc-a102-45ae-a93f-7d9cee3a74b1.gif" width="300"> | <img src="https://user-images.githubusercontent.com/4282741/150885591-92beae94-7887-461b-8f1a-e5be52e2c329.gif" width="300"> |

# ✅ Acceptance criteria

- [x] Links are clickable.
