### PR TITLE
[WEB-862] AppTrackingTransparency Authorization

### DIFF
--- a/Kickstarter-iOS/AppDelegateViewModel.swift
+++ b/Kickstarter-iOS/AppDelegateViewModel.swift
@@ -798,7 +798,10 @@ public final class AppDelegateViewModel: AppDelegateViewModelType, AppDelegateVi
 
     self.requestATTrackingAuthorizationStatus = self.applicationLaunchOptionsProperty.signal
       .skipNil()
-      .map { _ in atTrackingAuthorizationStatus() }
+      .map { _ -> ATTrackingAuthorizationStatus in
+        guard featureConsentManagementDialogEnabled() else { return .notDetermined }
+        return atTrackingAuthorizationStatus()
+      }
   }
 
   public var inputs: AppDelegateViewModelInputs { return self }
@@ -997,7 +1000,7 @@ private func atTrackingAuthorizationStatus() -> ATTrackingAuthorizationStatus {
       }
     })
   }
-  
+
   return authorizationStatus
 }
 

--- a/Kickstarter-iOS/AppDelegateViewModel.swift
+++ b/Kickstarter-iOS/AppDelegateViewModel.swift
@@ -1,4 +1,5 @@
 import AppboyKit
+import AppTrackingTransparency
 import KsApi
 import Library
 import Prelude
@@ -16,6 +17,12 @@ public enum NotificationAuthorizationStatus {
   case denied
   case notDetermined
   case provisional
+}
+
+public enum ATTrackingAuthorizationStatus {
+  case authorized
+  case denied
+  case notDetermined
 }
 
 public protocol AppDelegateViewModelInputs {
@@ -179,6 +186,9 @@ public protocol AppDelegateViewModelOutputs {
 
   /// Emits when we should register the device push token in Segment Analytics.
   var registerPushTokenInSegment: Signal<Data, Never> { get }
+  
+  /// Emits when  application didFinishLaunchingWithOptions.
+  var requestATTrackingAuthorizationStatus: Signal<ATTrackingAuthorizationStatus, Never> { get }
 
   /// Emits when our config updates with the enabled state for Semgent Analytics.
   var segmentIsEnabled: Signal<Bool, Never> { get }
@@ -785,6 +795,10 @@ public final class AppDelegateViewModel: AppDelegateViewModelType, AppDelegateVi
     self.brazeWillDisplayInAppMessageReturnProperty <~ self.brazeWillDisplayInAppMessageProperty.signal
       .skipNil()
       .map { _ in .displayInAppMessageNow }
+    
+    self.requestATTrackingAuthorizationStatus = self.applicationLaunchOptionsProperty.signal
+      .skipNil()
+      .map { _ in atTrackingAuthorizationStatus() }
   }
 
   public var inputs: AppDelegateViewModelInputs { return self }
@@ -956,6 +970,7 @@ public final class AppDelegateViewModel: AppDelegateViewModelType, AppDelegateVi
   public let pushTokenRegistrationStarted: Signal<(), Never>
   public let pushTokenSuccessfullyRegistered: Signal<String, Never>
   public let registerPushTokenInSegment: Signal<Data, Never>
+  public let requestATTrackingAuthorizationStatus: Signal<ATTrackingAuthorizationStatus, Never>
   public let segmentIsEnabled: Signal<Bool, Never>
   public let setApplicationShortcutItems: Signal<[ShortcutItem], Never>
   public let showAlert: Signal<Notification, Never>
@@ -963,6 +978,27 @@ public final class AppDelegateViewModel: AppDelegateViewModelType, AppDelegateVi
   public let unregisterForRemoteNotifications: Signal<(), Never>
   public let updateCurrentUserInEnvironment: Signal<User, Never>
   public let updateConfigInEnvironment: Signal<Config, Never>
+}
+
+private func atTrackingAuthorizationStatus() -> ATTrackingAuthorizationStatus {
+  var authorizationStatus: ATTrackingAuthorizationStatus = .notDetermined
+  
+  DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+    ATTrackingManager.requestTrackingAuthorization(completionHandler: { status in
+      switch status {
+      case .notDetermined:
+        authorizationStatus = .notDetermined
+      case .authorized:
+        authorizationStatus = .authorized
+      case .denied:
+        authorizationStatus = .denied
+      default:
+        authorizationStatus = .denied
+      }
+    })
+  }
+  
+  return authorizationStatus
 }
 
 /// Handles the deeplink route with both an id and text based name for a deeplink to categories.

--- a/Kickstarter-iOS/AppDelegateViewModel.swift
+++ b/Kickstarter-iOS/AppDelegateViewModel.swift
@@ -792,7 +792,7 @@ public final class AppDelegateViewModel: AppDelegateViewModelType, AppDelegateVi
 
     self.requestATTrackingAuthorizationStatus = self.applicationLaunchOptionsProperty.signal
       .skipNil()
-      .ksr_debounce(.seconds(1), on: AppEnvironment.current.scheduler)
+      .ksr_delay(.seconds(1), on: AppEnvironment.current.scheduler)
       .map { _ -> ATTrackingAuthorizationStatus in
         guard featureConsentManagementDialogEnabled() else { return .notDetermined }
         return atTrackingAuthorizationStatus()

--- a/Kickstarter-iOS/AppDelegateViewModel.swift
+++ b/Kickstarter-iOS/AppDelegateViewModel.swift
@@ -186,7 +186,7 @@ public protocol AppDelegateViewModelOutputs {
 
   /// Emits when we should register the device push token in Segment Analytics.
   var registerPushTokenInSegment: Signal<Data, Never> { get }
-  
+
   /// Emits when  application didFinishLaunchingWithOptions.
   var requestATTrackingAuthorizationStatus: Signal<ATTrackingAuthorizationStatus, Never> { get }
 
@@ -795,7 +795,7 @@ public final class AppDelegateViewModel: AppDelegateViewModelType, AppDelegateVi
     self.brazeWillDisplayInAppMessageReturnProperty <~ self.brazeWillDisplayInAppMessageProperty.signal
       .skipNil()
       .map { _ in .displayInAppMessageNow }
-    
+
     self.requestATTrackingAuthorizationStatus = self.applicationLaunchOptionsProperty.signal
       .skipNil()
       .map { _ in atTrackingAuthorizationStatus() }
@@ -982,7 +982,7 @@ public final class AppDelegateViewModel: AppDelegateViewModelType, AppDelegateVi
 
 private func atTrackingAuthorizationStatus() -> ATTrackingAuthorizationStatus {
   var authorizationStatus: ATTrackingAuthorizationStatus = .notDetermined
-  
+
   DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
     ATTrackingManager.requestTrackingAuthorization(completionHandler: { status in
       switch status {

--- a/Kickstarter-iOS/AppDelegateViewModelTests.swift
+++ b/Kickstarter-iOS/AppDelegateViewModelTests.swift
@@ -3009,7 +3009,11 @@ final class AppDelegateViewModelTests: TestCase {
   }
 
   func testRequestATTrackingAuthorizationStatus_CalledOnceOnDidFinishLaunching() {
+    self.requestATTrackingAuthorizationStatus.assertValueCount(0)
+
     self.vm.inputs.applicationDidFinishLaunching(application: UIApplication.shared, launchOptions: nil)
+
+    self.scheduler.advance(by: .seconds(1))
 
     self.requestATTrackingAuthorizationStatus.assertValueCount(1)
   }

--- a/Kickstarter-iOS/AppDelegateViewModelTests.swift
+++ b/Kickstarter-iOS/AppDelegateViewModelTests.swift
@@ -97,7 +97,8 @@ final class AppDelegateViewModelTests: TestCase {
     self.vm.outputs.pushTokenRegistrationStarted.observe(self.pushRegistrationStarted.observer)
     self.vm.outputs.pushTokenSuccessfullyRegistered.observe(self.pushTokenSuccessfullyRegistered.observer)
     self.vm.outputs.registerPushTokenInSegment.observe(self.registerPushTokenInSegment.observer)
-    self.vm.outputs.requestATTrackingAuthorizationStatus.observe(self.requestATTrackingAuthorizationStatus.observer)
+    self.vm.outputs.requestATTrackingAuthorizationStatus
+      .observe(self.requestATTrackingAuthorizationStatus.observer)
     self.vm.outputs.setApplicationShortcutItems.observe(self.setApplicationShortcutItems.observer)
     self.vm.outputs.showAlert.observe(self.showAlert.observer)
     self.vm.outputs.segmentIsEnabled.observe(self.segmentIsEnabled.observer)
@@ -3006,7 +3007,7 @@ final class AppDelegateViewModelTests: TestCase {
       self.updateCurrentUserInEnvironment.assertValues([user, updatedUser])
     }
   }
-  
+
   func testRequestATTrackingAuthorizationStatus_CalledOnceOnDidFinishLaunching() {
     self.vm.inputs.applicationDidFinishLaunching(application: UIApplication.shared, launchOptions: nil)
 

--- a/Kickstarter-iOS/AppDelegateViewModelTests.swift
+++ b/Kickstarter-iOS/AppDelegateViewModelTests.swift
@@ -42,6 +42,7 @@ final class AppDelegateViewModelTests: TestCase {
   private let pushRegistrationStarted = TestObserver<(), Never>()
   private let pushTokenSuccessfullyRegistered = TestObserver<String, Never>()
   private let registerPushTokenInSegment = TestObserver<Data, Never>()
+  private let requestATTrackingAuthorizationStatus = TestObserver<ATTrackingAuthorizationStatus, Never>()
   private let setApplicationShortcutItems = TestObserver<[ShortcutItem], Never>()
   private let segmentIsEnabled = TestObserver<Bool, Never>()
   private let showAlert = TestObserver<Notification, Never>()
@@ -96,6 +97,7 @@ final class AppDelegateViewModelTests: TestCase {
     self.vm.outputs.pushTokenRegistrationStarted.observe(self.pushRegistrationStarted.observer)
     self.vm.outputs.pushTokenSuccessfullyRegistered.observe(self.pushTokenSuccessfullyRegistered.observer)
     self.vm.outputs.registerPushTokenInSegment.observe(self.registerPushTokenInSegment.observer)
+    self.vm.outputs.requestATTrackingAuthorizationStatus.observe(self.requestATTrackingAuthorizationStatus.observer)
     self.vm.outputs.setApplicationShortcutItems.observe(self.setApplicationShortcutItems.observer)
     self.vm.outputs.showAlert.observe(self.showAlert.observer)
     self.vm.outputs.segmentIsEnabled.observe(self.segmentIsEnabled.observer)
@@ -3003,6 +3005,12 @@ final class AppDelegateViewModelTests: TestCase {
 
       self.updateCurrentUserInEnvironment.assertValues([user, updatedUser])
     }
+  }
+  
+  func testRequestATTrackingAuthorizationStatus_CalledOnceOnDidFinishLaunching() {
+    self.vm.inputs.applicationDidFinishLaunching(application: UIApplication.shared, launchOptions: nil)
+
+    self.requestATTrackingAuthorizationStatus.assertValueCount(1)
   }
 }
 

--- a/Kickstarter-iOS/Info.plist
+++ b/Kickstarter-iOS/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSUserTrackingUsageDescription</key>
+	<string>We use personal data to provide a good experience on Kickstarter, and to help connect you with projects you&apos;ll love.</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleExecutable</key>

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -485,6 +485,7 @@
 		6067BCE9293E49AC0036ABB1 /* FacebookResetPasswordViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6067BCE7293E48140036ABB1 /* FacebookResetPasswordViewController.swift */; };
 		6067BCEC293E49F00036ABB1 /* FacebookResetPasswordViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6067BCEA293E49CB0036ABB1 /* FacebookResetPasswordViewModel.swift */; };
 		6067BCF2293FC3520036ABB1 /* FacebookResetPasswordViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6067BCEF293FC10E0036ABB1 /* FacebookResetPasswordViewModelTests.swift */; };
+		606F214429799A1200BA5CDF /* ATTrackingAuthorizationStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 606F214229799A0000BA5CDF /* ATTrackingAuthorizationStatus.swift */; };
 		608E7A5328ABDBAE00289E92 /* SetYourPasswordViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 608E7A5128ABD5E700289E92 /* SetYourPasswordViewController.swift */; };
 		608E7A5628ABE6CD00289E92 /* SetYourPasswordViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 608E7A5428ABE27400289E92 /* SetYourPasswordViewModel.swift */; };
 		60DA50EB28B689A4002E2DF1 /* SetYourPasswordViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60DA50E928B68990002E2DF1 /* SetYourPasswordViewModelTests.swift */; };
@@ -2069,6 +2070,7 @@
 		6067BCE7293E48140036ABB1 /* FacebookResetPasswordViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FacebookResetPasswordViewController.swift; sourceTree = "<group>"; };
 		6067BCEA293E49CB0036ABB1 /* FacebookResetPasswordViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FacebookResetPasswordViewModel.swift; sourceTree = "<group>"; };
 		6067BCEF293FC10E0036ABB1 /* FacebookResetPasswordViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FacebookResetPasswordViewModelTests.swift; sourceTree = "<group>"; };
+		606F214229799A0000BA5CDF /* ATTrackingAuthorizationStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ATTrackingAuthorizationStatus.swift; sourceTree = "<group>"; };
 		608E7A5128ABD5E700289E92 /* SetYourPasswordViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetYourPasswordViewController.swift; sourceTree = "<group>"; };
 		608E7A5428ABE27400289E92 /* SetYourPasswordViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetYourPasswordViewModel.swift; sourceTree = "<group>"; };
 		60DA50E928B68990002E2DF1 /* SetYourPasswordViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetYourPasswordViewModelTests.swift; sourceTree = "<group>"; };
@@ -5971,6 +5973,7 @@
 				8A213CE4239EAEA400BBB4C7 /* TrackingClientType.swift */,
 				94BE15C125E857C4007CD9A4 /* TrackingHelpers.swift */,
 				94BE15C925E96F06007CD9A4 /* TrackingHelpersTests.swift */,
+				606F214229799A0000BA5CDF /* ATTrackingAuthorizationStatus.swift */,
 			);
 			path = Tracking;
 			sourceTree = "<group>";
@@ -7733,6 +7736,7 @@
 				8A6C58932475E5950098D5A2 /* UIRefreshControl+StartRefreshing.swift in Sources */,
 				D7A37CCF1E2FF93D00EA066D /* SearchEmptyStateCellViewModel.swift in Sources */,
 				80D73AF61D50F1A60099231F /* Navigation.swift in Sources */,
+				606F214429799A1200BA5CDF /* ATTrackingAuthorizationStatus.swift in Sources */,
 				473DE012273C502F0033331D /* ProjectRisksCellViewModel.swift in Sources */,
 				A755115F1C8642C3005355CF /* Format.swift in Sources */,
 				598D96CB1D42AE85003F3F66 /* ActivitySampleProjectCellViewModel.swift in Sources */,

--- a/Library/Tracking/ATTrackingAuthorizationStatus.swift
+++ b/Library/Tracking/ATTrackingAuthorizationStatus.swift
@@ -1,0 +1,6 @@
+public enum ATTrackingAuthorizationStatus {
+  case authorized
+  case denied
+  case notDetermined
+  case restricted
+}


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Presents Apple's AppTransparencyFramework [dialog](https://developer.apple.com/app-store/user-privacy-and-data-use/#:~:text=Learn%20more-,Asking%20Permission%20to%20Track,-With) on app didFinishLaunching.

# 🤔 Why

With iOS 14.5+ you need to receive the user’s permission through the AppTrackingTransparency framework in order to track them or access their device’s advertising identifier. 

We need to meet this requirement in order to ethically track facebook ads related data. 

context around our [consent management initiative](https://kickstarter.atlassian.net/wiki/spaces/NEW/pages/2225766401/iOS+Consent+Management)
context around our [facebook conversions api initiative ](https://kickstarter.atlassian.net/wiki/spaces/NEW/pages/2231762945/iOS+Facebook+Conversion+API)that will be gates by this authorization status

# 🛠 How

- Add `NSUserTrackingUsageDescription` in the info.plist
- when application `didFinishLaunchingWithOptions` use the [AppTrackingTransparency Framework](https://developer.apple.com/documentation/apptrackingtransparency) to request authorization
- The framework takes care of saving the authorization status for us. I have the completion handler here returning an internal `ATTrackingAuthorizationStatus` enum to be used by whomever consumes the Signal.

Apple only allows us to request this dialog once per fresh install until someone decides to allow or deny permission.

# 👀 See

Trello, screenshots, external resources?

| After 🦋 |
| ---- |
|  ![Simulator Screen Recording - iPhone 13 Pro - 2023-01-18 at 10 27 06](https://user-images.githubusercontent.com/110618242/213252129-f9fb30cf-8b89-4e26-9ca8-9d49752a025b.gif) |

# ⏰ TODO
- [ ] verify that the dialog still shows up when the app is opened from a deep-link
