### PR TITLE
Fix CircleCI error caused by GraphQL change to GraphAPI.FlaggingKind

### DIFF
--- a/Kickstarter-iOS/Features/ReportProject/ReportProjectFormView.swift
+++ b/Kickstarter-iOS/Features/ReportProject/ReportProjectFormView.swift
@@ -10,7 +10,7 @@ struct ReportProjectFormView: View {
   @Binding var popToRoot: Bool
   let projectID: String
   let projectURL: String
-  let projectFlaggingKind: GraphAPI.FlaggingKind
+  let projectFlaggingKind: GraphAPI.NonDeprecatedFlaggingKind
 
   @SwiftUI.Environment(\.dismiss) private var dismiss
   @StateObject private var viewModel = ReportProjectFormViewModel()

--- a/Kickstarter-iOS/Features/ReportProject/ReportProjectInfoView.swift
+++ b/Kickstarter-iOS/Features/ReportProject/ReportProjectInfoView.swift
@@ -130,7 +130,8 @@ struct RowView: View {
                     popToRoot: $popToRoot,
                     projectID: self.projectID,
                     projectURL: self.projectUrl,
-                    projectFlaggingKind: item.flaggingKind ?? GraphAPI.FlaggingKind.guidelinesViolation
+                    projectFlaggingKind: item.flaggingKind ?? GraphAPI.NonDeprecatedFlaggingKind
+                      .guidelinesViolation
                   )
                 },
                 label: { BaseRowView(item: item) }

--- a/KsApi/GraphAPI.swift
+++ b/KsApi/GraphAPI.swift
@@ -483,7 +483,7 @@ public enum GraphAPI {
     ///   - kind
     ///   - details
     ///   - clientMutationId: A unique identifier for the client performing the mutation.
-    public init(contentId: GraphQLID, kind: FlaggingKind, details: Swift.Optional<String?> = nil, clientMutationId: Swift.Optional<String?> = nil) {
+    public init(contentId: GraphQLID, kind: NonDeprecatedFlaggingKind, details: Swift.Optional<String?> = nil, clientMutationId: Swift.Optional<String?> = nil) {
       graphQLMap = ["contentId": contentId, "kind": kind, "details": details, "clientMutationId": clientMutationId]
     }
 
@@ -496,9 +496,9 @@ public enum GraphAPI {
       }
     }
 
-    public var kind: FlaggingKind {
+    public var kind: NonDeprecatedFlaggingKind {
       get {
-        return graphQLMap["kind"] as! FlaggingKind
+        return graphQLMap["kind"] as! NonDeprecatedFlaggingKind
       }
       set {
         graphQLMap.updateValue(newValue, forKey: "kind")
@@ -525,8 +525,8 @@ public enum GraphAPI {
     }
   }
 
-  /// The bucket for a flagging (general reason).
-  public enum FlaggingKind: RawRepresentable, Equatable, Hashable, CaseIterable, Apollo.JSONDecodable, Apollo.JSONEncodable {
+  /// The bucket for a flagging (general reason). Does not included deprecated kinds.
+  public enum NonDeprecatedFlaggingKind: RawRepresentable, Equatable, Hashable, CaseIterable, Apollo.JSONDecodable, Apollo.JSONEncodable {
     public typealias RawValue = String
     /// prohibited-items
     case prohibitedItems
@@ -546,8 +546,6 @@ public enum GraphAPI {
     case postFundingIssues
     /// spam
     case spam
-    /// abuse
-    case abuse
     /// vices-drugs
     case vicesDrugs
     /// vices-alcohol
@@ -646,7 +644,6 @@ public enum GraphAPI {
         case "GUIDELINES_VIOLATION": self = .guidelinesViolation
         case "POST_FUNDING_ISSUES": self = .postFundingIssues
         case "SPAM": self = .spam
-        case "ABUSE": self = .abuse
         case "VICES_DRUGS": self = .vicesDrugs
         case "VICES_ALCOHOL": self = .vicesAlcohol
         case "VICES_WEAPONS": self = .vicesWeapons
@@ -704,7 +701,6 @@ public enum GraphAPI {
         case .guidelinesViolation: return "GUIDELINES_VIOLATION"
         case .postFundingIssues: return "POST_FUNDING_ISSUES"
         case .spam: return "SPAM"
-        case .abuse: return "ABUSE"
         case .vicesDrugs: return "VICES_DRUGS"
         case .vicesAlcohol: return "VICES_ALCOHOL"
         case .vicesWeapons: return "VICES_WEAPONS"
@@ -751,7 +747,7 @@ public enum GraphAPI {
       }
     }
 
-    public static func == (lhs: FlaggingKind, rhs: FlaggingKind) -> Bool {
+    public static func == (lhs: NonDeprecatedFlaggingKind, rhs: NonDeprecatedFlaggingKind) -> Bool {
       switch (lhs, rhs) {
         case (.prohibitedItems, .prohibitedItems): return true
         case (.charity, .charity): return true
@@ -762,7 +758,6 @@ public enum GraphAPI {
         case (.guidelinesViolation, .guidelinesViolation): return true
         case (.postFundingIssues, .postFundingIssues): return true
         case (.spam, .spam): return true
-        case (.abuse, .abuse): return true
         case (.vicesDrugs, .vicesDrugs): return true
         case (.vicesAlcohol, .vicesAlcohol): return true
         case (.vicesWeapons, .vicesWeapons): return true
@@ -810,7 +805,7 @@ public enum GraphAPI {
       }
     }
 
-    public static var allCases: [FlaggingKind] {
+    public static var allCases: [NonDeprecatedFlaggingKind] {
       return [
         .prohibitedItems,
         .charity,
@@ -821,7 +816,6 @@ public enum GraphAPI {
         .guidelinesViolation,
         .postFundingIssues,
         .spam,
-        .abuse,
         .vicesDrugs,
         .vicesAlcohol,
         .vicesWeapons,
@@ -875,10 +869,11 @@ public enum GraphAPI {
     /// - Parameters:
     ///   - projectId: kickstarter project id
     ///   - amount: total amount to be paid (eg. 10.55)
+    ///   - paymentIntentContext: Context in which this stripe intent is created
     ///   - digitalMarketingAttributed: if the payment is attributed to digital marketing (default: false)
     ///   - clientMutationId: A unique identifier for the client performing the mutation.
-    public init(projectId: GraphQLID, amount: String, digitalMarketingAttributed: Swift.Optional<Bool?> = nil, clientMutationId: Swift.Optional<String?> = nil) {
-      graphQLMap = ["projectId": projectId, "amount": amount, "digitalMarketingAttributed": digitalMarketingAttributed, "clientMutationId": clientMutationId]
+    public init(projectId: GraphQLID, amount: String, paymentIntentContext: Swift.Optional<StripeIntentContextTypes?> = nil, digitalMarketingAttributed: Swift.Optional<Bool?> = nil, clientMutationId: Swift.Optional<String?> = nil) {
+      graphQLMap = ["projectId": projectId, "amount": amount, "paymentIntentContext": paymentIntentContext, "digitalMarketingAttributed": digitalMarketingAttributed, "clientMutationId": clientMutationId]
     }
 
     /// kickstarter project id
@@ -901,6 +896,16 @@ public enum GraphAPI {
       }
     }
 
+    /// Context in which this stripe intent is created
+    public var paymentIntentContext: Swift.Optional<StripeIntentContextTypes?> {
+      get {
+        return graphQLMap["paymentIntentContext"] as? Swift.Optional<StripeIntentContextTypes?> ?? Swift.Optional<StripeIntentContextTypes?>.none
+      }
+      set {
+        graphQLMap.updateValue(newValue, forKey: "paymentIntentContext")
+      }
+    }
+
     /// if the payment is attributed to digital marketing (default: false)
     public var digitalMarketingAttributed: Swift.Optional<Bool?> {
       get {
@@ -919,6 +924,57 @@ public enum GraphAPI {
       set {
         graphQLMap.updateValue(newValue, forKey: "clientMutationId")
       }
+    }
+  }
+
+  /// Different contexts for which stripe intents can be created
+  public enum StripeIntentContextTypes: RawRepresentable, Equatable, Hashable, CaseIterable, Apollo.JSONDecodable, Apollo.JSONEncodable {
+    public typealias RawValue = String
+    case crowdfundingCheckout
+    case postCampaignCheckout
+    case projectBuild
+    case profileSettings
+    /// Auto generated constant for unknown enum values
+    case __unknown(RawValue)
+
+    public init?(rawValue: RawValue) {
+      switch rawValue {
+        case "CROWDFUNDING_CHECKOUT": self = .crowdfundingCheckout
+        case "POST_CAMPAIGN_CHECKOUT": self = .postCampaignCheckout
+        case "PROJECT_BUILD": self = .projectBuild
+        case "PROFILE_SETTINGS": self = .profileSettings
+        default: self = .__unknown(rawValue)
+      }
+    }
+
+    public var rawValue: RawValue {
+      switch self {
+        case .crowdfundingCheckout: return "CROWDFUNDING_CHECKOUT"
+        case .postCampaignCheckout: return "POST_CAMPAIGN_CHECKOUT"
+        case .projectBuild: return "PROJECT_BUILD"
+        case .profileSettings: return "PROFILE_SETTINGS"
+        case .__unknown(let value): return value
+      }
+    }
+
+    public static func == (lhs: StripeIntentContextTypes, rhs: StripeIntentContextTypes) -> Bool {
+      switch (lhs, rhs) {
+        case (.crowdfundingCheckout, .crowdfundingCheckout): return true
+        case (.postCampaignCheckout, .postCampaignCheckout): return true
+        case (.projectBuild, .projectBuild): return true
+        case (.profileSettings, .profileSettings): return true
+        case (.__unknown(let lhsValue), .__unknown(let rhsValue)): return lhsValue == rhsValue
+        default: return false
+      }
+    }
+
+    public static var allCases: [StripeIntentContextTypes] {
+      return [
+        .crowdfundingCheckout,
+        .postCampaignCheckout,
+        .projectBuild,
+        .profileSettings,
+      ]
     }
   }
 
@@ -1034,10 +1090,21 @@ public enum GraphAPI {
     public var graphQLMap: GraphQLMap
 
     /// - Parameters:
+    ///   - setupIntentContext: Context in which this stripe intent is created
     ///   - projectId
     ///   - clientMutationId: A unique identifier for the client performing the mutation.
-    public init(projectId: Swift.Optional<GraphQLID?> = nil, clientMutationId: Swift.Optional<String?> = nil) {
-      graphQLMap = ["projectId": projectId, "clientMutationId": clientMutationId]
+    public init(setupIntentContext: Swift.Optional<StripeIntentContextTypes?> = nil, projectId: Swift.Optional<GraphQLID?> = nil, clientMutationId: Swift.Optional<String?> = nil) {
+      graphQLMap = ["setupIntentContext": setupIntentContext, "projectId": projectId, "clientMutationId": clientMutationId]
+    }
+
+    /// Context in which this stripe intent is created
+    public var setupIntentContext: Swift.Optional<StripeIntentContextTypes?> {
+      get {
+        return graphQLMap["setupIntentContext"] as? Swift.Optional<StripeIntentContextTypes?> ?? Swift.Optional<StripeIntentContextTypes?>.none
+      }
+      set {
+        graphQLMap.updateValue(newValue, forKey: "setupIntentContext")
+      }
     }
 
     public var projectId: Swift.Optional<GraphQLID?> {
@@ -1904,6 +1971,349 @@ public enum GraphAPI {
       set {
         graphQLMap.updateValue(newValue, forKey: "clientMutationId")
       }
+    }
+  }
+
+  /// The bucket for a flagging (general reason).
+  public enum FlaggingKind: RawRepresentable, Equatable, Hashable, CaseIterable, Apollo.JSONDecodable, Apollo.JSONEncodable {
+    public typealias RawValue = String
+    /// prohibited-items
+    case prohibitedItems
+    /// charity
+    case charity
+    /// resale
+    case resale
+    /// false-claims
+    case falseClaims
+    /// misrep-support
+    case misrepSupport
+    /// not-project
+    case notProject
+    /// guidelines-violation
+    case guidelinesViolation
+    /// post-funding-issues
+    case postFundingIssues
+    /// spam
+    case spam
+    /// abuse
+    case abuse
+    /// vices-drugs
+    case vicesDrugs
+    /// vices-alcohol
+    case vicesAlcohol
+    /// vices-weapons
+    case vicesWeapons
+    /// health-claims
+    case healthClaims
+    /// health-regulations
+    case healthRegulations
+    /// health-gmos
+    case healthGmos
+    /// health-live-animals
+    case healthLiveAnimals
+    /// health-energy-food-and-drink
+    case healthEnergyFoodAndDrink
+    /// financial-contests-coupons
+    case financialContestsCoupons
+    /// financial-services
+    case financialServices
+    /// financial-political-donations
+    case financialPoliticalDonations
+    /// offensive-content-hate
+    case offensiveContentHate
+    /// offensive-content-porn
+    case offensiveContentPorn
+    /// reselling
+    case reselling
+    /// plagiarism
+    case plagiarism
+    /// prototype-misrepresentation
+    case prototypeMisrepresentation
+    /// misrep-support-impersonation
+    case misrepSupportImpersonation
+    /// misrep-support-outstanding-fulfillment
+    case misrepSupportOutstandingFulfillment
+    /// misrep-support-suspicious-pledging
+    case misrepSupportSuspiciousPledging
+    /// misrep-support-other
+    case misrepSupportOther
+    /// not-project-charity
+    case notProjectCharity
+    /// not-project-stunt-or-hoax
+    case notProjectStuntOrHoax
+    /// not-project-personal-expenses
+    case notProjectPersonalExpenses
+    /// not-project-barebones
+    case notProjectBarebones
+    /// not-project-other
+    case notProjectOther
+    /// guidelines-spam
+    case guidelinesSpam
+    /// guidelines-abuse
+    case guidelinesAbuse
+    /// post-funding-reward-not-as-described
+    case postFundingRewardNotAsDescribed
+    /// post-funding-reward-delayed
+    case postFundingRewardDelayed
+    /// post-funding-shipped-never-received
+    case postFundingShippedNeverReceived
+    /// post-funding-creator-selling-elsewhere
+    case postFundingCreatorSellingElsewhere
+    /// post-funding-creator-uncommunicative
+    case postFundingCreatorUncommunicative
+    /// post-funding-creator-inappropriate
+    case postFundingCreatorInappropriate
+    /// post-funding-suspicious-third-party
+    case postFundingSuspiciousThirdParty
+    /// comment-abuse
+    case commentAbuse
+    /// comment-doxxing
+    case commentDoxxing
+    /// comment-offtopic
+    case commentOfftopic
+    /// comment-spam
+    case commentSpam
+    /// backing-abuse
+    case backingAbuse
+    /// backing-doxxing
+    case backingDoxxing
+    /// backing-fraud
+    case backingFraud
+    /// backing-spam
+    case backingSpam
+    /// Auto generated constant for unknown enum values
+    case __unknown(RawValue)
+
+    public init?(rawValue: RawValue) {
+      switch rawValue {
+        case "PROHIBITED_ITEMS": self = .prohibitedItems
+        case "CHARITY": self = .charity
+        case "RESALE": self = .resale
+        case "FALSE_CLAIMS": self = .falseClaims
+        case "MISREP_SUPPORT": self = .misrepSupport
+        case "NOT_PROJECT": self = .notProject
+        case "GUIDELINES_VIOLATION": self = .guidelinesViolation
+        case "POST_FUNDING_ISSUES": self = .postFundingIssues
+        case "SPAM": self = .spam
+        case "ABUSE": self = .abuse
+        case "VICES_DRUGS": self = .vicesDrugs
+        case "VICES_ALCOHOL": self = .vicesAlcohol
+        case "VICES_WEAPONS": self = .vicesWeapons
+        case "HEALTH_CLAIMS": self = .healthClaims
+        case "HEALTH_REGULATIONS": self = .healthRegulations
+        case "HEALTH_GMOS": self = .healthGmos
+        case "HEALTH_LIVE_ANIMALS": self = .healthLiveAnimals
+        case "HEALTH_ENERGY_FOOD_AND_DRINK": self = .healthEnergyFoodAndDrink
+        case "FINANCIAL_CONTESTS_COUPONS": self = .financialContestsCoupons
+        case "FINANCIAL_SERVICES": self = .financialServices
+        case "FINANCIAL_POLITICAL_DONATIONS": self = .financialPoliticalDonations
+        case "OFFENSIVE_CONTENT_HATE": self = .offensiveContentHate
+        case "OFFENSIVE_CONTENT_PORN": self = .offensiveContentPorn
+        case "RESELLING": self = .reselling
+        case "PLAGIARISM": self = .plagiarism
+        case "PROTOTYPE_MISREPRESENTATION": self = .prototypeMisrepresentation
+        case "MISREP_SUPPORT_IMPERSONATION": self = .misrepSupportImpersonation
+        case "MISREP_SUPPORT_OUTSTANDING_FULFILLMENT": self = .misrepSupportOutstandingFulfillment
+        case "MISREP_SUPPORT_SUSPICIOUS_PLEDGING": self = .misrepSupportSuspiciousPledging
+        case "MISREP_SUPPORT_OTHER": self = .misrepSupportOther
+        case "NOT_PROJECT_CHARITY": self = .notProjectCharity
+        case "NOT_PROJECT_STUNT_OR_HOAX": self = .notProjectStuntOrHoax
+        case "NOT_PROJECT_PERSONAL_EXPENSES": self = .notProjectPersonalExpenses
+        case "NOT_PROJECT_BAREBONES": self = .notProjectBarebones
+        case "NOT_PROJECT_OTHER": self = .notProjectOther
+        case "GUIDELINES_SPAM": self = .guidelinesSpam
+        case "GUIDELINES_ABUSE": self = .guidelinesAbuse
+        case "POST_FUNDING_REWARD_NOT_AS_DESCRIBED": self = .postFundingRewardNotAsDescribed
+        case "POST_FUNDING_REWARD_DELAYED": self = .postFundingRewardDelayed
+        case "POST_FUNDING_SHIPPED_NEVER_RECEIVED": self = .postFundingShippedNeverReceived
+        case "POST_FUNDING_CREATOR_SELLING_ELSEWHERE": self = .postFundingCreatorSellingElsewhere
+        case "POST_FUNDING_CREATOR_UNCOMMUNICATIVE": self = .postFundingCreatorUncommunicative
+        case "POST_FUNDING_CREATOR_INAPPROPRIATE": self = .postFundingCreatorInappropriate
+        case "POST_FUNDING_SUSPICIOUS_THIRD_PARTY": self = .postFundingSuspiciousThirdParty
+        case "COMMENT_ABUSE": self = .commentAbuse
+        case "COMMENT_DOXXING": self = .commentDoxxing
+        case "COMMENT_OFFTOPIC": self = .commentOfftopic
+        case "COMMENT_SPAM": self = .commentSpam
+        case "BACKING_ABUSE": self = .backingAbuse
+        case "BACKING_DOXXING": self = .backingDoxxing
+        case "BACKING_FRAUD": self = .backingFraud
+        case "BACKING_SPAM": self = .backingSpam
+        default: self = .__unknown(rawValue)
+      }
+    }
+
+    public var rawValue: RawValue {
+      switch self {
+        case .prohibitedItems: return "PROHIBITED_ITEMS"
+        case .charity: return "CHARITY"
+        case .resale: return "RESALE"
+        case .falseClaims: return "FALSE_CLAIMS"
+        case .misrepSupport: return "MISREP_SUPPORT"
+        case .notProject: return "NOT_PROJECT"
+        case .guidelinesViolation: return "GUIDELINES_VIOLATION"
+        case .postFundingIssues: return "POST_FUNDING_ISSUES"
+        case .spam: return "SPAM"
+        case .abuse: return "ABUSE"
+        case .vicesDrugs: return "VICES_DRUGS"
+        case .vicesAlcohol: return "VICES_ALCOHOL"
+        case .vicesWeapons: return "VICES_WEAPONS"
+        case .healthClaims: return "HEALTH_CLAIMS"
+        case .healthRegulations: return "HEALTH_REGULATIONS"
+        case .healthGmos: return "HEALTH_GMOS"
+        case .healthLiveAnimals: return "HEALTH_LIVE_ANIMALS"
+        case .healthEnergyFoodAndDrink: return "HEALTH_ENERGY_FOOD_AND_DRINK"
+        case .financialContestsCoupons: return "FINANCIAL_CONTESTS_COUPONS"
+        case .financialServices: return "FINANCIAL_SERVICES"
+        case .financialPoliticalDonations: return "FINANCIAL_POLITICAL_DONATIONS"
+        case .offensiveContentHate: return "OFFENSIVE_CONTENT_HATE"
+        case .offensiveContentPorn: return "OFFENSIVE_CONTENT_PORN"
+        case .reselling: return "RESELLING"
+        case .plagiarism: return "PLAGIARISM"
+        case .prototypeMisrepresentation: return "PROTOTYPE_MISREPRESENTATION"
+        case .misrepSupportImpersonation: return "MISREP_SUPPORT_IMPERSONATION"
+        case .misrepSupportOutstandingFulfillment: return "MISREP_SUPPORT_OUTSTANDING_FULFILLMENT"
+        case .misrepSupportSuspiciousPledging: return "MISREP_SUPPORT_SUSPICIOUS_PLEDGING"
+        case .misrepSupportOther: return "MISREP_SUPPORT_OTHER"
+        case .notProjectCharity: return "NOT_PROJECT_CHARITY"
+        case .notProjectStuntOrHoax: return "NOT_PROJECT_STUNT_OR_HOAX"
+        case .notProjectPersonalExpenses: return "NOT_PROJECT_PERSONAL_EXPENSES"
+        case .notProjectBarebones: return "NOT_PROJECT_BAREBONES"
+        case .notProjectOther: return "NOT_PROJECT_OTHER"
+        case .guidelinesSpam: return "GUIDELINES_SPAM"
+        case .guidelinesAbuse: return "GUIDELINES_ABUSE"
+        case .postFundingRewardNotAsDescribed: return "POST_FUNDING_REWARD_NOT_AS_DESCRIBED"
+        case .postFundingRewardDelayed: return "POST_FUNDING_REWARD_DELAYED"
+        case .postFundingShippedNeverReceived: return "POST_FUNDING_SHIPPED_NEVER_RECEIVED"
+        case .postFundingCreatorSellingElsewhere: return "POST_FUNDING_CREATOR_SELLING_ELSEWHERE"
+        case .postFundingCreatorUncommunicative: return "POST_FUNDING_CREATOR_UNCOMMUNICATIVE"
+        case .postFundingCreatorInappropriate: return "POST_FUNDING_CREATOR_INAPPROPRIATE"
+        case .postFundingSuspiciousThirdParty: return "POST_FUNDING_SUSPICIOUS_THIRD_PARTY"
+        case .commentAbuse: return "COMMENT_ABUSE"
+        case .commentDoxxing: return "COMMENT_DOXXING"
+        case .commentOfftopic: return "COMMENT_OFFTOPIC"
+        case .commentSpam: return "COMMENT_SPAM"
+        case .backingAbuse: return "BACKING_ABUSE"
+        case .backingDoxxing: return "BACKING_DOXXING"
+        case .backingFraud: return "BACKING_FRAUD"
+        case .backingSpam: return "BACKING_SPAM"
+        case .__unknown(let value): return value
+      }
+    }
+
+    public static func == (lhs: FlaggingKind, rhs: FlaggingKind) -> Bool {
+      switch (lhs, rhs) {
+        case (.prohibitedItems, .prohibitedItems): return true
+        case (.charity, .charity): return true
+        case (.resale, .resale): return true
+        case (.falseClaims, .falseClaims): return true
+        case (.misrepSupport, .misrepSupport): return true
+        case (.notProject, .notProject): return true
+        case (.guidelinesViolation, .guidelinesViolation): return true
+        case (.postFundingIssues, .postFundingIssues): return true
+        case (.spam, .spam): return true
+        case (.abuse, .abuse): return true
+        case (.vicesDrugs, .vicesDrugs): return true
+        case (.vicesAlcohol, .vicesAlcohol): return true
+        case (.vicesWeapons, .vicesWeapons): return true
+        case (.healthClaims, .healthClaims): return true
+        case (.healthRegulations, .healthRegulations): return true
+        case (.healthGmos, .healthGmos): return true
+        case (.healthLiveAnimals, .healthLiveAnimals): return true
+        case (.healthEnergyFoodAndDrink, .healthEnergyFoodAndDrink): return true
+        case (.financialContestsCoupons, .financialContestsCoupons): return true
+        case (.financialServices, .financialServices): return true
+        case (.financialPoliticalDonations, .financialPoliticalDonations): return true
+        case (.offensiveContentHate, .offensiveContentHate): return true
+        case (.offensiveContentPorn, .offensiveContentPorn): return true
+        case (.reselling, .reselling): return true
+        case (.plagiarism, .plagiarism): return true
+        case (.prototypeMisrepresentation, .prototypeMisrepresentation): return true
+        case (.misrepSupportImpersonation, .misrepSupportImpersonation): return true
+        case (.misrepSupportOutstandingFulfillment, .misrepSupportOutstandingFulfillment): return true
+        case (.misrepSupportSuspiciousPledging, .misrepSupportSuspiciousPledging): return true
+        case (.misrepSupportOther, .misrepSupportOther): return true
+        case (.notProjectCharity, .notProjectCharity): return true
+        case (.notProjectStuntOrHoax, .notProjectStuntOrHoax): return true
+        case (.notProjectPersonalExpenses, .notProjectPersonalExpenses): return true
+        case (.notProjectBarebones, .notProjectBarebones): return true
+        case (.notProjectOther, .notProjectOther): return true
+        case (.guidelinesSpam, .guidelinesSpam): return true
+        case (.guidelinesAbuse, .guidelinesAbuse): return true
+        case (.postFundingRewardNotAsDescribed, .postFundingRewardNotAsDescribed): return true
+        case (.postFundingRewardDelayed, .postFundingRewardDelayed): return true
+        case (.postFundingShippedNeverReceived, .postFundingShippedNeverReceived): return true
+        case (.postFundingCreatorSellingElsewhere, .postFundingCreatorSellingElsewhere): return true
+        case (.postFundingCreatorUncommunicative, .postFundingCreatorUncommunicative): return true
+        case (.postFundingCreatorInappropriate, .postFundingCreatorInappropriate): return true
+        case (.postFundingSuspiciousThirdParty, .postFundingSuspiciousThirdParty): return true
+        case (.commentAbuse, .commentAbuse): return true
+        case (.commentDoxxing, .commentDoxxing): return true
+        case (.commentOfftopic, .commentOfftopic): return true
+        case (.commentSpam, .commentSpam): return true
+        case (.backingAbuse, .backingAbuse): return true
+        case (.backingDoxxing, .backingDoxxing): return true
+        case (.backingFraud, .backingFraud): return true
+        case (.backingSpam, .backingSpam): return true
+        case (.__unknown(let lhsValue), .__unknown(let rhsValue)): return lhsValue == rhsValue
+        default: return false
+      }
+    }
+
+    public static var allCases: [FlaggingKind] {
+      return [
+        .prohibitedItems,
+        .charity,
+        .resale,
+        .falseClaims,
+        .misrepSupport,
+        .notProject,
+        .guidelinesViolation,
+        .postFundingIssues,
+        .spam,
+        .abuse,
+        .vicesDrugs,
+        .vicesAlcohol,
+        .vicesWeapons,
+        .healthClaims,
+        .healthRegulations,
+        .healthGmos,
+        .healthLiveAnimals,
+        .healthEnergyFoodAndDrink,
+        .financialContestsCoupons,
+        .financialServices,
+        .financialPoliticalDonations,
+        .offensiveContentHate,
+        .offensiveContentPorn,
+        .reselling,
+        .plagiarism,
+        .prototypeMisrepresentation,
+        .misrepSupportImpersonation,
+        .misrepSupportOutstandingFulfillment,
+        .misrepSupportSuspiciousPledging,
+        .misrepSupportOther,
+        .notProjectCharity,
+        .notProjectStuntOrHoax,
+        .notProjectPersonalExpenses,
+        .notProjectBarebones,
+        .notProjectOther,
+        .guidelinesSpam,
+        .guidelinesAbuse,
+        .postFundingRewardNotAsDescribed,
+        .postFundingRewardDelayed,
+        .postFundingShippedNeverReceived,
+        .postFundingCreatorSellingElsewhere,
+        .postFundingCreatorUncommunicative,
+        .postFundingCreatorInappropriate,
+        .postFundingSuspiciousThirdParty,
+        .commentAbuse,
+        .commentDoxxing,
+        .commentOfftopic,
+        .commentSpam,
+        .backingAbuse,
+        .backingDoxxing,
+        .backingFraud,
+        .backingSpam,
+      ]
     }
   }
 
@@ -7620,7 +8030,7 @@ public enum GraphAPI {
       }
 
       public struct Node: GraphQLSelectionSet {
-        public static let possibleTypes: [String] = ["Backing", "Reward", "Photo", "RewardItem", "Project", "Comment", "User", "Address", "Conversation", "Message", "CuratedPage", "Location", "Organization", "UserUrl", "Category", "AiDisclosure", "BusinessAddress", "Flagging", "Video", "VideoTrack", "VideoTrackCue", "ProjectProfile", "AttachedAudio", "AttachedVideo", "Tag", "CreatorInterview", "InterviewAnswer", "InterviewQuestion", "CreatorPrompt", "FreeformPost", "ShippingRule", "Checkout", "Order", "OrderAddress", "UniversalAddress", "Survey"]
+        public static let possibleTypes: [String] = ["Backing", "Reward", "Photo", "RewardItem", "Project", "Comment", "User", "Address", "Conversation", "Message", "CuratedPage", "Location", "Organization", "UserUrl", "Category", "AiDisclosure", "BusinessAddress", "Flagging", "Video", "VideoTrack", "VideoTrackCue", "ProjectProfile", "AttachedAudio", "AttachedVideo", "Tag", "CreatorInterview", "InterviewAnswer", "InterviewQuestion", "CreatorPrompt", "FreeformPost", "ShippingRule", "Checkout", "Order", "OrderAddress", "Survey"]
 
         public static var selections: [GraphQLSelection] {
           return [
@@ -7769,10 +8179,6 @@ public enum GraphAPI {
 
         public static func makeOrderAddress() -> Node {
           return Node(unsafeResultMap: ["__typename": "OrderAddress"])
-        }
-
-        public static func makeUniversalAddress() -> Node {
-          return Node(unsafeResultMap: ["__typename": "UniversalAddress"])
         }
 
         public static func makeSurvey() -> Node {
@@ -8081,7 +8487,7 @@ public enum GraphAPI {
       }
 
       public struct Comment: GraphQLSelectionSet {
-        public static let possibleTypes: [String] = ["Backing", "Reward", "Photo", "RewardItem", "Project", "Comment", "User", "Address", "Conversation", "Message", "CuratedPage", "Location", "Organization", "UserUrl", "Category", "AiDisclosure", "BusinessAddress", "Flagging", "Video", "VideoTrack", "VideoTrackCue", "ProjectProfile", "AttachedAudio", "AttachedVideo", "Tag", "CreatorInterview", "InterviewAnswer", "InterviewQuestion", "CreatorPrompt", "FreeformPost", "ShippingRule", "Checkout", "Order", "OrderAddress", "UniversalAddress", "Survey"]
+        public static let possibleTypes: [String] = ["Backing", "Reward", "Photo", "RewardItem", "Project", "Comment", "User", "Address", "Conversation", "Message", "CuratedPage", "Location", "Organization", "UserUrl", "Category", "AiDisclosure", "BusinessAddress", "Flagging", "Video", "VideoTrack", "VideoTrackCue", "ProjectProfile", "AttachedAudio", "AttachedVideo", "Tag", "CreatorInterview", "InterviewAnswer", "InterviewQuestion", "CreatorPrompt", "FreeformPost", "ShippingRule", "Checkout", "Order", "OrderAddress", "Survey"]
 
         public static var selections: [GraphQLSelection] {
           return [
@@ -8226,10 +8632,6 @@ public enum GraphAPI {
 
         public static func makeOrderAddress() -> Comment {
           return Comment(unsafeResultMap: ["__typename": "OrderAddress"])
-        }
-
-        public static func makeUniversalAddress() -> Comment {
-          return Comment(unsafeResultMap: ["__typename": "UniversalAddress"])
         }
 
         public static func makeSurvey() -> Comment {

--- a/KsApi/GraphQLFiles.xcfilelist
+++ b/KsApi/GraphQLFiles.xcfilelist
@@ -52,3 +52,4 @@ $(PROJECT_DIR)/KsApi/queries/FetchProjectRewardsByIdQuery.graphql
 $(PROJECT_DIR)/KsApi/queries/FetchAddOnsQuery.graphql
 $(PROJECT_DIR)/KsApi/queries/FetchBackerProjectsQuery.graphql
 $(PROJECT_DIR)/KsApi/queries/FetchCategory.graphql
+$(PROJECT_DIR)/KsApi/graphql-schema.json

--- a/KsApi/graphql-schema.json
+++ b/KsApi/graphql-schema.json
@@ -2251,11 +2251,6 @@
           },
           {
             "kind": "OBJECT",
-            "name": "UniversalAddress",
-            "ofType": null
-          },
-          {
-            "kind": "OBJECT",
             "name": "Survey",
             "ofType": null
           }
@@ -2738,6 +2733,18 @@
             "deprecationReason": null
           },
           {
+            "name": "endCondition",
+            "description": "For post-campaign enabled rewards, the conditions under which to stop offering the reward.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "endsAt",
             "description": "When the reward is scheduled to end in seconds",
             "args": [],
@@ -2785,6 +2792,22 @@
               "kind": "OBJECT",
               "name": "Photo",
               "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "inPostCampaignPledgingPhase",
+            "description": "Is this reward currently accepting post-campaign pledges?",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -2854,6 +2877,22 @@
               "kind": "OBJECT",
               "name": "RewardItemsConnection",
               "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "latePledgeAmount",
+            "description": "Amount for claiming this reward after the campaign.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Money",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -2929,6 +2968,22 @@
               "kind": "SCALAR",
               "name": "String",
               "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pledgeAmount",
+            "description": "Amount for claiming this reward during the campaign.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Money",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -3140,6 +3195,18 @@
                   "ofType": null
                 }
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "startCondition",
+            "description": "For post-campaign enabled rewards, the conditions under which to start offering the reward.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -4190,6 +4257,16 @@
                   "ofType": null
                 },
                 "defaultValue": null
+              },
+              {
+                "name": "followed",
+                "description": "Limit to backers that the current user is following",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": null
               }
             ],
             "type": {
@@ -4714,6 +4791,18 @@
                 "name": "CurrencyCode",
                 "ofType": null
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "currentAmountPledgedUsd",
+            "description": "The current amount pledged in USD",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -9277,6 +9366,22 @@
             "deprecationReason": null
           },
           {
+            "name": "primary",
+            "description": "Is this the user's primary address?",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "projectsWithUpdatableSurveyResponses",
             "description": "The title of projects with updatable survey responses",
             "args": [],
@@ -11992,12 +12097,6 @@
             "deprecationReason": null
           },
           {
-            "name": "mobile_project_collection_optimizations",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "ios_crashlytics",
             "description": null,
             "isDeprecated": false,
@@ -12550,12 +12649,6 @@
             "deprecationReason": null
           },
           {
-            "name": "backing_details_2024",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "delay_backer_trust_module_2024",
             "description": null,
             "isDeprecated": false,
@@ -12563,6 +12656,12 @@
           },
           {
             "name": "remove_address_event_sourcing_2024",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "user_settings_upgrade_2024",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
@@ -32453,6 +32552,33 @@
             "deprecationReason": null
           },
           {
+            "name": "createOrUpdateBackingAddress",
+            "description": null,
+            "args": [
+              {
+                "name": "input",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "CreateOrUpdateBackingAddressInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "CreateOrUpdateBackingAddressPayload",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "createOrUpdateItemTaxConfig",
             "description": "Sets tax related info for an item",
             "args": [
@@ -32906,33 +33032,6 @@
             "type": {
               "kind": "OBJECT",
               "name": "CreateTrackEventPayload",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "createUniversalAddress",
-            "description": "Creates an address.",
-            "args": [
-              {
-                "name": "input",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "CreateUniversalAddressInput",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null
-              }
-            ],
-            "type": {
-              "kind": "OBJECT",
-              "name": "CreateUniversalAddressPayload",
               "ofType": null
             },
             "isDeprecated": false,
@@ -33500,6 +33599,33 @@
             "type": {
               "kind": "OBJECT",
               "name": "DislikeProjectPayload",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "endLatePledges",
+            "description": "End late pledges for a Kickstarter project.",
+            "args": [
+              {
+                "name": "input",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "EndLatePledgesInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "EndLatePledgesPayload",
               "ofType": null
             },
             "isDeprecated": false,
@@ -36370,6 +36496,26 @@
             "defaultValue": null
           },
           {
+            "name": "primary",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "backingId",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "ID",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
             "name": "clientMutationId",
             "description": "A unique identifier for the client performing the mutation.",
             "type": {
@@ -36399,6 +36545,22 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "Address",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "assignedToBacking",
+            "description": "Backing was associated with address",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
                 "ofType": null
               }
             },
@@ -38102,7 +38264,7 @@
               "name": null,
               "ofType": {
                 "kind": "ENUM",
-                "name": "FlaggingKind",
+                "name": "NonDeprecatedFlaggingKind",
                 "ofType": null
               }
             },
@@ -38131,6 +38293,323 @@
         ],
         "interfaces": null,
         "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "NonDeprecatedFlaggingKind",
+        "description": "The bucket for a flagging (general reason). Does not included deprecated kinds.",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "PROHIBITED_ITEMS",
+            "description": "prohibited-items",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "CHARITY",
+            "description": "charity",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "RESALE",
+            "description": "resale",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "FALSE_CLAIMS",
+            "description": "false-claims",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "MISREP_SUPPORT",
+            "description": "misrep-support",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "NOT_PROJECT",
+            "description": "not-project",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "GUIDELINES_VIOLATION",
+            "description": "guidelines-violation",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "POST_FUNDING_ISSUES",
+            "description": "post-funding-issues",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "SPAM",
+            "description": "spam",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "VICES_DRUGS",
+            "description": "vices-drugs",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "VICES_ALCOHOL",
+            "description": "vices-alcohol",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "VICES_WEAPONS",
+            "description": "vices-weapons",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "HEALTH_CLAIMS",
+            "description": "health-claims",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "HEALTH_REGULATIONS",
+            "description": "health-regulations",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "HEALTH_GMOS",
+            "description": "health-gmos",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "HEALTH_LIVE_ANIMALS",
+            "description": "health-live-animals",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "HEALTH_ENERGY_FOOD_AND_DRINK",
+            "description": "health-energy-food-and-drink",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "FINANCIAL_CONTESTS_COUPONS",
+            "description": "financial-contests-coupons",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "FINANCIAL_SERVICES",
+            "description": "financial-services",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "FINANCIAL_POLITICAL_DONATIONS",
+            "description": "financial-political-donations",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "OFFENSIVE_CONTENT_HATE",
+            "description": "offensive-content-hate",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "OFFENSIVE_CONTENT_PORN",
+            "description": "offensive-content-porn",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "RESELLING",
+            "description": "reselling",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "PLAGIARISM",
+            "description": "plagiarism",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "PROTOTYPE_MISREPRESENTATION",
+            "description": "prototype-misrepresentation",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "MISREP_SUPPORT_IMPERSONATION",
+            "description": "misrep-support-impersonation",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "MISREP_SUPPORT_OUTSTANDING_FULFILLMENT",
+            "description": "misrep-support-outstanding-fulfillment",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "MISREP_SUPPORT_SUSPICIOUS_PLEDGING",
+            "description": "misrep-support-suspicious-pledging",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "MISREP_SUPPORT_OTHER",
+            "description": "misrep-support-other",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "NOT_PROJECT_CHARITY",
+            "description": "not-project-charity",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "NOT_PROJECT_STUNT_OR_HOAX",
+            "description": "not-project-stunt-or-hoax",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "NOT_PROJECT_PERSONAL_EXPENSES",
+            "description": "not-project-personal-expenses",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "NOT_PROJECT_BAREBONES",
+            "description": "not-project-barebones",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "NOT_PROJECT_OTHER",
+            "description": "not-project-other",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "GUIDELINES_SPAM",
+            "description": "guidelines-spam",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "GUIDELINES_ABUSE",
+            "description": "guidelines-abuse",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "POST_FUNDING_REWARD_NOT_AS_DESCRIBED",
+            "description": "post-funding-reward-not-as-described",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "POST_FUNDING_REWARD_DELAYED",
+            "description": "post-funding-reward-delayed",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "POST_FUNDING_SHIPPED_NEVER_RECEIVED",
+            "description": "post-funding-shipped-never-received",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "POST_FUNDING_CREATOR_SELLING_ELSEWHERE",
+            "description": "post-funding-creator-selling-elsewhere",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "POST_FUNDING_CREATOR_UNCOMMUNICATIVE",
+            "description": "post-funding-creator-uncommunicative",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "POST_FUNDING_CREATOR_INAPPROPRIATE",
+            "description": "post-funding-creator-inappropriate",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "POST_FUNDING_SUSPICIOUS_THIRD_PARTY",
+            "description": "post-funding-suspicious-third-party",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "COMMENT_ABUSE",
+            "description": "comment-abuse",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "COMMENT_DOXXING",
+            "description": "comment-doxxing",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "COMMENT_OFFTOPIC",
+            "description": "comment-offtopic",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "COMMENT_SPAM",
+            "description": "comment-spam",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "BACKING_ABUSE",
+            "description": "backing-abuse",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "BACKING_DOXXING",
+            "description": "backing-doxxing",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "BACKING_FRAUD",
+            "description": "backing-fraud",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "BACKING_SPAM",
+            "description": "backing-spam",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
         "possibleTypes": null
       },
       {
@@ -38389,6 +38868,94 @@
                   "name": "Nexus",
                   "ofType": null
                 }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "CreateOrUpdateBackingAddressInput",
+        "description": "Autogenerated input type of CreateOrUpdateBackingAddress",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "backingId",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "addressId",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "clientMutationId",
+            "description": "A unique identifier for the client performing the mutation.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "CreateOrUpdateBackingAddressPayload",
+        "description": "Autogenerated return type of CreateOrUpdateBackingAddress",
+        "fields": [
+          {
+            "name": "clientMutationId",
+            "description": "A unique identifier for the client performing the mutation.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "success",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
               }
             },
             "isDeprecated": false,
@@ -38853,6 +39420,16 @@
             "defaultValue": null
           },
           {
+            "name": "paymentIntentContext",
+            "description": "Context in which this stripe intent is created",
+            "type": {
+              "kind": "ENUM",
+              "name": "StripeIntentContextTypes",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
             "name": "digitalMarketingAttributed",
             "description": "if the payment is attributed to digital marketing (default: false)",
             "type": {
@@ -38875,6 +39452,41 @@
         ],
         "interfaces": null,
         "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "StripeIntentContextTypes",
+        "description": "Different contexts for which stripe intents can be created",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "CROWDFUNDING_CHECKOUT",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "POST_CAMPAIGN_CHECKOUT",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "PROJECT_BUILD",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "PROFILE_SETTINGS",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
         "possibleTypes": null
       },
       {
@@ -39941,6 +40553,16 @@
             "defaultValue": null
           },
           {
+            "name": "latePledgeAmount",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
             "name": "limit",
             "description": null,
             "type": {
@@ -40068,6 +40690,26 @@
             "type": {
               "kind": "SCALAR",
               "name": "ID",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "startCondition",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "endCondition",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
               "ofType": null
             },
             "defaultValue": null
@@ -40436,6 +41078,16 @@
         "fields": null,
         "inputFields": [
           {
+            "name": "setupIntentContext",
+            "description": "Context in which this stripe intent is created",
+            "type": {
+              "kind": "ENUM",
+              "name": "StripeIntentContextTypes",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
             "name": "projectId",
             "description": null,
             "type": {
@@ -40676,325 +41328,6 @@
         ],
         "inputFields": null,
         "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "INPUT_OBJECT",
-        "name": "CreateUniversalAddressInput",
-        "description": "Autogenerated input type of CreateUniversalAddress",
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "contactName",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null
-          },
-          {
-            "name": "referenceName",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null
-          },
-          {
-            "name": "addressLine1",
-            "description": null,
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "defaultValue": null
-          },
-          {
-            "name": "addressLine2",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null
-          },
-          {
-            "name": "city",
-            "description": null,
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "defaultValue": null
-          },
-          {
-            "name": "region",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null
-          },
-          {
-            "name": "postalCode",
-            "description": null,
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "defaultValue": null
-          },
-          {
-            "name": "countryCode",
-            "description": null,
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "ENUM",
-                "name": "CountryCode",
-                "ofType": null
-              }
-            },
-            "defaultValue": null
-          },
-          {
-            "name": "phoneNumber",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null
-          },
-          {
-            "name": "clientMutationId",
-            "description": "A unique identifier for the client performing the mutation.",
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null
-          }
-        ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "CreateUniversalAddressPayload",
-        "description": "Autogenerated return type of CreateUniversalAddress",
-        "fields": [
-          {
-            "name": "address",
-            "description": "Address that was created",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "UniversalAddress",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "clientMutationId",
-            "description": "A unique identifier for the client performing the mutation.",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "UniversalAddress",
-        "description": "An address associated with a backer or creator",
-        "fields": [
-          {
-            "name": "addressLine1",
-            "description": "The first address line",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "addressLine2",
-            "description": "The second address line",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "city",
-            "description": "The address city",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "contactName",
-            "description": "The contact name of the backer or creator",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "countryCode",
-            "description": "The address two-digit country code, e.g. US",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "ENUM",
-                "name": "CountryCode",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "id",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "ID",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "phoneNumber",
-            "description": "The address contact's phone number",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "postalCode",
-            "description": "The address postal code",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "referenceName",
-            "description": "A descriptor for the address, e.g. Home or Miami Warehouse",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "region",
-            "description": "The address region, e.g. North Dakota",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [
-          {
-            "kind": "INTERFACE",
-            "name": "Node",
-            "ofType": null
-          }
-        ],
         "enumValues": null,
         "possibleTypes": null
       },
@@ -42741,6 +43074,76 @@
             "type": {
               "kind": "OBJECT",
               "name": "User",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "EndLatePledgesInput",
+        "description": "Autogenerated input type of EndLatePledges",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "projectId",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "clientMutationId",
+            "description": "A unique identifier for the client performing the mutation.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "EndLatePledgesPayload",
+        "description": "Autogenerated return type of EndLatePledges",
+        "fields": [
+          {
+            "name": "clientMutationId",
+            "description": "A unique identifier for the client performing the mutation.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "project",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Project",
               "ofType": null
             },
             "isDeprecated": false,
@@ -48791,6 +49194,16 @@
             "defaultValue": null
           },
           {
+            "name": "latePledgeAmount",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
             "name": "image",
             "description": null,
             "type": {
@@ -48924,6 +49337,26 @@
             "type": {
               "kind": "SCALAR",
               "name": "ID",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "startCondition",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "endCondition",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
               "ofType": null
             },
             "defaultValue": null

--- a/KsApi/models/graphql/adapters/GraphAPI.CreateFlaggingInput+CreateFlaggingInputTests.swift
+++ b/KsApi/models/graphql/adapters/GraphAPI.CreateFlaggingInput+CreateFlaggingInputTests.swift
@@ -6,7 +6,7 @@ class GraphAPI_CreateFlaggingInput_CreateFlaggingInputTests: XCTestCase {
     let input =
       CreateFlaggingInput(
         contentId: "contentId",
-        kind: GraphAPI.FlaggingKind.prohibitedItems,
+        kind: GraphAPI.NonDeprecatedFlaggingKind.prohibitedItems,
         details: "details",
         clientMutationId: ""
       )

--- a/KsApi/mutations/inputs/CreateFlaggingInput.swift
+++ b/KsApi/mutations/inputs/CreateFlaggingInput.swift
@@ -2,13 +2,13 @@ import Foundation
 
 public struct CreateFlaggingInput: GraphMutationInput {
   let contentId: String
-  let kind: GraphAPI.FlaggingKind
+  let kind: GraphAPI.NonDeprecatedFlaggingKind
   let details: String?
   let clientMutationId: String?
 
   public init(
     contentId: String,
-    kind: GraphAPI.FlaggingKind,
+    kind: GraphAPI.NonDeprecatedFlaggingKind,
     details: String?,
     clientMutationId: String?
   ) {

--- a/KsApi/mutations/inputs/CreateFlaggingInputTests.swift
+++ b/KsApi/mutations/inputs/CreateFlaggingInputTests.swift
@@ -6,7 +6,7 @@ final class CreateFlaggingInputTests: XCTestCase {
     let createFlaggingInput =
       CreateFlaggingInput(
         contentId: "contentId",
-        kind: GraphAPI.FlaggingKind.prohibitedItems,
+        kind: GraphAPI.NonDeprecatedFlaggingKind.prohibitedItems,
         details: "details",
         clientMutationId: ""
       )
@@ -14,7 +14,10 @@ final class CreateFlaggingInputTests: XCTestCase {
     let input = createFlaggingInput.toInputDictionary()
 
     XCTAssertEqual(input["contentId"] as? String, "contentId")
-    XCTAssertEqual(input["kind"] as? GraphAPI.FlaggingKind, GraphAPI.FlaggingKind.prohibitedItems)
+    XCTAssertEqual(
+      input["kind"] as? GraphAPI.NonDeprecatedFlaggingKind,
+      GraphAPI.NonDeprecatedFlaggingKind.prohibitedItems
+    )
     XCTAssertEqual(input["details"] as? String, "details")
     XCTAssertEqual(input["clientMutationId"] as? String, "")
   }

--- a/Library/ReportProjectInfoListItem.swift
+++ b/Library/ReportProjectInfoListItem.swift
@@ -10,7 +10,7 @@ enum ReportProjectInfoListItemType {
 struct ReportProjectInfoListItem: Identifiable, Hashable {
   var id = UUID()
   var type: ReportProjectInfoListItemType
-  var flaggingKind: GraphAPI.FlaggingKind?
+  var flaggingKind: GraphAPI.NonDeprecatedFlaggingKind?
   var title: String
   var subtitle: String
   var subItems: [ReportProjectInfoListItem]?
@@ -84,7 +84,7 @@ let reportSpamSubListItems = [
   ),
   ReportProjectInfoListItem(
     type: .child,
-    flaggingKind: .abuse,
+    flaggingKind: .guidelinesAbuse,
     title: Strings.Abuse(),
     subtitle: Strings.Ex_posting()
   )

--- a/Library/ViewModels/ReportProjectFormViewModel.swift
+++ b/Library/ViewModels/ReportProjectFormViewModel.swift
@@ -30,7 +30,7 @@ public final class ReportProjectFormViewModel: ReportProjectFormViewModelType,
   private var cancellables = Set<AnyCancellable>()
 
   public var projectID: String?
-  public var projectFlaggingKind: GraphAPI.FlaggingKind?
+  public var projectFlaggingKind: GraphAPI.NonDeprecatedFlaggingKind?
 
   public init() {
     /// Only enable the save button if the user has entered detail text

--- a/Library/ViewModels/ReportProjectFormViewModelTests.swift
+++ b/Library/ViewModels/ReportProjectFormViewModelTests.swift
@@ -24,7 +24,7 @@ final class ReportProjectFormViewModelTests: TestCase {
   func testEmailText_AfterFetchingUsersEmail() {
     let vm = ReportProjectFormViewModel()
     vm.projectID = "123"
-    vm.projectFlaggingKind = GraphAPI.FlaggingKind.commentDoxxing
+    vm.projectFlaggingKind = GraphAPI.NonDeprecatedFlaggingKind.commentDoxxing
 
     withEnvironment(apiService: self.userEmailSuccessMockService) {
       let userEmail = CombineTestObserver<String?, Never>()
@@ -52,7 +52,7 @@ final class ReportProjectFormViewModelTests: TestCase {
   func test_submitIsDisabled_untilDetailTextIsNotEmpty() {
     let vm = ReportProjectFormViewModel()
     vm.projectID = "123"
-    vm.projectFlaggingKind = GraphAPI.FlaggingKind.commentDoxxing
+    vm.projectFlaggingKind = GraphAPI.NonDeprecatedFlaggingKind.commentDoxxing
 
     let saveButtonEnabled = CombineTestObserver<Bool, Never>()
     saveButtonEnabled.observe(vm.$saveButtonEnabled)

--- a/bin/find-graphql-files.sh
+++ b/bin/find-graphql-files.sh
@@ -5,6 +5,7 @@ GRAPHQL_FILE_LIST="$PROJECT_DIR/KsApi/GraphQLFiles.xcfilelist"
 #Find all GraphQL files in KsApi.
 #Replace the literal $PROJECT_DIR with the token $(PROJECT_DIR)
 find $PROJECT_DIR -name "*.graphql" | sed "s#^$PROJECT_DIR#\$(PROJECT_DIR)#" > "$GRAPHQL_FILE_LIST.tmp"
+echo "\$(PROJECT_DIR)/KsApi/graphql-schema.json" >> "$GRAPHQL_FILE_LIST.tmp"
 
 GRAPHQL_FILE_COUNT=$(wc -l $GRAPHQL_FILE_LIST.tmp | awk '{print $1}')
 echo "Found $GRAPHQL_FILE_COUNT GraphQL file dependencies."


### PR DESCRIPTION
# 📲 What

* Add graphql-schema.json to dependency list for Apollo update script
* Change type of CreateFlaggingInput from GraphAPI.FlaggingKind to GraphAPI.NonDeprecatedFlaggingKind

# 🤔 Why

Ingerid encountered this issue in a CircleCI build. Looks like we were running the Apollo update script on Circle, and it was making changes to `GraphAPI.swift` which broke her build. This fixes both the change to the schema, as well as makes sure that future updates to the schema will correctly cause a re-run of the Apollo build script.
