### PR TITLE
[Unticketed] Update Segment Appboy Dependency

### DIFF
--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -247,8 +247,6 @@
 		1937A71F28C94FFC00DD732D /* SettingsFormFieldView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 7790DF882200D3BD005DBB11 /* SettingsFormFieldView.xib */; };
 		1937A72328C9570A00DD732D /* ErroredBackingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1937A72228C9570900DD732D /* ErroredBackingView.swift */; };
 		1937A72628C959DD00DD732D /* FundingGraphViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7ED205B1E83240D00BFFA01 /* FundingGraphViewTests.swift */; };
-		1938951B29959D6400FF1D16 /* AppboySegment in Frameworks */ = {isa = PBXBuildFile; productRef = 1938951A29959D6400FF1D16 /* AppboySegment */; };
-		1938951D29959D9800FF1D16 /* AppboySegment in Frameworks */ = {isa = PBXBuildFile; productRef = 1938951C29959D9800FF1D16 /* AppboySegment */; };
 		194154CE28D8ED69004648C8 /* CreatePaymentSourceSetupIntentInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 194154CD28D8ED69004648C8 /* CreatePaymentSourceSetupIntentInput.swift */; };
 		194154D128D8FBAA004648C8 /* CreatePaymentSourceSetupIntentClientSecret+Constructor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 194154CF28D8F2DE004648C8 /* CreatePaymentSourceSetupIntentClientSecret+Constructor.swift */; };
 		194154D328D928C9004648C8 /* CreatePaymentSourceSetupIntentInputTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 194154D228D928C9004648C8 /* CreatePaymentSourceSetupIntentInputTests.swift */; };
@@ -260,6 +258,8 @@
 		1965437428C811B000457EC6 /* ProjectNotificationsViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77F6E764212355C3005A5C55 /* ProjectNotificationsViewControllerTests.swift */; };
 		1965437E28C8165200457EC6 /* ProjectPageNavigationBarViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06AF78772710DB57009587F1 /* ProjectPageNavigationBarViewTests.swift */; };
 		1981AC90289075D900BB4897 /* Stripe in Frameworks */ = {isa = PBXBuildFile; productRef = 1981AC8F289075D900BB4897 /* Stripe */; };
+		19821C85299D392400EF312F /* AppboySegment in Frameworks */ = {isa = PBXBuildFile; productRef = 19821C84299D392400EF312F /* AppboySegment */; };
+		19821C87299D3E8300EF312F /* AppboySegment in Frameworks */ = {isa = PBXBuildFile; productRef = 19821C86299D3E8300EF312F /* AppboySegment */; };
 		198E574B28E2705100D5B8A9 /* PerimeterX in Frameworks */ = {isa = PBXBuildFile; productRef = 198E574A28E2705100D5B8A9 /* PerimeterX */; };
 		198E574D28E2705E00D5B8A9 /* PerimeterX in Frameworks */ = {isa = PBXBuildFile; productRef = 198E574C28E2705E00D5B8A9 /* PerimeterX */; };
 		198ED05D28D21AD40008CB98 /* iOSSnapshotTestCase in Frameworks */ = {isa = PBXBuildFile; productRef = 60EAD1B328D0EE45009F9474 /* iOSSnapshotTestCase */; };
@@ -3182,7 +3182,7 @@
 				D0D10BB81EEB394D005EBAD0 /* KsApi.framework in Frameworks */,
 				198E574B28E2705100D5B8A9 /* PerimeterX in Frameworks */,
 				1981AC90289075D900BB4897 /* Stripe in Frameworks */,
-				1938951D29959D9800FF1D16 /* AppboySegment in Frameworks */,
+				19821C87299D3E8300EF312F /* AppboySegment in Frameworks */,
 				60DA510F28C7E04B002E2DF1 /* Kingfisher in Frameworks */,
 				191A4B4228FF3897009D62A5 /* ReactiveExtensions in Frameworks */,
 				606754BF28CF91DD0033CD5E /* FacebookLogin in Frameworks */,
@@ -3221,7 +3221,7 @@
 				60EAD1C728D25A36009F9474 /* AppCenterDistribute in Frameworks */,
 				06EA2D4C280F76B700F4DE2E /* Prelude in Frameworks */,
 				A73924001D27230B004524C3 /* Kickstarter_Framework.framework in Frameworks */,
-				1938951B29959D6400FF1D16 /* AppboySegment in Frameworks */,
+				19821C85299D392400EF312F /* AppboySegment in Frameworks */,
 				191EDC6728E29BB9009B41B2 /* PerimeterX in Frameworks */,
 				19BF226328D10497007F4197 /* FirebaseCrashlytics in Frameworks */,
 				1905787B28F8CD2500428375 /* ReactiveSwift in Frameworks */,
@@ -7224,7 +7224,7 @@
 				198E574A28E2705100D5B8A9 /* PerimeterX */,
 				191A4B3F28FF386C009D62A5 /* ReactiveSwift */,
 				191A4B4128FF3897009D62A5 /* ReactiveExtensions */,
-				1938951C29959D9800FF1D16 /* AppboySegment */,
+				19821C86299D3E8300EF312F /* AppboySegment */,
 			);
 			productName = "Library-iOS";
 			productReference = A755113C1C8642B3005355CF /* Library.framework */;
@@ -7304,7 +7304,7 @@
 				191EDC6628E29BB9009B41B2 /* PerimeterX */,
 				1998BCA728F60E8900D04077 /* ReactiveExtensions */,
 				1905787A28F8CD2500428375 /* ReactiveSwift */,
-				1938951A29959D6400FF1D16 /* AppboySegment */,
+				19821C84299D392400EF312F /* AppboySegment */,
 			);
 			productName = Kickstarter;
 			productReference = A7D1F9451C850B7C000D41D5 /* KickDebug.app */;
@@ -7465,7 +7465,7 @@
 				602C97D628DB787900919CA8 /* XCRemoteSwiftPackageReference "px-iOS-Framework" */,
 				194C593E28F5E7FF00453249 /* XCRemoteSwiftPackageReference "Kickstarter-ReactiveExtensions" */,
 				1905787928F8CD2500428375 /* XCRemoteSwiftPackageReference "ReactiveSwift" */,
-				1938951929959D6400FF1D16 /* XCRemoteSwiftPackageReference "appboy-segment-ios" */,
+				19821C83299D392300EF312F /* XCRemoteSwiftPackageReference "appboy-segment-ios" */,
 			);
 			productRefGroup = A7E06C7A1C5A6EB300EBDCC2 /* Products */;
 			projectDirPath = "";
@@ -10394,14 +10394,6 @@
 				minimumVersion = 6.5.0;
 			};
 		};
-		1938951929959D6400FF1D16 /* XCRemoteSwiftPackageReference "appboy-segment-ios" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/Appboy/appboy-segment-ios";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 4.0.0;
-			};
-		};
 		194520C12888542100CA9B88 /* XCRemoteSwiftPackageReference "stripe-ios" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/stripe/stripe-ios";
@@ -10416,6 +10408,14 @@
 			requirement = {
 				branch = "feature/swift-package";
 				kind = branch;
+			};
+		};
+		19821C83299D392300EF312F /* XCRemoteSwiftPackageReference "appboy-segment-ios" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/Appboy/appboy-segment-ios";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 4.0.0;
 			};
 		};
 		19BF225F28D10497007F4197 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {
@@ -10568,20 +10568,20 @@
 			package = 602C97D628DB787900919CA8 /* XCRemoteSwiftPackageReference "px-iOS-Framework" */;
 			productName = PerimeterX;
 		};
-		1938951A29959D6400FF1D16 /* AppboySegment */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 1938951929959D6400FF1D16 /* XCRemoteSwiftPackageReference "appboy-segment-ios" */;
-			productName = AppboySegment;
-		};
-		1938951C29959D9800FF1D16 /* AppboySegment */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 1938951929959D6400FF1D16 /* XCRemoteSwiftPackageReference "appboy-segment-ios" */;
-			productName = AppboySegment;
-		};
 		1981AC8F289075D900BB4897 /* Stripe */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 194520C12888542100CA9B88 /* XCRemoteSwiftPackageReference "stripe-ios" */;
 			productName = Stripe;
+		};
+		19821C84299D392400EF312F /* AppboySegment */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 19821C83299D392300EF312F /* XCRemoteSwiftPackageReference "appboy-segment-ios" */;
+			productName = AppboySegment;
+		};
+		19821C86299D3E8300EF312F /* AppboySegment */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 19821C83299D392300EF312F /* XCRemoteSwiftPackageReference "appboy-segment-ios" */;
+			productName = AppboySegment;
 		};
 		198E574A28E2705100D5B8A9 /* PerimeterX */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Kickstarter.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Kickstarter.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -77,8 +77,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/braze-inc/braze-ios-sdk.git",
       "state" : {
-        "revision" : "ddd02f32ab3f546f13582f8a2f7b0334c49382f3",
-        "version" : "4.5.1"
+        "revision" : "538e3729ec56f1c10e678c0e83266c57da17b5fa",
+        "version" : "4.5.4"
       }
     },
     {


### PR DESCRIPTION
Just a quick one here to update the dependency of `appboy-segment-ios` wrt this [issue](https://github.com/Appboy/appboy-segment-ios/issues/67). They fixed the crash scenario occuring for in-app notifications and this is the updated dependency `Appboy_iOS_SDK` going from `4.5.1` to `4.5.4`.