### PR TITLE
[WEB-741] Appboy SDK to Braze SDK in SPM

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -5,7 +5,3 @@ github "kickstarter/Kickstarter-ReactiveExtensions" "e3f7786b5bcc7b99c14b9fd3133
 ### 3rd Party
 
 github "ReactiveCocoa/ReactiveSwift" == 6.5.0
-
-### Binaries
-
-binary "https://raw.githubusercontent.com/Appboy/appboy-ios-sdk/master/appboy_ios_sdk_full.json" == 4.3.2

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,2 @@
-binary "https://raw.githubusercontent.com/Appboy/appboy-ios-sdk/master/appboy_ios_sdk_full.json" "4.3.2"
 github "ReactiveCocoa/ReactiveSwift" "6.5.0"
 github "kickstarter/Kickstarter-ReactiveExtensions" "e3f7786b5bcc7b99c14b9fd313302bb59d9c3fe9"

--- a/Carthage-xcfilelist/app-input-files.xcfilelist
+++ b/Carthage-xcfilelist/app-input-files.xcfilelist
@@ -1,6 +1,4 @@
 # Carthage input files
 
-$(SRCROOT)/Carthage/Build/iOS/Appboy_iOS_SDK.framework
 $(SRCROOT)/Carthage/Build/iOS/ReactiveExtensions.framework
 $(SRCROOT)/Carthage/Build/iOS/ReactiveSwift.framework
-$(SRCROOT)/Carthage/Build/iOS/SDWebImage.framework

--- a/Carthage-xcfilelist/app-output-files.xcfilelist
+++ b/Carthage-xcfilelist/app-output-files.xcfilelist
@@ -1,6 +1,4 @@
 # Carthage output files
 
-$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/Appboy_iOS_SDK.framework
 $(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/ReactiveExtensions.framework
 $(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/ReactiveSwift.framework
-$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/SDWebImage.framework

--- a/Carthage-xcfilelist/library-input-files.xcfilelist
+++ b/Carthage-xcfilelist/library-input-files.xcfilelist
@@ -1,6 +1,4 @@
 # Carthage input files
 
-$(SRCROOT)/Carthage/Build/iOS/Appboy_iOS_SDK.framework
 $(SRCROOT)/Carthage/Build/iOS/ReactiveExtensions.framework
 $(SRCROOT)/Carthage/Build/iOS/ReactiveSwift.framework
-$(SRCROOT)/Carthage/Build/iOS/SDWebImage.framework

--- a/Carthage-xcfilelist/library-output-files.xcfilelist
+++ b/Carthage-xcfilelist/library-output-files.xcfilelist
@@ -1,6 +1,4 @@
 # Carthage output files
 
-$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/Appboy_iOS_SDK.framework
 $(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/ReactiveExtensions.framework
 $(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/ReactiveSwift.framework
-$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/SDWebImage.framework

--- a/Kickstarter-iOS/AppDelegate.swift
+++ b/Kickstarter-iOS/AppDelegate.swift
@@ -1,4 +1,4 @@
-import Appboy_iOS_SDK
+import AppboyKit
 import AppCenter
 import AppCenterDistribute
 import FBSDKCoreKit

--- a/Kickstarter-iOS/AppDelegateViewModel.swift
+++ b/Kickstarter-iOS/AppDelegateViewModel.swift
@@ -1,9 +1,10 @@
-import Appboy_iOS_SDK
+import AppboyUI
 import KsApi
 import Library
 import Prelude
 import ReactiveSwift
 import UserNotifications
+import AppboyKit
 
 public struct AppCenterConfigData: Equatable {
   public let appSecret: String

--- a/Kickstarter-iOS/AppDelegateViewModel.swift
+++ b/Kickstarter-iOS/AppDelegateViewModel.swift
@@ -1,4 +1,3 @@
-import AppboyUI
 import KsApi
 import Library
 import Prelude

--- a/Kickstarter-iOS/AppDelegateViewModel.swift
+++ b/Kickstarter-iOS/AppDelegateViewModel.swift
@@ -1,9 +1,9 @@
+import AppboyKit
 import KsApi
 import Library
 import Prelude
 import ReactiveSwift
 import UserNotifications
-import AppboyKit
 
 public struct AppCenterConfigData: Equatable {
   public let appSecret: String

--- a/Kickstarter-iOS/Library/BrazeTypes.swift
+++ b/Kickstarter-iOS/Library/BrazeTypes.swift
@@ -1,5 +1,4 @@
 import AppboyKit
-import AppboyUI
 import AppboySegment
 import Foundation
 

--- a/Kickstarter-iOS/Library/BrazeTypes.swift
+++ b/Kickstarter-iOS/Library/BrazeTypes.swift
@@ -1,4 +1,5 @@
-import Appboy_iOS_SDK
+import AppboyKit
+import AppboyUI
 import AppboySegment
 import Foundation
 

--- a/Kickstarter-iOS/Library/SharedFunctions.swift
+++ b/Kickstarter-iOS/Library/SharedFunctions.swift
@@ -1,4 +1,4 @@
-import Appboy_iOS_SDK
+import BrazeKit
 import Library
 import UIKit
 

--- a/Kickstarter-iOS/Library/SharedFunctions.swift
+++ b/Kickstarter-iOS/Library/SharedFunctions.swift
@@ -1,4 +1,4 @@
-import BrazeKit
+import AppboyKit
 import Library
 import UIKit
 

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -9345,8 +9345,8 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = "app-icon-beta";
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = "Kickstarter-iOS/Beta.entitlements";
-				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_IDENTITY = "iPhone Distribution";
+				CODE_SIGN_STYLE = Manual;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = 5DAN4UM3NC;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
@@ -9360,7 +9360,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.kickstarter.kickstarter.beta;
 				PRODUCT_MODULE_NAME = Kickstarter_iOS;
 				PRODUCT_NAME = KickBeta;
-				PROVISIONING_PROFILE_SPECIFIER = "";
+				PROVISIONING_PROFILE_SPECIFIER = "match InHouse com.kickstarter.kickstarter.beta";
 				SDKROOT = iphoneos;
 				VALIDATE_WORKSPACE = NO;
 			};

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -249,6 +249,8 @@
 		1965436D28C807FB00457EC6 /* PledgePaymentMethodsViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 192016C728B6731A0046919B /* PledgePaymentMethodsViewControllerTests.swift */; };
 		1965437428C811B000457EC6 /* ProjectNotificationsViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77F6E764212355C3005A5C55 /* ProjectNotificationsViewControllerTests.swift */; };
 		1965437E28C8165200457EC6 /* ProjectPageNavigationBarViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06AF78772710DB57009587F1 /* ProjectPageNavigationBarViewTests.swift */; };
+		197C398928EC7D6C006A3C6B /* BrazeKit in Frameworks */ = {isa = PBXBuildFile; productRef = 197C398828EC7D6C006A3C6B /* BrazeKit */; };
+		197C398B28EC7D6C006A3C6B /* BrazeUI in Frameworks */ = {isa = PBXBuildFile; productRef = 197C398A28EC7D6C006A3C6B /* BrazeUI */; };
 		1981AC90289075D900BB4897 /* Stripe in Frameworks */ = {isa = PBXBuildFile; productRef = 1981AC8F289075D900BB4897 /* Stripe */; };
 		198E574B28E2705100D5B8A9 /* PerimeterX in Frameworks */ = {isa = PBXBuildFile; productRef = 198E574A28E2705100D5B8A9 /* PerimeterX */; };
 		198E574D28E2705E00D5B8A9 /* PerimeterX in Frameworks */ = {isa = PBXBuildFile; productRef = 198E574C28E2705E00D5B8A9 /* PerimeterX */; };
@@ -629,16 +631,6 @@
 		8479CF2C2530A5D700FD13F1 /* Service+DecodeHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8479CF2B2530A5D700FD13F1 /* Service+DecodeHelpers.swift */; };
 		84F3C492251C87B400AEF24D /* UpdateActivityItemProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84F3C491251C87A400AEF24D /* UpdateActivityItemProviderTests.swift */; };
 		8A00CCFF24BD439E00E12D49 /* RewardAddOnCardViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A00CCFE24BD439E00E12D49 /* RewardAddOnCardViewModelTests.swift */; };
-		8A04FE26262781240056F413 /* Appboy_iOS_SDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A04FE23262781240056F413 /* Appboy_iOS_SDK.framework */; };
-		8A04FE28262781240056F413 /* SDWebImage.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A04FE25262781240056F413 /* SDWebImage.framework */; };
-		8A04FE29262781550056F413 /* SDWebImage.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A04FE25262781240056F413 /* SDWebImage.framework */; };
-		8A04FE2B262781550056F413 /* Appboy_iOS_SDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A04FE23262781240056F413 /* Appboy_iOS_SDK.framework */; };
-		8A04FE2C262781560056F413 /* SDWebImage.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A04FE25262781240056F413 /* SDWebImage.framework */; };
-		8A04FE2E262781560056F413 /* Appboy_iOS_SDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A04FE23262781240056F413 /* Appboy_iOS_SDK.framework */; };
-		8A04FE2F262781570056F413 /* SDWebImage.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A04FE25262781240056F413 /* SDWebImage.framework */; };
-		8A04FE31262781570056F413 /* Appboy_iOS_SDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A04FE23262781240056F413 /* Appboy_iOS_SDK.framework */; };
-		8A04FE382627839A0056F413 /* Appboy_iOS_SDK.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 8A04FE23262781240056F413 /* Appboy_iOS_SDK.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		8A04FE392627839A0056F413 /* SDWebImage.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 8A04FE25262781240056F413 /* SDWebImage.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		8A05CB0E23DB82D3002B01EE /* CookieRefTagFunctions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A05CB0D23DB82D3002B01EE /* CookieRefTagFunctions.swift */; };
 		8A072D3A230223B200BA1538 /* UIImage+Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A072D39230223B200BA1538 /* UIImage+Color.swift */; };
 		8A07CF052660344E00426B1C /* CommentRepliesViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A07CEFD2660344200426B1C /* CommentRepliesViewControllerTests.swift */; };
@@ -721,8 +713,6 @@
 		8A6C979024BFCDED00C4FA71 /* RewardAddOnSelectionContinueCTAViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A6C978F24BFCDED00C4FA71 /* RewardAddOnSelectionContinueCTAViewModel.swift */; };
 		8A73EACF2339528000FF9051 /* PledgePaymentMethodCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A73EACE2339528000FF9051 /* PledgePaymentMethodCellViewModel.swift */; };
 		8A73EAD12339732900FF9051 /* PledgePaymentMethodCellViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A73EAD02339732900FF9051 /* PledgePaymentMethodCellViewModelTests.swift */; };
-		8A741BC1262A358700E864E6 /* Appboy_iOS_SDK.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 8A04FE23262781240056F413 /* Appboy_iOS_SDK.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		8A741BC6262A35B000E864E6 /* SDWebImage.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 8A04FE25262781240056F413 /* SDWebImage.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		8A788F0D263B6E5800A89DAE /* BrazeTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A788F0C263B6E5800A89DAE /* BrazeTypes.swift */; };
 		8A788F15263B770100A89DAE /* BrazeMockTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A788F14263B770100A89DAE /* BrazeMockTypes.swift */; };
 		8A788F27263C80D600A89DAE /* BrazeDebounceMiddleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A788F26263C80D600A89DAE /* BrazeDebounceMiddleware.swift */; };
@@ -1652,9 +1642,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				8A04FE382627839A0056F413 /* Appboy_iOS_SDK.framework in CopyFiles */,
 				198ED06328D229560008CB98 /* iOSSnapshotTestCase in CopyFiles */,
-				8A04FE392627839A0056F413 /* SDWebImage.framework in CopyFiles */,
 				D0936294225D50B900E1411A /* ReactiveSwift.framework in CopyFiles */,
 				D0936293225D4FEB00E1411A /* ReactiveExtensions_TestHelpers.framework in CopyFiles */,
 				D0936292225D4FE000E1411A /* ReactiveExtensions.framework in CopyFiles */,
@@ -1667,8 +1655,6 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				8A741BC6262A35B000E864E6 /* SDWebImage.framework in CopyFiles */,
-				8A741BC1262A358700E864E6 /* Appboy_iOS_SDK.framework in CopyFiles */,
 				D00698E9225CF61F00EB58BD /* ReactiveExtensions.framework in CopyFiles */,
 				D00698E4225CF59B00EB58BD /* ReactiveSwift.framework in CopyFiles */,
 				D00698E3225CF58D00EB58BD /* ReactiveExtensions_TestHelpers.framework in CopyFiles */,
@@ -2263,8 +2249,6 @@
 		8479CF2B2530A5D700FD13F1 /* Service+DecodeHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Service+DecodeHelpers.swift"; sourceTree = "<group>"; };
 		84F3C491251C87A400AEF24D /* UpdateActivityItemProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateActivityItemProviderTests.swift; sourceTree = "<group>"; };
 		8A00CCFE24BD439E00E12D49 /* RewardAddOnCardViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RewardAddOnCardViewModelTests.swift; sourceTree = "<group>"; };
-		8A04FE23262781240056F413 /* Appboy_iOS_SDK.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Appboy_iOS_SDK.framework; path = Carthage/Build/iOS/Appboy_iOS_SDK.framework; sourceTree = "<group>"; };
-		8A04FE25262781240056F413 /* SDWebImage.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SDWebImage.framework; path = Carthage/Build/iOS/SDWebImage.framework; sourceTree = "<group>"; };
 		8A05CB0D23DB82D3002B01EE /* CookieRefTagFunctions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CookieRefTagFunctions.swift; sourceTree = "<group>"; };
 		8A072D39230223B200BA1538 /* UIImage+Color.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+Color.swift"; sourceTree = "<group>"; };
 		8A07CEF52660338600426B1C /* CommentRepliesViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentRepliesViewController.swift; sourceTree = "<group>"; };
@@ -3228,12 +3212,10 @@
 				D0D10BB81EEB394D005EBAD0 /* KsApi.framework in Frameworks */,
 				198E574B28E2705100D5B8A9 /* PerimeterX in Frameworks */,
 				1981AC90289075D900BB4897 /* Stripe in Frameworks */,
-				8A04FE31262781570056F413 /* Appboy_iOS_SDK.framework in Frameworks */,
 				60DA510F28C7E04B002E2DF1 /* Kingfisher in Frameworks */,
 				606754BF28CF91DD0033CD5E /* FacebookLogin in Frameworks */,
 				606754BD28CF91D60033CD5E /* FacebookCore in Frameworks */,
 				D0BE6F282286397400D05A10 /* ReactiveExtensions.framework in Frameworks */,
-				8A04FE2F262781570056F413 /* SDWebImage.framework in Frameworks */,
 				D00A3766225BCE8400F46F47 /* ReactiveSwift.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -3243,8 +3225,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				19F91B14289C8097000AEC6A /* Stripe in Frameworks */,
-				8A04FE2C262781560056F413 /* SDWebImage.framework in Frameworks */,
-				8A04FE2E262781560056F413 /* Appboy_iOS_SDK.framework in Frameworks */,
 				198ED06228D229560008CB98 /* iOSSnapshotTestCase in Frameworks */,
 				8AA3DB32250AC42F009AC8EA /* Library.framework in Frameworks */,
 			);
@@ -3265,10 +3245,10 @@
 			buildActionMask = 2147483647;
 			files = (
 				19BF226528D10497007F4197 /* FirebasePerformance in Frameworks */,
-				8A04FE26262781240056F413 /* Appboy_iOS_SDK.framework in Frameworks */,
+				197C398928EC7D6C006A3C6B /* BrazeKit in Frameworks */,
+				197C398B28EC7D6C006A3C6B /* BrazeUI in Frameworks */,
 				19BF226128D10497007F4197 /* FirebaseAnalytics in Frameworks */,
 				60EAD1C728D25A36009F9474 /* AppCenterDistribute in Frameworks */,
-				8A04FE28262781240056F413 /* SDWebImage.framework in Frameworks */,
 				06EA2D4C280F76B700F4DE2E /* Prelude in Frameworks */,
 				A73924001D27230B004524C3 /* Kickstarter_Framework.framework in Frameworks */,
 				19A824AE28DA54ED00325124 /* AppboySegment in Frameworks */,
@@ -3285,9 +3265,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				198ED05D28D21AD40008CB98 /* iOSSnapshotTestCase in Frameworks */,
-				8A04FE2B262781550056F413 /* Appboy_iOS_SDK.framework in Frameworks */,
 				A724BA641D2BFCC80041863C /* Kickstarter_Framework.framework in Frameworks */,
-				8A04FE29262781550056F413 /* SDWebImage.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -6492,11 +6470,9 @@
 			isa = PBXGroup;
 			children = (
 				06EA2D36280F1F1900F4DE2E /* XCTest.framework */,
-				8A04FE23262781240056F413 /* Appboy_iOS_SDK.framework */,
 				D0D58D822257FAE000532AC1 /* ReactiveExtensions_TestHelpers.framework */,
 				D0D58D7B2257FADE00532AC1 /* ReactiveExtensions.framework */,
 				D0D58D7F2257FADF00532AC1 /* ReactiveSwift.framework */,
-				8A04FE25262781240056F413 /* SDWebImage.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -7337,6 +7313,8 @@
 				60EAD1C628D25A36009F9474 /* AppCenterDistribute */,
 				19A824AD28DA54ED00325124 /* AppboySegment */,
 				191EDC6628E29BB9009B41B2 /* PerimeterX */,
+				197C398828EC7D6C006A3C6B /* BrazeKit */,
+				197C398A28EC7D6C006A3C6B /* BrazeUI */,
 			);
 			productName = Kickstarter;
 			productReference = A7D1F9451C850B7C000D41D5 /* KickDebug.app */;
@@ -7498,6 +7476,7 @@
 				60EAD1C528D25A36009F9474 /* XCRemoteSwiftPackageReference "appcenter-sdk-apple" */,
 				19A824AC28DA54ED00325124 /* XCRemoteSwiftPackageReference "appboy-segment-ios" */,
 				602C97D628DB787900919CA8 /* XCRemoteSwiftPackageReference "px-iOS-Framework" */,
+				197C398728EC7D6C006A3C6B /* XCRemoteSwiftPackageReference "braze-swift-sdk" */,
 			);
 			productRefGroup = A7E06C7A1C5A6EB300EBDCC2 /* Products */;
 			projectDirPath = "";
@@ -9653,10 +9632,10 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = "app-icon-debug";
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = "Kickstarter-iOS/Debug.entitlements";
-				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 48YBP49Y5N;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "Kickstarter-iOS/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -9668,7 +9647,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.kickstarter.kickstarter.debug;
 				PRODUCT_MODULE_NAME = Kickstarter_iOS;
 				PRODUCT_NAME = KickDebug;
-				PROVISIONING_PROFILE_SPECIFIER = "";
+				PROVISIONING_PROFILE_SPECIFIER = "match Development com.kickstarter.kickstarter.debug";
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				VALIDATE_WORKSPACE = NO;
@@ -10454,6 +10433,14 @@
 				minimumVersion = 22.7.1;
 			};
 		};
+		197C398728EC7D6C006A3C6B /* XCRemoteSwiftPackageReference "braze-swift-sdk" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/braze-inc/braze-swift-sdk";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 5.0.0;
+			};
+		};
 		19A824AC28DA54ED00325124 /* XCRemoteSwiftPackageReference "appboy-segment-ios" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/Appboy/appboy-segment-ios";
@@ -10571,6 +10558,16 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 602C97D628DB787900919CA8 /* XCRemoteSwiftPackageReference "px-iOS-Framework" */;
 			productName = PerimeterX;
+		};
+		197C398828EC7D6C006A3C6B /* BrazeKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 197C398728EC7D6C006A3C6B /* XCRemoteSwiftPackageReference "braze-swift-sdk" */;
+			productName = BrazeKit;
+		};
+		197C398A28EC7D6C006A3C6B /* BrazeUI */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 197C398728EC7D6C006A3C6B /* XCRemoteSwiftPackageReference "braze-swift-sdk" */;
+			productName = BrazeUI;
 		};
 		1981AC8F289075D900BB4897 /* Stripe */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -249,8 +249,8 @@
 		1965436D28C807FB00457EC6 /* PledgePaymentMethodsViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 192016C728B6731A0046919B /* PledgePaymentMethodsViewControllerTests.swift */; };
 		1965437428C811B000457EC6 /* ProjectNotificationsViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77F6E764212355C3005A5C55 /* ProjectNotificationsViewControllerTests.swift */; };
 		1965437E28C8165200457EC6 /* ProjectPageNavigationBarViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06AF78772710DB57009587F1 /* ProjectPageNavigationBarViewTests.swift */; };
-		197C398928EC7D6C006A3C6B /* BrazeKit in Frameworks */ = {isa = PBXBuildFile; productRef = 197C398828EC7D6C006A3C6B /* BrazeKit */; };
-		197C398B28EC7D6C006A3C6B /* BrazeUI in Frameworks */ = {isa = PBXBuildFile; productRef = 197C398A28EC7D6C006A3C6B /* BrazeUI */; };
+		197C398E28ECB3E2006A3C6B /* BrazeKit in Frameworks */ = {isa = PBXBuildFile; productRef = 197C398D28ECB3E2006A3C6B /* BrazeKit */; };
+		197C399028ECB3E2006A3C6B /* BrazeUI in Frameworks */ = {isa = PBXBuildFile; productRef = 197C398F28ECB3E2006A3C6B /* BrazeUI */; };
 		1981AC90289075D900BB4897 /* Stripe in Frameworks */ = {isa = PBXBuildFile; productRef = 1981AC8F289075D900BB4897 /* Stripe */; };
 		198E574B28E2705100D5B8A9 /* PerimeterX in Frameworks */ = {isa = PBXBuildFile; productRef = 198E574A28E2705100D5B8A9 /* PerimeterX */; };
 		198E574D28E2705E00D5B8A9 /* PerimeterX in Frameworks */ = {isa = PBXBuildFile; productRef = 198E574C28E2705E00D5B8A9 /* PerimeterX */; };
@@ -3245,8 +3245,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				19BF226528D10497007F4197 /* FirebasePerformance in Frameworks */,
-				197C398928EC7D6C006A3C6B /* BrazeKit in Frameworks */,
-				197C398B28EC7D6C006A3C6B /* BrazeUI in Frameworks */,
 				19BF226128D10497007F4197 /* FirebaseAnalytics in Frameworks */,
 				60EAD1C728D25A36009F9474 /* AppCenterDistribute in Frameworks */,
 				06EA2D4C280F76B700F4DE2E /* Prelude in Frameworks */,
@@ -3254,6 +3252,8 @@
 				19A824AE28DA54ED00325124 /* AppboySegment in Frameworks */,
 				191EDC6728E29BB9009B41B2 /* PerimeterX in Frameworks */,
 				19BF226328D10497007F4197 /* FirebaseCrashlytics in Frameworks */,
+				197C398E28ECB3E2006A3C6B /* BrazeKit in Frameworks */,
+				197C399028ECB3E2006A3C6B /* BrazeUI in Frameworks */,
 				D0B45B6B1EF858C00020A8DA /* KsApi.framework in Frameworks */,
 				D0D58D882257FAE000532AC1 /* ReactiveExtensions.framework in Frameworks */,
 				D0D58D8C2257FAE000532AC1 /* ReactiveSwift.framework in Frameworks */,
@@ -7313,8 +7313,8 @@
 				60EAD1C628D25A36009F9474 /* AppCenterDistribute */,
 				19A824AD28DA54ED00325124 /* AppboySegment */,
 				191EDC6628E29BB9009B41B2 /* PerimeterX */,
-				197C398828EC7D6C006A3C6B /* BrazeKit */,
-				197C398A28EC7D6C006A3C6B /* BrazeUI */,
+				197C398D28ECB3E2006A3C6B /* BrazeKit */,
+				197C398F28ECB3E2006A3C6B /* BrazeUI */,
 			);
 			productName = Kickstarter;
 			productReference = A7D1F9451C850B7C000D41D5 /* KickDebug.app */;
@@ -7476,7 +7476,7 @@
 				60EAD1C528D25A36009F9474 /* XCRemoteSwiftPackageReference "appcenter-sdk-apple" */,
 				19A824AC28DA54ED00325124 /* XCRemoteSwiftPackageReference "appboy-segment-ios" */,
 				602C97D628DB787900919CA8 /* XCRemoteSwiftPackageReference "px-iOS-Framework" */,
-				197C398728EC7D6C006A3C6B /* XCRemoteSwiftPackageReference "braze-swift-sdk" */,
+				197C398C28ECB3E2006A3C6B /* XCRemoteSwiftPackageReference "braze-swift-sdk" */,
 			);
 			productRefGroup = A7E06C7A1C5A6EB300EBDCC2 /* Products */;
 			projectDirPath = "";
@@ -9345,6 +9345,8 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = "app-icon-beta";
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = "Kickstarter-iOS/Beta.entitlements";
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = 5DAN4UM3NC;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
@@ -9358,7 +9360,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.kickstarter.kickstarter.beta;
 				PRODUCT_MODULE_NAME = Kickstarter_iOS;
 				PRODUCT_NAME = KickBeta;
-				PROVISIONING_PROFILE_SPECIFIER = "match InHouse com.kickstarter.kickstarter.beta";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = iphoneos;
 				VALIDATE_WORKSPACE = NO;
 			};
@@ -10433,7 +10435,7 @@
 				minimumVersion = 22.7.1;
 			};
 		};
-		197C398728EC7D6C006A3C6B /* XCRemoteSwiftPackageReference "braze-swift-sdk" */ = {
+		197C398C28ECB3E2006A3C6B /* XCRemoteSwiftPackageReference "braze-swift-sdk" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/braze-inc/braze-swift-sdk";
 			requirement = {
@@ -10559,14 +10561,14 @@
 			package = 602C97D628DB787900919CA8 /* XCRemoteSwiftPackageReference "px-iOS-Framework" */;
 			productName = PerimeterX;
 		};
-		197C398828EC7D6C006A3C6B /* BrazeKit */ = {
+		197C398D28ECB3E2006A3C6B /* BrazeKit */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 197C398728EC7D6C006A3C6B /* XCRemoteSwiftPackageReference "braze-swift-sdk" */;
+			package = 197C398C28ECB3E2006A3C6B /* XCRemoteSwiftPackageReference "braze-swift-sdk" */;
 			productName = BrazeKit;
 		};
-		197C398A28EC7D6C006A3C6B /* BrazeUI */ = {
+		197C398F28ECB3E2006A3C6B /* BrazeUI */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 197C398728EC7D6C006A3C6B /* XCRemoteSwiftPackageReference "braze-swift-sdk" */;
+			package = 197C398C28ECB3E2006A3C6B /* XCRemoteSwiftPackageReference "braze-swift-sdk" */;
 			productName = BrazeUI;
 		};
 		1981AC8F289075D900BB4897 /* Stripe */ = {

--- a/Kickstarter.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Kickstarter.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -82,6 +82,15 @@
       }
     },
     {
+      "identity" : "braze-swift-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/braze-inc/braze-swift-sdk",
+      "state" : {
+        "revision" : "b8147a77d726f6c75e0ef7efcf0b26f9d1c7b4b5",
+        "version" : "5.5.0"
+      }
+    },
+    {
       "identity" : "facebook-ios-sdk",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/facebook/facebook-ios-sdk",


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

As part of our Carthage -> SPM migration we need to migrate Appboy-iOS-SDK (AppboyKit) and its dependency SDWebImage

# 🤔 Why

Checkout  this [Guru Card](https://app.getguru.com/card/TzA8Rpac/-Carthage-to-Swift-Package-Manager-Migration-2022) for more details  

# 🛠 How

- Remove the dependencies from Cartfile and Cartfile.resolved and add them to main and Library targets
- Minimum version to 4.3.2
```
AppDelegate.swift
import Appboy_iOS_SDK -> import AppboyKit

AppDelegateViewModel.swift
import Appboy_iOS_SDK -> import AppboyKit

BrazeTypes.swift
import Appboy_iOS_SDK -> import AppboyKit

SharedFunctions.swift
import Appboy_iOS_SDK -> import AppboyKit
```


# ✅ Acceptance criteria

- [x] Breakpoint most instances of code used in files that `import AppboyKit` (KsAPI Target) and run the app on device to check the breakpoints are hit and the app continues to run as expected.. 
- [x] Run/build app, smoke test, and verify that all tests pass.

**Important to Note**
While testing, neither pns or in-app pns came through after this library was changed over. To rule out any certifcate signing issues related to enterprise distribution builds, let's create a a beta by merging this branch and testing the beta for those pns.