### PR TITLE
[MBL-1305] Don't dismiss view controller when payment fails

### DIFF
--- a/Kickstarter-iOS/Features/PledgeView/Controllers/PostCampaignCheckoutViewController.swift
+++ b/Kickstarter-iOS/Features/PledgeView/Controllers/PostCampaignCheckoutViewController.swift
@@ -77,7 +77,6 @@ final class PostCampaignCheckoutViewController: UIViewController, MessageBannerV
     self.title = Strings.Back_this_project()
 
     self.messageBannerViewController = self.configureMessageBannerViewController(on: self)
-    self.messageBannerViewController?.delegate = self
 
     self.configureChildViewControllers()
     self.setupConstraints()
@@ -377,17 +376,6 @@ extension PostCampaignCheckoutViewController: PledgeViewControllerMessageDisplay
 }
 
 // MARK: - MessageBannerViewControllerDelegate
-
-extension PostCampaignCheckoutViewController: MessageBannerViewControllerDelegate {
-  func messageBannerViewDidHide(type: MessageBannerType) {
-    switch type {
-    case .error:
-      self.navigationController?.popViewController(animated: true)
-    default:
-      break
-    }
-  }
-}
 
 extension PostCampaignCheckoutViewController: PKPaymentAuthorizationViewControllerDelegate {
   func paymentAuthorizationViewControllerDidFinish(_ controller: PKPaymentAuthorizationViewController) {


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Instead of dismissing the checkout vc when there's an issue and the "Something went wrong, try again" banner shows, stay in the checkout vc in order to let the user actually try again.

# 👀 See

[Jira](https://kickstarter.atlassian.net/browse/MBL-1305)

| Before 🐛 | After 🦋 |
| --- | --- |
| b | ![Simulator Screen Recording - iPhone 15 Pro Max - 2024-03-28 at 14 21 40](https://github.com/kickstarter/ios-oss/assets/6799207/3a3f3e64-cf25-4d93-a9d3-408df2aea3b9) |

# ✅ Acceptance criteria

- [x] Error banner shows but doesn't dismiss the view controller

