### PR TITLE
[MBL-701] Remove Payment Sheet Feature Flags

### DIFF
--- a/Kickstarter-iOS/Features/OptimizelyFeatureFlagTools/Controller/OptimizelyFeatureFlagToolsViewControllerTests.swift
+++ b/Kickstarter-iOS/Features/OptimizelyFeatureFlagTools/Controller/OptimizelyFeatureFlagToolsViewControllerTests.swift
@@ -24,8 +24,6 @@ final class OptimizelyFeatureFlagToolsViewControllerTests: TestCase {
       |> \.features .~ [
         OptimizelyFeature.commentFlaggingEnabled.rawValue: false,
         OptimizelyFeature.projectPageStoryTabEnabled.rawValue: false,
-        OptimizelyFeature.paymentSheetEnabled.rawValue: false,
-        OptimizelyFeature.settingsPaymentSheetEnabled.rawValue: false,
         OptimizelyFeature.facebookLoginDeprecationEnabled.rawValue: false,
         OptimizelyFeature.consentManagementDialogEnabled.rawValue: false
       ]

--- a/Kickstarter-iOS/Features/PaymentMethods/Controller/PaymentMethodsViewController.swift
+++ b/Kickstarter-iOS/Features/PaymentMethods/Controller/PaymentMethodsViewController.swift
@@ -102,12 +102,6 @@ internal final class PaymentMethodsViewController: UIViewController, MessageBann
         self?.tableView.reloadData()
       }
 
-    self.viewModel.outputs.goToAddCardScreenWithIntent
-      .observeForUI()
-      .observeValues { [weak self] intent in
-        self?.goToAddCardScreen(with: intent)
-      }
-
     self.viewModel.outputs.goToPaymentSheet
       .observeForUI()
       .observeValues { [weak self] data in

--- a/Kickstarter-iOS/Features/PaymentMethods/Views/PaymentMethodsFooterView.swift
+++ b/Kickstarter-iOS/Features/PaymentMethods/Views/PaymentMethodsFooterView.swift
@@ -35,11 +35,8 @@ public final class PaymentMethodsFooterView: UIView, NibLoading {
   }
 
   @IBAction func addNewCardButtonTapped(_: Any) {
-    if featureSettingsPaymentSheetEnabled() {
-      self.loadingIndicator.startAnimating()
-      self.addCardButton.isHidden = true
-    }
-
+    self.loadingIndicator.startAnimating()
+    self.addCardButton.isHidden = true
     self.addCardButton.isUserInteractionEnabled = false
     self.delegate?.paymentMethodsFooterViewDidTapAddNewCardButton(self)
   }

--- a/Kickstarter-iOS/Features/PledgePaymentMethods/Controller/PledgePaymentMethodsViewController.swift
+++ b/Kickstarter-iOS/Features/PledgePaymentMethods/Controller/PledgePaymentMethodsViewController.swift
@@ -118,12 +118,6 @@ final class PledgePaymentMethodsViewController: UIViewController {
         self.delegate?.pledgePaymentMethodsViewController(self, didSelectCreditCard: paymentSourceId)
       }
 
-    self.viewModel.outputs.goToAddCardScreen
-      .observeForUI()
-      .observeValues { [weak self] intent, project in
-        self?.goToAddNewCard(intent: intent, project: project)
-      }
-
     self.viewModel.outputs.goToAddCardViaStripeScreen
       .observeForUI()
       .observeValues { [weak self] data in

--- a/Kickstarter-iOS/Features/PledgePaymentMethods/Controller/PledgePaymentMethodsViewControllerTests.swift
+++ b/Kickstarter-iOS/Features/PledgePaymentMethods/Controller/PledgePaymentMethodsViewControllerTests.swift
@@ -29,8 +29,6 @@ final class PledgePaymentMethodsViewControllerTests: TestCase {
   func testView_PledgeContext_AddNewCardNonLoadingState_Success() {
     let response = UserEnvelope<GraphUser>(me: self.userWithCards)
     let envelope = ClientSecretEnvelope(clientSecret: "test")
-    let mockOptimizelyClient = MockOptimizelyClient()
-      |> \.features .~ [OptimizelyFeature.paymentSheetEnabled.rawValue: true]
     let mockService = MockService(
       createStripeSetupIntentResult: .success(envelope),
       fetchGraphUserResult: .success(response)
@@ -42,8 +40,7 @@ final class PledgePaymentMethodsViewControllerTests: TestCase {
       withEnvironment(
         apiService: mockService,
         currentUser: User.template,
-        language: language,
-        optimizelyClient: mockOptimizelyClient
+        language: language
       ) {
         let controller = PledgePaymentMethodsViewController.instantiate()
 
@@ -70,8 +67,6 @@ final class PledgePaymentMethodsViewControllerTests: TestCase {
 
   func testView_PledgeContext_AddNewCardLoadingState_Success() {
     let response = UserEnvelope<GraphUser>(me: self.userWithCards)
-    let mockOptimizelyClient = MockOptimizelyClient()
-      |> \.features .~ [OptimizelyFeature.paymentSheetEnabled.rawValue: true]
     /// Using .failure case to prevent real Stripe sheet from being shown.
     let mockService = MockService(
       createStripeSetupIntentResult: .failure(.couldNotParseJSON),
@@ -84,8 +79,7 @@ final class PledgePaymentMethodsViewControllerTests: TestCase {
       withEnvironment(
         apiService: mockService,
         currentUser: User.template,
-        language: language,
-        optimizelyClient: mockOptimizelyClient
+        language: language
       ) {
         let controller = PledgePaymentMethodsViewController.instantiate()
 

--- a/Library/OptimizelyClientTypeTests.swift
+++ b/Library/OptimizelyClientTypeTests.swift
@@ -24,7 +24,7 @@ final class OptimizelyClientTypeTests: TestCase {
         OptimizelyFeature.commentFlaggingEnabled.rawValue: true
       ]
 
-    XCTAssert(mockOptimizelyClient.allFeatures().count == 7)
+    XCTAssert(mockOptimizelyClient.allFeatures().count == 5)
   }
 
   func testVariantForExperiment_NoError() {

--- a/Library/OptimizelyFeature+Helpers.swift
+++ b/Library/OptimizelyFeature+Helpers.swift
@@ -14,20 +14,6 @@ public func featureProjectPageStoryTabEnabled() -> Bool {
       .isFeatureEnabled(featureKey: OptimizelyFeature.projectPageStoryTabEnabled.rawValue) ?? false)
 }
 
-public func featurePaymentSheetEnabled() -> Bool {
-  return AppEnvironment.current.userDefaults
-    .optimizelyFeatureFlags[OptimizelyFeature.paymentSheetEnabled.rawValue] ??
-    (AppEnvironment.current.optimizelyClient?
-      .isFeatureEnabled(featureKey: OptimizelyFeature.paymentSheetEnabled.rawValue) ?? false)
-}
-
-public func featureSettingsPaymentSheetEnabled() -> Bool {
-  return AppEnvironment.current.userDefaults
-    .optimizelyFeatureFlags[OptimizelyFeature.settingsPaymentSheetEnabled.rawValue] ??
-    (AppEnvironment.current.optimizelyClient?
-      .isFeatureEnabled(featureKey: OptimizelyFeature.settingsPaymentSheetEnabled.rawValue) ?? false)
-}
-
 public func featureFacebookLoginDeprecationEnabled() -> Bool {
   return AppEnvironment.current.userDefaults
     .optimizelyFeatureFlags[OptimizelyFeature.facebookLoginDeprecationEnabled.rawValue] ??

--- a/Library/OptimizelyFeature+HelpersTests.swift
+++ b/Library/OptimizelyFeature+HelpersTests.swift
@@ -39,33 +39,6 @@ final class OptimizelyFeatureHelpersTests: TestCase {
     }
   }
 
-  func testPaymentSheet_Optimizely_FeatureFlag_True() {
-    let mockOptimizelyClient = MockOptimizelyClient()
-      |> \.features .~ [OptimizelyFeature.paymentSheetEnabled.rawValue: true]
-
-    withEnvironment(optimizelyClient: mockOptimizelyClient) {
-      XCTAssertTrue(featurePaymentSheetEnabled())
-    }
-  }
-
-  func testPaymentSheet_Optimizely_FeatureFlag_False() {
-    let mockOptimizelyClient = MockOptimizelyClient()
-      |> \.features .~ [OptimizelyFeature.paymentSheetEnabled.rawValue: false]
-
-    withEnvironment(optimizelyClient: mockOptimizelyClient) {
-      XCTAssertFalse(featurePaymentSheetEnabled())
-    }
-  }
-
-  func testSettingsPaymentSheet_Optimizely_FeatureFlag_False() {
-    let mockOptimizelyClient = MockOptimizelyClient()
-      |> \.features .~ [OptimizelyFeature.settingsPaymentSheetEnabled.rawValue: false]
-
-    withEnvironment(optimizelyClient: mockOptimizelyClient) {
-      XCTAssertFalse(featureSettingsPaymentSheetEnabled())
-    }
-  }
-
   func testFacebookDeprecation_Optimizely_FeatureFlag_False() {
     let mockOptimizelyClient = MockOptimizelyClient()
       |> \.features .~ [OptimizelyFeature.facebookLoginDeprecationEnabled.rawValue: false]

--- a/Library/OptimizelyFeature.swift
+++ b/Library/OptimizelyFeature.swift
@@ -5,9 +5,7 @@ public enum OptimizelyFeature: String, CaseIterable {
   case consentManagementDialogEnabled = "ios_consent_management_dialog"
   case facebookConversionsAPI = "ios_facebook_conversions_api"
   case facebookLoginDeprecationEnabled = "ios_facebook_deprecation"
-  case paymentSheetEnabled = "ios_payment_sheet"
   case projectPageStoryTabEnabled = "project_page_v2_story"
-  case settingsPaymentSheetEnabled = "ios_settings_payment_sheet"
 }
 
 extension OptimizelyFeature: CustomStringConvertible {
@@ -17,9 +15,7 @@ extension OptimizelyFeature: CustomStringConvertible {
     case .consentManagementDialogEnabled: return "Consent Management Dialog"
     case .facebookConversionsAPI: return "Facebook Conversions API"
     case .facebookLoginDeprecationEnabled: return "Facebook Login Deprecation"
-    case .paymentSheetEnabled: return "Payment Sheet"
     case .projectPageStoryTabEnabled: return "Project Page Story Tab"
-    case .settingsPaymentSheetEnabled: return "Settings Payment Sheet"
     }
   }
 }

--- a/Library/ViewModels/OptimizelyFeatureFlagToolsViewModel.swift
+++ b/Library/ViewModels/OptimizelyFeatureFlagToolsViewModel.swift
@@ -101,12 +101,6 @@ private func getValueFromUserDefaults(for feature: OptimizelyFeature) -> Bool? {
   case .projectPageStoryTabEnabled:
     return AppEnvironment.current.userDefaults
       .optimizelyFeatureFlags[OptimizelyFeature.projectPageStoryTabEnabled.rawValue]
-  case .paymentSheetEnabled:
-    return AppEnvironment.current.userDefaults
-      .optimizelyFeatureFlags[OptimizelyFeature.paymentSheetEnabled.rawValue]
-  case .settingsPaymentSheetEnabled:
-    return AppEnvironment.current.userDefaults
-      .optimizelyFeatureFlags[OptimizelyFeature.settingsPaymentSheetEnabled.rawValue]
   case .facebookConversionsAPI:
     return AppEnvironment.current.userDefaults
       .optimizelyFeatureFlags[OptimizelyFeature.facebookConversionsAPI.rawValue]
@@ -129,12 +123,6 @@ private func setValueInUserDefaults(for feature: OptimizelyFeature, and value: B
   case .projectPageStoryTabEnabled:
     AppEnvironment.current.userDefaults
       .optimizelyFeatureFlags[OptimizelyFeature.projectPageStoryTabEnabled.rawValue] = value
-  case .paymentSheetEnabled:
-    return AppEnvironment.current.userDefaults
-      .optimizelyFeatureFlags[OptimizelyFeature.paymentSheetEnabled.rawValue] = value
-  case .settingsPaymentSheetEnabled:
-    return AppEnvironment.current.userDefaults
-      .optimizelyFeatureFlags[OptimizelyFeature.settingsPaymentSheetEnabled.rawValue] = value
   case .facebookConversionsAPI:
     return AppEnvironment.current.userDefaults
       .optimizelyFeatureFlags[OptimizelyFeature.facebookConversionsAPI.rawValue] = value

--- a/Library/ViewModels/OptimizelyFeatureFlagToolsViewModelTests.swift
+++ b/Library/ViewModels/OptimizelyFeatureFlagToolsViewModelTests.swift
@@ -25,8 +25,6 @@ final class OptimizelyFlagToolsViewModelTests: TestCase {
         OptimizelyFeature.commentFlaggingEnabled.rawValue: true,
         OptimizelyFeature.consentManagementDialogEnabled.rawValue: true,
         OptimizelyFeature.projectPageStoryTabEnabled.rawValue: true,
-        OptimizelyFeature.paymentSheetEnabled.rawValue: true,
-        OptimizelyFeature.settingsPaymentSheetEnabled.rawValue: true,
         OptimizelyFeature.facebookConversionsAPI.rawValue: true,
         OptimizelyFeature.facebookLoginDeprecationEnabled.rawValue: true
       ]
@@ -50,8 +48,6 @@ final class OptimizelyFlagToolsViewModelTests: TestCase {
         OptimizelyFeature.commentFlaggingEnabled.rawValue: false,
         OptimizelyFeature.consentManagementDialogEnabled.rawValue: false,
         OptimizelyFeature.projectPageStoryTabEnabled.rawValue: false,
-        OptimizelyFeature.paymentSheetEnabled.rawValue: false,
-        OptimizelyFeature.settingsPaymentSheetEnabled.rawValue: false,
         OptimizelyFeature.facebookConversionsAPI.rawValue: false,
         OptimizelyFeature.facebookLoginDeprecationEnabled.rawValue: false
       ]

--- a/Library/ViewModels/PaymentMethodsViewModel.swift
+++ b/Library/ViewModels/PaymentMethodsViewModel.swift
@@ -22,7 +22,6 @@ public protocol PaymentMethodsViewModelOutputs {
   var editButtonIsEnabled: Signal<Bool, Never> { get }
   var editButtonTitle: Signal<String, Never> { get }
   var errorLoadingPaymentMethodsOrSetupIntent: Signal<String, Never> { get }
-  var goToAddCardScreenWithIntent: Signal<AddNewCardIntent, Never> { get }
   var goToPaymentSheet: Signal<PaymentSheetSetupData, Never> { get }
   var paymentMethods: Signal<[UserCreditCards.CreditCard], Never> { get }
   var presentBanner: Signal<String, Never> { get }
@@ -52,10 +51,6 @@ public final class PaymentMethodsViewModel: PaymentMethodsViewModelType,
         .ksr_delay(AppEnvironment.current.apiDelayInterval, on: AppEnvironment.current.scheduler)
         .materialize()
     }
-
-    lazy var paymentSheetEnabled: Bool = {
-      featureSettingsPaymentSheetEnabled()
-    }()
 
     let deletePaymentMethodEvents = self.didDeleteCreditCardSignal
       .map(first)
@@ -139,11 +134,6 @@ public final class PaymentMethodsViewModel: PaymentMethodsViewModelType,
     )
     .skipRepeats()
 
-    self.goToAddCardScreenWithIntent = self.didTapAddCardButtonProperty.signal
-      .switchMap { SignalProducer(value: paymentSheetEnabled) }
-      .filter(isFalse)
-      .mapConst(.settings)
-
     self.presentBanner = self.addNewCardSucceededProperty.signal.skipNil()
 
     let stopEditing = Signal.merge(
@@ -165,8 +155,6 @@ public final class PaymentMethodsViewModel: PaymentMethodsViewModelType,
       .map { $0 ? Strings.Done() : Strings.discovery_favorite_categories_buttons_edit() }
 
     let createSetupIntentEvent = self.didTapAddCardButtonProperty.signal
-      .switchMap { SignalProducer(value: paymentSheetEnabled) }
-      .filter(isTrue)
       .switchMap { _ -> SignalProducer<Signal<PaymentSheetSetupData, ErrorEnvelope>.Event, Never> in
         AppEnvironment.current.apiService
           .createStripeSetupIntent(input: CreateSetupIntentInput(projectId: nil))
@@ -279,7 +267,6 @@ public final class PaymentMethodsViewModel: PaymentMethodsViewModelType,
   public let editButtonIsEnabled: Signal<Bool, Never>
   public let editButtonTitle: Signal<String, Never>
   public let errorLoadingPaymentMethodsOrSetupIntent: Signal<String, Never>
-  public let goToAddCardScreenWithIntent: Signal<AddNewCardIntent, Never>
   public let goToPaymentSheet: Signal<PaymentSheetSetupData, Never>
   public let paymentMethods: Signal<[UserCreditCards.CreditCard], Never>
   public let presentBanner: Signal<String, Never>

--- a/Library/ViewModels/PaymentMethodsViewModelTests.swift
+++ b/Library/ViewModels/PaymentMethodsViewModelTests.swift
@@ -351,13 +351,13 @@ internal final class PaymentMethodsViewModelTests: TestCase {
   }
 
   func testGoToAddCardScreenEmits_WhenAddNewCardIsTapped_Failure() {
-      self.goToAddCardScreenWithIntent.assertValueCount(0)
+    self.goToAddCardScreenWithIntent.assertValueCount(0)
 
-      self.vm.inputs.paymentMethodsFooterViewDidTapAddNewCardButton()
+    self.vm.inputs.paymentMethodsFooterViewDidTapAddNewCardButton()
 
-      self.scheduler.advance()
+    self.scheduler.advance()
 
-      self.goToAddCardScreenWithIntent.assertValueCount(0)
+    self.goToAddCardScreenWithIntent.assertValueCount(0)
   }
 
   func testGoToPaymentSheet_WhenAddNewCardIsTapped_Success() {

--- a/Library/ViewModels/PledgePaymentMethodsViewModel.swift
+++ b/Library/ViewModels/PledgePaymentMethodsViewModel.swift
@@ -297,27 +297,27 @@ public final class PledgePaymentMethodsViewModel: PledgePaymentMethodsViewModelT
       .mapConst(true)
 
     let createSetupIntentEvent = project.signal
-    .takeWhen(didTapToAddNewCard)
-    .switchMap { project -> SignalProducer<Signal<PaymentSheetSetupData, ErrorEnvelope>.Event, Never> in
-      AppEnvironment.current.apiService
-        .createStripeSetupIntent(input: CreateSetupIntentInput(projectId: project.graphID))
-        .ksr_debounce(.seconds(1), on: AppEnvironment.current.scheduler)
-        .ksr_delay(AppEnvironment.current.apiDelayInterval, on: AppEnvironment.current.scheduler)
-        .switchMap { envelope -> SignalProducer<PaymentSheetSetupData, ErrorEnvelope> in
+      .takeWhen(didTapToAddNewCard)
+      .switchMap { project -> SignalProducer<Signal<PaymentSheetSetupData, ErrorEnvelope>.Event, Never> in
+        AppEnvironment.current.apiService
+          .createStripeSetupIntent(input: CreateSetupIntentInput(projectId: project.graphID))
+          .ksr_debounce(.seconds(1), on: AppEnvironment.current.scheduler)
+          .ksr_delay(AppEnvironment.current.apiDelayInterval, on: AppEnvironment.current.scheduler)
+          .switchMap { envelope -> SignalProducer<PaymentSheetSetupData, ErrorEnvelope> in
 
-          var configuration = PaymentSheet.Configuration()
-          configuration.merchantDisplayName = Strings.general_accessibility_kickstarter()
-          configuration.allowsDelayedPaymentMethods = true
+            var configuration = PaymentSheet.Configuration()
+            configuration.merchantDisplayName = Strings.general_accessibility_kickstarter()
+            configuration.allowsDelayedPaymentMethods = true
 
-          let data = PaymentSheetSetupData(
-            clientSecret: envelope.clientSecret,
-            configuration: configuration
-          )
+            let data = PaymentSheetSetupData(
+              clientSecret: envelope.clientSecret,
+              configuration: configuration
+            )
 
-          return SignalProducer(value: data)
-        }
-        .materialize()
-    }
+            return SignalProducer(value: data)
+          }
+          .materialize()
+      }
 
     self.goToAddCardViaStripeScreen = createSetupIntentEvent.values()
       .withLatestFrom(self.shouldCancelPaymentSheetAppearance.signal)

--- a/Library/ViewModels/PledgePaymentMethodsViewModelTests.swift
+++ b/Library/ViewModels/PledgePaymentMethodsViewModelTests.swift
@@ -35,8 +35,6 @@ final class PledgePaymentMethodsViewModelTests: TestCase {
   override func setUp() {
     super.setUp()
 
-    self.vm.outputs.goToAddCardScreen.map(first).observe(self.goToAddCardIntent.observer)
-    self.vm.outputs.goToAddCardScreen.map(second).observe(self.goToProject.observer)
     self.vm.outputs.notifyDelegateCreditCardSelected
       .observe(self.notifyDelegateCreditCardSelected.observer)
     self.vm.outputs.notifyDelegateLoadPaymentMethodsError
@@ -754,189 +752,16 @@ final class PledgePaymentMethodsViewModelTests: TestCase {
     }
   }
 
-  func testGoToAddNewCard_PledgeContext_PaymentSheetDisabled_Success() {
-    let project = Project.template
-
-    let mockOptimizelyClient = MockOptimizelyClient()
-      |> \.features .~ [
-        OptimizelyFeature.paymentSheetEnabled.rawValue: false
-      ]
-    let envelope = ClientSecretEnvelope(clientSecret: "test")
-    let mockService = MockService(createStripeSetupIntentResult: .success(envelope))
-
-    withEnvironment(
-      apiService: mockService,
-      currentUser: User.template,
-      optimizelyClient: mockOptimizelyClient
-    ) {
-      self.vm.inputs.viewDidLoad()
-      self.vm.inputs.configure(with: (User.template, project, Reward.template, .pledge, .discovery))
-
-      let addNewCardIndexPath = IndexPath(
-        row: 0,
-        section: PaymentMethodsTableViewSection.addNewCard.rawValue
-      )
-      self.vm.inputs.didSelectRowAtIndexPath(addNewCardIndexPath)
-
-      self.goToProject.assertValues([project])
-
-      self.scheduler.run()
-
-      XCTAssertEqual(self.goToAddCardIntent.values.count, 1)
-      XCTAssertEqual(self.goToAddStripeCardIntent.values.count, 0)
-    }
-  }
-
-  func testGoToAddNewCard_UpdatePledgeContext_PaymentSheetDisabled_Success() {
-    let project = Project.template
-
-    let mockOptimizelyClient = MockOptimizelyClient()
-      |> \.features .~ [
-        OptimizelyFeature.paymentSheetEnabled.rawValue: false
-      ]
-    let envelope = ClientSecretEnvelope(clientSecret: "test")
-    let mockService = MockService(createStripeSetupIntentResult: .success(envelope))
-
-    withEnvironment(
-      apiService: mockService,
-      currentUser: User.template,
-      optimizelyClient: mockOptimizelyClient
-    ) {
-      self.vm.inputs.viewDidLoad()
-      self.vm.inputs.configure(with: (User.template, project, Reward.template, .update, .discovery))
-
-      let addNewCardIndexPath = IndexPath(
-        row: 0,
-        section: PaymentMethodsTableViewSection.addNewCard.rawValue
-      )
-      self.vm.inputs.didSelectRowAtIndexPath(addNewCardIndexPath)
-
-      self.goToProject.assertValues([project])
-
-      self.scheduler.run()
-
-      XCTAssertEqual(self.goToAddCardIntent.values.count, 1)
-      XCTAssertEqual(self.goToAddStripeCardIntent.values.count, 0)
-    }
-  }
-
-  func testGoToAddNewCard_UpdateRewardContexts_PaymentSheetDisabled_Success() {
-    let project = Project.template
-
-    let mockOptimizelyClient = MockOptimizelyClient()
-      |> \.features .~ [
-        OptimizelyFeature.paymentSheetEnabled.rawValue: false
-      ]
-    let envelope = ClientSecretEnvelope(clientSecret: "test")
-    let mockService = MockService(createStripeSetupIntentResult: .success(envelope))
-
-    withEnvironment(
-      apiService: mockService,
-      currentUser: User.template,
-      optimizelyClient: mockOptimizelyClient
-    ) {
-      self.vm.inputs.viewDidLoad()
-      self.vm.inputs.configure(with: (User.template, project, Reward.template, .updateReward, .discovery))
-
-      let addNewCardIndexPath = IndexPath(
-        row: 0,
-        section: PaymentMethodsTableViewSection.addNewCard.rawValue
-      )
-      self.vm.inputs.didSelectRowAtIndexPath(addNewCardIndexPath)
-
-      XCTAssertEqual(self.goToAddStripeCardIntent.values.count, 0)
-      self.goToProject.assertValues([project])
-
-      self.scheduler.run()
-
-      XCTAssertEqual(self.goToAddCardIntent.values.count, 1)
-      XCTAssertEqual(self.goToAddStripeCardIntent.values.count, 0)
-    }
-  }
-
-  func testGoToAddNewCard_ChangePaymentMethodContext_PaymentSheetDisabled_Success() {
-    let project = Project.template
-
-    let mockOptimizelyClient = MockOptimizelyClient()
-      |> \.features .~ [
-        OptimizelyFeature.paymentSheetEnabled.rawValue: false
-      ]
-    let envelope = ClientSecretEnvelope(clientSecret: "test")
-    let mockService = MockService(createStripeSetupIntentResult: .success(envelope))
-
-    withEnvironment(
-      apiService: mockService,
-      currentUser: User.template,
-      optimizelyClient: mockOptimizelyClient
-    ) {
-      self.vm.inputs.viewDidLoad()
-      self.vm.inputs
-        .configure(with: (User.template, project, Reward.template, .changePaymentMethod, .discovery))
-
-      let addNewCardIndexPath = IndexPath(
-        row: 0,
-        section: PaymentMethodsTableViewSection.addNewCard.rawValue
-      )
-      self.vm.inputs.didSelectRowAtIndexPath(addNewCardIndexPath)
-
-      XCTAssertEqual(self.goToAddStripeCardIntent.values.count, 0)
-      self.goToProject.assertValues([project])
-
-      self.scheduler.run()
-
-      XCTAssertEqual(self.goToAddCardIntent.values.count, 1)
-      XCTAssertEqual(self.goToAddStripeCardIntent.values.count, 0)
-    }
-  }
-
-  func testGoToAddNewCard_FixPaymentMethodContext_PaymentSheetDisabled_Success() {
-    let project = Project.template
-
-    let mockOptimizelyClient = MockOptimizelyClient()
-      |> \.features .~ [
-        OptimizelyFeature.paymentSheetEnabled.rawValue: false
-      ]
-    let envelope = ClientSecretEnvelope(clientSecret: "test")
-    let mockService = MockService(createStripeSetupIntentResult: .success(envelope))
-
-    withEnvironment(
-      apiService: mockService,
-      currentUser: User.template,
-      optimizelyClient: mockOptimizelyClient
-    ) {
-      self.vm.inputs.viewDidLoad()
-      self.vm.inputs.configure(with: (User.template, project, Reward.template, .fixPaymentMethod, .discovery))
-
-      let addNewCardIndexPath = IndexPath(
-        row: 0,
-        section: PaymentMethodsTableViewSection.addNewCard.rawValue
-      )
-      self.vm.inputs.didSelectRowAtIndexPath(addNewCardIndexPath)
-
-      XCTAssertEqual(self.goToAddStripeCardIntent.values.count, 0)
-      self.goToProject.assertValues([project])
-
-      self.scheduler.run()
-
-      XCTAssertEqual(self.goToAddCardIntent.values.count, 1)
-      XCTAssertEqual(self.goToAddStripeCardIntent.values.count, 0)
-    }
-  }
 
   func testGoToAddNewCard_PledgeContext_PaymentSheetEnabled_Failure() {
     let project = Project.template
 
-    let mockOptimizelyClient = MockOptimizelyClient()
-      |> \.features .~ [
-        OptimizelyFeature.paymentSheetEnabled.rawValue: true
-      ]
     let envelope = ClientSecretEnvelope(clientSecret: "test")
     let mockService = MockService(createStripeSetupIntentResult: .success(envelope))
 
     withEnvironment(
       apiService: mockService,
-      currentUser: User.template,
-      optimizelyClient: mockOptimizelyClient
+      currentUser: User.template
     ) {
       self.vm.inputs.viewDidLoad()
       self.vm.inputs.configure(with: (User.template, project, Reward.template, .pledge, .discovery))
@@ -954,171 +779,6 @@ final class PledgePaymentMethodsViewModelTests: TestCase {
 
       XCTAssertEqual(self.goToAddCardIntent.values.count, 0)
       XCTAssertEqual(self.goToAddStripeCardIntent.values.count, 1)
-    }
-  }
-
-  func testGoToAddNewCard_UpdatePledgeContext_PaymentSheetEnabled_Failure() {
-    let project = Project.template
-
-    let mockOptimizelyClient = MockOptimizelyClient()
-      |> \.features .~ [
-        OptimizelyFeature.paymentSheetEnabled.rawValue: true
-      ]
-    let envelope = ClientSecretEnvelope(clientSecret: "test")
-    let mockService = MockService(createStripeSetupIntentResult: .success(envelope))
-
-    withEnvironment(
-      apiService: mockService,
-      currentUser: User.template,
-      optimizelyClient: mockOptimizelyClient
-    ) {
-      self.vm.inputs.viewDidLoad()
-      self.vm.inputs.configure(with: (User.template, project, Reward.template, .update, .discovery))
-
-      let addNewCardIndexPath = IndexPath(
-        row: 0,
-        section: PaymentMethodsTableViewSection.addNewCard.rawValue
-      )
-      self.vm.inputs.didSelectRowAtIndexPath(addNewCardIndexPath)
-
-      self.goToAddCardIntent.assertDidNotEmitValue()
-      self.goToAddStripeCardIntent.assertDidNotEmitValue()
-
-      self.scheduler.run()
-
-      XCTAssertEqual(self.goToAddCardIntent.values.count, 0)
-      XCTAssertEqual(self.goToAddStripeCardIntent.values.count, 1)
-    }
-  }
-
-  func testGoToAddNewCard_UpdateRewardContexts_PaymentSheetEnabled_Failure() {
-    let project = Project.template
-
-    let mockOptimizelyClient = MockOptimizelyClient()
-      |> \.features .~ [
-        OptimizelyFeature.paymentSheetEnabled.rawValue: true
-      ]
-    let envelope = ClientSecretEnvelope(clientSecret: "test")
-    let mockService = MockService(createStripeSetupIntentResult: .success(envelope))
-
-    withEnvironment(
-      apiService: mockService,
-      currentUser: User.template,
-      optimizelyClient: mockOptimizelyClient
-    ) {
-      self.vm.inputs.viewDidLoad()
-      self.vm.inputs.configure(with: (User.template, project, Reward.template, .updateReward, .discovery))
-
-      let addNewCardIndexPath = IndexPath(
-        row: 0,
-        section: PaymentMethodsTableViewSection.addNewCard.rawValue
-      )
-      self.vm.inputs.didSelectRowAtIndexPath(addNewCardIndexPath)
-
-      self.goToAddCardIntent.assertDidNotEmitValue()
-      self.goToAddStripeCardIntent.assertDidNotEmitValue()
-
-      self.scheduler.run()
-
-      XCTAssertEqual(self.goToAddCardIntent.values.count, 0)
-      XCTAssertEqual(self.goToAddStripeCardIntent.values.count, 1)
-    }
-  }
-
-  func testGoToAddNewCard_ChangePaymentMethodContext_PaymentSheetEnabled_Failure() {
-    let project = Project.template
-
-    let mockOptimizelyClient = MockOptimizelyClient()
-      |> \.features .~ [
-        OptimizelyFeature.paymentSheetEnabled.rawValue: true
-      ]
-    let envelope = ClientSecretEnvelope(clientSecret: "test")
-    let mockService = MockService(createStripeSetupIntentResult: .success(envelope))
-
-    withEnvironment(
-      apiService: mockService,
-      currentUser: User.template,
-      optimizelyClient: mockOptimizelyClient
-    ) {
-      self.vm.inputs.viewDidLoad()
-      self.vm.inputs
-        .configure(with: (User.template, project, Reward.template, .changePaymentMethod, .discovery))
-
-      let addNewCardIndexPath = IndexPath(
-        row: 0,
-        section: PaymentMethodsTableViewSection.addNewCard.rawValue
-      )
-      self.vm.inputs.didSelectRowAtIndexPath(addNewCardIndexPath)
-
-      self.goToAddCardIntent.assertDidNotEmitValue()
-      self.goToAddStripeCardIntent.assertDidNotEmitValue()
-
-      self.scheduler.run()
-
-      XCTAssertEqual(self.goToAddCardIntent.values.count, 0)
-      XCTAssertEqual(self.goToAddStripeCardIntent.values.count, 1)
-    }
-  }
-
-  func testGoToAddNewCard_FixPaymentMethodContext_PaymentSheetEnabled_Failure() {
-    let project = Project.template
-
-    let mockOptimizelyClient = MockOptimizelyClient()
-      |> \.features .~ [
-        OptimizelyFeature.paymentSheetEnabled.rawValue: true
-      ]
-    let envelope = ClientSecretEnvelope(clientSecret: "test")
-    let mockService = MockService(createStripeSetupIntentResult: .success(envelope))
-
-    withEnvironment(
-      apiService: mockService,
-      currentUser: User.template,
-      optimizelyClient: mockOptimizelyClient
-    ) {
-      self.vm.inputs.viewDidLoad()
-      self.vm.inputs.configure(with: (User.template, project, Reward.template, .fixPaymentMethod, .discovery))
-
-      let addNewCardIndexPath = IndexPath(
-        row: 0,
-        section: PaymentMethodsTableViewSection.addNewCard.rawValue
-      )
-      self.vm.inputs.didSelectRowAtIndexPath(addNewCardIndexPath)
-
-      XCTAssertEqual(self.goToAddStripeCardIntent.values.count, 0)
-
-      self.scheduler.run()
-
-      XCTAssertEqual(self.goToAddCardIntent.values.count, 0)
-      XCTAssertEqual(self.goToAddStripeCardIntent.values.count, 1)
-    }
-  }
-
-  func testGoToAddNewCard_WithPaymentSheetDisabled_NoStoredCards_Success() {
-    let project = Project.template
-    let graphUser = GraphUser.template |> \.storedCards .~ UserCreditCards.withCards([])
-    let response = UserEnvelope<GraphUser>(me: graphUser)
-    let mockService = MockService(fetchGraphUserResult: .success(response))
-    let mockOptimizelyClient = MockOptimizelyClient()
-      |> \.features .~ [
-        OptimizelyFeature.paymentSheetEnabled.rawValue: false
-      ]
-
-    withEnvironment(
-      apiService: mockService,
-      currentUser: User.template,
-      optimizelyClient: mockOptimizelyClient
-    ) {
-      self.vm.inputs.viewDidLoad()
-      self.vm.inputs.configure(with: (User.template, project, Reward.template, .pledge, .discovery))
-
-      let addNewCardIndexPath = IndexPath(
-        row: 0,
-        section: PaymentMethodsTableViewSection.addNewCard.rawValue
-      )
-
-      self.vm.inputs.didSelectRowAtIndexPath(addNewCardIndexPath)
-      self.goToAddCardIntent.assertValues([.pledge])
-      self.goToProject.assertValues([project])
     }
   }
 
@@ -1127,15 +787,10 @@ final class PledgePaymentMethodsViewModelTests: TestCase {
     let graphUser = GraphUser.template |> \.storedCards .~ UserCreditCards.withCards([])
     let response = UserEnvelope<GraphUser>(me: graphUser)
     let mockService = MockService(fetchGraphUserResult: .success(response))
-    let mockOptimizelyClient = MockOptimizelyClient()
-      |> \.features .~ [
-        OptimizelyFeature.paymentSheetEnabled.rawValue: true
-      ]
 
     withEnvironment(
       apiService: mockService,
-      currentUser: User.template,
-      optimizelyClient: mockOptimizelyClient
+      currentUser: User.template
     ) {
       self.vm.inputs.viewDidLoad()
       self.vm.inputs.configure(with: (User.template, project, Reward.template, .pledge, .discovery))
@@ -1170,15 +825,10 @@ final class PledgePaymentMethodsViewModelTests: TestCase {
     let graphUser = GraphUser.template |> \.storedCards .~ UserCreditCards.withCards([UserCreditCards.visa])
     let response = UserEnvelope<GraphUser>(me: graphUser)
     let mockService = MockService(fetchGraphUserResult: .success(response))
-    let mockOptimizelyClient = MockOptimizelyClient()
-      |> \.features .~ [
-        OptimizelyFeature.paymentSheetEnabled.rawValue: true
-      ]
 
     withEnvironment(
       apiService: mockService,
-      currentUser: User.template,
-      optimizelyClient: mockOptimizelyClient
+      currentUser: User.template
     ) {
       self.vm.inputs.viewDidLoad()
       self.vm.inputs.configure(with: (User.template, project, Reward.template, .pledge, .discovery))
@@ -1215,17 +865,11 @@ final class PledgePaymentMethodsViewModelTests: TestCase {
       row: 0,
       section: PaymentMethodsTableViewSection.addNewCard.rawValue
     )
-    let mockOptimizelyClient = MockOptimizelyClient()
-      |> \.features .~ [
-        OptimizelyFeature.paymentSheetEnabled.rawValue: true
-      ]
-
     let mockService = MockService(createStripeSetupIntentResult: .failure(.couldNotParseErrorEnvelopeJSON))
 
     withEnvironment(
       apiService: mockService,
-      currentUser: User.template,
-      optimizelyClient: mockOptimizelyClient
+      currentUser: User.template
     ) {
       self.vm.inputs.viewDidLoad()
       self.vm.inputs.configure(with: (User.template, project, Reward.template, .pledge, .discovery))
@@ -1237,47 +881,13 @@ final class PledgePaymentMethodsViewModelTests: TestCase {
     }
   }
 
-  func testLoadingStateAddNewCard_NoEmissions_WhenPaymentSheetFlagDisabled_Success() {
-    let project = Project.template
-    let addNewCardIndexPath = IndexPath(
-      row: 0,
-      section: PaymentMethodsTableViewSection.addNewCard.rawValue
-    )
-    let mockOptimizelyClient = MockOptimizelyClient()
-      |> \.features .~ [
-        OptimizelyFeature.paymentSheetEnabled.rawValue: false
-      ]
-
-    let mockService = MockService(createStripeSetupIntentResult: .failure(.couldNotParseErrorEnvelopeJSON))
-
-    withEnvironment(
-      apiService: mockService,
-      currentUser: User.template,
-      optimizelyClient: mockOptimizelyClient
-    ) {
-      self.vm.inputs.viewDidLoad()
-      self.vm.inputs.configure(with: (User.template, project, Reward.template, .pledge, .discovery))
-      self.vm.inputs.didSelectRowAtIndexPath(addNewCardIndexPath)
-
-      self.scheduler.run()
-
-      self.addNewCardLoadingState.assertValues([])
-    }
-  }
-
   func testLoadingStateAddNewCard_ShowAndHide_NonCardSelectionNonAddNewCardContext_WhenPaymentSheetFlagEnabled_Success() {
     let project = Project.template
-    let mockOptimizelyClient = MockOptimizelyClient()
-      |> \.features .~ [
-        OptimizelyFeature.paymentSheetEnabled.rawValue: true
-      ]
-
     let mockService = MockService(createStripeSetupIntentResult: .failure(.couldNotParseErrorEnvelopeJSON))
 
     withEnvironment(
       apiService: mockService,
-      currentUser: User.template,
-      optimizelyClient: mockOptimizelyClient
+      currentUser: User.template
     ) {
       self.vm.inputs.viewDidLoad()
       self.vm.inputs.configure(with: (User.template, project, Reward.template, .pledge, .discovery))
@@ -1303,11 +913,6 @@ final class PledgePaymentMethodsViewModelTests: TestCase {
     let mockService = MockService(fetchGraphUserResult: .success(response))
     let project = Project.template
       |> \.availableCardTypes .~ ["AMEX", "VISA", "MASTERCARD"]
-
-    let mockOptimizelyClient = MockOptimizelyClient()
-      |> \.features .~ [
-        OptimizelyFeature.paymentSheetEnabled.rawValue: true
-      ]
     let paymentMethodSelectionIndexPath = IndexPath(
       row: 1,
       section: PaymentMethodsTableViewSection.paymentMethods.rawValue
@@ -1315,8 +920,7 @@ final class PledgePaymentMethodsViewModelTests: TestCase {
 
     withEnvironment(
       apiService: mockService,
-      currentUser: User.template,
-      optimizelyClient: mockOptimizelyClient
+      currentUser: User.template
     ) {
       self.vm.inputs.viewDidLoad()
       self.vm.inputs.configure(with: (User.template, project, Reward.template, .pledge, .discovery))
@@ -1338,10 +942,6 @@ final class PledgePaymentMethodsViewModelTests: TestCase {
       section: PaymentMethodsTableViewSection.addNewCard.rawValue
     )
     let envelope = ClientSecretEnvelope(clientSecret: "test")
-    let mockOptimizelyClient = MockOptimizelyClient()
-      |> \.features .~ [
-        OptimizelyFeature.paymentSheetEnabled.rawValue: true
-      ]
     let mockService = MockService(createStripeSetupIntentResult: .success(envelope))
     var configuration = PaymentSheet.Configuration()
     configuration.merchantDisplayName = Strings.general_accessibility_kickstarter()
@@ -1349,8 +949,7 @@ final class PledgePaymentMethodsViewModelTests: TestCase {
 
     withEnvironment(
       apiService: mockService,
-      currentUser: User.template,
-      optimizelyClient: mockOptimizelyClient
+      currentUser: User.template
     ) {
       self.vm.inputs.viewDidLoad()
       self.vm.inputs.configure(with: (User.template, project, Reward.template, .pledge, .discovery))

--- a/Library/ViewModels/PledgePaymentMethodsViewModelTests.swift
+++ b/Library/ViewModels/PledgePaymentMethodsViewModelTests.swift
@@ -752,7 +752,7 @@ final class PledgePaymentMethodsViewModelTests: TestCase {
     }
   }
 
-  func testGoToAddNewCard_PledgeContext_PaymentSheetEnabled_Failure() {
+  func testGoToAddNewCard_PledgeContext_Failure() {
     let project = Project.template
 
     let envelope = ClientSecretEnvelope(clientSecret: "test")
@@ -781,7 +781,7 @@ final class PledgePaymentMethodsViewModelTests: TestCase {
     }
   }
 
-  func testGoToAddNewStripeCard_WithPaymentSheetEnabled_NoStoredCards_Success() {
+  func testGoToAddNewStripeCard_NoStoredCards_Success() {
     let project = Project.template
     let graphUser = GraphUser.template |> \.storedCards .~ UserCreditCards.withCards([])
     let response = UserEnvelope<GraphUser>(me: graphUser)
@@ -819,7 +819,7 @@ final class PledgePaymentMethodsViewModelTests: TestCase {
     }
   }
 
-  func testGoToAddNewStripeCard_WhenPaymentSheetEnabled_WithStoredCards_Sucess() {
+  func testGoToAddNewStripeCard_WithStoredCards_Sucess() {
     let project = Project.template
     let graphUser = GraphUser.template |> \.storedCards .~ UserCreditCards.withCards([UserCreditCards.visa])
     let response = UserEnvelope<GraphUser>(me: graphUser)
@@ -934,7 +934,7 @@ final class PledgePaymentMethodsViewModelTests: TestCase {
     }
   }
 
-  func testGoToAddNewStripeCardScreen_WhenPaymentSheetEnabled_PledgeContext_Success() {
+  func testGoToAddNewStripeCardScreen_PledgeContext_Success() {
     let project = Project.template
     let addNewCardIndexPath = IndexPath(
       row: 0,

--- a/Library/ViewModels/PledgePaymentMethodsViewModelTests.swift
+++ b/Library/ViewModels/PledgePaymentMethodsViewModelTests.swift
@@ -752,7 +752,6 @@ final class PledgePaymentMethodsViewModelTests: TestCase {
     }
   }
 
-
   func testGoToAddNewCard_PledgeContext_PaymentSheetEnabled_Failure() {
     let project = Project.template
 


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Removes both `ios_payments_sheet` and `ios_settings_payment_sheet` feature flags, reference, and updates appropriate tests.

# 🤔 Why

Optimizely is an expensive tool. It is currently used to handle feature flags and A/B testing in the mobile apps. 
In order to reduce costs the mobile team has decided to migrate to a different tool. we'll be removing feature flags that have been rolled out to 100% of users.

# 🛠 How

- First removing the feature flag references from our Optimizely feature files
- Followed compile errors and global searches for these keys and helper methods to ensure that all code that was gated behind this feature flag was updated to be the prioritized code
   - This included removing the older `goToCardScreen` inputs/outputs since that was the original implementation before the payment sheet was added.


# ✅ Acceptance criteria
### Cases where this sheet appears:
1. Settings -> Account -> Payment Methods -> Add New payment method
2. Project -> Back this project -> Select a pledge amount -> Add new payment method

 
- [ ] Both feature flags should no longer be shown in the Optimizely feature flags screen
| <img src="https://user-images.githubusercontent.com/110618242/230426270-e44b0845-00a0-4e41-b0ef-9503b44978f8.png" width="300"> |
- [ ] The payment sheet should still be shown as expected in Settings and when dealing with payment methods in the backing flow.
| <img src="https://user-images.githubusercontent.com/110618242/230426337-28a3eefc-6b01-45f1-9a88-8332ea85763e.gif" width="300"> | | <img src="https://user-images.githubusercontent.com/110618242/230426381-bc7019c7-b497-4eb2-9ef5-8716070d9ddd.gif" width="300"> |

# Todo
- [x] ~~Remove Feature Flag in Optimizely once approved~~ 
   actually we could just leave these in the Optimizely dashboard since our account will be going away 
