### PR TITLE
[WEB-669] Facebook Conversions API Feature Flag

### DIFF
--- a/Library/OptimizelyClientTypeTests.swift
+++ b/Library/OptimizelyClientTypeTests.swift
@@ -24,7 +24,7 @@ final class OptimizelyClientTypeTests: TestCase {
         OptimizelyFeature.commentFlaggingEnabled.rawValue: true
       ]
 
-    XCTAssert(mockOptimizelyClient.allFeatures().count == 7)
+    XCTAssert(mockOptimizelyClient.allFeatures().count == 8)
   }
 
   func testVariantForExperiment_NoError() {

--- a/Library/OptimizelyFeature+Helpers.swift
+++ b/Library/OptimizelyFeature+Helpers.swift
@@ -48,3 +48,10 @@ public func featureConsentManagementDialogEnabled() -> Bool {
     (AppEnvironment.current.optimizelyClient?
       .isFeatureEnabled(featureKey: OptimizelyFeature.consentManagementDialogEnabled.rawValue) ?? false)
 }
+
+public func featureFacebookConversionsAPIEnabled() -> Bool {
+  return AppEnvironment.current.userDefaults
+    .optimizelyFeatureFlags[OptimizelyFeature.facebookConversionsAPI.rawValue] ??
+    (AppEnvironment.current.optimizelyClient?
+      .isFeatureEnabled(featureKey: OptimizelyFeature.facebookConversionsAPI.rawValue) ?? false)
+}

--- a/Library/OptimizelyFeature+HelpersTests.swift
+++ b/Library/OptimizelyFeature+HelpersTests.swift
@@ -110,4 +110,22 @@ final class OptimizelyFeatureHelpersTests: TestCase {
       XCTAssertFalse(featureConsentManagementDialogEnabled())
     }
   }
+  
+  func testFacebookConversionsAPI_Optimizely_FeatureFlag_True() {
+    let mockOptimizelyClient = MockOptimizelyClient()
+      |> \.features .~ [OptimizelyFeature.facebookConversionsAPI.rawValue: true]
+
+    withEnvironment(optimizelyClient: mockOptimizelyClient) {
+      XCTAssertTrue(featureFacebookConversionsAPIEnabled())
+    }
+  }
+
+  func testFacebookConversionsAPI_Optimizely_FeatureFlag_False() {
+    let mockOptimizelyClient = MockOptimizelyClient()
+      |> \.features .~ [OptimizelyFeature.facebookConversionsAPI.rawValue: false]
+
+    withEnvironment(optimizelyClient: mockOptimizelyClient) {
+      XCTAssertFalse(featureFacebookConversionsAPIEnabled())
+    }
+  }
 }

--- a/Library/OptimizelyFeature+HelpersTests.swift
+++ b/Library/OptimizelyFeature+HelpersTests.swift
@@ -110,7 +110,7 @@ final class OptimizelyFeatureHelpersTests: TestCase {
       XCTAssertFalse(featureConsentManagementDialogEnabled())
     }
   }
-  
+
   func testFacebookConversionsAPI_Optimizely_FeatureFlag_True() {
     let mockOptimizelyClient = MockOptimizelyClient()
       |> \.features .~ [OptimizelyFeature.facebookConversionsAPI.rawValue: true]

--- a/Library/OptimizelyFeature.swift
+++ b/Library/OptimizelyFeature.swift
@@ -3,6 +3,7 @@ import Foundation
 public enum OptimizelyFeature: String, CaseIterable {
   case commentFlaggingEnabled = "ios_comment_threading_comment_flagging"
   case consentManagementDialogEnabled = "ios_consent_management_dialog"
+  case facebookConversionsAPI = "ios_facebook_conversions_api"
   case facebookLoginDeprecationEnabled = "ios_facebook_deprecation"
   case paymentSheetEnabled = "ios_payment_sheet"
   case projectPageStoryTabEnabled = "project_page_v2_story"
@@ -15,6 +16,7 @@ extension OptimizelyFeature: CustomStringConvertible {
     switch self {
     case .commentFlaggingEnabled: return "Comment Flagging"
     case .consentManagementDialogEnabled: return "Consent Management Dialog"
+    case .facebookConversionsAPI: return "Facebook Conversions API"
     case .facebookLoginDeprecationEnabled: return "Facebook Login Deprecation"
     case .paymentSheetEnabled: return "Payment Sheet"
     case .projectPageStoryTabEnabled: return "Project Page Story Tab"

--- a/Library/ViewModels/OptimizelyFeatureFlagToolsViewModel.swift
+++ b/Library/ViewModels/OptimizelyFeatureFlagToolsViewModel.swift
@@ -110,6 +110,9 @@ private func getValueFromUserDefaults(for feature: OptimizelyFeature) -> Bool? {
   case .settingsPaymentSheetEnabled:
     return AppEnvironment.current.userDefaults
       .optimizelyFeatureFlags[OptimizelyFeature.settingsPaymentSheetEnabled.rawValue]
+  case .facebookConversionsAPI:
+    return AppEnvironment.current.userDefaults
+      .optimizelyFeatureFlags[OptimizelyFeature.facebookConversionsAPI.rawValue]
   case .facebookLoginDeprecationEnabled:
     return AppEnvironment.current.userDefaults
       .optimizelyFeatureFlags[OptimizelyFeature.facebookLoginDeprecationEnabled.rawValue]
@@ -138,6 +141,9 @@ private func setValueInUserDefaults(for feature: OptimizelyFeature, and value: B
   case .settingsPaymentSheetEnabled:
     return AppEnvironment.current.userDefaults
       .optimizelyFeatureFlags[OptimizelyFeature.settingsPaymentSheetEnabled.rawValue] = value
+  case .facebookConversionsAPI:
+    return AppEnvironment.current.userDefaults
+      .optimizelyFeatureFlags[OptimizelyFeature.facebookConversionsAPI.rawValue] = value
   case .facebookLoginDeprecationEnabled:
     return AppEnvironment.current.userDefaults
       .optimizelyFeatureFlags[OptimizelyFeature.facebookLoginDeprecationEnabled.rawValue] = value

--- a/Library/ViewModels/OptimizelyFeatureFlagToolsViewModelTests.swift
+++ b/Library/ViewModels/OptimizelyFeatureFlagToolsViewModelTests.swift
@@ -54,7 +54,7 @@ final class OptimizelyFlagToolsViewModelTests: TestCase {
         OptimizelyFeature.rewardLocalPickupEnabled.rawValue: false,
         OptimizelyFeature.paymentSheetEnabled.rawValue: false,
         OptimizelyFeature.settingsPaymentSheetEnabled.rawValue: false,
-        OptimizelyFeature.facebookConversionsAPI.rawValue: true,
+        OptimizelyFeature.facebookConversionsAPI.rawValue: false,
         OptimizelyFeature.facebookLoginDeprecationEnabled.rawValue: false
       ]
 

--- a/Library/ViewModels/OptimizelyFeatureFlagToolsViewModelTests.swift
+++ b/Library/ViewModels/OptimizelyFeatureFlagToolsViewModelTests.swift
@@ -28,6 +28,7 @@ final class OptimizelyFlagToolsViewModelTests: TestCase {
         OptimizelyFeature.rewardLocalPickupEnabled.rawValue: true,
         OptimizelyFeature.paymentSheetEnabled.rawValue: true,
         OptimizelyFeature.settingsPaymentSheetEnabled.rawValue: true,
+        OptimizelyFeature.facebookConversionsAPI.rawValue: true,
         OptimizelyFeature.facebookLoginDeprecationEnabled.rawValue: true
       ]
 
@@ -53,6 +54,7 @@ final class OptimizelyFlagToolsViewModelTests: TestCase {
         OptimizelyFeature.rewardLocalPickupEnabled.rawValue: false,
         OptimizelyFeature.paymentSheetEnabled.rawValue: false,
         OptimizelyFeature.settingsPaymentSheetEnabled.rawValue: false,
+        OptimizelyFeature.facebookConversionsAPI.rawValue: true,
         OptimizelyFeature.facebookLoginDeprecationEnabled.rawValue: false
       ]
 


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

This PR makes the necessary code changes to add a new 'Facebook Conversions API' feature flag. 

# 🤔 Why

With iOS 14.5+ Apple requires members to grant permission for apps to track them or access their device’s advertising identifier. This means that facebook app members can choose to "Ask app not to track".

If they do this, the facebook pixel that KS uses won't send or receive tracking data. Instead, we'll need to use their Conversions API to track and send events ourselves. 

More details around this initiative can be found [here](https://kickstarter.atlassian.net/wiki/spaces/NEW/pages/2231762945/iOS+Facebook+Conversion+API)

# 🛠 How

Boilerplate code that adds a new case to the `OptimizelyFeature` enum and then a helper function that checks user defaults before returning the value from the `Optimizely` SDK. Finally a case for the new `facebookConversionsAPI` feature case in `OptimizelyFeatureFlagTools` 

# 👀 See

You can view the new Optimizely flag [here](https://app.optimizely.com/v2/projects/17017800748/features/22854810498/rules)

| After 🦋 |

| <img src="https://user-images.githubusercontent.com/110618242/211857959-bf249714-fbfe-4b42-a7a6-571c671fc806.gif" width="300"> |


# ❗️Important Notes❗️
- Need to update snapshot tests
- Due to ongoing CircleCI issues I've changed the base branch to a new `circleci/pipeline-queue` branch off of `main`
