### PR TITLE
[MBL-1075] Prevent blocking for users that are already blocked

### DIFF
--- a/Kickstarter-iOS/Features/Messages/Controller/MessagesViewController.swift
+++ b/Kickstarter-iOS/Features/Messages/Controller/MessagesViewController.swift
@@ -218,7 +218,13 @@ extension MessagesViewController: BackingCellDelegate {
 
 extension MessagesViewController: MessageCellDelegate {
   func messageCellDidTapHeader(_ cell: MessageCell, _ user: User) {
-    guard AppEnvironment.current.currentUser != nil, featureBlockUsersEnabled() else { return }
+    guard
+      AppEnvironment.current.currentUser != nil,
+      featureBlockUsersEnabled(),
+      !user.isBlocked
+    else {
+      return
+    }
 
     let actionSheet = UIAlertController
       .blockUserActionSheet(

--- a/Kickstarter-iOS/Features/ProjectPage/Controller/ProjectPageViewController.swift
+++ b/Kickstarter-iOS/Features/ProjectPage/Controller/ProjectPageViewController.swift
@@ -989,7 +989,11 @@ extension ProjectPageViewController: ProjectPamphletMainCellDelegate {
     _ cell: ProjectPamphletMainCell,
     goToCreatorForProject project: Project
   ) {
-    guard AppEnvironment.current.currentUser != nil, featureBlockUsersEnabled() else {
+    guard
+      AppEnvironment.current.currentUser != nil,
+      featureBlockUsersEnabled(),
+      !project.creator.isBlocked
+    else {
       self.goToCreatorProfile(forProject: project)
       return
     }


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

If a user is already blocked, we'll revert to old behavior (clicking on the username on the project page opens the creator page immediately and clicking usernames elsewhere has no effect.)

Note: this required no changes in comments, since that was already checking for blocked users.

# 👀 See

[Jira](https://kickstarter.atlassian.net/browse/MBL-1075)

# ✅ Acceptance criteria

- [x] User should not be blockable if already blocked. This is currently only testable on the project page

# ⏰ TODO

- [ ] Messages API doesn't include `isBlocked` info about the sender, so we'll need to test this for messages once that's fixed (probably after this PR is submitted).
