### PR TITLE
[MBL-1093] Messages don't refresh when a user is blocked

### DIFF
--- a/Kickstarter-iOS/Features/MessageThreads/Controller/MessageThreadsViewController.swift
+++ b/Kickstarter-iOS/Features/MessageThreads/Controller/MessageThreadsViewController.swift
@@ -86,7 +86,9 @@ internal final class MessageThreadsViewController: UITableViewController {
     if let messageThread = self.dataSource[indexPath] as? MessageThread {
       let vc = MessagesViewController.configuredWith(messageThread: messageThread)
 
-      vc.dismissedAfterBlockingUserHandler = { self.viewModel.inputs.refresh() }
+      vc.dismissedAfterBlockingUserHandler = { [weak self] in
+        self?.viewModel.inputs.refresh()
+      }
 
       self.navigationController?.pushViewController(vc, animated: true)
     }

--- a/Kickstarter-iOS/Features/MessageThreads/Controller/MessageThreadsViewController.swift
+++ b/Kickstarter-iOS/Features/MessageThreads/Controller/MessageThreadsViewController.swift
@@ -85,6 +85,9 @@ internal final class MessageThreadsViewController: UITableViewController {
   ) {
     if let messageThread = self.dataSource[indexPath] as? MessageThread {
       let vc = MessagesViewController.configuredWith(messageThread: messageThread)
+
+      vc.dismissedAfterBlockingUserHandler = { self.viewModel.inputs.refresh() }
+
       self.navigationController?.pushViewController(vc, animated: true)
     }
   }

--- a/Kickstarter-iOS/Features/Messages/Controller/MessagesViewController.swift
+++ b/Kickstarter-iOS/Features/Messages/Controller/MessagesViewController.swift
@@ -11,6 +11,7 @@ internal final class MessagesViewController: UITableViewController, MessageBanne
   fileprivate let dataSource = MessagesDataSource()
 
   public var messageBannerViewController: MessageBannerViewController?
+  var dismissedAfterBlockingUserHandler: (() -> Void)?
 
   internal static func configuredWith(messageThread: MessageThread) -> MessagesViewController {
     let vc = self.instantiate()
@@ -249,6 +250,7 @@ extension MessagesViewController: MessageBannerViewControllerDelegate {
   func messageBannerViewDidHide(type: MessageBannerType) {
     if type == .success {
       self.navigationController?.popViewController(animated: true)
+      self.dismissedAfterBlockingUserHandler?()
     }
   }
 }

--- a/Kickstarter-iOS/Features/Messages/Controller/MessagesViewController.swift
+++ b/Kickstarter-iOS/Features/Messages/Controller/MessagesViewController.swift
@@ -249,8 +249,8 @@ extension MessagesViewController: MessageCellDelegate {
 extension MessagesViewController: MessageBannerViewControllerDelegate {
   func messageBannerViewDidHide(type: MessageBannerType) {
     if type == .success {
-      self.navigationController?.popViewController(animated: true)
       self.dismissedAfterBlockingUserHandler?()
+      self.navigationController?.popViewController(animated: true)
     }
   }
 }


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Refreshes `MessageThreadsViewController` after successfully blocking a user within a message.

# 🤔 Why

Blocking a user through messages doesn’t update the UI until it’s manually refreshed. 

**Steps to reproduce**
1. Block user from messages
2. Get automatically navigated back to inbox
3. Click back in on message thread and see no difference
4. Go back to inbox, pull to refresh, click on message thread again. Notice that message thread now says user is blocked

# 🛠 How

In other parts of this flow we use the `.ksr_blockedUser` notification to update other parts of the app. For this case, the simpler approach is to use the existing refresh functionality in `MessageThreadsViewModel`.

- Added a callback, `var dismissedAfterBlockingUserHandler: (() -> Void)?`, in `MessagesViewController`
- When a user successfully blocks someone from a message, we currently auto-pop the VC. This new callback is triggered in `MessageThreadsViewController,` which calls its `viewModel.inputs.refresh()` and pulls in updated thread data.

# 👀 See

![Simulator Screen Recording - iPhone 15 Pro - 2024-01-08 at 09 54 56](https://github.com/kickstarter/ios-oss/assets/110618242/844fd16a-57d0-4862-b75c-fc8de52e6fd1)

# 🧪 TESTING

- [x] User feels like blocking works immediately (UI is updated the next time the thread is navigated to).
