### PR TITLE
[PAY-2021] Error Backing Payment Card Being Unselected

### DIFF
--- a/Library/ViewModels/PledgePaymentMethodsViewModel.swift
+++ b/Library/ViewModels/PledgePaymentMethodsViewModel.swift
@@ -434,7 +434,7 @@ public final class PledgePaymentMethodsViewModel: PledgePaymentMethodsViewModelT
 
 private func pledgePaymentSheetMethodCellDataAndSelectedCardSetupIntent(
   with paymentMethodData: PledgePaymentMethodsAndSelectionData,
-  project: Project
+  project _: Project
 ) -> PledgePaymentMethodsAndSelectionData {
   // We know we have a new payment sheet card, so de-select all existing non-payment sheet cards.
   let preexistingCardDataUnselected: [PledgePaymentMethodCellData] = {
@@ -491,28 +491,11 @@ private func pledgePaymentSheetMethodCellDataAndSelectedCardSetupIntent(
     return updatePaymentMethodData
   }()
 
-  // If there is no backing, simply select the first payment sheet card in the list
-  guard let backing = project.personalization.backing else {
-    return updatedDataWithSelection
-  }
+  return updatedDataWithSelection
 
-  /*
-   In keeping with existing logic inside `pledgePaymentMethodCellDataAndSelectedCard` , if newly added payment intent card is on an errored backing, then do not select any new/existing cards.
+  /**
+   Unlike the existing logic inside `pledgePaymentMethodCellDataAndSelectedCard`, we don't know the card id after its' been added, because new payment sheet cards only contain an image and a redacted card number. If we did we can ensure that an errored backing does not highlight the new card if it matches the payment source id on the backing. Right now this flow only handles the latest cards from the payment sheet, so we can simply select the first one added. If this code path is taken the method above is not called again for the same instance of this view controller, the flag is lazy initialized and doesn't change while this page is displayed.
    */
-  if backing.status == .errored {
-    let updatePaymentMethodData = paymentMethodData
-      |> \.paymentMethodsCellData .~ preexistingCardDataUnselected
-      |> \.paymentSheetPaymentMethodsCellData .~ preexistingPaymentSheetCardDataUnselected
-      |> \.selectedCard .~ nil
-      |> \.selectedSetupIntent .~ nil
-
-    return updatePaymentMethodData
-  } else {
-    /*
-     If we're working with a backing, select the first payment sheet card added
-     */
-    return updatedDataWithSelection
-  }
 }
 
 private func pledgePaymentMethodCellDataAndSelectedCard(

--- a/Library/ViewModels/PledgePaymentMethodsViewModelTests.swift
+++ b/Library/ViewModels/PledgePaymentMethodsViewModelTests.swift
@@ -476,8 +476,7 @@ final class PledgePaymentMethodsViewModelTests: TestCase {
         )
       self.reloadPaymentMethodsSelectedCard
         .assertValues(
-          [nil, nil, nil],
-          "No card to select after payment sheet card added because of errored backing."
+          [nil, nil, nil]
         )
       self.reloadPaymentMethodsShouldReload.assertValues([true, true, true])
       self.reloadPaymentMethodsIsLoading.assertValues([true, false, false])

--- a/Library/ViewModels/PledgePaymentMethodsViewModelTests.swift
+++ b/Library/ViewModels/PledgePaymentMethodsViewModelTests.swift
@@ -467,12 +467,12 @@ final class PledgePaymentMethodsViewModelTests: TestCase {
       )
       XCTAssertEqual(
         self.reloadPaymentSheetPaymentMethodsCards.lastValue?.last?.isEnabled,
-        expectedPaymentSheetPaymentMethodCard.isEnabled
+        !expectedPaymentSheetPaymentMethodCard.isEnabled
       )
       self.reloadPaymentMethodsSelectedSetupIntent
         .assertValues(
-          [nil, nil, nil],
-          "Newly added payment sheet card not selected because of errored backing."
+          [expectedPaymentSheetPaymentMethodCard.setupIntent, nil, nil],
+          "Newly added payment sheet card still selected even on errored backing."
         )
       self.reloadPaymentMethodsSelectedCard
         .assertValues(

--- a/Library/ViewModels/PledgePaymentMethodsViewModelTests.swift
+++ b/Library/ViewModels/PledgePaymentMethodsViewModelTests.swift
@@ -437,7 +437,7 @@ final class PledgePaymentMethodsViewModelTests: TestCase {
         image: UIImage(),
         redactedCardNumber: "••••1234",
         setupIntent: "seti_1LVlHO4VvJ2PtfhK43R6p7FI_secret_MEDiGbxfYVnHGsQy8v8TbZJTQhlNKLZ",
-        isSelected: false,
+        isSelected: true,
         isEnabled: true
       )
 
@@ -463,7 +463,7 @@ final class PledgePaymentMethodsViewModelTests: TestCase {
       )
       XCTAssertEqual(
         self.reloadPaymentSheetPaymentMethodsCards.lastValue?.last?.isSelected,
-        !expectedPaymentSheetPaymentMethodCard.isSelected
+        expectedPaymentSheetPaymentMethodCard.isSelected
       )
       XCTAssertEqual(
         self.reloadPaymentSheetPaymentMethodsCards.lastValue?.last?.isEnabled,

--- a/Library/ViewModels/PledgePaymentMethodsViewModelTests.swift
+++ b/Library/ViewModels/PledgePaymentMethodsViewModelTests.swift
@@ -463,15 +463,15 @@ final class PledgePaymentMethodsViewModelTests: TestCase {
       )
       XCTAssertEqual(
         self.reloadPaymentSheetPaymentMethodsCards.lastValue?.last?.isSelected,
-        expectedPaymentSheetPaymentMethodCard.isSelected
+        !expectedPaymentSheetPaymentMethodCard.isSelected
       )
       XCTAssertEqual(
         self.reloadPaymentSheetPaymentMethodsCards.lastValue?.last?.isEnabled,
-        !expectedPaymentSheetPaymentMethodCard.isEnabled
+        expectedPaymentSheetPaymentMethodCard.isEnabled
       )
       self.reloadPaymentMethodsSelectedSetupIntent
         .assertValues(
-          [expectedPaymentSheetPaymentMethodCard.setupIntent, nil, nil],
+          [nil, nil, expectedPaymentSheetPaymentMethodCard.setupIntent],
           "Newly added payment sheet card still selected even on errored backing."
         )
       self.reloadPaymentMethodsSelectedCard


### PR DESCRIPTION
# 📲 What

A bug was found with adding a new payment sheet card on an errored backing, it wasn't being auto-selected. The previous flow did auto-select it.

# 🤔 Why

Preserve existing functionality with add new payment cards, even with errored backings.

# 🛠 How

Removed the conditional logic to deselect the newest payment sheet card if the backing was errorred.

# 👀 See

Before 🐛 

https://user-images.githubusercontent.com/4282741/195655249-441fabbf-3d2f-4824-a8f7-138773c3fd05.MP4

After 🦋

...coming...

# ✅ Acceptance criteria

- [x] Adding a payment sheet card to an errored backing selects that card.

# ⏰ TODO

- [x] Test on device and write unit test.
