### PR TITLE
MBL-1214: Send OAuth token only in headers, not in request parameters

### DIFF
--- a/KsApi/MockService.swift
+++ b/KsApi/MockService.swift
@@ -1403,7 +1403,7 @@
       return SignalProducer(value: self.fetchUserSelfResponse ?? .template)
     }
 
-    func fetchUserSelf_combine(withToken _: String) -> AnyPublisher<User, ErrorEnvelope> {
+    func fetchUserSelf_combine(withOAuthToken _: String) -> AnyPublisher<User, ErrorEnvelope> {
       if let error = fetchUserSelfError {
         return Fail(outputType: User.self, failure: self.fetchUserSelfError!).eraseToAnyPublisher()
       }

--- a/KsApi/Service.swift
+++ b/KsApi/Service.swift
@@ -619,8 +619,8 @@ public struct Service: ServiceType {
     return request(.userSelf)
   }
 
-  public func fetchUserSelf_combine(withToken token: String) -> AnyPublisher<User, ErrorEnvelope> {
-    return request(.userSelfWithToken(token: token))
+  public func fetchUserSelf_combine(withOAuthToken token: String) -> AnyPublisher<User, ErrorEnvelope> {
+    return requestWithAuthentication(.userSelf, oauthToken: token)
   }
 
   public func fetchUser(userId: Int) -> SignalProducer<User, ErrorEnvelope> {

--- a/KsApi/ServiceType.swift
+++ b/KsApi/ServiceType.swift
@@ -605,7 +605,6 @@ extension ServiceType {
     var query: [String: String] = [:]
     query["client_id"] = self.serverConfig.apiClientAuth.clientId
     query["currency"] = self.currency
-    query["oauth_token"] = self.oauthToken?.token
     return query
   }
 

--- a/KsApi/ServiceType.swift
+++ b/KsApi/ServiceType.swift
@@ -285,7 +285,7 @@ public protocol ServiceType {
   func fetchUserSelf() -> SignalProducer<User, ErrorEnvelope>
 
   /// Fetch the logged-in user's data.
-  func fetchUserSelf_combine(withToken: String) -> AnyPublisher<User, ErrorEnvelope>
+  func fetchUserSelf_combine(withOAuthToken: String) -> AnyPublisher<User, ErrorEnvelope>
 
   /// Mark reward received.
   func backingUpdate(forProject project: Project, forUser user: User, received: Bool)
@@ -528,6 +528,12 @@ extension ServiceType {
   public func isPrepared(request: URLRequest) -> Bool {
     return request.value(forHTTPHeaderField: "Authorization") == self.authorizationHeader
       && request.value(forHTTPHeaderField: "Kickstarter-iOS-App") != nil
+  }
+
+  public func addV1AuthenticationToRequest(_ request: inout URLRequest, oauthToken: String) {
+    var headers = request.allHTTPHeaderFields ?? [:]
+    headers["X-Auth"] = "token \(oauthToken)"
+    request.allHTTPHeaderFields = headers
   }
 
   internal var defaultHeaders: [String: String] {

--- a/KsApi/ServiceType.swift
+++ b/KsApi/ServiceType.swift
@@ -491,37 +491,6 @@ extension ServiceType {
   }
 
   /**
-   Prepares a URL request to be sent to the server.
-
-   - parameter originalRequest: The request that should be prepared.
-   - parameter queryString:     The GraphQL query string for the request.
-
-   - returns: A new URL request that is properly configured for the server.
-   */
-  public func preparedRequest(forRequest originalRequest: URLRequest, queryString: String)
-    -> URLRequest {
-    var request = originalRequest
-    guard let URL = request.url else {
-      return originalRequest
-    }
-
-    request.httpBody = "query=\(queryString)".data(using: .utf8)
-
-    let components = URLComponents(url: URL, resolvingAgainstBaseURL: false)!
-    request.url = components.url
-    request.allHTTPHeaderFields = self.defaultHeaders
-
-    return request
-  }
-
-  public func preparedRequest(forURL url: URL, queryString: String)
-    -> URLRequest {
-    var request = URLRequest(url: url)
-    request.httpMethod = Method.POST.rawValue
-    return self.preparedRequest(forRequest: request, queryString: queryString)
-  }
-
-  /**
      Prepares a URL request to be sent to the server.
      - parameter originalRequest: The request that should be prepared
      - parameter queryString: The GraphQL mutation string description

--- a/KsApi/ServiceTypeTests.swift
+++ b/KsApi/ServiceTypeTests.swift
@@ -103,7 +103,8 @@ final class ServiceTypeTests: XCTestCase {
         "Kickstarter-App-Id": "com.kickstarter.test",
         "X-KICKSTARTER-CLIENT": "deadbeef",
         "User-Agent": userAgent(),
-        "Kickstarter-iOS-App-UUID": "DEADBEEF-DEAD-BEEF-DEAD-DEADBEEFBEEF"
+        "Kickstarter-iOS-App-UUID": "DEADBEEF-DEAD-BEEF-DEAD-DEADBEEFBEEF",
+        "X-Auth": "token cafebeef"
       ],
       request.allHTTPHeaderFields!
     )
@@ -125,7 +126,8 @@ final class ServiceTypeTests: XCTestCase {
         "Kickstarter-App-Id": "com.kickstarter.test",
         "X-KICKSTARTER-CLIENT": "deadbeef",
         "User-Agent": userAgent(),
-        "Kickstarter-iOS-App-UUID": "DEADBEEF-DEAD-BEEF-DEAD-DEADBEEFBEEF"
+        "Kickstarter-iOS-App-UUID": "DEADBEEF-DEAD-BEEF-DEAD-DEADBEEFBEEF",
+        "X-Auth": "token cafebeef"
       ],
       request.allHTTPHeaderFields!
     )
@@ -148,7 +150,8 @@ final class ServiceTypeTests: XCTestCase {
         "Kickstarter-App-Id": "com.kickstarter.test",
         "X-KICKSTARTER-CLIENT": "deadbeef",
         "User-Agent": userAgent(),
-        "Kickstarter-iOS-App-UUID": "DEADBEEF-DEAD-BEEF-DEAD-DEADBEEFBEEF"
+        "Kickstarter-iOS-App-UUID": "DEADBEEF-DEAD-BEEF-DEAD-DEADBEEFBEEF",
+        "X-Auth": "token cafebeef"
       ],
       request.allHTTPHeaderFields!
     )
@@ -172,7 +175,8 @@ final class ServiceTypeTests: XCTestCase {
         "Content-Type": "application/json; charset=utf-8",
         "X-KICKSTARTER-CLIENT": "deadbeef",
         "User-Agent": userAgent(),
-        "Kickstarter-iOS-App-UUID": "DEADBEEF-DEAD-BEEF-DEAD-DEADBEEFBEEF"
+        "Kickstarter-iOS-App-UUID": "DEADBEEF-DEAD-BEEF-DEAD-DEADBEEFBEEF",
+        "X-Auth": "token cafebeef"
       ],
       request.allHTTPHeaderFields!
     )
@@ -203,7 +207,8 @@ final class ServiceTypeTests: XCTestCase {
         "Kickstarter-App-Id": "com.kickstarter.test",
         "X-KICKSTARTER-CLIENT": "deadbeef",
         "User-Agent": userAgent(),
-        "Kickstarter-iOS-App-UUID": "DEADBEEF-DEAD-BEEF-DEAD-DEADBEEFBEEF"
+        "Kickstarter-iOS-App-UUID": "DEADBEEF-DEAD-BEEF-DEAD-DEADBEEFBEEF",
+        "X-Auth": "token cafebeef"
       ],
       request.allHTTPHeaderFields!
     )

--- a/KsApi/ServiceTypeTests.swift
+++ b/KsApi/ServiceTypeTests.swift
@@ -74,7 +74,7 @@ final class ServiceTypeTests: XCTestCase {
   }
 
   func testIsPreparedWithOauthToken() {
-    let url = URL(string: "http://api.ksr.com/v1/test?key=value&oauth_token=cafebeef")!
+    let url = URL(string: "http://api.ksr.com/v1/test?key=value")!
     let request = URLRequest(url: url)
     XCTAssertFalse(self.service.isPrepared(request: request))
     XCTAssertTrue(self.service.isPrepared(request: self.service.preparedRequest(forRequest: request)))
@@ -92,7 +92,7 @@ final class ServiceTypeTests: XCTestCase {
     let request = self.service.preparedRequest(forRequest: .init(url: url))
 
     XCTAssertEqual(
-      "http://api.ksr.com/v1/test?client_id=deadbeef&currency=USD&key=value&oauth_token=cafebeef",
+      "http://api.ksr.com/v1/test?client_id=deadbeef&currency=USD&key=value",
       request.url?.absoluteString
     )
     XCTAssertEqual(
@@ -114,7 +114,7 @@ final class ServiceTypeTests: XCTestCase {
     let request = self.service.preparedRequest(forURL: url, query: ["extra": "1"])
 
     XCTAssertEqual(
-      "http://api.ksr.com/v1/test?client_id=deadbeef&currency=USD&extra=1&key=value&oauth_token=cafebeef",
+      "http://api.ksr.com/v1/test?client_id=deadbeef&currency=USD&extra=1&key=value",
       request.url?.absoluteString
     )
     XCTAssertEqual(
@@ -137,7 +137,7 @@ final class ServiceTypeTests: XCTestCase {
     let request = self.service.preparedRequest(forURL: url, method: .DELETE, query: ["extra": "1"])
 
     XCTAssertEqual(
-      "http://api.ksr.com/v1/test?client_id=deadbeef&currency=USD&extra=1&key=value&oauth_token=cafebeef",
+      "http://api.ksr.com/v1/test?client_id=deadbeef&currency=USD&extra=1&key=value",
       request.url?.absoluteString
     )
     XCTAssertEqual(
@@ -160,7 +160,7 @@ final class ServiceTypeTests: XCTestCase {
     let request = self.service.preparedRequest(forURL: url, method: .POST, query: ["extra": "1"])
 
     XCTAssertEqual(
-      "http://api.ksr.com/v1/test?client_id=deadbeef&currency=USD&key=value&oauth_token=cafebeef",
+      "http://api.ksr.com/v1/test?client_id=deadbeef&currency=USD&key=value",
       request.url?.absoluteString
     )
     XCTAssertEqual(
@@ -192,7 +192,7 @@ final class ServiceTypeTests: XCTestCase {
     let request = self.service.preparedRequest(forRequest: baseRequest, query: ["extra": "1"])
 
     XCTAssertEqual(
-      "http://api.ksr.com/v1/test?client_id=deadbeef&currency=USD&key=value&oauth_token=cafebeef",
+      "http://api.ksr.com/v1/test?client_id=deadbeef&currency=USD&key=value",
       request.url?.absoluteString
     )
     XCTAssertEqual(

--- a/KsApi/lib/Route.swift
+++ b/KsApi/lib/Route.swift
@@ -51,7 +51,6 @@ internal enum Route {
   case updateUpdateDraft(UpdateDraft, title: String, body: String, isPublic: Bool)
   case updateUserSelf(User)
   case userSelf
-  case userSelfWithToken(token: String)
   case user(userId: Int)
   case verifyEmail(accessToken: String)
 
@@ -247,9 +246,6 @@ internal enum Route {
 
       case .userSelf:
         return (.GET, "/v1/users/self", [:], nil)
-
-      case let .userSelfWithToken(token):
-        return (.GET, "/v1/users/self", ["oauth_token": token], nil)
 
       case let .user(userId):
         return (.GET, "/v1/users/\(userId)", [:], nil)

--- a/Library/OAuth.swift
+++ b/Library/OAuth.swift
@@ -103,7 +103,7 @@ public struct OAuth {
 
         // Return a publisher that emits a tuple of (token, user) when the user request completes
         return Just(token).setFailureType(to: ErrorEnvelope.self)
-          .zip(AppEnvironment.current.apiService.fetchUserSelf_combine(withToken: token))
+          .zip(AppEnvironment.current.apiService.fetchUserSelf_combine(withOAuthToken: token))
       }
       .receive(on: RunLoop.main)
       .sink { result in

--- a/Library/OAuth.swift
+++ b/Library/OAuth.swift
@@ -97,7 +97,6 @@ public struct OAuth {
     let params = OAuthTokenExchangeParams(temporaryToken: code, codeVerifier: verifier)
 
     AppEnvironment.current.apiService.exchangeTokenForOAuthToken(params: params)
-      .receive(on: RunLoop.main)
       .flatMap { response in
         let token = response.token
         // TODO: This would be neater if we can just return the V1 user from the exchange endpoint.
@@ -106,6 +105,7 @@ public struct OAuth {
         return Just(token).setFailureType(to: ErrorEnvelope.self)
           .zip(AppEnvironment.current.apiService.fetchUserSelf_combine(withToken: token))
       }
+      .receive(on: RunLoop.main)
       .sink { result in
         if case let .failure(error) = result {
           let message = error.errorMessages.first ?? Strings.login_errors_unable_to_log_in()


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Send OAuth tokens only in the request headers, not in the request parameters.

# 🤔 Why

This is a security concern which we wanted to address with the MVP of OAuth. Moving the authorization parameters into headers is a best practice.

See: https://github.com/kickstarter/kickstarter/pull/26425 and https://github.com/kickstarter/kickstarter/pull/26432


# 🛠 How

Note that this isn't behind any flags. The server change to accept the OAuth token in the headers was made globally, for all V1 requests, and already applied for GraphQL. We decided a ramp-up would be difficult, due to how deep the headers are buried in our networking stack, and of limited use, compared to testing this change manually.

Also note that we are sometimes sending _redundant headers_, like both `Authorization` and `X-Auth` with the OAuth token. To the best of my knowledge, both V1 and GraphQL discard extra headers, so there's no harm in this - and it makes our code significantly simpler. 