### PR TITLE
[PAY-1790] Create Backing With Setup Intent Client Secret

### DIFF
--- a/Kickstarter-iOS/Views/Controllers/PledgePaymentMethodsViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/PledgePaymentMethodsViewController.swift
@@ -8,7 +8,7 @@ import UIKit
 protocol PledgePaymentMethodsViewControllerDelegate: AnyObject {
   func pledgePaymentMethodsViewController(
     _ viewController: PledgePaymentMethodsViewController,
-    didSelectCreditCard paymentSourceId: String
+    didSelectCreditCard paymentSource: PaymentSourceSelected
   )
 
   func pledgePaymentMethodsViewController(

--- a/Kickstarter-iOS/Views/Controllers/PledgeViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/PledgeViewController.swift
@@ -654,9 +654,9 @@ extension PledgeViewController: PledgeViewControllerMessageDisplaying {
 extension PledgeViewController: PledgePaymentMethodsViewControllerDelegate {
   func pledgePaymentMethodsViewController(
     _: PledgePaymentMethodsViewController,
-    didSelectCreditCard paymentSourceId: String
+    didSelectCreditCard paymentSource: PaymentSourceSelected
   ) {
-    self.viewModel.inputs.creditCardSelected(with: paymentSourceId)
+    self.viewModel.inputs.creditCardSelected(with: paymentSource)
   }
 
   func pledgePaymentMethodsViewController(_: PledgePaymentMethodsViewController, loading flag: Bool) {

--- a/KsApi/graphql-schema.json
+++ b/KsApi/graphql-schema.json
@@ -11531,6 +11531,12 @@
             "deprecationReason": null
           },
           {
+            "name": "hide_facebook_login_button_2022",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "stripe_connect_onboarding_only_for_kyc",
             "description": null,
             "isDeprecated": false,

--- a/KsApi/models/graphql/adapters/GraphAPI.CreateBackingInput+CreateBackingInput.swift
+++ b/KsApi/models/graphql/adapters/GraphAPI.CreateBackingInput+CreateBackingInput.swift
@@ -9,7 +9,7 @@ extension GraphAPI.CreateBackingInput {
       rewardIds: input.rewardIds,
       refParam: input.refParam,
       paymentSourceId: input.paymentSourceId,
-      setupIntentClientSecret: nil,
+      setupIntentClientSecret: input.setupIntentClientSecret,
       applePay: GraphAPI.ApplePayInput.from(input.applePay)
     )
   }

--- a/KsApi/models/graphql/adapters/GraphAPI.CreateBackingInput+CreateBackingInputTests.swift
+++ b/KsApi/models/graphql/adapters/GraphAPI.CreateBackingInput+CreateBackingInputTests.swift
@@ -23,7 +23,7 @@ final class GraphAPI_CreateBackingInput_CreateBackingInputTests: XCTestCase {
     XCTAssertEqual(graphInput.projectId, input.projectId)
     XCTAssertEqual(graphInput.refParam, input.refParam)
     XCTAssertEqual(graphInput.rewardIds, input.rewardIds)
-    XCTAssertNil(graphInput.setupIntentClientSecret!)
+    XCTAssertEqual(graphInput.setupIntentClientSecret!, input.setupIntentClientSecret)
   }
 
   func test_ApplePay() {
@@ -55,6 +55,6 @@ final class GraphAPI_CreateBackingInput_CreateBackingInputTests: XCTestCase {
     XCTAssertEqual(graphInput.projectId, input.projectId)
     XCTAssertEqual(graphInput.refParam, input.refParam)
     XCTAssertEqual(graphInput.rewardIds, input.rewardIds)
-    XCTAssertNil(graphInput.setupIntentClientSecret!)
+    XCTAssertNil(graphInput.setupIntentClientSecret as? String)
   }
 }

--- a/Library/CreateBackingConstructorTests.swift
+++ b/Library/CreateBackingConstructorTests.swift
@@ -16,13 +16,14 @@ final class CreateBackingInputConstructorTests: XCTestCase {
       token: "token"
     )
 
-    let data: CreateBackingData = (
+    let data = CreateBackingData(
       project: project,
       rewards: [reward],
       pledgeTotal: 10,
       selectedQuantities: [reward.id: 1],
       shippingRule: nil,
       paymentSourceId: UserCreditCards.amex.id,
+      setupIntentClientSecret: nil,
       applePayParams: applePayParams,
       refTag: RefTag.projectPage
     )
@@ -59,6 +60,7 @@ final class CreateBackingInputConstructorTests: XCTestCase {
       selectedQuantities: [reward.id: 1],
       shippingRule: shippingRule,
       paymentSourceId: "123",
+      setupIntentClientSecret: "xyz",
       applePayParams: applePayParams,
       refTag: nil
     )
@@ -100,6 +102,7 @@ final class CreateBackingInputConstructorTests: XCTestCase {
       selectedQuantities: [reward.id: 1, addOn1.id: 2, addOn2.id: 3],
       shippingRule: shippingRule,
       paymentSourceId: "123",
+      setupIntentClientSecret: "xyz",
       applePayParams: applePayParams,
       refTag: .discovery
     )
@@ -116,5 +119,72 @@ final class CreateBackingInputConstructorTests: XCTestCase {
     )
     XCTAssertNil(input.paymentSourceId)
     XCTAssertEqual(input.refParam, "discovery")
+  }
+
+  func testCreateBackingInput_WithApplePay_AndPaymentSource_AndSetupIntentClientSecret_OnlyApplePayIsValid_Success() {
+    let applePayParams = ApplePayParams(
+      paymentInstrumentName: "paymentInstrumentName",
+      paymentNetwork: "paymentNetwork",
+      transactionIdentifier: "transactionIdentifier",
+      token: "token"
+    )
+
+    let data: CreateBackingData = (
+      project: .template,
+      rewards: [.noReward],
+      pledgeTotal: 10,
+      selectedQuantities: [Reward.noReward.id: 1],
+      shippingRule: nil,
+      paymentSourceId: UserCreditCards.amex.id,
+      setupIntentClientSecret: "xyz",
+      applePayParams: applePayParams,
+      refTag: RefTag.projectPage
+    )
+
+    let input = CreateBackingInput.input(from: data, isApplePay: true)
+
+    XCTAssertNotNil(input.applePay)
+    XCTAssertNil(input.paymentSourceId)
+    XCTAssertNil(input.setupIntentClientSecret)
+  }
+
+  func testCreateBackingInput_WithNoApplePay_AndPaymentSource_AndSetupIntentClientSecret_OnlyPaymentSourceIsValid_Success() {
+    let data: CreateBackingData = (
+      project: .template,
+      rewards: [.noReward],
+      pledgeTotal: 10,
+      selectedQuantities: [Reward.noReward.id: 1],
+      shippingRule: nil,
+      paymentSourceId: UserCreditCards.amex.id,
+      setupIntentClientSecret: nil,
+      applePayParams: nil,
+      refTag: RefTag.projectPage
+    )
+
+    let input = CreateBackingInput.input(from: data, isApplePay: false)
+
+    XCTAssertNil(input.applePay)
+    XCTAssertEqual(input.paymentSourceId, UserCreditCards.amex.id)
+    XCTAssertNil(input.setupIntentClientSecret)
+  }
+
+  func testCreateBackingInput_WithNoApplePay_NoPaymentSource_AndSetupIntentClientSecret_OnlySetupIntentClientSecretIsValid_Success() {
+    let data: CreateBackingData = (
+      project: .template,
+      rewards: [.noReward],
+      pledgeTotal: 10,
+      selectedQuantities: [Reward.noReward.id: 1],
+      shippingRule: nil,
+      paymentSourceId: nil,
+      setupIntentClientSecret: "xyz",
+      applePayParams: nil,
+      refTag: RefTag.projectPage
+    )
+
+    let input = CreateBackingInput.input(from: data, isApplePay: false)
+
+    XCTAssertNil(input.applePay)
+    XCTAssertNil(input.paymentSourceId)
+    XCTAssertEqual(input.setupIntentClientSecret, "xyz")
   }
 }

--- a/Library/CreateBackingInput+Constructor.swift
+++ b/Library/CreateBackingInput+Constructor.swift
@@ -21,7 +21,7 @@ extension CreateBackingInput {
       projectId: createBackingData.project.graphID,
       refParam: createBackingData.refTag?.description,
       rewardIds: pledgeParams.rewardIds,
-      setupIntentClientSecret: nil
+      setupIntentClientSecret: isApplePay ? nil : createBackingData.setupIntentClientSecret
     )
   }
 }

--- a/Library/CreateBackingInput+Constructor.swift
+++ b/Library/CreateBackingInput+Constructor.swift
@@ -13,15 +13,20 @@ extension CreateBackingInput {
       shippingRule: createBackingData.shippingRule
     )
 
+    let setupIntentClientSecret = isApplePay ? nil : createBackingData
+      .paymentSourceId == nil ? createBackingData.setupIntentClientSecret : nil
+    let paymentSourceId = isApplePay ? nil : createBackingData
+      .setupIntentClientSecret == nil ? createBackingData.paymentSourceId : nil
+
     return CreateBackingInput(
       amount: pledgeParams.pledgeTotal,
       applePay: isApplePay ? createBackingData.applePayParams : nil,
       locationId: pledgeParams.locationId,
-      paymentSourceId: isApplePay ? nil : createBackingData.paymentSourceId,
+      paymentSourceId: paymentSourceId,
       projectId: createBackingData.project.graphID,
       refParam: createBackingData.refTag?.description,
       rewardIds: pledgeParams.rewardIds,
-      setupIntentClientSecret: isApplePay ? nil : createBackingData.setupIntentClientSecret
+      setupIntentClientSecret: setupIntentClientSecret
     )
   }
 }

--- a/Library/UpdateBackingInput+Constructor.swift
+++ b/Library/UpdateBackingInput+Constructor.swift
@@ -20,7 +20,7 @@ extension UpdateBackingInput {
       id: backingId,
       locationId: locationId,
       paymentSourceId: isApplePay ? nil : updateBackingData.paymentSourceId,
-      rewardIds: rewardIds
+      rewardIds: rewardIds // FIXME: Update with `setupIntentClientSecret` when available on GQL schema.
     )
   }
 }

--- a/Library/UpdateBackingInput+ConstructorTests.swift
+++ b/Library/UpdateBackingInput+ConstructorTests.swift
@@ -21,6 +21,7 @@ final class UpdateBackingInput_ConstructorTests: TestCase {
       selectedQuantities: [reward.id: 1],
       shippingRule: ShippingRule.template,
       paymentSourceId: UserCreditCards.amex.id,
+      setupIntentClientSecret: nil,
       applePayParams: applePayParams
     )
 
@@ -51,6 +52,7 @@ final class UpdateBackingInput_ConstructorTests: TestCase {
       selectedQuantities: [reward.id: 1],
       shippingRule: ShippingRule.template,
       paymentSourceId: UserCreditCards.amex.id,
+      setupIntentClientSecret: nil,
       applePayParams: applePayParams
     )
 
@@ -89,6 +91,7 @@ final class UpdateBackingInput_ConstructorTests: TestCase {
       selectedQuantities: [reward.id: 1, addOn1.id: 2, addOn2.id: 3],
       shippingRule: shippingRule,
       paymentSourceId: "123",
+      setupIntentClientSecret: nil,
       applePayParams: applePayParams
     )
 

--- a/Library/ViewModels/PledgePaymentMethodsViewModel.swift
+++ b/Library/ViewModels/PledgePaymentMethodsViewModel.swift
@@ -46,7 +46,7 @@ public protocol PledgePaymentMethodsViewModelInputs {
 public protocol PledgePaymentMethodsViewModelOutputs {
   var goToAddCardScreen: Signal<(AddNewCardIntent, Project), Never> { get }
   var goToAddCardViaStripeScreen: Signal<PaymentSheetSetupData, Never> { get }
-  var notifyDelegateCreditCardSelected: Signal<String, Never> { get }
+  var notifyDelegateCreditCardSelected: Signal<PaymentSourceSelected, Never> { get }
   var notifyDelegateLoadPaymentMethodsError: Signal<String, Never> { get }
   var reloadPaymentMethods: Signal<PledgePaymentMethodsAndSelectionData, Never> { get }
   var showLoadingIndicatorView: Signal<Bool, Never> { get }
@@ -265,15 +265,21 @@ public final class PledgePaymentMethodsViewModel: PledgePaymentMethodsViewModelT
     )
 
     self.notifyDelegateCreditCardSelected = self.reloadPaymentMethods
-      .map { paymentMethodData -> String? in
+      .map { paymentMethodData -> PaymentSourceSelected? in
         let selectedPaymentMethodCardId = paymentMethodData.selectedCard?.id
         let selectedPaymentSheetPaymentMethodCardId = paymentMethodData.selectedSetupIntent
 
         switch (selectedPaymentMethodCardId, selectedPaymentSheetPaymentMethodCardId) {
         case let (.none, .some(selectedPaymentSheetPaymentMethodCardId)):
-          return selectedPaymentSheetPaymentMethodCardId
+          return PaymentSourceSelected(
+            paymentSourceId: selectedPaymentSheetPaymentMethodCardId,
+            isSetupIntentClientSecret: true
+          )
         case let (.some(selectedPaymentMethodCardId), .none):
-          return selectedPaymentMethodCardId
+          return PaymentSourceSelected(
+            paymentSourceId: selectedPaymentMethodCardId,
+            isSetupIntentClientSecret: false
+          )
         default:
           return nil
         }
@@ -407,7 +413,7 @@ public final class PledgePaymentMethodsViewModel: PledgePaymentMethodsViewModelT
 
   public let goToAddCardScreen: Signal<(AddNewCardIntent, Project), Never>
   public let goToAddCardViaStripeScreen: Signal<PaymentSheetSetupData, Never>
-  public let notifyDelegateCreditCardSelected: Signal<String, Never>
+  public let notifyDelegateCreditCardSelected: Signal<PaymentSourceSelected, Never>
   public let notifyDelegateLoadPaymentMethodsError: Signal<String, Never>
   public let reloadPaymentMethods: Signal<PledgePaymentMethodsAndSelectionData, Never>
   public let showLoadingIndicatorView: Signal<Bool, Never>

--- a/Library/ViewModels/PledgePaymentMethodsViewModelTests.swift
+++ b/Library/ViewModels/PledgePaymentMethodsViewModelTests.swift
@@ -14,7 +14,7 @@ final class PledgePaymentMethodsViewModelTests: TestCase {
   private let goToAddCardIntent = TestObserver<AddNewCardIntent, Never>()
   private let goToAddStripeCardIntent = TestObserver<PaymentSheetSetupData, Never>()
   private let goToProject = TestObserver<Project, Never>()
-  private let notifyDelegateCreditCardSelected = TestObserver<String, Never>()
+  private let notifyDelegateCreditCardSelected = TestObserver<PaymentSourceSelected, Never>()
   private let notifyDelegateLoadPaymentMethodsError = TestObserver<String, Never>()
 
   private let reloadPaymentMethodsCards = TestObserver<[UserCreditCards.CreditCard], Never>()
@@ -671,7 +671,8 @@ final class PledgePaymentMethodsViewModelTests: TestCase {
       self.scheduler.run()
 
       self.notifyDelegateCreditCardSelected.assertValues(
-        [UserCreditCards.amex.id], "First card selected by default"
+        [PaymentSourceSelected(paymentSourceId: UserCreditCards.amex.id, isSetupIntentClientSecret: false)],
+        "First card selected by default"
       )
 
       let discoverIndexPath = IndexPath(
@@ -682,7 +683,11 @@ final class PledgePaymentMethodsViewModelTests: TestCase {
       self.vm.inputs.didSelectRowAtIndexPath(discoverIndexPath)
 
       self.notifyDelegateCreditCardSelected.assertValues([
-        UserCreditCards.amex.id, UserCreditCards.discover.id
+        PaymentSourceSelected(paymentSourceId: UserCreditCards.amex.id, isSetupIntentClientSecret: false),
+        PaymentSourceSelected(
+          paymentSourceId: UserCreditCards.discover.id,
+          isSetupIntentClientSecret: false
+        )
       ])
     }
   }
@@ -700,7 +705,8 @@ final class PledgePaymentMethodsViewModelTests: TestCase {
       self.scheduler.run()
 
       self.notifyDelegateCreditCardSelected.assertValues(
-        [UserCreditCards.visa.id], "First card selected by default"
+        [PaymentSourceSelected(paymentSourceId: UserCreditCards.visa.id, isSetupIntentClientSecret: false)],
+        "First card selected by default"
       )
 
       guard let paymentMethod = STPPaymentMethod.decodedObject(fromAPIResponse: [
@@ -727,7 +733,11 @@ final class PledgePaymentMethodsViewModelTests: TestCase {
         )
 
       self.notifyDelegateCreditCardSelected.assertValues([
-        UserCreditCards.visa.id, "seti_1LVlHO4VvJ2PtfhK43R6p7FI_secret_MEDiGbxfYVnHGsQy8v8TbZJTQhlNKLZ"
+        PaymentSourceSelected(paymentSourceId: UserCreditCards.visa.id, isSetupIntentClientSecret: false),
+        PaymentSourceSelected(
+          paymentSourceId: "seti_1LVlHO4VvJ2PtfhK43R6p7FI_secret_MEDiGbxfYVnHGsQy8v8TbZJTQhlNKLZ",
+          isSetupIntentClientSecret: true
+        )
       ])
     }
   }

--- a/Library/ViewModels/PledgePaymentMethodsViewModelTests.swift
+++ b/Library/ViewModels/PledgePaymentMethodsViewModelTests.swift
@@ -991,7 +991,7 @@ final class PledgePaymentMethodsViewModelTests: TestCase {
     }
   }
 
-  func testGoToAddNewStripeCardScreen_WhenPaymentSheetEnabled_Success() {
+  func testGoToAddNewStripeCardScreen_WhenPaymentSheetEnabled_PledgeContext_Success() {
     let project = Project.template
     let addNewCardIndexPath = IndexPath(
       row: 0,
@@ -1033,6 +1033,130 @@ final class PledgePaymentMethodsViewModelTests: TestCase {
       }
 
       XCTAssertTrue(allowedDelayedPaymentMethods)
+    }
+  }
+  
+  func testGoToAddNewStripeCardScreen_WhenPaymentSheetEnabled_UpdateContext_Failure() {
+    let project = Project.template
+    let addNewCardIndexPath = IndexPath(
+      row: 0,
+      section: PaymentMethodsTableViewSection.addNewCard.rawValue
+    )
+    let envelope = ClientSecretEnvelope(clientSecret: "test")
+    let mockOptimizelyClient = MockOptimizelyClient()
+      |> \.features .~ [
+        OptimizelyFeature.paymentSheetEnabled.rawValue: true
+      ]
+    let mockService = MockService(createStripeSetupIntentResult: .success(envelope))
+    var configuration = PaymentSheet.Configuration()
+    configuration.merchantDisplayName = Strings.general_accessibility_kickstarter()
+    configuration.allowsDelayedPaymentMethods = true
+
+    withEnvironment(
+      apiService: mockService,
+      currentUser: User.template,
+      optimizelyClient: mockOptimizelyClient
+    ) {
+      self.vm.inputs.viewDidLoad()
+      self.vm.inputs.configure(with: (User.template, project, Reward.template, .update, .discovery))
+      self.vm.inputs.didSelectRowAtIndexPath(addNewCardIndexPath)
+
+      self.scheduler.run()
+
+      self.goToAddStripeCardIntent.assertDidNotEmitValue()
+    }
+  }
+  
+  func testGoToAddNewStripeCardScreen_WhenPaymentSheetEnabled_UpdateRewardContext_Failure() {
+    let project = Project.template
+    let addNewCardIndexPath = IndexPath(
+      row: 0,
+      section: PaymentMethodsTableViewSection.addNewCard.rawValue
+    )
+    let envelope = ClientSecretEnvelope(clientSecret: "test")
+    let mockOptimizelyClient = MockOptimizelyClient()
+      |> \.features .~ [
+        OptimizelyFeature.paymentSheetEnabled.rawValue: true
+      ]
+    let mockService = MockService(createStripeSetupIntentResult: .success(envelope))
+    var configuration = PaymentSheet.Configuration()
+    configuration.merchantDisplayName = Strings.general_accessibility_kickstarter()
+    configuration.allowsDelayedPaymentMethods = true
+
+    withEnvironment(
+      apiService: mockService,
+      currentUser: User.template,
+      optimizelyClient: mockOptimizelyClient
+    ) {
+      self.vm.inputs.viewDidLoad()
+      self.vm.inputs.configure(with: (User.template, project, Reward.template, .updateReward, .discovery))
+      self.vm.inputs.didSelectRowAtIndexPath(addNewCardIndexPath)
+
+      self.scheduler.run()
+
+      self.goToAddStripeCardIntent.assertDidNotEmitValue()
+    }
+  }
+  
+  func testGoToAddNewStripeCardScreen_WhenPaymentSheetEnabled_ChangePaymentMethodContext_Failure() {
+    let project = Project.template
+    let addNewCardIndexPath = IndexPath(
+      row: 0,
+      section: PaymentMethodsTableViewSection.addNewCard.rawValue
+    )
+    let envelope = ClientSecretEnvelope(clientSecret: "test")
+    let mockOptimizelyClient = MockOptimizelyClient()
+      |> \.features .~ [
+        OptimizelyFeature.paymentSheetEnabled.rawValue: true
+      ]
+    let mockService = MockService(createStripeSetupIntentResult: .success(envelope))
+    var configuration = PaymentSheet.Configuration()
+    configuration.merchantDisplayName = Strings.general_accessibility_kickstarter()
+    configuration.allowsDelayedPaymentMethods = true
+
+    withEnvironment(
+      apiService: mockService,
+      currentUser: User.template,
+      optimizelyClient: mockOptimizelyClient
+    ) {
+      self.vm.inputs.viewDidLoad()
+      self.vm.inputs.configure(with: (User.template, project, Reward.template, .changePaymentMethod, .discovery))
+      self.vm.inputs.didSelectRowAtIndexPath(addNewCardIndexPath)
+
+      self.scheduler.run()
+
+      self.goToAddStripeCardIntent.assertDidNotEmitValue()
+    }
+  }
+  
+  func testGoToAddNewStripeCardScreen_WhenPaymentSheetEnabled_FixPaymentMethodContext_Failure() {
+    let project = Project.template
+    let addNewCardIndexPath = IndexPath(
+      row: 0,
+      section: PaymentMethodsTableViewSection.addNewCard.rawValue
+    )
+    let envelope = ClientSecretEnvelope(clientSecret: "test")
+    let mockOptimizelyClient = MockOptimizelyClient()
+      |> \.features .~ [
+        OptimizelyFeature.paymentSheetEnabled.rawValue: true
+      ]
+    let mockService = MockService(createStripeSetupIntentResult: .success(envelope))
+    var configuration = PaymentSheet.Configuration()
+    configuration.merchantDisplayName = Strings.general_accessibility_kickstarter()
+    configuration.allowsDelayedPaymentMethods = true
+
+    withEnvironment(
+      apiService: mockService,
+      currentUser: User.template,
+      optimizelyClient: mockOptimizelyClient
+    ) {
+      self.vm.inputs.viewDidLoad()
+      self.vm.inputs.configure(with: (User.template, project, Reward.template, .fixPaymentMethod, .discovery))
+      self.vm.inputs.didSelectRowAtIndexPath(addNewCardIndexPath)
+
+      self.scheduler.run()
+
+      self.goToAddStripeCardIntent.assertDidNotEmitValue()
     }
   }
 }

--- a/Library/ViewModels/PledgePaymentMethodsViewModelTests.swift
+++ b/Library/ViewModels/PledgePaymentMethodsViewModelTests.swift
@@ -1035,7 +1035,7 @@ final class PledgePaymentMethodsViewModelTests: TestCase {
       XCTAssertTrue(allowedDelayedPaymentMethods)
     }
   }
-  
+
   func testGoToAddNewStripeCardScreen_WhenPaymentSheetEnabled_UpdateContext_Failure() {
     let project = Project.template
     let addNewCardIndexPath = IndexPath(
@@ -1066,7 +1066,7 @@ final class PledgePaymentMethodsViewModelTests: TestCase {
       self.goToAddStripeCardIntent.assertDidNotEmitValue()
     }
   }
-  
+
   func testGoToAddNewStripeCardScreen_WhenPaymentSheetEnabled_UpdateRewardContext_Failure() {
     let project = Project.template
     let addNewCardIndexPath = IndexPath(
@@ -1097,7 +1097,7 @@ final class PledgePaymentMethodsViewModelTests: TestCase {
       self.goToAddStripeCardIntent.assertDidNotEmitValue()
     }
   }
-  
+
   func testGoToAddNewStripeCardScreen_WhenPaymentSheetEnabled_ChangePaymentMethodContext_Failure() {
     let project = Project.template
     let addNewCardIndexPath = IndexPath(
@@ -1120,7 +1120,8 @@ final class PledgePaymentMethodsViewModelTests: TestCase {
       optimizelyClient: mockOptimizelyClient
     ) {
       self.vm.inputs.viewDidLoad()
-      self.vm.inputs.configure(with: (User.template, project, Reward.template, .changePaymentMethod, .discovery))
+      self.vm.inputs
+        .configure(with: (User.template, project, Reward.template, .changePaymentMethod, .discovery))
       self.vm.inputs.didSelectRowAtIndexPath(addNewCardIndexPath)
 
       self.scheduler.run()
@@ -1128,7 +1129,7 @@ final class PledgePaymentMethodsViewModelTests: TestCase {
       self.goToAddStripeCardIntent.assertDidNotEmitValue()
     }
   }
-  
+
   func testGoToAddNewStripeCardScreen_WhenPaymentSheetEnabled_FixPaymentMethodContext_Failure() {
     let project = Project.template
     let addNewCardIndexPath = IndexPath(

--- a/Library/ViewModels/PledgeViewModelTests.swift
+++ b/Library/ViewModels/PledgeViewModelTests.swift
@@ -588,7 +588,12 @@ final class PledgeViewModelTests: TestCase {
       self.summarySectionSeparatorHidden.assertValues([true])
       self.shippingLocationViewHidden.assertValues([true])
 
-      self.vm.inputs.creditCardSelected(with: backing.paymentSource?.id ?? "")
+      let paymentSourceSelected = PaymentSourceSelected(
+        paymentSourceId: backing.paymentSource?.id ?? "",
+        isSetupIntentClientSecret: false
+      )
+
+      self.vm.inputs.creditCardSelected(with: paymentSourceSelected)
 
       self.configurePledgeViewCTAContainerViewWillRetryPaymentMethod.assertValues([false, true])
 
@@ -2182,7 +2187,12 @@ final class PledgeViewModelTests: TestCase {
       self.goToThanksProject.assertDidNotEmitValue()
       self.showErrorBannerWithMessage.assertDidNotEmitValue()
 
-      self.vm.inputs.creditCardSelected(with: "123")
+      let paymentSourceSelected = PaymentSourceSelected(
+        paymentSourceId: "123",
+        isSetupIntentClientSecret: false
+      )
+
+      self.vm.inputs.creditCardSelected(with: paymentSourceSelected)
 
       self.configurePledgeViewCTAContainerViewIsEnabled.assertValues([false])
 
@@ -2301,7 +2311,12 @@ final class PledgeViewModelTests: TestCase {
       self.goToThanksProject.assertDidNotEmitValue()
       self.showErrorBannerWithMessage.assertDidNotEmitValue()
 
-      self.vm.inputs.creditCardSelected(with: "123")
+      let paymentSourceSelected = PaymentSourceSelected(
+        paymentSourceId: "123",
+        isSetupIntentClientSecret: false
+      )
+
+      self.vm.inputs.creditCardSelected(with: paymentSourceSelected)
 
       self.configurePledgeViewCTAContainerViewIsEnabled.assertValues([false])
 
@@ -2399,7 +2414,12 @@ final class PledgeViewModelTests: TestCase {
       self.goToThanksProject.assertDidNotEmitValue()
       self.showErrorBannerWithMessage.assertDidNotEmitValue()
 
-      self.vm.inputs.creditCardSelected(with: "123")
+      let paymentSourceSelected = PaymentSourceSelected(
+        paymentSourceId: "123",
+        isSetupIntentClientSecret: false
+      )
+
+      self.vm.inputs.creditCardSelected(with: paymentSourceSelected)
 
       self.configurePledgeViewCTAContainerViewIsEnabled.assertValues([false])
 
@@ -2478,7 +2498,12 @@ final class PledgeViewModelTests: TestCase {
       self.showErrorBannerWithMessage.assertDidNotEmitValue()
       self.processingViewIsHidden.assertDidNotEmitValue()
 
-      self.vm.inputs.creditCardSelected(with: "123")
+      let paymentSourceSelected = PaymentSourceSelected(
+        paymentSourceId: "123",
+        isSetupIntentClientSecret: false
+      )
+
+      self.vm.inputs.creditCardSelected(with: paymentSourceSelected)
 
       self.configurePledgeViewCTAContainerViewIsEnabled.assertValues([false])
 
@@ -3183,14 +3208,24 @@ final class PledgeViewModelTests: TestCase {
       "Amount and shipping rule unchanged"
     )
 
-    self.vm.inputs.creditCardSelected(with: "12345")
+    var paymentSourceSelected = PaymentSourceSelected(
+      paymentSourceId: "12345",
+      isSetupIntentClientSecret: false
+    )
+
+    self.vm.inputs.creditCardSelected(with: paymentSourceSelected)
 
     self.configurePledgeViewCTAContainerViewIsEnabled.assertValues(
       [false, true, false, true, false, true],
       "Payment method changed"
     )
 
-    self.vm.inputs.creditCardSelected(with: Backing.PaymentSource.template.id ?? "")
+    paymentSourceSelected = PaymentSourceSelected(
+      paymentSourceId: Backing.PaymentSource.template.id ?? "",
+      isSetupIntentClientSecret: false
+    )
+
+    self.vm.inputs.creditCardSelected(with: paymentSourceSelected)
 
     self.configurePledgeViewCTAContainerViewIsEnabled.assertValues(
       [false, true, false, true, false, true, false],
@@ -4644,7 +4679,12 @@ final class PledgeViewModelTests: TestCase {
     )
 
     withEnvironment(apiService: mockService2) {
-      self.vm.inputs.creditCardSelected(with: "123")
+      let paymentSourceSelected = PaymentSourceSelected(
+        paymentSourceId: "123",
+        isSetupIntentClientSecret: false
+      )
+
+      self.vm.inputs.creditCardSelected(with: paymentSourceSelected)
 
       self.goToApplePayPaymentAuthorizationProject.assertValues([project])
       self.goToApplePayPaymentAuthorizationReward.assertValues([reward])
@@ -4749,7 +4789,12 @@ final class PledgeViewModelTests: TestCase {
       let pledgeAmountData = (amount: 15.0, min: 5.0, max: 10_000.0, isValid: true)
       self.vm.inputs.pledgeAmountViewControllerDidUpdate(with: pledgeAmountData)
 
-      self.vm.inputs.creditCardSelected(with: "123")
+      let paymentSourceSelected = PaymentSourceSelected(
+        paymentSourceId: "123",
+        isSetupIntentClientSecret: false
+      )
+
+      self.vm.inputs.creditCardSelected(with: paymentSourceSelected)
 
       self.goToApplePayPaymentAuthorizationProject.assertDidNotEmitValue()
       self.goToApplePayPaymentAuthorizationReward.assertDidNotEmitValue()
@@ -4958,7 +5003,12 @@ final class PledgeViewModelTests: TestCase {
       let pledgeAmountData = (amount: 15.0, min: 5.0, max: 10_000.0, isValid: true)
       self.vm.inputs.pledgeAmountViewControllerDidUpdate(with: pledgeAmountData)
 
-      self.vm.inputs.creditCardSelected(with: "123")
+      let paymentSourceSelected = PaymentSourceSelected(
+        paymentSourceId: "123",
+        isSetupIntentClientSecret: false
+      )
+
+      self.vm.inputs.creditCardSelected(with: paymentSourceSelected)
 
       self.goToApplePayPaymentAuthorizationProject.assertDidNotEmitValue()
       self.goToApplePayPaymentAuthorizationReward.assertDidNotEmitValue()
@@ -5141,7 +5191,12 @@ final class PledgeViewModelTests: TestCase {
       self.goToThanksProject.assertDidNotEmitValue()
       self.showErrorBannerWithMessage.assertDidNotEmitValue()
 
-      self.vm.inputs.creditCardSelected(with: "123")
+      let paymentSourceSelected = PaymentSourceSelected(
+        paymentSourceId: "123",
+        isSetupIntentClientSecret: false
+      )
+
+      self.vm.inputs.creditCardSelected(with: paymentSourceSelected)
 
       self.beginSCAFlowWithClientSecret.assertDidNotEmitValue()
       self.configurePledgeViewCTAContainerViewIsEnabled.assertValues([false])
@@ -5259,7 +5314,12 @@ final class PledgeViewModelTests: TestCase {
       self.goToThanksProject.assertDidNotEmitValue()
       self.showErrorBannerWithMessage.assertDidNotEmitValue()
 
-      self.vm.inputs.creditCardSelected(with: "123")
+      let paymentSourceSelected = PaymentSourceSelected(
+        paymentSourceId: "123",
+        isSetupIntentClientSecret: false
+      )
+
+      self.vm.inputs.creditCardSelected(with: paymentSourceSelected)
 
       self.beginSCAFlowWithClientSecret.assertDidNotEmitValue()
       self.configurePledgeViewCTAContainerViewIsEnabled.assertValues([false])
@@ -5358,7 +5418,12 @@ final class PledgeViewModelTests: TestCase {
       self.goToThanksProject.assertDidNotEmitValue()
       self.showErrorBannerWithMessage.assertDidNotEmitValue()
 
-      self.vm.inputs.creditCardSelected(with: "123")
+      let paymentSourceSelected = PaymentSourceSelected(
+        paymentSourceId: "123",
+        isSetupIntentClientSecret: false
+      )
+
+      self.vm.inputs.creditCardSelected(with: paymentSourceSelected)
 
       self.beginSCAFlowWithClientSecret.assertDidNotEmitValue()
       self.configurePledgeViewCTAContainerViewIsEnabled.assertValues([false])
@@ -6083,6 +6148,212 @@ final class PledgeViewModelTests: TestCase {
     self.pledgeAmountSummaryViewHidden.assertValues([false])
   }
 
+  func testCreateBacking_WithNewPaymentSheetCard_TappedPledgeButton_Success() {
+    let createBacking = CreateBackingEnvelope.CreateBacking(
+      checkout: Checkout(
+        id: "Q2hlY2tvdXQtMQ==",
+        state: .verifying,
+        backing: .init(clientSecret: nil, requiresAction: false)
+      )
+    )
+    let mockService = MockService(
+      createBackingResult:
+      Result.success(CreateBackingEnvelope(createBacking: createBacking))
+    )
+
+    withEnvironment(apiService: mockService, currentUser: .template) {
+      let project = Project.template
+      let reward = Reward.template
+        |> Reward.lens.hasAddOns .~ true
+        |> Reward.lens.id .~ 99
+      let addOnReward1 = Reward.template
+        |> Reward.lens.id .~ 1
+      let addOnReward2 = Reward.template
+        |> Reward.lens.id .~ 2
+
+      let data = PledgeViewData(
+        project: project,
+        rewards: [reward],
+        selectedQuantities: [reward.id: 1, addOnReward1.id: 2, addOnReward2.id: 1],
+        selectedLocationId: nil,
+        refTag: .activity,
+        context: .pledge
+      )
+
+      self.vm.inputs.configure(with: data)
+      self.vm.inputs.viewDidLoad()
+
+      self.beginSCAFlowWithClientSecret.assertDidNotEmitValue()
+      self.configurePledgeViewCTAContainerViewIsEnabled.assertValues([false])
+      self.goToThanksProject.assertDidNotEmitValue()
+      self.showErrorBannerWithMessage.assertDidNotEmitValue()
+
+      let paymentSourceSelected = PaymentSourceSelected(
+        paymentSourceId: "123",
+        isSetupIntentClientSecret: true
+      )
+
+      self.vm.inputs.creditCardSelected(with: paymentSourceSelected)
+
+      self.configurePledgeViewCTAContainerViewIsEnabled.assertValues([false])
+
+      self.vm.inputs.pledgeAmountViewControllerDidUpdate(
+        with: (amount: 25.0, min: 10.0, max: 10_000.0, isValid: true)
+      )
+
+      self.processingViewIsHidden.assertDidNotEmitValue()
+      self.configurePledgeViewCTAContainerViewIsEnabled.assertValues([false, true])
+
+      self.vm.inputs.submitButtonTapped()
+
+      self.processingViewIsHidden.assertValues([false])
+      self.beginSCAFlowWithClientSecret.assertDidNotEmitValue()
+      self.configurePledgeViewCTAContainerViewIsEnabled.assertValues([false, true, false])
+      self.goToThanksProject.assertDidNotEmitValue()
+      self.showErrorBannerWithMessage.assertDidNotEmitValue()
+
+      self.scheduler.run()
+
+      self.processingViewIsHidden.assertValues([false, true])
+      self.beginSCAFlowWithClientSecret.assertDidNotEmitValue()
+      self.configurePledgeViewCTAContainerViewIsEnabled.assertValues([false, true, false, true])
+      self.showErrorBannerWithMessage.assertDidNotEmitValue()
+
+      let checkoutData = KSRAnalytics.CheckoutPropertiesData(
+        addOnsCountTotal: 0,
+        addOnsCountUnique: 0,
+        addOnsMinimumUsd: 0.00,
+        bonusAmountInUsd: 25.00,
+        checkoutId: "1",
+        estimatedDelivery: reward.estimatedDeliveryOn,
+        paymentType: "credit_card",
+        revenueInUsd: 35.00,
+        rewardId: String(reward.id),
+        rewardMinimumUsd: 10.00,
+        rewardTitle: reward.title,
+        shippingEnabled: reward.shipping.enabled,
+        shippingAmountUsd: nil,
+        userHasStoredApplePayCard: true
+      )
+
+      self.goToThanksProject.assertValues([.template])
+      self.goToThanksReward.assertValues([reward])
+      self.goToThanksCheckoutData.assertValues([checkoutData])
+
+      XCTAssertEqual(
+        ["Page Viewed", "CTA Clicked"],
+        self.segmentTrackingClient.events
+      )
+    }
+  }
+
+  func testCreateBacking_WithNewPaymentSheetCard_TappedApplePayButton_Success() {
+    let createBacking = CreateBackingEnvelope.CreateBacking(
+      checkout: Checkout(
+        id: "Q2hlY2tvdXQtMQ==",
+        state: .successful,
+        backing: .init(clientSecret: nil, requiresAction: false)
+      )
+    )
+    let mockService = MockService(
+      createBackingResult:
+      Result.success(CreateBackingEnvelope(createBacking: createBacking))
+    )
+
+    withEnvironment(apiService: mockService, currentUser: .template) {
+      let project = Project.template
+      let reward = Reward.template
+        |> Reward.lens.hasAddOns .~ true
+        |> Reward.lens.id .~ 99
+      let addOnReward1 = Reward.template
+        |> Reward.lens.id .~ 1
+      let addOnReward2 = Reward.template
+        |> Reward.lens.id .~ 2
+
+      let data = PledgeViewData(
+        project: project,
+        rewards: [reward],
+        selectedQuantities: [reward.id: 1, addOnReward1.id: 1, addOnReward2.id: 1],
+        selectedLocationId: nil,
+        refTag: .projectPage,
+        context: .pledge
+      )
+
+      self.vm.inputs.configure(with: data)
+      self.vm.inputs.viewDidLoad()
+
+      self.beginSCAFlowWithClientSecret.assertDidNotEmitValue()
+      self.configurePledgeViewCTAContainerViewIsEnabled.assertValues([false])
+      self.goToThanksProject.assertDidNotEmitValue()
+      self.showErrorBannerWithMessage.assertDidNotEmitValue()
+
+      let paymentSourceSelected = PaymentSourceSelected(
+        paymentSourceId: "123",
+        isSetupIntentClientSecret: true
+      )
+
+      self.vm.inputs.creditCardSelected(with: paymentSourceSelected)
+
+      self.configurePledgeViewCTAContainerViewIsEnabled.assertValues([false])
+
+      self.processingViewIsHidden.assertDidNotEmitValue()
+
+      self.vm.inputs.applePayButtonTapped()
+
+      self.vm.inputs.paymentAuthorizationDidAuthorizePayment(
+        paymentData: (displayName: "Visa 123", network: "Visa", transactionIdentifier: "12345")
+      )
+
+      self.vm.inputs.pledgeAmountViewControllerDidUpdate(
+        with: (amount: 25.0, min: 10.0, max: 10_000.0, isValid: true)
+      )
+
+      XCTAssertEqual(
+        PKPaymentAuthorizationStatus.success,
+        self.vm.inputs.stripeTokenCreated(token: "stripe_token", error: nil)
+      )
+
+      self.vm.inputs.paymentAuthorizationViewControllerDidFinish()
+
+      self.beginSCAFlowWithClientSecret.assertDidNotEmitValue()
+      self.configurePledgeViewCTAContainerViewIsEnabled.assertValues([false, true])
+      self.goToThanksProject.assertDidNotEmitValue()
+      self.showErrorBannerWithMessage.assertDidNotEmitValue()
+
+      self.scheduler.run()
+
+      self.beginSCAFlowWithClientSecret.assertDidNotEmitValue()
+      self.configurePledgeViewCTAContainerViewIsEnabled.assertValues([false, true])
+      self.showErrorBannerWithMessage.assertDidNotEmitValue()
+
+      let checkoutData = KSRAnalytics.CheckoutPropertiesData(
+        addOnsCountTotal: 0,
+        addOnsCountUnique: 0,
+        addOnsMinimumUsd: 0.00,
+        bonusAmountInUsd: 25.00,
+        checkoutId: "1",
+        estimatedDelivery: reward.estimatedDeliveryOn,
+        paymentType: "apple_pay",
+        revenueInUsd: 35.00,
+        rewardId: String(reward.id),
+        rewardMinimumUsd: 10.00,
+        rewardTitle: reward.title,
+        shippingEnabled: reward.shipping.enabled,
+        shippingAmountUsd: nil,
+        userHasStoredApplePayCard: true
+      )
+
+      self.goToThanksProject.assertValues([project])
+      self.goToThanksReward.assertValues([reward])
+      self.goToThanksCheckoutData.assertValues([checkoutData])
+
+      XCTAssertEqual(
+        ["Page Viewed", "CTA Clicked"],
+        self.segmentTrackingClient.events
+      )
+    }
+  }
+
   // MARK: - Tracking
 
   func testTrackingEvents_CheckoutPaymentPageViewed() {
@@ -6363,7 +6634,13 @@ final class PledgeViewModelTests: TestCase {
       isValid: true
     ))
     self.vm.inputs.shippingRuleSelected(.template)
-    self.vm.inputs.creditCardSelected(with: "123")
+
+    let paymentSourceSelected = PaymentSourceSelected(
+      paymentSourceId: "123",
+      isSetupIntentClientSecret: false
+    )
+
+    self.vm.inputs.creditCardSelected(with: paymentSourceSelected)
 
     self.vm.inputs.submitButtonTapped()
 
@@ -6439,7 +6716,13 @@ final class PledgeViewModelTests: TestCase {
         isValid: true
       ))
       self.vm.inputs.shippingRuleSelected(.template)
-      self.vm.inputs.creditCardSelected(with: "123")
+
+      let paymentSourceSelected = PaymentSourceSelected(
+        paymentSourceId: "123",
+        isSetupIntentClientSecret: false
+      )
+
+      self.vm.inputs.creditCardSelected(with: paymentSourceSelected)
 
       self.vm.inputs.submitButtonTapped()
 
@@ -6515,7 +6798,13 @@ final class PledgeViewModelTests: TestCase {
 
       self.vm.inputs.configure(with: data)
       self.vm.inputs.viewDidLoad()
-      self.vm.inputs.creditCardSelected(with: "12345")
+
+      let paymentSourceSelected = PaymentSourceSelected(
+        paymentSourceId: "12345",
+        isSetupIntentClientSecret: false
+      )
+
+      self.vm.inputs.creditCardSelected(with: paymentSourceSelected)
 
       XCTAssertEqual([], self.segmentTrackingClient.events)
 


### PR DESCRIPTION
# 📲 What

This PR wraps up the major portion of work to use a newly created card from the Stripe Payment Sheet to complete a backing within the iOS app.

# 🤔 Why

Part of the ongoing Epic to include Stripe in our payments systems so we can offload much of the complexity of payment processing to an expert vendor.

# 🛠 How

Previously used `creditCardSelectedSignal` is updated to use a tuple that knows if the payment source id is coming from an existing payment source or new payment sheet source.

Leaving `selectedPaymentSourceId` as is to update the `willRetryPaymentMethod` having mapped `creditCardSelectedSignal` to its `paymentSourceId`

Also `creditCardSelectedSignal` is mapping to its `paymentSourceid` whereever its used except in the new signal `selectedPaymentSourceIdOrSetupIntentClientSecret` 

That signal is used directly in the creation of the `creatingBackingEvents` and `updateBackingEvents` network requests, the result of which is passed on to SCA flow detection or thank you page creation.

When `CreateBackingData` is created we take precedence of 1. Apple Pay, 2. Payment Source ID, 3. Setup Intent Client Secret. Only one of these values is passed to the `CreateBackingInput` mutation.

# 👀 See

Before 🐛 

https://user-images.githubusercontent.com/4282741/185483536-8d43c559-44ed-41c8-82b4-791a2c46d446.MP4

After 🦋

https://user-images.githubusercontent.com/4282741/185484795-f893ce5d-edb5-4328-8816-f42fab11c333.MP4


# ✅ Acceptance criteria

- [x] Ensure create backing works with newly created card from payment sheet.

# ⏰ TODO

- [x] Fix happy path (vanilla `CreateBacking` with `setupIntentClientSecret`)
- [x] Ensure other contexts besides `.pledge` never see the Payment Sheet
- [x] Ensure the 3DS flow and Apple Pay still work as expected (in code)
- [x] Ensure cards used to pledge are retained in both settings and in the manage pledge page. 
- [x] Ensure change payment methods, updating reward, updating pledge amount, (fix is kinda hard to test, it should work -- see if I can spoof it) are all working
- [x] Write unit tests