### PR TITLE
NTV-1435 - Migrate Shipping V1 to GQL

### DIFF
--- a/Kickstarter-iOS/Views/Controllers/ProjectPageViewControllerTests.swift
+++ b/Kickstarter-iOS/Views/Controllers/ProjectPageViewControllerTests.swift
@@ -607,7 +607,7 @@ internal final class ProjectPageViewControllerTests: TestCase {
           parent.view.frame.size.height = 2_300
         }
 
-        self.scheduler.advance(by: .milliseconds(1))
+        self.scheduler.run()
 
         FBSnapshotVerifyView(vc.view, identifier: "lang_\(language)_device_\(device)")
       }

--- a/Kickstarter-iOS/Views/RewardCardContainerViewTests.swift
+++ b/Kickstarter-iOS/Views/RewardCardContainerViewTests.swift
@@ -407,6 +407,7 @@ let allRewards: [(String, Reward)] = {
       .template
         |> Reward.Shipping.lens.enabled .~ true
         |> Reward.Shipping.lens.type .~ .anywhere
+        |> Reward.Shipping.lens.summary .~ "Ships worldwide"
     )
 
   let unavailableLimitedReward = Reward.postcards
@@ -433,6 +434,7 @@ let allRewards: [(String, Reward)] = {
       .template
         |> Reward.Shipping.lens.enabled .~ true
         |> Reward.Shipping.lens.type .~ .anywhere
+        |> Reward.Shipping.lens.summary .~ "Ships worldwide"
     )
   let noReward = Reward.noReward
     |> Reward.lens.convertedMinimum .~ 1

--- a/KsApi/GraphAPI.swift
+++ b/KsApi/GraphAPI.swift
@@ -12390,6 +12390,7 @@ public enum GraphAPI {
         }
         remainingQuantity
         shippingPreference
+        shippingSummary
         shippingRules @include(if: $includeShippingRules) {
           __typename
           ...ShippingRuleFragment
@@ -12420,6 +12421,7 @@ public enum GraphAPI {
         GraphQLField("project", type: .object(Project.selections)),
         GraphQLField("remainingQuantity", type: .scalar(Int.self)),
         GraphQLField("shippingPreference", type: .scalar(ShippingPreference.self)),
+        GraphQLField("shippingSummary", type: .scalar(String.self)),
         GraphQLBooleanCondition(variableName: "includeShippingRules", inverted: false, selections: [
           GraphQLField("shippingRules", type: .nonNull(.list(.object(ShippingRule.selections)))),
         ]),
@@ -12433,8 +12435,8 @@ public enum GraphAPI {
       self.resultMap = unsafeResultMap
     }
 
-    public init(amount: Amount, backersCount: Int? = nil, convertedAmount: ConvertedAmount, allowedAddons: AllowedAddon, description: String, displayName: String, endsAt: String? = nil, estimatedDeliveryOn: String? = nil, id: GraphQLID, isMaxPledge: Bool, items: Item? = nil, limit: Int? = nil, limitPerBacker: Int? = nil, name: String? = nil, project: Project? = nil, remainingQuantity: Int? = nil, shippingPreference: ShippingPreference? = nil, shippingRules: [ShippingRule?]? = nil, startsAt: String? = nil) {
-      self.init(unsafeResultMap: ["__typename": "Reward", "amount": amount.resultMap, "backersCount": backersCount, "convertedAmount": convertedAmount.resultMap, "allowedAddons": allowedAddons.resultMap, "description": description, "displayName": displayName, "endsAt": endsAt, "estimatedDeliveryOn": estimatedDeliveryOn, "id": id, "isMaxPledge": isMaxPledge, "items": items.flatMap { (value: Item) -> ResultMap in value.resultMap }, "limit": limit, "limitPerBacker": limitPerBacker, "name": name, "project": project.flatMap { (value: Project) -> ResultMap in value.resultMap }, "remainingQuantity": remainingQuantity, "shippingPreference": shippingPreference, "shippingRules": shippingRules.flatMap { (value: [ShippingRule?]) -> [ResultMap?] in value.map { (value: ShippingRule?) -> ResultMap? in value.flatMap { (value: ShippingRule) -> ResultMap in value.resultMap } } }, "startsAt": startsAt])
+    public init(amount: Amount, backersCount: Int? = nil, convertedAmount: ConvertedAmount, allowedAddons: AllowedAddon, description: String, displayName: String, endsAt: String? = nil, estimatedDeliveryOn: String? = nil, id: GraphQLID, isMaxPledge: Bool, items: Item? = nil, limit: Int? = nil, limitPerBacker: Int? = nil, name: String? = nil, project: Project? = nil, remainingQuantity: Int? = nil, shippingPreference: ShippingPreference? = nil, shippingSummary: String? = nil, shippingRules: [ShippingRule?]? = nil, startsAt: String? = nil) {
+      self.init(unsafeResultMap: ["__typename": "Reward", "amount": amount.resultMap, "backersCount": backersCount, "convertedAmount": convertedAmount.resultMap, "allowedAddons": allowedAddons.resultMap, "description": description, "displayName": displayName, "endsAt": endsAt, "estimatedDeliveryOn": estimatedDeliveryOn, "id": id, "isMaxPledge": isMaxPledge, "items": items.flatMap { (value: Item) -> ResultMap in value.resultMap }, "limit": limit, "limitPerBacker": limitPerBacker, "name": name, "project": project.flatMap { (value: Project) -> ResultMap in value.resultMap }, "remainingQuantity": remainingQuantity, "shippingPreference": shippingPreference, "shippingSummary": shippingSummary, "shippingRules": shippingRules.flatMap { (value: [ShippingRule?]) -> [ResultMap?] in value.map { (value: ShippingRule?) -> ResultMap? in value.flatMap { (value: ShippingRule) -> ResultMap in value.resultMap } } }, "startsAt": startsAt])
     }
 
     public var __typename: String {
@@ -12614,6 +12616,16 @@ public enum GraphAPI {
       }
       set {
         resultMap.updateValue(newValue, forKey: "shippingPreference")
+      }
+    }
+
+    /// A shipping summary
+    public var shippingSummary: String? {
+      get {
+        return resultMap["shippingSummary"] as? String
+      }
+      set {
+        resultMap.updateValue(newValue, forKey: "shippingSummary")
       }
     }
 

--- a/KsApi/ServiceType.swift
+++ b/KsApi/ServiceType.swift
@@ -220,7 +220,7 @@ public protocol ServiceType {
   func fetchRewardAddOnsSelectionViewRewards(slug: String, shippingEnabled: Bool, locationId: String?)
     -> SignalProducer<Project, ErrorEnvelope>
 
-  /// Fetches a reward for a project and reward id.
+  /// Fetches a reward's shipping rules for a project and reward id.
   func fetchRewardShippingRules(projectId: Int, rewardId: Int)
     -> SignalProducer<ShippingRulesEnvelope, ErrorEnvelope>
 

--- a/KsApi/fragments/RewardFragment.graphql
+++ b/KsApi/fragments/RewardFragment.graphql
@@ -34,6 +34,7 @@ fragment RewardFragment on Reward {
   }
   remainingQuantity
   shippingPreference
+  shippingSummary
   shippingRules @include(if: $includeShippingRules) {
     ...ShippingRuleFragment
   }

--- a/KsApi/models/graphql/adapters/Backing+BackingFragmentTests.swift
+++ b/KsApi/models/graphql/adapters/Backing+BackingFragmentTests.swift
@@ -128,6 +128,7 @@ private func backingDictionary() -> [String: Any] {
           "name": "Art of the Quietly Quixotic",
           "remainingQuantity": null,
           "shippingPreference": "unrestricted",
+          "shippingSummary": "Ships worldwide",
           "shippingRules": [
             {
               "__typename": "ShippingRule",
@@ -205,6 +206,7 @@ private func backingDictionary() -> [String: Any] {
           "name": "Wee William Journal & Coloring Book",
           "remainingQuantity": null,
           "shippingPreference": "unrestricted",
+          "shippingSummary": "Ships worldwide",
           "shippingRules": [
             {
               "__typename": "ShippingRule",
@@ -282,6 +284,7 @@ private func backingDictionary() -> [String: Any] {
           "name": "Wee William Journal & Coloring Book",
           "remainingQuantity": null,
           "shippingPreference": "unrestricted",
+          "shippingSummary": "Ships worldwide",
           "shippingRules": [
             {
               "__typename": "ShippingRule",
@@ -359,6 +362,7 @@ private func backingDictionary() -> [String: Any] {
           "name": "Wee William Journal & Coloring Book",
           "remainingQuantity": null,
           "shippingPreference": "unrestricted",
+          "shippingSummary": "Ships worldwide",
           "shippingRules": [
             {
               "__typename": "ShippingRule",
@@ -793,6 +797,7 @@ private func backingDictionary() -> [String: Any] {
       },
       "remainingQuantity": null,
       "shippingPreference": "unrestricted",
+      "shippingSummary": "Ships worldwide",
       "shippingRules": [
         {
           "__typename": "ShippingRule",

--- a/KsApi/models/graphql/adapters/Project+FetchAddOnsQueryDataTests.swift
+++ b/KsApi/models/graphql/adapters/Project+FetchAddOnsQueryDataTests.swift
@@ -41,11 +41,11 @@ final class Project_FetchAddOnsQueryDataTests: XCTestCase {
     XCTAssertEqual(addOn.minimum, 4.0)
     XCTAssertEqual(addOn.shipping.enabled, false)
     XCTAssertEqual(addOn.shipping.preference!, .none)
+    XCTAssertEqual(addOn.shipping.summary, "Ships worldwide")
     XCTAssertNil(addOn.limit)
     XCTAssertNil(addOn.remaining)
     XCTAssertNil(addOn.startsAt)
     XCTAssertNil(addOn.shipping.location)
-    XCTAssertNil(addOn.shipping.summary)
     XCTAssertNil(addOn.shipping.type)
 
     guard let hasAnExpandedShippingRule = envelope.addOns?.first?.shippingRulesExpanded?.first else {

--- a/KsApi/models/graphql/adapters/Project+FetchProjectRewardsByIdQueryDataTests.swift
+++ b/KsApi/models/graphql/adapters/Project+FetchProjectRewardsByIdQueryDataTests.swift
@@ -66,9 +66,9 @@ final class Project_FetchProjectRewardsByIdQueryDataTests: XCTestCase {
     XCTAssertEqual(lastReward.shippingRules?[1].location.id, decompose(id: "TG9jYXRpb24tMjM0MjQ5NTc="))
     XCTAssertFalse(lastReward.shipping.enabled)
     XCTAssertEqual(lastReward.shipping.preference!, .none)
+    XCTAssertEqual(lastReward.shipping.summary, "Ships worldwide")
     XCTAssertNil(lastReward.shippingRulesExpanded)
     XCTAssertNil(lastReward.shipping.location)
-    XCTAssertNil(lastReward.shipping.summary)
     XCTAssertNil(lastReward.shipping.type)
   }
 }

--- a/KsApi/models/graphql/adapters/Reward+RewardFragment.swift
+++ b/KsApi/models/graphql/adapters/Reward+RewardFragment.swift
@@ -86,7 +86,7 @@ private func shippingData(
     enabled: [.restricted, .unrestricted].contains(rewardFragment.shippingPreference),
     location: nil,
     preference: shippingPreference(from: rewardFragment),
-    summary: nil,
+    summary: rewardFragment.shippingSummary,
     type: nil
   )
 }

--- a/KsApi/models/graphql/adapters/Reward+RewardFragmentTests.swift
+++ b/KsApi/models/graphql/adapters/Reward+RewardFragmentTests.swift
@@ -42,6 +42,7 @@ final class Reward_RewardFragmentTests: XCTestCase {
 
       XCTAssertEqual(v1Reward.shipping.enabled, true)
       XCTAssertEqual(v1Reward.shipping.preference, .unrestricted)
+      XCTAssertEqual(v1Reward.shipping.summary, "Ships worldwide")
       XCTAssertEqual(v1Reward.shippingRules?.count, 2)
       XCTAssertEqual(v1Reward.startsAt, nil)
       XCTAssertEqual(v1Reward.title, "Soft Cover Book (Signed)")
@@ -115,6 +116,7 @@ private func rewardDictionary() -> [String: Any] {
       "id": "UHJvamVjdC0xNTk2NTk0NDYz"
     },
     "remainingQuantity": null,
+    "shippingSummary": "Ships worldwide",
     "shippingPreference": "unrestricted",
     "shippingRules": [{
         "__typename": "ShippingRule",

--- a/KsApi/mutations/templates/query/FetchAddOnsQueryTemplate.swift
+++ b/KsApi/mutations/templates/query/FetchAddOnsQueryTemplate.swift
@@ -99,6 +99,7 @@ public enum FetchAddsOnsQueryTemplate {
                 },
                 "remainingQuantity": null,
                 "shippingPreference": "unrestricted",
+                "shippingSummary": "Ships worldwide",
                 "shippingRules": [
                   {
                     "__typename": "ShippingRule",
@@ -213,6 +214,7 @@ public enum FetchAddsOnsQueryTemplate {
                 },
                 "remainingQuantity": null,
                 "shippingPreference": "restricted",
+                "shippingSummary": "Ships worldwide",
                 "shippingRules": [
                   {
                     "__typename": "ShippingRule",

--- a/KsApi/mutations/templates/query/FetchProjectRewardsByIdQueryTemplate.swift
+++ b/KsApi/mutations/templates/query/FetchProjectRewardsByIdQueryTemplate.swift
@@ -68,6 +68,7 @@ public enum FetchProjectRewardsByIdQueryTemplate {
                    },
                    "remainingQuantity":null,
                    "shippingPreference":"none",
+                   "shippingSummary": "Ships worldwide",
                    "shippingRules":[
                       
                    ],
@@ -127,6 +128,7 @@ public enum FetchProjectRewardsByIdQueryTemplate {
                    },
                    "remainingQuantity":44,
                    "shippingPreference":"unrestricted",
+                   "shippingSummary": "Ships worldwide",
                    "shippingRules":[
                       {
                          "cost":{
@@ -230,6 +232,7 @@ public enum FetchProjectRewardsByIdQueryTemplate {
                    },
                    "remainingQuantity":0,
                    "shippingPreference":"unrestricted",
+                   "shippingSummary": "Ships worldwide",
                    "shippingRules":[
                       {
                          "cost":{
@@ -318,6 +321,7 @@ public enum FetchProjectRewardsByIdQueryTemplate {
                    },
                    "remainingQuantity":null,
                    "shippingPreference":"unrestricted",
+                   "shippingSummary": "Ships worldwide",
                    "shippingRules":[
                       {
                          "cost":{
@@ -421,6 +425,7 @@ public enum FetchProjectRewardsByIdQueryTemplate {
                    },
                    "remainingQuantity":0,
                    "shippingPreference":"unrestricted",
+                   "shippingSummary": "Ships worldwide",
                    "shippingRules":[
                       {
                          "cost":{
@@ -509,6 +514,7 @@ public enum FetchProjectRewardsByIdQueryTemplate {
                    },
                    "remainingQuantity":null,
                    "shippingPreference":"unrestricted",
+                   "shippingSummary": "Ships worldwide",
                    "shippingRules":[
                       {
                          "cost":{
@@ -606,6 +612,7 @@ public enum FetchProjectRewardsByIdQueryTemplate {
                    },
                    "remainingQuantity":1,
                    "shippingPreference":"unrestricted",
+                   "shippingSummary": "Ships worldwide",
                    "shippingRules":[
                       {
                          "cost":{
@@ -703,6 +710,7 @@ public enum FetchProjectRewardsByIdQueryTemplate {
                    },
                    "remainingQuantity":0,
                    "shippingPreference":"unrestricted",
+                   "shippingSummary": "Ships worldwide",
                    "shippingRules":[
                       {
                          "cost":{
@@ -800,6 +808,7 @@ public enum FetchProjectRewardsByIdQueryTemplate {
                    },
                    "remainingQuantity":7,
                    "shippingPreference":"unrestricted",
+                   "shippingSummary": "Ships worldwide",
                    "shippingRules":[
                       {
                          "cost":{
@@ -897,6 +906,7 @@ public enum FetchProjectRewardsByIdQueryTemplate {
                    },
                    "remainingQuantity":6,
                    "shippingPreference":"unrestricted",
+                   "shippingSummary": "Ships worldwide",
                    "shippingRules":[
                       {
                          "cost":{
@@ -994,6 +1004,7 @@ public enum FetchProjectRewardsByIdQueryTemplate {
                    },
                    "remainingQuantity":4,
                    "shippingPreference":"unrestricted",
+                   "shippingSummary": "Ships worldwide",
                    "shippingRules":[
                       {
                          "cost":{
@@ -1091,6 +1102,7 @@ public enum FetchProjectRewardsByIdQueryTemplate {
                    },
                    "remainingQuantity":7,
                    "shippingPreference":"unrestricted",
+                   "shippingSummary": "Ships worldwide",
                    "shippingRules":[
                       {
                          "cost":{
@@ -1188,6 +1200,7 @@ public enum FetchProjectRewardsByIdQueryTemplate {
                    },
                    "remainingQuantity":9,
                    "shippingPreference":"unrestricted",
+                   "shippingSummary": "Ships worldwide",
                    "shippingRules":[
                       {
                          "cost":{
@@ -1285,6 +1298,7 @@ public enum FetchProjectRewardsByIdQueryTemplate {
                    },
                    "remainingQuantity":9,
                    "shippingPreference":"restricted",
+                   "shippingSummary": "Ships worldwide",
                    "shippingRules":[
                       {
                          "cost":{

--- a/Library/ViewModels/RewardCardViewModel.swift
+++ b/Library/ViewModels/RewardCardViewModel.swift
@@ -294,32 +294,19 @@ private func backerCountOrRemainingString(project: Project, reward: Reward) -> R
 }
 
 private func shippingSummaryString(project: Project, reward: Reward) -> RewardCardPillData? {
-  if project.state == .live, reward.shipping.enabled, let type = reward.shipping.type {
-    switch type {
-    case .anywhere:
-      return RewardCardPillData(
-        backgroundColor: UIColor.ksr_create_700.withAlphaComponent(0.06),
-        text: Strings.Ships_worldwide(),
-        textColor: UIColor.ksr_create_700
-      )
-    case .multipleLocations:
-      return RewardCardPillData(
-        backgroundColor: UIColor.ksr_create_700.withAlphaComponent(0.06),
-        text: Strings.Limited_shipping(),
-        textColor: UIColor.ksr_create_700
-      )
-    case .noShipping: return nil
-    case .singleLocation:
-      if let name = reward.shipping.location?.localizedName {
-        return RewardCardPillData(
-          backgroundColor: UIColor.ksr_create_700.withAlphaComponent(0.06),
-          text: Strings.location_name_only(location_name: name),
-          textColor: UIColor.ksr_create_700
-        )
-      }
-
-      return nil
-    }
+  if project.state == .live,
+    reward.shipping.enabled,
+    let shippingSummaryText = reward.shipping.summary {
+    return RewardCardPillData(
+      backgroundColor: UIColor.ksr_create_700.withAlphaComponent(0.06),
+      text: shippingSummaryText,
+      textColor: UIColor.ksr_create_700
+    )
+    /** Remove these from Localized Strings
+     Strings.Ships_worldwide()
+     Strings.Limited_shipping()
+     Strings.location_name_only(location_name: name)
+     */
   }
 
   return nil

--- a/Library/ViewModels/RewardCardViewModel.swift
+++ b/Library/ViewModels/RewardCardViewModel.swift
@@ -302,10 +302,10 @@ private func shippingSummaryString(project: Project, reward: Reward) -> RewardCa
       text: shippingSummaryText,
       textColor: UIColor.ksr_create_700
     )
-    /** Remove these from Localized Strings
+    /** FIXME: No longer used on iOS. Might still be needed on Android/Web before removing from: `Kickstarter` `config/locales/native/en.yml`
      Strings.Ships_worldwide()
      Strings.Limited_shipping()
-     Strings.location_name_only(location_name: name)
+     Strings.location_name_only(location_name: name)(location_name: name)
      */
   }
 

--- a/Library/ViewModels/RewardCardViewModelTests.swift
+++ b/Library/ViewModels/RewardCardViewModelTests.swift
@@ -680,7 +680,7 @@ final class RewardCardViewModelTests: TestCase {
       |> Reward.lens.shipping .~ (
         .template
           |> Reward.Shipping.lens.enabled .~ true
-          |> Reward.Shipping.lens.type .~ .anywhere
+          |> Reward.Shipping.lens.summary .~ "Ships worldwide"
       )
 
     self.vm.inputs.configure(with: (.template, reward, .pledge))
@@ -722,7 +722,7 @@ final class RewardCardViewModelTests: TestCase {
         .template
           |> Reward.Shipping.lens.enabled .~ true
           |> Reward.Shipping.lens.type .~ .singleLocation
-          |> Reward.Shipping.lens.location .~ .init(id: 123, localizedName: "United States")
+          |> Reward.Shipping.lens.summary .~ "United States only"
       )
 
     self.vm.inputs.configure(with: (.template, reward, .pledge))
@@ -763,7 +763,7 @@ final class RewardCardViewModelTests: TestCase {
       |> Reward.lens.shipping .~ (
         .template
           |> Reward.Shipping.lens.enabled .~ true
-          |> Reward.Shipping.lens.type .~ .multipleLocations
+          |> Reward.Shipping.lens.summary .~ "Limited shipping"
       )
 
     self.vm.inputs.configure(with: (.template, reward, .pledge))
@@ -804,7 +804,7 @@ final class RewardCardViewModelTests: TestCase {
       |> Reward.lens.shipping .~ (
         .template
           |> Reward.Shipping.lens.enabled .~ true
-          |> Reward.Shipping.lens.type .~ .anywhere
+          |> Reward.Shipping.lens.summary .~ "Ships worldwide"
       )
 
     let project = Project.template
@@ -848,7 +848,7 @@ final class RewardCardViewModelTests: TestCase {
       |> Reward.lens.shipping .~ (
         .template
           |> Reward.Shipping.lens.enabled .~ true
-          |> Reward.Shipping.lens.type .~ .anywhere
+          |> Reward.Shipping.lens.summary .~ "Ships worldwide"
       )
 
     let project = Project.template


### PR DESCRIPTION
# 📲 What

Fix the missing shipping badges. [Slack Thread](https://kickstarter.slack.com/archives/C3LS41US0/p1652715231204919).

"Shipping Worldwide"
"Limited Shipping"
"Only {country}"

These badges have been missing since we migrated our project model to gql. Also is connected to the data/UX for updating local receipt information.

# 🤔 Why

This [investigation](https://kickstarter.atlassian.net/wiki/spaces/~294637594/pages/2003763209/iOS+Rewards+Shipping+Selector+Upgrade+to+GraphQL) was needed to understand the logic between the shipping data in the reward card and the badge related to shipping. [ui/ux](https://www.figma.com/file/QCpTglZe3PcprhI5TyCKmm/Local-Pickup-Reward?node-id=1338%3A18649)

Also all the places where shipping address selector, shipping label got its data. Will hopefully help with QA all possible scenarios when feature complete.

# 🛠 How

[gql logic](https://github.com/kickstarter/kickstarter/blob/d7f547e567c43bd40b7fb9eb69360141877f508e/app/decorators/backer_reward_decorator.rb#L120-L140) for returning shipping summary information.

If the reward isn't local, above logic states shipping summary can be used to display the badge data for shipping labels. This replaces the v1 `shipping_type` previously used.

Left the `shipping_type` in the existing v1 model because it causes crashes when v1's `discover` endpoint is called (app launch). Didn't do a deep dive but there are still use cases for `Reward` model `shipping` `type` field.

Anyway, the logic above also clarifies that if the reward has `localReceiptLocation` then the badge for shipping data should be hidden, and instead `shipping` `summary` is used for the `Reward Location` field.

# 👀 See

Before 🐛 

![Simulator Screen Recording - iPhone 8 - 2022-05-16 at 18 43 33](https://user-images.githubusercontent.com/4282741/168694259-5f84dd78-ea25-421c-82bc-dde6fb2a8fee.gif)

After 🦋

![Simulator Screen Recording - iPhone 8 - 2022-05-16 at 18 46 02](https://user-images.githubusercontent.com/4282741/168694510-a78dfa1e-4463-4951-96ee-4543e0355852.gif)

# ✅ Acceptance criteria

- [x] Shipping badges "Anywhere in the world", "Only ships to certain countries" and "Only ships to { country }" get displayed in app.

# ⏰ TODO
- [x] Update tests.
