### PR TITLE
Navigate To Thank You Page On Successful Late Pledge

### DIFF
--- a/Kickstarter-iOS/Features/PledgeView/Controllers/PostCampaignCheckoutViewController.swift
+++ b/Kickstarter-iOS/Features/PledgeView/Controllers/PostCampaignCheckoutViewController.swift
@@ -241,14 +241,9 @@ final class PostCampaignCheckoutViewController: UIViewController, MessageBannerV
 
     self.viewModel.outputs.checkoutComplete
       .observeForUI()
-      .observeValues { [weak self] _ in
-        let alert = UIAlertController(
-          title: "Wow!",
-          message: "It worked! Your checkout is done. This should push us to the Thanks page.",
-          preferredStyle: .alert
-        )
-        alert.addAction(UIAlertAction.init(title: "OK", style: .cancel))
-        self?.present(alert, animated: true)
+      .observeValues { [weak self] thanksPageData in
+        let thanksVC = ThanksViewController.configured(with: thanksPageData)
+        self?.navigationController?.pushViewController(thanksVC, animated: true)
       }
 
     self.viewModel.outputs.checkoutError

--- a/Library/ViewModels/PostCampaignCheckoutViewModel.swift
+++ b/Library/ViewModels/PostCampaignCheckoutViewModel.swift
@@ -65,7 +65,7 @@ public protocol PostCampaignCheckoutViewModelOutputs {
   var showWebHelp: Signal<HelpType, Never> { get }
   var validateCheckoutSuccess: Signal<PaymentSourceValidation, Never> { get }
   var goToApplePayPaymentAuthorization: Signal<PostCampaignPaymentAuthorizationData, Never> { get }
-  var checkoutComplete: Signal<(), Never> { get }
+  var checkoutComplete: Signal<ThanksPageData, Never> { get }
   var checkoutError: Signal<ErrorEnvelope, Never> { get }
 }
 
@@ -87,6 +87,7 @@ public class PostCampaignCheckoutViewModel: PostCampaignCheckoutViewModelType,
 
     let context = initialData.map(\.context)
     let checkoutId = initialData.map(\.checkoutId)
+    let baseReward = initialData.map(\.rewards).map(\.first)
 
     let configurePaymentMethodsData = Signal.merge(
       initialData,
@@ -369,7 +370,17 @@ public class PostCampaignCheckoutViewModel: PostCampaignCheckoutViewModelType,
         AppEnvironment.current.apiService.completeOnSessionCheckout(input: input).materialize()
       }
 
-    self.checkoutComplete = checkoutCompleteSignal.signal.values().ignoreValues()
+    let thanksPageData = Signal.combineLatest(initialData, baseReward)
+      .map { initialData, baseReward -> ThanksPageData? in
+        guard let reward = baseReward else { return nil }
+
+        return (initialData.project, reward, nil, initialData.total)
+      }
+
+    self.checkoutComplete = thanksPageData.skipNil()
+      .takeWhen(checkoutCompleteSignal.signal.values())
+      .map { $0 }
+
     self.checkoutError = checkoutCompleteSignal.signal.errors()
   }
 
@@ -477,7 +488,7 @@ public class PostCampaignCheckoutViewModel: PostCampaignCheckoutViewModelType,
   public let showWebHelp: Signal<HelpType, Never>
   public let validateCheckoutSuccess: Signal<PaymentSourceValidation, Never>
   public let goToApplePayPaymentAuthorization: Signal<PostCampaignPaymentAuthorizationData, Never>
-  public let checkoutComplete: Signal<(), Never>
+  public let checkoutComplete: Signal<ThanksPageData, Never>
   public let checkoutError: Signal<ErrorEnvelope, Never>
 
   public var inputs: PostCampaignCheckoutViewModelInputs { return self }


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Navigates To Thank You Page On Successful Late Pledge

# 🤔 Why

So we can formally thank users for their pledge, show them verification, and suggest other projects to them

# 🛠 How

Using data we already have in the PostCampaignCheckoutViewModel, gather the data needed for the Thanks Page.

# 👀 See

I can't remove backings rn and only have 2 accounts that I used to test already so I can't screen record this.

# ✅ Acceptance criteria

- [x] On successful backing, users are navigated to the Thanks Page which displays [the appropriate info ](https://www.figma.com/file/sFfDKxlJ2tiuq1xgIsaoiI/Late-Campaign-Backings?type=design&node-id=54-5016&mode=design&t=oQ3DObf65PfyXZKz-0)
