### PR TITLE
[WEB-935] Creator Dashboard Analytics

### DIFF
--- a/Kickstarter-iOS/Features/Dashboard/Controller/DashboardViewController.swift
+++ b/Kickstarter-iOS/Features/Dashboard/Controller/DashboardViewController.swift
@@ -218,6 +218,8 @@ internal final class DashboardViewController: UITableViewController {
   }
 
   fileprivate func goToPostUpdate(_ project: Project) {
+    self.viewModel.inputs.trackPostUpdateClicked()
+
     let vc = UpdateDraftViewController.configuredWith(project: project)
     vc.delegate = self
 

--- a/Library/Tracking/KSRAnalytics.swift
+++ b/Library/Tracking/KSRAnalytics.swift
@@ -152,6 +152,7 @@ public final class KSRAnalytics {
     case pledgeInitiate
     case pledgeSubmit
     case project
+    case projectSelect
     case rewardContinue
     case search
     case signUpInitiate
@@ -171,6 +172,7 @@ public final class KSRAnalytics {
       case .pledgeConfirm: return "pledge_confirm"
       case .pledgeSubmit: return "pledge_submit"
       case .project: return "project"
+      case .projectSelect: return "project_select"
       case .logInInitiate: return "log_in_initiate"
       case .logInOrSignUp: return "log_in_or_sign_up"
       case .logInSubmit: return "log_in_submit"
@@ -768,6 +770,21 @@ public final class KSRAnalytics {
   public func trackCreatorDasboardPageViewed() {
     let props = contextProperties(page: .creatorDashboard, sectionContext: .dashboard)
     self.track(event: SegmentEvent.pageViewed.rawValue, properties: props)
+  }
+
+  public func trackCreatorDasboardSwitchProjectClicked(project: Project, refTag: RefTag) {
+    let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
+      .withAllValuesFrom(contextProperties(
+        ctaContext: .projectSelect,
+        page: .creatorDashboard,
+        sectionContext: .dashboard
+      ))
+
+    self.track(
+      event: SegmentEvent.ctaClicked.rawValue,
+      properties: props,
+      refTag: refTag.stringTag
+    )
   }
 
   // MARK: - Pledge Events

--- a/Library/Tracking/KSRAnalytics.swift
+++ b/Library/Tracking/KSRAnalytics.swift
@@ -140,6 +140,7 @@ public final class KSRAnalytics {
   public enum CTAContext {
     case addOnsContinue
     case campaignDetails
+    case creatorDashboard
     case creatorDetails
     case discover
     case discoverFilter
@@ -153,6 +154,7 @@ public final class KSRAnalytics {
     case pledgeSubmit
     case project
     case projectSelect
+    case projectUpdateCreateDraft
     case rewardContinue
     case search
     case signUpInitiate
@@ -163,6 +165,7 @@ public final class KSRAnalytics {
       switch self {
       case .addOnsContinue: return "add_ons_continue"
       case .campaignDetails: return "campaign_details"
+      case .creatorDashboard: return "creator_dashboard"
       case .creatorDetails: return "creator_details"
       case .discover: return "discover"
       case .discoverFilter: return "discover_filter"
@@ -173,6 +176,7 @@ public final class KSRAnalytics {
       case .pledgeSubmit: return "pledge_submit"
       case .project: return "project"
       case .projectSelect: return "project_select"
+      case .projectUpdateCreateDraft: return "project_update_create_draft"
       case .logInInitiate: return "log_in_initiate"
       case .logInOrSignUp: return "log_in_or_sign_up"
       case .logInSubmit: return "log_in_submit"
@@ -768,7 +772,11 @@ public final class KSRAnalytics {
    */
 
   public func trackCreatorDasboardPageViewed() {
-    let props = contextProperties(page: .creatorDashboard, sectionContext: .dashboard)
+    let props = contextProperties(
+      ctaContext: .creatorDashboard,
+      page: .creatorDashboard,
+      sectionContext: .dashboard
+    )
     self.track(event: SegmentEvent.pageViewed.rawValue, properties: props)
   }
 
@@ -776,6 +784,21 @@ public final class KSRAnalytics {
     let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
       .withAllValuesFrom(contextProperties(
         ctaContext: .projectSelect,
+        page: .creatorDashboard,
+        sectionContext: .dashboard
+      ))
+
+    self.track(
+      event: SegmentEvent.ctaClicked.rawValue,
+      properties: props,
+      refTag: refTag.stringTag
+    )
+  }
+
+  public func trackCreatorDasboardPostUpdateClicked(project: Project, refTag: RefTag) {
+    let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
+      .withAllValuesFrom(contextProperties(
+        ctaContext: .projectUpdateCreateDraft,
         page: .creatorDashboard,
         sectionContext: .dashboard
       ))

--- a/Library/Tracking/KSRAnalytics.swift
+++ b/Library/Tracking/KSRAnalytics.swift
@@ -34,6 +34,7 @@ public final class KSRAnalytics {
     case campaign // ProjectDescriptionViewController
     case changePayment = "change_payment" // PledgeViewController
     case checkout // // PledgeViewController
+    case creatorDashboard = "creator_dashboard"
     case discovery = "discover" // DiscoveryViewController
     case forgotPassword = "forgot_password" // ResetPasswordViewController
     case landingPage = "landing_page" // LandingViewController
@@ -267,6 +268,7 @@ public final class KSRAnalytics {
     case backed
     case campaign
     case comments
+    case dashboard
     case overview
     case updates
     case watched
@@ -277,6 +279,7 @@ public final class KSRAnalytics {
       case .backed: return "backed"
       case .campaign: return "campaign"
       case .comments: return "comments"
+      case .dashboard: return "dashboard"
       case .overview: return "overview"
       case .updates: return "updates"
       case .watched: return "watched"
@@ -754,6 +757,17 @@ public final class KSRAnalytics {
       event: SegmentEvent.videoPlaybackStarted.rawValue,
       properties: props
     )
+  }
+
+  // MARK: - Creator Dashboard Events
+
+  /**
+   Call when the creator dashboard page is viewed and the first page is loaded.
+   */
+
+  public func trackCreatorDasboardPageViewed() {
+    let props = contextProperties(page: .creatorDashboard, sectionContext: .dashboard)
+    self.track(event: SegmentEvent.pageViewed.rawValue, properties: props)
   }
 
   // MARK: - Pledge Events

--- a/Library/Tracking/KSRAnalyticsTests.swift
+++ b/Library/Tracking/KSRAnalyticsTests.swift
@@ -528,6 +528,18 @@ final class KSRAnalyticsTests: TestCase {
     XCTAssertEqual(["dashboard"], segmentClient.properties(forKey: "context_section"))
   }
 
+  func testCreatorDasboardPostUpdateClicked() {
+    let segmentClient = MockTrackingClient()
+    let ksrAnalytics = KSRAnalytics(segmentClient: segmentClient)
+
+    ksrAnalytics.trackCreatorDasboardPostUpdateClicked(project: .template, refTag: RefTag.dashboard)
+
+    XCTAssertEqual(["CTA Clicked"], segmentClient.events)
+    XCTAssertEqual(["project_update_create_draft"], segmentClient.properties(forKey: "context_cta"))
+    XCTAssertEqual(["creator_dashboard"], segmentClient.properties(forKey: "context_page"))
+    XCTAssertEqual(["dashboard"], segmentClient.properties(forKey: "context_section"))
+  }
+
   // MARK: - Discovery Properties Tests
 
   func testDiscoveryProperties() {

--- a/Library/Tracking/KSRAnalyticsTests.swift
+++ b/Library/Tracking/KSRAnalyticsTests.swift
@@ -499,6 +499,23 @@ final class KSRAnalyticsTests: TestCase {
     XCTAssertEqual("Art", segmentClientProperties?["project_category"] as? String)
   }
 
+  // MARK: - Creator Dashboard Properties Tests
+
+  func testCreatorDashboardPageViewed() {
+    let segmentClient = MockTrackingClient()
+    let loggedInUser = User.template |> \.id .~ 23
+    let ksrAnalytics = KSRAnalytics(
+      loggedInUser: loggedInUser,
+      segmentClient: segmentClient
+    )
+
+    ksrAnalytics.trackCreatorDasboardPageViewed()
+
+    XCTAssertEqual(["Page Viewed"], segmentClient.events)
+    XCTAssertEqual(["creator_dashboard"], segmentClient.properties(forKey: "context_page"))
+    XCTAssertEqual(["dashboard"], segmentClient.properties(forKey: "context_section"))
+  }
+
   // MARK: - Discovery Properties Tests
 
   func testDiscoveryProperties() {

--- a/Library/Tracking/KSRAnalyticsTests.swift
+++ b/Library/Tracking/KSRAnalyticsTests.swift
@@ -516,6 +516,18 @@ final class KSRAnalyticsTests: TestCase {
     XCTAssertEqual(["dashboard"], segmentClient.properties(forKey: "context_section"))
   }
 
+  func testCreatorDasboardSwitchProjectClicked() {
+    let segmentClient = MockTrackingClient()
+    let ksrAnalytics = KSRAnalytics(segmentClient: segmentClient)
+
+    ksrAnalytics.trackCreatorDasboardSwitchProjectClicked(project: .template, refTag: RefTag.dashboard)
+
+    XCTAssertEqual(["CTA Clicked"], segmentClient.events)
+    XCTAssertEqual(["project_select"], segmentClient.properties(forKey: "context_cta"))
+    XCTAssertEqual(["creator_dashboard"], segmentClient.properties(forKey: "context_page"))
+    XCTAssertEqual(["dashboard"], segmentClient.properties(forKey: "context_section"))
+  }
+
   // MARK: - Discovery Properties Tests
 
   func testDiscoveryProperties() {

--- a/Library/ViewModels/DashboardViewModel.swift
+++ b/Library/ViewModels/DashboardViewModel.swift
@@ -46,6 +46,9 @@ public protocol DashboardViewModelInputs {
   /// Call when to show or hide the projects drawer.
   func showHideProjectsDrawer()
 
+  /// Call when Post Update is clicked
+  func trackPostUpdateClicked()
+
   /// Call when the view loads.
   func viewDidLoad()
 
@@ -303,6 +306,15 @@ public final class DashboardViewModel: DashboardViewModelInputs, DashboardViewMo
         AppEnvironment.current.ksrAnalytics
           .trackCreatorDasboardSwitchProjectClicked(project: project, refTag: RefTag.dashboard)
       }
+
+    _ = self.project
+      .takeWhen(self.trackPostUpdateClickedProperty.signal)
+      .observeValues { project in
+        AppEnvironment.current.ksrAnalytics.trackCreatorDasboardPostUpdateClicked(
+          project: project,
+          refTag: RefTag.dashboard
+        )
+      }
   }
 
   fileprivate let showHideProjectsDrawerProperty = MutableProperty(())
@@ -333,6 +345,11 @@ public final class DashboardViewModel: DashboardViewModelInputs, DashboardViewMo
   fileprivate let projectsDrawerDidAnimateOutProperty = MutableProperty(())
   public func dashboardProjectsDrawerDidAnimateOut() {
     self.projectsDrawerDidAnimateOutProperty.value = ()
+  }
+
+  fileprivate let trackPostUpdateClickedProperty = MutableProperty(())
+  public func trackPostUpdateClicked() {
+    self.trackPostUpdateClickedProperty.value = ()
   }
 
   fileprivate let viewDidLoadProperty = MutableProperty(())

--- a/Library/ViewModels/DashboardViewModel.swift
+++ b/Library/ViewModels/DashboardViewModel.swift
@@ -290,6 +290,10 @@ public final class DashboardViewModel: DashboardViewModelInputs, DashboardViewMo
 
     self.focusScreenReaderOnTitleView = self.viewWillAppearAnimatedProperty.signal.ignoreValues()
       .filter { AppEnvironment.current.isVoiceOverRunning() }
+
+    self.viewDidLoadProperty.signal.observeValues {
+      AppEnvironment.current.ksrAnalytics.trackCreatorDasboardPageViewed()
+    }
   }
 
   fileprivate let showHideProjectsDrawerProperty = MutableProperty(())

--- a/Library/ViewModels/DashboardViewModel.swift
+++ b/Library/ViewModels/DashboardViewModel.swift
@@ -291,9 +291,18 @@ public final class DashboardViewModel: DashboardViewModelInputs, DashboardViewMo
     self.focusScreenReaderOnTitleView = self.viewWillAppearAnimatedProperty.signal.ignoreValues()
       .filter { AppEnvironment.current.isVoiceOverRunning() }
 
+    // MARK: - Tracking
+
     self.viewDidLoadProperty.signal.observeValues {
       AppEnvironment.current.ksrAnalytics.trackCreatorDasboardPageViewed()
     }
+
+    _ = self.project
+      .takeWhen(self.switchToProjectProperty.signal)
+      .observeValues { project in
+        AppEnvironment.current.ksrAnalytics
+          .trackCreatorDasboardSwitchProjectClicked(project: project, refTag: RefTag.dashboard)
+      }
   }
 
   fileprivate let showHideProjectsDrawerProperty = MutableProperty(())

--- a/Library/ViewModels/DashboardViewModel.swift
+++ b/Library/ViewModels/DashboardViewModel.swift
@@ -293,7 +293,7 @@ public final class DashboardViewModel: DashboardViewModelInputs, DashboardViewMo
 
     // MARK: - Tracking
 
-    self.viewDidLoadProperty.signal.observeValues {
+    self.viewWillAppearAnimatedProperty.signal.observeValues { _ in
       AppEnvironment.current.ksrAnalytics.trackCreatorDasboardPageViewed()
     }
 

--- a/Library/ViewModels/DashboardViewModelTests.swift
+++ b/Library/ViewModels/DashboardViewModelTests.swift
@@ -379,4 +379,24 @@ internal final class DashboardViewModelTests: TestCase {
       XCTAssertEqual(["Page Viewed", "CTA Clicked", "CTA Clicked"], self.segmentTrackingClient.events)
     }
   }
+
+  func testTrackingEvents_CreatorDashboardPostUpdateClicked() {
+    withEnvironment(apiService: MockService(fetchProjectsResponse: [Project.template])) {
+      XCTAssertEqual([], self.segmentTrackingClient.events)
+
+      self.vm.inputs.viewWillAppear(animated: false)
+
+      self.scheduler.advance()
+
+      XCTAssertEqual(["Page Viewed"], self.segmentTrackingClient.events)
+
+      self.vm.inputs.trackPostUpdateClicked()
+
+      XCTAssertEqual(["Page Viewed", "CTA Clicked"], self.segmentTrackingClient.events)
+
+      self.vm.inputs.trackPostUpdateClicked()
+
+      XCTAssertEqual(["Page Viewed", "CTA Clicked", "CTA Clicked"], self.segmentTrackingClient.events)
+    }
+  }
 }


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Adding the following segment events in the creator dashboard screen.
- Page Viewed, creator dashboard screen
- CTA Clicked, when a creator switches between projects via the dropdown at the top of the screen.
- CTA Clicked when a creator taps “Post Update”

# 🤔 Why

The creator dashboard doesn't have any analytic events. We want to start collecting data around whether members are finding it valuable enough to keep. The current assumption is that they don't and that we can possibly remove this feature in an effort to focus more on the backing experience.

# 🛠 How

I've added 3 new SegmentEvents in `KSRAnalytics`, as well as tests in `KSRAnalyticsTests` and `DashboardViewModelTests`

1. `trackCreatorDasboardPageViewed`
2. `trackCreatorDasboardSwitchProjectClicked`
3. `trackCreatorDasboardPostUpdateClicked`

# 👀 See

No UI updates

# 🧪 TESTING

- [ ] Check in [Segment](https://app.segment.com/kickstarter/sources) that these events are being received at the appropriate times. 
