### PR TITLE
MBL-1159: Exchange temporary token for OAuth token and login

### DIFF
--- a/Kickstarter-iOS/Features/LoginTout/Controller/LoginToutViewController.swift
+++ b/Kickstarter-iOS/Features/LoginTout/Controller/LoginToutViewController.swift
@@ -402,12 +402,32 @@ public final class LoginToutViewController: UIViewController, MFMailComposeViewC
   }
 
   fileprivate func pushLoginViewController() {
-    if featureLoginWithOAuthEnabled(), let session = OAuth.createAuthorizationSession() {
+    if featureLoginWithOAuthEnabled(), let session = createAuthorizationSession() {
       session.presentationContextProvider = self
       session.start()
     } else {
       self.navigationController?.pushViewController(LoginViewController.instantiate(), animated: true)
       self.navigationItem.backBarButtonItem = UIBarButtonItem.back(nil, selector: nil)
+    }
+  }
+
+  fileprivate func createAuthorizationSession() -> ASWebAuthenticationSession? {
+    return OAuth.createAuthorizationSession { [weak self] result in
+      switch result {
+      case .loggedIn:
+        self?.viewModel.inputs.environmentLoggedIn()
+      case let .failure(errorMessage):
+        let alert = UIAlertController(
+          title: Strings.login_errors_title(),
+          message: errorMessage,
+          preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: Strings.login_errors_button_ok(), style: .cancel))
+        self?.present(alert, animated: true)
+      case .cancelled:
+        // Do nothing
+        break
+      }
     }
   }
 

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -1507,6 +1507,7 @@
 		E113BD912B7D615000D3A809 /* Prelude in Frameworks */ = {isa = PBXBuildFile; productRef = E113BD902B7D615000D3A809 /* Prelude */; };
 		E118351F2B75639F007B42E6 /* PaginationExampleViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E118351E2B75639F007B42E6 /* PaginationExampleViewModel.swift */; };
 		E11CFE4B2B6C42CE00497375 /* OAuth.swift in Sources */ = {isa = PBXBuildFile; fileRef = E11CFE492B6C41B400497375 /* OAuth.swift */; };
+		E16794282B7EAA5200064063 /* OAuthTokenExchange.swift in Sources */ = {isa = PBXBuildFile; fileRef = E16794272B7EAA5200064063 /* OAuthTokenExchange.swift */; };
 		E170B9112B20E83B001BEDD7 /* MockGraphQLClient+CombineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E170B9102B20E83B001BEDD7 /* MockGraphQLClient+CombineTests.swift */; };
 		E17611E02B7287CF00DF2F50 /* PaginationExampleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E11CFE4E2B7162A400497375 /* PaginationExampleView.swift */; };
 		E17611E22B73D9A400DF2F50 /* Data+PKCE.swift in Sources */ = {isa = PBXBuildFile; fileRef = E17611E12B73D9A400DF2F50 /* Data+PKCE.swift */; };
@@ -3113,6 +3114,7 @@
 		E118351E2B75639F007B42E6 /* PaginationExampleViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginationExampleViewModel.swift; sourceTree = "<group>"; };
 		E11CFE492B6C41B400497375 /* OAuth.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuth.swift; sourceTree = "<group>"; };
 		E11CFE4E2B7162A400497375 /* PaginationExampleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginationExampleView.swift; sourceTree = "<group>"; };
+		E16794272B7EAA5200064063 /* OAuthTokenExchange.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthTokenExchange.swift; sourceTree = "<group>"; };
 		E170B9102B20E83B001BEDD7 /* MockGraphQLClient+CombineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MockGraphQLClient+CombineTests.swift"; sourceTree = "<group>"; };
 		E17611E12B73D9A400DF2F50 /* Data+PKCE.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+PKCE.swift"; sourceTree = "<group>"; };
 		E17611E32B751E8100DF2F50 /* Paginator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Paginator.swift; sourceTree = "<group>"; };
@@ -6730,6 +6732,7 @@
 				D01587D21EEB2ED7006E7684 /* MessageThreadsEnvelope.swift */,
 				D01587D31EEB2ED7006E7684 /* MessageThreadTests.swift */,
 				8A4E953A2450FE1500A578CF /* Money.swift */,
+				E16794272B7EAA5200064063 /* OAuthTokenExchange.swift */,
 				D01587D41EEB2ED7006E7684 /* Param.swift */,
 				6051C6822B683E6300514202 /* PaymentIntentEnvelope.swift */,
 				D79CF38521AC9AD200ECB73A /* PaymentType.swift */,
@@ -8637,6 +8640,7 @@
 				D01588D51EEB2ED7006E7684 /* UpdateDraftLenses.swift in Sources */,
 				8ACF558923E8D467001654A2 /* TryDecodable.swift in Sources */,
 				D01589211EEB2ED7006E7684 /* StarEnvelope.swift in Sources */,
+				E16794282B7EAA5200064063 /* OAuthTokenExchange.swift in Sources */,
 				8ADCCD862655CA680079D308 /* ApolloClient+Singleton.swift in Sources */,
 				E10BE8E02B1517FB00F73DC9 /* GraphAPI.BlockUserInput+BlockUserInput.swift in Sources */,
 				D01588EF1EEB2ED7006E7684 /* MessageThread.swift in Sources */,

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -1508,6 +1508,7 @@
 		E118351F2B75639F007B42E6 /* PaginationExampleViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E118351E2B75639F007B42E6 /* PaginationExampleViewModel.swift */; };
 		E11CFE4B2B6C42CE00497375 /* OAuth.swift in Sources */ = {isa = PBXBuildFile; fileRef = E11CFE492B6C41B400497375 /* OAuth.swift */; };
 		E16794282B7EAA5200064063 /* OAuthTokenExchange.swift in Sources */ = {isa = PBXBuildFile; fileRef = E16794272B7EAA5200064063 /* OAuthTokenExchange.swift */; };
+		E167942A2B85136900064063 /* OAuthTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E16794292B85136900064063 /* OAuthTests.swift */; };
 		E170B9112B20E83B001BEDD7 /* MockGraphQLClient+CombineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E170B9102B20E83B001BEDD7 /* MockGraphQLClient+CombineTests.swift */; };
 		E17611E02B7287CF00DF2F50 /* PaginationExampleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E11CFE4E2B7162A400497375 /* PaginationExampleView.swift */; };
 		E17611E22B73D9A400DF2F50 /* Data+PKCE.swift in Sources */ = {isa = PBXBuildFile; fileRef = E17611E12B73D9A400DF2F50 /* Data+PKCE.swift */; };
@@ -3115,6 +3116,7 @@
 		E11CFE492B6C41B400497375 /* OAuth.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuth.swift; sourceTree = "<group>"; };
 		E11CFE4E2B7162A400497375 /* PaginationExampleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginationExampleView.swift; sourceTree = "<group>"; };
 		E16794272B7EAA5200064063 /* OAuthTokenExchange.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthTokenExchange.swift; sourceTree = "<group>"; };
+		E16794292B85136900064063 /* OAuthTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthTests.swift; sourceTree = "<group>"; };
 		E170B9102B20E83B001BEDD7 /* MockGraphQLClient+CombineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MockGraphQLClient+CombineTests.swift"; sourceTree = "<group>"; };
 		E17611E12B73D9A400DF2F50 /* Data+PKCE.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+PKCE.swift"; sourceTree = "<group>"; };
 		E17611E32B751E8100DF2F50 /* Paginator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Paginator.swift; sourceTree = "<group>"; };
@@ -6071,6 +6073,7 @@
 				37EB3E4B228CF4A400076E4C /* NumberFormatter.swift */,
 				37EB3E4D228CF4FB00076E4C /* NumberFormatterTests.swift */,
 				E11CFE492B6C41B400497375 /* OAuth.swift */,
+				E16794292B85136900064063 /* OAuthTests.swift */,
 				94C92E7B2659EDBF00A96818 /* PaddingLabel.swift */,
 				A77D7B061CBAAF5D0077586B /* Paginate.swift */,
 				A7ED1F1C1E830FDC00BFFA01 /* PaginateTests.swift */,
@@ -8052,6 +8055,7 @@
 				37DEC2202257CA0A0051EF9B /* PledgeViewModelTests.swift in Sources */,
 				A7ED20001E831C5C00BFFA01 /* SearchViewModelTests.swift in Sources */,
 				8A213CF3239EAEB700BBB4C7 /* KSRAnalyticsTests.swift in Sources */,
+				E167942A2B85136900064063 /* OAuthTests.swift in Sources */,
 				77C9122B23C5079200F3D2C9 /* MockApplePayCapable.swift in Sources */,
 				D08CD201219216BA009F89F0 /* WatchProjectViewModelTests.swift in Sources */,
 				A7ED1F291E830FDC00BFFA01 /* EnvironmentTests.swift in Sources */,

--- a/KsApi/MockService.swift
+++ b/KsApi/MockService.swift
@@ -1399,6 +1399,15 @@
       return SignalProducer(value: self.fetchUserSelfResponse ?? .template)
     }
 
+    func fetchUserSelf_combine(withToken _: String) -> AnyPublisher<User, ErrorEnvelope> {
+      if let error = fetchUserSelfError {
+        return Fail(outputType: User.self, failure: self.fetchUserSelfError!).eraseToAnyPublisher()
+      }
+
+      return Just(self.fetchUserSelfResponse ?? .template).setFailureType(to: ErrorEnvelope.self)
+        .eraseToAnyPublisher()
+    }
+
     internal func fetchSurveyResponse(surveyResponseId id: Int)
       -> SignalProducer<SurveyResponse, ErrorEnvelope> {
       if let response = fetchSurveyResponseResponse {
@@ -1742,6 +1751,12 @@
     }
 
     func fetchDiscovery_combine(paginationUrl _: String) -> AnyPublisher<DiscoveryEnvelope, ErrorEnvelope> {
+      Empty(completeImmediately: false).eraseToAnyPublisher()
+    }
+
+    func exchangeTokenForOAuthToken(params _: OAuthTokenExchangeParams)
+      -> AnyPublisher<OAuthTokenExchangeResponse, ErrorEnvelope> {
+      // TODO: Implement for testing.
       Empty(completeImmediately: false).eraseToAnyPublisher()
     }
   }

--- a/KsApi/MockService.swift
+++ b/KsApi/MockService.swift
@@ -159,6 +159,7 @@
 
     fileprivate let signupResponse: AccessTokenEnvelope?
     fileprivate let signupError: ErrorEnvelope?
+    fileprivate let tokenExchangeResponse: OAuthTokenExchangeResponse?
 
     fileprivate let unfollowFriendError: ErrorEnvelope?
 
@@ -302,6 +303,7 @@
       postCommentResult: Result<Comment, ErrorEnvelope>? = nil,
       loginResponse: AccessTokenEnvelope? = nil,
       loginError: ErrorEnvelope? = nil,
+      tokenExchangeResponse: OAuthTokenExchangeResponse? = nil,
       resendCodeResponse: ErrorEnvelope? = nil,
       resendCodeError: ErrorEnvelope? = nil,
       resetPasswordResponse: User? = nil,
@@ -524,6 +526,8 @@
       self.verifyEmailResult = verifyEmailResult
 
       self.watchProjectMutationResult = watchProjectMutationResult
+
+      self.tokenExchangeResponse = tokenExchangeResponse
     }
 
     public func addNewCreditCard(input: CreatePaymentSourceInput)
@@ -1756,8 +1760,13 @@
 
     func exchangeTokenForOAuthToken(params _: OAuthTokenExchangeParams)
       -> AnyPublisher<OAuthTokenExchangeResponse, ErrorEnvelope> {
-      // TODO: Implement for testing.
-      Empty(completeImmediately: false).eraseToAnyPublisher()
+      if let tokenExchangeResponse = self.tokenExchangeResponse {
+        return Just(tokenExchangeResponse).setFailureType(to: ErrorEnvelope.self).eraseToAnyPublisher()
+      } else if let loginError = self.loginError {
+        return Fail(outputType: OAuthTokenExchangeResponse.self, failure: loginError).eraseToAnyPublisher()
+      } else {
+        return Empty(completeImmediately: false).eraseToAnyPublisher()
+      }
     }
   }
 

--- a/KsApi/Service.swift
+++ b/KsApi/Service.swift
@@ -619,6 +619,10 @@ public struct Service: ServiceType {
     return request(.userSelf)
   }
 
+  public func fetchUserSelf_combine(withToken token: String) -> AnyPublisher<User, ErrorEnvelope> {
+    return request(.userSelfWithToken(token: token))
+  }
+
   public func fetchUser(userId: Int) -> SignalProducer<User, ErrorEnvelope> {
     return request(.user(userId: userId))
   }
@@ -638,6 +642,11 @@ public struct Service: ServiceType {
 
   public func fetchUnansweredSurveyResponses() -> SignalProducer<[SurveyResponse], ErrorEnvelope> {
     return request(.unansweredSurveyResponses)
+  }
+
+  public func exchangeTokenForOAuthToken(params: OAuthTokenExchangeParams)
+    -> AnyPublisher<OAuthTokenExchangeResponse, ErrorEnvelope> {
+    return request(.exchangeToken(params: params))
   }
 
   public func backingUpdate(forProject project: Project, forUser user: User, received: Bool) ->

--- a/KsApi/ServiceType.swift
+++ b/KsApi/ServiceType.swift
@@ -284,6 +284,9 @@ public protocol ServiceType {
   /// Fetch the logged-in user's data.
   func fetchUserSelf() -> SignalProducer<User, ErrorEnvelope>
 
+  /// Fetch the logged-in user's data.
+  func fetchUserSelf_combine(withToken: String) -> AnyPublisher<User, ErrorEnvelope>
+
   /// Mark reward received.
   func backingUpdate(forProject project: Project, forUser user: User, received: Bool)
     -> SignalProducer<Backing, ErrorEnvelope>
@@ -402,6 +405,9 @@ public protocol ServiceType {
 
   func fetchDiscovery_combine(params: DiscoveryParams)
     -> AnyPublisher<DiscoveryEnvelope, ErrorEnvelope>
+
+  func exchangeTokenForOAuthToken(params: OAuthTokenExchangeParams)
+    -> AnyPublisher<OAuthTokenExchangeResponse, ErrorEnvelope>
 }
 
 extension ServiceType {

--- a/KsApi/lib/Route.swift
+++ b/KsApi/lib/Route.swift
@@ -12,6 +12,7 @@ internal enum Route {
   case config
   case deleteImage(UpdateDraft.Image, fromDraft: UpdateDraft)
   case discover(DiscoveryParams)
+  case exchangeToken(params: OAuthTokenExchangeParams)
   case facebookConnect(facebookAccessToken: String)
   case facebookLogin(facebookAccessToken: String, code: String?)
   case facebookSignup(facebookAccessToken: String, sendNewsletters: Bool)
@@ -50,6 +51,7 @@ internal enum Route {
   case updateUpdateDraft(UpdateDraft, title: String, body: String, isPublic: Bool)
   case updateUserSelf(User)
   case userSelf
+  case userSelfWithToken(token: String)
   case user(userId: Int)
   case verifyEmail(accessToken: String)
 
@@ -80,6 +82,9 @@ internal enum Route {
 
       case .config:
         return (.GET, "/v1/app/ios/config", ["no_cache": "\(Date().timeIntervalSince1970)"], nil)
+
+      case let .exchangeToken(params):
+        return (.POST, "v1/oauth/authorizations/exchange", params.queryParams, nil)
 
       case let .deleteImage(i, draft):
         return (.DELETE, "/v1/projects/\(draft.update.projectId)/updates/draft/images/\(i.id)", [:], nil)
@@ -242,6 +247,9 @@ internal enum Route {
 
       case .userSelf:
         return (.GET, "/v1/users/self", [:], nil)
+
+      case let .userSelfWithToken(token):
+        return (.GET, "/v1/users/self", ["oauth_token": token], nil)
 
       case let .user(userId):
         return (.GET, "/v1/users/\(userId)", [:], nil)

--- a/KsApi/models/OAuthTokenExchange.swift
+++ b/KsApi/models/OAuthTokenExchange.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+public struct OAuthTokenExchangeParams {
+  public init(temporaryToken: String, codeVerifier: String) {
+    self.temporaryToken = temporaryToken
+    self.codeVerifier = codeVerifier
+  }
+
+  let temporaryToken: String
+  let codeVerifier: String
+
+  var queryParams: [String: String] {
+    return [
+      "code": self.temporaryToken,
+      "code_verifier": self.codeVerifier
+    ]
+  }
+}
+
+public struct OAuthTokenExchangeResponse: Decodable {
+  public let token: String
+
+  public init(token: String) {
+    self.token = token
+  }
+}

--- a/Library/OAuth.swift
+++ b/Library/OAuth.swift
@@ -1,10 +1,19 @@
 import AuthenticationServices
+import Combine
 import FirebaseCrashlytics
 import Foundation
 import KsApi
 
+public enum OAuthAuthorizationResult {
+  case loggedIn
+  case failure(errorMessage: String)
+  case cancelled
+}
+
 public struct OAuth {
   public init() {}
+
+  private static var cancellables = Set<AnyCancellable>()
 
   static let redirectScheme = "ksrauth2"
 
@@ -28,7 +37,8 @@ public struct OAuth {
     return components?.url
   }
 
-  public static func createAuthorizationSession() -> ASWebAuthenticationSession? {
+  public static func createAuthorizationSession(onComplete: @escaping (OAuthAuthorizationResult) -> Void)
+    -> ASWebAuthenticationSession? {
     do {
       let verifier = try PKCE.createCodeVerifier(byteLength: 32)
       if !PKCE.checkCodeVerifier(verifier) {
@@ -44,8 +54,47 @@ public struct OAuth {
       let session = ASWebAuthenticationSession(
         url: url,
         callbackURLScheme: OAuth.redirectScheme
-      ) { _, _ in
-        // TODO: MBL-1159: Exchange information in callback for credentials, then login.
+      ) { url, error in
+        guard error == nil else {
+          if let authenticationError = error as? ASWebAuthenticationSessionError,
+            authenticationError.code == .canceledLogin {
+            onComplete(.cancelled)
+          } else {
+            onComplete(.failure(errorMessage: Strings.Something_went_wrong_please_try_again()))
+          }
+
+          return
+        }
+
+        guard let code = codeFromRedirectURL(url) else {
+          onComplete(.failure(errorMessage: Strings.Something_went_wrong_please_try_again()))
+          return
+        }
+
+        let params = OAuthTokenExchangeParams(temporaryToken: code, codeVerifier: verifier)
+
+        AppEnvironment.current.apiService.exchangeTokenForOAuthToken(params: params)
+          .receive(on: RunLoop.main)
+          .flatMap { response in
+            let token = response.token
+            // TODO: This would be neater if we can just return the V1 user from the exchange endpoint.
+
+            // Return a publisher that emits a tuple of (token, user) when the user request completes
+            return Just(token).setFailureType(to: ErrorEnvelope.self)
+              .zip(AppEnvironment.current.apiService.fetchUserSelf_combine(withToken: token))
+          }
+          .sink { result in
+            if case let .failure(error) = result {
+              let message = error.errorMessages.first ?? Strings.login_errors_unable_to_log_in()
+              onComplete(.failure(errorMessage: message))
+            }
+          } receiveValue: { token, user in
+            let accessEnvelope = AccessTokenEnvelope(accessToken: token, user: user)
+            AppEnvironment.login(accessEnvelope)
+
+            onComplete(.loggedIn)
+
+          }.store(in: &cancellables)
       }
 
       return session
@@ -54,5 +103,14 @@ public struct OAuth {
       Crashlytics.crashlytics().record(error: error)
       return nil
     }
+  }
+
+  private static func codeFromRedirectURL(_ url: URL?) -> String? {
+    guard let redirectURL = url else {
+      return nil
+    }
+
+    let components = URLComponents(url: redirectURL, resolvingAgainstBaseURL: false)
+    return components?.queryItems?.first(where: { $0.name == "code" })?.value
   }
 }

--- a/Library/OAuthTests.swift
+++ b/Library/OAuthTests.swift
@@ -1,0 +1,94 @@
+import AuthenticationServices
+@testable import KsApi
+@testable import Library
+import XCTest
+
+final class OAuthTests: XCTestCase {
+  func verifyRedirectAsync(redirectURL url: URL?,
+                           error: Error?,
+                           verifier: String,
+                           verify: @escaping (OAuthAuthorizationResult) -> Void) {
+    let expectation = XCTestExpectation(description: "OAuth completion block should be called asynchronously")
+
+    OAuth.handleRedirect(redirectURL: url, error: error, verifier: verifier) { result in
+
+      verify(result)
+      expectation.fulfill()
+    }
+
+    wait(for: [expectation], timeout: 0.01)
+  }
+
+  func testHandleRedirect_missingRedirectURL_fails() {
+    self.verifyRedirectAsync(redirectURL: nil, error: nil, verifier: "") { result in
+      if case .failure = result {
+        // Success
+      } else {
+        XCTFail("Expected call to fail")
+      }
+    }
+  }
+
+  func testHandleRedirect_missingRedirectCode_fails() {
+    self.verifyRedirectAsync(
+      redirectURL: URL(string: "ksrauth2://authenticate?foo=bar"),
+      error: nil,
+      verifier: ""
+    ) { result in
+      if case .failure = result {
+        // Success
+      } else {
+        XCTFail("Expected call to fail")
+      }
+    }
+  }
+
+  func testHandleRedirect_cancellationError_cancels() {
+    let cancelledError = ASWebAuthenticationSessionError(.canceledLogin)
+    verifyRedirectAsync(redirectURL: nil, error: cancelledError, verifier: "") { result in
+      if case .cancelled = result {
+        // Success
+      } else {
+        XCTFail("Expected call to be canceled")
+      }
+    }
+  }
+
+  func testHandleRedirect_anotherError_fails() {
+    let anotherError = ASWebAuthenticationSessionError(.presentationContextNotProvided)
+    verifyRedirectAsync(redirectURL: nil, error: anotherError, verifier: "") { result in
+      if case .failure = result {
+        // Success
+      } else {
+        XCTFail("Expected call to fail")
+      }
+    }
+  }
+
+  func testHandleRedirect_validCodeAndVerifier_logsIn() {
+    let urlWithCode = URL(string: "ksrauth2://authenticate?code=a1b2c3")
+
+    XCTAssertNil(AppEnvironment.current.currentUser)
+    XCTAssertNil(AppEnvironment.current.apiService.oauthToken)
+
+    // The redirect makes two calls - the first is for token exchange, the second fetches the current user.
+    let exchangeResponse = OAuthTokenExchangeResponse(token: "test_token")
+    var currentUser = User.template
+    currentUser.id = 123_456
+    let mockService = MockService(fetchUserSelfResponse: currentUser, tokenExchangeResponse: exchangeResponse)
+
+    withEnvironment(apiService: mockService) {
+      verifyRedirectAsync(redirectURL: urlWithCode, error: nil, verifier: "test_verifier") { result in
+        if case .loggedIn = result {
+          XCTAssertNotNil(AppEnvironment.current.currentUser)
+          XCTAssertEqual(AppEnvironment.current.currentUser?.id, currentUser.id)
+
+          XCTAssertNotNil(AppEnvironment.current.apiService.oauthToken)
+          XCTAssertEqual(AppEnvironment.current.apiService.oauthToken?.token, exchangeResponse.token)
+        } else {
+          XCTFail("Expected call to succeed")
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
# 📲 What

This implements the MVP of login with OAuth. 

It works like this:

1. Open a web authentication session
2. If it completes successful, the website redirects to a URL which includes a tempoary authorization code
3. We exchange that code and a secret for the real OAuth token
4. We use that OAuth token to fetch the user's information
5. ...and then save that to the app environment login. 

# 🤔 Why

We are porting the app to use OAuth via a web authentication session to improve security.

# 👀 See

This snazzy demo!

https://github.com/kickstarter/ios-oss/assets/146007185/19803d96-04c0-4e1c-b596-c9527bc63d8e



