### PR TITLE
Store failed snapshots in Failed_Snapshot_Tests/ and save as artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,6 +53,8 @@ test_job: &test_job
         command: bundle exec slather coverage -x --scheme $SCHEME ./Kickstarter.xcodeproj
     - codecov/upload:
         file: cobertura.xml
+    - store_artifacts:
+        path: ./Failed_Snapshot_Tests
 
 distribute_job: &distribute_job
   steps:

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 ## Build generated
 build/
 DerivedData
+Failed_Snapshot_Tests/
 
 ## Various settings
 *.pbxuser

--- a/Kickstarter.xcodeproj/xcshareddata/xcschemes/Kickstarter-Framework-iOS.xcscheme
+++ b/Kickstarter.xcodeproj/xcshareddata/xcschemes/Kickstarter-Framework-iOS.xcscheme
@@ -80,6 +80,11 @@
             value = "$(SOURCE_ROOT)/Screenshots/FailureDiffs"
             isEnabled = "YES">
          </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "SNAPSHOT_ARTIFACTS"
+            value = "$(SOURCE_ROOT)/Failed_Snapshot_Tests"
+            isEnabled = "YES">
+         </EnvironmentVariable>
       </EnvironmentVariables>
    </LaunchAction>
    <ProfileAction


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 🤔 Why

CircleCI runs snapshot tests. However, if a snapshot test fails, we had no way of _seeing_ that failed test. This will make debugging test failures on CircleCI easier. 

# 🛠 How

`swift-snapshot-testing` will automatically saved failed screenshots to a directory defined by the environment variable `SNAPSHOT_ARTIFACTS`. I added that variable, and also added a `save_artifacts` step to our build pipeline.

# 👀 See

Here's an example of uploaded artifacts, from a copy of this PR that I forced to fail:
https://app.circleci.com/pipelines/github/kickstarter/ios-oss/4281/workflows/c037a3a3-fd45-4d62-ac8b-5a5a29b02f96/jobs/52311/artifacts

It's worth noting that these changes will also affect your local machine. See this test report:

```
failed - Snapshot "lang_de_device_phone4_7inch" does not match reference.

@−
"file:///Users/amy/Projects/ios-oss/Kickstarter-iOS/Features/Activities/Controller/__Snapshots__/ActivitiesViewControllerTests/testActivities_All.lang_de_device_phone4_7inch.png"
@+
"file:///Users/amy/Projects/ios-oss/Failed_Snapshot_Tests/ActivitiesViewControllerTests/testActivities_All.lang_de_device_phone4_7inch.png"

```