### PR TITLE
Add short delay before presenting push notification dialog

### DIFF
--- a/Kickstarter-iOS/AppDelegate.swift
+++ b/Kickstarter-iOS/AppDelegate.swift
@@ -365,7 +365,11 @@ internal final class AppDelegate: UIResponder, UIApplicationDelegate {
       })
     )
 
-    DispatchQueue.main.async {
+    // Sometimes, the "sign up for push" popup doesn't appear when you sign in via web authentication session.
+    // My best guess is that this happens because the dismissal of the web login screen accidentally dismisses this popup, too.
+    // The delay isn't pretty, but it works.
+
+    DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
       if let viewController = notification.userInfo?[UserInfoKeys.viewController] as? UIViewController {
         viewController.present(alert, animated: true, completion: nil)
       } else {


### PR DESCRIPTION
# 📲 What

Add a 0.5 second delay before presenting our push notification permission dialog.

# 🤔 Why

When you sign in with OAuth, this permission dialog was showing up only rarely. I dug into the code and found that we were calling everything correctly, but the popup was disappearing, somehow.

My best guess is that something internal is dismissing both the web authentication screen and, since it happens at the same time, the push notification dialog. Adding a short delay before presenting the push notification dialog solves this problem, and doesn't feel any different as a user.

https://github.com/kickstarter/ios-oss/assets/146007185/82705da9-2ac1-4010-94ef-b31c6065266b


