### PR TITLE
MBL-1029: Refresh Discover page after a user is blocked

### DIFF
--- a/Kickstarter-iOS/Features/Discovery/Controller/DiscoveryPageViewController.swift
+++ b/Kickstarter-iOS/Features/Discovery/Controller/DiscoveryPageViewController.swift
@@ -18,6 +18,7 @@ internal final class DiscoveryPageViewController: UITableViewController {
 
   private var configUpdatedObserver: Any?
   private var currentEnvironmentChangedObserver: Any?
+  private var blockedUserObserver: Any?
   fileprivate let dataSource = DiscoveryProjectsDataSource()
   public weak var delegate: DiscoveryPageViewControllerDelegate?
   fileprivate var emptyStatesController: EmptyStatesViewController?
@@ -75,6 +76,11 @@ internal final class DiscoveryPageViewController: UITableViewController {
     self.configUpdatedObserver = NotificationCenter.default
       .addObserver(forName: .ksr_configUpdated, object: nil, queue: nil, using: { [weak self] _ in
         self?.viewModel.inputs.configUpdated(config: AppEnvironment.current.config)
+      })
+
+    self.blockedUserObserver = NotificationCenter.default
+      .addObserver(forName: .ksr_blockedUser, object: nil, queue: nil, using: { [weak self] _ in
+        self?.viewModel.inputs.blockedUser()
       })
 
     let emptyVC = EmptyStatesViewController.configuredWith(emptyState: nil)

--- a/Library/Notifications.swift
+++ b/Library/Notifications.swift
@@ -17,6 +17,7 @@ public enum CurrentUserNotifications {
   public static let sessionStarted = "CurrentUserNotifications.sessionStarted"
   public static let showNotificationsDialog = "CurrentUserNotifications.showNotificationsDialog"
   public static let userUpdated = "CurrentUserNotifications.userUpdated"
+  public static let blockedUser = "CurrentUserNotifications.blockedUser"
 }
 
 public enum AppStateNotifications {
@@ -61,4 +62,5 @@ extension Notification.Name {
     CurrentUserNotifications.localePreferencesChanged
   )
   public static let ksr_userUpdated = Notification.Name(rawValue: CurrentUserNotifications.userUpdated)
+  public static let ksr_blockedUser = Notification.Name(rawValue: CurrentUserNotifications.blockedUser)
 }

--- a/Library/ViewModels/CommentRepliesViewModel.swift
+++ b/Library/ViewModels/CommentRepliesViewModel.swift
@@ -250,6 +250,11 @@ public final class CommentRepliesViewModel: CommentRepliesViewModelType,
 
     // TODO: Call blocking GraphQL mutation
     self.userBlocked = self.blockUserProperty.signal.map { true }
+
+    self.userBlocked.observeValues { didBlock in
+      guard didBlock == true else { return }
+      NotificationCenter.default.post(.init(name: .ksr_blockedUser))
+    }
   }
 
   private let blockUserProperty = MutableProperty(())

--- a/Library/ViewModels/CommentsViewModel.swift
+++ b/Library/ViewModels/CommentsViewModel.swift
@@ -359,6 +359,11 @@ public final class CommentsViewModel: CommentsViewModelType,
 
     // TODO: Call blocking GraphQL mutation
     self.userBlocked = self.blockUserProperty.signal.map { true }
+
+    self.userBlocked.observeValues { didBlock in
+      guard didBlock == true else { return }
+      NotificationCenter.default.post(.init(name: .ksr_blockedUser))
+    }
   }
 
   // Properties to assist with injecting these values into the existing data streams.

--- a/Library/ViewModels/DiscoveryPageViewModel.swift
+++ b/Library/ViewModels/DiscoveryPageViewModel.swift
@@ -14,6 +14,9 @@ public protocol DiscoveryPageViewModelInputs {
   /// Call when the current environment has changed
   func currentEnvironmentChanged(environment: EnvironmentType)
 
+  /// Call when the logged in user has blocked another user
+  func blockedUser()
+
   /// Call when onboarding has been completed
   func onboardingCompleted()
 
@@ -174,7 +177,8 @@ public final class DiscoveryPageViewModel: DiscoveryPageViewModelType, Discovery
     let requestFirstPageWith = Signal.merge(
       firstPageParams,
       firstPageParams.takeWhen(environmentChanged),
-      firstPageParams.takeWhen(self.pulledToRefreshProperty.signal)
+      firstPageParams.takeWhen(self.pulledToRefreshProperty.signal),
+      firstPageParams.takeWhen(self.blockedUserProperty.signal)
     )
 
     let paginatedProjects: Signal<[Project], Never>
@@ -376,6 +380,11 @@ public final class DiscoveryPageViewModel: DiscoveryPageViewModelType, Discovery
   fileprivate let currentEnvironmentChangedProperty = MutableProperty<EnvironmentType?>(nil)
   public func currentEnvironmentChanged(environment: EnvironmentType) {
     self.currentEnvironmentChangedProperty.value = environment
+  }
+
+  fileprivate let blockedUserProperty = MutableProperty(())
+  public func blockedUser() {
+    self.blockedUserProperty.value = ()
   }
 
   fileprivate let onboardingCompletedProperty = MutableProperty(())

--- a/Library/ViewModels/DiscoveryPageViewModelTests.swift
+++ b/Library/ViewModels/DiscoveryPageViewModelTests.swift
@@ -1193,11 +1193,11 @@ internal final class DiscoveryPageViewModelTests: TestCase {
 
       self.projectsAreLoading.assertValueCount(2)
 
-      NotificationCenter.default.post(.init(name: .ksr_blockedUser))
+      self.vm.inputs.blockedUser()
 
       self.scheduler.advance()
 
-      self.projectsAreLoading.assertValueCount(6)
+      self.projectsAreLoading.assertValueCount(4)
     }
   }
 }

--- a/Library/ViewModels/DiscoveryPageViewModelTests.swift
+++ b/Library/ViewModels/DiscoveryPageViewModelTests.swift
@@ -1175,4 +1175,29 @@ internal final class DiscoveryPageViewModelTests: TestCase {
 
     XCTAssertEqual("ending_soon", segmentClientProps?["discover_sort"] as? String)
   }
+
+  func testBlockedUserNotification_RefreshesProjects() {
+    let playlist = (0...10).map { idx in .template |> Project.lens.id .~ (idx + 42) }
+    let projectEnv = .template
+      |> DiscoveryEnvelope.lens.projects .~ playlist
+
+    withEnvironment(apiService: MockService(fetchDiscoveryResponse: projectEnv)) {
+      self.vm.inputs.configureWith(sort: .magic)
+      self.vm.inputs.viewWillAppear()
+      self.vm.inputs.viewDidAppear()
+      self.vm.inputs.selectedFilter(.defaults)
+
+      self.projectsAreLoading.assertValueCount(1)
+
+      self.scheduler.advance()
+
+      self.projectsAreLoading.assertValueCount(2)
+
+      NotificationCenter.default.post(.init(name: .ksr_blockedUser))
+
+      self.scheduler.advance()
+
+      self.projectsAreLoading.assertValueCount(6)
+    }
+  }
 }

--- a/Library/ViewModels/MessagesViewModel.swift
+++ b/Library/ViewModels/MessagesViewModel.swift
@@ -1,3 +1,4 @@
+import Foundation
 import KsApi
 import Prelude
 import ReactiveSwift
@@ -191,6 +192,11 @@ public final class MessagesViewModel: MessagesViewModelType, MessagesViewModelIn
 
     // TODO: Call blocking GraphQL mutation
     self.userBlocked = self.blockUserProperty.signal.map { true }
+
+    self.userBlocked.observeValues { didBlock in
+      guard didBlock == true else { return }
+      NotificationCenter.default.post(.init(name: .ksr_blockedUser))
+    }
   }
 
   private let backingInfoPressedProperty = MutableProperty(())

--- a/Library/ViewModels/ProjectPageViewModel.swift
+++ b/Library/ViewModels/ProjectPageViewModel.swift
@@ -502,7 +502,13 @@ public final class ProjectPageViewModel: ProjectPageViewModelType, ProjectPageVi
 
     self.goToURL = self.didSelectCampaignImageLinkProperty.signal.skipNil()
 
-    self.userBlocked = self.blockUserProperty.signal.map { false }
+    // TODO: Call blocking GraphQL mutation
+    self.userBlocked = self.blockUserProperty.signal.map { true }
+
+    self.userBlocked.observeValues { didBlock in
+      guard didBlock == true else { return }
+      NotificationCenter.default.post(.init(name: .ksr_blockedUser))
+    }
   }
 
   fileprivate let askAQuestionCellTappedProperty = MutableProperty(())


### PR DESCRIPTION
# 📲 What

Once you block a user, anywhere in the app, the Discover page will be refreshed.

# 🤔 Why

Once you've blocked someone, we want to stop showing that person's content. Refreshing the Discover page means that we'll re-fetch the list of projects, filtering out any projects by blocked users.

# ⏰ TODO

If I throw in a`logEvent()`, it indicates that my signal is hooked up correctly, but I don't think it's actually refreshing the page like I would expect. I could use a little help debugging this behavior to make sure it's working properly.
