### PR TITLE
MBL-1074: Disable Github annotations in .codecov.yml

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -7,3 +7,5 @@ coverage:
     patch:
       default:
         informational: true
+github_checks:
+    annotations: false


### PR DESCRIPTION
# 📲 What

Disable inline annotations from Codecov in Github PRs.

# 🤔 Why

The team agreed that these annotations are more annoying than they are helpful. While they can be disabled easily in Github, it's a small distraction we don't need.

The same coverage information is still posted in the Codecov summary in the PR.

# 👀 See

Here's an example of this change in action: https://github.com/kickstarter/ios-oss/pull/1898

You'll note that there are complaints in the Codecov summary, but not inline.