### PR TITLE
[NTV-452] Ensure Images With No Caption Action A Clickable Link

### DIFF
--- a/Kickstarter-iOS/DataSources/ProjectPageViewControllerDataSource.swift
+++ b/Kickstarter-iOS/DataSources/ProjectPageViewControllerDataSource.swift
@@ -387,6 +387,24 @@ internal final class ProjectPageViewControllerDataSource: ValueCellDataSource {
     return false
   }
 
+  internal func imageViewElementURL(tableView: UITableView,
+                                    indexPath: IndexPath) -> URL? {
+    let section = ProjectPageViewControllerDataSource.Section.campaign
+
+    guard indexPath.section == section.rawValue else { return nil }
+
+    if self.numberOfSections(in: tableView) > section.rawValue,
+      self.numberOfItems(in: section.rawValue) > indexPath.row,
+      let (imageViewElement, _) = self.items(in: section.rawValue)[indexPath.row]
+      .value as? (ImageViewElement, UIImage?),
+      let urlString = imageViewElement.href,
+      let url = URL(string: urlString) {
+      return url
+    }
+
+    return nil
+  }
+
   internal func videoViewElementWithNoPlayer(
     tableView: UITableView,
     indexPath: IndexPath,

--- a/Kickstarter-iOS/DataSources/ProjectPageViewControllerDataSourceTests.swift
+++ b/Kickstarter-iOS/DataSources/ProjectPageViewControllerDataSourceTests.swift
@@ -884,6 +884,53 @@ final class ProjectPageViewControllerDataSourceTests: XCTestCase {
     }
   }
 
+  func testCampaign_ImageViewElementURL_Success() {
+    let project = Project.template
+      |> \.extendedProjectProperties .~ ExtendedProjectProperties(
+        environmentalCommitments: [],
+        faqs: [],
+        risks: "",
+        story: self.storyViewableElements,
+        minimumPledgeAmount: 1
+      )
+
+    withEnvironment(currentUser: .template) {
+      self.dataSource.load(
+        navigationSection: .campaign,
+        project: project,
+        refTag: nil,
+        isExpandedStates: nil
+      )
+
+      let textViewIndexPath = IndexPath(
+        row: 1,
+        section: ProjectPageViewControllerDataSource.Section.campaign
+          .rawValue
+      )
+
+      let textViewElementURL = self.dataSource.imageViewElementURL(
+        tableView: self.tableView,
+        indexPath: textViewIndexPath
+      )
+
+      XCTAssertNil(textViewElementURL)
+
+      let imageViewIndexPath = IndexPath(
+        row: 2,
+        section: ProjectPageViewControllerDataSource.Section.campaign
+          .rawValue
+      )
+
+      let imageViewElementURL = self.dataSource.imageViewElementURL(
+        tableView: self.tableView,
+        indexPath: imageViewIndexPath
+      )!
+      let url = URL(string: "https://href.com")!
+
+      XCTAssertEqual(imageViewElementURL, url)
+    }
+  }
+
   func testCampaign_VideoViewElementWithNoPlayer_Updated_Success() {
     let project = Project.template
       |> \.extendedProjectProperties .~ ExtendedProjectProperties(

--- a/Kickstarter-iOS/Views/Controllers/ProjectPageViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/ProjectPageViewController.swift
@@ -365,6 +365,12 @@ public final class ProjectPageViewController: UIViewController, MessageBannerVie
         self?.goToUpdates(project: $0)
       }
 
+    self.viewModel.outputs.goToURL
+      .observeForControllerAction()
+      .observeValues { url in
+        UIApplication.shared.open(url)
+      }
+
     self.viewModel.outputs.prefetchImageURLs
       .observeValues { [weak self] urls, indexPath in
         self?.prefetchImageDataAndUpdateWith(indexPath, imageUrls: urls)
@@ -774,7 +780,7 @@ extension ProjectPageViewController: ProjectNavigationSelectorViewDelegate {
 // MARK: - UITableViewDelegate
 
 extension ProjectPageViewController: UITableViewDelegate {
-  public func tableView(_: UITableView, didSelectRowAt indexPath: IndexPath) {
+  public func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
     switch indexPath.section {
     case ProjectPageViewControllerDataSource.Section.overviewSubpages.rawValue:
       if self.dataSource.indexPathIsCommentsSubpage(indexPath) {
@@ -787,6 +793,10 @@ extension ProjectPageViewController: UITableViewDelegate {
     case ProjectPageViewControllerDataSource.Section.faqs.rawValue:
       let values = self.dataSource.isExpandedValuesForFAQsSection() ?? []
       self.viewModel.inputs.didSelectFAQsRowAt(row: indexPath.row, values: values)
+    case ProjectPageViewControllerDataSource.Section.campaign.rawValue:
+      if let url = self.dataSource.imageViewElementURL(tableView: tableView, indexPath: indexPath) {
+        self.viewModel.inputs.didSelectCampaignImageLink(url: url)
+      }
     default:
       return
     }

--- a/Library/ViewModels/ProjectPageViewModel.swift
+++ b/Library/ViewModels/ProjectPageViewModel.swift
@@ -18,6 +18,9 @@ public protocol ProjectPageViewModelInputs {
   /// Call with the `Int` (index) of the cell selected and the existing values (`[Bool]`) in the data source
   func didSelectFAQsRowAt(row: Int, values: [Bool])
 
+  /// Call with the `URL` of the `ImageViewElement` cell selected in the Campaign section of the data source.
+  func didSelectCampaignImageLink(url: URL)
+
   /// Call when the navigation bar should be hidden/shown.
   func showNavigationBar(_ flag: Bool)
 
@@ -97,6 +100,9 @@ public protocol ProjectPageViewModelOutputs {
 
   /// Emits a project and refTag to be used to navigate to the reward selection screen.
   var goToRewards: Signal<(Project, RefTag?), Never> { get }
+
+  /// Emits a URL that will be opened by an external Safari browser.
+  var goToURL: Signal<URL, Never> { get }
 
   /// Emits a `Bool` to hide the navigation bar.
   var navigationBarIsHidden: Signal<Bool, Never> { get }
@@ -401,6 +407,8 @@ public final class ProjectPageViewModel: ProjectPageViewModelType, ProjectPageVi
       .takeWhen(self.viewWillTransitionProperty.signal)
       .filter { NavigationSection(rawValue: $0) == .campaign }
       .ignoreValues()
+
+    self.goToURL = self.didSelectCampaignImageLinkProperty.signal.skipNil()
   }
 
   fileprivate let askAQuestionCellTappedProperty = MutableProperty(())
@@ -426,6 +434,11 @@ public final class ProjectPageViewModel: ProjectPageViewModelType, ProjectPageVi
   fileprivate let didSelectFAQsRowAtProperty = MutableProperty<(Int, [Bool])?>(nil)
   public func didSelectFAQsRowAt(row: Int, values: [Bool]) {
     self.didSelectFAQsRowAtProperty.value = (row, values)
+  }
+
+  fileprivate let didSelectCampaignImageLinkProperty = MutableProperty<(URL)?>(nil)
+  public func didSelectCampaignImageLink(url: URL) {
+    self.didSelectCampaignImageLinkProperty.value = url
   }
 
   fileprivate let showNavigationBarProperty = MutableProperty<Bool>(false)
@@ -518,6 +531,7 @@ public final class ProjectPageViewModel: ProjectPageViewModelType, ProjectPageVi
   public let goToManagePledge: Signal<ManagePledgeViewParamConfigData, Never>
   public let goToRewards: Signal<(Project, RefTag?), Never>
   public let goToUpdates: Signal<Project, Never>
+  public let goToURL: Signal<URL, Never>
   public let navigationBarIsHidden: Signal<Bool, Never>
   public let pauseMedia: Signal<Void, Never>
   public let popToRootViewController: Signal<(), Never>

--- a/Library/ViewModels/ProjectPageViewModelTests.swift
+++ b/Library/ViewModels/ProjectPageViewModelTests.swift
@@ -40,6 +40,7 @@ final class ProjectPageViewModelTests: TestCase {
   private let goToRewardsProject = TestObserver<Project, Never>()
   private let goToRewardsRefTag = TestObserver<RefTag?, Never>()
   private let goToUpdates = TestObserver<Project, Never>()
+  private let goToURL = TestObserver<URL, Never>()
   private let navigationBarIsHidden = TestObserver<Bool, Never>()
   private let pauseMedia = TestObserver<(), Never>()
   private let popToRootViewController = TestObserver<(), Never>()
@@ -104,6 +105,7 @@ final class ProjectPageViewModelTests: TestCase {
     self.vm.outputs.goToRewards.map(first).observe(self.goToRewardsProject.observer)
     self.vm.outputs.goToRewards.map(second).observe(self.goToRewardsRefTag.observer)
     self.vm.outputs.goToUpdates.observe(self.goToUpdates.observer)
+    self.vm.outputs.goToURL.observe(self.goToURL.observer)
     self.vm.outputs.navigationBarIsHidden.observe(self.navigationBarIsHidden.observer)
     self.vm.outputs.pauseMedia.observe(self.pauseMedia.observer)
     self.vm.outputs.popToRootViewController.observe(self.popToRootViewController.observer)
@@ -1766,6 +1768,29 @@ final class ProjectPageViewModelTests: TestCase {
     self.vm.inputs.viewWillTransition()
 
     self.reloadCampaignData.assertDidEmitValue()
+  }
+
+  func testSelectCampaignImageLink_WhenURLAvailable_ReturnsURL_Success() {
+    let url = URL(string: "https://www.kickstarter.com")!
+
+    let project = Project.template
+      |> \.extendedProjectProperties .~ ExtendedProjectProperties(
+        environmentalCommitments: [],
+        faqs: [],
+        risks: "",
+        story: ProjectStoryElements(htmlViewElements: []),
+        minimumPledgeAmount: 1
+      )
+
+    self.vm.inputs.configureWith(projectOrParam: .left(project), refTag: .category)
+
+    self.vm.inputs.viewDidLoad()
+
+    self.goToURL.assertDidNotEmitValue()
+
+    self.vm.inputs.didSelectCampaignImageLink(url: url)
+
+    self.goToURL.assertValue(url)
   }
 
   // MARK: - Functions


### PR DESCRIPTION
# 📲 What 🤔 Why

We found a bug where clicking an image link wouldn't open an external browser as it was doing with a caption.
Found out because the caption was empty text, there was nothing for the user to click on.

# 🛠 How

Ask the data source for the url if it's there for an image. Open it in Safari.

# 👀 See

Before 🐛 

<img src="https://user-images.githubusercontent.com/4282741/159975954-caa3b6c1-d7b7-460a-a172-408951340590.gif" width="300">

After �

<img src="https://user-images.githubusercontent.com/4282741/159975517-b68b310e-8f08-4e73-9b0b-55b7d47e360e.gif" width="300">

# ✅ Acceptance criteria

- [x] Images are clickable, as with this [project](https://www.kickstarter.com/projects/mightyboards/hamlet-the-village-building-game).

# ⏰ TODO

- [x] Write tests
