### PR TITLE
Remove old legacyOauthToken code (from 2016)

### DIFF
--- a/Library/AppEnvironment.swift
+++ b/Library/AppEnvironment.swift
@@ -298,11 +298,6 @@ public struct AppEnvironment: AppEnvironmentType {
     if let oauthToken = data["apiService.oauthToken.token"] as? String {
       // If there is an oauth token stored in the defaults, then we can authenticate our api service
       service = service.login(OauthToken(token: oauthToken))
-      removeLegacyOauthToken(fromUserDefaults: userDefaults)
-    } else if let oauthToken = legacyOauthToken(forUserDefaults: userDefaults) {
-      // Otherwise if there is a token in the legacy user defaults entry we can use that
-      service = service.login(OauthToken(token: oauthToken))
-      removeLegacyOauthToken(fromUserDefaults: userDefaults)
     }
 
     // Try restoring the client id for the api service
@@ -412,12 +407,4 @@ public struct AppEnvironment: AppEnvironmentType {
 
     userDefaults.set(data, forKey: self.environmentStorageKey)
   }
-}
-
-private func legacyOauthToken(forUserDefaults userDefaults: KeyValueStoreType) -> String? {
-  return userDefaults.object(forKey: "com.kickstarter.access_token") as? String
-}
-
-private func removeLegacyOauthToken(fromUserDefaults userDefaults: KeyValueStoreType) {
-  userDefaults.removeObject(forKey: "com.kickstarter.access_token")
 }

--- a/Library/AppEnvironmentTests.swift
+++ b/Library/AppEnvironmentTests.swift
@@ -126,16 +126,6 @@ final class AppEnvironmentTests: XCTestCase {
     XCTAssertNotNil(env.appTrackingTransparency)
   }
 
-  func testFromStorage_LegacyUserDefaults() {
-    let userDefaults = MockKeyValueStore()
-    userDefaults.set("deadbeef", forKey: "com.kickstarter.access_token")
-    let env = AppEnvironment.fromStorage(ubiquitousStore: MockKeyValueStore(), userDefaults: userDefaults)
-
-    XCTAssertEqual("deadbeef", env.apiService.oauthToken?.token)
-    XCTAssertTrue(env.apiService.isAuthenticated)
-    XCTAssertNil(userDefaults.object(forKey: "com.kickstarter.access_token"))
-  }
-
   func testSaveEnvironment() {
     let apiService = MockService(
       serverConfig: ServerConfig(


### PR DESCRIPTION
# 📲 What

Remove a switch in the code that checks for a legacy OAuth token.

# 🤔 Why

As part of OAuth (or as a fast follow), we're going to swap the apps over to save our OAuth tokens in the keychain. I noticed while poking around our login code that we have this very, very old migration. I look at the commit 9e53ab9 where this was added, and it was back in 2016. If I'm reading our tags right, it was shipped around version 3.0.2, which is so old it's not even tracked in Firebase.

I think it's resoundingly safe to delete this, and it will make the code cleaner when we add a _new_ migration for the _new_ way to store OAuth tokens. 

Worst case scenario is that someone upgrading from a truly ancient version of the app will have to log in again. 🤷‍♀️ 

# ✔️ TODO
- [x] Login before the commit, and again afterwards, to double-check I didn't break anything 