### PR TITLE
[Unticketed] Rewards Navigation Controller Broken Navigation Bar

### DIFF
--- a/Kickstarter-iOS/Views/Controllers/RewardPledgeNavigationController.swift
+++ b/Kickstarter-iOS/Views/Controllers/RewardPledgeNavigationController.swift
@@ -9,8 +9,17 @@ final class RewardPledgeNavigationController: UINavigationController {
     super.viewDidLoad()
 
     _ = self.navigationBar
-      ?|> \.barTintColor .~ .ksr_support_100
+      ?|> \.standardAppearance .~ self.navigationBarAppearance
+      ?|> \.scrollEdgeAppearance .~ self.navigationBarAppearance
       ?|> \.isTranslucent .~ false
       ?|> \.shadowImage .~ UIImage()
+  }
+
+  private var navigationBarAppearance: UINavigationBarAppearance {
+    let navBarAppearance = UINavigationBarAppearance()
+    navBarAppearance.configureWithOpaqueBackground()
+    navBarAppearance.backgroundColor = .ksr_white
+
+    return navBarAppearance
   }
 }


### PR DESCRIPTION
# 📲 What

Simliar to the fix [here](https://github.com/kickstarter/ios-oss/pull/1684), one spot that was missed was `RewardPledgeNavigationController`. So adding that in here. Did a global search for `barTintColor` and no other `UINavigationController`'s seem to affected, so confirming this is the fix for all navigation bars app-wide.

@hadia Thanks for finding this!

# 🤔 Why

Broken navigation bars are unsightly and give the impression of a broken app. Also pretty sure this would fail Apple's review process.

These issues only seem apparent in the actual device, not the simulator, so that is why tests didn't fail.

# 🛠 How

Similar fix the linked PR above.

# 👀 See

Before 🐛 

https://user-images.githubusercontent.com/4282741/167486840-dca412ad-7977-4a5e-9f0e-96c484a32580.mp4

After 🦋

https://user-images.githubusercontent.com/4282741/167486972-b66ce4c7-f2d0-4e57-8995-d6607b76a918.MP4

# ✅ Acceptance criteria

- [x] Ensure no broken navigation bars in add-ons selection/any other screen.
