### PR TITLE
Processing View On PostCampaignCheckoutViewController

### DIFF
--- a/Kickstarter-iOS/Features/PledgeView/Controllers/PostCampaignCheckoutViewController.swift
+++ b/Kickstarter-iOS/Features/PledgeView/Controllers/PostCampaignCheckoutViewController.swift
@@ -11,10 +11,12 @@ private enum PostCampaignCheckoutLayout {
   }
 }
 
-final class PostCampaignCheckoutViewController: UIViewController, MessageBannerViewControllerPresenting {
+final class PostCampaignCheckoutViewController: UIViewController, MessageBannerViewControllerPresenting,
+  ProcessingViewPresenting {
   // MARK: - Properties
 
   internal var messageBannerViewController: MessageBannerViewController?
+  internal var processingView: ProcessingView? = ProcessingView(frame: .zero)
 
   private lazy var titleLabel = UILabel(frame: .zero)
 
@@ -265,6 +267,16 @@ final class PostCampaignCheckoutViewController: UIViewController, MessageBannerV
         self?.messageBannerViewController?
           .showBanner(with: .error, message: message)
       }
+
+    self.viewModel.outputs.processingViewIsHidden
+      .observeForUI()
+      .observeValues { [weak self] isHidden in
+        if isHidden {
+          self?.hideProcessingView()
+        } else {
+          self?.showProcessingView()
+        }
+      }
   }
 
   // MARK: - Functions
@@ -386,6 +398,14 @@ extension PostCampaignCheckoutViewController: PledgePaymentMethodsViewController
         .creditCardSelected(source: paymentSource, paymentMethodId: savedCardId, isNewPaymentMethod: false)
     default:
       break
+    }
+  }
+
+  func pledgePaymentMethodsViewController(_: PledgePaymentMethodsViewController, loading flag: Bool) {
+    if flag {
+      self.showProcessingView()
+    } else {
+      self.hideProcessingView()
     }
   }
 }


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Adds ProcessingViewPresenting conformance to show a loading state when tapping pledge. 

# 🤔 Why

Right now, it looks like nothing happens when tapping pledge. The normal flow uses a "processing" view as a loading state that keeps users from spamming the pledge buttons. 

# 🛠 How

We need the View Controller to conform and react to processing view state changes and ensure that we update said state when making our API calls. 

# ✅ Acceptance criteria

- [x] When tapping pledge, the "Processing" UI is shown until our API calls have completed. 
- [x] When processing, the pledge buttons are not tappable. 
