### PR TITLE
MBL-1211: Pass down pledge total to thank you page for new page copy

### DIFF
--- a/Kickstarter-iOS/Features/ThanksProjects/Controller/ThanksViewControllerTests.swift
+++ b/Kickstarter-iOS/Features/ThanksProjects/Controller/ThanksViewControllerTests.swift
@@ -37,7 +37,7 @@ class ThanksViewControllerTests: TestCase {
         let project = Project.cosmicSurgery
           |> Project.lens.id .~ 3
 
-        let controller = ThanksViewController.configured(with: (project, Reward.template, nil))
+        let controller = ThanksViewController.configured(with: (project, Reward.template, nil, 1))
 
         let (parent, _) = traitControllers(device: device, orientation: .portrait, child: controller)
         parent.view.frame.size.height = 1_000

--- a/Library/ViewModels/PledgeViewModel.swift
+++ b/Library/ViewModels/PledgeViewModel.swift
@@ -905,7 +905,7 @@ public class PledgeViewModel: PledgeViewModelType, PledgeViewModelInputs, Pledge
         isApplePay: isApplePay
       )
 
-      return (data.project, baseReward, checkoutPropsData)
+      return (data.project, baseReward, checkoutPropsData, data.pledgeTotal)
     }
     .skipNil()
 

--- a/Library/ViewModels/PledgeViewModelTests.swift
+++ b/Library/ViewModels/PledgeViewModelTests.swift
@@ -156,9 +156,9 @@ final class PledgeViewModelTests: TestCase {
 
     self.vm.outputs.goToRiskMessagingModal.observe(self.goToRiskMessagingModal.observer)
 
-    self.vm.outputs.goToThanks.map(first).observe(self.goToThanksProject.observer)
-    self.vm.outputs.goToThanks.map(second).observe(self.goToThanksReward.observer)
-    self.vm.outputs.goToThanks.map(third).observe(self.goToThanksCheckoutData.observer)
+    self.vm.outputs.goToThanks.map { $0.project }.observe(self.goToThanksProject.observer)
+    self.vm.outputs.goToThanks.map { $0.reward }.observe(self.goToThanksReward.observer)
+    self.vm.outputs.goToThanks.map { $0.checkoutData }.observe(self.goToThanksCheckoutData.observer)
     self.vm.outputs.localPickupViewHidden.observe(self.localPickupViewHidden.observer)
 
     self.vm.outputs.notifyDelegateUpdatePledgeDidSucceedWithMessage

--- a/Library/ViewModels/ThanksViewModel.swift
+++ b/Library/ViewModels/ThanksViewModel.swift
@@ -7,7 +7,8 @@ import UIKit
 public typealias ThanksPageData = (
   project: Project,
   reward: Reward,
-  checkoutData: KSRAnalytics.CheckoutPropertiesData?
+  checkoutData: KSRAnalytics.CheckoutPropertiesData?,
+  pledgeTotal: Double
 )
 
 public protocol ThanksViewModelInputs {
@@ -77,21 +78,25 @@ public final class ThanksViewModel: ThanksViewModelType, ThanksViewModelInputs, 
   public init() {
     let project = self.configureWithDataProperty.signal
       .skipNil()
-      .map(first)
+      .map { $0.project }
 
     let rewardAndCheckoutData = self.configureWithDataProperty.signal
       .skipNil()
       .map { ($0.reward, $0.checkoutData) }
 
-    self.backedProjectText = project.map {
-      let string = Strings.You_have_successfully_backed_project_html(
-        project_name: $0.name
-      )
+    self.backedProjectText = self.configureWithDataProperty.signal
+      .skipNil()
+      .map { project, _, _, _ in
 
-      return string.simpleHtmlAttributedString(font: UIFont.ksr_subhead(), bold: UIFont.ksr_subhead().bolded)
-        ?? NSAttributedString(string: "")
-    }
-    .takeWhen(self.viewDidLoadProperty.signal)
+        let string = Strings.You_have_successfully_backed_project_html(
+          project_name: project.name
+        )
+
+        return string
+          .simpleHtmlAttributedString(font: UIFont.ksr_subhead(), bold: UIFont.ksr_subhead().bolded)
+          ?? NSAttributedString(string: "")
+      }
+      .takeWhen(self.viewDidLoadProperty.signal)
 
     let shouldShowGamesAlert = project
       .map { project in

--- a/Library/ViewModels/ThanksViewModelTests.swift
+++ b/Library/ViewModels/ThanksViewModelTests.swift
@@ -48,8 +48,16 @@ final class ThanksViewModelTests: TestCase {
     self.vm.outputs.updateUserInEnvironment.observe(self.updateUserInEnvironment.observer)
   }
 
+  private func thanksPageData(
+    project: Project = Project.template,
+    reward: Reward = Reward.template,
+    checkoutData: KSRAnalytics.CheckoutPropertiesData? = nil
+  ) -> ThanksPageData {
+    return (project, reward, checkoutData, 1)
+  }
+
   func testDismissToRootViewController() {
-    self.vm.inputs.configure(with: (Project.template, Reward.template, nil))
+    self.vm.inputs.configure(with: self.thanksPageData())
     self.vm.inputs.viewDidLoad()
 
     self.vm.inputs.closeButtonTapped()
@@ -71,7 +79,7 @@ final class ThanksViewModelTests: TestCase {
       fetchGraphCategoryResult: .success(self.categoryEnvelope),
       fetchDiscoveryResponse: response
     )) {
-      self.vm.inputs.configure(with: (project, Reward.template, nil))
+      self.vm.inputs.configure(with: thanksPageData(project: project))
       self.vm.inputs.viewDidLoad()
 
       scheduler.advance()
@@ -94,7 +102,7 @@ final class ThanksViewModelTests: TestCase {
 
   func testDisplayBackedProjectText() {
     let project = Project.template |> \.category .~ .games
-    self.vm.inputs.configure(with: (project, Reward.template, nil))
+    self.vm.inputs.configure(with: self.thanksPageData(project: project))
     self.vm.inputs.viewDidLoad()
 
     self.backedProjectText.assertValues(
@@ -109,7 +117,7 @@ final class ThanksViewModelTests: TestCase {
     withEnvironment(currentUser: .template) {
       showRatingAlert.assertValueCount(0, "Rating Alert does not emit")
 
-      self.vm.inputs.configure(with: (Project.template, Reward.template, nil))
+      self.vm.inputs.configure(with: thanksPageData())
       self.vm.inputs.viewDidLoad()
 
       showRatingAlert.assertValueCount(1, "Rating Alert emits when view did load")
@@ -130,7 +138,7 @@ final class ThanksViewModelTests: TestCase {
       )
 
       let project = Project.template |> Project.lens.category .~ .games
-      self.vm.inputs.configure(with: (project, Reward.template, nil))
+      self.vm.inputs.configure(with: thanksPageData(project: project))
       self.vm.inputs.viewDidLoad()
 
       showRatingAlert.assertValueCount(0, "Rating alert does not show on games project")
@@ -146,7 +154,7 @@ final class ThanksViewModelTests: TestCase {
       let secondShowGamesNewsletterAlert = TestObserver<(), Never>()
       secondVM.outputs.showGamesNewsletterAlert.observe(secondShowGamesNewsletterAlert.observer)
 
-      secondVM.inputs.configure(with: (project, Reward.template, nil))
+      secondVM.inputs.configure(with: thanksPageData(project: project))
       secondVM.inputs.viewDidLoad()
 
       secondShowRatingAlert.assertValueCount(1, "Rating alert shows on games project")
@@ -160,7 +168,7 @@ final class ThanksViewModelTests: TestCase {
     let project = Project.template |> Project.lens.category .~ .games
 
     withEnvironment(currentUser: user) {
-      self.vm.inputs.configure(with: (project, Reward.template, nil))
+      self.vm.inputs.configure(with: thanksPageData(project: project))
       self.vm.inputs.viewDidLoad()
 
       showGamesNewsletterAlert.assertValueCount(0, "Games alert does not show on games project")
@@ -171,7 +179,7 @@ final class ThanksViewModelTests: TestCase {
     let project = Project.template |> Project.lens.category .~ .games
 
     withEnvironment(currentUser: .template) {
-      self.vm.inputs.configure(with: (project, Reward.template, nil))
+      self.vm.inputs.configure(with: thanksPageData(project: project))
       self.vm.inputs.viewDidLoad()
 
       showGamesNewsletterAlert.assertValueCount(1)
@@ -219,7 +227,7 @@ final class ThanksViewModelTests: TestCase {
     let project = Project.template |> Project.lens.category .~ .games
 
     withEnvironment(countryCode: "DE", currentUser: User.template) {
-      self.vm.inputs.configure(with: (project, Reward.template, nil))
+      self.vm.inputs.configure(with: thanksPageData(project: project))
       self.vm.inputs.viewDidLoad()
 
       showGamesNewsletterAlert.assertValueCount(1)
@@ -251,7 +259,7 @@ final class ThanksViewModelTests: TestCase {
         fetchDiscoveryResponse: response
       )
     ) {
-      self.vm.inputs.configure(with: (project, Reward.template, nil))
+      self.vm.inputs.configure(with: thanksPageData(project: project))
       self.vm.inputs.viewDidLoad()
 
       scheduler.advance()
@@ -291,7 +299,7 @@ final class ThanksViewModelTests: TestCase {
       fetchGraphCategoryResult: .success(self.categoryEnvelope),
       fetchDiscoveryResponse: response
     )) {
-      self.vm.inputs.configure(with: (project, Reward.template, nil))
+      self.vm.inputs.configure(with: thanksPageData(project: project))
       self.vm.inputs.viewDidLoad()
 
       scheduler.advance()
@@ -305,7 +313,7 @@ final class ThanksViewModelTests: TestCase {
     let project = Project.template |> Project.lens.category .~ .games
 
     withEnvironment(apiService: MockService(fetchDiscoveryResponse: response)) {
-      self.vm.inputs.configure(with: (project, Reward.template, nil))
+      self.vm.inputs.configure(with: thanksPageData(project: project))
       self.vm.inputs.viewDidLoad()
 
       scheduler.advance()
@@ -333,7 +341,7 @@ final class ThanksViewModelTests: TestCase {
     )
 
     (self.appTrackingTransparency as? MockAppTrackingTransparency)?.shouldRequestAuthStatus = false
-    self.vm.inputs.configure(with: (Project.template, Reward.template, checkoutData))
+    self.vm.inputs.configure(with: self.thanksPageData(checkoutData: checkoutData))
     self.vm.inputs.viewDidLoad()
 
     XCTAssertNil(self.segmentTrackingClient.properties.last)
@@ -357,7 +365,7 @@ final class ThanksViewModelTests: TestCase {
       userHasStoredApplePayCard: true
     )
 
-    self.vm.inputs.configure(with: (Project.template, Reward.template, checkoutData))
+    self.vm.inputs.configure(with: self.thanksPageData(checkoutData: checkoutData))
     self.vm.inputs.viewDidLoad()
 
     let segmentClientProps = self.segmentTrackingClient.properties.last


### PR DESCRIPTION
# 📲 What

Pass the pledge total into the thank you page.

# 🤔 Why

The new string for post-campaign backings on the thank-you page will reference the pledge amount, so we need it in the view model.