### PR TITLE
[NTV-343] External Source Cell

### DIFF
--- a/Kickstarter-iOS/DataSources/ProjectPageViewControllerDataSource.swift
+++ b/Kickstarter-iOS/DataSources/ProjectPageViewControllerDataSource.swift
@@ -128,6 +128,12 @@ internal final class ProjectPageViewControllerDataSource: ValueCellDataSource {
             cellClass: VideoViewElementCell.self,
             toSection: Section.campaign.rawValue
           )
+        case let element as ExternalSourceViewElement:
+          self.appendRow(
+            value: element,
+            cellClass: ExternalSourceViewElementCell.self,
+            toSection: Section.campaign.rawValue
+          )
         default:
           break
         }
@@ -244,6 +250,8 @@ internal final class ProjectPageViewControllerDataSource: ValueCellDataSource {
     case let (cell as ImageViewElementCell, value as (ImageViewElement, UIImage?)):
       cell.configureWith(value: value)
     case let (cell as VideoViewElementCell, value as (VideoViewElement, AVPlayer?)):
+      cell.configureWith(value: value)
+    case let (cell as ExternalSourceViewElementCell, value as ExternalSourceViewElement):
       cell.configureWith(value: value)
     default:
       assertionFailure("Unrecognized combo: \(cell), \(value)")

--- a/Kickstarter-iOS/DataSources/ProjectPageViewControllerDataSourceTests.swift
+++ b/Kickstarter-iOS/DataSources/ProjectPageViewControllerDataSourceTests.swift
@@ -56,6 +56,10 @@ final class ProjectPageViewControllerDataSourceTests: XCTestCase {
         sourceURLString: "https://source.com",
         thumbnailURLString: "https://thumbnail.com",
         seekPosition: .zero
+      ),
+      ExternalSourceViewElement(
+        embeddedURLString: "https://externalsource.com",
+        embeddedURLContentHeight: 123
       )
     ])
 
@@ -453,7 +457,7 @@ final class ProjectPageViewControllerDataSourceTests: XCTestCase {
         refTag: nil,
         isExpandedStates: nil
       )
-      XCTAssertEqual(5, self.dataSource.numberOfSections(in: self.tableView))
+      XCTAssertEqual(6, self.dataSource.numberOfSections(in: self.tableView))
 
       // campaign header section
       XCTAssertEqual(
@@ -463,7 +467,7 @@ final class ProjectPageViewControllerDataSourceTests: XCTestCase {
 
       // campaign
       XCTAssertEqual(
-        4,
+        5,
         self.dataSource.tableView(self.tableView, numberOfRowsInSection: self.campaignSection)
       )
 
@@ -474,6 +478,14 @@ final class ProjectPageViewControllerDataSourceTests: XCTestCase {
       XCTAssertEqual(
         "ImageViewElementCell",
         self.dataSource.reusableId(item: 2, section: self.campaignSection)
+      )
+      XCTAssertEqual(
+        "VideoViewElementCell",
+        self.dataSource.reusableId(item: 3, section: self.campaignSection)
+      )
+      XCTAssertEqual(
+        "ExternalSourceViewElementCell",
+        self.dataSource.reusableId(item: 4, section: self.campaignSection)
       )
       XCTAssertEqual(
         "ProjectHeaderCell",

--- a/Kickstarter-iOS/DataSources/ProjectPageViewControllerDataSourceTests.swift
+++ b/Kickstarter-iOS/DataSources/ProjectPageViewControllerDataSourceTests.swift
@@ -457,7 +457,7 @@ final class ProjectPageViewControllerDataSourceTests: XCTestCase {
         refTag: nil,
         isExpandedStates: nil
       )
-      XCTAssertEqual(6, self.dataSource.numberOfSections(in: self.tableView))
+      XCTAssertEqual(5, self.dataSource.numberOfSections(in: self.tableView))
 
       // campaign header section
       XCTAssertEqual(

--- a/Kickstarter-iOS/Views/Cells/HTML Parser/ExternalSourceViewElementCell.swift
+++ b/Kickstarter-iOS/Views/Cells/HTML Parser/ExternalSourceViewElementCell.swift
@@ -1,0 +1,128 @@
+import KsApi
+import Library
+import Prelude
+import Prelude_UIKit
+import WebKit
+
+internal protocol ExternalSourceViewElementCellDelegate: AnyObject {
+  func resetContentHeight()
+  func resetWebViewContent()
+}
+
+class ExternalSourceViewElementCell: UITableViewCell, ValueCell {
+  // MARK: Properties
+
+  private lazy var webView = WKWebView(frame: .zero, configuration: WKWebViewConfiguration())
+  private var contentHeightConstraint: NSLayoutConstraint?
+  private let viewModel: ExternalSourceViewElementCellViewModelType = ExternalSourceViewElementCellViewModel()
+
+  weak var delegate: ExternalSourceViewElementCellDelegate?
+
+  // MARK: Initializers
+
+  override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+    super.init(style: style, reuseIdentifier: reuseIdentifier)
+
+    self.configureViews()
+    self.setupConstraints()
+    self.bindStyles()
+    self.bindViewModel()
+  }
+
+  // MARK: Lifecycle
+
+  required init?(coder _: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  // MARK: View Model
+
+  internal override func bindViewModel() {
+    self.viewModel.outputs.htmlText
+      .observeForUI()
+      .observeValues { [weak self] htmlText in
+        guard let url = URL(string: htmlText) else { return }
+        let request = URLRequest(url: url)
+
+        self?.webView.load(request)
+      }
+
+    self.viewModel.outputs.contentHeight
+      .observeForUI()
+      .observeValues { [weak self] value in
+        self?.contentHeightConstraint = self?.webView.heightAnchor.constraint(equalToConstant: CGFloat(value))
+        self?.viewModel.inputs.toggleContentHeight(true)
+      }
+
+    self.viewModel.outputs.toggleContentHeight
+      .observeForUI()
+      .observeValues { [weak self] isActive in
+        self?.contentHeightConstraint?.isActive = isActive
+      }
+
+    self.viewModel.outputs.resetWebViewContent
+      .observeValues { [weak self] emptyHTML in
+        guard let emptyContentURL = URL(string: emptyHTML) else { return }
+
+        let request = URLRequest(url: emptyContentURL)
+
+        self?.webView.load(request)
+      }
+  }
+
+  // MARK: View Styles
+
+  internal override func bindStyles() {
+    super.bindStyles()
+
+    _ = self
+      |> baseTableViewCellStyle()
+      |> \.separatorInset .~
+      .init(
+        top: 0,
+        left: 0,
+        bottom: 0,
+        right: self.bounds.size.width + ProjectHeaderCellStyles.Layout.insets
+      )
+
+    _ = self.contentView
+      |> \.layoutMargins .~ .init(
+        topBottom: Styles.gridHalf(3),
+        leftRight: Styles.grid(3)
+      )
+  }
+
+  // MARK: Helpers
+
+  func configureWith(value: ExternalSourceViewElement) {
+    self.viewModel.inputs.configureWith(element: value)
+  }
+
+  private func configureViews() {
+    self.webView.configuration.suppressesIncrementalRendering = true
+    self.webView.configuration.allowsInlineMediaPlayback = true
+    self.webView.configuration.applicationNameForUserAgent = "Kickstarter-iOS"
+    self.webView.customUserAgent = Service.userAgent
+    self.delegate = self
+
+    _ = (self.webView, self.contentView)
+      |> ksr_addSubviewToParent()
+      |> ksr_constrainViewToMarginsInParent()
+  }
+
+  private func setupConstraints() {
+    self.contentHeightConstraint = self.webView.heightAnchor.constraint(equalToConstant: .zero)
+    self.contentHeightConstraint?.priority = .defaultHigh
+    self.contentHeightConstraint?.isActive = true
+  }
+}
+
+extension ExternalSourceViewElementCell: ExternalSourceViewElementCellDelegate {
+  func resetContentHeight() {
+    self.viewModel.inputs.toggleContentHeight(false)
+  }
+
+  func resetWebViewContent() {
+    self.viewModel.inputs.resetWebView()
+  }
+}

--- a/Kickstarter-iOS/Views/Controllers/ProjectPageViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/ProjectPageViewController.swift
@@ -671,8 +671,6 @@ extension ProjectPageViewController: UITableViewDelegate {
       cell.delegate = self
     } else if let cell = cell as? ImageViewElementCell {
       cell.delegate = self
-    } else if let cell = cell as? ExternalSourceViewElementCell {
-      cell.delegate?.resetContentHeight()
     }
 
     /// If we are displaying the `ProjectPamphletSubpageCell` we do not want to show the cells separator.
@@ -690,6 +688,7 @@ extension ProjectPageViewController: UITableViewDelegate {
       self.dataSource
         .updateVideoViewElementSeektime(with: seekTime, tableView: self.tableView, indexPath: indexPath)
     } else if let cell = cell as? ExternalSourceViewElementCell {
+      cell.delegate?.resetContentHeight()
       cell.delegate?.resetWebViewContent()
     }
   }

--- a/Kickstarter-iOS/Views/Controllers/ProjectPageViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/ProjectPageViewController.swift
@@ -80,6 +80,7 @@ public final class ProjectPageViewController: UIViewController, MessageBannerVie
     self.tableView.registerCellClass(TextViewElementCell.self)
     self.tableView.registerCellClass(ImageViewElementCell.self)
     self.tableView.registerCellClass(VideoViewElementCell.self)
+    self.tableView.registerCellClass(ExternalSourceViewElementCell.self)
     self.tableView.register(nib: .ProjectPamphletMainCell)
     self.tableView.register(nib: .ProjectPamphletSubpageCell)
     self.tableView.registerCellClass(ProjectRisksCell.self)
@@ -670,6 +671,8 @@ extension ProjectPageViewController: UITableViewDelegate {
       cell.delegate = self
     } else if let cell = cell as? ImageViewElementCell {
       cell.delegate = self
+    } else if let cell = cell as? ExternalSourceViewElementCell {
+      cell.delegate?.resetContentHeight()
     }
 
     /// If we are displaying the `ProjectPamphletSubpageCell` we do not want to show the cells separator.
@@ -686,6 +689,8 @@ extension ProjectPageViewController: UITableViewDelegate {
       let seekTime = cell.delegate?.pausePlayback() {
       self.dataSource
         .updateVideoViewElementSeektime(with: seekTime, tableView: self.tableView, indexPath: indexPath)
+    } else if let cell = cell as? ExternalSourceViewElementCell {
+      cell.delegate?.resetWebViewContent()
     }
   }
 }

--- a/Kickstarter-iOS/Views/Controllers/ProjectPageViewControllerTests.swift
+++ b/Kickstarter-iOS/Views/Controllers/ProjectPageViewControllerTests.swift
@@ -42,6 +42,10 @@ internal final class ProjectPageViewControllerTests: TestCase {
           sourceURLString: "https://source.com",
           thumbnailURLString: nil,
           seekPosition: .zero
+        ),
+        ExternalSourceViewElement(
+          embeddedURLString: "https://source.com",
+          embeddedURLContentHeight: 123
         )
       ]),
     minimumPledgeAmount: 1

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -67,6 +67,7 @@
 		01F219561DC12BF7005DD2E4 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 01F219521DC12697005DD2E4 /* LaunchScreen.storyboard */; };
 		01F547ED1D53994B000A98EF /* TabBarItemStyles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F547EC1D53994B000A98EF /* TabBarItemStyles.swift */; };
 		01FD71EC1D3808E500070BAC /* BarButtonItemStyles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01FD71EB1D3808E500070BAC /* BarButtonItemStyles.swift */; };
+		0602002A27D271B900909500 /* ExternalSourceViewElementCellViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0602002927D271B900909500 /* ExternalSourceViewElementCellViewModelTests.swift */; };
 		06032A8C26CEADED0013AAB9 /* FetchProjectCommentsQueryTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06032A8926CEAD2F0013AAB9 /* FetchProjectCommentsQueryTemplate.swift */; };
 		06032A8E26CEB3E50013AAB9 /* CommentFragmentTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06032A8D26CEB3E50013AAB9 /* CommentFragmentTemplate.swift */; };
 		06032A9026CEC3290013AAB9 /* FetchUpdateCommentsQueryTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06032A8F26CEC3290013AAB9 /* FetchUpdateCommentsQueryTemplate.swift */; };
@@ -1853,6 +1854,7 @@
 		01F219521DC12697005DD2E4 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
 		01F547EC1D53994B000A98EF /* TabBarItemStyles.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabBarItemStyles.swift; sourceTree = "<group>"; };
 		01FD71EB1D3808E500070BAC /* BarButtonItemStyles.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BarButtonItemStyles.swift; sourceTree = "<group>"; };
+		0602002927D271B900909500 /* ExternalSourceViewElementCellViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExternalSourceViewElementCellViewModelTests.swift; sourceTree = "<group>"; };
 		06032A8926CEAD2F0013AAB9 /* FetchProjectCommentsQueryTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchProjectCommentsQueryTemplate.swift; sourceTree = "<group>"; };
 		06032A8D26CEB3E50013AAB9 /* CommentFragmentTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentFragmentTemplate.swift; sourceTree = "<group>"; };
 		06032A8F26CEC3290013AAB9 /* FetchUpdateCommentsQueryTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchUpdateCommentsQueryTemplate.swift; sourceTree = "<group>"; };
@@ -3525,6 +3527,7 @@
 				067E7EC827BF0F2B00F02B33 /* VideoViewElementCellViewModel.swift */,
 				064E10BE27CF038300A9A75F /* VideoViewElementCellViewModelTests.swift */,
 				0634C2F827CFEEC2003A6D6E /* ExternalSourceViewElementCellViewModel.swift */,
+				0602002927D271B900909500 /* ExternalSourceViewElementCellViewModelTests.swift */,
 			);
 			path = "HTML Parser";
 			sourceTree = "<group>";
@@ -6463,6 +6466,7 @@
 				D72370542118C19B001EA4CA /* SettingsRecommendationsCellViewModelTests.swift in Sources */,
 				06BD75BC26C42BA100A12D4E /* OptimizelyFeature+HelpersTests.swift in Sources */,
 				A7ED1FCC1E831C5C00BFFA01 /* ProjectActivityBackingCellViewModelTests.swift in Sources */,
+				0602002A27D271B900909500 /* ExternalSourceViewElementCellViewModelTests.swift in Sources */,
 				A7ED1FED1E831C5C00BFFA01 /* DashboardProjectsDrawerCellViewModelTests.swift in Sources */,
 				A7ED1FE01E831C5C00BFFA01 /* DiscoveryNavigationHeaderViewModelTests.swift in Sources */,
 				A7ED1F481E831BA200BFFA01 /* AlertError+Equatable.swift in Sources */,

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -109,6 +109,8 @@
 		062868EC26B9E25F00EC5052 /* DeletePaymentSourceEnvelope+DeletePaymentSourceMutation.DataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 062868EB26B9E25F00EC5052 /* DeletePaymentSourceEnvelope+DeletePaymentSourceMutation.DataTests.swift */; };
 		062868EE26B9F4E100EC5052 /* GraphAPI.DeletePaymentSourceInput+DeletePaymentSourceInputTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 062868ED26B9F4E100EC5052 /* GraphAPI.DeletePaymentSourceInput+DeletePaymentSourceInputTests.swift */; };
 		062BE3BA27B3224A006B5251 /* ImageViewElementCellViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 062BE3B927B3224A006B5251 /* ImageViewElementCellViewModelTests.swift */; };
+		0634C2F727CFEE40003A6D6E /* ExternalSourceViewElementCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0634C2F627CFEE40003A6D6E /* ExternalSourceViewElementCell.swift */; };
+		0634C2F927CFEEC2003A6D6E /* ExternalSourceViewElementCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0634C2F827CFEEC2003A6D6E /* ExternalSourceViewElementCellViewModel.swift */; };
 		063BBA812799C7BA00659198 /* TextViewElementCellViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 063BBA802799C7BA00659198 /* TextViewElementCellViewModelTests.swift */; };
 		064AEF11270CF867006605DD /* FetchProjectRewardsByIdQueryTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 064AEF10270CF867006605DD /* FetchProjectRewardsByIdQueryTemplate.swift */; };
 		064AEF13270CFB53006605DD /* Project+FetchProjectRewardsByIdQueryDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 064AEF0E270CECF0006605DD /* Project+FetchProjectRewardsByIdQueryDataTests.swift */; };
@@ -1879,6 +1881,8 @@
 		062868EB26B9E25F00EC5052 /* DeletePaymentSourceEnvelope+DeletePaymentSourceMutation.DataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DeletePaymentSourceEnvelope+DeletePaymentSourceMutation.DataTests.swift"; sourceTree = "<group>"; };
 		062868ED26B9F4E100EC5052 /* GraphAPI.DeletePaymentSourceInput+DeletePaymentSourceInputTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GraphAPI.DeletePaymentSourceInput+DeletePaymentSourceInputTests.swift"; sourceTree = "<group>"; };
 		062BE3B927B3224A006B5251 /* ImageViewElementCellViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageViewElementCellViewModelTests.swift; sourceTree = "<group>"; };
+		0634C2F627CFEE40003A6D6E /* ExternalSourceViewElementCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExternalSourceViewElementCell.swift; sourceTree = "<group>"; };
+		0634C2F827CFEEC2003A6D6E /* ExternalSourceViewElementCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExternalSourceViewElementCellViewModel.swift; sourceTree = "<group>"; };
 		063BBA802799C7BA00659198 /* TextViewElementCellViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextViewElementCellViewModelTests.swift; sourceTree = "<group>"; };
 		064AEF0E270CECF0006605DD /* Project+FetchProjectRewardsByIdQueryDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Project+FetchProjectRewardsByIdQueryDataTests.swift"; sourceTree = "<group>"; };
 		064AEF10270CF867006605DD /* FetchProjectRewardsByIdQueryTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchProjectRewardsByIdQueryTemplate.swift; sourceTree = "<group>"; };
@@ -3520,6 +3524,7 @@
 				062BE3B927B3224A006B5251 /* ImageViewElementCellViewModelTests.swift */,
 				067E7EC827BF0F2B00F02B33 /* VideoViewElementCellViewModel.swift */,
 				064E10BE27CF038300A9A75F /* VideoViewElementCellViewModelTests.swift */,
+				0634C2F827CFEEC2003A6D6E /* ExternalSourceViewElementCellViewModel.swift */,
 			);
 			path = "HTML Parser";
 			sourceTree = "<group>";
@@ -3614,6 +3619,7 @@
 			isa = PBXGroup;
 			children = (
 				475D16FA2773B0DE009E4354 /* VideoViewElementCell.swift */,
+				0634C2F627CFEE40003A6D6E /* ExternalSourceViewElementCell.swift */,
 				475D16F62773AD36009E4354 /* ImageViewElementCell.swift */,
 				475D16F82773AD9F009E4354 /* TextViewElementCell.swift */,
 			);
@@ -6101,6 +6107,7 @@
 				8016BFE81D0F582D00067956 /* String+Whitespace.swift in Sources */,
 				A76126AD1C90C94000EDCCB9 /* ValueCellDataSource.swift in Sources */,
 				4791BDE6271762E600DFE5D5 /* ProjectFAQsCellViewModel.swift in Sources */,
+				0634C2F927CFEEC2003A6D6E /* ExternalSourceViewElementCellViewModel.swift in Sources */,
 				94BA16E426698C8B0034CC3F /* CommentTableViewFooterViewModel.swift in Sources */,
 				59B0E0061D1207070081D2DC /* DashboardActionCellViewModel.swift in Sources */,
 				77D19FF5240813240058FC8E /* NavigationController.swift in Sources */,
@@ -6761,6 +6768,7 @@
 				A749001F1D00E27100BC3BE7 /* SignupViewController.swift in Sources */,
 				D69C553323A2C30300B0987A /* ErroredBackingView.swift in Sources */,
 				59B0DFFE1D11B2E50081D2DC /* DashboardContextCell.swift in Sources */,
+				0634C2F727CFEE40003A6D6E /* ExternalSourceViewElementCell.swift in Sources */,
 				47F95ED72672C594001365B2 /* ViewRepliesView.swift in Sources */,
 				37CA16AD23300376006044F9 /* ManageViewPledgeRewardReceivedViewController.swift in Sources */,
 				D770DE75217E598C00B5319A /* AddNewCardViewController.swift in Sources */,

--- a/KsApi/lib/HTML Parser/HTMLParserTests.swift
+++ b/KsApi/lib/HTML Parser/HTMLParserTests.swift
@@ -181,9 +181,23 @@ final class HTMLParserTests: XCTestCase {
     }
 
     XCTAssertEqual(
-      viewElement.iFrameContent,
-      "<iframe width=\"100%\" height=\"200\" src=\"https://www.youtube.com/embed/GcoaQ3LlqWI?start=8&amp;feature=oembed&amp;wmode=transparent\" frameborder=\"0\" allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture\" allowfullscreen></iframe>"
+      viewElement.embeddedURLString,
+      "https://www.youtube.com/embed/GcoaQ3LlqWI?start=8&feature=oembed&wmode=transparent"
     )
+    XCTAssertEqual(viewElement.embeddedURLContentHeight, 200)
+  }
+
+  func testHTMLParser_WithExternalEmbeddedSource_Success() {
+    let viewElements = self.htmlParser.parse(bodyHtml: HTMLParserTemplates.validIFrameWithEmbeddedSource.data)
+
+    guard let viewElement = viewElements.first as? ExternalSourceViewElement else {
+      XCTFail("external source view element should be created.")
+
+      return
+    }
+
+    XCTAssertEqual(viewElement.embeddedURLString, "https://www.tiktok.com/embed/v2/7056148230324653359")
+    XCTAssertEqual(viewElement.embeddedURLContentHeight, 400)
   }
 
   func testHTMLParser_WithTextHeadline_Success() {

--- a/KsApi/lib/HTML Parser/HTMLRawText.swift
+++ b/KsApi/lib/HTML Parser/HTMLRawText.swift
@@ -3,7 +3,8 @@ import Foundation
 public enum HTMLRawText {
   enum Base: String {
     case htmlClass = "class"
-    case width
+    case height
+    case iframe
     case div
     case video
   }
@@ -12,10 +13,6 @@ public enum HTMLRawText {
     case listItem = "li"
     case unorderedList = "ul"
     case orderedList = "ol"
-  }
-
-  enum Size: String {
-    case hundredPercent = "100%"
   }
 
   enum Link: String {

--- a/KsApi/lib/HTML Parser/Templates/HTMLParserTemplates.swift
+++ b/KsApi/lib/HTML Parser/Templates/HTMLParserTemplates.swift
@@ -9,6 +9,7 @@ public enum HTMLParserTemplates {
   case validVideoHigh
   case validHiddenVideo
   case validIFrame
+  case validIFrameWithEmbeddedSource
   case validHeaderText
   case validParagraphTextWithStyles
   case validParagraphTextWithLinksAndStyles
@@ -33,6 +34,8 @@ public enum HTMLParserTemplates {
       return self.validVideoHigh
     case .validIFrame:
       return self.validExternalSource
+    case .validIFrameWithEmbeddedSource:
+      return self.validEmbeddedExternalSource
     case .validHeaderText:
       return self.validHeaderText
     case .validParagraphTextWithLinksAndStyles:
@@ -168,6 +171,13 @@ public enum HTMLParserTemplates {
   private var validExternalSource: String {
     """
     <div class=\"template oembed\" contenteditable=\"false\" data-href=\"https://www.youtube.com/watch?v=GcoaQ3LlqWI&amp;t=8s\">\n<iframe width=\"356\" height=\"200\" src=\"https://www.youtube.com/embed/GcoaQ3LlqWI?start=8&amp;feature=oembed&amp;wmode=transparent\" frameborder=\"0\" allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture\" allowfullscreen></iframe>\n\n</div>
+    \n\n
+    """
+  }
+
+  private var validEmbeddedExternalSource: String {
+    """
+    <div class=\"template oembed\" contenteditable=\"false\" data-href=\"https://www.youtube.com/watch?v=GcoaQ3LlqWI&amp;t=8s\">\n<iframe width=\"356\" height=\"400\" src=\"https://cdn.embedly.com/widgets/media.html?src=https%3A%2F%2Fwww.tiktok.com%2Fembed%2Fv2%2F7056148230324653359&amp;display_name=tiktok&amp;url=https%3A%2F%2Fwww.tiktok.com%2F%40mister.larrie%2Fvideo%2F7056148230324653359&amp;image=https%3A%2F%2Fp16-sign.tiktokcdn-us.com%2Ftos-useast5-p-0068-tx%2Fc2fb40eb0e5d416b8b4e8e6cc9da6877_1642887536%7Etplv-tiktok-play.jpeg%3Fx-expires%3D1646848800%26x-signature%3D%252BVY%252Bg5hMnnAHb%252B24XUDHSPRNFUQ%253D&amp;key=d3cf44f504524614bc66d6797c5dd848&amp;type=text%2Fhtml&amp;schema=tiktok" frameborder=\"0\" allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture\" allowfullscreen></iframe>\n\n</div>
     \n\n
     """
   }

--- a/KsApi/lib/HTML Parser/View Elements/ExternalSourceViewElement.swift
+++ b/KsApi/lib/HTML Parser/View Elements/ExternalSourceViewElement.swift
@@ -2,5 +2,6 @@ import Foundation
 
 // Represents iFrame HTML, loaded on webview...
 public struct ExternalSourceViewElement: HTMLViewElement {
-  let iFrameContent: String
+  public let embeddedURLString: String
+  public let embeddedURLContentHeight: Int?
 }

--- a/KsApi/models/graphql/adapters/Project+ProjectFragment.swift
+++ b/KsApi/models/graphql/adapters/Project+ProjectFragment.swift
@@ -247,7 +247,7 @@ private func extendedProject(from projectFragment: GraphAPI.ProjectFragment) -> 
  Returns a `ProjectStoryElements` object from `ProjectFragment`
  */
 private func storyElements(from projectFragment: GraphAPI.ProjectFragment) -> ProjectStoryElements {
-  var viewElements = Project.htmlParser.parse(bodyHtml: projectFragment.story)
+  let viewElements = Project.htmlParser.parse(bodyHtml: projectFragment.story)
   var seenURLStrings = Set<String>()
   var htmlElementsWithUniqueVideoViewElements = [HTMLViewElement]()
 

--- a/KsApi/models/graphql/adapters/Project+ProjectFragmentTests.swift
+++ b/KsApi/models/graphql/adapters/Project+ProjectFragmentTests.swift
@@ -68,7 +68,9 @@ final class Project_ProjectFragmentTests: XCTestCase {
         let textElement = extendedProjectProperties.story.htmlViewElements[2] as? TextViewElement,
         let imageViewElement = extendedProjectProperties.story.htmlViewElements[8] as? ImageViewElement,
         let videoViewElement = extendedProjectProperties.story.htmlViewElements[11] as? VideoViewElement,
-        textElement.components.count > 4 else {
+        let externalSourceViewElement = extendedProjectProperties.story
+        .htmlViewElements[17] as? ExternalSourceViewElement,
+        textElement.components.count > 5 else {
         XCTFail("extended project properties should exist.")
 
         return
@@ -101,6 +103,12 @@ final class Project_ProjectFragmentTests: XCTestCase {
         "https://dr0rfahizzuzj.cloudfront.net/assets/035/786/501/b99cdfe87fc9b942dce0fe9a59a3767a_h264_base.jpg?2021"
       )
       XCTAssertEqual(videoViewElement.seekPosition, .zero)
+
+      XCTAssertEqual(
+        externalSourceViewElement.embeddedURLString,
+        "https://open.spotify.com/embed/track/0dpyzcT3RMNNSd2xKBf35I?si=8c3a869d82464083&utm_source=oembed"
+      )
+      XCTAssertEqual(externalSourceViewElement.embeddedURLContentHeight, 80)
 
       XCTAssertNotNil(extendedProjectProperties.risks)
       XCTAssertEqual(extendedProjectProperties.environmentalCommitments.count, 1)

--- a/Library/ViewModels/HTML Parser/ExternalSourceViewElementCellViewModel.swift
+++ b/Library/ViewModels/HTML Parser/ExternalSourceViewElementCellViewModel.swift
@@ -1,0 +1,91 @@
+import KsApi
+import Prelude
+import ReactiveSwift
+
+public protocol ExternalSourceViewElementCellViewModelInputs {
+  /// Call to configure with a `ExternalSourceViewElement` representing external source element.
+  func configureWith(element: ExternalSourceViewElement)
+
+  /// Call to configure with a `WKWebView` with a blank html source string.
+  func resetWebView()
+
+  /// Call to configure with cell with its' contents' height.
+  func toggleContentHeight(_ flag: Bool)
+}
+
+public protocol ExternalSourceViewElementCellViewModelOutputs {
+  /// Emits a text `String` representing the iframe tag's src attibute captured in the html parser.
+  var htmlText: Signal<String, Never> { get }
+
+  /// Emits an optional `Int` taken from iframe representing that embedded content's height in a webview.
+  var contentHeight: Signal<Int, Never> { get }
+
+  /// Emits a signal to reset the `WKWebView`'s HTML content
+  var resetWebViewContent: Signal<String, Never> { get }
+
+  /// Emits a `Bool` to render the cells' height based on it's content size height.
+  var toggleContentHeight: Signal<Bool, Never> { get }
+}
+
+public protocol ExternalSourceViewElementCellViewModelType {
+  var inputs: ExternalSourceViewElementCellViewModelInputs { get }
+  var outputs: ExternalSourceViewElementCellViewModelOutputs { get }
+}
+
+public final class ExternalSourceViewElementCellViewModel:
+  ExternalSourceViewElementCellViewModelType, ExternalSourceViewElementCellViewModelInputs,
+  ExternalSourceViewElementCellViewModelOutputs {
+  // MARK: Initializers
+
+  public init() {
+    self.htmlText = self.externalSourceViewElement.signal.skipNil()
+      .switchMap { element -> SignalProducer<String?, Never> in
+        guard !element.embeddedURLString.isEmpty else {
+          return SignalProducer(value: nil)
+        }
+
+        return SignalProducer(value: element.embeddedURLString)
+      }
+      .skipNil()
+
+    self.contentHeight = self.externalSourceViewElement.signal.skipNil()
+      .switchMap { element -> SignalProducer<Int?, Never> in
+        guard let contentHeight = element.embeddedURLContentHeight,
+          !element.embeddedURLString.isEmpty else {
+          return SignalProducer(value: nil)
+        }
+
+        return SignalProducer(value: contentHeight)
+      }
+      .skipNil()
+
+    self.resetWebViewContent = self.resetWebViewContentProperty.signal.skipNil()
+    self.toggleContentHeight = self.toggleContentProperty.signal
+  }
+
+  fileprivate let externalSourceViewElement =
+    MutableProperty<ExternalSourceViewElement?>(nil)
+  public func configureWith(element: ExternalSourceViewElement) {
+    self.externalSourceViewElement.value = element
+  }
+
+  fileprivate let resetWebViewContentProperty =
+    MutableProperty<String?>(nil)
+  public func resetWebView() {
+    self.resetWebViewContentProperty.value = "about:blank"
+  }
+
+  fileprivate let toggleContentProperty =
+    MutableProperty<Bool>(false)
+  public func toggleContentHeight(_ flag: Bool) {
+    self.toggleContentProperty.value = flag
+  }
+
+  public let contentHeight: Signal<Int, Never>
+  public let htmlText: Signal<String, Never>
+  public let resetWebViewContent: Signal<String, Never>
+  public let toggleContentHeight: Signal<Bool, Never>
+
+  public var inputs: ExternalSourceViewElementCellViewModelInputs { self }
+  public var outputs: ExternalSourceViewElementCellViewModelOutputs { self }
+}

--- a/Library/ViewModels/HTML Parser/ExternalSourceViewElementCellViewModelTests.swift
+++ b/Library/ViewModels/HTML Parser/ExternalSourceViewElementCellViewModelTests.swift
@@ -1,0 +1,57 @@
+@testable import KsApi
+@testable import Library
+import Prelude
+import ReactiveExtensions_TestHelpers
+import ReactiveSwift
+import XCTest
+
+internal final class ExternalElementSourceViewElementCellViewModelTests: TestCase {
+  private let vm: ExternalSourceViewElementCellViewModelType = ExternalSourceViewElementCellViewModel()
+  private let expectedExternalURLString = "https://source.com"
+  private let expectedContentHeight = 32
+  private let htmlText = TestObserver<String, Never>()
+  private let contentHeight = TestObserver<Int, Never>()
+  private let resetWebViewContent = TestObserver<String, Never>()
+  private let toggleContentHeight = TestObserver<Bool, Never>()
+
+  override func setUp() {
+    super.setUp()
+
+    self.vm.outputs.htmlText.observe(self.htmlText.observer)
+    self.vm.outputs.contentHeight.observe(self.contentHeight.observer)
+    self.vm.outputs.resetWebViewContent.observe(self.resetWebViewContent.observer)
+    self.vm.outputs.toggleContentHeight.observe(self.toggleContentHeight.observer)
+  }
+
+  func testExternalSourceElementData_Success() {
+    let externalSourceElement = ExternalSourceViewElement(
+      embeddedURLString: expectedExternalURLString,
+      embeddedURLContentHeight: expectedContentHeight
+    )
+
+    self.vm.inputs.configureWith(element: externalSourceElement)
+
+    self.htmlText.assertLastValue(self.expectedExternalURLString)
+    self.contentHeight.assertLastValue(self.expectedContentHeight)
+  }
+
+  func testToggleContentHeight_Success() {
+    self.toggleContentHeight.assertDidNotEmitValue()
+
+    self.vm.inputs.toggleContentHeight(true)
+
+    self.toggleContentHeight.assertLastValue(true)
+
+    self.vm.inputs.toggleContentHeight(false)
+
+    self.toggleContentHeight.assertLastValue(false)
+  }
+
+  func testResetWebView_Success() {
+    self.resetWebViewContent.assertDidNotEmitValue()
+
+    self.vm.inputs.resetWebView()
+
+    self.resetWebViewContent.assertDidEmitValue()
+  }
+}


### PR DESCRIPTION
# 📲 What

Final piece of content for the Campaign tab before cleaning up the overview tab. [Story](https://kickstarter.atlassian.net/browse/NTV-188).

# 🤔 Why

Add parity to Android Campaign tab.

# 🛠 How

`WKWebView` handles the rendering of external source `iframe` content. The parser will also find `src` embedded in iframe class's `src` attribute. Also resetting the content height and web view content to zero and empty respectively when `didEndDisplay`  is called.

# 👀 See

Trello, screenshots, external resources?

Before 🐛

https://user-images.githubusercontent.com/4282741/156661077-aa12a08c-7b20-40f4-892e-7c119defbb66.mp4

After 🦋

https://user-images.githubusercontent.com/4282741/156663668-9c85a64b-0288-4d8b-b323-4d4a848492e9.mp4

# ✅ Acceptance criteria

- [x] Ensure external sources play, full screen, correctly displayed when rotated.
- There are rotation issues with external elements.
- Thumbnail previews missing for kickstarter videos.
- Some external sources keep playing when you scroll them away.

# ⏰ TODO

- [x] Write unit tests
- [x] Fix rotation issue hiding external sources when phone rotated.
- [x] Test scrolling with multiple types of external sources (listed below) with varying heights.
(Spotify, Bandcamp, Soundcloud, TikTok, Youtube and Vimeo)
