### PR TITLE
MBL-1128: Fix crash when trying to block a user while using an iPad

### DIFF
--- a/Kickstarter-iOS/Features/Comments/Controllers/CommentRepliesViewController.swift
+++ b/Kickstarter-iOS/Features/Comments/Controllers/CommentRepliesViewController.swift
@@ -211,7 +211,7 @@ final class CommentRepliesViewController: UITableViewController, MessageBannerVi
       .blockUserActionSheet(
         blockUserHandler: { _ in self.presentBlockUserAlert(username: author.name, userId: author.id) },
         sourceView: cell,
-        isIPad: self.traitCollection.horizontalSizeClass == .regular
+        isIPad: self.traitCollection.userInterfaceIdiom == .pad
       )
 
     self.present(actionSheet, animated: true)

--- a/Kickstarter-iOS/Features/Comments/Controllers/CommentsViewController.swift
+++ b/Kickstarter-iOS/Features/Comments/Controllers/CommentsViewController.swift
@@ -281,7 +281,7 @@ extension CommentsViewController: CommentCellDelegate {
       .blockUserActionSheet(
         blockUserHandler: { _ in self.presentBlockUserAlert(username: author.name, userId: author.id) },
         sourceView: cell,
-        isIPad: self.traitCollection.horizontalSizeClass == .regular
+        isIPad: self.traitCollection.userInterfaceIdiom == .pad
       )
 
     self.present(actionSheet, animated: true)

--- a/Kickstarter-iOS/Features/Messages/Controller/MessagesViewController.swift
+++ b/Kickstarter-iOS/Features/Messages/Controller/MessagesViewController.swift
@@ -237,7 +237,7 @@ extension MessagesViewController: MessageCellDelegate {
       .blockUserActionSheet(
         blockUserHandler: { _ in self.presentBlockUserAlert(username: user.name, userId: user.id) },
         sourceView: cell,
-        isIPad: self.traitCollection.horizontalSizeClass == .regular
+        isIPad: self.traitCollection.userInterfaceIdiom == .pad
       )
 
     self.present(actionSheet, animated: true)

--- a/Kickstarter-iOS/Features/ProjectPage/Controller/ProjectPageViewController.swift
+++ b/Kickstarter-iOS/Features/ProjectPage/Controller/ProjectPageViewController.swift
@@ -1012,8 +1012,8 @@ extension ProjectPageViewController: ProjectPamphletMainCellDelegate {
           self.presentBlockUserAlert(username: project.creator.name, userId: project.creator.id)
         },
         viewProfileHandler: { _ in self.goToCreatorProfile(forProject: project) },
-        sourceView: cell,
-        isIPad: self.traitCollection.horizontalSizeClass == .regular
+        sourceView: cell.creatorButton,
+        isIPad: self.traitCollection.userInterfaceIdiom == .pad
       )
 
     self.present(actionSheet, animated: true)

--- a/Kickstarter-iOS/Features/ProjectPage/Views/Cells/ProjectPamphletMainCell.swift
+++ b/Kickstarter-iOS/Features/ProjectPage/Views/Cells/ProjectPamphletMainCell.swift
@@ -33,7 +33,7 @@ internal final class ProjectPamphletMainCell: UITableViewCell, ValueCell {
   @IBOutlet fileprivate var categoryNameLabel: UILabel!
   @IBOutlet fileprivate var contentStackView: UIStackView!
   @IBOutlet fileprivate var conversionLabel: UILabel!
-  @IBOutlet fileprivate var creatorButton: UIButton!
+  @IBOutlet fileprivate(set) var creatorButton: UIButton! // Made visible so it can be used as a popover target
   @IBOutlet fileprivate var creatorImageView: UIImageView!
   @IBOutlet fileprivate var creatorLabel: UILabel!
   @IBOutlet fileprivate var creatorStackView: UIStackView!


### PR DESCRIPTION
# 📲 What

Fix [this crash](https://console.firebase.google.com/u/0/project/kickstarter-ios/crashlytics/app/ios:com.kickstarter.kickstarter/issues/e328c5b10cd249143c0846f18587c92f?time=last-twenty-four-hours&versions=5.11.0%20(1702566)&types=crash&sessionEventKey=b69cc5f5cd214edc928e1bb5f75d22d9_1899936616456567754) found in 5.11.0.

To duplicate, try blocking a user from the Comments screen while you're using an iPad in Landscape mode.

# 🤔 Why

At least reading the crash log, it sounds like that when you present a `UIAlertController` on an iPad in a navigation controller, it _forces_ it to be presented as a popover. However, our check `IsIPad` checked the horizontal size class of the view controller. Because we present the comment view controllers in a modal screen - which _isn't the full width_ - the `IsIPad` check turned out `false`, even though we were still presenting as a popover. Hence, the crash.