### PR TITLE
Clean up RemoteConfigFeature+Helpers and RemoteConfigFeatureFlagToolsViewModel

### DIFF
--- a/Kickstarter-iOS/Features/RemoteConfigFeatureFlagTools/Controller/RemoteConfigFeatureFlagToolsViewControllerTests.swift
+++ b/Kickstarter-iOS/Features/RemoteConfigFeatureFlagTools/Controller/RemoteConfigFeatureFlagToolsViewControllerTests.swift
@@ -21,15 +21,10 @@ final class RemoteConfigFeatureFlagToolsViewControllerTests: TestCase {
 
   func testRemoteConfigFeatureFlagToolsViewController() {
     let mockRemoteConfigClient = MockRemoteConfigClient()
-      |> \.features .~ [
-        RemoteConfigFeature.blockUsersEnabled.rawValue: false,
-        RemoteConfigFeature.consentManagementDialogEnabled.rawValue: false,
-        RemoteConfigFeature.darkModeEnabled.rawValue: false,
-        RemoteConfigFeature.facebookLoginInterstitialEnabled
-          .rawValue: false,
-        RemoteConfigFeature.postCampaignPledgeEnabled.rawValue: false,
-        RemoteConfigFeature.reportThisProjectEnabled.rawValue: false
-      ]
+
+    for feature in RemoteConfigFeature.allCases {
+      mockRemoteConfigClient.features[feature.rawValue] = false
+    }
 
     withEnvironment(language: .en, mainBundle: MockBundle(), remoteConfigClient: mockRemoteConfigClient) {
       let controller = RemoteConfigFeatureFlagToolsViewController.instantiate()

--- a/Library/RemoteConfig/RemoteConfigFeature+Helpers.swift
+++ b/Library/RemoteConfig/RemoteConfigFeature+Helpers.swift
@@ -1,43 +1,32 @@
 /// Return remote config values either a value from the cloud, if it found one, or a default value based on the provided key
 
-public func featureBlockUsersEnabled() -> Bool {
+private func featureEnabled(feature: RemoteConfigFeature) -> Bool {
   return AppEnvironment.current.userDefaults
-    .remoteConfigFeatureFlags[RemoteConfigFeature.blockUsersEnabled.rawValue] ??
+    .remoteConfigFeatureFlags[feature.rawValue] ??
     (AppEnvironment.current.remoteConfigClient?
-      .isFeatureEnabled(featureKey: RemoteConfigFeature.blockUsersEnabled) ?? false)
+      .isFeatureEnabled(featureKey: feature) ?? false)
+}
+
+public func featureBlockUsersEnabled() -> Bool {
+  return featureEnabled(feature: .blockUsersEnabled)
 }
 
 public func featureConsentManagementDialogEnabled() -> Bool {
-  return AppEnvironment.current.userDefaults
-    .remoteConfigFeatureFlags[RemoteConfigFeature.consentManagementDialogEnabled.rawValue] ??
-    (AppEnvironment.current.remoteConfigClient?
-      .isFeatureEnabled(featureKey: RemoteConfigFeature.consentManagementDialogEnabled) ?? false)
+  return featureEnabled(feature: .consentManagementDialogEnabled)
 }
 
 public func featureDarkModeEnabled() -> Bool {
-  return AppEnvironment.current.userDefaults
-    .remoteConfigFeatureFlags[RemoteConfigFeature.darkModeEnabled.rawValue] ??
-    (AppEnvironment.current.remoteConfigClient?
-      .isFeatureEnabled(featureKey: RemoteConfigFeature.darkModeEnabled) ?? false)
+  return featureEnabled(feature: .darkModeEnabled)
 }
 
 public func featureFacebookLoginInterstitialEnabled() -> Bool {
-  return AppEnvironment.current.userDefaults
-    .remoteConfigFeatureFlags[RemoteConfigFeature.facebookLoginInterstitialEnabled.rawValue] ??
-    (AppEnvironment.current.remoteConfigClient?
-      .isFeatureEnabled(featureKey: RemoteConfigFeature.facebookLoginInterstitialEnabled) ?? false)
+  return featureEnabled(feature: .facebookLoginInterstitialEnabled)
 }
 
 public func featurePostCampaignPledgeEnabled() -> Bool {
-  return AppEnvironment.current.userDefaults
-    .remoteConfigFeatureFlags[RemoteConfigFeature.postCampaignPledgeEnabled.rawValue] ??
-    (AppEnvironment.current.remoteConfigClient?
-      .isFeatureEnabled(featureKey: RemoteConfigFeature.postCampaignPledgeEnabled) ?? false)
+  featureEnabled(feature: .postCampaignPledgeEnabled)
 }
 
 public func featureReportThisProjectEnabled() -> Bool {
-  return AppEnvironment.current.userDefaults
-    .remoteConfigFeatureFlags[RemoteConfigFeature.reportThisProjectEnabled.rawValue] ??
-    (AppEnvironment.current.remoteConfigClient?
-      .isFeatureEnabled(featureKey: RemoteConfigFeature.reportThisProjectEnabled) ?? false)
+  featureEnabled(feature: .reportThisProjectEnabled)
 }

--- a/Library/RemoteConfig/RemoteConfigFeature+HelpersTests.swift
+++ b/Library/RemoteConfig/RemoteConfigFeature+HelpersTests.swift
@@ -3,10 +3,8 @@ import Prelude
 import XCTest
 
 final class RemoteConfigFeatureHelpersTests: TestCase {
-  func assertFeatureIsFalse(
-    whenRemoteConfigFeatureIsFalse feature: RemoteConfigFeature,
-    checkFeatureFlag: () -> Bool
-  ) {
+  func assert(featureFlagIsFalse checkFeatureFlag: () -> Bool,
+              whenRemoteConfigFeatureIsFalse feature: RemoteConfigFeature) {
     let mockRemoteConfigClient = MockRemoteConfigClient()
       |> \.features .~ [feature.rawValue: false]
 
@@ -15,10 +13,8 @@ final class RemoteConfigFeatureHelpersTests: TestCase {
     }
   }
 
-  func assertFeatureIsTrue(
-    whenRemoteConfigFeatureIsTrue feature: RemoteConfigFeature,
-    checkFeatureFlag: () -> Bool
-  ) {
+  func assert(featureFlagIsTrue checkFeatureFlag: () -> Bool,
+              whenRemoteConfigFeatureIsTrue feature: RemoteConfigFeature) {
     let mockRemoteConfigClient = MockRemoteConfigClient()
       |> \.features .~ [feature.rawValue: true]
 
@@ -28,93 +24,98 @@ final class RemoteConfigFeatureHelpersTests: TestCase {
   }
 
   func testBlockUsers_RemoteConfig_FeatureFlag_False() {
-    self.assertFeatureIsFalse(whenRemoteConfigFeatureIsFalse: .blockUsersEnabled) {
-      featureBlockUsersEnabled()
-    }
+    self
+      .assert(
+        featureFlagIsFalse: featureBlockUsersEnabled,
+        whenRemoteConfigFeatureIsFalse: .blockUsersEnabled
+      )
   }
 
   func testBlockUsers_RemoteConfig_FeatureFlag_True() {
-    self.assertFeatureIsTrue(whenRemoteConfigFeatureIsTrue: .blockUsersEnabled) {
-      featureBlockUsersEnabled()
-    }
+    self
+      .assert(
+        featureFlagIsTrue: featureBlockUsersEnabled,
+        whenRemoteConfigFeatureIsTrue: .blockUsersEnabled
+      )
   }
 
   func testConsentManagementDialog_RemoteConfig_FeatureFlag_False() {
     self
-      .assertFeatureIsFalse(
+      .assert(
+        featureFlagIsFalse: featureConsentManagementDialogEnabled,
         whenRemoteConfigFeatureIsFalse: .consentManagementDialogEnabled
-      ) {
-        featureConsentManagementDialogEnabled()
-      }
+      )
   }
 
   func testConsentManagementDialog_RemoteConfig_FeatureFlag_True() {
     self
-      .assertFeatureIsTrue(
+      .assert(
+        featureFlagIsTrue: featureConsentManagementDialogEnabled,
         whenRemoteConfigFeatureIsTrue: .consentManagementDialogEnabled
-      ) {
-        featureConsentManagementDialogEnabled()
-      }
+      )
   }
 
   func testDarkMode_RemoteConfig_FeatureFlag_False() {
-    self.assertFeatureIsFalse(whenRemoteConfigFeatureIsFalse: .darkModeEnabled) {
-      featureDarkModeEnabled()
-    }
+    self
+      .assert(
+        featureFlagIsFalse: featureDarkModeEnabled,
+        whenRemoteConfigFeatureIsFalse: .darkModeEnabled
+      )
   }
 
   func testDarkMode_RemoteConfig_FeatureFlag_True() {
-    self.assertFeatureIsTrue(whenRemoteConfigFeatureIsTrue: .darkModeEnabled) {
-      featureDarkModeEnabled()
-    }
+    self
+      .assert(
+        featureFlagIsTrue: featureDarkModeEnabled,
+        whenRemoteConfigFeatureIsTrue: .darkModeEnabled
+      )
   }
 
   func testFacebookDeprecation_RemoteConfig_FeatureFlag_True() {
     self
-      .assertFeatureIsTrue(whenRemoteConfigFeatureIsTrue: .facebookLoginInterstitialEnabled
-      ) {
-        featureFacebookLoginInterstitialEnabled()
-      }
+      .assert(
+        featureFlagIsTrue: featureFacebookLoginInterstitialEnabled,
+        whenRemoteConfigFeatureIsTrue: .facebookLoginInterstitialEnabled
+      )
   }
 
   func testFacebookDeprecation_RemoteConfig_FeatureFlag_False() {
     self
-      .assertFeatureIsFalse(whenRemoteConfigFeatureIsFalse: .facebookLoginInterstitialEnabled
-      ) {
-        featureFacebookLoginInterstitialEnabled()
-      }
+      .assert(
+        featureFlagIsFalse: featureFacebookLoginInterstitialEnabled,
+        whenRemoteConfigFeatureIsFalse: .facebookLoginInterstitialEnabled
+      )
   }
 
   func testPostCampaignPledge_RemoteConfig_FeatureFlag_True() {
     self
-      .assertFeatureIsTrue(whenRemoteConfigFeatureIsTrue: .postCampaignPledgeEnabled
-      ) {
-        featurePostCampaignPledgeEnabled()
-      }
+      .assert(
+        featureFlagIsTrue: featurePostCampaignPledgeEnabled,
+        whenRemoteConfigFeatureIsTrue: .postCampaignPledgeEnabled
+      )
   }
 
   func testPostCampaignPledge_RemoteConfig_FeatureFlag_False() {
     self
-      .assertFeatureIsFalse(
+      .assert(
+        featureFlagIsFalse: featurePostCampaignPledgeEnabled,
         whenRemoteConfigFeatureIsFalse: .postCampaignPledgeEnabled
-      ) {
-        featurePostCampaignPledgeEnabled()
-      }
+      )
   }
 
   func testReportThisProject_RemoteConfig_FeatureFlag_True() {
     self
-      .assertFeatureIsTrue(
+      .assert(
+        featureFlagIsTrue: featureReportThisProjectEnabled,
         whenRemoteConfigFeatureIsTrue: .reportThisProjectEnabled
-      ) { featureReportThisProjectEnabled() }
+      )
   }
 
   func testReportThisProject_RemoteConfig_FeatureFlag_False() {
     self
-      .assertFeatureIsFalse(
+      .assert(
+        featureFlagIsFalse: featureReportThisProjectEnabled,
         whenRemoteConfigFeatureIsFalse: .reportThisProjectEnabled
-      ) {
-        featureReportThisProjectEnabled()
-      }
+      )
   }
 }

--- a/Library/RemoteConfig/RemoteConfigFeature+HelpersTests.swift
+++ b/Library/RemoteConfig/RemoteConfigFeature+HelpersTests.swift
@@ -3,111 +3,102 @@ import Prelude
 import XCTest
 
 final class RemoteConfigFeatureHelpersTests: TestCase {
-  func testBlockUsers_RemoteConfig_FeatureFlag_False() {
+  func assertFeatureIsFalse(_ featureFlag: Bool,
+                            whenRemoteConfigFeatureIsFalse feature: RemoteConfigFeature) {
     let mockRemoteConfigClient = MockRemoteConfigClient()
-      |> \.features .~ [RemoteConfigFeature.blockUsersEnabled.rawValue: false]
+      |> \.features .~ [feature.rawValue: false]
 
     withEnvironment(remoteConfigClient: mockRemoteConfigClient) {
-      XCTAssertFalse(featureBlockUsersEnabled())
+      XCTAssertFalse(featureFlag)
     }
+  }
+
+  func assertFeatureIsTrue(_ featureFlag: Bool, whenRemoteConfigFeatureIsTrue feature: RemoteConfigFeature) {
+    let mockRemoteConfigClient = MockRemoteConfigClient()
+      |> \.features .~ [feature.rawValue: true]
+
+    withEnvironment(remoteConfigClient: mockRemoteConfigClient) {
+      XCTAssertFalse(featureFlag)
+    }
+  }
+
+  func testBlockUsers_RemoteConfig_FeatureFlag_False() {
+    self.assertFeatureIsFalse(featureBlockUsersEnabled(), whenRemoteConfigFeatureIsFalse: .blockUsersEnabled)
   }
 
   func testBlockUsers_RemoteConfig_FeatureFlag_True() {
-    let mockRemoteConfigClient = MockRemoteConfigClient()
-      |> \.features .~ [RemoteConfigFeature.blockUsersEnabled.rawValue: true]
-
-    withEnvironment(remoteConfigClient: mockRemoteConfigClient) {
-      XCTAssertTrue(featureBlockUsersEnabled())
-    }
+    self.assertFeatureIsTrue(featureBlockUsersEnabled(), whenRemoteConfigFeatureIsTrue: .blockUsersEnabled)
   }
 
   func testConsentManagementDialog_RemoteConfig_FeatureFlag_False() {
-    let mockRemoteConfigClient = MockRemoteConfigClient()
-      |> \.features .~ [RemoteConfigFeature.consentManagementDialogEnabled.rawValue: false]
-
-    withEnvironment(remoteConfigClient: mockRemoteConfigClient) {
-      XCTAssertFalse(featureConsentManagementDialogEnabled())
-    }
+    self
+      .assertFeatureIsFalse(
+        featureConsentManagementDialogEnabled(),
+        whenRemoteConfigFeatureIsFalse: .consentManagementDialogEnabled
+      )
   }
 
   func testConsentManagementDialog_RemoteConfig_FeatureFlag_True() {
-    let mockRemoteConfigClient = MockRemoteConfigClient()
-      |> \.features .~ [RemoteConfigFeature.consentManagementDialogEnabled.rawValue: true]
-
-    withEnvironment(remoteConfigClient: mockRemoteConfigClient) {
-      XCTAssertTrue(featureConsentManagementDialogEnabled())
-    }
+    self
+      .assertFeatureIsTrue(
+        featureConsentManagementDialogEnabled(),
+        whenRemoteConfigFeatureIsTrue: .consentManagementDialogEnabled
+      )
   }
 
   func testDarkMode_RemoteConfig_FeatureFlag_False() {
-    let mockRemoteConfigClient = MockRemoteConfigClient()
-      |> \.features .~ [RemoteConfigFeature.darkModeEnabled.rawValue: false]
-
-    withEnvironment(remoteConfigClient: mockRemoteConfigClient) {
-      XCTAssertFalse(featureDarkModeEnabled())
-    }
+    self.assertFeatureIsFalse(featureDarkModeEnabled(), whenRemoteConfigFeatureIsFalse: .darkModeEnabled)
   }
 
   func testDarkMode_RemoteConfig_FeatureFlag_True() {
-    let mockRemoteConfigClient = MockRemoteConfigClient()
-      |> \.features .~ [RemoteConfigFeature.darkModeEnabled.rawValue: true]
-
-    withEnvironment(remoteConfigClient: mockRemoteConfigClient) {
-      XCTAssertTrue(featureDarkModeEnabled())
-    }
+    self.assertFeatureIsTrue(featureDarkModeEnabled(), whenRemoteConfigFeatureIsTrue: .darkModeEnabled)
   }
 
   func testFacebookDeprecation_RemoteConfig_FeatureFlag_True() {
-    let mockRemoteConfigClient = MockRemoteConfigClient()
-      |> \.features .~ [RemoteConfigFeature.facebookLoginInterstitialEnabled.rawValue: true]
-
-    withEnvironment(remoteConfigClient: mockRemoteConfigClient) {
-      XCTAssertTrue(featureFacebookLoginInterstitialEnabled())
-    }
+    self
+      .assertFeatureIsTrue(
+        featureFacebookLoginInterstitialEnabled(),
+        whenRemoteConfigFeatureIsTrue: .facebookLoginInterstitialEnabled
+      )
   }
 
   func testFacebookDeprecation_RemoteConfig_FeatureFlag_False() {
-    let mockRemoteConfigClient = MockRemoteConfigClient()
-      |> \.features .~ [RemoteConfigFeature.facebookLoginInterstitialEnabled.rawValue: false]
-
-    withEnvironment(remoteConfigClient: mockRemoteConfigClient) {
-      XCTAssertFalse(featureFacebookLoginInterstitialEnabled())
-    }
+    self
+      .assertFeatureIsFalse(
+        featureFacebookLoginInterstitialEnabled(),
+        whenRemoteConfigFeatureIsFalse: .facebookLoginInterstitialEnabled
+      )
   }
 
   func testPostCampaignPledge_RemoteConfig_FeatureFlag_True() {
-    let mockRemoteConfigClient = MockRemoteConfigClient()
-      |> \.features .~ [RemoteConfigFeature.postCampaignPledgeEnabled.rawValue: true]
-
-    withEnvironment(remoteConfigClient: mockRemoteConfigClient) {
-      XCTAssertTrue(featurePostCampaignPledgeEnabled())
-    }
+    self
+      .assertFeatureIsTrue(
+        featurePostCampaignPledgeEnabled(),
+        whenRemoteConfigFeatureIsTrue: .postCampaignPledgeEnabled
+      )
   }
 
   func testPostCampaignPledge_RemoteConfig_FeatureFlag_False() {
-    let mockRemoteConfigClient = MockRemoteConfigClient()
-      |> \.features .~ [RemoteConfigFeature.postCampaignPledgeEnabled.rawValue: false]
-
-    withEnvironment(remoteConfigClient: mockRemoteConfigClient) {
-      XCTAssertFalse(featurePostCampaignPledgeEnabled())
-    }
+    self
+      .assertFeatureIsFalse(
+        featurePostCampaignPledgeEnabled(),
+        whenRemoteConfigFeatureIsFalse: .postCampaignPledgeEnabled
+      )
   }
 
   func testReportThisProject_RemoteConfig_FeatureFlag_True() {
-    let mockRemoteConfigClient = MockRemoteConfigClient()
-      |> \.features .~ [RemoteConfigFeature.reportThisProjectEnabled.rawValue: true]
-
-    withEnvironment(remoteConfigClient: mockRemoteConfigClient) {
-      XCTAssertTrue(featureReportThisProjectEnabled())
-    }
+    self
+      .assertFeatureIsTrue(
+        featureReportThisProjectEnabled(),
+        whenRemoteConfigFeatureIsTrue: .reportThisProjectEnabled
+      )
   }
 
   func testReportThisProject_RemoteConfig_FeatureFlag_False() {
-    let mockRemoteConfigClient = MockRemoteConfigClient()
-      |> \.features .~ [RemoteConfigFeature.reportThisProjectEnabled.rawValue: false]
-
-    withEnvironment(remoteConfigClient: mockRemoteConfigClient) {
-      XCTAssertFalse(featureReportThisProjectEnabled())
-    }
+    self
+      .assertFeatureIsFalse(
+        featureReportThisProjectEnabled(),
+        whenRemoteConfigFeatureIsFalse: .reportThisProjectEnabled
+      )
   }
 }

--- a/Library/RemoteConfig/RemoteConfigFeature+HelpersTests.swift
+++ b/Library/RemoteConfig/RemoteConfigFeature+HelpersTests.swift
@@ -3,102 +3,118 @@ import Prelude
 import XCTest
 
 final class RemoteConfigFeatureHelpersTests: TestCase {
-  func assertFeatureIsFalse(_ featureFlag: Bool,
-                            whenRemoteConfigFeatureIsFalse feature: RemoteConfigFeature) {
+  func assertFeatureIsFalse(
+    whenRemoteConfigFeatureIsFalse feature: RemoteConfigFeature,
+    checkFeatureFlag: () -> Bool
+  ) {
     let mockRemoteConfigClient = MockRemoteConfigClient()
       |> \.features .~ [feature.rawValue: false]
 
     withEnvironment(remoteConfigClient: mockRemoteConfigClient) {
-      XCTAssertFalse(featureFlag)
+      XCTAssertFalse(checkFeatureFlag())
     }
   }
 
-  func assertFeatureIsTrue(_ featureFlag: Bool, whenRemoteConfigFeatureIsTrue feature: RemoteConfigFeature) {
+  func assertFeatureIsTrue(
+    whenRemoteConfigFeatureIsTrue feature: RemoteConfigFeature,
+    checkFeatureFlag: () -> Bool
+  ) {
     let mockRemoteConfigClient = MockRemoteConfigClient()
       |> \.features .~ [feature.rawValue: true]
 
     withEnvironment(remoteConfigClient: mockRemoteConfigClient) {
-      XCTAssertFalse(featureFlag)
+      XCTAssertTrue(checkFeatureFlag())
     }
   }
 
   func testBlockUsers_RemoteConfig_FeatureFlag_False() {
-    self.assertFeatureIsFalse(featureBlockUsersEnabled(), whenRemoteConfigFeatureIsFalse: .blockUsersEnabled)
+    self.assertFeatureIsFalse(whenRemoteConfigFeatureIsFalse: .blockUsersEnabled) {
+      featureBlockUsersEnabled()
+    }
   }
 
   func testBlockUsers_RemoteConfig_FeatureFlag_True() {
-    self.assertFeatureIsTrue(featureBlockUsersEnabled(), whenRemoteConfigFeatureIsTrue: .blockUsersEnabled)
+    self.assertFeatureIsTrue(whenRemoteConfigFeatureIsTrue: .blockUsersEnabled) {
+      featureBlockUsersEnabled()
+    }
   }
 
   func testConsentManagementDialog_RemoteConfig_FeatureFlag_False() {
     self
       .assertFeatureIsFalse(
-        featureConsentManagementDialogEnabled(),
         whenRemoteConfigFeatureIsFalse: .consentManagementDialogEnabled
-      )
+      ) {
+        featureConsentManagementDialogEnabled()
+      }
   }
 
   func testConsentManagementDialog_RemoteConfig_FeatureFlag_True() {
     self
       .assertFeatureIsTrue(
-        featureConsentManagementDialogEnabled(),
         whenRemoteConfigFeatureIsTrue: .consentManagementDialogEnabled
-      )
+      ) {
+        featureConsentManagementDialogEnabled()
+      }
   }
 
   func testDarkMode_RemoteConfig_FeatureFlag_False() {
-    self.assertFeatureIsFalse(featureDarkModeEnabled(), whenRemoteConfigFeatureIsFalse: .darkModeEnabled)
+    self.assertFeatureIsFalse(whenRemoteConfigFeatureIsFalse: .darkModeEnabled) {
+      featureDarkModeEnabled()
+    }
   }
 
   func testDarkMode_RemoteConfig_FeatureFlag_True() {
-    self.assertFeatureIsTrue(featureDarkModeEnabled(), whenRemoteConfigFeatureIsTrue: .darkModeEnabled)
+    self.assertFeatureIsTrue(whenRemoteConfigFeatureIsTrue: .darkModeEnabled) {
+      featureDarkModeEnabled()
+    }
   }
 
   func testFacebookDeprecation_RemoteConfig_FeatureFlag_True() {
     self
-      .assertFeatureIsTrue(
-        featureFacebookLoginInterstitialEnabled(),
-        whenRemoteConfigFeatureIsTrue: .facebookLoginInterstitialEnabled
-      )
+      .assertFeatureIsTrue(whenRemoteConfigFeatureIsTrue: .facebookLoginInterstitialEnabled
+      ) {
+        featureFacebookLoginInterstitialEnabled()
+      }
   }
 
   func testFacebookDeprecation_RemoteConfig_FeatureFlag_False() {
     self
-      .assertFeatureIsFalse(
-        featureFacebookLoginInterstitialEnabled(),
-        whenRemoteConfigFeatureIsFalse: .facebookLoginInterstitialEnabled
-      )
+      .assertFeatureIsFalse(whenRemoteConfigFeatureIsFalse: .facebookLoginInterstitialEnabled
+      ) {
+        featureFacebookLoginInterstitialEnabled()
+      }
   }
 
   func testPostCampaignPledge_RemoteConfig_FeatureFlag_True() {
     self
-      .assertFeatureIsTrue(
-        featurePostCampaignPledgeEnabled(),
-        whenRemoteConfigFeatureIsTrue: .postCampaignPledgeEnabled
-      )
+      .assertFeatureIsTrue(whenRemoteConfigFeatureIsTrue: .postCampaignPledgeEnabled
+      ) {
+        featurePostCampaignPledgeEnabled()
+      }
   }
 
   func testPostCampaignPledge_RemoteConfig_FeatureFlag_False() {
     self
       .assertFeatureIsFalse(
-        featurePostCampaignPledgeEnabled(),
         whenRemoteConfigFeatureIsFalse: .postCampaignPledgeEnabled
-      )
+      ) {
+        featurePostCampaignPledgeEnabled()
+      }
   }
 
   func testReportThisProject_RemoteConfig_FeatureFlag_True() {
     self
       .assertFeatureIsTrue(
-        featureReportThisProjectEnabled(),
         whenRemoteConfigFeatureIsTrue: .reportThisProjectEnabled
-      )
+      ) { featureReportThisProjectEnabled() }
   }
 
   func testReportThisProject_RemoteConfig_FeatureFlag_False() {
     self
       .assertFeatureIsFalse(
-        featureReportThisProjectEnabled(),
         whenRemoteConfigFeatureIsFalse: .reportThisProjectEnabled
-      )
+      ) {
+        featureReportThisProjectEnabled()
+      }
   }
 }

--- a/Library/TestHelpers/TestCase.swift
+++ b/Library/TestHelpers/TestCase.swift
@@ -88,11 +88,11 @@ internal class TestCase: XCTestCase {
   }
 
   internal func preferredSimulatorCheck() {
-    let deviceName = ProcessInfo().environment["SIMULATOR_DEVICE_NAME"]
+    let deviceName = ProcessInfo().environment["SIMULATOR_VERSION_INFO"]
     let iOSVersion = ProcessInfo().environment["SIMULATOR_RUNTIME_VERSION"]
 
     // Keep this check in sync with the device specified in `.cicleci/config.yml` and `Makefile`.
-    guard deviceName == "iPhone SE (3rd generation)", iOSVersion == "17.2" else {
+    guard deviceName!.localizedStandardContains("iPhone SE (3rd generation)"), iOSVersion == "17.2" else {
       fatalError("Please only test and record screenshots on an iPhone SE simulator running iOS 17.2")
     }
   }

--- a/Library/ViewModels/RemoteConfigFeatureFlagToolsViewModel.swift
+++ b/Library/ViewModels/RemoteConfigFeatureFlagToolsViewModel.swift
@@ -103,49 +103,13 @@ private func isFeatureEnabled(_ feature: RemoteConfigFeature) -> Bool {
 /** Returns the value of the User Defaults key in the AppEnvironment.
  */
 private func getValueFromUserDefaults(for feature: RemoteConfigFeature) -> Bool? {
-  switch feature {
-  case .blockUsersEnabled:
-    return AppEnvironment.current.userDefaults
-      .remoteConfigFeatureFlags[RemoteConfigFeature.blockUsersEnabled.rawValue]
-  case .consentManagementDialogEnabled:
-    return AppEnvironment.current.userDefaults
-      .remoteConfigFeatureFlags[RemoteConfigFeature.consentManagementDialogEnabled.rawValue]
-  case .darkModeEnabled:
-    return AppEnvironment.current.userDefaults
-      .remoteConfigFeatureFlags[RemoteConfigFeature.darkModeEnabled.rawValue]
-  case .facebookLoginInterstitialEnabled:
-    return AppEnvironment.current.userDefaults
-      .remoteConfigFeatureFlags[RemoteConfigFeature.facebookLoginInterstitialEnabled.rawValue]
-  case .postCampaignPledgeEnabled:
-    return AppEnvironment.current.userDefaults
-      .remoteConfigFeatureFlags[RemoteConfigFeature.postCampaignPledgeEnabled.rawValue]
-  case .reportThisProjectEnabled:
-    return AppEnvironment.current.userDefaults
-      .remoteConfigFeatureFlags[RemoteConfigFeature.reportThisProjectEnabled.rawValue]
-  }
+  return AppEnvironment.current.userDefaults
+    .remoteConfigFeatureFlags[feature.rawValue]
 }
 
 /** Sets the value for the UserDefaults key in the AppEnvironment.
  */
 private func setValueInUserDefaults(for feature: RemoteConfigFeature, and value: Bool) {
-  switch feature {
-  case .blockUsersEnabled:
-    AppEnvironment.current.userDefaults
-      .remoteConfigFeatureFlags[RemoteConfigFeature.blockUsersEnabled.rawValue] = value
-  case .consentManagementDialogEnabled:
-    AppEnvironment.current.userDefaults
-      .remoteConfigFeatureFlags[RemoteConfigFeature.consentManagementDialogEnabled.rawValue] = value
-  case .darkModeEnabled:
-    AppEnvironment.current.userDefaults
-      .remoteConfigFeatureFlags[RemoteConfigFeature.darkModeEnabled.rawValue] = value
-  case .facebookLoginInterstitialEnabled:
-    return AppEnvironment.current.userDefaults
-      .remoteConfigFeatureFlags[RemoteConfigFeature.facebookLoginInterstitialEnabled.rawValue] = value
-  case .postCampaignPledgeEnabled:
-    return AppEnvironment.current.userDefaults
-      .remoteConfigFeatureFlags[RemoteConfigFeature.postCampaignPledgeEnabled.rawValue] = value
-  case .reportThisProjectEnabled:
-    return AppEnvironment.current.userDefaults
-      .remoteConfigFeatureFlags[RemoteConfigFeature.reportThisProjectEnabled.rawValue] = value
-  }
+  AppEnvironment.current.userDefaults
+    .remoteConfigFeatureFlags[feature.rawValue] = value
 }


### PR DESCRIPTION
# 📲 What

Remove boilerplate from our feature flag code.

# 🤔 Why

1. I was about to add a new feature, and the amount of copy-paste was bothering me.
2. This particular copy-pasted code seemed really easy to make mistakes in. We have tests for it, but those tests were also easy to put mistakes in! 

# 👀 See

Note the test runs for the three commits below - I did the code cleanup _first_, waited for the tests to pass, and then did the test cleanup. Just to ensure I didn't break both the code and tests simultaneously.

