### PR TITLE
[NTV-532] Navigation Bar Issue Related To iOS 15

### DIFF
--- a/Kickstarter-iOS/Views/Controllers/ProjectPageViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/ProjectPageViewController.swift
@@ -133,9 +133,6 @@ public final class ProjectPageViewController: UIViewController, MessageBannerVie
       return
     }
 
-    // Remove bottom border
-    defaultNavigationBarView.shadowImage = UIImage()
-
     _ = (self.navigationBarView, defaultNavigationBarView)
       |> ksr_addSubviewToParent()
       |> ksr_constrainViewToEdgesInParent()
@@ -290,6 +287,17 @@ public final class ProjectPageViewController: UIViewController, MessageBannerVie
 
   private func bindProjectPageViewModel() {
     self.navigationBarView.rac.hidden = self.viewModel.outputs.navigationBarIsHidden
+
+    self.viewModel.outputs.navigationBarIsHidden
+      .observeForUI()
+      .observeValues { [weak self] _ in
+        guard let defaultNavigationBarView = self?.navigationController?.navigationBar else {
+          return
+        }
+
+        defaultNavigationBarView.standardAppearance.shadowColor = .ksr_white
+        defaultNavigationBarView.scrollEdgeAppearance?.shadowColor = .ksr_white
+      }
 
     self.viewModel.outputs.goToRewards
       .observeForControllerAction()

--- a/Kickstarter.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Kickstarter.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,7 +24,7 @@
       "location" : "https://github.com/kickstarter/Kickstarter-Prelude.git",
       "state" : {
         "branch" : "feature/swift-package",
-        "revision" : "1a9213ebdb0c416a4dbdb494052d0d186ebb3797"
+        "revision" : "b0cec69c19a13088864b52ad1745397f587daec7"
       }
     },
     {

--- a/Library/Styles/BaseStyles.swift
+++ b/Library/Styles/BaseStyles.swift
@@ -180,8 +180,17 @@ private let baseNavigationBarStyle =
     NSAttributedString.Key.foregroundColor: UIColor.ksr_black
   ]
   <> UINavigationBar.lens.isTranslucent .~ false
-  <> UINavigationBar.lens.barTintColor .~ .ksr_white
   <> UINavigationBar.lens.tintColor .~ .ksr_create_700
+  <> UINavigationBar.lens.standardAppearance .~ navigationBarAppearance
+  <> UINavigationBar.lens.scrollEdgeAppearance .~ navigationBarAppearance
+
+private var navigationBarAppearance: UINavigationBarAppearance {
+  let navBarAppearance = UINavigationBarAppearance()
+  navBarAppearance.configureWithOpaqueBackground()
+  navBarAppearance.backgroundColor = .ksr_white
+
+  return navBarAppearance
+}
 
 public let keyboardToolbarStyle: ToolbarStyle = { toolbar -> UIToolbar in
   toolbar


### PR DESCRIPTION
# 📲 What and Why

Due to a recent change building against iOS 15 instead of iOS 14 (using Xcode 13 now) We noticed this issue:

# 🛠 How

It appears according to this [post](https://developer.apple.com/forums/thread/682420), iOS 15 changes the state of the navigation bar to have `standardAppearance` and `barTintColor` is no longer applied. By creating `UINavigationBarAppearance` object, we can set the `UINavigationBar`'s `standardAppearance` and `scrollEdgeAppearance` to be the same value, which sets the `backgroundColor` of the navigation bar to `white`.

# 👀 See

Before 🐛 

https://user-images.githubusercontent.com/4282741/164311439-c353aa9d-6772-4de2-8db2-f60e16ad1bf2.MP4

After 🦋

https://user-images.githubusercontent.com/4282741/164326693-cbb58572-d6a1-4c7f-a8d9-498a2a23ed2b.MP4

# ✅ Acceptance criteria

- [x] Navigation bar always opaque and white background

# ⏰ TODO

- [x] Fix an issue with the navigation bar underline being shown when returning from the campaign web view.
