### PR TITLE
[Unticketed] user needs_password not returned in v1/discover/ creator

### DIFF
--- a/Kickstarter-iOS/Features/LoginTout/Controller/LoginToutViewController.swift
+++ b/Kickstarter-iOS/Features/LoginTout/Controller/LoginToutViewController.swift
@@ -200,7 +200,8 @@ public final class LoginToutViewController: UIViewController, MFMailComposeViewC
         AppEnvironment.login(accessTokenEnv)
 
         guard featureFacebookLoginDeprecationEnabled(),
-          accessTokenEnv.user.needsPassword else {
+          let needsPassword = accessTokenEnv.user.needsPassword,
+          needsPassword else {
           strongSelf.pushSetYourPasswordViewController()
 
           return

--- a/KsApi/models/User.swift
+++ b/KsApi/models/User.swift
@@ -162,7 +162,7 @@ extension User: EncodableType {
     result["is_friend"] = self.isFriend ?? false
     result["location"] = self.location?.encode()
     result["name"] = self.name
-    result["needs_password"] = self.needsPassword
+    result["needs_password"] = self.needsPassword ?? false
     result["opted_out_of_recommendations"] = self.optedOutOfRecommendations ?? false
     result["social"] = self.social ?? false
     result["show_public_profile"] = self.showPublicProfile ?? false

--- a/KsApi/models/User.swift
+++ b/KsApi/models/User.swift
@@ -11,7 +11,7 @@ public struct User {
   public var location: Location?
   public var name: String
   public var needsFreshFacebookToken: Bool?
-  public var needsPassword: Bool
+  public var needsPassword: Bool?
   public var newsletters: NewsletterSubscriptions
   public var notifications: Notifications
   public var optedOutOfRecommendations: Bool?
@@ -122,7 +122,7 @@ extension User: Decodable {
     self.location = try? values.decodeIfPresent(Location.self, forKey: .location)
     self.name = try values.decode(String.self, forKey: .name)
     self.needsFreshFacebookToken = try values.decodeIfPresent(Bool.self, forKey: .needsFreshFacebookToken)
-    self.needsPassword = try values.decode(Bool.self, forKey: .needsPassword)
+    self.needsPassword = try values.decodeIfPresent(Bool.self, forKey: .needsPassword)
     self.newsletters = try User.NewsletterSubscriptions(from: decoder)
     self.notifications = try User.Notifications(from: decoder)
     self.optedOutOfRecommendations = try values.decodeIfPresent(Bool.self, forKey: .optedOutOfRecommendations)

--- a/KsApi/models/UserTests.swift
+++ b/KsApi/models/UserTests.swift
@@ -64,7 +64,7 @@ final class UserTests: XCTestCase {
     XCTAssertEqual(true, user.notifications.mobileMarketingUpdate)
     XCTAssertEqual(false, user.facebookConnected)
     XCTAssertEqual(false, user.isEmailVerified)
-    XCTAssertTrue(user.needsPassword)
+    XCTAssertTrue(user.needsPassword!)
     XCTAssertEqual(false, user.isFriend)
     XCTAssertNotNil(user.location)
     XCTAssertEqual(json as NSDictionary?, user.encode() as NSDictionary?)


### PR DESCRIPTION
# 📲 What

Noticed a small regression in [web-666](https://github.com/kickstarter/ios-oss/pull/1755/files#diff-5dc87b11382b334c49b55e40127334addd07f9e644760491481746b017a87369R14) where `User.needsPassword` was documented as being non-optional in the v1 swagger [docs](https://staging.kickstarter.com/admin/api-docs/index.html) but in other v1 calls that return a user object the field is missing entirely.

Example:
`/v1/discover?client_id=1HP13YYFC4N278H30RJYKPAQR3H8KK4SF6IWI0JPXHPRP46VWN&currency=USD&sort=magic`

```
		"creator": {
			"id": 357970774,
			"name": "Rebecca Lemme",
			"slug": "actsofmatter",
			"is_registered": null,
			"is_email_verified": null,
			"chosen_currency": null,
			"is_superbacker": null,
			"avatar": {
				"thumb": "https://ksr-ugc.imgix.net/",
				"small": "https://ksr-ugc.imgix.net/",
				"medium": "https://ksr-ugc.imgix.net/"
			},
			"urls": {
				"web": {
					"user": "https://www.kickstarter.com/profile/actsofmatter"
				},
				"api": {
					"user": "https://api.kickstarter.com/v1/users/357970774?signature=1669755294.e10ce7f978c62fa789273d34c52089a8c49f0232"
				}
			}
		},
```

# 🤔 Why

v1 API is seemingly not well documented which makes sense given it is being phased out.

# 🛠 How

Made the `User.needsPassword` property optional.

# 👀 See

Trello, screenshots, external resources?

| Before 🐛 | After 🦋 |
| --- | --- |
| ![Simulator Screen Recording - iPhone 8 - 2022-11-28 at 16 06 27](https://user-images.githubusercontent.com/4282741/204381211-bce650b2-598f-4474-b54c-71d296ba1b4f.gif) | ![Simulator Screen Recording - iPhone 8 - 2022-11-28 at 16 16 11](https://user-images.githubusercontent.com/4282741/204382658-650c21a7-0741-4993-a27d-d9fcef7589b2.gif) |

# ✅ Acceptance criteria

- [x] Ensure projects load when app is opened (ie. `v1/discover/`)

# ⏰ TODO

- [x] Ensure tests pass
