### PR TITLE
Add tracking event for logins/signups that happen via OAuth

### DIFF
--- a/Library/OAuth.swift
+++ b/Library/OAuth.swift
@@ -115,6 +115,10 @@ public struct OAuth {
         let accessEnvelope = AccessTokenEnvelope(accessToken: token, user: user)
         AppEnvironment.login(accessEnvelope)
 
+        // This is an imperfect bit of logging, since it doesn't differentiate between logins and signups.
+        // But it makes up for the fact that we can't track any of this through the embedded web views.
+        AppEnvironment.current.ksrAnalytics.trackLoginSubmitButtonClicked()
+
         onComplete(.loggedIn)
 
       }.store(in: &self.cancellables)


### PR DESCRIPTION
# 📲 What

Add an analytics event to the OAuth login workflow.

# 🤔 Why

We want to be able to track some basic health metrics for logins; unfortunately this is hard because now most of the relevant events are logged _in the webview_ and not via the app. This adds back one of the missing events so we can hopefully get some statistics.