### PR TITLE
[NTV-1690] Reward Card Shipping Preference Check + Other Cleanup

### DIFF
--- a/Kickstarter-iOS/Views/Cells/RewardTableViewCell.swift
+++ b/Kickstarter-iOS/Views/Cells/RewardTableViewCell.swift
@@ -52,6 +52,8 @@ final class RewardTableViewCell: UITableViewCell, ValueCell {
   internal func configureWith(value: RewardCardViewData) {
     self.rewardCardView.configure(with: value)
 
+    self.rewardCardView.setNeedsLayout()
+    self.rewardCardView.layoutIfNeeded()
     self.contentView.setNeedsLayout()
     self.contentView.layoutIfNeeded()
   }

--- a/Kickstarter-iOS/Views/Controllers/ManagePledgeViewControllerTests.swift
+++ b/Kickstarter-iOS/Views/Controllers/ManagePledgeViewControllerTests.swift
@@ -295,6 +295,7 @@ final class ManagePledgeViewControllerTests: TestCase {
       Reward.postcards
         |> Reward.lens.minimum .~ 10
         |> Reward.lens.localPickup .~ .greatBritain
+        |> Reward.lens.shipping.preference .~ .local
         |> Reward.lens.rewardsItems .~ []
     ]
 

--- a/Kickstarter-iOS/Views/Controllers/RewardAddOnSelectionViewControllerTests.swift
+++ b/Kickstarter-iOS/Views/Controllers/RewardAddOnSelectionViewControllerTests.swift
@@ -247,10 +247,11 @@ final class RewardAddOnSelectionViewControllerTests: TestCase {
     let reward = Reward.template
       |> Reward.lens.shipping.enabled .~ false
       |> Reward.lens.localPickup .~ .london
+      |> Reward.lens.shipping.preference .~ .local
 
     let noShippingAddOn = Reward.template
       |> Reward.lens.shipping.enabled .~ false
-      |> Reward.lens.shipping.preference .~ Reward.Shipping.Preference.none
+      |> Reward.lens.shipping.preference .~ .local
       |> Reward.lens.localPickup .~ .australia
 
     let project = Project.template

--- a/Kickstarter-iOS/Views/Controllers/RewardsCollectionViewControllerTests.swift
+++ b/Kickstarter-iOS/Views/Controllers/RewardsCollectionViewControllerTests.swift
@@ -86,9 +86,13 @@ final class RewardsCollectionViewControllerTests: TestCase {
   }
 
   func testRewards_LocalPickUp_LiveProject_Landscape() {
+    let reward = Reward.template
+      |> Reward.lens.shipping.preference .~ .local
+      |> Reward.lens.localPickup .~ .canada
+
     let project = Project.cosmicSurgery
       |> Project.lens.state .~ .live
-      |> Project.lens.rewardData.rewards .~ [.template]
+      |> Project.lens.rewardData.rewards .~ [reward]
 
     combos(Language.allLanguages, [Device.pad]).forEach {
       language, device in
@@ -106,9 +110,13 @@ final class RewardsCollectionViewControllerTests: TestCase {
   }
 
   func testRewards_LocalPickUp_LiveProject_Portrait() {
+    let reward = Reward.template
+      |> Reward.lens.shipping.preference .~ .local
+      |> Reward.lens.localPickup .~ .canada
+
     let project = Project.cosmicSurgery
       |> Project.lens.state .~ .live
-      |> Project.lens.rewardData.rewards .~ [.template]
+      |> Project.lens.rewardData.rewards .~ [reward]
 
     combos(Language.allLanguages, [Device.phone5_8inch]).forEach {
       language, device in

--- a/KsApi/models/templates/RewardTemplates.swift
+++ b/KsApi/models/templates/RewardTemplates.swift
@@ -28,7 +28,7 @@ extension Reward {
     shippingRulesExpanded: nil,
     startsAt: nil,
     title: "My Reward",
-    localPickup: .canada
+    localPickup: nil
   )
 
   public static let noReward = Reward(

--- a/Library/ViewModels/ManagePledgeViewModelTests.swift
+++ b/Library/ViewModels/ManagePledgeViewModelTests.swift
@@ -560,11 +560,14 @@ internal final class ManagePledgeViewModelTests: TestCase {
 
   func testGoToRewards_WithRewardDataIncludingLocalPickup_Success() {
     let project = Project.template
+    let reward = Reward.template
+      |> Reward.lens.localPickup .~ .canada
+      |> Reward.lens.shipping.preference .~ .local
 
     let mockService = MockService(
       fetchManagePledgeViewBackingResult: .success(.template),
       fetchProjectResult: .success(project),
-      fetchProjectRewardsResult: .success([.template])
+      fetchProjectRewardsResult: .success([reward])
     )
 
     withEnvironment(apiService: mockService) {
@@ -582,7 +585,7 @@ internal final class ManagePledgeViewModelTests: TestCase {
       XCTAssertNotNil(self.goToRewards.lastValue?.rewards.first?.localPickup)
       XCTAssertEqual(
         self.goToRewards.lastValue?.rewards.first?.localPickup,
-        Reward.template.localPickup
+        .canada
       )
     }
   }

--- a/Library/ViewModels/RewardAddOnCardViewModel.swift
+++ b/Library/ViewModels/RewardAddOnCardViewModel.swift
@@ -131,7 +131,7 @@ public final class RewardAddOnCardViewModel: RewardAddOnCardViewModelType, Rewar
       .withLatest(from: reward.map(\.id))
 
     self.rewardLocationStackViewHidden = reward
-      .map { $0.localPickup == nil }
+      .map { !isRewardLocalPickup($0) }
 
     self.rewardLocationPickupLabelText = reward.map { $0.localPickup?.displayableName }.skipNil()
 

--- a/Library/ViewModels/RewardAddOnCardViewModelTests.swift
+++ b/Library/ViewModels/RewardAddOnCardViewModelTests.swift
@@ -359,9 +359,13 @@ final class RewardAddOnCardViewModelTests: TestCase {
     self.rewardLocationStackViewHidden.assertDidNotEmitValue()
     self.rewardLocationPickupLabelText.assertDidNotEmitValue()
 
+    let reward = .template
+      |> Reward.lens.localPickup .~ nil
+      |> Reward.lens.shipping.preference .~ .local
+
     self.vm.inputs.configure(with: .init(
       project: .template,
-      reward: .template |> Reward.lens.localPickup .~ nil,
+      reward: reward,
       context: .pledge,
       shippingRule: nil,
       selectedQuantities: [:]
@@ -375,15 +379,39 @@ final class RewardAddOnCardViewModelTests: TestCase {
     self.rewardLocationStackViewHidden.assertDidNotEmitValue()
     self.rewardLocationPickupLabelText.assertDidNotEmitValue()
 
+    let reward = .template
+      |> Reward.lens.localPickup .~ .brooklyn
+      |> Reward.lens.shipping.preference .~ .local
+
     self.vm.inputs.configure(with: .init(
       project: .template,
-      reward: .template |> Reward.lens.localPickup .~ .brooklyn,
+      reward: reward,
       context: .pledge,
       shippingRule: nil,
       selectedQuantities: [:]
     ))
 
     self.rewardLocationStackViewHidden.assertValues([false])
+    self.rewardLocationPickupLabelText.assertValue("Brooklyn, NY")
+  }
+
+  func testRewardLocalPickup_WithLocationAndNoShippingPreference() {
+    self.rewardLocationStackViewHidden.assertDidNotEmitValue()
+    self.rewardLocationPickupLabelText.assertDidNotEmitValue()
+
+    let reward = .template
+      |> Reward.lens.localPickup .~ .brooklyn
+      |> Reward.lens.shipping.preference .~ Reward.Shipping.Preference.none
+
+    self.vm.inputs.configure(with: .init(
+      project: .template,
+      reward: reward,
+      context: .pledge,
+      shippingRule: nil,
+      selectedQuantities: [:]
+    ))
+
+    self.rewardLocationStackViewHidden.assertValues([true])
     self.rewardLocationPickupLabelText.assertValue("Brooklyn, NY")
   }
 

--- a/Library/ViewModels/RewardCardViewModel.swift
+++ b/Library/ViewModels/RewardCardViewModel.swift
@@ -119,7 +119,7 @@ public final class RewardCardViewModel: RewardCardViewModelType, RewardCardViewM
       }
 
     self.rewardLocationStackViewHidden = reward
-      .map { $0.localPickup == nil }
+      .map { !isRewardLocalPickup($0) }
 
     self.estimatedDeliveryDateLabelText = reward.map(estimatedDeliveryDateText(with:)).skipNil()
     self.rewardLocationPickupLabelText = reward.map { $0.localPickup?.displayableName }.skipNil()

--- a/Library/ViewModels/RewardCardViewModelTests.swift
+++ b/Library/ViewModels/RewardCardViewModelTests.swift
@@ -1084,6 +1084,7 @@ final class RewardCardViewModelTests: TestCase {
       |> Reward.lens.remaining .~ 50
       |> Reward.lens.backersCount .~ 50
       |> Reward.lens.localPickup .~ .losAngeles
+      |> Reward.lens.shipping.preference .~ .local
 
     let project = Project.template
       |> Project.lens.state .~ .successful


### PR DESCRIPTION
# 📲 What

This pr address two issues:
- The initial base reward card seen in the video below (happens on device only) has an unusual gap between the content and the title on first load.
- Checks the reward cards currently displaying Reward Location to ensure they show as usual.

# 🤔 Why

- More consistent UI experience.
- Ensure shipping preference is also checked to ensure to strange behavior if for example the reward has a `localPickup` but shipping preference is `unrestricted`. (Shouldn't happen, but if it does, at least there is no confusion to the user.)

# 🛠 How

So for the display issue, the requirement is simply to `setNeedsLayout` then call `layoutIfNeeded` within the `RewardCardTableViewCell` to not effect existing uses of `RewardCardView` outside the manage pledge page.

For the `shippingPreference` check, just use the existing `isRewardLocalPickup` where Reward Location is shown.

# 👀 See
Before 🐛

https://user-images.githubusercontent.com/4282741/172227390-01503417-9ecc-4bf1-8b7b-8e4cdec87633.MP4 

After 🦋

https://user-images.githubusercontent.com/4282741/172228734-025b222b-0641-4e68-ba20-98c05ff0e7de.MP4

# ✅ Acceptance criteria

- [x] Ensure on first load and after picking a different reward through edit reward and returning to the manage pledge page, the reward cards do not show odd gaps on in the ui/ux.

# ⏰ TODO

- [x] Add the check for `shippingPreference` via the `isRewardLocalPickup` shared function.
- [x] Validate all the logic for `RewardCardView`, `RewardTableViewCell` and `RewardAddOnCardView` to ensure that the Reward Location only shows up if Reward `localPickup` exists **and** `shippingPreference` is `local`
