### PR TITLE
[MBL-1147] Track push notifications

### DIFF
--- a/Kickstarter-iOS/AppDelegate.swift
+++ b/Kickstarter-iOS/AppDelegate.swift
@@ -27,6 +27,8 @@ internal final class AppDelegate: UIResponder, UIApplicationDelegate {
   internal var rootTabBarController: RootTabBarViewController? {
     return self.window?.rootViewController as? RootTabBarViewController
   }
+  
+  internal var appBoyHelper: SEGAppboyHelper? = nil
 
   func application(
     _ application: UIApplication,
@@ -240,6 +242,11 @@ internal final class AppDelegate: UIResponder, UIApplicationDelegate {
         ]
 
         Analytics.setup(with: configuration)
+        
+        // Store the helper from this appBoyInstance, which is different from
+        // SEGAppboyIntegrationFactory.instance()?.appboyHelper, and importantly
+        // contains an active version of Appboy.
+        strongSelf.appBoyHelper = appBoyInstance?.appboyHelper
 
         AppEnvironment.current.ksrAnalytics.configureSegmentClient(Analytics.shared())
       }
@@ -460,10 +467,14 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
   }
 
   func userNotificationCenter(
-    _: UNUserNotificationCenter,
+    _ center: UNUserNotificationCenter,
     didReceive response: UNNotificationResponse,
     withCompletionHandler completion: @escaping () -> Void
   ) {
+    // Track notification opened.
+    // `appBoyHelper` gets set in `applicationDidFinishLaunching`, so it should not be nil here.
+    appBoyHelper?.userNotificationCenter(center, receivedNotificationResponse: response)
+
     guard let rootTabBarController = self.rootTabBarController else {
       completion()
       return

--- a/Library/Tracking/Segment.swift
+++ b/Library/Tracking/Segment.swift
@@ -6,23 +6,11 @@ public extension Analytics {
   /**
    Returns an `Analytics` and `SEGAppboyIntegrationFactory` instance, with Segment, using an `AnalyticsConfiguration`.
    */
-  static func configuredClient(withWriteKey writeKey: String)
-    -> (AnalyticsConfiguration, SEGAppboyIntegrationFactory?) {
+  static func configuredClient(withWriteKey writeKey: String) -> AnalyticsConfiguration {
     let configuration = AnalyticsConfiguration(writeKey: writeKey)
-    configuration
-      .trackApplicationLifecycleEvents = true
-
+    configuration.trackApplicationLifecycleEvents = true
     configuration.sourceMiddleware = [BrazeDebounceMiddleware()]
-    // Braze is always configured but feature-flagged elsewhere.
-    // Data sent to Braze is feature-flagged by the enabling/disabling Segment.
-    // FIXME: For some reason this instance of SEGAppyboyIntegrationFactory is not the same as one passed in. It's supposed to be the same singleton.
-    guard let factoryInstance = SEGAppboyIntegrationFactory.instance() else {
-      return (configuration, nil)
-    }
-
-    configuration.use(factoryInstance)
-
-    return (configuration, factoryInstance)
+    return configuration
   }
 }
 


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Track push notifications by telling braze/appboy when they're opened.

Note: In order to do this smoothly, `Appboy.sharedInstance()` is moved out of the helper function we had it in. I've verified that the shared instance that exists in that helper is different from the one that exists in AppDelegate (but within each file, they're consistent). I'm not sure why that's the case, but I'd theorize it has something to do with different targets or the helper function being static or that it lives within a SEG class and is itself a SEG class. In any case, moving these lines of code out means that `Appboy.sharedInstance()` is consistent from when we add it to the configuration to when we need it for reporting push notifications.

(In the original commit, I stored appboyHelper instead to make it consistent between the config and the push notification report, since I hadn't tried to investigate why they were different yet. This solution is much cleaner.)

# 🤔 Why

Direct opens for push notifications weren't being tracked; now they will be!

# 👀 See

[Jira](https://kickstarter.atlassian.net/browse/MBL-1147)

# ✅ Acceptance criteria

- [x] Direct opens are now tracked

