### PR TITLE
[MBL-1024] Wire Up Block User Mutation

### DIFF
--- a/Kickstarter-iOS/Features/Comments/Controllers/CommentRepliesViewController.swift
+++ b/Kickstarter-iOS/Features/Comments/Controllers/CommentRepliesViewController.swift
@@ -169,26 +169,28 @@ final class CommentRepliesViewController: UITableViewController, MessageBannerVi
         }
       }
 
-    self.viewModel.outputs.userBlocked
+    self.viewModel.outputs.didBlockUser
       .observeForUI()
-      .observeValues { [weak self] success in
-        guard let self else { return }
-        self.commentComposer.isHidden = true
+      .observeValues { [weak self] _ in
+        guard let self, let messageBanner = self.messageBannerViewController else { return }
 
-        if success {
-          self.messageBannerViewController?
-            .showBanner(with: .success, message: Strings.Block_user_success())
-          self.delegate?.commentRepliesViewControllerDidBlockUser(self)
-        } else {
-          self.messageBannerViewController?
-            .showBanner(with: .error, message: Strings.Block_user_fail())
-        }
+        messageBanner.showBanner(with: .success, message: Strings.Block_user_success())
+      }
+
+    self.viewModel.outputs.didBlockUserError
+      .observeForUI()
+      .observeValues { [weak self] _ in
+        guard let self, let messageBanner = self.messageBannerViewController else { return }
+
+        messageBanner.showBanner(with: .error, message: Strings.Block_user_fail())
       }
   }
 
-  private func presentBlockUserAlert(username: String) {
+  private func presentBlockUserAlert(username: String, userId: String) {
     let alert = UIAlertController
-      .blockUserAlert(username: username, blockUserHandler: { _ in self.viewModel.inputs.blockUser() })
+      .blockUserAlert(username: username, blockUserHandler: { _ in
+        self.viewModel.inputs.blockUser(id: userId)
+      })
     self.present(alert, animated: true)
   }
 
@@ -198,7 +200,7 @@ final class CommentRepliesViewController: UITableViewController, MessageBannerVi
 
     let actionSheet = UIAlertController
       .blockUserActionSheet(
-        blockUserHandler: { _ in self.presentBlockUserAlert(username: author.name) },
+        blockUserHandler: { _ in self.presentBlockUserAlert(username: author.name, userId: author.id) },
         sourceView: cell,
         isIPad: self.traitCollection.horizontalSizeClass == .regular
       )

--- a/Kickstarter-iOS/Features/Comments/Controllers/CommentRepliesViewController.swift
+++ b/Kickstarter-iOS/Features/Comments/Controllers/CommentRepliesViewController.swift
@@ -174,6 +174,9 @@ final class CommentRepliesViewController: UITableViewController, MessageBannerVi
       .observeValues { [weak self] _ in
         guard let self, let messageBanner = self.messageBannerViewController else { return }
 
+        self.commentComposer.isHidden = true
+        self.delegate?.commentRepliesViewControllerDidBlockUser(self)
+
         messageBanner.showBanner(with: .success, message: Strings.Block_user_success())
       }
 

--- a/Kickstarter-iOS/Features/Comments/Controllers/CommentsViewController.swift
+++ b/Kickstarter-iOS/Features/Comments/Controllers/CommentsViewController.swift
@@ -188,6 +188,7 @@ internal final class CommentsViewController: UITableViewController, MessageBanne
       .observeValues { [weak self] _ in
         guard let self, let messageBanner = self.messageBannerViewController else { return }
 
+        self.commentComposer.isHidden = true
         messageBanner.showBanner(with: .success, message: Strings.Block_user_success())
       }
 
@@ -267,7 +268,7 @@ extension CommentsViewController {
 
 extension CommentsViewController: CommentCellDelegate {
   func commentCellDidTapHeader(_ cell: CommentCell, _ author: Comment.Author) {
-    guard AppEnvironment.current.currentUser != nil, featureBlockUsersEnabled() else { return }
+//    guard AppEnvironment.current.currentUser != nil, featureBlockUsersEnabled() else { return }
     guard author.isBlocked == false else { return }
 
     let actionSheet = UIAlertController

--- a/Kickstarter-iOS/Features/Comments/Controllers/CommentsViewController.swift
+++ b/Kickstarter-iOS/Features/Comments/Controllers/CommentsViewController.swift
@@ -268,7 +268,7 @@ extension CommentsViewController {
 
 extension CommentsViewController: CommentCellDelegate {
   func commentCellDidTapHeader(_ cell: CommentCell, _ author: Comment.Author) {
-//    guard AppEnvironment.current.currentUser != nil, featureBlockUsersEnabled() else { return }
+    guard AppEnvironment.current.currentUser != nil, featureBlockUsersEnabled() else { return }
     guard author.isBlocked == false else { return }
 
     let actionSheet = UIAlertController

--- a/Kickstarter-iOS/Features/Messages/Controller/MessagesViewController.swift
+++ b/Kickstarter-iOS/Features/Messages/Controller/MessagesViewController.swift
@@ -117,15 +117,17 @@ internal final class MessagesViewController: UITableViewController, MessageBanne
     self.viewModel.outputs.didBlockUser
       .observeForUI()
       .observeValues { [weak self] _ in
-        self?.messageBannerViewController?
-          .showBanner(with: .success, message: Strings.Block_user_success())
+        guard let self, let messageBanner = self.messageBannerViewController else { return }
+
+        messageBanner.showBanner(with: .success, message: Strings.Block_user_success())
       }
 
     self.viewModel.outputs.didBlockUserError
       .observeForUI()
       .observeValues { [weak self] _ in
-        self?.messageBannerViewController?
-          .showBanner(with: .error, message: Strings.Block_user_fail())
+        guard let self, let messageBanner = self.messageBannerViewController else { return }
+
+        messageBanner.showBanner(with: .error, message: Strings.Block_user_fail())
       }
   }
 

--- a/Kickstarter-iOS/Features/Messages/Controller/MessagesViewController.swift
+++ b/Kickstarter-iOS/Features/Messages/Controller/MessagesViewController.swift
@@ -116,15 +116,16 @@ internal final class MessagesViewController: UITableViewController, MessageBanne
 
     self.viewModel.outputs.didBlockUser
       .observeForUI()
-      .observeValues { [weak self] success in
+      .observeValues { [weak self] _ in
+        self?.messageBannerViewController?
+          .showBanner(with: .success, message: Strings.Block_user_success())
+      }
 
-        if success {
-          self?.messageBannerViewController?
-            .showBanner(with: .success, message: Strings.Block_user_success())
-        } else {
-          self?.messageBannerViewController?
-            .showBanner(with: .error, message: Strings.Block_user_fail())
-        }
+    self.viewModel.outputs.didBlockUserError
+      .observeForUI()
+      .observeValues { [weak self] _ in
+        self?.messageBannerViewController?
+          .showBanner(with: .error, message: Strings.Block_user_fail())
       }
   }
 
@@ -189,9 +190,11 @@ internal final class MessagesViewController: UITableViewController, MessageBanne
     }
   }
 
-  private func presentBlockUserAlert(username: String) {
+  private func presentBlockUserAlert(username: String, userId: Int) {
     let alert = UIAlertController
-      .blockUserAlert(username: username, blockUserHandler: { _ in self.viewModel.inputs.blockUser() })
+      .blockUserAlert(username: username, blockUserHandler: { _ in
+        self.viewModel.inputs.blockUser(id: "\(userId)")
+      })
     self.present(alert, animated: true)
   }
 }
@@ -222,7 +225,7 @@ extension MessagesViewController: MessageCellDelegate {
 
     let actionSheet = UIAlertController
       .blockUserActionSheet(
-        blockUserHandler: { _ in self.presentBlockUserAlert(username: user.name) },
+        blockUserHandler: { _ in self.presentBlockUserAlert(username: user.name, userId: user.id) },
         sourceView: cell,
         isIPad: self.traitCollection.horizontalSizeClass == .regular
       )

--- a/Kickstarter-iOS/Features/ProjectPage/Controller/ProjectPageViewController.swift
+++ b/Kickstarter-iOS/Features/ProjectPage/Controller/ProjectPageViewController.swift
@@ -744,7 +744,7 @@ public final class ProjectPageViewController: UIViewController, MessageBannerVie
   private func presentBlockUserAlert(username: String, userId: Int) {
     let alert = UIAlertController
       .blockUserAlert(username: username, blockUserHandler: { _ in
-        self.viewModel.inputs.blockUser(id: "\(userId)")
+        self.viewModel.inputs.blockUser(id: userId)
       })
 
     self.present(alert, animated: true)

--- a/Kickstarter-iOS/Features/ProjectPage/Controller/ProjectPageViewController.swift
+++ b/Kickstarter-iOS/Features/ProjectPage/Controller/ProjectPageViewController.swift
@@ -540,15 +540,17 @@ public final class ProjectPageViewController: UIViewController, MessageBannerVie
     self.viewModel.outputs.didBlockUser
       .observeForUI()
       .observeValues { [weak self] _ in
-        self?.messageBannerViewController?
-          .showBanner(with: .success, message: Strings.Block_user_success())
+        guard let self, let messageBanner = self.messageBannerViewController else { return }
+
+        messageBanner.showBanner(with: .success, message: Strings.Block_user_success())
       }
 
     self.viewModel.outputs.didBlockUserError
       .observeForUI()
       .observeValues { [weak self] _ in
-        self?.messageBannerViewController?
-          .showBanner(with: .error, message: Strings.Block_user_fail())
+        guard let self, let messageBanner = self.messageBannerViewController else { return }
+
+        messageBanner.showBanner(with: .error, message: Strings.Block_user_fail())
       }
   }
 

--- a/Kickstarter-iOS/Features/ProjectPage/Controller/ProjectPageViewController.swift
+++ b/Kickstarter-iOS/Features/ProjectPage/Controller/ProjectPageViewController.swift
@@ -744,6 +744,7 @@ public final class ProjectPageViewController: UIViewController, MessageBannerVie
       .blockUserAlert(username: username, blockUserHandler: { _ in
         self.viewModel.inputs.blockUser(id: "\(userId)")
       })
+
     self.present(alert, animated: true)
   }
 
@@ -993,10 +994,10 @@ extension ProjectPageViewController: ProjectPamphletMainCellDelegate {
     _ cell: ProjectPamphletMainCell,
     goToCreatorForProject project: Project
   ) {
-//    guard AppEnvironment.current.currentUser != nil, featureBlockUsersEnabled() else {
-//      self.goToCreatorProfile(forProject: project)
-//      return
-//    }
+    guard AppEnvironment.current.currentUser != nil, featureBlockUsersEnabled() else {
+      self.goToCreatorProfile(forProject: project)
+      return
+    }
 
     let actionSheet = UIAlertController
       .blockUserActionSheet(

--- a/KsApi/MockService.swift
+++ b/KsApi/MockService.swift
@@ -19,6 +19,8 @@
 
     fileprivate let addPaymentSheetPaymentSourceResult: Result<CreatePaymentSourceEnvelope, ErrorEnvelope>?
 
+    fileprivate let blockUserResult: Result<EmptyResponseEnvelope, ErrorEnvelope>?
+
     fileprivate let cancelBackingResult: Result<EmptyResponseEnvelope, ErrorEnvelope>?
 
     fileprivate let changeCurrencyResult: Result<EmptyResponseEnvelope, ErrorEnvelope>?
@@ -219,6 +221,7 @@
       addNewCreditCardResult: Result<CreatePaymentSourceEnvelope, ErrorEnvelope>? = nil,
       addPaymentSheetPaymentSourceResult: Result<CreatePaymentSourceEnvelope, ErrorEnvelope>? = nil,
       apolloClient: ApolloClientType? = nil,
+      blockUserResult: Result<EmptyResponseEnvelope, ErrorEnvelope>? = nil,
       cancelBackingResult: Result<EmptyResponseEnvelope, ErrorEnvelope>? = nil,
       changeEmailResult: Result<EmptyResponseEnvelope, ErrorEnvelope>? = nil,
       changePasswordResult: Result<EmptyResponseEnvelope, ErrorEnvelope>? = nil,
@@ -331,6 +334,8 @@
       self.addPaymentSheetPaymentSourceResult = addPaymentSheetPaymentSourceResult
 
       self.apolloClient = apolloClient ?? MockGraphQLClient.shared.client
+
+      self.blockUserResult = blockUserResult
 
       self.cancelBackingResult = cancelBackingResult
 
@@ -541,6 +546,18 @@
         .CreatePaymentSourceMutation(input: GraphAPI.CreatePaymentSourceInput.from(input))
 
       return client.performWithResult(mutation: mutation, result: self.addPaymentSheetPaymentSourceResult)
+    }
+
+    public func blockUser(input: BlockUserInput)
+      -> SignalProducer<EmptyResponseEnvelope, ErrorEnvelope> {
+      guard let client = self.apolloClient else {
+        return .empty
+      }
+
+      let mutation = GraphAPI
+        .BlockUserMutation(input: GraphAPI.BlockUserInput(blockUserId: input.blockUserId))
+
+      return client.performWithResult(mutation: mutation, result: self.blockUserResult)
     }
 
     public func cancelBacking(input: CancelBackingInput)
@@ -1679,10 +1696,6 @@
       }
 
       return SignalProducer(value: self.fetchUpdateResponse)
-    }
-
-    func blockUser(input _: BlockUserInput) -> SignalProducer<EmptyResponseEnvelope, ErrorEnvelope> {
-      return SignalProducer(value: EmptyResponseEnvelope())
     }
 
     internal func previewUrl(forDraft draft: UpdateDraft) -> URL? {

--- a/KsApi/mutations/inputs/BlockUserInput.swift
+++ b/KsApi/mutations/inputs/BlockUserInput.swift
@@ -2,4 +2,8 @@ import Foundation
 
 public struct BlockUserInput: GraphMutationInput, Encodable {
   let blockUserId: String
+
+  public init(blockUserId: String) {
+    self.blockUserId = blockUserId
+  }
 }

--- a/Library/ViewModels/CommentRepliesViewModel.swift
+++ b/Library/ViewModels/CommentRepliesViewModel.swift
@@ -65,10 +65,10 @@ public protocol CommentRepliesViewModelOutputs {
   /// Emits when a pagination error has occurred.
   var showPaginationErrorState: Signal<(), Never> { get }
 
-  /// Emits when a block a user request is successful.
+  /// Emits when a block user request is successful.
   var didBlockUser: Signal<(), Never> { get }
 
-  /// Emits when a block a user request fails.
+  /// Emits when a block user request fails.
   var didBlockUserError: Signal<(), Never> { get }
 }
 

--- a/Library/ViewModels/CommentsViewModel.swift
+++ b/Library/ViewModels/CommentsViewModel.swift
@@ -68,10 +68,10 @@ public protocol CommentsViewModelOutputs {
   /// Emits when a comment has been posted and we should scroll to top and reset the composer.
   var resetCommentComposerAndScrollToTop: Signal<(), Never> { get }
 
-  /// Emits when a block a user request is successful.
+  /// Emits when a block user request is successful.
   var didBlockUser: Signal<(), Never> { get }
 
-  /// Emits when a block a user request fails.
+  /// Emits when a block user request fails.
   var didBlockUserError: Signal<(), Never> { get }
 }
 

--- a/Library/ViewModels/MessagesViewModel.swift
+++ b/Library/ViewModels/MessagesViewModel.swift
@@ -63,10 +63,10 @@ public protocol MessagesViewModelOutputs {
   /// Emits when the thread has been marked as read.
   var successfullyMarkedAsRead: Signal<(), Never> { get }
 
-  /// Emits when a block a user request is successful.
+  /// Emits when a block user request is successful.
   var didBlockUser: Signal<(), Never> { get }
 
-  /// Emits when a block a user request fails.
+  /// Emits when a block user request fails.
   var didBlockUserError: Signal<(), Never> { get }
 }
 

--- a/Library/ViewModels/MessagesViewModel.swift
+++ b/Library/ViewModels/MessagesViewModel.swift
@@ -8,7 +8,7 @@ public protocol MessagesViewModelInputs {
   func backingInfoPressed()
 
   /// Call when block user is tapped
-  func blockUser()
+  func blockUser(id: String)
 
   /// Configures the view model with either a message thread or a project and a backing.
   func configureWith(data: Either<MessageThread, (project: Project, backing: Backing)>)
@@ -63,8 +63,11 @@ public protocol MessagesViewModelOutputs {
   /// Emits when the thread has been marked as read.
   var successfullyMarkedAsRead: Signal<(), Never> { get }
 
-  /// Emits whether a request to block a user was successful.
-  var didBlockUser: Signal<Bool, Never> { get }
+  /// Emits when a block a user request is successful.
+  var didBlockUser: Signal<(), Never> { get }
+
+  /// Emits when a block a user request fails.
+  var didBlockUserError: Signal<(), Never> { get }
 }
 
 public protocol MessagesViewModelType {
@@ -197,16 +200,23 @@ public final class MessagesViewModel: MessagesViewModelType, MessagesViewModelIn
       }
       .ignoreValues()
 
-    // TODO: Call blocking GraphQL mutation
-    self.didBlockUser = self.blockUserProperty.signal.map { false }
+    let blockUserEvent = self.blockUserProperty.signal
+      .map(BlockUserInput.init(blockUserId:))
+      .switchMap { input in
+        AppEnvironment.current.apiService
+          .blockUser(input: input)
+          .ksr_delay(AppEnvironment.current.apiDelayInterval, on: AppEnvironment.current.scheduler)
+          .materialize()
+      }
 
-    self.didBlockUser.observeValues { didBlock in
-      guard didBlock == true else { return }
-      NotificationCenter.default.post(.init(name: .ksr_blockedUser))
-    }
+    self.didBlockUser = blockUserEvent.values().ignoreValues()
+      .map { _ in NotificationCenter.default.post(.init(name: .ksr_blockedUser)) }
+
+    // TODO: Display proper error messaging from the backend
+    self.didBlockUserError = blockUserEvent.errors().ignoreValues()
 
     self.participantPreviouslyBlocked = self.project
-      .map { $0.creator.isBlocked ?? false }
+      .map { $0.creator.isBlocked }
       .takeWhen(self.viewWillAppearProperty.signal)
   }
 
@@ -215,9 +225,9 @@ public final class MessagesViewModel: MessagesViewModelType, MessagesViewModelIn
     self.backingInfoPressedProperty.value = ()
   }
 
-  private let blockUserProperty = MutableProperty(())
-  public func blockUser() {
-    self.blockUserProperty.value = ()
+  private let blockUserProperty = MutableProperty<String>("")
+  public func blockUser(id: String) {
+    self.blockUserProperty.value = id
   }
 
   private let configData = MutableProperty<Either<MessageThread, (project: Project, backing: Backing)>?>(nil)
@@ -260,7 +270,8 @@ public final class MessagesViewModel: MessagesViewModelType, MessagesViewModelIn
   public let project: Signal<Project, Never>
   public let replyButtonIsEnabled: Signal<Bool, Never>
   public let successfullyMarkedAsRead: Signal<(), Never>
-  public let didBlockUser: Signal<Bool, Never>
+  public let didBlockUser: Signal<(), Never>
+  public let didBlockUserError: Signal<(), Never>
 
   public var inputs: MessagesViewModelInputs { return self }
   public var outputs: MessagesViewModelOutputs { return self }

--- a/Library/ViewModels/MessagesViewModelTests.swift
+++ b/Library/ViewModels/MessagesViewModelTests.swift
@@ -42,7 +42,7 @@ internal final class MessagesViewModelTests: TestCase {
     self.vm.outputs.replyButtonIsEnabled.observe(self.replyButtonIsEnabled.observer)
     self.vm.outputs.successfullyMarkedAsRead.observe(self.successfullyMarkedAsRead.observer)
     self.vm.outputs.didBlockUser.observe(self.didBlockUser.observer)
-    self.vm.outputs.didBlockUserError.observe(self.didBlockUser.observer)
+    self.vm.outputs.didBlockUserError.observe(self.didBlockUserError.observer)
 
     AppEnvironment.login(AccessTokenEnvelope(accessToken: "deadbeef", user: User.template))
   }
@@ -276,6 +276,51 @@ internal final class MessagesViewModelTests: TestCase {
       self.scheduler.advance()
 
       self.participantPreviouslyBlocked.assertValues([true])
+    }
+  }
+
+  func testDidBlockUser_EmitsOnSuccess() {
+    let envelope = EmptyResponseEnvelope()
+
+    withEnvironment(apiService: MockService(blockUserResult: .success(envelope)), currentUser: .template) {
+      self.vm.inputs.configureWith(data: .right((project: .template, backing: .template)))
+
+      self.vm.inputs.viewDidLoad()
+
+      self.didBlockUser.assertValueCount(0)
+      self.didBlockUserError.assertValueCount(0)
+
+      self.vm.inputs.blockUser(id: "\(User.template.id)")
+
+      self.scheduler.advance()
+
+      self.didBlockUser.assertValueCount(1)
+      self.didBlockUserError.assertValueCount(0)
+    }
+  }
+
+  func testDidBlockUserError_EmitsOnFailure() {
+    let error = ErrorEnvelope(
+      errorMessages: ["block user request error"],
+      ksrCode: .GraphQLError,
+      httpCode: 401,
+      exception: nil
+    )
+
+    withEnvironment(apiService: MockService(blockUserResult: .failure(error)), currentUser: .template) {
+      self.vm.inputs.configureWith(data: .right((project: .template, backing: .template)))
+
+      self.vm.inputs.viewDidLoad()
+
+      self.didBlockUser.assertValueCount(0)
+      self.didBlockUserError.assertValueCount(0)
+
+      self.vm.inputs.blockUser(id: "\(User.template.id)")
+
+      self.scheduler.advance()
+
+      self.didBlockUser.assertValueCount(0)
+      self.didBlockUserError.assertValueCount(1)
     }
   }
 

--- a/Library/ViewModels/MessagesViewModelTests.swift
+++ b/Library/ViewModels/MessagesViewModelTests.swift
@@ -21,7 +21,8 @@ internal final class MessagesViewModelTests: TestCase {
   fileprivate let project = TestObserver<Project, Never>()
   fileprivate let replyButtonIsEnabled = TestObserver<Bool, Never>()
   fileprivate let successfullyMarkedAsRead = TestObserver<(), Never>()
-  fileprivate let didBlockUser = TestObserver<Bool, Never>()
+  fileprivate let didBlockUser = TestObserver<(), Never>()
+  fileprivate let didBlockUserError = TestObserver<(), Never>()
 
   override func setUp() {
     super.setUp()
@@ -41,6 +42,7 @@ internal final class MessagesViewModelTests: TestCase {
     self.vm.outputs.replyButtonIsEnabled.observe(self.replyButtonIsEnabled.observer)
     self.vm.outputs.successfullyMarkedAsRead.observe(self.successfullyMarkedAsRead.observer)
     self.vm.outputs.didBlockUser.observe(self.didBlockUser.observer)
+    self.vm.outputs.didBlockUserError.observe(self.didBlockUser.observer)
 
     AppEnvironment.login(AccessTokenEnvelope(accessToken: "deadbeef", user: User.template))
   }

--- a/Library/ViewModels/ProjectPageViewModel.swift
+++ b/Library/ViewModels/ProjectPageViewModel.swift
@@ -11,7 +11,7 @@ public protocol ProjectPageViewModelInputs {
   func applicationDidEnterBackground()
 
   /// Call when block user is tapped
-  func blockUser(id: String)
+  func blockUser(id: Int)
 
   /// Call with the project given to the view controller.
   func configureWith(projectOrParam: Either<Project, Param>, refTag: RefTag?)
@@ -506,7 +506,7 @@ public final class ProjectPageViewModel: ProjectPageViewModelType, ProjectPageVi
     self.goToURL = self.didSelectCampaignImageLinkProperty.signal.skipNil()
 
     let blockUserEvent = self.blockUserProperty.signal
-      .map(BlockUserInput.init(blockUserId:))
+      .map { BlockUserInput.init(blockUserId: "\($0)") }
       .switchMap { input in
         AppEnvironment.current.apiService
           .blockUser(input: input)
@@ -531,8 +531,8 @@ public final class ProjectPageViewModel: ProjectPageViewModelType, ProjectPageVi
     self.applicationDidEnterBackgroundProperty.value = ()
   }
 
-  fileprivate let blockUserProperty = MutableProperty<String>("")
-  public func blockUser(id: String) {
+  fileprivate let blockUserProperty = MutableProperty<Int>(0)
+  public func blockUser(id: Int) {
     self.blockUserProperty.value = id
   }
 

--- a/Library/ViewModels/ProjectPageViewModel.swift
+++ b/Library/ViewModels/ProjectPageViewModel.swift
@@ -11,7 +11,7 @@ public protocol ProjectPageViewModelInputs {
   func applicationDidEnterBackground()
 
   /// Call when block user is tapped
-  func blockUser()
+  func blockUser(id: String)
 
   /// Call with the project given to the view controller.
   func configureWith(projectOrParam: Either<Project, Param>, refTag: RefTag?)
@@ -150,8 +150,11 @@ public protocol ProjectPageViewModelOutputs {
   /// Emits a prelaunch save state that updates the navigation bar's watch project state.
   var updateWatchProjectWithPrelaunchProjectState: Signal<PledgeCTAPrelaunchState, Never> { get }
 
-  /// Emits when a request to block a user has been made
-  var userBlocked: Signal<Bool, Never> { get }
+  /// Emits when a block a user request is successful.
+  var didBlockUser: Signal<(), Never> { get }
+
+  /// Emits when a block a user request fails.
+  var didBlockUserError: Signal<(), Never> { get }
 }
 
 public protocol ProjectPageViewModelType {
@@ -502,13 +505,20 @@ public final class ProjectPageViewModel: ProjectPageViewModelType, ProjectPageVi
 
     self.goToURL = self.didSelectCampaignImageLinkProperty.signal.skipNil()
 
-    // TODO: Call blocking GraphQL mutation
-    self.userBlocked = self.blockUserProperty.signal.map { true }
+    let blockUserEvent = self.blockUserProperty.signal
+      .map(BlockUserInput.init(blockUserId:))
+      .switchMap { input in
+        AppEnvironment.current.apiService
+          .blockUser(input: input)
+          .ksr_delay(AppEnvironment.current.apiDelayInterval, on: AppEnvironment.current.scheduler)
+          .materialize()
+      }
 
-    self.userBlocked.observeValues { didBlock in
-      guard didBlock == true else { return }
-      NotificationCenter.default.post(.init(name: .ksr_blockedUser))
-    }
+    self.didBlockUser = blockUserEvent.values().ignoreValues()
+      .map { _ in NotificationCenter.default.post(.init(name: .ksr_blockedUser)) }
+
+    // TODO: Display proper error messaging from the backend
+    self.didBlockUserError = blockUserEvent.errors().ignoreValues()
   }
 
   fileprivate let askAQuestionCellTappedProperty = MutableProperty(())
@@ -521,9 +531,9 @@ public final class ProjectPageViewModel: ProjectPageViewModelType, ProjectPageVi
     self.applicationDidEnterBackgroundProperty.value = ()
   }
 
-  fileprivate let blockUserProperty = MutableProperty(())
-  public func blockUser() {
-    self.blockUserProperty.value = ()
+  fileprivate let blockUserProperty = MutableProperty<String>("")
+  public func blockUser(id: String) {
+    self.blockUserProperty.value = id
   }
 
   private let configDataProperty = MutableProperty<(Either<Project, Param>, RefTag?)?>(nil)
@@ -651,7 +661,8 @@ public final class ProjectPageViewModel: ProjectPageViewModelType, ProjectPageVi
   public let updateDataSource: Signal<(NavigationSection, Project, RefTag?, [Bool], [URL]), Never>
   public let updateFAQsInDataSource: Signal<(Project, RefTag?, [Bool]), Never>
   public let updateWatchProjectWithPrelaunchProjectState: Signal<PledgeCTAPrelaunchState, Never>
-  public let userBlocked: Signal<Bool, Never>
+  public let didBlockUser: Signal<(), Never>
+  public let didBlockUserError: Signal<(), Never>
 
   public var inputs: ProjectPageViewModelInputs { return self }
   public var outputs: ProjectPageViewModelOutputs { return self }

--- a/Library/ViewModels/ProjectPageViewModel.swift
+++ b/Library/ViewModels/ProjectPageViewModel.swift
@@ -150,10 +150,10 @@ public protocol ProjectPageViewModelOutputs {
   /// Emits a prelaunch save state that updates the navigation bar's watch project state.
   var updateWatchProjectWithPrelaunchProjectState: Signal<PledgeCTAPrelaunchState, Never> { get }
 
-  /// Emits when a block a user request is successful.
+  /// Emits when a block user request is successful.
   var didBlockUser: Signal<(), Never> { get }
 
-  /// Emits when a block a user request fails.
+  /// Emits when a block user request fails.
   var didBlockUserError: Signal<(), Never> { get }
 }
 

--- a/Library/ViewModels/ProjectPageViewModelTests.swift
+++ b/Library/ViewModels/ProjectPageViewModelTests.swift
@@ -330,7 +330,7 @@ final class ProjectPageViewModelTests: TestCase {
       self.didBlockUser.assertValueCount(0)
       self.didBlockUserError.assertValueCount(0)
 
-      self.vm.inputs.blockUser(id: "\(User.template.id)")
+      self.vm.inputs.blockUser(id: User.template.id)
 
       self.scheduler.advance()
 
@@ -355,7 +355,7 @@ final class ProjectPageViewModelTests: TestCase {
       self.didBlockUser.assertValueCount(0)
       self.didBlockUserError.assertValueCount(0)
 
-      self.vm.inputs.blockUser(id: "\(User.template.id)")
+      self.vm.inputs.blockUser(id: User.template.id)
 
       self.scheduler.advance()
 


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Now that the block mutation has been [added](https://github.com/kickstarter/ios-oss/pull/1890), let's implement it.

# 🤔 Why

So we can block users!

# 🛠 How

We are letting users block someone from the following places:
- Project Page
- Message Threads
- Comments & Comment Replies

When we call this mutation via `AppEnvironment.current.apiService.blockUser...` either an error will occur or it'll be successful. So, in each view model, I've set up an output for each case that will in turn present a success or error message banner. 

We currently don't have the error messages that we can receive from the backend translated and localized so for now we are showing a generic "This didn't work" message. Not ideal. Showing a more useful message like, "You can only block someone that doesn't have a live project you have backed" would be better for obvious reasons so I think this should be a fast follow. Added a //TODO for this inline.

# 👀 See

expects the same UI/UX that we've been working with up to now. 

# ✅ Acceptance criteria

- [ ] We can block someone through each location listed above.
- [ ] Attempting to block someone who has already been blocked will return an error
- [ ] Attempting to block someone without internet will throw an error
- [ ] The UI reflects newly blocked users
   - [ ] Info banner in message threads
   - [ ] Blocked user comments
   - [ ] Once the backend is finished projects by blocked users will be filtered out, so there is no UI to inform you of this directly on a project page.

- you can also double-check that someone has been blocked successfully here https://staging.kickstarter.com/graphiql 

# ⏰ TODO

- [ ] Waiting on the `id` vs `uid` change to be made on prod. Once that's updated we can test that the app reloads after blocking and filters out blocked content correctly
- [x] Add VM tests
