### PR TITLE
Add a nonfatal error; delete another nonfatal error

### DIFF
--- a/Kickstarter-iOS/AppDelegate.swift
+++ b/Kickstarter-iOS/AppDelegate.swift
@@ -416,9 +416,16 @@ internal final class AppDelegate: UIResponder, UIApplicationDelegate {
         return
       }
 
-      print("🔴 Remote Config SDK Activation Failed with Error: \(remoteConfigActivationError.localizedDescription)")
+      let errorAsNSError = remoteConfigActivationError as NSError
 
-      Crashlytics.crashlytics().record(error: remoteConfigActivationError)
+      if errorAsNSError.domain == RemoteConfigErrorDomain,
+        errorAsNSError.code == RemoteConfigError.internalError.rawValue {
+        // This is (almost certainly) just a connection error; we won't log it.
+      } else {
+        Crashlytics.crashlytics().record(error: remoteConfigActivationError)
+      }
+
+      print("🔴 Remote Config SDK Activation Failed with Error: \(remoteConfigActivationError.localizedDescription)")
 
       self.viewModel.inputs.remoteConfigClientConfigurationFailed()
     }

--- a/Library/OAuth.swift
+++ b/Library/OAuth.swift
@@ -1,4 +1,5 @@
 import AuthenticationServices
+import FirebaseCrashlytics
 import Foundation
 import KsApi
 
@@ -50,7 +51,7 @@ public struct OAuth {
       return session
 
     } catch {
-      // TODO: Is there a way we can log/monitor these errors?
+      Crashlytics.crashlytics().record(error: error)
       return nil
     }
   }


### PR DESCRIPTION
# 📲 What

1. Stop logging remote configuration errors to Crashlytics when a user boots the app with no connectivity.
2. Log when OAuth setup fails.

# 🤔 Why

This is to take better advantage of our non-fatal error logging in Crashlytics. Removing a noisy error, adding one I care about.