### PR TITLE
Revert "attempt to fix Fastlane S3 access"

### DIFF
--- a/.fastlane/Fastfile
+++ b/.fastlane/Fastfile
@@ -269,6 +269,8 @@ platform :ios do
 
   private_lane :upload_s3 do |options|
     aws_s3(
+      access_key: ENV['AWS_ACCESS_KEY_ID'],
+      secret_access_key: ENV['AWS_SECRET_ACCESS_KEY'],
       bucket: ENV['AWS_BUCKET'],
       region: ENV['AWS_REGION'],
       ipa: options[:ipa],


### PR DESCRIPTION
Reverts kickstarter/ios-oss#1771 to update branch name so it propagates to `ios-private`