### PR TITLE
MBL-1226: Add stripeCardId to UserStoredCardsFragment and CreditCardFragment

### DIFF
--- a/KsApi/GraphAPI.swift
+++ b/KsApi/GraphAPI.swift
@@ -16858,6 +16858,7 @@ public enum GraphAPI {
           id
           lastFour
           type
+          stripeCardId
         }
         totalCount
       }
@@ -16921,6 +16922,7 @@ public enum GraphAPI {
           GraphQLField("id", type: .nonNull(.scalar(String.self))),
           GraphQLField("lastFour", type: .nonNull(.scalar(String.self))),
           GraphQLField("type", type: .nonNull(.scalar(CreditCardTypes.self))),
+          GraphQLField("stripeCardId", type: .nonNull(.scalar(String.self))),
         ]
       }
 
@@ -16930,8 +16932,8 @@ public enum GraphAPI {
         self.resultMap = unsafeResultMap
       }
 
-      public init(expirationDate: String, id: String, lastFour: String, type: CreditCardTypes) {
-        self.init(unsafeResultMap: ["__typename": "CreditCard", "expirationDate": expirationDate, "id": id, "lastFour": lastFour, "type": type])
+      public init(expirationDate: String, id: String, lastFour: String, type: CreditCardTypes, stripeCardId: String) {
+        self.init(unsafeResultMap: ["__typename": "CreditCard", "expirationDate": expirationDate, "id": id, "lastFour": lastFour, "type": type, "stripeCardId": stripeCardId])
       }
 
       public var __typename: String {
@@ -16980,6 +16982,16 @@ public enum GraphAPI {
         }
         set {
           resultMap.updateValue(newValue, forKey: "type")
+        }
+      }
+
+      /// Stripe card id
+      public var stripeCardId: String {
+        get {
+          return resultMap["stripeCardId"]! as! String
+        }
+        set {
+          resultMap.updateValue(newValue, forKey: "stripeCardId")
         }
       }
     }

--- a/KsApi/GraphAPI.swift
+++ b/KsApi/GraphAPI.swift
@@ -4733,8 +4733,8 @@ public enum GraphAPI {
             self.resultMap = unsafeResultMap
           }
 
-          public init(expirationDate: String, id: String, lastFour: String, paymentType: CreditCardPaymentType, state: CreditCardState, type: CreditCardTypes) {
-            self.init(unsafeResultMap: ["__typename": "CreditCard", "expirationDate": expirationDate, "id": id, "lastFour": lastFour, "paymentType": paymentType, "state": state, "type": type])
+          public init(expirationDate: String, id: String, lastFour: String, paymentType: CreditCardPaymentType, state: CreditCardState, type: CreditCardTypes, stripeCardId: String) {
+            self.init(unsafeResultMap: ["__typename": "CreditCard", "expirationDate": expirationDate, "id": id, "lastFour": lastFour, "paymentType": paymentType, "state": state, "type": type, "stripeCardId": stripeCardId])
           }
 
           public var __typename: String {
@@ -11721,8 +11721,8 @@ public enum GraphAPI {
         return CreditCard(unsafeResultMap: ["__typename": "BankAccount"])
       }
 
-      public static func makeCreditCard(expirationDate: String, id: String, lastFour: String, paymentType: CreditCardPaymentType, state: CreditCardState, type: CreditCardTypes) -> CreditCard {
-        return CreditCard(unsafeResultMap: ["__typename": "CreditCard", "expirationDate": expirationDate, "id": id, "lastFour": lastFour, "paymentType": paymentType, "state": state, "type": type])
+      public static func makeCreditCard(expirationDate: String, id: String, lastFour: String, paymentType: CreditCardPaymentType, state: CreditCardState, type: CreditCardTypes, stripeCardId: String) -> CreditCard {
+        return CreditCard(unsafeResultMap: ["__typename": "CreditCard", "expirationDate": expirationDate, "id": id, "lastFour": lastFour, "paymentType": paymentType, "state": state, "type": type, "stripeCardId": stripeCardId])
       }
 
       public var __typename: String {
@@ -12964,6 +12964,7 @@ public enum GraphAPI {
           paymentType
           state
           type
+          stripeCardId
         }
       }
       """
@@ -12991,8 +12992,8 @@ public enum GraphAPI {
       return CreditCardFragment(unsafeResultMap: ["__typename": "BankAccount"])
     }
 
-    public static func makeCreditCard(expirationDate: String, id: String, lastFour: String, paymentType: CreditCardPaymentType, state: CreditCardState, type: CreditCardTypes) -> CreditCardFragment {
-      return CreditCardFragment(unsafeResultMap: ["__typename": "CreditCard", "expirationDate": expirationDate, "id": id, "lastFour": lastFour, "paymentType": paymentType, "state": state, "type": type])
+    public static func makeCreditCard(expirationDate: String, id: String, lastFour: String, paymentType: CreditCardPaymentType, state: CreditCardState, type: CreditCardTypes, stripeCardId: String) -> CreditCardFragment {
+      return CreditCardFragment(unsafeResultMap: ["__typename": "CreditCard", "expirationDate": expirationDate, "id": id, "lastFour": lastFour, "paymentType": paymentType, "state": state, "type": type, "stripeCardId": stripeCardId])
     }
 
     public var __typename: String {
@@ -13027,6 +13028,7 @@ public enum GraphAPI {
           GraphQLField("paymentType", type: .nonNull(.scalar(CreditCardPaymentType.self))),
           GraphQLField("state", type: .nonNull(.scalar(CreditCardState.self))),
           GraphQLField("type", type: .nonNull(.scalar(CreditCardTypes.self))),
+          GraphQLField("stripeCardId", type: .nonNull(.scalar(String.self))),
         ]
       }
 
@@ -13036,8 +13038,8 @@ public enum GraphAPI {
         self.resultMap = unsafeResultMap
       }
 
-      public init(expirationDate: String, id: String, lastFour: String, paymentType: CreditCardPaymentType, state: CreditCardState, type: CreditCardTypes) {
-        self.init(unsafeResultMap: ["__typename": "CreditCard", "expirationDate": expirationDate, "id": id, "lastFour": lastFour, "paymentType": paymentType, "state": state, "type": type])
+      public init(expirationDate: String, id: String, lastFour: String, paymentType: CreditCardPaymentType, state: CreditCardState, type: CreditCardTypes, stripeCardId: String) {
+        self.init(unsafeResultMap: ["__typename": "CreditCard", "expirationDate": expirationDate, "id": id, "lastFour": lastFour, "paymentType": paymentType, "state": state, "type": type, "stripeCardId": stripeCardId])
       }
 
       public var __typename: String {
@@ -13106,6 +13108,16 @@ public enum GraphAPI {
         }
         set {
           resultMap.updateValue(newValue, forKey: "type")
+        }
+      }
+
+      /// Stripe card id
+      public var stripeCardId: String {
+        get {
+          return resultMap["stripeCardId"]! as! String
+        }
+        set {
+          resultMap.updateValue(newValue, forKey: "stripeCardId")
         }
       }
     }

--- a/KsApi/fragments/CreditCardFragment.graphql
+++ b/KsApi/fragments/CreditCardFragment.graphql
@@ -6,5 +6,6 @@ fragment CreditCardFragment on PaymentSource {
     paymentType
     state
     type
+    stripeCardId
   }
 }

--- a/KsApi/fragments/UserStoredCardsFragment.graphql
+++ b/KsApi/fragments/UserStoredCardsFragment.graphql
@@ -4,6 +4,7 @@ fragment UserStoredCardsFragment on UserCreditCardTypeConnection {
       id
       lastFour
       type
+      stripeCardId
     }
     totalCount
 }

--- a/KsApi/models/DeletePaymentMethodEnvelopeTests.swift
+++ b/KsApi/models/DeletePaymentMethodEnvelopeTests.swift
@@ -13,13 +13,15 @@ class DeletePaymentMethodEnvelopeTests: XCTestCase {
                   "expirationDate": "2055-11-01",
                   "id": "1057",
                   "lastFour": "1111",
-                  "type": "VISA"
+                  "type": "VISA",
+                  "stripeCardId": "pm_1OtGFX4VvJ2PtfhK3Gp00SWK",
                 },
                 {
                   "expirationDate": "2044-04-01",
                   "id": "1055",
                   "lastFour": "4444",
-                  "type": "MASTERCARD"
+                  "type": "MASTERCARD",
+                  "stripeCardId": "pm_1OpDEC4VvJ2PtfhKftPrpgJ2",
                 }
               ]
             }

--- a/KsApi/models/graphql/GraphUserTests.swift
+++ b/KsApi/models/graphql/GraphUserTests.swift
@@ -24,7 +24,8 @@ final class GraphUserTests: XCTestCase {
             "expirationDate": "2023-01-01",
             "id": "6",
             "lastFour": "4242",
-            "type": "VISA"
+            "type": "VISA",
+            "stripeCardId": "pm_1OtGFX4VvJ2PtfhK3Gp00SWK",
           }
         ],
         "totalCount": 1
@@ -79,7 +80,8 @@ final class GraphUserTests: XCTestCase {
             "expirationDate": "2023-01-01",
             "id": "6",
             "lastFour": "4242",
-            "type": "VISA"
+            "type": "VISA",
+            "stripeCardId": "pm_1OtGFX4VvJ2PtfhK3Gp00SWK",
           }
         ],
         "totalCount": 1

--- a/KsApi/models/graphql/UserCreditCardsTests.swift
+++ b/KsApi/models/graphql/UserCreditCardsTests.swift
@@ -28,13 +28,15 @@ final class UserCreditCardsTests: XCTestCase {
             "expirationDate": "2023-02-01",
             "lastFour": "4242",
             "id": "3021",
-            "type": "VISA"
+            "type": "VISA",
+            "stripeCardId": "pm_1OpDEC4VvJ2PtfhKftPrpgJ2",
           },
           {
             "expirationDate": "2020-02-01",
             "lastFour": "1111",
             "id": "2768",
-            "type": "VISA"
+            "type": "VISA",
+            "stripeCardId": "pm_1OtGFX4VvJ2PtfhK3Gp00SWK",
           }
       ],
       "totalCount": 2
@@ -69,7 +71,8 @@ final class UserCreditCardsTests: XCTestCase {
           {
             "expirationDate": "2020-02-01",
             "lastFour": "1111",
-            "id": "2768"
+            "id": "2768",
+            "stripeCardId": "pm_1OtGFX4VvJ2PtfhK3Gp00SWK",
           }
       ],
       "totalCount": 1
@@ -103,7 +106,8 @@ final class UserCreditCardsTests: XCTestCase {
             "expirationDate": "2020-02-01",
             "lastFour": "1111",
             "type": "UNKNOWN",
-            "id": "2768"
+            "id": "2768",
+            "stripeCardId": "pm_1OtGFX4VvJ2PtfhK3Gp00SWK",
           }
       ],
       "totalCount": 1

--- a/KsApi/models/graphql/adapters/Backing+BackingFragmentTests.swift
+++ b/KsApi/models/graphql/adapters/Backing+BackingFragmentTests.swift
@@ -517,7 +517,8 @@ private func backingDictionary() -> [String: Any] {
       "lastFour": "4242",
       "paymentType": "CREDIT_CARD",
       "state": "ACTIVE",
-      "type": "VISA"
+      "type": "VISA",
+      "stripeCardId": "pm_1OtGFX4VvJ2PtfhK3Gp00SWK",
     },
     "id": "QmFja2luZy0xNDQ5NTI3MTc=",
     "location": {

--- a/KsApi/models/graphql/adapters/Backing+BackingFragmentTests.swift
+++ b/KsApi/models/graphql/adapters/Backing+BackingFragmentTests.swift
@@ -494,7 +494,8 @@ private func backingDictionary() -> [String: Any] {
             "expirationDate": "2023-01-01",
             "id": "6",
             "lastFour": "4242",
-            "type": "VISA"
+            "type": "VISA",
+            "stripeCardId": "pm_1OtGFX4VvJ2PtfhK3Gp00SWK",
           }
         ],
         "totalCount": 1
@@ -676,7 +677,8 @@ private func backingDictionary() -> [String: Any] {
               "expirationDate": "2023-01-01",
               "id": "6",
               "lastFour": "4242",
-              "type": "VISA"
+              "type": "VISA",
+              "stripeCardId": "pm_1OtGFX4VvJ2PtfhK3Gp00SWK",
             }
           ],
           "totalCount": 1

--- a/KsApi/models/graphql/adapters/UserCreditCards+UserFragmentTests.swift
+++ b/KsApi/models/graphql/adapters/UserCreditCards+UserFragmentTests.swift
@@ -13,7 +13,8 @@ class UserCreditCards_UserFragmentTests: XCTestCase {
           "expirationDate": "2025-02-01",
           "id": "69021256",
           "lastFour": "4242",
-          "type": "VISA"
+          "type": "VISA",
+          "stripeCardId": "pm_1OtGFX4VvJ2PtfhK3Gp00SWK"
         ]],
       "totalCount": 1
     ]

--- a/KsApi/models/graphql/adapters/UserEnvelope+GraphUserEnvelopeTemplates.swift
+++ b/KsApi/models/graphql/adapters/UserEnvelope+GraphUserEnvelopeTemplates.swift
@@ -21,7 +21,8 @@ public struct GraphUserEnvelopeTemplates {
               "expirationDate": "2023-01-01",
               "id": "6",
               "lastFour": "4242",
-              "type": GraphAPI.CreditCardTypes(rawValue: "VISA") as Any
+              "type": GraphAPI.CreditCardTypes(rawValue: "VISA") as Any,
+              "stripeCardId": "pm_1OtGFX4VvJ2PtfhK3Gp00SWK"
             ]
           ],
           "totalCount": 1

--- a/KsApi/mutations/templates/fragment/CommentFragmentTemplate.swift
+++ b/KsApi/mutations/templates/fragment/CommentFragmentTemplate.swift
@@ -91,7 +91,8 @@ public enum CommentFragmentTemplate {
               "expirationDate": "2023-01-01",
               "id": "6",
               "lastFour": "4242",
-              "type": "VISA"
+              "type": "VISA",
+              "stripeCardId": "pm_1OtGFX4VvJ2PtfhK3Gp00SWK",
             }
           ],
           "totalCount": 1

--- a/KsApi/mutations/templates/fragment/UserFragmentTemplate.swift
+++ b/KsApi/mutations/templates/fragment/UserFragmentTemplate.swift
@@ -146,7 +146,8 @@ public enum UserFragmentTemplate {
                 "expirationDate":"2023-01-01",
                 "id":"6",
                 "lastFour":"4242",
-                "type":"VISA"
+                "type":"VISA",
+                "stripeCardId": "pm_1OtGFX4VvJ2PtfhK3Gp00SWK",
              }
           ],
           "totalCount":1

--- a/KsApi/mutations/templates/mutation/CreatePaymentSourceMutationTemplate.swift
+++ b/KsApi/mutations/templates/mutation/CreatePaymentSourceMutationTemplate.swift
@@ -31,7 +31,8 @@ public enum CreatePaymentSourceMutationTemplate {
           "lastFour": "4242",
           "paymentType": GraphAPI.PaymentTypes.creditCard,
           "state": GraphAPI.CreditCardState.active,
-          "type": GraphAPI.CreditCardTypes.visa
+          "type": GraphAPI.CreditCardTypes.visa,
+          "stripeCardId": "pm_1OtGFX4VvJ2PtfhK3Gp00SWK"
         ]
       ]
     ]

--- a/KsApi/mutations/templates/mutation/DeletePaymentSourceMutationTemplate.swift
+++ b/KsApi/mutations/templates/mutation/DeletePaymentSourceMutationTemplate.swift
@@ -28,13 +28,15 @@ public enum DeletePaymentSourceMutationTemplate {
                 "expirationDate": "2023-02-01",
                 "id": "69021326",
                 "lastFour": "4242",
-                "type": GraphAPI.CreditCardTypes.visa
+                "type": GraphAPI.CreditCardTypes.visa,
+                "stripeCardId": "pm_1OtGFX4VvJ2PtfhK3Gp00SWK"
               ],
               [
                 "expirationDate": "2024-01-01",
                 "id": "69021329",
                 "lastFour": "4243",
-                "type": GraphAPI.CreditCardTypes.discover
+                "type": GraphAPI.CreditCardTypes.discover,
+                "stripeCardId": "pm_1OpDEC4VvJ2PtfhKftPrpgJ2"
               ]
             ]
           ],

--- a/KsApi/mutations/templates/query/FetchAddOnsQueryTemplate.swift
+++ b/KsApi/mutations/templates/query/FetchAddOnsQueryTemplate.swift
@@ -527,7 +527,8 @@ public enum FetchAddsOnsQueryTemplate {
                   "expirationDate": "2023-01-01",
                   "id": "6",
                   "lastFour": "4242",
-                  "type": "VISA"
+                  "type": "VISA",
+                  "stripeCardId": "pm_1OtGFX4VvJ2PtfhK3Gp00SWK",
                 }
               ],
               "totalCount": 1

--- a/KsApi/mutations/templates/query/FetchProjectFriendsQueryTemplate.swift
+++ b/KsApi/mutations/templates/query/FetchProjectFriendsQueryTemplate.swift
@@ -55,7 +55,8 @@ public enum FetchProjectFriendsQueryTemplate {
                             "expirationDate":"2023-01-01",
                             "id":"6",
                             "lastFour":"4242",
-                            "type":"VISA"
+                            "type":"VISA",
+                            "stripeCardId": "pm_1OtGFX4VvJ2PtfhK3Gp00SWK",
                          }
                       ],
                       "totalCount":1

--- a/KsApi/mutations/templates/query/FetchUserBackingsQueryTemplate.swift
+++ b/KsApi/mutations/templates/query/FetchUserBackingsQueryTemplate.swift
@@ -65,7 +65,8 @@ public enum FetchUserBackingsQueryTemplate {
                 "lastFour": "0341",
                 "paymentType": "CREDIT_CARD",
                 "state": "ACTIVE",
-                "type": "VISA"
+                "type": "VISA",
+                "stripeCardId": "pm_1OtGFX4VvJ2PtfhK3Gp00SWK"
               ],
               "id": "QmFja2luZy0xNDQ5NTI3NTQ=",
               "location": nil,


### PR DESCRIPTION
# 📲 What

Add `stripeCardId` to `UserStoredCardsFragment`

# 🤔 Why

From the ticket:
> When we end up calling Stripe.confirmPayment to process late pledges, we need to pass in a [paymentMethodId](https://stripe.dev/stripe-ios/stripe/documentation/stripe/stppaymentintentparams/paymentmethodid). This is accessible to us via the stripeCardId field that we can get in the UserStoredCardsFragment.

# 🛠 How

For the example IDs in all the templates in the tests, I used test cards I had on staging and pulled their IDs from GraphQL.