### PR TITLE
[PAY-1980] Update Backing Errored Pledge Flow

### DIFF
--- a/Library/ViewModels/PledgePaymentMethodsViewModel.swift
+++ b/Library/ViewModels/PledgePaymentMethodsViewModel.swift
@@ -291,7 +291,7 @@ public final class PledgePaymentMethodsViewModel: PledgePaymentMethodsViewModelT
     let didTapToAddNewCard = self.didSelectRowAtIndexPathProperty.signal.skipNil()
       .filter { $0.section == PaymentMethodsTableViewSection.addNewCard.rawValue }
 
-    let paymentSheetOnPledgeContext = context.ignoreValues().map(paymentSheetEnabled)
+    let paymentSheetOnPledgeContext = context.map { _ in paymentSheetEnabled }
 
     self.goToAddCardScreen = Signal.combineLatest(
       project,

--- a/Library/ViewModels/PledgePaymentMethodsViewModel.swift
+++ b/Library/ViewModels/PledgePaymentMethodsViewModel.swift
@@ -291,15 +291,7 @@ public final class PledgePaymentMethodsViewModel: PledgePaymentMethodsViewModelT
     let didTapToAddNewCard = self.didSelectRowAtIndexPathProperty.signal.skipNil()
       .filter { $0.section == PaymentMethodsTableViewSection.addNewCard.rawValue }
 
-    let paymentSheetOnPledgeContext = context
-      .map { context -> Bool in
-        guard context.isCreating || context.isUpdating,
-          context != .fixPaymentMethod else {
-          return false
-        }
-
-        return paymentSheetEnabled
-      }
+    let paymentSheetOnPledgeContext = context.ignoreValues().map(paymentSheetEnabled)
 
     self.goToAddCardScreen = Signal.combineLatest(
       project,

--- a/Library/ViewModels/PledgePaymentMethodsViewModelTests.swift
+++ b/Library/ViewModels/PledgePaymentMethodsViewModelTests.swift
@@ -923,7 +923,7 @@ final class PledgePaymentMethodsViewModelTests: TestCase {
     }
   }
 
-  func testGoToAddNewCard_PledgeContext_PaymentSheetEnabled_Success() {
+  func testGoToAddNewCard_PledgeContext_PaymentSheetEnabled_Failure() {
     let project = Project.template
 
     let mockOptimizelyClient = MockOptimizelyClient()
@@ -957,7 +957,7 @@ final class PledgePaymentMethodsViewModelTests: TestCase {
     }
   }
 
-  func testGoToAddNewCard_UpdatePledgeContext_PaymentSheetEnabled_Success() {
+  func testGoToAddNewCard_UpdatePledgeContext_PaymentSheetEnabled_Failure() {
     let project = Project.template
 
     let mockOptimizelyClient = MockOptimizelyClient()
@@ -991,7 +991,7 @@ final class PledgePaymentMethodsViewModelTests: TestCase {
     }
   }
 
-  func testGoToAddNewCard_UpdateRewardContexts_PaymentSheetEnabled_Success() {
+  func testGoToAddNewCard_UpdateRewardContexts_PaymentSheetEnabled_Failure() {
     let project = Project.template
 
     let mockOptimizelyClient = MockOptimizelyClient()
@@ -1025,7 +1025,7 @@ final class PledgePaymentMethodsViewModelTests: TestCase {
     }
   }
 
-  func testGoToAddNewCard_ChangePaymentMethodContext_PaymentSheetEnabled_Success() {
+  func testGoToAddNewCard_ChangePaymentMethodContext_PaymentSheetEnabled_Failure() {
     let project = Project.template
 
     let mockOptimizelyClient = MockOptimizelyClient()
@@ -1060,7 +1060,7 @@ final class PledgePaymentMethodsViewModelTests: TestCase {
     }
   }
 
-  func testGoToAddNewCard_FixPaymentMethodContext_PaymentSheetEnabled_Success() {
+  func testGoToAddNewCard_FixPaymentMethodContext_PaymentSheetEnabled_Failure() {
     let project = Project.template
 
     let mockOptimizelyClient = MockOptimizelyClient()
@@ -1088,8 +1088,8 @@ final class PledgePaymentMethodsViewModelTests: TestCase {
 
       self.scheduler.run()
 
-      XCTAssertEqual(self.goToAddCardIntent.values.count, 1)
-      XCTAssertEqual(self.goToAddStripeCardIntent.values.count, 0)
+      XCTAssertEqual(self.goToAddCardIntent.values.count, 0)
+      XCTAssertEqual(self.goToAddStripeCardIntent.values.count, 1)
     }
   }
 


### PR DESCRIPTION
# 📲 What

Continue development of using Stripe's payment sheet on the pledge view page.

# 🤔 Why

We need to cover the final context `.fixPaymentMethod` for using the payment sheet.

# 🛠 How

So removed the context logic and the only remaining logic is to use the feature flag to expose the payment sheet vs the add new card page.

# 👀 See

Before 🐛 

Didn't record this as the old flow is a little difficult to co-ordinate. Requires backend support to close project, but backing into errored state.

After 🦋

Success flow:

https://user-images.githubusercontent.com/4282741/195427591-462177b8-74c8-4154-b1dc-3380cc3df107.MP4

Errored flow:

https://user-images.githubusercontent.com/4282741/195429889-cd544a9b-313b-4802-8846-94c9858f10f8.MP4

# ✅ Acceptance criteria

- [x] Fixed errored pledge flow shows up and successfully updates an errored backing. Preferrably do this on device.
- [x] As a final check, ensure all contexts show payment sheet when feature flag is on. Off otherwise.
