### PR TITLE
[NTV-453] Overview Tab Video Pause When Tabs Are Switched

### DIFF
--- a/Kickstarter-iOS/Views/Cells/ProjectPamphletMainCell.swift
+++ b/Kickstarter-iOS/Views/Cells/ProjectPamphletMainCell.swift
@@ -363,6 +363,7 @@ internal final class ProjectPamphletMainCell: UITableViewCell, ValueCell {
 
     self.delegate?.projectPamphletMainCell(self, addChildController: vc)
     self.videoController = vc
+    self.videoController?.playbackDelegate = vc
   }
 
   @objc fileprivate func readMoreButtonTapped() {
@@ -383,5 +384,11 @@ extension ProjectPamphletMainCell: VideoViewControllerDelegate {
   internal func videoViewControllerDidStart(_ controller: VideoViewController) {
     self.delegate?.videoViewControllerDidStart(controller)
     self.viewModel.inputs.videoDidStart()
+  }
+}
+
+extension ProjectPamphletMainCell: VideoViewControllerPlaybackDelegate {
+  func pauseVideoPlayback() {
+    self.videoController?.playbackDelegate?.pauseVideoPlayback()
   }
 }

--- a/Kickstarter-iOS/Views/Controllers/VideoViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/VideoViewController.swift
@@ -15,6 +15,7 @@ public protocol VideoViewControllerDelegate: AnyObject {
 
 public final class VideoViewController: UIViewController {
   internal weak var delegate: VideoViewControllerDelegate?
+  internal weak var playbackDelegate: VideoViewControllerPlaybackDelegate?
   fileprivate let viewModel: VideoViewModelType = VideoViewModel()
   fileprivate var playerController: AVPlayerViewController!
   fileprivate var timeObserver: Any?
@@ -223,4 +224,12 @@ public final class VideoViewController: UIViewController {
 // Helper function inserted by Swift 4.2 migrator.
 private func convertFromAVAudioSessionCategory(_ input: AVAudioSession.Category) -> String {
   return input.rawValue
+}
+
+extension VideoViewController: VideoViewControllerPlaybackDelegate {
+  func pauseVideoPlayback() {
+    if self.playerController.player?.timeControlStatus == .playing {
+      self.playerController.player?.pause()
+    }
+  }
 }


### PR DESCRIPTION
# 📲 What

A bug was found when the overview tabs' video was playing and the tab was switched.

# 🤔 Why

Don't want a constantly playing video when the user is focused on another part of the page.

# 🛠 How

Normally our `VideoViewControllerDelegate` works outward from the `VideoViewController` within the `ProjectPamphletMainCell` to the view controller and then the navigation bar, passing along the status of the video playback.

So we can't communicate down to the cell using the same delegate. We need to do that because `ProjectPageViewController` has the signal that is updated when the tabs are changed.

`VideoViewControllerPlaybackDelegate` calls down to the cell's video play to pause if the tabs are switched away from the overview tab.

# 👀 See

Before 🐛

https://user-images.githubusercontent.com/4282741/159797822-fc06678d-3888-4c79-a95d-7eadd62d2dbb.mp4

After 🦋

https://user-images.githubusercontent.com/4282741/159797810-4803246a-8e03-4c41-8f5a-260ed67b42c1.mp4

# ✅ Acceptance criteria

- [x] Ensure switching tabs pauses the video playback from occurring on a playing video in the overview tab.
