### PR TITLE
MBL-1285: Implement CompleteOnSessionCheckoutMutation for new and existing cards

### DIFF
--- a/Kickstarter-iOS/Features/PledgeView/Controllers/PostCampaignCheckoutViewController.swift
+++ b/Kickstarter-iOS/Features/PledgeView/Controllers/PostCampaignCheckoutViewController.swift
@@ -238,6 +238,33 @@ final class PostCampaignCheckoutViewController: UIViewController, MessageBannerV
       .observeValues { [weak self] paymentAuthorizationData in
         self?.goToPaymentAuthorization(paymentAuthorizationData)
       }
+
+    self.viewModel.outputs.checkoutComplete
+      .observeForUI()
+      .observeValues { [weak self] _ in
+        let alert = UIAlertController(
+          title: "Wow!",
+          message: "It worked! Your checkout is done. This should push us to the Thanks page.",
+          preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction.init(title: "OK", style: .cancel))
+        self?.present(alert, animated: true)
+      }
+
+    self.viewModel.outputs.checkoutError
+      .observeForUI()
+      .observeValues { [weak self] error in
+
+        #if DEBUG
+          let serverError = error.errorMessages.first ?? ""
+          let message = "\(Strings.Something_went_wrong_please_try_again())\n\(serverError)"
+        #else
+          let message = Strings.Something_went_wrong_please_try_again()
+        #endif
+
+        self?.messageBannerViewController?
+          .showBanner(with: .error, message: message)
+      }
   }
 
   // MARK: - Functions

--- a/KsApi/models/graphql/adapters/GraphAPI.ApplePay+ApplePayParams.swift
+++ b/KsApi/models/graphql/adapters/GraphAPI.ApplePay+ApplePayParams.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-extension GraphAPI.ApplePayInput {
+public extension GraphAPI.ApplePayInput {
   static func from(_ input: ApplePayParams?) -> GraphAPI.ApplePayInput? {
     guard let input = input else { return nil }
     return GraphAPI.ApplePayInput(

--- a/KsApi/models/graphql/adapters/GraphAPI.ApplePay+ApplePayParams.swift
+++ b/KsApi/models/graphql/adapters/GraphAPI.ApplePay+ApplePayParams.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public extension GraphAPI.ApplePayInput {
+extension GraphAPI.ApplePayInput {
   static func from(_ input: ApplePayParams?) -> GraphAPI.ApplePayInput? {
     guard let input = input else { return nil }
     return GraphAPI.ApplePayInput(


### PR DESCRIPTION
# 📲 What

Implement `CompleteOnSessionCheckoutMutation` for new and existing cards in the late-pledge flow

# 🤔 Why

This is the last mutation call required to actually complete the pledge! 

This PR is _intentionally_ incomplete, to keep the changes a bit more manageable. Follow-up PRs will do the following:

- Implement `CompleteOnSessionCheckoutMutation` for ApplePay
- Route successful transactions to the Thanks page
- Route unsuccessful transactions back to the Select Reward page

# 👀 See
<img width="392" alt="Screenshot 2024-03-28 at 11 05 56 AM" src="https://github.com/kickstarter/ios-oss/assets/146007185/6c781f8f-b1b4-4081-b4ff-fe573a27ed73">

