### PR TITLE
[NO TICKET] Create Checkout Fails When Pledging With No Reward

### DIFF
--- a/Kickstarter-iOS/Features/PledgePaymentMethods/Controller/PostCampaignPledgeRewardsSummaryViewController.swift
+++ b/Kickstarter-iOS/Features/PledgePaymentMethods/Controller/PostCampaignPledgeRewardsSummaryViewController.swift
@@ -46,7 +46,7 @@ final class PostCampaignPledgeRewardsSummaryViewController: UIViewController {
 
     self.configureSubviews()
     self.setupConstraints()
-    setEntireViewToIsHidden(true)
+    self.setEntireViewToIsHidden(true)
 
     self.viewModel.inputs.viewDidLoad()
   }
@@ -165,8 +165,9 @@ final class PostCampaignPledgeRewardsSummaryViewController: UIViewController {
       |> \.backgroundColor .~ .ksr_support_200
       |> \.translatesAutoresizingMaskIntoConstraints .~ false
   }
-  
+
   // MARK: - Helpers
+
   private func setEntireViewToIsHidden(_ isHidden: Bool) {
     self.view.isHidden = isHidden
     self.pledgeTotalViewController.view.isHidden = isHidden

--- a/Library/ViewModels/ConfirmDetailsViewModel.swift
+++ b/Library/ViewModels/ConfirmDetailsViewModel.swift
@@ -330,7 +330,7 @@ public class ConfirmDetailsViewModel: ConfirmDetailsViewModelType, ConfirmDetail
     let createCheckoutEvents = pledgeDetailsData
       .takeWhen(self.continueCTATappedProperty.signal)
       .map { project, rewards, pledgeTotal, refTag in
-        let rewardsIDs = rewards.map { $0.graphID }
+        let rewardsIDs = rewards.first?.isNoReward == true ? [] : rewards.map { $0.graphID }
 
         return CreateCheckoutInput(
           projectId: project.graphID,


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

When pledging with no reward, `CreateCheckout` fails

# 🤔 Why

There is technically a reward ID that is sent in this case that the backend won't recognize

# 🛠 How

When no rewards are selected set rewardIDs to an empty array. The backend expects this.

# ✅ Acceptance criteria

- [x] When pledging with no reward, the user can continue to the checkout screen after confirming pledge details.
