### PR TITLE
[Prototype] Replace Backer Dashboard Backed/Saved Tabs With SwiftUI Version

### DIFF
--- a/Kickstarter-iOS/Features/BackerDashboardPages/SwiftUI/BackerDashboardTabView.swift
+++ b/Kickstarter-iOS/Features/BackerDashboardPages/SwiftUI/BackerDashboardTabView.swift
@@ -22,6 +22,7 @@ struct BackerDashboardTabBarView: View {
   }
 
   // MARK: @ViewBuilders
+
   private func TabView(tab: BackerDashboardTab, number: Int) -> some View {
     Button {
       currentTab = tab
@@ -48,7 +49,6 @@ struct BackerDashboardTabBarView: View {
       }
       .animation(.spring(), value: currentTab)
     }
-
   }
 }
 

--- a/Kickstarter-iOS/Features/BackerDashboardPages/SwiftUI/BackerDashboardTabView.swift
+++ b/Kickstarter-iOS/Features/BackerDashboardPages/SwiftUI/BackerDashboardTabView.swift
@@ -1,0 +1,65 @@
+import Library
+import SwiftUI
+
+@available(iOS 15.0, *)
+struct BackerDashboardTabBarView: View {
+  @State var currentTab: BackerDashboardTab = .backed
+  @State var backedProjects: Int
+  @State var savedProjects: Int
+
+  @Namespace var animation
+
+  var selectTab: (BackerDashboardTab) -> ()
+
+  var body: some View {
+    ScrollView(.horizontal, showsIndicators: false) {
+      HStack(spacing: 48) {
+        TabView(tab: .backed, number: backedProjects)
+        TabView(tab: .saved, number: savedProjects)
+      }
+      .padding(.leading, 21)
+    }
+  }
+
+  // MARK: @ViewBuilders
+  private func TabView(tab: BackerDashboardTab, number: Int) -> some View {
+    Button {
+      currentTab = tab
+      selectTab(currentTab)
+    } label: {
+      VStack(alignment: .leading) {
+        Text("\(number)\n\(tab.rawValue)")
+          .font(.system(size: 13))
+          .fontWeight(.semibold)
+          .multilineTextAlignment(.leading)
+          .foregroundColor(currentTab == tab ? .black : .gray)
+          .padding(.bottom, 15)
+
+        if currentTab == tab {
+          Capsule()
+            .fill(.black)
+            .matchedGeometryEffect(id: animation.self, in: animation, properties: .frame)
+            .frame(height: 2)
+        } else {
+          Capsule()
+            .fill(.clear)
+            .frame(height: 2)
+        }
+      }
+      .animation(.spring(), value: currentTab)
+    }
+
+  }
+}
+
+@available(iOS 15.0, *)
+struct BackerDashboardTabBar_Previews: PreviewProvider {
+  static var previews: some View {
+    BackerDashboardTabBarView(
+      backedProjects: 0,
+      savedProjects: 0,
+      selectTab: { _ in }
+    )
+    .previewLayout(.sizeThatFits)
+  }
+}

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -500,6 +500,7 @@
 		60DA510F28C7E04B002E2DF1 /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 60DA510E28C7E04B002E2DF1 /* Kingfisher */; };
 		60DA511428C96A65002E2DF1 /* SwiftSoup in Frameworks */ = {isa = PBXBuildFile; productRef = 60DA511328C96A65002E2DF1 /* SwiftSoup */; };
 		60EAD1C728D25A36009F9474 /* AppCenterDistribute in Frameworks */ = {isa = PBXBuildFile; productRef = 60EAD1C628D25A36009F9474 /* AppCenterDistribute */; };
+		60FE36842A2A2B1A002764D6 /* BackerDashboardTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60FE36822A2A2B08002764D6 /* BackerDashboardTabView.swift */; };
 		701160D4291ECB9F0095BF24 /* LoadingBarButtonItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 701160D2291ECB250095BF24 /* LoadingBarButtonItem.swift */; };
 		70495690299D53ED00B273DF /* SnapshotTesting in Frameworks */ = {isa = PBXBuildFile; productRef = 7049568F299D53ED00B273DF /* SnapshotTesting */; };
 		7061848B29BE4CD8008F9941 /* MessageBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7061848829BE4C11008F9941 /* MessageBannerView.swift */; };
@@ -2076,6 +2077,7 @@
 		608E7A5428ABE27400289E92 /* SetYourPasswordViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetYourPasswordViewModel.swift; sourceTree = "<group>"; };
 		60DA50E928B68990002E2DF1 /* SetYourPasswordViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetYourPasswordViewModelTests.swift; sourceTree = "<group>"; };
 		60DA50EF28B69534002E2DF1 /* SetYourPasswordViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetYourPasswordViewControllerTests.swift; sourceTree = "<group>"; };
+		60FE36822A2A2B08002764D6 /* BackerDashboardTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackerDashboardTabView.swift; sourceTree = "<group>"; };
 		701160D2291ECB250095BF24 /* LoadingBarButtonItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingBarButtonItem.swift; sourceTree = "<group>"; };
 		7061848829BE4C11008F9941 /* MessageBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageBannerView.swift; sourceTree = "<group>"; };
 		7061848C29BE577B008F9941 /* MessageBannerViewViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageBannerViewViewModel.swift; sourceTree = "<group>"; };
@@ -4952,6 +4954,7 @@
 		19A97CE428C7DC1C0031B857 /* BackerDashboardPages */ = {
 			isa = PBXGroup;
 			children = (
+				60FE36812A2A2ADD002764D6 /* SwiftUI */,
 				1937A72B28C95C2D00DD732D /* Views */,
 				19A97CE528C7DD260031B857 /* Controller */,
 				19A97CE628C7DD2F0031B857 /* Storyboard */,
@@ -5785,6 +5788,14 @@
 				70B1889329A521000004E293 /* FacebookResetPasswordViewControllerTests.swift */,
 			);
 			path = Controller;
+			sourceTree = "<group>";
+		};
+		60FE36812A2A2ADD002764D6 /* SwiftUI */ = {
+			isa = PBXGroup;
+			children = (
+				60FE36822A2A2B08002764D6 /* BackerDashboardTabView.swift */,
+			);
+			path = SwiftUI;
 			sourceTree = "<group>";
 		};
 		7061848A29BE4C1E008F9941 /* Views */ = {
@@ -8348,6 +8359,7 @@
 				774F8D5B22B1B0B300A1ACD5 /* FeatureFlagToolsViewController.swift in Sources */,
 				7754A0AE215A8361003AA36D /* ChangePasswordViewController.swift in Sources */,
 				608E7A5328ABDBAE00289E92 /* SetYourPasswordViewController.swift in Sources */,
+				60FE36842A2A2B1A002764D6 /* BackerDashboardTabView.swift in Sources */,
 				A72C3AB71D00FB1F0075227E /* DiscoveryExpandedSelectableRow.swift in Sources */,
 				063D2D0A2846767F00CEDE33 /* PledgeLocalPickupView.swift in Sources */,
 				37059843226F79A700BDA6E3 /* PledgeShippingLocationViewController.swift in Sources */,

--- a/Library/ViewModels/BackerDashboardViewModel.swift
+++ b/Library/ViewModels/BackerDashboardViewModel.swift
@@ -3,7 +3,7 @@ import Prelude
 import ReactiveSwift
 import UIKit
 
-public enum BackerDashboardTab {
+public enum BackerDashboardTab: String {
   case backed
   case saved
 


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

As we consider integrating SwiftUI into our iOS app, I'd like to get a feel for how this would work myself in an effort to provide more useful feedback and understand the pros/cons. 

There's an existing prototype PR for replacing an entire screen [here](https://github.com/kickstarter/ios-oss/pull/1750), so for this PR I wanted to work through a slightly different context...
1. How does a piecemeal approach look?
2. How can we replace a UIKit view that exists inside of a storyboard with a SwiftUI view. 

# 🤔 Why

Check out this [doc](https://kickstarter.atlassian.net/l/cp/a96RSutZ) for more info on why SwiftUI could benefit KS.

# 🛠 How
There are a couple of ways to approach this. 
1. We could embed a `UIHostingViewController` directly into the storyboard via AutoLayout and a IBASegueAction. 
2. To do so programmatically.
   - I chose to this approach so that it would be easier to manage injecting the right properties into this new SwiftUI View

- Replaces the "backed" and "saved" tabs within `BackerDasboardViewController` with a new `BackerDashboardTabBarView` (SwiftUI code)
- This new SwiftUI view is embedded in a `UIHostingViewController` and added programmatically to this ViewController 
- The UIKit tabs and selectedTabIndicator are removed from the storyboard and swift code. 

# 👀 See

UIKit 🐛 

https://user-images.githubusercontent.com/110618242/199745647-f1e37fe1-3283-44e7-8d1c-ef5dc698e286.mp4


SwiftUI 🦋

https://user-images.githubusercontent.com/110618242/199749402-a69cca28-b84f-4068-af84-87e03aa8ee59.mp4


# ✅ Acceptance criteria

- [x] Replaces the "backed" and "saved" tabs within `BackerDasboardViewController` with a new SwiftUI `BackerDashboardTabBarView`  

# ⏰ TODO
- [ ] Refactor ReactiveSwift code for showing backed/saved projects, or empty states, based on selected tab using Combine
- [ ] Add accessibility labels
