### PR TITLE
[MBL-1006] Use shallow clone to speed up build times

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,7 @@ orbs:
   macos: circleci/macos@2
   aws-cli: circleci/aws-cli@3.1
   codecov: codecov/codecov@1.1.3
+  git-shallow-clone: guitarrapc/git-shallow-clone@2.8.0
 
 aws_cli_setup: &aws_cli_setup
   role-arn: $AWS_ROLE_ARN
@@ -98,7 +99,7 @@ jobs:
       - *default_environment
     steps:
       - macos/install-rosetta
-      - checkout
+      - git-shallow-clone/checkout
       - run:
           name: SPM SSH Workaround
           command: *spm_ssh_workaround
@@ -159,7 +160,7 @@ jobs:
       - *default_environment
     steps:
       - macos/install-rosetta
-      - checkout
+      - git-shallow-clone/checkout
       - aws-cli/setup:
           <<: *aws_cli_setup
       - run:
@@ -172,7 +173,7 @@ jobs:
       - *default_environment
     steps:
       - macos/install-rosetta
-      - checkout
+      - git-shallow-clone/checkout
       - aws-cli/setup:
           <<: *aws_cli_setup
       - run:


### PR DESCRIPTION
# 📲 What

Use a shallow `git clone`, instead of a full `git clone`, when downloading our app code in CircleCI.

# 🤔 Why

We have a long and storied git history. If you peek at your `.git` repo locally, you'll notice it's over 3GB of data. Downloading this extra 3GB significantly slows down the `checkout` step in CircleCI, as well as our later caching steps`persist_workspace` and `attach_workspace`.

[A shallow clone](https://git-scm.com/docs/git-clone) only clones the most recent git history, instead of the _entire_ history. This vastly reduces the size of the `.git` repo. By reducing the repo size, we speed up the rest of the job. 

Shallow clones do have some limitations - you can't switch branches on a shallow clone, or push. However, we don't perform any git commands on CircleCI, so a shallow clone is totally fine for us.

# 👀 See

Check out these speed-ups! Checkout is down from 4 minutes to 15 seconds, and persisting the workspace is reduced from 4 minutes to 2 minutes.

![Screenshot 2023-10-24 at 3 18 07 PM](https://github.com/kickstarter/ios-oss/assets/146007185/9ea2b124-744d-4399-87ba-969493127024)
![Screenshot 2023-10-24 at 3 18 02 PM](https://github.com/kickstarter/ios-oss/assets/146007185/7f95a9e8-7a51-431f-8513-767a2afac2ce)

The overall build is down to ~19 minutes, compared to our average of 26 minutes:
![Screenshot 2023-10-24 at 3 39 30 PM](https://github.com/kickstarter/ios-oss/assets/146007185/70c4cc5c-6077-4a06-9c60-ae6b35abf2b8)



# ✅ Acceptance criteria

- Builds don't break
