### PR TITLE
[ADHOCREQ-106] Redirect to safari for braze links that aren't deep links

### DIFF
--- a/Kickstarter-iOS/AppDelegateViewModelTests.swift
+++ b/Kickstarter-iOS/AppDelegateViewModelTests.swift
@@ -2527,6 +2527,19 @@ final class AppDelegateViewModelTests: TestCase {
     }
   }
 
+  func testGoToMobileSafari_BrazeInAppNotificaton() {
+    self.vm.inputs.applicationDidFinishLaunching(
+      application: UIApplication.shared,
+      launchOptions: [:]
+    )
+
+    let url = URL(string: "https://fake-url.com")!
+    self.vm.inputs.urlFromBrazeInAppNotification(url)
+
+    self.goToMobileSafari.assertValues([url])
+    self.presentViewController.assertValues([])
+  }
+
   func testRemoteConfigClientConfiguredNotification_Success() {
     let mockService = MockService(serverConfig: ServerConfig.staging)
 


### PR DESCRIPTION
# 📲 What

We currently try to parse all braze links as deep links. This is a simple change that looks at the link itself to determine if it's a deep link or not. Deep links are handled the same as before; other links will now open in Safari instead of doing nothing.

Note that this does not try to parse the braze info to see if the link was intended to be opened in web or not.

# 🤔 Why

External links from braze notifications are currently broken; nothing happens if the user tries to click on them.

# 👀 See

[JIRA bug](https://kickstarter.atlassian.net/browse/ADHOCREQ-106)

[Screencast after fix](https://github.com/kickstarter/ios-oss/assets/6799207/9af4d689-73c7-42d5-b1dd-8cea482f932f)

# ✅ Acceptance criteria

- [x] Current deep links are unchanged
- [x] Current external urls are unchanged
- [x] Braze urls that aren't deep links should now open in Safari

# ⏰ TODO

- [x] Add screencast
