### PR TITLE
[NTV-428] Add Thumbnail Images to Video Player Component

### DIFF
--- a/Kickstarter-iOS/DataSources/ProjectPageViewControllerDataSourceTests.swift
+++ b/Kickstarter-iOS/DataSources/ProjectPageViewControllerDataSourceTests.swift
@@ -893,7 +893,7 @@ final class ProjectPageViewControllerDataSourceTests: XCTestCase {
         story: self.storyViewableElements,
         minimumPledgeAmount: 1
       )
-    let camera = UIImage(named: "camera")!
+    let camera = UIImage(systemName: "camera")!
 
     withEnvironment(currentUser: .template) {
       self.dataSource.load(

--- a/Kickstarter-iOS/DataSources/ProjectPageViewControllerDataSourceTests.swift
+++ b/Kickstarter-iOS/DataSources/ProjectPageViewControllerDataSourceTests.swift
@@ -796,6 +796,7 @@ final class ProjectPageViewControllerDataSourceTests: XCTestCase {
         story: self.storyViewableElements,
         minimumPledgeAmount: 1
       )
+    let image = UIImage(systemName: "camera")!
 
     withEnvironment(currentUser: .template) {
       guard let videoViewElement = self.storyViewableElements.htmlViewElements[3] as? VideoViewElement
@@ -810,7 +811,7 @@ final class ProjectPageViewControllerDataSourceTests: XCTestCase {
         section: ProjectPageViewControllerDataSource.Section.campaign.rawValue
       )
 
-      self.dataSource.preloadCampaignVideoViewElement(videoViewElement, player: AVPlayer())
+      self.dataSource.preloadCampaignVideoViewElement(videoViewElement, player: AVPlayer(), image: image)
 
       self.dataSource.load(
         navigationSection: .campaign,
@@ -821,7 +822,7 @@ final class ProjectPageViewControllerDataSourceTests: XCTestCase {
 
       guard let updatedItem = self.dataSource
         .items(in: expectedIndexPath.section)[expectedIndexPath.row] as? (
-          value: (VideoViewElement, AVPlayer),
+          value: (VideoViewElement, AVPlayer, UIImage),
           reusableId: String
         ) else {
         XCTFail("video view element should exist")
@@ -833,6 +834,7 @@ final class ProjectPageViewControllerDataSourceTests: XCTestCase {
       XCTAssertEqual(updatedItem.value.0.thumbnailURLString, "https://thumbnail.com")
       XCTAssertEqual(updatedItem.value.0.seekPosition, .zero)
       XCTAssertNotNil(updatedItem.value.1)
+      XCTAssertNotNil(updatedItem.value.2)
     }
   }
 
@@ -891,6 +893,7 @@ final class ProjectPageViewControllerDataSourceTests: XCTestCase {
         story: self.storyViewableElements,
         minimumPledgeAmount: 1
       )
+    let camera = UIImage(named: "camera")!
 
     withEnvironment(currentUser: .template) {
       self.dataSource.load(
@@ -918,6 +921,7 @@ final class ProjectPageViewControllerDataSourceTests: XCTestCase {
         .updateVideoViewElementWith(
           videoViewElementWithNoPlayer!.0,
           player: AVPlayer(),
+          thumbnailImage: camera,
           indexPath: videoViewElementWithNoPlayer!.1
         )
 
@@ -967,6 +971,7 @@ final class ProjectPageViewControllerDataSourceTests: XCTestCase {
         .updateVideoViewElementWith(
           videoViewElementWithNoPlayer!.0,
           player: AVPlayer(),
+          thumbnailImage: nil,
           indexPath: videoViewElementWithNoPlayer!.1
         )
 
@@ -977,7 +982,10 @@ final class ProjectPageViewControllerDataSourceTests: XCTestCase {
       )
       guard let updatedItem = self.dataSource
         .items(in: videoViewIndexPath
-          .section)[videoViewIndexPath.row] as? (value: (VideoViewElement, AVPlayer), reusableId: String)
+          .section)[videoViewIndexPath.row] as? (
+          value: (VideoViewElement, AVPlayer, UIImage?),
+            reusableId: String
+          )
       else {
         XCTFail("video view element should exist")
 

--- a/Kickstarter-iOS/Views/Cells/HTML Parser/VideoViewElementCell.swift
+++ b/Kickstarter-iOS/Views/Cells/HTML Parser/VideoViewElementCell.swift
@@ -76,8 +76,11 @@ class VideoViewElementCell: UITableViewCell, ValueCell {
 
         if let contentOverlayView = strongSelf.playerController.contentOverlayView {
           let imageView = UIImageView()
-
           imageView.image = image
+
+          _ = imageView
+            |> thumbnailImageViewStyle
+            |> \.isUserInteractionEnabled .~ false
 
           _ = (imageView, contentOverlayView)
             |> ksr_addSubviewToParent()

--- a/Library/Styles/HTMLViewElementStyles.swift
+++ b/Library/Styles/HTMLViewElementStyles.swift
@@ -27,3 +27,11 @@ public let imageViewStyle: ImageViewStyle = { imageView in
     |> \.contentMode .~ .scaleAspectFit
     |> ignoresInvertColorsImageViewStyle
 }
+
+public let thumbnailImageViewStyle: ImageViewStyle = { imageView in
+  imageView
+    |> \.clipsToBounds .~ true
+    |> \.backgroundColor .~ .ksr_black
+    |> \.contentMode .~ .scaleAspectFit
+    |> ignoresInvertColorsImageViewStyle
+}

--- a/Library/ViewModels/HTML Parser/VideoViewElementCellViewModel.swift
+++ b/Library/ViewModels/HTML Parser/VideoViewElementCellViewModel.swift
@@ -4,8 +4,8 @@ import Prelude
 import ReactiveSwift
 
 public protocol VideoViewElementCellViewModelInputs {
-  /// Call to configure with a `VideoViewElement` representing raw video view with an optional `AVPlayer` if its ready with its asset.
-  func configureWith(element: VideoViewElement, player: AVPlayer?)
+  /// Call to configure with a `VideoViewElement` representing raw video view with an optional `AVPlayer` and `UIImage`` if its ready with its asset.
+  func configureWith(element: VideoViewElement, player: AVPlayer?, thumbnailImage: UIImage?)
 
   /// Call to send a pause signal to `AVPlayer` to pause the playing video and return a seek time.
   func pausePlayback() -> CMTime
@@ -17,6 +17,9 @@ public protocol VideoViewElementCellViewModelInputs {
 public protocol VideoViewElementCellViewModelOutputs {
   /// Emits a signal to pause playback of video
   var pauseVideo: Signal<Void, Never> { get }
+
+  /// Emits an optional `UIImage` that is the thumbnail image for the video.
+  var thumbnailImage: Signal<UIImage, Never> { get }
 
   /// Emits an optional `AVPlayer` with an `AVPlayerItem` for video view with a preset seektime if the element contained one.
   var videoItem: Signal<AVPlayer, Never> { get }
@@ -33,7 +36,7 @@ public final class VideoViewElementCellViewModel:
   // MARK: Initializers
 
   public init() {
-    self.videoItem = self.videoViewElementWithPlayer.signal
+    self.videoItem = self.videoViewElementWithPlayerAndThumbnailProperty.signal
       .switchMap { videoElementWithPlayer -> SignalProducer<AVPlayer?, Never> in
         guard let player = videoElementWithPlayer?.player else {
           return SignalProducer(value: nil)
@@ -49,6 +52,16 @@ public final class VideoViewElementCellViewModel:
       .skipNil()
 
     self.pauseVideo = self.pausePlaybackProperty.signal.ignoreValues()
+    self.thumbnailImage = self.videoViewElementWithPlayerAndThumbnailProperty.signal
+      .skipNil()
+      .switchMap { (element, _, thumbnailImage) -> SignalProducer<UIImage?, Never> in
+        guard element.seekPosition == .zero else {
+          return SignalProducer(value: nil)
+        }
+
+        return SignalProducer(value: thumbnailImage)
+      }
+      .skipNil()
   }
 
   fileprivate let pausePlaybackProperty = MutableProperty<Void>(())
@@ -63,14 +76,15 @@ public final class VideoViewElementCellViewModel:
     self.seekTimeProperty.value = seekTime
   }
 
-  fileprivate let videoViewElementWithPlayer =
-    MutableProperty<(element: VideoViewElement, player: AVPlayer?)?>(nil)
-  public func configureWith(element: VideoViewElement, player: AVPlayer?) {
-    self.videoViewElementWithPlayer.value = (element, player)
+  fileprivate let videoViewElementWithPlayerAndThumbnailProperty =
+    MutableProperty<(element: VideoViewElement, player: AVPlayer?, thumbnailImage: UIImage?)?>(nil)
+  public func configureWith(element: VideoViewElement, player: AVPlayer?, thumbnailImage: UIImage?) {
+    self.videoViewElementWithPlayerAndThumbnailProperty.value = (element, player, thumbnailImage)
   }
 
   public let pauseVideo: Signal<Void, Never>
   public let videoItem: Signal<AVPlayer, Never>
+  public let thumbnailImage: Signal<UIImage, Never>
 
   public var inputs: VideoViewElementCellViewModelInputs { self }
   public var outputs: VideoViewElementCellViewModelOutputs { self }

--- a/Library/ViewModels/HTML Parser/VideoViewElementCellViewModelTests.swift
+++ b/Library/ViewModels/HTML Parser/VideoViewElementCellViewModelTests.swift
@@ -11,6 +11,7 @@ internal final class VideoViewElementCellViewModelTests: TestCase {
 
   private let pauseVideo = TestObserver<Void, Never>()
   private let videoItem = TestObserver<AVPlayer, Never>()
+  private let thumbnailImage = TestObserver<UIImage, Never>()
 
   override func setUp() {
     super.setUp()
@@ -19,7 +20,7 @@ internal final class VideoViewElementCellViewModelTests: TestCase {
     self.vm.outputs.videoItem.observe(self.videoItem.observer)
   }
 
-  func testImageViewElementData_Success() {
+  func testVideoViewElementData_Success() {
     let expectedTime = CMTime(
       seconds: 123.4,
       preferredTimescale: CMTimeScale(1)
@@ -33,9 +34,25 @@ internal final class VideoViewElementCellViewModelTests: TestCase {
       seekPosition: expectedTime
     )
 
-    self.vm.inputs.configureWith(element: videoViewElement, player: expectedPlayer)
+    self.vm.inputs.configureWith(element: videoViewElement, player: expectedPlayer, thumbnailImage: nil)
 
     self.videoItem.assertLastValue(expectedPlayer)
+  }
+
+  func testThumbnailImage_Success() {
+    let thumbnailImage = UIImage(systemName: "camera")!
+    let expectedPlayer = AVPlayer()
+
+    let videoViewElement = VideoViewElement(
+      sourceURLString: "https://video.com",
+      thumbnailURLString: "https://thumbnail.com",
+      seekPosition: .zero
+    )
+
+    self.vm.inputs
+      .configureWith(element: videoViewElement, player: expectedPlayer, thumbnailImage: thumbnailImage)
+
+    self.thumbnailImage.assertLastValue(thumbnailImage)
   }
 
   func testPausePlaybackDataAndRecordSeektime_Success() {
@@ -52,7 +69,7 @@ internal final class VideoViewElementCellViewModelTests: TestCase {
       seekPosition: expectedTime
     )
 
-    self.vm.inputs.configureWith(element: videoViewElement, player: expectedPlayer)
+    self.vm.inputs.configureWith(element: videoViewElement, player: expectedPlayer, thumbnailImage: nil)
 
     self.pauseVideo.assertDidNotEmitValue()
 

--- a/Library/ViewModels/HTML Parser/VideoViewElementCellViewModelTests.swift
+++ b/Library/ViewModels/HTML Parser/VideoViewElementCellViewModelTests.swift
@@ -18,6 +18,7 @@ internal final class VideoViewElementCellViewModelTests: TestCase {
 
     self.vm.outputs.pauseVideo.observe(self.pauseVideo.observer)
     self.vm.outputs.videoItem.observe(self.videoItem.observer)
+    self.vm.outputs.thumbnailImage.observe(self.thumbnailImage.observer)
   }
 
   func testVideoViewElementData_Success() {

--- a/Library/ViewModels/ProjectPageViewModel.swift
+++ b/Library/ViewModels/ProjectPageViewModel.swift
@@ -119,7 +119,7 @@ public protocol ProjectPageViewModelOutputs {
   /// Emits `[URL]` and `IndexPath` when the project has campaign data to download for a row
   var prefetchImageURLs: Signal<([URL], IndexPath), Never> { get }
 
-  /// Emits `[ImageViewElement]` when the project has campaign data to download for a row as soon as the urls are available.
+  /// Emits `[ImageViewElement]` when the project has campaign data to download for an image row as soon as the urls are available.
   var prefetchImageURLsOnFirstLoad: Signal<[ImageViewElement], Never> { get }
 
   /// Emits a signal when an orientation change happens if the currently selected tab is campaign.


### PR DESCRIPTION
# 📲 What and 🤔 Why

To gain parity with Android and Web on the player thumbnail, we need to add a thumbnail image to each native video player.

# 🛠 How

Use an observer on the `AVPlayer` to listen for the `timeControlStatus` property which changes when any change to the player occurs. Only needs to happen once and the observer is removed along with the thumbnail image.

Loads images from the network asynchronously, just using the same technique as image urls from `ImageViewElement`.
If the thumbnail gets loaded in time, the cell get has a thumbnail, if not it will be there when the cell reloads (only shows if seek position is 0)

# 👀 See

Trello, screenshots, external resources?

Before 🐛

https://user-images.githubusercontent.com/4282741/158492040-fca08901-d158-4fc9-98ed-05f1867de22f.mp4

After 🦋

https://user-images.githubusercontent.com/4282741/158491841-2a7d326c-785e-4172-b16f-5a4883d3fb02.mp4


# ✅ Acceptance criteria

- [x] Thumbnail for videos appears and then disappears when playback begins/fullscreened/paused.

# ⏰ TODO

- [x] Cache image url and recieve it with the player, optionally, if its' ready in time. (Both prefetch and first load)
- [x] Write any tests.
