### PR TITLE
Reorder build phases so firebase crashlytics is last

### DIFF
--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -7002,8 +7002,8 @@
 				A7D1F9421C850B7C000D41D5 /* Frameworks */,
 				A7D1F9431C850B7C000D41D5 /* Resources */,
 				A7D1F9C21C850DDE000D41D5 /* Embed Frameworks */,
-				8A86D7C124FDB7A000037A7B /* Firebase Crashlytics */,
 				E10BE8D52B02975C00F73DC9 /* Embed Foundation Extensions */,
+				8A86D7C124FDB7A000037A7B /* Firebase Crashlytics */,
 			);
 			buildRules = (
 			);


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

The crashlytics script needs to be run last in the build phases; otherwise it breaks the build.

# ✅ Acceptance criteria

- [x] Building (beta version) works again

