### PR TITLE
[MBL-1224] Round rewards up instead of down

### DIFF
--- a/Library/ViewModels/RewardCardViewModel.swift
+++ b/Library/ViewModels/RewardCardViewModel.swift
@@ -70,7 +70,8 @@ public final class RewardCardViewModel: RewardCardViewModelType, RewardCardViewM
         Format.currency(
           reward.convertedMinimum,
           country: project.stats.currentCountry ?? .us,
-          omitCurrencyCode: project.stats.omitUSCurrencyCode
+          omitCurrencyCode: project.stats.omitUSCurrencyCode,
+          roundingMode: .up
         )
       }
       .map(Strings.About_reward_amount(reward_amount:))

--- a/Library/ViewModels/RewardCardViewModelTests.swift
+++ b/Library/ViewModels/RewardCardViewModelTests.swift
@@ -297,6 +297,21 @@ final class RewardCardViewModelTests: TestCase {
       )
     }
   }
+  
+  func testConversionLabel() {
+    let project = Project.template
+      |> Project.lens.country .~ .us
+      |> Project.lens.stats.currency .~ Project.Country.mx.currencyCode
+    let reward = Reward.noReward
+      |> Reward.lens.convertedMinimum .~ 0.6
+
+    withEnvironment(countryCode: "US") {
+      self.vm.inputs.configure(with: (project, reward, .pledge))
+
+      self.conversionLabelText.assertValues(["About $1"],
+        "No-reward min is rounded up.")
+    }
+  }
 
   // MARK: - Included Items
 


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Round up when formatting the converted amount string for rewards.

# 🤔 Why

Rewards should all be rounded up to be consistent with our rounding for add-ons and the rounding done on web. Note that this change only affects the "no reward" option (ie "pledge because you believe in it"), since the converted value we use for actual rewards is rounded by the backend before we see it.

With this change, we'll no longer see "About $0" pledge options.

# 👀 See

[Jira](https://kickstarter.atlassian.net/browse/MBL-1224)
[Spike for more details](https://kickstarter.atlassian.net/wiki/spaces/NT/pages/2677145760/Currency+conversion+on+iOS)

| Before 🐛 | After 🦋 |
| --- | --- |
| ![image](https://github.com/kickstarter/ios-oss/assets/6799207/840744eb-c4f1-4d1f-86e2-efc353eb5547) | ![image](https://github.com/kickstarter/ios-oss/assets/6799207/fa5bc397-1d80-4107-ac1e-e33fa4cad449)  |


# ✅ Acceptance criteria

- [ ] Rewards are rounded up
