### PR TITLE
[WEB-999] Prelaunch Dates Blockers

### DIFF
--- a/Kickstarter-iOS/Features/Dashboard/Controller/DashboardViewControllerTests.swift
+++ b/Kickstarter-iOS/Features/Dashboard/Controller/DashboardViewControllerTests.swift
@@ -130,5 +130,5 @@ private let fundingStats = stats.enumerated().map { idx, pledged in
   .template
     |> ProjectStatsEnvelope.FundingDateStats.lens.cumulativePledged .~ pledged
     |> ProjectStatsEnvelope.FundingDateStats.lens.date
-    .~ (cosmicSurgery.dates.launchedAt + TimeInterval(idx * 86_400))
+    .~ ((cosmicSurgery.dates.launchedAt ?? 0) + TimeInterval(idx * 86_400))
 }

--- a/Kickstarter-iOS/Features/DashboardProjects/Views/FundingGraphView.swift
+++ b/Kickstarter-iOS/Features/DashboardProjects/Views/FundingGraphView.swift
@@ -66,10 +66,15 @@ public final class FundingGraphView: UIView {
       .enumerated()
       .map { index, stat in CGPoint(x: index, y: stat.cumulativePledged) }
 
-    let durationInDays = dateToDayNumber(
-      launchDate: project.dates.launchedAt,
-      currentDate: self.project.dates.deadline
-    )
+    var durationInDays: CGFloat = 1
+
+    if let launchedAt = project.dates.launchedAt,
+      let deadline = project.dates.deadline {
+      durationInDays = dateToDayNumber(
+        launchDate: launchedAt,
+        currentDate: deadline
+      )
+    }
 
     let goal = self.project.stats.goal
 

--- a/Kickstarter-iOS/Features/DashboardProjects/Views/FundingGraphViewTests.swift
+++ b/Kickstarter-iOS/Features/DashboardProjects/Views/FundingGraphViewTests.swift
@@ -133,6 +133,6 @@ private func fundingStats(forProject project: Project, pledgeValues: [Int])
     ProjectStatsEnvelope.FundingDateStats.template
       |> ProjectStatsEnvelope.FundingDateStats.lens.cumulativePledged .~ pledged
       |> ProjectStatsEnvelope.FundingDateStats.lens.date
-      .~ (project.dates.launchedAt + TimeInterval(idx * 60 * 60 * 24))
+      .~ ((project.dates.launchedAt ?? 0.0) + TimeInterval(idx * 60 * 60 * 24))
   }
 }

--- a/Kickstarter-iOS/Library/CookieRefTagFunctions.swift
+++ b/Kickstarter-iOS/Library/CookieRefTagFunctions.swift
@@ -55,8 +55,10 @@ public func cookieFrom(refTag: RefTag, project: Project) -> HTTPCookie? {
   properties[.domain] = URL(string: project.urls.web.project)?.host
   properties[.path] = URL(string: project.urls.web.project)?.path
   properties[.version] = 0
-  properties[.expires] = AppEnvironment.current.dateType
-    .init(timeIntervalSince1970: project.dates.deadline).date
+
+  if let deadline = project.dates.deadline {
+    properties[.expires] = AppEnvironment.current.dateType.init(timeIntervalSince1970: deadline).date
+  }
 
   return HTTPCookie(properties: properties)
 }

--- a/KsApi/models/Project.swift
+++ b/KsApi/models/Project.swift
@@ -166,24 +166,33 @@ public struct Project {
   }
 
   public struct Dates {
-    public var deadline: TimeInterval
+    public var deadline: TimeInterval?
     public var featuredAt: TimeInterval?
     public var finalCollectionDate: TimeInterval?
-    public var launchedAt: TimeInterval
+    public var launchedAt: TimeInterval?
     public var stateChangedAt: TimeInterval
 
     /**
      Returns project duration in Days
      */
     public func duration(using calendar: Calendar = .current) -> Int? {
-      let deadlineDate = Date(timeIntervalSince1970: self.deadline)
-      let launchedAtDate = Date(timeIntervalSince1970: self.launchedAt)
+      guard let deadlineDateValue = self.deadline,
+        let launchedAtDateValue = self.launchedAt else {
+        return nil
+      }
+
+      let deadlineDate = Date(timeIntervalSince1970: deadlineDateValue)
+      let launchedAtDate = Date(timeIntervalSince1970: launchedAtDateValue)
 
       return calendar.dateComponents([.day], from: launchedAtDate, to: deadlineDate).day
     }
 
     public func hoursRemaining(from date: Date = Date(), using calendar: Calendar = .current) -> Int? {
-      let deadlineDate = Date(timeIntervalSince1970: self.deadline)
+      guard let deadlineDateValue = self.deadline else {
+        return nil
+      }
+
+      let deadlineDate = Date(timeIntervalSince1970: deadlineDateValue)
 
       guard let hoursRemaining = calendar.dateComponents([.hour], from: date, to: deadlineDate).hour else {
         return nil
@@ -225,8 +234,12 @@ public struct Project {
   }
 
   public func endsIn48Hours(today: Date = Date()) -> Bool {
+    guard let datesDeadlineValue = self.dates.deadline else {
+      return true
+    }
+
     let twoDays: TimeInterval = 60.0 * 60.0 * 48.0
-    return self.dates.deadline - today.timeIntervalSince1970 <= twoDays
+    return datesDeadlineValue - today.timeIntervalSince1970 <= twoDays
   }
 
   public func isFeaturedToday(today: Date = Date(), calendar: Calendar = .current) -> Bool {

--- a/KsApi/models/lenses/Project.DatesLenses.swift
+++ b/KsApi/models/lenses/Project.DatesLenses.swift
@@ -3,7 +3,7 @@ import Prelude
 
 extension Project.Dates {
   public enum lens {
-    public static let deadline = Lens<Project.Dates, TimeInterval>(
+    public static let deadline = Lens<Project.Dates, TimeInterval?>(
       view: { $0.deadline },
       set: { Project.Dates(
         deadline: $0, featuredAt: $1.featuredAt, launchedAt: $1.launchedAt,
@@ -19,7 +19,7 @@ extension Project.Dates {
       ) }
     )
 
-    public static let launchedAt = Lens<Project.Dates, TimeInterval>(
+    public static let launchedAt = Lens<Project.Dates, TimeInterval?>(
       view: { $0.launchedAt },
       set: { Project.Dates(
         deadline: $1.deadline, featuredAt: $1.featuredAt, launchedAt: $0,

--- a/KsApi/models/lenses/ProjectLenses.swift
+++ b/KsApi/models/lenses/ProjectLenses.swift
@@ -502,7 +502,7 @@ extension Lens where Whole == Project, Part == Project.MemberData {
 }
 
 extension Lens where Whole == Project, Part == Project.Dates {
-  public var deadline: Lens<Project, TimeInterval> {
+  public var deadline: Lens<Project, TimeInterval?> {
     return Project.lens.dates .. Project.Dates.lens.deadline
   }
 
@@ -510,7 +510,7 @@ extension Lens where Whole == Project, Part == Project.Dates {
     return Project.lens.dates .. Project.Dates.lens.featuredAt
   }
 
-  public var launchedAt: Lens<Project, TimeInterval> {
+  public var launchedAt: Lens<Project, TimeInterval?> {
     return Project.lens.dates .. Project.Dates.lens.launchedAt
   }
 

--- a/Library/Tracking/KSRAnalytics.swift
+++ b/Library/Tracking/KSRAnalytics.swift
@@ -1336,9 +1336,9 @@ private func projectProperties(
   props["comments_count"] = project.stats.commentsCount ?? 0
   props["currency"] = project.stats.currency
   props["creator_uid"] = String(project.creator.id)
-  props["deadline"] = project.dates.deadline.toISO8601DateTimeString()
+  props["deadline"] = project.dates.deadline?.toISO8601DateTimeString()
   props["has_add_ons"] = project.hasAddOns
-  props["launched_at"] = project.dates.launchedAt.toISO8601DateTimeString()
+  props["launched_at"] = project.dates.launchedAt?.toISO8601DateTimeString()
   props["name"] = project.name
   props["pid"] = String(project.id)
   props["category"] = project.category.parentAnalyticsName

--- a/Library/ViewModels/BackerDashboardProjectCellViewModel.swift
+++ b/Library/ViewModels/BackerDashboardProjectCellViewModel.swift
@@ -88,7 +88,11 @@ public final class BackerDashboardProjectCellViewModel: BackerDashboardProjectCe
 private func metadataString(for project: Project) -> String {
   switch project.state {
   case .live:
-    let duration = Format.duration(secondsInUTC: project.dates.deadline, abbreviate: true, useToGo: false)
+    guard let deadline = project.dates.deadline else {
+      return ""
+    }
+
+    let duration = Format.duration(secondsInUTC: deadline, abbreviate: true, useToGo: false)
     return "\(duration.time) \(duration.unit)"
   default:
     return stateString(for: project)

--- a/Library/ViewModels/DashboardFundingCellViewModel.swift
+++ b/Library/ViewModels/DashboardFundingCellViewModel.swift
@@ -79,7 +79,11 @@ public final class DashboardFundingCellViewModel: DashboardFundingCellViewModelI
     self.backersText = statsProject.map { _, project in Format.wholeNumber(project.stats.backersCount) }
 
     self.deadlineDateText = statsProject.map { _, project in
-      Format.date(secondsInUTC: project.dates.deadline, dateStyle: .short, timeStyle: .none)
+      guard let deadline = project.dates.deadline else {
+        return ""
+      }
+
+      return Format.date(secondsInUTC: deadline, dateStyle: .short, timeStyle: .none)
     }
 
     self.goalText = statsProject.map { _, project in
@@ -111,14 +115,22 @@ public final class DashboardFundingCellViewModel: DashboardFundingCellViewModelI
 
     self.launchDateText = statsProject
       .map { _, project in
-        Format.date(secondsInUTC: project.dates.launchedAt, dateStyle: .short, timeStyle: .none)
+        guard let launchedAt = project.dates.launchedAt else {
+          return ""
+        }
+
+        return Format.date(secondsInUTC: launchedAt, dateStyle: .short, timeStyle: .none)
       }
 
     self.pledgedText = statsProject
       .map { _, project in Format.currency(project.stats.pledged, country: project.country) }
 
-    let timeRemaining = statsProject.map { _, project in
-      Format.duration(secondsInUTC: project.dates.deadline, useToGo: true)
+    let timeRemaining = statsProject.map { _, project -> (String, String) in
+      guard let deadline = project.dates.deadline else {
+        return ("", "")
+      }
+
+      return Format.duration(secondsInUTC: deadline, useToGo: true)
     }
 
     self.timeRemainingTitleText = timeRemaining.map(first)
@@ -130,7 +142,12 @@ public final class DashboardFundingCellViewModel: DashboardFundingCellViewModelI
         let pledged = Format.currency(project.stats.pledged, country: project.country)
         let goal = Format.currency(project.stats.goal, country: project.country)
         let backersCount = project.stats.backersCount
-        let (time, unit) = Format.duration(secondsInUTC: project.dates.deadline, useToGo: false)
+        var (time, unit) = ("", "")
+
+        if let deadline = project.dates.deadline {
+          (time, unit) = Format.duration(secondsInUTC: deadline, useToGo: false)
+        }
+
         let timeLeft = time + " " + unit
 
         return project.state == .live ?

--- a/Library/ViewModels/DashboardFundingCellViewModelTests.swift
+++ b/Library/ViewModels/DashboardFundingCellViewModelTests.swift
@@ -44,6 +44,7 @@ internal final class DashboardFundingCellViewModelTests: TestCase {
       |> Project.lens.country .~ .us
 
     let stats = [ProjectStatsEnvelope.FundingDateStats.template]
+    let deadline = liveProject.dates.deadline!
 
     self.vm.inputs.configureWith(fundingDateStats: stats, project: liveProject)
 
@@ -53,14 +54,15 @@ internal final class DashboardFundingCellViewModelTests: TestCase {
           pledged: Format.currency(liveProject.stats.pledged, country: liveProject.country),
           goal: Format.currency(liveProject.stats.goal, country: liveProject.country),
           backers_count: liveProject.stats.backersCount,
-          time_left: Format.duration(secondsInUTC: liveProject.dates.deadline).time + " " +
-            Format.duration(secondsInUTC: liveProject.dates.deadline).unit
+          time_left: Format.duration(secondsInUTC: deadline).time + " " +
+            Format.duration(secondsInUTC: deadline).unit
         )
       ],
       "Live project stats value emits."
     )
 
     let nonLiveProject = .template |> Project.lens.state .~ .successful
+    let nonLiveDeadline = nonLiveProject.dates.deadline!
 
     self.vm.inputs.configureWith(fundingDateStats: stats, project: nonLiveProject)
 
@@ -70,15 +72,15 @@ internal final class DashboardFundingCellViewModelTests: TestCase {
           pledged: Format.currency(liveProject.stats.pledged, country: liveProject.country),
           goal: Format.currency(liveProject.stats.goal, country: liveProject.country),
           backers_count: liveProject.stats.backersCount,
-          time_left: Format.duration(secondsInUTC: liveProject.dates.deadline).time + " " +
-            Format.duration(secondsInUTC: liveProject.dates.deadline).unit
+          time_left: Format.duration(secondsInUTC: deadline).time + " " +
+            Format.duration(secondsInUTC: deadline).unit
         ),
         Strings.dashboard_graphs_funding_accessibility_non_live_stat_value(
           pledged: Format.currency(nonLiveProject.stats.pledged, country: nonLiveProject.country),
           goal: Format.currency(nonLiveProject.stats.goal, country: nonLiveProject.country),
           backers_count: nonLiveProject.stats.backersCount,
-          time_left: Format.duration(secondsInUTC: nonLiveProject.dates.deadline).time + " " +
-            Format.duration(secondsInUTC: nonLiveProject.dates.deadline).unit
+          time_left: Format.duration(secondsInUTC: nonLiveDeadline).time + " " +
+            Format.duration(secondsInUTC: nonLiveDeadline).unit
         )
       ],
       "Non live project stats value emits."

--- a/Library/ViewModels/DiscoveryPostcardViewModel.swift
+++ b/Library/ViewModels/DiscoveryPostcardViewModel.swift
@@ -164,9 +164,13 @@ public final class DiscoveryPostcardViewModel: DiscoveryPostcardViewModelType,
     self.backersSubtitleLabelText = backersTitleAndSubtitleText.map { _, subtitle in subtitle ?? "" }
 
     let deadlineTitleAndSubtitle = configuredProject
-      .map {
-        $0.state == .live
-          ? Format.duration(secondsInUTC: $0.dates.deadline, useToGo: true)
+      .map { project -> (String, String) in
+        guard let datesDeadline = project.dates.deadline else {
+          return ("", "")
+        }
+
+        return project.state == .live
+          ? Format.duration(secondsInUTC: datesDeadline, useToGo: true)
           : ("", "")
       }
 

--- a/Library/ViewModels/DiscoveryPostcardViewModelTests.swift
+++ b/Library/ViewModels/DiscoveryPostcardViewModelTests.swift
@@ -166,12 +166,13 @@ internal final class DiscoveryPostcardViewModelTests: TestCase {
 
   func testProjectStatsEmit() {
     let project = Project.template
+    let deadline = project.dates.deadline!
 
     self.vm.inputs.configure(with: (project, nil, nil))
 
     self.backersTitleLabelText.assertValues([Format.wholeNumber(project.stats.backersCount)])
 
-    let deadlineTitleAndSubtitle = Format.duration(secondsInUTC: project.dates.deadline, useToGo: true)
+    let deadlineTitleAndSubtitle = Format.duration(secondsInUTC: deadline, useToGo: true)
     self.deadlineSubtitleLabelText.assertValues([deadlineTitleAndSubtitle.unit])
     self.deadlineTitleLabelText.assertValues([deadlineTitleAndSubtitle.time])
 

--- a/Library/ViewModels/DiscoveryProjectCardViewModel.swift
+++ b/Library/ViewModels/DiscoveryProjectCardViewModel.swift
@@ -115,8 +115,12 @@ public final class DiscoveryProjectCardViewModel: DiscoveryProjectCardViewModelT
       case .failed: return ("", Strings.profile_projects_status_unsuccessful())
       case .successful: return ("", Strings.profile_projects_status_successful())
       case .live:
+        guard let projectDeadline = project.dates.deadline else {
+          return ("", "")
+        }
+
         let (duration, unit) = Format.duration(
-          secondsInUTC: project.dates.deadline,
+          secondsInUTC: projectDeadline,
           abbreviate: false,
           useToGo: true,
           env: AppEnvironment.current

--- a/Library/ViewModels/ManagePledgeViewModel.swift
+++ b/Library/ViewModels/ManagePledgeViewModel.swift
@@ -526,7 +526,8 @@ private func managePledgeSummaryViewData(
   backedReward: Reward,
   backing: Backing
 ) -> ManagePledgeSummaryViewData? {
-  guard let backer = backing.backer else { return nil }
+  guard let backer = backing.backer,
+    let deadline = project.dates.deadline else { return nil }
 
   let isRewardLocalPickup = isRewardLocalPickup(backing.reward)
 
@@ -546,7 +547,7 @@ private func managePledgeSummaryViewData(
     pledgeAmount: backing.amount,
     pledgedOn: backing.pledgedAt,
     projectCurrencyCountry: projectCurrencyCountry,
-    projectDeadline: project.dates.deadline,
+    projectDeadline: deadline,
     projectState: project.state,
     rewardMinimum: allRewardsTotal(for: backing),
     shippingAmount: backing.shippingAmount.flatMap(Double.init),

--- a/Library/ViewModels/MostPopularSearchProjectCellViewModel.swift
+++ b/Library/ViewModels/MostPopularSearchProjectCellViewModel.swift
@@ -69,7 +69,12 @@ public final class MostPopularSearchProjectCellViewModel: MostPopularSearchProje
 private func metadataString(for project: Project) -> String {
   switch project.state {
   case .live:
-    let duration = Format.duration(secondsInUTC: project.dates.deadline, abbreviate: true, useToGo: false)
+    guard let deadline = project.dates.deadline else {
+      return ""
+    }
+
+    let duration = Format.duration(secondsInUTC: deadline, abbreviate: true, useToGo: false)
+
     return "\(duration.time) \(duration.unit)"
   default:
     return stateString(for: project)

--- a/Library/ViewModels/PledgeSummaryViewModel.swift
+++ b/Library/ViewModels/PledgeSummaryViewModel.swift
@@ -125,7 +125,12 @@ private func attributedCurrency(with project: Project, total: Double) -> NSAttri
 }
 
 private func attributedConfirmationString(with project: Project, pledgeTotal: Double) -> NSAttributedString {
-  let date = Format.date(secondsInUTC: project.dates.deadline, template: "MMMM d, yyyy")
+  var date = ""
+
+  if let deadline = project.dates.deadline {
+    date = Format.date(secondsInUTC: deadline, template: "MMMM d, yyyy")
+  }
+
   let projectCurrencyCountry = projectCountry(forCurrency: project.stats.currency) ?? project.country
   let pledgeTotal = Format.currency(pledgeTotal, country: projectCurrencyCountry)
 

--- a/Library/ViewModels/ProjectActivityLaunchCellViewModel.swift
+++ b/Library/ViewModels/ProjectActivityLaunchCellViewModel.swift
@@ -31,12 +31,18 @@ public final class ProjectActivityLaunchCellViewModel: ProjectActivityLaunchCell
     self.backgroundImageURL = project.map { $0.photo.med }.map(URL.init(string:))
 
     self.title = project.map { project in
-      Strings.dashboard_activity_project_name_launched(
-        project_name: project.name,
-        launch_date: Format.date(
-          secondsInUTC: project.dates.launchedAt,
+      var formatted = ""
+
+      if let launchedAtDate = project.dates.launchedAt {
+        formatted = Format.date(
+          secondsInUTC: launchedAtDate,
           dateStyle: .long, timeStyle: .none
-        ).nonBreakingSpaced(),
+        ).nonBreakingSpaced()
+      }
+
+      return Strings.dashboard_activity_project_name_launched(
+        project_name: project.name,
+        launch_date: formatted,
         goal: Format.currency(project.stats.goal, country: project.country).nonBreakingSpaced()
       )
     }

--- a/Library/ViewModels/ProjectActivitySuccessCellViewModel.swift
+++ b/Library/ViewModels/ProjectActivitySuccessCellViewModel.swift
@@ -31,14 +31,20 @@ public final class ProjectActivitySuccessCellViewModel: ProjectActivitySuccessCe
     self.backgroundImageURL = project.map { $0.photo.med }.map(URL.init(string:))
 
     self.title = project.map { project in
-      Strings.dashboard_activity_successfully_raised_pledged(
+      var projectDeadline = ""
+
+      if let projectDeadlineValue = project.dates.deadline {
+        projectDeadline = Format.date(
+          secondsInUTC: projectDeadlineValue, dateStyle: .long,
+          timeStyle: .none
+        ).nonBreakingSpaced()
+      }
+
+      return Strings.dashboard_activity_successfully_raised_pledged(
         pledged: Format.currency(project.stats.pledged, country: project.country).nonBreakingSpaced(),
         backers: Strings.general_backer_count_backers(backer_count: project.stats.backersCount)
           .nonBreakingSpaced(),
-        deadline: Format.date(
-          secondsInUTC: project.dates.deadline, dateStyle: .long,
-          timeStyle: .none
-        ).nonBreakingSpaced()
+        deadline: projectDeadline
       )
     }
   }

--- a/Library/ViewModels/ProjectPamphletCreatorHeaderCellViewModel.swift
+++ b/Library/ViewModels/ProjectPamphletCreatorHeaderCellViewModel.swift
@@ -56,19 +56,23 @@ private func title(for project: Project) -> String {
   return project.state == .live ? Strings.View_progress() : Strings.View_dashboard()
 }
 
-private func attributedLaunchDateString(with project: Project)
-  -> NSAttributedString? {
-  let date = Format.date(
-    secondsInUTC: project.dates.launchedAt,
-    dateStyle: .long,
-    timeStyle: .none,
-    timeZone: UTCTimeZone
-  )
-  let fullString = Strings.You_launched_this_project_on_launch_date(launch_date: date)
+private func attributedLaunchDateString(with project: Project) -> NSAttributedString? {
+  var launchDate = ""
+
+  if let date = project.dates.launchedAt {
+    launchDate = Format.date(
+      secondsInUTC: date,
+      dateStyle: .long,
+      timeStyle: .none,
+      timeZone: UTCTimeZone
+    )
+  }
+
+  let fullString = Strings.You_launched_this_project_on_launch_date(launch_date: launchDate)
 
   let attributedString: NSMutableAttributedString = NSMutableAttributedString(string: fullString)
   let fullRange = (fullString as NSString).localizedStandardRange(of: fullString)
-  let rangeDate: NSRange = (fullString as NSString).localizedStandardRange(of: date)
+  let rangeDate: NSRange = (fullString as NSString).localizedStandardRange(of: launchDate)
 
   let paragraphStyle = NSMutableParagraphStyle()
   paragraphStyle.alignment = .left

--- a/Library/ViewModels/ProjectPamphletMainCellViewModel.swift
+++ b/Library/ViewModels/ProjectPamphletMainCellViewModel.swift
@@ -190,8 +190,14 @@ public final class ProjectPamphletMainCellViewModel: ProjectPamphletMainCellView
 
     self.categoryNameLabelText = project.map { $0.category.name }
 
-    let deadlineTitleAndSubtitle = project.map {
-      Format.duration(secondsInUTC: $0.dates.deadline, useToGo: true)
+    let deadlineTitleAndSubtitle = project.map { project -> (String, String) in
+      var durationValue = ("", "")
+
+      if let deadline = project.dates.deadline {
+        durationValue = Format.duration(secondsInUTC: deadline, useToGo: true)
+      }
+
+      return durationValue
     }
 
     self.deadlineTitleLabelText = deadlineTitleAndSubtitle.map(first)
@@ -345,7 +351,12 @@ private func statsStackViewAccessibilityLabelForProject(_ project: Project, need
   )
 
   let backersCount = project.stats.backersCount
-  let (time, unit) = Format.duration(secondsInUTC: project.dates.deadline, useToGo: true)
+  var (time, unit) = ("", "")
+
+  if let deadline = project.dates.deadline {
+    (time, unit) = Format.duration(secondsInUTC: deadline, useToGo: true)
+  }
+
   let timeLeft = time + " " + unit
 
   return project.state == .live

--- a/Library/ViewModels/RewardAddOnCardViewModel.swift
+++ b/Library/ViewModels/RewardAddOnCardViewModel.swift
@@ -317,11 +317,12 @@ private func timeLeftString(project: Project, reward: Reward) -> String? {
   let isUnlimitedOrAvailable = reward.limit == nil || reward.remaining ?? 0 > 0
 
   if let endsAt = reward.endsAt,
+    let deadline = project.dates.deadline,
     endsAt > 0,
     endsAt >= AppEnvironment.current.dateType.init().timeIntervalSince1970,
     isUnlimitedOrAvailable {
     let (time, unit) = Format.duration(
-      secondsInUTC: min(endsAt, project.dates.deadline),
+      secondsInUTC: min(endsAt, deadline),
       abbreviate: true,
       useToGo: false
     )

--- a/Library/ViewModels/RewardCardViewModel.swift
+++ b/Library/ViewModels/RewardCardViewModel.swift
@@ -259,11 +259,12 @@ private func timeLeftString(project: Project, reward: Reward) -> RewardCardPillD
 
   if project.state == .live,
     let endsAt = reward.endsAt,
+    let deadline = project.dates.deadline,
     endsAt > 0,
     endsAt >= AppEnvironment.current.dateType.init().timeIntervalSince1970,
     isUnlimitedOrAvailable {
     let (time, unit) = Format.duration(
-      secondsInUTC: min(endsAt, project.dates.deadline),
+      secondsInUTC: min(endsAt, deadline),
       abbreviate: true,
       useToGo: false
     )


### PR DESCRIPTION
# 📲 What

As outlined in this [ticket](https://kickstarter.atlassian.net/browse/WEB-999) we needed to update our existing project model `deadline` and `launchedAt` properties to optional instead of non-optional.

Reason is because the prelaunch pages do not have those fields populated in GQL and the existing project page works off of GQL not v1.

Obviously this isn't the final version of the prelaunch, but necessary to get the latest data for the eventual page UI.

# 🤔 Why

As stated above, we need the `deadline` and `launchedAt` dates to be non-optional for those fields to be populated in order for the guard check to pass in `Project+ProjectFragment` `dates`

# 🛠 How

Did a project search for both properties and found instances of their use. In cases where optionals where being returned already, just needed to add the property to the `if let` or `guard let`. Otherwise returned a sensible value (ie. for String was "", or Int was 1).

There are lot of places where these fields occur and going through them all with breakpoints helped validate that nothing was broken or out of place.

Mostly though relied on optional checks to safely unwrap properties that were once non-optional.

Also fixed up tests to pass, not too much to do there.

# 👀 See

| Before 🐛 | After 🦋 |
| --- | --- |
| ![non-optional_v1](https://user-images.githubusercontent.com/4282741/223858157-71b57bf7-e4a9-459e-81e3-f132427f5b5a.jpeg) | ![optional_gql](https://user-images.githubusercontent.com/4282741/223858144-b8deff10-5121-4f0b-8003-c51814a131ec.jpeg) |

# ✅ Acceptance criteria

- [x] Run through the app with breakpoints for whereever `deadline` or `launchedAt` or computed properties of those two were being used, hit breakpoint, ensure optional check passes.
