### PR TITLE
[No Ticket] Activate Remote Config Values When Config Listener Receives Updates

### DIFF
--- a/Kickstarter-iOS/AppDelegate.swift
+++ b/Kickstarter-iOS/AppDelegate.swift
@@ -440,6 +440,27 @@ internal final class AppDelegate: UIResponder, UIApplicationDelegate {
 
     AppEnvironment.current.remoteConfigClient?.setDefaults(appDefaults as? [String: NSObject])
 
+    self.activateRemoteConfigValues()
+
+    AppEnvironment.current.remoteConfigClient?.fetch { _, _ in }
+
+    _ = AppEnvironment.current.remoteConfigClient?
+      .addOnConfigUpdateListener { [weak self] configUpdate, error in
+        guard let strongSelf = self else { return }
+
+        guard let realtimeUpdateError = error else {
+          print("🔮 Remote Config Keys Update: \(configUpdate?.updatedKeys)")
+
+          strongSelf.activateRemoteConfigValues()
+
+          return
+        }
+
+        print("🔴 Remote Config SDK Config Update Listener Failure: \(realtimeUpdateError.localizedDescription)")
+      }
+  }
+
+  private func activateRemoteConfigValues() {
     AppEnvironment.current.remoteConfigClient?.activate { _, error in
       guard let remoteConfigActivationError = error else {
         print("🔮 Remote Config SDK Successfully Activated")
@@ -453,18 +474,6 @@ internal final class AppDelegate: UIResponder, UIApplicationDelegate {
       Crashlytics.crashlytics().record(error: remoteConfigActivationError)
 
       self.viewModel.inputs.remoteConfigClientConfigurationFailed()
-    }
-
-    AppEnvironment.current.remoteConfigClient?.fetch { _, _ in }
-
-    _ = AppEnvironment.current.remoteConfigClient?.addOnConfigUpdateListener { _, error in
-      guard let realtimeUpdateError = error else {
-        print("🔮 Remote Config Key/Value Pair Updated")
-
-        return
-      }
-
-      print("🔴 Remote Config SDK Config Update Listener Failure: \(realtimeUpdateError.localizedDescription)")
     }
   }
 }

--- a/Library/ViewModels/RemoteConfigFeatureFlagToolsViewModel.swift
+++ b/Library/ViewModels/RemoteConfigFeatureFlagToolsViewModel.swift
@@ -38,7 +38,7 @@ public final class RemoteConfigFeatureFlagToolsViewModel: RemoteConfigFeatureFla
     let remoteConfigFeatures = features
       .map { features in
         features.map { feature -> (RemoteConfigFeature, Bool) in
-          (feature, AppEnvironment.current.remoteConfigClient?.isFeatureEnabled(featureKey: feature) ?? false)
+          (feature, isFeatureEnabled(feature))
         }
       }
 
@@ -82,6 +82,15 @@ public final class RemoteConfigFeatureFlagToolsViewModel: RemoteConfigFeatureFla
 }
 
 // MARK: - Private Helpers
+
+private func isFeatureEnabled(_ feature: RemoteConfigFeature) -> Bool {
+  switch feature {
+  case .consentManagementDialogEnabled:
+    return featureConsentManagementDialogEnabled()
+  case .facebookLoginInterstitialEnabled:
+    return featureFacebookLoginInterstitialEnabled()
+  }
+}
 
 /** Returns the value of the User Defaults key in the AppEnvironment.
  */


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Activate Remote Config values when config listener receives updates.

# 🤔 Why

If we don't `RemoteConfig.remoteConfig().activate()` values when the `addOnConfigUpdateListener` receives values (from the dashboard) then the app won't actually update its behavior/appearance until the app is re launched.

# 🛠 How

let's update this call in AppDelegate to activate values when they've been updated
```
 _ = AppEnvironment.current.remoteConfigClient?.addOnConfigUpdateListener { [weak self] configUpdate, error in
        guard let strongSelf = self else { return }

        guard let realtimeUpdateError = error else {
          print("🔮 Remote Config Keys Update: \(configUpdate?.updatedKeys)")

          AppEnvironment.current.remoteConfigClient?.activate { _, error in
            guard let remoteConfigActivationError = error else {
              print("🔮 Remote Config SDK Successfully Activated")

              self.viewModel.inputs.didUpdateRemoteConfigClient()
              return
            }

            print("🔴 Remote Config SDK Activation Failed with Error: \(remoteConfigActivationError.localizedDescription)")

            Crashlytics.crashlytics().record(error: remoteConfigActivationError)

            self.viewModel.inputs.remoteConfigClientConfigurationFailed()
          }

          return
        }

        print("🔴 Remote Config SDK Config Update Listener Failure: \(realtimeUpdateError.localizedDescription)")
      }
  }

```

# ✅ Acceptance criteria

- [ ] Updating values in [firebase dashboard](https://console.firebase.google.com/u/0/project/kickstarter-ios-alpha-94cf4/config) updates the app in real time w/o relaunching the app

# ⏰ TODO

- [ ] Test on a real device. The simulator doesn't seem be receiving updates consistently. 
