### PR TITLE
[Unticketed] UI on the Creator Dashboard Breaking

### DIFF
--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -247,6 +247,7 @@
 		1937A71F28C94FFC00DD732D /* SettingsFormFieldView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 7790DF882200D3BD005DBB11 /* SettingsFormFieldView.xib */; };
 		1937A72328C9570A00DD732D /* ErroredBackingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1937A72228C9570900DD732D /* ErroredBackingView.swift */; };
 		1937A72628C959DD00DD732D /* FundingGraphViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7ED205B1E83240D00BFFA01 /* FundingGraphViewTests.swift */; };
+		193C7FB629DA74990023B95E /* GraphUserMemberStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 193C7FB429DA73D90023B95E /* GraphUserMemberStatusTests.swift */; };
 		194154CE28D8ED69004648C8 /* CreatePaymentSourceSetupIntentInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 194154CD28D8ED69004648C8 /* CreatePaymentSourceSetupIntentInput.swift */; };
 		194154D128D8FBAA004648C8 /* CreatePaymentSourceSetupIntentClientSecret+Constructor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 194154CF28D8F2DE004648C8 /* CreatePaymentSourceSetupIntentClientSecret+Constructor.swift */; };
 		194154D328D928C9004648C8 /* CreatePaymentSourceSetupIntentInputTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 194154D228D928C9004648C8 /* CreatePaymentSourceSetupIntentInputTests.swift */; };
@@ -1862,6 +1863,7 @@
 		192016C728B6731A0046919B /* PledgePaymentMethodsViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PledgePaymentMethodsViewControllerTests.swift; sourceTree = "<group>"; };
 		1923770928DA2AE300F68635 /* Stripe+PaymentMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Stripe+PaymentMethod.swift"; sourceTree = "<group>"; };
 		1937A72228C9570900DD732D /* ErroredBackingView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ErroredBackingView.swift; sourceTree = "<group>"; };
+		193C7FB429DA73D90023B95E /* GraphUserMemberStatusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphUserMemberStatusTests.swift; sourceTree = "<group>"; };
 		194154CD28D8ED69004648C8 /* CreatePaymentSourceSetupIntentInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreatePaymentSourceSetupIntentInput.swift; sourceTree = "<group>"; };
 		194154CF28D8F2DE004648C8 /* CreatePaymentSourceSetupIntentClientSecret+Constructor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CreatePaymentSourceSetupIntentClientSecret+Constructor.swift"; sourceTree = "<group>"; };
 		194154D228D928C9004648C8 /* CreatePaymentSourceSetupIntentInputTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreatePaymentSourceSetupIntentInputTests.swift; sourceTree = "<group>"; };
@@ -6057,6 +6059,7 @@
 				7798B56421750041008BC50D /* GraphUser.swift */,
 				6008633329B8FBD700B87B39 /* GraphUserEmail.swift */,
 				19C1CE3429DA44C600899A17 /* GraphUserMemberStatus.swift */,
+				193C7FB429DA73D90023B95E /* GraphUserMemberStatusTests.swift */,
 				D63BBD30217F7212007E01F0 /* UserCreditCards.swift */,
 				77DB53292215D0AA0078991C /* UserCreditCardsTests.swift */,
 				77FA1AF22445FB810035D659 /* GraphUserTests.swift */,
@@ -9158,6 +9161,7 @@
 				06232D3C2795EC2400A81755 /* HTMLParserTests.swift in Sources */,
 				D015899E1EEB2ED7006E7684 /* ServiceTests.swift in Sources */,
 				06962F8B273B32D900FB0B3D /* PostCommentEnvelope+PostCommentMutationDataTests.swift in Sources */,
+				193C7FB629DA74990023B95E /* GraphUserMemberStatusTests.swift in Sources */,
 				8AF34C7A2342D864000B211D /* Encodable+DictionaryTests.swift in Sources */,
 				D0D10C0C1EEB4550005EBAD0 /* FindFriendsEnvelopeTests.swift in Sources */,
 				47B1338F26B35AA000080048 /* GraphAPI.BackingState+BackingStateTests.swift in Sources */,

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -275,6 +275,9 @@
 		19BF226128D10497007F4197 /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = 19BF226028D10497007F4197 /* FirebaseAnalytics */; };
 		19BF226328D10497007F4197 /* FirebaseCrashlytics in Frameworks */ = {isa = PBXBuildFile; productRef = 19BF226228D10497007F4197 /* FirebaseCrashlytics */; };
 		19BF226528D10497007F4197 /* FirebasePerformance in Frameworks */ = {isa = PBXBuildFile; productRef = 19BF226428D10497007F4197 /* FirebasePerformance */; };
+		19C1CE3329DA43C100899A17 /* FetchUserMemberStatus.graphql in Sources */ = {isa = PBXBuildFile; fileRef = 19C1CE3229DA43C100899A17 /* FetchUserMemberStatus.graphql */; };
+		19C1CE3529DA44C600899A17 /* GraphUserMemberStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19C1CE3429DA44C600899A17 /* GraphUserMemberStatus.swift */; };
+		19C1CE3729DA478000899A17 /* UserMemberStatusFragment.graphql in Resources */ = {isa = PBXBuildFile; fileRef = 19C1CE3629DA478000899A17 /* UserMemberStatusFragment.graphql */; };
 		19C8E56929A9249D007C3504 /* TextInputFieldModifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19C8E56829A9249D007C3504 /* TextInputFieldModifiers.swift */; };
 		19D988482979CA4E00A5EE61 /* BrazePushEnvelope.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19D988472979CA4E00A5EE61 /* BrazePushEnvelope.swift */; };
 		19E9F01729C0F9A20002AD69 /* MockAppTrackingTransparency.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6008633E29BF750700B87B39 /* MockAppTrackingTransparency.swift */; };
@@ -1865,6 +1868,9 @@
 		194154D428D92A26004648C8 /* CreatePaymentSourceSetupIntentClientSecret+ConstructorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CreatePaymentSourceSetupIntentClientSecret+ConstructorTests.swift"; sourceTree = "<group>"; };
 		194520C4288859A600CA9B88 /* PaymentCardTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentCardTextField.swift; sourceTree = "<group>"; };
 		19A97CF128C7E2D30031B857 /* CategoryPillCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CategoryPillCell.swift; sourceTree = "<group>"; };
+		19C1CE3229DA43C100899A17 /* FetchUserMemberStatus.graphql */ = {isa = PBXFileReference; lastKnownFileType = text; path = FetchUserMemberStatus.graphql; sourceTree = "<group>"; };
+		19C1CE3429DA44C600899A17 /* GraphUserMemberStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphUserMemberStatus.swift; sourceTree = "<group>"; };
+		19C1CE3629DA478000899A17 /* UserMemberStatusFragment.graphql */ = {isa = PBXFileReference; lastKnownFileType = text; path = UserMemberStatusFragment.graphql; sourceTree = "<group>"; };
 		19C8E56829A9249D007C3504 /* TextInputFieldModifiers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextInputFieldModifiers.swift; sourceTree = "<group>"; };
 		19D988472979CA4E00A5EE61 /* BrazePushEnvelope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrazePushEnvelope.swift; sourceTree = "<group>"; };
 		19F0940028B3D75800973138 /* PledgePaymentMethodAddCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PledgePaymentMethodAddCellViewModel.swift; sourceTree = "<group>"; };
@@ -5959,6 +5965,7 @@
 				4778EE1E26A1E8230059EA69 /* FetchUser.graphql */,
 				4758484D26B31CF8005AAC1C /* FetchUserBackings.graphql */,
 				6008632D29B8F66F00B87B39 /* FetchUserEmail.graphql */,
+				19C1CE3229DA43C100899A17 /* FetchUserMemberStatus.graphql */,
 				0655C7272732FDA30087281F /* FetchRootCategories.graphql */,
 				0655C7292732FDE00087281F /* FetchCategory.graphql */,
 			);
@@ -6049,6 +6056,7 @@
 				D002CAE4218CF951009783F2 /* WatchProjectResponseEnvelope.swift */,
 				7798B56421750041008BC50D /* GraphUser.swift */,
 				6008633329B8FBD700B87B39 /* GraphUserEmail.swift */,
+				19C1CE3429DA44C600899A17 /* GraphUserMemberStatus.swift */,
 				D63BBD30217F7212007E01F0 /* UserCreditCards.swift */,
 				77DB53292215D0AA0078991C /* UserCreditCardsTests.swift */,
 				77FA1AF22445FB810035D659 /* GraphUserTests.swift */,
@@ -6074,6 +6082,7 @@
 				8A1556DF269394B600017845 /* RewardFragment.graphql */,
 				8AC3E08D2698CE8200168BF8 /* ShippingRuleFragment.graphql */,
 				6008632B29B8F64700B87B39 /* UserEmailFragment.graphql */,
+				19C1CE3629DA478000899A17 /* UserMemberStatusFragment.graphql */,
 				8A1556F1269398CB00017845 /* UserFragment.graphql */,
 				06DAAE5C26AA3CF500194E58 /* UserStoredCardsFragment.graphql */,
 			);
@@ -7653,6 +7662,7 @@
 				19047FBB2889A16300BDD1A8 /* CreateSetupIntent.graphql in Resources */,
 				062868E626B999EF00EC5052 /* DeletePaymentSource.graphql in Resources */,
 				06C38CB926A9D13400591CED /* UpdateUserProfile.graphql in Resources */,
+				19C1CE3729DA478000899A17 /* UserMemberStatusFragment.graphql in Resources */,
 				47D7D09626C2EA5200D2BAB5 /* SignInWithApple.graphql in Resources */,
 				06DAAE5926AA3CD100194E58 /* CommentFragment.graphql in Resources */,
 				06261603273B0E1500389981 /* PostComment.graphql in Resources */,
@@ -9036,6 +9046,7 @@
 				D67B6CD6221F468100B63A6B /* Location+Encode.swift in Sources */,
 				8AC3E105269F4D1C00168BF8 /* GraphAPI.ApplePay+ApplePayParams.swift in Sources */,
 				D01588331EEB2ED7006E7684 /* Decodable.swift in Sources */,
+				19C1CE3529DA44C600899A17 /* GraphUserMemberStatus.swift in Sources */,
 				06232D3E2795EC2C00A81755 /* Element+Helpers.swift in Sources */,
 				8ACF36E22627481C0026E74D /* ApiDateProtocol.swift in Sources */,
 				8A07D00C26657FCE00426B1C /* CommentRepliesEnvelopeTemplates.swift in Sources */,
@@ -9065,6 +9076,7 @@
 				8479CF2C2530A5D700FD13F1 /* Service+DecodeHelpers.swift in Sources */,
 				D68F0B16243CFF3F009FC948 /* SignInWithAppleEnvelope.swift in Sources */,
 				D6B686EB2191FEEE005F5DA7 /* UserSendEmailVerificationMutation.swift in Sources */,
+				19C1CE3329DA43C100899A17 /* FetchUserMemberStatus.graphql in Sources */,
 				D6F5C60F2437DD2A00C1A79D /* SignInWithAppleMutation.swift in Sources */,
 				D67B6CD8221F46D700B63A6B /* Project.Country+Encode.swift in Sources */,
 				8AA8A38424EC6DA400085282 /* ProjectAndBackingEnvelopeTemplates.swift in Sources */,

--- a/KsApi/GraphAPI.swift
+++ b/KsApi/GraphAPI.swift
@@ -9185,6 +9185,112 @@ public enum GraphAPI {
     }
   }
 
+  public final class FetchUserMemberStatusQuery: GraphQLQuery {
+    /// The raw GraphQL definition of this operation.
+    public let operationDefinition: String =
+      """
+      query FetchUserMemberStatus {
+        me {
+          __typename
+          ...UserMemberStatusFragment
+        }
+      }
+      """
+
+    public let operationName: String = "FetchUserMemberStatus"
+
+    public var queryDocument: String {
+      var document: String = operationDefinition
+      document.append("\n" + UserMemberStatusFragment.fragmentDefinition)
+      return document
+    }
+
+    public init() {
+    }
+
+    public struct Data: GraphQLSelectionSet {
+      public static let possibleTypes: [String] = ["Query"]
+
+      public static var selections: [GraphQLSelection] {
+        return [
+          GraphQLField("me", type: .object(Me.selections)),
+        ]
+      }
+
+      public private(set) var resultMap: ResultMap
+
+      public init(unsafeResultMap: ResultMap) {
+        self.resultMap = unsafeResultMap
+      }
+
+      public init(me: Me? = nil) {
+        self.init(unsafeResultMap: ["__typename": "Query", "me": me.flatMap { (value: Me) -> ResultMap in value.resultMap }])
+      }
+
+      /// You.
+      public var me: Me? {
+        get {
+          return (resultMap["me"] as? ResultMap).flatMap { Me(unsafeResultMap: $0) }
+        }
+        set {
+          resultMap.updateValue(newValue?.resultMap, forKey: "me")
+        }
+      }
+
+      public struct Me: GraphQLSelectionSet {
+        public static let possibleTypes: [String] = ["User"]
+
+        public static var selections: [GraphQLSelection] {
+          return [
+            GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+            GraphQLFragmentSpread(UserMemberStatusFragment.self),
+          ]
+        }
+
+        public private(set) var resultMap: ResultMap
+
+        public init(unsafeResultMap: ResultMap) {
+          self.resultMap = unsafeResultMap
+        }
+
+        public var __typename: String {
+          get {
+            return resultMap["__typename"]! as! String
+          }
+          set {
+            resultMap.updateValue(newValue, forKey: "__typename")
+          }
+        }
+
+        public var fragments: Fragments {
+          get {
+            return Fragments(unsafeResultMap: resultMap)
+          }
+          set {
+            resultMap += newValue.resultMap
+          }
+        }
+
+        public struct Fragments {
+          public private(set) var resultMap: ResultMap
+
+          public init(unsafeResultMap: ResultMap) {
+            self.resultMap = unsafeResultMap
+          }
+
+          public var userMemberStatusFragment: UserMemberStatusFragment {
+            get {
+              return UserMemberStatusFragment(unsafeResultMap: resultMap)
+            }
+            set {
+              resultMap += newValue.resultMap
+            }
+          }
+        }
+      }
+    }
+  }
+
   public final class FetchUserStoredCardsQuery: GraphQLQuery {
     /// The raw GraphQL definition of this operation.
     public let operationDefinition: String =
@@ -14756,6 +14862,151 @@ public enum GraphAPI {
 
       public init(totalCount: Int) {
         self.init(unsafeResultMap: ["__typename": "SurveyResponsesConnection", "totalCount": totalCount])
+      }
+
+      public var __typename: String {
+        get {
+          return resultMap["__typename"]! as! String
+        }
+        set {
+          resultMap.updateValue(newValue, forKey: "__typename")
+        }
+      }
+
+      public var totalCount: Int {
+        get {
+          return resultMap["totalCount"]! as! Int
+        }
+        set {
+          resultMap.updateValue(newValue, forKey: "totalCount")
+        }
+      }
+    }
+  }
+
+  public struct UserMemberStatusFragment: GraphQLFragment {
+    /// The raw GraphQL definition of this fragment.
+    public static let fragmentDefinition: String =
+      """
+      fragment UserMemberStatusFragment on User {
+        __typename
+        createdProjects {
+          __typename
+          totalCount
+        }
+        membershipProjects {
+          __typename
+          totalCount
+        }
+      }
+      """
+
+    public static let possibleTypes: [String] = ["User"]
+
+    public static var selections: [GraphQLSelection] {
+      return [
+        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+        GraphQLField("createdProjects", type: .object(CreatedProject.selections)),
+        GraphQLField("membershipProjects", type: .object(MembershipProject.selections)),
+      ]
+    }
+
+    public private(set) var resultMap: ResultMap
+
+    public init(unsafeResultMap: ResultMap) {
+      self.resultMap = unsafeResultMap
+    }
+
+    public init(createdProjects: CreatedProject? = nil, membershipProjects: MembershipProject? = nil) {
+      self.init(unsafeResultMap: ["__typename": "User", "createdProjects": createdProjects.flatMap { (value: CreatedProject) -> ResultMap in value.resultMap }, "membershipProjects": membershipProjects.flatMap { (value: MembershipProject) -> ResultMap in value.resultMap }])
+    }
+
+    public var __typename: String {
+      get {
+        return resultMap["__typename"]! as! String
+      }
+      set {
+        resultMap.updateValue(newValue, forKey: "__typename")
+      }
+    }
+
+    /// Projects a user has created.
+    public var createdProjects: CreatedProject? {
+      get {
+        return (resultMap["createdProjects"] as? ResultMap).flatMap { CreatedProject(unsafeResultMap: $0) }
+      }
+      set {
+        resultMap.updateValue(newValue?.resultMap, forKey: "createdProjects")
+      }
+    }
+
+    /// Projects the user has collaborated on.
+    public var membershipProjects: MembershipProject? {
+      get {
+        return (resultMap["membershipProjects"] as? ResultMap).flatMap { MembershipProject(unsafeResultMap: $0) }
+      }
+      set {
+        resultMap.updateValue(newValue?.resultMap, forKey: "membershipProjects")
+      }
+    }
+
+    public struct CreatedProject: GraphQLSelectionSet {
+      public static let possibleTypes: [String] = ["UserCreatedProjectsConnection"]
+
+      public static var selections: [GraphQLSelection] {
+        return [
+          GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+          GraphQLField("totalCount", type: .nonNull(.scalar(Int.self))),
+        ]
+      }
+
+      public private(set) var resultMap: ResultMap
+
+      public init(unsafeResultMap: ResultMap) {
+        self.resultMap = unsafeResultMap
+      }
+
+      public init(totalCount: Int) {
+        self.init(unsafeResultMap: ["__typename": "UserCreatedProjectsConnection", "totalCount": totalCount])
+      }
+
+      public var __typename: String {
+        get {
+          return resultMap["__typename"]! as! String
+        }
+        set {
+          resultMap.updateValue(newValue, forKey: "__typename")
+        }
+      }
+
+      public var totalCount: Int {
+        get {
+          return resultMap["totalCount"]! as! Int
+        }
+        set {
+          resultMap.updateValue(newValue, forKey: "totalCount")
+        }
+      }
+    }
+
+    public struct MembershipProject: GraphQLSelectionSet {
+      public static let possibleTypes: [String] = ["MembershipProjectsConnection"]
+
+      public static var selections: [GraphQLSelection] {
+        return [
+          GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+          GraphQLField("totalCount", type: .nonNull(.scalar(Int.self))),
+        ]
+      }
+
+      public private(set) var resultMap: ResultMap
+
+      public init(unsafeResultMap: ResultMap) {
+        self.resultMap = unsafeResultMap
+      }
+
+      public init(totalCount: Int) {
+        self.init(unsafeResultMap: ["__typename": "MembershipProjectsConnection", "totalCount": totalCount])
       }
 
       public var __typename: String {

--- a/KsApi/MockService.swift
+++ b/KsApi/MockService.swift
@@ -1679,6 +1679,8 @@
             fetchDraftError: $1.fetchDraftError,
             fetchGraphUserResult: $1.fetchGraphUserResult,
             fetchGraphUserSelfResult: $1.fetchGraphUserSelfResult,
+            fetchGraphUserEmailResult: $1.fetchGraphUserEmailResult,
+            fetchGraphUserMemberStatusResult: $1.fetchGraphUserMemberStatusResult,
             addAttachmentResponse: $1.addAttachmentResponse,
             addAttachmentError: $1.addAttachmentError,
             removeAttachmentResponse: $1.removeAttachmentResponse,

--- a/KsApi/MockService.swift
+++ b/KsApi/MockService.swift
@@ -80,6 +80,10 @@
     fileprivate let fetchGraphUserResult: Result<UserEnvelope<GraphUser>, ErrorEnvelope>?
     fileprivate let fetchGraphUserSelfResult: Result<UserEnvelope<User>, ErrorEnvelope>?
     fileprivate let fetchGraphUserEmailResult: Result<UserEnvelope<GraphUserEmail>, ErrorEnvelope>?
+    fileprivate let fetchGraphUserMemberStatusResult: Result<
+      UserEnvelope<GraphUserMemberStatus>,
+      ErrorEnvelope
+    >?
     fileprivate let fetchErroredUserBackingsResult: Result<ErroredBackingsEnvelope, ErrorEnvelope>?
 
     fileprivate let addAttachmentResponse: UpdateDraft.Image?
@@ -252,6 +256,7 @@
       fetchGraphUserResult: Result<UserEnvelope<GraphUser>, ErrorEnvelope>? = nil,
       fetchGraphUserSelfResult: Result<UserEnvelope<User>, ErrorEnvelope>? = nil,
       fetchGraphUserEmailResult: Result<UserEnvelope<GraphUserEmail>, ErrorEnvelope>? = nil,
+      fetchGraphUserMemberStatusResult: Result<UserEnvelope<GraphUserMemberStatus>, ErrorEnvelope>? = nil,
       fetchErroredUserBackingsResult: Result<ErroredBackingsEnvelope, ErrorEnvelope>? = nil,
       addAttachmentResponse: UpdateDraft.Image? = nil,
       addAttachmentError: ErrorEnvelope? = nil,
@@ -366,6 +371,7 @@
       self.fetchGraphUserResult = fetchGraphUserResult
       self.fetchGraphUserSelfResult = fetchGraphUserSelfResult
       self.fetchGraphUserEmailResult = fetchGraphUserEmailResult
+      self.fetchGraphUserMemberStatusResult = fetchGraphUserMemberStatusResult
 
       self.fetchErroredUserBackingsResult = fetchErroredUserBackingsResult
 
@@ -808,6 +814,21 @@
       let fetchGraphUserEmailQuery = GraphAPI.FetchUserEmailQuery()
 
       return client.fetchWithResult(query: fetchGraphUserEmailQuery, result: self.fetchGraphUserEmailResult)
+    }
+
+    internal func fetchGraphUserMemberStatus()
+      -> SignalProducer<UserEnvelope<GraphUserMemberStatus>, ErrorEnvelope> {
+      guard let client = self.apolloClient else {
+        return .empty
+      }
+
+      let fetchGraphUserMemberStatusQuery = GraphAPI.FetchUserMemberStatusQuery()
+
+      return client
+        .fetchWithResult(
+          query: fetchGraphUserMemberStatusQuery,
+          result: self.fetchGraphUserMemberStatusResult
+        )
     }
 
     // TODO: Refactor this test to use `self.apolloClient`, `ErroredBackingsEnvelope` needs to be `Decodable` and tested in-app.

--- a/KsApi/Service.swift
+++ b/KsApi/Service.swift
@@ -344,6 +344,13 @@ public struct Service: ServiceType {
       .flatMap(UserEnvelope<GraphUserEmail>.envelopeProducer(from:))
   }
 
+  public func fetchGraphUserMemberStatus()
+    -> SignalProducer<UserEnvelope<GraphUserMemberStatus>, ErrorEnvelope> {
+    return GraphQL.shared.client
+      .fetch(query: GraphAPI.FetchUserMemberStatusQuery())
+      .flatMap(UserEnvelope<GraphUserMemberStatus>.envelopeProducer(from:))
+  }
+
   public func fetchGraphUserSelf()
     -> SignalProducer<UserEnvelope<User>, ErrorEnvelope> {
     return GraphQL.shared.client

--- a/KsApi/ServiceType.swift
+++ b/KsApi/ServiceType.swift
@@ -169,6 +169,10 @@ public protocol ServiceType {
   func fetchGraphUserEmail()
     -> SignalProducer<UserEnvelope<GraphUserEmail>, ErrorEnvelope>
 
+  /// Fetches creator and collaborator status of the currently logged in User.
+  func fetchGraphUserMemberStatus()
+    -> SignalProducer<UserEnvelope<GraphUserMemberStatus>, ErrorEnvelope>
+
   /// Fetches GraphQL user fragment and returns User instance.
   func fetchGraphUserSelf()
     -> SignalProducer<UserEnvelope<User>, ErrorEnvelope>

--- a/KsApi/fragments/UserMemberStatusFragment.graphql
+++ b/KsApi/fragments/UserMemberStatusFragment.graphql
@@ -1,0 +1,8 @@
+fragment UserMemberStatusFragment on User {
+  createdProjects {
+    totalCount
+  }
+  membershipProjects {
+    totalCount
+  }
+}

--- a/KsApi/models/UserEnvelope.swift
+++ b/KsApi/models/UserEnvelope.swift
@@ -24,6 +24,14 @@ extension UserEnvelope {
     return SignalProducer(value: envelope)
   }
 
+  static func envelopeProducer(from data: GraphAPI.FetchUserMemberStatusQuery.Data)
+    -> SignalProducer<UserEnvelope<GraphUserMemberStatus>, ErrorEnvelope> {
+    guard let envelope = UserEnvelope.userEnvelope(from: data) else {
+      return .empty
+    }
+    return SignalProducer(value: envelope)
+  }
+
   static func envelopeProducer(from data: GraphAPI.FetchUserQuery.Data)
     -> SignalProducer<UserEnvelope<User>, ErrorEnvelope> {
     guard let envelope = UserEnvelope.user(from: data) else {

--- a/KsApi/models/graphql/GraphUserMemberStatus.swift
+++ b/KsApi/models/graphql/GraphUserMemberStatus.swift
@@ -1,0 +1,14 @@
+import Foundation
+import Prelude
+
+public struct GraphUserMemberStatus: Decodable {
+  public var creatorProjectsTotalCount: Int
+  public var memberProjectsTotalCount: Int
+}
+
+extension GraphUserMemberStatus: Equatable {
+  public static func == (lhs: GraphUserMemberStatus, rhs: GraphUserMemberStatus) -> Bool {
+    lhs.creatorProjectsTotalCount == rhs.creatorProjectsTotalCount &&
+      lhs.memberProjectsTotalCount == rhs.memberProjectsTotalCount
+  }
+}

--- a/KsApi/models/graphql/GraphUserMemberStatusTests.swift
+++ b/KsApi/models/graphql/GraphUserMemberStatusTests.swift
@@ -1,0 +1,28 @@
+import Foundation
+@testable import KsApi
+import XCTest
+
+final class GraphUserMemberStatusTests: XCTestCase {
+  func testDecoding_NoNilValues() {
+    let dictionary: [String: Any] =
+      [
+        "creatorProjectsTotalCount": 12,
+        "memberProjectsTotalCount": 20
+      ]
+
+    guard let data = try? JSONSerialization.data(withJSONObject: dictionary, options: []) else {
+      XCTFail("JSON should be convertible to data")
+
+      return
+    }
+
+    do {
+      let userMemberStatus = try JSONDecoder().decode(GraphUserMemberStatus.self, from: data)
+
+      XCTAssertEqual(userMemberStatus.creatorProjectsTotalCount, 12)
+      XCTAssertEqual(userMemberStatus.memberProjectsTotalCount, 20)
+    } catch {
+      XCTFail("Failed to decode \(error)")
+    }
+  }
+}

--- a/KsApi/models/graphql/adapters/User+UserFragment.swift
+++ b/KsApi/models/graphql/adapters/User+UserFragment.swift
@@ -10,7 +10,12 @@ extension User {
     let erroredBackingsCount = erroredBackingsCount(userFragment: userFragment)
 
     /// Not accurate, but GQL doesn't currently return an unseen activity count as a top-level property on the `UserFragment`
-    let unseenUserActivityCount = userFragment.hasUnseenActivity != nil ? 1 : 0
+    var unseenUserActivityCount = 0
+
+    if let hasUnseenActivity = userFragment.hasUnseenActivity,
+      hasUnseenActivity {
+      unseenUserActivityCount = 1
+    }
 
     return User(
       avatar: Avatar(

--- a/KsApi/models/graphql/adapters/UserEnvelope+GraphUserEnvelope.swift
+++ b/KsApi/models/graphql/adapters/UserEnvelope+GraphUserEnvelope.swift
@@ -40,7 +40,7 @@ extension UserEnvelope {
   }
 
   /**
-   Returns a `UserEnvelope<GraphUser>` from a `FetchUserQuery.Data` object.
+   Returns a `UserEnvelope<GraphUser>` from a `FetchUserEmailQuery.Data` object.
    */
   static func userEnvelope(from data: GraphAPI.FetchUserEmailQuery.Data) -> UserEnvelope<GraphUserEmail>? {
     guard let userFragment = data.me?.fragments.userEmailFragment else { return nil }
@@ -50,5 +50,20 @@ extension UserEnvelope {
     )
 
     return UserEnvelope<GraphUserEmail>(me: graphUser)
+  }
+
+  /**
+   Returns a `UserEnvelope<GraphUserMemberStatus>` from a `FetchUserMemberStatusQuery.Data` object.
+   */
+  static func userEnvelope(from data: GraphAPI.FetchUserMemberStatusQuery
+    .Data) -> UserEnvelope<GraphUserMemberStatus>? {
+    guard let userMemberStatusFragment = data.me?.fragments.userMemberStatusFragment else { return nil }
+
+    let graphUserMemberStatus = GraphUserMemberStatus(
+      creatorProjectsTotalCount: userMemberStatusFragment.createdProjects?.totalCount ?? 0,
+      memberProjectsTotalCount: userMemberStatusFragment.membershipProjects?.totalCount ?? 0
+    )
+
+    return UserEnvelope<GraphUserMemberStatus>(me: graphUserMemberStatus)
   }
 }

--- a/KsApi/models/graphql/adapters/UserEnvelope+GraphUserEnvelopeTemplates.swift
+++ b/KsApi/models/graphql/adapters/UserEnvelope+GraphUserEnvelopeTemplates.swift
@@ -28,4 +28,13 @@ public struct GraphUserEnvelopeTemplates {
         "uid": "1470952545"
       ]
     ]
+
+  static let userMemberStatusJSONDict: [String: Any?] =
+    [
+      "me": [
+        "__typename": "User",
+        "createdProjects": ["__typename": "UserCreatedProjectsConnection", "totalCount": 12],
+        "membershipProjects": ["__typename": "MembershipProjectsConnection", "totalCount": 20]
+      ]
+    ]
 }

--- a/KsApi/models/graphql/adapters/UserEnvelope+GraphUserEnvelopeTests.swift
+++ b/KsApi/models/graphql/adapters/UserEnvelope+GraphUserEnvelopeTests.swift
@@ -78,4 +78,18 @@ final class UserEnvelope_GraphUserEnvelopeTests: XCTestCase {
 
     XCTAssertEqual(envelope.me.email, "nativesquad@ksr.com")
   }
+
+  func testFetchUserMemberStatus() {
+    let fetchUserMemberStatusQueryData = GraphAPI.FetchUserMemberStatusQuery
+      .Data(unsafeResultMap: GraphUserEnvelopeTemplates.userMemberStatusJSONDict)
+
+    guard let envelope = UserEnvelope<GraphUserMemberStatus>
+      .userEnvelope(from: fetchUserMemberStatusQueryData) else {
+      XCTFail()
+      return
+    }
+
+    XCTAssertEqual(envelope.me.creatorProjectsTotalCount, 12)
+    XCTAssertEqual(envelope.me.memberProjectsTotalCount, 20)
+  }
 }

--- a/KsApi/queries/FetchUserMemberStatus.graphql
+++ b/KsApi/queries/FetchUserMemberStatus.graphql
@@ -1,0 +1,5 @@
+query FetchUserMemberStatus {
+  me {
+    ...UserMemberStatusFragment
+  }
+}

--- a/Library/ViewModels/BackerDashboardViewModel.swift
+++ b/Library/ViewModels/BackerDashboardViewModel.swift
@@ -128,6 +128,9 @@ public final class BackerDashboardViewModel: BackerDashboardViewModelType, Backe
 
               return updatedUser
             }
+            .flatMapError { _ in
+              SignalProducer(value: userValue)
+            }
         }
         .prefix(SignalProducer([AppEnvironment.current.currentUser].compact()))
         .materialize()

--- a/Library/ViewModels/RootViewModel.swift
+++ b/Library/ViewModels/RootViewModel.swift
@@ -168,7 +168,6 @@ public final class RootViewModel: RootViewModelType, RootViewModelInputs, RootVi
           (($0?.stats.memberProjectsCount ?? 0) > 0) || (($0?.stats.createdProjectsCount ?? 0) > 0)
         )
       }
-      // FIXME: This isn't correct because a collaborating member is not a creator and our GQL call for `User` doesn't return `memberProjectsCount` (which is collaborated on projects)
       .skipRepeats(==)
 
     let standardViewControllers = self.viewDidLoadProperty.signal.map { _ -> [RootViewControllerData] in
@@ -495,7 +494,6 @@ private func generatePersonalizedViewControllers(userState: (isMember: Bool, isL
 private func tabData(forUser user: User?) -> TabBarItemsData {
   let isMember =
     (((user?.stats.memberProjectsCount ?? 0) > 0) || ((user?.stats.createdProjectsCount ?? 0) > 0))
-  // FIXME: This isn't correct because a collaborating member is not a creator and our GQL call for `User` doesn't return `memberProjectsCount` (which is collaborated on projects)
   let items: [TabBarItem] = isMember
     ? [
       .home(index: 0), .activity(index: 1), .search(index: 2), .dashboard(index: 3),

--- a/Library/ViewModels/RootViewModel.swift
+++ b/Library/ViewModels/RootViewModel.swift
@@ -162,7 +162,8 @@ public final class RootViewModel: RootViewModelType, RootViewModelInputs, RootVi
     .map { _ in AppEnvironment.current.currentUser }
 
     let userState: Signal<(isLoggedIn: Bool, isMember: Bool), Never> = currentUser
-      .map { ($0 != nil, ($0?.stats.memberProjectsCount ?? 0) > 0) }
+      .map { ($0 != nil, (($0?.stats.memberProjectsCount ?? 0) > 0) || ($0?.isCreator ?? false)) }
+      // FIXME: This isn't correct because a collaborating member is not a creator and our GQL call for `User` doesn't return `memberProjectsCount` (which is collaborated on projects)
       .skipRepeats(==)
 
     let standardViewControllers = self.viewDidLoadProperty.signal.map { _ -> [RootViewControllerData] in
@@ -487,8 +488,8 @@ private func generatePersonalizedViewControllers(userState: (isMember: Bool, isL
 }
 
 private func tabData(forUser user: User?) -> TabBarItemsData {
-  let isMember = (user?.stats.memberProjectsCount ?? 0) > 0
-
+  let isMember = (((user?.stats.memberProjectsCount ?? 0) > 0) || user?.isCreator ?? false)
+  // FIXME: This isn't correct because a collaborating member is not a creator and our GQL call for `User` doesn't return `memberProjectsCount` (which is collaborated on projects)
   let items: [TabBarItem] = isMember
     ? [
       .home(index: 0), .activity(index: 1), .search(index: 2), .dashboard(index: 3),

--- a/Library/ViewModels/RootViewModel.swift
+++ b/Library/ViewModels/RootViewModel.swift
@@ -162,7 +162,12 @@ public final class RootViewModel: RootViewModelType, RootViewModelInputs, RootVi
     .map { _ in AppEnvironment.current.currentUser }
 
     let userState: Signal<(isLoggedIn: Bool, isMember: Bool), Never> = currentUser
-      .map { ($0 != nil, (($0?.stats.memberProjectsCount ?? 0) > 0) || ($0?.isCreator ?? false)) }
+      .map {
+        (
+          $0 != nil,
+          (($0?.stats.memberProjectsCount ?? 0) > 0) || (($0?.stats.createdProjectsCount ?? 0) > 0)
+        )
+      }
       // FIXME: This isn't correct because a collaborating member is not a creator and our GQL call for `User` doesn't return `memberProjectsCount` (which is collaborated on projects)
       .skipRepeats(==)
 
@@ -488,7 +493,8 @@ private func generatePersonalizedViewControllers(userState: (isMember: Bool, isL
 }
 
 private func tabData(forUser user: User?) -> TabBarItemsData {
-  let isMember = (((user?.stats.memberProjectsCount ?? 0) > 0) || user?.isCreator ?? false)
+  let isMember =
+    (((user?.stats.memberProjectsCount ?? 0) > 0) || ((user?.stats.createdProjectsCount ?? 0) > 0))
   // FIXME: This isn't correct because a collaborating member is not a creator and our GQL call for `User` doesn't return `memberProjectsCount` (which is collaborated on projects)
   let items: [TabBarItem] = isMember
     ? [


### PR DESCRIPTION
# 📲 What

On the latest build noticed a weird UI break with inconsistent number of tabs in the dashboard leading to a black background for creators and collaborators.

# 🤔 Why

We are going to remove the creator dashboard in the future (for something like 3000 users), but for now we support that side of things so we shouldn't introduce regressions there.

# 🛠 How

There was no `isCollaborator` field in GQL (unlike `isCreator`) UserFragment we already have, so had to create a new query, fragment, GraphUser adapter and test them all.

The new call is chained within `BackerDashboardViewModel` you'll see even if it fails the GraphUser data is propogated without `GraphUserMemberStatus`

# 👀 See

Before 🐛 

https://user-images.githubusercontent.com/4282741/229403649-e439c69c-cc66-426c-b457-6fd67c68e5f7.mp4

After 🦋 

https://user-images.githubusercontent.com/4282741/229403060-003a85d3-425b-4cbc-80c8-eac84808319e.mp4

# ✅ Acceptance criteria

- [x] Ensure logging in as a collaborator (user invited by a creator as a collaborator on the created project) still has saving/unsaving prelaunch and other projects working. (realnativesquad@proton.me in 1Pass)
- [x] Ensure logging in as a creator still has saving/unsaving prelaunch and other projects working. (therealnativesquad@gmail.com in 1Pass)
- [x] Ensure regular backer can save/unsave prelaunch or other projects working. (your login)

Note: There are minor hiccups in the UI, _sometimes_ the saved projects doesn't always show the updated "saved" project in the list. Try a few times and it works. Seems to be an issue only on creator/collaborator users.
