### PR TITLE
[MBL-1288] Update pledge CTA

### DIFF
--- a/Kickstarter-iOS/Features/PledgeView/Views/PledgeViewCTAContainerView.swift
+++ b/Kickstarter-iOS/Features/PledgeView/Views/PledgeViewCTAContainerView.swift
@@ -92,6 +92,7 @@ final class PledgeViewCTAContainerView: UIView {
     self.pledgeImmediatelyLabel.attributedText = pledgeImmediatelyText()
     self.pledgeImmediatelyLabel.numberOfLines = 0
     self.pledgeImmediatelyLabel.textAlignment = .center
+    self.pledgeImmediatelyLabel.textColor = UIColor.ksr_support_400
 
     _ = self.disclaimerStackView
       |> disclaimerStackViewStyle
@@ -307,52 +308,5 @@ private func attributedTermsText() -> NSAttributedString? {
 
 private func pledgeImmediatelyText() -> NSAttributedString? {
   let rawText = Strings.Your_payment_method_will_be_charged()
-
-  guard let text = try? NSMutableAttributedString(
-    data: Data(rawText.utf8),
-    options: [
-      .documentType: NSAttributedString.DocumentType.html,
-      .characterEncoding: String.Encoding.utf8.rawValue
-    ],
-    documentAttributes: nil
-  ) else {
-    return nil
-  }
-
-  let attributes: String.Attributes = [
-    .font: UIFont.ksr_caption2(),
-    .foregroundColor: UIColor.ksr_support_400
-  ]
-
-  let fullRange = (text.string as NSString).range(of: text.string)
-  text.addAttributes(attributes, range: fullRange)
-
-  let boldRanges = getBoldRangesFromHtmlTags(plainString: text.string, htmlString: rawText)
-  for range in boldRanges {
-    text.addAttribute(.font, value: UIFont.ksr_caption2().bolded, range: range)
-  }
-
-  return text
-}
-
-private func getBoldRangesFromHtmlTags(plainString: String, htmlString: String) -> [NSRange] {
-  let stringWithoutHtml = plainString as NSString
-  var boldRanges: [NSRange] = []
-
-  var currentString = htmlString as NSString
-  while currentString.contains("<b>") {
-    let startTagRange = currentString.range(of: "<b>")
-    let endTagRange = currentString.range(of: "</b>")
-
-    // Calculate range of bolded text in the string without html tags.
-    let location = startTagRange.location
-    let length = endTagRange.location - (location + startTagRange.length)
-    let toBold = NSRange(location: location, length: length)
-    boldRanges.append(toBold)
-
-    let processedSubstring = stringWithoutHtml.substring(to: toBold.location + toBold.length)
-    let remainingHtml = currentString.substring(from: endTagRange.location + endTagRange.length)
-    currentString = (processedSubstring + remainingHtml) as NSString
-  }
-  return boldRanges
+  return rawText.simpleHtmlAttributedString(font: UIFont.ksr_caption2())
 }

--- a/Kickstarter-iOS/Features/RewardAddOnSelection/Controller/RewardAddOnSelectionViewController.swift
+++ b/Kickstarter-iOS/Features/RewardAddOnSelection/Controller/RewardAddOnSelectionViewController.swift
@@ -179,7 +179,7 @@ final class RewardAddOnSelectionViewController: UIViewController {
       .observeValues { [weak self] data in
         guard let self else { return }
 
-        if featurePostCampaignPledgeEnabled(), data.project.isInPostCampaignPledgingPhase {
+        if data.context == .latePledge {
           self.goToConfirmDetails(data: data)
         } else {
           self.goToPledge(data: data)

--- a/Kickstarter-iOS/Features/RewardsCollection/Controller/RewardsCollectionViewController.swift
+++ b/Kickstarter-iOS/Features/RewardsCollection/Controller/RewardsCollectionViewController.swift
@@ -172,7 +172,7 @@ final class RewardsCollectionViewController: UICollectionViewController {
       .observeValues { [weak self] data in
         guard let self else { return }
 
-        if featurePostCampaignPledgeEnabled(), data.project.isInPostCampaignPledgingPhase {
+        if data.context == .latePledge {
           self.goToConfirmDetails(data: data)
         } else {
           self.goToPledge(data: data)

--- a/Kickstarter-iOS/Locales/Base.lproj/Localizable.strings
+++ b/Kickstarter-iOS/Locales/Base.lproj/Localizable.strings
@@ -815,6 +815,7 @@
 "Your_message_has_been_sent" = "Your message has been sent!";
 "Your_name_displayed" = "Your name is always displayed on your profile.";
 "Your_payment_method_was_successfully_charged" = "Your payment method was successfully charged.";
+"Your_payment_method_will_be_charged" = "Your payment method will be <b>charged immediately</b> upon pledge. Your pledge cannot be <b>canceled or modified</b>.";
 "Your_payment_method_will_be_charged_immediately" = "Your payment method will be charged immediately upon pledge and you’ll receive a confirmation email at %{user_email}. Your pledge cannot be canceled or modified.";
 "Your_pledge" = "Your pledge";
 "Your_pledge_amount" = "Your pledge amount";

--- a/Kickstarter-iOS/Locales/Base.lproj/Localizable.strings
+++ b/Kickstarter-iOS/Locales/Base.lproj/Localizable.strings
@@ -815,7 +815,7 @@
 "Your_message_has_been_sent" = "Your message has been sent!";
 "Your_name_displayed" = "Your name is always displayed on your profile.";
 "Your_payment_method_was_successfully_charged" = "Your payment method was successfully charged.";
-"Your_payment_method_will_be_charged" = "Your payment method will be <b>charged immediately</b> upon pledge. Your pledge cannot be <b>canceled or modified</b>.";
+"Your_payment_method_will_be_charged" = "Your payment method will be <b>charged immediately</b> upon pledge. Your pledge <b>cannot be canceled or modified</b>.";
 "Your_payment_method_will_be_charged_immediately" = "Your payment method will be charged immediately upon pledge and you’ll receive a confirmation email at %{user_email}. Your pledge cannot be canceled or modified.";
 "Your_pledge" = "Your pledge";
 "Your_pledge_amount" = "Your pledge amount";

--- a/Kickstarter-iOS/Locales/de.lproj/Localizable.strings
+++ b/Kickstarter-iOS/Locales/de.lproj/Localizable.strings
@@ -109,7 +109,7 @@
 "Check_out_these_handpicked_projects" = "Sieh dir dieses speziell für dich ausgesuchten Projekte an.";
 "Check_your_inbox_to_complete_this_simple_step" = "Sieh bitte in deinem Posteingang nach und schließe diesen einfachen Schritt ab.";
 "Check_your_payment_details" = "Überprüfe die Daten deiner Zahlungsweise";
-"Checkout" = "Checkout";
+"Checkout" = "Kasse";
 "Choose_another_reward" = "Andere Belohnung auswählen";
 "Chooses_location_for_shipping" = "Legt %{location} als Versandort fest.";
 "Chosen_just_for_you" = "Speziell für dich ausgewählt";
@@ -126,7 +126,7 @@
 "Complete_payment" = "Zahlung abschließen";
 "Confirm" = "Bestätigen";
 "Confirm_password" = "Neues Passwort bestätigen";
-"Confirm_your_pledge_details" = "Confirm your pledge details";
+"Confirm_your_pledge_details" = "Bestätige die Details zu deinem Finanzierungsbeitrag";
 "Connect_with_Facebook_to_follow_friends_and_get_notified" = "Verknüpfe dein Konto mit Facebook - du kannst deinen Freunden folgen und wirst benachrichtigt, sobald sie ein Projekt veröffentlichen oder unterstützen.";
 "Contact_backer" = "Unterstützer kontaktieren";
 "Contact_creator" = "Projektgründer kontaktieren";
@@ -596,7 +596,7 @@
 "Select_this_reward" = "Diese Belohnung wählen";
 "Select_this_reward_instead" = "Diese Belohnung auswählen";
 "Select_up_to_five" = "Wähle bis zu fünf aus den unten stehenden Optionen aus.";
-"Select_your_reward" = "Select your reward";
+"Select_your_reward" = "Belohnung auswählen";
 "Selected" = "Ausgewählt";
 "Selected_card" = "Ausgewählte Karte";
 "Selected_reward" = "Gewählte Belohnung";
@@ -800,7 +800,7 @@
 "You_canceled_your_pledge_for_this_project" = "Du hast den Finanzierungsbeitrag für dieses Projekt zurückgezogen.";
 "You_cant_use_this_credit_card_to_back_a_project_from_project_country" = "Diese Karte kann nicht verwendet werden, um ein Projekt aus dem folgenden Land zu unterstützen: %{project_country}.";
 "You_have_successfully_backed_project_html" = "Dank deiner Unterstützung ist <b>%{project_name}</b> seiner Verwirklichung einen Schritt näher. Sag es weiter!";
-"You_have_successfully_pledged_to_project_post_campaign_html" = "<p>You have successfully pledged to <b>%{project_name}</b>. Your pledge of <b>%{pledge_total}</b> has been collected.</p>\n<p>You’ll receive a confirmation email at %{user_email} when your rewards are ready to fulfill so that you can finalize and pay shipping and tax.</p>\n<p>This project is now one step closer to a reality, thanks to you. Spread the word!</p>";
+"You_have_successfully_pledged_to_project_post_campaign_html" = "<p>Du hast <b>%{project_name}</b> mit deinem Beitrag erfolgreich unterstützt. Dein Beitrag in Höhe von <b>%{pledge_total}</b> wurde eingezogen.</p>\n<p>Du erhältst eine E-Mail an %{user_email}, wenn deine Belohnungen zur Erfüllung bereit sind, damit du alles finalisieren und für Versand und Steuern zahlen kannst.</p>\n<p>Dank dir ist dieses Projekt seiner Realisierung einen Schritt nähergekommen. Erzähl auch deinen Freunden und Bekannten davon!</p>";
 "You_launched_this_project_on_launch_date" = "Du hast dieses Projekt am %{launch_date} veröffentlicht. Tools für Projektgründer findest du auf unserer Website.";
 "You_need_to_pledge_at_least_reward_minimum_for_this_reward" = "Diese Belohnung hat einen Mindestfinanzierungsbeitrag von %{reward_minimum}.";
 "You_pledged_on_date" = "<b>Finanzierungsbeitrag geleistet</b> im %{pledge_date}";
@@ -815,7 +815,8 @@
 "Your_message_has_been_sent" = "Deine Nachricht wurde versandt!";
 "Your_name_displayed" = "Dein Name wird auf deinem Profil angezeigt.";
 "Your_payment_method_was_successfully_charged" = "Deine Zahlungsmethode wurde erfolgreich belastet.";
-"Your_payment_method_will_be_charged_immediately" = "Your payment method will be charged immediately upon pledge and you’ll receive a confirmation email at %{user_email}. Your pledge cannot be canceled or modified.";
+"Your_payment_method_will_be_charged" = "Your payment method will be <b>charged immediately</b> upon pledge. Your pledge cannot be <b>canceled or modified</b>.";
+"Your_payment_method_will_be_charged_immediately" = "Deine Zahlungsmethode wird umgehend belastet und du erhältst eine Bestätigungs-E-Mail an %{user_email}. Dein Beitrag kann nicht storniert oder geändert werden.";
 "Your_pledge" = "Dein Beitrag";
 "Your_pledge_amount" = "Dein Beitrag:";
 "Your_pledge_details" = "Einzelheiten deines Beitrags";

--- a/Kickstarter-iOS/Locales/de.lproj/Localizable.strings
+++ b/Kickstarter-iOS/Locales/de.lproj/Localizable.strings
@@ -815,7 +815,7 @@
 "Your_message_has_been_sent" = "Deine Nachricht wurde versandt!";
 "Your_name_displayed" = "Dein Name wird auf deinem Profil angezeigt.";
 "Your_payment_method_was_successfully_charged" = "Deine Zahlungsmethode wurde erfolgreich belastet.";
-"Your_payment_method_will_be_charged" = "Your payment method will be <b>charged immediately</b> upon pledge. Your pledge cannot be <b>canceled or modified</b>.";
+"Your_payment_method_will_be_charged" = "Your payment method will be <b>charged immediately</b> upon pledge. Your pledge <b>cannot be canceled or modified</b>.";
 "Your_payment_method_will_be_charged_immediately" = "Deine Zahlungsmethode wird umgehend belastet und du erhältst eine Bestätigungs-E-Mail an %{user_email}. Dein Beitrag kann nicht storniert oder geändert werden.";
 "Your_pledge" = "Dein Beitrag";
 "Your_pledge_amount" = "Dein Beitrag:";

--- a/Kickstarter-iOS/Locales/es.lproj/Localizable.strings
+++ b/Kickstarter-iOS/Locales/es.lproj/Localizable.strings
@@ -109,7 +109,7 @@
 "Check_out_these_handpicked_projects" = "Echa un vistazo a estos proyectos seleccionados exclusivamente para ti.";
 "Check_your_inbox_to_complete_this_simple_step" = "Revisa tu bandeja de entrada para completar este simple paso.";
 "Check_your_payment_details" = "Revisa tu información de pago";
-"Checkout" = "Checkout";
+"Checkout" = "Pago";
 "Choose_another_reward" = "Elegir otra recompensa";
 "Chooses_location_for_shipping" = "Destino determinado: %{location}.";
 "Chosen_just_for_you" = "Elegidos especialmente para ti";
@@ -126,7 +126,7 @@
 "Complete_payment" = "Completar pago";
 "Confirm" = "Confirmar";
 "Confirm_password" = "Confirmar nueva contraseña";
-"Confirm_your_pledge_details" = "Confirm your pledge details";
+"Confirm_your_pledge_details" = "Confirma los datos de tu contribución";
 "Connect_with_Facebook_to_follow_friends_and_get_notified" = "Si te conectas via Facebook puedes seguir a tus amigos y te avisaremos cada vez que publican o patrocinan un proyecto.";
 "Contact_backer" = "Contacta al patrocinador";
 "Contact_creator" = "Comunicarse con el creador";
@@ -596,7 +596,7 @@
 "Select_this_reward" = "Seleccionar esta recompensa";
 "Select_this_reward_instead" = "Selecciona esta recompensa";
 "Select_up_to_five" = "Selecciona hasta cinco de las opciones que aparecen a continuación.";
-"Select_your_reward" = "Select your reward";
+"Select_your_reward" = "Selecciona tu recompensa";
 "Selected" = "Seleccionada";
 "Selected_card" = "Tarjeta seleccionada";
 "Selected_reward" = "Recompensa seleccionada";
@@ -800,7 +800,7 @@
 "You_canceled_your_pledge_for_this_project" = "Has cancelado tu contribución a este proyecto.";
 "You_cant_use_this_credit_card_to_back_a_project_from_project_country" = "No puedes usar esta tarjeta de crédito para patrocinar un proyecto de %{project_country}.";
 "You_have_successfully_backed_project_html" = "Has patrocinado <b>%{project_name}</b> con éxito. Gracias a ti, este proyecto está ahora un paso más cerca de hacerse realidad. ¡Corre la voz!";
-"You_have_successfully_pledged_to_project_post_campaign_html" = "<p>You have successfully pledged to <b>%{project_name}</b>. Your pledge of <b>%{pledge_total}</b> has been collected.</p>\n<p>You’ll receive a confirmation email at %{user_email} when your rewards are ready to fulfill so that you can finalize and pay shipping and tax.</p>\n<p>This project is now one step closer to a reality, thanks to you. Spread the word!</p>";
+"You_have_successfully_pledged_to_project_post_campaign_html" = "<p>Has patrocinado <b>%{project_name}</b> con éxito y tu contribución por <b>%{pledge_total}</b> se ha recaudado.</p>\n<p>Recibirás la confirmación en %{user_email} cuando estemos por entregarte las recompensas para que puedas pagar los costos de envío e impuestos.</p>\n<p>Gracias a ti, este proyecto está ahora un paso más cerca de hacerse realidad. ¡Ayuda a correr la voz!</p>";
 "You_launched_this_project_on_launch_date" = "Publicaste el proyecto el %{launch_date}. Encuentra las herramientas para creadores en nuestro sitio web.";
 "You_need_to_pledge_at_least_reward_minimum_for_this_reward" = "Debes contribuir, al menos, %{reward_minimum} para obtener esta recompensa.";
 "You_pledged_on_date" = "<b>Contribuiste</b> el %{pledge_date}";
@@ -815,7 +815,8 @@
 "Your_message_has_been_sent" = "Se envió tu mensaje.";
 "Your_name_displayed" = "Tu nombre siempre se muestra en tu perfil.";
 "Your_payment_method_was_successfully_charged" = "Se efectuó el cargo a tu método de pago.";
-"Your_payment_method_will_be_charged_immediately" = "Your payment method will be charged immediately upon pledge and you’ll receive a confirmation email at %{user_email}. Your pledge cannot be canceled or modified.";
+"Your_payment_method_will_be_charged" = "Your payment method will be <b>charged immediately</b> upon pledge. Your pledge cannot be <b>canceled or modified</b>.";
+"Your_payment_method_will_be_charged_immediately" = "Al hacer la contribución, se hará el cargo inmediatamente a tu método de pago y recibirás un correo electrónico de confirmación en %{user_email}. Tu contribución no puede cancelarse ni modificarse.";
 "Your_pledge" = "Tu contribución";
 "Your_pledge_amount" = "Monto de tu contribución:";
 "Your_pledge_details" = "Los detalles de tu contribución";

--- a/Kickstarter-iOS/Locales/es.lproj/Localizable.strings
+++ b/Kickstarter-iOS/Locales/es.lproj/Localizable.strings
@@ -815,7 +815,7 @@
 "Your_message_has_been_sent" = "Se envió tu mensaje.";
 "Your_name_displayed" = "Tu nombre siempre se muestra en tu perfil.";
 "Your_payment_method_was_successfully_charged" = "Se efectuó el cargo a tu método de pago.";
-"Your_payment_method_will_be_charged" = "Your payment method will be <b>charged immediately</b> upon pledge. Your pledge cannot be <b>canceled or modified</b>.";
+"Your_payment_method_will_be_charged" = "Your payment method will be <b>charged immediately</b> upon pledge. Your pledge <b>cannot be canceled or modified</b>.";
 "Your_payment_method_will_be_charged_immediately" = "Al hacer la contribución, se hará el cargo inmediatamente a tu método de pago y recibirás un correo electrónico de confirmación en %{user_email}. Tu contribución no puede cancelarse ni modificarse.";
 "Your_pledge" = "Tu contribución";
 "Your_pledge_amount" = "Monto de tu contribución:";

--- a/Kickstarter-iOS/Locales/fr.lproj/Localizable.strings
+++ b/Kickstarter-iOS/Locales/fr.lproj/Localizable.strings
@@ -815,7 +815,7 @@
 "Your_message_has_been_sent" = "Votre message a été envoyé.";
 "Your_name_displayed" = "Votre nom s'affichera toujours sur votre profil.";
 "Your_payment_method_was_successfully_charged" = "Votre moyen de paiement a bien été débité.";
-"Your_payment_method_will_be_charged" = "Your payment method will be <b>charged immediately</b> upon pledge. Your pledge cannot be <b>canceled or modified</b>.";
+"Your_payment_method_will_be_charged" = "Your payment method will be <b>charged immediately</b> upon pledge. Your pledge <b>cannot be canceled or modified</b>.";
 "Your_payment_method_will_be_charged_immediately" = "La somme sera immédiatement prélevée sur votre moyen de paiement et vous recevrez une confirmation à l'adresse %{user_email}. Cet engagement ne pourra être ni annulé, ni modifié.";
 "Your_pledge" = "Mon engagement";
 "Your_pledge_amount" = "Montant engagé :";

--- a/Kickstarter-iOS/Locales/fr.lproj/Localizable.strings
+++ b/Kickstarter-iOS/Locales/fr.lproj/Localizable.strings
@@ -815,6 +815,7 @@
 "Your_message_has_been_sent" = "Votre message a été envoyé.";
 "Your_name_displayed" = "Votre nom s'affichera toujours sur votre profil.";
 "Your_payment_method_was_successfully_charged" = "Votre moyen de paiement a bien été débité.";
+"Your_payment_method_will_be_charged" = "Your payment method will be <b>charged immediately</b> upon pledge. Your pledge cannot be <b>canceled or modified</b>.";
 "Your_payment_method_will_be_charged_immediately" = "La somme sera immédiatement prélevée sur votre moyen de paiement et vous recevrez une confirmation à l'adresse %{user_email}. Cet engagement ne pourra être ni annulé, ni modifié.";
 "Your_pledge" = "Mon engagement";
 "Your_pledge_amount" = "Montant engagé :";

--- a/Kickstarter-iOS/Locales/ja.lproj/Localizable.strings
+++ b/Kickstarter-iOS/Locales/ja.lproj/Localizable.strings
@@ -815,7 +815,7 @@
 "Your_message_has_been_sent" = "メッセージが送信されました！";
 "Your_name_displayed" = "あなたの名前はプロフィールに常に表示されます。";
 "Your_payment_method_was_successfully_charged" = "支払方法の登録完了。";
-"Your_payment_method_will_be_charged" = "Your payment method will be <b>charged immediately</b> upon pledge. Your pledge cannot be <b>canceled or modified</b>.";
+"Your_payment_method_will_be_charged" = "Your payment method will be <b>charged immediately</b> upon pledge. Your pledge <b>cannot be canceled or modified</b>.";
 "Your_payment_method_will_be_charged_immediately" = "お支払い方法にはプレッジ時にただちに請求が行われ、その確認メールが %{user_email} 宛てに送られます。プレッジをキャンセルまたは変更することはできません。";
 "Your_pledge" = "プレッジ";
 "Your_pledge_amount" = "プレッジ額：";

--- a/Kickstarter-iOS/Locales/ja.lproj/Localizable.strings
+++ b/Kickstarter-iOS/Locales/ja.lproj/Localizable.strings
@@ -109,7 +109,7 @@
 "Check_out_these_handpicked_projects" = "あなたにピッタリの Kickstarter イチオシのプロジェクトをご覧ください。";
 "Check_your_inbox_to_complete_this_simple_step" = "メールの受信箱をチェックしてこの簡単手続きを完了してください。";
 "Check_your_payment_details" = "お支払い情報をご確認ください";
-"Checkout" = "Checkout";
+"Checkout" = "チェックアウト";
 "Choose_another_reward" = "他のリワードを選択";
 "Chooses_location_for_shipping" = "配送先%{location} を選択";
 "Chosen_just_for_you" = "あなたのために選びました";
@@ -126,7 +126,7 @@
 "Complete_payment" = "支払いを完了";
 "Confirm" = "確定する";
 "Confirm_password" = "新しいパスワードの確認";
-"Confirm_your_pledge_details" = "Confirm your pledge details";
+"Confirm_your_pledge_details" = "プレッジの詳細を確認";
 "Connect_with_Facebook_to_follow_friends_and_get_notified" = "Facebookとリンクさせ、友達がプロジェクトを作成したりバックしたりした際に通知を受け取る";
 "Contact_backer" = "バッカーに連絡する";
 "Contact_creator" = "クリエイターに連絡";
@@ -596,7 +596,7 @@
 "Select_this_reward" = "このリワードを選ぶ";
 "Select_this_reward_instead" = "このリワードを選択";
 "Select_up_to_five" = "以下のオプションから最大5つをお選びください。";
-"Select_your_reward" = "Select your reward";
+"Select_your_reward" = "リワードの選択";
 "Selected" = "選択済み";
 "Selected_card" = "選択済みのカード";
 "Selected_reward" = "選択したリワード";
@@ -800,7 +800,7 @@
 "You_canceled_your_pledge_for_this_project" = "このプロジェクトのプレッジはキャンセルされました。";
 "You_cant_use_this_credit_card_to_back_a_project_from_project_country" = "%{project_country} のプロジェクトをバックするのにこのクレジットカードを利用することはできません。";
 "You_have_successfully_backed_project_html" = "<b>%{project_name}</b>へのバックが完了しました。このプロジェクトは、成功に一歩近づきました！ありがとうございます。";
-"You_have_successfully_pledged_to_project_post_campaign_html" = "<p>You have successfully pledged to <b>%{project_name}</b>. Your pledge of <b>%{pledge_total}</b> has been collected.</p>\n<p>You’ll receive a confirmation email at %{user_email} when your rewards are ready to fulfill so that you can finalize and pay shipping and tax.</p>\n<p>This project is now one step closer to a reality, thanks to you. Spread the word!</p>";
+"You_have_successfully_pledged_to_project_post_campaign_html" = "<p><b>%{project_name}</b>にプレッジしました。これに伴い、<b>%{pledge_total}</b>のプレッジが収集されました。</p>\n<p>リワード配送の準備が整い次第、%{user_email} 宛てに確認メールが届き、配送料と税金の最終確認とお支払いを行うことができます。</p>\n<p>あなたのプレッジのおかげで、このプロジェクトが実現へと一歩近づきました。ありがとうございます。ぜひこのプロジェクトを沢山の人に知ってもらいましょう！</p>";
 "You_launched_this_project_on_launch_date" = "%{launch_date} にこのプロジェクトをローンチしました。クリエイター向けツールにアクセスするには、Kickstarter ウェブサイトにアクセスしてください！";
 "You_need_to_pledge_at_least_reward_minimum_for_this_reward" = "このリワードには、最低%{reward_minimum}のプレッジが必要です。";
 "You_pledged_on_date" = "%{pledge_date} に<b>プレッジ</b>";
@@ -815,7 +815,8 @@
 "Your_message_has_been_sent" = "メッセージが送信されました！";
 "Your_name_displayed" = "あなたの名前はプロフィールに常に表示されます。";
 "Your_payment_method_was_successfully_charged" = "支払方法の登録完了。";
-"Your_payment_method_will_be_charged_immediately" = "Your payment method will be charged immediately upon pledge and you’ll receive a confirmation email at %{user_email}. Your pledge cannot be canceled or modified.";
+"Your_payment_method_will_be_charged" = "Your payment method will be <b>charged immediately</b> upon pledge. Your pledge cannot be <b>canceled or modified</b>.";
+"Your_payment_method_will_be_charged_immediately" = "お支払い方法にはプレッジ時にただちに請求が行われ、その確認メールが %{user_email} 宛てに送られます。プレッジをキャンセルまたは変更することはできません。";
 "Your_pledge" = "プレッジ";
 "Your_pledge_amount" = "プレッジ額：";
 "Your_pledge_details" = "プレッジの詳細";

--- a/Library/PledgeViewContext.swift
+++ b/Library/PledgeViewContext.swift
@@ -3,6 +3,7 @@ import Foundation
 public enum PledgeViewContext {
   case fixPaymentMethod
   case pledge
+  case latePledge
   case update
   case changePaymentMethod
   case updateReward
@@ -10,55 +11,55 @@ public enum PledgeViewContext {
   var confirmationLabelHidden: Bool {
     switch self {
     case .fixPaymentMethod, .changePaymentMethod, .updateReward: return true
-    case .pledge, .update: return false
+    case .pledge, .latePledge, .update: return false
     }
   }
 
   var continueViewHidden: Bool {
     switch self {
-    case .pledge: return false
+    case .pledge, .latePledge: return false
     case .fixPaymentMethod, .update, .changePaymentMethod, .updateReward: return true
     }
   }
 
   var descriptionViewHidden: Bool {
     switch self {
-    case .pledge, .updateReward: return false
+    case .pledge, .latePledge, .updateReward: return false
     case .fixPaymentMethod, .update, .changePaymentMethod: return true
     }
   }
 
   var expandableRewardViewHidden: Bool {
     switch self {
-    case .pledge, .updateReward: return false
+    case .pledge, .latePledge, .updateReward: return false
     case .fixPaymentMethod, .update, .changePaymentMethod: return true
     }
   }
 
   var isCreating: Bool {
     switch self {
-    case .pledge: return true
+    case .pledge, .latePledge: return true
     case .fixPaymentMethod, .update, .changePaymentMethod, .updateReward: return false
     }
   }
 
   var isUpdating: Bool {
     switch self {
-    case .pledge: return false
+    case .pledge, .latePledge: return false
     case .fixPaymentMethod, .update, .changePaymentMethod, .updateReward: return true
     }
   }
 
   var paymentMethodsViewHidden: Bool {
     switch self {
-    case .fixPaymentMethod, .pledge, .changePaymentMethod: return false
+    case .fixPaymentMethod, .pledge, .latePledge, .changePaymentMethod: return false
     case .update, .updateReward: return true
     }
   }
 
   var pledgeAmountViewHidden: Bool {
     switch self {
-    case .pledge, .update, .updateReward: return false
+    case .pledge, .latePledge, .update, .updateReward: return false
     case .fixPaymentMethod, .changePaymentMethod: return true
     }
   }
@@ -66,27 +67,34 @@ public enum PledgeViewContext {
   var pledgeAmountSummaryViewHidden: Bool {
     switch self {
     case .fixPaymentMethod, .changePaymentMethod, .update: return false
-    case .pledge, .updateReward: return true
+    case .pledge, .latePledge, .updateReward: return true
     }
   }
 
   var sectionSeparatorsHidden: Bool {
     switch self {
-    case .pledge, .updateReward: return false
+    case .pledge, .latePledge, .updateReward: return false
     case .fixPaymentMethod, .update, .changePaymentMethod: return true
     }
   }
 
   var shippingLocationViewHidden: Bool {
     switch self {
-    case .pledge, .update, .updateReward: return false
+    case .pledge, .latePledge, .update, .updateReward: return false
     case .fixPaymentMethod, .changePaymentMethod: return true
+    }
+  }
+
+  var applePayButtonHidden: Bool {
+    switch self {
+    case .pledge, .latePledge, .fixPaymentMethod, .changePaymentMethod: return false
+    case .update, .updateReward: return true
     }
   }
 
   var submitButtonTitle: String {
     switch self {
-    case .pledge: return Strings.Pledge()
+    case .pledge, .latePledge: return Strings.Pledge()
     case .fixPaymentMethod, .update, .changePaymentMethod, .updateReward: return Strings.Confirm()
     }
   }
@@ -94,7 +102,7 @@ public enum PledgeViewContext {
   var title: String {
     switch self {
     case .fixPaymentMethod: return Strings.Fix_payment_method()
-    case .pledge: return Strings.Back_this_project()
+    case .pledge, .latePledge: return Strings.Back_this_project()
     case .update, .updateReward: return Strings.Update_pledge()
     case .changePaymentMethod: return Strings.Change_payment_method()
     }

--- a/Library/Strings.swift
+++ b/Library/Strings.swift
@@ -1841,10 +1841,10 @@ contributeurs"
    "Checkout"
 
    - **en**: "Checkout"
-   - **de**: "Checkout"
-   - **es**: "Checkout"
+   - **de**: "Kasse"
+   - **es**: "Pago"
    - **fr**: "Règlement"
-   - **ja**: "Checkout"
+   - **ja**: "チェックアウト"
   */
   public static func Checkout() -> String {
     return localizedString(
@@ -2130,10 +2130,10 @@ contributeurs"
    "Confirm your pledge details"
 
    - **en**: "Confirm your pledge details"
-   - **de**: "Confirm your pledge details"
-   - **es**: "Confirm your pledge details"
+   - **de**: "Bestätige die Details zu deinem Finanzierungsbeitrag"
+   - **es**: "Confirma los datos de tu contribución"
    - **fr**: "Confirmons le détail de votre engagement"
-   - **ja**: "Confirm your pledge details"
+   - **ja**: "プレッジの詳細を確認"
   */
   public static func Confirm_your_pledge_details() -> String {
     return localizedString(
@@ -9733,10 +9733,10 @@ daring ideas."
    "Select your reward"
 
    - **en**: "Select your reward"
-   - **de**: "Select your reward"
-   - **es**: "Select your reward"
+   - **de**: "Belohnung auswählen"
+   - **es**: "Selecciona tu recompensa"
    - **fr**: "Veuillez sélectionner votre récompense"
-   - **ja**: "Select your reward"
+   - **ja**: "リワードの選択"
   */
   public static func Select_your_reward() -> String {
     return localizedString(
@@ -13145,18 +13145,18 @@ Veuillez réessayer ultérieurement."
    - **en**: "<p>You have successfully pledged to <b>%{project_name}</b>. Your pledge of <b>%{pledge_total}</b> has been collected.</p>
 <p>You’ll receive a confirmation email at %{user_email} when your rewards are ready to fulfill so that you can finalize and pay shipping and tax.</p>
 <p>This project is now one step closer to a reality, thanks to you. Spread the word!</p>"
-   - **de**: "<p>You have successfully pledged to <b>%{project_name}</b>. Your pledge of <b>%{pledge_total}</b> has been collected.</p>
-<p>You’ll receive a confirmation email at %{user_email} when your rewards are ready to fulfill so that you can finalize and pay shipping and tax.</p>
-<p>This project is now one step closer to a reality, thanks to you. Spread the word!</p>"
-   - **es**: "<p>You have successfully pledged to <b>%{project_name}</b>. Your pledge of <b>%{pledge_total}</b> has been collected.</p>
-<p>You’ll receive a confirmation email at %{user_email} when your rewards are ready to fulfill so that you can finalize and pay shipping and tax.</p>
-<p>This project is now one step closer to a reality, thanks to you. Spread the word!</p>"
+   - **de**: "<p>Du hast <b>%{project_name}</b> mit deinem Beitrag erfolgreich unterstützt. Dein Beitrag in Höhe von <b>%{pledge_total}</b> wurde eingezogen.</p>
+<p>Du erhältst eine E-Mail an %{user_email}, wenn deine Belohnungen zur Erfüllung bereit sind, damit du alles finalisieren und für Versand und Steuern zahlen kannst.</p>
+<p>Dank dir ist dieses Projekt seiner Realisierung einen Schritt nähergekommen. Erzähl auch deinen Freunden und Bekannten davon!</p>"
+   - **es**: "<p>Has patrocinado <b>%{project_name}</b> con éxito y tu contribución por <b>%{pledge_total}</b> se ha recaudado.</p>
+<p>Recibirás la confirmación en %{user_email} cuando estemos por entregarte las recompensas para que puedas pagar los costos de envío e impuestos.</p>
+<p>Gracias a ti, este proyecto está ahora un paso más cerca de hacerse realidad. ¡Ayuda a correr la voz!</p>"
    - **fr**: "<p>Vous venez de vous engager à soutenir le projet <b>%{project_name}</b>. Votre contribution de <b>%{pledge_total}</b> a bien été prélevée.</p>
 <p>Vous recevrez une confirmation à l'adresse %{user_email} dès que votre récompense sera prête à être expédiée. Il vous sera alors demandé de régler les taxes et frais de port.</p>
 <p>Grâce à vous, ce projet se concrétise. Parlez-en autour de vous !</p>"
-   - **ja**: "<p>You have successfully pledged to <b>%{project_name}</b>. Your pledge of <b>%{pledge_total}</b> has been collected.</p>
-<p>You’ll receive a confirmation email at %{user_email} when your rewards are ready to fulfill so that you can finalize and pay shipping and tax.</p>
-<p>This project is now one step closer to a reality, thanks to you. Spread the word!</p>"
+   - **ja**: "<p><b>%{project_name}</b>にプレッジしました。これに伴い、<b>%{pledge_total}</b>のプレッジが収集されました。</p>
+<p>リワード配送の準備が整い次第、%{user_email} 宛てに確認メールが届き、配送料と税金の最終確認とお支払いを行うことができます。</p>
+<p>あなたのプレッジのおかげで、このプロジェクトが実現へと一歩近づきました。ありがとうございます。ぜひこのプロジェクトを沢山の人に知ってもらいましょう！</p>"
   */
   public static func You_have_successfully_pledged_to_project_post_campaign_html(project_name: String, pledge_total: String, user_email: String) -> String {
     return localizedString(
@@ -13405,13 +13405,30 @@ Veuillez réessayer ultérieurement."
     )
   }
   /**
+   "Your payment method will be <b>charged immediately</b> upon pledge. Your pledge cannot be <b>canceled or modified</b>."
+
+   - **en**: "Your payment method will be <b>charged immediately</b> upon pledge. Your pledge cannot be <b>canceled or modified</b>."
+   - **de**: "Your payment method will be <b>charged immediately</b> upon pledge. Your pledge cannot be <b>canceled or modified</b>."
+   - **es**: "Your payment method will be <b>charged immediately</b> upon pledge. Your pledge cannot be <b>canceled or modified</b>."
+   - **fr**: "Your payment method will be <b>charged immediately</b> upon pledge. Your pledge cannot be <b>canceled or modified</b>."
+   - **ja**: "Your payment method will be <b>charged immediately</b> upon pledge. Your pledge cannot be <b>canceled or modified</b>."
+  */
+  public static func Your_payment_method_will_be_charged() -> String {
+    return localizedString(
+      key: "Your_payment_method_will_be_charged",
+      defaultValue: "Your payment method will be <b>charged immediately</b> upon pledge. Your pledge cannot be <b>canceled or modified</b>.",
+      count: nil,
+      substitutions: [:]
+    )
+  }
+  /**
    "Your payment method will be charged immediately upon pledge and you’ll receive a confirmation email at %{user_email}. Your pledge cannot be canceled or modified."
 
    - **en**: "Your payment method will be charged immediately upon pledge and you’ll receive a confirmation email at %{user_email}. Your pledge cannot be canceled or modified."
-   - **de**: "Your payment method will be charged immediately upon pledge and you’ll receive a confirmation email at %{user_email}. Your pledge cannot be canceled or modified."
-   - **es**: "Your payment method will be charged immediately upon pledge and you’ll receive a confirmation email at %{user_email}. Your pledge cannot be canceled or modified."
+   - **de**: "Deine Zahlungsmethode wird umgehend belastet und du erhältst eine Bestätigungs-E-Mail an %{user_email}. Dein Beitrag kann nicht storniert oder geändert werden."
+   - **es**: "Al hacer la contribución, se hará el cargo inmediatamente a tu método de pago y recibirás un correo electrónico de confirmación en %{user_email}. Tu contribución no puede cancelarse ni modificarse."
    - **fr**: "La somme sera immédiatement prélevée sur votre moyen de paiement et vous recevrez une confirmation à l'adresse %{user_email}. Cet engagement ne pourra être ni annulé, ni modifié."
-   - **ja**: "Your payment method will be charged immediately upon pledge and you’ll receive a confirmation email at %{user_email}. Your pledge cannot be canceled or modified."
+   - **ja**: "お支払い方法にはプレッジ時にただちに請求が行われ、その確認メールが %{user_email} 宛てに送られます。プレッジをキャンセルまたは変更することはできません。"
   */
   public static func Your_payment_method_will_be_charged_immediately(user_email: String) -> String {
     return localizedString(

--- a/Library/Strings.swift
+++ b/Library/Strings.swift
@@ -13405,18 +13405,18 @@ Veuillez réessayer ultérieurement."
     )
   }
   /**
-   "Your payment method will be <b>charged immediately</b> upon pledge. Your pledge cannot be <b>canceled or modified</b>."
+   "Your payment method will be <b>charged immediately</b> upon pledge. Your pledge <b>cannot be canceled or modified</b>."
 
-   - **en**: "Your payment method will be <b>charged immediately</b> upon pledge. Your pledge cannot be <b>canceled or modified</b>."
-   - **de**: "Your payment method will be <b>charged immediately</b> upon pledge. Your pledge cannot be <b>canceled or modified</b>."
-   - **es**: "Your payment method will be <b>charged immediately</b> upon pledge. Your pledge cannot be <b>canceled or modified</b>."
-   - **fr**: "Your payment method will be <b>charged immediately</b> upon pledge. Your pledge cannot be <b>canceled or modified</b>."
-   - **ja**: "Your payment method will be <b>charged immediately</b> upon pledge. Your pledge cannot be <b>canceled or modified</b>."
+   - **en**: "Your payment method will be <b>charged immediately</b> upon pledge. Your pledge <b>cannot be canceled or modified</b>."
+   - **de**: "Your payment method will be <b>charged immediately</b> upon pledge. Your pledge <b>cannot be canceled or modified</b>."
+   - **es**: "Your payment method will be <b>charged immediately</b> upon pledge. Your pledge <b>cannot be canceled or modified</b>."
+   - **fr**: "Your payment method will be <b>charged immediately</b> upon pledge. Your pledge <b>cannot be canceled or modified</b>."
+   - **ja**: "Your payment method will be <b>charged immediately</b> upon pledge. Your pledge <b>cannot be canceled or modified</b>."
   */
   public static func Your_payment_method_will_be_charged() -> String {
     return localizedString(
       key: "Your_payment_method_will_be_charged",
-      defaultValue: "Your payment method will be <b>charged immediately</b> upon pledge. Your pledge cannot be <b>canceled or modified</b>.",
+      defaultValue: "Your payment method will be <b>charged immediately</b> upon pledge. Your pledge <b>cannot be canceled or modified</b>.",
       count: nil,
       substitutions: [:]
     )
@@ -19412,7 +19412,7 @@ Veuillez réessayer ultérieurement."
    - **de**: "Gesamt %{backers_count} Unterstützer, %{percent_funded} finanziert, noch %{time_left}"
    - **es**: "De momento tiene %{backers_count} patrocinadores, financiado al %{percent_funded}, tiempo restante: %{time_left}"
    - **fr**: "%{backers_count} contributeurs, projet financé à %{percent_funded}, plus que %{time_left}"
-   - **ja**: "バッカー%{backers_count} 人。%{percent_funded} 達成、%{time_left} で締切"
+   - **ja**: "バッカー%{backers_count} 人、%{percent_funded} 達成、%{time_left} で締切"
   */
   public static func discovery_baseball_card_stats_accessibility_non_live_stat_value(backers_count: Int, percent_funded: String, time_left: String) -> String {
     return localizedString(
@@ -22824,7 +22824,7 @@ iOSの場合、設定からFacebookのアクセスを許可してください。
 
    - **en**: "BACKED %{project_count} PROJECTS"
    - **de**: "HAT %{project_count} PROJEKTE UNTERSTÜTZT"
-   - **es**: "%{project_count} PROYECTOS PATROCINADOS"
+   - **es**: "%{project_count} PROYECTOS APOYADOS"
    - **fr**: "%{project_count} PROJETS SOUTENUS"
    - **ja**: "%{project_count} プロジェクトへバック済"
   */
@@ -25935,7 +25935,7 @@ unterstützt"
 patrocinados"
    - **fr**: "%{projects_count}
 projets soutenus"
-   - **ja**: "%{projects_count} \n件バック済み"
+   - **ja**: "%{projects_count}\n件バック済み"
   */
   public static func projects_count_newline_backed(projects_count: Int) -> String {
     return localizedString(
@@ -26887,7 +26887,7 @@ projets enregistrés"
    - **de**: "%{created_count} erstellt"
    - **es**: "%{created_count} creados"
    - **fr**: "%{created_count} projets créés"
-   - **ja**: "%{created_count} プロジェクト"
+   - **ja**: "%{created_count}プロジェクト"
   */
   public static func social_following_friend_projects_count_created(created_count: Int) -> String {
     return localizedString(

--- a/Library/Tracking/TrackingHelpers.swift
+++ b/Library/Tracking/TrackingHelpers.swift
@@ -3,7 +3,7 @@ import Foundation
 final class TrackingHelpers {
   static func pledgeContext(for viewContext: PledgeViewContext) -> KSRAnalytics.TypeContext.PledgeContext {
     switch viewContext {
-    case .pledge:
+    case .pledge, .latePledge:
       return .newPledge
     case .update, .updateReward, .changePaymentMethod:
       return .managePledge

--- a/Library/ViewModels/ConfirmDetailsViewModel.swift
+++ b/Library/ViewModels/ConfirmDetailsViewModel.swift
@@ -211,7 +211,7 @@ public class ConfirmDetailsViewModel: ConfirmDetailsViewModelType, ConfirmDetail
 
     /// Hide when there is a reward and shipping is enabled (accounts for digital rewards), and in a pledge context
     self.pledgeSummaryViewHidden = Signal.zip(baseReward, context).map { baseReward, context in
-      (baseReward.isNoReward == false && baseReward.shipping.enabled) && context == .pledge
+      (baseReward.isNoReward == false && baseReward.shipping.enabled) && context == .latePledge
     }
 
     let allRewardsTotal = Signal.combineLatest(

--- a/Library/ViewModels/PledgeViewCTAContainerViewModel.swift
+++ b/Library/ViewModels/PledgeViewCTAContainerViewModel.swift
@@ -26,6 +26,7 @@ public protocol PledgeViewCTAContainerViewModelOutputs {
   var notifyDelegateOpenHelpType: Signal<HelpType, Never> { get }
   var notifyDelegateSubmitButtonTapped: Signal<Void, Never> { get }
   var notifyDelegateToGoToLoginSignup: Signal<Void, Never> { get }
+  var pledgeImmediatelyLabelIsHidden: Signal<Bool, Never> { get }
   var submitButtonIsEnabled: Signal<Bool, Never> { get }
   var submitButtonIsHidden: Signal<Bool, Never> { get }
   var submitButtonTitle: Signal<String, Never> { get }
@@ -63,6 +64,11 @@ public final class PledgeViewCTAContainerViewModel: PledgeViewCTAContainerViewMo
     self.notifyDelegateApplePayButtonTapped = self.applePayButtonTappedProperty.signal
     self.notifyDelegateSubmitButtonTapped = self.submitButtonTappedProperty.signal
     self.notifyDelegateToGoToLoginSignup = self.continueButtonTappedProperty.signal
+
+    self.pledgeImmediatelyLabelIsHidden = context
+      .map { context in
+        context != .latePledge
+      }
   }
 
   private let applePayButtonTappedProperty = MutableProperty(())
@@ -97,6 +103,7 @@ public final class PledgeViewCTAContainerViewModel: PledgeViewCTAContainerViewMo
   public let notifyDelegateOpenHelpType: Signal<HelpType, Never>
   public let notifyDelegateSubmitButtonTapped: Signal<Void, Never>
   public let notifyDelegateToGoToLoginSignup: Signal<Void, Never>
+  public let pledgeImmediatelyLabelIsHidden: Signal<Bool, Never>
   public let submitButtonIsEnabled: Signal<Bool, Never>
   public let submitButtonTitle: Signal<String, Never>
 

--- a/Library/ViewModels/PledgeViewCTAContainerViewModel.swift
+++ b/Library/ViewModels/PledgeViewCTAContainerViewModel.swift
@@ -56,7 +56,7 @@ public final class PledgeViewCTAContainerViewModel: PledgeViewCTAContainerViewMo
     self.submitButtonIsHidden = isLoggedIn.map { $0 }.negate()
     self.applePayButtonIsHidden = Signal.combineLatest(context, isLoggedIn)
       .map { context, isLoggedIn in
-        context.isAny(of: .pledge, .fixPaymentMethod, .changePaymentMethod) == false || isLoggedIn == false
+        context.applePayButtonHidden || isLoggedIn == false
       }
     self.continueButtonIsHidden = isLoggedIn
 

--- a/Library/ViewModels/RewardsCollectionViewModel.swift
+++ b/Library/ViewModels/RewardsCollectionViewModel.swift
@@ -99,13 +99,17 @@ public final class RewardsCollectionViewModel: RewardsCollectionViewModelType,
       rewardsCarouselCanNavigateToReward(reward, in: project)
     }
     .map { project, reward, refTag -> (PledgeViewData, Bool) in
+      let pledgeContext =
+        featurePostCampaignPledgeEnabled() && project.isInPostCampaignPledgingPhase
+          ? PledgeViewContext.latePledge
+          : PledgeViewContext.pledge
       let data = PledgeViewData(
         project: project,
         rewards: [reward],
         selectedQuantities: [reward.id: 1],
         selectedLocationId: nil, // Set during add-ons selection.
         refTag: refTag,
-        context: project.personalization.backing == nil ? .pledge : .updateReward
+        context: project.personalization.backing == nil ? pledgeContext : .updateReward
       )
 
       return (data, reward.hasAddOns)


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Update pledge CTA by adding a separate context for late pledges and showing the "pledge immediately" string in a late pledge context.

Note: the bolding is currently a little off. I have a pr that fixes that submitted but not yet in staging, so this will be fixed the next time we make strings.

# 👀 See

[Jira](https://kickstarter.atlassian.net/browse/MBL-1288)

| Logged out | Logged in (new string) |
| --- | --- |
| ![image](https://github.com/kickstarter/ios-oss/assets/6799207/7e0a3beb-b8f3-4242-8f4a-1cb43c0acbd6) | ![image](https://github.com/kickstarter/ios-oss/assets/6799207/036ffd21-041e-42af-917f-30e6bff2c2a5) |

# ✅ Acceptance criteria

- [x] Pledge immediately string shows in late pledge context and does not show for normal pledges
