### PR TITLE
Increase shallow fetch depth to 100, to make Danger work

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,7 +99,9 @@ jobs:
       - *default_environment
     steps:
       - macos/install-rosetta
-      - git-shallow-clone/checkout
+      - git-shallow-clone/checkout:
+          # This is for Danger, which requires a bit more git history
+          fetch_depth: 100 
       - run:
           name: SPM SSH Workaround
           command: *spm_ssh_workaround


### PR DESCRIPTION
# 📲 What

Increase the our shallow fetch depth.

# 🛠 How

Danger, which we use to run `swift-format` and check PR size, doesn't play nicely with shallow clones. By increasing our shallow clone depth, we can get Danger to work but keep the speedup we get from the shallow clone.
