### PR TITLE
[old] Show processing view while payment is processing

### DIFF
--- a/Kickstarter-iOS/Features/PledgeView/Controllers/PostCampaignCheckoutViewController.swift
+++ b/Kickstarter-iOS/Features/PledgeView/Controllers/PostCampaignCheckoutViewController.swift
@@ -11,7 +11,9 @@ private enum PostCampaignCheckoutLayout {
   }
 }
 
-final class PostCampaignCheckoutViewController: UIViewController, MessageBannerViewControllerPresenting {
+final class PostCampaignCheckoutViewController: UIViewController,
+  MessageBannerViewControllerPresenting,
+  ProcessingViewPresenting {
   // MARK: - Properties
 
   internal var messageBannerViewController: MessageBannerViewController?
@@ -39,6 +41,8 @@ final class PostCampaignCheckoutViewController: UIViewController, MessageBannerV
   private lazy var pledgeRewardsSummaryViewController = {
     PostCampaignPledgeRewardsSummaryViewController.instantiate()
   }()
+
+  internal var processingView: ProcessingView? = ProcessingView(frame: .zero)
 
   private lazy var rootScrollView: UIScrollView = {
     UIScrollView(frame: .zero)
@@ -90,6 +94,7 @@ final class PostCampaignCheckoutViewController: UIViewController, MessageBannerV
   }
 
   deinit {
+    self.hideProcessingView()
     self.sessionStartedObserver.doIfSome(NotificationCenter.default.removeObserver)
   }
 
@@ -187,6 +192,16 @@ final class PostCampaignCheckoutViewController: UIViewController, MessageBannerV
         self?.pledgeCTAContainerView.configureWith(value: value)
       }
 
+    self.viewModel.outputs.processingViewIsHidden
+      .observeForUI()
+      .observeValues { [weak self] isHidden in
+        if isHidden {
+          self?.hideProcessingView()
+        } else {
+          self?.showProcessingView()
+        }
+      }
+
     self.viewModel.outputs.configurePaymentMethodsViewControllerWithValue
       .observeForUI()
       .observeValues { [weak self] value in
@@ -273,6 +288,7 @@ final class PostCampaignCheckoutViewController: UIViewController, MessageBannerV
         guard error == nil, status == .succeeded else {
           self.messageBannerViewController?
             .showBanner(with: .error, message: Strings.Something_went_wrong_please_try_again())
+          self.viewModel.inputs.checkoutTerminated()
           return
         }
 
@@ -285,7 +301,10 @@ final class PostCampaignCheckoutViewController: UIViewController, MessageBannerV
 
     guard
       let paymentAuthorizationViewController = PKPaymentAuthorizationViewController(paymentRequest: request)
-    else { return }
+    else {
+      self.viewModel.inputs.checkoutTerminated()
+      return
+    }
     paymentAuthorizationViewController.delegate = self
 
     self.present(paymentAuthorizationViewController, animated: true)


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Show processing view while payment is processing. This prevents further user interaction until it's dismissed.

Note: It's very important that we make sure that regardless of how checkout goes/where it fails, the processing view will get dismissed. It will lock the app otherwise. The original pledge VC ties the processing view to specific API calls, but we can't do that for post campaign pledges, since we require multiple different API calls to finish the payment flow.

Since the payment flow isn't done yet, the processing view dismisses early (and doesn't show at all for apple pay).

# 👀 See

[Jira](https://kickstarter.atlassian.net/browse/MBL-1307)

| Before 🐛 | After 🦋 |
| --- | --- |
|  |  |

# ✅ Acceptance criteria

- [x] Processing overlay shows when it should and hides again when it should

# ⏰ TODO

- [ ] I might leave this PR open for now and wait to update & submit it until the payment flow is done.
- [ ] Add tests
