### PR TITLE
MBL-1161: Run AppEnvironmentTests in both hosted and unhosted test bundles

### DIFF
--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -1515,6 +1515,7 @@
 		E17611E22B73D9A400DF2F50 /* Data+PKCE.swift in Sources */ = {isa = PBXBuildFile; fileRef = E17611E12B73D9A400DF2F50 /* Data+PKCE.swift */; };
 		E17611E42B751E8100DF2F50 /* Paginator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E17611E32B751E8100DF2F50 /* Paginator.swift */; };
 		E17611E62B75242A00DF2F50 /* PaginatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E17611E52B75242A00DF2F50 /* PaginatorTests.swift */; };
+		E182E5BA2B8CDFDE0008DD69 /* AppEnvironmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7ED1F121E830FDC00BFFA01 /* AppEnvironmentTests.swift */; };
 		E1A1491E2ACDD76800F49709 /* FetchBackerProjectsQuery.graphql in Resources */ = {isa = PBXBuildFile; fileRef = E1A1491D2ACDD76700F49709 /* FetchBackerProjectsQuery.graphql */; };
 		E1A149202ACDD7BF00F49709 /* FetchProjectsEnvelope+FetchBackerProjectsQueryData.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1A1491F2ACDD7BF00F49709 /* FetchProjectsEnvelope+FetchBackerProjectsQueryData.swift */; };
 		E1A149222ACE013100F49709 /* FetchProjectsEnvelope.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1A149212ACE013100F49709 /* FetchProjectsEnvelope.swift */; };
@@ -8989,6 +8990,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E182E5BA2B8CDFDE0008DD69 /* AppEnvironmentTests.swift in Sources */,
 				E113BD842B7D255000D3A809 /* Library_Keychain_iOSTests.swift in Sources */,
 				E113BD8D2B7D255A00D3A809 /* KeychainTests.swift in Sources */,
 			);

--- a/Library/AppEnvironment.swift
+++ b/Library/AppEnvironment.swift
@@ -133,7 +133,19 @@ public struct AppEnvironment: AppEnvironmentType {
       ubiquitousStore: next.ubiquitousStore,
       userDefaults: next.userDefaults
     )
+
+    // If there are no more items in the stack,
+    // then the next call to AppEvironment.current will fail.
+    assert(self.stack.count > 0)
+
     return last
+  }
+
+  internal static func resetStackForUnitTests() {
+    while self.stack.popLast() != nil {}
+
+    let next = Environment()
+    self.pushEnvironment(next)
   }
 
   // Replace the current environment with a new environment.

--- a/Library/AppEnvironmentTests.swift
+++ b/Library/AppEnvironmentTests.swift
@@ -5,6 +5,10 @@ import Prelude
 import XCTest
 
 final class AppEnvironmentTests: XCTestCase {
+  override func setUp() {
+    AppEnvironment.resetStackForUnitTests()
+  }
+
   func testPushAndPopEnvironment() {
     let lang = AppEnvironment.current.language
 

--- a/Library/ViewModels/PledgeDisclaimerViewModelTests.swift
+++ b/Library/ViewModels/PledgeDisclaimerViewModelTests.swift
@@ -9,6 +9,7 @@ final class PledgeDisclaimerViewModelTests: TestCase {
   private let notifyDelegateLinkTappedWithURL = TestObserver<URL, Never>()
 
   override func setUp() {
+    super.setUp()
     self.vm.outputs.notifyDelegateLinkTappedWithURL
       .observe(self.notifyDelegateLinkTappedWithURL.observer)
   }


### PR DESCRIPTION
# 📲 What

Add `AppEnvironmentTests` to the hosted test bundle, `Library-Keychain-iOSTests`. This also includes some bug fixes to make that change work. 

# 🤔 Why

As part of OAuth, we want to start storing our OAuth token in the keychain, instead of in user defaults. This has led to some interesting problems with our test environment. The keychain _only works_ if your unit tests are "hosted" within an application, which means the tests will actually boot our app before running the unit tests. However, many of our unit tests break in a hosted environment. This is because the app has its own state - it pushes/pops/manipulates a lot of global environment, and that overlaps with tests.

# 🛠 How

By adding `AppEnvironmentTests` to both the hosted and the unhosted test bundles, I'll be able to test the `AppEnvironment` both with and without the keychain. When I moved the test over, I noticed certain things break - state from the app was leaking into `AppEnvironmentTests`.

The solution I landed on was pretty simple; I just added some extra code to `setUp` to wipe out any state from `AppEnvironment` before running the tests. Interestingly, I noticed that doing this broke a completelely unrelated test `PledgeDisclaimerViewModelTests`. This was because `PledgeDisclaimerViewModelTests` had an unmatched environment push/pop. 

# 👀 See

![Screenshot 2024-02-26 at 10 44 45 AM](https://github.com/kickstarter/ios-oss/assets/146007185/c01706de-1126-4fcd-b25c-c7331d25a0ab)

![Screenshot 2024-02-26 at 10 53 20 AM](https://github.com/kickstarter/ios-oss/assets/146007185/7f2c86af-d4c3-4895-b778-14485f618c1c)