### PR TITLE
[MBL-1210] Fix logged out and login flow for post campaign checkout

### DIFF
--- a/Kickstarter-iOS/Features/PledgePaymentMethods/Controller/PledgePaymentMethodsViewController.swift
+++ b/Kickstarter-iOS/Features/PledgePaymentMethods/Controller/PledgePaymentMethodsViewController.swift
@@ -216,7 +216,7 @@ final class PledgePaymentMethodsViewController: UIViewController {
 
   // MARK: - Public functions
 
-  func setShouldCancelPaymentSheetAppearance(hidden: Bool) {
+  func cancelModalPresentation(_ hidden: Bool) {
     self.viewModel.inputs.shouldCancelPaymentSheetAppearance(state: hidden)
   }
 }

--- a/Kickstarter-iOS/Features/PledgePaymentMethods/Controller/PledgePaymentMethodsViewController.swift
+++ b/Kickstarter-iOS/Features/PledgePaymentMethods/Controller/PledgePaymentMethodsViewController.swift
@@ -216,8 +216,8 @@ final class PledgePaymentMethodsViewController: UIViewController {
 
   // MARK: - Public functions
 
-  func cancelPaymentSheetAppearance() {
-    self.viewModel.inputs.shouldCancelPaymentSheetAppearance(state: true)
+  func setShouldCancelPaymentSheetAppearance(hidden: Bool) {
+    self.viewModel.inputs.shouldCancelPaymentSheetAppearance(state: hidden)
   }
 }
 

--- a/Kickstarter-iOS/Features/PledgePaymentMethods/Controller/PledgePaymentMethodsViewController.swift
+++ b/Kickstarter-iOS/Features/PledgePaymentMethods/Controller/PledgePaymentMethodsViewController.swift
@@ -213,6 +213,12 @@ final class PledgePaymentMethodsViewController: UIViewController {
       self.tableView.reloadSections([PaymentMethodsTableViewSection.addNewCard.rawValue], with: .none)
     }
   }
+
+  // MARK: - Public functions
+
+  func cancelPaymentSheetAppearance() {
+    self.viewModel.inputs.shouldCancelPaymentSheetAppearance(state: true)
+  }
 }
 
 // MARK: - UITableViewDelegate
@@ -229,13 +235,5 @@ extension PledgePaymentMethodsViewController: UITableViewDelegate {
     tableView.deselectRow(at: indexPath, animated: true)
 
     self.viewModel.inputs.didSelectRowAtIndexPath(indexPath)
-  }
-}
-
-// MARK: - PaymentSheetAppearanceDelegate
-
-extension PledgePaymentMethodsViewController: PaymentSheetAppearanceDelegate {
-  func pledgeViewControllerPaymentSheet(_: PledgeViewController, hidden: Bool) {
-    self.viewModel.inputs.shouldCancelPaymentSheetAppearance(state: hidden)
   }
 }

--- a/Kickstarter-iOS/Features/PledgePaymentMethods/Controller/PledgePaymentMethodsViewControllerTests.swift
+++ b/Kickstarter-iOS/Features/PledgePaymentMethods/Controller/PledgePaymentMethodsViewControllerTests.swift
@@ -99,7 +99,7 @@ final class PledgePaymentMethodsViewControllerTests: TestCase {
 
         self.scheduler.advance(by: .seconds(1))
 
-        controller.pledgeViewControllerPaymentSheet(PledgeViewController(), hidden: false)
+        controller.setShouldCancelPaymentSheetAppearance(hidden: false)
 
         self.scheduler.advance(by: .seconds(1))
 

--- a/Kickstarter-iOS/Features/PledgePaymentMethods/Controller/PledgePaymentMethodsViewControllerTests.swift
+++ b/Kickstarter-iOS/Features/PledgePaymentMethods/Controller/PledgePaymentMethodsViewControllerTests.swift
@@ -99,7 +99,7 @@ final class PledgePaymentMethodsViewControllerTests: TestCase {
 
         self.scheduler.advance(by: .seconds(1))
 
-        controller.setShouldCancelPaymentSheetAppearance(hidden: false)
+        controller.cancelModalPresentation(false)
 
         self.scheduler.advance(by: .seconds(1))
 

--- a/Kickstarter-iOS/Features/PledgeView/Controllers/PledgeViewController.swift
+++ b/Kickstarter-iOS/Features/PledgeView/Controllers/PledgeViewController.swift
@@ -21,10 +21,6 @@ protocol PledgeViewControllerDelegate: AnyObject {
   func pledgeViewControllerDidUpdatePledge(_ viewController: PledgeViewController, message: String)
 }
 
-protocol PaymentSheetAppearanceDelegate: AnyObject {
-  func pledgeViewControllerPaymentSheet(_ viewController: PledgeViewController, hidden: Bool)
-}
-
 final class PledgeViewController: UIViewController,
   MessageBannerViewControllerPresenting, ProcessingViewPresenting {
   // MARK: - Properties
@@ -34,7 +30,6 @@ final class PledgeViewController: UIViewController,
   }()
 
   public weak var delegate: PledgeViewControllerDelegate?
-  public weak var paymentSheetAppearanceDelegate: PaymentSheetAppearanceDelegate?
 
   private lazy var descriptionSectionSeparator: UIView = {
     UIView(frame: .zero)
@@ -362,7 +357,6 @@ final class PledgeViewController: UIViewController,
       .observeForUI()
       .observeValues { [weak self] value in
         self?.paymentMethodsViewController.configure(with: value)
-        self?.paymentSheetAppearanceDelegate = self?.paymentMethodsViewController
       }
 
     self.viewModel.outputs.goToLoginSignup
@@ -460,7 +454,7 @@ final class PledgeViewController: UIViewController,
       .observeForControllerAction()
       .observeValues { [weak self] helpType in
         guard let self = self else { return }
-        self.paymentSheetAppearanceDelegate?.pledgeViewControllerPaymentSheet(self, hidden: true)
+        self.paymentMethodsViewController.cancelPaymentSheetAppearance()
         self.presentHelpWebViewController(with: helpType, presentationStyle: .formSheet)
       }
 
@@ -601,22 +595,22 @@ extension PledgeViewController: PKPaymentAuthorizationViewControllerDelegate {
 
 extension PledgeViewController: PledgeViewCTAContainerViewDelegate {
   func goToLoginSignup() {
-    self.paymentSheetAppearanceDelegate?.pledgeViewControllerPaymentSheet(self, hidden: true)
+    self.paymentMethodsViewController.cancelPaymentSheetAppearance()
     self.viewModel.inputs.goToLoginSignupTapped()
   }
 
   func applePayButtonTapped() {
-    self.paymentSheetAppearanceDelegate?.pledgeViewControllerPaymentSheet(self, hidden: true)
+    self.paymentMethodsViewController.cancelPaymentSheetAppearance()
     self.viewModel.inputs.applePayButtonTapped()
   }
 
   func submitButtonTapped() {
-    self.paymentSheetAppearanceDelegate?.pledgeViewControllerPaymentSheet(self, hidden: true)
+    self.paymentMethodsViewController.cancelPaymentSheetAppearance()
     self.viewModel.inputs.submitButtonTapped()
   }
 
   func termsOfUseTapped(with helpType: HelpType) {
-    self.paymentSheetAppearanceDelegate?.pledgeViewControllerPaymentSheet(self, hidden: true)
+    self.paymentMethodsViewController.cancelPaymentSheetAppearance()
     self.viewModel.inputs.termsOfUseTapped(with: helpType)
   }
 }

--- a/Kickstarter-iOS/Features/PledgeView/Controllers/PledgeViewController.swift
+++ b/Kickstarter-iOS/Features/PledgeView/Controllers/PledgeViewController.swift
@@ -454,7 +454,7 @@ final class PledgeViewController: UIViewController,
       .observeForControllerAction()
       .observeValues { [weak self] helpType in
         guard let self = self else { return }
-        self.paymentMethodsViewController.setShouldCancelPaymentSheetAppearance(hidden: true)
+        self.paymentMethodsViewController.cancelModalPresentation(true)
         self.presentHelpWebViewController(with: helpType, presentationStyle: .formSheet)
       }
 
@@ -595,22 +595,22 @@ extension PledgeViewController: PKPaymentAuthorizationViewControllerDelegate {
 
 extension PledgeViewController: PledgeViewCTAContainerViewDelegate {
   func goToLoginSignup() {
-    self.paymentMethodsViewController.setShouldCancelPaymentSheetAppearance(hidden: true)
+    self.paymentMethodsViewController.cancelModalPresentation(true)
     self.viewModel.inputs.goToLoginSignupTapped()
   }
 
   func applePayButtonTapped() {
-    self.paymentMethodsViewController.setShouldCancelPaymentSheetAppearance(hidden: true)
+    self.paymentMethodsViewController.cancelModalPresentation(true)
     self.viewModel.inputs.applePayButtonTapped()
   }
 
   func submitButtonTapped() {
-    self.paymentMethodsViewController.setShouldCancelPaymentSheetAppearance(hidden: true)
+    self.paymentMethodsViewController.cancelModalPresentation(true)
     self.viewModel.inputs.submitButtonTapped()
   }
 
   func termsOfUseTapped(with helpType: HelpType) {
-    self.paymentMethodsViewController.setShouldCancelPaymentSheetAppearance(hidden: true)
+    self.paymentMethodsViewController.cancelModalPresentation(true)
     self.viewModel.inputs.termsOfUseTapped(with: helpType)
   }
 }

--- a/Kickstarter-iOS/Features/PledgeView/Controllers/PledgeViewController.swift
+++ b/Kickstarter-iOS/Features/PledgeView/Controllers/PledgeViewController.swift
@@ -454,7 +454,7 @@ final class PledgeViewController: UIViewController,
       .observeForControllerAction()
       .observeValues { [weak self] helpType in
         guard let self = self else { return }
-        self.paymentMethodsViewController.cancelPaymentSheetAppearance()
+        self.paymentMethodsViewController.setShouldCancelPaymentSheetAppearance(hidden: true)
         self.presentHelpWebViewController(with: helpType, presentationStyle: .formSheet)
       }
 
@@ -595,22 +595,22 @@ extension PledgeViewController: PKPaymentAuthorizationViewControllerDelegate {
 
 extension PledgeViewController: PledgeViewCTAContainerViewDelegate {
   func goToLoginSignup() {
-    self.paymentMethodsViewController.cancelPaymentSheetAppearance()
+    self.paymentMethodsViewController.setShouldCancelPaymentSheetAppearance(hidden: true)
     self.viewModel.inputs.goToLoginSignupTapped()
   }
 
   func applePayButtonTapped() {
-    self.paymentMethodsViewController.cancelPaymentSheetAppearance()
+    self.paymentMethodsViewController.setShouldCancelPaymentSheetAppearance(hidden: true)
     self.viewModel.inputs.applePayButtonTapped()
   }
 
   func submitButtonTapped() {
-    self.paymentMethodsViewController.cancelPaymentSheetAppearance()
+    self.paymentMethodsViewController.setShouldCancelPaymentSheetAppearance(hidden: true)
     self.viewModel.inputs.submitButtonTapped()
   }
 
   func termsOfUseTapped(with helpType: HelpType) {
-    self.paymentMethodsViewController.cancelPaymentSheetAppearance()
+    self.paymentMethodsViewController.setShouldCancelPaymentSheetAppearance(hidden: true)
     self.viewModel.inputs.termsOfUseTapped(with: helpType)
   }
 }

--- a/Kickstarter-iOS/Features/PledgeView/Controllers/PostCampaignCheckoutViewController.swift
+++ b/Kickstarter-iOS/Features/PledgeView/Controllers/PostCampaignCheckoutViewController.swift
@@ -234,22 +234,22 @@ extension PostCampaignCheckoutViewController: PledgeDisclaimerViewDelegate {
 
 extension PostCampaignCheckoutViewController: PledgeViewCTAContainerViewDelegate {
   func goToLoginSignup() {
-    self.paymentMethodsViewController.setShouldCancelPaymentSheetAppearance(hidden: true)
+    self.paymentMethodsViewController.cancelModalPresentation(true)
     self.viewModel.inputs.goToLoginSignupTapped()
   }
 
   func applePayButtonTapped() {
-    self.paymentMethodsViewController.setShouldCancelPaymentSheetAppearance(hidden: true)
+    self.paymentMethodsViewController.cancelModalPresentation(true)
     // TODO: Respond to button tap
   }
 
   func submitButtonTapped() {
-    self.paymentMethodsViewController.setShouldCancelPaymentSheetAppearance(hidden: true)
+    self.paymentMethodsViewController.cancelModalPresentation(true)
     // TODO: Respond to button tap
   }
 
   func termsOfUseTapped(with helpType: HelpType) {
-    self.paymentMethodsViewController.setShouldCancelPaymentSheetAppearance(hidden: true)
+    self.paymentMethodsViewController.cancelModalPresentation(true)
     self.viewModel.inputs.termsOfUseTapped(with: helpType)
   }
 }

--- a/Kickstarter-iOS/Features/PledgeView/Controllers/PostCampaignCheckoutViewController.swift
+++ b/Kickstarter-iOS/Features/PledgeView/Controllers/PostCampaignCheckoutViewController.swift
@@ -22,7 +22,7 @@ final class PostCampaignCheckoutViewController: UIViewController {
   private lazy var pledgeCTAContainerView: PledgeViewCTAContainerView = {
     PledgeViewCTAContainerView(frame: .zero)
       |> \.translatesAutoresizingMaskIntoConstraints .~ false
-    // TODO: Add self as delegate and add support for delegate methods.
+      |> \.delegate .~ self
   }()
 
   private lazy var pledgeDisclaimerView: PledgeDisclaimerView = {
@@ -49,6 +49,8 @@ final class PostCampaignCheckoutViewController: UIViewController {
     UIStackView(frame: .zero)
       |> \.translatesAutoresizingMaskIntoConstraints .~ false
   }()
+
+  private var sessionStartedObserver: Any?
 
   private let viewModel: PostCampaignCheckoutViewModelType = PostCampaignCheckoutViewModel()
 
@@ -77,6 +79,10 @@ final class PostCampaignCheckoutViewController: UIViewController {
     }
 
     self.viewModel.inputs.viewDidLoad()
+  }
+
+  deinit {
+    self.sessionStartedObserver.doIfSome(NotificationCenter.default.removeObserver)
   }
 
   // MARK: - Configuration
@@ -180,12 +186,38 @@ final class PostCampaignCheckoutViewController: UIViewController {
         self?.paymentMethodsViewController.configure(with: value)
       }
 
+    self.viewModel.outputs.goToLoginSignup
+      .observeForControllerAction()
+      .observeValues { [weak self] intent, project, reward in
+        self?.goToLoginSignup(with: intent, project: project, reward: reward)
+      }
+
     self.viewModel.outputs.showWebHelp
       .observeForControllerAction()
       .observeValues { [weak self] helpType in
         guard let self = self else { return }
         self.presentHelpWebViewController(with: helpType, presentationStyle: .formSheet)
       }
+
+    self.sessionStartedObserver = NotificationCenter.default
+      .addObserver(forName: .ksr_sessionStarted, object: nil, queue: nil) { [weak self] _ in
+        self?.viewModel.inputs.userSessionStarted()
+      }
+  }
+
+  // MARK: - Functions
+
+  private func goToLoginSignup(with intent: LoginIntent, project: Project, reward: Reward?) {
+    let loginSignupViewController = LoginToutViewController.configuredWith(
+      loginIntent: intent,
+      project: project,
+      reward: reward
+    )
+
+    let navigationController = UINavigationController(rootViewController: loginSignupViewController)
+    let navigationBarHeight = navigationController.navigationBar.bounds.height
+
+    self.present(navigationController, animated: true)
   }
 }
 
@@ -194,5 +226,29 @@ final class PostCampaignCheckoutViewController: UIViewController {
 extension PostCampaignCheckoutViewController: PledgeDisclaimerViewDelegate {
   func pledgeDisclaimerView(_: PledgeDisclaimerView, didTapURL _: URL) {
     self.viewModel.inputs.pledgeDisclaimerViewDidTapLearnMore()
+  }
+}
+
+// MARK: - PledgeViewCTAContainerViewDelegate
+
+extension PostCampaignCheckoutViewController: PledgeViewCTAContainerViewDelegate {
+  func goToLoginSignup() {
+    self.paymentMethodsViewController.cancelPaymentSheetAppearance()
+    self.viewModel.inputs.goToLoginSignupTapped()
+  }
+
+  func applePayButtonTapped() {
+    self.paymentMethodsViewController.cancelPaymentSheetAppearance()
+    // TODO: Respond to button tap
+  }
+
+  func submitButtonTapped() {
+    self.paymentMethodsViewController.cancelPaymentSheetAppearance()
+    // TODO: Respond to button tap
+  }
+
+  func termsOfUseTapped(with helpType: HelpType) {
+    self.paymentMethodsViewController.cancelPaymentSheetAppearance()
+    // TODO
   }
 }

--- a/Kickstarter-iOS/Features/PledgeView/Controllers/PostCampaignCheckoutViewController.swift
+++ b/Kickstarter-iOS/Features/PledgeView/Controllers/PostCampaignCheckoutViewController.swift
@@ -235,22 +235,22 @@ extension PostCampaignCheckoutViewController: PledgeDisclaimerViewDelegate {
 
 extension PostCampaignCheckoutViewController: PledgeViewCTAContainerViewDelegate {
   func goToLoginSignup() {
-    self.paymentMethodsViewController.cancelPaymentSheetAppearance()
+    self.paymentMethodsViewController.setShouldCancelPaymentSheetAppearance(hidden: true)
     self.viewModel.inputs.goToLoginSignupTapped()
   }
 
   func applePayButtonTapped() {
-    self.paymentMethodsViewController.cancelPaymentSheetAppearance()
+    self.paymentMethodsViewController.setShouldCancelPaymentSheetAppearance(hidden: true)
     // TODO: Respond to button tap
   }
 
   func submitButtonTapped() {
-    self.paymentMethodsViewController.cancelPaymentSheetAppearance()
+    self.paymentMethodsViewController.setShouldCancelPaymentSheetAppearance(hidden: true)
     // TODO: Respond to button tap
   }
 
   func termsOfUseTapped(with helpType: HelpType) {
-    self.paymentMethodsViewController.cancelPaymentSheetAppearance()
+    self.paymentMethodsViewController.setShouldCancelPaymentSheetAppearance(hidden: true)
     self.viewModel.inputs.termsOfUseTapped(with: helpType)
   }
 }

--- a/Kickstarter-iOS/Features/PledgeView/Controllers/PostCampaignCheckoutViewController.swift
+++ b/Kickstarter-iOS/Features/PledgeView/Controllers/PostCampaignCheckoutViewController.swift
@@ -203,6 +203,8 @@ final class PostCampaignCheckoutViewController: UIViewController {
       .addObserver(forName: .ksr_sessionStarted, object: nil, queue: nil) { [weak self] _ in
         self?.viewModel.inputs.userSessionStarted()
       }
+    
+    self.paymentMethodsViewController.view.rac.hidden = self.viewModel.outputs.paymentMethodsViewHidden
   }
 
   // MARK: - Functions

--- a/Kickstarter-iOS/Features/PledgeView/Controllers/PostCampaignCheckoutViewController.swift
+++ b/Kickstarter-iOS/Features/PledgeView/Controllers/PostCampaignCheckoutViewController.swift
@@ -203,7 +203,7 @@ final class PostCampaignCheckoutViewController: UIViewController {
       .addObserver(forName: .ksr_sessionStarted, object: nil, queue: nil) { [weak self] _ in
         self?.viewModel.inputs.userSessionStarted()
       }
-    
+
     self.paymentMethodsViewController.view.rac.hidden = self.viewModel.outputs.paymentMethodsViewHidden
   }
 
@@ -251,6 +251,6 @@ extension PostCampaignCheckoutViewController: PledgeViewCTAContainerViewDelegate
 
   func termsOfUseTapped(with helpType: HelpType) {
     self.paymentMethodsViewController.cancelPaymentSheetAppearance()
-    // TODO
+    self.viewModel.inputs.termsOfUseTapped(with: helpType)
   }
 }

--- a/Library/ViewModels/PledgePaymentMethodsViewModel.swift
+++ b/Library/ViewModels/PledgePaymentMethodsViewModel.swift
@@ -290,6 +290,8 @@ public final class PledgePaymentMethodsViewModel: PledgePaymentMethodsViewModelT
       .mapConst(true)
 
     // Only ever use the value if the view model is configured and the payment sheet could exist.
+    // In the logged out state, the payment sheet is part of the view without being configured,
+    // so this is a real risk.
     let safeShouldCancelPaymentSheet = Signal.combineLatest(
       self.shouldCancelPaymentSheetAppearance.signal,
       configureWithValue

--- a/Library/ViewModels/PledgePaymentMethodsViewModel.swift
+++ b/Library/ViewModels/PledgePaymentMethodsViewModel.swift
@@ -288,13 +288,13 @@ public final class PledgePaymentMethodsViewModel: PledgePaymentMethodsViewModelT
 
     self.shouldCancelPaymentSheetAppearance <~ updatedCards.signal
       .mapConst(true)
-    
+
     // Only ever use the value if the view model is configured and the payment sheet could exist.
     let safeShouldCancelPaymentSheet = Signal.combineLatest(
       self.shouldCancelPaymentSheetAppearance.signal,
       configureWithValue
     )
-      .map(first)
+    .map(first)
 
     let createSetupIntentEvent = Signal.combineLatest(
       project,

--- a/Library/ViewModels/PostCampaignCheckoutViewModel.swift
+++ b/Library/ViewModels/PostCampaignCheckoutViewModel.swift
@@ -70,8 +70,7 @@ public class PostCampaignCheckoutViewModel: PostCampaignCheckoutViewModelType,
         return (user, data.project, reward, data.context, data.refTag)
       }
 
-    self.goToLoginSignup = Signal.combineLatest(initialData, self.goToLoginSignupSignal)
-      .map(first)
+    self.goToLoginSignup = initialData.takeWhen(self.goToLoginSignupSignal)
       .map { (LoginIntent.backProject, $0.project, $0.rewards.first) }
 
     let isLoggedIn = Signal.merge(initialData.ignoreValues(), self.userSessionStartedSignal)
@@ -92,7 +91,9 @@ public class PostCampaignCheckoutViewModel: PostCampaignCheckoutViewModelType,
     }
 
     self.paymentMethodsViewHidden = Signal.combineLatest(isLoggedIn, context)
-      .map { !$0 || $1.paymentMethodsViewHidden }
+      .map { isLoggedIn, context in
+        !isLoggedIn || context.paymentMethodsViewHidden
+      }
 
     self.showWebHelp = Signal.merge(
       self.termsOfUseTappedSignal,

--- a/Library/ViewModels/PostCampaignCheckoutViewModel.swift
+++ b/Library/ViewModels/PostCampaignCheckoutViewModel.swift
@@ -22,6 +22,7 @@ public protocol PostCampaignCheckoutViewModelInputs {
   func configure(with data: PostCampaignCheckoutData)
   func goToLoginSignupTapped()
   func pledgeDisclaimerViewDidTapLearnMore()
+  func termsOfUseTapped(with: HelpType)
   func userSessionStarted()
   func viewDidLoad()
 }
@@ -93,7 +94,10 @@ public class PostCampaignCheckoutViewModel: PostCampaignCheckoutViewModelType,
     self.paymentMethodsViewHidden = Signal.combineLatest(isLoggedIn, context)
       .map { !$0 || $1.paymentMethodsViewHidden }
 
-    self.showWebHelp = self.pledgeDisclaimerViewDidTapLearnMoreSignal.mapConst(.trust)
+    self.showWebHelp = Signal.merge(
+      self.termsOfUseTappedSignal,
+      self.pledgeDisclaimerViewDidTapLearnMoreSignal.mapConst(.trust)
+    )
 
     self.configurePledgeRewardsSummaryViewWithData = initialData
       .compactMap { data in
@@ -129,6 +133,11 @@ public class PostCampaignCheckoutViewModel: PostCampaignCheckoutViewModelType,
     = Signal<Void, Never>.pipe()
   public func pledgeDisclaimerViewDidTapLearnMore() {
     self.pledgeDisclaimerViewDidTapLearnMoreObserver.send(value: ())
+  }
+
+  private let (termsOfUseTappedSignal, termsOfUseTappedObserver) = Signal<HelpType, Never>.pipe()
+  public func termsOfUseTapped(with helpType: HelpType) {
+    self.termsOfUseTappedObserver.send(value: helpType)
   }
 
   private let (userSessionStartedSignal, userSessionStartedObserver) = Signal<Void, Never>.pipe()

--- a/Library/ViewModels/PostCampaignCheckoutViewModel.swift
+++ b/Library/ViewModels/PostCampaignCheckoutViewModel.swift
@@ -56,7 +56,7 @@ public class PostCampaignCheckoutViewModel: PostCampaignCheckoutViewModelType,
     .skipNil()
 
     let context = initialData.map(\.context)
-    
+
     let configurePaymentMethodsData = Signal.merge(
       initialData,
       initialData.takeWhen(self.userSessionStartedSignal)


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Make "continue" button launch the login flow. Payment methods sheet should be hidden in logged out case and show up again once the user is logged in.

This makes the checkout VC a delegate of the pledge CTA and implements methods other than those corresponding to the "pledge" and "apple pay" buttons.

Note: This still hasn't added the extra warning to the pledge CTA. Since that can probably be added without touching the checkout VC, I'm going to do that in another pr to minimize merge conflicts.

# 👀 See

[Jira](https://kickstarter.atlassian.net/browse/MBL-1210)

![Simulator Screen Recording - iPhone 15 Pro Max - 2024-03-20 at 16 02 58](https://github.com/kickstarter/ios-oss/assets/6799207/728ff5cb-202b-423d-be26-3e15bd188427)

# ✅ Acceptance criteria

- [x] Checkout screen looks good when the user is logged out
- [x] Checkout screen is back to normal when the user logs in by hitting "continue" button


