### PR TITLE
[WEB-958] FIX: FB Deprecation (Set a password) flow disregarding guard statement

### DIFF
--- a/Kickstarter-iOS/Features/LoginTout/Controller/LoginToutViewController.swift
+++ b/Kickstarter-iOS/Features/LoginTout/Controller/LoginToutViewController.swift
@@ -199,15 +199,10 @@ public final class LoginToutViewController: UIViewController, MFMailComposeViewC
 
         AppEnvironment.login(accessTokenEnv)
 
-        /** FIXME: Not releasing this yet - re-test functionality as it failed regression testing on release-5.6.1 (see confluence regression testing document)
-         guard featureFacebookLoginDeprecationEnabled(),
-           let needsPassword = accessTokenEnv.user.needsPassword,
-           needsPassword else {
-           strongSelf.pushSetYourPasswordViewController()
-
-           return
-         }
-         */
+        if featureFacebookLoginDeprecationEnabled(), accessTokenEnv.user.needsPassword == true {
+          strongSelf.pushSetYourPasswordViewController()
+          return
+        }
 
         strongSelf.viewModel.inputs.environmentLoggedIn()
       }


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What
A regression was found during 5.6.1. testing where the FB deprecation flow was being triggered at every fb login, rather than only when the FF is on and the user needs a password.

# 🤔 Why

We only want to present this flow when the feature flag is enabled _and_ members need a password set on their account.

# 🛠 How

The `guard` statement in `LoginToutViewController line: 196` is disregarding the `needsPassword` check on the user object. Currently, it is storing the value in a variable and essentially checking that it is is not null rather than the value itself.

We don’t need to extract the value into the variable, so we can simplify this check into a more straightforward if/else like this:
```
if featureFacebookLoginDeprecationEnabled() && accessTokenEnv.user.needsPassword == true {
  strongSelf.pushSetYourPasswordViewController()
  return
}
```

# ✅ Testing Steps

- The Set your password screen should not be presented at any point, after logging in with FB, when the Facebook Login Deprecation FF is off 
- If the flag is on this screen should only show if the member also needs a password to be set you their account
