### PR TITLE
[MBL-1208] Part 1: Initial ConfirmDetailsViewController | Shipping Location + Pledge/Bonus Steppers

### DIFF
--- a/Kickstarter-iOS/Features/ConfirmDetails/Controllers/ConfirmDetailsViewController.swift
+++ b/Kickstarter-iOS/Features/ConfirmDetails/Controllers/ConfirmDetailsViewController.swift
@@ -1,0 +1,282 @@
+import KsApi
+import Library
+import Prelude
+import UIKit
+
+public enum ConfirmDetailsLayout {
+  enum Margin {
+    static let topBottom: CGFloat = Styles.grid(3)
+    static let leftRight: CGFloat = CheckoutConstants.PledgeView.Inset.leftRight
+  }
+}
+
+protocol ConfirmDetailsViewControllerDelegate: AnyObject {}
+
+final class ConfirmDetailsViewController: UIViewController {
+  // MARK: - Properties
+
+  public weak var delegate: ConfirmDetailsViewControllerDelegate?
+
+  private lazy var titleLabel = UILabel(frame: .zero)
+
+  /// The pledge stepper used to change the pledge amount
+  private lazy var pledgeAmountViewController = {
+    PledgeAmountViewController.instantiate()
+      |> \.delegate .~ self
+  }()
+
+  /// The shipping location shown when changing shipping locations isn't an option
+  private lazy var shippingSummaryView: PledgeShippingSummaryView = {
+    PledgeShippingSummaryView(frame: .zero)
+  }()
+
+  /// The bottom-up modal for selecting a new shipping location
+  private lazy var shippingLocationViewController = {
+    PledgeShippingLocationViewController.instantiate()
+      |> \.delegate .~ self
+  }()
+
+  private lazy var localPickupLocationView = {
+    PledgeLocalPickupView(frame: .zero)
+  }()
+
+  private lazy var inputsSectionViews = {
+    [
+      self.shippingLocationViewController.view,
+      self.shippingSummaryView,
+      self.localPickupLocationView,
+      self.pledgeAmountViewController.view
+    ]
+  }()
+
+  private lazy var keyboardDimissingTapGestureRecognizer: UITapGestureRecognizer = {
+    UITapGestureRecognizer(
+      target: self,
+      action: #selector(ConfirmDetailsViewController.dismissKeyboard)
+    )
+      |> \.cancelsTouchesInView .~ false
+  }()
+
+  private lazy var rootScrollView: UIScrollView = {
+    UIScrollView(frame: .zero)
+      |> \.translatesAutoresizingMaskIntoConstraints .~ false
+  }()
+
+  private lazy var rootStackView: UIStackView = {
+    UIStackView(frame: .zero)
+      |> \.translatesAutoresizingMaskIntoConstraints .~ false
+  }()
+
+  private lazy var rootInsetStackView: UIStackView = {
+    UIStackView(frame: .zero)
+      |> \.translatesAutoresizingMaskIntoConstraints .~ false
+  }()
+
+  private let viewModel: ConfirmDetailsViewModelType = ConfirmDetailsViewModel()
+
+  // MARK: - Lifecycle
+
+  func configure(with data: PledgeViewData) {
+    self.viewModel.inputs.configure(with: data)
+  }
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+
+    self.navigationItem
+      .backBarButtonItem = UIBarButtonItem(title: " ", style: .plain, target: nil, action: nil)
+
+    _ = self
+      |> \.extendedLayoutIncludesOpaqueBars .~ true
+
+    _ = self
+      |> \.title .~ Strings.Back_this_project()
+
+    self.view.addGestureRecognizer(self.keyboardDimissingTapGestureRecognizer)
+
+    self.configureChildViewControllers()
+    self.setupConstraints()
+
+    self.viewModel.inputs.viewDidLoad()
+  }
+
+  // MARK: - Configuration
+
+  private func configureChildViewControllers() {
+    _ = (self.rootScrollView, self.view)
+      |> ksr_addSubviewToParent()
+
+    _ = (self.rootStackView, self.rootScrollView)
+      |> ksr_addSubviewToParent()
+      |> ksr_constrainViewToEdgesInParent()
+
+    let childViewControllers = [
+      self.pledgeAmountViewController,
+      self.shippingLocationViewController
+    ]
+
+    let arrangedSubviews = [
+      self.rootInsetStackView
+    ]
+
+    let arrangedInsetSubviews = [
+      [self.titleLabel],
+      self.inputsSectionViews
+    ]
+    .flatMap { $0 }
+    .compact()
+
+    arrangedSubviews.forEach { view in
+      self.rootStackView.addArrangedSubview(view)
+    }
+
+    arrangedInsetSubviews.forEach { view in
+      self.rootInsetStackView.addArrangedSubview(view)
+    }
+
+    childViewControllers.forEach { viewController in
+      self.addChild(viewController)
+      viewController.didMove(toParent: self)
+    }
+  }
+
+  private func setupConstraints() {
+    NSLayoutConstraint.activate([
+      self.rootScrollView.topAnchor.constraint(equalTo: self.view.topAnchor),
+      self.rootScrollView.leftAnchor.constraint(equalTo: self.view.leftAnchor),
+      self.rootScrollView.rightAnchor.constraint(equalTo: self.view.rightAnchor),
+      self.rootScrollView.bottomAnchor.constraint(equalTo: self.view.bottomAnchor),
+      self.rootStackView.widthAnchor.constraint(equalTo: self.view.widthAnchor)
+    ])
+  }
+
+  // MARK: - Styles
+
+  override func bindStyles() {
+    super.bindStyles()
+
+    _ = self.view
+      |> checkoutBackgroundStyle
+
+    _ = self.titleLabel
+      |> titleLabelStyle
+
+    _ = self.rootScrollView
+      |> rootScrollViewStyle
+
+    _ = self.rootStackView
+      |> rootStackViewStyle
+
+    _ = self.rootInsetStackView
+      |> rootInsetStackViewStyle
+  }
+
+  // MARK: - View model
+
+  override func bindViewModel() {
+    super.bindViewModel()
+
+    self.viewModel.outputs.configureLocalPickupViewWithData
+      .observeForUI()
+      .observeValues { [weak self] data in
+        self?.localPickupLocationView.configure(with: data)
+      }
+
+    self.viewModel.outputs.configureShippingLocationViewWithData
+      .observeForUI()
+      .observeValues { [weak self] data in
+        self?.shippingLocationViewController.configureWith(value: data)
+      }
+
+    self.viewModel.outputs.configureShippingSummaryViewWithData
+      .observeForUI()
+      .observeValues { [weak self] data in
+        self?.shippingSummaryView.configure(with: data)
+      }
+
+    self.viewModel.outputs.configurePledgeAmountViewWithData
+      .observeForUI()
+      .observeValues { [weak self] data in
+        self?.pledgeAmountViewController.configureWith(value: data)
+      }
+
+    Keyboard.change
+      .observeForUI()
+      .observeValues { [weak self] change in
+        self?.rootScrollView.handleKeyboardVisibilityDidChange(change)
+      }
+
+    self.pledgeAmountViewController.view.rac.hidden = self.viewModel.outputs.pledgeAmountViewHidden
+
+    self.shippingLocationViewController.view.rac.hidden = self.viewModel.outputs.shippingLocationViewHidden
+
+    self.shippingSummaryView.rac.hidden = self.viewModel.outputs.shippingSummaryViewHidden
+
+    self.localPickupLocationView.rac.hidden = self.viewModel.outputs.localPickupViewHidden
+  }
+
+  // MARK: - Actions
+
+  @objc private func dismissKeyboard() {
+    self.view.endEditing(true)
+  }
+}
+
+// MARK: - PledgeAmountViewControllerDelegate
+
+extension ConfirmDetailsViewController: PledgeAmountViewControllerDelegate {
+  func pledgeAmountViewController(
+    _: PledgeAmountViewController,
+    didUpdateWith data: PledgeAmountData
+  ) {
+    self.viewModel.inputs.pledgeAmountViewControllerDidUpdate(with: data)
+  }
+}
+
+// MARK: - PledgeShippingLocationViewControllerDelegate
+
+extension ConfirmDetailsViewController: PledgeShippingLocationViewControllerDelegate {
+  func pledgeShippingLocationViewController(
+    _: PledgeShippingLocationViewController,
+    didSelect shippingRule: ShippingRule
+  ) {
+    self.viewModel.inputs.shippingRuleSelected(shippingRule)
+  }
+
+  func pledgeShippingLocationViewControllerLayoutDidUpdate(_: PledgeShippingLocationViewController) {}
+  func pledgeShippingLocationViewControllerFailedToLoad(_: PledgeShippingLocationViewController) {}
+}
+
+// MARK: - Styles
+
+private let titleLabelStyle: LabelStyle = { label in
+  label
+    // TODO: [MBL-1217] Update string once translations are done
+    |> \.text %~ { _ in "Confirm your pledge details." }
+    |> \.font .~ UIFont.ksr_title2().bolded
+    |> \.numberOfLines .~ 0
+}
+
+private let rootScrollViewStyle: ScrollStyle = { scrollView in
+  scrollView
+    |> \.showsVerticalScrollIndicator .~ false
+    |> \.alwaysBounceVertical .~ true
+}
+
+private let rootStackViewStyle: StackViewStyle = { stackView in
+  stackView
+    |> \.axis .~ NSLayoutConstraint.Axis.vertical
+    |> \.spacing .~ Styles.grid(4)
+    |> \.isLayoutMarginsRelativeArrangement .~ true
+}
+
+private let rootInsetStackViewStyle: StackViewStyle = { stackView in
+  stackView
+    |> \.axis .~ NSLayoutConstraint.Axis.vertical
+    |> \.spacing .~ Styles.grid(4)
+    |> \.isLayoutMarginsRelativeArrangement .~ true
+    |> \.layoutMargins .~ UIEdgeInsets(
+      topBottom: ConfirmDetailsLayout.Margin.topBottom,
+      leftRight: ConfirmDetailsLayout.Margin.leftRight
+    )
+}

--- a/Kickstarter-iOS/Features/RewardAddOnSelection/Controller/RewardAddOnSelectionViewController.swift
+++ b/Kickstarter-iOS/Features/RewardAddOnSelection/Controller/RewardAddOnSelectionViewController.swift
@@ -22,7 +22,6 @@ final class RewardAddOnSelectionViewController: UIViewController {
   }()
 
   public weak var pledgeViewDelegate: PledgeViewControllerDelegate?
-  public weak var confirmDetailsViewControllerDelegate: ConfirmDetailsViewControllerDelegate?
 
   private lazy var refreshControl: UIRefreshControl = { UIRefreshControl() }()
 
@@ -214,7 +213,6 @@ final class RewardAddOnSelectionViewController: UIViewController {
 
   private func goToConfirmDetails(data: PledgeViewData) {
     let vc = ConfirmDetailsViewController.instantiate()
-    vc.delegate = self.confirmDetailsViewControllerDelegate
     vc.configure(with: data)
     vc.title = self.title
 

--- a/Kickstarter-iOS/Features/RewardsCollection/Controller/RewardsCollectionViewController.swift
+++ b/Kickstarter-iOS/Features/RewardsCollection/Controller/RewardsCollectionViewController.swift
@@ -33,7 +33,6 @@ final class RewardsCollectionViewController: UICollectionViewController {
   }()
 
   public weak var pledgeViewDelegate: PledgeViewControllerDelegate?
-  public weak var confirmDetailsViewControllerDelegate: ConfirmDetailsViewControllerDelegate?
 
   private lazy var rewardsCollectionFooterView: RewardsCollectionViewFooter = {
     RewardsCollectionViewFooter(frame: .zero)
@@ -295,7 +294,6 @@ final class RewardsCollectionViewController: UICollectionViewController {
 
   private func goToConfirmDetails(data: PledgeViewData) {
     let vc = ConfirmDetailsViewController.instantiate()
-    vc.delegate = self.confirmDetailsViewControllerDelegate
     vc.configure(with: data)
     vc.title = self.title
 

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -452,6 +452,9 @@
 		6008633F29BF750700B87B39 /* MockAppTrackingTransparency.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6008633E29BF750700B87B39 /* MockAppTrackingTransparency.swift */; };
 		6018626629A9194600EA2842 /* AppTrackingTransparency.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6018626529A9194600EA2842 /* AppTrackingTransparency.swift */; };
 		6018626829A91B8C00EA2842 /* ThirdPartyEventInputName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6018626729A91B8C00EA2842 /* ThirdPartyEventInputName.swift */; };
+		6021F66A2B97BC8100F76031 /* ConfirmDetailsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6021F6692B97BC8100F76031 /* ConfirmDetailsViewController.swift */; };
+		6021F66C2B97BCE200F76031 /* ConfirmDetailsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6021F66B2B97BCE200F76031 /* ConfirmDetailsViewModel.swift */; };
+		6021F66E2B98AF0C00F76031 /* ConfirmDetailsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6021F66D2B98AF0C00F76031 /* ConfirmDetailsViewModelTests.swift */; };
 		6031A8462AB2485800F8184D /* ReportProjectInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6031A8452AB2485800F8184D /* ReportProjectInfoView.swift */; };
 		60368E662AC334B9005EE9A5 /* ReportProjectFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60368E652AC334B9005EE9A5 /* ReportProjectFormView.swift */; };
 		60368E6A2AC35BD9005EE9A5 /* ReportProjectFormViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60368E692AC35BD9005EE9A5 /* ReportProjectFormViewModel.swift */; };
@@ -2039,6 +2042,9 @@
 		6008633E29BF750700B87B39 /* MockAppTrackingTransparency.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockAppTrackingTransparency.swift; sourceTree = "<group>"; };
 		6018626529A9194600EA2842 /* AppTrackingTransparency.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppTrackingTransparency.swift; sourceTree = "<group>"; };
 		6018626729A91B8C00EA2842 /* ThirdPartyEventInputName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThirdPartyEventInputName.swift; sourceTree = "<group>"; };
+		6021F6692B97BC8100F76031 /* ConfirmDetailsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfirmDetailsViewController.swift; sourceTree = "<group>"; };
+		6021F66B2B97BCE200F76031 /* ConfirmDetailsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfirmDetailsViewModel.swift; sourceTree = "<group>"; };
+		6021F66D2B98AF0C00F76031 /* ConfirmDetailsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfirmDetailsViewModelTests.swift; sourceTree = "<group>"; };
 		6031A8452AB2485800F8184D /* ReportProjectInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportProjectInfoView.swift; sourceTree = "<group>"; };
 		60368E652AC334B9005EE9A5 /* ReportProjectFormView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportProjectFormView.swift; sourceTree = "<group>"; };
 		60368E692AC35BD9005EE9A5 /* ReportProjectFormViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportProjectFormViewModel.swift; sourceTree = "<group>"; };
@@ -4693,6 +4699,7 @@
 				1937A6DF28C92AFE00DD732D /* ChangePassword */,
 				1937A6E028C92B1D00DD732D /* CreatePassword */,
 				19A97CD428C79BF60031B857 /* Comments */,
+				6021F6672B97BC6A00F76031 /* ConfirmDetails */,
 				1937A6E128C92BBD00DD732D /* CuratedProjects */,
 				1937A6E228C92BD400DD732D /* DebugPushNotifications */,
 				6049D00E2A9CF6530015BB0D /* DesignSystem */,
@@ -5541,6 +5548,22 @@
 			path = Layouts;
 			sourceTree = "<group>";
 		};
+		6021F6672B97BC6A00F76031 /* ConfirmDetails */ = {
+			isa = PBXGroup;
+			children = (
+				6021F6682B97BC7400F76031 /* Controllers */,
+			);
+			path = ConfirmDetails;
+			sourceTree = "<group>";
+		};
+		6021F6682B97BC7400F76031 /* Controllers */ = {
+			isa = PBXGroup;
+			children = (
+				6021F6692B97BC8100F76031 /* ConfirmDetailsViewController.swift */,
+			);
+			path = Controllers;
+			sourceTree = "<group>";
+		};
 		6031A8442AB247D900F8184D /* ReportProject */ = {
 			isa = PBXGroup;
 			children = (
@@ -6338,6 +6361,8 @@
 				061645AD26697D55007D8D96 /* CommentRepliesViewModelTests.swift */,
 				94BA16E326698C8B0034CC3F /* CommentTableViewFooterViewModel.swift */,
 				94BA16E826698EF00034CC3F /* CommentTableViewFooterViewModelTests.swift */,
+				6021F66B2B97BCE200F76031 /* ConfirmDetailsViewModel.swift */,
+				6021F66D2B98AF0C00F76031 /* ConfirmDetailsViewModelTests.swift */,
 				373AB221222A058600769FC2 /* CreatePasswordViewModel.swift */,
 				373AB25A222A063500769FC2 /* CreatePasswordViewModelTests.swift */,
 				D63BBD36217FC224007E01F0 /* CreditCardCellViewModel.swift */,
@@ -7834,6 +7859,7 @@
 				A75C811C1D210C4700B5AD03 /* SafariActivity.swift in Sources */,
 				A796FF591D425A4D00CD58AA /* ProjectStyles.swift in Sources */,
 				A796A88F1D48DE79009B6EF6 /* ProjectPamphletContentViewModel.swift in Sources */,
+				6021F66C2B97BCE200F76031 /* ConfirmDetailsViewModel.swift in Sources */,
 				77F6E73921222F4B005A5C55 /* SettingsNotificationCellType.swift in Sources */,
 				A71404391CAF215900A2795B /* KeyValueStoreType.swift in Sources */,
 				8A788F27263C80D600A89DAE /* BrazeDebounceMiddleware.swift in Sources */,
@@ -7965,6 +7991,7 @@
 				373AB25B222A063500769FC2 /* CreatePasswordViewModelTests.swift in Sources */,
 				A7ED1FF11E831C5C00BFFA01 /* MessageThreadCellViewModelTests.swift in Sources */,
 				8A49395F24B53D1900C3C3CE /* RewardAddOnSelectionViewModelTests.swift in Sources */,
+				6021F66E2B98AF0C00F76031 /* ConfirmDetailsViewModelTests.swift in Sources */,
 				D72370922118FEFA001EA4CA /* SettingsPrivacyViewModelTests.swift in Sources */,
 				A7ED1FAE1E831C5C00BFFA01 /* FindFriendsViewModelTests.swift in Sources */,
 				A7ED1FE11E831C5C00BFFA01 /* DiscoveryPostcardViewModelTests.swift in Sources */,
@@ -8315,6 +8342,7 @@
 				77FD8B46216D6245000A95AC /* LoadingBarButtonItemView.swift in Sources */,
 				017508161D67A4E300BB1863 /* DiscoveryNavigationHeaderViewController.swift in Sources */,
 				064B007627A462AA007B21FE /* ImageViewElementCell.swift in Sources */,
+				6021F66A2B97BC8100F76031 /* ConfirmDetailsViewController.swift in Sources */,
 				8AD486352359F34700A1463E /* STPPaymentHandler+StripePaymentHandlerActionStatus.swift in Sources */,
 				D69C553123A17A0700B0987A /* ActivityErroredBackingsCellHeader.swift in Sources */,
 				014D625B1E6E20BB0033D2BD /* BackerDashboardProjectsDataSource.swift in Sources */,

--- a/Library/ViewModels/ConfirmDetailsViewModel.swift
+++ b/Library/ViewModels/ConfirmDetailsViewModel.swift
@@ -1,0 +1,264 @@
+import Foundation
+import KsApi
+import PassKit
+import Prelude
+import ReactiveSwift
+
+public protocol ConfirmDetailsViewModelInputs {
+  func configure(with data: PledgeViewData)
+  func pledgeAmountViewControllerDidUpdate(with data: PledgeAmountData)
+  func shippingRuleSelected(_ shippingRule: ShippingRule)
+  func viewDidLoad()
+}
+
+public protocol ConfirmDetailsViewModelOutputs {
+  var configureLocalPickupViewWithData: Signal<PledgeLocalPickupViewData, Never> { get }
+  var configurePledgeAmountViewWithData: Signal<PledgeAmountViewConfigData, Never> { get }
+  var configureShippingLocationViewWithData: Signal<PledgeShippingLocationViewData, Never> { get }
+  var configureShippingSummaryViewWithData: Signal<PledgeShippingSummaryViewData, Never> { get }
+  var localPickupViewHidden: Signal<Bool, Never> { get }
+  var pledgeAmountViewHidden: Signal<Bool, Never> { get }
+  var shippingLocationViewHidden: Signal<Bool, Never> { get }
+  var shippingSummaryViewHidden: Signal<Bool, Never> { get }
+}
+
+public protocol ConfirmDetailsViewModelType {
+  var inputs: ConfirmDetailsViewModelInputs { get }
+  var outputs: ConfirmDetailsViewModelOutputs { get }
+}
+
+public class ConfirmDetailsViewModel: ConfirmDetailsViewModelType, ConfirmDetailsViewModelInputs,
+  ConfirmDetailsViewModelOutputs {
+  public init() {
+    let initialData = Signal.combineLatest(
+      self.configureWithDataProperty.signal,
+      self.viewDidLoadProperty.signal
+    )
+    .map(first)
+    .skipNil()
+
+    let project = initialData.map(\.project)
+    let baseReward = initialData.map(\.rewards).map(\.first).skipNil()
+    let rewards = initialData.map(\.rewards)
+    let selectedQuantities = initialData.map(\.selectedQuantities)
+    let selectedLocationId = initialData.map(\.selectedLocationId)
+    let context = initialData.map(\.context)
+
+    let backing = project.map { $0.personalization.backing }.skipNil()
+
+    // MARK: Pledge Amount
+
+    self.pledgeAmountViewHidden = context.map { $0.pledgeAmountViewHidden }
+
+    let selectedShippingRule = Signal.merge(
+      project.mapConst(nil),
+      self.shippingRuleSelectedSignal.wrapInOptional()
+    )
+
+    let calculatedShippingTotal = Signal.combineLatest(
+      selectedShippingRule.skipNil(),
+      rewards,
+      selectedQuantities
+    )
+    .map(calculateShippingTotal)
+
+    let baseRewardShippingTotal = Signal.zip(project, baseReward, selectedShippingRule)
+      .map(getBaseRewardShippingTotal)
+
+    let allRewardsShippingTotal = Signal.merge(
+      baseRewardShippingTotal,
+      calculatedShippingTotal
+    )
+
+    // Initial pledge amount is zero if not backed.
+    let initialAdditionalPledgeAmount = Signal.merge(
+      initialData.filter { $0.project.personalization.backing == nil }.mapConst(0.0),
+      backing.map(\.bonusAmount)
+    )
+    .take(first: 1)
+
+    let projectAndReward = Signal.zip(project, baseReward)
+
+    // MARK: Local Pickup + Shipping
+
+    /**
+     Shipping location selector is hidden if the context hides it,
+     if the base reward has no shipping, when add-ons were selected or when base reward has local pickup option.
+     */
+    let nonLocalPickupShippingLocationViewHidden = Signal.combineLatest(baseReward, rewards, context)
+      .map { baseReward, rewards, context in
+        [
+          context.shippingLocationViewHidden,
+          !baseReward.shipping.enabled,
+          rewards.count > 1
+        ].contains(true)
+      }
+
+    self.shippingLocationViewHidden = Signal
+      .combineLatest(nonLocalPickupShippingLocationViewHidden, baseReward)
+      .map { flag, baseReward in
+        isRewardLocalPickup(baseReward) ? true : flag
+      }
+
+    /**
+     Shipping summary view is hidden when updating,
+     if the base reward has no shipping, when NO add-ons were selected or when base reward has local pickup option.
+     */
+    let nonLocalPickupShippingSummaryViewHidden = Signal.combineLatest(baseReward, rewards, context)
+      .map { baseReward, rewards, context in
+        [
+          context.isAny(of: .update, .changePaymentMethod, .fixPaymentMethod),
+          !baseReward.shipping.enabled,
+          rewards.count == 1
+        ].contains(true)
+      }
+
+    self.shippingSummaryViewHidden = Signal.combineLatest(nonLocalPickupShippingSummaryViewHidden, baseReward)
+      .map { flag, baseReward in
+        isRewardLocalPickup(baseReward) ? true : flag
+      }
+
+    let shippingViewsHidden: Signal<Bool, Never> = Signal.combineLatest(
+      self.shippingSummaryViewHidden,
+      self.shippingLocationViewHidden
+    )
+    .map { a, b -> Bool in
+      let r = a && b
+      return r
+    }
+
+    self.localPickupViewHidden = baseReward.map(isRewardLocalPickup).negate()
+
+    // Only shown for regular non-add-ons based rewards
+    self.configureShippingLocationViewWithData = Signal.combineLatest(
+      projectAndReward,
+      shippingViewsHidden.filter(isFalse),
+      selectedLocationId
+    )
+    .map { projectAndReward, _, selectedLocationId in
+      (projectAndReward.0, projectAndReward.1, selectedLocationId)
+    }
+    .map { project, reward, locationId in
+      (project, reward, true, locationId)
+    }
+
+    // Only shown for add-ons based rewards
+    self.configureShippingSummaryViewWithData = Signal.combineLatest(
+      selectedShippingRule.skipNil().map(\.location.localizedName),
+      project.map(\.stats.omitUSCurrencyCode),
+      project.map { project in
+        projectCountry(forCurrency: project.stats.currency) ?? project.country
+      },
+      allRewardsShippingTotal
+    )
+    .map(PledgeShippingSummaryViewData.init)
+
+    self.configurePledgeAmountViewWithData = Signal.combineLatest(
+      projectAndReward,
+      initialAdditionalPledgeAmount
+    )
+    .map(unpack)
+    .map { project, reward, additionalPledgeAmount in
+      (
+        project,
+        reward,
+        additionalPledgeAmount
+      )
+    }
+
+    // Only shown for if the shipping summary view and shipping location view are hidden
+    self.configureLocalPickupViewWithData = Signal.combineLatest(
+      projectAndReward,
+      shippingViewsHidden.filter(isTrue)
+    )
+    .switchMap { projectAndReward, _ -> SignalProducer<PledgeLocalPickupViewData?, Never> in
+      guard let locationName = projectAndReward.1.localPickup?.displayableName else {
+        return SignalProducer(value: nil)
+      }
+
+      let localPickupLocationData = PledgeLocalPickupViewData(locationName: locationName)
+
+      return SignalProducer(value: localPickupLocationData)
+    }
+    .skipNil()
+  }
+
+  // MARK: - Inputs
+
+  private let configureWithDataProperty = MutableProperty<PledgeViewData?>(nil)
+  public func configure(with data: PledgeViewData) {
+    self.configureWithDataProperty.value = data
+  }
+
+  private let (pledgeAmountDataSignal, pledgeAmountObserver) = Signal<PledgeAmountData, Never>.pipe()
+  public func pledgeAmountViewControllerDidUpdate(with data: PledgeAmountData) {
+    self.pledgeAmountObserver.send(value: data)
+  }
+
+  private let (shippingRuleSelectedSignal, shippingRuleSelectedObserver) = Signal<ShippingRule, Never>.pipe()
+  public func shippingRuleSelected(_ shippingRule: ShippingRule) {
+    self.shippingRuleSelectedObserver.send(value: shippingRule)
+  }
+
+  private let (submitButtonTappedSignal, submitButtonTappedObserver) = Signal<Void, Never>.pipe()
+  public func submitButtonTapped() {
+    self.submitButtonTappedObserver.send(value: ())
+  }
+
+  private let viewDidLoadProperty = MutableProperty(())
+  public func viewDidLoad() {
+    self.viewDidLoadProperty.value = ()
+  }
+
+  // MARK: - Outputs
+
+  public let configureLocalPickupViewWithData: Signal<PledgeLocalPickupViewData, Never>
+  public let configurePledgeAmountViewWithData: Signal<PledgeAmountViewConfigData, Never>
+  public let configureShippingLocationViewWithData: Signal<PledgeShippingLocationViewData, Never>
+  public let configureShippingSummaryViewWithData: Signal<PledgeShippingSummaryViewData, Never>
+  public let localPickupViewHidden: Signal<Bool, Never>
+  public let pledgeAmountViewHidden: Signal<Bool, Never>
+  public let shippingLocationViewHidden: Signal<Bool, Never>
+  public let shippingSummaryViewHidden: Signal<Bool, Never>
+
+  public var inputs: ConfirmDetailsViewModelInputs { return self }
+  public var outputs: ConfirmDetailsViewModelOutputs { return self }
+}
+
+// MARK: - Helper Functions
+
+private func pledgeSummaryViewData(
+  project: Project,
+  total: Double,
+  confirmationLabelHidden: Bool
+) -> PledgeSummaryViewData {
+  return (project, total, confirmationLabelHidden)
+}
+
+private func pledgeAmountSummaryViewData(
+  with project: Project,
+  reward _: Reward,
+  allRewardsTotal: Double,
+  additionalPledgeAmount: Double,
+  shippingViewsHidden: Bool,
+  context: PledgeViewContext
+) -> PledgeAmountSummaryViewData? {
+  guard let backing = project.personalization.backing else { return nil }
+
+  let rewardIsLocalPickup = isRewardLocalPickup(backing.reward)
+  let projectCurrencyCountry = projectCountry(forCurrency: project.stats.currency) ?? project.country
+
+  return .init(
+    bonusAmount: additionalPledgeAmount,
+    bonusAmountHidden: context == .update,
+    isNoReward: backing.reward?.isNoReward ?? false,
+    locationName: backing.locationName,
+    omitUSCurrencyCode: project.stats.omitUSCurrencyCode,
+    projectCurrencyCountry: projectCurrencyCountry,
+    pledgedOn: backing.pledgedAt,
+    rewardMinimum: allRewardsTotal,
+    shippingAmount: backing.shippingAmount.flatMap(Double.init),
+    shippingAmountHidden: !shippingViewsHidden,
+    rewardIsLocalPickup: rewardIsLocalPickup
+  )
+}

--- a/Library/ViewModels/ConfirmDetailsViewModelTests.swift
+++ b/Library/ViewModels/ConfirmDetailsViewModelTests.swift
@@ -12,22 +12,19 @@ final class ConfirmDetailsViewModelTests: TestCase {
   private let vm: ConfirmDetailsViewModelType = ConfirmDetailsViewModel()
 
   private let configureLocalPickupViewWithData = TestObserver<PledgeLocalPickupViewData, Never>()
-
   private let configureShippingSummaryViewWithData = TestObserver<PledgeShippingSummaryViewData, Never>()
-
   private let configureShippingLocationViewWithDataProject = TestObserver<Project, Never>()
   private let configureShippingLocationViewWithDataReward = TestObserver<Reward, Never>()
   private let configureShippingLocationViewWithDataShowAmount = TestObserver<Bool, Never>()
-
   private let localPickupViewHidden = TestObserver<Bool, Never>()
-
   private let pledgeAmountViewHidden = TestObserver<Bool, Never>()
   private let shippingLocationViewHidden = TestObserver<Bool, Never>()
   private let shippingSummaryViewHidden = TestObserver<Bool, Never>()
-  private let title = TestObserver<String, Never>()
 
   override func setUp() {
     super.setUp()
+
+    self.vm.outputs.configureLocalPickupViewWithData.observe(self.configureLocalPickupViewWithData.observer)
 
     self.vm.outputs.configureShippingLocationViewWithData.map { $0.project }
       .observe(self.configureShippingLocationViewWithDataProject.observer)
@@ -45,5 +42,683 @@ final class ConfirmDetailsViewModelTests: TestCase {
 
     self.vm.outputs.shippingLocationViewHidden.observe(self.shippingLocationViewHidden.observer)
     self.vm.outputs.shippingSummaryViewHidden.observe(self.shippingSummaryViewHidden.observer)
+  }
+
+  func testPledgeContext_LoggedIn() {
+    let mockService = MockService(serverConfig: ServerConfig.staging)
+
+    withEnvironment(apiService: mockService, currentUser: .template) {
+      let project = Project.template
+      let reward = Reward.template
+        |> Reward.lens.shipping.enabled .~ true
+
+      let data = PledgeViewData(
+        project: project,
+        rewards: [reward],
+        selectedQuantities: [reward.id: 1],
+        selectedLocationId: nil,
+        refTag: .projectPage,
+        context: .pledge
+      )
+
+      self.vm.inputs.configure(with: data)
+      self.vm.inputs.viewDidLoad()
+
+      self.configureShippingLocationViewWithDataProject.assertValues([project])
+      self.configureShippingLocationViewWithDataReward.assertValues([reward])
+      self.configureShippingLocationViewWithDataShowAmount.assertValues([true])
+
+      self.pledgeAmountViewHidden.assertValues([false])
+      self.shippingLocationViewHidden.assertValues([false])
+    }
+  }
+
+  func testPledgeContext_LoggedOut() {
+    let mockService = MockService(serverConfig: ServerConfig.staging)
+
+    withEnvironment(apiService: mockService, currentUser: nil) {
+      let project = Project.template
+      let reward = Reward.template
+        |> Reward.lens.shipping.enabled .~ true
+
+      let data = PledgeViewData(
+        project: project,
+        rewards: [reward],
+        selectedQuantities: [reward.id: 1],
+        selectedLocationId: nil,
+        refTag: .projectPage,
+        context: .pledge
+      )
+
+      self.vm.inputs.configure(with: data)
+      self.vm.inputs.viewDidLoad()
+
+      self.configureShippingLocationViewWithDataProject.assertValues([project])
+      self.configureShippingLocationViewWithDataReward.assertValues([reward])
+      self.configureShippingLocationViewWithDataShowAmount.assertValues([true])
+
+      self.pledgeAmountViewHidden.assertValues([false])
+    }
+  }
+
+  func testPledgeView_Logged_Out_Shipping_Disabled() {
+    withEnvironment(currentUser: nil) {
+      let project = Project.template
+      let reward = Reward.template
+        |> Reward.lens.shipping.enabled .~ false
+
+      let data = PledgeViewData(
+        project: project,
+        rewards: [reward],
+        selectedQuantities: [reward.id: 1],
+        selectedLocationId: nil,
+        refTag: .projectPage,
+        context: .pledge
+      )
+
+      self.vm.inputs.configure(with: data)
+      self.vm.inputs.viewDidLoad()
+
+      self.configureShippingLocationViewWithDataProject.assertDidNotEmitValue()
+      self.configureShippingLocationViewWithDataReward.assertDidNotEmitValue()
+      self.configureShippingLocationViewWithDataShowAmount.assertDidNotEmitValue()
+
+      self.pledgeAmountViewHidden.assertValues([false])
+    }
+  }
+
+  func testPledgeView_Logged_Out_Shipping_Enabled() {
+    withEnvironment(currentUser: nil) {
+      let project = Project.template
+      let reward = Reward.template
+        |> Reward.lens.shipping.enabled .~ true
+
+      let data = PledgeViewData(
+        project: project,
+        rewards: [reward],
+        selectedQuantities: [reward.id: 1],
+        selectedLocationId: nil,
+        refTag: .projectPage,
+        context: .pledge
+      )
+
+      self.vm.inputs.configure(with: data)
+      self.vm.inputs.viewDidLoad()
+
+      self.configureShippingLocationViewWithDataProject.assertValues([project])
+      self.configureShippingLocationViewWithDataReward.assertValues([reward])
+      self.configureShippingLocationViewWithDataShowAmount.assertValues([true])
+    }
+  }
+
+  func testPledgeView_Logged_In_Shipping_Disabled() {
+    let project = Project.template
+    let reward = Reward.template
+      |> Reward.lens.shipping.enabled .~ false
+
+    withEnvironment(currentUser: .template) {
+      let data = PledgeViewData(
+        project: project,
+        rewards: [reward],
+        selectedQuantities: [reward.id: 1],
+        selectedLocationId: nil,
+        refTag: .projectPage,
+        context: .pledge
+      )
+
+      self.vm.inputs.configure(with: data)
+      self.vm.inputs.viewDidLoad()
+
+      self.configureShippingLocationViewWithDataProject.assertDidNotEmitValue()
+      self.configureShippingLocationViewWithDataReward.assertDidNotEmitValue()
+      self.configureShippingLocationViewWithDataShowAmount.assertDidNotEmitValue()
+    }
+  }
+
+  func testPledgeView_Logged_In_Shipping_Enabled() {
+    let project = Project.template
+    let reward = Reward.template
+      |> Reward.lens.shipping.enabled .~ true
+
+    withEnvironment(currentUser: .template) {
+      let data = PledgeViewData(
+        project: project,
+        rewards: [reward],
+        selectedQuantities: [reward.id: 1],
+        selectedLocationId: nil,
+        refTag: .projectPage,
+        context: .pledge
+      )
+
+      self.vm.inputs.configure(with: data)
+      self.vm.inputs.viewDidLoad()
+
+      self.configureShippingLocationViewWithDataProject.assertValues([project])
+      self.configureShippingLocationViewWithDataReward.assertValues([reward])
+      self.configureShippingLocationViewWithDataShowAmount.assertValues([true])
+    }
+  }
+
+  func testShippingRuleSelectedDefaultShippingRule() {
+    let project = Project.template
+    let reward = Reward.template
+      |> Reward.lens.shipping .~ (.template |> Reward.Shipping.lens.enabled .~ true)
+
+    withEnvironment(currentUser: .template) {
+      let data = PledgeViewData(
+        project: project,
+        rewards: [reward],
+        selectedQuantities: [reward.id: 1],
+        selectedLocationId: nil,
+        refTag: .projectPage,
+        context: .pledge
+      )
+
+      self.vm.inputs.configure(with: data)
+      self.vm.inputs.viewDidLoad()
+
+      self.configureShippingLocationViewWithDataProject.assertValues([project])
+      self.configureShippingLocationViewWithDataReward.assertValues([reward])
+      self.configureShippingLocationViewWithDataShowAmount.assertValues([true])
+    }
+  }
+
+  func testShippingRuleSelectedUpdatedShippingRule() {
+    let project = Project.template
+    let reward = Reward.template
+      |> Reward.lens.shipping .~ (.template |> Reward.Shipping.lens.enabled .~ true)
+
+    withEnvironment(currentUser: .template) {
+      let data = PledgeViewData(
+        project: project,
+        rewards: [reward],
+        selectedQuantities: [reward.id: 1],
+        selectedLocationId: nil,
+        refTag: .projectPage,
+        context: .pledge
+      )
+
+      self.vm.inputs.configure(with: data)
+      self.vm.inputs.viewDidLoad()
+
+      self.configureShippingLocationViewWithDataProject.assertValues([project])
+      self.configureShippingLocationViewWithDataReward.assertValues([reward])
+      self.configureShippingLocationViewWithDataShowAmount.assertValues([true])
+    }
+  }
+
+  func testPledgeAmountUpdates() {
+    let project = Project.template
+    let reward = Reward.template
+      |> Reward.lens.shipping.enabled .~ true
+
+    withEnvironment(currentUser: .template) {
+      let data = PledgeViewData(
+        project: project,
+        rewards: [reward],
+        selectedQuantities: [reward.id: 1],
+        selectedLocationId: nil,
+        refTag: .projectPage,
+        context: .pledge
+      )
+
+      self.vm.inputs.configure(with: data)
+      self.vm.inputs.viewDidLoad()
+
+      self.configureShippingLocationViewWithDataProject.assertValues([project])
+      self.configureShippingLocationViewWithDataReward.assertValues([reward])
+      self.configureShippingLocationViewWithDataShowAmount.assertValues([true])
+
+      self.pledgeAmountViewHidden.assertValues([false])
+      self.shippingLocationViewHidden.assertValues([false])
+
+      let data1 = (amount: 66.0, min: 10.0, max: 10_000.0, isValid: true)
+
+      self.vm.inputs.pledgeAmountViewControllerDidUpdate(with: data1)
+
+      self.configureShippingLocationViewWithDataProject.assertValues([project])
+      self.configureShippingLocationViewWithDataReward.assertValues([reward])
+      self.configureShippingLocationViewWithDataShowAmount.assertValues([true])
+
+      let data2 = (amount: 93.0, min: 10.0, max: 10_000.0, isValid: true)
+
+      self.vm.inputs.pledgeAmountViewControllerDidUpdate(with: data2)
+
+      self.configureShippingLocationViewWithDataProject.assertValues([project])
+      self.configureShippingLocationViewWithDataReward.assertValues([reward])
+      self.configureShippingLocationViewWithDataShowAmount.assertValues([true])
+    }
+  }
+
+  func testSelectedShippingRuleAndPledgeAmountUpdates() {
+    let project = Project.template
+    let reward = Reward.template
+      |> Reward.lens.shipping .~ (.template |> Reward.Shipping.lens.enabled .~ true)
+
+    withEnvironment(currentUser: .template) {
+      let data = PledgeViewData(
+        project: project,
+        rewards: [reward],
+        selectedQuantities: [reward.id: 1],
+        selectedLocationId: nil,
+        refTag: .projectPage,
+        context: .pledge
+      )
+
+      self.vm.inputs.configure(with: data)
+      self.vm.inputs.viewDidLoad()
+
+      self.configureShippingLocationViewWithDataProject.assertValues([project])
+      self.configureShippingLocationViewWithDataReward.assertValues([reward])
+      self.configureShippingLocationViewWithDataShowAmount.assertValues([true])
+
+      self.pledgeAmountViewHidden.assertValues([false])
+      self.shippingLocationViewHidden.assertValues([false])
+
+      let shippingRule1 = ShippingRule.template
+        |> ShippingRule.lens.cost .~ 20.0
+
+      self.vm.inputs.shippingRuleSelected(shippingRule1)
+
+      self.configureShippingLocationViewWithDataProject.assertValues([project])
+      self.configureShippingLocationViewWithDataReward.assertValues([reward])
+      self.configureShippingLocationViewWithDataShowAmount.assertValues([true])
+
+      let data1 = (amount: 200.0, min: 10.0, max: 10_000.0, isValid: true)
+
+      self.vm.inputs.pledgeAmountViewControllerDidUpdate(with: data1)
+
+      self.configureShippingLocationViewWithDataProject.assertValues([project])
+      self.configureShippingLocationViewWithDataReward.assertValues([reward])
+      self.configureShippingLocationViewWithDataShowAmount.assertValues([true])
+
+      let shippingRule2 = ShippingRule.template
+        |> ShippingRule.lens.cost .~ 123.0
+
+      self.vm.inputs.shippingRuleSelected(shippingRule2)
+
+      self.configureShippingLocationViewWithDataProject.assertValues([project])
+      self.configureShippingLocationViewWithDataReward.assertValues([reward])
+      self.configureShippingLocationViewWithDataShowAmount.assertValues([true])
+
+      let data2 = (amount: 1_999.0, min: 10.0, max: 10_000.0, isValid: true)
+
+      self.vm.inputs.pledgeAmountViewControllerDidUpdate(with: data2)
+
+      self.configureShippingLocationViewWithDataProject.assertValues([project])
+      self.configureShippingLocationViewWithDataReward.assertValues([reward])
+      self.configureShippingLocationViewWithDataShowAmount.assertValues([true])
+    }
+  }
+
+  func testShippingSummaryViewHidden_IsHidden_NoReward() {
+    self.shippingSummaryViewHidden.assertDidNotEmitValue()
+    self.shippingLocationViewHidden.assertDidNotEmitValue()
+
+    let reward = Reward.noReward
+    let project = Project.template
+      |> Project.lens.rewardData.rewards .~ [reward]
+
+    let data = PledgeViewData(
+      project: project,
+      rewards: [reward],
+      selectedQuantities: [reward.id: 1],
+      selectedLocationId: nil,
+      refTag: nil,
+      context: .pledge
+    )
+
+    self.vm.inputs.configure(with: data)
+    self.vm.inputs.viewDidLoad()
+
+    self.shippingLocationViewHidden.assertValues([true])
+    self.shippingSummaryViewHidden.assertValues([true])
+  }
+
+  func testShippingSummaryViewHidden_IsHidden_RegularReward_NoShipping() {
+    self.shippingSummaryViewHidden.assertDidNotEmitValue()
+    self.shippingLocationViewHidden.assertDidNotEmitValue()
+
+    let reward = Reward.template
+      |> Reward.lens.shipping.enabled .~ false
+    let project = Project.template
+      |> Project.lens.rewardData.rewards .~ [reward]
+
+    let data = PledgeViewData(
+      project: project,
+      rewards: [reward],
+      selectedQuantities: [reward.id: 1],
+      selectedLocationId: nil,
+      refTag: nil,
+      context: .pledge
+    )
+
+    self.vm.inputs.configure(with: data)
+    self.vm.inputs.viewDidLoad()
+
+    self.shippingLocationViewHidden.assertValues([true])
+    self.shippingSummaryViewHidden.assertValues([true])
+  }
+
+  func testShippingSummaryViewHidden_IsHidden_RegularReward_Shipping_NoAddOns() {
+    self.shippingSummaryViewHidden.assertDidNotEmitValue()
+    self.shippingLocationViewHidden.assertDidNotEmitValue()
+
+    let reward = Reward.template
+      |> Reward.lens.shipping.enabled .~ true
+    let project = Project.template
+      |> Project.lens.rewardData.rewards .~ [reward]
+
+    let data = PledgeViewData(
+      project: project,
+      rewards: [reward],
+      selectedQuantities: [reward.id: 1],
+      selectedLocationId: nil,
+      refTag: nil,
+      context: .pledge
+    )
+
+    self.vm.inputs.configure(with: data)
+    self.vm.inputs.viewDidLoad()
+
+    self.shippingLocationViewHidden.assertValues([false])
+    self.shippingSummaryViewHidden.assertValues([true])
+  }
+
+  func testShippingSummaryViewHidden_IsHidden_RegularReward_Shipping_HasAddOns_ChangePaymentContext() {
+    self.shippingSummaryViewHidden.assertDidNotEmitValue()
+    self.shippingLocationViewHidden.assertDidNotEmitValue()
+
+    let reward = Reward.template
+      |> Reward.lens.shipping.enabled .~ true
+    let addOnReward1 = Reward.template
+      |> Reward.lens.id .~ 2
+    let project = Project.template
+      |> Project.lens.rewardData.rewards .~ [reward]
+
+    let data = PledgeViewData(
+      project: project,
+      rewards: [reward, addOnReward1],
+      selectedQuantities: [reward.id: 1, addOnReward1.id: 1],
+      selectedLocationId: nil,
+      refTag: nil,
+      context: .changePaymentMethod
+    )
+
+    self.vm.inputs.configure(with: data)
+    self.vm.inputs.viewDidLoad()
+
+    self.shippingLocationViewHidden.assertValues(
+      [true],
+      "All shipping location views are hidden in this context"
+    )
+    self.shippingSummaryViewHidden.assertValues([true])
+  }
+
+  func testShippingSummaryViewHidden_IsVisible_RegularReward_Shipping_HasAddOns() {
+    self.shippingSummaryViewHidden.assertDidNotEmitValue()
+    self.shippingLocationViewHidden.assertDidNotEmitValue()
+
+    let reward = Reward.template
+      |> Reward.lens.shipping.enabled .~ true
+    let addOnReward1 = Reward.template
+      |> Reward.lens.id .~ 2
+    let project = Project.template
+      |> Project.lens.rewardData.rewards .~ [reward]
+
+    let data = PledgeViewData(
+      project: project,
+      rewards: [reward, addOnReward1],
+      selectedQuantities: [reward.id: 1, addOnReward1.id: 1],
+      selectedLocationId: nil,
+      refTag: nil,
+      context: .pledge
+    )
+
+    self.vm.inputs.configure(with: data)
+    self.vm.inputs.viewDidLoad()
+
+    self.shippingLocationViewHidden.assertValues([true])
+    self.shippingSummaryViewHidden.assertValues([false])
+  }
+
+  func testShippingLocationViewHidden_IsHidden_RegularReward_Shipping_NoAddOns_RewardIsLocalPckup() {
+    self.shippingSummaryViewHidden.assertDidNotEmitValue()
+    self.shippingLocationViewHidden.assertDidNotEmitValue()
+
+    let reward = Reward.template
+      |> Reward.lens.shipping.enabled .~ false
+      |> Reward.lens.shipping.preference .~ .local
+      |> Reward.lens.localPickup .~ .losAngeles
+    let project = Project.template
+      |> Project.lens.rewardData.rewards .~ [reward]
+
+    let data = PledgeViewData(
+      project: project,
+      rewards: [reward],
+      selectedQuantities: [reward.id: 1],
+      selectedLocationId: nil,
+      refTag: nil,
+      context: .pledge
+    )
+
+    self.vm.inputs.configure(with: data)
+    self.vm.inputs.viewDidLoad()
+
+    self.shippingLocationViewHidden.assertValues([true])
+    self.shippingSummaryViewHidden.assertValues([true])
+  }
+
+  func testLocalRewardViewHidden_IsVisible_RegularReward_Shipping_NoAddOns_RewardIsLocalPckup() {
+    self.shippingSummaryViewHidden.assertDidNotEmitValue()
+    self.shippingLocationViewHidden.assertDidNotEmitValue()
+    self.localPickupViewHidden.assertDidNotEmitValue()
+
+    let reward = Reward.template
+      |> Reward.lens.shipping.enabled .~ false
+      |> Reward.lens.shipping.preference .~ .local
+      |> Reward.lens.localPickup .~ .losAngeles
+    let project = Project.template
+      |> Project.lens.rewardData.rewards .~ [reward]
+
+    let data = PledgeViewData(
+      project: project,
+      rewards: [reward],
+      selectedQuantities: [reward.id: 1],
+      selectedLocationId: nil,
+      refTag: nil,
+      context: .pledge
+    )
+
+    self.vm.inputs.configure(with: data)
+    self.vm.inputs.viewDidLoad()
+
+    self.shippingLocationViewHidden.assertValues([true])
+    self.shippingSummaryViewHidden.assertValues([true])
+    self.localPickupViewHidden.assertValues([false])
+  }
+
+  func testLocalRewardView_IsHidden_RegularReward_Shipping_HasAddOns_RewardIsNotLocalPickup() {
+    self.shippingSummaryViewHidden.assertDidNotEmitValue()
+    self.shippingLocationViewHidden.assertDidNotEmitValue()
+    self.localPickupViewHidden.assertDidNotEmitValue()
+
+    let reward = Reward.template
+      |> Reward.lens.shipping.enabled .~ true
+      |> Reward.lens.shipping.preference .~ .unrestricted
+      |> Reward.lens.localPickup .~ .losAngeles
+    let addOnReward1 = Reward.template
+      |> Reward.lens.id .~ 2
+    let project = Project.template
+      |> Project.lens.rewardData.rewards .~ [reward]
+
+    let data = PledgeViewData(
+      project: project,
+      rewards: [reward, addOnReward1],
+      selectedQuantities: [reward.id: 1, addOnReward1.id: 1],
+      selectedLocationId: nil,
+      refTag: nil,
+      context: .pledge
+    )
+
+    self.vm.inputs.configure(with: data)
+    self.vm.inputs.viewDidLoad()
+
+    self.shippingLocationViewHidden.assertValues([true])
+    self.shippingSummaryViewHidden.assertValues([false])
+    self.localPickupViewHidden.assertValues([true])
+  }
+
+  func testConfigureShippingSummaryViewWithData_HasAddOns() {
+    self.configureShippingSummaryViewWithData.assertDidNotEmitValue()
+
+    let reward = Reward.template
+      |> Reward.lens.shipping.enabled .~ true
+    let addOnReward1 = Reward.template
+      |> Reward.lens.id .~ 2
+      |> Reward.lens.shipping.enabled .~ true
+    let project = Project.template
+      |> Project.lens.rewardData.rewards .~ [reward]
+
+    let shippingRule = ShippingRule.template
+
+    let data = PledgeViewData(
+      project: project,
+      rewards: [reward, addOnReward1],
+      selectedQuantities: [reward.id: 1, addOnReward1.id: 1],
+      selectedLocationId: shippingRule.id,
+      refTag: nil,
+      context: .pledge
+    )
+
+    self.vm.inputs.configure(with: data)
+    self.vm.inputs.viewDidLoad()
+
+    self.vm.inputs.shippingRuleSelected(shippingRule)
+
+    self.configureShippingSummaryViewWithData.assertValues([
+      PledgeShippingSummaryViewData(
+        locationName: "Brooklyn, NY",
+        omitUSCurrencyCode: true,
+        projectCountry: .us,
+        total: 10
+      )
+    ])
+  }
+
+  func testConfigureShippingSummaryViewWithData_HasAddOns_NonUS_ProjectCurrency_US_ProjectCountry() {
+    self.configureShippingSummaryViewWithData.assertDidNotEmitValue()
+
+    let reward = Reward.template
+      |> Reward.lens.shipping.enabled .~ true
+    let addOnReward1 = Reward.template
+      |> Reward.lens.id .~ 2
+      |> Reward.lens.shipping.enabled .~ true
+    let project = Project.template
+      |> Project.lens.country .~ .us
+      |> Project.lens.stats.currency .~ Project.Country.mx.currencyCode
+      |> Project.lens.rewardData.rewards .~ [reward]
+
+    let shippingRule = ShippingRule.template
+
+    let data = PledgeViewData(
+      project: project,
+      rewards: [reward, addOnReward1],
+      selectedQuantities: [reward.id: 1, addOnReward1.id: 1],
+      selectedLocationId: shippingRule.id,
+      refTag: nil,
+      context: .pledge
+    )
+
+    self.vm.inputs.configure(with: data)
+    self.vm.inputs.viewDidLoad()
+
+    self.vm.inputs.shippingRuleSelected(shippingRule)
+
+    self.configureShippingSummaryViewWithData.assertValues([
+      PledgeShippingSummaryViewData(
+        locationName: "Brooklyn, NY",
+        omitUSCurrencyCode: true,
+        projectCountry: .mx,
+        total: 10
+      )
+    ])
+  }
+
+  func testConfigureShippingSummaryViewWithData_HasAddOns_OnlyOneHasShipping() {
+    self.configureShippingSummaryViewWithData.assertDidNotEmitValue()
+
+    let reward = Reward.template
+      |> Reward.lens.shipping.enabled .~ true
+      |> Reward.lens.shipping.preference .~ Reward.Shipping.Preference.restricted
+    let addOnReward1 = Reward.template
+      |> Reward.lens.id .~ 2
+      |> Reward.lens.shipping.enabled .~ true
+      |> Reward.lens.shipping.preference .~ Reward.Shipping.Preference.unrestricted
+    let addOnReward2 = Reward.template
+      |> Reward.lens.id .~ 3
+      |> Reward.lens.shipping.enabled .~ false
+
+    let project = Project.template
+      |> Project.lens.rewardData.rewards .~ [reward]
+
+    let shippingRule = ShippingRule.template
+
+    let data = PledgeViewData(
+      project: project,
+      rewards: [reward, addOnReward1, addOnReward2],
+      selectedQuantities: [reward.id: 1, addOnReward1.id: 1, addOnReward2.id: 2],
+      selectedLocationId: shippingRule.location.id,
+      refTag: nil,
+      context: .pledge
+    )
+
+    self.vm.inputs.configure(with: data)
+    self.vm.inputs.viewDidLoad()
+
+    self.vm.inputs.shippingRuleSelected(shippingRule)
+
+    self.configureShippingSummaryViewWithData.assertValues([
+      PledgeShippingSummaryViewData(
+        locationName: "Brooklyn, NY",
+        omitUSCurrencyCode: true,
+        projectCountry: .us,
+        total: 10
+      )
+    ])
+  }
+
+  func testConfigureLocalPickupViewWithData_Success() {
+    self.configureLocalPickupViewWithData.assertDidNotEmitValue()
+
+    let reward = Reward.template
+      |> Reward.lens.shipping.enabled .~ false
+      |> Reward.lens.localPickup .~ .losAngeles
+      |> Reward.lens.shipping.preference .~ .local
+
+    let addOnReward1 = Reward.template
+      |> Reward.lens.id .~ 2
+      |> Reward.lens.shipping.enabled .~ false
+
+    let project = Project.template
+      |> Project.lens.rewardData.rewards .~ [reward]
+
+    let shippingRule = ShippingRule.template
+
+    let data = PledgeViewData(
+      project: project,
+      rewards: [reward, addOnReward1],
+      selectedQuantities: [reward.id: 1, addOnReward1.id: 1],
+      selectedLocationId: shippingRule.id,
+      refTag: nil,
+      context: .pledge
+    )
+
+    self.vm.inputs.configure(with: data)
+    self.vm.inputs.viewDidLoad()
+
+    self.configureLocalPickupViewWithData.assertValues([
+      PledgeLocalPickupViewData(locationName: "Los Angeles, CA")
+    ])
   }
 }

--- a/Library/ViewModels/ConfirmDetailsViewModelTests.swift
+++ b/Library/ViewModels/ConfirmDetailsViewModelTests.swift
@@ -1,0 +1,49 @@
+import Foundation
+@testable import KsApi
+@testable import Library
+import PassKit
+import Prelude
+import ReactiveExtensions
+import ReactiveExtensions_TestHelpers
+import ReactiveSwift
+import XCTest
+
+final class ConfirmDetailsViewModelTests: TestCase {
+  private let vm: ConfirmDetailsViewModelType = ConfirmDetailsViewModel()
+
+  private let configureLocalPickupViewWithData = TestObserver<PledgeLocalPickupViewData, Never>()
+
+  private let configureShippingSummaryViewWithData = TestObserver<PledgeShippingSummaryViewData, Never>()
+
+  private let configureShippingLocationViewWithDataProject = TestObserver<Project, Never>()
+  private let configureShippingLocationViewWithDataReward = TestObserver<Reward, Never>()
+  private let configureShippingLocationViewWithDataShowAmount = TestObserver<Bool, Never>()
+
+  private let localPickupViewHidden = TestObserver<Bool, Never>()
+
+  private let pledgeAmountViewHidden = TestObserver<Bool, Never>()
+  private let shippingLocationViewHidden = TestObserver<Bool, Never>()
+  private let shippingSummaryViewHidden = TestObserver<Bool, Never>()
+  private let title = TestObserver<String, Never>()
+
+  override func setUp() {
+    super.setUp()
+
+    self.vm.outputs.configureShippingLocationViewWithData.map { $0.project }
+      .observe(self.configureShippingLocationViewWithDataProject.observer)
+    self.vm.outputs.configureShippingLocationViewWithData.map { $0.reward }
+      .observe(self.configureShippingLocationViewWithDataReward.observer)
+    self.vm.outputs.configureShippingLocationViewWithData.map { $0.showAmount }
+      .observe(self.configureShippingLocationViewWithDataShowAmount.observer)
+
+    self.vm.outputs.configureShippingSummaryViewWithData
+      .observe(self.configureShippingSummaryViewWithData.observer)
+
+    self.vm.outputs.localPickupViewHidden.observe(self.localPickupViewHidden.observer)
+
+    self.vm.outputs.pledgeAmountViewHidden.observe(self.pledgeAmountViewHidden.observer)
+
+    self.vm.outputs.shippingLocationViewHidden.observe(self.shippingLocationViewHidden.observer)
+    self.vm.outputs.shippingSummaryViewHidden.observe(self.shippingSummaryViewHidden.observer)
+  }
+}


### PR DESCRIPTION
# 📲 What
Part 1 in the breakdown of adding a new [Confirm Details Screen](https://www.figma.com/file/sFfDKxlJ2tiuq1xgIsaoiI/Late-Campaign-Backings?type=design&node-id=73-5208&mode=design&t=30TTqFlNfFrutqCM-0)
When a user selects an option in the rewards screen, navigate to the new screen. 
- To keep these PRs small, the new view controller, right now, only displays the shipping location selector and pledge/bonus steppers. See the [designs](https://www.figma.com/file/sFfDKxlJ2tiuq1xgIsaoiI/Late-Campaign-Backings?type=design&node-id=73-5038&mode=design&t=30TTqFlNfFrutqCM-0) for reference.

# 🤔 Why

This screen will allow backers to confirm their pledge info before reaching the final checkout screen. This allows us to call PCP validation mutations before creating stipe intents and initializing the payment sheet.

# 🛠 How

This initiative is time-sensitive and is part of our more complicated and very important checkout flow. With that in mind, I'm choosing to follow existing patterns closely rather than spending more time refactoring or using new patterns like SwiftUI or Combine.

Navigation sources: `RewardAddOnSelectionViewController` and `RewardsCollectionViewController`

# 👀 See

![Simulator Screen Recording - iPhone 15 Pro - 2024-03-06 at 09 28 46](https://github.com/kickstarter/ios-oss/assets/110618242/85d4f0d3-d07d-4832-91e4-c919f5fd03d3)

# ✅ Acceptance criteria

- [x] Navigating to new VC when selecting a $1 pledge with no reward only shows the pledge stepper
- [x] Navigating to new VC when selecting a pledge with a digital reward and no add-ons shows only the bonus stepper
- [x] Navigating to new VC when selecting a pledge with a physical reward and no add-ons shows the shipping dropdown selector and bonus stepper
- [x] Navigating to new VC when selecting a pledge with a physical reward that includes add-ons shows the static dropdown info and bonus stepper

# ⏰ TODO

- [x] Unit tests for the view model. This is pretty involved so I wanted to get the review on this started in the meantime
Part 2 will be all about adding the [pledge total section](https://www.figma.com/file/sFfDKxlJ2tiuq1xgIsaoiI/Late-Campaign-Backings?type=design&node-id=73-5025&mode=design&t=Nz3VCG5iDaQPeLjn-4) https://github.com/kickstarter/ios-oss/pull/1970
