### PR TITLE
Fix regressions found in the login with OAuth flow

### DIFF
--- a/Kickstarter-iOS/Features/LoginTout/Controller/LoginToutViewControllerTests.swift
+++ b/Kickstarter-iOS/Features/LoginTout/Controller/LoginToutViewControllerTests.swift
@@ -15,11 +15,16 @@ internal final class LoginToutViewControllerTests: TestCase {
   }
 
   func testLoginToutView() {
+    let mockConfigClient = MockRemoteConfigClient()
+    mockConfigClient.features = [
+      RemoteConfigFeature.loginWithOAuthEnabled.rawValue: false
+    ]
+
     let devices = [Device.phone4_7inch, Device.phone5_8inch, Device.pad]
     let intents = [LoginIntent.generic, .starProject, .messageCreator, .backProject]
 
     orthogonalCombos(Language.allLanguages, devices, intents).forEach { language, device, intent in
-      withEnvironment(language: language) {
+      withEnvironment(language: language, remoteConfigClient: mockConfigClient) {
         let controller = LoginToutViewController.configuredWith(loginIntent: intent)
         let (parent, _) = traitControllers(device: device, orientation: .portrait, child: controller)
 

--- a/Library/RemoteConfig/RemoteConfigFeature+Helpers.swift
+++ b/Library/RemoteConfig/RemoteConfigFeature+Helpers.swift
@@ -1,10 +1,12 @@
 /// Return remote config values either a value from the cloud, if it found one, or a default value based on the provided key
+private func featureEnabled(feature: RemoteConfigFeature, defaultValue: Bool = false) -> Bool {
+  let valueFromDefaults = AppEnvironment.current.userDefaults
+    .remoteConfigFeatureFlags[feature.rawValue]
 
-private func featureEnabled(feature: RemoteConfigFeature) -> Bool {
-  return AppEnvironment.current.userDefaults
-    .remoteConfigFeatureFlags[feature.rawValue] ??
-    (AppEnvironment.current.remoteConfigClient?
-      .isFeatureEnabled(featureKey: feature) ?? false)
+  let valueFromRemoteConfig = AppEnvironment.current.remoteConfigClient?
+    .isFeatureEnabled(featureKey: feature)
+
+  return valueFromDefaults ?? valueFromRemoteConfig ?? defaultValue
 }
 
 public func featureBlockUsersEnabled() -> Bool {
@@ -32,7 +34,7 @@ public func featureReportThisProjectEnabled() -> Bool {
 }
 
 public func featureLoginWithOAuthEnabled() -> Bool {
-  featureEnabled(feature: .loginWithOAuthEnabled)
+  featureEnabled(feature: .loginWithOAuthEnabled, defaultValue: true)
 }
 
 public func featureUseKeychainForOAuthTokenEnabled() -> Bool {

--- a/Library/RemoteConfig/RemoteConfigFeature+Helpers.swift
+++ b/Library/RemoteConfig/RemoteConfigFeature+Helpers.swift
@@ -1,12 +1,16 @@
 /// Return remote config values either a value from the cloud, if it found one, or a default value based on the provided key
 private func featureEnabled(feature: RemoteConfigFeature, defaultValue: Bool = false) -> Bool {
-  let valueFromDefaults = AppEnvironment.current.userDefaults
-    .remoteConfigFeatureFlags[feature.rawValue]
+  if let valueFromDefaults = AppEnvironment.current.userDefaults
+    .remoteConfigFeatureFlags[feature.rawValue] {
+    return valueFromDefaults
+  }
 
-  let valueFromRemoteConfig = AppEnvironment.current.remoteConfigClient?
-    .isFeatureEnabled(featureKey: feature)
+  if let valueFromRemoteConfig = AppEnvironment.current.remoteConfigClient?
+    .isFeatureEnabled(featureKey: feature) {
+    return valueFromRemoteConfig
+  }
 
-  return valueFromDefaults ?? valueFromRemoteConfig ?? defaultValue
+  return defaultValue
 }
 
 public func featureBlockUsersEnabled() -> Bool {

--- a/Library/ViewModels/LoginToutViewModel.swift
+++ b/Library/ViewModels/LoginToutViewModel.swift
@@ -41,6 +41,9 @@ public protocol LoginToutViewModelInputs {
   /// Call when sign up button is pressed
   func signupButtonPressed()
 
+  /// Call with login with OAuth button is pressed
+  func signupOrLoginWithOAuthButtonPressed()
+
   /// Call when a user session starts.
   func userSessionStarted()
 
@@ -92,6 +95,9 @@ public protocol LoginToutViewModelOutputs {
   /// Emits when Signup view should be shown
   var startSignup: Signal<(), Never> { get }
 
+  /// Emits when OAuth flow should be shown
+  var startOAuthSignupOrLogin: Signal<(), Never> { get }
+
   /// Emits a Facebook user and access token when Facebook login has occurred
   var startFacebookConfirmation: Signal<(ErrorEnvelope.FacebookUser?, String), Never> { get }
 
@@ -100,7 +106,7 @@ public protocol LoginToutViewModelOutputs {
 
   /// True if the feature flag for OAuth login is true.
   /// Note that this is not a signal, because we don't want it to ever change after the screen is loaded.
-  var loginWithOAuthEnabled: Bool { get }
+  var showLoginWithOAuth: Signal<Bool, Never> { get }
 }
 
 public protocol LoginToutViewModelType {
@@ -125,6 +131,7 @@ public final class LoginToutViewModel: LoginToutViewModelType, LoginToutViewMode
     self.isLoading = isLoading.signal.skipRepeats()
     self.startLogin = self.loginButtonPressedProperty.signal
     self.startSignup = self.signupButtonPressedProperty.signal
+    self.startOAuthSignupOrLogin = self.signupOrLoginWithOAuthButtonPressedProperty.signal
     self.attemptFacebookLogin = self.facebookLoginButtonPressedProperty.signal
     self.attemptAppleLogin = self.appleLoginButtonPressedProperty.signal.ignoreValues()
 
@@ -269,7 +276,9 @@ public final class LoginToutViewModel: LoginToutViewModelType, LoginToutViewMode
 
     self.logIntoEnvironmentWithApple = logIntoEnvironmentWithApple.signal
     self.logIntoEnvironmentWithFacebook = logIntoEnvironmentWithFacebook.signal
-    self.loginWithOAuthEnabled = featureLoginWithOAuthEnabled()
+    self.showLoginWithOAuth = self.viewWillAppearProperty.signal.map { _ in
+      featureLoginWithOAuthEnabled()
+    }
   }
 
   public var inputs: LoginToutViewModelInputs { return self }
@@ -329,6 +338,11 @@ public final class LoginToutViewModel: LoginToutViewModelType, LoginToutViewMode
     self.signupButtonPressedProperty.value = ()
   }
 
+  fileprivate let signupOrLoginWithOAuthButtonPressedProperty = MutableProperty(())
+  public func signupOrLoginWithOAuthButtonPressed() {
+    self.signupOrLoginWithOAuthButtonPressedProperty.value = ()
+  }
+
   fileprivate let userSessionStartedProperty = MutableProperty(())
   public func userSessionStarted() {
     self.userSessionStartedProperty.value = ()
@@ -356,10 +370,11 @@ public final class LoginToutViewModel: LoginToutViewModelType, LoginToutViewMode
   public let startFacebookConfirmation: Signal<(ErrorEnvelope.FacebookUser?, String), Never>
   public let startLogin: Signal<(), Never>
   public let startSignup: Signal<(), Never>
+  public let startOAuthSignupOrLogin: Signal<(), Never>
   public let startTwoFactorChallenge: Signal<String, Never>
   public let showAppleErrorAlert: Signal<String, Never>
   public let showFacebookErrorAlert: Signal<AlertError, Never>
-  public let loginWithOAuthEnabled: Bool
+  public let showLoginWithOAuth: Signal<Bool, Never>
 }
 
 private func statusString(_ forStatus: LoginIntent) -> String {

--- a/Library/ViewModels/LoginToutViewModelTests.swift
+++ b/Library/ViewModels/LoginToutViewModelTests.swift
@@ -25,7 +25,9 @@ final class LoginToutViewModelTests: TestCase {
   fileprivate let startFacebookConfirmation = TestObserver<String, Never>()
   fileprivate let startLogin = TestObserver<(), Never>()
   fileprivate let startSignup = TestObserver<(), Never>()
+  fileprivate let startOAuthSignupOrLogin = TestObserver<(), Never>()
   fileprivate let startTwoFactorChallenge = TestObserver<String, Never>()
+  fileprivate let showLoginWithOAuth = TestObserver<Bool, Never>()
 
   override func setUp() {
     super.setUp()
@@ -47,7 +49,9 @@ final class LoginToutViewModelTests: TestCase {
       .observe(self.startFacebookConfirmation.observer)
     self.vm.outputs.startLogin.observe(self.startLogin.observer)
     self.vm.outputs.startSignup.observe(self.startSignup.observer)
+    self.vm.outputs.startOAuthSignupOrLogin.observe(self.startOAuthSignupOrLogin.observer)
     self.vm.outputs.startTwoFactorChallenge.observe(self.startTwoFactorChallenge.observer)
+    self.vm.outputs.showLoginWithOAuth.observe(self.showLoginWithOAuth.observer)
   }
 
   func testLoginIntent_Pledge() {
@@ -115,6 +119,36 @@ final class LoginToutViewModelTests: TestCase {
       ["Please log in or sign up to back this project."],
       "Emits Signup with pledge login Context Text"
     )
+  }
+
+  func testStartSignupOrLoginWithOAuth() {
+    self.vm.inputs.viewWillAppear()
+    self.vm.inputs.signupOrLoginWithOAuthButtonPressed()
+    self.startOAuthSignupOrLogin.assertValueCount(1, "OAuth signup/loginlogin emitted")
+  }
+
+  func testShowSignupOrLoginWithOAuth_featureFlagOn() {
+    let mockConfigClient = MockRemoteConfigClient()
+    mockConfigClient.features = [
+      RemoteConfigFeature.loginWithOAuthEnabled.rawValue: true
+    ]
+
+    withEnvironment(remoteConfigClient: mockConfigClient) {
+      self.vm.inputs.viewWillAppear()
+      self.showLoginWithOAuth.assertValues([true])
+    }
+  }
+
+  func testShowSignupOrLoginWithOAuth_featureFlagOff() {
+    let mockConfigClient = MockRemoteConfigClient()
+    mockConfigClient.features = [
+      RemoteConfigFeature.loginWithOAuthEnabled.rawValue: false
+    ]
+
+    withEnvironment(remoteConfigClient: mockConfigClient) {
+      self.vm.inputs.viewWillAppear()
+      self.showLoginWithOAuth.assertValues([false])
+    }
   }
 
   func testHeadlineLabelHidden() {

--- a/Library/ViewModels/LoginToutViewModelTests.swift
+++ b/Library/ViewModels/LoginToutViewModelTests.swift
@@ -151,6 +151,13 @@ final class LoginToutViewModelTests: TestCase {
     }
   }
 
+  func testShowSignupOrLoginWithOAuth_featureFlagUnset() {
+    withEnvironment(remoteConfigClient: nil) {
+      self.vm.inputs.viewWillAppear()
+      self.showLoginWithOAuth.assertValues([true])
+    }
+  }
+
   func testHeadlineLabelHidden() {
     self.vm.inputs.configureWith(.starProject, project: nil, reward: nil)
     self.vm.inputs.viewWillAppear()


### PR DESCRIPTION
# 📲 What

1. Make the old login, old sign up, and new OAuth "signup or login" buttons reactive.
2. Make the default value of the `featureLoginWithOAuthEnabled` true.

# 🤔 Why

1. One copy of our login screen is created as a root view of the app - in the Profile tab in the tab bar. This copy of the screen was always getting the _first_ (ie cached or default value) of `featureLoginWithOAuthEnabled()`. This means it was never updating, even after new values of the OAuth feature flag loaded.  Fixing this bug ensures we can correctly use the feature flag for OAuth, in case we need to ramp down.
2. If the remote config hasn't loaded yet, we want to show the new flow, not the old flow.