### PR TITLE
Fix Failing KickAlpha Build 5.1.0 16428035

### DIFF
--- a/Carthage-xcfilelist/ksapi-input-files.xcfilelist
+++ b/Carthage-xcfilelist/ksapi-input-files.xcfilelist
@@ -5,4 +5,5 @@ $(SRCROOT)/Carthage/Build/iOS/ApolloAPI.framework
 $(SRCROOT)/Carthage/Build/iOS/ApolloUtils.framework
 $(SRCROOT)/Carthage/Build/iOS/Prelude.framework
 $(SRCROOT)/Carthage/Build/iOS/ReactiveExtensions.framework
+$(SRCROOT)/Carthage/Build/iOS/ReactiveSwift.framework
 $(SRCROOT)/Carthage/Build/iOS/SwiftSoup.framework


### PR DESCRIPTION
Latest KickAlpha 5.1.0 (16428035) is crashing on launch, but this isn't the case for the version before it 5.1.0 (16419434).
Found a possible point of failure in the change below, but also suspect flaky builds from AppCenter/CI, because multiple versions back KickAlpha (16419296) was crashing so its' probably not related to this fix specifically.
