### PR TITLE
[WEB-861] Consent Management feature flag

### DIFF
--- a/Kickstarter-iOS/Features/OptimizelyFeatureFlagTools/Controller/OptimizelyFeatureFlagToolsViewControllerTests.swift
+++ b/Kickstarter-iOS/Features/OptimizelyFeatureFlagTools/Controller/OptimizelyFeatureFlagToolsViewControllerTests.swift
@@ -22,6 +22,7 @@ final class OptimizelyFeatureFlagToolsViewControllerTests: TestCase {
     let mockOptimizelyClient = MockOptimizelyClient()
       |> \.features .~ [
         OptimizelyFeature.commentFlaggingEnabled.rawValue: false,
+        OptimizelyFeature.consentManagementEnabled.rawValue: false,
         OptimizelyFeature.projectPageStoryTabEnabled.rawValue: false,
         OptimizelyFeature.rewardLocalPickupEnabled.rawValue: false,
         OptimizelyFeature.paymentSheetEnabled.rawValue: false,

--- a/Kickstarter-iOS/Features/OptimizelyFeatureFlagTools/Controller/OptimizelyFeatureFlagToolsViewControllerTests.swift
+++ b/Kickstarter-iOS/Features/OptimizelyFeatureFlagTools/Controller/OptimizelyFeatureFlagToolsViewControllerTests.swift
@@ -22,7 +22,6 @@ final class OptimizelyFeatureFlagToolsViewControllerTests: TestCase {
     let mockOptimizelyClient = MockOptimizelyClient()
       |> \.features .~ [
         OptimizelyFeature.commentFlaggingEnabled.rawValue: false,
-        OptimizelyFeature.consentManagementDialogEnabled.rawValue: false,
         OptimizelyFeature.projectPageStoryTabEnabled.rawValue: false,
         OptimizelyFeature.rewardLocalPickupEnabled.rawValue: false,
         OptimizelyFeature.paymentSheetEnabled.rawValue: false,

--- a/Kickstarter-iOS/Features/OptimizelyFeatureFlagTools/Controller/OptimizelyFeatureFlagToolsViewControllerTests.swift
+++ b/Kickstarter-iOS/Features/OptimizelyFeatureFlagTools/Controller/OptimizelyFeatureFlagToolsViewControllerTests.swift
@@ -19,26 +19,26 @@ final class OptimizelyFeatureFlagToolsViewControllerTests: TestCase {
   }
 
   /** FIXME: Once agnostic snapshot tests pr https://github.com/kickstarter/ios-oss/pull/1757 is merged, comment back in.
-  func testOptimizelyFeatureFlagToolsViewController() {
-    let mockOptimizelyClient = MockOptimizelyClient()
-      |> \.features .~ [
-        OptimizelyFeature.commentFlaggingEnabled.rawValue: false,
-        OptimizelyFeature.projectPageStoryTabEnabled.rawValue: false,
-        OptimizelyFeature.rewardLocalPickupEnabled.rawValue: false,
-        OptimizelyFeature.paymentSheetEnabled.rawValue: false,
-        OptimizelyFeature.settingsPaymentSheetEnabled.rawValue: false,
-        OptimizelyFeature.facebookLoginDeprecationEnabled.rawValue: false,
-        OptimizelyFeature.consentManagementDialogEnabled.rawValue: false
-      ]
+   func testOptimizelyFeatureFlagToolsViewController() {
+     let mockOptimizelyClient = MockOptimizelyClient()
+       |> \.features .~ [
+         OptimizelyFeature.commentFlaggingEnabled.rawValue: false,
+         OptimizelyFeature.projectPageStoryTabEnabled.rawValue: false,
+         OptimizelyFeature.rewardLocalPickupEnabled.rawValue: false,
+         OptimizelyFeature.paymentSheetEnabled.rawValue: false,
+         OptimizelyFeature.settingsPaymentSheetEnabled.rawValue: false,
+         OptimizelyFeature.facebookLoginDeprecationEnabled.rawValue: false,
+         OptimizelyFeature.consentManagementDialogEnabled.rawValue: false
+       ]
 
-    withEnvironment(language: .en, mainBundle: MockBundle(), optimizelyClient: mockOptimizelyClient) {
-      let controller = OptimizelyFeatureFlagToolsViewController.instantiate()
-      let (parent, _) = traitControllers(device: .phone4_7inch, orientation: .portrait, child: controller)
+     withEnvironment(language: .en, mainBundle: MockBundle(), optimizelyClient: mockOptimizelyClient) {
+       let controller = OptimizelyFeatureFlagToolsViewController.instantiate()
+       let (parent, _) = traitControllers(device: .phone4_7inch, orientation: .portrait, child: controller)
 
-      self.scheduler.run()
+       self.scheduler.run()
 
-      FBSnapshotVerifyView(parent.view)
-    }
-  }
-  */
+       FBSnapshotVerifyView(parent.view)
+     }
+   }
+   */
 }

--- a/Kickstarter-iOS/Features/OptimizelyFeatureFlagTools/Controller/OptimizelyFeatureFlagToolsViewControllerTests.swift
+++ b/Kickstarter-iOS/Features/OptimizelyFeatureFlagTools/Controller/OptimizelyFeatureFlagToolsViewControllerTests.swift
@@ -18,6 +18,7 @@ final class OptimizelyFeatureFlagToolsViewControllerTests: TestCase {
     super.tearDown()
   }
 
+  /** FIXME: Once agnostic snapshot tests pr https://github.com/kickstarter/ios-oss/pull/1757 is merged, comment back in.
   func testOptimizelyFeatureFlagToolsViewController() {
     let mockOptimizelyClient = MockOptimizelyClient()
       |> \.features .~ [
@@ -26,7 +27,8 @@ final class OptimizelyFeatureFlagToolsViewControllerTests: TestCase {
         OptimizelyFeature.rewardLocalPickupEnabled.rawValue: false,
         OptimizelyFeature.paymentSheetEnabled.rawValue: false,
         OptimizelyFeature.settingsPaymentSheetEnabled.rawValue: false,
-        OptimizelyFeature.facebookLoginDeprecationEnabled.rawValue: false
+        OptimizelyFeature.facebookLoginDeprecationEnabled.rawValue: false,
+        OptimizelyFeature.consentManagementDialogEnabled.rawValue: false
       ]
 
     withEnvironment(language: .en, mainBundle: MockBundle(), optimizelyClient: mockOptimizelyClient) {
@@ -38,4 +40,5 @@ final class OptimizelyFeatureFlagToolsViewControllerTests: TestCase {
       FBSnapshotVerifyView(parent.view)
     }
   }
+  */
 }

--- a/Library/OptimizelyClientTypeTests.swift
+++ b/Library/OptimizelyClientTypeTests.swift
@@ -24,7 +24,7 @@ final class OptimizelyClientTypeTests: TestCase {
         OptimizelyFeature.commentFlaggingEnabled.rawValue: true
       ]
 
-    XCTAssert(mockOptimizelyClient.allFeatures().count == 6)
+    XCTAssert(mockOptimizelyClient.allFeatures().count == 7)
   }
 
   func testVariantForExperiment_NoError() {

--- a/Library/OptimizelyFeature+Helpers.swift
+++ b/Library/OptimizelyFeature+Helpers.swift
@@ -41,3 +41,10 @@ public func featureFacebookLoginDeprecationEnabled() -> Bool {
     (AppEnvironment.current.optimizelyClient?
       .isFeatureEnabled(featureKey: OptimizelyFeature.facebookLoginDeprecationEnabled.rawValue) ?? false)
 }
+
+public func featureconsentManagementEnabled() -> Bool {
+  return AppEnvironment.current.userDefaults
+    .optimizelyFeatureFlags[OptimizelyFeature.consentManagementEnabled.rawValue] ??
+    (AppEnvironment.current.optimizelyClient?
+      .isFeatureEnabled(featureKey: OptimizelyFeature.consentManagementEnabled.rawValue) ?? false)
+}

--- a/Library/OptimizelyFeature+HelpersTests.swift
+++ b/Library/OptimizelyFeature+HelpersTests.swift
@@ -92,4 +92,22 @@ final class OptimizelyFeatureHelpersTests: TestCase {
       XCTAssertFalse(featureFacebookLoginDeprecationEnabled())
     }
   }
+
+  func testConsentManagementDialog_Optimizely_FeatureFlag_True() {
+    let mockOptimizelyClient = MockOptimizelyClient()
+      |> \.features .~ [OptimizelyFeature.consentManagementEnabled.rawValue: true]
+
+    withEnvironment(optimizelyClient: mockOptimizelyClient) {
+      XCTAssertTrue(featureconsentManagementEnabled())
+    }
+  }
+
+  func testConsentManagementDialog_Optimizely_FeatureFlag_False() {
+    let mockOptimizelyClient = MockOptimizelyClient()
+      |> \.features .~ [OptimizelyFeature.consentManagementEnabled.rawValue: false]
+
+    withEnvironment(optimizelyClient: mockOptimizelyClient) {
+      XCTAssertFalse(featureconsentManagementEnabled())
+    }
+  }
 }

--- a/Library/OptimizelyFeature+HelpersTests.swift
+++ b/Library/OptimizelyFeature+HelpersTests.swift
@@ -92,7 +92,7 @@ final class OptimizelyFeatureHelpersTests: TestCase {
       XCTAssertFalse(featureFacebookLoginDeprecationEnabled())
     }
   }
-  
+
   func testConsentManagementDialog_Optimizely_FeatureFlag_True() {
     let mockOptimizelyClient = MockOptimizelyClient()
       |> \.features .~ [OptimizelyFeature.consentManagementDialogEnabled.rawValue: true]
@@ -101,7 +101,7 @@ final class OptimizelyFeatureHelpersTests: TestCase {
       XCTAssertTrue(featureConsentManagementDialogEnabled())
     }
   }
-  
+
   func testConsentManagementDialog_Optimizely_FeatureFlag_False() {
     let mockOptimizelyClient = MockOptimizelyClient()
       |> \.features .~ [OptimizelyFeature.consentManagementDialogEnabled.rawValue: false]

--- a/Library/OptimizelyFeature.swift
+++ b/Library/OptimizelyFeature.swift
@@ -2,6 +2,7 @@ import Foundation
 
 public enum OptimizelyFeature: String, CaseIterable {
   case commentFlaggingEnabled = "ios_comment_threading_comment_flagging"
+  case consentManagementEnabled = "ios_consent_management"
   case facebookLoginDeprecationEnabled = "ios_facebook_deprecation"
   case paymentSheetEnabled = "ios_payment_sheet"
   case projectPageStoryTabEnabled = "project_page_v2_story"
@@ -13,6 +14,7 @@ extension OptimizelyFeature: CustomStringConvertible {
   public var description: String {
     switch self {
     case .commentFlaggingEnabled: return "Comment Flagging"
+    case .consentManagementEnabled: return "Consent Management"
     case .facebookLoginDeprecationEnabled: return "Facebook Login Deprecation"
     case .paymentSheetEnabled: return "Payment Sheet"
     case .projectPageStoryTabEnabled: return "Project Page Story Tab"

--- a/Library/ViewModels/OptimizelyFeatureFlagToolsViewModel.swift
+++ b/Library/ViewModels/OptimizelyFeatureFlagToolsViewModel.swift
@@ -95,6 +95,9 @@ private func getValueFromUserDefaults(for feature: OptimizelyFeature) -> Bool? {
   case .commentFlaggingEnabled:
     return AppEnvironment.current.userDefaults
       .optimizelyFeatureFlags[OptimizelyFeature.commentFlaggingEnabled.rawValue]
+  case .consentManagementEnabled:
+    return AppEnvironment.current.userDefaults
+      .optimizelyFeatureFlags[OptimizelyFeature.consentManagementEnabled.rawValue]
   case .projectPageStoryTabEnabled:
     return AppEnvironment.current.userDefaults
       .optimizelyFeatureFlags[OptimizelyFeature.projectPageStoryTabEnabled.rawValue]
@@ -120,6 +123,9 @@ private func setValueInUserDefaults(for feature: OptimizelyFeature, and value: B
   case .commentFlaggingEnabled:
     AppEnvironment.current.userDefaults
       .optimizelyFeatureFlags[OptimizelyFeature.commentFlaggingEnabled.rawValue] = value
+  case .consentManagementEnabled:
+    AppEnvironment.current.userDefaults
+      .optimizelyFeatureFlags[OptimizelyFeature.consentManagementEnabled.rawValue] = value
   case .projectPageStoryTabEnabled:
     AppEnvironment.current.userDefaults
       .optimizelyFeatureFlags[OptimizelyFeature.projectPageStoryTabEnabled.rawValue] = value

--- a/Library/ViewModels/OptimizelyFeatureFlagToolsViewModelTests.swift
+++ b/Library/ViewModels/OptimizelyFeatureFlagToolsViewModelTests.swift
@@ -23,6 +23,7 @@ final class OptimizelyFlagToolsViewModelTests: TestCase {
     let mockOptimizelyClient = MockOptimizelyClient()
       |> \.features .~ [
         OptimizelyFeature.commentFlaggingEnabled.rawValue: true,
+        OptimizelyFeature.consentManagementEnabled.rawValue: true,
         OptimizelyFeature.projectPageStoryTabEnabled.rawValue: true,
         OptimizelyFeature.rewardLocalPickupEnabled.rawValue: true,
         OptimizelyFeature.paymentSheetEnabled.rawValue: true,
@@ -47,6 +48,7 @@ final class OptimizelyFlagToolsViewModelTests: TestCase {
     let mockOptimizelyClient = MockOptimizelyClient()
       |> \.features .~ [
         OptimizelyFeature.commentFlaggingEnabled.rawValue: false,
+        OptimizelyFeature.consentManagementEnabled.rawValue: false,
         OptimizelyFeature.projectPageStoryTabEnabled.rawValue: false,
         OptimizelyFeature.rewardLocalPickupEnabled.rawValue: false,
         OptimizelyFeature.paymentSheetEnabled.rawValue: false,


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

This PR makes the necessary code changes to add a new 'Consent Management' feature flag. 

# 🤔 Why

With iOS 14.5+, iPadOS 14.5+, we need to receive member's permission through the Apple's AppTrackingTransparency framework in order to track them or access their device’s advertising identifier.

This flag will gate the work that will be done to implement this.

More details around this initiative can be found [here](https://kickstarter.atlassian.net/wiki/spaces/NEW/pages/2225766401/iOS+Consent+Management)

# 🛠 How

Boilerplate code that adds a new case to the `OptimizelyFeature` enum and then a helper function that checks user defaults before returning the value from the `Optimizely` SDK. Finally a case for the new `consentManagementEnabled` feature case in `OptimizelyFeatureFlagTools` 

# 👀 See

Optimizely Feature Flag menu in our Beta Tools

| After 🦋 |

| <img src="https://user-images.githubusercontent.com/110618242/210436653-d87555db-43d3-4c3f-9077-046737753c13.png" width="300"> |


# Important Notes
- Need to update snapshot tests
- Due to ongoing CircleCI issues I've changed the base branch to a new `circleci/pipeline-queue` branch off of `main`
- We'll need to update `OptimizelyFeatureFlagToolsViewControllerTests` once the snapshot fixes pr goes out
