### PR TITLE
[MBL-1036] Block User Popup + Banner Message

### DIFF
--- a/Kickstarter-iOS/Features/Comments/Controllers/CommentRepliesViewController.swift
+++ b/Kickstarter-iOS/Features/Comments/Controllers/CommentRepliesViewController.swift
@@ -75,7 +75,6 @@ final class CommentRepliesViewController: UITableViewController, MessageBannerVi
     self.navigationItem.title = Strings.Replies()
 
     self.messageBannerViewController = self.configureMessageBannerViewController(on: self)
-    self.messageBannerViewController?.delegate = self
     self.tableView.dataSource = self.dataSource
     self.tableView.delegate = self
     self.tableView.registerCellClass(CommentCell.self)
@@ -249,15 +248,6 @@ extension CommentRepliesViewController: CommentCellDelegate {
 extension CommentRepliesViewController: RootCommentCellDelegate {
   func commentCellDidTapHeader(_ cell: RootCommentCell, _ author: Comment.Author) {
     self.handleCommentCellHeaderTapped(in: cell, author)
-  }
-}
-
-// MARK: - MessageBannerViewControllerDelegate
-
-extension CommentRepliesViewController: MessageBannerViewControllerDelegate {
-  func messageBannerViewDidHide(type _: MessageBannerType) {
-    self.commentComposer.isHidden = false
-    self.view.isUserInteractionEnabled = true
   }
 }
 

--- a/Kickstarter-iOS/Features/Comments/Controllers/CommentRepliesViewController.swift
+++ b/Kickstarter-iOS/Features/Comments/Controllers/CommentRepliesViewController.swift
@@ -51,12 +51,6 @@ final class CommentRepliesViewController: UITableViewController, MessageBannerVi
     super.bindStyles()
 
     _ = self.tableView |> tableViewStyle
-
-    if let banner = messageBannerViewController?.view {
-      NSLayoutConstraint.activate([
-        banner.widthAnchor.constraint(equalTo: self.view.widthAnchor)
-      ])
-    }
   }
 
   // MARK: Lifecycle

--- a/Kickstarter-iOS/Features/Comments/Controllers/CommentRepliesViewController.swift
+++ b/Kickstarter-iOS/Features/Comments/Controllers/CommentRepliesViewController.swift
@@ -51,6 +51,12 @@ final class CommentRepliesViewController: UITableViewController, MessageBannerVi
     super.bindStyles()
 
     _ = self.tableView |> tableViewStyle
+
+    if let banner = messageBannerViewController?.view {
+      NSLayoutConstraint.activate([
+        banner.widthAnchor.constraint(equalTo: self.view.widthAnchor)
+      ])
+    }
   }
 
   // MARK: Lifecycle

--- a/Kickstarter-iOS/Features/Comments/Controllers/CommentRepliesViewController.swift
+++ b/Kickstarter-iOS/Features/Comments/Controllers/CommentRepliesViewController.swift
@@ -161,16 +161,22 @@ final class CommentRepliesViewController: UITableViewController {
       }
   }
 
-  private func blockUser() {
-    // Scott TODO: present popup UI [mbl-1036](https://kickstarter.atlassian.net/browse/MBL-1036)
+  private func presentBlockUserAlert(username: String) {
+    let alert = UIAlertController
+      .blockUserAlert(username: username, blockUserHandler: { _ in self.blockUser() })
+    self.present(alert, animated: true)
   }
 
-  private func handleCommentCellHeaderTapped(in cell: UITableViewCell, _: Comment.Author) {
+  private func blockUser() {
+    // Scott TODO: call viewModel.inputs.blockUser
+  }
+
+  private func handleCommentCellHeaderTapped(in cell: UITableViewCell, _ author: Comment.Author) {
     guard AppEnvironment.current.currentUser != nil, featureBlockUsersEnabled() else { return }
 
     let actionSheet = UIAlertController
       .blockUserActionSheet(
-        blockUserHandler: { _ in self.blockUser() },
+        blockUserHandler: { _ in self.presentBlockUserAlert(username: author.name) },
         sourceView: cell,
         isIPad: self.traitCollection.horizontalSizeClass == .regular
       )

--- a/Kickstarter-iOS/Features/Comments/Controllers/CommentRepliesViewController.swift
+++ b/Kickstarter-iOS/Features/Comments/Controllers/CommentRepliesViewController.swift
@@ -178,6 +178,7 @@ final class CommentRepliesViewController: UITableViewController, MessageBannerVi
         if success {
           self?.messageBannerViewController?
             .showBanner(with: .success, message: "This user has been successfully blocked")
+          self?.view.isUserInteractionEnabled = false
         } else {
           self?.messageBannerViewController?
             .showBanner(with: .error, message: "Your request did not go through. Try again.")
@@ -262,6 +263,7 @@ extension CommentRepliesViewController: RootCommentCellDelegate {
 extension CommentRepliesViewController: MessageBannerViewControllerDelegate {
   func messageBannerViewDidHide(type _: MessageBannerType) {
     self.commentComposer.isHidden = false
+    self.view.isUserInteractionEnabled = true
   }
 }
 

--- a/Kickstarter-iOS/Features/Comments/Controllers/CommentRepliesViewController.swift
+++ b/Kickstarter-iOS/Features/Comments/Controllers/CommentRepliesViewController.swift
@@ -168,10 +168,10 @@ final class CommentRepliesViewController: UITableViewController, MessageBannerVi
       .observeValues { [weak self] success in
         self?.commentComposer.isHidden = true
 
+        // Scott TODO: Use localized strings once translations can be done [mbl-1037](https://kickstarter.atlassian.net/browse/MBL-1037)
         if success {
           self?.messageBannerViewController?
             .showBanner(with: .success, message: "This user has been successfully blocked")
-          self?.view.isUserInteractionEnabled = false
         } else {
           self?.messageBannerViewController?
             .showBanner(with: .error, message: "Your request did not go through. Try again.")

--- a/Kickstarter-iOS/Features/Comments/Controllers/CommentsViewController.swift
+++ b/Kickstarter-iOS/Features/Comments/Controllers/CommentsViewController.swift
@@ -107,12 +107,6 @@ internal final class CommentsViewController: UITableViewController, MessageBanne
     _ = self.tableView
       |> \.tableFooterView .~ self.footerView
       |> tableViewStyle
-
-    if let banner = messageBannerViewController?.view {
-      NSLayoutConstraint.activate([
-        banner.widthAnchor.constraint(equalTo: self.view.widthAnchor)
-      ])
-    }
   }
 
   // MARK: - View Model

--- a/Kickstarter-iOS/Features/Comments/Controllers/CommentsViewController.swift
+++ b/Kickstarter-iOS/Features/Comments/Controllers/CommentsViewController.swift
@@ -107,6 +107,12 @@ internal final class CommentsViewController: UITableViewController, MessageBanne
     _ = self.tableView
       |> \.tableFooterView .~ self.footerView
       |> tableViewStyle
+
+    if let banner = messageBannerViewController?.view {
+      NSLayoutConstraint.activate([
+        banner.widthAnchor.constraint(equalTo: self.view.widthAnchor)
+      ])
+    }
   }
 
   // MARK: - View Model

--- a/Kickstarter-iOS/Features/Comments/Controllers/CommentsViewController.swift
+++ b/Kickstarter-iOS/Features/Comments/Controllers/CommentsViewController.swift
@@ -65,7 +65,6 @@ internal final class CommentsViewController: UITableViewController, MessageBanne
     self.commentComposer.delegate = self
 
     self.messageBannerViewController = self.configureMessageBannerViewController(on: self)
-    self.messageBannerViewController?.delegate = self
     self.tableView.registerCellClass(CommentCell.self)
     self.tableView.registerCellClass(CommentPostFailedCell.self)
     self.tableView.registerCellClass(CommentRemovedCell.self)
@@ -186,7 +185,6 @@ internal final class CommentsViewController: UITableViewController, MessageBanne
       .observeForUI()
       .observeValues { [weak self] success in
         self?.commentComposer.isHidden = true
-        self?.view.isUserInteractionEnabled = false
 
         if success {
           self?.messageBannerViewController?
@@ -289,15 +287,6 @@ extension CommentsViewController: CommentCellDelegate {
 extension CommentsViewController: CommentRemovedCellDelegate {
   func commentRemovedCell(_: CommentRemovedCell, didTapURL: URL) {
     self.viewModel.inputs.commentRemovedCellDidTapURL(didTapURL)
-  }
-}
-
-// MARK: - MessageBannerViewControllerDelegate
-
-extension CommentsViewController: MessageBannerViewControllerDelegate {
-  func messageBannerViewDidHide(type _: MessageBannerType) {
-    self.commentComposer.isHidden = false
-    self.view.isUserInteractionEnabled = true
   }
 }
 

--- a/Kickstarter-iOS/Features/Comments/Controllers/CommentsViewController.swift
+++ b/Kickstarter-iOS/Features/Comments/Controllers/CommentsViewController.swift
@@ -192,6 +192,7 @@ internal final class CommentsViewController: UITableViewController, MessageBanne
       .observeForUI()
       .observeValues { [weak self] success in
         self?.commentComposer.isHidden = true
+        self?.view.isUserInteractionEnabled = false
 
         if success {
           self?.messageBannerViewController?
@@ -302,6 +303,7 @@ extension CommentsViewController: CommentRemovedCellDelegate {
 extension CommentsViewController: MessageBannerViewControllerDelegate {
   func messageBannerViewDidHide(type _: MessageBannerType) {
     self.commentComposer.isHidden = false
+    self.view.isUserInteractionEnabled = true
   }
 }
 

--- a/Kickstarter-iOS/Features/Comments/Controllers/CommentsViewController.swift
+++ b/Kickstarter-iOS/Features/Comments/Controllers/CommentsViewController.swift
@@ -186,6 +186,7 @@ internal final class CommentsViewController: UITableViewController, MessageBanne
       .observeValues { [weak self] success in
         self?.commentComposer.isHidden = true
 
+        // Scott TODO: Use localized strings once translations can be done [mbl-1037](https://kickstarter.atlassian.net/browse/MBL-1037)
         if success {
           self?.messageBannerViewController?
             .showBanner(with: .success, message: "This user has been successfully blocked")

--- a/Kickstarter-iOS/Features/Comments/Controllers/CommentsViewController.swift
+++ b/Kickstarter-iOS/Features/Comments/Controllers/CommentsViewController.swift
@@ -179,8 +179,14 @@ internal final class CommentsViewController: UITableViewController {
       }
   }
 
+  private func presentBlockUserAlert(username: String) {
+    let alert = UIAlertController
+      .blockUserAlert(username: username, blockUserHandler: { _ in self.blockUser() })
+    self.present(alert, animated: true)
+  }
+
   private func blockUser() {
-    // Scott  TODO: present popup ui
+    // Scott TODO: call viewModel.inputs.blockUser
   }
 
   // MARK: - Actions
@@ -241,12 +247,12 @@ extension CommentsViewController {
 // MARK: - CommentCellDelegate
 
 extension CommentsViewController: CommentCellDelegate {
-  func commentCellDidTapHeader(_ cell: CommentCell, _: Comment.Author) {
+  func commentCellDidTapHeader(_ cell: CommentCell, _ author: Comment.Author) {
     guard AppEnvironment.current.currentUser != nil, featureBlockUsersEnabled() else { return }
 
     let actionSheet = UIAlertController
       .blockUserActionSheet(
-        blockUserHandler: { _ in self.blockUser() },
+        blockUserHandler: { _ in self.presentBlockUserAlert(username: author.name) },
         sourceView: cell,
         isIPad: self.traitCollection.horizontalSizeClass == .regular
       )

--- a/Kickstarter-iOS/Features/MessageBanner/Controller/MessageBannerViewController.swift
+++ b/Kickstarter-iOS/Features/MessageBanner/Controller/MessageBannerViewController.swift
@@ -9,13 +9,21 @@ public protocol MessageBannerViewControllerPresenting {
     -> MessageBannerViewController?
 }
 
+public protocol MessageBannerViewControllerDelegate: AnyObject {
+  func messageBannerViewDidHide(type: MessageBannerType)
+}
+
 public final class MessageBannerViewController: UIViewController, NibLoading {
   @IBOutlet fileprivate var backgroundView: UIView!
   @IBOutlet fileprivate var iconImageView: UIImageView!
   @IBOutlet fileprivate var messageLabel: UILabel!
 
+  private var bannerType: MessageBannerType?
+
   internal var bottomConstraint: NSLayoutConstraint?
   private let viewModel: MessageBannerViewModelType = MessageBannerViewModel()
+
+  weak var delegate: MessageBannerViewControllerDelegate?
 
   struct AnimationConstants {
     static let hideDuration: TimeInterval = 0.25
@@ -88,6 +96,7 @@ public final class MessageBannerViewController: UIViewController, NibLoading {
   }
 
   public func showBanner(with type: MessageBannerType, message: String) {
+    self.bannerType = type
     self.viewModel.inputs.update(with: (type, message))
     self.viewModel.inputs.bannerViewWillShow(true)
   }
@@ -139,6 +148,10 @@ public final class MessageBannerViewController: UIViewController, NibLoading {
               notification: UIAccessibility.Notification.layoutChanged,
               argument: self?.backgroundView
             )
+          }
+        } else {
+          if let type = self?.bannerType {
+            self?.delegate?.messageBannerViewDidHide(type: type)
           }
         }
       }

--- a/Kickstarter-iOS/Features/MessageBanner/Controller/MessageBannerViewController.swift
+++ b/Kickstarter-iOS/Features/MessageBanner/Controller/MessageBannerViewController.swift
@@ -219,8 +219,7 @@ extension MessageBannerViewControllerPresenting where Self: UIViewController {
 
     parentViewController.view.addConstraints([
       bottomViewBannerConstraint,
-      messageBannerView.leftAnchor.constraint(equalTo: parentViewController.view.leftAnchor),
-      messageBannerView.rightAnchor.constraint(equalTo: parentViewController.view.rightAnchor)
+      messageBannerView.widthAnchor.constraint(equalTo: parentViewController.view.widthAnchor)
     ])
 
     return messageBannerViewController

--- a/Kickstarter-iOS/Features/MessageBanner/Controller/MessageBannerViewController.swift
+++ b/Kickstarter-iOS/Features/MessageBanner/Controller/MessageBannerViewController.swift
@@ -108,6 +108,7 @@ public final class MessageBannerViewController: UIViewController, NibLoading {
 
     if !isHidden {
       self.view.superview?.bringSubviewToFront(self.view)
+      self.view.superview?.isUserInteractionEnabled = false
 
       self.view.isHidden = isHidden
 
@@ -150,6 +151,8 @@ public final class MessageBannerViewController: UIViewController, NibLoading {
             )
           }
         } else {
+          self?.view.superview?.isUserInteractionEnabled = true
+
           if let type = self?.bannerType {
             self?.delegate?.messageBannerViewDidHide(type: type)
           }

--- a/Kickstarter-iOS/Features/Messages/Controller/MessagesViewController.swift
+++ b/Kickstarter-iOS/Features/Messages/Controller/MessagesViewController.swift
@@ -42,6 +42,12 @@ internal final class MessagesViewController: UITableViewController, MessageBanne
 
     _ = self.replyBarButtonItem
       |> UIBarButtonItem.lens.title %~ { _ in Strings.general_navigation_buttons_reply() }
+
+    if let banner = messageBannerViewController?.view {
+      NSLayoutConstraint.activate([
+        banner.widthAnchor.constraint(equalTo: self.view.widthAnchor)
+      ])
+    }
   }
 
   internal override func bindViewModel() {

--- a/Kickstarter-iOS/Features/Messages/Controller/MessagesViewController.swift
+++ b/Kickstarter-iOS/Features/Messages/Controller/MessagesViewController.swift
@@ -96,6 +96,7 @@ internal final class MessagesViewController: UITableViewController, MessageBanne
       .observeForUI()
       .observeValues { [weak self] success in
 
+        // Scott TODO: Use localized strings once translations can be done [mbl-1037](https://kickstarter.atlassian.net/browse/MBL-1037)
         if success {
           self?.messageBannerViewController?
             .showBanner(with: .success, message: "This user has been successfully blocked")
@@ -189,12 +190,12 @@ extension MessagesViewController: BackingCellDelegate {
 // MARK: - MessageCellDelegate
 
 extension MessagesViewController: MessageCellDelegate {
-  func messageCellDidTapHeader(_ cell: MessageCell, _ author: User) {
+  func messageCellDidTapHeader(_ cell: MessageCell, _ user: User) {
     guard AppEnvironment.current.currentUser != nil, featureBlockUsersEnabled() else { return }
 
     let actionSheet = UIAlertController
       .blockUserActionSheet(
-        blockUserHandler: { _ in self.presentBlockUserAlert(username: author.name) },
+        blockUserHandler: { _ in self.presentBlockUserAlert(username: user.name) },
         sourceView: cell,
         isIPad: self.traitCollection.horizontalSizeClass == .regular
       )

--- a/Kickstarter-iOS/Features/Messages/Controller/MessagesViewController.swift
+++ b/Kickstarter-iOS/Features/Messages/Controller/MessagesViewController.swift
@@ -144,8 +144,14 @@ internal final class MessagesViewController: UITableViewController {
     self.present(vc, animated: true)
   }
 
+  private func presentBlockUserAlert(username: String) {
+    let alert = UIAlertController
+      .blockUserAlert(username: username, blockUserHandler: { _ in self.blockUser() })
+    self.present(alert, animated: true)
+  }
+
   private func blockUser() {
-    // Scott TODO: present popup UI [mbl-1036](https://kickstarter.atlassian.net/browse/MBL-1036)
+    // Scott TODO: call viewModel.inputs.blockUser
   }
 }
 
@@ -170,12 +176,12 @@ extension MessagesViewController: BackingCellDelegate {
 // MARK: - MessageCellDelegate
 
 extension MessagesViewController: MessageCellDelegate {
-  func messageCellDidTapHeader(_ cell: MessageCell, _: User) {
+  func messageCellDidTapHeader(_ cell: MessageCell, _ author: User) {
     guard AppEnvironment.current.currentUser != nil, featureBlockUsersEnabled() else { return }
 
     let actionSheet = UIAlertController
       .blockUserActionSheet(
-        blockUserHandler: { _ in self.blockUser() },
+        blockUserHandler: { _ in self.presentBlockUserAlert(username: author.name) },
         sourceView: cell,
         isIPad: self.traitCollection.horizontalSizeClass == .regular
       )

--- a/Kickstarter-iOS/Features/Messages/Controller/MessagesViewController.swift
+++ b/Kickstarter-iOS/Features/Messages/Controller/MessagesViewController.swift
@@ -31,6 +31,7 @@ internal final class MessagesViewController: UITableViewController, MessageBanne
     super.viewDidLoad()
 
     self.messageBannerViewController = self.configureMessageBannerViewController(on: self)
+    self.messageBannerViewController?.delegate = self
     self.tableView.rowHeight = UITableView.automaticDimension
     self.tableView.dataSource = self.dataSource
 
@@ -100,9 +101,11 @@ internal final class MessagesViewController: UITableViewController, MessageBanne
     self.viewModel.outputs.userBlocked
       .observeForUI()
       .observeValues { [weak self] success in
+
         if success {
           self?.messageBannerViewController?
             .showBanner(with: .success, message: "This user has been successfully blocked")
+          self?.view.isUserInteractionEnabled = false
         } else {
           self?.messageBannerViewController?
             .showBanner(with: .error, message: "Your request did not go through. Try again.")
@@ -204,5 +207,15 @@ extension MessagesViewController: MessageCellDelegate {
       )
 
     self.present(actionSheet, animated: true)
+  }
+}
+
+// MARK: - MessageBannerViewControllerDelegate
+
+extension MessagesViewController: MessageBannerViewControllerDelegate {
+  func messageBannerViewDidHide(type: MessageBannerType) {
+    if type == .success {
+      self.navigationController?.popViewController(animated: true)
+    }
   }
 }

--- a/Kickstarter-iOS/Features/Messages/Controller/MessagesViewController.swift
+++ b/Kickstarter-iOS/Features/Messages/Controller/MessagesViewController.swift
@@ -99,7 +99,6 @@ internal final class MessagesViewController: UITableViewController, MessageBanne
         if success {
           self?.messageBannerViewController?
             .showBanner(with: .success, message: "This user has been successfully blocked")
-          self?.view.isUserInteractionEnabled = false
         } else {
           self?.messageBannerViewController?
             .showBanner(with: .error, message: "Your request did not go through. Try again.")

--- a/Kickstarter-iOS/Features/Messages/Controller/MessagesViewController.swift
+++ b/Kickstarter-iOS/Features/Messages/Controller/MessagesViewController.swift
@@ -43,12 +43,6 @@ internal final class MessagesViewController: UITableViewController, MessageBanne
 
     _ = self.replyBarButtonItem
       |> UIBarButtonItem.lens.title %~ { _ in Strings.general_navigation_buttons_reply() }
-
-    if let banner = messageBannerViewController?.view {
-      NSLayoutConstraint.activate([
-        banner.widthAnchor.constraint(equalTo: self.view.widthAnchor)
-      ])
-    }
   }
 
   internal override func bindViewModel() {

--- a/Kickstarter-iOS/Features/ProjectPage/Controller/ProjectPageViewController.swift
+++ b/Kickstarter-iOS/Features/ProjectPage/Controller/ProjectPageViewController.swift
@@ -536,6 +536,20 @@ public final class ProjectPageViewController: UIViewController, MessageBannerVie
       .observeValues { _ in
         // TODO: Use this flag to hide or show the Report this project label [MBL-983](https://kickstarter.atlassian.net/browse/MBL-983)
       }
+
+    self.viewModel.outputs.userBlocked
+      .observeForUI()
+      .observeValues { [weak self] success in
+        if success {
+          self?.messageBannerViewController?
+            .showBanner(with: .success, message: "This user has been successfully blocked")
+        } else {
+          self?.messageBannerViewController?
+            .showBanner(with: .error, message: "Your request did not go through. Try again.")
+        }
+
+        self?.view.isUserInteractionEnabled = false
+      }
   }
 
   private func prepareToPlayAudioVideoURL(audioVideoURL: URL,

--- a/Kickstarter-iOS/Features/ProjectPage/Controller/ProjectPageViewController.swift
+++ b/Kickstarter-iOS/Features/ProjectPage/Controller/ProjectPageViewController.swift
@@ -540,10 +540,10 @@ public final class ProjectPageViewController: UIViewController, MessageBannerVie
     self.viewModel.outputs.userBlocked
       .observeForUI()
       .observeValues { [weak self] success in
+        // Scott TODO: Use localized strings once translations can be done [mbl-1037](https://kickstarter.atlassian.net/browse/MBL-1037)
         if success {
           self?.messageBannerViewController?
             .showBanner(with: .success, message: "This user has been successfully blocked")
-          self?.view.isUserInteractionEnabled = false
         } else {
           self?.messageBannerViewController?
             .showBanner(with: .error, message: "Your request did not go through. Try again.")

--- a/Kickstarter-iOS/Features/ProjectPage/Controller/ProjectPageViewController.swift
+++ b/Kickstarter-iOS/Features/ProjectPage/Controller/ProjectPageViewController.swift
@@ -724,8 +724,14 @@ public final class ProjectPageViewController: UIViewController, MessageBannerVie
     }
   }
 
+  private func presentBlockUserAlert(username: String) {
+    let alert = UIAlertController
+      .blockUserAlert(username: username, blockUserHandler: { _ in self.blockUser() })
+    self.present(alert, animated: true)
+  }
+
   private func blockUser() {
-    // Scott TODO: present popup UI [mbl-1036](https://kickstarter.atlassian.net/browse/MBL-1036)
+    // Scott TODO: call viewModel.inputs.blockUser
   }
 
   private func goToCreatorProfile(forProject project: Project) {
@@ -981,7 +987,7 @@ extension ProjectPageViewController: ProjectPamphletMainCellDelegate {
 
     let actionSheet = UIAlertController
       .blockUserActionSheet(
-        blockUserHandler: { _ in self.blockUser() },
+        blockUserHandler: { _ in self.presentBlockUserAlert(username: project.creator.name) },
         viewProfileHandler: { _ in self.goToCreatorProfile(forProject: project) },
         sourceView: cell,
         isIPad: self.traitCollection.horizontalSizeClass == .regular

--- a/Kickstarter-iOS/Features/ProjectPage/Controller/ProjectPageViewController.swift
+++ b/Kickstarter-iOS/Features/ProjectPage/Controller/ProjectPageViewController.swift
@@ -82,6 +82,7 @@ public final class ProjectPageViewController: UIViewController, MessageBannerVie
     self.configureNavigationSelectorView()
 
     self.messageBannerViewController = self.configureMessageBannerViewController(on: self)
+    self.messageBannerViewController?.delegate = self
     self.tableView.registerCellClass(ProjectFAQsAskAQuestionCell.self)
     self.tableView.registerCellClass(ProjectFAQsCell.self)
     self.tableView.registerCellClass(ProjectFAQsEmptyStateCell.self)
@@ -984,6 +985,8 @@ extension ProjectPageViewController: ProjectPamphletMainCellDelegate {
       self.goToCreatorProfile(forProject: project)
       return
     }
+//      return
+//    }
 
     let actionSheet = UIAlertController
       .blockUserActionSheet(
@@ -1077,5 +1080,13 @@ extension ProjectPageViewController: PinchToZoomDelegate, OverlayViewPresenting 
       self?.hideOverlayView()
       completionHandler()
     })
+  }
+}
+
+extension ProjectPageViewController: MessageBannerViewControllerDelegate {
+  public func messageBannerViewDidHide(type: MessageBannerType) {
+    if type == .success {
+      self.dismiss(animated: true)
+    }
   }
 }

--- a/Kickstarter-iOS/Features/ProjectPage/Controller/ProjectPageViewController.swift
+++ b/Kickstarter-iOS/Features/ProjectPage/Controller/ProjectPageViewController.swift
@@ -727,12 +727,8 @@ public final class ProjectPageViewController: UIViewController, MessageBannerVie
 
   private func presentBlockUserAlert(username: String) {
     let alert = UIAlertController
-      .blockUserAlert(username: username, blockUserHandler: { _ in self.blockUser() })
+      .blockUserAlert(username: username, blockUserHandler: { _ in self.viewModel.inputs.blockUser() })
     self.present(alert, animated: true)
-  }
-
-  private func blockUser() {
-    // Scott TODO: call viewModel.inputs.blockUser
   }
 
   private func goToCreatorProfile(forProject project: Project) {
@@ -985,8 +981,6 @@ extension ProjectPageViewController: ProjectPamphletMainCellDelegate {
       self.goToCreatorProfile(forProject: project)
       return
     }
-//      return
-//    }
 
     let actionSheet = UIAlertController
       .blockUserActionSheet(

--- a/Kickstarter-iOS/Features/ProjectPage/Controller/ProjectPageViewController.swift
+++ b/Kickstarter-iOS/Features/ProjectPage/Controller/ProjectPageViewController.swift
@@ -543,12 +543,11 @@ public final class ProjectPageViewController: UIViewController, MessageBannerVie
         if success {
           self?.messageBannerViewController?
             .showBanner(with: .success, message: "This user has been successfully blocked")
+          self?.view.isUserInteractionEnabled = false
         } else {
           self?.messageBannerViewController?
             .showBanner(with: .error, message: "Your request did not go through. Try again.")
         }
-
-        self?.view.isUserInteractionEnabled = false
       }
   }
 

--- a/Library/UIAlertController.swift
+++ b/Library/UIAlertController.swift
@@ -357,6 +357,35 @@ public extension UIAlertController {
     return alertController
   }
 
+  static func blockUserAlert(username: String,
+                             blockUserHandler: @escaping (UIAlertAction) -> Void) -> UIAlertController {
+    // Scott TODO: Use localized strings once translations can be done [mbl-1037](https://kickstarter.atlassian.net/browse/MBL-1037)
+    let alertController = UIAlertController(
+      title: "Block \(username)",
+      message: "Blocking this user means that you won’t see their comments or content anymore. If you have saved or backed projects from this user and would like to withdraw your support, you must remove your pledge before blocking. To unblock a user in the future, please go through our Help Center.",
+      preferredStyle: .alert
+    )
+
+    // Scott TODO: Use localized strings once translations can be done [mbl-1037](https://kickstarter.atlassian.net/browse/MBL-1037)
+    alertController.addAction(
+      UIAlertAction(
+        title: "Block",
+        style: .destructive,
+        handler: blockUserHandler
+      )
+    )
+
+    alertController.addAction(
+      UIAlertAction(
+        title: Strings.Cancel(),
+        style: .cancel,
+        handler: nil
+      )
+    )
+
+    return alertController
+  }
+
   static func blockUserActionSheet(
     blockUserHandler: @escaping (UIAlertAction) -> Void,
     viewProfileHandler: ((UIAlertAction) -> Void)? = nil,

--- a/Library/ViewModels/CommentRepliesViewModel.swift
+++ b/Library/ViewModels/CommentRepliesViewModel.swift
@@ -5,6 +5,9 @@ import ReactiveExtensions
 import ReactiveSwift
 
 public protocol CommentRepliesViewModelInputs {
+  /// Call when block user is tapped
+  func blockUser()
+
   /**
     Call with the comment and project that we are viewing replies for. `Comment` can be provided to minimize
     the number of API requests made (ie. no need to find the comment id), but this is for viewing the replies for the root comment.
@@ -61,6 +64,9 @@ public protocol CommentRepliesViewModelOutputs {
 
   /// Emits when a pagination error has occurred.
   var showPaginationErrorState: Signal<(), Never> { get }
+
+  /// Emits when a request to block a user has been made
+  var userBlocked: Signal<Bool, Never> { get }
 }
 
 public protocol CommentRepliesViewModelType {
@@ -241,6 +247,14 @@ public final class CommentRepliesViewModel: CommentRepliesViewModelType,
     self.scrollToReply = self.replyIdProperty.signal
       .skipNil()
       .takeWhen(self.dataSourceLoadedProperty.signal)
+
+    // TODO: Call blocking GraphQL mutation
+    self.userBlocked = self.blockUserProperty.signal.map { true }
+  }
+
+  private let blockUserProperty = MutableProperty(())
+  public func blockUser() {
+    self.blockUserProperty.value = ()
   }
 
   private let didSelectCommentProperty = MutableProperty<Comment?>(nil)
@@ -300,6 +314,7 @@ public final class CommentRepliesViewModel: CommentRepliesViewModelType,
   public let resetCommentComposer: Signal<(), Never>
   public let scrollToReply: Signal<String, Never>
   public let showPaginationErrorState: Signal<(), Never>
+  public let userBlocked: Signal<Bool, Never>
 
   public var inputs: CommentRepliesViewModelInputs { return self }
   public var outputs: CommentRepliesViewModelOutputs { return self }

--- a/Library/ViewModels/CommentsViewModel.swift
+++ b/Library/ViewModels/CommentsViewModel.swift
@@ -5,6 +5,9 @@ import ReactiveExtensions
 import ReactiveSwift
 
 public protocol CommentsViewModelInputs {
+  /// Call when block user is tapped
+  func blockUser()
+
   /// Call when the delegate method for the CommentCellDelegate is called.
   func commentCellDidTapReply(comment: Comment)
 
@@ -64,6 +67,9 @@ public protocol CommentsViewModelOutputs {
 
   /// Emits when a comment has been posted and we should scroll to top and reset the composer.
   var resetCommentComposerAndScrollToTop: Signal<(), Never> { get }
+
+  /// Emits when a request to block a user has been made
+  var userBlocked: Signal<Bool, Never> { get }
 }
 
 public protocol CommentsViewModelType {
@@ -350,12 +356,20 @@ public final class CommentsViewModel: CommentsViewModelType,
     self.showHelpWebViewController = self.commentRemovedCellDidTapURLProperty.signal.skipNil()
       .map(HelpType.helpType)
       .skipNil()
+
+    // TODO: Call blocking GraphQL mutation
+    self.userBlocked = self.blockUserProperty.signal.map { true }
   }
 
   // Properties to assist with injecting these values into the existing data streams.
   private let currentComments = MutableProperty<[Comment]?>(nil)
   private let retryingComment = MutableProperty<(Comment, String)?>(nil)
   private let failableOrComment = MutableProperty<(Comment, String)?>(nil)
+
+  private let blockUserProperty = MutableProperty(())
+  public func blockUser() {
+    self.blockUserProperty.value = ()
+  }
 
   private let commentCellDidTapViewRepliesProperty = MutableProperty<Comment?>(nil)
   public func commentCellDidTapViewReplies(_ comment: Comment) {
@@ -418,6 +432,7 @@ public final class CommentsViewModel: CommentsViewModelType,
   public let loadCommentsAndProjectIntoDataSource: Signal<([Comment], Project, Bool), Never>
   public let showHelpWebViewController: Signal<HelpType, Never>
   public let resetCommentComposerAndScrollToTop: Signal<(), Never>
+  public let userBlocked: Signal<Bool, Never>
 
   public var inputs: CommentsViewModelInputs { return self }
   public var outputs: CommentsViewModelOutputs { return self }

--- a/Library/ViewModels/MessagesViewModel.swift
+++ b/Library/ViewModels/MessagesViewModel.swift
@@ -6,6 +6,9 @@ public protocol MessagesViewModelInputs {
   /// Call when the backing button is pressed.
   func backingInfoPressed()
 
+  /// Call when block user is tapped
+  func blockUser()
+
   /// Configures the view model with either a message thread or a project and a backing.
   func configureWith(data: Either<MessageThread, (project: Project, backing: Backing)>)
 
@@ -52,6 +55,9 @@ public protocol MessagesViewModelOutputs {
 
   /// Emits when the thread has been marked as read.
   var successfullyMarkedAsRead: Signal<(), Never> { get }
+
+  /// Emits when a request to block a user has been made
+  var userBlocked: Signal<Bool, Never> { get }
 }
 
 public protocol MessagesViewModelType {
@@ -182,11 +188,19 @@ public final class MessagesViewModel: MessagesViewModelType, MessagesViewModelIn
           .demoteErrors()
       }
       .ignoreValues()
+
+    // TODO: Call blocking GraphQL mutation
+    self.userBlocked = self.blockUserProperty.signal.map { true }
   }
 
   private let backingInfoPressedProperty = MutableProperty(())
   public func backingInfoPressed() {
     self.backingInfoPressedProperty.value = ()
+  }
+
+  private let blockUserProperty = MutableProperty(())
+  public func blockUser() {
+    self.blockUserProperty.value = ()
   }
 
   private let configData = MutableProperty<Either<MessageThread, (project: Project, backing: Backing)>?>(nil)
@@ -223,6 +237,7 @@ public final class MessagesViewModel: MessagesViewModelType, MessagesViewModelIn
   public let project: Signal<Project, Never>
   public let replyButtonIsEnabled: Signal<Bool, Never>
   public let successfullyMarkedAsRead: Signal<(), Never>
+  public let userBlocked: Signal<Bool, Never>
 
   public var inputs: MessagesViewModelInputs { return self }
   public var outputs: MessagesViewModelOutputs { return self }

--- a/Library/ViewModels/ProjectPageViewModel.swift
+++ b/Library/ViewModels/ProjectPageViewModel.swift
@@ -10,6 +10,9 @@ public protocol ProjectPageViewModelInputs {
   /// Call when `AppDelegate`'s `applicationDidEnterBackground` is triggered.
   func applicationDidEnterBackground()
 
+  /// Call when block user is tapped
+  func blockUser()
+
   /// Call with the project given to the view controller.
   func configureWith(projectOrParam: Either<Project, Param>, refTag: RefTag?)
 
@@ -146,6 +149,9 @@ public protocol ProjectPageViewModelOutputs {
 
   /// Emits a prelaunch save state that updates the navigation bar's watch project state.
   var updateWatchProjectWithPrelaunchProjectState: Signal<PledgeCTAPrelaunchState, Never> { get }
+
+  /// Emits when a request to block a user has been made
+  var userBlocked: Signal<Bool, Never> { get }
 }
 
 public protocol ProjectPageViewModelType {
@@ -495,6 +501,8 @@ public final class ProjectPageViewModel: ProjectPageViewModelType, ProjectPageVi
       .ignoreValues()
 
     self.goToURL = self.didSelectCampaignImageLinkProperty.signal.skipNil()
+
+    self.userBlocked = self.blockUserProperty.signal.map { false }
   }
 
   fileprivate let askAQuestionCellTappedProperty = MutableProperty(())
@@ -505,6 +513,11 @@ public final class ProjectPageViewModel: ProjectPageViewModelType, ProjectPageVi
   fileprivate let applicationDidEnterBackgroundProperty = MutableProperty(())
   public func applicationDidEnterBackground() {
     self.applicationDidEnterBackgroundProperty.value = ()
+  }
+
+  fileprivate let blockUserProperty = MutableProperty(())
+  public func blockUser() {
+    self.blockUserProperty.value = ()
   }
 
   private let configDataProperty = MutableProperty<(Either<Project, Param>, RefTag?)?>(nil)
@@ -632,6 +645,7 @@ public final class ProjectPageViewModel: ProjectPageViewModelType, ProjectPageVi
   public let updateDataSource: Signal<(NavigationSection, Project, RefTag?, [Bool], [URL]), Never>
   public let updateFAQsInDataSource: Signal<(Project, RefTag?, [Bool]), Never>
   public let updateWatchProjectWithPrelaunchProjectState: Signal<PledgeCTAPrelaunchState, Never>
+  public let userBlocked: Signal<Bool, Never>
 
   public var inputs: ProjectPageViewModelInputs { return self }
   public var outputs: ProjectPageViewModelOutputs { return self }


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

1. Presents a confirmation alert when "Block this user" is selected from the block user action sheet
2. Presents a success or fail Message Banner when tapping block in this new alert. This isn't wired up to an API or anything yet. This behavior is hardcoded for now.

# 🤔 Why

Rather than sending a blocking request from the action sheet, we're going to use this confirmation alert pattern so that we can provide extra information and double-check that they want to block a user. 

# 🛠 How

The key areas are:
- Comments
- CommentReplies
- ProjectPage
- Messages

I'm taking advantage of the existing MessageBannerViewController that we use elsewhere in the app to display API response success and error banners. This means that each ViewController, except ProjectPage, needs to conform to `MessageBannerViewControllerPresenting` and present an instance of the banner when the corresponding ViewModel outputs a response from the API (which isn't wired up yet).

One caveat is that to keep users from spamming the block action sheet and alert, I'm disabling user interaction on the parent view until the success/error banner message is finished displaying. Once the success banner is dismissed on the project page, we auto-dismiss the view since the user doesn't want to see that content anymore. This could also set us up to more easily refresh our app content.
   - we won't dismiss when blocking from comments since users could block a user that doesn't own that project. 

So basically I've:
1. added functionality to display a new UIAlert when tapping the action sheet
2. when tapping Block on this new alert, we trigger an input to the ViewModel (this will eventually kick off our backend request) and then a new `userBlocked` output notifies the ViewController of which banner to display. Success or error.

# 👀 See

| 🦋 |
| --- |
![Simulator Screen Recording - iPhone 15 Pro - 2023-11-07 at 10 44 02](https://github.com/kickstarter/ios-oss/assets/110618242/968a7d20-1337-4130-97d9-947be71a48e7)

# ✅ Acceptance criteria

_**Run the AppCenter Beta build. Make sure you're logged in and that the Block User FF is on.**_

- [x] Tapping the Block this user action sheet, from any of the key areas listed above, presents a UIAlert with an option to block or cancel
- [x] Tapping block user presents a banner message at the bottom of the screen. (this is temporarily controlled by a manual bool in the view model until we have an API to wire this up to)
- [x] If showing the success banner, the parent view is not tappable and dismisses once the banner hides
- [x] If showing the error banner, the parent view does not dismiss and users can try to again to block.
