### PR TITLE
Refresh comments when a user is blocked

### DIFF
--- a/Kickstarter-iOS/Features/Comments/Controllers/CommentsViewController.swift
+++ b/Kickstarter-iOS/Features/Comments/Controllers/CommentsViewController.swift
@@ -65,6 +65,7 @@ internal final class CommentsViewController: UITableViewController, MessageBanne
     self.commentComposer.delegate = self
 
     self.messageBannerViewController = self.configureMessageBannerViewController(on: self)
+    self.messageBannerViewController?.delegate = self
     self.tableView.registerCellClass(CommentCell.self)
     self.tableView.registerCellClass(CommentPostFailedCell.self)
     self.tableView.registerCellClass(CommentRemovedCell.self)
@@ -147,6 +148,7 @@ internal final class CommentsViewController: UITableViewController, MessageBanne
           inputAreaBecomeFirstResponder: becomeFirstResponder,
           replyId: nil
         )
+        vc.delegate = self
         self?.navigationController?.pushViewController(vc, animated: true)
       }
 
@@ -284,11 +286,30 @@ extension CommentsViewController: CommentCellDelegate {
   }
 }
 
+// MARK: - CommentRepliesViewControllerDelegate
+
+extension CommentsViewController: CommentRepliesViewControllerDelegate {
+  func commentRepliesViewControllerDidBlockUser(_: CommentRepliesViewController) {
+    self.tableView.scrollToTop()
+    self.viewModel.inputs.refresh()  }
+}
+
 // MARK: - CommentRemovedCellDelegate
 
 extension CommentsViewController: CommentRemovedCellDelegate {
   func commentRemovedCell(_: CommentRemovedCell, didTapURL: URL) {
     self.viewModel.inputs.commentRemovedCellDidTapURL(didTapURL)
+  }
+}
+
+// MARK: - MessageBannerViewControllerDelegate
+
+extension CommentsViewController: MessageBannerViewControllerDelegate {
+  func messageBannerViewDidHide(type: MessageBannerType) {
+    if type == .success {
+      self.tableView.scrollToTop()
+      self.viewModel.inputs.refresh()
+    }
   }
 }
 


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

If a user is blocked, comments are reset - refetched and the user is jumped back to top. If a user is blocked from the `CommentRepliesViewController`, they're navigated back to the main `CommentsViewController`.

Note: I did consider refetching comments in place instead, but getting it to work with pagination seemed tricky, so I'm clearing state instead for now. If we have time, it would be nice to revisit this approach and try to let the user keep their place in our comments.

# 👀 See

[Jira](https://kickstarter.atlassian.net/browse/MBL-1026)

# ✅ Acceptance criteria

- [ ] Comment state is reset when a user is successfully blocked (from the commentsViewController or the CommentRepliesViewController)

