### PR TITLE
[MBL-1146] Update transcend privacy url to use current locale

### DIFF
--- a/Library/ViewModels/SettingsDeleteOrRequestCellViewModel.swift
+++ b/Library/ViewModels/SettingsDeleteOrRequestCellViewModel.swift
@@ -23,8 +23,8 @@ public final class SettingsDeleteOrRequestCellViewModel: SettingsDeleteOrRequest
   public init() {
     self.notifyDeleteAccountTapped = self.deleteAccountTappedProperty.signal
       .map {
-        // TODO(MBL-1063): Replace hardcoded URL with translatable string.
-        URL(string: "https://legal.kickstarter.com/policies/en/?modal=take-control")
+        let code = Locale.current.languageCode ?? "en"
+        return URL(string: "https://legal.kickstarter.com/policies/\(code)/?modal=take-control")
       }.skipNil()
   }
 


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Update the url to use the language code for the current locale. We're doing this instead of a translatable string because this is how they construct urls on web, so they explicitly ask translators to not translate urls.

# 👀 See

[JIRA](https://kickstarter.atlassian.net/browse/MBL-1146)

# ✅ Acceptance criteria

- [x] Url (request my data or delete my account button) opens the modal in the app language for all the languages we support
