### PR TITLE
[MBL-1021] Fix user blocking voiceOver

### DIFF
--- a/Kickstarter-iOS/Features/Comments/Views/Cells/CommentCell.swift
+++ b/Kickstarter-iOS/Features/Comments/Views/Cells/CommentCell.swift
@@ -49,6 +49,8 @@ final class CommentCell: UITableViewCell, ValueCell {
       target: self,
       action: #selector(self.commentCellHeaderTapped)
     ))
+
+    self.configureAccessibilityElements()
   }
 
   required init?(coder aDecoder: NSCoder) {
@@ -124,6 +126,26 @@ final class CommentCell: UITableViewCell, ValueCell {
 
     let viewRepliesGesture = UITapGestureRecognizer(target: self, action: #selector(self.viewRepliesTapped))
     self.viewRepliesView.addGestureRecognizer(viewRepliesGesture)
+  }
+
+  private func configureAccessibilityElements() {
+    self.isAccessibilityElement = false
+    self.accessibilityContainerType = .semanticGroup
+    self.accessibilityElements = [
+      self.commentCellHeaderStackView,
+      self.commentCellHeaderStackView.postTimeLabel,
+      self.bodyTextView,
+      self.viewRepliesView,
+      self.replyButton
+    ]
+    self.viewRepliesView.isAccessibilityElement = true
+    self.viewRepliesView.accessibilityTraits.insert(.button)
+    self.commentCellHeaderStackView.isAccessibilityElement = true
+    if featureBlockUsersEnabled() {
+      self.commentCellHeaderStackView.accessibilityTraits.insert(.button)
+    }
+    self.commentCellHeaderStackView.postTimeLabel.isAccessibilityElement = true
+    self.bodyTextView.isAccessibilityElement = true
   }
 
   // MARK: - View model

--- a/Kickstarter-iOS/Features/Comments/Views/Cells/RootCommentCell.swift
+++ b/Kickstarter-iOS/Features/Comments/Views/Cells/RootCommentCell.swift
@@ -49,6 +49,7 @@ final class RootCommentCell: UITableViewCell, ValueCell {
       target: self,
       action: #selector(self.commentCellHeaderTapped)
     ))
+    self.configureAccessibilityElements()
   }
 
   required init?(coder aDecoder: NSCoder) {
@@ -100,6 +101,22 @@ final class RootCommentCell: UITableViewCell, ValueCell {
       self.bottomBorder.bottomAnchor.constraint(equalTo: self.rootStackView.bottomAnchor),
       self.bottomBorder.heightAnchor.constraint(equalToConstant: Layout.Border.height)
     ])
+  }
+
+  private func configureAccessibilityElements() {
+    self.isAccessibilityElement = false
+    self.accessibilityContainerType = .semanticGroup
+    self.accessibilityElements = [
+      self.commentCellHeaderStackView,
+      self.commentCellHeaderStackView.postTimeLabel,
+      self.bodyTextView
+    ]
+    self.commentCellHeaderStackView.isAccessibilityElement = true
+    if featureBlockUsersEnabled() {
+      self.commentCellHeaderStackView.accessibilityTraits.insert(.button)
+    }
+    self.commentCellHeaderStackView.postTimeLabel.isAccessibilityElement = true
+    self.bodyTextView.isAccessibilityElement = true
   }
 
   // MARK: - View model

--- a/Kickstarter-iOS/Features/Comments/Views/CommentCellHeaderStackView.swift
+++ b/Kickstarter-iOS/Features/Comments/Views/CommentCellHeaderStackView.swift
@@ -19,7 +19,7 @@ internal final class CommentCellHeaderStackView: UIStackView {
     |> \.translatesAutoresizingMaskIntoConstraints .~ false
   }()
 
-  private lazy var postTimeLabel: UILabel = { UILabel(frame: .zero) }()
+  private(set) lazy var postTimeLabel: UILabel = { UILabel(frame: .zero) }()
   private let viewModel = CommentCellViewModel()
 
   override init(frame: CGRect) {
@@ -142,6 +142,7 @@ internal final class CommentCellHeaderStackView: UIStackView {
 
     self.authorNameLabel.rac.text = self.viewModel.authorName
     self.postTimeLabel.rac.text = self.viewModel.postTime
+    self.rac.accessibilityLabel = self.viewModel.authorName
   }
 }
 

--- a/Kickstarter-iOS/Features/Comments/Views/ViewRepliesView.swift
+++ b/Kickstarter-iOS/Features/Comments/Views/ViewRepliesView.swift
@@ -48,5 +48,9 @@ final class ViewRepliesView: UIView {
 
     _ = self.iconImageView
       |> UIImageView.lens.image .~ Library.image(named: "right-diagonal")
+
+    // Add accessibility label to self instead of to the textLabel, so the cell can be treated as
+    // one accessibility element.
+    self.accessibilityLabel = Strings.View_replies()
   }
 }

--- a/Kickstarter-iOS/Features/Messages/Views/Cells/MessageCell.swift
+++ b/Kickstarter-iOS/Features/Messages/Views/Cells/MessageCell.swift
@@ -31,6 +31,20 @@ internal final class MessageCell: UITableViewCell, ValueCell {
       target: self,
       action: #selector(self.messageCellHeaderTapped)
     ))
+
+    self.configureAccessibilityElements()
+  }
+
+  private func configureAccessibilityElements() {
+    self.participantStackView.isAccessibilityElement = true
+    if featureBlockUsersEnabled() {
+      self.participantStackView.accessibilityTraits.insert(.button)
+    }
+    self.timestampLabel.isAccessibilityElement = true
+    self.bodyTextView.isAccessibilityElement = true
+    self.isAccessibilityElement = false
+    self.accessibilityContainerType = .semanticGroup
+    self.accessibilityElements = [self.participantStackView!, self.timestampLabel!, self.bodyTextView!]
   }
 
   internal func configureWith(value message: Message) {
@@ -69,6 +83,7 @@ internal final class MessageCell: UITableViewCell, ValueCell {
 
   internal override func bindViewModel() {
     self.nameLabel.rac.text = self.viewModel.outputs.name
+    self.participantStackView.rac.accessibilityLabel = self.viewModel.outputs.name
     self.timestampLabel.rac.text = self.viewModel.outputs.timestamp
     self.timestampLabel.rac.accessibilityLabel = self.viewModel.outputs.timestampAccessibilityLabel
     self.bodyTextView.rac.text = self.viewModel.outputs.body

--- a/Kickstarter-iOS/Features/ProjectPage/Views/Cells/ProjectPamphletMainCell.swift
+++ b/Kickstarter-iOS/Features/ProjectPage/Views/Cells/ProjectPamphletMainCell.swift
@@ -179,9 +179,6 @@ internal final class ProjectPamphletMainCell: UITableViewCell, ValueCell {
     _ = self.creatorImageView
       |> ignoresInvertColorsImageViewStyle
 
-    _ = self.creatorButton
-      |> UIButton.lens.accessibilityHint %~ { _ in Strings.Opens_creator_profile() }
-
     _ = self.creatorImageView
       |> UIImageView.lens.clipsToBounds .~ true
       |> UIImageView.lens.contentMode .~ .scaleAspectFill


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Fix accessibility for comments and messages by splitting the cells into accessibility components. The header/username is annotated as a button when the feature flag is enabled. The accessibility hint for the username button on the project page is removed.

Ideally we should add a "Opens user menu" accessibility hint instead, but that will need to wait until we have such a string translated.

# ♿️ Accessibility 

- [x] Works with VoiceOver

# ✅ Acceptance criteria

- [x] VoiceOver works as expected with feature flag on or off
