### PR TITLE
MBL-1014: Replace ReactiveSwift in ReportProjectFormViewModel with Combine

### DIFF
--- a/Kickstarter-iOS/Features/ReportProject/ReportProjectFormView.swift
+++ b/Kickstarter-iOS/Features/ReportProject/ReportProjectFormView.swift
@@ -7,45 +7,54 @@ enum ReportFormFocusField {
 }
 
 struct ReportProjectFormView: View {
-  let projectID: String
-  let projectURL: String
-  let projectFlaggingKind: GraphAPI.FlaggingKind
   @Binding var popToRoot: Bool
 
   @SwiftUI.Environment(\.dismiss) private var dismiss
-  @ObservedObject private var viewModel = ReportProjectFormViewModel()
+  @ObservedObject private var viewModel: ReportProjectFormViewModel
 
-  @State private var retrievedEmail = ""
-  @State private var details: String = ""
-  @State private var saveEnabled: Bool = false
-  @State private var saveTriggered: Bool = false
   @State private var showLoading: Bool = false
-  @State private var showBannerMessage = false
-  @State private var submitSuccess = false
-  @State private var bannerMessage: MessageBannerViewViewModel?
   @FocusState private var focusField: ReportFormFocusField?
+
+  init(projectID: String,
+       projectURL: String,
+       projectFlaggingKind: GraphAPI.FlaggingKind,
+       popToRoot: Binding<Bool>) {
+    self._popToRoot = popToRoot
+
+    self.viewModel = ReportProjectFormViewModel(
+      projectID: projectID,
+      projectURL: projectURL,
+      projectFlaggingKind: projectFlaggingKind
+    )
+  }
 
   var body: some View {
     GeometryReader { proxy in
       Form {
-        if !retrievedEmail.isEmpty {
-          SwiftUI.Section(Strings.Email()) {
+        SwiftUI.Section(Strings.Email()) {
+          if let retrievedEmail = viewModel.retrievedEmail, !retrievedEmail.isEmpty {
             Text(retrievedEmail)
               .font(Font(UIFont.ksr_body()))
               .foregroundColor(Color(.ksr_support_400))
+              .disabled(true)
+          } else {
+            Text(Strings.Loading())
+              .font(Font(UIFont.ksr_body()))
+              .foregroundColor(Color(.ksr_support_400))
+              .italic()
               .disabled(true)
           }
         }
 
         SwiftUI.Section(Strings.Project_url()) {
-          Text(projectURL)
+          Text(viewModel.projectURL)
             .font(Font(UIFont.ksr_body()))
             .foregroundColor(Color(.ksr_support_400))
             .disabled(true)
         }
 
         SwiftUI.Section {
-          TextEditor(text: $details)
+          TextEditor(text: $viewModel.detailsText)
             .frame(minHeight: 75)
             .font(Font(UIFont.ksr_body()))
             .focused($focusField, equals: .details)
@@ -59,8 +68,8 @@ struct ReportProjectFormView: View {
       .toolbar {
         ToolbarItem(placement: .navigationBarTrailing) {
           LoadingBarButtonItem(
-            saveEnabled: $saveEnabled,
-            saveTriggered: $saveTriggered,
+            saveEnabled: $viewModel.saveButtonEnabled,
+            saveTriggered: $viewModel.saveTriggered,
             showLoading: $showLoading,
             titleText: Strings.Send()
           )
@@ -69,42 +78,21 @@ struct ReportProjectFormView: View {
       .onAppear {
         focusField = .details
         viewModel.inputs.viewDidLoad()
-        viewModel.projectID.send(self.projectID)
-        viewModel.projectFlaggingKind.send(self.projectFlaggingKind)
       }
-      .onChange(of: details) { detailsText in
-        viewModel.detailsText.send(detailsText)
-      }
-      .onChange(of: saveTriggered) { triggered in
-        focusField = nil
-        showLoading = triggered
-        viewModel.saveTriggered.send(triggered)
-      }
-      .onChange(of: bannerMessage) { newValue in
+      .onReceive(viewModel.$bannerMessage) { newValue in
+        showLoading = false
+
         /// bannerMessage is set to nil when its done presenting. When it is done, and submit was successful,  dismiss this view.
-        if newValue == nil, self.submitSuccess {
+        if newValue == nil, viewModel.submitSuccess {
           dismiss()
           popToRoot = true
-        } else if newValue?.bannerBackgroundColor == Color(.ksr_alert) {
-          saveEnabled = true
         }
       }
-      .onReceive(viewModel.saveButtonEnabled) { newValue in
-        saveEnabled = newValue
-      }
-      .onReceive(viewModel.submitSuccess) { _ in
-        submitSuccess = true
-      }
-      .onReceive(viewModel.retrievedEmail) { email in
-        retrievedEmail = email
-      }
-      .onReceive(viewModel.bannerMessage) { newValue in
-        showLoading = false
-        saveEnabled = false
-        bannerMessage = newValue
+      .onReceive(viewModel.$saveTriggered) { triggered in
+        showLoading = triggered
       }
       .overlay(alignment: .bottom) {
-        MessageBannerView(viewModel: $bannerMessage)
+        MessageBannerView(viewModel: $viewModel.bannerMessage)
           .frame(
             minWidth: proxy.size.width,
             idealWidth: proxy.size.width,

--- a/Kickstarter-iOS/Features/ReportProject/ReportProjectFormView.swift
+++ b/Kickstarter-iOS/Features/ReportProject/ReportProjectFormView.swift
@@ -8,25 +8,15 @@ enum ReportFormFocusField {
 
 struct ReportProjectFormView: View {
   @Binding var popToRoot: Bool
+  let projectID: String
+  let projectURL: String
+  let projectFlaggingKind: GraphAPI.FlaggingKind
 
   @SwiftUI.Environment(\.dismiss) private var dismiss
-  @ObservedObject private var viewModel: ReportProjectFormViewModel
+  @StateObject private var viewModel = ReportProjectFormViewModel()
 
   @State private var showLoading: Bool = false
   @FocusState private var focusField: ReportFormFocusField?
-
-  init(projectID: String,
-       projectURL: String,
-       projectFlaggingKind: GraphAPI.FlaggingKind,
-       popToRoot: Binding<Bool>) {
-    self._popToRoot = popToRoot
-
-    self.viewModel = ReportProjectFormViewModel(
-      projectID: projectID,
-      projectURL: projectURL,
-      projectFlaggingKind: projectFlaggingKind
-    )
-  }
 
   var body: some View {
     GeometryReader { proxy in
@@ -47,7 +37,7 @@ struct ReportProjectFormView: View {
         }
 
         SwiftUI.Section(Strings.Project_url()) {
-          Text(viewModel.projectURL)
+          Text(projectURL)
             .font(Font(UIFont.ksr_body()))
             .foregroundColor(Color(.ksr_support_400))
             .disabled(true)
@@ -77,6 +67,10 @@ struct ReportProjectFormView: View {
       }
       .onAppear {
         focusField = .details
+
+        viewModel.projectID = projectID
+        viewModel.projectFlaggingKind = projectFlaggingKind
+
         viewModel.inputs.viewDidLoad()
       }
       .onReceive(viewModel.$bannerMessage) { newValue in

--- a/Kickstarter-iOS/Features/ReportProject/ReportProjectInfoView.swift
+++ b/Kickstarter-iOS/Features/ReportProject/ReportProjectInfoView.swift
@@ -127,10 +127,10 @@ struct RowView: View {
               NavigationLink(
                 destination: {
                   ReportProjectFormView(
+                    popToRoot: $popToRoot,
                     projectID: self.projectID,
                     projectURL: self.projectUrl,
-                    projectFlaggingKind: item.flaggingKind ?? GraphAPI.FlaggingKind.guidelinesViolation,
-                    popToRoot: $popToRoot
+                    projectFlaggingKind: item.flaggingKind ?? GraphAPI.FlaggingKind.guidelinesViolation
                   )
                 },
                 label: { BaseRowView(item: item) }

--- a/Kickstarter-iOS/SharedViews/LoadingBarButtonItem.swift
+++ b/Kickstarter-iOS/SharedViews/LoadingBarButtonItem.swift
@@ -1,6 +1,7 @@
 import Library
 import SwiftUI
 
+// TODO(MBL-1039) - Refactor this so that saveTriggered takes a closure, not a binding
 struct LoadingBarButtonItem: View {
   @Binding var saveEnabled: Bool
   @Binding var saveTriggered: Bool

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -1492,6 +1492,8 @@
 		E1A149222ACE013100F49709 /* FetchProjectsEnvelope.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1A149212ACE013100F49709 /* FetchProjectsEnvelope.swift */; };
 		E1A149242ACE02B300F49709 /* FetchProjectsEnvelope+FetchBackerProjectsQueryDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1A149232ACE02B300F49709 /* FetchProjectsEnvelope+FetchBackerProjectsQueryDataTests.swift */; };
 		E1A149272ACE063400F49709 /* FetchBackerProjectsQueryDataTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1A149262ACE063400F49709 /* FetchBackerProjectsQueryDataTemplate.swift */; };
+		E1AA8ABF2AEABBB100AC98BF /* Signal+Combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1EA34EE2AE1B28400942A04 /* Signal+Combine.swift */; };
+		E1FDB1E82AEAAC6100285F93 /* CombineTestObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1FDB1E72AEAAC6100285F93 /* CombineTestObserver.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -3041,6 +3043,8 @@
 		E1A149212ACE013100F49709 /* FetchProjectsEnvelope.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FetchProjectsEnvelope.swift; sourceTree = "<group>"; };
 		E1A149232ACE02B300F49709 /* FetchProjectsEnvelope+FetchBackerProjectsQueryDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FetchProjectsEnvelope+FetchBackerProjectsQueryDataTests.swift"; sourceTree = "<group>"; };
 		E1A149262ACE063400F49709 /* FetchBackerProjectsQueryDataTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchBackerProjectsQueryDataTemplate.swift; sourceTree = "<group>"; };
+		E1EA34EE2AE1B28400942A04 /* Signal+Combine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Signal+Combine.swift"; sourceTree = "<group>"; };
+		E1FDB1E72AEAAC6100285F93 /* CombineTestObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CombineTestObserver.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -6486,6 +6490,7 @@
 				D01588281EEB2ED7006E7684 /* ServiceTests.swift */,
 				D01588291EEB2ED7006E7684 /* ServiceType.swift */,
 				D015882A1EEB2ED7006E7684 /* ServiceTypeTests.swift */,
+				E1AA8ABE2AEABB1900AC98BF /* combine */,
 				D01587691EEB2ED6006E7684 /* extensions */,
 				8ADCCDAA2656BC020079D308 /* fragments */,
 				D015876B1EEB2ED6006E7684 /* lib */,
@@ -6825,6 +6830,15 @@
 				E10D06642AD48C9C00470B5C /* FetchBackerProjectsQueryRequestForTests.graphql_test */,
 			);
 			path = templates;
+			sourceTree = "<group>";
+		};
+		E1AA8ABE2AEABB1900AC98BF /* combine */ = {
+			isa = PBXGroup;
+			children = (
+				E1EA34EE2AE1B28400942A04 /* Signal+Combine.swift */,
+				E1FDB1E72AEAAC6100285F93 /* CombineTestObserver.swift */,
+			);
+			path = combine;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -8427,6 +8441,7 @@
 				D0158A1E1EEB30A2006E7684 /* ProjectStatsEnvelope.FundingDateStatsTemplates.swift in Sources */,
 				D015899B1EEB2ED7006E7684 /* Service.swift in Sources */,
 				47D7D09A26C2EE5800D2BAB5 /* SignInWithAppleEnvelope+SignInWithAppleMutation.Data.swift in Sources */,
+				E1FDB1E82AEAAC6100285F93 /* CombineTestObserver.swift in Sources */,
 				D6ED1B39216D50BE007F7547 /* UserEmailFields.swift in Sources */,
 				06232D3F2795EC3000A81755 /* TextNode+Helpers.swift in Sources */,
 				D01588731EEB2ED7006E7684 /* FindFriendsEnvelope.swift in Sources */,
@@ -8573,6 +8588,7 @@
 				D015886B1EEB2ED7006E7684 /* DiscoveryParams.swift in Sources */,
 				D755ECAB232005A70096F189 /* Checkout.swift in Sources */,
 				8A4E953B2450FE1500A578CF /* Money.swift in Sources */,
+				E1AA8ABF2AEABBB100AC98BF /* Signal+Combine.swift in Sources */,
 				4758485026B32110005AAC1C /* GraphAPI.BackingState+BackingState.swift in Sources */,
 				D01588BF1EEB2ED7006E7684 /* ProjectStatsEnvelope.VideoStatsLenses.swift in Sources */,
 				8AF34C802343C41C000B211D /* UpdateBackingEnvelope.swift in Sources */,

--- a/KsApi/MockService.swift
+++ b/KsApi/MockService.swift
@@ -1,4 +1,5 @@
 #if DEBUG
+  import Combine
   import Foundation
   import Prelude
   import ReactiveSwift
@@ -609,6 +610,18 @@
       .SignalProducer<EmptyResponseEnvelope, ErrorEnvelope> {
       guard let client = self.apolloClient else {
         return .empty
+      }
+
+      let mutation = GraphAPI
+        .CreateFlaggingMutation(input: GraphAPI.CreateFlaggingInput.from(input))
+
+      return client.performWithResult(mutation: mutation, result: self.createFlaggingResult)
+    }
+
+    internal func createFlaggingInputCombine(input: CreateFlaggingInput)
+      -> AnyPublisher<EmptyResponseEnvelope, ErrorEnvelope> {
+      guard let client = self.apolloClient else {
+        return Empty(completeImmediately: false).eraseToAnyPublisher()
       }
 
       let mutation = GraphAPI

--- a/KsApi/MockService.swift
+++ b/KsApi/MockService.swift
@@ -848,6 +848,15 @@
       return client.fetchWithResult(query: fetchGraphUserEmailQuery, result: self.fetchGraphUserEmailResult)
     }
 
+    func fetchGraphUserEmailCombine() -> AnyPublisher<UserEnvelope<GraphUserEmail>, ErrorEnvelope> {
+      guard let client = self.apolloClient else {
+        return Empty(completeImmediately: false).eraseToAnyPublisher()
+      }
+
+      let fetchGraphUserEmailQuery = GraphAPI.FetchUserEmailQuery()
+      return client.fetchWithResult(query: fetchGraphUserEmailQuery, result: self.fetchGraphUserEmailResult)
+    }
+
     // TODO: Refactor this test to use `self.apolloClient`, `ErroredBackingsEnvelope` needs to be `Decodable` and tested in-app.
     internal func fetchErroredUserBackings(status _: BackingState)
       -> SignalProducer<ErroredBackingsEnvelope, ErrorEnvelope> {

--- a/KsApi/Service.swift
+++ b/KsApi/Service.swift
@@ -1,4 +1,5 @@
 import Apollo
+import Combine
 import Foundation
 import Prelude
 import ReactiveExtensions
@@ -158,6 +159,17 @@ public struct Service: ServiceType {
       .flatMap { _ in
         SignalProducer(value: EmptyResponseEnvelope())
       }
+  }
+
+  public func createFlaggingInputCombine(input: CreateFlaggingInput)
+    -> AnyPublisher<EmptyResponseEnvelope, ErrorEnvelope> {
+    return GraphQL.shared.client
+      .perform(mutation: GraphAPI
+        .CreateFlaggingMutation(input: GraphAPI.CreateFlaggingInput.from(input)))
+      .map { _ in
+        EmptyResponseEnvelope()
+      }
+      .eraseToAnyPublisher()
   }
 
   public func createPassword(input: CreatePasswordInput)

--- a/KsApi/ServiceType.swift
+++ b/KsApi/ServiceType.swift
@@ -177,6 +177,9 @@ public protocol ServiceType {
   func fetchGraphUserEmail()
     -> SignalProducer<UserEnvelope<GraphUserEmail>, ErrorEnvelope>
 
+  func fetchGraphUserEmailCombine()
+    -> AnyPublisher<UserEnvelope<GraphUserEmail>, ErrorEnvelope>
+
   /// Fetches GraphQL user fragment and returns User instance.
   func fetchGraphUserSelf()
     -> SignalProducer<UserEnvelope<User>, ErrorEnvelope>

--- a/KsApi/ServiceType.swift
+++ b/KsApi/ServiceType.swift
@@ -1,3 +1,4 @@
+import Combine
 import Prelude
 import ReactiveSwift
 import UIKit
@@ -77,6 +78,9 @@ public protocol ServiceType {
   /// Sends report project data for a specific project
   func createFlaggingInput(input: CreateFlaggingInput)
     -> SignalProducer<EmptyResponseEnvelope, ErrorEnvelope>
+
+  func createFlaggingInputCombine(input: CreateFlaggingInput)
+    -> AnyPublisher<EmptyResponseEnvelope, ErrorEnvelope>
 
   /// Creates the password on a user account
   func createPassword(input: CreatePasswordInput) ->

--- a/KsApi/combine/CombineTestObserver.swift
+++ b/KsApi/combine/CombineTestObserver.swift
@@ -7,6 +7,7 @@ public final class CombineTestObserver<Value, Error: Swift.Error> {
 
   public func observe(_ publisher: any Publisher<Value, Error>) {
     publisher.sink { _ in
+      // TODO(MBL-1017) implement this as part of writing a new test observer for Combine
       fatalError("Errors haven't been handled here yet.")
     } receiveValue: { [weak self] value in
       self?.events.append(value)

--- a/KsApi/combine/CombineTestObserver.swift
+++ b/KsApi/combine/CombineTestObserver.swift
@@ -1,0 +1,16 @@
+import Combine
+import Foundation
+
+public final class CombineTestObserver<Value, Error: Swift.Error> {
+  public private(set) var events: [Value] = []
+  private var subscriptions = Set<AnyCancellable>()
+
+  public func observe(_ publisher: any Publisher<Value, Error>) {
+    publisher.sink { _ in
+      fatalError("Errors haven't been handled here yet.")
+    } receiveValue: { [weak self] value in
+      self?.events.append(value)
+    }
+    .store(in: &self.subscriptions)
+  }
+}

--- a/KsApi/combine/Signal+Combine.swift
+++ b/KsApi/combine/Signal+Combine.swift
@@ -1,0 +1,18 @@
+import Combine
+import Foundation
+import ReactiveSwift
+
+extension Signal where Error == Never {
+  var combinePublisher: AnyPublisher<Value, Never> {
+    let subject = PassthroughSubject<Value, Never>()
+    self.observeValues { value in
+      subject.send(value)
+    }
+
+    return subject.eraseToAnyPublisher()
+  }
+
+  public func assign(toCombine published: inout Published<Value>.Publisher) {
+    self.combinePublisher.assign(to: &published)
+  }
+}

--- a/KsApi/extensions/ApolloClient+RAC.swift
+++ b/KsApi/extensions/ApolloClient+RAC.swift
@@ -1,4 +1,5 @@
 import Apollo
+import Combine
 import Foundation
 import ReactiveSwift
 
@@ -34,6 +35,43 @@ extension ApolloClient: ApolloClientType {
   }
 
   /**
+   Performs a GraphQL fetch request with a given query.
+
+   - parameter query: The `Query` to fetch.
+
+   - returns: A `AnyPublisher` generic over `Query.Data` and `ErrorEnvelope`.
+   */
+  public func fetch<Query: GraphQLQuery>(query: Query) -> AnyPublisher<Query.Data, ErrorEnvelope> {
+    let fetchSubject: PassthroughSubject<Query.Data, ErrorEnvelope> = .init()
+    let fetchPublisher: AnyPublisher<Query.Data, ErrorEnvelope> = fetchSubject.eraseToAnyPublisher()
+
+    self.fetch(query: query, cachePolicy: .fetchIgnoringCacheCompletely) { result in
+      switch result {
+      case let .success(response):
+        if let error = response.errors?.first?.errorDescription {
+          fetchSubject.send(completion: .failure(.graphError(error)))
+
+          return
+        }
+
+        guard let data = response.data else {
+          fetchSubject.send(completion: .failure(.couldNotParseJSON))
+
+          return
+        }
+
+        fetchSubject.send(data)
+        fetchSubject.send(completion: .finished)
+      case let .failure(error):
+        print("🔴 [KsApi] ApolloClient query failure - error : \((error as NSError).description)")
+        fetchSubject.send(completion: .failure(.couldNotParseJSON))
+      }
+    }
+
+    return fetchPublisher
+  }
+
+  /**
    Performs a GraphQL mutation request with a given mutation.
 
    - parameter mutation: The `Mutation` to perform.
@@ -61,5 +99,43 @@ extension ApolloClient: ApolloClientType {
         }
       }
     }
+  }
+
+  /**
+   Performs a GraphQL mutation request with a given mutation.
+
+   - parameter mutation: The `Mutation` to perform.
+
+   - returns: A `AnyPublisher` generic over `Mutation.Data` and `ErrorEnvelope`.
+   */
+  public func perform<Mutation: GraphQLMutation>(
+    mutation: Mutation
+  ) -> AnyPublisher<Mutation.Data, ErrorEnvelope> {
+    let fetchSubject: PassthroughSubject<Mutation.Data, ErrorEnvelope> = .init()
+    let fetchPublisher: AnyPublisher<Mutation.Data, ErrorEnvelope> = fetchSubject.eraseToAnyPublisher()
+
+    self.perform(mutation: mutation) { result in
+      switch result {
+      case let .success(response):
+        if let error = response.errors?.first?.errorDescription {
+          fetchSubject.send(completion: .failure(.graphError(error)))
+
+          return
+        }
+        guard let data = response.data else {
+          fetchSubject.send(completion: .failure(.couldNotParseJSON))
+
+          return
+        }
+
+        fetchSubject.send(data)
+        fetchSubject.send(completion: .finished)
+      case let .failure(error):
+        print("🔴 [KsApi] ApolloClient mutation failure - error : \((error as NSError).description)")
+        fetchSubject.send(completion: .failure(.couldNotParseJSON))
+      }
+    }
+
+    return fetchPublisher
   }
 }

--- a/KsApi/extensions/MockGraphQLClient.swift
+++ b/KsApi/extensions/MockGraphQLClient.swift
@@ -93,6 +93,7 @@ private func producer<T, E>(for property: Result<T, E>?) -> AnyPublisher<T, E> {
   case let .success(data):
     return CurrentValueSubject(data).eraseToAnyPublisher()
   case .failure:
+    // TODO(MBL-1015) Implement this as part of further networking code updates for SwiftUI.
     assertionFailure("Need to implement this behavior. I think the Fail() subject is what we want, possibly with a deferred?")
     return Empty(completeImmediately: false).eraseToAnyPublisher()
   case .none:

--- a/KsApi/extensions/MockGraphQLClient.swift
+++ b/KsApi/extensions/MockGraphQLClient.swift
@@ -46,19 +46,18 @@ extension ApolloClientType {
     producer(for: result)
   }
 
+  public func fetchWithResult<Query: GraphQLQuery, Data: Decodable>(
+    query _: Query,
+    result: Result<Data, ErrorEnvelope>?
+  ) -> AnyPublisher<Data, ErrorEnvelope> {
+    return producer(for: result)
+  }
+
   public func performWithResult<Mutation: GraphQLMutation, Data: Decodable>(
     mutation _: Mutation,
     result: Result<Data, ErrorEnvelope>?
   ) -> AnyPublisher<Data, ErrorEnvelope> {
-    switch result {
-    case let .success(data):
-      return CurrentValueSubject(data).eraseToAnyPublisher()
-    case .failure:
-      assertionFailure("Need to implement this behavior. I think the Fail() subject is what we want, possibly with a deferred?")
-      return Empty(completeImmediately: false).eraseToAnyPublisher()
-    case .none:
-      return Empty(completeImmediately: false).eraseToAnyPublisher()
-    }
+    return producer(for: result)
   }
 
   public func data<Data: Decodable>(from producer: SignalProducer<Data, ErrorEnvelope>) -> Data? {
@@ -86,6 +85,18 @@ private func producer<T, E>(for property: Result<T, E>?) -> SignalProducer<T, E>
   switch result {
   case let .success(value): return .init(value: value)
   case let .failure(error): return .init(error: error)
+  }
+}
+
+private func producer<T, E>(for property: Result<T, E>?) -> AnyPublisher<T, E> {
+  switch property {
+  case let .success(data):
+    return CurrentValueSubject(data).eraseToAnyPublisher()
+  case .failure:
+    assertionFailure("Need to implement this behavior. I think the Fail() subject is what we want, possibly with a deferred?")
+    return Empty(completeImmediately: false).eraseToAnyPublisher()
+  case .none:
+    return Empty(completeImmediately: false).eraseToAnyPublisher()
   }
 }
 

--- a/KsApi/extensions/MockGraphQLClient.swift
+++ b/KsApi/extensions/MockGraphQLClient.swift
@@ -1,4 +1,5 @@
 import Apollo
+import Combine
 import Foundation
 import ReactiveSwift
 
@@ -43,6 +44,21 @@ extension ApolloClientType {
     result: Result<Data, ErrorEnvelope>?
   ) -> SignalProducer<Data, ErrorEnvelope> {
     producer(for: result)
+  }
+
+  public func performWithResult<Mutation: GraphQLMutation, Data: Decodable>(
+    mutation _: Mutation,
+    result: Result<Data, ErrorEnvelope>?
+  ) -> AnyPublisher<Data, ErrorEnvelope> {
+    switch result {
+    case let .success(data):
+      return CurrentValueSubject(data).eraseToAnyPublisher()
+    case .failure:
+      assertionFailure("Need to implement this behavior. I think the Fail() subject is what we want, possibly with a deferred?")
+      return Empty(completeImmediately: false).eraseToAnyPublisher()
+    case .none:
+      return Empty(completeImmediately: false).eraseToAnyPublisher()
+    }
   }
 
   public func data<Data: Decodable>(from producer: SignalProducer<Data, ErrorEnvelope>) -> Data? {

--- a/Library/ViewModels/ReportProjectFormViewModel.swift
+++ b/Library/ViewModels/ReportProjectFormViewModel.swift
@@ -28,17 +28,10 @@ public final class ReportProjectFormViewModel: ReportProjectFormViewModelType,
 
   private var cancellables = Set<AnyCancellable>()
 
-  public let projectID: String
-  public let projectURL: String
-  public let projectFlaggingKind: GraphAPI.FlaggingKind
+  public var projectID: String?
+  public var projectFlaggingKind: GraphAPI.FlaggingKind?
 
-  public init(projectID: String,
-              projectURL: String,
-              projectFlaggingKind: GraphAPI.FlaggingKind) {
-    self.projectID = projectID
-    self.projectURL = projectURL
-    self.projectFlaggingKind = projectFlaggingKind
-
+  public init() {
     /// Only enable the save button if the user has entered detail text
     self.$detailsText
       .map { !$0.isEmpty }
@@ -92,8 +85,8 @@ public final class ReportProjectFormViewModel: ReportProjectFormViewModelType,
 
   private func createFlaggingInput() -> AnyPublisher<EmptyResponseEnvelope, ErrorEnvelope> {
     let input = CreateFlaggingInput(
-      contentId: projectID,
-      kind: projectFlaggingKind,
+      contentId: projectID!,
+      kind: projectFlaggingKind!,
       details: detailsText,
       clientMutationId: nil
     )

--- a/Library/ViewModels/ReportProjectFormViewModelTests.swift
+++ b/Library/ViewModels/ReportProjectFormViewModelTests.swift
@@ -22,10 +22,9 @@ final class ReportProjectFormViewModelTests: TestCase {
   }
 
   func testEmailText_AfterFetchingUsersEmail() {
-    let vm = ReportProjectFormViewModel(
-      projectID: "123", projectURL: "https://www.kickstarter.com/projects/foo/bar",
-      projectFlaggingKind: GraphAPI.FlaggingKind.commentDoxxing
-    )
+    let vm = ReportProjectFormViewModel()
+    vm.projectID = "123"
+    vm.projectFlaggingKind = GraphAPI.FlaggingKind.commentDoxxing
 
     withEnvironment(apiService: self.userEmailSuccessMockService) {
       let userEmail = CombineTestObserver<String?, Never>()
@@ -43,10 +42,9 @@ final class ReportProjectFormViewModelTests: TestCase {
   }
 
   func test_submitIsDisabled_untilDetailTextIsNotEmpty() {
-    let vm = ReportProjectFormViewModel(
-      projectID: "123", projectURL: "https://www.kickstarter.com/projects/foo/bar",
-      projectFlaggingKind: GraphAPI.FlaggingKind.commentDoxxing
-    )
+    let vm = ReportProjectFormViewModel()
+    vm.projectID = "123"
+    vm.projectFlaggingKind = GraphAPI.FlaggingKind.commentDoxxing
 
     let saveButtonEnabled = CombineTestObserver<Bool, Never>()
     saveButtonEnabled.observe(vm.$saveButtonEnabled)

--- a/Library/ViewModels/ReportProjectFormViewModelTests.swift
+++ b/Library/ViewModels/ReportProjectFormViewModelTests.swift
@@ -1,43 +1,65 @@
 @testable import KsApi
 @testable import Library
-import ReactiveExtensions
-import ReactiveExtensions_TestHelpers
-import ReactiveSwift
+
 import XCTest
 
 final class ReportProjectFormViewModelTests: TestCase {
-  fileprivate let vm: ReportProjectFormViewModelType = ReportProjectFormViewModel()
-
-  private let userEmail = TestObserver<String, Never>()
-
   // MARK: Computed Properties
 
   private var userEmailSuccessMockService: MockService {
-    let fetchUserQueryData = GraphAPI.FetchUserQuery
+    let fetchUserEmailQueryData = GraphAPI.FetchUserEmailQuery
       .Data(unsafeResultMap: GraphUserEnvelopeTemplates.userJSONDict)
-    guard let envelope = UserEnvelope<GraphUser>.userEnvelope(from: fetchUserQueryData) else {
+
+    guard let envelope = UserEnvelope<GraphUserEmail>.userEnvelope(from: fetchUserEmailQueryData) else {
       return MockService()
     }
 
     let mockService = MockService(
-      fetchGraphUserResult: .success(envelope)
+      fetchGraphUserEmailResult: .success(envelope)
     )
 
     return mockService
   }
 
-  override func setUp() {
-    super.setUp()
-
-    self.vm.outputs.userEmail.observe(self.userEmail.observer)
-  }
-
   func testEmailText_AfterFetchingUsersEmail() {
+    let vm = ReportProjectFormViewModel(
+      projectID: "123", projectURL: "https://www.kickstarter.com/projects/foo/bar",
+      projectFlaggingKind: GraphAPI.FlaggingKind.commentDoxxing
+    )
+
     withEnvironment(apiService: self.userEmailSuccessMockService) {
-      self.vm.inputs.viewDidLoad()
+      let userEmail = CombineTestObserver<String?, Never>()
+      userEmail.observe(vm.$retrievedEmail)
+
+      XCTAssertEqual(userEmail.events.count, 1)
+      XCTAssertEqual(userEmail.events.last, Optional.some(nil))
+
+      vm.inputs.viewDidLoad()
       self.scheduler.advance()
 
-      self.userEmail.assertValues(["nativesquad@ksr.com"])
+      XCTAssertEqual(userEmail.events.count, 2)
+      XCTAssertEqual(userEmail.events.last, Optional("nativesquad@ksr.com"))
     }
+  }
+
+  func test_submitIsDisabled_untilDetailTextIsNotEmpty() {
+    let vm = ReportProjectFormViewModel(
+      projectID: "123", projectURL: "https://www.kickstarter.com/projects/foo/bar",
+      projectFlaggingKind: GraphAPI.FlaggingKind.commentDoxxing
+    )
+
+    let saveButtonEnabled = CombineTestObserver<Bool, Never>()
+    saveButtonEnabled.observe(vm.$saveButtonEnabled)
+
+    XCTAssertEqual(saveButtonEnabled.events.count, 1)
+    XCTAssertEqual(saveButtonEnabled.events.last, false)
+
+    vm.detailsText = "This is my report. I don't like this project very much."
+    XCTAssertEqual(saveButtonEnabled.events.count, 2)
+    XCTAssertEqual(saveButtonEnabled.events.last, true)
+
+    vm.detailsText = ""
+    XCTAssertEqual(saveButtonEnabled.events.count, 3)
+    XCTAssertEqual(saveButtonEnabled.events.last, false)
   }
 }


### PR DESCRIPTION
# 📲 What

This removes ReactiveSwift from `ReportProjectFormViewModel`. As part of that change, I also did some refactoring, to take advantage of as much brevity as I could squeeze out of that change.

# 🤔 Why

This is one of our experiments in moving the app off of ReactiveSwift. The goal here is twofold:

1. Learn more about what that might look like, and how we'd have to architect things
2. Make sure that we can actually ship a Combine + SwiftUI feature without something going terribly wrong

# 👀 See

Because I had to make a lot of architectural choices here, I'm leaving a lot of comments in the code. Take a look and let me know if you agree or disagree! This is all part of figuring out how we want to use Combine in the future.


# ✅ Acceptance criteria

You'll need to turn on the Report Projects feature flag (either in the code directly, or in the app debug interface.) This should have no changes from previous Report Projects behavior, except for a little extra UI when the e-mail is loading.
