### PR TITLE
Stop using rawState in exportDataEnvelope

### DIFF
--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -344,6 +344,7 @@
 		37FDAFAC2273BA4700662CC8 /* UIStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37FDAF702273B7FF00662CC8 /* UIStackView.swift */; };
 		37FDAFAD2273BA4B00662CC8 /* UIStackView+Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37FDAFAA2273B86800662CC8 /* UIStackView+Tests.swift */; };
 		37FEFBC8222F1E4F00FCA608 /* ProcessInfoType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37FEFBC7222F1E4F00FCA608 /* ProcessInfoType.swift */; };
+		39742BBF2B27AA8D004944E6 /* ExportDataEnvelopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39742BBD2B27A91C004944E6 /* ExportDataEnvelopeTests.swift */; };
 		399DAD882ACD15D000238BA1 /* UpdateUserAccount.graphql in Resources */ = {isa = PBXBuildFile; fileRef = 06643F3926A5FF1C002C5997 /* UpdateUserAccount.graphql */; };
 		399DAD892ACD162C00238BA1 /* FetchProjectFriendsById.graphql in Resources */ = {isa = PBXBuildFile; fileRef = 06BD057526F15CFB00C44E36 /* FetchProjectFriendsById.graphql */; };
 		399DAD8A2ACD163400238BA1 /* UnwatchProject.graphql in Resources */ = {isa = PBXBuildFile; fileRef = 478E31C026C1C4C6004BF898 /* UnwatchProject.graphql */; };
@@ -1889,6 +1890,7 @@
 		37FDAF702273B7FF00662CC8 /* UIStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIStackView.swift; sourceTree = "<group>"; };
 		37FDAFAA2273B86800662CC8 /* UIStackView+Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIStackView+Tests.swift"; sourceTree = "<group>"; };
 		37FEFBC7222F1E4F00FCA608 /* ProcessInfoType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessInfoType.swift; sourceTree = "<group>"; };
+		39742BBD2B27A91C004944E6 /* ExportDataEnvelopeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExportDataEnvelopeTests.swift; sourceTree = "<group>"; };
 		3D1363951F0191FB00B53420 /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/Localizable.strings; sourceTree = "<group>"; };
 		4705D8972742E20900A13BBE /* ProjectHeaderCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectHeaderCell.swift; sourceTree = "<group>"; };
 		470B771926FCDC8900EBD5CA /* RiskMessagingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RiskMessagingViewModel.swift; sourceTree = "<group>"; };
@@ -6642,6 +6644,7 @@
 				D015878F1EEB2ED6006E7684 /* ErrorEnvelope.swift */,
 				D01587901EEB2ED6006E7684 /* ErrorEnvelopeTests.swift */,
 				D7417CD520BF12F4004DABA6 /* ExportDataEnvelope.swift */,
+				39742BBD2B27A91C004944E6 /* ExportDataEnvelopeTests.swift */,
 				D01587911EEB2ED6006E7684 /* FindFriendsEnvelope.swift */,
 				D01587921EEB2ED6006E7684 /* FindFriendsEnvelopeTests.swift */,
 				D01587931EEB2ED6006E7684 /* FriendStatsEnvelope.swift */,
@@ -8788,6 +8791,7 @@
 				47A662F726AF75B7001CE7B1 /* GraphAPI.WatchProjectInput+WatchProjectInputTests.swift in Sources */,
 				D0D10C1D1EEB4550005EBAD0 /* UpdatePledgeEnvelopeTests.swift in Sources */,
 				069CD29726B08C170076045F /* GraphAPI.UpdateUserProfileInput+UpdateUserProfileInputTests.swift in Sources */,
+				39742BBF2B27AA8D004944E6 /* ExportDataEnvelopeTests.swift in Sources */,
 				064AEF11270CF867006605DD /* FetchProjectRewardsByIdQueryTemplate.swift in Sources */,
 				D0D10C0E1EEB4550005EBAD0 /* ItemTests.swift in Sources */,
 				0620176E276956D600818A47 /* GraphCommentTests.swift in Sources */,

--- a/KsApi/models/ExportDataEnvelope.swift
+++ b/KsApi/models/ExportDataEnvelope.swift
@@ -5,7 +5,7 @@ public struct ExportDataEnvelope {
   public var state: State
   public let dataUrl: String?
 
-  public enum State: String, Decodable {
+  public enum State: String, Decodable, Equatable {
     case none
     case created
     case queued

--- a/KsApi/models/ExportDataEnvelope.swift
+++ b/KsApi/models/ExportDataEnvelope.swift
@@ -16,7 +16,7 @@ public struct ExportDataEnvelope {
     case failed
     case expired
     case unknown // Default value if server response can't be parsed.
-    
+
     // Throws error if the value isn't a valid string. If the value is a valid string, it maps to
     // its corresponding enum case, if it exists, and to `unknown` otherwise.
     public init(from decoder: Decoder) throws {

--- a/KsApi/models/ExportDataEnvelope.swift
+++ b/KsApi/models/ExportDataEnvelope.swift
@@ -2,27 +2,8 @@
 
 public struct ExportDataEnvelope {
   public let expiresAt: String?
+  public var state: State
   public let dataUrl: String?
-  public var state: State {
-    guard let rawState, let state = State(rawValue: rawState) else {
-      return .unknown
-    }
-    return state
-  }
-
-  private let rawState: String?
-
-  public init(expiresAt: String?, state: State, dataUrl: String?) {
-    self.expiresAt = expiresAt
-    self.dataUrl = dataUrl
-    self.rawState = state.rawValue
-  }
-
-  public init(expiresAt: String?, rawState: String?, dataUrl: String?) {
-    self.expiresAt = expiresAt
-    self.dataUrl = dataUrl
-    self.rawState = rawState
-  }
 
   public enum State: String, Decodable {
     case none
@@ -35,13 +16,20 @@ public struct ExportDataEnvelope {
     case failed
     case expired
     case unknown // Default value if server response can't be parsed.
+    
+    // Throws error if the value isn't a valid string. If the value is a valid string, it maps to
+    // its corresponding enum case, if it exists, and to `unknown` otherwise.
+    public init(from decoder: Decoder) throws {
+      let rawSelf = try decoder.singleValueContainer().decode(String.self)
+      self = .init(rawValue: rawSelf) ?? .unknown
+    }
   }
 }
 
 extension ExportDataEnvelope: Decodable {
   enum CodingKeys: String, CodingKey {
     case expiresAt = "expires_at"
-    case rawState = "state"
+    case state
     case dataUrl = "data_url"
   }
 }

--- a/KsApi/models/ExportDataEnvelopeTests.swift
+++ b/KsApi/models/ExportDataEnvelopeTests.swift
@@ -4,9 +4,9 @@ import XCTest
 class ExportDataEnvelopeTests: XCTestCase {
   func testJsonDecodingWithValidState() {
     let env: ExportDataEnvelope = try! ExportDataEnvelope.decodeJSONDictionary([
-      "expires_at":"fake-date",
-      "state":"none",
-      "data_url":"fake-url"
+      "expires_at": "fake-date",
+      "state": "none",
+      "data_url": "fake-url"
     ])
     XCTAssertNotNil(env)
     XCTAssertEqual(env.state, .none)
@@ -14,12 +14,11 @@ class ExportDataEnvelopeTests: XCTestCase {
 
   func testJsonDecodingWithInvalidState() {
     let env: ExportDataEnvelope = try! ExportDataEnvelope.decodeJSONDictionary([
-      "expires_at":"fake-date",
-      "state":"invalid-state",
-      "data_url":"fake-url"
+      "expires_at": "fake-date",
+      "state": "invalid-state",
+      "data_url": "fake-url"
     ])
     XCTAssertNotNil(env)
     XCTAssertEqual(env.state, .unknown)
   }
-  
 }

--- a/KsApi/models/ExportDataEnvelopeTests.swift
+++ b/KsApi/models/ExportDataEnvelopeTests.swift
@@ -1,0 +1,25 @@
+@testable import KsApi
+import XCTest
+
+class ExportDataEnvelopeTests: XCTestCase {
+  func testJsonDecodingWithValidState() {
+    let env: ExportDataEnvelope = try! ExportDataEnvelope.decodeJSONDictionary([
+      "expires_at":"fake-date",
+      "state":"none",
+      "data_url":"fake-url"
+    ])
+    XCTAssertNotNil(env)
+    XCTAssertEqual(env.state, .none)
+  }
+
+  func testJsonDecodingWithInvalidState() {
+    let env: ExportDataEnvelope = try! ExportDataEnvelope.decodeJSONDictionary([
+      "expires_at":"fake-date",
+      "state":"invalid-state",
+      "data_url":"fake-url"
+    ])
+    XCTAssertNotNil(env)
+    XCTAssertEqual(env.state, .unknown)
+  }
+  
+}

--- a/KsApi/models/lenses/ExportDataEnvelopeLenses.swift
+++ b/KsApi/models/lenses/ExportDataEnvelopeLenses.swift
@@ -14,10 +14,5 @@ extension ExportDataEnvelope {
       view: { $0.dataUrl },
       set: { ExportDataEnvelope(expiresAt: $1.expiresAt, state: $1.state, dataUrl: $0) }
     )
-
-    public static let rawState = Lens<ExportDataEnvelope, String?>(
-      view: { $0.state.rawValue },
-      set: { ExportDataEnvelope(expiresAt: $1.expiresAt, rawState: $0, dataUrl: $1.dataUrl) }
-    )
   }
 }

--- a/Library/ViewModels/SettingsRequestDataCellViewModelTests.swift
+++ b/Library/ViewModels/SettingsRequestDataCellViewModelTests.swift
@@ -64,7 +64,7 @@ internal final class SettingsRequestDataCellViewModelTests: TestCase {
   func testRequestDataButtonIsEnabledUnknownState() {
     let user = User.template
     let export = .template
-    |> ExportDataEnvelope.lens.state .~ .unknown
+      |> ExportDataEnvelope.lens.state .~ .unknown
       |> ExportDataEnvelope.lens.expiresAt .~ nil
       |> ExportDataEnvelope.lens.dataUrl .~ nil
 

--- a/Library/ViewModels/SettingsRequestDataCellViewModelTests.swift
+++ b/Library/ViewModels/SettingsRequestDataCellViewModelTests.swift
@@ -64,7 +64,7 @@ internal final class SettingsRequestDataCellViewModelTests: TestCase {
   func testRequestDataButtonIsEnabledUnknownState() {
     let user = User.template
     let export = .template
-      |> ExportDataEnvelope.lens.rawState .~ "invalid-state"
+    |> ExportDataEnvelope.lens.state .~ .unknown
       |> ExportDataEnvelope.lens.expiresAt .~ nil
       |> ExportDataEnvelope.lens.dataUrl .~ nil
 


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

This is a cleaner way to handle any future server changes; I just didn't understand decoders well enough to to this initially. The actual behavior (unknown strings default to `.unknown` and anything that can't be parsed as a string throws an error) remains the same.

# ✅ Acceptance criteria

- [x] Tests pass
- [x] Project builds & personal data can still be requested
