### PR TITLE
[MBL-1076] Fix v1 user

### DIFF
--- a/Kickstarter-iOS/Features/Comments/Controllers/CommentRepliesViewController.swift
+++ b/Kickstarter-iOS/Features/Comments/Controllers/CommentRepliesViewController.swift
@@ -198,8 +198,14 @@ final class CommentRepliesViewController: UITableViewController, MessageBannerVi
   }
 
   private func handleCommentCellHeaderTapped(in cell: UITableViewCell, _ author: Comment.Author) {
-    guard AppEnvironment.current.currentUser != nil, featureBlockUsersEnabled() else { return }
-    guard author.isBlocked == false else { return }
+    guard
+      featureBlockUsersEnabled(),
+      let currentUser = AppEnvironment.current.currentUser,
+      String(currentUser.id) != author.id,
+      !author.isBlocked
+    else {
+      return
+    }
 
     let actionSheet = UIAlertController
       .blockUserActionSheet(

--- a/Kickstarter-iOS/Features/Comments/Controllers/CommentsViewController.swift
+++ b/Kickstarter-iOS/Features/Comments/Controllers/CommentsViewController.swift
@@ -268,8 +268,14 @@ extension CommentsViewController {
 
 extension CommentsViewController: CommentCellDelegate {
   func commentCellDidTapHeader(_ cell: CommentCell, _ author: Comment.Author) {
-    guard AppEnvironment.current.currentUser != nil, featureBlockUsersEnabled() else { return }
-    guard author.isBlocked == false else { return }
+    guard
+      featureBlockUsersEnabled(),
+      let currentUser = AppEnvironment.current.currentUser,
+      String(currentUser.id) != author.id,
+      !author.isBlocked
+    else {
+      return
+    }
 
     let actionSheet = UIAlertController
       .blockUserActionSheet(

--- a/Kickstarter-iOS/Features/Messages/Controller/MessagesViewController.swift
+++ b/Kickstarter-iOS/Features/Messages/Controller/MessagesViewController.swift
@@ -224,8 +224,9 @@ extension MessagesViewController: BackingCellDelegate {
 extension MessagesViewController: MessageCellDelegate {
   func messageCellDidTapHeader(_ cell: MessageCell, _ user: User) {
     guard
-      AppEnvironment.current.currentUser != nil,
       featureBlockUsersEnabled(),
+      let currentUser = AppEnvironment.current.currentUser,
+      currentUser != user,
       !user.isBlocked
     else {
       return

--- a/Kickstarter-iOS/Features/ProjectPage/Controller/ProjectPageViewController.swift
+++ b/Kickstarter-iOS/Features/ProjectPage/Controller/ProjectPageViewController.swift
@@ -997,8 +997,9 @@ extension ProjectPageViewController: ProjectPamphletMainCellDelegate {
     goToCreatorForProject project: Project
   ) {
     guard
-      AppEnvironment.current.currentUser != nil,
       featureBlockUsersEnabled(),
+      let currentUser = AppEnvironment.current.currentUser,
+      currentUser != project.creator,
       !project.creator.isBlocked
     else {
       self.goToCreatorProfile(forProject: project)

--- a/KsApi/models/User.swift
+++ b/KsApi/models/User.swift
@@ -142,7 +142,7 @@ extension User: Decodable {
     case isAdmin = "is_admin"
     case isEmailVerified = "is_email_verified"
     case isFriend = "is_friend"
-    case isBlocked = "is_blocked"
+    case isBlocked
     case location
     case name
     case needsFreshFacebookToken = "needs_fresh_facebook_token"


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

The backend field is `isBlocked` not `is_blocked`. This also stops users from blocking themselves.

# 👀 See

[Jira](https://kickstarter.atlassian.net/browse/MBL-1076)

# ✅ Acceptance criteria

- [ ] isBlocked is correctly propagated to v1 user objects, particularly in messages.
- [ ] Clicking on the name of a logged in user does not show a "Block user" option. 
