### PR TITLE
Update deeplinks

### DIFF
--- a/Kickstarter-iOS/Alpha.entitlements
+++ b/Kickstarter-iOS/Alpha.entitlements
@@ -1,26 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>aps-environment</key>
-    <string>production</string>
-    <key>com.apple.developer.associated-domains</key>
-    <array>
-      <string>applinks:www.kickstarter.com</string>
-      <string>applinks:native.dev.kickstarter.com</string>
-      <string>applinks:staging.kickstarter.com</string>
-      <string>applinks:click.e.kickstarter.com</string>
-      <string>applinks:click.em.kickstarter.com</string>
-      <string>applinks:email.kickstarter.com</string>
-      <string>applinks:emails.kickstarter.com</string>
-      <string>applinks:e2.kickstarter.com</string>
-      <string>applinks:e3.kickstarter.com</string>
-      <string>applinks:clicks.kickstarter.com</string>
-      <string>applinks:ea.kickstarter.com</string>
-      <string>applinks:me.kickstarter.com</string>
-      <string>webcredentials:kickstarter.com</string>
-    </array>
-    <key>com.apple.developer.ubiquity-kvstore-identifier</key>
-    <string>$(TeamIdentifierPrefix)$(CFBundleIdentifier)</string>
-  </dict>
+<dict>
+	<key>aps-environment</key>
+	<string>production</string>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:www.kickstarter.com</string>
+		<string>applinks:kickstarter.com</string>
+		<string>applinks:emails.kickstarter.com</string>
+		<string>applinks:clicks.kickstarter.com</string>
+		<string>webcredentials:kickstarter.com</string>
+	</array>
+	<key>com.apple.developer.ubiquity-kvstore-identifier</key>
+	<string>$(TeamIdentifierPrefix)$(CFBundleIdentifier)</string>
+</dict>
 </plist>

--- a/Kickstarter-iOS/AppDelegateViewModelTests.swift
+++ b/Kickstarter-iOS/AppDelegateViewModelTests.swift
@@ -1681,7 +1681,7 @@ final class AppDelegateViewModelTests: TestCase {
 
   func testEmailDeepLinking() {
     withEnvironment(apiService: MockService(fetchProjectResult: .success(.template))) {
-      let emailUrl = URL(string: "https://click.e.kickstarter.com/?qs=deadbeef")!
+      let emailUrl = URL(string: "https://clicks.kickstarter.com/?qs=deadbeef")!
 
       // The application launches.
       self.vm.inputs.applicationDidFinishLaunching(
@@ -1718,7 +1718,7 @@ final class AppDelegateViewModelTests: TestCase {
 
   func testEmailDeepLinking_ContinuedUserActivity() {
     withEnvironment(apiService: MockService(fetchProjectResult: .success(.template))) {
-      let emailUrl = URL(string: "https://click.e.kickstarter.com/?qs=deadbeef")!
+      let emailUrl = URL(string: "https://emails.kickstarter.com/?qs=deadbeef")!
       let userActivity = NSUserActivity(activityType: NSUserActivityTypeBrowsingWeb)
       userActivity.webpageURL = emailUrl
 
@@ -1752,7 +1752,7 @@ final class AppDelegateViewModelTests: TestCase {
   }
 
   func testEmailDeepLinking_UnrecognizedUrl() {
-    let emailUrl = URL(string: "https://click.e.kickstarter.com/?qs=deadbeef")!
+    let emailUrl = URL(string: "https://clicks.kickstarter.com/?qs=deadbeef")!
 
     // The application launches.
     self.vm.inputs.applicationDidFinishLaunching(
@@ -1788,7 +1788,7 @@ final class AppDelegateViewModelTests: TestCase {
   }
 
   func testEmailDeepLinking_UnrecognizedUrl_ProjectPreview() {
-    let emailUrl = URL(string: "https://click.e.kickstarter.com/?qs=deadbeef")!
+    let emailUrl = URL(string: "https://emails.kickstarter.com/?qs=deadbeef")!
 
     // The application launches.
     self.vm.inputs.applicationDidFinishLaunching(
@@ -1821,43 +1821,6 @@ final class AppDelegateViewModelTests: TestCase {
     self.findRedirectUrl.assertValues([emailUrl], "Nothing new is emitted.")
     self.presentViewController.assertValues([], "Do not present controller since the url was unrecognizable.")
     self.goToMobileSafari.assertValues([unrecognizedUrl], "Go to mobile safari for the unrecognized url.")
-  }
-
-  func testOtherEmailDeepLink() {
-    withEnvironment(apiService: MockService(fetchProjectResult: .success(.template))) {
-      let emailUrl = URL(string: "https://email.kickstarter.com/mpss/a/b/c/d/e/f/g")!
-
-      // The application launches.
-      self.vm.inputs.applicationDidFinishLaunching(
-        application: UIApplication.shared,
-        launchOptions: [:]
-      )
-
-      self.findRedirectUrl.assertValues([])
-      self.presentViewController.assertValues([])
-      self.goToMobileSafari.assertValues([])
-
-      // We deep-link to an email url.
-      self.vm.inputs.applicationDidEnterBackground()
-      self.vm.inputs.applicationWillEnterForeground()
-      let result = self.vm.inputs.applicationOpenUrl(
-        application: UIApplication.shared,
-        url: emailUrl,
-        options: [:]
-      )
-      XCTAssertTrue(result)
-
-      self.findRedirectUrl.assertValues([emailUrl], "Ask to find the redirect after open the email url.")
-      self.presentViewController.assertValues([], "No view controller is presented yet.")
-      self.goToMobileSafari.assertValues([])
-
-      // We find the redirect to be a project url.
-      self.vm.inputs.foundRedirectUrl(URL(string: "https://www.kickstarter.com/projects/creator/project")!)
-
-      self.findRedirectUrl.assertValues([emailUrl], "Nothing new is emitted.")
-      self.presentViewController.assertValueCount(1, "Present the project view controller.")
-      self.goToMobileSafari.assertValues([])
-    }
   }
 
   func testProjectSurveyDeepLink() {

--- a/Kickstarter-iOS/Beta.entitlements
+++ b/Kickstarter-iOS/Beta.entitlements
@@ -1,26 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>aps-environment</key>
-    <string>production</string>
-    <key>com.apple.developer.associated-domains</key>
-    <array>
-      <string>applinks:www.kickstarter.com</string>
-      <string>applinks:native.dev.kickstarter.com</string>
-      <string>applinks:staging.kickstarter.com</string>
-      <string>applinks:click.e.kickstarter.com</string>
-      <string>applinks:click.em.kickstarter.com</string>
-      <string>applinks:email.kickstarter.com</string>
-      <string>applinks:emails.kickstarter.com</string>
-      <string>applinks:e2.kickstarter.com</string>
-      <string>applinks:e3.kickstarter.com</string>
-      <string>applinks:clicks.kickstarter.com</string>
-      <string>applinks:ea.kickstarter.com</string>
-      <string>applinks:me.kickstarter.com</string>
-      <string>webcredentials:kickstarter.com</string>
-    </array>
-    <key>com.apple.developer.ubiquity-kvstore-identifier</key>
-    <string>$(TeamIdentifierPrefix)$(CFBundleIdentifier)</string>
-  </dict>
+<dict>
+	<key>aps-environment</key>
+	<string>production</string>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:staging.kickstarter.com</string>
+		<string>webcredentials:kickstarter.com</string>
+	</array>
+	<key>com.apple.developer.ubiquity-kvstore-identifier</key>
+	<string>$(TeamIdentifierPrefix)$(CFBundleIdentifier)</string>
+</dict>
 </plist>

--- a/Kickstarter-iOS/Debug.entitlements
+++ b/Kickstarter-iOS/Debug.entitlements
@@ -1,36 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>aps-environment</key>
-    <string>development</string>
-    <key>com.apple.developer.applesignin</key>
-    <array>
-      <string>Default</string>
-    </array>
-    <key>com.apple.developer.associated-domains</key>
-    <array>
-      <string>applinks:staging.kickstarter.com</string>
-      <string>applinks:native.dev.kickstarter.com</string>
-      <string>applinks:www.kickstarter.com</string>
-      <string>applinks:click.e.kickstarter.com</string>
-      <string>applinks:click.em.kickstarter.com</string>
-      <string>applinks:email.kickstarter.com</string>
-      <string>applinks:emails.kickstarter.com</string>
-      <string>applinks:e2.kickstarter.com</string>
-      <string>applinks:e3.kickstarter.com</string>
-      <string>applinks:clicks.kickstarter.com</string>
-      <string>applinks:ea.kickstarter.com</string>
-      <string>applinks:me.kickstarter.com</string>
-      <string>webcredentials:kickstarter.com</string>
-    </array>
-    <key>com.apple.developer.icloud-container-identifiers</key>
-    <array/>
-    <key>com.apple.developer.in-app-payments</key>
-    <array>
-      <string>merchant.com.kickstarter</string>
-    </array>
-    <key>com.apple.developer.ubiquity-kvstore-identifier</key>
-    <string>$(TeamIdentifierPrefix)$(CFBundleIdentifier)</string>
-  </dict>
+<dict>
+	<key>aps-environment</key>
+	<string>development</string>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>webcredentials:kickstarter.com</string>
+	</array>
+	<key>com.apple.developer.icloud-container-identifiers</key>
+	<array/>
+	<key>com.apple.developer.in-app-payments</key>
+	<array>
+		<string>merchant.com.kickstarter</string>
+	</array>
+	<key>com.apple.developer.ubiquity-kvstore-identifier</key>
+	<string>$(TeamIdentifierPrefix)$(CFBundleIdentifier)</string>
+</dict>
 </plist>

--- a/Kickstarter-iOS/Release.entitlements
+++ b/Kickstarter-iOS/Release.entitlements
@@ -1,34 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>aps-environment</key>
-    <string>production</string>
-    <key>com.apple.developer.applesignin</key>
-    <array>
-      <string>Default</string>
-    </array>
-    <key>com.apple.developer.associated-domains</key>
-    <array>
-      <string>applinks:www.kickstarter.com</string>
-      <string>applinks:click.e.kickstarter.com</string>
-      <string>applinks:click.em.kickstarter.com</string>
-      <string>applinks:email.kickstarter.com</string>
-      <string>applinks:emails.kickstarter.com</string>
-      <string>applinks:e2.kickstarter.com</string>
-      <string>applinks:e3.kickstarter.com</string>
-      <string>applinks:clicks.kickstarter.com</string>
-      <string>applinks:ea.kickstarter.com</string>
-      <string>applinks:me.kickstarter.com</string>
-      <string>webcredentials:kickstarter.com</string>
-    </array>
-    <key>com.apple.developer.icloud-container-identifiers</key>
-    <array/>
-    <key>com.apple.developer.in-app-payments</key>
-    <array>
-      <string>merchant.com.kickstarter</string>
-    </array>
-    <key>com.apple.developer.ubiquity-kvstore-identifier</key>
-    <string>$(TeamIdentifierPrefix)$(CFBundleIdentifier)</string>
-  </dict>
+<dict>
+	<key>aps-environment</key>
+	<string>production</string>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:www.kickstarter.com</string>
+		<string>applinks:kickstarter.com</string>
+		<string>applinks:emails.kickstarter.com</string>
+		<string>applinks:clicks.kickstarter.com</string>
+		<string>webcredentials:kickstarter.com</string>
+	</array>
+	<key>com.apple.developer.icloud-container-identifiers</key>
+	<array/>
+	<key>com.apple.developer.in-app-payments</key>
+	<array>
+		<string>merchant.com.kickstarter</string>
+	</array>
+	<key>com.apple.developer.ubiquity-kvstore-identifier</key>
+	<string>$(TeamIdentifierPrefix)$(CFBundleIdentifier)</string>
+</dict>
 </plist>

--- a/Library/Navigation.swift
+++ b/Library/Navigation.swift
@@ -500,15 +500,8 @@ private func settingsNotifications(_ params: RouteParamsDecoded) -> Navigation? 
 
 private func parsedParams(url: URL, fromTemplate template: String) -> RouteParamsDecoded? {
   let recognizedEmailHosts = [
-    "me.kickstarter.com",
-    "ea.kickstarter.com",
     "clicks.kickstarter.com",
-    "click.e.kickstarter.com",
-    "click.em.kickstarter.com",
-    "emails.kickstarter.com",
-    "email.kickstarter.com",
-    "e2.kickstarter.com",
-    "e3.kickstarter.com"
+    "emails.kickstarter.com"
   ]
 
   let hostRecognizer = { accum, host in
@@ -519,7 +512,9 @@ private func parsedParams(url: URL, fromTemplate template: String) -> RouteParam
 
   let recognizedHosts = [
     AppEnvironment.current.apiService.serverConfig.apiBaseUrl.host,
-    AppEnvironment.current.apiService.serverConfig.webBaseUrl.host
+    AppEnvironment.current.apiService.serverConfig.webBaseUrl.host,
+    AppEnvironment.current.apiService.serverConfig.webBaseUrl.host?
+      .replacingOccurrences(of: "www.", with: "")
   ].compact()
 
   let isRecognizedHost = recognizedHosts.reduce(false, hostRecognizer)

--- a/Library/NavigationTests.swift
+++ b/Library/NavigationTests.swift
@@ -230,24 +230,6 @@ public final class NavigationTests: XCTestCase {
   }
 
   func testRecognizesEmailClickUrls() {
-    let url = URL(string: "https://email.kickstarter.com/mpss/c/2gA/Oiw/t.25j/deadbeef/h1/dead-beef")!
-    XCTAssertEqual(.emailClick, Navigation.match(url))
-
-    XCTAssertEqual(
-      .emailClick,
-      Navigation.match(URL(string: "https://me.kickstarter.com/wf/click?upn=deadbeef")!)
-    )
-
-    XCTAssertEqual(
-      .emailClick,
-      Navigation.match(URL(string: "https://ea.kickstarter.com/wf/click?upn=deadbeef")!)
-    )
-
-    XCTAssertEqual(
-      .emailClick,
-      Navigation.match(URL(string: "https://click.e.kickstarter.com/wf/click?upn=deadbeef")!)
-    )
-
     XCTAssertEqual(
       .emailClick,
       Navigation.match(URL(string: "https://clicks.kickstarter.com/wf/click?upn=deadbeef")!)
@@ -255,31 +237,18 @@ public final class NavigationTests: XCTestCase {
 
     XCTAssertEqual(
       .emailClick,
-      Navigation.match(URL(string: "https://click.em.kickstarter.com/wf/click?upn=deadbeef")!)
-    )
-
-    XCTAssertEqual(
-      .emailClick,
       Navigation.match(URL(string: "https://emails.kickstarter.com/anything/?qs=deadbeef")!)
-    )
-
-    XCTAssertEqual(
-      .emailClick,
-      Navigation.match(URL(string: "https://email.kickstarter.com/garbage/?random=deadbeef")!)
-    )
-
-    XCTAssertEqual(
-      .emailClick,
-      Navigation.match(URL(string: "https://e2.kickstarter.com/anypath/?b=deadbeef")!)
-    )
-
-    XCTAssertEqual(
-      .emailClick,
-      Navigation.match(URL(string: "https://e3.kickstarter.com/wildcard")!)
     )
 
     XCTAssertNil(
       Navigation.match(URL(string: "https://notemailhost.kickstarter.com/wf/click?upn=deadbeef")!)
+    )
+  }
+
+  func testRecognizesTruncatedUrl() {
+    XCTAssertEqual(
+      .profile(.verifyEmail),
+      Navigation.match(URL(string: "https://kickstarter.com/profile/verify_email")!)
     )
   }
 


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Delete unused deeplink subdomains, update tests, and add support for `kickstarter.com` without the `www.`.

# 🤔 Why

Becca and Ali confirmed in slack that the only email redirect domains we need are `clicks.` and `emails.`.

Note: If anyone tries to test this locally, `www.kickstarter.com` and `kickstarter.com` deeplinks might not work today. This is expected; it takes the `apple-app-site-association` file info about 24 hours to propagate through apple's servers. In the meanwhile, this can be tested by updating the entitlement to `applinks:www.kickstarter.com?mode=developer`

# ♿️ Accessibility 

- [ ] Works with VoiceOver

# ✅ Acceptance criteria

- [ ] staging.kickstarter.com deeplinks work for the beta version of the app
- [ ] www.kickstarter.com and kickstarter.com deeplinks work for the release version of the app
- [ ] email deeplinks (emails. and clicks.) work for the release version of the app

# ⏰ TODO

- [ ] Double-check that deeplinks from Braze are not affected
- [ ] Test non-email deeplinks once the app site association file has time to propagate.
