### PR TITLE
[NTV-1896] Present Payment Sheet With Feature Flag Enabled.

### DIFF
--- a/Kickstarter-iOS/Features/PaymentMethods/Controller/PaymentMethodsViewController.swift
+++ b/Kickstarter-iOS/Features/PaymentMethods/Controller/PaymentMethodsViewController.swift
@@ -1,11 +1,13 @@
 import KsApi
 import Library
 import Prelude
+import Stripe
 import UIKit
 
 internal final class PaymentMethodsViewController: UIViewController, MessageBannerViewControllerPresenting {
   private let dataSource = PaymentMethodsDataSource()
   private let viewModel: PaymentMethodsViewModelType = PaymentMethodsViewModel()
+  private var paymentSheetFlowController: PaymentSheet.FlowController?
 
   @IBOutlet private var tableView: UITableView!
 
@@ -93,6 +95,14 @@ internal final class PaymentMethodsViewController: UIViewController, MessageBann
         self?.goToAddCardScreen(with: intent)
       }
 
+    self.viewModel.outputs.goToPaymentSheet
+      .observeForUI()
+      .observeValues { [weak self] data in
+        guard let strongSelf = self else { return }
+
+        strongSelf.goToPaymentSheet(data: data)
+      }
+
     self.viewModel.outputs.errorLoadingPaymentMethods
       .observeForUI()
       .observeValues { [weak self] message in
@@ -142,6 +152,66 @@ internal final class PaymentMethodsViewController: UIViewController, MessageBann
   }
 
   // MARK: - Private Helpers
+
+  private func goToPaymentSheet(data: PaymentSheetSetupData) {
+    PaymentSheet.FlowController
+      .create(
+        setupIntentClientSecret: data.clientSecret,
+        configuration: data.configuration
+      ) { [weak self] result in
+        guard let strongSelf = self else { return }
+
+        switch result {
+        case let .failure(error):
+          // strongSelf.viewModel.inputs.shouldCancelPaymentSheetAppearance(state: true)
+          strongSelf.messageBannerViewController?
+            .showBanner(with: .error, message: error.localizedDescription)
+        case let .success(paymentSheetFlowController):
+          strongSelf.paymentSheetFlowController = paymentSheetFlowController
+          strongSelf.paymentSheetFlowController?.presentPaymentOptions(from: strongSelf) { [weak self] in
+            guard let strongSelf = self else { return }
+
+            /** Handle updating payment methods with new card/errors
+             strongSelf.confirmPaymentResult(with: data.clientSecret)
+             */
+          }
+        }
+      }
+  }
+
+  private func confirmPaymentResult(with _: String) {
+    guard self.paymentSheetFlowController?.paymentOption != nil else {
+      /** Handle errors
+       self.viewModel.inputs.shouldCancelPaymentSheetAppearance(state: true)
+       */
+
+      return
+    }
+
+    self.paymentSheetFlowController?.confirm(from: self) { [weak self] paymentResult in
+
+      guard let strongSelf = self else { return }
+
+      /** Handle errors
+       self.viewModel.inputs.shouldCancelPaymentSheetAppearance(state: true)
+       */
+
+      guard let existingPaymentOption = strongSelf.paymentSheetFlowController?.paymentOption else { return }
+
+      switch paymentResult {
+      case .completed:
+        /** Handle updating payment methods
+         strongSelf.viewModel.inputs.paymentSheetDidAdd(newCard: existingPaymentOption, setupIntent: clientSecret)
+         */
+        fatalError()
+      case .canceled:
+        strongSelf.messageBannerViewController?
+          .showBanner(with: .error, message: Strings.general_error_something_wrong())
+      case let .failed(error):
+        strongSelf.messageBannerViewController?.showBanner(with: .error, message: error.localizedDescription)
+      }
+    }
+  }
 
   private func configureHeaderFooterViews() {
     if let header = SettingsTableViewHeader.fromNib(nib: Nib.SettingsTableViewHeader) {

--- a/Kickstarter-iOS/Features/PaymentMethods/Controller/PaymentMethodsViewController.swift
+++ b/Kickstarter-iOS/Features/PaymentMethods/Controller/PaymentMethodsViewController.swift
@@ -163,7 +163,10 @@ internal final class PaymentMethodsViewController: UIViewController, MessageBann
 
         switch result {
         case let .failure(error):
-          // strongSelf.viewModel.inputs.shouldCancelPaymentSheetAppearance(state: true)
+          /** TODO: https://kickstarter.atlassian.net/browse/PAY-1954
+           * strongSelf.viewModel.inputs.shouldCancelPaymentSheetAppearance(state: true)
+           */
+
           strongSelf.messageBannerViewController?
             .showBanner(with: .error, message: error.localizedDescription)
         case let .success(paymentSheetFlowController):
@@ -171,8 +174,8 @@ internal final class PaymentMethodsViewController: UIViewController, MessageBann
           strongSelf.paymentSheetFlowController?.presentPaymentOptions(from: strongSelf) { [weak self] in
             guard let strongSelf = self else { return }
 
-            /** Handle updating payment methods with new card/errors
-             strongSelf.confirmPaymentResult(with: data.clientSecret)
+            /** TODO: https://kickstarter.atlassian.net/browse/PAY-1900
+             * strongSelf.confirmPaymentResult(with: data.clientSecret)
              */
           }
         }
@@ -181,8 +184,8 @@ internal final class PaymentMethodsViewController: UIViewController, MessageBann
 
   private func confirmPaymentResult(with _: String) {
     guard self.paymentSheetFlowController?.paymentOption != nil else {
-      /** Handle errors
-       self.viewModel.inputs.shouldCancelPaymentSheetAppearance(state: true)
+      /** TODO: https://kickstarter.atlassian.net/browse/PAY-1954
+       * strongSelf.viewModel.inputs.shouldCancelPaymentSheetAppearance(state: true)
        */
 
       return
@@ -192,16 +195,16 @@ internal final class PaymentMethodsViewController: UIViewController, MessageBann
 
       guard let strongSelf = self else { return }
 
-      /** Handle errors
-       self.viewModel.inputs.shouldCancelPaymentSheetAppearance(state: true)
+      /** TODO: https://kickstarter.atlassian.net/browse/PAY-1954
+       * strongSelf.viewModel.inputs.shouldCancelPaymentSheetAppearance(state: true)
        */
 
       guard let existingPaymentOption = strongSelf.paymentSheetFlowController?.paymentOption else { return }
 
       switch paymentResult {
       case .completed:
-        /** Handle updating payment methods
-         strongSelf.viewModel.inputs.paymentSheetDidAdd(newCard: existingPaymentOption, setupIntent: clientSecret)
+        /** TODO: https://kickstarter.atlassian.net/browse/PAY-1898
+         * strongSelf.viewModel.inputs.paymentSheetDidAdd(newCard: existingPaymentOption, setupIntent: clientSecret)
          */
         fatalError()
       case .canceled:

--- a/Kickstarter-iOS/Features/PaymentMethods/Controller/PaymentMethodsViewController.swift
+++ b/Kickstarter-iOS/Features/PaymentMethods/Controller/PaymentMethodsViewController.swift
@@ -103,7 +103,7 @@ internal final class PaymentMethodsViewController: UIViewController, MessageBann
         strongSelf.goToPaymentSheet(data: data)
       }
 
-    self.viewModel.outputs.errorLoadingPaymentMethods
+    self.viewModel.outputs.errorLoadingPaymentMethodsOrSetupIntent
       .observeForUI()
       .observeValues { [weak self] message in
         self?.messageBannerViewController?.showBanner(with: .error, message: message)

--- a/KsApi/GraphAPI.swift
+++ b/KsApi/GraphAPI.swift
@@ -254,23 +254,24 @@ public enum GraphAPI {
     ///   - stripeToken
     ///   - stripeCardId
     ///   - reusable
+    ///   - intentClientSecret
     ///   - clientMutationId: A unique identifier for the client performing the mutation.
-    public init(paymentType: PaymentTypes, stripeToken: String, stripeCardId: Swift.Optional<String?> = nil, reusable: Swift.Optional<Bool?> = nil, clientMutationId: Swift.Optional<String?> = nil) {
-      graphQLMap = ["paymentType": paymentType, "stripeToken": stripeToken, "stripeCardId": stripeCardId, "reusable": reusable, "clientMutationId": clientMutationId]
+    public init(paymentType: Swift.Optional<PaymentTypes?> = nil, stripeToken: Swift.Optional<String?> = nil, stripeCardId: Swift.Optional<String?> = nil, reusable: Swift.Optional<Bool?> = nil, intentClientSecret: Swift.Optional<String?> = nil, clientMutationId: Swift.Optional<String?> = nil) {
+      graphQLMap = ["paymentType": paymentType, "stripeToken": stripeToken, "stripeCardId": stripeCardId, "reusable": reusable, "intentClientSecret": intentClientSecret, "clientMutationId": clientMutationId]
     }
 
-    public var paymentType: PaymentTypes {
+    public var paymentType: Swift.Optional<PaymentTypes?> {
       get {
-        return graphQLMap["paymentType"] as! PaymentTypes
+        return graphQLMap["paymentType"] as? Swift.Optional<PaymentTypes?> ?? Swift.Optional<PaymentTypes?>.none
       }
       set {
         graphQLMap.updateValue(newValue, forKey: "paymentType")
       }
     }
 
-    public var stripeToken: String {
+    public var stripeToken: Swift.Optional<String?> {
       get {
-        return graphQLMap["stripeToken"] as! String
+        return graphQLMap["stripeToken"] as? Swift.Optional<String?> ?? Swift.Optional<String?>.none
       }
       set {
         graphQLMap.updateValue(newValue, forKey: "stripeToken")
@@ -292,6 +293,15 @@ public enum GraphAPI {
       }
       set {
         graphQLMap.updateValue(newValue, forKey: "reusable")
+      }
+    }
+
+    public var intentClientSecret: Swift.Optional<String?> {
+      get {
+        return graphQLMap["intentClientSecret"] as? Swift.Optional<String?> ?? Swift.Optional<String?>.none
+      }
+      set {
+        graphQLMap.updateValue(newValue, forKey: "intentClientSecret")
       }
     }
 
@@ -349,13 +359,13 @@ public enum GraphAPI {
     /// - Parameters:
     ///   - projectId
     ///   - clientMutationId: A unique identifier for the client performing the mutation.
-    public init(projectId: GraphQLID, clientMutationId: Swift.Optional<String?> = nil) {
+    public init(projectId: Swift.Optional<GraphQLID?> = nil, clientMutationId: Swift.Optional<String?> = nil) {
       graphQLMap = ["projectId": projectId, "clientMutationId": clientMutationId]
     }
 
-    public var projectId: GraphQLID {
+    public var projectId: Swift.Optional<GraphQLID?> {
       get {
-        return graphQLMap["projectId"] as! GraphQLID
+        return graphQLMap["projectId"] as? Swift.Optional<GraphQLID?> ?? Swift.Optional<GraphQLID?>.none
       }
       set {
         graphQLMap.updateValue(newValue, forKey: "projectId")

--- a/KsApi/graphql-schema.json
+++ b/KsApi/graphql-schema.json
@@ -606,86 +606,6 @@
             "deprecationReason": null
           },
           {
-            "name": "patron",
-            "description": "Fetches a patron given its slug.",
-            "args": [
-              {
-                "name": "slug",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null
-              }
-            ],
-            "type": {
-              "kind": "OBJECT",
-              "name": "Patron",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "patrons",
-            "description": null,
-            "args": [
-              {
-                "name": "first",
-                "description": "Returns the first _n_ elements from the list.",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "after",
-                "description": "Returns the elements in the list that come after the specified cursor.",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "last",
-                "description": "Returns the last _n_ elements from the list.",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                },
-                "defaultValue": null
-              },
-              {
-                "name": "before",
-                "description": "Returns the elements in the list that come before the specified cursor.",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                },
-                "defaultValue": null
-              }
-            ],
-            "type": {
-              "kind": "OBJECT",
-              "name": "PatronConnection",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "post",
             "description": "Fetches a post given its ID.",
             "args": [
@@ -11537,12 +11457,6 @@
             "deprecationReason": null
           },
           {
-            "name": "stripe_connect_onboarding_only_for_kyc",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "creator_onboarding_flow_2021",
             "description": null,
             "isDeprecated": false,
@@ -11556,6 +11470,18 @@
           },
           {
             "name": "payment_element_web_checkout_2022",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "payment_element_user_settings_2022",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "payment_element_project_build_2022",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
@@ -11580,6 +11506,12 @@
           },
           {
             "name": "creator_osat_survey_2022",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "use_new_blog_url",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
@@ -28123,283 +28055,6 @@
         "possibleTypes": null
       },
       {
-        "kind": "OBJECT",
-        "name": "Patron",
-        "description": "A patron on Kickstarter.",
-        "fields": [
-          {
-            "name": "about",
-            "description": "About this patron.",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "criteria",
-            "description": "What this patron looks for in a project.",
-            "args": [],
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "description",
-            "description": "Description of this patron.",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "fundRemaining",
-            "description": "Fund size remaining for this patron",
-            "args": [],
-            "type": {
-              "kind": "OBJECT",
-              "name": "Money",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "fundSize",
-            "description": "Fund size for this patron.",
-            "args": [],
-            "type": {
-              "kind": "OBJECT",
-              "name": "Money",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "how_to_apply",
-            "description": "How to submit a project to this patron.",
-            "args": [],
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "slug",
-            "description": "Patron's url slug.",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "spentToDate",
-            "description": "The amount the patron has pledged to live and successful projects",
-            "args": [],
-            "type": {
-              "kind": "OBJECT",
-              "name": "Money",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "support",
-            "description": "Additional support provided by this patron.",
-            "args": [],
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "url",
-            "description": "A URL to the patron's profile page.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "user",
-            "description": "The user that backs for this patron.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "User",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "PatronConnection",
-        "description": "The connection type for Patron.",
-        "fields": [
-          {
-            "name": "edges",
-            "description": "A list of edges.",
-            "args": [],
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "PatronEdge",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "nodes",
-            "description": "A list of nodes.",
-            "args": [],
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "Patron",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "pageInfo",
-            "description": "Information to aid in pagination.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "PageInfo",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "totalCount",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "PatronEdge",
-        "description": "An edge in a connection.",
-        "fields": [
-          {
-            "name": "cursor",
-            "description": "A cursor for use in pagination.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "node",
-            "description": "The item at the end of the edge.",
-            "args": [],
-            "type": {
-              "kind": "OBJECT",
-              "name": "Patron",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
         "kind": "ENUM",
         "name": "GoalBuckets",
         "description": "Buckets of project goals",
@@ -34893,13 +34548,9 @@
             "name": "paymentType",
             "description": null,
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "ENUM",
-                "name": "PaymentTypes",
-                "ofType": null
-              }
+              "kind": "ENUM",
+              "name": "PaymentTypes",
+              "ofType": null
             },
             "defaultValue": null
           },
@@ -34907,13 +34558,9 @@
             "name": "stripeToken",
             "description": null,
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "defaultValue": null
           },
@@ -34933,6 +34580,16 @@
             "type": {
               "kind": "SCALAR",
               "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "intentClientSecret",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
               "ofType": null
             },
             "defaultValue": null
@@ -36269,13 +35926,9 @@
             "name": "projectId",
             "description": null,
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "ID",
-                "ofType": null
-              }
+              "kind": "SCALAR",
+              "name": "ID",
+              "ofType": null
             },
             "defaultValue": null
           },

--- a/KsApi/mutations/inputs/CreateSetupIntentInput.swift
+++ b/KsApi/mutations/inputs/CreateSetupIntentInput.swift
@@ -1,17 +1,17 @@
 import Foundation
 
 public struct CreateSetupIntentInput: GraphMutationInput, Encodable {
-  let projectId: String
+  let projectId: String?
 
   /**
    An input object for the CreateSetupIntentMutation
    - parameter projectId: A project id that is needed by GraphQL to generate a client secret.
    */
-  public init(projectId: String) {
+  public init(projectId: String?) {
     self.projectId = projectId
   }
 
-  public func toInputDictionary() -> [String: Any] {
+  public func toInputDictionary() -> [String: Any?] {
     return [
       "projectId": self.projectId
     ]

--- a/KsApi/mutations/inputs/CreateSetupIntentInputTests.swift
+++ b/KsApi/mutations/inputs/CreateSetupIntentInputTests.swift
@@ -3,11 +3,19 @@ import Prelude
 import XCTest
 
 final class CreateSetupIntentInputTests: XCTestCase {
-  func testCreateSetupIntentInputDictionary() {
+  func testCreateSetupIntentInputDictionary_WithValue_Success() {
     let createSetupIntentInput = CreateSetupIntentInput(projectId: "UHJvamVjdC0yMzEyODc5ODc")
 
     let input = createSetupIntentInput.toInputDictionary()
 
     XCTAssertEqual(input["projectId"] as? String, "UHJvamVjdC0yMzEyODc5ODc")
+  }
+
+  func testCreateSetupIntentInputDictionary_WithNoValue_Success() {
+    let createSetupIntentInput = CreateSetupIntentInput(projectId: nil)
+
+    let input = createSetupIntentInput.toInputDictionary()
+
+    XCTAssertNil(input["projectId"] as? String)
   }
 }

--- a/Library/ViewModels/PaymentMethodsViewModel.swift
+++ b/Library/ViewModels/PaymentMethodsViewModel.swift
@@ -147,7 +147,9 @@ public final class PaymentMethodsViewModel: PaymentMethodsViewModelType,
           .materialize()
       }
 
-    /** FIXME: Add cancellation signal similiar to `shouldCancelPaymentSheetAppearance` in `PledgePaymentMethodsViewModel` */
+    /** TODO: https://kickstarter.atlassian.net/browse/PAY-1954
+     * Add cancellation signal similiar to `shouldCancelPaymentSheetAppearance` in `PledgePaymentMethodsViewModel`
+     */
     self.goToPaymentSheet = createSetupIntentEvent.values()
 
     self.errorLoadingPaymentMethodsOrSetupIntent = Signal.merge(


### PR DESCRIPTION
# 📲 What 🤔 Why

As continued integration of Stripe's Payment Sheet, while native waits for `CreatePaymentSourceType` mutation to be built on web, we can do some upfront work for presenting the payment sheet without completing the add new card flow.

# 🛠 How

This one is pretty similar to the `PledgePaymentMethodsViewModel` where we introduce an
`AppEnvironment.current.apiService.createStripeSetupIntent(input: nil)` and an output to handle the showing of the payment sheet alongside the feature flag. If the feature flag is off, we can show the usual add new card page.

# 👀 See

Before 🐛 

https://user-images.githubusercontent.com/4282741/190508221-8f358c8d-6fb6-4697-a5b1-3c79f1cc71a7.mp4

After 🦋

https://user-images.githubusercontent.com/4282741/190508249-3ad3e37d-4241-4bc6-a606-ea0019a31e50.mp4

# ✅ Acceptance criteria

- [x] Payment sheet present when feature flag is on (not able to complete payments yet)
- [x] Any errors in presenting payment sheet or creating the setup intent are displayed as errors were displayed before.

# ⏰ TODO

- [x] Integrate feature flag with payment sheet presentation.
- [x] Test error flow
- [x] Write unit tests.
