### PR TITLE
MBL-1268: Check for 'canceled' param in login redirect

### DIFF
--- a/Kickstarter-iOS/Features/LoginTout/Controller/LoginToutViewController.swift
+++ b/Kickstarter-iOS/Features/LoginTout/Controller/LoginToutViewController.swift
@@ -432,7 +432,7 @@ public final class LoginToutViewController: UIViewController, MFMailComposeViewC
         )
         alert.addAction(UIAlertAction(title: Strings.login_errors_button_ok(), style: .cancel))
         self?.present(alert, animated: true)
-      case .cancelled:
+      case .canceled:
         // Do nothing
         break
       }

--- a/Library/OAuth.swift
+++ b/Library/OAuth.swift
@@ -7,7 +7,7 @@ import KsApi
 public enum OAuthAuthorizationResult {
   case loggedIn
   case failure(errorMessage: String)
-  case cancelled
+  case canceled
 }
 
 public struct OAuth {
@@ -76,7 +76,7 @@ public struct OAuth {
       if let authenticationError = error as? ASWebAuthenticationSessionError,
         authenticationError.code == .canceledLogin {
         DispatchQueue.main.async {
-          onComplete(.cancelled)
+          onComplete(.canceled)
         }
       } else {
         DispatchQueue.main.async {
@@ -84,6 +84,13 @@ public struct OAuth {
         }
       }
 
+      return
+    }
+
+    guard !self.isRedirectURLCanceled(url) else {
+      DispatchQueue.main.async {
+        onComplete(.canceled)
+      }
       return
     }
 
@@ -131,5 +138,14 @@ public struct OAuth {
 
     let components = URLComponents(url: redirectURL, resolvingAgainstBaseURL: false)
     return components?.queryItems?.first(where: { $0.name == "code" })?.value
+  }
+
+  private static func isRedirectURLCanceled(_ url: URL?) -> Bool {
+    guard let redirectURL = url else {
+      return false
+    }
+
+    let components = URLComponents(url: redirectURL, resolvingAgainstBaseURL: false)
+    return components?.queryItems?.first(where: { $0.name == "canceled" && $0.value == "true" }) != nil
   }
 }

--- a/Library/OAuthTests.swift
+++ b/Library/OAuthTests.swift
@@ -29,7 +29,7 @@ final class OAuthTests: XCTestCase {
     }
   }
 
-  func testHandleRedirect_missingRedirectCode_fails() {
+  func testHandleRedirect_missingRedirectCodeWithNoCancelParam_fails() {
     self.verifyRedirectAsync(
       redirectURL: URL(string: "ksrauth2://authenticate?foo=bar"),
       error: nil,
@@ -43,10 +43,24 @@ final class OAuthTests: XCTestCase {
     }
   }
 
+  func testHandleRedirect_missingRedirectCodeAndIncludesCancelParam_cancels() {
+    self.verifyRedirectAsync(
+      redirectURL: URL(string: "ksrauth2://authenticate?canceled=true"),
+      error: nil,
+      verifier: ""
+    ) { result in
+      if case .canceled = result {
+        // Success
+      } else {
+        XCTFail("Expected call to be cancelled")
+      }
+    }
+  }
+
   func testHandleRedirect_cancellationError_cancels() {
     let cancelledError = ASWebAuthenticationSessionError(.canceledLogin)
     verifyRedirectAsync(redirectURL: nil, error: cancelledError, verifier: "") { result in
-      if case .cancelled = result {
+      if case .canceled = result {
         // Success
       } else {
         XCTFail("Expected call to be canceled")


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Check if redirect was canceled.

# 🤔 Why

Otherwise, if the user cancels somewhere inside the webview, we would show an error message, which looks a little silly.
https://github.com/kickstarter/ios-oss/assets/146007185/2a073c11-be58-4217-9385-f29c608d19b6


