### PR TITLE
[MBL-978] Remove creator dashboard button

### DIFF
--- a/Kickstarter-iOS/Features/ProjectPage/Controller/ProjectPageViewController.swift
+++ b/Kickstarter-iOS/Features/ProjectPage/Controller/ProjectPageViewController.swift
@@ -841,8 +841,6 @@ extension ProjectPageViewController: UITableViewDelegate {
       cell.delegate = self
     } else if let cell = cell as? ProjectPamphletMainCell, playbackDelegate == nil {
       playbackDelegate = cell
-    } else if let cell = cell as? ProjectPamphletCreatorHeaderCell {
-      cell.delegate = self
     } else if let cell = cell as? ImageViewElementCell {
       cell.pinchToZoomDelegate = self
     }
@@ -971,17 +969,6 @@ extension ProjectPageViewController: ProjectPamphletMainCellDelegate {
       self.viewModel.inputs.showNavigationBar(false)
       self.navigationController?.pushViewController(vc, animated: true)
     }
-  }
-}
-
-// MARK: ProjectPamphletCreatorHeaderCellDelegate
-
-extension ProjectPageViewController: ProjectPamphletCreatorHeaderCellDelegate {
-  func projectPamphletCreatorHeaderCellDidTapViewProgress(
-    _: ProjectPamphletCreatorHeaderCell,
-    with project: Project
-  ) {
-    self.viewModel.inputs.tappedViewProgress(of: project)
   }
 }
 

--- a/Kickstarter-iOS/Features/ProjectPage/Views/Cells/ProjectPamphletCreatorHeaderCell.swift
+++ b/Kickstarter-iOS/Features/ProjectPage/Views/Cells/ProjectPamphletCreatorHeaderCell.swift
@@ -3,37 +3,18 @@ import Library
 import Prelude
 import UIKit
 
-private enum Layout {
-  enum Button {
-    static let height: CGFloat = 48
-    static let width: CGFloat = 152
-  }
-}
-
-protocol ProjectPamphletCreatorHeaderCellDelegate: AnyObject {
-  func projectPamphletCreatorHeaderCellDidTapViewProgress(
-    _ cell: ProjectPamphletCreatorHeaderCell,
-    with project: Project
-  )
-}
-
 final class ProjectPamphletCreatorHeaderCell: UITableViewCell, ValueCell {
   // MARK: Properties
 
   private let launchDateLabel: UILabel = { UILabel(frame: .zero) }()
-  private let rootStackView: UIStackView = { UIStackView(frame: .zero) }()
-  private let viewProgressButton: UIButton = { UIButton(frame: .zero) }()
   private let viewModel: ProjectPamphletCreatorHeaderCellViewModelType =
     ProjectPamphletCreatorHeaderCellViewModel()
-
-  internal weak var delegate: ProjectPamphletCreatorHeaderCellDelegate?
 
   // MARK: Lifecycle
 
   override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
     super.init(style: style, reuseIdentifier: reuseIdentifier)
     self.configureViews()
-    self.setupConstraints()
     self.bindViewModel()
   }
 
@@ -48,23 +29,9 @@ final class ProjectPamphletCreatorHeaderCell: UITableViewCell, ValueCell {
   }
 
   private func configureViews() {
-    _ = ([self.launchDateLabel, self.viewProgressButton], self.rootStackView)
-      |> ksr_addArrangedSubviewsToStackView()
-
-    _ = (self.rootStackView, self.contentView)
+    _ = (self.launchDateLabel, self.contentView)
       |> ksr_addSubviewToParent()
       |> ksr_constrainViewToMarginsInParent()
-
-    self.viewProgressButton.addTarget(
-      self, action: #selector(self.viewProgressButtonTapped), for: .touchUpInside
-    )
-  }
-
-  private func setupConstraints() {
-    NSLayoutConstraint.activate([
-      self.viewProgressButton.heightAnchor.constraint(equalToConstant: Layout.Button.height),
-      self.viewProgressButton.widthAnchor.constraint(equalToConstant: Layout.Button.width)
-    ])
   }
 
   // MARK: - View model
@@ -72,15 +39,6 @@ final class ProjectPamphletCreatorHeaderCell: UITableViewCell, ValueCell {
   override func bindViewModel() {
     super.bindViewModel()
     self.launchDateLabel.rac.attributedText = self.viewModel.outputs.launchDateLabelAttributedText
-    self.viewProgressButton.rac.title = self.viewModel.outputs.buttonTitle
-
-    self.viewModel.outputs.notifyDelegateViewProgressButtonTapped
-      .observeForUI()
-      .observeValues { [weak self] project in
-        guard let self = self else { return }
-
-        self.delegate?.projectPamphletCreatorHeaderCellDidTapViewProgress(self, with: project)
-      }
   }
 
   // MARK: - Styles
@@ -93,21 +51,6 @@ final class ProjectPamphletCreatorHeaderCell: UITableViewCell, ValueCell {
 
     _ = self.launchDateLabel
       |> projectCreationInfoLabelStyle
-
-    _ = self.rootStackView
-      |> adaptableStackViewStyle(
-        self.traitCollection.preferredContentSizeCategory.isAccessibilityCategory
-      )
-      |> rootStackViewStyle
-
-    _ = self.viewProgressButton
-      |> viewProgressButtonStyle
-  }
-
-  // MARK: - Actions
-
-  @objc private func viewProgressButtonTapped() {
-    self.viewModel.inputs.viewProgressButtonTapped()
   }
 }
 
@@ -127,14 +70,4 @@ private let projectCreationInfoLabelStyle: LabelStyle = { label in
   label
     |> \.adjustsFontForContentSizeCategory .~ true
     |> \.numberOfLines .~ 0
-}
-
-private let rootStackViewStyle: StackViewStyle = { stackView in
-  stackView
-    |> \.spacing .~ Styles.grid(1)
-}
-
-private let viewProgressButtonStyle: ButtonStyle = { button in
-  button
-    |> greyButtonStyle
 }

--- a/Library/ViewModels/ProjectPageViewModel.swift
+++ b/Library/ViewModels/ProjectPageViewModel.swift
@@ -58,9 +58,6 @@ public protocol ProjectPageViewModelInputs {
   /// Call when didSelectRow is called on the report project cell.
   func tappedReportProject()
 
-  /// Call when the creator header cell progress view is tapped.
-  func tappedViewProgress(of project: Project)
-
   /// Call when the user session starts and we want to reload the data source.
   func userSessionStarted()
 
@@ -588,11 +585,6 @@ public final class ProjectPageViewModel: ProjectPageViewModelType, ProjectPageVi
   fileprivate let tappedReportProjectProperty = MutableProperty(())
   public func tappedReportProject() {
     self.tappedReportProjectProperty.value = ()
-  }
-
-  fileprivate let tappedViewProgressProperty = MutableProperty<Project?>(nil)
-  public func tappedViewProgress(of project: Project) {
-    self.tappedViewProgressProperty.value = project
   }
 
   fileprivate let userSessionStartedProperty = MutableProperty(())

--- a/Library/ViewModels/ProjectPamphletCreatorHeaderCellViewModel.swift
+++ b/Library/ViewModels/ProjectPamphletCreatorHeaderCellViewModel.swift
@@ -5,13 +5,10 @@ import UIKit
 
 public protocol ProjectPamphletCreatorHeaderCellViewModelInputs {
   func configure(with project: Project)
-  func viewProgressButtonTapped()
 }
 
 public protocol ProjectPamphletCreatorHeaderCellViewModelOutputs {
-  var buttonTitle: Signal<String, Never> { get }
   var launchDateLabelAttributedText: Signal<NSAttributedString, Never> { get }
-  var notifyDelegateViewProgressButtonTapped: Signal<Project, Never> { get }
 }
 
 public protocol ProjectPamphletCreatorHeaderCellViewModelType {
@@ -22,15 +19,9 @@ public protocol ProjectPamphletCreatorHeaderCellViewModelType {
 public final class ProjectPamphletCreatorHeaderCellViewModel: ProjectPamphletCreatorHeaderCellViewModelType,
   ProjectPamphletCreatorHeaderCellViewModelInputs, ProjectPamphletCreatorHeaderCellViewModelOutputs {
   public init() {
-    self.buttonTitle = self.projectSignal
-      .map(title(for:))
-
     self.launchDateLabelAttributedText = self.projectSignal
       .map(attributedLaunchDateString(with:))
       .skipNil()
-
-    self.notifyDelegateViewProgressButtonTapped = self.projectSignal
-      .takeWhen(self.viewProgressButtonTappedSignal.ignoreValues())
   }
 
   private let (projectSignal, projectObserver) = Signal<Project, Never>.pipe()
@@ -38,22 +29,10 @@ public final class ProjectPamphletCreatorHeaderCellViewModel: ProjectPamphletCre
     self.projectObserver.send(value: project)
   }
 
-  private let (viewProgressButtonTappedSignal, viewProgressButtonTappedObserver) =
-    Signal<Void, Never>.pipe()
-  public func viewProgressButtonTapped() {
-    self.viewProgressButtonTappedObserver.send(value: ())
-  }
-
-  public let buttonTitle: Signal<String, Never>
   public let launchDateLabelAttributedText: Signal<NSAttributedString, Never>
-  public let notifyDelegateViewProgressButtonTapped: Signal<Project, Never>
 
   public var inputs: ProjectPamphletCreatorHeaderCellViewModelInputs { return self }
   public var outputs: ProjectPamphletCreatorHeaderCellViewModelOutputs { return self }
-}
-
-private func title(for project: Project) -> String {
-  return project.state == .live ? Strings.View_progress() : Strings.View_dashboard()
 }
 
 private func attributedLaunchDateString(with project: Project) -> NSAttributedString? {

--- a/Library/ViewModels/ProjectPamphletCreatorHeaderCellViewModelTests.swift
+++ b/Library/ViewModels/ProjectPamphletCreatorHeaderCellViewModelTests.swift
@@ -7,41 +7,13 @@ import ReactiveExtensions_TestHelpers
 final class ProjectPamphletCreatorHeaderCellViewModelTests: TestCase {
   private let vm: ProjectPamphletCreatorHeaderCellViewModelType = ProjectPamphletCreatorHeaderCellViewModel()
 
-  private let buttonTitle = TestObserver<String, Never>()
   private let launchDateLabelAttributedText = TestObserver<String, Never>()
-  private let notifyDelegateViewProgressButtonTapped = TestObserver<Project, Never>()
 
   override func setUp() {
     super.setUp()
 
-    self.vm.outputs.buttonTitle.observe(self.buttonTitle.observer)
     self.vm.outputs.launchDateLabelAttributedText.map { $0.string }
       .observe(self.launchDateLabelAttributedText.observer)
-    self.vm.outputs.notifyDelegateViewProgressButtonTapped.observe(
-      self.notifyDelegateViewProgressButtonTapped.observer
-    )
-  }
-
-  func testButtonTitle_LiveProject() {
-    let project = Project.template
-      |> \.state .~ .live
-
-    self.buttonTitle.assertDidNotEmitValue()
-
-    self.vm.inputs.configure(with: project)
-
-    self.buttonTitle.assertValue("View progress")
-  }
-
-  func testButtonTitle_NonLiveProject() {
-    let project = Project.template
-      |> \.state .~ .successful
-
-    self.buttonTitle.assertDidNotEmitValue()
-
-    self.vm.inputs.configure(with: project)
-
-    self.buttonTitle.assertValue("View dashboard")
   }
 
   func testLaunchDateLabelAttributedText() {
@@ -66,16 +38,5 @@ final class ProjectPamphletCreatorHeaderCellViewModelTests: TestCase {
 
       self.launchDateLabelAttributedText.assertValue("You launched this project on November 7, 2019.")
     }
-  }
-
-  func testNotifyDelegateViewProgressButtonTapped() {
-    let project = Project.template
-    self.vm.inputs.configure(with: project)
-
-    self.notifyDelegateViewProgressButtonTapped.assertDidNotEmitValue()
-
-    self.vm.inputs.viewProgressButtonTapped()
-
-    self.notifyDelegateViewProgressButtonTapped.assertValue(project)
   }
 }


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Remove button that allows a creator to navigate from the project page of a project they own to the dashboard.

# 👀 See

 [JIRA](https://kickstarter.atlassian.net/browse/MBL-978)

| Before 🐛 | After 🦋 |
| --- | --- |
| ![image](https://github.com/kickstarter/ios-oss/assets/6799207/39fa2734-f743-4b5d-a0ca-969d36623643) | ![image](https://github.com/kickstarter/ios-oss/assets/6799207/8eb7ae87-658c-4c29-8273-1fd8dca1a11b) |

# ✅ Acceptance criteria

- [x] Log into a creator account and open the project page for a project they own. Ex "Help me transform this pile of wood" by therealnativesquad@gmail.com. Make sure "You launched this project..." banner still shows, but doesn't have a "View progress" or "View dashboard" button

# TODO

- [ ] Wait for initial remove creator dashboard pr to be submitted before this