### PR TITLE
MBL-1211: Rewire current user email in AppEnvironment/AppDelegateViewModel

### DIFF
--- a/Kickstarter-iOS/AppDelegateViewModel.swift
+++ b/Kickstarter-iOS/AppDelegateViewModel.swift
@@ -214,9 +214,11 @@ public final class AppDelegateViewModel: AppDelegateViewModelType, AppDelegateVi
         AppEnvironment.current.apiService.fetchGraphUserEmail().wrapInOptional().materialize()
       }
 
-    _ = fetchUserEmailEvent.values()
+    self.fetchUserEmail = fetchUserEmailEvent.values()
       .map { user in
-        guard let email = user?.me.email else { return }
+        guard let email = user?.me.email else {
+          return
+        }
 
         AppEnvironment.updateCurrentUserEmail(email)
       }
@@ -904,6 +906,7 @@ public final class AppDelegateViewModel: AppDelegateViewModelType, AppDelegateVi
   public let emailVerificationCompleted: Signal<(String, Bool), Never>
   public let findRedirectUrl: Signal<URL, Never>
   public let forceLogout: Signal<(), Never>
+  private let fetchUserEmail: Signal<(), Never>
   public let goToActivity: Signal<(), Never>
   public let goToDiscovery: Signal<DiscoveryParams?, Never>
   public let goToLoginWithIntent: Signal<LoginIntent, Never>

--- a/Kickstarter-iOS/AppDelegateViewModelTests.swift
+++ b/Kickstarter-iOS/AppDelegateViewModelTests.swift
@@ -2434,6 +2434,37 @@ final class AppDelegateViewModelTests: TestCase {
       self.postNotificationName.assertValues([.ksr_remoteConfigClientConfigurationFailed])
     }
   }
+
+  func testUserSessionStarted_fetchesUserEmail_andClearsOnLogout() {
+    let fetchUserEmailQueryData = GraphAPI.FetchUserEmailQuery
+      .Data(unsafeResultMap: [
+        "me": [
+          "email": "nativesquad@ksr.com"
+        ]
+      ]
+      )
+
+    guard let envelope = UserEnvelope<GraphUserEmail>.userEnvelope(from: fetchUserEmailQueryData) else {
+      XCTFail()
+      return
+    }
+
+    let mockService = MockService(
+      fetchGraphUserEmailResult: .success(envelope)
+    )
+
+    withEnvironment(apiService: mockService) {
+      XCTAssertNil(AppEnvironment.current.currentUserEmail)
+
+      self.vm.inputs.userSessionStarted()
+
+      XCTAssertEqual(AppEnvironment.current.currentUserEmail, "nativesquad@ksr.com")
+
+      AppEnvironment.logout()
+
+      XCTAssertNil(AppEnvironment.current.currentUserEmail)
+    }
+  }
 }
 
 private let backingForCreatorPushData: [String: Any] = [

--- a/Library/AppEnvironment.swift
+++ b/Library/AppEnvironment.swift
@@ -107,6 +107,7 @@ public struct AppEnvironment: AppEnvironmentType {
       apiService: AppEnvironment.current.apiService.logout(),
       cache: type(of: AppEnvironment.current.cache).init(),
       currentUser: nil,
+      currentUserEmail: nil,
       ksrAnalytics: self.current.ksrAnalytics |> KSRAnalytics.lens.loggedInUser .~ nil
     )
   }


### PR DESCRIPTION
# 📲 What

Fix `AppEnvironment.current.currentUserEmail`, which did not appear to be correctly saving the currently logged-in user's e-mail.

# 🤔 Why

We need the user's e-mail on the Thanks page for post-campaign backings. I noticed that we had this `currentUserEmail` property on `Environment`, but it wasn't working correctly. I did some digging and I figured it's because the signal is being deallocated before the value is set.

An interesting question is why `currentUserEmail` isn't just part of `currentUser`. Apparently the V1 `User` object doesn't appear to have an e-mail attached to it, and the e-mail is coming from GraphQL, instead. It's a bit messy but I wanted to keep this change fairly low-profile instead of doing more refactoring.
