### PR TITLE
[NTV-424] Fix External Source Bugs

### DIFF
--- a/Kickstarter-iOS/ViewModels/AppDelegateViewModel.swift
+++ b/Kickstarter-iOS/ViewModels/AppDelegateViewModel.swift
@@ -258,11 +258,15 @@ public final class AppDelegateViewModel: AppDelegateViewModelType, AppDelegateVi
       .signal
       .mapConst(Notification(name: .ksr_optimizelyClientConfigurationFailed, object: nil))
 
+    let appEnteredBackgroundNotification = self.applicationDidEnterBackgroundProperty.signal
+      .mapConst(Notification(name: .ksr_applicationDidEnterBackground, object: nil))
+
     self.postNotification = Signal.merge(
       currentUserUpdatedNotification,
       configUpdatedNotification,
       optimizelyClientConfiguredNotification,
-      optimizelyClientConfigurationFailedNotification
+      optimizelyClientConfigurationFailedNotification,
+      appEnteredBackgroundNotification
     )
 
     let openUrl = self.applicationOpenUrlProperty.signal.skipNil()

--- a/Kickstarter-iOS/ViewModels/AppDelegateViewModelTests.swift
+++ b/Kickstarter-iOS/ViewModels/AppDelegateViewModelTests.swift
@@ -479,7 +479,7 @@ final class AppDelegateViewModelTests: TestCase {
     )
   }
 
-  func testAppStateEnteringBackground_SendNotification_Sucess() {
+  func testAppStateEnteringBackground_SendNotification_Success() {
     let env = AccessTokenEnvelope(accessToken: "deadbeef", user: User.template)
     AppEnvironment.login(env)
 

--- a/Kickstarter-iOS/ViewModels/AppDelegateViewModelTests.swift
+++ b/Kickstarter-iOS/ViewModels/AppDelegateViewModelTests.swift
@@ -465,7 +465,6 @@ final class AppDelegateViewModelTests: TestCase {
     self.updateCurrentUserInEnvironment.assertValues([env.user])
     self.postNotificationName.assertValues([.ksr_userUpdated])
 
-    self.vm.inputs.applicationDidEnterBackground()
     self.vm.inputs.applicationWillEnterForeground()
     self.scheduler.advance(by: .seconds(5))
 
@@ -477,6 +476,26 @@ final class AppDelegateViewModelTests: TestCase {
     self.updateCurrentUserInEnvironment.assertValues([env.user, env.user])
     self.postNotificationName.assertValues(
       [.ksr_userUpdated, .ksr_userUpdated]
+    )
+  }
+
+  func testAppStateEnteringBackground_SendNotification_Sucess() {
+    let env = AccessTokenEnvelope(accessToken: "deadbeef", user: User.template)
+    AppEnvironment.login(env)
+
+    self.vm.inputs.applicationDidFinishLaunching(
+      application: UIApplication.shared,
+      launchOptions: [:]
+    )
+
+    self.scheduler.advance(by: .seconds(5))
+
+    self.postNotificationName.assertDidNotEmitValue()
+
+    self.vm.inputs.applicationDidEnterBackground()
+    self.scheduler.advance(by: .seconds(5))
+
+    self.postNotificationName.assertValues([.ksr_applicationDidEnterBackground]
     )
   }
 

--- a/Kickstarter-iOS/Views/Cells/HTML Parser/ExternalSourceViewElementCell.swift
+++ b/Kickstarter-iOS/Views/Cells/HTML Parser/ExternalSourceViewElementCell.swift
@@ -23,6 +23,8 @@ class ExternalSourceViewElementCell: UITableViewCell, ValueCell {
   override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
     super.init(style: style, reuseIdentifier: reuseIdentifier)
 
+    self.delegate = self
+
     self.configureViews()
     self.setupConstraints()
     self.bindStyles()
@@ -42,6 +44,7 @@ class ExternalSourceViewElementCell: UITableViewCell, ValueCell {
       .observeForUI()
       .observeValues { [weak self] htmlText in
         guard let url = URL(string: htmlText) else { return }
+
         let request = URLRequest(url: url)
 
         self?.webView.load(request)
@@ -61,6 +64,7 @@ class ExternalSourceViewElementCell: UITableViewCell, ValueCell {
       }
 
     self.viewModel.outputs.resetWebViewContent
+      .observeForUI()
       .observeValues { [weak self] emptyHTML in
         guard let emptyContentURL = URL(string: emptyHTML) else { return }
 

--- a/Kickstarter-iOS/Views/Cells/HTML Parser/ExternalSourceViewElementCell.swift
+++ b/Kickstarter-iOS/Views/Cells/HTML Parser/ExternalSourceViewElementCell.swift
@@ -41,7 +41,7 @@ class ExternalSourceViewElementCell: UITableViewCell, ValueCell {
         self?.webView.load(request)
       })
       .observeValues { [weak self] htmlText in
-        guard let url = URL(string: htmlText + "?playsline=0") else { return }
+        guard let url = URL(string: htmlText + "?playsinline=0") else { return }
 
         let request = URLRequest(url: url)
 

--- a/Kickstarter-iOS/Views/Cells/HTML Parser/VideoViewElementCell.swift
+++ b/Kickstarter-iOS/Views/Cells/HTML Parser/VideoViewElementCell.swift
@@ -7,6 +7,7 @@ import UIKit
 
 internal protocol VideoViewElementCellPlaybackDelegate: AnyObject {
   func pausePlayback() -> CMTime
+  func isPlaying() -> Bool
 }
 
 class VideoViewElementCell: UITableViewCell, ValueCell {
@@ -115,5 +116,9 @@ class VideoViewElementCell: UITableViewCell, ValueCell {
 extension VideoViewElementCell: VideoViewElementCellPlaybackDelegate {
   func pausePlayback() -> CMTime {
     self.viewModel.inputs.pausePlayback()
+  }
+
+  func isPlaying() -> Bool {
+    self.playerController.player?.timeControlStatus == .playing
   }
 }

--- a/Kickstarter-iOS/Views/Controllers/ProjectPageViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/ProjectPageViewController.swift
@@ -408,8 +408,6 @@ public final class ProjectPageViewController: UIViewController, MessageBannerVie
       .observeValues { [weak self] in
         guard let tableView = self?.tableView else { return }
 
-        var reloadableUpdateIndexPaths = [IndexPath]()
-
         tableView.indexPathsForVisibleRows?.forEach { indexPath in
           if let cell = tableView.cellForRow(at: indexPath) as? VideoViewElementCell,
             let isPlaying = cell.delegate?.isPlaying(),
@@ -420,24 +418,7 @@ public final class ProjectPageViewController: UIViewController, MessageBannerVie
               tableView: tableView,
               indexPath: indexPath
             )
-          } else if let cell = tableView.cellForRow(at: indexPath) as? ExternalSourceViewElementCell {
-            reloadableUpdateIndexPaths.append(indexPath)
-
-            cell.delegate?.resetWebViewContent()
-            cell.delegate?.resetContentHeight()
           }
-        }
-
-        var allowableIndexPaths = [IndexPath]()
-
-        reloadableUpdateIndexPaths.forEach { indexPath in
-          if let _ = tableView.cellForRow(at: indexPath) as? ExternalSourceViewElementCell {
-            allowableIndexPaths.append(indexPath)
-          }
-        }
-
-        tableView.performBatchUpdates {
-          tableView.reloadRows(at: allowableIndexPaths, with: .none)
         }
       }
   }
@@ -737,9 +718,6 @@ extension ProjectPageViewController: UITableViewDelegate {
       let seekTime = cell.delegate?.pausePlayback() {
       self.dataSource
         .updateVideoViewElementSeektime(with: seekTime, tableView: self.tableView, indexPath: indexPath)
-    } else if let cell = cell as? ExternalSourceViewElementCell {
-      cell.delegate?.resetContentHeight()
-      cell.delegate?.resetWebViewContent()
     }
   }
 }

--- a/Kickstarter-iOS/Views/Controllers/ProjectPageViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/ProjectPageViewController.swift
@@ -408,6 +408,8 @@ public final class ProjectPageViewController: UIViewController, MessageBannerVie
       .observeValues { [weak self] in
         guard let tableView = self?.tableView else { return }
 
+        var reloadableUpdateIndexPaths = [IndexPath]()
+
         tableView.indexPathsForVisibleRows?.forEach { indexPath in
           if let cell = tableView.cellForRow(at: indexPath) as? VideoViewElementCell,
             let isPlaying = cell.delegate?.isPlaying(),
@@ -418,7 +420,24 @@ public final class ProjectPageViewController: UIViewController, MessageBannerVie
               tableView: tableView,
               indexPath: indexPath
             )
+          } else if let cell = tableView.cellForRow(at: indexPath) as? ExternalSourceViewElementCell {
+            reloadableUpdateIndexPaths.append(indexPath)
+
+            cell.delegate?.resetWebViewContent()
+            cell.delegate?.resetContentHeight()
           }
+        }
+
+        var allowableIndexPaths = [IndexPath]()
+
+        reloadableUpdateIndexPaths.forEach { indexPath in
+          if let _ = tableView.cellForRow(at: indexPath) as? ExternalSourceViewElementCell {
+            allowableIndexPaths.append(indexPath)
+          }
+        }
+
+        tableView.performBatchUpdates {
+          tableView.reloadRows(at: allowableIndexPaths, with: .none)
         }
       }
   }

--- a/Kickstarter-iOS/Views/Controllers/ProjectPageViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/ProjectPageViewController.swift
@@ -421,6 +421,12 @@ public final class ProjectPageViewController: UIViewController, MessageBannerVie
           }
         }
       }
+
+    self.viewModel.outputs.reloadCampaignData
+      .observeForUI()
+      .observeValues { [weak self] in
+        self?.tableView.reloadData()
+      }
   }
 
   private func prepareToPlayVideoURL(_ url: URL, completionHandler: @escaping (AVPlayer) -> Void) {
@@ -719,6 +725,15 @@ extension ProjectPageViewController: UITableViewDelegate {
       self.dataSource
         .updateVideoViewElementSeektime(with: seekTime, tableView: self.tableView, indexPath: indexPath)
     }
+  }
+
+  public override func viewWillTransition(
+    to size: CGSize,
+    with coordinator: UIViewControllerTransitionCoordinator
+  ) {
+    super.viewWillTransition(to: size, with: coordinator)
+
+    self.viewModel.inputs.viewWillTransition()
   }
 }
 

--- a/Kickstarter-iOS/Views/Controllers/VideoViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/VideoViewController.swift
@@ -37,6 +37,8 @@ public final class VideoViewController: UIViewController {
     self.playButton.addTarget(self, action: #selector(self.playButtonTapped), for: .touchUpInside)
 
     self.viewModel.inputs.viewDidLoad()
+
+    self.setupNotifications()
   }
 
   public override func viewDidAppear(_ animated: Bool) {
@@ -201,6 +203,20 @@ public final class VideoViewController: UIViewController {
     self.playerController.player?.removeObserver(self, forKeyPath: durationKeyPath)
     self.playerController.player?.removeObserver(self, forKeyPath: rateKeyPath)
     self.playerController?.player?.replaceCurrentItem(with: nil)
+  }
+
+  private func setupNotifications() {
+    NotificationCenter.default
+      .addObserver(
+        self,
+        selector: #selector(self.pauseVideo),
+        name: .ksr_applicationDidEnterBackground,
+        object: nil
+      )
+  }
+
+  @objc private func pauseVideo() {
+    self.viewModel.inputs.viewWillDisappear()
   }
 }
 

--- a/Library/Notifications.swift
+++ b/Library/Notifications.swift
@@ -19,12 +19,18 @@ public enum CurrentUserNotifications {
   public static let userUpdated = "CurrentUserNotifications.userUpdated"
 }
 
+public enum AppStateNotifications {
+  public static let didEnterBackground = "AppStateNotifications.didEnterBackground"
+}
+
 public enum UserInfoKeys {
   public static let context = "UserInfoKeys.context"
   public static let viewController = "UserInfoKeys.viewController"
 }
 
 extension Notification.Name {
+  public static let ksr_applicationDidEnterBackground = Notification
+    .Name(rawValue: AppStateNotifications.didEnterBackground)
   public static let ksr_configUpdated = Notification.Name(rawValue: CurrentUserNotifications.configUpdated)
   public static let ksr_dataRequested = Notification.Name(rawValue: CurrentUserNotifications.dataRequested)
   public static let ksr_environmentChanged = Notification.Name(

--- a/Library/ViewModels/HTML Parser/ExternalSourceViewElementCellViewModel.swift
+++ b/Library/ViewModels/HTML Parser/ExternalSourceViewElementCellViewModel.swift
@@ -5,12 +5,6 @@ import ReactiveSwift
 public protocol ExternalSourceViewElementCellViewModelInputs {
   /// Call to configure with a `ExternalSourceViewElement` representing external source element.
   func configureWith(element: ExternalSourceViewElement)
-
-  /// Call to configure with a `WKWebView` with a blank html source string.
-  func resetWebView()
-
-  /// Call to configure with cell with its' contents' height.
-  func toggleContentHeight(_ flag: Bool)
 }
 
 public protocol ExternalSourceViewElementCellViewModelOutputs {
@@ -19,12 +13,6 @@ public protocol ExternalSourceViewElementCellViewModelOutputs {
 
   /// Emits an optional `Int` taken from iframe representing that embedded content's height in a webview.
   var contentHeight: Signal<Int, Never> { get }
-
-  /// Emits a signal to reset the `WKWebView`'s HTML content
-  var resetWebViewContent: Signal<String, Never> { get }
-
-  /// Emits a `Bool` to render the cells' height based on it's content size height.
-  var toggleContentHeight: Signal<Bool, Never> { get }
 }
 
 public protocol ExternalSourceViewElementCellViewModelType {
@@ -58,9 +46,6 @@ public final class ExternalSourceViewElementCellViewModel:
         return SignalProducer(value: contentHeight)
       }
       .skipNil()
-
-    self.resetWebViewContent = self.resetWebViewContentProperty.signal.skipNil()
-    self.toggleContentHeight = self.toggleContentProperty.signal
   }
 
   fileprivate let externalSourceViewElement =
@@ -69,22 +54,8 @@ public final class ExternalSourceViewElementCellViewModel:
     self.externalSourceViewElement.value = element
   }
 
-  fileprivate let resetWebViewContentProperty =
-    MutableProperty<String?>(nil)
-  public func resetWebView() {
-    self.resetWebViewContentProperty.value = "about:blank"
-  }
-
-  fileprivate let toggleContentProperty =
-    MutableProperty<Bool>(false)
-  public func toggleContentHeight(_ flag: Bool) {
-    self.toggleContentProperty.value = flag
-  }
-
   public let contentHeight: Signal<Int, Never>
   public let htmlText: Signal<String, Never>
-  public let resetWebViewContent: Signal<String, Never>
-  public let toggleContentHeight: Signal<Bool, Never>
 
   public var inputs: ExternalSourceViewElementCellViewModelInputs { self }
   public var outputs: ExternalSourceViewElementCellViewModelOutputs { self }

--- a/Library/ViewModels/HTML Parser/ExternalSourceViewElementCellViewModelTests.swift
+++ b/Library/ViewModels/HTML Parser/ExternalSourceViewElementCellViewModelTests.swift
@@ -11,16 +11,12 @@ internal final class ExternalElementSourceViewElementCellViewModelTests: TestCas
   private let expectedContentHeight = 32
   private let htmlText = TestObserver<String, Never>()
   private let contentHeight = TestObserver<Int, Never>()
-  private let resetWebViewContent = TestObserver<String, Never>()
-  private let toggleContentHeight = TestObserver<Bool, Never>()
 
   override func setUp() {
     super.setUp()
 
     self.vm.outputs.htmlText.observe(self.htmlText.observer)
     self.vm.outputs.contentHeight.observe(self.contentHeight.observer)
-    self.vm.outputs.resetWebViewContent.observe(self.resetWebViewContent.observer)
-    self.vm.outputs.toggleContentHeight.observe(self.toggleContentHeight.observer)
   }
 
   func testExternalSourceElementData_Success() {
@@ -33,25 +29,5 @@ internal final class ExternalElementSourceViewElementCellViewModelTests: TestCas
 
     self.htmlText.assertLastValue(self.expectedExternalURLString)
     self.contentHeight.assertLastValue(self.expectedContentHeight)
-  }
-
-  func testToggleContentHeight_Success() {
-    self.toggleContentHeight.assertDidNotEmitValue()
-
-    self.vm.inputs.toggleContentHeight(true)
-
-    self.toggleContentHeight.assertLastValue(true)
-
-    self.vm.inputs.toggleContentHeight(false)
-
-    self.toggleContentHeight.assertLastValue(false)
-  }
-
-  func testResetWebView_Success() {
-    self.resetWebViewContent.assertDidNotEmitValue()
-
-    self.vm.inputs.resetWebView()
-
-    self.resetWebViewContent.assertDidEmitValue()
   }
 }

--- a/Library/ViewModels/ProjectPageViewModel.swift
+++ b/Library/ViewModels/ProjectPageViewModel.swift
@@ -6,6 +6,9 @@ public protocol ProjectPageViewModelInputs {
   /// Call when didSelectRowAt is called on a `ProjectFAQAskAQuestionCell`
   func askAQuestionCellTapped()
 
+  /// Call when `AppDelegate`'s `applicationDidEnterBackground` is triggered.
+  func applicationDidEnterBackground()
+
   /// Call with the project given to the view controller.
   func configureWith(projectOrParam: Either<Project, Param>, refTag: RefTag?)
 
@@ -94,6 +97,9 @@ public protocol ProjectPageViewModelOutputs {
 
   /// Emits a `Bool` to hide the navigation bar.
   var navigationBarIsHidden: Signal<Bool, Never> { get }
+
+  /// Emits a signal when the app is no longer being actively used to pause any playing media.
+  var pauseMedia: Signal<Void, Never> { get }
 
   /// Emits when the navigation stack should be popped to the root view controller.
   var popToRootViewController: Signal<(), Never> { get }
@@ -383,11 +389,18 @@ public final class ProjectPageViewModel: ProjectPageViewModelType, ProjectPageVi
 
         return (project, refTag, updatedValues)
       }
+
+    self.pauseMedia = self.applicationDidEnterBackgroundProperty.signal
   }
 
   fileprivate let askAQuestionCellTappedProperty = MutableProperty(())
   public func askAQuestionCellTapped() {
     self.askAQuestionCellTappedProperty.value = ()
+  }
+
+  fileprivate let applicationDidEnterBackgroundProperty = MutableProperty(())
+  public func applicationDidEnterBackground() {
+    self.applicationDidEnterBackgroundProperty.value = ()
   }
 
   private let configDataProperty = MutableProperty<(Either<Project, Param>, RefTag?)?>(nil)
@@ -491,6 +504,7 @@ public final class ProjectPageViewModel: ProjectPageViewModelType, ProjectPageVi
   public let goToRewards: Signal<(Project, RefTag?), Never>
   public let goToUpdates: Signal<Project, Never>
   public let navigationBarIsHidden: Signal<Bool, Never>
+  public let pauseMedia: Signal<Void, Never>
   public let popToRootViewController: Signal<(), Never>
   public let presentMessageDialog: Signal<Project, Never>
   public let precreateVideoURLs: Signal<(VideoViewElement, IndexPath), Never>


### PR DESCRIPTION
# 📲 What

A few minor issues were found in testing the external sources. Namely:
- media playback should pause when scrolled away or the app is backgrounded.
- sometimes on iPad/iPhone, playing an external source then rotating the device and exiting full screen causes the player to float above a part of the page. Persists even if scrolled back to its' original cell. Need to ensure rotation works for inline/fullscreen webview that is playing content and resumes its correct place in the table view.

# 🤔 Why

Just some odds and ends need fixing.

# 🛠 How

Right now we're using a new notification called `ksr_applicationDidEnterBackground` that will alert the `VideoViewController` and the `ProjectPageViewController` if the app enters a background state. Added functionality to pause playing `AVPlayer` content, but that wasn't a huge issue as it seems as though the media would stop automatically when the app was backgrounded anyway.

Update: Due to the number of elements we have to keep track of (there's hundreds), its' impossible to "adjust" the source code of the web view for each element, as each element will generate its' own content and player. Made some generic improvements to ensure video and audio plays full screen, (that prevents the user scrolling way content while media is playing), but overall we have to accept that scrolled away content will continue to play until user stops it. Audio will play when backgrounded, video will not play when backgrounded.

For the elements hovering out place when resume from fullscreen, it was because the table view data was out of place when the orientation change occured. This can be fixed by calling `reloadData` on the table view, when `viewWillTransition` delegate is called on the `ProjectPageViewController`. So that being the fix, we isolated the reload data call to the campaign tab only.

# 👀 See

Before 🐛

https://user-images.githubusercontent.com/4282741/157765975-f50ea915-356d-488b-83d7-cf588f5c586c.mp4

After 🦋

https://user-images.githubusercontent.com/4282741/157766315-b08effd7-3d31-4517-bbab-1e4126d103cd.mp4

# ✅ Acceptance criteria

- [x] Ensure the two things mentioned in the "What" section are no longer occuring.
       - Ignore the pause functionality, because fixing the pause is a difficult task that would require building a custom player, which is large task on its' own just due to the number of external sources we allow. Basically anything that plays on the web, is playable in `WKWebView`, so managing the state of _any_ external source is something that can't be tackled here until we at least know which sources are testable.

# ⏰ TODO

- [x] Write tests.
- [x] Fix fullscreen rotation and resume issues on webview. No hovering elements out of place.
