### PR TITLE
Update README.md with Carthage installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ and read more about our journey to open source [here](https://kickstarter.engine
 ## Getting Started
 
 1. Install Xcode.
+1. Install [Carthage](https://github.com/Carthage/Carthage).
 1. Clone this repository.
 1. Run `make bootstrap` to install tools and dependencies.
 


### PR DESCRIPTION
If you clone the repo today, you cannot just run `make bootstrap` after clone, because it runs `bin/carthage.sh` which assumes you already have carthage installed:

```
// Makefile
carthage-bootstrap:
	bin/carthage.sh bootstrap --platform iOS || exit 1
```

```
// bin/carthage.sh
carthage bootstrap --platform iOS
```

which results in:

```
❯ make bootstrap             
bin/carthage.sh bootstrap --platform iOS || exit 1
bin/carthage.sh: line 25: carthage: command not found
make: *** [carthage-bootstrap] Error 1
```

Obviously the bootstrap should install carthage, but I didn't want to do all that so I'm just updating the README to note this requirement. 

Installing carthage is its own can of worms (how should it install, should it use homebrew, should it use a local pkg, should the pkg be bundled with the repo, what version of carthage, etc).

<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

A description of the change.

# 🤔 Why

Some background context on why the change is needed.

# 🛠 How

More in-depth discussion of the change or implementation.

# 👀 See

Trello, screenshots, external resources?

| Before 🐛 | After 🦋 |
| --- | --- |
|  |  |

# ♿️ Accessibility 

- [ ] Tap targets use minimum of 44x44 pts dimensions
- [ ] Works with VoiceOver
- [ ] Supports Dynamic Type 

# 🏎 Performance

- [ ] Optimized Blended Layers (screenshots)

# ✅ Acceptance criteria

- [ ] Steps to test this feature
- [ ] Environment to test on
- [ ] Issues to look out for

# ⏰ TODO

- [ ] Got planned refactors to come
- [ ] Will add more tests
- [ ] Need feedback on a design
