### PR TITLE
Rename PaymentSourceSelected.paymentSourceId to .savedCreditCard

### DIFF
--- a/Kickstarter-iOS/Features/PledgePaymentMethods/Controller/PledgePaymentMethodsViewController.swift
+++ b/Kickstarter-iOS/Features/PledgePaymentMethods/Controller/PledgePaymentMethodsViewController.swift
@@ -95,7 +95,7 @@ final class PledgePaymentMethodsViewController: UIViewController {
             self.tableView.visibleCells
               .compactMap { $0 as? PledgePaymentSheetPaymentMethodCell }
               .forEach { $0.setSelectedCard(selectedPaymentSheetCardId) }
-          case let .paymentSourceId(selectedCardId):
+          case let .savedCreditCard(selectedCardId):
             self.tableView.visibleCells
               .compactMap { $0 as? PledgePaymentMethodCell }
               .forEach { $0.setSelectedCardId(selectedCardId) }

--- a/Library/ViewModels/PaymentSourceSelected.swift
+++ b/Library/ViewModels/PaymentSourceSelected.swift
@@ -1,12 +1,12 @@
 import Foundation
 public enum PaymentSourceSelected: Equatable {
-  case paymentSourceId(String)
+  case savedCreditCard(String)
   case setupIntentClientSecret(String)
   case paymentIntentClientSecret(String)
 
-  public var paymentSourceId: String? {
+  public var savedCreditCardId: String? {
     switch self {
-    case let .paymentSourceId(value):
+    case let .savedCreditCard(value):
       return value
     default:
       return nil

--- a/Library/ViewModels/PledgePaymentMethodsViewModel.swift
+++ b/Library/ViewModels/PledgePaymentMethodsViewModel.swift
@@ -147,7 +147,7 @@ public final class PledgePaymentMethodsViewModel: PledgePaymentMethodsViewModelT
 
         var selectedPaymentMethod: PaymentSourceSelected?
         if let selectedCardId = selectedCard?.id {
-          selectedPaymentMethod = .paymentSourceId(selectedCardId)
+          selectedPaymentMethod = .savedCreditCard(selectedCardId)
         }
 
         return PledgePaymentMethodsAndSelectionData(
@@ -246,7 +246,7 @@ public final class PledgePaymentMethodsViewModel: PledgePaymentMethodsViewModelT
           let selectionUpdatedData = updatedData
             |> \.paymentMethodsCellData .~ cellData(data.paymentMethodsCellData, selecting: card)
             |> \.paymentSheetPaymentMethodsCellData .~ deselectAllSheetPaymentMethods
-            |> \.selectedPaymentMethod .~ .paymentSourceId(card.id)
+            |> \.selectedPaymentMethod .~ .savedCreditCard(card.id)
 
           return selectionUpdatedData
         }

--- a/Library/ViewModels/PledgePaymentMethodsViewModelTests.swift
+++ b/Library/ViewModels/PledgePaymentMethodsViewModelTests.swift
@@ -49,7 +49,7 @@ final class PledgePaymentMethodsViewModelTests: TestCase {
       .observe(self.reloadPaymentMethodsProjectCountry.observer)
     self.vm.outputs.reloadPaymentMethods.map { $0.1 }
       .observe(self.reloadPaymentSheetPaymentMethodsCards.observer)
-    self.vm.outputs.reloadPaymentMethods.map { data in data.selectedPaymentMethod?.paymentSourceId }
+    self.vm.outputs.reloadPaymentMethods.map { data in data.selectedPaymentMethod?.savedCreditCardId }
       .observe(self.reloadPaymentMethodsSelectedCardId.observer)
     self.vm.outputs.reloadPaymentMethods.map { data in data.selectedPaymentMethod?.setupIntentClientSecret }
       .observe(self.reloadPaymentMethodsSelectedSetupIntent.observer)
@@ -805,7 +805,7 @@ final class PledgePaymentMethodsViewModelTests: TestCase {
       self.scheduler.run()
 
       self.notifyDelegateCreditCardSelected.assertValues(
-        [PaymentSourceSelected.paymentSourceId(UserCreditCards.amex.id)],
+        [PaymentSourceSelected.savedCreditCard(UserCreditCards.amex.id)],
         "First card selected by default"
       )
 
@@ -817,8 +817,8 @@ final class PledgePaymentMethodsViewModelTests: TestCase {
       self.vm.inputs.didSelectRowAtIndexPath(discoverIndexPath)
 
       self.notifyDelegateCreditCardSelected.assertValues([
-        PaymentSourceSelected.paymentSourceId(UserCreditCards.amex.id),
-        PaymentSourceSelected.paymentSourceId(UserCreditCards.discover.id)
+        PaymentSourceSelected.savedCreditCard(UserCreditCards.amex.id),
+        PaymentSourceSelected.savedCreditCard(UserCreditCards.discover.id)
       ])
     }
   }
@@ -845,7 +845,7 @@ final class PledgePaymentMethodsViewModelTests: TestCase {
       self.scheduler.run()
 
       self.notifyDelegateCreditCardSelected.assertValues(
-        [PaymentSourceSelected.paymentSourceId(UserCreditCards.visa.id)],
+        [PaymentSourceSelected.savedCreditCard(UserCreditCards.visa.id)],
         "First card selected by default"
       )
 
@@ -864,7 +864,7 @@ final class PledgePaymentMethodsViewModelTests: TestCase {
         )
 
       self.notifyDelegateCreditCardSelected.assertValues([
-        PaymentSourceSelected.paymentSourceId(UserCreditCards.visa.id),
+        PaymentSourceSelected.savedCreditCard(UserCreditCards.visa.id),
         PaymentSourceSelected
           .setupIntentClientSecret("seti_1LVlHO4VvJ2PtfhK43R6p7FI_secret_MEDiGbxfYVnHGsQy8v8TbZJTQhlNKLZ")
       ])

--- a/Library/ViewModels/PledgeViewModel.swift
+++ b/Library/ViewModels/PledgeViewModel.swift
@@ -563,7 +563,7 @@ public class PledgeViewModel: PledgeViewModelType, PledgeViewModelInputs, Pledge
       refTag
     ) -> CreateBackingData in
 
-    var paymentSourceId = selectedPaymentSource?.paymentSourceId
+    var paymentSourceId = selectedPaymentSource?.savedCreditCardId
     var setupIntentClientSecret = selectedPaymentSource?.setupIntentClientSecret
 
     return (
@@ -637,7 +637,7 @@ public class PledgeViewModel: PledgeViewModelType, PledgeViewModelInputs, Pledge
       selectedPaymentSource,
       applePayParams
     ) -> UpdateBackingData in
-    var paymentSourceId = selectedPaymentSource?.paymentSourceId
+    var paymentSourceId = selectedPaymentSource?.savedCreditCardId
     var setupIntentClientSecret = selectedPaymentSource?.setupIntentClientSecret
 
     return (
@@ -940,7 +940,7 @@ public class PledgeViewModel: PledgeViewModelType, PledgeViewModelInputs, Pledge
     .map { context, project, selectedPaymentSource -> Bool in
 
       context == .fixPaymentMethod
-        && project.personalization.backing?.paymentSource?.id == selectedPaymentSource?.paymentSourceId
+        && project.personalization.backing?.paymentSource?.id == selectedPaymentSource?.savedCreditCardId
     }
     .skipRepeats()
 
@@ -1328,7 +1328,7 @@ private func paymentMethodValid(
 
   if project.personalization.backing?.status == .errored {
     return true
-  } else if backedPaymentSourceId != paymentSource.paymentSourceId {
+  } else if backedPaymentSourceId != paymentSource.savedCreditCardId {
     return true
   }
 

--- a/Library/ViewModels/PledgeViewModelTests.swift
+++ b/Library/ViewModels/PledgeViewModelTests.swift
@@ -620,7 +620,7 @@ final class PledgeViewModelTests: TestCase {
       self.summarySectionSeparatorHidden.assertValues([true])
       self.shippingLocationViewHidden.assertValues([true])
 
-      let paymentSourceSelected = PaymentSourceSelected.paymentSourceId(backing.paymentSource!.id!)
+      let paymentSourceSelected = PaymentSourceSelected.savedCreditCard(backing.paymentSource!.id!)
 
       self.vm.inputs.creditCardSelected(with: paymentSourceSelected)
 
@@ -2201,7 +2201,7 @@ final class PledgeViewModelTests: TestCase {
       self.goToThanksProject.assertDidNotEmitValue()
       self.showErrorBannerWithMessage.assertDidNotEmitValue()
 
-      let paymentSourceSelected = PaymentSourceSelected.paymentSourceId("123")
+      let paymentSourceSelected = PaymentSourceSelected.savedCreditCard("123")
 
       self.vm.inputs.creditCardSelected(with: paymentSourceSelected)
 
@@ -2300,7 +2300,7 @@ final class PledgeViewModelTests: TestCase {
       self.goToThanksProject.assertDidNotEmitValue()
       self.showErrorBannerWithMessage.assertDidNotEmitValue()
 
-      let paymentSourceSelected = PaymentSourceSelected.paymentSourceId("123")
+      let paymentSourceSelected = PaymentSourceSelected.savedCreditCard("123")
 
       self.vm.inputs.creditCardSelected(with: paymentSourceSelected)
 
@@ -2382,7 +2382,7 @@ final class PledgeViewModelTests: TestCase {
       self.showErrorBannerWithMessage.assertDidNotEmitValue()
       self.processingViewIsHidden.assertDidNotEmitValue()
 
-      let paymentSourceSelected = PaymentSourceSelected.paymentSourceId("123")
+      let paymentSourceSelected = PaymentSourceSelected.savedCreditCard("123")
 
       self.vm.inputs.creditCardSelected(with: paymentSourceSelected)
 
@@ -2985,7 +2985,7 @@ final class PledgeViewModelTests: TestCase {
       "Amount and shipping rule unchanged"
     )
 
-    var paymentSourceSelected = PaymentSourceSelected.paymentSourceId("12345")
+    var paymentSourceSelected = PaymentSourceSelected.savedCreditCard("12345")
 
     self.vm.inputs.creditCardSelected(with: paymentSourceSelected)
 
@@ -2994,7 +2994,7 @@ final class PledgeViewModelTests: TestCase {
       "Payment method changed"
     )
 
-    paymentSourceSelected = PaymentSourceSelected.paymentSourceId(Backing.PaymentSource.template.id ?? "")
+    paymentSourceSelected = PaymentSourceSelected.savedCreditCard(Backing.PaymentSource.template.id ?? "")
 
     self.vm.inputs.creditCardSelected(with: paymentSourceSelected)
 
@@ -3958,7 +3958,7 @@ final class PledgeViewModelTests: TestCase {
     )
 
     withEnvironment(apiService: mockService2) {
-      let paymentSourceSelected = PaymentSourceSelected.paymentSourceId("123")
+      let paymentSourceSelected = PaymentSourceSelected.savedCreditCard("123")
 
       self.vm.inputs.creditCardSelected(with: paymentSourceSelected)
 
@@ -4065,7 +4065,7 @@ final class PledgeViewModelTests: TestCase {
       let pledgeAmountData = (amount: 15.0, min: 5.0, max: 10_000.0, isValid: true)
       self.vm.inputs.pledgeAmountViewControllerDidUpdate(with: pledgeAmountData)
 
-      let paymentSourceSelected = PaymentSourceSelected.paymentSourceId("123")
+      let paymentSourceSelected = PaymentSourceSelected.savedCreditCard("123")
 
       self.vm.inputs.creditCardSelected(with: paymentSourceSelected)
 
@@ -4276,7 +4276,7 @@ final class PledgeViewModelTests: TestCase {
       let pledgeAmountData = (amount: 15.0, min: 5.0, max: 10_000.0, isValid: true)
       self.vm.inputs.pledgeAmountViewControllerDidUpdate(with: pledgeAmountData)
 
-      let paymentSourceSelected = PaymentSourceSelected.paymentSourceId("123")
+      let paymentSourceSelected = PaymentSourceSelected.savedCreditCard("123")
       self.vm.inputs.creditCardSelected(with: paymentSourceSelected)
 
       self.goToApplePayPaymentAuthorizationProject.assertDidNotEmitValue()
@@ -4460,7 +4460,7 @@ final class PledgeViewModelTests: TestCase {
       self.goToThanksProject.assertDidNotEmitValue()
       self.showErrorBannerWithMessage.assertDidNotEmitValue()
 
-      let paymentSourceSelected = PaymentSourceSelected.paymentSourceId("123")
+      let paymentSourceSelected = PaymentSourceSelected.savedCreditCard("123")
 
       self.vm.inputs.creditCardSelected(with: paymentSourceSelected)
 
@@ -4581,7 +4581,7 @@ final class PledgeViewModelTests: TestCase {
       self.goToThanksProject.assertDidNotEmitValue()
       self.showErrorBannerWithMessage.assertDidNotEmitValue()
 
-      let paymentSourceSelected = PaymentSourceSelected.paymentSourceId("123")
+      let paymentSourceSelected = PaymentSourceSelected.savedCreditCard("123")
 
       self.vm.inputs.creditCardSelected(with: paymentSourceSelected)
 
@@ -4682,7 +4682,7 @@ final class PledgeViewModelTests: TestCase {
       self.goToThanksProject.assertDidNotEmitValue()
       self.showErrorBannerWithMessage.assertDidNotEmitValue()
 
-      let paymentSourceSelected = PaymentSourceSelected.paymentSourceId("123")
+      let paymentSourceSelected = PaymentSourceSelected.savedCreditCard("123")
 
       self.vm.inputs.creditCardSelected(with: paymentSourceSelected)
 
@@ -5488,7 +5488,7 @@ final class PledgeViewModelTests: TestCase {
       self.goToThanksProject.assertDidNotEmitValue()
       self.showErrorBannerWithMessage.assertDidNotEmitValue()
 
-      let paymentSourceSelected = PaymentSourceSelected.paymentSourceId("123")
+      let paymentSourceSelected = PaymentSourceSelected.savedCreditCard("123")
 
       self.vm.inputs.creditCardSelected(with: paymentSourceSelected)
 
@@ -5585,7 +5585,7 @@ final class PledgeViewModelTests: TestCase {
       self.goToThanksProject.assertDidNotEmitValue()
       self.showErrorBannerWithMessage.assertDidNotEmitValue()
 
-      let paymentSourceSelected = PaymentSourceSelected.paymentSourceId("123")
+      let paymentSourceSelected = PaymentSourceSelected.savedCreditCard("123")
 
       self.vm.inputs.creditCardSelected(with: paymentSourceSelected)
 
@@ -5914,7 +5914,7 @@ final class PledgeViewModelTests: TestCase {
     ))
     self.vm.inputs.shippingRuleSelected(.template)
 
-    let paymentSourceSelected = PaymentSourceSelected.paymentSourceId("123")
+    let paymentSourceSelected = PaymentSourceSelected.savedCreditCard("123")
 
     self.vm.inputs.creditCardSelected(with: paymentSourceSelected)
 
@@ -5987,7 +5987,7 @@ final class PledgeViewModelTests: TestCase {
       ))
       self.vm.inputs.shippingRuleSelected(.template)
 
-      let paymentSourceSelected = PaymentSourceSelected.paymentSourceId("123")
+      let paymentSourceSelected = PaymentSourceSelected.savedCreditCard("123")
 
       self.vm.inputs.creditCardSelected(with: paymentSourceSelected)
 
@@ -6066,7 +6066,7 @@ final class PledgeViewModelTests: TestCase {
       self.vm.inputs.configure(with: data)
       self.vm.inputs.viewDidLoad()
 
-      let paymentSourceSelected = PaymentSourceSelected.paymentSourceId("12345")
+      let paymentSourceSelected = PaymentSourceSelected.savedCreditCard("12345")
 
       self.vm.inputs.creditCardSelected(with: paymentSourceSelected)
 


### PR DESCRIPTION
# 📲 What

Rename `PaymentSourceSelected.paymentSourceId` to `.savedCreditCard`

# 🤔 Why

This makes it slightly clearer what is actually being saved in the enum.