### PR TITLE
[NTV-647] Braze In-App Notification Fix

### DIFF
--- a/Kickstarter-iOS/AppDelegate.swift
+++ b/Kickstarter-iOS/AppDelegate.swift
@@ -269,6 +269,7 @@ internal final class AppDelegate: UIResponder, UIApplicationDelegate {
         appBoyInstance?.saveLaunchOptions(launchOptions)
         appBoyInstance?.appboyOptions = [
           ABKInAppMessageControllerDelegateKey: strongSelf,
+          ABKURLDelegateKey: strongSelf,
           ABKMinimumTriggerTimeIntervalKey: 5
         ]
 
@@ -523,5 +524,15 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
 extension AppDelegate: ABKInAppMessageControllerDelegate {
   func before(inAppMessageDisplayed inAppMessage: ABKInAppMessage) -> ABKInAppMessageDisplayChoice {
     return self.viewModel.inputs.brazeWillDisplayInAppMessage(inAppMessage)
+  }
+}
+
+// MARK: - ABKURLDelegate
+
+extension AppDelegate: ABKURLDelegate {
+  func handleAppboyURL(_ url: URL?, from _: ABKChannel, withExtras _: [AnyHashable: Any]?) -> Bool {
+    self.viewModel.inputs.urlFromBrazeInAppNotification(url)
+
+    return true
   }
 }

--- a/Kickstarter-iOS/AppDelegate.swift
+++ b/Kickstarter-iOS/AppDelegate.swift
@@ -264,14 +264,13 @@ internal final class AppDelegate: UIResponder, UIApplicationDelegate {
       .observeValues { [weak self] writeKey in
         guard let strongSelf = self else { return }
 
-        let factoryInstance = SEGAppboyIntegrationFactory.instance()
-        factoryInstance?.saveLaunchOptions(launchOptions)
-        factoryInstance?.appboyOptions = [
+        let (configuration, appBoyInstance) = Analytics.configuredClient(withWriteKey: writeKey)
+
+        appBoyInstance?.saveLaunchOptions(launchOptions)
+        appBoyInstance?.appboyOptions = [
           ABKInAppMessageControllerDelegateKey: strongSelf,
           ABKMinimumTriggerTimeIntervalKey: 5
         ]
-
-        let configuration = Analytics.configuredClient(withWriteKey: writeKey, braze: factoryInstance)
 
         Analytics.setup(with: configuration)
 

--- a/Kickstarter-iOS/AppDelegateViewModel.swift
+++ b/Kickstarter-iOS/AppDelegateViewModel.swift
@@ -86,6 +86,9 @@ public protocol AppDelegateViewModelInputs {
   /// Call when the contextual PushNotification dialog should be presented.
   func showNotificationDialog(notification: Notification)
 
+  /// Call when Braze in-app notifications send a valid URL.
+  func urlFromBrazeInAppNotification(_ url: URL?)
+
   /// Call when the controller has received a user session ended notification.
   func userSessionEnded()
 
@@ -344,6 +347,9 @@ public final class AppDelegateViewModel: AppDelegateViewModelType, AppDelegateVi
       .skipNil()
       .map(Navigation.deepLinkMatch)
 
+    let deepLinkFromBrazeInAppNotification = self.brazeInAppNotificationURL.signal.skipNil()
+      .map(Navigation.deepLinkMatch)
+
     let continueUserActivity = self.applicationContinueUserActivityProperty.signal.skipNil()
 
     let continueUserActivityWithNavigation = continueUserActivity
@@ -381,6 +387,7 @@ public final class AppDelegateViewModel: AppDelegateViewModelType, AppDelegateVi
         deepLinkFromUrl,
         deepLinkFromNotification,
         deepLinkFromBrazeNotification,
+        deepLinkFromBrazeInAppNotification,
         deepLinkFromShortcut
       )
       .skipNil()
@@ -925,6 +932,11 @@ public final class AppDelegateViewModel: AppDelegateViewModelType, AppDelegateVi
   fileprivate let userSessionStartedProperty = MutableProperty(())
   public func userSessionStarted() {
     self.userSessionStartedProperty.value = ()
+  }
+
+  fileprivate let brazeInAppNotificationURL = MutableProperty<URL?>(nil)
+  public func urlFromBrazeInAppNotification(_ url: URL?) {
+    self.brazeInAppNotificationURL.value = url
   }
 
   fileprivate let applicationDidFinishLaunchingReturnValueProperty = MutableProperty(true)

--- a/Kickstarter-iOS/AppDelegateViewModel.swift
+++ b/Kickstarter-iOS/AppDelegateViewModel.swift
@@ -347,7 +347,7 @@ public final class AppDelegateViewModel: AppDelegateViewModelType, AppDelegateVi
       .skipNil()
       .map(Navigation.deepLinkMatch)
 
-    let deepLinkFromBrazeInAppNotification = self.brazeInAppNotificationURL.signal.skipNil()
+    let deepLinkFromBrazeInAppNotification = self.brazeInAppNotificationURLProperty.signal.skipNil()
       .map(Navigation.deepLinkMatch)
 
     let continueUserActivity = self.applicationContinueUserActivityProperty.signal.skipNil()
@@ -934,9 +934,9 @@ public final class AppDelegateViewModel: AppDelegateViewModelType, AppDelegateVi
     self.userSessionStartedProperty.value = ()
   }
 
-  fileprivate let brazeInAppNotificationURL = MutableProperty<URL?>(nil)
+  fileprivate let brazeInAppNotificationURLProperty = MutableProperty<URL?>(nil)
   public func urlFromBrazeInAppNotification(_ url: URL?) {
-    self.brazeInAppNotificationURL.value = url
+    self.brazeInAppNotificationURLProperty.value = url
   }
 
   fileprivate let applicationDidFinishLaunchingReturnValueProperty = MutableProperty(true)

--- a/Kickstarter-iOS/AppDelegateViewModelTests.swift
+++ b/Kickstarter-iOS/AppDelegateViewModelTests.swift
@@ -3017,6 +3017,25 @@ final class AppDelegateViewModelTests: TestCase {
 
     self.requestATTrackingAuthorizationStatus.assertValueCount(1)
   }
+
+  func testPresentViewController_BrazeInAppNotificationDeeplink_ProjectCommentThread_Success() {
+    self.vm.inputs.applicationDidFinishLaunching(
+      application: UIApplication.shared,
+      launchOptions: [:]
+    )
+
+    withEnvironment(apiService: MockService(fetchCommentRepliesEnvelopeResult: .success(CommentRepliesEnvelope
+        .successfulRepliesTemplate), fetchProjectResult: .success(.template))) {
+      let url =
+        "https://\(AppEnvironment.current.apiService.serverConfig.webBaseUrl.host ?? "")/projects/fjorden/fjorden-iphone-photography-reinvented/"
+
+      self.presentViewController.assertValues([])
+
+      self.vm.inputs.urlFromBrazeInAppNotification(URL(string: url)!)
+
+      self.presentViewController.assertValues([1])
+    }
+  }
 }
 
 private let backingForCreatorPushData: [String: Any] = [

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -247,6 +247,8 @@
 		1937A71F28C94FFC00DD732D /* SettingsFormFieldView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 7790DF882200D3BD005DBB11 /* SettingsFormFieldView.xib */; };
 		1937A72328C9570A00DD732D /* ErroredBackingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1937A72228C9570900DD732D /* ErroredBackingView.swift */; };
 		1937A72628C959DD00DD732D /* FundingGraphViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7ED205B1E83240D00BFFA01 /* FundingGraphViewTests.swift */; };
+		1938951B29959D6400FF1D16 /* AppboySegment in Frameworks */ = {isa = PBXBuildFile; productRef = 1938951A29959D6400FF1D16 /* AppboySegment */; };
+		1938951D29959D9800FF1D16 /* AppboySegment in Frameworks */ = {isa = PBXBuildFile; productRef = 1938951C29959D9800FF1D16 /* AppboySegment */; };
 		194154CE28D8ED69004648C8 /* CreatePaymentSourceSetupIntentInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 194154CD28D8ED69004648C8 /* CreatePaymentSourceSetupIntentInput.swift */; };
 		194154D128D8FBAA004648C8 /* CreatePaymentSourceSetupIntentClientSecret+Constructor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 194154CF28D8F2DE004648C8 /* CreatePaymentSourceSetupIntentClientSecret+Constructor.swift */; };
 		194154D328D928C9004648C8 /* CreatePaymentSourceSetupIntentInputTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 194154D228D928C9004648C8 /* CreatePaymentSourceSetupIntentInputTests.swift */; };
@@ -493,12 +495,6 @@
 		60DA512928CA580B002E2DF1 /* Optimizely in Frameworks */ = {isa = PBXBuildFile; productRef = 60DA512828CA580B002E2DF1 /* Optimizely */; };
 		60EAD1B528D0EE45009F9474 /* iOSSnapshotTestCase in Embed Frameworks */ = {isa = PBXBuildFile; productRef = 60EAD1B328D0EE45009F9474 /* iOSSnapshotTestCase */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		60EAD1C728D25A36009F9474 /* AppCenterDistribute in Frameworks */ = {isa = PBXBuildFile; productRef = 60EAD1C628D25A36009F9474 /* AppCenterDistribute */; };
-		70CEC164298B2A2A0009D67A /* AppboyKit in Frameworks */ = {isa = PBXBuildFile; productRef = 70CEC163298B2A2A0009D67A /* AppboyKit */; };
-		70CEC166298B2A2A0009D67A /* AppboyUI in Frameworks */ = {isa = PBXBuildFile; productRef = 70CEC165298B2A2A0009D67A /* AppboyUI */; };
-		70CEC168298B2A770009D67A /* AppboyKit in Frameworks */ = {isa = PBXBuildFile; productRef = 70CEC167298B2A770009D67A /* AppboyKit */; };
-		70CEC16A298B2A810009D67A /* AppboyUI in Frameworks */ = {isa = PBXBuildFile; productRef = 70CEC169298B2A810009D67A /* AppboyUI */; };
-		70CEC16D298B2ACA0009D67A /* AppboySegment in Frameworks */ = {isa = PBXBuildFile; productRef = 70CEC16C298B2ACA0009D67A /* AppboySegment */; };
-		70CEC16F298B2B010009D67A /* AppboySegment in Frameworks */ = {isa = PBXBuildFile; productRef = 70CEC16E298B2B010009D67A /* AppboySegment */; };
 		770187C022FDCFCA0019129D /* PledgeViewControllerMessageDisplaying.swift in Sources */ = {isa = PBXBuildFile; fileRef = 770187BE22FDCF960019129D /* PledgeViewControllerMessageDisplaying.swift */; };
 		7703B42223217D4F00169EF3 /* EnvironmentType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7703B42123217D4F00169EF3 /* EnvironmentType.swift */; };
 		7703B4242321844900169EF3 /* PKPaymentRequest+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7703B4232321844900169EF3 /* PKPaymentRequest+Helpers.swift */; };
@@ -3179,7 +3175,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				70CEC168298B2A770009D67A /* AppboyKit in Frameworks */,
 				60DA50FE28C38DDB002E2DF1 /* AlamofireImage in Frameworks */,
 				60DA512928CA580B002E2DF1 /* Optimizely in Frameworks */,
 				06634FC72807A4EB00950F60 /* Prelude_UIKit in Frameworks */,
@@ -3187,12 +3182,11 @@
 				D0D10BB81EEB394D005EBAD0 /* KsApi.framework in Frameworks */,
 				198E574B28E2705100D5B8A9 /* PerimeterX in Frameworks */,
 				1981AC90289075D900BB4897 /* Stripe in Frameworks */,
+				1938951D29959D9800FF1D16 /* AppboySegment in Frameworks */,
 				60DA510F28C7E04B002E2DF1 /* Kingfisher in Frameworks */,
 				191A4B4228FF3897009D62A5 /* ReactiveExtensions in Frameworks */,
-				70CEC16A298B2A810009D67A /* AppboyUI in Frameworks */,
 				606754BF28CF91DD0033CD5E /* FacebookLogin in Frameworks */,
 				606754BD28CF91D60033CD5E /* FacebookCore in Frameworks */,
-				70CEC16F298B2B010009D67A /* AppboySegment in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3223,17 +3217,15 @@
 			buildActionMask = 2147483647;
 			files = (
 				19BF226528D10497007F4197 /* FirebasePerformance in Frameworks */,
-				70CEC166298B2A2A0009D67A /* AppboyUI in Frameworks */,
 				19BF226128D10497007F4197 /* FirebaseAnalytics in Frameworks */,
-				70CEC16D298B2ACA0009D67A /* AppboySegment in Frameworks */,
 				60EAD1C728D25A36009F9474 /* AppCenterDistribute in Frameworks */,
 				06EA2D4C280F76B700F4DE2E /* Prelude in Frameworks */,
 				A73924001D27230B004524C3 /* Kickstarter_Framework.framework in Frameworks */,
+				1938951B29959D6400FF1D16 /* AppboySegment in Frameworks */,
 				191EDC6728E29BB9009B41B2 /* PerimeterX in Frameworks */,
 				19BF226328D10497007F4197 /* FirebaseCrashlytics in Frameworks */,
 				1905787B28F8CD2500428375 /* ReactiveSwift in Frameworks */,
 				1998BCA828F60E8900D04077 /* ReactiveExtensions in Frameworks */,
-				70CEC164298B2A2A0009D67A /* AppboyKit in Frameworks */,
 				D0B45B6B1EF858C00020A8DA /* KsApi.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -7232,9 +7224,7 @@
 				198E574A28E2705100D5B8A9 /* PerimeterX */,
 				191A4B3F28FF386C009D62A5 /* ReactiveSwift */,
 				191A4B4128FF3897009D62A5 /* ReactiveExtensions */,
-				70CEC167298B2A770009D67A /* AppboyKit */,
-				70CEC169298B2A810009D67A /* AppboyUI */,
-				70CEC16E298B2B010009D67A /* AppboySegment */,
+				1938951C29959D9800FF1D16 /* AppboySegment */,
 			);
 			productName = "Library-iOS";
 			productReference = A755113C1C8642B3005355CF /* Library.framework */;
@@ -7314,9 +7304,7 @@
 				191EDC6628E29BB9009B41B2 /* PerimeterX */,
 				1998BCA728F60E8900D04077 /* ReactiveExtensions */,
 				1905787A28F8CD2500428375 /* ReactiveSwift */,
-				70CEC163298B2A2A0009D67A /* AppboyKit */,
-				70CEC165298B2A2A0009D67A /* AppboyUI */,
-				70CEC16C298B2ACA0009D67A /* AppboySegment */,
+				1938951A29959D6400FF1D16 /* AppboySegment */,
 			);
 			productName = Kickstarter;
 			productReference = A7D1F9451C850B7C000D41D5 /* KickDebug.app */;
@@ -7477,8 +7465,7 @@
 				602C97D628DB787900919CA8 /* XCRemoteSwiftPackageReference "px-iOS-Framework" */,
 				194C593E28F5E7FF00453249 /* XCRemoteSwiftPackageReference "Kickstarter-ReactiveExtensions" */,
 				1905787928F8CD2500428375 /* XCRemoteSwiftPackageReference "ReactiveSwift" */,
-				70CEC162298B2A290009D67A /* XCRemoteSwiftPackageReference "braze-ios-sdk" */,
-				70CEC16B298B2AC90009D67A /* XCRemoteSwiftPackageReference "appboy-segment-ios" */,
+				1938951929959D6400FF1D16 /* XCRemoteSwiftPackageReference "appboy-segment-ios" */,
 			);
 			productRefGroup = A7E06C7A1C5A6EB300EBDCC2 /* Products */;
 			projectDirPath = "";
@@ -10407,6 +10394,14 @@
 				minimumVersion = 6.5.0;
 			};
 		};
+		1938951929959D6400FF1D16 /* XCRemoteSwiftPackageReference "appboy-segment-ios" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/Appboy/appboy-segment-ios";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 4.0.0;
+			};
+		};
 		194520C12888542100CA9B88 /* XCRemoteSwiftPackageReference "stripe-ios" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/stripe/stripe-ios";
@@ -10495,22 +10490,6 @@
 				minimumVersion = 4.0.0;
 			};
 		};
-		70CEC162298B2A290009D67A /* XCRemoteSwiftPackageReference "braze-ios-sdk" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/braze-inc/braze-ios-sdk.git";
-			requirement = {
-				kind = exactVersion;
-				version = 4.5.1;
-			};
-		};
-		70CEC16B298B2AC90009D67A /* XCRemoteSwiftPackageReference "appboy-segment-ios" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/Appboy/appboy-segment-ios.git";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 4.0.0;
-			};
-		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -10588,6 +10567,16 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 602C97D628DB787900919CA8 /* XCRemoteSwiftPackageReference "px-iOS-Framework" */;
 			productName = PerimeterX;
+		};
+		1938951A29959D6400FF1D16 /* AppboySegment */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 1938951929959D6400FF1D16 /* XCRemoteSwiftPackageReference "appboy-segment-ios" */;
+			productName = AppboySegment;
+		};
+		1938951C29959D9800FF1D16 /* AppboySegment */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 1938951929959D6400FF1D16 /* XCRemoteSwiftPackageReference "appboy-segment-ios" */;
+			productName = AppboySegment;
 		};
 		1981AC8F289075D900BB4897 /* Stripe */ = {
 			isa = XCSwiftPackageProductDependency;
@@ -10683,36 +10672,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 60EAD1C528D25A36009F9474 /* XCRemoteSwiftPackageReference "appcenter-sdk-apple" */;
 			productName = AppCenterDistribute;
-		};
-		70CEC163298B2A2A0009D67A /* AppboyKit */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 70CEC162298B2A290009D67A /* XCRemoteSwiftPackageReference "braze-ios-sdk" */;
-			productName = AppboyKit;
-		};
-		70CEC165298B2A2A0009D67A /* AppboyUI */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 70CEC162298B2A290009D67A /* XCRemoteSwiftPackageReference "braze-ios-sdk" */;
-			productName = AppboyUI;
-		};
-		70CEC167298B2A770009D67A /* AppboyKit */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 70CEC162298B2A290009D67A /* XCRemoteSwiftPackageReference "braze-ios-sdk" */;
-			productName = AppboyKit;
-		};
-		70CEC169298B2A810009D67A /* AppboyUI */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 70CEC162298B2A290009D67A /* XCRemoteSwiftPackageReference "braze-ios-sdk" */;
-			productName = AppboyUI;
-		};
-		70CEC16C298B2ACA0009D67A /* AppboySegment */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 70CEC16B298B2AC90009D67A /* XCRemoteSwiftPackageReference "appboy-segment-ios" */;
-			productName = AppboySegment;
-		};
-		70CEC16E298B2B010009D67A /* AppboySegment */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 70CEC16B298B2AC90009D67A /* XCRemoteSwiftPackageReference "appboy-segment-ios" */;
-			productName = AppboySegment;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Kickstarter.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Kickstarter.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -48,7 +48,7 @@
     {
       "identity" : "appboy-segment-ios",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/Appboy/appboy-segment-ios.git",
+      "location" : "https://github.com/Appboy/appboy-segment-ios",
       "state" : {
         "revision" : "08a061113e8a7e835e6bc9c0e1629d94e63aa29e",
         "version" : "4.6.0"

--- a/Library/Tracking/Segment.swift
+++ b/Library/Tracking/Segment.swift
@@ -4,22 +4,25 @@ import KsApi
 
 public extension Analytics {
   /**
-   Returns an `Analytics` instance, with Segment, using an `AnalyticsConfiguration`.
+   Returns an `Analytics` and `SEGAppboyIntegrationFactory` instance, with Segment, using an `AnalyticsConfiguration`.
    */
-  static func configuredClient(withWriteKey writeKey: String,
-                               braze: SEGAppboyIntegrationFactory?) -> AnalyticsConfiguration {
+  static func configuredClient(withWriteKey writeKey: String)
+    -> (AnalyticsConfiguration, SEGAppboyIntegrationFactory?) {
     let configuration = AnalyticsConfiguration(writeKey: writeKey)
     configuration
       .trackApplicationLifecycleEvents = true
 
+    configuration.sourceMiddleware = [BrazeDebounceMiddleware()]
     // Braze is always configured but feature-flagged elsewhere.
     // Data sent to Braze is feature-flagged by the enabling/disabling Segment.
-    if let availableBrazeInstance = braze {
-      configuration.use(availableBrazeInstance)
-      configuration.sourceMiddleware = [BrazeDebounceMiddleware()]
+    // FIXME: For some reason this instance of SEGAppyboyIntegrationFactory is not the same as one passed in. It's supposed to be the same singleton.
+    guard let factoryInstance = SEGAppboyIntegrationFactory.instance() else {
+      return (configuration, nil)
     }
 
-    return configuration
+    configuration.use(factoryInstance)
+
+    return (configuration, factoryInstance)
   }
 }
 


### PR DESCRIPTION
# 📲 What

We noticed in-app notifications were broken (or not appearing) in release 5.6.1.
Needed to fix those. 

# 🤔 Why

Strangely two different instances of `SEGAppboyIntegrationFactory` were being created when calling `instance()` on that class. Somehow this caused in-app notifications not to show up.

# 🛠 How

Created one instance of `SEGAppboyIntegrationFactory` inside the `Analytics` `configuredClient` function and pass it back out to be configure in the `AppDelegate`. (Previously passing it into the function).

Also it seems like segment-appboy-ios is pinning Appboy_iOS_SDK to `4.5.1` now, so let's use it's dependency instead of doing the pinning on our own.

# ✅ Acceptance criteria

- [x] Test that in-app notifications show on staging.
- [x] Test push notifications deeplink on staging.
- [x] Test in-app notification deeplinks on staging.
 
# ⏰ TODO

- [ ] Validate that Apply Pay crash scenario doesn't occur without manually pinning Appboy_iOS_SDK.
- [x] Check to see if 5.6.0 had in-app notifications deeplink correctly and re-test with this code.
