### PR TITLE
[NTV-341] Image Scale Gap Fix

### DIFF
--- a/Kickstarter-iOS/Views/Cells/HTML Parser/ImageViewElementCell.swift
+++ b/Kickstarter-iOS/Views/Cells/HTML Parser/ImageViewElementCell.swift
@@ -58,15 +58,16 @@ class ImageViewElementCell: UITableViewCell, ValueCell {
         self?.resetImageView()
       })
       .observeValues { [weak self] image in
-        guard let viewableImage = image else { return }
+        guard let strongSelf = self,
+          let viewableImage = image else { return }
 
         var newScale: CGFloat = 1.0
-        let maxWidth = UIScreen.main.bounds.width - Styles.grid(3)
+        let maxWidth = strongSelf.contentView.bounds.size.width - Styles.grid(6)
         let currentWidth = viewableImage.size.width
         let currentHeight = viewableImage.size.height
 
         if currentWidth <= maxWidth {
-          self?.storyImageView.setImageWith(viewableImage, scaledImageSize: viewableImage.size)
+          strongSelf.storyImageView.setImageWith(viewableImage, scaledImageSize: viewableImage.size)
         } else {
           newScale = currentWidth / maxWidth
           let newSize = CGSize(
@@ -77,13 +78,13 @@ class ImageViewElementCell: UITableViewCell, ValueCell {
 
           switch viewableImage.sd_imageFormat {
           case .GIF:
-            self?.storyImageView.setImageWith(viewableImage, scaledImageSize: scaledImage.size)
+            strongSelf.storyImageView.setImageWith(viewableImage, scaledImageSize: scaledImage.size)
           default:
-            self?.storyImageView.setImageWith(scaledImage, scaledImageSize: scaledImage.size)
+            strongSelf.storyImageView.setImageWith(scaledImage, scaledImageSize: scaledImage.size)
           }
         }
 
-        self?.storyImageView.invalidateIntrinsicContentSize()
+        strongSelf.storyImageView.invalidateIntrinsicContentSize()
       }
   }
 


### PR DESCRIPTION
# 📲 What 🤔 Why

Quick fix to the images ticket to resolve a gap in image scaling.

# 🛠 How

After a little investigation, realized the `contentView` `margins` account for `Style(6)` in total, was previously using `Style(3)` as max width of image.

# 👀 See

| Before 🐛 | After 🦋 |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/4282741/158881106-ea832ed3-85bb-431a-83e4-63665caa3425.png" width="300"> | <img src="https://user-images.githubusercontent.com/4282741/158880656-980685bb-935d-4784-a030-46ad872fd792.png" width="300"> |

# ✅ Acceptance criteria

- [x] Images above captions and between other images do not show extra padding. (there's about 0.5 pixel gap, which is pretty much a rounding error, so ignoring it.)
