### PR TITLE
[WEB-749] ReactiveExtensions and ReactiveSwift to SPM

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,5 +1,3 @@
 ### Internal
 
 ### 3rd Party
-
-github "ReactiveCocoa/ReactiveSwift" == 6.5.0

--- a/Cartfile
+++ b/Cartfile
@@ -1,7 +1,5 @@
 ### Internal
 
-github "kickstarter/Kickstarter-ReactiveExtensions" "e3f7786b5bcc7b99c14b9fd313302bb59d9c3fe9"
-
 ### 3rd Party
 
 github "ReactiveCocoa/ReactiveSwift" == 6.5.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "ReactiveCocoa/ReactiveSwift" "6.5.0"
+

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,1 @@
 github "ReactiveCocoa/ReactiveSwift" "6.5.0"
-github "kickstarter/Kickstarter-ReactiveExtensions" "e3f7786b5bcc7b99c14b9fd313302bb59d9c3fe9"

--- a/Carthage-xcfilelist/app-input-files.xcfilelist
+++ b/Carthage-xcfilelist/app-input-files.xcfilelist
@@ -1,4 +1,3 @@
 # Carthage input files
 
-$(SRCROOT)/Carthage/Build/iOS/ReactiveExtensions.framework
 $(SRCROOT)/Carthage/Build/iOS/ReactiveSwift.framework

--- a/Carthage-xcfilelist/app-input-files.xcfilelist
+++ b/Carthage-xcfilelist/app-input-files.xcfilelist
@@ -1,3 +1,1 @@
 # Carthage input files
-
-$(SRCROOT)/Carthage/Build/iOS/ReactiveSwift.framework

--- a/Carthage-xcfilelist/app-output-files.xcfilelist
+++ b/Carthage-xcfilelist/app-output-files.xcfilelist
@@ -1,3 +1,1 @@
 # Carthage output files
-
-$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/ReactiveSwift.framework

--- a/Carthage-xcfilelist/app-output-files.xcfilelist
+++ b/Carthage-xcfilelist/app-output-files.xcfilelist
@@ -1,4 +1,3 @@
 # Carthage output files
 
-$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/ReactiveExtensions.framework
 $(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/ReactiveSwift.framework

--- a/Carthage-xcfilelist/kickstarter-framework-input-files.xcfilelist
+++ b/Carthage-xcfilelist/kickstarter-framework-input-files.xcfilelist
@@ -1,4 +1,3 @@
 # Carthage input files
 
-$(SRCROOT)/Carthage/Build/iOS/ReactiveExtensions.framework
 $(SRCROOT)/Carthage/Build/iOS/ReactiveSwift.framework

--- a/Carthage-xcfilelist/kickstarter-framework-input-files.xcfilelist
+++ b/Carthage-xcfilelist/kickstarter-framework-input-files.xcfilelist
@@ -1,3 +1,1 @@
 # Carthage input files
-
-$(SRCROOT)/Carthage/Build/iOS/ReactiveSwift.framework

--- a/Carthage-xcfilelist/kickstarter-framework-output-files.xcfilelist
+++ b/Carthage-xcfilelist/kickstarter-framework-output-files.xcfilelist
@@ -1,3 +1,1 @@
 # Carthage output files
-
-$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/ReactiveSwift.framework

--- a/Carthage-xcfilelist/kickstarter-framework-output-files.xcfilelist
+++ b/Carthage-xcfilelist/kickstarter-framework-output-files.xcfilelist
@@ -1,4 +1,3 @@
 # Carthage output files
 
-$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/ReactiveExtensions.framework
 $(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/ReactiveSwift.framework

--- a/Carthage-xcfilelist/ksapi-input-files.xcfilelist
+++ b/Carthage-xcfilelist/ksapi-input-files.xcfilelist
@@ -1,4 +1,3 @@
 # Carthage input files
 
-$(SRCROOT)/Carthage/Build/iOS/ReactiveExtensions.framework
 $(SRCROOT)/Carthage/Build/iOS/ReactiveSwift.framework

--- a/Carthage-xcfilelist/ksapi-input-files.xcfilelist
+++ b/Carthage-xcfilelist/ksapi-input-files.xcfilelist
@@ -1,3 +1,1 @@
 # Carthage input files
-
-$(SRCROOT)/Carthage/Build/iOS/ReactiveSwift.framework

--- a/Carthage-xcfilelist/ksapi-output-files.xcfilelist
+++ b/Carthage-xcfilelist/ksapi-output-files.xcfilelist
@@ -1,3 +1,1 @@
 # Carthage output files
-
-$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/ReactiveSwift.framework

--- a/Carthage-xcfilelist/ksapi-output-files.xcfilelist
+++ b/Carthage-xcfilelist/ksapi-output-files.xcfilelist
@@ -1,4 +1,3 @@
 # Carthage output files
 
-$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/ReactiveExtensions.framework
 $(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/ReactiveSwift.framework

--- a/Carthage-xcfilelist/library-input-files.xcfilelist
+++ b/Carthage-xcfilelist/library-input-files.xcfilelist
@@ -1,4 +1,3 @@
 # Carthage input files
 
-$(SRCROOT)/Carthage/Build/iOS/ReactiveExtensions.framework
 $(SRCROOT)/Carthage/Build/iOS/ReactiveSwift.framework

--- a/Carthage-xcfilelist/library-input-files.xcfilelist
+++ b/Carthage-xcfilelist/library-input-files.xcfilelist
@@ -1,3 +1,1 @@
 # Carthage input files
-
-$(SRCROOT)/Carthage/Build/iOS/ReactiveSwift.framework

--- a/Carthage-xcfilelist/library-output-files.xcfilelist
+++ b/Carthage-xcfilelist/library-output-files.xcfilelist
@@ -1,3 +1,1 @@
 # Carthage output files
-
-$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/ReactiveSwift.framework

--- a/Carthage-xcfilelist/library-output-files.xcfilelist
+++ b/Carthage-xcfilelist/library-output-files.xcfilelist
@@ -1,4 +1,3 @@
 # Carthage output files
 
-$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/ReactiveExtensions.framework
 $(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/ReactiveSwift.framework

--- a/Kickstarter-iOS/Features/Help/ViewModel/HelpWebViewModel.swift
+++ b/Kickstarter-iOS/Features/Help/ViewModel/HelpWebViewModel.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Library
 import Prelude
 import ReactiveSwift

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -235,8 +235,6 @@
 		19047FCF2889D4BC00BDD1A8 /* GraphAPI.CreateSetupIntentInput+CreateSetupIntentInputTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19047FCE2889D4BC00BDD1A8 /* GraphAPI.CreateSetupIntentInput+CreateSetupIntentInputTests.swift */; };
 		19047FD12889D6DC00BDD1A8 /* ClientSecretEnvelope+CreateSetupIntentMutation.DataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19047FD02889D6DC00BDD1A8 /* ClientSecretEnvelope+CreateSetupIntentMutation.DataTests.swift */; };
 		1905787B28F8CD2500428375 /* ReactiveSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 1905787A28F8CD2500428375 /* ReactiveSwift */; };
-		1905787D28F8CD4D00428375 /* ReactiveSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 1905787C28F8CD4D00428375 /* ReactiveSwift */; };
-		1905787F28F8CD5E00428375 /* ReactiveSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 1905787E28F8CD5E00428375 /* ReactiveSwift */; };
 		1905788128F8CD7000428375 /* ReactiveSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 1905788028F8CD7000428375 /* ReactiveSwift */; };
 		191EDC6728E29BB9009B41B2 /* PerimeterX in Frameworks */ = {isa = PBXBuildFile; productRef = 191EDC6628E29BB9009B41B2 /* PerimeterX */; };
 		1923770A28DA2AE300F68635 /* Stripe+PaymentMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1923770928DA2AE300F68635 /* Stripe+PaymentMethod.swift */; };
@@ -262,9 +260,7 @@
 		198ED06228D229560008CB98 /* iOSSnapshotTestCase in Frameworks */ = {isa = PBXBuildFile; productRef = 198ED06128D229560008CB98 /* iOSSnapshotTestCase */; };
 		198ED06328D229560008CB98 /* iOSSnapshotTestCase in CopyFiles */ = {isa = PBXBuildFile; productRef = 198ED06128D229560008CB98 /* iOSSnapshotTestCase */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		1998BCA828F60E8900D04077 /* ReactiveExtensions in Frameworks */ = {isa = PBXBuildFile; productRef = 1998BCA728F60E8900D04077 /* ReactiveExtensions */; };
-		1998BCAA28F60E9600D04077 /* ReactiveExtensions in Frameworks */ = {isa = PBXBuildFile; productRef = 1998BCA928F60E9600D04077 /* ReactiveExtensions */; };
 		1998BCAC28F60EA700D04077 /* ReactiveExtensions-TestHelpers in Frameworks */ = {isa = PBXBuildFile; productRef = 1998BCAB28F60EA700D04077 /* ReactiveExtensions-TestHelpers */; };
-		1998BCAE28F60EB700D04077 /* ReactiveExtensions in Frameworks */ = {isa = PBXBuildFile; productRef = 1998BCAD28F60EB700D04077 /* ReactiveExtensions */; };
 		1998BCB028F60EC300D04077 /* ReactiveExtensions-TestHelpers in Frameworks */ = {isa = PBXBuildFile; productRef = 1998BCAF28F60EC300D04077 /* ReactiveExtensions-TestHelpers */; };
 		1998BCB228F60ED400D04077 /* ReactiveExtensions in Frameworks */ = {isa = PBXBuildFile; productRef = 1998BCB128F60ED400D04077 /* ReactiveExtensions */; };
 		1998BCB428F60EE800D04077 /* ReactiveExtensions-TestHelpers in Frameworks */ = {isa = PBXBuildFile; productRef = 1998BCB328F60EE800D04077 /* ReactiveExtensions-TestHelpers */; };
@@ -3172,7 +3168,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				60DA50FE28C38DDB002E2DF1 /* AlamofireImage in Frameworks */,
-				1905787D28F8CD4D00428375 /* ReactiveSwift in Frameworks */,
 				60DA512928CA580B002E2DF1 /* Optimizely in Frameworks */,
 				06634FC72807A4EB00950F60 /* Prelude_UIKit in Frameworks */,
 				19A824B028DA562800325124 /* AppboySegment in Frameworks */,
@@ -3181,7 +3176,6 @@
 				1981AC90289075D900BB4897 /* Stripe in Frameworks */,
 				60DA510F28C7E04B002E2DF1 /* Kingfisher in Frameworks */,
 				606754BF28CF91DD0033CD5E /* FacebookLogin in Frameworks */,
-				1998BCAA28F60E9600D04077 /* ReactiveExtensions in Frameworks */,
 				606754BD28CF91D60033CD5E /* FacebookCore in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -3201,8 +3195,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				1998BCAE28F60EB700D04077 /* ReactiveExtensions in Frameworks */,
-				1905787F28F8CD5E00428375 /* ReactiveSwift in Frameworks */,
 				A76127C01C93100C00EDCCB9 /* Library.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -7202,8 +7194,6 @@
 				606754BE28CF91DD0033CD5E /* FacebookLogin */,
 				19A824AF28DA562800325124 /* AppboySegment */,
 				198E574A28E2705100D5B8A9 /* PerimeterX */,
-				1998BCA928F60E9600D04077 /* ReactiveExtensions */,
-				1905787C28F8CD4D00428375 /* ReactiveSwift */,
 			);
 			productName = "Library-iOS";
 			productReference = A755113C1C8642B3005355CF /* Library.framework */;
@@ -7249,8 +7239,6 @@
 			);
 			name = "Kickstarter-Framework-iOS";
 			packageProductDependencies = (
-				1998BCAD28F60EB700D04077 /* ReactiveExtensions */,
-				1905787E28F8CD5E00428375 /* ReactiveSwift */,
 			);
 			productName = "Kickstarter-iOS-Framework";
 			productReference = A7C7959E1C873A870081977F /* Kickstarter_Framework.framework */;
@@ -10470,16 +10458,6 @@
 			package = 1905787928F8CD2500428375 /* XCRemoteSwiftPackageReference "ReactiveSwift" */;
 			productName = ReactiveSwift;
 		};
-		1905787C28F8CD4D00428375 /* ReactiveSwift */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 1905787928F8CD2500428375 /* XCRemoteSwiftPackageReference "ReactiveSwift" */;
-			productName = ReactiveSwift;
-		};
-		1905787E28F8CD5E00428375 /* ReactiveSwift */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 1905787928F8CD2500428375 /* XCRemoteSwiftPackageReference "ReactiveSwift" */;
-			productName = ReactiveSwift;
-		};
 		1905788028F8CD7000428375 /* ReactiveSwift */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 1905787928F8CD2500428375 /* XCRemoteSwiftPackageReference "ReactiveSwift" */;
@@ -10525,20 +10503,10 @@
 			package = 194C593E28F5E7FF00453249 /* XCRemoteSwiftPackageReference "Kickstarter-ReactiveExtensions" */;
 			productName = ReactiveExtensions;
 		};
-		1998BCA928F60E9600D04077 /* ReactiveExtensions */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 194C593E28F5E7FF00453249 /* XCRemoteSwiftPackageReference "Kickstarter-ReactiveExtensions" */;
-			productName = ReactiveExtensions;
-		};
 		1998BCAB28F60EA700D04077 /* ReactiveExtensions-TestHelpers */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 194C593E28F5E7FF00453249 /* XCRemoteSwiftPackageReference "Kickstarter-ReactiveExtensions" */;
 			productName = "ReactiveExtensions-TestHelpers";
-		};
-		1998BCAD28F60EB700D04077 /* ReactiveExtensions */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 194C593E28F5E7FF00453249 /* XCRemoteSwiftPackageReference "Kickstarter-ReactiveExtensions" */;
-			productName = ReactiveExtensions;
 		};
 		1998BCAF28F60EC300D04077 /* ReactiveExtensions-TestHelpers */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -236,6 +236,12 @@
 		19047FD12889D6DC00BDD1A8 /* ClientSecretEnvelope+CreateSetupIntentMutation.DataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19047FD02889D6DC00BDD1A8 /* ClientSecretEnvelope+CreateSetupIntentMutation.DataTests.swift */; };
 		1905787B28F8CD2500428375 /* ReactiveSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 1905787A28F8CD2500428375 /* ReactiveSwift */; };
 		1905788128F8CD7000428375 /* ReactiveSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 1905788028F8CD7000428375 /* ReactiveSwift */; };
+		191A4B4028FF386C009D62A5 /* ReactiveSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 191A4B3F28FF386C009D62A5 /* ReactiveSwift */; };
+		191A4B4228FF3897009D62A5 /* ReactiveExtensions in Frameworks */ = {isa = PBXBuildFile; productRef = 191A4B4128FF3897009D62A5 /* ReactiveExtensions */; };
+		191A4B4428FF395E009D62A5 /* ReactiveExtensions in Frameworks */ = {isa = PBXBuildFile; productRef = 191A4B4328FF395E009D62A5 /* ReactiveExtensions */; };
+		191A4B4628FF3965009D62A5 /* ReactiveSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 191A4B4528FF3965009D62A5 /* ReactiveSwift */; };
+		191A4B4C28FF3AF8009D62A5 /* ReactiveExtensions-TestHelpers in Frameworks */ = {isa = PBXBuildFile; productRef = 191A4B4B28FF3AF8009D62A5 /* ReactiveExtensions-TestHelpers */; };
+		191A4B5028FF44D8009D62A5 /* ReactiveExtensions in Frameworks */ = {isa = PBXBuildFile; productRef = 191A4B4F28FF44D8009D62A5 /* ReactiveExtensions */; };
 		191EDC6728E29BB9009B41B2 /* PerimeterX in Frameworks */ = {isa = PBXBuildFile; productRef = 191EDC6628E29BB9009B41B2 /* PerimeterX */; };
 		1923770A28DA2AE300F68635 /* Stripe+PaymentMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1923770928DA2AE300F68635 /* Stripe+PaymentMethod.swift */; };
 		1937A71F28C94FFC00DD732D /* SettingsFormFieldView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 7790DF882200D3BD005DBB11 /* SettingsFormFieldView.xib */; };
@@ -260,7 +266,6 @@
 		198ED06228D229560008CB98 /* iOSSnapshotTestCase in Frameworks */ = {isa = PBXBuildFile; productRef = 198ED06128D229560008CB98 /* iOSSnapshotTestCase */; };
 		198ED06328D229560008CB98 /* iOSSnapshotTestCase in CopyFiles */ = {isa = PBXBuildFile; productRef = 198ED06128D229560008CB98 /* iOSSnapshotTestCase */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		1998BCA828F60E8900D04077 /* ReactiveExtensions in Frameworks */ = {isa = PBXBuildFile; productRef = 1998BCA728F60E8900D04077 /* ReactiveExtensions */; };
-		1998BCAC28F60EA700D04077 /* ReactiveExtensions-TestHelpers in Frameworks */ = {isa = PBXBuildFile; productRef = 1998BCAB28F60EA700D04077 /* ReactiveExtensions-TestHelpers */; };
 		1998BCB028F60EC300D04077 /* ReactiveExtensions-TestHelpers in Frameworks */ = {isa = PBXBuildFile; productRef = 1998BCAF28F60EC300D04077 /* ReactiveExtensions-TestHelpers */; };
 		1998BCB228F60ED400D04077 /* ReactiveExtensions in Frameworks */ = {isa = PBXBuildFile; productRef = 1998BCB128F60ED400D04077 /* ReactiveExtensions */; };
 		1998BCB428F60EE800D04077 /* ReactiveExtensions-TestHelpers in Frameworks */ = {isa = PBXBuildFile; productRef = 1998BCB328F60EE800D04077 /* ReactiveExtensions-TestHelpers */; };
@@ -3170,11 +3175,13 @@
 				60DA50FE28C38DDB002E2DF1 /* AlamofireImage in Frameworks */,
 				60DA512928CA580B002E2DF1 /* Optimizely in Frameworks */,
 				06634FC72807A4EB00950F60 /* Prelude_UIKit in Frameworks */,
+				191A4B4028FF386C009D62A5 /* ReactiveSwift in Frameworks */,
 				19A824B028DA562800325124 /* AppboySegment in Frameworks */,
 				D0D10BB81EEB394D005EBAD0 /* KsApi.framework in Frameworks */,
 				198E574B28E2705100D5B8A9 /* PerimeterX in Frameworks */,
 				1981AC90289075D900BB4897 /* Stripe in Frameworks */,
 				60DA510F28C7E04B002E2DF1 /* Kingfisher in Frameworks */,
+				191A4B4228FF3897009D62A5 /* ReactiveExtensions in Frameworks */,
 				606754BF28CF91DD0033CD5E /* FacebookLogin in Frameworks */,
 				606754BD28CF91D60033CD5E /* FacebookCore in Frameworks */,
 			);
@@ -3185,9 +3192,10 @@
 			buildActionMask = 2147483647;
 			files = (
 				19F91B14289C8097000AEC6A /* Stripe in Frameworks */,
-				1998BCAC28F60EA700D04077 /* ReactiveExtensions-TestHelpers in Frameworks */,
 				198ED06228D229560008CB98 /* iOSSnapshotTestCase in Frameworks */,
+				191A4B5028FF44D8009D62A5 /* ReactiveExtensions in Frameworks */,
 				8AA3DB32250AC42F009AC8EA /* Library.framework in Frameworks */,
+				191A4B4C28FF3AF8009D62A5 /* ReactiveExtensions-TestHelpers in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3196,6 +3204,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				A76127C01C93100C00EDCCB9 /* Library.framework in Frameworks */,
+				191A4B4628FF3965009D62A5 /* ReactiveSwift in Frameworks */,
+				191A4B4428FF395E009D62A5 /* ReactiveExtensions in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -7194,6 +7204,8 @@
 				606754BE28CF91DD0033CD5E /* FacebookLogin */,
 				19A824AF28DA562800325124 /* AppboySegment */,
 				198E574A28E2705100D5B8A9 /* PerimeterX */,
+				191A4B3F28FF386C009D62A5 /* ReactiveSwift */,
+				191A4B4128FF3897009D62A5 /* ReactiveExtensions */,
 			);
 			productName = "Library-iOS";
 			productReference = A755113C1C8642B3005355CF /* Library.framework */;
@@ -7217,7 +7229,8 @@
 			packageProductDependencies = (
 				19F91B13289C8097000AEC6A /* Stripe */,
 				198ED06128D229560008CB98 /* iOSSnapshotTestCase */,
-				1998BCAB28F60EA700D04077 /* ReactiveExtensions-TestHelpers */,
+				191A4B4B28FF3AF8009D62A5 /* ReactiveExtensions-TestHelpers */,
+				191A4B4F28FF44D8009D62A5 /* ReactiveExtensions */,
 			);
 			productName = "Library-iOSTests";
 			productReference = A75511451C8642B3005355CF /* Library-iOSTests.xctest */;
@@ -7239,6 +7252,8 @@
 			);
 			name = "Kickstarter-Framework-iOS";
 			packageProductDependencies = (
+				191A4B4328FF395E009D62A5 /* ReactiveExtensions */,
+				191A4B4528FF3965009D62A5 /* ReactiveSwift */,
 			);
 			productName = "Kickstarter-iOS-Framework";
 			productReference = A7C7959E1C873A870081977F /* Kickstarter_Framework.framework */;
@@ -9194,7 +9209,6 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SYMROOT)/Release$(EFFECTIVE_PLATFORM_NAME)",
 					"$(PROJECT_DIR)/Frameworks",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
 				);
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -9646,10 +9660,7 @@
 					"${PROJECT_DIR}/Frameworks/native-secrets/ios/Firebase-Beta/GoogleService-Info.plist",
 					"${PROJECT_DIR}/Frameworks/native-secrets/ios/Firebase-Production/GoogleService-Info.plist",
 				);
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(PROJECT_DIR)/Frameworks",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/Frameworks";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -9724,10 +9735,7 @@
 					"${PROJECT_DIR}/Frameworks/native-secrets/ios/Firebase-Beta/GoogleService-Info.plist",
 					"${PROJECT_DIR}/Configs/GoogleService-Info.plist",
 				);
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(PROJECT_DIR)/Frameworks",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/Frameworks";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
@@ -9981,7 +9989,6 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SYMROOT)/Release$(EFFECTIVE_PLATFORM_NAME)",
 					"$(PROJECT_DIR)/Frameworks",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
 				);
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -10463,6 +10470,36 @@
 			package = 1905787928F8CD2500428375 /* XCRemoteSwiftPackageReference "ReactiveSwift" */;
 			productName = ReactiveSwift;
 		};
+		191A4B3F28FF386C009D62A5 /* ReactiveSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 1905787928F8CD2500428375 /* XCRemoteSwiftPackageReference "ReactiveSwift" */;
+			productName = ReactiveSwift;
+		};
+		191A4B4128FF3897009D62A5 /* ReactiveExtensions */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 194C593E28F5E7FF00453249 /* XCRemoteSwiftPackageReference "Kickstarter-ReactiveExtensions" */;
+			productName = ReactiveExtensions;
+		};
+		191A4B4328FF395E009D62A5 /* ReactiveExtensions */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 194C593E28F5E7FF00453249 /* XCRemoteSwiftPackageReference "Kickstarter-ReactiveExtensions" */;
+			productName = ReactiveExtensions;
+		};
+		191A4B4528FF3965009D62A5 /* ReactiveSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 1905787928F8CD2500428375 /* XCRemoteSwiftPackageReference "ReactiveSwift" */;
+			productName = ReactiveSwift;
+		};
+		191A4B4B28FF3AF8009D62A5 /* ReactiveExtensions-TestHelpers */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 194C593E28F5E7FF00453249 /* XCRemoteSwiftPackageReference "Kickstarter-ReactiveExtensions" */;
+			productName = "ReactiveExtensions-TestHelpers";
+		};
+		191A4B4F28FF44D8009D62A5 /* ReactiveExtensions */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 194C593E28F5E7FF00453249 /* XCRemoteSwiftPackageReference "Kickstarter-ReactiveExtensions" */;
+			productName = ReactiveExtensions;
+		};
 		191EDC6628E29BB9009B41B2 /* PerimeterX */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 602C97D628DB787900919CA8 /* XCRemoteSwiftPackageReference "px-iOS-Framework" */;
@@ -10502,11 +10539,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 194C593E28F5E7FF00453249 /* XCRemoteSwiftPackageReference "Kickstarter-ReactiveExtensions" */;
 			productName = ReactiveExtensions;
-		};
-		1998BCAB28F60EA700D04077 /* ReactiveExtensions-TestHelpers */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 194C593E28F5E7FF00453249 /* XCRemoteSwiftPackageReference "Kickstarter-ReactiveExtensions" */;
-			productName = "ReactiveExtensions-TestHelpers";
 		};
 		1998BCAF28F60EC300D04077 /* ReactiveExtensions-TestHelpers */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -268,7 +268,6 @@
 		1998BCA828F60E8900D04077 /* ReactiveExtensions in Frameworks */ = {isa = PBXBuildFile; productRef = 1998BCA728F60E8900D04077 /* ReactiveExtensions */; };
 		1998BCB028F60EC300D04077 /* ReactiveExtensions-TestHelpers in Frameworks */ = {isa = PBXBuildFile; productRef = 1998BCAF28F60EC300D04077 /* ReactiveExtensions-TestHelpers */; };
 		1998BCB228F60ED400D04077 /* ReactiveExtensions in Frameworks */ = {isa = PBXBuildFile; productRef = 1998BCB128F60ED400D04077 /* ReactiveExtensions */; };
-		1998BCB428F60EE800D04077 /* ReactiveExtensions-TestHelpers in Frameworks */ = {isa = PBXBuildFile; productRef = 1998BCB328F60EE800D04077 /* ReactiveExtensions-TestHelpers */; };
 		19A824AE28DA54ED00325124 /* AppboySegment in Frameworks */ = {isa = PBXBuildFile; productRef = 19A824AD28DA54ED00325124 /* AppboySegment */; };
 		19A824B028DA562800325124 /* AppboySegment in Frameworks */ = {isa = PBXBuildFile; productRef = 19A824AF28DA562800325124 /* AppboySegment */; };
 		19A97CE228C7DA7B0031B857 /* ActivitiesDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = A75AB1F81C8A84B5002FC3E6 /* ActivitiesDataSource.swift */; };
@@ -3259,7 +3258,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				D01587591EEB2DE4006E7684 /* KsApi.framework in Frameworks */,
-				1998BCB428F60EE800D04077 /* ReactiveExtensions-TestHelpers in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -7360,7 +7358,6 @@
 			);
 			name = KsApiTests;
 			packageProductDependencies = (
-				1998BCB328F60EE800D04077 /* ReactiveExtensions-TestHelpers */,
 			);
 			productName = KsApiTests;
 			productReference = D01587581EEB2DE4006E7684 /* KsApiTests.xctest */;
@@ -10549,11 +10546,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 194C593E28F5E7FF00453249 /* XCRemoteSwiftPackageReference "Kickstarter-ReactiveExtensions" */;
 			productName = ReactiveExtensions;
-		};
-		1998BCB328F60EE800D04077 /* ReactiveExtensions-TestHelpers */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 194C593E28F5E7FF00453249 /* XCRemoteSwiftPackageReference "Kickstarter-ReactiveExtensions" */;
-			productName = "ReactiveExtensions-TestHelpers";
 		};
 		19A824AD28DA54ED00325124 /* AppboySegment */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -257,6 +257,14 @@
 		198ED05D28D21AD40008CB98 /* iOSSnapshotTestCase in Frameworks */ = {isa = PBXBuildFile; productRef = 60EAD1B328D0EE45009F9474 /* iOSSnapshotTestCase */; };
 		198ED06228D229560008CB98 /* iOSSnapshotTestCase in Frameworks */ = {isa = PBXBuildFile; productRef = 198ED06128D229560008CB98 /* iOSSnapshotTestCase */; };
 		198ED06328D229560008CB98 /* iOSSnapshotTestCase in CopyFiles */ = {isa = PBXBuildFile; productRef = 198ED06128D229560008CB98 /* iOSSnapshotTestCase */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		1998BC9828F5EC3400D04077 /* ReactiveSwift.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = D0D58D7F2257FADF00532AC1 /* ReactiveSwift.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		1998BCA828F60E8900D04077 /* ReactiveExtensions in Frameworks */ = {isa = PBXBuildFile; productRef = 1998BCA728F60E8900D04077 /* ReactiveExtensions */; };
+		1998BCAA28F60E9600D04077 /* ReactiveExtensions in Frameworks */ = {isa = PBXBuildFile; productRef = 1998BCA928F60E9600D04077 /* ReactiveExtensions */; };
+		1998BCAC28F60EA700D04077 /* ReactiveExtensions-TestHelpers in Frameworks */ = {isa = PBXBuildFile; productRef = 1998BCAB28F60EA700D04077 /* ReactiveExtensions-TestHelpers */; };
+		1998BCAE28F60EB700D04077 /* ReactiveExtensions in Frameworks */ = {isa = PBXBuildFile; productRef = 1998BCAD28F60EB700D04077 /* ReactiveExtensions */; };
+		1998BCB028F60EC300D04077 /* ReactiveExtensions-TestHelpers in Frameworks */ = {isa = PBXBuildFile; productRef = 1998BCAF28F60EC300D04077 /* ReactiveExtensions-TestHelpers */; };
+		1998BCB228F60ED400D04077 /* ReactiveExtensions in Frameworks */ = {isa = PBXBuildFile; productRef = 1998BCB128F60ED400D04077 /* ReactiveExtensions */; };
+		1998BCB428F60EE800D04077 /* ReactiveExtensions-TestHelpers in Frameworks */ = {isa = PBXBuildFile; productRef = 1998BCB328F60EE800D04077 /* ReactiveExtensions-TestHelpers */; };
 		19A824AE28DA54ED00325124 /* AppboySegment in Frameworks */ = {isa = PBXBuildFile; productRef = 19A824AD28DA54ED00325124 /* AppboySegment */; };
 		19A824B028DA562800325124 /* AppboySegment in Frameworks */ = {isa = PBXBuildFile; productRef = 19A824AF28DA562800325124 /* AppboySegment */; };
 		19A97CE228C7DA7B0031B857 /* ActivitiesDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = A75AB1F81C8A84B5002FC3E6 /* ActivitiesDataSource.swift */; };
@@ -1147,11 +1155,7 @@
 		D002CAE1218CF8F1009783F2 /* WatchProjectMutation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D002CAE0218CF8F1009783F2 /* WatchProjectMutation.swift */; };
 		D002CAE3218CF91D009783F2 /* WatchProjectInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = D002CAE2218CF91D009783F2 /* WatchProjectInput.swift */; };
 		D002CAE5218CF951009783F2 /* WatchProjectResponseEnvelope.swift in Sources */ = {isa = PBXBuildFile; fileRef = D002CAE4218CF951009783F2 /* WatchProjectResponseEnvelope.swift */; };
-		D00698E3225CF58D00EB58BD /* ReactiveExtensions_TestHelpers.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = D0D58D822257FAE000532AC1 /* ReactiveExtensions_TestHelpers.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		D00698E4225CF59B00EB58BD /* ReactiveSwift.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = D0D58D7F2257FADF00532AC1 /* ReactiveSwift.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		D00698E9225CF61F00EB58BD /* ReactiveExtensions.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = D0D58D7B2257FADE00532AC1 /* ReactiveExtensions.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		D00A375022582A1300F46F47 /* ReactiveExtensions.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = D0D58D7B2257FADE00532AC1 /* ReactiveExtensions.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		D00A375122582A1B00F46F47 /* ReactiveSwift.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = D0D58D7F2257FADF00532AC1 /* ReactiveSwift.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		D00A3766225BCE8400F46F47 /* ReactiveSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D0D58D7F2257FADF00532AC1 /* ReactiveSwift.framework */; };
 		D00A376E225BDAF800F46F47 /* UIAlertControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D69BACEF21C856F2006EAA00 /* UIAlertControllerTests.swift */; };
 		D01587591EEB2DE4006E7684 /* KsApi.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D01587501EEB2DE4006E7684 /* KsApi.framework */; };
@@ -1326,15 +1330,12 @@
 		D08CD1FF21913166009F89F0 /* WatchProjectViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D08CD1FE21913166009F89F0 /* WatchProjectViewModel.swift */; };
 		D08CD201219216BA009F89F0 /* WatchProjectViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D08CD200219216BA009F89F0 /* WatchProjectViewModelTests.swift */; };
 		D08CD20321922025009F89F0 /* WatchProjectResponseEnvelopeTemplates.swift in Sources */ = {isa = PBXBuildFile; fileRef = D08CD20221922025009F89F0 /* WatchProjectResponseEnvelopeTemplates.swift */; };
-		D0936292225D4FE000E1411A /* ReactiveExtensions.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = D0D58D7B2257FADE00532AC1 /* ReactiveExtensions.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		D0936293225D4FEB00E1411A /* ReactiveExtensions_TestHelpers.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = D0D58D822257FAE000532AC1 /* ReactiveExtensions_TestHelpers.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		D0936294225D50B900E1411A /* ReactiveSwift.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = D0D58D7F2257FADF00532AC1 /* ReactiveSwift.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		D09362B0225D803600E1411A /* UIViewController+URLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 370BE74E22541C8F00B44DB2 /* UIViewController+URLTests.swift */; };
 		D093B46321A86F7F00910962 /* PushRegistrationType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D093B46221A86F7E00910962 /* PushRegistrationType.swift */; };
 		D093B49C21A86FD800910962 /* PushRegistration.swift in Sources */ = {isa = PBXBuildFile; fileRef = D093B49B21A86FD800910962 /* PushRegistration.swift */; };
 		D0971E14221E070800DFEF9B /* SelectCurrencyDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0971DDB221E05B600DFEF9B /* SelectCurrencyDataSource.swift */; };
 		D0971E16221E083100DFEF9B /* SelectCurrencyCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0971E15221E083100DFEF9B /* SelectCurrencyCell.swift */; };
-		D09D4ED62289D6D100C33B77 /* ReactiveExtensions.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D0D58D7B2257FADE00532AC1 /* ReactiveExtensions.framework */; };
 		D09D4ED72289D6E600C33B77 /* ReactiveSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D0D58D7F2257FADF00532AC1 /* ReactiveSwift.framework */; };
 		D0A787B52204D40E006AE4F4 /* SelectCurrencyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0A787B42204D40E006AE4F4 /* SelectCurrencyViewController.swift */; };
 		D0A787BB2204D66B006AE4F4 /* SelectCurrencyViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0A787BA2204D66A006AE4F4 /* SelectCurrencyViewModel.swift */; };
@@ -1343,9 +1344,7 @@
 		D0A7880F2204EF93006AE4F4 /* SelectCurrencyViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0A7880E2204EF93006AE4F4 /* SelectCurrencyViewModelTests.swift */; };
 		D0B45B6B1EF858C00020A8DA /* KsApi.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D01587501EEB2DE4006E7684 /* KsApi.framework */; };
 		D0B45B6C1EF858C00020A8DA /* KsApi.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D01587501EEB2DE4006E7684 /* KsApi.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		D0BE6F1F228634C700D05A10 /* ReactiveExtensions.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D0D58D7B2257FADE00532AC1 /* ReactiveExtensions.framework */; };
 		D0BE6F20228634C700D05A10 /* ReactiveSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D0D58D7F2257FADF00532AC1 /* ReactiveSwift.framework */; };
-		D0BE6F282286397400D05A10 /* ReactiveExtensions.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D0D58D7B2257FADE00532AC1 /* ReactiveExtensions.framework */; };
 		D0D10BB81EEB394D005EBAD0 /* KsApi.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D01587501EEB2DE4006E7684 /* KsApi.framework */; };
 		D0D10C021EEB4550005EBAD0 /* ActivityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D015877B1EEB2ED6006E7684 /* ActivityTests.swift */; };
 		D0D10C031EEB4550005EBAD0 /* BackingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D015877D1EEB2ED6006E7684 /* BackingTests.swift */; };
@@ -1376,7 +1375,6 @@
 		D0D10C211EEB4550005EBAD0 /* User.NotificationsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D01588221EEB2ED7006E7684 /* User.NotificationsTests.swift */; };
 		D0D10C221EEB4550005EBAD0 /* UserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D01588241EEB2ED7006E7684 /* UserTests.swift */; };
 		D0D19BCA22BD886F0043A4E5 /* PledgeSummaryViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0D19BC922BD886F0043A4E5 /* PledgeSummaryViewModelTests.swift */; };
-		D0D58D882257FAE000532AC1 /* ReactiveExtensions.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D0D58D7B2257FADE00532AC1 /* ReactiveExtensions.framework */; };
 		D0D58D8C2257FAE000532AC1 /* ReactiveSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D0D58D7F2257FADF00532AC1 /* ReactiveSwift.framework */; };
 		D0D77C1E22D3FC3400356FEA /* UIPageViewController+ThreadSafety.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0D77C1D22D3FC3400356FEA /* UIPageViewController+ThreadSafety.swift */; };
 		D0E78C3622A980A600AAB645 /* ClearUserUnseenActivityEnvelope.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0E78C3522A980A600AAB645 /* ClearUserUnseenActivityEnvelope.swift */; };
@@ -1644,8 +1642,6 @@
 			files = (
 				198ED06328D229560008CB98 /* iOSSnapshotTestCase in CopyFiles */,
 				D0936294225D50B900E1411A /* ReactiveSwift.framework in CopyFiles */,
-				D0936293225D4FEB00E1411A /* ReactiveExtensions_TestHelpers.framework in CopyFiles */,
-				D0936292225D4FE000E1411A /* ReactiveExtensions.framework in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1655,9 +1651,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				D00698E9225CF61F00EB58BD /* ReactiveExtensions.framework in CopyFiles */,
 				D00698E4225CF59B00EB58BD /* ReactiveSwift.framework in CopyFiles */,
-				D00698E3225CF58D00EB58BD /* ReactiveExtensions_TestHelpers.framework in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1667,8 +1661,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				D00A375122582A1B00F46F47 /* ReactiveSwift.framework in CopyFiles */,
-				D00A375022582A1300F46F47 /* ReactiveExtensions.framework in CopyFiles */,
+				1998BC9828F5EC3400D04077 /* ReactiveSwift.framework in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2996,9 +2989,7 @@
 		D0A7880E2204EF93006AE4F4 /* SelectCurrencyViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectCurrencyViewModelTests.swift; sourceTree = "<group>"; };
 		D0C9BAD521B1AB920098CABA /* Alpha.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Alpha.entitlements; sourceTree = "<group>"; };
 		D0D19BC922BD886F0043A4E5 /* PledgeSummaryViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PledgeSummaryViewModelTests.swift; sourceTree = "<group>"; };
-		D0D58D7B2257FADE00532AC1 /* ReactiveExtensions.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ReactiveExtensions.framework; path = Carthage/Build/iOS/ReactiveExtensions.framework; sourceTree = "<group>"; };
 		D0D58D7F2257FADF00532AC1 /* ReactiveSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ReactiveSwift.framework; path = Carthage/Build/iOS/ReactiveSwift.framework; sourceTree = "<group>"; };
-		D0D58D822257FAE000532AC1 /* ReactiveExtensions_TestHelpers.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ReactiveExtensions_TestHelpers.framework; path = Carthage/Build/iOS/ReactiveExtensions_TestHelpers.framework; sourceTree = "<group>"; };
 		D0D77C1D22D3FC3400356FEA /* UIPageViewController+ThreadSafety.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIPageViewController+ThreadSafety.swift"; sourceTree = "<group>"; };
 		D0E78C3522A980A600AAB645 /* ClearUserUnseenActivityEnvelope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClearUserUnseenActivityEnvelope.swift; sourceTree = "<group>"; };
 		D0E78C3722A981EE00AAB645 /* ClearUserUnseenActivityEnvelopeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClearUserUnseenActivityEnvelopeTests.swift; sourceTree = "<group>"; };
@@ -3214,8 +3205,8 @@
 				1981AC90289075D900BB4897 /* Stripe in Frameworks */,
 				60DA510F28C7E04B002E2DF1 /* Kingfisher in Frameworks */,
 				606754BF28CF91DD0033CD5E /* FacebookLogin in Frameworks */,
+				1998BCAA28F60E9600D04077 /* ReactiveExtensions in Frameworks */,
 				606754BD28CF91D60033CD5E /* FacebookCore in Frameworks */,
-				D0BE6F282286397400D05A10 /* ReactiveExtensions.framework in Frameworks */,
 				D00A3766225BCE8400F46F47 /* ReactiveSwift.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -3225,6 +3216,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				19F91B14289C8097000AEC6A /* Stripe in Frameworks */,
+				1998BCAC28F60EA700D04077 /* ReactiveExtensions-TestHelpers in Frameworks */,
 				198ED06228D229560008CB98 /* iOSSnapshotTestCase in Frameworks */,
 				8AA3DB32250AC42F009AC8EA /* Library.framework in Frameworks */,
 			);
@@ -3234,8 +3226,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1998BCAE28F60EB700D04077 /* ReactiveExtensions in Frameworks */,
 				A76127C01C93100C00EDCCB9 /* Library.framework in Frameworks */,
-				D09D4ED62289D6D100C33B77 /* ReactiveExtensions.framework in Frameworks */,
 				D09D4ED72289D6E600C33B77 /* ReactiveSwift.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -3254,8 +3246,8 @@
 				19BF226328D10497007F4197 /* FirebaseCrashlytics in Frameworks */,
 				197C398E28ECB3E2006A3C6B /* BrazeKit in Frameworks */,
 				197C399028ECB3E2006A3C6B /* BrazeUI in Frameworks */,
+				1998BCA828F60E8900D04077 /* ReactiveExtensions in Frameworks */,
 				D0B45B6B1EF858C00020A8DA /* KsApi.framework in Frameworks */,
-				D0D58D882257FAE000532AC1 /* ReactiveExtensions.framework in Frameworks */,
 				D0D58D8C2257FAE000532AC1 /* ReactiveSwift.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -3266,6 +3258,7 @@
 			files = (
 				198ED05D28D21AD40008CB98 /* iOSSnapshotTestCase in Frameworks */,
 				A724BA641D2BFCC80041863C /* Kickstarter_Framework.framework in Frameworks */,
+				1998BCB028F60EC300D04077 /* ReactiveExtensions-TestHelpers in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3273,12 +3266,12 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D0BE6F1F228634C700D05A10 /* ReactiveExtensions.framework in Frameworks */,
 				06634FBE2807A4C300950F60 /* Apollo in Frameworks */,
 				06634FC52807A4EB00950F60 /* Prelude in Frameworks */,
 				D0BE6F20228634C700D05A10 /* ReactiveSwift.framework in Frameworks */,
 				06634FC02807A4C300950F60 /* ApolloAPI in Frameworks */,
 				06634FC22807A4C300950F60 /* ApolloUtils in Frameworks */,
+				1998BCB228F60ED400D04077 /* ReactiveExtensions in Frameworks */,
 				60DA511428C96A65002E2DF1 /* SwiftSoup in Frameworks */,
 				198E574D28E2705E00D5B8A9 /* PerimeterX in Frameworks */,
 			);
@@ -3289,6 +3282,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D01587591EEB2DE4006E7684 /* KsApi.framework in Frameworks */,
+				1998BCB428F60EE800D04077 /* ReactiveExtensions-TestHelpers in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -6470,8 +6464,6 @@
 			isa = PBXGroup;
 			children = (
 				06EA2D36280F1F1900F4DE2E /* XCTest.framework */,
-				D0D58D822257FAE000532AC1 /* ReactiveExtensions_TestHelpers.framework */,
-				D0D58D7B2257FADE00532AC1 /* ReactiveExtensions.framework */,
 				D0D58D7F2257FADF00532AC1 /* ReactiveSwift.framework */,
 			);
 			name = Frameworks;
@@ -7237,6 +7229,7 @@
 				606754BE28CF91DD0033CD5E /* FacebookLogin */,
 				19A824AF28DA562800325124 /* AppboySegment */,
 				198E574A28E2705100D5B8A9 /* PerimeterX */,
+				1998BCA928F60E9600D04077 /* ReactiveExtensions */,
 			);
 			productName = "Library-iOS";
 			productReference = A755113C1C8642B3005355CF /* Library.framework */;
@@ -7260,6 +7253,7 @@
 			packageProductDependencies = (
 				19F91B13289C8097000AEC6A /* Stripe */,
 				198ED06128D229560008CB98 /* iOSSnapshotTestCase */,
+				1998BCAB28F60EA700D04077 /* ReactiveExtensions-TestHelpers */,
 			);
 			productName = "Library-iOSTests";
 			productReference = A75511451C8642B3005355CF /* Library-iOSTests.xctest */;
@@ -7282,6 +7276,7 @@
 			);
 			name = "Kickstarter-Framework-iOS";
 			packageProductDependencies = (
+				1998BCAD28F60EB700D04077 /* ReactiveExtensions */,
 			);
 			productName = "Kickstarter-iOS-Framework";
 			productReference = A7C7959E1C873A870081977F /* Kickstarter_Framework.framework */;
@@ -7315,6 +7310,7 @@
 				191EDC6628E29BB9009B41B2 /* PerimeterX */,
 				197C398D28ECB3E2006A3C6B /* BrazeKit */,
 				197C398F28ECB3E2006A3C6B /* BrazeUI */,
+				1998BCA728F60E8900D04077 /* ReactiveExtensions */,
 			);
 			productName = Kickstarter;
 			productReference = A7D1F9451C850B7C000D41D5 /* KickDebug.app */;
@@ -7338,6 +7334,7 @@
 			name = "Kickstarter-Framework-iOSTests";
 			packageProductDependencies = (
 				60EAD1B328D0EE45009F9474 /* iOSSnapshotTestCase */,
+				1998BCAF28F60EC300D04077 /* ReactiveExtensions-TestHelpers */,
 			);
 			productName = KickstarterTests;
 			productReference = A7D1F95A1C850B7C000D41D5 /* Kickstarter-Framework-iOSTests.xctest */;
@@ -7366,6 +7363,7 @@
 				06634FC42807A4EB00950F60 /* Prelude */,
 				60DA511328C96A65002E2DF1 /* SwiftSoup */,
 				198E574C28E2705E00D5B8A9 /* PerimeterX */,
+				1998BCB128F60ED400D04077 /* ReactiveExtensions */,
 			);
 			productName = KsApi;
 			productReference = D01587501EEB2DE4006E7684 /* KsApi.framework */;
@@ -7386,6 +7384,9 @@
 				D015875B1EEB2DE4006E7684 /* PBXTargetDependency */,
 			);
 			name = KsApiTests;
+			packageProductDependencies = (
+				1998BCB328F60EE800D04077 /* ReactiveExtensions-TestHelpers */,
+			);
 			productName = KsApiTests;
 			productReference = D01587581EEB2DE4006E7684 /* KsApiTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
@@ -7477,6 +7478,7 @@
 				19A824AC28DA54ED00325124 /* XCRemoteSwiftPackageReference "appboy-segment-ios" */,
 				602C97D628DB787900919CA8 /* XCRemoteSwiftPackageReference "px-iOS-Framework" */,
 				197C398C28ECB3E2006A3C6B /* XCRemoteSwiftPackageReference "braze-swift-sdk" */,
+				194C593E28F5E7FF00453249 /* XCRemoteSwiftPackageReference "Kickstarter-ReactiveExtensions" */,
 			);
 			productRefGroup = A7E06C7A1C5A6EB300EBDCC2 /* Products */;
 			projectDirPath = "";
@@ -10433,6 +10435,14 @@
 				minimumVersion = 22.7.1;
 			};
 		};
+		194C593E28F5E7FF00453249 /* XCRemoteSwiftPackageReference "Kickstarter-ReactiveExtensions" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/kickstarter/Kickstarter-ReactiveExtensions";
+			requirement = {
+				branch = "feature/swift-package";
+				kind = branch;
+			};
+		};
 		197C398C28ECB3E2006A3C6B /* XCRemoteSwiftPackageReference "braze-swift-sdk" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/braze-inc/braze-swift-sdk";
@@ -10588,6 +10598,41 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 60EAD1B028D0EE24009F9474 /* XCRemoteSwiftPackageReference "ios-snapshot-test-case" */;
 			productName = iOSSnapshotTestCase;
+		};
+		1998BCA728F60E8900D04077 /* ReactiveExtensions */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 194C593E28F5E7FF00453249 /* XCRemoteSwiftPackageReference "Kickstarter-ReactiveExtensions" */;
+			productName = ReactiveExtensions;
+		};
+		1998BCA928F60E9600D04077 /* ReactiveExtensions */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 194C593E28F5E7FF00453249 /* XCRemoteSwiftPackageReference "Kickstarter-ReactiveExtensions" */;
+			productName = ReactiveExtensions;
+		};
+		1998BCAB28F60EA700D04077 /* ReactiveExtensions-TestHelpers */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 194C593E28F5E7FF00453249 /* XCRemoteSwiftPackageReference "Kickstarter-ReactiveExtensions" */;
+			productName = "ReactiveExtensions-TestHelpers";
+		};
+		1998BCAD28F60EB700D04077 /* ReactiveExtensions */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 194C593E28F5E7FF00453249 /* XCRemoteSwiftPackageReference "Kickstarter-ReactiveExtensions" */;
+			productName = ReactiveExtensions;
+		};
+		1998BCAF28F60EC300D04077 /* ReactiveExtensions-TestHelpers */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 194C593E28F5E7FF00453249 /* XCRemoteSwiftPackageReference "Kickstarter-ReactiveExtensions" */;
+			productName = "ReactiveExtensions-TestHelpers";
+		};
+		1998BCB128F60ED400D04077 /* ReactiveExtensions */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 194C593E28F5E7FF00453249 /* XCRemoteSwiftPackageReference "Kickstarter-ReactiveExtensions" */;
+			productName = ReactiveExtensions;
+		};
+		1998BCB328F60EE800D04077 /* ReactiveExtensions-TestHelpers */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 194C593E28F5E7FF00453249 /* XCRemoteSwiftPackageReference "Kickstarter-ReactiveExtensions" */;
+			productName = "ReactiveExtensions-TestHelpers";
 		};
 		19A824AD28DA54ED00325124 /* AppboySegment */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -234,6 +234,10 @@
 		19047FCB2889CDAC00BDD1A8 /* GraphAPI.CreateSetupIntentInput+CreateSetupIntentInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19047FCA2889CDAC00BDD1A8 /* GraphAPI.CreateSetupIntentInput+CreateSetupIntentInput.swift */; };
 		19047FCF2889D4BC00BDD1A8 /* GraphAPI.CreateSetupIntentInput+CreateSetupIntentInputTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19047FCE2889D4BC00BDD1A8 /* GraphAPI.CreateSetupIntentInput+CreateSetupIntentInputTests.swift */; };
 		19047FD12889D6DC00BDD1A8 /* ClientSecretEnvelope+CreateSetupIntentMutation.DataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19047FD02889D6DC00BDD1A8 /* ClientSecretEnvelope+CreateSetupIntentMutation.DataTests.swift */; };
+		1905787B28F8CD2500428375 /* ReactiveSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 1905787A28F8CD2500428375 /* ReactiveSwift */; };
+		1905787D28F8CD4D00428375 /* ReactiveSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 1905787C28F8CD4D00428375 /* ReactiveSwift */; };
+		1905787F28F8CD5E00428375 /* ReactiveSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 1905787E28F8CD5E00428375 /* ReactiveSwift */; };
+		1905788128F8CD7000428375 /* ReactiveSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 1905788028F8CD7000428375 /* ReactiveSwift */; };
 		191EDC6728E29BB9009B41B2 /* PerimeterX in Frameworks */ = {isa = PBXBuildFile; productRef = 191EDC6628E29BB9009B41B2 /* PerimeterX */; };
 		1923770A28DA2AE300F68635 /* Stripe+PaymentMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1923770928DA2AE300F68635 /* Stripe+PaymentMethod.swift */; };
 		1937A71F28C94FFC00DD732D /* SettingsFormFieldView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 7790DF882200D3BD005DBB11 /* SettingsFormFieldView.xib */; };
@@ -257,7 +261,6 @@
 		198ED05D28D21AD40008CB98 /* iOSSnapshotTestCase in Frameworks */ = {isa = PBXBuildFile; productRef = 60EAD1B328D0EE45009F9474 /* iOSSnapshotTestCase */; };
 		198ED06228D229560008CB98 /* iOSSnapshotTestCase in Frameworks */ = {isa = PBXBuildFile; productRef = 198ED06128D229560008CB98 /* iOSSnapshotTestCase */; };
 		198ED06328D229560008CB98 /* iOSSnapshotTestCase in CopyFiles */ = {isa = PBXBuildFile; productRef = 198ED06128D229560008CB98 /* iOSSnapshotTestCase */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
-		1998BC9828F5EC3400D04077 /* ReactiveSwift.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = D0D58D7F2257FADF00532AC1 /* ReactiveSwift.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		1998BCA828F60E8900D04077 /* ReactiveExtensions in Frameworks */ = {isa = PBXBuildFile; productRef = 1998BCA728F60E8900D04077 /* ReactiveExtensions */; };
 		1998BCAA28F60E9600D04077 /* ReactiveExtensions in Frameworks */ = {isa = PBXBuildFile; productRef = 1998BCA928F60E9600D04077 /* ReactiveExtensions */; };
 		1998BCAC28F60EA700D04077 /* ReactiveExtensions-TestHelpers in Frameworks */ = {isa = PBXBuildFile; productRef = 1998BCAB28F60EA700D04077 /* ReactiveExtensions-TestHelpers */; };
@@ -1155,8 +1158,6 @@
 		D002CAE1218CF8F1009783F2 /* WatchProjectMutation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D002CAE0218CF8F1009783F2 /* WatchProjectMutation.swift */; };
 		D002CAE3218CF91D009783F2 /* WatchProjectInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = D002CAE2218CF91D009783F2 /* WatchProjectInput.swift */; };
 		D002CAE5218CF951009783F2 /* WatchProjectResponseEnvelope.swift in Sources */ = {isa = PBXBuildFile; fileRef = D002CAE4218CF951009783F2 /* WatchProjectResponseEnvelope.swift */; };
-		D00698E4225CF59B00EB58BD /* ReactiveSwift.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = D0D58D7F2257FADF00532AC1 /* ReactiveSwift.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		D00A3766225BCE8400F46F47 /* ReactiveSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D0D58D7F2257FADF00532AC1 /* ReactiveSwift.framework */; };
 		D00A376E225BDAF800F46F47 /* UIAlertControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D69BACEF21C856F2006EAA00 /* UIAlertControllerTests.swift */; };
 		D01587591EEB2DE4006E7684 /* KsApi.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D01587501EEB2DE4006E7684 /* KsApi.framework */; };
 		D015882B1EEB2ED7006E7684 /* NSURLSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = D015876A1EEB2ED6006E7684 /* NSURLSession.swift */; };
@@ -1330,13 +1331,11 @@
 		D08CD1FF21913166009F89F0 /* WatchProjectViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D08CD1FE21913166009F89F0 /* WatchProjectViewModel.swift */; };
 		D08CD201219216BA009F89F0 /* WatchProjectViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D08CD200219216BA009F89F0 /* WatchProjectViewModelTests.swift */; };
 		D08CD20321922025009F89F0 /* WatchProjectResponseEnvelopeTemplates.swift in Sources */ = {isa = PBXBuildFile; fileRef = D08CD20221922025009F89F0 /* WatchProjectResponseEnvelopeTemplates.swift */; };
-		D0936294225D50B900E1411A /* ReactiveSwift.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = D0D58D7F2257FADF00532AC1 /* ReactiveSwift.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		D09362B0225D803600E1411A /* UIViewController+URLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 370BE74E22541C8F00B44DB2 /* UIViewController+URLTests.swift */; };
 		D093B46321A86F7F00910962 /* PushRegistrationType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D093B46221A86F7E00910962 /* PushRegistrationType.swift */; };
 		D093B49C21A86FD800910962 /* PushRegistration.swift in Sources */ = {isa = PBXBuildFile; fileRef = D093B49B21A86FD800910962 /* PushRegistration.swift */; };
 		D0971E14221E070800DFEF9B /* SelectCurrencyDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0971DDB221E05B600DFEF9B /* SelectCurrencyDataSource.swift */; };
 		D0971E16221E083100DFEF9B /* SelectCurrencyCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0971E15221E083100DFEF9B /* SelectCurrencyCell.swift */; };
-		D09D4ED72289D6E600C33B77 /* ReactiveSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D0D58D7F2257FADF00532AC1 /* ReactiveSwift.framework */; };
 		D0A787B52204D40E006AE4F4 /* SelectCurrencyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0A787B42204D40E006AE4F4 /* SelectCurrencyViewController.swift */; };
 		D0A787BB2204D66B006AE4F4 /* SelectCurrencyViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0A787BA2204D66A006AE4F4 /* SelectCurrencyViewModel.swift */; };
 		D0A787BD2204D865006AE4F4 /* SelectCurrencyTableViewHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0A787BC2204D865006AE4F4 /* SelectCurrencyTableViewHeader.swift */; };
@@ -1344,7 +1343,6 @@
 		D0A7880F2204EF93006AE4F4 /* SelectCurrencyViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0A7880E2204EF93006AE4F4 /* SelectCurrencyViewModelTests.swift */; };
 		D0B45B6B1EF858C00020A8DA /* KsApi.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D01587501EEB2DE4006E7684 /* KsApi.framework */; };
 		D0B45B6C1EF858C00020A8DA /* KsApi.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D01587501EEB2DE4006E7684 /* KsApi.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		D0BE6F20228634C700D05A10 /* ReactiveSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D0D58D7F2257FADF00532AC1 /* ReactiveSwift.framework */; };
 		D0D10BB81EEB394D005EBAD0 /* KsApi.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D01587501EEB2DE4006E7684 /* KsApi.framework */; };
 		D0D10C021EEB4550005EBAD0 /* ActivityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D015877B1EEB2ED6006E7684 /* ActivityTests.swift */; };
 		D0D10C031EEB4550005EBAD0 /* BackingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D015877D1EEB2ED6006E7684 /* BackingTests.swift */; };
@@ -1375,7 +1373,6 @@
 		D0D10C211EEB4550005EBAD0 /* User.NotificationsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D01588221EEB2ED7006E7684 /* User.NotificationsTests.swift */; };
 		D0D10C221EEB4550005EBAD0 /* UserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D01588241EEB2ED7006E7684 /* UserTests.swift */; };
 		D0D19BCA22BD886F0043A4E5 /* PledgeSummaryViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0D19BC922BD886F0043A4E5 /* PledgeSummaryViewModelTests.swift */; };
-		D0D58D8C2257FAE000532AC1 /* ReactiveSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D0D58D7F2257FADF00532AC1 /* ReactiveSwift.framework */; };
 		D0D77C1E22D3FC3400356FEA /* UIPageViewController+ThreadSafety.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0D77C1D22D3FC3400356FEA /* UIPageViewController+ThreadSafety.swift */; };
 		D0E78C3622A980A600AAB645 /* ClearUserUnseenActivityEnvelope.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0E78C3522A980A600AAB645 /* ClearUserUnseenActivityEnvelope.swift */; };
 		D0E78C3822A981EE00AAB645 /* ClearUserUnseenActivityEnvelopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0E78C3722A981EE00AAB645 /* ClearUserUnseenActivityEnvelopeTests.swift */; };
@@ -1641,27 +1638,6 @@
 			dstSubfolderSpec = 10;
 			files = (
 				198ED06328D229560008CB98 /* iOSSnapshotTestCase in CopyFiles */,
-				D0936294225D50B900E1411A /* ReactiveSwift.framework in CopyFiles */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		D00698DF225CF54300EB58BD /* CopyFiles */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = "";
-			dstSubfolderSpec = 10;
-			files = (
-				D00698E4225CF59B00EB58BD /* ReactiveSwift.framework in CopyFiles */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		D00A374C225829E900F46F47 /* CopyFiles */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = "";
-			dstSubfolderSpec = 10;
-			files = (
-				1998BC9828F5EC3400D04077 /* ReactiveSwift.framework in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2989,7 +2965,6 @@
 		D0A7880E2204EF93006AE4F4 /* SelectCurrencyViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectCurrencyViewModelTests.swift; sourceTree = "<group>"; };
 		D0C9BAD521B1AB920098CABA /* Alpha.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Alpha.entitlements; sourceTree = "<group>"; };
 		D0D19BC922BD886F0043A4E5 /* PledgeSummaryViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PledgeSummaryViewModelTests.swift; sourceTree = "<group>"; };
-		D0D58D7F2257FADF00532AC1 /* ReactiveSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ReactiveSwift.framework; path = Carthage/Build/iOS/ReactiveSwift.framework; sourceTree = "<group>"; };
 		D0D77C1D22D3FC3400356FEA /* UIPageViewController+ThreadSafety.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIPageViewController+ThreadSafety.swift"; sourceTree = "<group>"; };
 		D0E78C3522A980A600AAB645 /* ClearUserUnseenActivityEnvelope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClearUserUnseenActivityEnvelope.swift; sourceTree = "<group>"; };
 		D0E78C3722A981EE00AAB645 /* ClearUserUnseenActivityEnvelopeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClearUserUnseenActivityEnvelopeTests.swift; sourceTree = "<group>"; };
@@ -3197,6 +3172,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				60DA50FE28C38DDB002E2DF1 /* AlamofireImage in Frameworks */,
+				1905787D28F8CD4D00428375 /* ReactiveSwift in Frameworks */,
 				60DA512928CA580B002E2DF1 /* Optimizely in Frameworks */,
 				06634FC72807A4EB00950F60 /* Prelude_UIKit in Frameworks */,
 				19A824B028DA562800325124 /* AppboySegment in Frameworks */,
@@ -3207,7 +3183,6 @@
 				606754BF28CF91DD0033CD5E /* FacebookLogin in Frameworks */,
 				1998BCAA28F60E9600D04077 /* ReactiveExtensions in Frameworks */,
 				606754BD28CF91D60033CD5E /* FacebookCore in Frameworks */,
-				D00A3766225BCE8400F46F47 /* ReactiveSwift.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3227,8 +3202,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				1998BCAE28F60EB700D04077 /* ReactiveExtensions in Frameworks */,
+				1905787F28F8CD5E00428375 /* ReactiveSwift in Frameworks */,
 				A76127C01C93100C00EDCCB9 /* Library.framework in Frameworks */,
-				D09D4ED72289D6E600C33B77 /* ReactiveSwift.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3245,10 +3220,10 @@
 				191EDC6728E29BB9009B41B2 /* PerimeterX in Frameworks */,
 				19BF226328D10497007F4197 /* FirebaseCrashlytics in Frameworks */,
 				197C398E28ECB3E2006A3C6B /* BrazeKit in Frameworks */,
+				1905787B28F8CD2500428375 /* ReactiveSwift in Frameworks */,
 				197C399028ECB3E2006A3C6B /* BrazeUI in Frameworks */,
 				1998BCA828F60E8900D04077 /* ReactiveExtensions in Frameworks */,
 				D0B45B6B1EF858C00020A8DA /* KsApi.framework in Frameworks */,
-				D0D58D8C2257FAE000532AC1 /* ReactiveSwift.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3268,10 +3243,10 @@
 			files = (
 				06634FBE2807A4C300950F60 /* Apollo in Frameworks */,
 				06634FC52807A4EB00950F60 /* Prelude in Frameworks */,
-				D0BE6F20228634C700D05A10 /* ReactiveSwift.framework in Frameworks */,
 				06634FC02807A4C300950F60 /* ApolloAPI in Frameworks */,
 				06634FC22807A4C300950F60 /* ApolloUtils in Frameworks */,
 				1998BCB228F60ED400D04077 /* ReactiveExtensions in Frameworks */,
+				1905788128F8CD7000428375 /* ReactiveSwift in Frameworks */,
 				60DA511428C96A65002E2DF1 /* SwiftSoup in Frameworks */,
 				198E574D28E2705E00D5B8A9 /* PerimeterX in Frameworks */,
 			);
@@ -6464,7 +6439,6 @@
 			isa = PBXGroup;
 			children = (
 				06EA2D36280F1F1900F4DE2E /* XCTest.framework */,
-				D0D58D7F2257FADF00532AC1 /* ReactiveSwift.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -7212,7 +7186,6 @@
 				A75511381C8642B3005355CF /* Frameworks */,
 				A75511391C8642B3005355CF /* Headers */,
 				A755113A1C8642B3005355CF /* Resources */,
-				D0EA60A2228B6A85007DB557 /* Carthage */,
 			);
 			buildRules = (
 			);
@@ -7230,6 +7203,7 @@
 				19A824AF28DA562800325124 /* AppboySegment */,
 				198E574A28E2705100D5B8A9 /* PerimeterX */,
 				1998BCA928F60E9600D04077 /* ReactiveExtensions */,
+				1905787C28F8CD4D00428375 /* ReactiveSwift */,
 			);
 			productName = "Library-iOS";
 			productReference = A755113C1C8642B3005355CF /* Library.framework */;
@@ -7267,7 +7241,6 @@
 				A7C7959A1C873A870081977F /* Frameworks */,
 				A7C7959B1C873A870081977F /* Headers */,
 				A7C7959C1C873A870081977F /* Resources */,
-				D0EA60A3228B6AD6007DB557 /* Carthage */,
 			);
 			buildRules = (
 			);
@@ -7277,6 +7250,7 @@
 			name = "Kickstarter-Framework-iOS";
 			packageProductDependencies = (
 				1998BCAD28F60EB700D04077 /* ReactiveExtensions */,
+				1905787E28F8CD5E00428375 /* ReactiveSwift */,
 			);
 			productName = "Kickstarter-iOS-Framework";
 			productReference = A7C7959E1C873A870081977F /* Kickstarter_Framework.framework */;
@@ -7290,7 +7264,6 @@
 				A7D1F9421C850B7C000D41D5 /* Frameworks */,
 				A7D1F9431C850B7C000D41D5 /* Resources */,
 				A7D1F9C21C850DDE000D41D5 /* Embed Frameworks */,
-				D0D58D772257F95E00532AC1 /* Carthage */,
 				8A86D7C124FDB7A000037A7B /* Firebase Crashlytics */,
 			);
 			buildRules = (
@@ -7311,6 +7284,7 @@
 				197C398D28ECB3E2006A3C6B /* BrazeKit */,
 				197C398F28ECB3E2006A3C6B /* BrazeUI */,
 				1998BCA728F60E8900D04077 /* ReactiveExtensions */,
+				1905787A28F8CD2500428375 /* ReactiveSwift */,
 			);
 			productName = Kickstarter;
 			productReference = A7D1F9451C850B7C000D41D5 /* KickDebug.app */;
@@ -7324,7 +7298,6 @@
 				A7D1F9571C850B7C000D41D5 /* Frameworks */,
 				77539E692147E2C700A564CD /* Embed Frameworks */,
 				A7D1F9581C850B7C000D41D5 /* Resources */,
-				D00698DF225CF54300EB58BD /* CopyFiles */,
 			);
 			buildRules = (
 			);
@@ -7349,7 +7322,6 @@
 				D015874C1EEB2DE4006E7684 /* Frameworks */,
 				D015874D1EEB2DE4006E7684 /* Headers */,
 				D015874E1EEB2DE4006E7684 /* Resources */,
-				D0EA60A4228B6BB6007DB557 /* Carthage */,
 			);
 			buildRules = (
 			);
@@ -7364,6 +7336,7 @@
 				60DA511328C96A65002E2DF1 /* SwiftSoup */,
 				198E574C28E2705E00D5B8A9 /* PerimeterX */,
 				1998BCB128F60ED400D04077 /* ReactiveExtensions */,
+				1905788028F8CD7000428375 /* ReactiveSwift */,
 			);
 			productName = KsApi;
 			productReference = D01587501EEB2DE4006E7684 /* KsApi.framework */;
@@ -7376,7 +7349,6 @@
 				D01587541EEB2DE4006E7684 /* Sources */,
 				D01587551EEB2DE4006E7684 /* Frameworks */,
 				D01587561EEB2DE4006E7684 /* Resources */,
-				D00A374C225829E900F46F47 /* CopyFiles */,
 			);
 			buildRules = (
 			);
@@ -7479,6 +7451,7 @@
 				602C97D628DB787900919CA8 /* XCRemoteSwiftPackageReference "px-iOS-Framework" */,
 				197C398C28ECB3E2006A3C6B /* XCRemoteSwiftPackageReference "braze-swift-sdk" */,
 				194C593E28F5E7FF00453249 /* XCRemoteSwiftPackageReference "Kickstarter-ReactiveExtensions" */,
+				1905787928F8CD2500428375 /* XCRemoteSwiftPackageReference "ReactiveSwift" */,
 			);
 			productRefGroup = A7E06C7A1C5A6EB300EBDCC2 /* Products */;
 			projectDirPath = "";
@@ -7675,86 +7648,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "# Don't run this during index builds\nif [ $ACTION = \"indexbuild\" ]; then exit 0; fi\n\n# Go to the build root and search up the chain to find the Derived Data Path where the source packages are checked out.\nDERIVED_DATA_CANDIDATE=\"${BUILD_ROOT}\"\n\nwhile ! [ -d \"${DERIVED_DATA_CANDIDATE}/SourcePackages\" ]; do\n  if [ \"${DERIVED_DATA_CANDIDATE}\" = / ]; then\n    echo >&2 \"error: Unable to locate SourcePackages directory from BUILD_ROOT: '${BUILD_ROOT}'\"\n    exit 1\n  fi\n\n  DERIVED_DATA_CANDIDATE=\"$(dirname \"${DERIVED_DATA_CANDIDATE}\")\"\ndone\n\n# Grab a reference to the directory where scripts are checked out\nSCRIPT_PATH=\"${DERIVED_DATA_CANDIDATE}/SourcePackages/checkouts/apollo-ios/scripts\"\n\nif [ -z \"${SCRIPT_PATH}\" ]; then\n    echo >&2 \"error: Couldn't find the CLI script in your checked out SPM packages; make sure to add the framework to your project.\"\n    exit 1\nfi\n\ncd \"${SRCROOT}/${TARGET_NAME}\"\n\"${SCRIPT_PATH}\"/run-bundled-codegen.sh codegen:generate --target=swift --includes=./**/*.graphql --localSchemaFile=\"${SRCROOT}/KsApi/graphql-schema.json\" --namespace=GraphAPI GraphAPI.swift\n";
-		};
-		D0D58D772257F95E00532AC1 /* Carthage */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"$(SRCROOT)/Carthage-xcfilelist/app-input-files.xcfilelist",
-			);
-			inputPaths = (
-			);
-			name = Carthage;
-			outputFileListPaths = (
-				"$(SRCROOT)/Carthage-xcfilelist/app-output-files.xcfilelist",
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "/usr/local/bin/carthage copy-frameworks\n";
-		};
-		D0EA60A2228B6A85007DB557 /* Carthage */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"$(SRCROOT)/Carthage-xcfilelist/library-input-files.xcfilelist",
-			);
-			inputPaths = (
-			);
-			name = Carthage;
-			outputFileListPaths = (
-				"$(SRCROOT)/Carthage-xcfilelist/library-output-files.xcfilelist",
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "${SRCROOT}/bin/carthage-debug-copy.sh\n";
-		};
-		D0EA60A3228B6AD6007DB557 /* Carthage */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"$(SRCROOT)/Carthage-xcfilelist/kickstarter-framework-input-files.xcfilelist",
-			);
-			inputPaths = (
-			);
-			name = Carthage;
-			outputFileListPaths = (
-				"$(SRCROOT)/Carthage-xcfilelist/kickstarter-framework-output-files.xcfilelist",
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "${SRCROOT}/bin/carthage-debug-copy.sh\n";
-		};
-		D0EA60A4228B6BB6007DB557 /* Carthage */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"$(SRCROOT)/Carthage-xcfilelist/ksapi-input-files.xcfilelist",
-			);
-			inputPaths = (
-			);
-			name = Carthage;
-			outputFileListPaths = (
-				"$(SRCROOT)/Carthage-xcfilelist/ksapi-output-files.xcfilelist",
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "${SRCROOT}/bin/carthage-debug-copy.sh\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -10427,6 +10320,14 @@
 				kind = branch;
 			};
 		};
+		1905787928F8CD2500428375 /* XCRemoteSwiftPackageReference "ReactiveSwift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/ReactiveCocoa/ReactiveSwift";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 6.5.0;
+			};
+		};
 		194520C12888542100CA9B88 /* XCRemoteSwiftPackageReference "stripe-ios" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/stripe/stripe-ios";
@@ -10563,6 +10464,26 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 06634FC32807A4EB00950F60 /* XCRemoteSwiftPackageReference "Kickstarter-Prelude" */;
 			productName = Prelude;
+		};
+		1905787A28F8CD2500428375 /* ReactiveSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 1905787928F8CD2500428375 /* XCRemoteSwiftPackageReference "ReactiveSwift" */;
+			productName = ReactiveSwift;
+		};
+		1905787C28F8CD4D00428375 /* ReactiveSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 1905787928F8CD2500428375 /* XCRemoteSwiftPackageReference "ReactiveSwift" */;
+			productName = ReactiveSwift;
+		};
+		1905787E28F8CD5E00428375 /* ReactiveSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 1905787928F8CD2500428375 /* XCRemoteSwiftPackageReference "ReactiveSwift" */;
+			productName = ReactiveSwift;
+		};
+		1905788028F8CD7000428375 /* ReactiveSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 1905787928F8CD2500428375 /* XCRemoteSwiftPackageReference "ReactiveSwift" */;
+			productName = ReactiveSwift;
 		};
 		191EDC6628E29BB9009B41B2 /* PerimeterX */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Kickstarter.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Kickstarter.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -186,7 +186,7 @@
       "location" : "https://github.com/kickstarter/Kickstarter-ReactiveExtensions",
       "state" : {
         "branch" : "feature/swift-package",
-        "revision" : "d5eebfaa728a09a736c9fa1d526e5e4d8aa7bccb"
+        "revision" : "34276be97fa5acae36e714ad65f8ecb733c0566b"
       }
     },
     {
@@ -257,8 +257,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ReactiveCocoa/ReactiveSwift",
       "state" : {
-        "revision" : "c43bae3dac73fdd3cb906bd5a1914686ca71ed3c",
-        "version" : "6.7.0"
+        "revision" : "e03cda84105ba707de039b757e2b2de868c65a3e",
+        "version" : "6.5.0"
       }
     },
     {

--- a/Kickstarter.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Kickstarter.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -181,6 +181,15 @@
       }
     },
     {
+      "identity" : "kickstarter-reactiveextensions",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kickstarter/Kickstarter-ReactiveExtensions",
+      "state" : {
+        "branch" : "feature/swift-package",
+        "revision" : "d5eebfaa728a09a736c9fa1d526e5e4d8aa7bccb"
+      }
+    },
+    {
       "identity" : "kingfisher",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/onevcat/Kingfisher",
@@ -241,6 +250,15 @@
       "state" : {
         "revision" : "50eec61be35fcece00b4b6580367f16cc8a4f96d",
         "version" : "1.16.3"
+      }
+    },
+    {
+      "identity" : "reactiveswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ReactiveCocoa/ReactiveSwift",
+      "state" : {
+        "revision" : "c43bae3dac73fdd3cb906bd5a1914686ca71ed3c",
+        "version" : "6.7.0"
       }
     },
     {

--- a/KsApi/models/Project.swift
+++ b/KsApi/models/Project.swift
@@ -1,4 +1,4 @@
-
+import Foundation
 import Prelude
 import ReactiveSwift
 

--- a/Library/ViewModels/ActivitySampleBackingCellViewModel.swift
+++ b/Library/ViewModels/ActivitySampleBackingCellViewModel.swift
@@ -2,6 +2,7 @@ import KsApi
 import Prelude
 import ReactiveExtensions
 import ReactiveSwift
+import UIKit
 
 public protocol ActivitySampleBackingCellViewModelInputs {
   /// Call to configure cell with activity value.

--- a/Library/ViewModels/ActivitySampleFollowCellViewModel.swift
+++ b/Library/ViewModels/ActivitySampleFollowCellViewModel.swift
@@ -1,3 +1,4 @@
+import Foundation
 import KsApi
 import Prelude
 import ReactiveExtensions

--- a/Library/ViewModels/ActivitySampleProjectCellViewModel.swift
+++ b/Library/ViewModels/ActivitySampleProjectCellViewModel.swift
@@ -1,3 +1,4 @@
+import Foundation
 import KsApi
 import Prelude
 import ReactiveExtensions

--- a/Library/ViewModels/AddNewCardViewModel.swift
+++ b/Library/ViewModels/AddNewCardViewModel.swift
@@ -1,3 +1,4 @@
+import Foundation
 import KsApi
 import Prelude
 import ReactiveExtensions

--- a/Library/ViewModels/BetaToolsViewModel.swift
+++ b/Library/ViewModels/BetaToolsViewModel.swift
@@ -1,8 +1,8 @@
-import Foundation
 import KsApi
 import Prelude
 import ReactiveExtensions
 import ReactiveSwift
+import UIKit
 
 public enum BetaToolsRow: Int, CaseIterable {
   case debugConfigFeatureFlags

--- a/Library/ViewModels/CommentCellViewModel.swift
+++ b/Library/ViewModels/CommentCellViewModel.swift
@@ -1,3 +1,4 @@
+import Foundation
 import KsApi
 import Prelude
 import ReactiveSwift

--- a/Library/ViewModels/CommentRepliesViewModel.swift
+++ b/Library/ViewModels/CommentRepliesViewModel.swift
@@ -1,3 +1,4 @@
+import Foundation
 import KsApi
 import Prelude
 import ReactiveExtensions

--- a/Library/ViewModels/CommentsViewModel.swift
+++ b/Library/ViewModels/CommentsViewModel.swift
@@ -1,3 +1,4 @@
+import Foundation
 import KsApi
 import Prelude
 import ReactiveExtensions

--- a/Library/ViewModels/DashboardFundingCellViewModel.swift
+++ b/Library/ViewModels/DashboardFundingCellViewModel.swift
@@ -2,6 +2,7 @@ import KsApi
 import Prelude
 import ReactiveExtensions
 import ReactiveSwift
+import UIKit
 
 public struct FundingGraphData {
   public let project: Project

--- a/Library/ViewModels/DashboardReferrerRowStackViewViewModel.swift
+++ b/Library/ViewModels/DashboardReferrerRowStackViewViewModel.swift
@@ -2,6 +2,7 @@ import KsApi
 import Prelude
 import ReactiveExtensions
 import ReactiveSwift
+import UIKit
 
 public protocol DashboardReferrerRowStackViewViewModelInputs {
   /// Call to configure cell with referrer data.

--- a/Library/ViewModels/DashboardVideoCellViewModel.swift
+++ b/Library/ViewModels/DashboardVideoCellViewModel.swift
@@ -2,6 +2,7 @@ import KsApi
 import Prelude
 import ReactiveExtensions
 import ReactiveSwift
+import UIKit
 
 public protocol DashboardVideoCellViewModelInputs {
   /// Call to configure cell with video stats.

--- a/Library/ViewModels/DiscoveryNavigationHeaderViewModel.swift
+++ b/Library/ViewModels/DiscoveryNavigationHeaderViewModel.swift
@@ -2,6 +2,7 @@ import KsApi
 import Prelude
 import ReactiveExtensions
 import ReactiveSwift
+import UIKit
 
 public protocol DiscoveryNavigationHeaderViewModelInputs {
   /// Call to configure with Discovery params.

--- a/Library/ViewModels/DiscoveryPageViewModel.swift
+++ b/Library/ViewModels/DiscoveryPageViewModel.swift
@@ -2,6 +2,7 @@ import KsApi
 import Prelude
 import ReactiveExtensions
 import ReactiveSwift
+import UIKit
 
 public protocol DiscoveryPageViewModelInputs {
   /// Call when the Config has been updated in the AppEnvironment

--- a/Library/ViewModels/DiscoveryViewModel.swift
+++ b/Library/ViewModels/DiscoveryViewModel.swift
@@ -2,6 +2,7 @@ import KsApi
 import Prelude
 import ReactiveExtensions
 import ReactiveSwift
+import UIKit
 
 public protocol DiscoveryViewModelInputs {
   /// Call when Recommendations setting changes on Settings > Account > Privacy > Recommendations.

--- a/Library/ViewModels/ErroredBackingViewViewModel.swift
+++ b/Library/ViewModels/ErroredBackingViewViewModel.swift
@@ -1,3 +1,4 @@
+import Foundation
 import KsApi
 import Prelude
 import ReactiveSwift

--- a/Library/ViewModels/FacebookConfirmationViewModel.swift
+++ b/Library/ViewModels/FacebookConfirmationViewModel.swift
@@ -1,3 +1,4 @@
+import Foundation
 import KsApi
 import ReactiveExtensions
 import ReactiveSwift

--- a/Library/ViewModels/FindFriendsFriendFollowCellViewModel.swift
+++ b/Library/ViewModels/FindFriendsFriendFollowCellViewModel.swift
@@ -1,3 +1,4 @@
+import Foundation
 import KsApi
 import Prelude
 import ReactiveExtensions

--- a/Library/ViewModels/LoginViewModel.swift
+++ b/Library/ViewModels/LoginViewModel.swift
@@ -1,3 +1,4 @@
+import Foundation
 import KsApi
 import Prelude
 import ReactiveExtensions

--- a/Library/ViewModels/ManagePledgePaymentMethodViewModel.swift
+++ b/Library/ViewModels/ManagePledgePaymentMethodViewModel.swift
@@ -1,3 +1,4 @@
+import Foundation
 import KsApi
 import Prelude
 import ReactiveExtensions

--- a/Library/ViewModels/MessageCellViewModel.swift
+++ b/Library/ViewModels/MessageCellViewModel.swift
@@ -1,3 +1,4 @@
+import Foundation
 import KsApi
 import ReactiveSwift
 

--- a/Library/ViewModels/MessageCellViewModelTests.swift
+++ b/Library/ViewModels/MessageCellViewModelTests.swift
@@ -1,5 +1,6 @@
 @testable import KsApi
 import Library
+import Foundation
 import ReactiveExtensions_TestHelpers
 import ReactiveSwift
 

--- a/Library/ViewModels/MessageCellViewModelTests.swift
+++ b/Library/ViewModels/MessageCellViewModelTests.swift
@@ -1,6 +1,6 @@
+import Foundation
 @testable import KsApi
 import Library
-import Foundation
 import ReactiveExtensions_TestHelpers
 import ReactiveSwift
 

--- a/Library/ViewModels/MessageThreadCellViewModel.swift
+++ b/Library/ViewModels/MessageThreadCellViewModel.swift
@@ -1,3 +1,4 @@
+import Foundation
 import KsApi
 import Prelude
 import ReactiveExtensions

--- a/Library/ViewModels/MessageThreadCellViewModelTests.swift
+++ b/Library/ViewModels/MessageThreadCellViewModelTests.swift
@@ -1,6 +1,6 @@
+import Foundation
 @testable import KsApi
 import Library
-import Foundation
 import Prelude
 import ReactiveExtensions_TestHelpers
 import ReactiveSwift

--- a/Library/ViewModels/MessageThreadCellViewModelTests.swift
+++ b/Library/ViewModels/MessageThreadCellViewModelTests.swift
@@ -1,5 +1,6 @@
 @testable import KsApi
 import Library
+import Foundation
 import Prelude
 import ReactiveExtensions_TestHelpers
 import ReactiveSwift

--- a/Library/ViewModels/PledgeAmountViewModel.swift
+++ b/Library/ViewModels/PledgeAmountViewModel.swift
@@ -1,8 +1,8 @@
-import Foundation
 import KsApi
 import Prelude
 import ReactiveExtensions
 import ReactiveSwift
+import UIKit
 
 public typealias PledgeAmountData = (amount: Double, min: Double, max: Double, isValid: Bool)
 

--- a/Library/ViewModels/PledgeViewCTAContainerViewModel.swift
+++ b/Library/ViewModels/PledgeViewCTAContainerViewModel.swift
@@ -1,3 +1,4 @@
+import Foundation
 import KsApi
 import Prelude
 import ReactiveExtensions

--- a/Library/ViewModels/ProjectActivityBackingCellViewModel.swift
+++ b/Library/ViewModels/ProjectActivityBackingCellViewModel.swift
@@ -1,3 +1,4 @@
+import Foundation
 import KsApi
 import Prelude
 import ReactiveExtensions

--- a/Library/ViewModels/ProjectActivityCommentCellViewModel.swift
+++ b/Library/ViewModels/ProjectActivityCommentCellViewModel.swift
@@ -1,3 +1,4 @@
+import Foundation
 import KsApi
 import Prelude
 import ReactiveExtensions

--- a/Library/ViewModels/ProjectActivityLaunchCellViewModel.swift
+++ b/Library/ViewModels/ProjectActivityLaunchCellViewModel.swift
@@ -1,3 +1,4 @@
+import Foundation
 import KsApi
 import Prelude
 import ReactiveExtensions

--- a/Library/ViewModels/ProjectActivitySuccessCellViewModel.swift
+++ b/Library/ViewModels/ProjectActivitySuccessCellViewModel.swift
@@ -1,3 +1,4 @@
+import Foundation
 import KsApi
 import Prelude
 import ReactiveExtensions

--- a/Library/ViewModels/ProjectEnvironmentalCommitmentDisclaimerCellViewModel.swift
+++ b/Library/ViewModels/ProjectEnvironmentalCommitmentDisclaimerCellViewModel.swift
@@ -1,3 +1,4 @@
+import Foundation
 import KsApi
 import Prelude
 import ReactiveSwift

--- a/Library/ViewModels/ProjectPageViewModel.swift
+++ b/Library/ViewModels/ProjectPageViewModel.swift
@@ -1,3 +1,4 @@
+import Foundation
 import KsApi
 import Prelude
 import ReactiveSwift

--- a/Library/ViewModels/ProjectRisksDisclaimerCellViewModel.swift
+++ b/Library/ViewModels/ProjectRisksDisclaimerCellViewModel.swift
@@ -1,3 +1,4 @@
+import Foundation
 import KsApi
 import Prelude
 import ReactiveSwift

--- a/Library/ViewModels/RootCommentCellViewModel.swift
+++ b/Library/ViewModels/RootCommentCellViewModel.swift
@@ -1,3 +1,4 @@
+import Foundation
 import KsApi
 import Prelude
 import ReactiveSwift

--- a/Library/ViewModels/ThanksViewModel.swift
+++ b/Library/ViewModels/ThanksViewModel.swift
@@ -2,6 +2,7 @@ import KsApi
 import Prelude
 import ReactiveExtensions
 import ReactiveSwift
+import UIKit
 
 public typealias ThanksPageData = (
   project: Project,

--- a/Library/ViewModels/TwoFactorViewModel.swift
+++ b/Library/ViewModels/TwoFactorViewModel.swift
@@ -1,3 +1,4 @@
+import Foundation
 import KsApi
 import Prelude
 import ReactiveExtensions

--- a/Library/ViewModels/WatchProjectViewModel.swift
+++ b/Library/ViewModels/WatchProjectViewModel.swift
@@ -1,3 +1,4 @@
+import Foundation
 import KsApi
 import Prelude
 import ReactiveSwift


### PR DESCRIPTION
# 📲 What

Our final two Carthage dependency Reactive-Extensions and ReactiveSwift needs to move to SPM.

# 🤔 Why

Part of a platform upgrade to move all our dependencies away from Carthage and shell scripts building for non-M1 architectures to more dependable Swift Package Manager. [Context](https://app.getguru.com/card/TzA8Rpac/-Carthage-to-Swift-Package-Manager-Migration).

# 🛠 How

This requires us making our internal ReactiveExtensions library SPM compatible. Here is the [diff](https://github.com/kickstarter/Kickstarter-ReactiveExtensions/compare/feature/swift-package?expand=1) on the changes, but essentially what that requires is:
- creating a top level `Package.swift` [file](https://github.com/kickstarter/Kickstarter-ReactiveExtensions/compare/feature/swift-package?expand=1#diff-f913940c58e8744a2af1c68b909bb6383e49007e6c5a12fb03104a9006ae677e).
- Put all library files inside a `Sources` directory. Put tests inside a `Tests` directory.
- For some reason in the package library we need to `import Foundation` in 3 files (`KsrDebounce.swift`, `KsrDelay.swift`, `WithLatestFrom.swift`) not sure why exactly, but seeing as this is the most basic of dependencies provided by Apple and the foundation for almost every other framework/library in existence on iOS, it is safe.
- use `swift package dump-package` to validate `Package.swift` 

The above were changes to the `ReactiveExtensions` repo to make it SPM compatible. After importing that library via SPM into our Kickstarter project, we include `ReactiveExtensions` into our main app target `Kickstarter-iOS`, `Library-iOS`, `Kickstarter-Framework-iOS` and `KsApi`. We also include `ReactiveExtensions-TestHelpers` into the test targets of the aforementioned libraries.

As for `ReactiveSwift` we tried to use the included dependency within `ReactiveExtensions` instead of importing it via SPM separately but ended up with this strange linking error not being able to link it it through the RE package.

<details>

```
ld: warning: directory not found for option '-F/Users/mubarak/Desktop/Kickstarter/ios-oss/Carthage/Build/iOS'
Undefined symbols for architecture x86_64:
  "(extension in ReactiveSwift):ReactiveSwift.ReactiveExtensionsProvider.reactive.getter : ReactiveSwift.Reactive<A>", referenced from:
      (extension in KsApi):__C.NSURLSession.rac_dataResponse(_: Foundation.URLRequest, uploading: (url: Foundation.URL, name: Swift.String)?, and: KsApi.ErrorHandler?) -> ReactiveSwift.SignalProducer<Foundation.Data, KsApi.ErrorEnvelope> in NSURLSession.o
  "protocol witness table for ReactiveSwift.QueueScheduler : ReactiveSwift.Scheduler in ReactiveSwift", referenced from:
      (extension in KsApi):__C.NSURLSession.rac_dataResponse(_: Foundation.URLRequest, uploading: (url: Foundation.URL, name: Swift.String)?, and: KsApi.ErrorHandler?) -> ReactiveSwift.SignalProducer<Foundation.Data, KsApi.ErrorEnvelope> in NSURLSession.o
  "(extension in ReactiveSwift):ReactiveSwift.Reactive<A where A: __C.NSURLSession>.data(with: Foundation.URLRequest) -> ReactiveSwift.SignalProducer<(Foundation.Data, __C.NSURLResponse), Swift.Error>", referenced from:
      (extension in KsApi):__C.NSURLSession.rac_dataResponse(_: Foundation.URLRequest, uploading: (url: Foundation.URL, name: Swift.String)?, and: KsApi.ErrorHandler?) -> ReactiveSwift.SignalProducer<Foundation.Data, KsApi.ErrorEnvelope> in NSURLSession.o
  "ReactiveSwift.SignalProducer.start(on: ReactiveSwift.Scheduler) -> ReactiveSwift.SignalProducer<A, B>", referenced from:
      (extension in KsApi):__C.NSURLSession.rac_dataResponse(_: Foundation.URLRequest, uploading: (url: Foundation.URL, name: Swift.String)?, and: KsApi.ErrorHandler?) -> ReactiveSwift.SignalProducer<Foundation.Data, KsApi.ErrorEnvelope> in NSURLSession.o
  "ReactiveSwift.SignalProducer.flatMap<A>(ReactiveSwift.FlattenStrategy, (A) -> ReactiveSwift.SignalProducer<A1, B>) -> ReactiveSwift.SignalProducer<A1, B>", referenced from:
      (extension in KsApi):__C.NSURLSession.rac_dataResponse(_: Foundation.URLRequest, uploading: (url: Foundation.URL, name: Swift.String)?, and: KsApi.ErrorHandler?) -> ReactiveSwift.SignalProducer<Foundation.Data, KsApi.ErrorEnvelope> in NSURLSession.o
  "ReactiveSwift.SignalProducer.map<A>((A) -> A1) -> ReactiveSwift.SignalProducer<A1, B>", referenced from:
      (extension in KsApi):__C.NSURLSession.rac_JSONResponse(_: Foundation.URLRequest, uploading: (url: Foundation.URL, name: Swift.String)?) -> ReactiveSwift.SignalProducer<Any, KsApi.ErrorEnvelope> in NSURLSession.o
      KsApi.Service.decodeModel<A where A: Swift.Decodable>(data: Foundation.Data) -> ReactiveSwift.SignalProducer<A?, KsApi.ErrorEnvelope> in Service+DecodeHelpers.o
  "type metadata accessor for ReactiveSwift.QueueScheduler", referenced from:
      one-time initialization function for (scheduler in _EE2FFDFE3F55EAB482860367DB4D56EC) in NSURLSession.o
  "ReactiveSwift.SignalProducer.first() -> Swift.Result<A, B>?", referenced from:
      (extension in KsApi):KsApi.ApolloClientType.data<A where A1: Swift.Decodable>(from: ReactiveSwift.SignalProducer<A1, KsApi.ErrorEnvelope>) -> A1? in MockGraphQLClient.o
      (extension in KsApi):KsApi.ApolloClientType.error<A where A1: Swift.Decodable>(from: ReactiveSwift.SignalProducer<A1, KsApi.ErrorEnvelope>) -> KsApi.ErrorEnvelope? in MockGraphQLClient.o
  "protocol witness table for __C.NSURLSession : ReactiveSwift.ReactiveExtensionsProvider in ReactiveSwift", referenced from:
      (extension in KsApi):__C.NSURLSession.rac_dataResponse(_: Foundation.URLRequest, uploading: (url: Foundation.URL, name: Swift.String)?, and: KsApi.ErrorHandler?) -> ReactiveSwift.SignalProducer<Foundation.Data, KsApi.ErrorEnvelope> in NSURLSession.o
  "ReactiveSwift.SignalProducer.flatMapError<A where A1: Swift.Error>((B) -> ReactiveSwift.SignalProducer<A, A1>) -> ReactiveSwift.SignalProducer<A, A1>", referenced from:
      KsApi.Service.incrementVideoCompletion(forProject: KsApi.Project) -> ReactiveSwift.SignalProducer<KsApi.VoidEnvelope, KsApi.ErrorEnvelope> in Service.o
      KsApi.Service.incrementVideoStart(forProject: KsApi.Project) -> ReactiveSwift.SignalProducer<KsApi.VoidEnvelope, KsApi.ErrorEnvelope> in Service.o
      (extension in KsApi):__C.NSURLSession.rac_dataResponse(_: Foundation.URLRequest, uploading: (url: Foundation.URL, name: Swift.String)?, and: KsApi.ErrorHandler?) -> ReactiveSwift.SignalProducer<Foundation.Data, KsApi.ErrorEnvelope> in NSURLSession.o
  "ReactiveSwift.SignalProducer.init(value: A) -> ReactiveSwift.SignalProducer<A, B>", referenced from:
      static KsApi.ClientSecretEnvelope.envelopeProducer(from: KsApi.GraphAPI.CreateSetupIntentMutation.Data) -> ReactiveSwift.SignalProducer<KsApi.ClientSecretEnvelope, KsApi.ErrorEnvelope> in ClientSecretEnvelope.o
      static KsApi.ErroredBackingsEnvelope.producer(from: KsApi.GraphAPI.FetchUserBackingsQuery.Data) -> ReactiveSwift.SignalProducer<KsApi.ErroredBackingsEnvelope, KsApi.ErrorEnvelope> in ErroredBackingsEnvelope.o
      static KsApi.ProjectAndBackingEnvelope.envelopeProducer(from: KsApi.GraphAPI.FetchBackingQuery.Data) -> ReactiveSwift.SignalProducer<KsApi.ProjectAndBackingEnvelope, KsApi.ErrorEnvelope> in ProjectAndBackingEnvelope.o
      static KsApi.WatchProjectResponseEnvelope.producer(from: KsApi.GraphAPI.WatchProjectMutation.Data) -> ReactiveSwift.SignalProducer<KsApi.WatchProjectResponseEnvelope, KsApi.ErrorEnvelope> in WatchProjectResponseEnvelope+WatchProjectMutation.Data.o
      static KsApi.CreatePaymentSourceEnvelope.producer(from: KsApi.GraphAPI.CreatePaymentSourceMutation.Data) -> ReactiveSwift.SignalProducer<KsApi.CreatePaymentSourceEnvelope, KsApi.ErrorEnvelope> in CreatePaymentSourceEnvelope+CreatePaymentSourceMutation.Data.o
      static KsApi.Project.projectProducer(from: KsApi.GraphAPI.FetchAddOnsQuery.Data) -> ReactiveSwift.SignalProducer<KsApi.Project, KsApi.ErrorEnvelope> in Project+FetchAddOnsQueryData.o
      static KsApi.CategoryEnvelope.envelopeProducer(from: KsApi.GraphAPI.FetchCategoryQuery.Data) -> ReactiveSwift.SignalProducer<KsApi.CategoryEnvelope, KsApi.ErrorEnvelope> in CategoryEnvelope+FetchCategoryQueryData.o
      ...
  "ReactiveSwift.SignalProducer.on(starting: (() -> ())?, started: (() -> ())?, event: ((ReactiveSwift.Signal<A, B>.Event) -> ())?, failed: ((B) -> ())?, completed: (() -> ())?, interrupted: (() -> ())?, terminated: (() -> ())?, disposed: (() -> ())?, value: ((A) -> ())?) -> ReactiveSwift.SignalProducer<A, B>", referenced from:
      KsApi.MockService.fetchProject(projectParam: KsApi.Param, configCurrency: Swift.String?) -> ReactiveSwift.SignalProducer<(project: KsApi.Project, backingId: Swift.Int?), KsApi.ErrorEnvelope> in MockService.o
  "nominal type descriptor for ReactiveSwift.Signal.Observer", referenced from:
      _symbolic _____y4Data_____Qz______G 13ReactiveSwift6SignalC8ObserverC 6Apollo16GraphQLOperationP 5KsApi13ErrorEnvelopeV in ApolloClient+RAC.o
  "ReactiveSwift.QueueScheduler.__allocating_init(qos: Dispatch.DispatchQoS, name: Swift.String, targeting: __C.OS_dispatch_queue?) -> ReactiveSwift.QueueScheduler", referenced from:
      one-time initialization function for (scheduler in _EE2FFDFE3F55EAB482860367DB4D56EC) in NSURLSession.o
  "ReactiveSwift.SignalProducer.init(error: B) -> ReactiveSwift.SignalProducer<A, B>", referenced from:
      static KsApi.ClientSecretEnvelope.envelopeProducer(from: KsApi.GraphAPI.CreateSetupIntentMutation.Data) -> ReactiveSwift.SignalProducer<KsApi.ClientSecretEnvelope, KsApi.ErrorEnvelope> in ClientSecretEnvelope.o
      static KsApi.ErroredBackingsEnvelope.producer(from: KsApi.GraphAPI.FetchUserBackingsQuery.Data) -> ReactiveSwift.SignalProducer<KsApi.ErroredBackingsEnvelope, KsApi.ErrorEnvelope> in ErroredBackingsEnvelope.o
      static KsApi.ProjectAndBackingEnvelope.envelopeProducer(from: KsApi.GraphAPI.FetchBackingQuery.Data) -> ReactiveSwift.SignalProducer<KsApi.ProjectAndBackingEnvelope, KsApi.ErrorEnvelope> in ProjectAndBackingEnvelope.o
      static KsApi.WatchProjectResponseEnvelope.producer(from: KsApi.GraphAPI.WatchProjectMutation.Data) -> ReactiveSwift.SignalProducer<KsApi.WatchProjectResponseEnvelope, KsApi.ErrorEnvelope> in WatchProjectResponseEnvelope+WatchProjectMutation.Data.o
      static KsApi.CreatePaymentSourceEnvelope.producer(from: KsApi.GraphAPI.CreatePaymentSourceMutation.Data) -> ReactiveSwift.SignalProducer<KsApi.CreatePaymentSourceEnvelope, KsApi.ErrorEnvelope> in CreatePaymentSourceEnvelope+CreatePaymentSourceMutation.Data.o
      static KsApi.Project.projectProducer(from: KsApi.GraphAPI.FetchAddOnsQuery.Data) -> ReactiveSwift.SignalProducer<KsApi.Project, KsApi.ErrorEnvelope> in Project+FetchAddOnsQueryData.o
      static KsApi.ClearUserUnseenActivityEnvelope.producer(from: KsApi.GraphAPI.ClearUserUnseenActivityMutation.Data) -> ReactiveSwift.SignalProducer<KsApi.ClearUserUnseenActivityEnvelope, KsApi.ErrorEnvelope> in ClearUserUnseenActivityEnvelope+ClearUserUnseenActivityMutation.Data.o
      ...
  "nominal type descriptor for ReactiveSwift.SignalProducer", referenced from:
      _symbolic __________yx_____GIeggo_ 10Foundation4DataV 13ReactiveSwift14SignalProducerV 5KsApi13ErrorEnvelopeV in Service+RequestHelpers.o
      _symbolic _____y_____7project_SiSg9backingIdt_____G 13ReactiveSwift14SignalProducerV 5KsApi7ProjectV AD13ErrorEnvelopeV in MockService.o
      _symbolic _____y_____7project_SiSg9backingIdt_____Gz_Xx 13ReactiveSwift14SignalProducerV 5KsApi7ProjectV AD13ErrorEnvelopeV in MockService.o
      _symbolic __________y__________GIeggo_ 5KsApi8GraphAPIO27CreatePaymentSourceMutationC4DataV 13ReactiveSwift14SignalProducerV AA0efG8EnvelopeV AA05ErrorN0V in Service.o
      _symbolic __________y__________GIeggo_ 5KsApi8GraphAPIO21CreateBackingMutationC4DataV 13ReactiveSwift14SignalProducerV AA0eF8EnvelopeV AA05ErrorM0V in Service.o
      _symbolic __________y__________GIeggo_ 5KsApi8GraphAPIO25CreateSetupIntentMutationC4DataV 13ReactiveSwift14SignalProducerV AA20ClientSecretEnvelopeV AA05ErrorP0V in Service.o
      _symbolic __________y__________GIeggo_ 5KsApi8GraphAPIO31ClearUserUnseenActivityMutationC4DataV 13ReactiveSwift14SignalProducerV AA0efgH8EnvelopeV AA05ErrorO0V in Service.o
      ...
  "ReactiveSwift.Signal.Observer.send(value: A) -> ()", referenced from:
      closure #1 (Swift.Result<Apollo.GraphQLResult<A.Data>, Swift.Error>) -> () in closure #1 (ReactiveSwift.Signal<A.Data, KsApi.ErrorEnvelope>.Observer, ReactiveSwift.Lifetime) -> () in (extension in KsApi):Apollo.ApolloClient.fetch<A where A: Apollo.GraphQLQuery>(query: A) -> ReactiveSwift.SignalProducer<A.Data, KsApi.ErrorEnvelope> in ApolloClient+RAC.o
      closure #1 (Swift.Result<Apollo.GraphQLResult<A.Data>, Swift.Error>) -> () in closure #1 (ReactiveSwift.Signal<A.Data, KsApi.ErrorEnvelope>.Observer, ReactiveSwift.Lifetime) -> () in (extension in KsApi):Apollo.ApolloClient.perform<A where A: Apollo.GraphQLMutation>(mutation: A) -> ReactiveSwift.SignalProducer<A.Data, KsApi.ErrorEnvelope> in ApolloClient+RAC.o
      closure #1 (Foundation.Data?, __C.NSURLResponse?, Swift.Error?) -> () in closure #1 (ReactiveSwift.Signal<(Foundation.Data, __C.NSURLResponse), Swift.Error>.Observer, ReactiveSwift.Lifetime) -> () in (extension in KsApi):__C.NSURLSession.(rac_dataWithRequest in _EE2FFDFE3F55EAB482860367DB4D56EC)(_: Foundation.URLRequest, uploading: Foundation.URL, named: Swift.String) -> ReactiveSwift.SignalProducer<(Foundation.Data, __C.NSURLResponse), Swift.Error> in NSURLSession.o
  "ReactiveSwift.Signal.Observer.sendCompleted() -> ()", referenced from:
      closure #1 (Swift.Result<Apollo.GraphQLResult<A.Data>, Swift.Error>) -> () in closure #1 (ReactiveSwift.Signal<A.Data, KsApi.ErrorEnvelope>.Observer, ReactiveSwift.Lifetime) -> () in (extension in KsApi):Apollo.ApolloClient.fetch<A where A: Apollo.GraphQLQuery>(query: A) -> ReactiveSwift.SignalProducer<A.Data, KsApi.ErrorEnvelope> in ApolloClient+RAC.o
      closure #1 (Swift.Result<Apollo.GraphQLResult<A.Data>, Swift.Error>) -> () in closure #1 (ReactiveSwift.Signal<A.Data, KsApi.ErrorEnvelope>.Observer, ReactiveSwift.Lifetime) -> () in (extension in KsApi):Apollo.ApolloClient.perform<A where A: Apollo.GraphQLMutation>(mutation: A) -> ReactiveSwift.SignalProducer<A.Data, KsApi.ErrorEnvelope> in ApolloClient+RAC.o
      closure #1 (Foundation.Data?, __C.NSURLResponse?, Swift.Error?) -> () in closure #1 (ReactiveSwift.Signal<(Foundation.Data, __C.NSURLResponse), Swift.Error>.Observer, ReactiveSwift.Lifetime) -> () in (extension in KsApi):__C.NSURLSession.(rac_dataWithRequest in _EE2FFDFE3F55EAB482860367DB4D56EC)(_: Foundation.URLRequest, uploading: Foundation.URL, named: Swift.String) -> ReactiveSwift.SignalProducer<(Foundation.Data, __C.NSURLResponse), Swift.Error> in NSURLSession.o
  "static ReactiveSwift.SignalProducer.empty.getter : ReactiveSwift.SignalProducer<A, B>", referenced from:
      static KsApi.CategoryEnvelope.envelopeProducer(from: KsApi.GraphAPI.FetchCategoryQuery.Data) -> ReactiveSwift.SignalProducer<KsApi.CategoryEnvelope, KsApi.ErrorEnvelope> in CategoryEnvelope+FetchCategoryQueryData.o
      KsApi.MockService.addNewCreditCard(input: KsApi.CreatePaymentSourceInput) -> ReactiveSwift.SignalProducer<KsApi.CreatePaymentSourceEnvelope, KsApi.ErrorEnvelope> in MockService.o
      KsApi.MockService.addPaymentSheetPaymentSource(input: KsApi.CreatePaymentSourceSetupIntentInput) -> ReactiveSwift.SignalProducer<KsApi.CreatePaymentSourceEnvelope, KsApi.ErrorEnvelope> in MockService.o
      KsApi.MockService.cancelBacking(input: KsApi.CancelBackingInput) -> ReactiveSwift.SignalProducer<KsApi.EmptyResponseEnvelope, KsApi.ErrorEnvelope> in MockService.o
      KsApi.MockService.changeEmail(input: KsApi.ChangeEmailInput) -> ReactiveSwift.SignalProducer<KsApi.EmptyResponseEnvelope, KsApi.ErrorEnvelope> in MockService.o
      KsApi.MockService.changePassword(input: KsApi.ChangePasswordInput) -> ReactiveSwift.SignalProducer<KsApi.EmptyResponseEnvelope, KsApi.ErrorEnvelope> in MockService.o
      KsApi.MockService.createBacking(input: KsApi.CreateBackingInput) -> ReactiveSwift.SignalProducer<KsApi.CreateBackingEnvelope, KsApi.ErrorEnvelope> in MockService.o
      ...
  "ReactiveSwift.Signal.Observer.send(error: B) -> ()", referenced from:
      closure #1 (Swift.Result<Apollo.GraphQLResult<A.Data>, Swift.Error>) -> () in closure #1 (ReactiveSwift.Signal<A.Data, KsApi.ErrorEnvelope>.Observer, ReactiveSwift.Lifetime) -> () in (extension in KsApi):Apollo.ApolloClient.fetch<A where A: Apollo.GraphQLQuery>(query: A) -> ReactiveSwift.SignalProducer<A.Data, KsApi.ErrorEnvelope> in ApolloClient+RAC.o
      closure #1 (Swift.Result<Apollo.GraphQLResult<A.Data>, Swift.Error>) -> () in closure #1 (ReactiveSwift.Signal<A.Data, KsApi.ErrorEnvelope>.Observer, ReactiveSwift.Lifetime) -> () in (extension in KsApi):Apollo.ApolloClient.perform<A where A: Apollo.GraphQLMutation>(mutation: A) -> ReactiveSwift.SignalProducer<A.Data, KsApi.ErrorEnvelope> in ApolloClient+RAC.o
      closure #1 (Foundation.Data?, __C.NSURLResponse?, Swift.Error?) -> () in closure #1 (ReactiveSwift.Signal<(Foundation.Data, __C.NSURLResponse), Swift.Error>.Observer, ReactiveSwift.Lifetime) -> () in (extension in KsApi):__C.NSURLSession.(rac_dataWithRequest in _EE2FFDFE3F55EAB482860367DB4D56EC)(_: Foundation.URLRequest, uploading: Foundation.URL, named: Swift.String) -> ReactiveSwift.SignalProducer<(Foundation.Data, __C.NSURLResponse), Swift.Error> in NSURLSession.o
  "ReactiveSwift.Lifetime.observeEnded(() -> ()) -> ReactiveSwift.Disposable?", referenced from:
      closure #1 (ReactiveSwift.Signal<(Foundation.Data, __C.NSURLResponse), Swift.Error>.Observer, ReactiveSwift.Lifetime) -> () in (extension in KsApi):__C.NSURLSession.(rac_dataWithRequest in _EE2FFDFE3F55EAB482860367DB4D56EC)(_: Foundation.URLRequest, uploading: Foundation.URL, named: Swift.String) -> ReactiveSwift.SignalProducer<(Foundation.Data, __C.NSURLResponse), Swift.Error> in NSURLSession.o
  "ReactiveSwift.FlattenStrategy.concat.unsafeMutableAddressor : ReactiveSwift.FlattenStrategy", referenced from:
      (extension in KsApi):__C.NSURLSession.rac_dataResponse(_: Foundation.URLRequest, uploading: (url: Foundation.URL, name: Swift.String)?, and: KsApi.ErrorHandler?) -> ReactiveSwift.SignalProducer<Foundation.Data, KsApi.ErrorEnvelope> in NSURLSession.o
  "ReactiveSwift.SignalProducer.init((ReactiveSwift.Signal<A, B>.Observer, ReactiveSwift.Lifetime) -> ()) -> ReactiveSwift.SignalProducer<A, B>", referenced from:
      (extension in KsApi):Apollo.ApolloClient.fetch<A where A: Apollo.GraphQLQuery>(query: A) -> ReactiveSwift.SignalProducer<A.Data, KsApi.ErrorEnvelope> in ApolloClient+RAC.o
      (extension in KsApi):Apollo.ApolloClient.perform<A where A: Apollo.GraphQLMutation>(mutation: A) -> ReactiveSwift.SignalProducer<A.Data, KsApi.ErrorEnvelope> in ApolloClient+RAC.o
      (extension in KsApi):__C.NSURLSession.(rac_dataWithRequest in _EE2FFDFE3F55EAB482860367DB4D56EC)(_: Foundation.URLRequest, uploading: Foundation.URL, named: Swift.String) -> ReactiveSwift.SignalProducer<(Foundation.Data, __C.NSURLResponse), Swift.Error> in NSURLSession.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

</details>

Without spending too much time on it, already been about a day, safest is to import it via SPM and include it in all targets with `ReactiveExtensions`. This affects the app size and we've already increased it by about 25% by moving the existing Carthage dependencies over. It will increase more with these two big dependencies now moved as well. This means longer install times and longer app start times. But with our newer initiatives to remove existing unused features in the app, we can start to look at things like [optimizing](https://developer.apple.com/documentation/xcode/reducing-your-app-s-size) app size and build times. Especially for noticeably long start times from first install and subsequent launches.

The strong argument for this change (and the reason we did all this platform work) is that developer efficiency is increased substantially due to all builds now working on M1 processors. It's actually twice as fast as a non-M1 MBP after a clean + build.

2019 Intel i9 8-Core 32GB

<img width="386" alt="Screen Shot 2022-10-13 at 8 11 13 PM" src="https://user-images.githubusercontent.com/4282741/195734235-0576e969-138e-43d1-8cba-1be1f3536adc.png">

2021 M1 Pro 16GB

<img width="386" alt="Screen Shot 2022-10-13 at 8 11 35 PM" src="https://user-images.githubusercontent.com/4282741/195734258-67fab2f9-1059-48c7-8845-39e6e12efb65.png">

The size/launch time increase seem to be worth it, but we'll do more testing and follow up.

# ✅ Acceptance criteria

- [x] Ensure long start times are not noticeable from first install.

# ⏰ TODO

- [x] Bug related to `import ReactiveExtensions` in `KsApi` `Service+RequestHelpers` file...
- [x] Fix broken tests