### PR TITLE
MBL-1233: Consolidate login and signup buttons when OAuth is enabled

### DIFF
--- a/Kickstarter-iOS/Features/LoginTout/Controller/LoginToutViewController.swift
+++ b/Kickstarter-iOS/Features/LoginTout/Controller/LoginToutViewController.swift
@@ -138,11 +138,14 @@ public final class LoginToutViewController: UIViewController, MFMailComposeViewC
       }
       |> UILabel.lens.text %~ { _ in Strings.Get_notified_when_your_friends_back_and_launch_projects() }
 
-    _ = self.loginButton
-      |> greyButtonStyle
-      |> UIButton.lens.title(for: .normal) %~ { _ in
-        Strings.login_tout_back_intent_traditional_login_button()
-      }
+    if self.viewModel.outputs.loginWithOAuthEnabled {
+      // TODO: Add and translate a new version of this string for this page.
+      _ = self.loginButton |> greenButtonStyle
+      self.loginButton.setTitle(Strings.discovery_onboarding_buttons_signup_or_login(), for: .normal)
+    } else {
+      _ = self.loginButton |> greyButtonStyle
+      self.loginButton.setTitle(Strings.login_tout_back_intent_traditional_login_button(), for: .normal)
+    }
 
     _ = self.loginContextStackView
       |> UIStackView.lens.spacing .~ Styles.gridHalf(1)
@@ -353,8 +356,12 @@ public final class LoginToutViewController: UIViewController, MFMailComposeViewC
     _ = ([self.appleLoginButton, self.fbLoginButton, self.getNotifiedLabel], self.fbLoginStackView)
       |> ksr_addArrangedSubviewsToStackView()
 
-    _ = ([self.signupButton, self.loginButton], self.emailLoginStackView)
-      |> ksr_addArrangedSubviewsToStackView()
+    if self.viewModel.outputs.loginWithOAuthEnabled {
+      self.emailLoginStackView.addArrangedSubview(self.loginButton)
+    } else {
+      self.emailLoginStackView.addArrangedSubview(self.signupButton)
+      self.emailLoginStackView.addArrangedSubview(self.loginButton)
+    }
   }
 
   private func setupConstraints() {
@@ -402,7 +409,7 @@ public final class LoginToutViewController: UIViewController, MFMailComposeViewC
   }
 
   fileprivate func pushLoginViewController() {
-    if featureLoginWithOAuthEnabled(), let session = createAuthorizationSession() {
+    if self.viewModel.outputs.loginWithOAuthEnabled, let session = createAuthorizationSession() {
       session.presentationContextProvider = self
       session.start()
     } else {

--- a/Library/ViewModels/LoginToutViewModel.swift
+++ b/Library/ViewModels/LoginToutViewModel.swift
@@ -97,6 +97,10 @@ public protocol LoginToutViewModelOutputs {
 
   /// Emits an access token to show 2fa view when Facebook login fails with tfaRequired error
   var startTwoFactorChallenge: Signal<String, Never> { get }
+
+  /// True if the feature flag for OAuth login is true.
+  /// Note that this is not a signal, because we don't want it to ever change after the screen is loaded.
+  var loginWithOAuthEnabled: Bool { get }
 }
 
 public protocol LoginToutViewModelType {
@@ -265,6 +269,7 @@ public final class LoginToutViewModel: LoginToutViewModelType, LoginToutViewMode
 
     self.logIntoEnvironmentWithApple = logIntoEnvironmentWithApple.signal
     self.logIntoEnvironmentWithFacebook = logIntoEnvironmentWithFacebook.signal
+    self.loginWithOAuthEnabled = featureLoginWithOAuthEnabled()
   }
 
   public var inputs: LoginToutViewModelInputs { return self }
@@ -354,6 +359,7 @@ public final class LoginToutViewModel: LoginToutViewModelType, LoginToutViewMode
   public let startTwoFactorChallenge: Signal<String, Never>
   public let showAppleErrorAlert: Signal<String, Never>
   public let showFacebookErrorAlert: Signal<AlertError, Never>
+  public let loginWithOAuthEnabled: Bool
 }
 
 private func statusString(_ forStatus: LoginIntent) -> String {


### PR DESCRIPTION
# 📲 What

Remove the sign up button (and change the login button text) when OAuth is turned on.

# 🤔 Why

Users who want to sign up will go through the web-based sign up flow, using the same web view as login.
<img width="200" alt="Screenshot 2024-02-23 at 12 14 38 PM" src="https://github.com/kickstarter/ios-oss/assets/146007185/791b06e7-4c2b-4c79-b88a-499d93cfe0fd">

# 👀 See

OAuth off:
<img width="200" alt="Screenshot 2024-02-23 at 12 12 52 PM" src="https://github.com/kickstarter/ios-oss/assets/146007185/0306cce3-4e8a-48b6-af25-1ce67b1170cd">

OAuth on:
<img width="200" alt="Screenshot 2024-02-23 at 12 34 10 PM" src="https://github.com/kickstarter/ios-oss/assets/146007185/4863a447-1065-42dd-ade1-f3e8570c55c2">

