### PR TITLE
MBL-1123: Refactor PaymentSourceSelected to be an enum

### DIFF
--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -1525,6 +1525,7 @@
 		E17611E22B73D9A400DF2F50 /* Data+PKCE.swift in Sources */ = {isa = PBXBuildFile; fileRef = E17611E12B73D9A400DF2F50 /* Data+PKCE.swift */; };
 		E17611E42B751E8100DF2F50 /* Paginator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E17611E32B751E8100DF2F50 /* Paginator.swift */; };
 		E17611E62B75242A00DF2F50 /* PaginatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E17611E52B75242A00DF2F50 /* PaginatorTests.swift */; };
+		E1801FAA2BAB6D0900EBB533 /* PaymentSourceSelected.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1801FA82BAB6CD400EBB533 /* PaymentSourceSelected.swift */; };
 		E182E5BA2B8CDFDE0008DD69 /* AppEnvironmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7ED1F121E830FDC00BFFA01 /* AppEnvironmentTests.swift */; };
 		E182E5BC2B8D36FE0008DD69 /* AppEnvironmentTests+OAuthInKeychain.swift in Sources */ = {isa = PBXBuildFile; fileRef = E182E5BB2B8D36FE0008DD69 /* AppEnvironmentTests+OAuthInKeychain.swift */; };
 		E1A1491E2ACDD76800F49709 /* FetchBackerProjectsQuery.graphql in Resources */ = {isa = PBXBuildFile; fileRef = E1A1491D2ACDD76700F49709 /* FetchBackerProjectsQuery.graphql */; };
@@ -3148,6 +3149,7 @@
 		E17611E12B73D9A400DF2F50 /* Data+PKCE.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+PKCE.swift"; sourceTree = "<group>"; };
 		E17611E32B751E8100DF2F50 /* Paginator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Paginator.swift; sourceTree = "<group>"; };
 		E17611E52B75242A00DF2F50 /* PaginatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginatorTests.swift; sourceTree = "<group>"; };
+		E1801FA82BAB6CD400EBB533 /* PaymentSourceSelected.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentSourceSelected.swift; sourceTree = "<group>"; };
 		E182E5BB2B8D36FE0008DD69 /* AppEnvironmentTests+OAuthInKeychain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppEnvironmentTests+OAuthInKeychain.swift"; sourceTree = "<group>"; };
 		E1889D8D2B6065D6004FBE21 /* CombineTestObserverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CombineTestObserverTests.swift; sourceTree = "<group>"; };
 		E1A1491D2ACDD76700F49709 /* FetchBackerProjectsQuery.graphql */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = FetchBackerProjectsQuery.graphql; sourceTree = "<group>"; };
@@ -6529,6 +6531,7 @@
 				D710ADFA243FB94A00DC7199 /* PledgeViewCTAContainerViewModel.swift */,
 				D710ADFC2441172100DC7199 /* PledgeViewCTAContainerViewModelTests.swift */,
 				37DEC1E62257C9F30051EF9B /* PledgeViewModel.swift */,
+				E1801FA82BAB6CD400EBB533 /* PaymentSourceSelected.swift */,
 				37DEC21F2257CA0A0051EF9B /* PledgeViewModelTests.swift */,
 				395A3BC82BA8D43F0091A379 /* PostCampaignCheckoutViewModel.swift */,
 				6044532D2BA0905600B8F485 /* PostCampaignPledgeRewardsSummaryViewModel.swift */,
@@ -7698,6 +7701,7 @@
 				D7ADDFE722E0DAFA00157D83 /* RewardCellProjectBackingStateType.swift in Sources */,
 				D79D61151FD0979D000F958B /* String+Base64.swift in Sources */,
 				7727494723FC66EA0065E9F2 /* CategorySelectionViewModel.swift in Sources */,
+				E1801FAA2BAB6D0900EBB533 /* PaymentSourceSelected.swift in Sources */,
 				77EFBAE32268D48A00DA5C3C /* RewardsCollectionViewModel.swift in Sources */,
 				3705CF0F222EE7670025D37E /* EnvironmentVariables.swift in Sources */,
 				A73379601D0EDFEE00C91445 /* UIViewController-Preparation.swift in Sources */,

--- a/Library/ViewModels/PaymentSourceSelected.swift
+++ b/Library/ViewModels/PaymentSourceSelected.swift
@@ -4,17 +4,19 @@ public enum PaymentSourceSelected: Equatable {
   case setupIntentClientSecret(String)
 
   public var paymentSourceId: String? {
-    if case let .paymentSourceId(value) = self {
+    switch self {
+    case let .paymentSourceId(value):
       return value
-    } else {
+    default:
       return nil
     }
   }
 
   public var setupIntentClientSecret: String? {
-    if case let .setupIntentClientSecret(value) = self {
+    switch self {
+    case let .setupIntentClientSecret(value):
       return value
-    } else {
+    default:
       return nil
     }
   }

--- a/Library/ViewModels/PaymentSourceSelected.swift
+++ b/Library/ViewModels/PaymentSourceSelected.swift
@@ -1,0 +1,21 @@
+import Foundation
+public enum PaymentSourceSelected: Equatable {
+  case paymentSourceId(String)
+  case setupIntentClientSecret(String)
+
+  public var paymentSourceId: String? {
+    if case let .paymentSourceId(value) = self {
+      return value
+    } else {
+      return nil
+    }
+  }
+
+  public var setupIntentClientSecret: String? {
+    if case let .setupIntentClientSecret(value) = self {
+      return value
+    } else {
+      return nil
+    }
+  }
+}

--- a/Library/ViewModels/PledgePaymentMethodsViewModel.swift
+++ b/Library/ViewModels/PledgePaymentMethodsViewModel.swift
@@ -259,15 +259,9 @@ public final class PledgePaymentMethodsViewModel: PledgePaymentMethodsViewModelT
 
         switch (selectedPaymentMethodCardId, selectedPaymentSheetPaymentMethodCardId) {
         case let (.none, .some(selectedPaymentSheetPaymentMethodCardId)):
-          return PaymentSourceSelected(
-            paymentSourceId: selectedPaymentSheetPaymentMethodCardId,
-            isSetupIntentClientSecret: true
-          )
+          return PaymentSourceSelected.setupIntentClientSecret(selectedPaymentSheetPaymentMethodCardId)
         case let (.some(selectedPaymentMethodCardId), .none):
-          return PaymentSourceSelected(
-            paymentSourceId: selectedPaymentMethodCardId,
-            isSetupIntentClientSecret: false
-          )
+          return PaymentSourceSelected.paymentSourceId(selectedPaymentMethodCardId)
         default:
           return nil
         }

--- a/Library/ViewModels/PledgePaymentMethodsViewModelTests.swift
+++ b/Library/ViewModels/PledgePaymentMethodsViewModelTests.swift
@@ -740,7 +740,7 @@ final class PledgePaymentMethodsViewModelTests: TestCase {
       self.scheduler.run()
 
       self.notifyDelegateCreditCardSelected.assertValues(
-        [PaymentSourceSelected(paymentSourceId: UserCreditCards.amex.id, isSetupIntentClientSecret: false)],
+        [PaymentSourceSelected.paymentSourceId(UserCreditCards.amex.id)],
         "First card selected by default"
       )
 
@@ -752,11 +752,8 @@ final class PledgePaymentMethodsViewModelTests: TestCase {
       self.vm.inputs.didSelectRowAtIndexPath(discoverIndexPath)
 
       self.notifyDelegateCreditCardSelected.assertValues([
-        PaymentSourceSelected(paymentSourceId: UserCreditCards.amex.id, isSetupIntentClientSecret: false),
-        PaymentSourceSelected(
-          paymentSourceId: UserCreditCards.discover.id,
-          isSetupIntentClientSecret: false
-        )
+        PaymentSourceSelected.paymentSourceId(UserCreditCards.amex.id),
+        PaymentSourceSelected.paymentSourceId(UserCreditCards.discover.id)
       ])
     }
   }
@@ -774,7 +771,7 @@ final class PledgePaymentMethodsViewModelTests: TestCase {
       self.scheduler.run()
 
       self.notifyDelegateCreditCardSelected.assertValues(
-        [PaymentSourceSelected(paymentSourceId: UserCreditCards.visa.id, isSetupIntentClientSecret: false)],
+        [PaymentSourceSelected.paymentSourceId(UserCreditCards.visa.id)],
         "First card selected by default"
       )
 
@@ -793,11 +790,9 @@ final class PledgePaymentMethodsViewModelTests: TestCase {
         )
 
       self.notifyDelegateCreditCardSelected.assertValues([
-        PaymentSourceSelected(paymentSourceId: UserCreditCards.visa.id, isSetupIntentClientSecret: false),
-        PaymentSourceSelected(
-          paymentSourceId: "seti_1LVlHO4VvJ2PtfhK43R6p7FI_secret_MEDiGbxfYVnHGsQy8v8TbZJTQhlNKLZ",
-          isSetupIntentClientSecret: true
-        )
+        PaymentSourceSelected.paymentSourceId(UserCreditCards.visa.id),
+        PaymentSourceSelected
+          .setupIntentClientSecret("seti_1LVlHO4VvJ2PtfhK43R6p7FI_secret_MEDiGbxfYVnHGsQy8v8TbZJTQhlNKLZ")
       ])
     }
   }

--- a/Library/ViewModels/PledgeViewModelTests.swift
+++ b/Library/ViewModels/PledgeViewModelTests.swift
@@ -620,10 +620,7 @@ final class PledgeViewModelTests: TestCase {
       self.summarySectionSeparatorHidden.assertValues([true])
       self.shippingLocationViewHidden.assertValues([true])
 
-      let paymentSourceSelected = PaymentSourceSelected(
-        paymentSourceId: backing.paymentSource?.id ?? "",
-        isSetupIntentClientSecret: false
-      )
+      let paymentSourceSelected = PaymentSourceSelected.paymentSourceId(backing.paymentSource!.id!)
 
       self.vm.inputs.creditCardSelected(with: paymentSourceSelected)
 
@@ -2204,10 +2201,7 @@ final class PledgeViewModelTests: TestCase {
       self.goToThanksProject.assertDidNotEmitValue()
       self.showErrorBannerWithMessage.assertDidNotEmitValue()
 
-      let paymentSourceSelected = PaymentSourceSelected(
-        paymentSourceId: "123",
-        isSetupIntentClientSecret: false
-      )
+      let paymentSourceSelected = PaymentSourceSelected.paymentSourceId("123")
 
       self.vm.inputs.creditCardSelected(with: paymentSourceSelected)
 
@@ -2306,10 +2300,7 @@ final class PledgeViewModelTests: TestCase {
       self.goToThanksProject.assertDidNotEmitValue()
       self.showErrorBannerWithMessage.assertDidNotEmitValue()
 
-      let paymentSourceSelected = PaymentSourceSelected(
-        paymentSourceId: "123",
-        isSetupIntentClientSecret: false
-      )
+      let paymentSourceSelected = PaymentSourceSelected.paymentSourceId("123")
 
       self.vm.inputs.creditCardSelected(with: paymentSourceSelected)
 
@@ -2391,10 +2382,7 @@ final class PledgeViewModelTests: TestCase {
       self.showErrorBannerWithMessage.assertDidNotEmitValue()
       self.processingViewIsHidden.assertDidNotEmitValue()
 
-      let paymentSourceSelected = PaymentSourceSelected(
-        paymentSourceId: "123",
-        isSetupIntentClientSecret: false
-      )
+      let paymentSourceSelected = PaymentSourceSelected.paymentSourceId("123")
 
       self.vm.inputs.creditCardSelected(with: paymentSourceSelected)
 
@@ -2997,10 +2985,7 @@ final class PledgeViewModelTests: TestCase {
       "Amount and shipping rule unchanged"
     )
 
-    var paymentSourceSelected = PaymentSourceSelected(
-      paymentSourceId: "12345",
-      isSetupIntentClientSecret: false
-    )
+    var paymentSourceSelected = PaymentSourceSelected.paymentSourceId("12345")
 
     self.vm.inputs.creditCardSelected(with: paymentSourceSelected)
 
@@ -3009,10 +2994,7 @@ final class PledgeViewModelTests: TestCase {
       "Payment method changed"
     )
 
-    paymentSourceSelected = PaymentSourceSelected(
-      paymentSourceId: Backing.PaymentSource.template.id ?? "",
-      isSetupIntentClientSecret: false
-    )
+    paymentSourceSelected = PaymentSourceSelected.paymentSourceId(Backing.PaymentSource.template.id ?? "")
 
     self.vm.inputs.creditCardSelected(with: paymentSourceSelected)
 
@@ -3976,10 +3958,7 @@ final class PledgeViewModelTests: TestCase {
     )
 
     withEnvironment(apiService: mockService2) {
-      let paymentSourceSelected = PaymentSourceSelected(
-        paymentSourceId: "123",
-        isSetupIntentClientSecret: false
-      )
+      let paymentSourceSelected = PaymentSourceSelected.paymentSourceId("123")
 
       self.vm.inputs.creditCardSelected(with: paymentSourceSelected)
 
@@ -4086,10 +4065,7 @@ final class PledgeViewModelTests: TestCase {
       let pledgeAmountData = (amount: 15.0, min: 5.0, max: 10_000.0, isValid: true)
       self.vm.inputs.pledgeAmountViewControllerDidUpdate(with: pledgeAmountData)
 
-      let paymentSourceSelected = PaymentSourceSelected(
-        paymentSourceId: "123",
-        isSetupIntentClientSecret: false
-      )
+      let paymentSourceSelected = PaymentSourceSelected.paymentSourceId("123")
 
       self.vm.inputs.creditCardSelected(with: paymentSourceSelected)
 
@@ -4300,11 +4276,7 @@ final class PledgeViewModelTests: TestCase {
       let pledgeAmountData = (amount: 15.0, min: 5.0, max: 10_000.0, isValid: true)
       self.vm.inputs.pledgeAmountViewControllerDidUpdate(with: pledgeAmountData)
 
-      let paymentSourceSelected = PaymentSourceSelected(
-        paymentSourceId: "123",
-        isSetupIntentClientSecret: false
-      )
-
+      let paymentSourceSelected = PaymentSourceSelected.paymentSourceId("123")
       self.vm.inputs.creditCardSelected(with: paymentSourceSelected)
 
       self.goToApplePayPaymentAuthorizationProject.assertDidNotEmitValue()
@@ -4488,10 +4460,7 @@ final class PledgeViewModelTests: TestCase {
       self.goToThanksProject.assertDidNotEmitValue()
       self.showErrorBannerWithMessage.assertDidNotEmitValue()
 
-      let paymentSourceSelected = PaymentSourceSelected(
-        paymentSourceId: "123",
-        isSetupIntentClientSecret: false
-      )
+      let paymentSourceSelected = PaymentSourceSelected.paymentSourceId("123")
 
       self.vm.inputs.creditCardSelected(with: paymentSourceSelected)
 
@@ -4612,10 +4581,7 @@ final class PledgeViewModelTests: TestCase {
       self.goToThanksProject.assertDidNotEmitValue()
       self.showErrorBannerWithMessage.assertDidNotEmitValue()
 
-      let paymentSourceSelected = PaymentSourceSelected(
-        paymentSourceId: "123",
-        isSetupIntentClientSecret: false
-      )
+      let paymentSourceSelected = PaymentSourceSelected.paymentSourceId("123")
 
       self.vm.inputs.creditCardSelected(with: paymentSourceSelected)
 
@@ -4716,10 +4682,7 @@ final class PledgeViewModelTests: TestCase {
       self.goToThanksProject.assertDidNotEmitValue()
       self.showErrorBannerWithMessage.assertDidNotEmitValue()
 
-      let paymentSourceSelected = PaymentSourceSelected(
-        paymentSourceId: "123",
-        isSetupIntentClientSecret: false
-      )
+      let paymentSourceSelected = PaymentSourceSelected.paymentSourceId("123")
 
       self.vm.inputs.creditCardSelected(with: paymentSourceSelected)
 
@@ -5525,10 +5488,7 @@ final class PledgeViewModelTests: TestCase {
       self.goToThanksProject.assertDidNotEmitValue()
       self.showErrorBannerWithMessage.assertDidNotEmitValue()
 
-      let paymentSourceSelected = PaymentSourceSelected(
-        paymentSourceId: "123",
-        isSetupIntentClientSecret: true
-      )
+      let paymentSourceSelected = PaymentSourceSelected.paymentSourceId("123")
 
       self.vm.inputs.creditCardSelected(with: paymentSourceSelected)
 
@@ -5625,10 +5585,7 @@ final class PledgeViewModelTests: TestCase {
       self.goToThanksProject.assertDidNotEmitValue()
       self.showErrorBannerWithMessage.assertDidNotEmitValue()
 
-      let paymentSourceSelected = PaymentSourceSelected(
-        paymentSourceId: "123",
-        isSetupIntentClientSecret: true
-      )
+      let paymentSourceSelected = PaymentSourceSelected.paymentSourceId("123")
 
       self.vm.inputs.creditCardSelected(with: paymentSourceSelected)
 
@@ -5957,10 +5914,7 @@ final class PledgeViewModelTests: TestCase {
     ))
     self.vm.inputs.shippingRuleSelected(.template)
 
-    let paymentSourceSelected = PaymentSourceSelected(
-      paymentSourceId: "123",
-      isSetupIntentClientSecret: false
-    )
+    let paymentSourceSelected = PaymentSourceSelected.paymentSourceId("123")
 
     self.vm.inputs.creditCardSelected(with: paymentSourceSelected)
 
@@ -6033,10 +5987,7 @@ final class PledgeViewModelTests: TestCase {
       ))
       self.vm.inputs.shippingRuleSelected(.template)
 
-      let paymentSourceSelected = PaymentSourceSelected(
-        paymentSourceId: "123",
-        isSetupIntentClientSecret: false
-      )
+      let paymentSourceSelected = PaymentSourceSelected.paymentSourceId("123")
 
       self.vm.inputs.creditCardSelected(with: paymentSourceSelected)
 
@@ -6115,10 +6066,7 @@ final class PledgeViewModelTests: TestCase {
       self.vm.inputs.configure(with: data)
       self.vm.inputs.viewDidLoad()
 
-      let paymentSourceSelected = PaymentSourceSelected(
-        paymentSourceId: "12345",
-        isSetupIntentClientSecret: false
-      )
+      let paymentSourceSelected = PaymentSourceSelected.paymentSourceId("12345")
 
       self.vm.inputs.creditCardSelected(with: paymentSourceSelected)
 


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Refactor `PaymentSourceSelected` to be an `enum`, instead of a `struct`.

# 🤔 Why

For `MBL-1123`, I'm adding another type of payment source to `PledgeViewModel`. We start to create `PaymentIntent` secrets, which are a separate kind of client secret from our existing `SetupIntent` secrets. 

Before, the different between payment types was modeled by storing the payment source ID and a boolean, which flagged whether or not the string was a stripe token or a Kickstarter ID. 

After, this is modeled as an enum, so that it should be much clearer what kind of payment source we're passing around the codebase. As a bonus, this actually deleted a few lines of redundant code, since it makes the plumbing a little simpler.

When I finish this ticket, we'll have an enum like this:
```
public enum PaymentSourceSelected: Equatable {
  case paymentSourceId(String)
  case setupIntentClientSecret(String)
  case paymentIntentClientSecret(String)
}
```