### PR TITLE
[PAY-1765] Refresh Pledge Screen UI With Payment Card From Payment Sheet

### DIFF
--- a/Kickstarter-iOS/DataSources/PledgePaymentMethodsDataSource.swift
+++ b/Kickstarter-iOS/DataSources/PledgePaymentMethodsDataSource.swift
@@ -19,15 +19,20 @@ internal final class PledgePaymentMethodsDataSource: ValueCellDataSource {
       )
     }
 
-    let updatedCardsWithPaymentSheetCard = cards.map {
-      ($0, paymentSheetCard)
-    }
-
     self.set(
-      values: updatedCardsWithPaymentSheetCard,
+      values: cards,
       cellClass: PledgePaymentMethodCell.self,
       inSection: PaymentMethodsTableViewSection.paymentMethods.rawValue
     )
+
+    if let paymentSheetCard = paymentSheetCard {
+      self
+        .appendRow(
+          value: paymentSheetCard,
+          cellClass: PledgePaymentSheetPaymentMethodCell.self,
+          toSection: PaymentMethodsTableViewSection.paymentMethods.rawValue
+        )
+    }
 
     self.set(
       values: [()],
@@ -40,7 +45,12 @@ internal final class PledgePaymentMethodsDataSource: ValueCellDataSource {
     switch (cell, value) {
     case let (
       cell as PledgePaymentMethodCell,
-      value as (PledgePaymentMethodCellData, PaymentSheetPaymentMethodCellData?)
+      value as PledgePaymentMethodCellData
+    ):
+      cell.configureWith(value: value)
+    case let (
+      cell as PledgePaymentSheetPaymentMethodCell,
+      value as PaymentSheetPaymentMethodCellData
     ):
       cell.configureWith(value: value)
     case let (cell as PledgePaymentMethodAddCell, value as Void):

--- a/Kickstarter-iOS/DataSources/PledgePaymentMethodsDataSource.swift
+++ b/Kickstarter-iOS/DataSources/PledgePaymentMethodsDataSource.swift
@@ -6,7 +6,7 @@ import UIKit
 internal final class PledgePaymentMethodsDataSource: ValueCellDataSource {
   internal func load(
     _ cards: [PledgePaymentMethodCellData],
-    paymentSheetCard: PaymentSheetPaymentMethodCellData?,
+    paymentSheetCards: [PaymentSheetPaymentMethodCellData],
     isLoading: Bool = false
   ) {
     self.clearValues()
@@ -19,19 +19,30 @@ internal final class PledgePaymentMethodsDataSource: ValueCellDataSource {
       )
     }
 
-    self.set(
-      values: cards,
-      cellClass: PledgePaymentMethodCell.self,
-      inSection: PaymentMethodsTableViewSection.paymentMethods.rawValue
-    )
+    let paymentSheetCardsAvailable = paymentSheetCards.count > 0
 
-    if let paymentSheetCard = paymentSheetCard {
-      self
-        .appendRow(
-          value: paymentSheetCard,
-          cellClass: PledgePaymentSheetPaymentMethodCell.self,
-          toSection: PaymentMethodsTableViewSection.paymentMethods.rawValue
-        )
+    switch paymentSheetCardsAvailable {
+    case true:
+      self.set(
+        values: paymentSheetCards,
+        cellClass: PledgePaymentSheetPaymentMethodCell.self,
+        inSection: PaymentMethodsTableViewSection.paymentMethods.rawValue
+      )
+
+      cards.forEach { cardData in
+        self
+          .appendRow(
+            value: cardData,
+            cellClass: PledgePaymentMethodCell.self,
+            toSection: PaymentMethodsTableViewSection.paymentMethods.rawValue
+          )
+      }
+    case false:
+      self.set(
+        values: cards,
+        cellClass: PledgePaymentMethodCell.self,
+        inSection: PaymentMethodsTableViewSection.paymentMethods.rawValue
+      )
     }
 
     self.set(

--- a/Kickstarter-iOS/DataSources/PledgePaymentMethodsDataSource.swift
+++ b/Kickstarter-iOS/DataSources/PledgePaymentMethodsDataSource.swift
@@ -4,7 +4,11 @@ import Prelude
 import UIKit
 
 internal final class PledgePaymentMethodsDataSource: ValueCellDataSource {
-  internal func load(_ cards: [PledgePaymentMethodCellData], isLoading: Bool = false) {
+  internal func load(
+    _ cards: [PledgePaymentMethodCellData],
+    paymentSheetCard: PaymentSheetPaymentMethodCellData?,
+    isLoading: Bool = false
+  ) {
     self.clearValues()
 
     guard isLoading == false else {
@@ -15,8 +19,12 @@ internal final class PledgePaymentMethodsDataSource: ValueCellDataSource {
       )
     }
 
+    let updatedCardsWithPaymentSheetCard = cards.map {
+      ($0, paymentSheetCard)
+    }
+
     self.set(
-      values: cards,
+      values: updatedCardsWithPaymentSheetCard,
       cellClass: PledgePaymentMethodCell.self,
       inSection: PaymentMethodsTableViewSection.paymentMethods.rawValue
     )
@@ -30,7 +38,10 @@ internal final class PledgePaymentMethodsDataSource: ValueCellDataSource {
 
   override func configureCell(tableCell cell: UITableViewCell, withValue value: Any) {
     switch (cell, value) {
-    case let (cell as PledgePaymentMethodCell, value as PledgePaymentMethodCellData):
+    case let (
+      cell as PledgePaymentMethodCell,
+      value as (PledgePaymentMethodCellData, PaymentSheetPaymentMethodCellData?)
+    ):
       cell.configureWith(value: value)
     case let (cell as PledgePaymentMethodAddCell, value as Void):
       cell.configureWith(value: value)

--- a/Kickstarter-iOS/DataSources/PledgePaymentMethodsDataSourceTests.swift
+++ b/Kickstarter-iOS/DataSources/PledgePaymentMethodsDataSourceTests.swift
@@ -8,7 +8,7 @@ final class PledgePaymentMethodsDataSourceTests: XCTestCase {
   private let dataSource = PledgePaymentMethodsDataSource()
   private let tableView = UITableView()
 
-  func testLoadValues() {
+  func testLoad_NonPaymentSheetCardValues() {
     let cellData = [
       (
         card: UserCreditCards.amex,
@@ -26,7 +26,7 @@ final class PledgePaymentMethodsDataSourceTests: XCTestCase {
       )
     ]
 
-    self.dataSource.load(cellData)
+    self.dataSource.load(cellData, paymentSheetCards: [])
 
     XCTAssertEqual(2, self.dataSource.numberOfSections(in: self.tableView))
     XCTAssertEqual(
@@ -39,8 +39,63 @@ final class PledgePaymentMethodsDataSourceTests: XCTestCase {
     )
   }
 
+  func testLoad_PaymentSheetCardValues() {
+    let paymentSheetData = [
+      (image: UIImage(), redactedCardNumber: "test1"),
+      (image: UIImage(), redactedCardNumber: "test2")
+    ]
+
+    self.dataSource.load([], paymentSheetCards: paymentSheetData)
+
+    XCTAssertEqual(2, self.dataSource.numberOfSections(in: self.tableView))
+    XCTAssertEqual(
+      2,
+      self.dataSource.numberOfItems(in: PaymentMethodsTableViewSection.paymentMethods.rawValue)
+    )
+    XCTAssertEqual(
+      1,
+      self.dataSource.numberOfItems(in: PaymentMethodsTableViewSection.addNewCard.rawValue)
+    )
+  }
+
+  func testLoad_PaymentSheetCardAndNonPaymentSheetCardValues() {
+    let cellData = [
+      (
+        card: UserCreditCards.amex,
+        isEnabled: true,
+        isSelected: true,
+        projectCountry: "Country 1",
+        isErroredPaymentMethod: false
+      ),
+      (
+        card: UserCreditCards.visa,
+        isEnabled: false,
+        isSelected: false,
+        projectCountry: "Country 2",
+        isErroredPaymentMethod: false
+      )
+    ]
+
+    let paymentSheetData = [
+      (image: UIImage(), redactedCardNumber: "test1"),
+      (image: UIImage(), redactedCardNumber: "test2")
+    ]
+
+    self.dataSource.load(cellData, paymentSheetCards: paymentSheetData)
+
+    XCTAssertEqual(2, self.dataSource.numberOfSections(in: self.tableView))
+    XCTAssertEqual(
+      4,
+      self.dataSource.numberOfItems(in: PaymentMethodsTableViewSection.paymentMethods.rawValue)
+    )
+    XCTAssertEqual(
+      1,
+      self.dataSource.numberOfItems(in: PaymentMethodsTableViewSection.addNewCard.rawValue)
+    )
+  }
+
   func testLoadingState() {
-    self.dataSource.load([], isLoading: true)
+    self.dataSource.load([], paymentSheetCards: [], isLoading: true)
 
     XCTAssertEqual(3, self.dataSource.numberOfSections(in: self.tableView), "Sections padded")
     XCTAssertEqual(

--- a/Kickstarter-iOS/Views/Cells/PledgePaymentMethodCell.swift
+++ b/Kickstarter-iOS/Views/Cells/PledgePaymentMethodCell.swift
@@ -136,6 +136,13 @@ final class PledgePaymentMethodCell: UITableViewCell, ValueCell {
         self?.checkmarkImageView.alpha = hidden ? 0 : 1
       }
 
+    self.viewModel.outputs.cardImage
+      .observeForUI()
+      .observeValues { [weak self] image in
+        _ = self?.cardImageView
+          ?|> \.image .~ image
+      }
+
     self.viewModel.outputs.cardImageName
       .observeForUI()
       .observeValues { [weak self] imageName in
@@ -157,8 +164,14 @@ final class PledgePaymentMethodCell: UITableViewCell, ValueCell {
       }
   }
 
-  func configureWith(value: PledgePaymentMethodCellData) {
-    self.viewModel.inputs.configureWith(value: value)
+  func configureWith(value: (PledgePaymentMethodCellData, PaymentSheetPaymentMethodCellData?)) {
+    guard let paymentSheetCardData = value.1 else {
+      self.viewModel.inputs.configureWith(value: value.0)
+
+      return
+    }
+
+    self.viewModel.inputs.configureWithPaymentSheetCard(value: paymentSheetCardData)
   }
 
   // MARK: - Accessors

--- a/Kickstarter-iOS/Views/Cells/PledgePaymentSheetPaymentMethodCell.swift
+++ b/Kickstarter-iOS/Views/Cells/PledgePaymentSheetPaymentMethodCell.swift
@@ -3,7 +3,7 @@ import Library
 import Prelude
 import UIKit
 
-final class PledgePaymentMethodCell: UITableViewCell, ValueCell {
+final class PledgePaymentSheetPaymentMethodCell: UITableViewCell, ValueCell {
   // MARK: - Properties
 
   private lazy var cardImageAndLabelsStackView: UIStackView = { UIStackView(frame: .zero) }()
@@ -18,7 +18,8 @@ final class PledgePaymentMethodCell: UITableViewCell, ValueCell {
   private lazy var selectionView: UIView = { UIView(frame: .zero) |> \.backgroundColor .~ .ksr_support_100 }()
   private lazy var unavailableCardTypeLabel: UILabel = { UILabel(frame: .zero) }()
 
-  private let viewModel: PledgePaymentMethodCellViewModelType = PledgePaymentMethodCellViewModel()
+  private let viewModel: PledgePaymentSheetPaymentMethodCellViewModelType =
+    PledgePaymentSheetPaymentMethodCellViewModel()
 
   // MARK: - Lifecycle
 
@@ -136,13 +137,6 @@ final class PledgePaymentMethodCell: UITableViewCell, ValueCell {
         self?.checkmarkImageView.alpha = hidden ? 0 : 1
       }
 
-    self.viewModel.outputs.cardImageName
-      .observeForUI()
-      .observeValues { [weak self] imageName in
-        _ = self?.cardImageView
-          ?|> \.image .~ Library.image(named: imageName)
-      }
-
     self.viewModel.outputs.checkmarkImageName
       .observeForUI()
       .observeValues { [weak self] imageName in
@@ -157,7 +151,7 @@ final class PledgePaymentMethodCell: UITableViewCell, ValueCell {
       }
   }
 
-  func configureWith(value: PledgePaymentMethodCellData) {
+  func configureWith(value: PaymentSheetPaymentMethodCellData) {
     self.viewModel.inputs.configureWith(value: value)
   }
 

--- a/Kickstarter-iOS/Views/Cells/PledgePaymentSheetPaymentMethodCell.swift
+++ b/Kickstarter-iOS/Views/Cells/PledgePaymentSheetPaymentMethodCell.swift
@@ -137,6 +137,13 @@ final class PledgePaymentSheetPaymentMethodCell: UITableViewCell, ValueCell {
         self?.checkmarkImageView.alpha = hidden ? 0 : 1
       }
 
+    self.viewModel.outputs.cardImage
+      .observeForUI()
+      .observeValues { [weak self] image in
+        _ = self?.cardImageView
+          ?|> \.image .~ image
+      }
+
     self.viewModel.outputs.checkmarkImageName
       .observeForUI()
       .observeValues { [weak self] imageName in

--- a/Kickstarter-iOS/Views/Controllers/PledgePaymentMethodsViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/PledgePaymentMethodsViewController.swift
@@ -81,12 +81,12 @@ final class PledgePaymentMethodsViewController: UIViewController {
 
     self.viewModel.outputs.reloadPaymentMethods
       .observeForUI()
-      .observeValues { [weak self] cards, paymentSheetCard, selectedCard, shouldReload, isLoading in
+      .observeValues { [weak self] cards, paymentSheetCards, selectedCard, shouldReload, isLoading in
         guard let self = self else { return }
 
         self.dataSource.load(
           cards,
-          paymentSheetCard: paymentSheetCard,
+          paymentSheetCards: paymentSheetCards,
           isLoading: isLoading
         )
 
@@ -95,6 +95,7 @@ final class PledgePaymentMethodsViewController: UIViewController {
         } else {
           guard let selectedCard = selectedCard else { return }
 
+          /** FIXME: Revisit this for card selection */
           self.tableView.visibleCells
             .compactMap { $0 as? PledgePaymentMethodCell }
             .forEach { $0.setSelectedCard(selectedCard) }

--- a/Kickstarter-iOS/Views/Controllers/PledgePaymentMethodsViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/PledgePaymentMethodsViewController.swift
@@ -53,6 +53,7 @@ final class PledgePaymentMethodsViewController: UIViewController {
       |> ksr_addSubviewToParent()
 
     self.tableView.registerCellClass(PledgePaymentMethodCell.self)
+    self.tableView.registerCellClass(PledgePaymentSheetPaymentMethodCell.self)
     self.tableView.registerCellClass(PledgePaymentMethodAddCell.self)
     self.tableView.registerCellClass(PledgePaymentMethodLoadingCell.self)
   }

--- a/Kickstarter-iOS/Views/Controllers/PledgePaymentMethodsViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/PledgePaymentMethodsViewController.swift
@@ -95,7 +95,6 @@ final class PledgePaymentMethodsViewController: UIViewController {
         } else {
           guard let selectedCard = selectedCard else { return }
 
-          /** FIXME: Revisit this for card selection */
           self.tableView.visibleCells
             .compactMap { $0 as? PledgePaymentMethodCell }
             .forEach { $0.setSelectedCard(selectedCard) }

--- a/Kickstarter-iOS/Views/Controllers/PledgePaymentMethodsViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/PledgePaymentMethodsViewController.swift
@@ -80,10 +80,14 @@ final class PledgePaymentMethodsViewController: UIViewController {
 
     self.viewModel.outputs.reloadPaymentMethods
       .observeForUI()
-      .observeValues { [weak self] cards, selectedCard, shouldReload, isLoading in
+      .observeValues { [weak self] cards, paymentSheetCard, selectedCard, shouldReload, isLoading in
         guard let self = self else { return }
 
-        self.dataSource.load(cards, isLoading: isLoading)
+        self.dataSource.load(
+          cards,
+          paymentSheetCard: paymentSheetCard,
+          isLoading: isLoading
+        )
 
         if shouldReload {
           self.tableView.reloadData()
@@ -168,7 +172,11 @@ final class PledgePaymentMethodsViewController: UIViewController {
             .pledgeViewController(strongSelf, didErrorWith: error.localizedDescription)
         case let .success(paymentSheetFlowController):
           strongSelf.paymentSheetFlowController = paymentSheetFlowController
-          strongSelf.paymentSheetFlowController?.presentPaymentOptions(from: strongSelf)
+          strongSelf.paymentSheetFlowController?.presentPaymentOptions(from: strongSelf) { [weak self] in
+            guard let strongSelf = self,
+              let existingPaymentOption = strongSelf.paymentSheetFlowController?.paymentOption else { return }
+            strongSelf.viewModel.inputs.paymentSheetDidAdd(newCard: existingPaymentOption)
+          }
         }
       }
   }

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -242,6 +242,8 @@
 		194520C5288859A600CA9B88 /* PaymentCardTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 194520C4288859A600CA9B88 /* PaymentCardTextField.swift */; };
 		194520CD28888F8900CA9B88 /* Stripe in Frameworks */ = {isa = PBXBuildFile; productRef = 194520CC28888F8900CA9B88 /* Stripe */; };
 		1981AC90289075D900BB4897 /* Stripe in Frameworks */ = {isa = PBXBuildFile; productRef = 1981AC8F289075D900BB4897 /* Stripe */; };
+		19F91B0E289C1DD6000AEC6A /* PledgePaymentSheetPaymentMethodCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19F91B0D289C1DD6000AEC6A /* PledgePaymentSheetPaymentMethodCell.swift */; };
+		19F91B10289C1E51000AEC6A /* PledgePaymentSheetPaymentMethodCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19F91B0F289C1E51000AEC6A /* PledgePaymentSheetPaymentMethodCellViewModel.swift */; };
 		203015582666FECF0063B629 /* CommentsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 477290F9264AE91800B83E10 /* CommentsViewModel.swift */; };
 		20338E1F26566F9E00F2C43A /* CommentComposerViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D7EE6526544F8B0094B04C /* CommentComposerViewModelTests.swift */; };
 		20338E262656AAD900F2C43A /* CommentComposerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D7EE6026544F200094B04C /* CommentComposerViewModel.swift */; };
@@ -1920,6 +1922,8 @@
 		19047FCE2889D4BC00BDD1A8 /* GraphAPI.CreateSetupIntentInput+CreateSetupIntentInputTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GraphAPI.CreateSetupIntentInput+CreateSetupIntentInputTests.swift"; sourceTree = "<group>"; };
 		19047FD02889D6DC00BDD1A8 /* ClientSecretEnvelope+CreateSetupIntentMutation.DataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ClientSecretEnvelope+CreateSetupIntentMutation.DataTests.swift"; sourceTree = "<group>"; };
 		194520C4288859A600CA9B88 /* PaymentCardTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentCardTextField.swift; sourceTree = "<group>"; };
+		19F91B0D289C1DD6000AEC6A /* PledgePaymentSheetPaymentMethodCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PledgePaymentSheetPaymentMethodCell.swift; sourceTree = "<group>"; };
+		19F91B0F289C1E51000AEC6A /* PledgePaymentSheetPaymentMethodCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PledgePaymentSheetPaymentMethodCellViewModel.swift; sourceTree = "<group>"; };
 		20455E6626712A6A00F55EDC /* CommentsErrorCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentsErrorCell.swift; sourceTree = "<group>"; };
 		209B0E39265801D70006DB7D /* CommentComposerViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentComposerViewTests.swift; sourceTree = "<group>"; };
 		20A093852666575F00DEC258 /* CommentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentTests.swift; sourceTree = "<group>"; };
@@ -4041,6 +4045,7 @@
 				8A13D162249566B8007E2C0B /* PledgeExpandableHeaderRewardHeaderCell.swift */,
 				8AB87DF2243FF22B006D7451 /* PledgePaymentMethodAddCell.swift */,
 				D6534D3722E784B500E9D279 /* PledgePaymentMethodCell.swift */,
+				19F91B0D289C1DD6000AEC6A /* PledgePaymentSheetPaymentMethodCell.swift */,
 				8A864ACC24429A5B0026BF13 /* PledgePaymentMethodLoadingCell.swift */,
 				9D9F57CB1D131AF200CE81DE /* ProjectActivityBackingCell.swift */,
 				9D2546F71D23101E0053844D /* ProjectActivityCommentCell.swift */,
@@ -4838,6 +4843,7 @@
 				8A73EAD02339732900FF9051 /* PledgePaymentMethodCellViewModelTests.swift */,
 				D6534D3B22E7898B00E9D279 /* PledgePaymentMethodsViewModel.swift */,
 				D6534D3D22E789B900E9D279 /* PledgePaymentMethodsViewModelTests.swift */,
+				19F91B0F289C1E51000AEC6A /* PledgePaymentSheetPaymentMethodCellViewModel.swift */,
 				3706408522A8A6D700889CBD /* PledgeShippingLocationViewModel.swift */,
 				3706408722A8A6F200889CBD /* PledgeShippingLocationViewModelTests.swift */,
 				8A1A93D124C602300012FB43 /* PledgeShippingSummaryViewModel.swift */,
@@ -5938,6 +5944,7 @@
 				37EB3E4C228CF4A400076E4C /* NumberFormatter.swift in Sources */,
 				D0D77C1E22D3FC3400356FEA /* UIPageViewController+ThreadSafety.swift in Sources */,
 				A7F441C71D005A9400FE6FC5 /* MessageCellViewModel.swift in Sources */,
+				19F91B10289C1E51000AEC6A /* PledgePaymentSheetPaymentMethodCellViewModel.swift in Sources */,
 				59673CBF1D50EE9B0035AFD9 /* VideoViewModel.swift in Sources */,
 				9D10B91B1D35407C008B8045 /* String+Truncate.swift in Sources */,
 				8AD48633235939AF00A1463E /* StripeTypes.swift in Sources */,
@@ -6680,6 +6687,7 @@
 				018422BE1D2C484700CA7566 /* DashboardTitleView.swift in Sources */,
 				5970739A1D06346700B00444 /* ProjectNotificationsViewController.swift in Sources */,
 				A745D1411CAAB48F00C12802 /* LoginToutViewController.swift in Sources */,
+				19F91B0E289C1DD6000AEC6A /* PledgePaymentSheetPaymentMethodCell.swift in Sources */,
 				06B0FDB92702579800147E3E /* ProjectPageViewController.swift in Sources */,
 				8A07CF1226604E8F00426B1C /* CommentRepliesViewController.swift in Sources */,
 				77EFBAE52268E01400DA5C3C /* RewardCell.swift in Sources */,

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -244,6 +244,7 @@
 		1981AC90289075D900BB4897 /* Stripe in Frameworks */ = {isa = PBXBuildFile; productRef = 1981AC8F289075D900BB4897 /* Stripe */; };
 		19F91B0E289C1DD6000AEC6A /* PledgePaymentSheetPaymentMethodCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19F91B0D289C1DD6000AEC6A /* PledgePaymentSheetPaymentMethodCell.swift */; };
 		19F91B10289C1E51000AEC6A /* PledgePaymentSheetPaymentMethodCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19F91B0F289C1E51000AEC6A /* PledgePaymentSheetPaymentMethodCellViewModel.swift */; };
+		19F91B14289C8097000AEC6A /* Stripe in Frameworks */ = {isa = PBXBuildFile; productRef = 19F91B13289C8097000AEC6A /* Stripe */; };
 		203015582666FECF0063B629 /* CommentsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 477290F9264AE91800B83E10 /* CommentsViewModel.swift */; };
 		20338E1F26566F9E00F2C43A /* CommentComposerViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D7EE6526544F8B0094B04C /* CommentComposerViewModelTests.swift */; };
 		20338E262656AAD900F2C43A /* CommentComposerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D7EE6026544F200094B04C /* CommentComposerViewModel.swift */; };
@@ -3290,6 +3291,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				19F91B14289C8097000AEC6A /* Stripe in Frameworks */,
 				8A04FE2C262781560056F413 /* SDWebImage.framework in Frameworks */,
 				8A04FE2D262781560056F413 /* Segment_Appboy.framework in Frameworks */,
 				8A04FE2E262781560056F413 /* Appboy_iOS_SDK.framework in Frameworks */,
@@ -5389,6 +5391,9 @@
 				A75511481C8642B3005355CF /* PBXTargetDependency */,
 			);
 			name = "Library-iOSTests";
+			packageProductDependencies = (
+				19F91B13289C8097000AEC6A /* Stripe */,
+			);
 			productName = "Library-iOSTests";
 			productReference = A75511451C8642B3005355CF /* Library-iOSTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
@@ -8562,6 +8567,11 @@
 			productName = Stripe;
 		};
 		1981AC8F289075D900BB4897 /* Stripe */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 194520C12888542100CA9B88 /* XCRemoteSwiftPackageReference "stripe-ios" */;
+			productName = Stripe;
+		};
+		19F91B13289C8097000AEC6A /* Stripe */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 194520C12888542100CA9B88 /* XCRemoteSwiftPackageReference "stripe-ios" */;
 			productName = Stripe;

--- a/Library/ViewModels/PledgePaymentMethodCellViewModel.swift
+++ b/Library/ViewModels/PledgePaymentMethodCellViewModel.swift
@@ -12,14 +12,9 @@ public typealias PledgePaymentMethodCellData = (
   isErroredPaymentMethod: Bool
 )
 
-public typealias PaymentSheetPaymentMethodCellData = (image: UIImage, redactedCardNumber: String)
-
 public protocol PledgePaymentMethodCellViewModelInputs {
   /// Call to configure cell with card and selected card values.
   func configureWith(value: PledgePaymentMethodCellData)
-
-  /// Call to configure cell with payment sheet card values (temporary Stripe enabled cards)
-  func configureWithPaymentSheetCard(value: PaymentSheetPaymentMethodCellData)
 
   /// Call with the currently selected card.
   func setSelectedCard(_ creditCard: UserCreditCards.CreditCard)
@@ -31,9 +26,6 @@ public protocol PledgePaymentMethodCellViewModelOutputs {
 
   /// Emits the card's image name.
   var cardImageName: Signal<String, Never> { get }
-
-  /// Emits the card's image.
-  var cardImage: Signal<UIImage, Never> { get }
 
   /// Emits a formatted accessibility string containing the card type, number and last four digits
   var cardNumberAccessibilityLabel: Signal<String, Never> { get }
@@ -71,46 +63,30 @@ public protocol PledgePaymentMethodCellViewModelType {
 public final class PledgePaymentMethodCellViewModel: PledgePaymentMethodCellViewModelInputs,
   PledgePaymentMethodCellViewModelOutputs, PledgePaymentMethodCellViewModelType {
   public init() {
-    let paymentSheetCreditCardImage = self.configurePaymentSheetCardValueProperty.signal.skipNil()
-      .map(\.image)
-    let paymentSheetCreditCardRedactedNumber = self.configurePaymentSheetCardValueProperty.signal.skipNil()
-      .map(\.redactedCardNumber)
     let creditCard = self.configureValueProperty.signal.skipNil().map(\.card)
     let selectedCard = self.selectedCardProperty.signal.skipNil()
     let cardTypeIsAvailable = self.configureValueProperty.signal.skipNil().map(\.isEnabled)
     let configuredAsSelected = self.configureValueProperty.signal.skipNil().map(\.isSelected)
 
-    self.cardImage = paymentSheetCreditCardImage
-
     self.cardImageName = creditCard
       .map { $0.imageName }
 
-    let creditCardAccessibilityLabel = creditCard
+    self.cardNumberAccessibilityLabel = creditCard
       .map {
         [$0.type?.description, Strings.Card_ending_in_last_four(last_four: $0.lastFour)]
           .compact()
           .joined(separator: ", ")
       }
 
-    let paymentSheetCreditCardAccessibilityLabel = paymentSheetCreditCardRedactedNumber.map {
-      Strings.Card_ending_in_last_four(last_four: $0)
-    }
-
-    self.cardNumberAccessibilityLabel = Signal
-      .merge(creditCardAccessibilityLabel, paymentSheetCreditCardAccessibilityLabel)
-
     let redactedCardNumber = creditCard
       .map { "•••• \($0.lastFour)" }
 
-    self.cardNumberTextShortStyle = Signal.merge(redactedCardNumber, paymentSheetCreditCardRedactedNumber)
+    self.cardNumberTextShortStyle = redactedCardNumber
 
     let creditCardExpiryDate = creditCard
       .map { Strings.Credit_card_expiration(expiration_date: $0.expirationDate()) }
 
-    let paymentSheetCreditCardExpiryDate = paymentSheetCreditCardRedactedNumber
-      .map(String.init)
-
-    self.expirationDateText = Signal.merge(creditCardExpiryDate, paymentSheetCreditCardExpiryDate)
+    self.expirationDateText = creditCardExpiryDate
 
     let cardAndSelectedCard = Signal.combineLatest(
       creditCard,
@@ -122,21 +98,12 @@ public final class PledgePaymentMethodCellViewModel: PledgePaymentMethodCellView
     let creditCardCheckImageName = Signal.merge(configuredAsSelected, setAsSelected)
       .map { $0 ? "icon-payment-method-selected" : "icon-payment-method-unselected" }
 
-    // FIXME: All payment sheet cards are mapping to unselected temporarily. Revisit this once displaying multiple payment sheet cards is working.
-    let paymentSheetCheckImageName = paymentSheetCreditCardExpiryDate
-      .map { _ in "icon-payment-method-unselected" }
+    self.checkmarkImageName = creditCardCheckImageName
 
-    self.checkmarkImageName = Signal.merge(creditCardCheckImageName, paymentSheetCheckImageName)
+    self.unavailableCardLabelHidden = self.configureValueProperty.signal.skipNil()
+      .map { card in !card.isEnabled || card.isErroredPaymentMethod }.negate()
 
-    let creditCardLabelUnavailable = self.configureValueProperty.signal.skipNil()
-      .map { card in !card.isEnabled || card.isErroredPaymentMethod }
-
-    let paymentSheetCreditCardUnavailable = paymentSheetCreditCardRedactedNumber.mapConst(false)
-
-    self.unavailableCardLabelHidden = Signal
-      .merge(creditCardLabelUnavailable.negate(), paymentSheetCreditCardUnavailable.negate())
-
-    let cardText = self.configureValueProperty.signal.skipNil()
+    self.unavailableCardText = self.configureValueProperty.signal.skipNil()
       .filter { card in !card.isEnabled || card.isErroredPaymentMethod }
       .map { card -> String in
         if !card.isEnabled {
@@ -148,52 +115,24 @@ public final class PledgePaymentMethodCellViewModel: PledgePaymentMethodCellView
         return Strings.Retry_or_select_another_method()
       }
 
-    let paymentSheetCardText = paymentSheetCreditCardRedactedNumber.map { _ in Strings.general_error_oops() }
-
-    self.unavailableCardText = Signal.merge(cardText, paymentSheetCardText)
-
-    let creditCardIsAvailableForSelectionStyle = cardTypeIsAvailable.map {
+    self.selectionStyle = cardTypeIsAvailable.map {
       $0 ? UITableViewCell.SelectionStyle.default : .none
     }
 
-    let paymentSheetCreditCardIsAvailableForSelectionStyle = paymentSheetCreditCardRedactedNumber
-      .map { _ in UITableViewCell.SelectionStyle.default }
-
-    self.selectionStyle = Signal
-      .merge(creditCardIsAvailableForSelectionStyle, paymentSheetCreditCardIsAvailableForSelectionStyle)
-
-    let creditCardIsAvailable = cardTypeIsAvailable.map {
-      CGFloat($0 ? 1.0 : 0.5)
+    self.cardImageAlpha = cardTypeIsAvailable.map {
+      $0 ? 1.0 : 0.5
     }
 
-    let paymentSheetCreditCardIsAvailable = paymentSheetCreditCardRedactedNumber.map { _ in CGFloat(1.0) }
+    self.checkmarkImageHidden = cardTypeIsAvailable.negate()
 
-    self.cardImageAlpha = Signal.merge(creditCardIsAvailable, paymentSheetCreditCardIsAvailable)
-
-    let creditCardImageHidden = cardTypeIsAvailable.negate()
-
-    let paymentSheetCreditCardImageHidden = paymentSheetCreditCardRedactedNumber.mapConst(false)
-
-    self.checkmarkImageHidden = Signal.merge(creditCardImageHidden, paymentSheetCreditCardImageHidden)
-
-    let creditCardTextColor = cardTypeIsAvailable.map { cardTypeIsAvailable in
+    self.lastFourLabelTextColor = cardTypeIsAvailable.map { cardTypeIsAvailable in
       cardTypeIsAvailable ? UIColor.ksr_support_700 : UIColor.ksr_support_400
     }
-
-    let paymentSheetTextColor = paymentSheetCreditCardRedactedNumber.mapConst(UIColor.ksr_support_700)
-
-    self.lastFourLabelTextColor = Signal.merge(creditCardTextColor, paymentSheetTextColor)
   }
 
   fileprivate let configureValueProperty = MutableProperty<PledgePaymentMethodCellData?>(nil)
   public func configureWith(value: PledgePaymentMethodCellData) {
     self.configureValueProperty.value = value
-  }
-
-  fileprivate let configurePaymentSheetCardValueProperty =
-    MutableProperty<PaymentSheetPaymentMethodCellData?>(nil)
-  public func configureWithPaymentSheetCard(value: PaymentSheetPaymentMethodCellData) {
-    self.configurePaymentSheetCardValueProperty.value = value
   }
 
   private let selectedCardProperty = MutableProperty<UserCreditCards.CreditCard?>(nil)
@@ -203,7 +142,6 @@ public final class PledgePaymentMethodCellViewModel: PledgePaymentMethodCellView
 
   public let cardImageAlpha: Signal<CGFloat, Never>
   public let cardImageName: Signal<String, Never>
-  public let cardImage: Signal<UIImage, Never>
   public let cardNumberAccessibilityLabel: Signal<String, Never>
   public let cardNumberTextShortStyle: Signal<String, Never>
   public let checkmarkImageHidden: Signal<Bool, Never>

--- a/Library/ViewModels/PledgePaymentMethodsViewModel.swift
+++ b/Library/ViewModels/PledgePaymentMethodsViewModel.swift
@@ -164,9 +164,23 @@ public final class PledgePaymentMethodsViewModel: PledgePaymentMethodsViewModelT
         isLoading: true
       ) }
 
+    let configuredCardsWithNewSetupIntentCards = configuredCards
+      .takePairWhen(newSetupIntentCard)
+      .map { cardData, setupIntentCardData -> PledgePaymentMethodsAndSelectionData in
+        let updatedCardData = cardData
+          |> \.paymentSheetPaymentMethodsCellData .~ setupIntentCardData
+
+        return updatedCardData
+      }
+
+    let configuredPaymentMethodsIncludingSetupIntentCards = Signal.merge(
+      configuredCards,
+      configuredCardsWithNewSetupIntentCards
+    )
+
     self.reloadPaymentMethods = Signal.merge(
       reloadWithLoadingCell,
-      configuredCards,
+      configuredPaymentMethodsIncludingSetupIntentCards,
       updatedCards
     )
 

--- a/Library/ViewModels/PledgePaymentSheetPaymentMethodCellViewModel.swift
+++ b/Library/ViewModels/PledgePaymentSheetPaymentMethodCellViewModel.swift
@@ -1,0 +1,133 @@
+import KsApi
+import Prelude
+import ReactiveExtensions
+import ReactiveSwift
+import UIKit
+
+public typealias PaymentSheetPaymentMethodCellData = (image: UIImage, redactedCardNumber: String)
+
+public protocol PledgePaymentSheetPaymentMethodCellViewModelInputs {
+  /// Call to configure cell with payment sheet card and selected payment sheet card values.
+  func configureWith(value: PaymentSheetPaymentMethodCellData)
+
+  // FIXME: All payment sheet cards are mapping to unselected temporarily. Revisit this once displaying multiple payment sheet cards is working.
+  /// Call with the currently selected card.
+  func setSelectedCard(_ creditCard: UserCreditCards.CreditCard)
+}
+
+public protocol PledgePaymentSheetPaymentMethodCellViewModelOutputs {
+  /// Emits the alpha for the card image
+  var cardImageAlpha: Signal<CGFloat, Never> { get }
+
+  /// Emits the card's image.
+  var cardImage: Signal<UIImage, Never> { get }
+
+  /// Emits a formatted accessibility string containing the card type, number and last four digits
+  var cardNumberAccessibilityLabel: Signal<String, Never> { get }
+
+  /// Emits a formatted string containing the card's last four digits.
+  var cardNumberTextShortStyle: Signal<String, Never> { get }
+
+  /// Emits when the checkmark image should be hidden.
+  var checkmarkImageHidden: Signal<Bool, Never> { get }
+
+  /// Emits the checkmark image.
+  var checkmarkImageName: Signal<String, Never> { get }
+
+  /// Emits the formatted card's expirationdate.
+  var expirationDateText: Signal<String, Never> { get }
+
+  /// Emits the text color for the last four digits label.
+  var lastFourLabelTextColor: Signal<UIColor, Never> { get }
+
+  /// Emits the selection cell's selection style.
+  var selectionStyle: Signal<UITableViewCell.SelectionStyle, Never> { get }
+
+  /// Emits whether or not the unavailable card type label should be hidden.
+  var unavailableCardLabelHidden: Signal<Bool, Never> { get }
+
+  /// Emits a string explaining why card type is unavailable.
+  var unavailableCardText: Signal<String, Never> { get }
+}
+
+public protocol PledgePaymentSheetPaymentMethodCellViewModelType {
+  var inputs: PledgePaymentSheetPaymentMethodCellViewModelInputs { get }
+  var outputs: PledgePaymentSheetPaymentMethodCellViewModelOutputs { get }
+}
+
+public final class PledgePaymentSheetPaymentMethodCellViewModel: PledgePaymentSheetPaymentMethodCellViewModelInputs,
+  PledgePaymentSheetPaymentMethodCellViewModelOutputs, PledgePaymentSheetPaymentMethodCellViewModelType {
+  public init() {
+    let paymentSheetCreditCardImage = self.configureValueProperty.signal.skipNil()
+      .map(\.image)
+    let paymentSheetCreditCardRedactedNumber = self.configureValueProperty.signal.skipNil()
+      .map(\.redactedCardNumber)
+
+    self.cardImage = paymentSheetCreditCardImage
+
+    self.cardNumberAccessibilityLabel = paymentSheetCreditCardRedactedNumber.map {
+      Strings.Card_ending_in_last_four(last_four: $0)
+    }
+
+    self.cardNumberTextShortStyle = paymentSheetCreditCardRedactedNumber
+
+    let paymentSheetCreditCardExpiryDate = paymentSheetCreditCardRedactedNumber
+      .map(value: "")
+
+    self.expirationDateText = paymentSheetCreditCardExpiryDate
+
+    // FIXME: All payment sheet cards are mapping to unselected temporarily. Revisit this once displaying multiple payment sheet cards is working.
+    let paymentSheetCheckImageName = paymentSheetCreditCardExpiryDate
+      .map { _ in "icon-payment-method-unselected" }
+
+    self.checkmarkImageName = paymentSheetCheckImageName
+
+    let paymentSheetCreditCardUnavailable = paymentSheetCreditCardRedactedNumber.mapConst(false)
+
+    self.unavailableCardLabelHidden = paymentSheetCreditCardUnavailable.negate()
+
+    let paymentSheetCardText = paymentSheetCreditCardRedactedNumber.map { _ in Strings.general_error_oops() }
+
+    self.unavailableCardText = paymentSheetCardText
+
+    let paymentSheetCreditCardIsAvailableForSelectionStyle = paymentSheetCreditCardRedactedNumber
+      .map { _ in UITableViewCell.SelectionStyle.default }
+
+    self.selectionStyle = paymentSheetCreditCardIsAvailableForSelectionStyle
+
+    let paymentSheetCreditCardIsAvailable = paymentSheetCreditCardRedactedNumber.map { _ in CGFloat(1.0) }
+
+    self.cardImageAlpha = paymentSheetCreditCardIsAvailable
+
+    let paymentSheetCreditCardImageHidden = paymentSheetCreditCardRedactedNumber.mapConst(false)
+
+    self.checkmarkImageHidden = paymentSheetCreditCardImageHidden
+
+    self.lastFourLabelTextColor = paymentSheetCreditCardRedactedNumber.mapConst(UIColor.ksr_support_700)
+  }
+
+  fileprivate let configureValueProperty = MutableProperty<PaymentSheetPaymentMethodCellData?>(nil)
+  public func configureWith(value: PaymentSheetPaymentMethodCellData) {
+    self.configureValueProperty.value = value
+  }
+
+  private let selectedCardProperty = MutableProperty<UserCreditCards.CreditCard?>(nil)
+  public func setSelectedCard(_ creditCard: UserCreditCards.CreditCard) {
+    self.selectedCardProperty.value = creditCard
+  }
+
+  public let cardImageAlpha: Signal<CGFloat, Never>
+  public let cardImage: Signal<UIImage, Never>
+  public let cardNumberAccessibilityLabel: Signal<String, Never>
+  public let cardNumberTextShortStyle: Signal<String, Never>
+  public let checkmarkImageHidden: Signal<Bool, Never>
+  public let checkmarkImageName: Signal<String, Never>
+  public let expirationDateText: Signal<String, Never>
+  public let lastFourLabelTextColor: Signal<UIColor, Never>
+  public let selectionStyle: Signal<UITableViewCell.SelectionStyle, Never>
+  public let unavailableCardLabelHidden: Signal<Bool, Never>
+  public let unavailableCardText: Signal<String, Never>
+
+  public var inputs: PledgePaymentSheetPaymentMethodCellViewModelInputs { return self }
+  public var outputs: PledgePaymentSheetPaymentMethodCellViewModelOutputs { return self }
+}


### PR DESCRIPTION
# 📲 What and 🤔 Why

We need to show the user the new payment option created from the Stripe Payment Sheet.

# 🛠 How

The key here is to merge into the `configuredCards` signal with any new Stripe `PaymentOptionDisplayData` coming in from the view controller.

With that, the `reloadPaymentMethods` passes the original card data along with the new `PaymentSheetPaymentMethodCellData` typealias to hold the Stripe data.

Data source modified to accept new payment sheet card data.

New cell (`PledgePaymentSheetPaymentMethodCell`) almost identical to the old one (`PledgePaymentMethodCell`) is displaying only data from the Stripe payment cards.

This way is lightweight in that we only display the data the user can select (coming..). 
Nothing in this PR will affect the flow of cards being returned from `fetchGraphUser(withStoredCards:)`. It just augments it. Even if the old add new card page is used, this flow in theory should be fine.

# 👀 See

Before 🐛

![Simulator Screen Recording - iPhone 8 - 2022-08-04 at 19 02 43](https://user-images.githubusercontent.com/4282741/182969574-cbcedc09-9f90-4f19-9af2-a6121e2760a7.gif)

After �

![Simulator Screen Recording - iPhone 8 - 2022-08-04 at 19 10 11](https://user-images.githubusercontent.com/4282741/182970267-9b4fb7e5-2963-401e-8cc8-be12b5f04bef.gif)

# ✅ Acceptance criteria

- [x] Ensure once user has created a new payment option it appears within the pledge screen along with other cards (no support for pledging/selecting a new card yet)

# ⏰ TODO

- [x] Hook up signal from `paymentOption` to `reloadPaymentMethods` in `PledgePaymentMethodsViewModel`
- [x] Expand logic for multiple cards created via the payment sheet
- [ ] Handle selection of new card vs exisiting cards. (will do in next [ticket](https://kickstarter.atlassian.net/browse/PAY-1829))
- [x] Unit/snapshot tests. Note: no view controller/cell/cell view model tests, because the screenshot tests for `AddNewCardViewControllerTests` need to be fixed first. Tip: Try using `@testable` with the `Stripe` framework imported into the `Kickstarter-Framework-iOSTests`.
