### PR TITLE
ENV-ize AWS role ARN

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
   codecov: codecov/codecov@1.1.3
 
 aws_cli_setup: &aws_cli_setup
-  role-arn: arn:aws:iam::116278940861:role/circleci-oidc-ios-private
+  role-arn: $AWS_ROLE_ARN
 
 xcode_version: &xcode_version 13.3.1
 iphone_name: &iphone_name iPhone 8


### PR DESCRIPTION
ENV-ize CircleCI IAM role ARN so it can be used in both ios-* repos