### PR TITLE
MBL-1016: Stub version of paginate that works with Combine

### DIFF
--- a/KsApi/combine/CombineTestObserver.swift
+++ b/KsApi/combine/CombineTestObserver.swift
@@ -1,12 +1,16 @@
 import Combine
 import Foundation
+// TODO: do I need to move CombineTestObserver into another package, so this isn't imported into KsApi?
+import XCTest
 
-public final class CombineTestObserver<Value, Error: Swift.Error> {
+public final class CombineTestObserver<Value: Equatable, Error: Swift.Error> {
   public enum Event {
     case value(Value)
     case error(Error)
     case finished
   }
+
+  public init() {}
 
   public private(set) var events: [Event] = []
 
@@ -26,5 +30,40 @@ public final class CombineTestObserver<Value, Error: Swift.Error> {
       self?.events.append(.value(value))
     }
     .store(in: &self.subscriptions)
+  }
+
+  public var values: [Value] {
+    let values: [Value?] = self.events.map { e in
+      if case let .value(value) = e {
+        return value
+      } else {
+        return nil
+      }
+    }
+
+    return values.filter { $0 != nil } as! [Value]
+  }
+
+  public func assertValues(_ values: [Value], _ message: String = "",
+                           file: StaticString = #file, line: UInt = #line) {
+    XCTAssertEqual(values, self.values, message, file: file, line: line)
+  }
+
+  public func assertDidNotEmitValue(_ message: String = "Should not have emitted any values.",
+                                    file: StaticString = #file, line: UInt = #line) {
+    XCTAssertEqual(0, self.values.count, message, file: file, line: line)
+  }
+
+  public func assertDidNotFinish(_ message: String = "Should not have finished.",
+                                 file: StaticString = #file, line: UInt = #line) {
+    let isFinished = self.events.contains { e in
+      if case .finished = e {
+        return true
+      } else {
+        return false
+      }
+    }
+
+    XCTAssertFalse(isFinished, message, file: file, line: line)
   }
 }

--- a/Library/Paginate.swift
+++ b/Library/Paginate.swift
@@ -1,3 +1,4 @@
+import Combine
 import Prelude
 import ReactiveExtensions
 import ReactiveSwift
@@ -105,5 +106,40 @@ public func paginate<Cursor, Value: Equatable, Envelope, ErrorEnvelope, RequestP
     isLoading.signal,
     pageCount,
     errors.signal.skipNil()
+  )
+}
+
+public func paginate_combine<Cursor, Value: Equatable, Envelope, ErrorEnvelope, RequestParams>(
+  requestFirstPageWith _: any Publisher<RequestParams, Never>,
+  requestNextPageWhen _: any Publisher<(), Never>,
+  clearOnNewRequest _: Bool,
+  skipRepeats _: Bool = true,
+  valuesFromEnvelope _: @escaping ((Envelope) -> [Value]),
+  cursorFromEnvelope _: @escaping ((Envelope) -> Cursor),
+  requestFromParams _: @escaping ((RequestParams) -> any Publisher<Envelope, ErrorEnvelope>),
+  requestFromCursor _: @escaping ((Cursor) -> any Publisher<Envelope, ErrorEnvelope>),
+  concater _: @escaping (([Value], [Value]) -> [Value]) = (+)
+)
+  ->
+  (
+    paginatedValues: AnyPublisher<[Value], Never>,
+    isLoading: AnyPublisher<Bool, Never>,
+    pageCount: AnyPublisher<Int, Never>,
+    errors: AnyPublisher<ErrorEnvelope, Never>
+  ) {
+  let paginatedValues = Empty(completeImmediately: false, outputType: [Value].self, failureType: Never.self)
+    .eraseToAnyPublisher()
+  let isLoading = Empty(completeImmediately: false, outputType: Bool.self, failureType: Never.self)
+    .eraseToAnyPublisher()
+  let pageCount = Empty(completeImmediately: false, outputType: Int.self, failureType: Never.self)
+    .eraseToAnyPublisher()
+  let errors = Empty(completeImmediately: false, outputType: ErrorEnvelope.self, failureType: Never.self)
+    .eraseToAnyPublisher()
+
+  return (
+    paginatedValues,
+    isLoading,
+    pageCount,
+    errors
   )
 }


### PR DESCRIPTION
# 📲 What

This is a draft - but I'm working on creating a Combine-compatible version of Paginate.

# 🤔 Why

We'd like free reign to write new code in SwiftUI + Combine. However, given that some large and important sections of our app still use API V1, it's likely we will (at some point) need to write API V1 functionality _in Combine_. This code is a big part of making that possible.

# 🛠 How

By stubbing out a Combine-compatible version of `paginate`, and re-implementing some of the `paginate` test suite to run against it. This will guarantee that the new version behaves the same as the old version.

# ⏰ TODO

This is merely a stub; it isn't the actual implementation. 
