### PR TITLE
Add a return after the assert

### DIFF
--- a/Library/Paginator.swift
+++ b/Library/Paginator.swift
@@ -120,6 +120,7 @@ public class Paginator<Envelope, Value: Equatable, Cursor, SomeError: Error, Req
     self.isLoading = true
     guard let cursor = self.lastCursor else {
       assert(false, "Requested next page, but there is no cursor.")
+      return
     }
 
     let request = self.requestFromCursor(cursor)


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

In our beta build (and probably release build, though I didn't check), having an assert inside a guard block with no other return causes the build to not compile. I'm not 100% sure, but I think the assert gets optimized out or at least doesn't crash the binary in these cases.

# ✅ Acceptance criteria

- [x] Our project builds!
