### PR TITLE
[PAY-1896] Present Payment Sheet Within User Settings

### DIFF
--- a/Kickstarter-iOS/Views/Controllers/PaymentMethodsViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/PaymentMethodsViewController.swift
@@ -95,6 +95,14 @@ internal final class PaymentMethodsViewController: UIViewController, MessageBann
         self?.goToAddCardScreen(with: intent)
       }
 
+    self.viewModel.outputs.goToPaymentSheet
+      .observeForUI()
+      .observeValues { [weak self] data in
+        guard let strongSelf = self else { return }
+
+        strongSelf.goToPaymentSheet(data: data)
+      }
+
     self.viewModel.outputs.errorLoadingPaymentMethods
       .observeForUI()
       .observeValues { [weak self] message in

--- a/Kickstarter-iOS/Views/Controllers/PaymentMethodsViewController.swift
+++ b/Kickstarter-iOS/Views/Controllers/PaymentMethodsViewController.swift
@@ -1,11 +1,13 @@
 import KsApi
 import Library
 import Prelude
+import Stripe
 import UIKit
 
 internal final class PaymentMethodsViewController: UIViewController, MessageBannerViewControllerPresenting {
   private let dataSource = PaymentMethodsDataSource()
   private let viewModel: PaymentMethodsViewModelType = PaymentMethodsViewModel()
+  private var paymentSheetFlowController: PaymentSheet.FlowController?
 
   @IBOutlet private var tableView: UITableView!
 
@@ -142,6 +144,66 @@ internal final class PaymentMethodsViewController: UIViewController, MessageBann
   }
 
   // MARK: - Private Helpers
+
+  private func goToPaymentSheet(data: PaymentSheetSetupData) {
+    PaymentSheet.FlowController
+      .create(
+        setupIntentClientSecret: data.clientSecret,
+        configuration: data.configuration
+      ) { [weak self] result in
+        guard let strongSelf = self else { return }
+
+        switch result {
+        case let .failure(error):
+          // strongSelf.viewModel.inputs.shouldCancelPaymentSheetAppearance(state: true)
+          strongSelf.messageBannerViewController?
+            .showBanner(with: .error, message: error.localizedDescription)
+        case let .success(paymentSheetFlowController):
+          strongSelf.paymentSheetFlowController = paymentSheetFlowController
+          strongSelf.paymentSheetFlowController?.presentPaymentOptions(from: strongSelf) { [weak self] in
+            guard let strongSelf = self else { return }
+
+            /** Handle updating payment methods with new card/errors
+             strongSelf.confirmPaymentResult(with: data.clientSecret)
+             */
+          }
+        }
+      }
+  }
+
+  private func confirmPaymentResult(with _: String) {
+    guard self.paymentSheetFlowController?.paymentOption != nil else {
+      /** Handle errors
+       self.viewModel.inputs.shouldCancelPaymentSheetAppearance(state: true)
+       */
+
+      return
+    }
+
+    self.paymentSheetFlowController?.confirm(from: self) { [weak self] paymentResult in
+
+      guard let strongSelf = self else { return }
+
+      /** Handle errors
+       self.viewModel.inputs.shouldCancelPaymentSheetAppearance(state: true)
+       */
+
+      guard let existingPaymentOption = strongSelf.paymentSheetFlowController?.paymentOption else { return }
+
+      switch paymentResult {
+      case .completed:
+        /** Handle updating payment methods
+         strongSelf.viewModel.inputs.paymentSheetDidAdd(newCard: existingPaymentOption, setupIntent: clientSecret)
+         */
+        fatalError()
+      case .canceled:
+        strongSelf.messageBannerViewController?
+          .showBanner(with: .error, message: Strings.general_error_something_wrong())
+      case let .failed(error):
+        strongSelf.messageBannerViewController?.showBanner(with: .error, message: error.localizedDescription)
+      }
+    }
+  }
 
   private func configureHeaderFooterViews() {
     if let header = SettingsTableViewHeader.fromNib(nib: Nib.SettingsTableViewHeader) {

--- a/Library/ViewModels/PaymentMethodsViewModel.swift
+++ b/Library/ViewModels/PaymentMethodsViewModel.swift
@@ -18,6 +18,7 @@ public protocol PaymentMethodsViewModelOutputs {
   var editButtonTitle: Signal<String, Never> { get }
   var errorLoadingPaymentMethods: Signal<String, Never> { get }
   var goToAddCardScreenWithIntent: Signal<AddNewCardIntent, Never> { get }
+  var goToPaymentSheet: Signal<PaymentSheetSetupData, Never> { get }
   var paymentMethods: Signal<[UserCreditCards.CreditCard], Never> { get }
   var presentBanner: Signal<String, Never> { get }
   var reloadData: Signal<Void, Never> { get }
@@ -33,6 +34,10 @@ public protocol PaymentMethodsViewModelType {
 public final class PaymentMethodsViewModel: PaymentMethodsViewModelType,
   PaymentMethodsViewModelInputs, PaymentMethodsViewModelOutputs {
   public init() {
+    lazy var paymentSheetEnabled: Bool = {
+      featureSettingsPaymentSheetEnabled()
+    }()
+
     self.reloadData = self.viewDidLoadProperty.signal
 
     let paymentMethodsEvent = Signal.merge(
@@ -73,8 +78,6 @@ public final class PaymentMethodsViewModel: PaymentMethodsViewModelType,
       deletePaymentMethodValues
     )
 
-    self.errorLoadingPaymentMethods = paymentMethodsEvent.errors().map { $0.localizedDescription }
-
     self.paymentMethods = Signal.merge(
       initialPaymentMethodsValues,
       deletePaymentMethodEventsErrors
@@ -98,6 +101,8 @@ public final class PaymentMethodsViewModel: PaymentMethodsViewModelType,
     .skipRepeats()
 
     self.goToAddCardScreenWithIntent = self.didTapAddCardButtonProperty.signal
+      .map(value: paymentSheetEnabled)
+      .filter(isFalse)
       .mapConst(.settings)
 
     self.presentBanner = self.addNewCardSucceededProperty.signal.skipNil()
@@ -120,31 +125,50 @@ public final class PaymentMethodsViewModel: PaymentMethodsViewModelType,
     self.editButtonTitle = self.tableViewIsEditing
       .map { $0 ? Strings.Done() : Strings.discovery_favorite_categories_buttons_edit() }
 
-    let createSetupIntentEvent = Signal.combineLatest(
-      project,
-      paymentSheetOnPledgeContext.filter(isTrue)
-    )
-    .takeWhen(didTapToAddNewCard)
-    .switchMap { (project, _) -> SignalProducer<Signal<PaymentSheetSetupData, ErrorEnvelope>.Event, Never> in
-      AppEnvironment.current.apiService
-        .createStripeSetupIntent(input: CreateSetupIntentInput(projectId: project.graphID))
-        .ksr_debounce(.seconds(1), on: AppEnvironment.current.scheduler)
-        .ksr_delay(AppEnvironment.current.apiDelayInterval, on: AppEnvironment.current.scheduler)
-        .switchMap { envelope -> SignalProducer<PaymentSheetSetupData, ErrorEnvelope> in
+    let createSetupIntentEvent = self.didTapAddCardButtonProperty.signal
+      .map(value: paymentSheetEnabled)
+      .filter(isTrue)
+      .switchMap { _ -> SignalProducer<Signal<PaymentSheetSetupData, ErrorEnvelope>.Event, Never> in
+        /** FIXME: We need a version of    `createStripeSetupIntent` that doesn't require a project id.
+         AppEnvironment.current.apiService
+           .createStripeSetupIntent(input: CreateSetupIntentInput(projectId: project.graphID))
+           .ksr_debounce(.seconds(1), on: AppEnvironment.current.scheduler)
+           .ksr_delay(AppEnvironment.current.apiDelayInterval, on: AppEnvironment.current.scheduler)
+           .switchMap { envelope -> SignalProducer<PaymentSheetSetupData, ErrorEnvelope> in
 
-          var configuration = PaymentSheet.Configuration()
-          configuration.merchantDisplayName = Strings.general_accessibility_kickstarter()
-          configuration.allowsDelayedPaymentMethods = true
+             var configuration = PaymentSheet.Configuration()
+             configuration.merchantDisplayName = Strings.general_accessibility_kickstarter()
+             configuration.allowsDelayedPaymentMethods = true
 
-          let data = PaymentSheetSetupData(
-            clientSecret: envelope.clientSecret,
-            configuration: configuration
+             let data = PaymentSheetSetupData(
+               clientSecret: envelope.clientSecret,
+               configuration: configuration
+             )
+
+             return SignalProducer(value: data)
+           }
+           .materialize()
+         */
+
+        let error = ErrorEnvelope
+          .init(
+            errorMessages: [""],
+            ksrCode: nil,
+            httpCode: 402,
+            exception: nil,
+            facebookUser: nil,
+            graphError: nil
           )
 
-          return SignalProducer(value: data)
-        }
-        .materialize()
-    }
+        return SignalProducer(error: error).materialize()
+      }
+
+    /** FIXME: Add cancellation signal similiar to `shouldCancelPaymentSheetAppearance` in `PledgePaymentMethodsViewModel` */
+    self.goToPaymentSheet = createSetupIntentEvent.values()
+
+    self.errorLoadingPaymentMethods = Signal
+      .merge(paymentMethodsEvent.errors(), createSetupIntentEvent.errors())
+      .map { $0.localizedDescription }
   }
 
   // Stores the table view's editing state as it is affected by multiple signals
@@ -193,6 +217,7 @@ public final class PaymentMethodsViewModel: PaymentMethodsViewModelType,
   public let editButtonTitle: Signal<String, Never>
   public let errorLoadingPaymentMethods: Signal<String, Never>
   public let goToAddCardScreenWithIntent: Signal<AddNewCardIntent, Never>
+  public let goToPaymentSheet: Signal<PaymentSheetSetupData, Never>
   public let paymentMethods: Signal<[UserCreditCards.CreditCard], Never>
   public let presentBanner: Signal<String, Never>
   public let reloadData: Signal<Void, Never>


### PR DESCRIPTION
# 📲 What 🤔 Why

As continued integration of Stripe's Payment Sheet, while native waits for `CreatePaymentSourceType` mutation to be built on web, we can do some upfront work for presenting the payment sheet without completing the add new card flow.


# 🛠 How

...coming...

# 👀 See

Before 🐛 

...tbd...

After 🦋

...tbd...

# ✅ Acceptance criteria

- [ ] Payment sheet present when feature flag is on (not able to complete payments yet)
- [ ] Any errors in presenting payment sheet or creating the setup intent are displayed as errors were displayed before.

# ⏰ TODO

- [ ] Integrate feature flag with payment sheet presentation.
- [ ] Test error flow
- [ ] Write unit tests.
