### PR TITLE
Update build schema to force you to select correct target when building tests

### DIFF
--- a/Kickstarter.xcodeproj/xcshareddata/xcschemes/Kickstarter-iOS.xcscheme
+++ b/Kickstarter.xcodeproj/xcshareddata/xcschemes/Kickstarter-iOS.xcscheme
@@ -25,7 +25,7 @@
       </PostActions>
       <BuildActionEntries>
          <BuildActionEntry
-            buildForTesting = "YES"
+            buildForTesting = "NO"
             buildForRunning = "YES"
             buildForProfiling = "YES"
             buildForArchiving = "YES"
@@ -39,7 +39,7 @@
             </BuildableReference>
          </BuildActionEntry>
          <BuildActionEntry
-            buildForTesting = "YES"
+            buildForTesting = "NO"
             buildForRunning = "NO"
             buildForProfiling = "NO"
             buildForArchiving = "NO"
@@ -49,6 +49,48 @@
                BlueprintIdentifier = "D01587571EEB2DE4006E7684"
                BuildableName = "KsApiTests.xctest"
                BlueprintName = "KsApiTests"
+               ReferencedContainer = "container:Kickstarter.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "NO"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A75511441C8642B3005355CF"
+               BuildableName = "Library-iOSTests.xctest"
+               BlueprintName = "Library-iOSTests"
+               ReferencedContainer = "container:Kickstarter.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "NO"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A7D1F9591C850B7C000D41D5"
+               BuildableName = "Kickstarter-Framework-iOSTests.xctest"
+               BlueprintName = "Kickstarter-Framework-iOSTests"
+               ReferencedContainer = "container:Kickstarter.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "NO"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D05DFC40227A578B006F3B68"
+               BuildableName = "KickstarterUITests.xctest"
+               BlueprintName = "KickstarterUITests"
                ReferencedContainer = "container:Kickstarter.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -69,52 +111,6 @@
          </BuildableReference>
       </MacroExpansion>
       <Testables>
-         <TestableReference
-            skipped = "NO"
-            parallelizable = "YES"
-            testExecutionOrdering = "random">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "A75511441C8642B3005355CF"
-               BuildableName = "Library-iOSTests.xctest"
-               BlueprintName = "Library-iOSTests"
-               ReferencedContainer = "container:Kickstarter.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO"
-            parallelizable = "YES"
-            testExecutionOrdering = "random">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "A7D1F9591C850B7C000D41D5"
-               BuildableName = "Kickstarter-Framework-iOSTests.xctest"
-               BlueprintName = "Kickstarter-Framework-iOSTests"
-               ReferencedContainer = "container:Kickstarter.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO"
-            parallelizable = "YES"
-            testExecutionOrdering = "random">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "D01587571EEB2DE4006E7684"
-               BuildableName = "KsApiTests.xctest"
-               BlueprintName = "KsApiTests"
-               ReferencedContainer = "container:Kickstarter.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "D05DFC40227A578B006F3B68"
-               BuildableName = "KickstarterUITests.xctest"
-               BlueprintName = "KickstarterUITests"
-               ReferencedContainer = "container:Kickstarter.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Force you to select the correct build schema when running tests via Xcode.

# 🤔 Why

Say you have an arbitrary target selected, and you try and run some tests by hitting the play button. In this example, I'm trying to run a test in `Library-iOS-Tests`, and I have the `Kickstarter-iOS` target selected, because I was running the app.

<img width="995" alt="Screenshot 2024-02-01 at 11 19 09 AM" src="https://github.com/kickstarter/ios-oss/assets/146007185/d3283c34-052f-42e2-9539-516d33c44a53">

You might be treated to this linker error. However, look closely - why is it trying and failing to build `KsApiTests`? 
<img width="696" alt="Screenshot 2024-02-01 at 11 19 55 AM" src="https://github.com/kickstarter/ios-oss/assets/146007185/783a1ea9-6d77-411b-9720-2b77ab2ef100">

This is odd - while `Library-iOS` depends on `KsApi`, `Library-iOS-Tests` does NOT depend on `KsApiTests`.

Looking into the dependency graphs, and it looks like the app is trying to build `Kickstarter-iOS`, and then as part of that, it _included_ `KsApiTests`. That is also odd. First, why is it building `Kickstarter-iOS` instead of just `Library-iOS` and `Library-iOS-Tests`? And for that matter, why would `Kickstarter-iOS` (the app) depend on `KsApiTests` (a test bundle)?

<img width="441" alt="Screenshot 2024-02-01 at 11 20 46 AM" src="https://github.com/kickstarter/ios-oss/assets/146007185/34a92c18-6a9f-45d4-b58a-043a6a05b22e">

It turns out the answer was in the schema. `Kickstarter-iOS` was set up so that it was associated with _all_ of our tests, and it would try to run them (all!) if it was selected as the schema when you run any tests. As far as I can tell, this led to general Xcode and linker strangeness, until you either swapped targets or ran a full project clean.

<img width="965" alt="Screenshot 2024-02-14 at 4 12 23 PM" src="https://github.com/kickstarter/ios-oss/assets/146007185/414a8d7c-1c8c-4e49-a0fc-7f3b00f05f9a">

The solution was to uncheck all those test boxes. Now, when you try to run a test in the same scenario, you get this handy pop-up that forces you to swap to the correct test target:

<img width="306" alt="Screenshot 2024-02-01 at 11 21 59 AM" src="https://github.com/kickstarter/ios-oss/assets/146007185/b8e8689c-2a03-4f3f-820a-a710df6231e6">
