### PR TITLE
Project filtering proof of concept

### DIFF
--- a/Library/ViewModels/DiscoveryPageViewModel.swift
+++ b/Library/ViewModels/DiscoveryPageViewModel.swift
@@ -177,9 +177,9 @@ public final class DiscoveryPageViewModel: DiscoveryPageViewModelType, Discovery
       firstPageParams.takeWhen(self.pulledToRefreshProperty.signal)
     )
 
-    let paginatedProjects: Signal<[Project], Never>
+    let rawProjects: Signal<[Project], Never>
     let isLoading: Signal<Bool, Never>
-    (paginatedProjects, isLoading, _, _) = paginate(
+    (rawProjects, isLoading, _, _) = paginate(
       requestFirstPageWith: requestFirstPageWith,
       requestNextPageWhen: isCloseToBottom,
       clearOnNewRequest: false,
@@ -190,6 +190,9 @@ public final class DiscoveryPageViewModel: DiscoveryPageViewModelType, Discovery
       requestFromCursor: { AppEnvironment.current.apiService.fetchDiscovery(paginationUrl: $0) },
       concater: { ($0 + $1).distincts() }
     )
+    
+    let paginatedProjects = rawProjects
+      .map { $0.filter { $0.category.name == "Tabletop Games" }}
 
     let projects = Signal.merge(
       paginatedProjects,


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Demonstrates client-side project filtering. This change will only show projects in the "Tabletop Games" category.

# 🤔 Why

If we want to filter out blocked projects, once we know what the backend for that will look like, we can take a similar approach.

# 👀 See

![Simulator Screen Recording - iPhone 13 Pro Max (iOS 16 2) - 2023-10-24 at 12 12 15](https://github.com/kickstarter/ios-oss/assets/6799207/04cbf2cf-75fe-4d34-a387-a6e536ccc0fb)


# ⏰ TODO

- [ ] Once actual user blocking approach is decided on, and actual work will be done in a new PR.
