### PR TITLE
[NTV-343] Fix External Links Not Working Inside Player

### DIFF
--- a/Kickstarter-iOS/Views/Cells/HTML Parser/ExternalSourceViewElementCell.swift
+++ b/Kickstarter-iOS/Views/Cells/HTML Parser/ExternalSourceViewElementCell.swift
@@ -17,6 +17,7 @@ class ExternalSourceViewElementCell: UITableViewCell, ValueCell {
     super.init(style: style, reuseIdentifier: reuseIdentifier)
 
     self.configureViews()
+    self.setupDelegate()
     self.setupConstraints()
     self.bindStyles()
     self.bindViewModel()
@@ -98,9 +99,31 @@ class ExternalSourceViewElementCell: UITableViewCell, ValueCell {
       |> ksr_constrainViewToMarginsInParent()
   }
 
+  private func setupDelegate() {
+    self.webView.uiDelegate = self
+  }
+
   private func setupConstraints() {
     self.contentHeightConstraint = self.webView.heightAnchor.constraint(equalToConstant: .zero)
     self.contentHeightConstraint?.priority = .defaultHigh
     self.contentHeightConstraint?.isActive = true
+  }
+}
+
+extension ExternalSourceViewElementCell: WKUIDelegate {
+  func webView(_: WKWebView,
+               createWebViewWith _: WKWebViewConfiguration,
+               for navigationAction: WKNavigationAction,
+               windowFeatures _: WKWindowFeatures) -> WKWebView? {
+    let canOpenInNewWindow = navigationAction.targetFrame == nil || navigationAction.targetFrame?
+      .isMainFrame == false
+
+    if canOpenInNewWindow,
+      let urlToLoad = navigationAction.request.url,
+      AppEnvironment.current.application.canOpenURL(urlToLoad) {
+      AppEnvironment.current.application.open(urlToLoad, options: [:], completionHandler: nil)
+    }
+
+    return nil
   }
 }

--- a/Kickstarter-iOS/Views/Cells/HTML Parser/ExternalSourceViewElementCell.swift
+++ b/Kickstarter-iOS/Views/Cells/HTML Parser/ExternalSourceViewElementCell.swift
@@ -7,9 +7,21 @@ import WebKit
 class ExternalSourceViewElementCell: UITableViewCell, ValueCell {
   // MARK: Properties
 
-  private lazy var webView = WKWebView(frame: .zero, configuration: WKWebViewConfiguration())
-  private var contentHeightConstraint: NSLayoutConstraint?
+  private lazy var webView: WKWebView = {
+    let configuration = WKWebViewConfiguration()
+    configuration.allowsInlineMediaPlayback = true
+    configuration.suppressesIncrementalRendering = true
+    configuration.applicationNameForUserAgent = "Kickstarter-iOS"
+
+    let webView = WKWebView(frame: .zero, configuration: configuration)
+
+    webView.customUserAgent = Service.userAgent
+
+    return webView
+  }()
+
   private let viewModel: ExternalSourceViewElementCellViewModelType = ExternalSourceViewElementCellViewModel()
+  private var contentHeightConstraint: NSLayoutConstraint?
 
   // MARK: Initializers
 
@@ -42,7 +54,7 @@ class ExternalSourceViewElementCell: UITableViewCell, ValueCell {
         self?.webView.load(request)
       })
       .observeValues { [weak self] htmlText in
-        guard let url = URL(string: htmlText + "?playsinline=0") else { return }
+        guard let url = URL(string: htmlText + "?playsinline=1") else { return }
 
         let request = URLRequest(url: url)
 
@@ -89,11 +101,6 @@ class ExternalSourceViewElementCell: UITableViewCell, ValueCell {
   }
 
   private func configureViews() {
-    self.webView.configuration.suppressesIncrementalRendering = true
-    self.webView.configuration.allowsInlineMediaPlayback = false
-    self.webView.configuration.applicationNameForUserAgent = "Kickstarter-iOS"
-    self.webView.customUserAgent = Service.userAgent
-
     _ = (self.webView, self.contentView)
       |> ksr_addSubviewToParent()
       |> ksr_constrainViewToMarginsInParent()


### PR DESCRIPTION
# 📲 What

We found in the latest beta (16505550) a host of issues related to links to being activated from the player. Turned out to be fairly simple fix based on this [post](https://developer.apple.com/forums/thread/117073):

> Embedded video works as expected
> 
> Soundcloud - link to “Play on Soundcloud” doesn’t work but listen in browser does (but only if you click it). Is there any way of changing this treatment or is it set by soundcloud? Is there anything we can do to make the link to Soundcloud work (or remove it)?
> 
> Bandcamp embed plays, but none of the links work (buy, share, or link to title name)
> 
> YouTube plays, but automatically goes to a full screen without selecting that option. Links out to YouTube also don’t work.
> 
> Vimeo plays, but also immediately goes to a full screen without selecting the option. And none of the links work out to vimeo (share, add to watch later, save, link to the title)
> 
> Spotify plays, but again no links work in the embed. At first I’m also seeing an incorrect message: “Video not available watch on YouTube” load first (not sure what’s that’s related to)
> 
> Tiktok plays but also goes immediately to full screen. Again none of the links work.

# 🤔 Why

It is odd to allow a link to be displayed that the user cannot click. Bad product/design/ux flow.

# 🛠 How

This [post](https://developer.apple.com/forums/thread/117073) basically says that you need to implement a delegate to check if the frame is within the main frame, if not allow it to be opened externally via the delegate method.

# 👀 See

Before 🐛

https://user-images.githubusercontent.com/4282741/165178629-b0ea91f9-ddd9-4d28-97e4-b71392ba21ed.MP4

ce14d2-db45-4729-9dd8-3bf018c3da9d.MP4

After 🦋

https://user-images.githubusercontent.com/4282741/165176785-e116b4df-f215-4850-992c-2d4d45fa61ed.MP4


# ✅ Acceptance criteria

- [x] Links work as expected with embedded content on iPhone and iPad.
- [x] Investigate keeping the playback inline and not always defaulting to fullscreen on video playback.

# ⏰ TODO

- [x] Look into getting video inline at least until the user wants it full screen. It's mostly a problem on iPad as the tableview shifts its position on the orientation. But double check this, ensure it wasn't a pre-iOS 15 bug or something.