### PR TITLE
[NTV-636] Regression: Crash when logging out of creator account and switching tabs 5.6.0

### DIFF
--- a/Library/ViewModels/RootViewModel.swift
+++ b/Library/ViewModels/RootViewModel.swift
@@ -338,7 +338,11 @@ public final class RootViewModel: RootViewModelType, RootViewModelInputs, RootVi
 
     let prevSelectedTabBarItem = Signal
       .combineLatest(prevSelectedIndex, self.tabBarItemsData)
-      .map { index, data in tabBarItemLabel(for: data.items[index]) }
+      .map { (index, data) -> KSRAnalytics.TabBarItemLabel in
+        guard index < data.items.count else { return tabBarItemLabel(for: data.items[0]) }
+
+        return tabBarItemLabel(for: data.items[index])
+      }
 
     let searchTabBarSelected = Signal
       .combineLatest(self.didSelectIndexProperty.signal, self.tabBarItemsData)


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

A crash was found during 5.6.0 regression testing when switching tabs after logging and then out of a creator account. More info [here](https://kickstarter.atlassian.net/wiki/spaces/NT/pages/edit-v2/2210562056)

# 🤔 Why

This is an index out of range crash when selecting a new tab.

When a creator logs out our RootTabBar immediately updates its tabs/indices. There is a bit of a race condition where the RootViewModel attempts to set athe`prevSelectedTabBarItem` property before it recognizes that the user is no longer a signed in creator. Since creators see 1 more tab than logged out or backers (5 in total), the last selected item is technically out of range. 

# 🛠 How

Added 
`guard index < data.items.count else { return tabBarItemLabel(for: data.items[0]) }` 
to`prevSelectedTabBarItem`'s signal chain to protect against this race condition.

So if this happens we’ll programmatically select the first tab, “Explore”, by default which is what we want anyway.


# ✅ Acceptance criteria

- [x] After logging out of a creator account you should be able to switch between tabs without a crash both when logged in as a back and as a non logged in member.