### PR TITLE
[MBL-888] Update Creator Dashboard Deprecation Date

### DIFF
--- a/Kickstarter-iOS/Features/DashboardDeprecationBanner/DashboardDeprecationView.swift
+++ b/Kickstarter-iOS/Features/DashboardDeprecationBanner/DashboardDeprecationView.swift
@@ -5,7 +5,7 @@ struct DashboardDeprecationView: View {
   private let contentPadding = 12.0
   private let imageSizeMultiplier = 1.5
   private var deprecationDateText: String {
-    self.formatted(dateString: "2023-08-14")
+    self.formatted(dateString: "2023-09-5")
   }
 
   var body: some View {


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Updates the date shown in the creator dashboard deprecation banner.

# 🤔 Why

Users should have an accurate notice of when this feature will be removed.

# 🛠 How

The banner has already been built and the existing date is formatted correctly. So, all we need to is update the date being passed in.

# 👀 See

Trello, screenshots, external resources?

| Before 🐛 | After 🦋 |
| --- | --- |
| <img src="https://github.com/kickstarter/ios-oss/assets/110618242/d8a8f4fc-359b-4eae-9d0f-6b425cfbc5cf" width="200"/> | <img src="https://github.com/kickstarter/ios-oss/assets/110618242/246d0006-baf5-4b70-9b6b-3e017e720c67" width="200"/> |


# ✅ Acceptance criteria

- [x] Login as a creator using the 1Password credentials for therealnativesquad@gmail.com, navigate to the creator dashboard tab, the new date on the banner should read September 5, 2023
