### PR TITLE
Confirm Details UI Cleanup

### DIFF
--- a/Kickstarter-iOS/Features/ConfirmDetails/Controllers/ConfirmDetailsViewController.swift
+++ b/Kickstarter-iOS/Features/ConfirmDetails/Controllers/ConfirmDetailsViewController.swift
@@ -135,11 +135,8 @@ final class ConfirmDetailsViewController: UIViewController, MessageBannerViewCon
   // MARK: - Configuration
 
   private func configureChildViewControllers() {
-    _ = (self.rootScrollView, self.view)
-      |> ksr_addSubviewToParent()
-
-    _ = (self.continueCTAView, self.view)
-      |> ksr_addSubviewToParent()
+    self.view.addSubview(self.rootScrollView)
+    self.view.addSubview(self.continueCTAView)
 
     _ = (self.rootStackView, self.rootScrollView)
       |> ksr_addSubviewToParent()
@@ -152,26 +149,21 @@ final class ConfirmDetailsViewController: UIViewController, MessageBannerViewCon
       self.pledgeRewardsSummaryViewController
     ]
 
-    let arrangedSubviews = [
-      self.rootInsetStackView
-    ]
+    self.rootStackView.addArrangedSubview(self.rootInsetStackView)
 
     let arrangedInsetSubviews = [
       [self.titleLabel],
       self.inputsSectionViews,
-      self.pledgeAmountSummarySectionViews,
-      [self.pledgeRewardsSummaryViewController.view]
+      self.pledgeAmountSummarySectionViews
     ]
     .flatMap { $0 }
     .compact()
 
-    arrangedSubviews.forEach { view in
-      self.rootStackView.addArrangedSubview(view)
-    }
-
     arrangedInsetSubviews.forEach { view in
       self.rootInsetStackView.addArrangedSubview(view)
     }
+
+    self.rootStackView.addArrangedSubview(self.pledgeRewardsSummaryViewController.view)
 
     childViewControllers.forEach { viewController in
       self.addChild(viewController)
@@ -198,23 +190,29 @@ final class ConfirmDetailsViewController: UIViewController, MessageBannerViewCon
   override func bindStyles() {
     super.bindStyles()
 
-    _ = self.view
-      |> checkoutBackgroundStyle
+    self.view.backgroundColor = UIColor.ksr_support_100
 
-    _ = self.titleLabel
-      |> titleLabelStyle
+    self.titleLabel.text = Strings.Confirm_your_pledge_details()
+    self.titleLabel.font = UIFont.ksr_title2().bolded
+    self.titleLabel.numberOfLines = 0
 
-    _ = self.rootScrollView
-      |> rootScrollViewStyle
+    self.rootScrollView.showsVerticalScrollIndicator = false
+    self.rootScrollView.alwaysBounceVertical = true
 
-    _ = self.rootStackView
-      |> rootStackViewStyle
+    self.rootStackView.axis = NSLayoutConstraint.Axis.vertical
+    self.rootStackView.spacing = Styles.grid(3)
+    self.rootStackView.isLayoutMarginsRelativeArrangement = true
 
-    _ = self.rootInsetStackView
-      |> rootInsetStackViewStyle
+    self.rootInsetStackView.axis = NSLayoutConstraint.Axis.vertical
+    self.rootInsetStackView.spacing = Styles.grid(4)
+    self.rootInsetStackView.isLayoutMarginsRelativeArrangement = true
+    self.rootInsetStackView.layoutMargins = UIEdgeInsets(
+      topBottom: ConfirmDetailsLayout.Margin.topBottom,
+      leftRight: ConfirmDetailsLayout.Margin.leftRight
+    )
 
-    _ = self.pledgeSummarySectionSeparator
-      |> separatorStyle
+    self.pledgeSummarySectionSeparator.backgroundColor = UIColor.ksr_support_300
+    self.pledgeSummarySectionSeparator.accessibilityElementsHidden = true
   }
 
   // MARK: - View model
@@ -349,37 +347,4 @@ extension ConfirmDetailsViewController: ConfirmDetailsContinueCTAViewDelegate {
   func continueButtonTapped() {
     self.viewModel.inputs.continueCTATapped()
   }
-}
-
-// MARK: - Styles
-
-private let titleLabelStyle: LabelStyle = { label in
-  label
-    |> \.text %~ { _ in Strings.Confirm_your_pledge_details() }
-    |> \.font .~ UIFont.ksr_title2().bolded
-    |> \.numberOfLines .~ 0
-}
-
-private let rootScrollViewStyle: ScrollStyle = { scrollView in
-  scrollView
-    |> \.showsVerticalScrollIndicator .~ false
-    |> \.alwaysBounceVertical .~ true
-}
-
-private let rootStackViewStyle: StackViewStyle = { stackView in
-  stackView
-    |> \.axis .~ NSLayoutConstraint.Axis.vertical
-    |> \.spacing .~ Styles.grid(4)
-    |> \.isLayoutMarginsRelativeArrangement .~ true
-}
-
-private let rootInsetStackViewStyle: StackViewStyle = { stackView in
-  stackView
-    |> \.axis .~ NSLayoutConstraint.Axis.vertical
-    |> \.spacing .~ Styles.grid(4)
-    |> \.isLayoutMarginsRelativeArrangement .~ true
-    |> \.layoutMargins .~ UIEdgeInsets(
-      topBottom: ConfirmDetailsLayout.Margin.topBottom,
-      leftRight: ConfirmDetailsLayout.Margin.leftRight
-    )
 }

--- a/Kickstarter-iOS/Features/ConfirmDetails/Views/ConfirmDetailsContinueCTAView.swift
+++ b/Kickstarter-iOS/Features/ConfirmDetails/Views/ConfirmDetailsContinueCTAView.swift
@@ -56,37 +56,45 @@ final class ConfirmDetailsContinueCTAView: UIView {
   override func bindStyles() {
     super.bindStyles()
 
-    _ = self
-      |> \.layoutMargins .~ .init(all: Styles.grid(3))
+    self.layoutMargins = .init(all: Styles.grid(3))
 
-    _ = self.layer
-      |> checkoutLayerCardRoundedStyle
-      |> \.backgroundColor .~ UIColor.ksr_white.cgColor
-      |> \.shadowColor .~ UIColor.ksr_black.cgColor
-      |> \.shadowOpacity .~ 0.12
-      |> \.shadowOffset .~ CGSize(width: 0, height: -1.0)
-      |> \.shadowRadius .~ CGFloat(1.0)
-      |> \.maskedCorners .~ [
-        CACornerMask.layerMaxXMinYCorner,
-        CACornerMask.layerMinXMinYCorner
-      ]
+    self.layer.cornerRadius = 16.0
+    self.layer.backgroundColor = UIColor.ksr_white.cgColor
+    self.layer.shadowColor = UIColor.ksr_black.cgColor
+    self.layer.shadowOpacity = 0.12
+    self.layer.shadowOffset = CGSize(width: 0, height: -1.0)
+    self.layer.shadowRadius = CGFloat(1.0)
+    self.layer.maskedCorners = [
+      CACornerMask.layerMaxXMinYCorner,
+      CACornerMask.layerMinXMinYCorner
+    ]
 
-    _ = self.rootStackView
-      |> verticalStackViewStyle
-      |> \.spacing .~ Styles.grid(3)
+    self.rootStackView.axis = NSLayoutConstraint.Axis.vertical
+    self.rootStackView.spacing = Styles.grid(3)
 
-    _ = self.titleAndAmountStackView
-      |> self.titleAndAmountStackViewStyle
+    self.titleAndAmountStackView.backgroundColor = .ksr_white
+    self.titleAndAmountStackView.layoutMargins = UIEdgeInsets(leftRight: Styles.gridHalf(4))
 
-    _ = self.titleLabel
-      |> self.titleLabelStyle
+    self.titleLabel.accessibilityTraits = UIAccessibilityTraits.header
+    self.titleLabel.adjustsFontForContentSizeCategory = true
+    self.titleLabel.font = UIFont.ksr_headline(size: 15)
+    self.titleLabel.numberOfLines = 0
+    self.titleLabel.text = Strings.Total_amount()
 
-    _ = self.amountLabel
-      |> self.amountLabelStyle
+    self.amountLabel.adjustsFontForContentSizeCategory = true
+    self.amountLabel.textAlignment = NSTextAlignment.right
+    self.amountLabel.isAccessibilityElement = true
+    self.amountLabel.minimumScaleFactor = 0.75
 
-    _ = self.continueButton
-      |> greenButtonStyle
-      |> UIButton.lens.title(for: .normal) %~ { _ in Strings.Continue() }
+    self.continueButton.setTitle(Strings.Continue(), for: .normal)
+    self.continueButton.setTitleColor(.ksr_white, for: .normal)
+    self.continueButton.setTitleColor(.ksr_white, for: .highlighted)
+    self.continueButton.setBackgroundColor(.ksr_create_700, for: .normal)
+    self.continueButton.setBackgroundColor(UIColor.ksr_create_700.mixDarker(0.36), for: .highlighted)
+    self.continueButton.setBackgroundColor(UIColor.ksr_create_700.mixLighter(0.36), for: .disabled)
+    self.continueButton.clipsToBounds = true
+    self.continueButton.layer.masksToBounds = true
+    self.continueButton.layer.cornerRadius = Styles.grid(2)
   }
 
   // MARK: Functions
@@ -112,6 +120,7 @@ final class ConfirmDetailsContinueCTAView: UIView {
   func configure(with data: ConfirmDetailsContinueCTAViewData) {
     if let attributedAmount = attributedCurrency(withProject: data.project, total: data.total) {
       self.amountLabel.attributedText = attributedAmount
+      self.layoutIfNeeded()
     }
   }
 
@@ -133,31 +142,5 @@ final class ConfirmDetailsContinueCTAView: UIView {
 
   @objc func continueButtonTapped() {
     self.delegate?.continueButtonTapped()
-  }
-
-  // MARK: - Styles
-
-  private let titleLabelStyle: LabelStyle = { (label: UILabel) -> UILabel in
-    _ = label
-      |> checkoutTitleLabelStyle
-      |> \.text %~ { _ in Strings.Total_amount() }
-
-    return label
-  }
-
-  private let amountLabelStyle: LabelStyle = { (label: UILabel) in
-    _ = label
-      |> \.adjustsFontForContentSizeCategory .~ true
-      |> \.textAlignment .~ NSTextAlignment.right
-      |> \.isAccessibilityElement .~ true
-      |> \.minimumScaleFactor .~ 0.75
-
-    return label
-  }
-
-  private let titleAndAmountStackViewStyle: StackViewStyle = { (stackView: UIStackView) in
-    stackView
-      |> \.backgroundColor .~ .ksr_white
-      |> \.layoutMargins .~ UIEdgeInsets(leftRight: Styles.gridHalf(4))
   }
 }

--- a/Kickstarter-iOS/Features/ConfirmDetails/Views/ConfirmDetailsContinueCTAView.swift
+++ b/Kickstarter-iOS/Features/ConfirmDetails/Views/ConfirmDetailsContinueCTAView.swift
@@ -120,7 +120,6 @@ final class ConfirmDetailsContinueCTAView: UIView {
   func configure(with data: ConfirmDetailsContinueCTAViewData) {
     if let attributedAmount = attributedCurrency(withProject: data.project, total: data.total) {
       self.amountLabel.attributedText = attributedAmount
-      self.layoutIfNeeded()
     }
   }
 

--- a/Kickstarter-iOS/Features/PledgeView/Controllers/PostCampaignCheckoutViewController.swift
+++ b/Kickstarter-iOS/Features/PledgeView/Controllers/PostCampaignCheckoutViewController.swift
@@ -88,9 +88,6 @@ final class PostCampaignCheckoutViewController: UIViewController {
   // MARK: - Configuration
 
   private func configureChildViewControllers() {
-    _ = (self.rootScrollView, self.view)
-      |> ksr_addSubviewToParent()
-
     self.view.addSubview(self.rootScrollView)
     self.view.addSubview(self.pledgeCTAContainerView)
 

--- a/Library/ViewModels/ConfirmDetailsViewModel.swift
+++ b/Library/ViewModels/ConfirmDetailsViewModel.swift
@@ -209,9 +209,9 @@ public class ConfirmDetailsViewModel: ConfirmDetailsViewModelType, ConfirmDetail
 
     // MARK: Total Pledge Summary
 
-    /// Hide when there is a reward and shipping is enabled (accounts for digital rewards), and in a pledge context
+    /// Hide when there is a reward and in a pledge context
     self.pledgeSummaryViewHidden = Signal.zip(baseReward, context).map { baseReward, context in
-      (baseReward.isNoReward == false && baseReward.shipping.enabled) && context == .pledge
+      baseReward.isNoReward == false && context == .pledge
     }
 
     let allRewardsTotal = Signal.combineLatest(


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

- Removes Prelude elements from ConfirmDetailsViewController and it's CTA ViewController
- Expands Pledge Rewards Summary Table to full width
- Ensure that the Pledge Summary Section make sure the pledge summary is only shown in IsNoReward states when pledging
   - We need to hid this regardless of whether there is shipping enabled for a reward or not

# 🤔 Why

Cleanup is nice, and we need to match the figma

# 👀 See

![Simulator Screen Recording - iPhone 15 Pro - 2024-03-25 at 11 52 18](https://github.com/kickstarter/ios-oss/assets/110618242/732815d5-37ca-4b53-90a8-8a4ece1bf752)

