### PR TITLE
[MBL-703] Prelaunch Page Watch Count Update

### DIFF
--- a/Kickstarter-iOS/SharedViews/PledgeCTAContainerView.swift
+++ b/Kickstarter-iOS/SharedViews/PledgeCTAContainerView.swift
@@ -174,7 +174,7 @@ final class PledgeCTAContainerView: UIView {
 
     self.viewModel.outputs.prelaunchCTASaved
       .observeForUI()
-      .observeValues { [weak self] isPrelaunch, saved in
+      .observeValues { [weak self] isPrelaunch, saved, _ in
         guard isPrelaunch else { return }
 
         _ = self?.pledgeCTAButton

--- a/KsApi/GraphAPI.swift
+++ b/KsApi/GraphAPI.swift
@@ -4440,6 +4440,7 @@ public enum GraphAPI {
             __typename
             id
             isWatched
+            watchesCount
           }
         }
       }
@@ -4542,6 +4543,7 @@ public enum GraphAPI {
               GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
               GraphQLField("id", type: .nonNull(.scalar(GraphQLID.self))),
               GraphQLField("isWatched", type: .nonNull(.scalar(Bool.self))),
+              GraphQLField("watchesCount", type: .scalar(Int.self)),
             ]
           }
 
@@ -4551,8 +4553,8 @@ public enum GraphAPI {
             self.resultMap = unsafeResultMap
           }
 
-          public init(id: GraphQLID, isWatched: Bool) {
-            self.init(unsafeResultMap: ["__typename": "Project", "id": id, "isWatched": isWatched])
+          public init(id: GraphQLID, isWatched: Bool, watchesCount: Int? = nil) {
+            self.init(unsafeResultMap: ["__typename": "Project", "id": id, "isWatched": isWatched, "watchesCount": watchesCount])
           }
 
           public var __typename: String {
@@ -4580,6 +4582,16 @@ public enum GraphAPI {
             }
             set {
               resultMap.updateValue(newValue, forKey: "isWatched")
+            }
+          }
+
+          /// Number of watchers a project has.
+          public var watchesCount: Int? {
+            get {
+              return resultMap["watchesCount"] as? Int
+            }
+            set {
+              resultMap.updateValue(newValue, forKey: "watchesCount")
             }
           }
         }
@@ -5039,6 +5051,7 @@ public enum GraphAPI {
             __typename
             id
             isWatched
+            watchesCount
           }
         }
       }
@@ -5141,6 +5154,7 @@ public enum GraphAPI {
               GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
               GraphQLField("id", type: .nonNull(.scalar(GraphQLID.self))),
               GraphQLField("isWatched", type: .nonNull(.scalar(Bool.self))),
+              GraphQLField("watchesCount", type: .scalar(Int.self)),
             ]
           }
 
@@ -5150,8 +5164,8 @@ public enum GraphAPI {
             self.resultMap = unsafeResultMap
           }
 
-          public init(id: GraphQLID, isWatched: Bool) {
-            self.init(unsafeResultMap: ["__typename": "Project", "id": id, "isWatched": isWatched])
+          public init(id: GraphQLID, isWatched: Bool, watchesCount: Int? = nil) {
+            self.init(unsafeResultMap: ["__typename": "Project", "id": id, "isWatched": isWatched, "watchesCount": watchesCount])
           }
 
           public var __typename: String {
@@ -5179,6 +5193,16 @@ public enum GraphAPI {
             }
             set {
               resultMap.updateValue(newValue, forKey: "isWatched")
+            }
+          }
+
+          /// Number of watchers a project has.
+          public var watchesCount: Int? {
+            get {
+              return resultMap["watchesCount"] as? Int
+            }
+            set {
+              resultMap.updateValue(newValue, forKey: "watchesCount")
             }
           }
         }

--- a/KsApi/models/graphql/WatchProjectResponseEnvelope.swift
+++ b/KsApi/models/graphql/WatchProjectResponseEnvelope.swift
@@ -9,6 +9,7 @@ public struct WatchProjectResponseEnvelope: Decodable {
     public struct Project: Decodable {
       public var id: String
       public var isWatched: Bool
+      public var watchesCount: Int
     }
   }
 }

--- a/KsApi/models/graphql/adapters/WatchProjectResponseEnvelope+UnwatchProjectMutation.Data.swift
+++ b/KsApi/models/graphql/adapters/WatchProjectResponseEnvelope+UnwatchProjectMutation.Data.swift
@@ -8,9 +8,11 @@ extension WatchProjectResponseEnvelope {
     guard let projectFromData = data.watchProject?.project else {
       return nil
     }
+
     let project = WatchProject.Project(
       id: projectFromData.id,
-      isWatched: projectFromData.isWatched
+      isWatched: projectFromData.isWatched,
+      watchesCount: projectFromData.watchesCount ?? 0
     )
 
     return WatchProjectResponseEnvelope(watchProject: WatchProject(project: project))

--- a/KsApi/models/graphql/adapters/WatchProjectResponseEnvelope+UnwatchProjectMutation.DataTest.swift
+++ b/KsApi/models/graphql/adapters/WatchProjectResponseEnvelope+UnwatchProjectMutation.DataTest.swift
@@ -9,6 +9,7 @@ final class WatchProjectResponseEnvelope_UnwatchProjectMutationTests: XCTestCase
 
     XCTAssertEqual(envelope?.watchProject.project.id, "id")
     XCTAssertEqual(envelope?.watchProject.project.isWatched, false)
+    XCTAssertEqual(envelope?.watchProject.project.watchesCount, 100)
   }
 
   func test_envelopeFrom_ReturnsNil() {

--- a/KsApi/models/graphql/adapters/WatchProjectResponseEnvelope+WatchProjectMutation.Data.swift
+++ b/KsApi/models/graphql/adapters/WatchProjectResponseEnvelope+WatchProjectMutation.Data.swift
@@ -11,7 +11,8 @@ extension WatchProjectResponseEnvelope {
     }
     let project = WatchProject.Project(
       id: projectFromData.id,
-      isWatched: projectFromData.isWatched
+      isWatched: projectFromData.isWatched,
+      watchesCount: projectFromData.watchesCount ?? 0
     )
 
     return WatchProjectResponseEnvelope(watchProject: WatchProject(project: project))

--- a/KsApi/models/graphql/adapters/WatchProjectResponseEnvelope+WatchProjectMutation.DataTests.swift
+++ b/KsApi/models/graphql/adapters/WatchProjectResponseEnvelope+WatchProjectMutation.DataTests.swift
@@ -10,6 +10,7 @@ final class WatchProjectResponseEnvelope_WatchProjectMutationTests: XCTestCase {
 
     XCTAssertEqual(envelope?.watchProject.project.id, "id")
     XCTAssertEqual(envelope?.watchProject.project.isWatched, true)
+    XCTAssertEqual(envelope?.watchProject.project.watchesCount, 100)
   }
 
   func test_envelopeFrom_ReturnsNil() {

--- a/KsApi/models/templates/graphql/WatchProjectResponseEnvelopeTemplates.swift
+++ b/KsApi/models/templates/graphql/WatchProjectResponseEnvelopeTemplates.swift
@@ -3,13 +3,13 @@ import Foundation
 extension WatchProjectResponseEnvelope {
   internal static let watchTemplate = WatchProjectResponseEnvelope(
     watchProject: .init(
-      project: .init(id: "UHJvamVjdC0xMzEzNzE3MDgy", isWatched: true)
+      project: .init(id: "UHJvamVjdC0xMzEzNzE3MDgy", isWatched: true, watchesCount: 10)
     )
   )
 
   internal static let unwatchTemplate = WatchProjectResponseEnvelope(
     watchProject: .init(
-      project: .init(id: "UHJvamVjdC0xMzEzNzE3MDgy", isWatched: true)
+      project: .init(id: "UHJvamVjdC0xMzEzNzE3MDgy", isWatched: true, watchesCount: 9)
     )
   )
 }

--- a/KsApi/mutations/UnwatchProject.graphql
+++ b/KsApi/mutations/UnwatchProject.graphql
@@ -4,6 +4,7 @@ mutation unwatchProject($input: UnwatchProjectInput!) {
     project {
       id
       isWatched
+      watchesCount
     }
   }
 }

--- a/KsApi/mutations/WatchProject.graphql
+++ b/KsApi/mutations/WatchProject.graphql
@@ -4,6 +4,7 @@ mutation watchProject($input: WatchProjectInput!) {
     project {
       id
       isWatched
+      watchesCount
     }
   }
 }

--- a/KsApi/mutations/templates/mutation/WatchProjectMutationTemplate.swift
+++ b/KsApi/mutations/templates/mutation/WatchProjectMutationTemplate.swift
@@ -35,7 +35,8 @@ public enum WatchProjectResponseMutationTemplate {
         "clientMutationId": nil,
         "project": [
           "id": "id",
-          "isWatched": watched
+          "isWatched": watched,
+          "watchesCount": 100
         ]
       ]
     ]
@@ -47,7 +48,8 @@ public enum WatchProjectResponseMutationTemplate {
         "clientMutationId": nil,
         "project": [
           "id": "id",
-          "isWatched": watched
+          "isWatched": watched,
+          "watchesCount": 100
         ]
       ]
     ]

--- a/Library/PledgeStateCTAType.swift
+++ b/Library/PledgeStateCTAType.swift
@@ -7,7 +7,7 @@ public enum PledgeStateCTAType: Equatable {
   case viewBacking
   case viewRewards
   case viewYourRewards
-  case prelaunch(saved: Bool)
+  case prelaunch(saved: Bool, watchCount: Int)
 
   public var buttonTitle: String {
     switch self {
@@ -23,7 +23,7 @@ public enum PledgeStateCTAType: Equatable {
       return Strings.View_rewards()
     case .viewYourRewards:
       return Strings.View_your_rewards()
-    case let .prelaunch(saved):
+    case let .prelaunch(saved, _):
       return saved ? Strings.Saved() : Strings.Notify_me_on_launch()
     }
   }
@@ -38,7 +38,7 @@ public enum PledgeStateCTAType: Equatable {
       return .blue
     case .viewBacking, .viewRewards, .viewYourRewards:
       return .black
-    case let .prelaunch(saved):
+    case let .prelaunch(saved, _):
       return saved ? .none : .black
     }
   }

--- a/Library/ViewModels/PledgeCTAContainerViewViewModelTests.swift
+++ b/Library/ViewModels/PledgeCTAContainerViewViewModelTests.swift
@@ -332,17 +332,17 @@ internal final class PledgeCTAContainerViewViewModelTests: TestCase {
   func testPledgeCTA_PrelaunchGoesFromUnsavedToSavedViaNotification_Success() {
     let unsavedProject = Project.template
       |> \.displayPrelaunch .~ true
-      |> \.watchesCount .~ 102
+      |> \.watchesCount .~ 99
       |> \.personalization.isStarred .~ false
 
-    let prelaunchCTAUnsaved = PledgeCTAPrelaunchState(prelaunch: true, saved: false)
-    let prelaunchCTASaved = PledgeCTAPrelaunchState(prelaunch: true, saved: true)
+    let prelaunchCTAUnsaved = PledgeCTAPrelaunchState(prelaunch: true, saved: false, watchesCount: 99)
+    let prelaunchCTASaved = PledgeCTAPrelaunchState(prelaunch: true, saved: true, watchesCount: 100)
 
     self.vm.inputs.configureWith(value: (.left((unsavedProject, nil)), false, .projectPamphlet))
 
     self.buttonStyleType.assertValues([.black])
     self.buttonTitleText.assertValues(["Notify me on launch"])
-    self.watchesCountText.assertValues(["102 followers"])
+    self.watchesCountText.assertValues(["99 followers"])
     self.watchesLabelHidden.assertValues([false])
     XCTAssertEqual(self.prelaunchCTASaved.values.count, 1)
     XCTAssertEqual(self.prelaunchCTASaved.values.first!.prelaunch, prelaunchCTAUnsaved.prelaunch)
@@ -351,7 +351,7 @@ internal final class PledgeCTAContainerViewViewModelTests: TestCase {
 
     let savedProject = Project.template
       |> \.displayPrelaunch .~ true
-      |> \.watchesCount .~ 102
+      |> \.watchesCount .~ 100
       |> \.personalization.isStarred .~ true
 
     self.vm.inputs.savedProjectFromNotification(project: savedProject)
@@ -360,7 +360,7 @@ internal final class PledgeCTAContainerViewViewModelTests: TestCase {
 
     self.buttonStyleType.assertValues([.black, .none])
     self.buttonTitleText.assertValues(["Notify me on launch", "Saved"])
-    self.watchesCountText.assertValues(["102 followers"])
+    self.watchesCountText.assertValues(["100 followers"])
     self.watchesLabelHidden.assertValues([false, false])
     XCTAssertEqual(self.prelaunchCTASaved.values.count, 2)
     XCTAssertEqual(self.prelaunchCTASaved.values.last!.prelaunch, prelaunchCTASaved.prelaunch)
@@ -383,6 +383,6 @@ internal final class PledgeCTAContainerViewViewModelTests: TestCase {
     self.scheduler.advance(by: .seconds(1))
 
     XCTAssertEqual(self.notifyDelegateCTATapped.values.count, 1)
-    XCTAssertEqual(self.notifyDelegateCTATapped.values.last!, .prelaunch(saved: true))
+    XCTAssertEqual(self.notifyDelegateCTATapped.values.last!, .prelaunch(saved: true, watchCount: 102))
   }
 }

--- a/Library/ViewModels/PledgeCTAContainerViewViewModelTests.swift
+++ b/Library/ViewModels/PledgeCTAContainerViewViewModelTests.swift
@@ -360,7 +360,7 @@ internal final class PledgeCTAContainerViewViewModelTests: TestCase {
 
     self.buttonStyleType.assertValues([.black, .none])
     self.buttonTitleText.assertValues(["Notify me on launch", "Saved"])
-    self.watchesCountText.assertValues(["100 followers"])
+    self.watchesCountText.assertValues(["99 followers", "100 followers"])
     self.watchesLabelHidden.assertValues([false, false])
     XCTAssertEqual(self.prelaunchCTASaved.values.count, 2)
     XCTAssertEqual(self.prelaunchCTASaved.values.last!.prelaunch, prelaunchCTASaved.prelaunch)

--- a/Library/ViewModels/ProjectPageViewModel.swift
+++ b/Library/ViewModels/ProjectPageViewModel.swift
@@ -289,8 +289,8 @@ public final class ProjectPageViewModel: ProjectPageViewModelType, ProjectPageVi
     self.updateWatchProjectWithPrelaunchProjectState = shouldUpdateWatchProjectOnPrelaunch
       .map { pledgeCTAType -> PledgeCTAPrelaunchState? in
         switch pledgeCTAType {
-        case let .prelaunch(saved):
-          return PledgeCTAPrelaunchState(prelaunch: true, saved: saved)
+        case let .prelaunch(saved, watchesCount):
+          return PledgeCTAPrelaunchState(prelaunch: true, saved: saved, watchesCount: watchesCount)
         default:
           return nil
         }

--- a/Library/ViewModels/ProjectPageViewModelTests.swift
+++ b/Library/ViewModels/ProjectPageViewModelTests.swift
@@ -811,11 +811,12 @@ final class ProjectPageViewModelTests: TestCase {
 
       self.updateWatchProjectWithPrelaunchProjectState.assertDidNotEmitValue()
 
-      self.vm.inputs.pledgeCTAButtonTapped(with: .prelaunch(saved: true))
+      self.vm.inputs.pledgeCTAButtonTapped(with: .prelaunch(saved: true, watchCount: 10))
 
       XCTAssertEqual(self.updateWatchProjectWithPrelaunchProjectState.values.count, 1)
       XCTAssertEqual(self.updateWatchProjectWithPrelaunchProjectState.values.last!.prelaunch, true)
       XCTAssertEqual(self.updateWatchProjectWithPrelaunchProjectState.values.last!.saved, true)
+      XCTAssertEqual(self.updateWatchProjectWithPrelaunchProjectState.values.last!.watchesCount, 10)
     }
   }
 

--- a/Library/ViewModels/WatchProjectViewModel.swift
+++ b/Library/ViewModels/WatchProjectViewModel.swift
@@ -275,14 +275,6 @@ private func cached(project: Project) -> Project {
   return project |> Project.lens.personalization.isStarred .~ isSaved
 }
 
-private func updateWatchCount(for project: Project, with watchCount: Int) -> Project {
-  var projectUpdatedWithWatchCount = project
-
-  projectUpdatedWithWatchCount.watchesCount = watchCount
-
-  return projectUpdatedWithWatchCount
-}
-
 private func watchAndCacheProject(_ project: Project, shouldWatch: Bool) -> (Project, Bool) {
   // create cache if it doesn't exist yet
   let tryCache = AppEnvironment.current.cache[KSCache.ksr_projectSaved]

--- a/Library/ViewModels/WatchProjectViewModelTests.swift
+++ b/Library/ViewModels/WatchProjectViewModelTests.swift
@@ -381,7 +381,7 @@ internal final class WatchProjectViewModelTests: TestCase {
     AppEnvironment.login(.init(accessToken: "deadbeef", user: .template))
 
     let project = Project.template
-      |> Project.lens.personalization.isStarred .~ true
+      |> Project.lens.personalization.isStarred .~ false
       |> Project.lens.watchesCount .~ 8
 
     withEnvironment(apiService: MockService(watchProjectMutationResult: .success(.watchTemplate))) {
@@ -391,7 +391,7 @@ internal final class WatchProjectViewModelTests: TestCase {
       self.postNotificationWithProject.assertValueCount(1)
       XCTAssertEqual(self.postNotificationWithProject.lastValue!.watchesCount, 8)
 
-      self.vm.inputs.saveButtonTapped(selected: true)
+      self.vm.inputs.saveButtonTapped(selected: false)
       self.scheduler.advance(by: .milliseconds(500))
 
       self.postNotificationWithProject.assertValueCount(3)


### PR DESCRIPTION
# 📲 What

We noticed that prelaunch page watch count was not being accurately update after saving/unsaving the project.

# 🤔 Why

Matching Android functionality. Also makes more sense to show the new follower count after following a project.

# 🛠 How

Modified the `.graphql` files for `Unwatch` and `Watch` project to include `watchesCount`.
Updated the envelope to have this property after getting it back from the mutation data.
The `PledgeStateCTAType` has a new property within the `prelaunch` enum case for `watchesCount`.

We merge the new pledge state with `watchesCount` to the `watchesCountText` in `PledgeCTAContainerViewViewModel` which was previously just using the project it was configured with for that text.

All the other signals/notifications should be the same, it's just about keeping track of the `watchesCount` after the network response returns for `unwatchProject` and `watchProject`.

# 👀 See

Before 🐛

https://user-images.githubusercontent.com/4282741/231535088-5b00b6fe-00a2-4b4a-a000-366c32ba9c7e.MP4

After 🦋

https://user-images.githubusercontent.com/4282741/231534817-bda29f52-08c5-40f2-847f-254b2b9fc3b5.MP4



# ✅ Acceptance criteria

- [ ] Ensure watching and unwatching a prelaunch project is accurate to the web.