### PR TITLE
MBL-1161: Read and store OAuth token from keychain

### DIFF
--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -1517,6 +1517,7 @@
 		E17611E42B751E8100DF2F50 /* Paginator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E17611E32B751E8100DF2F50 /* Paginator.swift */; };
 		E17611E62B75242A00DF2F50 /* PaginatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E17611E52B75242A00DF2F50 /* PaginatorTests.swift */; };
 		E182E5BA2B8CDFDE0008DD69 /* AppEnvironmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7ED1F121E830FDC00BFFA01 /* AppEnvironmentTests.swift */; };
+		E182E5BC2B8D36FE0008DD69 /* AppEnvironmentTests+OAuthInKeychain.swift in Sources */ = {isa = PBXBuildFile; fileRef = E182E5BB2B8D36FE0008DD69 /* AppEnvironmentTests+OAuthInKeychain.swift */; };
 		E1A1491E2ACDD76800F49709 /* FetchBackerProjectsQuery.graphql in Resources */ = {isa = PBXBuildFile; fileRef = E1A1491D2ACDD76700F49709 /* FetchBackerProjectsQuery.graphql */; };
 		E1A149202ACDD7BF00F49709 /* FetchProjectsEnvelope+FetchBackerProjectsQueryData.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1A1491F2ACDD7BF00F49709 /* FetchProjectsEnvelope+FetchBackerProjectsQueryData.swift */; };
 		E1A149222ACE013100F49709 /* FetchProjectsEnvelope.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1A149212ACE013100F49709 /* FetchProjectsEnvelope.swift */; };
@@ -3126,6 +3127,7 @@
 		E17611E12B73D9A400DF2F50 /* Data+PKCE.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+PKCE.swift"; sourceTree = "<group>"; };
 		E17611E32B751E8100DF2F50 /* Paginator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Paginator.swift; sourceTree = "<group>"; };
 		E17611E52B75242A00DF2F50 /* PaginatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginatorTests.swift; sourceTree = "<group>"; };
+		E182E5BB2B8D36FE0008DD69 /* AppEnvironmentTests+OAuthInKeychain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppEnvironmentTests+OAuthInKeychain.swift"; sourceTree = "<group>"; };
 		E1889D8D2B6065D6004FBE21 /* CombineTestObserverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CombineTestObserverTests.swift; sourceTree = "<group>"; };
 		E1A1491D2ACDD76700F49709 /* FetchBackerProjectsQuery.graphql */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = FetchBackerProjectsQuery.graphql; sourceTree = "<group>"; };
 		E1A1491F2ACDD7BF00F49709 /* FetchProjectsEnvelope+FetchBackerProjectsQueryData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "FetchProjectsEnvelope+FetchBackerProjectsQueryData.swift"; sourceTree = "<group>"; };
@@ -6000,6 +6002,7 @@
 				A709697D1D143D1300DB39D3 /* AlertError.swift */,
 				A7C725781C85D36D005A016B /* AppEnvironment.swift */,
 				A7ED1F121E830FDC00BFFA01 /* AppEnvironmentTests.swift */,
+				E182E5BB2B8D36FE0008DD69 /* AppEnvironmentTests+OAuthInKeychain.swift */,
 				D764373F22414FA900DAFC9E /* AppEnvironmentType.swift */,
 				77C9122823C4FC0B00F3D2C9 /* ApplePayCapabilities.swift */,
 				77C9122E23C508CF00F3D2C9 /* ApplePayCapabilitiesTests.swift */,
@@ -8994,6 +8997,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E182E5BC2B8D36FE0008DD69 /* AppEnvironmentTests+OAuthInKeychain.swift in Sources */,
 				E182E5BA2B8CDFDE0008DD69 /* AppEnvironmentTests.swift in Sources */,
 				E113BD842B7D255000D3A809 /* Library_Keychain_iOSTests.swift in Sources */,
 				E113BD8D2B7D255A00D3A809 /* KeychainTests.swift in Sources */,

--- a/Library/AppEnvironment.swift
+++ b/Library/AppEnvironment.swift
@@ -296,12 +296,12 @@ public struct AppEnvironment: AppEnvironmentType {
     )
   }
 
-  private static func accountNameForUserId(_ userId: Int) -> String {
+  internal static func accountNameForUserId(_ userId: Int) -> String {
     return "kickstarter_\(userId)"
   }
 
   private static func storeOAuthTokenToKeychain(_ oauthToken: String, forUserId id: Int?) -> Bool {
-    guard featureLoginWithOAuthEnabled(), let userId = id
+    guard featureUseKeychainForOAuthTokenEnabled(), let userId = id
     else {
       return false
     }
@@ -317,7 +317,7 @@ public struct AppEnvironment: AppEnvironmentType {
   }
 
   private static func fetchOAuthTokenFromKeychain(forUserId id: Int?) -> String? {
-    guard featureLoginWithOAuthEnabled(), let userId = id
+    guard featureUseKeychainForOAuthTokenEnabled(), let userId = id
     else {
       return nil
     }

--- a/Library/AppEnvironment.swift
+++ b/Library/AppEnvironment.swift
@@ -351,9 +351,6 @@ public struct AppEnvironment: AppEnvironmentType {
       service = service.login(OauthToken(token: oauthToken))
     } else if let oauthToken = data["apiService.oauthToken.token"] as? String {
       service = service.login(OauthToken(token: oauthToken))
-
-      // Move it over to the keychain if we can
-      _ = self.storeOAuthTokenToKeychain(oauthToken, forUserId: userFromDefaults?.id)
     }
 
     // Try restoring the client id for the api service

--- a/Library/AppEnvironmentTests+OAuthInKeychain.swift
+++ b/Library/AppEnvironmentTests+OAuthInKeychain.swift
@@ -49,7 +49,7 @@ final class AppEnvironmentTests_OAuthInKeychain: XCTestCase {
 
     do {
       let tokenFromKeychain = try Keychain
-        .fetchPassword(forAccount: AppEnvironment.accountNameForUserId(currentUser.id))
+        .fetchPassword(forAccount: AppEnvironment.accountNameForKeychain)
       XCTAssertEqual(tokenFromKeychain, "deadbeef")
 
     } catch {
@@ -190,6 +190,7 @@ final class AppEnvironmentTests_OAuthInKeychain: XCTestCase {
 
     XCTAssertNil(AppEnvironment.current.apiService.oauthToken)
     XCTAssertNil(AppEnvironment.current.currentUser)
+    XCTAssertFalse(Keychain.hasPassword(forAccount: AppEnvironment.accountNameForKeychain))
 
     let env = AppEnvironment
       .fromStorage(
@@ -221,7 +222,7 @@ final class AppEnvironmentTests_OAuthInKeychain: XCTestCase {
     )
 
     XCTAssertNoThrow(try Keychain
-      .storePassword(tokenInKeychain, forAccount: AppEnvironment.accountNameForUserId(user.id)))
+      .storePassword(tokenInKeychain, forAccount: AppEnvironment.accountNameForKeychain))
 
     let env = AppEnvironment
       .fromStorage(
@@ -263,7 +264,7 @@ final class AppEnvironmentTests_OAuthInKeychain: XCTestCase {
     AppEnvironment.pushEnvironment(env)
 
     let tokenFromKeychain = try! Keychain
-      .fetchPassword(forAccount: AppEnvironment.accountNameForUserId(user.id))
+      .fetchPassword(forAccount: AppEnvironment.accountNameForKeychain)
     XCTAssertEqual(tokenInDefaults, tokenFromKeychain)
   }
 
@@ -289,6 +290,7 @@ final class AppEnvironmentTests_OAuthInKeychain: XCTestCase {
 
     XCTAssertNil(AppEnvironment.current.apiService.oauthToken)
     XCTAssertNil(AppEnvironment.current.currentUser)
+    XCTAssertFalse(Keychain.hasPassword(forAccount: AppEnvironment.accountNameForKeychain))
 
     let env = AppEnvironment
       .fromStorage(
@@ -296,8 +298,8 @@ final class AppEnvironmentTests_OAuthInKeychain: XCTestCase {
         userDefaults: userDefaults
       )
 
-    XCTAssertNil(AppEnvironment.current.apiService.oauthToken)
-    XCTAssertNil(AppEnvironment.current.currentUser)
+    XCTAssertNil(env.apiService.oauthToken)
+    XCTAssertNil(env.currentUser)
   }
 
   func testFromStorage_featureUseKeychainEnabledIsFalse_hasTokenInDefaults_usesTokenInDefaults() {
@@ -319,7 +321,7 @@ final class AppEnvironmentTests_OAuthInKeychain: XCTestCase {
     )
 
     XCTAssertNoThrow(try Keychain
-      .storePassword(tokenInKeychain, forAccount: AppEnvironment.accountNameForUserId(user.id)))
+      .storePassword(tokenInKeychain, forAccount: AppEnvironment.accountNameForKeychain))
 
     let env = AppEnvironment
       .fromStorage(
@@ -358,7 +360,7 @@ final class AppEnvironmentTests_OAuthInKeychain: XCTestCase {
     XCTAssertNotNil(env.apiService.oauthToken)
     XCTAssertEqual(env.apiService.oauthToken?.token, tokenInDefaults)
 
-    let hasTokenInKeychain = Keychain.hasPassword(forAccount: AppEnvironment.accountNameForUserId(user.id))
+    let hasTokenInKeychain = Keychain.hasPassword(forAccount: AppEnvironment.accountNameForKeychain)
     XCTAssertFalse(hasTokenInKeychain)
   }
 
@@ -373,7 +375,7 @@ final class AppEnvironmentTests_OAuthInKeychain: XCTestCase {
     let user = User.template
     let token1 = "first token"
     let token2 = "second token"
-    let accountName = AppEnvironment.accountNameForUserId(user.id)
+    let accountName = AppEnvironment.accountNameForKeychain
 
     AppEnvironment.login(AccessTokenEnvelope(accessToken: token1, user: user))
 

--- a/Library/AppEnvironmentTests+OAuthInKeychain.swift
+++ b/Library/AppEnvironmentTests+OAuthInKeychain.swift
@@ -69,7 +69,7 @@ final class AppEnvironmentTests_OAuthInKeychain: XCTestCase {
 
     XCTAssertEqual(
       nil, ubiquitousStore.string(forKey: AppEnvironment.oauthTokenStorageKey),
-      "No token stored."
+      "Token should never have been stored in the ubiquitous store; only in the user defaults or keychain."
     )
   }
 

--- a/Library/AppEnvironmentTests+OAuthInKeychain.swift
+++ b/Library/AppEnvironmentTests+OAuthInKeychain.swift
@@ -234,7 +234,7 @@ final class AppEnvironmentTests_OAuthInKeychain: XCTestCase {
     XCTAssertNotEqual(env.apiService.oauthToken?.token, tokenInDefaults)
   }
 
-  func testFromStorage_featureUseKeychainEnabledIsTrue_hasTokenInDefaults_usesTokenAndMigratesToKeychain() {
+  func testFromStorage_featureUseKeychainEnabledIsTrue_hasTokenInDefaults_usesTokenAndMigratesToKeychainOnNextSave() {
     self.setFeatureUseKeychainEnabled(true)
 
     let tokenInDefaults = "this is my token"
@@ -259,6 +259,8 @@ final class AppEnvironmentTests_OAuthInKeychain: XCTestCase {
 
     XCTAssertNotNil(env.apiService.oauthToken)
     XCTAssertEqual(env.apiService.oauthToken?.token, tokenInDefaults)
+
+    AppEnvironment.pushEnvironment(env)
 
     let tokenFromKeychain = try! Keychain
       .fetchPassword(forAccount: AppEnvironment.accountNameForUserId(user.id))

--- a/Library/AppEnvironmentTests+OAuthInKeychain.swift
+++ b/Library/AppEnvironmentTests+OAuthInKeychain.swift
@@ -1,0 +1,422 @@
+@testable import KsApi
+@testable import Library
+import XCTest
+
+final class AppEnvironmentTests_OAuthInKeychain: XCTestCase {
+  override func setUp() {
+    AppEnvironment.resetStackForUnitTests()
+    XCTAssertNoThrow(try Keychain.deleteAllPasswords())
+  }
+
+  func setFeatureUseKeychainEnabled(_ setting: Bool) {
+    let mockConfigClient = MockRemoteConfigClient()
+    mockConfigClient.features = [
+      RemoteConfigFeature.useKeychainForOAuthToken.rawValue: setting
+    ]
+
+    /* Awkward bit of condition here - our feature flag values implicitly come from
+     AppEnvironment.current, which in some cases, is the PREVIOUS environment in the stack.
+     If you're pushing/saving a new stack, that can be confusing. */
+    AppEnvironment.updateRemoteConfigClient(mockConfigClient)
+  }
+
+  // MARK: - Tests copied from AppEnvironmentTests
+
+  func testSaveEnvironment_featureUseKeychainEnabledIsTrue() {
+    self.setFeatureUseKeychainEnabled(true)
+
+    let apiService = MockService(
+      serverConfig: ServerConfig(
+        apiBaseUrl: URL(string: "http://api.ksr.com")!,
+        webBaseUrl: URL(string: "http://ksr.com")!,
+        apiClientAuth: ClientAuth(clientId: "cafebeef"),
+        basicHTTPAuth: nil,
+        graphQLEndpointUrl: URL(string: "http://ksr.dev/graph")!
+      ),
+      oauthToken: OauthToken(token: "deadbeef")
+    )
+    let currentUser = User.template
+    let userDefaults = MockKeyValueStore()
+    let ubiquitousStore = MockKeyValueStore()
+
+    AppEnvironment.saveEnvironment(
+      environment: Environment(apiService: apiService, currentUser: currentUser),
+      ubiquitousStore: ubiquitousStore,
+      userDefaults: userDefaults
+    )
+
+    let result = userDefaults.dictionary(forKey: AppEnvironment.environmentStorageKey)!
+
+    do {
+      let tokenFromKeychain = try Keychain
+        .fetchPassword(forAccount: AppEnvironment.accountNameForUserId(currentUser.id))
+      XCTAssertEqual(tokenFromKeychain, "deadbeef")
+
+    } catch {
+      XCTFail("Expected keychain fetch not to throw")
+    }
+
+    XCTAssertNil(
+      result["apiService.oauthToken.token"] as? String,
+      "If login with keychain is enabled, the oauth token shouldn't be saved in the user defaults"
+    )
+
+    XCTAssertEqual("http://api.ksr.com", result["apiService.serverConfig.apiBaseUrl"] as? String)
+    XCTAssertEqual("cafebeef", result["apiService.serverConfig.apiClientAuth.clientId"] as? String)
+    XCTAssertEqual("http://ksr.com", result["apiService.serverConfig.webBaseUrl"] as? String)
+    XCTAssertEqual("en", result["apiService.language"] as? String)
+    XCTAssertEqual(User.template.id, (result["currentUser"] as? [String: AnyObject])?["id"] as? Int)
+
+    XCTAssertEqual(
+      nil, ubiquitousStore.string(forKey: AppEnvironment.oauthTokenStorageKey),
+      "No token stored."
+    )
+  }
+
+  func testRestoreFromEnvironment_featureUseKeychainEnabledIsTrue() {
+    self.setFeatureUseKeychainEnabled(true)
+
+    let apiService = MockService(
+      serverConfig: ServerConfig.production,
+      oauthToken: OauthToken(token: "deadbeef")
+    )
+
+    let currentUser = User.template
+    let userDefaults = MockKeyValueStore()
+    let ubiquitousStore = MockKeyValueStore()
+
+    AppEnvironment.saveEnvironment(
+      environment: Environment(
+        apiService: apiService,
+        currentUser: currentUser
+      ),
+      ubiquitousStore: ubiquitousStore,
+      userDefaults: userDefaults
+    )
+
+    let env = AppEnvironment.fromStorage(ubiquitousStore: ubiquitousStore, userDefaults: userDefaults)
+
+    XCTAssertEqual("deadbeef", env.apiService.oauthToken?.token)
+    XCTAssertEqual(
+      ServerConfig.production.apiBaseUrl.absoluteString,
+      env.apiService.serverConfig.apiBaseUrl.absoluteString
+    )
+    XCTAssertEqual(
+      ServerConfig.production.apiClientAuth.clientId,
+      env.apiService.serverConfig.apiClientAuth.clientId
+    )
+    XCTAssertNil(ServerConfig.production.basicHTTPAuth)
+    XCTAssertEqual(
+      ServerConfig.production.webBaseUrl.absoluteString,
+      env.apiService.serverConfig.webBaseUrl.absoluteString
+    )
+    XCTAssertEqual(EnvironmentType.production, env.apiService.serverConfig.environment)
+    XCTAssertEqual(currentUser, env.currentUser)
+    XCTAssertEqual(currentUser, env.ksrAnalytics.loggedInUser)
+  }
+
+  func testFromStorage_WithFullDataStored_featureUseKeychainEnabledIsTrue() {
+    self.setFeatureUseKeychainEnabled(true)
+
+    let userDefaults = MockKeyValueStore()
+    let ubiquitousStore = MockKeyValueStore()
+    let user = User.template
+
+    userDefaults.set(
+      [
+        "apiService.oauthToken.token": "deadbeef",
+        "apiService.serverConfig.apiBaseUrl": "http://api.ksr.com",
+        "apiService.serverConfig.apiClientAuth.clientId": "cafebeef",
+        "apiService.serverConfig.basicHTTPAuth.username": "hola",
+        "apiService.serverConfig.basicHTTPAuth.password": "mundo",
+        "apiService.serverConfig.webBaseUrl": "http://ksr.com",
+        "apiService.language": "en",
+        "currentUser": user.encode()
+      ] as [String: Any],
+      forKey: AppEnvironment.environmentStorageKey
+    )
+
+    let env = AppEnvironment.fromStorage(ubiquitousStore: ubiquitousStore, userDefaults: userDefaults)
+
+    XCTAssertEqual("deadbeef", env.apiService.oauthToken?.token)
+    XCTAssertEqual("http://api.ksr.com", env.apiService.serverConfig.apiBaseUrl.absoluteString)
+    XCTAssertEqual("cafebeef", env.apiService.serverConfig.apiClientAuth.clientId)
+    XCTAssertEqual("hola", env.apiService.serverConfig.basicHTTPAuth?.username)
+    XCTAssertEqual("mundo", env.apiService.serverConfig.basicHTTPAuth?.password)
+    XCTAssertEqual("http://ksr.com", env.apiService.serverConfig.webBaseUrl.absoluteString)
+    XCTAssertEqual(user, env.currentUser)
+    XCTAssertEqual(user, env.ksrAnalytics.loggedInUser)
+    XCTAssertNotNil(env.appTrackingTransparency)
+
+    let differentEnv = AppEnvironment.fromStorage(
+      ubiquitousStore: MockKeyValueStore(),
+      userDefaults: MockKeyValueStore()
+    )
+    XCTAssertNil(differentEnv.apiService.oauthToken?.token)
+    XCTAssertEqual(nil, differentEnv.currentUser)
+    XCTAssertNotNil(env.appTrackingTransparency)
+  }
+
+  func testFromStorage_WithNothingStored_featureUseKeychainEnabledIsTrue() {
+    self.setFeatureUseKeychainEnabled(true)
+
+    let userDefaults = MockKeyValueStore()
+    let ubiquitousStore = MockKeyValueStore()
+    let env = AppEnvironment.fromStorage(ubiquitousStore: ubiquitousStore, userDefaults: userDefaults)
+
+    XCTAssertNil(env.apiService.oauthToken?.token)
+    XCTAssertEqual(nil, env.currentUser)
+  }
+
+  func testUserSession_featureUseKeychainEnabledIsTrue() {
+    self.setFeatureUseKeychainEnabled(true)
+
+    AppEnvironment.pushEnvironment(userDefaults: MockKeyValueStore())
+
+    XCTAssertNil(AppEnvironment.current.apiService.oauthToken)
+    XCTAssertNil(AppEnvironment.current.currentUser)
+
+    AppEnvironment.login(AccessTokenEnvelope(accessToken: "deadbeef", user: User.template))
+
+    XCTAssertEqual("deadbeef", AppEnvironment.current.apiService.oauthToken?.token)
+    XCTAssertEqual(User.template, AppEnvironment.current.currentUser)
+
+    AppEnvironment.updateCurrentUser(User.template)
+
+    XCTAssertEqual("deadbeef", AppEnvironment.current.apiService.oauthToken?.token)
+    XCTAssertEqual(User.template, AppEnvironment.current.currentUser)
+
+    AppEnvironment.logout()
+
+    XCTAssertNil(AppEnvironment.current.apiService.oauthToken)
+    XCTAssertNil(AppEnvironment.current.currentUser)
+
+    let env = AppEnvironment
+      .fromStorage(
+        ubiquitousStore: AppEnvironment.current.ubiquitousStore,
+        userDefaults: AppEnvironment.current.userDefaults
+      )
+    XCTAssertNil(env.apiService.oauthToken)
+    XCTAssertNil(env.currentUser)
+  }
+
+  // MARK: - New tests
+
+  func testFromStorage_featureUseKeychainEnabledIsTrue_hasTokenInKeychain_usesToken() {
+    self.setFeatureUseKeychainEnabled(true)
+
+    let tokenInKeychain = "this is my token"
+    let tokenInDefaults = "this is NOT my token"
+    let user = User.template
+
+    let userDefaults = MockKeyValueStore()
+    let ubiquitousStore = MockKeyValueStore()
+
+    userDefaults.set(
+      [
+        "apiService.oauthToken.token": tokenInDefaults,
+        "currentUser": user.encode()
+      ] as [String: Any],
+      forKey: AppEnvironment.environmentStorageKey
+    )
+
+    XCTAssertNoThrow(try Keychain
+      .storePassword(tokenInKeychain, forAccount: AppEnvironment.accountNameForUserId(user.id)))
+
+    let env = AppEnvironment
+      .fromStorage(
+        ubiquitousStore: ubiquitousStore,
+        userDefaults: userDefaults
+      )
+
+    XCTAssertNotNil(env.apiService.oauthToken)
+    XCTAssertEqual(env.apiService.oauthToken?.token, tokenInKeychain)
+    XCTAssertNotEqual(env.apiService.oauthToken?.token, tokenInDefaults)
+  }
+
+  func testFromStorage_featureUseKeychainEnabledIsTrue_hasTokenInDefaults_usesTokenAndMigratesToKeychain() {
+    self.setFeatureUseKeychainEnabled(true)
+
+    let tokenInDefaults = "this is my token"
+    let user = User.template
+
+    let userDefaults = MockKeyValueStore()
+    let ubiquitousStore = MockKeyValueStore()
+
+    userDefaults.set(
+      [
+        "apiService.oauthToken.token": tokenInDefaults,
+        "currentUser": user.encode()
+      ] as [String: Any],
+      forKey: AppEnvironment.environmentStorageKey
+    )
+
+    let env = AppEnvironment
+      .fromStorage(
+        ubiquitousStore: ubiquitousStore,
+        userDefaults: userDefaults
+      )
+
+    XCTAssertNotNil(env.apiService.oauthToken)
+    XCTAssertEqual(env.apiService.oauthToken?.token, tokenInDefaults)
+
+    let tokenFromKeychain = try! Keychain
+      .fetchPassword(forAccount: AppEnvironment.accountNameForUserId(user.id))
+    XCTAssertEqual(tokenInDefaults, tokenFromKeychain)
+  }
+
+  func testLoginLogoutFromStorage_clearsKeychainTokenAfterLogout() {
+    self.setFeatureUseKeychainEnabled(true)
+    let user = User.template
+    let token = "this is a token"
+
+    let userDefaults = MockKeyValueStore()
+    let ubiquitousStore = MockKeyValueStore()
+
+    AppEnvironment.pushEnvironment(userDefaults: userDefaults)
+
+    XCTAssertNil(AppEnvironment.current.apiService.oauthToken)
+    XCTAssertNil(AppEnvironment.current.currentUser)
+
+    AppEnvironment.login(AccessTokenEnvelope(accessToken: token, user: user))
+
+    XCTAssertEqual(AppEnvironment.current.apiService.oauthToken?.token, token)
+    XCTAssertEqual(AppEnvironment.current.currentUser, user)
+
+    AppEnvironment.logout()
+
+    XCTAssertNil(AppEnvironment.current.apiService.oauthToken)
+    XCTAssertNil(AppEnvironment.current.currentUser)
+
+    let env = AppEnvironment
+      .fromStorage(
+        ubiquitousStore: ubiquitousStore,
+        userDefaults: userDefaults
+      )
+
+    XCTAssertNil(AppEnvironment.current.apiService.oauthToken)
+    XCTAssertNil(AppEnvironment.current.currentUser)
+  }
+
+  func testFromStorage_featureUseKeychainEnabledIsFalse_hasTokenInDefaults_usesTokenInDefaults() {
+    self.setFeatureUseKeychainEnabled(false)
+
+    let tokenInKeychain = "this is NOT my token"
+    let tokenInDefaults = "this is my token"
+    let user = User.template
+
+    let userDefaults = MockKeyValueStore()
+    let ubiquitousStore = MockKeyValueStore()
+
+    userDefaults.set(
+      [
+        "apiService.oauthToken.token": tokenInDefaults,
+        "currentUser": user.encode()
+      ] as [String: Any],
+      forKey: AppEnvironment.environmentStorageKey
+    )
+
+    XCTAssertNoThrow(try Keychain
+      .storePassword(tokenInKeychain, forAccount: AppEnvironment.accountNameForUserId(user.id)))
+
+    let env = AppEnvironment
+      .fromStorage(
+        ubiquitousStore: ubiquitousStore,
+        userDefaults: userDefaults
+      )
+
+    XCTAssertNotNil(env.apiService.oauthToken)
+    XCTAssertEqual(env.apiService.oauthToken?.token, tokenInDefaults)
+    XCTAssertNotEqual(env.apiService.oauthToken?.token, tokenInKeychain)
+  }
+
+  func testFromStorage_featureUseKeychainEnabledIsFalse_hasTokenInDefaults_usesTokenAndDoesntMigrateToKeychain() {
+    self.setFeatureUseKeychainEnabled(false)
+
+    let tokenInDefaults = "this is my token"
+    let user = User.template
+
+    let userDefaults = MockKeyValueStore()
+    let ubiquitousStore = MockKeyValueStore()
+
+    userDefaults.set(
+      [
+        "apiService.oauthToken.token": tokenInDefaults,
+        "currentUser": user.encode()
+      ] as [String: Any],
+      forKey: AppEnvironment.environmentStorageKey
+    )
+
+    let env = AppEnvironment
+      .fromStorage(
+        ubiquitousStore: ubiquitousStore,
+        userDefaults: userDefaults
+      )
+
+    XCTAssertNotNil(env.apiService.oauthToken)
+    XCTAssertEqual(env.apiService.oauthToken?.token, tokenInDefaults)
+
+    let hasTokenInKeychain = Keychain.hasPassword(forAccount: AppEnvironment.accountNameForUserId(user.id))
+    XCTAssertFalse(hasTokenInKeychain)
+  }
+
+  func testLoginTwice_differentToken_changesTokenInKeychain() {
+    self.setFeatureUseKeychainEnabled(true)
+
+    let userDefaults = MockKeyValueStore()
+    let ubiquitiousStore = MockKeyValueStore()
+
+    AppEnvironment.pushEnvironment(userDefaults: userDefaults)
+
+    let user = User.template
+    let token1 = "first token"
+    let token2 = "second token"
+    let accountName = AppEnvironment.accountNameForUserId(user.id)
+
+    AppEnvironment.login(AccessTokenEnvelope(accessToken: token1, user: user))
+
+    let fetchedToken1 = try! Keychain.fetchPassword(forAccount: accountName)
+    XCTAssertEqual(AppEnvironment.current.apiService.oauthToken?.token, token1)
+    XCTAssertEqual(fetchedToken1, token1)
+
+    AppEnvironment.login(AccessTokenEnvelope(accessToken: token2, user: user))
+
+    let fetchedToken2 = try! Keychain.fetchPassword(forAccount: accountName)
+    XCTAssertEqual(AppEnvironment.current.apiService.oauthToken?.token, token2)
+    XCTAssertEqual(fetchedToken2, token2)
+
+    let env = AppEnvironment.fromStorage(ubiquitousStore: ubiquitiousStore, userDefaults: userDefaults)
+    XCTAssertEqual(env.apiService.oauthToken?.token, token2)
+  }
+
+  func testMigrateToKeychain_thenTurnOffFeatureFlag() {
+    self.setFeatureUseKeychainEnabled(true)
+
+    let token = "this is a token"
+    let user = User.template
+
+    let userDefaults = MockKeyValueStore()
+    let ubiquitousStore = MockKeyValueStore()
+
+    userDefaults.set(
+      [
+        "apiService.oauthToken.token": token,
+        "currentUser": user.encode()
+      ] as [String: Any],
+      forKey: AppEnvironment.environmentStorageKey
+    )
+
+    let env = AppEnvironment.fromStorage(ubiquitousStore: ubiquitousStore, userDefaults: userDefaults)
+    XCTAssertEqual(env.apiService.oauthToken?.token, token)
+    XCTAssertEqual(env.currentUser, user)
+
+    AppEnvironment.saveEnvironment(ubiquitousStore: ubiquitousStore, userDefaults: userDefaults)
+
+    self.setFeatureUseKeychainEnabled(false)
+
+    // Keychain use is off, but the token has been deleted from userDefaults
+    let env2 = AppEnvironment.fromStorage(ubiquitousStore: ubiquitousStore, userDefaults: userDefaults)
+    XCTAssertNil(env2.apiService.oauthToken?.token)
+    XCTAssertNil(env2.currentUser)
+  }
+}


### PR DESCRIPTION
# 📲 What

Store the OAuth token in the keychain, instead of in user defaults. Additional code moves the old token out of defaults and into the keychain if you were already logged in.

# 🤔 Why

Leaving the token in user defaults is insecure. 

# 🛠 How

We store the OAuth token per-user, using a pseudo-account-name like `kickstarter_12345` for user with id `12345`. The change is gated behind a feature flag, and hopefully fairly robust to any keychain failures or exceptions.

# ⏰ TODO
- [x] Solicit feedback about storing token per-user vs. just one for the entire app
- [ ] Run testing on-device 


