### PR TITLE
MBL-1285: Add ApplePay into post-campaign pledge controller

### DIFF
--- a/Kickstarter-iOS/Features/PledgeView/Controllers/PostCampaignCheckoutViewController.swift
+++ b/Kickstarter-iOS/Features/PledgeView/Controllers/PostCampaignCheckoutViewController.swift
@@ -264,16 +264,8 @@ final class PostCampaignCheckoutViewController: UIViewController, MessageBannerV
     self.present(navigationController, animated: true)
   }
 
-  private func goToPaymentAuthorization(_ paymentAuthorizationData: PaymentAuthorizationData) {
-    let request = PKPaymentRequest
-      .paymentRequest(
-        for: paymentAuthorizationData.project,
-        reward: paymentAuthorizationData.reward,
-        allRewardsTotal: paymentAuthorizationData.allRewardsTotal,
-        additionalPledgeAmount: paymentAuthorizationData.additionalPledgeAmount,
-        allRewardsShippingTotal: paymentAuthorizationData.allRewardsShippingTotal,
-        merchantIdentifier: paymentAuthorizationData.merchantIdentifier
-      )
+  private func goToPaymentAuthorization(_ paymentAuthorizationData: PostCampaignPaymentAuthorizationData) {
+    let request = PKPaymentRequest.paymentRequest(for: paymentAuthorizationData)
 
     guard
       let paymentAuthorizationViewController = PKPaymentAuthorizationViewController(paymentRequest: request)

--- a/Kickstarter-iOS/Features/PledgeView/Controllers/PostCampaignCheckoutViewController.swift
+++ b/Kickstarter-iOS/Features/PledgeView/Controllers/PostCampaignCheckoutViewController.swift
@@ -1,5 +1,6 @@
 import KsApi
 import Library
+import PassKit
 import Prelude
 import Stripe
 import UIKit
@@ -240,6 +241,12 @@ final class PostCampaignCheckoutViewController: UIViewController, MessageBannerV
         STPAPIClient.shared.publishableKey = publishableKey
         STPAPIClient.shared.configuration.appleMerchantIdentifier = merchantIdentifier
       }
+
+    self.viewModel.outputs.goToApplePayPaymentAuthorization
+      .observeForControllerAction()
+      .observeValues { [weak self] paymentAuthorizationData in
+        self?.goToPaymentAuthorization(paymentAuthorizationData)
+      }
   }
 
   // MARK: - Functions
@@ -255,6 +262,25 @@ final class PostCampaignCheckoutViewController: UIViewController, MessageBannerV
     let navigationBarHeight = navigationController.navigationBar.bounds.height
 
     self.present(navigationController, animated: true)
+  }
+
+  private func goToPaymentAuthorization(_ paymentAuthorizationData: PaymentAuthorizationData) {
+    let request = PKPaymentRequest
+      .paymentRequest(
+        for: paymentAuthorizationData.project,
+        reward: paymentAuthorizationData.reward,
+        allRewardsTotal: paymentAuthorizationData.allRewardsTotal,
+        additionalPledgeAmount: paymentAuthorizationData.additionalPledgeAmount,
+        allRewardsShippingTotal: paymentAuthorizationData.allRewardsShippingTotal,
+        merchantIdentifier: paymentAuthorizationData.merchantIdentifier
+      )
+
+    guard
+      let paymentAuthorizationViewController = PKPaymentAuthorizationViewController(paymentRequest: request)
+    else { return }
+    paymentAuthorizationViewController.delegate = self
+
+    self.present(paymentAuthorizationViewController, animated: true)
   }
 }
 
@@ -276,7 +302,7 @@ extension PostCampaignCheckoutViewController: PledgeViewCTAContainerViewDelegate
 
   func applePayButtonTapped() {
     self.paymentMethodsViewController.cancelModalPresentation(true)
-    // TODO: Respond to button tap
+    self.viewModel.inputs.applePayButtonTapped()
   }
 
   func submitButtonTapped() {
@@ -343,6 +369,40 @@ extension PostCampaignCheckoutViewController: MessageBannerViewControllerDelegat
       self.navigationController?.popViewController(animated: true)
     default:
       break
+    }
+  }
+}
+
+extension PostCampaignCheckoutViewController: PKPaymentAuthorizationViewControllerDelegate {
+  func paymentAuthorizationViewControllerDidFinish(_ controller: PKPaymentAuthorizationViewController) {
+    controller.dismiss(animated: true, completion: { [weak self] in
+      self?.viewModel.inputs.paymentAuthorizationViewControllerDidFinish()
+    })
+  }
+
+  func paymentAuthorizationViewController(
+    _: PKPaymentAuthorizationViewController,
+    didAuthorizePayment payment: PKPayment,
+    handler completion: @escaping (PKPaymentAuthorizationResult)
+      -> Void
+  ) {
+    let paymentDisplayName = payment.token.paymentMethod.displayName
+    let paymentNetworkName = payment.token.paymentMethod.network?.rawValue
+    let transactionId = payment.token.transactionIdentifier
+
+    self.viewModel.inputs.paymentAuthorizationDidAuthorizePayment(paymentData: (
+      paymentDisplayName,
+      paymentNetworkName,
+      transactionId
+    ))
+
+    STPAPIClient.shared.createToken(with: payment) { [weak self] token, error in
+      guard let self = self else { return }
+
+      let status = self.viewModel.inputs.stripeTokenCreated(token: token?.tokenId, error: error)
+      let result = PKPaymentAuthorizationResult(status: status, errors: [])
+
+      completion(result)
     }
   }
 }

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -1528,6 +1528,7 @@
 		E1801FAA2BAB6D0900EBB533 /* PaymentSourceSelected.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1801FA82BAB6CD400EBB533 /* PaymentSourceSelected.swift */; };
 		E182E5BA2B8CDFDE0008DD69 /* AppEnvironmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7ED1F121E830FDC00BFFA01 /* AppEnvironmentTests.swift */; };
 		E182E5BC2B8D36FE0008DD69 /* AppEnvironmentTests+OAuthInKeychain.swift in Sources */ = {isa = PBXBuildFile; fileRef = E182E5BB2B8D36FE0008DD69 /* AppEnvironmentTests+OAuthInKeychain.swift */; };
+		E1972EA22BB4722D002517E6 /* PostCampaignCheckoutViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1972EA12BB4722D002517E6 /* PostCampaignCheckoutViewModelTests.swift */; };
 		E1A1491E2ACDD76800F49709 /* FetchBackerProjectsQuery.graphql in Resources */ = {isa = PBXBuildFile; fileRef = E1A1491D2ACDD76700F49709 /* FetchBackerProjectsQuery.graphql */; };
 		E1A149202ACDD7BF00F49709 /* FetchProjectsEnvelope+FetchBackerProjectsQueryData.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1A1491F2ACDD7BF00F49709 /* FetchProjectsEnvelope+FetchBackerProjectsQueryData.swift */; };
 		E1A149222ACE013100F49709 /* FetchProjectsEnvelope.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1A149212ACE013100F49709 /* FetchProjectsEnvelope.swift */; };
@@ -3152,6 +3153,7 @@
 		E1801FA82BAB6CD400EBB533 /* PaymentSourceSelected.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentSourceSelected.swift; sourceTree = "<group>"; };
 		E182E5BB2B8D36FE0008DD69 /* AppEnvironmentTests+OAuthInKeychain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppEnvironmentTests+OAuthInKeychain.swift"; sourceTree = "<group>"; };
 		E1889D8D2B6065D6004FBE21 /* CombineTestObserverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CombineTestObserverTests.swift; sourceTree = "<group>"; };
+		E1972EA12BB4722D002517E6 /* PostCampaignCheckoutViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostCampaignCheckoutViewModelTests.swift; sourceTree = "<group>"; };
 		E1A1491D2ACDD76700F49709 /* FetchBackerProjectsQuery.graphql */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = FetchBackerProjectsQuery.graphql; sourceTree = "<group>"; };
 		E1A1491F2ACDD7BF00F49709 /* FetchProjectsEnvelope+FetchBackerProjectsQueryData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "FetchProjectsEnvelope+FetchBackerProjectsQueryData.swift"; sourceTree = "<group>"; };
 		E1A149212ACE013100F49709 /* FetchProjectsEnvelope.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FetchProjectsEnvelope.swift; sourceTree = "<group>"; };
@@ -6534,6 +6536,7 @@
 				E1801FA82BAB6CD400EBB533 /* PaymentSourceSelected.swift */,
 				37DEC21F2257CA0A0051EF9B /* PledgeViewModelTests.swift */,
 				395A3BC82BA8D43F0091A379 /* PostCampaignCheckoutViewModel.swift */,
+				E1972EA12BB4722D002517E6 /* PostCampaignCheckoutViewModelTests.swift */,
 				6044532D2BA0905600B8F485 /* PostCampaignPledgeRewardsSummaryViewModel.swift */,
 				A7808BEF1D625C6A001CF96A /* ProjectCreatorViewModel.swift */,
 				A7ED1F971E831C5C00BFFA01 /* ProjectCreatorViewModelTests.swift */,
@@ -8126,6 +8129,7 @@
 				3767EDB322CFFF380088E8E4 /* ShippingRulesViewModelTests.swift in Sources */,
 				A7ED1FEF1E831C5C00BFFA01 /* LoginViewModelTests.swift in Sources */,
 				A7ED1FF31E831C5C00BFFA01 /* ProjectCreatorViewModelTests.swift in Sources */,
+				E1972EA22BB4722D002517E6 /* PostCampaignCheckoutViewModelTests.swift in Sources */,
 				473DE01A273C757D0033331D /* ProjectRisksDisclaimerCellViewModelTests.swift in Sources */,
 				A7ED1FB61E831C5C00BFFA01 /* MessageCellViewModelTests.swift in Sources */,
 				A7ED1F2F1E830FDC00BFFA01 /* LocalizedStringTests.swift in Sources */,

--- a/Library/PKPaymentRequestHelpersTests.swift
+++ b/Library/PKPaymentRequestHelpersTests.swift
@@ -166,30 +166,77 @@ final class PKPaymentRequestHelpersTests: XCTestCase {
     XCTAssertEqual(paymentRequest.paymentSummaryItems[3].type, .final)
   }
 
-  func testPaymentRequest_postCampaignPledgingEnabled() {
+  func testPaymentRequest_fromPostCampaignPaymentAuthorizationData_withReward() {
     var project = Project.template
-    project.country = .us
+    project.country = .jp
+    project.stats.currency = Project.Country.jp.currencyCode
+    project.isInPostCampaignPledgingPhase = true
+
+    let reward = Reward.template
+    let merchantId = "merchant_id"
+
+    let data = PostCampaignPaymentAuthorizationData(
+      project: project,
+      hasNoReward: false,
+      subtotal: 100,
+      bonus: 200,
+      shipping: 300,
+      total: 500,
+      merchantIdentifier: merchantId
+    )
+
+    let paymentRequest = PKPaymentRequest.paymentRequest(for: data)
+    XCTAssertEqual(paymentRequest.merchantIdentifier, merchantId)
+    XCTAssertEqual(paymentRequest.merchantCapabilities, .capability3DS)
+    XCTAssertEqual(paymentRequest.countryCode, "JP")
+    XCTAssertEqual(paymentRequest.currencyCode, "JPY")
+    XCTAssertEqual(paymentRequest.shippingType, .shipping)
+    XCTAssertEqual(paymentRequest.paymentSummaryItems.count, 4)
+    XCTAssertEqual(paymentRequest.paymentSummaryItems[0].label, "Reward")
+    XCTAssertEqual(paymentRequest.paymentSummaryItems[0].amount.doubleValue, 100)
+    XCTAssertEqual(paymentRequest.paymentSummaryItems[0].type, .final)
+    XCTAssertEqual(paymentRequest.paymentSummaryItems[1].label, "Bonus")
+    XCTAssertEqual(paymentRequest.paymentSummaryItems[1].amount.doubleValue, 200)
+    XCTAssertEqual(paymentRequest.paymentSummaryItems[1].type, .final)
+    XCTAssertEqual(paymentRequest.paymentSummaryItems[2].label, "Shipping")
+    XCTAssertEqual(paymentRequest.paymentSummaryItems[2].amount.doubleValue, 300)
+    XCTAssertEqual(paymentRequest.paymentSummaryItems[2].type, .final)
+    XCTAssertEqual(paymentRequest.paymentSummaryItems[3].label, "Kickstarter")
+    XCTAssertEqual(paymentRequest.paymentSummaryItems[3].amount.doubleValue, 500)
+    XCTAssertEqual(paymentRequest.paymentSummaryItems[3].type, .final)
+  }
+
+  func testPaymentRequest_fromPostCampaignPaymentAuthorizationData_noReward() {
+    var project = Project.template
+    project.country = .ca
+    project.stats.currency = Project.Country.ca.currencyCode
     project.isInPostCampaignPledgingPhase = true
 
     let reward = Reward.noReward
     let merchantId = "merchant_id"
 
-    let mockRemoteConfig = MockRemoteConfigClient()
-    mockRemoteConfig.features = [
-      RemoteConfigFeature.postCampaignPledgeEnabled.rawValue: true
-    ]
+    let data = PostCampaignPaymentAuthorizationData(
+      project: project,
+      hasNoReward: true,
+      subtotal: 500,
+      bonus: 0,
+      shipping: 0,
+      total: 500,
+      merchantIdentifier: merchantId
+    )
 
-    withEnvironment(remoteConfigClient: mockRemoteConfig) {
-      let paymentRequest = PKPaymentRequest.paymentRequest(
-        for: project,
-        reward: reward,
-        allRewardsTotal: 100,
-        additionalPledgeAmount: 50,
-        allRewardsShippingTotal: 0,
-        merchantIdentifier: merchantId
-      )
-
-      XCTAssertEqual(paymentRequest.paymentSummaryItems.last?.label, "Kickstarter")
-    }
+    let paymentRequest = PKPaymentRequest.paymentRequest(for: data)
+    XCTAssertEqual(paymentRequest.merchantIdentifier, merchantId)
+    XCTAssertEqual(paymentRequest.merchantCapabilities, .capability3DS)
+    XCTAssertEqual(paymentRequest.countryCode, "CA")
+    XCTAssertEqual(paymentRequest.currencyCode, "CAD")
+    XCTAssertEqual(paymentRequest.shippingType, .shipping)
+    XCTAssertEqual(paymentRequest.paymentSummaryItems.count, 2)
+    XCTAssertEqual(paymentRequest.paymentSummaryItems[0].label, "Total")
+    XCTAssertEqual(paymentRequest.paymentSummaryItems[0].amount.doubleValue, 500)
+    XCTAssertEqual(paymentRequest.paymentSummaryItems[0].type, .final)
+    XCTAssertEqual(paymentRequest.paymentSummaryItems[1].label, "Kickstarter")
+    XCTAssertEqual(paymentRequest.paymentSummaryItems[1].amount.doubleValue, 500)
+    XCTAssertEqual(paymentRequest.paymentSummaryItems[1].type, .final)
   }
 }

--- a/Library/ViewModels/PostCampaignCheckoutViewModelTests.swift
+++ b/Library/ViewModels/PostCampaignCheckoutViewModelTests.swift
@@ -1,0 +1,163 @@
+@testable import KsApi
+@testable import Library
+import Prelude
+import ReactiveExtensions_TestHelpers
+import XCTest
+
+final class PostCampaignCheckoutViewModelTests: XCTestCase {
+  fileprivate let vm = PostCampaignCheckoutViewModel()
+  fileprivate let goToApplePayPaymentAuthorization = TestObserver<
+    PostCampaignPaymentAuthorizationData,
+    Never
+  >()
+
+  override func setUp() {
+    self.vm.goToApplePayPaymentAuthorization.observe(self.goToApplePayPaymentAuthorization.observer)
+  }
+
+  func testApplePayAuthorization_noReward_isCorrect() {
+    let project = Project.cosmicSurgery
+    let reward = Reward.noReward |> Reward.lens.minimum .~ 5
+
+    let data = PostCampaignCheckoutData(
+      project: project,
+      rewards: [reward],
+      selectedQuantities: [:],
+      bonusAmount: 0,
+      total: 5,
+      projectCountry: project.country,
+      omitCurrencyCode: false,
+      shipping: nil,
+      refTag: nil,
+      context: .pledge,
+      checkoutId: "0"
+    )
+
+    self.vm.configure(with: data)
+    self.vm.inputs.applePayButtonTapped()
+
+    self.goToApplePayPaymentAuthorization.assertValueCount(1)
+    let output = self.goToApplePayPaymentAuthorization.lastValue!
+
+    XCTAssertEqual(output.project, project)
+    XCTAssertEqual(output.hasNoReward, true)
+    XCTAssertEqual(output.subtotal, 5)
+    XCTAssertEqual(output.bonus, 0)
+    XCTAssertEqual(output.shipping, 0)
+    XCTAssertEqual(output.total, 5)
+  }
+
+  func testApplePayAuthorization_reward_isCorrect() {
+    let project = Project.cosmicSurgery
+    let reward = project.rewards.first!
+
+    XCTAssertEqual(reward.minimum, 6)
+
+    let data = PostCampaignCheckoutData(
+      project: project,
+      rewards: [reward],
+      selectedQuantities: [reward.id: 3],
+      bonusAmount: 0,
+      total: 18,
+      projectCountry: project.country,
+      omitCurrencyCode: false,
+      shipping: nil,
+      refTag: nil,
+      context: .pledge,
+      checkoutId: "0"
+    )
+
+    self.vm.configure(with: data)
+    self.vm.inputs.applePayButtonTapped()
+
+    self.goToApplePayPaymentAuthorization.assertValueCount(1)
+    let output = self.goToApplePayPaymentAuthorization.lastValue!
+
+    XCTAssertEqual(output.project, project)
+    XCTAssertEqual(output.hasNoReward, false)
+    XCTAssertEqual(output.subtotal, 18)
+    XCTAssertEqual(output.bonus, 0)
+    XCTAssertEqual(output.shipping, 0)
+    XCTAssertEqual(output.total, 18)
+  }
+
+  func testApplePayAuthorization_rewardAndShipping_isCorrect() {
+    let project = Project.cosmicSurgery
+    let reward = project.rewards.first!
+
+    XCTAssertEqual(reward.minimum, 6)
+
+    let data = PostCampaignCheckoutData(
+      project: project,
+      rewards: [reward],
+      selectedQuantities: [reward.id: 3],
+      bonusAmount: 0,
+      total: 90,
+      projectCountry: project.country,
+      omitCurrencyCode: false,
+      shipping: PledgeShippingSummaryViewData(
+        locationName: "Somewhere",
+        omitUSCurrencyCode: false,
+        projectCountry: project.country,
+        total: 72
+      ),
+      refTag: nil,
+      context: .pledge,
+      checkoutId: "0"
+    )
+
+    self.vm.configure(with: data)
+    self.vm.inputs.applePayButtonTapped()
+
+    self.goToApplePayPaymentAuthorization.assertValueCount(1)
+    let output = self.goToApplePayPaymentAuthorization.lastValue!
+
+    XCTAssertEqual(output.project, project)
+    XCTAssertEqual(output.hasNoReward, false)
+    XCTAssertEqual(output.subtotal, 18)
+    XCTAssertEqual(output.bonus, 0)
+    XCTAssertEqual(output.shipping, 72)
+    XCTAssertEqual(output.total, 90)
+  }
+
+  func testApplePayAuthorization_rewardAndShippingAndBonus_isCorrect() {
+    let project = Project.cosmicSurgery
+    let reward1 = project.rewards[0]
+    let reward2 = project.rewards[1]
+
+    XCTAssertEqual(reward1.minimum, 6)
+    XCTAssertEqual(reward2.minimum, 25)
+
+    let data = PostCampaignCheckoutData(
+      project: project,
+      rewards: [reward1, reward2],
+      selectedQuantities: [reward1.id: 1, reward2.id: 2],
+      bonusAmount: 5,
+      total: 133,
+      projectCountry: project.country,
+      omitCurrencyCode: false,
+      shipping: PledgeShippingSummaryViewData(
+        locationName: "Somewhere",
+        omitUSCurrencyCode: false,
+        projectCountry: project.country,
+        total: 72
+      ),
+      refTag: nil,
+      context: .pledge,
+      checkoutId: "0"
+    )
+
+    self.vm.configure(with: data)
+    self.vm.inputs.applePayButtonTapped()
+
+    self.goToApplePayPaymentAuthorization.assertValueCount(1)
+    let output = self.goToApplePayPaymentAuthorization.lastValue!
+
+    XCTAssertEqual(output.project, project)
+    XCTAssertEqual(output.hasNoReward, false)
+    XCTAssertEqual(output.subtotal, 56)
+    XCTAssertEqual(output.bonus, 5)
+    XCTAssertEqual(output.shipping, 72)
+    XCTAssertEqual(output.total, 133)
+  }
+}


### PR DESCRIPTION
# 📲 What

Add ApplePay into post-campaign pledge controller

# 🤔 Why

This is another piece we needed before we can set up the final checkout call - we'll need ApplePay parameters (i.e. the token) to complete the payment.

# 👀 See

Example with a plain pledge:
<img width="200" alt="Screenshot 2024-03-26 at 4 55 46 PM" src="https://github.com/kickstarter/ios-oss/assets/146007185/82161f68-6633-4ab2-bac9-a6362fb355de">
<img width="200" alt="Screenshot 2024-03-26 at 4 55 48 PM" src="https://github.com/kickstarter/ios-oss/assets/146007185/098fd8ee-0b0f-4e51-8fc8-046a6c8effa8">

Example with shipping and a reward:
<img width="200" alt="Screenshot 2024-03-26 at 4 55 19 PM" src="https://github.com/kickstarter/ios-oss/assets/146007185/92d0f299-3fe8-4264-b1ea-af2bcf2e6039">

