### PR TITLE
    MBL-1039: Refactor LoadingBarButtonItem to take a closure instead of a binding for save actions

### DIFF
--- a/Kickstarter-iOS/Features/ChangeEmail/Controller/ChangeEmailView.swift
+++ b/Kickstarter-iOS/Features/ChangeEmail/Controller/ChangeEmailView.swift
@@ -16,7 +16,6 @@ struct ChangeEmailView: View {
   @State private var newEmailText = ""
   @State private var newPasswordText = ""
   @State private var saveEnabled = false
-  @State private var saveTriggered = false
   @State private var showLoading = false
   @State private var showBannerMessage = false
   @State private var bannerMessage: MessageBannerViewViewModel?
@@ -132,19 +131,17 @@ struct ChangeEmailView: View {
         ToolbarItem(placement: .navigationBarTrailing) {
           LoadingBarButtonItem(
             saveEnabled: $saveEnabled,
-            saveTriggered: $saveTriggered,
             showLoading: $showLoading,
             titleText: Strings.Save()
-          )
+          ) {
+            focusField = nil
+            reactiveViewModel.didTapSaveButton()
+          }
           .onReceive(reactiveViewModel.saveButtonEnabled) { newValue in
             saveEnabled = newValue
           }
           .onReceive(reactiveViewModel.resetEditableText) { newValue in
             showLoading = !newValue
-          }
-          .onChange(of: saveTriggered) { newValue in
-            focusField = nil
-            reactiveViewModel.saveTriggered.send(newValue)
           }
         }
       }

--- a/Kickstarter-iOS/Features/ReportProject/ReportProjectFormView.swift
+++ b/Kickstarter-iOS/Features/ReportProject/ReportProjectFormView.swift
@@ -15,7 +15,6 @@ struct ReportProjectFormView: View {
   @SwiftUI.Environment(\.dismiss) private var dismiss
   @StateObject private var viewModel = ReportProjectFormViewModel()
 
-  @State private var showLoading: Bool = false
   @FocusState private var focusField: ReportFormFocusField?
 
   var body: some View {
@@ -59,10 +58,11 @@ struct ReportProjectFormView: View {
         ToolbarItem(placement: .navigationBarTrailing) {
           LoadingBarButtonItem(
             saveEnabled: $viewModel.saveButtonEnabled,
-            saveTriggered: $viewModel.saveTriggered,
-            showLoading: $showLoading,
+            showLoading: $viewModel.saveButtonLoading,
             titleText: Strings.Send()
-          )
+          ) {
+            viewModel.didTapSave()
+          }
         }
       }
       .onAppear {
@@ -74,16 +74,11 @@ struct ReportProjectFormView: View {
         viewModel.inputs.viewDidLoad()
       }
       .onReceive(viewModel.$bannerMessage) { newValue in
-        showLoading = false
-
         /// bannerMessage is set to nil when its done presenting. When it is done, and submit was successful,  dismiss this view.
         if newValue == nil, viewModel.submitSuccess {
           dismiss()
           popToRoot = true
         }
-      }
-      .onReceive(viewModel.$saveTriggered) { triggered in
-        showLoading = triggered
       }
       .overlay(alignment: .bottom) {
         MessageBannerView(viewModel: $viewModel.bannerMessage)

--- a/Kickstarter-iOS/SharedViews/LoadingBarButtonItem.swift
+++ b/Kickstarter-iOS/SharedViews/LoadingBarButtonItem.swift
@@ -4,9 +4,9 @@ import SwiftUI
 // TODO(MBL-1039) - Refactor this so that saveTriggered takes a closure, not a binding
 struct LoadingBarButtonItem: View {
   @Binding var saveEnabled: Bool
-  @Binding var saveTriggered: Bool
   @Binding var showLoading: Bool
-  @State var titleText: String
+  let titleText: String
+  let action: () -> Void
 
   var body: some View {
     let buttonColor = $saveEnabled.wrappedValue ? Color(.ksr_create_700) : Color(.ksr_create_300)
@@ -15,7 +15,7 @@ struct LoadingBarButtonItem: View {
       if !showLoading {
         Button(titleText) {
           showLoading = true
-          saveTriggered = true
+          action()
         }
         .font(Font(UIFont.systemFont(ofSize: 17)))
         .foregroundColor(buttonColor)
@@ -23,9 +23,6 @@ struct LoadingBarButtonItem: View {
       } else {
         ProgressView()
           .foregroundColor(Color(.ksr_support_700))
-          .onDisappear {
-            saveTriggered = false
-          }
       }
     }
     .accessibilityElement(children: .combine)

--- a/Library/ViewModels/ChangeEmailViewModelSwiftUIIntegrationTest.swift
+++ b/Library/ViewModels/ChangeEmailViewModelSwiftUIIntegrationTest.swift
@@ -8,6 +8,7 @@ public protocol ChangeEmailViewModelInputsSwiftUIIntegrationTest {
   func resendVerificationEmailButtonTapped()
   func viewDidLoad()
   func updateEmail(newEmail: String, currentPassword: String)
+  func didTapSaveButton()
 }
 
 public protocol ChangeEmailViewModelOutputsSwiftUIIntegrationTest {
@@ -241,6 +242,10 @@ public final class ChangeEmailViewModelSwiftUIIntegrationTest: ChangeEmailViewMo
   private let viewDidLoadProperty = MutableProperty(())
   public func viewDidLoad() {
     self.viewDidLoadProperty.value = ()
+  }
+
+  public func didTapSaveButton() {
+    self.saveTriggered.send(true)
   }
 
   public let didFailToSendVerificationEmail: Signal<String, Never>


### PR DESCRIPTION
# 📲 What

This refactors `LoadingBarButtonItem` to take a closure.

# 🤔 Why

This pattern more closely follows how Apple handles save actions (e.g. in the `Button` class), which will make our code a little bit more canonical.

# ✅ Acceptance criteria

- [ ] Still able to submit a report
- [ ] Still able to change your e-mail
