### PR TITLE
MBL-1123: Refactor PledgePaymentMethodsViewModel to use PaymentSourceSelected

### DIFF
--- a/Kickstarter-iOS/Features/PledgePaymentMethods/Controller/PledgePaymentMethodsViewController.swift
+++ b/Kickstarter-iOS/Features/PledgePaymentMethods/Controller/PledgePaymentMethodsViewController.swift
@@ -96,7 +96,7 @@ final class PledgePaymentMethodsViewController: UIViewController {
           case let (.some(selectedCard), .none):
             self.tableView.visibleCells
               .compactMap { $0 as? PledgePaymentMethodCell }
-              .forEach { $0.setSelectedCard(selectedCard) }
+              .forEach { $0.setSelectedCardId(selectedCard.id) }
           default:
             break
           }

--- a/Kickstarter-iOS/Features/PledgePaymentMethods/Controller/PledgePaymentMethodsViewController.swift
+++ b/Kickstarter-iOS/Features/PledgePaymentMethods/Controller/PledgePaymentMethodsViewController.swift
@@ -76,7 +76,7 @@ final class PledgePaymentMethodsViewController: UIViewController {
 
     self.viewModel.outputs.reloadPaymentMethods
       .observeForUI()
-      .observeValues { [weak self] cards, paymentSheetCards, selectedCard, selectedPaymentSheetCardId, shouldReload, isLoading in
+      .observeValues { [weak self] cards, paymentSheetCards, selectedPaymentMethod, shouldReload, isLoading in
         guard let self = self else { return }
 
         self.dataSource.load(
@@ -88,15 +88,15 @@ final class PledgePaymentMethodsViewController: UIViewController {
         if shouldReload {
           self.tableView.reloadData()
         } else {
-          switch (selectedCard, selectedPaymentSheetCardId) {
-          case let (.none, .some(selectedPaymentSheetCardId)):
+          switch selectedPaymentMethod {
+          case let .setupIntentClientSecret(selectedPaymentSheetCardId):
             self.tableView.visibleCells
               .compactMap { $0 as? PledgePaymentSheetPaymentMethodCell }
               .forEach { $0.setSelectedCard(selectedPaymentSheetCardId) }
-          case let (.some(selectedCard), .none):
+          case let .paymentSourceId(selectedCardId):
             self.tableView.visibleCells
               .compactMap { $0 as? PledgePaymentMethodCell }
-              .forEach { $0.setSelectedCardId(selectedCard.id) }
+              .forEach { $0.setSelectedCardId(selectedCardId) }
           default:
             break
           }

--- a/Kickstarter-iOS/Features/PledgePaymentMethods/Views/Cells/PledgePaymentMethodCell.swift
+++ b/Kickstarter-iOS/Features/PledgePaymentMethods/Views/Cells/PledgePaymentMethodCell.swift
@@ -163,8 +163,8 @@ final class PledgePaymentMethodCell: UITableViewCell, ValueCell {
 
   // MARK: - Accessors
 
-  func setSelectedCard(_ card: UserCreditCards.CreditCard) {
-    self.viewModel.inputs.setSelectedCard(card)
+  func setSelectedCardId(_ id: String) {
+    self.viewModel.inputs.setSelectedCardId(id)
   }
 }
 

--- a/Library/ViewModels/PledgePaymentMethodCellViewModel.swift
+++ b/Library/ViewModels/PledgePaymentMethodCellViewModel.swift
@@ -17,7 +17,7 @@ public protocol PledgePaymentMethodCellViewModelInputs {
   func configureWith(value: PledgePaymentMethodCellData)
 
   /// Call with the currently selected card.
-  func setSelectedCard(_ creditCard: UserCreditCards.CreditCard)
+  func setSelectedCardId(_ id: String)
 }
 
 public protocol PledgePaymentMethodCellViewModelOutputs {
@@ -64,7 +64,7 @@ public final class PledgePaymentMethodCellViewModel: PledgePaymentMethodCellView
   PledgePaymentMethodCellViewModelOutputs, PledgePaymentMethodCellViewModelType {
   public init() {
     let creditCard = self.configureValueProperty.signal.skipNil().map(\.card)
-    let selectedCard = self.selectedCardProperty.signal.skipNil()
+    let selectedCardId = self.selectedCardIdProperty.signal.skipNil()
     let cardTypeIsAvailable = self.configureValueProperty.signal.skipNil().map(\.isEnabled)
     let configuredAsSelected = self.configureValueProperty.signal.skipNil().map(\.isSelected)
 
@@ -90,10 +90,12 @@ public final class PledgePaymentMethodCellViewModel: PledgePaymentMethodCellView
 
     let cardAndSelectedCard = Signal.combineLatest(
       creditCard,
-      selectedCard
+      selectedCardId
     )
 
-    let setAsSelected = cardAndSelectedCard.map(==)
+    let setAsSelected = cardAndSelectedCard.map { card, id in
+      card.id == id
+    }
 
     let creditCardCheckImageName = Signal.merge(configuredAsSelected, setAsSelected)
       .map { $0 ? "icon-payment-method-selected" : "icon-payment-method-unselected" }
@@ -135,9 +137,9 @@ public final class PledgePaymentMethodCellViewModel: PledgePaymentMethodCellView
     self.configureValueProperty.value = value
   }
 
-  private let selectedCardProperty = MutableProperty<UserCreditCards.CreditCard?>(nil)
-  public func setSelectedCard(_ creditCard: UserCreditCards.CreditCard) {
-    self.selectedCardProperty.value = creditCard
+  private let selectedCardIdProperty = MutableProperty<String?>(nil)
+  public func setSelectedCardId(_ id: String) {
+    self.selectedCardIdProperty.value = id
   }
 
   public let cardImageAlpha: Signal<CGFloat, Never>

--- a/Library/ViewModels/PledgePaymentMethodCellViewModelTests.swift
+++ b/Library/ViewModels/PledgePaymentMethodCellViewModelTests.swift
@@ -148,7 +148,7 @@ internal final class PledgePaymentMethodCellViewModelTests: TestCase {
     self.unavailableCardText.assertDidNotEmitValue()
 
     self.vm.inputs.configureWith(value: (UserCreditCards.generic, true, true, "Brooklyn, NY", false))
-    self.vm.inputs.setSelectedCard(UserCreditCards.diners)
+    self.vm.inputs.setSelectedCardId(UserCreditCards.diners.id)
 
     self.cardImageName.assertValues(["icon--generic"])
     self.cardImageAlpha.assertValues([1.0])
@@ -177,7 +177,7 @@ internal final class PledgePaymentMethodCellViewModelTests: TestCase {
     self.unavailableCardText.assertDidNotEmitValue()
 
     self.vm.inputs.configureWith(value: (UserCreditCards.generic, true, false, "Brooklyn, NY", false))
-    self.vm.inputs.setSelectedCard(UserCreditCards.generic)
+    self.vm.inputs.setSelectedCardId(UserCreditCards.generic.id)
 
     self.cardImageName.assertValues(["icon--generic"])
     self.cardImageAlpha.assertValues([1.0])
@@ -206,7 +206,7 @@ internal final class PledgePaymentMethodCellViewModelTests: TestCase {
     self.unavailableCardText.assertDidNotEmitValue()
 
     self.vm.inputs.configureWith(value: (UserCreditCards.generic, false, true, "Brooklyn, NY", false))
-    self.vm.inputs.setSelectedCard(UserCreditCards.generic)
+    self.vm.inputs.setSelectedCardId(UserCreditCards.generic.id)
 
     self.cardImageName.assertValues(["icon--generic"])
     self.cardImageAlpha.assertValues([0.5])


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Refactor `PledgePaymentMethodsViewModel` to use `PaymentSourceSelected`, instead of managing separate values for a `selectedSetupIntent` and a `selectedCreditCard`. 

# 🤔 Why
For MBL-1123, I need to pass the final selected value (whether it's from a `SetupIntent`, a `PaymentIntent` or an existing `CreditCard`) back to the delegate of the `PledgePaymentMethodsViewController`. This refactor makes that significantly easier - we'll be able to keep the declarative nature of the screen, but be explicit about what kind of payment method is selected.

The alternative would be to keep some kind of state in the `PledgePaymentMethodsViewController` that indicated whether or not it should use a `SetupIntent` or a `PaymentIntent`, and that felt messy in a different way.

