### PR TITLE
[MBL-1031] User Blocking Analytics

### DIFF
--- a/Kickstarter-iOS/Features/ProjectPage/Controller/ProjectPageViewController.swift
+++ b/Kickstarter-iOS/Features/ProjectPage/Controller/ProjectPageViewController.swift
@@ -329,7 +329,7 @@ public final class ProjectPageViewController: UIViewController, MessageBannerVie
       .observeValues { [weak self] project, _ in
         self?.navigationDelegate?.configureSharing(with: .project(project))
 
-        let watchProjectValue = WatchProjectValue(project, KSRAnalytics.PageContext.projectPage, nil)
+        let watchProjectValue = WatchProjectValue(project, KSRAnalytics.PageContext.project, nil)
 
         self?.navigationDelegate?.configureWatchProject(with: watchProjectValue)
       }

--- a/Kickstarter-iOS/Features/ProjectPage/Views/ProjectPageNavigationBarViewTests.swift
+++ b/Kickstarter-iOS/Features/ProjectPage/Views/ProjectPageNavigationBarViewTests.swift
@@ -28,7 +28,7 @@ internal final class ProjectPageNavBarViewTests: TestCase {
 
       let watchValue = WatchProjectValue(
         project: project,
-        context: .projectPage,
+        context: .project,
         discoveryParams: nil
       )
 
@@ -58,7 +58,7 @@ internal final class ProjectPageNavBarViewTests: TestCase {
 
       let watchValue = WatchProjectValue(
         project: project,
-        context: .projectPage,
+        context: .project,
         discoveryParams: nil
       )
 

--- a/Library/Tracking/KSRAnalytics.swift
+++ b/Library/Tracking/KSRAnalytics.swift
@@ -43,7 +43,7 @@ public final class KSRAnalytics {
     case onboarding // CategorySelectionViewController, CuratedProjectsViewController
     case pledgeAddNewCard = "pledge_add_new_card"
     case pledgeScreen = "pledge" // PledgeViewController
-    case projectPage = "project" // ProjectPageViewController
+    case project // ProjectPageViewController
     case profile // BackerDashboardProjectsViewController
     case rewards // RewardsViewController
     case search // SearchViewController
@@ -760,7 +760,7 @@ public final class KSRAnalytics {
   ) {
     let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
       .withAllValuesFrom(videoProperties(videoLength: videoLength, videoPosition: videoPosition))
-      .withAllValuesFrom(contextProperties(page: .projectPage))
+      .withAllValuesFrom(contextProperties(page: .project))
 
     self.track(
       event: SegmentEvent.videoPlaybackStarted.rawValue,
@@ -808,7 +808,7 @@ public final class KSRAnalytics {
     project: Project
   ) {
     let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
-      .withAllValuesFrom(contextProperties(page: .projectPage))
+      .withAllValuesFrom(contextProperties(page: .project))
 
     switch stateType {
     case .pledge:
@@ -1103,7 +1103,7 @@ public final class KSRAnalytics {
     sectionContext: KSRAnalytics.SectionContext
   ) {
     let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
-      .withAllValuesFrom(contextProperties(page: .projectPage, sectionContext: sectionContext))
+      .withAllValuesFrom(contextProperties(page: .project, sectionContext: sectionContext))
 
     self.track(
       event: SegmentEvent.pageViewed.rawValue,
@@ -1151,7 +1151,7 @@ public final class KSRAnalytics {
 
   public func trackGotoCreatorDetailsClicked(project: Project) {
     let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
-      .withAllValuesFrom(contextProperties(ctaContext: .creatorDetails, page: .projectPage))
+      .withAllValuesFrom(contextProperties(ctaContext: .creatorDetails, page: .project))
 
     self.track(
       event: SegmentEvent.ctaClicked.rawValue,
@@ -1165,7 +1165,7 @@ public final class KSRAnalytics {
    */
   public func trackCampaignDetailsButtonClicked(project: Project) {
     let props = projectProperties(from: project)
-      .withAllValuesFrom(contextProperties(ctaContext: .campaignDetails, page: .projectPage))
+      .withAllValuesFrom(contextProperties(ctaContext: .campaignDetails, page: .project))
 
     self.track(
       event: SegmentEvent.ctaClicked.rawValue,

--- a/Library/Tracking/KSRAnalytics.swift
+++ b/Library/Tracking/KSRAnalytics.swift
@@ -612,74 +612,32 @@ public final class KSRAnalytics {
   // MARK: - Block User Events
 
   /**
-   Call when a user attempts to block another user from a comment.
+   Call when a user attempts or succeeds  to block a user.
 
    - parameter project: The project being viewed.
+   - parameter page: The `PageContext` representing the specific area the UI is interacted in
+   - parameter sectionContext: The optional `SectionContext` representing the grouping of content
+   - parameter locationContext: The optional `LocationContext` representing additional details of the UI interaction
    - parameter typeContext: Additional information about where in the flow the event emitted.
    - parameter targetUserId: The uid of the user who is potentially being blocked.
    */
-  public func trackUserBlockedFromComment(
+
+  public func trackBlockedUser(
     _ project: Project,
+    page: KSRAnalytics.PageContext,
+    sectionContext: KSRAnalytics.SectionContext? = nil,
+    locationContext: KSRAnalytics.LocationContext? = nil,
     typeContext: KSRAnalytics.TypeContext,
     targetUserId: String
   ) {
     let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
       .withAllValuesFrom(contextProperties(
         ctaContext: .blockUser,
-        page: .project,
-        sectionContext: .comments,
-        typeContext: typeContext
-      ))
-      .withAllValuesFrom(interactionProperties(targetUserId: targetUserId))
-
-    self.track(
-      event: SegmentEvent.ctaClicked.rawValue,
-      properties: props
-    )
-  }
-
-  /**
-   Call when a user attempts to block another user from a project's overview page.
-
-   - parameter project: The project being viewed.
-   - parameter typeContext: Additional information about where in the flow the event emitted.
-   - parameter targetUserId: The uid of the user who is potentially being blocked.
-   */
-  public func trackUserBlockedFromProject(
-    _ project: Project,
-    typeContext: KSRAnalytics.TypeContext,
-    targetUserId: String
-  ) {
-    let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
-      .withAllValuesFrom(contextProperties(
-        ctaContext: .blockUser,
-        page: .project,
-        sectionContext: .overview,
+        page: page,
+        sectionContext: sectionContext,
         typeContext: typeContext,
-        locationContext: .creatorDetailsMenu
+        locationContext: locationContext
       ))
-      .withAllValuesFrom(interactionProperties(targetUserId: targetUserId))
-
-    self.track(
-      event: SegmentEvent.ctaClicked.rawValue,
-      properties: props
-    )
-  }
-
-  /**
-   Call when a user attempts to block another user from a message thread.
-
-   - parameter project: The project being viewed.
-   - parameter typeContext: Additional information about where in the flow the event emitted.
-   - parameter targetUserId: The uid of the user who is potentially being blocked.
-   */
-  public func trackUserBlockedFromMessage(
-    _ project: Project,
-    typeContext: KSRAnalytics.TypeContext,
-    targetUserId: String
-  ) {
-    let props = projectProperties(from: project, loggedInUser: self.loggedInUser)
-      .withAllValuesFrom(contextProperties(ctaContext: .blockUser, page: .messages, typeContext: typeContext))
       .withAllValuesFrom(interactionProperties(targetUserId: targetUserId))
 
     self.track(

--- a/Library/Tracking/KSRAnalytics.swift
+++ b/Library/Tracking/KSRAnalytics.swift
@@ -612,7 +612,7 @@ public final class KSRAnalytics {
   // MARK: - Block User Events
 
   /**
-   Call when a user attempts or succeeds  to block a user.
+   Call when a user attempts to block a user and when blocking succeeds
 
    - parameter project: The project being viewed.
    - parameter page: The `PageContext` representing the specific area the UI is interacted in

--- a/Library/Tracking/KSRAnalyticsTests.swift
+++ b/Library/Tracking/KSRAnalyticsTests.swift
@@ -484,14 +484,21 @@ final class KSRAnalyticsTests: TestCase {
 
   // MARK: - User Blocking Tests
 
-  func testTrackUserBlockedFromComment() {
+  func testTrackUserBlocked_FromComments() {
     let segmentClient = MockTrackingClient()
     let ksrAnalytics = KSRAnalytics(
       loggedInUser: nil,
       segmentClient: segmentClient, appTrackingTransparency: self.appTrackingTransparency
     )
 
-    ksrAnalytics.trackUserBlockedFromComment(.template, typeContext: .confirm, targetUserId: "2222")
+    ksrAnalytics
+      .trackBlockedUser(
+        Project.template,
+        page: .project,
+        sectionContext: .comments,
+        typeContext: .confirm,
+        targetUserId: "2222"
+      )
 
     XCTAssertEqual(["CTA Clicked"], segmentClient.events)
     XCTAssertEqual("block_user", segmentClient.properties.last?["context_cta"] as? String)
@@ -501,14 +508,21 @@ final class KSRAnalyticsTests: TestCase {
     XCTAssertEqual("2222", segmentClient.properties.last?["interaction_target_uid"] as? String)
   }
 
-  func testTrackUserBlockedFromProject() {
+  func testTrackUserBlocked_FromProject() {
     let segmentClient = MockTrackingClient()
     let ksrAnalytics = KSRAnalytics(
       loggedInUser: nil,
       segmentClient: segmentClient, appTrackingTransparency: self.appTrackingTransparency
     )
 
-    ksrAnalytics.trackUserBlockedFromProject(.template, typeContext: .initiate, targetUserId: "1111")
+    ksrAnalytics.trackBlockedUser(
+      Project.template,
+      page: .project,
+      sectionContext: .overview,
+      locationContext: .creatorDetailsMenu,
+      typeContext: .initiate,
+      targetUserId: "1111"
+    )
 
     XCTAssertEqual(["CTA Clicked"], segmentClient.events)
     XCTAssertEqual("block_user", segmentClient.properties.last?["context_cta"] as? String)
@@ -519,19 +533,24 @@ final class KSRAnalyticsTests: TestCase {
     XCTAssertEqual("1111", segmentClient.properties.last?["interaction_target_uid"] as? String)
   }
 
-  func testTrackUserBlockedFromMessage() {
+  func testTrackUserBlocked_FromMessages() {
     let segmentClient = MockTrackingClient()
     let ksrAnalytics = KSRAnalytics(
       loggedInUser: nil,
       segmentClient: segmentClient, appTrackingTransparency: self.appTrackingTransparency
     )
 
-    ksrAnalytics.trackUserBlockedFromMessage(.template, typeContext: .cancel, targetUserId: "3333")
+    ksrAnalytics.trackBlockedUser(
+      Project.template,
+      page: .messages,
+      typeContext: .confirm,
+      targetUserId: "3333"
+    )
 
     XCTAssertEqual(["CTA Clicked"], segmentClient.events)
     XCTAssertEqual("block_user", segmentClient.properties.last?["context_cta"] as? String)
     XCTAssertEqual("messages", segmentClient.properties.last?["context_page"] as? String)
-    XCTAssertEqual("cancel", segmentClient.properties.last?["context_type"] as? String)
+    XCTAssertEqual("confirm", segmentClient.properties.last?["context_type"] as? String)
     XCTAssertEqual("3333", segmentClient.properties.last?["interaction_target_uid"] as? String)
   }
 
@@ -1877,7 +1896,7 @@ final class KSRAnalyticsTests: TestCase {
       appTrackingTransparency: self.appTrackingTransparency
     )
 
-    ksrAnalytics.trackUserBlockedFromProject(.template, typeContext: .initiate, targetUserId: "1111")
+    ksrAnalytics.trackBlockedUser(.template, page: .project, typeContext: .initiate, targetUserId: "1111")
 
     XCTAssertEqual("1111", segmentClient.properties.last?["interaction_target_uid"] as? String)
   }

--- a/Library/Tracking/KSRAnalyticsTests.swift
+++ b/Library/Tracking/KSRAnalyticsTests.swift
@@ -482,6 +482,59 @@ final class KSRAnalyticsTests: TestCase {
     XCTAssertEqual("Art", segmentClientProperties?["project_category"] as? String)
   }
 
+  // MARK: - User Blocking Tests
+
+  func testTrackUserBlockedFromComment() {
+    let segmentClient = MockTrackingClient()
+    let ksrAnalytics = KSRAnalytics(
+      loggedInUser: nil,
+      segmentClient: segmentClient, appTrackingTransparency: self.appTrackingTransparency
+    )
+
+    ksrAnalytics.trackUserBlockedFromComment(.template, typeContext: .confirm, targetUserId: "2222")
+
+    XCTAssertEqual(["CTA Clicked"], segmentClient.events)
+    XCTAssertEqual("block_user", segmentClient.properties.last?["context_cta"] as? String)
+    XCTAssertEqual("project", segmentClient.properties.last?["context_page"] as? String)
+    XCTAssertEqual("comments", segmentClient.properties.last?["context_section"] as? String)
+    XCTAssertEqual("confirm", segmentClient.properties.last?["context_type"] as? String)
+    XCTAssertEqual("2222", segmentClient.properties.last?["interaction_target_uid"] as? String)
+  }
+
+  func testTrackUserBlockedFromProject() {
+    let segmentClient = MockTrackingClient()
+    let ksrAnalytics = KSRAnalytics(
+      loggedInUser: nil,
+      segmentClient: segmentClient, appTrackingTransparency: self.appTrackingTransparency
+    )
+
+    ksrAnalytics.trackUserBlockedFromProject(.template, typeContext: .initiate, targetUserId: "1111")
+
+    XCTAssertEqual(["CTA Clicked"], segmentClient.events)
+    XCTAssertEqual("block_user", segmentClient.properties.last?["context_cta"] as? String)
+    XCTAssertEqual("creator_details_menu", segmentClient.properties.last?["context_location"] as? String)
+    XCTAssertEqual("project", segmentClient.properties.last?["context_page"] as? String)
+    XCTAssertEqual("overview", segmentClient.properties.last?["context_section"] as? String)
+    XCTAssertEqual("initiate", segmentClient.properties.last?["context_type"] as? String)
+    XCTAssertEqual("1111", segmentClient.properties.last?["interaction_target_uid"] as? String)
+  }
+
+  func testTrackUserBlockedFromMessage() {
+    let segmentClient = MockTrackingClient()
+    let ksrAnalytics = KSRAnalytics(
+      loggedInUser: nil,
+      segmentClient: segmentClient, appTrackingTransparency: self.appTrackingTransparency
+    )
+
+    ksrAnalytics.trackUserBlockedFromMessage(.template, typeContext: .cancel, targetUserId: "3333")
+
+    XCTAssertEqual(["CTA Clicked"], segmentClient.events)
+    XCTAssertEqual("block_user", segmentClient.properties.last?["context_cta"] as? String)
+    XCTAssertEqual("messages", segmentClient.properties.last?["context_page"] as? String)
+    XCTAssertEqual("cancel", segmentClient.properties.last?["context_type"] as? String)
+    XCTAssertEqual("3333", segmentClient.properties.last?["interaction_target_uid"] as? String)
+  }
+
   // MARK: - Discovery Properties Tests
 
   func testDiscoveryProperties() {
@@ -1815,6 +1868,18 @@ final class KSRAnalyticsTests: TestCase {
     XCTAssertEqual("discover", segmentClient.properties.last?["context_cta"] as? String)
     XCTAssertEqual("global_nav", segmentClient.properties.last?["context_location"] as? String)
     XCTAssertEqual("search", segmentClient.properties.last?["context_page"] as? String)
+  }
+
+  func testInteractionProperties() {
+    let segmentClient = MockTrackingClient()
+    let ksrAnalytics = KSRAnalytics(
+      segmentClient: segmentClient,
+      appTrackingTransparency: self.appTrackingTransparency
+    )
+
+    ksrAnalytics.trackUserBlockedFromProject(.template, typeContext: .initiate, targetUserId: "1111")
+
+    XCTAssertEqual("1111", segmentClient.properties.last?["interaction_target_uid"] as? String)
   }
 
   func testContextLocationProperties() {

--- a/Library/Tracking/KSRAnalyticsTests.swift
+++ b/Library/Tracking/KSRAnalyticsTests.swift
@@ -984,7 +984,7 @@ final class KSRAnalyticsTests: TestCase {
 
     ksrAnalytics.trackWatchProjectButtonClicked(
       project: .template,
-      page: .projectPage,
+      page: .project,
       typeContext: .watch
     )
 
@@ -1005,7 +1005,7 @@ final class KSRAnalyticsTests: TestCase {
 
     ksrAnalytics.trackWatchProjectButtonClicked(
       project: .template,
-      page: .projectPage,
+      page: .project,
       typeContext: .unwatch
     )
 

--- a/Library/ViewModels/CommentRepliesViewModel.swift
+++ b/Library/ViewModels/CommentRepliesViewModel.swift
@@ -265,6 +265,23 @@ public final class CommentRepliesViewModel: CommentRepliesViewModelType,
 
     // TODO: Display proper error messaging from the backend
     self.didBlockUserError = blockUserEvent.errors().ignoreValues()
+
+    // MARK: User Blocking Analytics
+
+    _ = self.blockUserProperty.signal
+      .combineLatest(with: project)
+      .observeValues { blockedUserId, project in
+        AppEnvironment.current.ksrAnalytics
+          .trackUserBlockedFromComment(project, typeContext: .initiate, targetUserId: "\(blockedUserId)")
+      }
+
+    _ = self.blockUserProperty.signal
+      .combineLatest(with: project)
+      .takeWhen(blockUserEvent.values().ignoreValues())
+      .observeValues { blockedUserId, project in
+        AppEnvironment.current.ksrAnalytics
+          .trackUserBlockedFromComment(project, typeContext: .confirm, targetUserId: "\(blockedUserId)")
+      }
   }
 
   private let blockUserProperty = MutableProperty<String>("")

--- a/Library/ViewModels/CommentRepliesViewModel.swift
+++ b/Library/ViewModels/CommentRepliesViewModel.swift
@@ -272,7 +272,13 @@ public final class CommentRepliesViewModel: CommentRepliesViewModelType,
       .combineLatest(with: project)
       .observeValues { blockedUserId, project in
         AppEnvironment.current.ksrAnalytics
-          .trackUserBlockedFromComment(project, typeContext: .initiate, targetUserId: "\(blockedUserId)")
+          .trackBlockedUser(
+            project,
+            page: .project,
+            sectionContext: .comments,
+            typeContext: .initiate,
+            targetUserId: "\(blockedUserId)"
+          )
       }
 
     _ = self.blockUserProperty.signal
@@ -280,7 +286,13 @@ public final class CommentRepliesViewModel: CommentRepliesViewModelType,
       .takeWhen(blockUserEvent.values().ignoreValues())
       .observeValues { blockedUserId, project in
         AppEnvironment.current.ksrAnalytics
-          .trackUserBlockedFromComment(project, typeContext: .confirm, targetUserId: "\(blockedUserId)")
+          .trackBlockedUser(
+            project,
+            page: .project,
+            sectionContext: .comments,
+            typeContext: .confirm,
+            targetUserId: "\(blockedUserId)"
+          )
       }
   }
 

--- a/Library/ViewModels/CommentRepliesViewModelTests.swift
+++ b/Library/ViewModels/CommentRepliesViewModelTests.swift
@@ -172,6 +172,93 @@ internal final class CommentRepliesViewModelTests: TestCase {
     }
   }
 
+  func testTrackUserBlockedFromComment_InitialEventEmitted() {
+    let segmentClient = MockTrackingClient()
+    let ksrAnalytics = KSRAnalytics(
+      config: .template,
+      loggedInUser: User.template,
+      segmentClient: segmentClient,
+      appTrackingTransparency: MockAppTrackingTransparency()
+    )
+
+    withEnvironment(currentUser: .template, ksrAnalytics: ksrAnalytics) {
+      self.vm.inputs
+        .configureWith(
+          comment: .template,
+          project: .template,
+          update: nil,
+          inputAreaBecomeFirstResponder: false,
+          replyId: nil
+        )
+
+      self.vm.inputs.viewDidLoad()
+      self.vm.inputs.viewDidAppear()
+
+      self.vm.inputs.viewDidLoad()
+
+      self.vm.inputs.blockUser(id: "111")
+
+      self.scheduler.advance()
+
+      XCTAssertEqual(segmentClient.events, ["CTA Clicked"])
+
+      XCTAssertEqual(segmentClient.properties(forKey: "session_user_is_logged_in", as: Bool.self), [true])
+      XCTAssertEqual(segmentClient.properties(forKey: "user_uid", as: String.self), ["\(User.template.id)"])
+      XCTAssertEqual(segmentClient.properties(forKey: "context_cta"), ["block_user"])
+      XCTAssertEqual(segmentClient.properties(forKey: "context_page"), ["project"])
+      XCTAssertEqual(segmentClient.properties(forKey: "context_section"), ["comments"])
+      XCTAssertEqual(segmentClient.properties(forKey: "context_type"), ["initiate"])
+      XCTAssertEqual(segmentClient.properties(forKey: "interaction_target_uid"), ["111"])
+    }
+  }
+
+  func testTrackUserBlockedFromComment_ConfirmEventEmitted() {
+    let segmentClient = MockTrackingClient()
+    let ksrAnalytics = KSRAnalytics(
+      config: .template,
+      loggedInUser: User.template,
+      segmentClient: segmentClient,
+      appTrackingTransparency: MockAppTrackingTransparency()
+    )
+
+    withEnvironment(
+      apiService: MockService(blockUserResult: .success(EmptyResponseEnvelope())),
+      currentUser: .template,
+      ksrAnalytics: ksrAnalytics
+    ) {
+      self.vm.inputs
+        .configureWith(
+          comment: .template,
+          project: .template,
+          update: nil,
+          inputAreaBecomeFirstResponder: false,
+          replyId: nil
+        )
+
+      self.vm.inputs.viewDidLoad()
+      self.vm.inputs.viewDidAppear()
+
+      self.vm.inputs.viewDidLoad()
+
+      self.vm.inputs.blockUser(id: "111")
+
+      self.scheduler.advance()
+
+      XCTAssertEqual(segmentClient.events, ["CTA Clicked", "CTA Clicked"])
+
+      XCTAssertEqual(
+        segmentClient.properties(forKey: "session_user_is_logged_in", as: Bool.self),
+        [true, true]
+      )
+      XCTAssertEqual(segmentClient.properties(forKey: "user_uid", as: String.self), ["1", "1"])
+      XCTAssertEqual(segmentClient.properties(forKey: "context_cta"), ["block_user", "block_user"])
+      XCTAssertEqual(segmentClient.properties(forKey: "context_page"), ["project", "project"])
+      XCTAssertEqual(segmentClient.properties(forKey: "context_section"), ["comments", "comments"])
+      XCTAssertEqual(segmentClient.properties(forKey: "context_type"), ["initiate", "confirm"])
+      XCTAssertEqual(segmentClient.properties(forKey: "interaction_target_uid"), ["111", "111"])
+    }
+  }
+
   func testOutput_ConfigureCommentComposerViewWithData_IsLoggedIn_IsBacking_False_HasBlockedCommentComposer() {
     let user = User.template |> \.id .~ 12_345
 

--- a/Library/ViewModels/CommentRepliesViewModelTests.swift
+++ b/Library/ViewModels/CommentRepliesViewModelTests.swift
@@ -172,47 +172,7 @@ internal final class CommentRepliesViewModelTests: TestCase {
     }
   }
 
-  func testTrackUserBlockedFromComment_InitialEventEmitted() {
-    let segmentClient = MockTrackingClient()
-    let ksrAnalytics = KSRAnalytics(
-      config: .template,
-      loggedInUser: User.template,
-      segmentClient: segmentClient,
-      appTrackingTransparency: MockAppTrackingTransparency()
-    )
-
-    withEnvironment(currentUser: .template, ksrAnalytics: ksrAnalytics) {
-      self.vm.inputs
-        .configureWith(
-          comment: .template,
-          project: .template,
-          update: nil,
-          inputAreaBecomeFirstResponder: false,
-          replyId: nil
-        )
-
-      self.vm.inputs.viewDidLoad()
-      self.vm.inputs.viewDidAppear()
-
-      self.vm.inputs.viewDidLoad()
-
-      self.vm.inputs.blockUser(id: "111")
-
-      self.scheduler.advance()
-
-      XCTAssertEqual(segmentClient.events, ["CTA Clicked"])
-
-      XCTAssertEqual(segmentClient.properties(forKey: "session_user_is_logged_in", as: Bool.self), [true])
-      XCTAssertEqual(segmentClient.properties(forKey: "user_uid", as: String.self), ["\(User.template.id)"])
-      XCTAssertEqual(segmentClient.properties(forKey: "context_cta"), ["block_user"])
-      XCTAssertEqual(segmentClient.properties(forKey: "context_page"), ["project"])
-      XCTAssertEqual(segmentClient.properties(forKey: "context_section"), ["comments"])
-      XCTAssertEqual(segmentClient.properties(forKey: "context_type"), ["initiate"])
-      XCTAssertEqual(segmentClient.properties(forKey: "interaction_target_uid"), ["111"])
-    }
-  }
-
-  func testTrackUserBlockedFromComment_ConfirmEventEmitted() {
+  func testTrackUserBlockedFromComment_EventsEmitted() {
     let segmentClient = MockTrackingClient()
     let ksrAnalytics = KSRAnalytics(
       config: .template,

--- a/Library/ViewModels/CommentsViewModel.swift
+++ b/Library/ViewModels/CommentsViewModel.swift
@@ -374,6 +374,23 @@ public final class CommentsViewModel: CommentsViewModelType,
 
     // TODO: Display proper error messaging from the backend
     self.didBlockUserError = blockUserEvent.errors().ignoreValues()
+
+    // MARK: User Blocking Analytics
+
+    _ = self.blockUserProperty.signal
+      .combineLatest(with: initialProject)
+      .observeValues { blockedUserId, project in
+        AppEnvironment.current.ksrAnalytics
+          .trackUserBlockedFromComment(project, typeContext: .initiate, targetUserId: "\(blockedUserId)")
+      }
+
+    _ = self.blockUserProperty.signal
+      .combineLatest(with: initialProject)
+      .takeWhen(blockUserEvent.values().ignoreValues())
+      .observeValues { blockedUserId, project in
+        AppEnvironment.current.ksrAnalytics
+          .trackUserBlockedFromComment(project, typeContext: .confirm, targetUserId: "\(blockedUserId)")
+      }
   }
 
   // Properties to assist with injecting these values into the existing data streams.

--- a/Library/ViewModels/CommentsViewModel.swift
+++ b/Library/ViewModels/CommentsViewModel.swift
@@ -381,7 +381,13 @@ public final class CommentsViewModel: CommentsViewModelType,
       .combineLatest(with: initialProject)
       .observeValues { blockedUserId, project in
         AppEnvironment.current.ksrAnalytics
-          .trackUserBlockedFromComment(project, typeContext: .initiate, targetUserId: "\(blockedUserId)")
+          .trackBlockedUser(
+            project,
+            page: .project,
+            sectionContext: .comments,
+            typeContext: .initiate,
+            targetUserId: "\(blockedUserId)"
+          )
       }
 
     _ = self.blockUserProperty.signal
@@ -389,7 +395,13 @@ public final class CommentsViewModel: CommentsViewModelType,
       .takeWhen(blockUserEvent.values().ignoreValues())
       .observeValues { blockedUserId, project in
         AppEnvironment.current.ksrAnalytics
-          .trackUserBlockedFromComment(project, typeContext: .confirm, targetUserId: "\(blockedUserId)")
+          .trackBlockedUser(
+            project,
+            page: .project,
+            sectionContext: .comments,
+            typeContext: .confirm,
+            targetUserId: "\(blockedUserId)"
+          )
       }
   }
 

--- a/Library/ViewModels/CommentsViewModelTests.swift
+++ b/Library/ViewModels/CommentsViewModelTests.swift
@@ -191,6 +191,73 @@ internal final class CommentsViewModelTests: TestCase {
     }
   }
 
+  func testTrackUserBlockedFromComment_InitialEventEmitted() {
+    let segmentClient = MockTrackingClient()
+    let ksrAnalytics = KSRAnalytics(
+      config: .template,
+      loggedInUser: User.template,
+      segmentClient: segmentClient,
+      appTrackingTransparency: MockAppTrackingTransparency()
+    )
+
+    withEnvironment(currentUser: .template, ksrAnalytics: ksrAnalytics) {
+      self.vm.inputs.configureWith(project: .template, update: nil)
+
+      self.vm.inputs.viewDidLoad()
+
+      self.vm.inputs.blockUser(id: "111")
+
+      self.scheduler.advance()
+
+      XCTAssertEqual(segmentClient.events, ["CTA Clicked"])
+
+      XCTAssertEqual(segmentClient.properties(forKey: "session_user_is_logged_in", as: Bool.self), [true])
+      XCTAssertEqual(segmentClient.properties(forKey: "user_uid", as: String.self), ["\(User.template.id)"])
+      XCTAssertEqual(segmentClient.properties(forKey: "context_cta"), ["block_user"])
+      XCTAssertEqual(segmentClient.properties(forKey: "context_page"), ["project"])
+      XCTAssertEqual(segmentClient.properties(forKey: "context_section"), ["comments"])
+      XCTAssertEqual(segmentClient.properties(forKey: "context_type"), ["initiate"])
+      XCTAssertEqual(segmentClient.properties(forKey: "interaction_target_uid"), ["111"])
+    }
+  }
+
+  func testTrackUserBlockedFromComment_ConfirmEventEmitted() {
+    let segmentClient = MockTrackingClient()
+    let ksrAnalytics = KSRAnalytics(
+      config: .template,
+      loggedInUser: User.template,
+      segmentClient: segmentClient,
+      appTrackingTransparency: MockAppTrackingTransparency()
+    )
+
+    withEnvironment(
+      apiService: MockService(blockUserResult: .success(EmptyResponseEnvelope())),
+      currentUser: .template,
+      ksrAnalytics: ksrAnalytics
+    ) {
+      self.vm.inputs.configureWith(project: .template, update: nil)
+
+      self.vm.inputs.viewDidLoad()
+
+      self.vm.inputs.blockUser(id: "111")
+
+      self.scheduler.advance()
+
+      XCTAssertEqual(segmentClient.events, ["CTA Clicked", "CTA Clicked"])
+
+      XCTAssertEqual(
+        segmentClient.properties(forKey: "session_user_is_logged_in", as: Bool.self),
+        [true, true]
+      )
+      XCTAssertEqual(segmentClient.properties(forKey: "user_uid", as: String.self), ["1", "1"])
+      XCTAssertEqual(segmentClient.properties(forKey: "context_cta"), ["block_user", "block_user"])
+      XCTAssertEqual(segmentClient.properties(forKey: "context_page"), ["project", "project"])
+      XCTAssertEqual(segmentClient.properties(forKey: "context_section"), ["comments", "comments"])
+      XCTAssertEqual(segmentClient.properties(forKey: "context_type"), ["initiate", "confirm"])
+      XCTAssertEqual(segmentClient.properties(forKey: "interaction_target_uid"), ["111", "111"])
+    }
+  }
+
   func testCommentComposerHidden_WhenUserIsNotLoggedIn() {
     withEnvironment(currentUser: nil) {
       self.vm.inputs.configureWith(project: .template, update: nil)

--- a/Library/ViewModels/CommentsViewModelTests.swift
+++ b/Library/ViewModels/CommentsViewModelTests.swift
@@ -191,37 +191,7 @@ internal final class CommentsViewModelTests: TestCase {
     }
   }
 
-  func testTrackUserBlockedFromComment_InitialEventEmitted() {
-    let segmentClient = MockTrackingClient()
-    let ksrAnalytics = KSRAnalytics(
-      config: .template,
-      loggedInUser: User.template,
-      segmentClient: segmentClient,
-      appTrackingTransparency: MockAppTrackingTransparency()
-    )
-
-    withEnvironment(currentUser: .template, ksrAnalytics: ksrAnalytics) {
-      self.vm.inputs.configureWith(project: .template, update: nil)
-
-      self.vm.inputs.viewDidLoad()
-
-      self.vm.inputs.blockUser(id: "111")
-
-      self.scheduler.advance()
-
-      XCTAssertEqual(segmentClient.events, ["CTA Clicked"])
-
-      XCTAssertEqual(segmentClient.properties(forKey: "session_user_is_logged_in", as: Bool.self), [true])
-      XCTAssertEqual(segmentClient.properties(forKey: "user_uid", as: String.self), ["\(User.template.id)"])
-      XCTAssertEqual(segmentClient.properties(forKey: "context_cta"), ["block_user"])
-      XCTAssertEqual(segmentClient.properties(forKey: "context_page"), ["project"])
-      XCTAssertEqual(segmentClient.properties(forKey: "context_section"), ["comments"])
-      XCTAssertEqual(segmentClient.properties(forKey: "context_type"), ["initiate"])
-      XCTAssertEqual(segmentClient.properties(forKey: "interaction_target_uid"), ["111"])
-    }
-  }
-
-  func testTrackUserBlockedFromComment_ConfirmEventEmitted() {
+  func testTrackUserBlockedFromComment_EventsEmitted() {
     let segmentClient = MockTrackingClient()
     let ksrAnalytics = KSRAnalytics(
       config: .template,

--- a/Library/ViewModels/MessagesViewModel.swift
+++ b/Library/ViewModels/MessagesViewModel.swift
@@ -220,6 +220,23 @@ public final class MessagesViewModel: MessagesViewModelType, MessagesViewModelIn
 
     // TODO: Display proper error messaging from the backend
     self.didBlockUserError = blockUserEvent.errors().ignoreValues()
+
+    // MARK: User Blocking Analytics
+
+    _ = self.blockUserProperty.signal
+      .combineLatest(with: self.project)
+      .observeValues { blockedUserId, project in
+        AppEnvironment.current.ksrAnalytics
+          .trackUserBlockedFromMessage(project, typeContext: .initiate, targetUserId: "\(blockedUserId)")
+      }
+
+    _ = self.blockUserProperty.signal
+      .combineLatest(with: self.project)
+      .takeWhen(blockUserEvent.values().ignoreValues())
+      .observeValues { blockedUserId, project in
+        AppEnvironment.current.ksrAnalytics
+          .trackUserBlockedFromMessage(project, typeContext: .confirm, targetUserId: "\(blockedUserId)")
+      }
   }
 
   private let backingInfoPressedProperty = MutableProperty(())

--- a/Library/ViewModels/MessagesViewModel.swift
+++ b/Library/ViewModels/MessagesViewModel.swift
@@ -227,7 +227,12 @@ public final class MessagesViewModel: MessagesViewModelType, MessagesViewModelIn
       .combineLatest(with: self.project)
       .observeValues { blockedUserId, project in
         AppEnvironment.current.ksrAnalytics
-          .trackUserBlockedFromMessage(project, typeContext: .initiate, targetUserId: "\(blockedUserId)")
+          .trackBlockedUser(
+            project,
+            page: .messages,
+            typeContext: .initiate,
+            targetUserId: "\(blockedUserId)"
+          )
       }
 
     _ = self.blockUserProperty.signal
@@ -235,7 +240,7 @@ public final class MessagesViewModel: MessagesViewModelType, MessagesViewModelIn
       .takeWhen(blockUserEvent.values().ignoreValues())
       .observeValues { blockedUserId, project in
         AppEnvironment.current.ksrAnalytics
-          .trackUserBlockedFromMessage(project, typeContext: .confirm, targetUserId: "\(blockedUserId)")
+          .trackBlockedUser(project, page: .messages, typeContext: .confirm, targetUserId: "\(blockedUserId)")
       }
   }
 

--- a/Library/ViewModels/MessagesViewModelTests.swift
+++ b/Library/ViewModels/MessagesViewModelTests.swift
@@ -384,36 +384,7 @@ internal final class MessagesViewModelTests: TestCase {
     }
   }
 
-  func testTrackUserBlockedFromMessage_InitialEventEmitted() {
-    let segmentClient = MockTrackingClient()
-    let ksrAnalytics = KSRAnalytics(
-      config: .template,
-      loggedInUser: User.template,
-      segmentClient: segmentClient,
-      appTrackingTransparency: MockAppTrackingTransparency()
-    )
-
-    withEnvironment(currentUser: .template, ksrAnalytics: ksrAnalytics) {
-      self.vm.inputs.configureWith(data: .right((project: .template, backing: .template)))
-
-      self.vm.inputs.viewDidLoad()
-
-      self.vm.inputs.blockUser(id: "111")
-
-      self.scheduler.advance()
-
-      XCTAssertEqual(segmentClient.events, ["CTA Clicked"])
-
-      XCTAssertEqual(segmentClient.properties(forKey: "session_user_is_logged_in", as: Bool.self), [true])
-      XCTAssertEqual(segmentClient.properties(forKey: "user_uid", as: String.self), ["\(User.template.id)"])
-      XCTAssertEqual(segmentClient.properties(forKey: "context_cta"), ["block_user"])
-      XCTAssertEqual(segmentClient.properties(forKey: "context_page"), ["messages"])
-      XCTAssertEqual(segmentClient.properties(forKey: "context_type"), ["initiate"])
-      XCTAssertEqual(segmentClient.properties(forKey: "interaction_target_uid"), ["111"])
-    }
-  }
-
-  func testTrackUserBlockedFromMessage_ConfirmEventEmitted() {
+  func testTrackUserBlockedFromMessage_EventsEmitted() {
     let segmentClient = MockTrackingClient()
     let ksrAnalytics = KSRAnalytics(
       config: .template,

--- a/Library/ViewModels/ProjectPageViewModel.swift
+++ b/Library/ViewModels/ProjectPageViewModel.swift
@@ -526,7 +526,14 @@ public final class ProjectPageViewModel: ProjectPageViewModelType, ProjectPageVi
       .combineLatest(with: project)
       .observeValues { blockedUserId, project in
         AppEnvironment.current.ksrAnalytics
-          .trackUserBlockedFromProject(project, typeContext: .initiate, targetUserId: "\(blockedUserId)")
+          .trackBlockedUser(
+            project,
+            page: .project,
+            sectionContext: .overview,
+            locationContext: .creatorDetailsMenu,
+            typeContext: .initiate,
+            targetUserId: "\(blockedUserId)"
+          )
       }
 
     _ = self.blockUserProperty.signal
@@ -534,7 +541,14 @@ public final class ProjectPageViewModel: ProjectPageViewModelType, ProjectPageVi
       .takeWhen(blockUserEvent.values().ignoreValues())
       .observeValues { blockedUserId, project in
         AppEnvironment.current.ksrAnalytics
-          .trackUserBlockedFromProject(project, typeContext: .confirm, targetUserId: "\(blockedUserId)")
+          .trackBlockedUser(
+            project,
+            page: .project,
+            sectionContext: .overview,
+            locationContext: .creatorDetailsMenu,
+            typeContext: .confirm,
+            targetUserId: "\(blockedUserId)"
+          )
       }
   }
 

--- a/Library/ViewModels/ProjectPageViewModel.swift
+++ b/Library/ViewModels/ProjectPageViewModel.swift
@@ -519,6 +519,23 @@ public final class ProjectPageViewModel: ProjectPageViewModelType, ProjectPageVi
 
     // TODO: Display proper error messaging from the backend
     self.didBlockUserError = blockUserEvent.errors().ignoreValues()
+
+    // MARK: User Blocking Analytics
+
+    _ = self.blockUserProperty.signal
+      .combineLatest(with: project)
+      .observeValues { blockedUserId, project in
+        AppEnvironment.current.ksrAnalytics
+          .trackUserBlockedFromProject(project, typeContext: .initiate, targetUserId: "\(blockedUserId)")
+      }
+
+    _ = self.blockUserProperty.signal
+      .combineLatest(with: project)
+      .takeWhen(blockUserEvent.values().ignoreValues())
+      .observeValues { blockedUserId, project in
+        AppEnvironment.current.ksrAnalytics
+          .trackUserBlockedFromProject(project, typeContext: .confirm, targetUserId: "\(blockedUserId)")
+      }
   }
 
   fileprivate let askAQuestionCellTappedProperty = MutableProperty(())

--- a/Library/ViewModels/ProjectPageViewModelTests.swift
+++ b/Library/ViewModels/ProjectPageViewModelTests.swift
@@ -2017,45 +2017,7 @@ final class ProjectPageViewModelTests: TestCase {
     self.goToURL.assertValue(url)
   }
 
-  func testTrackUserBlockedFromProject_InitialEventTracked() {
-    let segmentClient = MockTrackingClient()
-    let ksrAnalytics = KSRAnalytics(
-      config: .template,
-      loggedInUser: User.template,
-      segmentClient: segmentClient,
-      appTrackingTransparency: MockAppTrackingTransparency()
-    )
-
-    let projectPamphletData = Project.ProjectPamphletData(project: .template, backingId: nil)
-
-    withEnvironment(
-      apiService: MockService(
-        fetchProjectPamphletResult: .success(projectPamphletData)
-      ),
-      currentUser: User.template,
-      ksrAnalytics: ksrAnalytics
-    ) {
-      self.vm.inputs.configureWith(projectOrParam: .left(.template), refTag: .discovery)
-      self.vm.inputs.viewDidLoad()
-      self.vm.inputs.viewDidAppear(animated: false)
-      self.vm.inputs.blockUser(id: 111)
-
-      self.scheduler.advance()
-
-      XCTAssertEqual(segmentClient.events, ["CTA Clicked"])
-
-      XCTAssertEqual(segmentClient.properties(forKey: "session_user_is_logged_in", as: Bool.self), [true])
-      XCTAssertEqual(segmentClient.properties(forKey: "user_uid", as: String.self), ["\(User.template.id)"])
-      XCTAssertEqual(segmentClient.properties(forKey: "context_cta"), ["block_user"])
-      XCTAssertEqual(segmentClient.properties(forKey: "context_location"), ["creator_details_menu"])
-      XCTAssertEqual(segmentClient.properties(forKey: "context_page"), ["project"])
-      XCTAssertEqual(segmentClient.properties(forKey: "context_section"), ["overview"])
-      XCTAssertEqual(segmentClient.properties(forKey: "context_type"), ["initiate"])
-      XCTAssertEqual(segmentClient.properties(forKey: "interaction_target_uid"), ["111"])
-    }
-  }
-
-  func testTrackUserBlockedFromProject_ConfirmedEventTracked() {
+  func testTrackUserBlockedFromProject_EventsEmitted() {
     let segmentClient = MockTrackingClient()
     let ksrAnalytics = KSRAnalytics(
       config: .template,

--- a/Library/ViewModels/WatchProjectViewModelTests.swift
+++ b/Library/ViewModels/WatchProjectViewModelTests.swift
@@ -35,7 +35,7 @@ internal final class WatchProjectViewModelTests: TestCase {
 
   func testSaveAlertNotification() {
     withEnvironment(currentUser: .template) {
-      self.vm.inputs.configure(with: (.template, .projectPage, nil))
+      self.vm.inputs.configure(with: (.template, .project, nil))
       self.vm.inputs.viewDidLoad()
       self.vm.inputs.saveButtonTapped(selected: true)
       self.scheduler.advance(by: .seconds(1))
@@ -45,7 +45,7 @@ internal final class WatchProjectViewModelTests: TestCase {
 
   func testGenerateImpactFeedback() {
     withEnvironment(currentUser: .template) {
-      self.vm.inputs.configure(with: (.template, .projectPage, nil))
+      self.vm.inputs.configure(with: (.template, .project, nil))
       self.vm.inputs.viewDidLoad()
 
       self.vm.inputs.saveButtonTouched()
@@ -55,7 +55,7 @@ internal final class WatchProjectViewModelTests: TestCase {
 
   func testGenerateSelectionFeedback() {
     withEnvironment(currentUser: .template) {
-      self.vm.inputs.configure(with: (.template, .projectPage, nil))
+      self.vm.inputs.configure(with: (.template, .project, nil))
       self.vm.inputs.viewDidLoad()
 
       self.vm.inputs.saveButtonTapped(selected: true)
@@ -67,7 +67,7 @@ internal final class WatchProjectViewModelTests: TestCase {
 
   func testGenerateNotificationSuccessFeedback() {
     withEnvironment(currentUser: .template) {
-      self.vm.inputs.configure(with: (.template, .projectPage, nil))
+      self.vm.inputs.configure(with: (.template, .project, nil))
       self.vm.inputs.viewDidLoad()
 
       self.vm.inputs.saveButtonTapped(selected: false)
@@ -84,7 +84,7 @@ internal final class WatchProjectViewModelTests: TestCase {
       apiService: MockService(watchProjectMutationResult: .failure(.couldNotParseJSON)),
       currentUser: .template
     ) {
-      self.vm.inputs.configure(with: (project, .projectPage, nil))
+      self.vm.inputs.configure(with: (project, .project, nil))
       self.vm.inputs.viewDidLoad()
 
       self.saveButtonSelected.assertValues([false], "Save button is not selected at first.")
@@ -114,7 +114,7 @@ internal final class WatchProjectViewModelTests: TestCase {
       apiService: MockService(unwatchProjectMutationResult: .success(.unwatchTemplate)),
       currentUser: .template
     ) {
-      self.vm.inputs.configure(with: (project, .projectPage, nil))
+      self.vm.inputs.configure(with: (project, .project, nil))
       self.vm.inputs.viewDidLoad()
 
       XCTAssertEqual(self.postNotificationWithProject.lastValue!.watchesCount, 1)
@@ -142,7 +142,7 @@ internal final class WatchProjectViewModelTests: TestCase {
       apiService: MockService(unwatchProjectMutationResult: .success(.unwatchTemplate)),
       currentUser: .template
     ) {
-      self.vm.inputs.configure(with: (project, .projectPage, nil))
+      self.vm.inputs.configure(with: (project, .project, nil))
       self.vm.inputs.viewDidLoad()
 
       self.saveButtonSelected.assertValues([true], "Save button is selected at first.")
@@ -179,7 +179,7 @@ internal final class WatchProjectViewModelTests: TestCase {
       |> Project.lens.personalization.isStarred .~ false
 
     withEnvironment(apiService: MockService(watchProjectMutationResult: .success(.watchTemplate))) {
-      self.vm.inputs.configure(with: (project, .projectPage, nil))
+      self.vm.inputs.configure(with: (project, .project, nil))
       self.vm.inputs.viewDidLoad()
 
       self.saveButtonSelected.assertValues([false], "Save button is not selected for logged out user.")
@@ -235,7 +235,7 @@ internal final class WatchProjectViewModelTests: TestCase {
     let projectUpdated = project
       |> Project.lens.personalization.isStarred .~ true
 
-    self.vm.inputs.configure(with: (project, .projectPage, nil))
+    self.vm.inputs.configure(with: (project, .project, nil))
     self.vm.inputs.viewDidLoad()
 
     self.saveButtonSelected.assertValues([false])
@@ -249,7 +249,7 @@ internal final class WatchProjectViewModelTests: TestCase {
     let user = User.template |> \.stats.starredProjectsCount .~ 0
 
     withEnvironment(currentUser: user) {
-      self.vm.inputs.configure(with: (.template, .projectPage, nil))
+      self.vm.inputs.configure(with: (.template, .project, nil))
       self.vm.inputs.viewDidLoad()
 
       self.vm.inputs.saveButtonTapped(selected: false)
@@ -264,7 +264,7 @@ internal final class WatchProjectViewModelTests: TestCase {
     let user = User.template |> \.stats.starredProjectsCount .~ 3
 
     withEnvironment(currentUser: user) {
-      self.vm.inputs.configure(with: (project, .projectPage, nil))
+      self.vm.inputs.configure(with: (project, .project, nil))
       self.vm.inputs.viewDidLoad()
 
       self.vm.inputs.saveButtonTapped(selected: true)
@@ -281,7 +281,7 @@ internal final class WatchProjectViewModelTests: TestCase {
       |> Project.lens.personalization.isStarred .~ false
 
     withEnvironment(apiService: MockService(watchProjectMutationResult: .success(.watchTemplate))) {
-      self.vm.inputs.configure(with: (project, .projectPage, nil))
+      self.vm.inputs.configure(with: (project, .project, nil))
       self.vm.inputs.viewDidLoad()
 
       self.saveButtonSelected.assertValues([false], "Save button is not selected at first")
@@ -356,7 +356,7 @@ internal final class WatchProjectViewModelTests: TestCase {
       |> Project.lens.dates.deadline .~ (MockDate().date.timeIntervalSince1970 + 60.0 * 60.0 * 24.0)
 
     withEnvironment(apiService: MockService(watchProjectMutationResult: .success(.watchTemplate))) {
-      self.vm.inputs.configure(with: (project, .projectPage, nil))
+      self.vm.inputs.configure(with: (project, .project, nil))
       self.vm.inputs.viewDidLoad()
 
       self.vm.inputs.saveButtonTapped(selected: false)
@@ -385,7 +385,7 @@ internal final class WatchProjectViewModelTests: TestCase {
       |> Project.lens.watchesCount .~ 8
 
     withEnvironment(apiService: MockService(watchProjectMutationResult: .success(.watchTemplate))) {
-      self.vm.inputs.configure(with: (project, .projectPage, nil))
+      self.vm.inputs.configure(with: (project, .project, nil))
       self.vm.inputs.viewDidLoad()
 
       self.postNotificationWithProject.assertValueCount(1)


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Adding a new `trackBlockedUser` segment event around in our user blocking flow.
[Event definition doc](https://kickstarter.atlassian.net/wiki/spaces/IN/pages/2548301877/User+Blocking+Flow) from the insights team

I also included an unrelated property name update here that is just a cleanup.

# 🤔 Why

This flow doesn't have any analytic events, and we want to know how useful users find this feature and how often they use it.

# 🛠 How

I've added this new event in `KSRAnalytics`, as well as tests in `KSRAnalyticsTests`
It is then used in these view models:

1. ProjectPageViewModel
2. MessagesViewModel
3. CommentsViewModel & CommentRepliesViewModel

# 👀 See

No UI updates

# 🧪 TESTING

- [x] Check in the [Segment Debugger](https://app.segment.com/kickstarter/sources/ios/debugger) that these events are being received at the appropriate times. The debugger can be, well, buggy and slow. If you don't see events in Staging, try Prod, but remember that it can take some time for new events to come in.
