### PR TITLE
[NTV-541] Crash Fix After Backing From Campaign Tab

### DIFF
--- a/Library/ViewModels/ProjectPageViewModel.swift
+++ b/Library/ViewModels/ProjectPageViewModel.swift
@@ -197,6 +197,10 @@ public final class ProjectPageViewModel: ProjectPageViewModelType, ProjectPageVi
     self.prefetchImageURLs = project.signal
       .skip(first: 1)
       .combineLatest(with: self.prepareImageAtProperty.signal.skipNil())
+      .filterWhenLatestFrom(
+        self.projectNavigationSelectorViewDidSelectProperty.signal.skipNil(),
+        satisfies: { NavigationSection(rawValue: $0) == .campaign }
+      )
       .switchMap { project, indexPath -> SignalProducer<([URL], IndexPath)?, Never> in
         let imageViewElements = project.extendedProjectProperties?.story.htmlViewElements
           .compactMap { $0 as? ImageViewElement } ?? []


### PR DESCRIPTION
# 📲 What

As detailed in the ticket, if the user was scrolling in the campaign tab and starts the backing flow, logs in before pledging, the app crashes. Need to prevent this as it is a common flow from project to pledging.

# 🤔 Why

The `prefetchImageUrls` signal was called whenever a notification was sent after the user session started.
This prefetch would eventually end up updating the datasource, but because the `userSessionStarted` signal resets the active tab to Overview, that caused a crash in the datasource, because the Campaign tab values were cleared.

# 🛠 How

The fix was a simple check to see if the existing tab was Campaign before the `prefetchImageUrls` passed its data to the view controller.

# 👀 See

Before 🐛 

https://user-images.githubusercontent.com/4282741/169423103-6da85f4b-163c-4fe4-bc2f-66c9902a382f.mp4

After 🦋

https://user-images.githubusercontent.com/4282741/169423644-877637bd-e1e1-4e0a-bbac-e2d2159b64af.mp4

# ✅ Acceptance criteria

- [ ] Ensure backing from campaign tab, and logging in before completing pledge works without crashing.
