### PR TITLE
MBL-1285: Integrate ApplePay into Post-Campaign Checkout

### DIFF
--- a/Kickstarter-iOS/Features/PledgeView/Controllers/PostCampaignCheckoutViewController.swift
+++ b/Kickstarter-iOS/Features/PledgeView/Controllers/PostCampaignCheckoutViewController.swift
@@ -16,6 +16,8 @@ final class PostCampaignCheckoutViewController: UIViewController, MessageBannerV
 
   internal var messageBannerViewController: MessageBannerViewController?
 
+  fileprivate var applePayPaymentIntent: String?
+
   private lazy var titleLabel = UILabel(frame: .zero)
 
   private lazy var paymentMethodsViewController = {
@@ -308,13 +310,12 @@ final class PostCampaignCheckoutViewController: UIViewController, MessageBannerV
 
   private func goToPaymentAuthorization(_ paymentAuthorizationData: PostCampaignPaymentAuthorizationData) {
     let request = PKPaymentRequest.paymentRequest(for: paymentAuthorizationData)
+    guard let applePayContext = STPApplePayContext(paymentRequest: request, delegate: self) else {
+      return
+    }
 
-    guard
-      let paymentAuthorizationViewController = PKPaymentAuthorizationViewController(paymentRequest: request)
-    else { return }
-    paymentAuthorizationViewController.delegate = self
-
-    self.present(paymentAuthorizationViewController, animated: true)
+    self.applePayPaymentIntent = paymentAuthorizationData.paymentIntent
+    applePayContext.presentApplePay()
   }
 }
 
@@ -402,38 +403,83 @@ extension PostCampaignCheckoutViewController: PledgeViewControllerMessageDisplay
   }
 }
 
-// MARK: - MessageBannerViewControllerDelegate
+// MARK: - STPApplePayContextDelegate
 
-extension PostCampaignCheckoutViewController: PKPaymentAuthorizationViewControllerDelegate {
-  func paymentAuthorizationViewControllerDidFinish(_ controller: PKPaymentAuthorizationViewController) {
-    controller.dismiss(animated: true, completion: { [weak self] in
-      self?.viewModel.inputs.paymentAuthorizationViewControllerDidFinish()
-    })
-  }
+enum PostCampaignCheckoutApplePayError: Error {
+  case missingToken(String)
+  case missingPaymentMethodInfo(String)
+  case missingPaymentIntent(String)
+}
 
-  func paymentAuthorizationViewController(
-    _: PKPaymentAuthorizationViewController,
-    didAuthorizePayment payment: PKPayment,
-    handler completion: @escaping (PKPaymentAuthorizationResult)
-      -> Void
+extension PostCampaignCheckoutViewController: STPApplePayContextDelegate {
+  func applePayContext(
+    _: StripeApplePay.STPApplePayContext,
+    didCreatePaymentMethod _: StripePayments.STPPaymentMethod,
+    paymentInformation payment: PKPayment,
+    completion: @escaping StripeApplePay.STPIntentClientSecretCompletionBlock
   ) {
-    let paymentDisplayName = payment.token.paymentMethod.displayName
-    let paymentNetworkName = payment.token.paymentMethod.network?.rawValue
+    guard let paymentIntentClientSecret = self.applePayPaymentIntent else {
+      completion(
+        nil,
+        PostCampaignCheckoutApplePayError.missingPaymentIntent("Missing PaymentIntent")
+      )
+      return
+    }
+
+    guard let paymentDisplayName = payment.token.paymentMethod.displayName,
+      let paymentNetworkName = payment.token.paymentMethod.network?.rawValue else {
+      completion(
+        nil,
+        PostCampaignCheckoutApplePayError
+          .missingPaymentMethodInfo("Unable to retrieve payment method information from ApplePay")
+      )
+      return
+    }
+
     let transactionId = payment.token.transactionIdentifier
 
-    self.viewModel.inputs.paymentAuthorizationDidAuthorizePayment(paymentData: (
-      paymentDisplayName,
-      paymentNetworkName,
-      transactionId
-    ))
+    // Tokens considered 'legacy' from Stripe's side, but we still store the token ourselves.
+    STPAPIClient.shared.createToken(with: payment) { [weak self] token, _ in
+      guard let self = self else {
+        return
+      }
 
-    STPAPIClient.shared.createToken(with: payment) { [weak self] token, error in
-      guard let self = self else { return }
+      guard let tokenId = token?.tokenId else {
+        completion(
+          nil,
+          PostCampaignCheckoutApplePayError.missingToken("Unable to retrieve token from Stripe")
+        )
+        return
+      }
 
-      let status = self.viewModel.inputs.stripeTokenCreated(token: token?.tokenId, error: error)
-      let result = PKPaymentAuthorizationResult(status: status, errors: [])
+      let params = ApplePayParams(
+        paymentInstrumentName: paymentDisplayName,
+        paymentNetwork: paymentNetworkName,
+        transactionIdentifier: transactionId,
+        token: tokenId
+      )
 
-      completion(result)
+      self.viewModel.inputs.applePayContextDidCreatePayment(params: params)
+      completion(paymentIntentClientSecret, nil)
+    }
+  }
+
+  func applePayContext(
+    _: StripeApplePay.STPApplePayContext,
+    didCompleteWith status: StripePayments.STPPaymentStatus,
+    error _: Error?
+  ) {
+    switch status {
+    case .success:
+      self.viewModel.inputs.applePayContextDidComplete()
+    case .error:
+      self.messageBannerViewController?
+        .showBanner(with: .error, message: Strings.Something_went_wrong_please_try_again())
+    case .userCancellation:
+      // User canceled the payment
+      break
+    @unknown default:
+      fatalError()
     }
   }
 }

--- a/KsApi/models/graphql/adapters/GraphAPI.ApplePay+ApplePayParams.swift
+++ b/KsApi/models/graphql/adapters/GraphAPI.ApplePay+ApplePayParams.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-extension GraphAPI.ApplePayInput {
+public extension GraphAPI.ApplePayInput {
   static func from(_ input: ApplePayParams?) -> GraphAPI.ApplePayInput? {
     guard let input = input else { return nil }
     return GraphAPI.ApplePayInput(

--- a/Library/PKPaymentRequestHelpersTests.swift
+++ b/Library/PKPaymentRequestHelpersTests.swift
@@ -172,7 +172,6 @@ final class PKPaymentRequestHelpersTests: XCTestCase {
     project.stats.currency = Project.Country.jp.currencyCode
     project.isInPostCampaignPledgingPhase = true
 
-    let reward = Reward.template
     let merchantId = "merchant_id"
 
     let data = PostCampaignPaymentAuthorizationData(
@@ -182,7 +181,8 @@ final class PKPaymentRequestHelpersTests: XCTestCase {
       bonus: 200,
       shipping: 300,
       total: 500,
-      merchantIdentifier: merchantId
+      merchantIdentifier: merchantId,
+      paymentIntent: "foo"
     )
 
     let paymentRequest = PKPaymentRequest.paymentRequest(for: data)
@@ -212,7 +212,6 @@ final class PKPaymentRequestHelpersTests: XCTestCase {
     project.stats.currency = Project.Country.ca.currencyCode
     project.isInPostCampaignPledgingPhase = true
 
-    let reward = Reward.noReward
     let merchantId = "merchant_id"
 
     let data = PostCampaignPaymentAuthorizationData(
@@ -222,7 +221,8 @@ final class PKPaymentRequestHelpersTests: XCTestCase {
       bonus: 0,
       shipping: 0,
       total: 500,
-      merchantIdentifier: merchantId
+      merchantIdentifier: merchantId,
+      paymentIntent: "foo"
     )
 
     let paymentRequest = PKPaymentRequest.paymentRequest(for: data)

--- a/Library/ViewModels/PostCampaignCheckoutViewModel.swift
+++ b/Library/ViewModels/PostCampaignCheckoutViewModel.swift
@@ -25,6 +25,7 @@ public struct PostCampaignPaymentAuthorizationData: Equatable {
   public let shipping: Double
   public let total: Double
   public let merchantIdentifier: String
+  public let paymentIntent: String
 }
 
 public struct PaymentSourceValidation {
@@ -44,11 +45,8 @@ public protocol PostCampaignCheckoutViewModelInputs {
   func userSessionStarted()
   func viewDidLoad()
   func applePayButtonTapped()
-  func paymentAuthorizationDidAuthorizePayment(
-    paymentData: (displayName: String?, network: String?, transactionIdentifier: String)
-  )
-  func paymentAuthorizationViewControllerDidFinish()
-  func stripeTokenCreated(token: String?, error: Error?) -> PKPaymentAuthorizationStatus
+  func applePayContextDidCreatePayment(params: ApplePayParams)
+  func applePayContextDidComplete()
 }
 
 public protocol PostCampaignCheckoutViewModelOutputs {
@@ -281,11 +279,40 @@ public class PostCampaignCheckoutViewModel: PostCampaignCheckoutViewModelType,
 
     // MARK: ApplePay
 
-    let paymentAuthorizationData: Signal<PostCampaignPaymentAuthorizationData, Never> = self
+    /*
+
+     Order of operations:
+     1) Apple pay button tapped
+     2) Generate a new payment intent
+     3) Present the payment authorization form
+     4) Payment authorization form calls applePayContextDidCreatePayment with ApplePay params
+     5) Payment authorization form calls paymentAuthorizationDidFinish
+     */
+
+    let newPaymentIntentForApplePay: Signal<String, Never> = self.configureWithDataProperty.signal
+      .skipNil()
+      .takeWhen(self.applePayButtonTappedSignal)
+      .switchMap { initialData in
+        let projectId = initialData.project.graphID
+        let pledgeTotal = initialData.total
+
+        return AppEnvironment.current.apiService
+          .createPaymentIntentInput(input: CreatePaymentIntentInput(
+            projectId: projectId,
+            amountDollars: String(format: "%.2f", pledgeTotal),
+            digitalMarketingAttributed: nil
+          ))
+          .materialize()
+      }
+      .values()
+      .map { $0.clientSecret }
+
+    self.goToApplePayPaymentAuthorization = self
       .configureWithDataProperty
       .signal
       .skipNil()
-      .map { (data: PostCampaignCheckoutData) -> PostCampaignPaymentAuthorizationData? in
+      .combineLatest(with: newPaymentIntentForApplePay)
+      .map { (data: PostCampaignCheckoutData, paymentIntent: String) -> PostCampaignPaymentAuthorizationData? in
         guard let firstReward = data.rewards.first else {
           // There should always be a reward - we create a special "no reward" reward if you make a monetary pledge
           return nil
@@ -301,41 +328,11 @@ public class PostCampaignCheckoutViewModel: PostCampaignCheckoutViewModelType,
           bonus: data.bonusAmount ?? 0,
           shipping: data.shipping?.total ?? 0,
           total: data.total,
-          merchantIdentifier: Secrets.ApplePay.merchantIdentifier
+          merchantIdentifier: Secrets.ApplePay.merchantIdentifier,
+          paymentIntent: paymentIntent
         )
       }
       .skipNil()
-
-    self.goToApplePayPaymentAuthorization = paymentAuthorizationData
-      .takeWhen(self.applePayButtonTappedSignal)
-
-    let pkPaymentData = self.pkPaymentSignal
-      .map { pkPayment -> PKPaymentData? in
-        guard let displayName = pkPayment.displayName, let network = pkPayment.network else {
-          return nil
-        }
-
-        return (displayName, network, pkPayment.transactionIdentifier)
-      }
-
-    let applePayParams = Signal.combineLatest(
-      pkPaymentData.skipNil(),
-      self.stripeTokenSignal.skipNil()
-    )
-    .map { paymentData, token in
-      (
-        paymentData.displayName,
-        paymentData.network,
-        paymentData.transactionIdentifier,
-        token
-      )
-    }
-    .map(ApplePayParams.init)
-
-    // TODO: Real implementation
-    applePayParams.observeValues { params in
-      print("Got ApplePay params: \(params)")
-    }
 
     // MARK: CompleteOnSessionCheckout
 
@@ -357,13 +354,25 @@ public class PostCampaignCheckoutViewModel: PostCampaignCheckoutViewModelType,
         )
       }
 
-    // TODO: Implement ApplePay
-    // let completeCheckoutWithApplePay =
+    let completeCheckoutWithApplePayInput: Signal<GraphAPI.CompleteOnSessionCheckoutInput, Never> = Signal
+      .combineLatest(newPaymentIntentForApplePay, checkoutId, self.applePayParamsSignal)
+      .takeWhen(self.applePayContextDidCompleteSignal)
+      .map {
+        (clientSecret: String, checkoutId: String, applePayParams: ApplePayParams) -> GraphAPI.CompleteOnSessionCheckoutInput in
+        GraphAPI
+          .CompleteOnSessionCheckoutInput(
+            checkoutId: encodeToBase64("Checkout-\(checkoutId)"),
+            paymentIntentClientSecret: clientSecret,
+            paymentSourceId: nil,
+            paymentSourceReusable: false,
+            applePay: GraphAPI.ApplePayInput.from(applePayParams)
+          )
+      }
 
     let checkoutCompleteSignal = Signal
       .merge(
-        completeCheckoutWithCreditCardInput
-        // completeCheckoutWithApplePayInput
+        completeCheckoutWithCreditCardInput,
+        completeCheckoutWithApplePayInput
       )
       .switchMap { input in
         AppEnvironment.current.apiService.completeOnSessionCheckout(input: input).materialize()
@@ -431,34 +440,15 @@ public class PostCampaignCheckoutViewModel: PostCampaignCheckoutViewModelType,
     self.applePayButtonTappedObserver.send(value: ())
   }
 
-  private let (pkPaymentSignal, pkPaymentObserver) = Signal<(
-    displayName: String?,
-    network: String?,
-    transactionIdentifier: String
-  ), Never>.pipe()
-  public func paymentAuthorizationDidAuthorizePayment(paymentData: (
-    displayName: String?,
-    network: String?,
-    transactionIdentifier: String
-  )) {
-    self.pkPaymentObserver.send(value: paymentData)
+  private let (applePayParamsSignal, applePayParamsObserver) = Signal<ApplePayParams, Never>.pipe()
+  public func applePayContextDidCreatePayment(params: ApplePayParams) {
+    self.applePayParamsObserver.send(value: params)
   }
 
-  private let (paymentAuthorizationDidFinishSignal, paymentAuthorizationDidFinishObserver)
+  private let (applePayContextDidCompleteSignal, applePayContextDidCompleteObserver)
     = Signal<Void, Never>.pipe()
-  public func paymentAuthorizationViewControllerDidFinish() {
-    self.paymentAuthorizationDidFinishObserver.send(value: ())
-  }
-
-  private let (stripeTokenSignal, stripeTokenObserver) = Signal<String?, Never>.pipe()
-  private let (stripeErrorSignal, stripeErrorObserver) = Signal<Error?, Never>.pipe()
-  private let createApplePayBackingStatusProperty = MutableProperty<PKPaymentAuthorizationStatus>(.failure)
-
-  public func stripeTokenCreated(token: String?, error: Error?) -> PKPaymentAuthorizationStatus {
-    self.stripeTokenObserver.send(value: token)
-    self.stripeErrorObserver.send(value: error)
-
-    return self.createApplePayBackingStatusProperty.value
+  public func applePayContextDidComplete() {
+    self.applePayContextDidCompleteObserver.send(value: ())
   }
 
   // MARK: - Outputs

--- a/Library/ViewModels/PostCampaignCheckoutViewModelTests.swift
+++ b/Library/ViewModels/PostCampaignCheckoutViewModelTests.swift
@@ -11,7 +11,7 @@ final class PostCampaignCheckoutViewModelTests: XCTestCase {
     PostCampaignPaymentAuthorizationData,
     Never
   >()
-  fileprivate let checkoutComplete = TestObserver<(), Never>()
+  fileprivate let checkoutComplete = TestObserver<ThanksPageData, Never>()
 
   override func setUp() {
     super.setUp()

--- a/Library/ViewModels/PostCampaignCheckoutViewModelTests.swift
+++ b/Library/ViewModels/PostCampaignCheckoutViewModelTests.swift
@@ -1,3 +1,4 @@
+import Apollo
 @testable import KsApi
 @testable import Library
 import Prelude
@@ -10,9 +11,12 @@ final class PostCampaignCheckoutViewModelTests: XCTestCase {
     PostCampaignPaymentAuthorizationData,
     Never
   >()
+  fileprivate let checkoutComplete = TestObserver<(), Never>()
 
   override func setUp() {
+    super.setUp()
     self.vm.goToApplePayPaymentAuthorization.observe(self.goToApplePayPaymentAuthorization.observer)
+    self.vm.checkoutComplete.observe(self.checkoutComplete.observer)
   }
 
   func testApplePayAuthorization_noReward_isCorrect() {
@@ -31,18 +35,24 @@ final class PostCampaignCheckoutViewModelTests: XCTestCase {
       checkoutId: "0"
     )
 
-    self.vm.configure(with: data)
-    self.vm.inputs.applePayButtonTapped()
+    let paymentIntent = PaymentIntentEnvelope(clientSecret: "foo")
+    let mockService = MockService(createPaymentIntentResult: .success(paymentIntent))
 
-    self.goToApplePayPaymentAuthorization.assertValueCount(1)
-    let output = self.goToApplePayPaymentAuthorization.lastValue!
+    withEnvironment(apiService: mockService) {
+      self.vm.inputs.configure(with: data)
+      self.vm.inputs.viewDidLoad()
+      self.vm.inputs.applePayButtonTapped()
 
-    XCTAssertEqual(output.project, project)
-    XCTAssertEqual(output.hasNoReward, true)
-    XCTAssertEqual(output.subtotal, 5)
-    XCTAssertEqual(output.bonus, 0)
-    XCTAssertEqual(output.shipping, 0)
-    XCTAssertEqual(output.total, 5)
+      self.goToApplePayPaymentAuthorization.assertValueCount(1)
+      let output = self.goToApplePayPaymentAuthorization.lastValue!
+
+      XCTAssertEqual(output.project, project)
+      XCTAssertEqual(output.hasNoReward, true)
+      XCTAssertEqual(output.subtotal, 5)
+      XCTAssertEqual(output.bonus, 0)
+      XCTAssertEqual(output.shipping, 0)
+      XCTAssertEqual(output.total, 5)
+    }
   }
 
   func testApplePayAuthorization_reward_isCorrect() {
@@ -63,18 +73,25 @@ final class PostCampaignCheckoutViewModelTests: XCTestCase {
       checkoutId: "0"
     )
 
-    self.vm.configure(with: data)
-    self.vm.inputs.applePayButtonTapped()
+    let paymentIntent = PaymentIntentEnvelope(clientSecret: "foo")
+    let mockService = MockService(createPaymentIntentResult: .success(paymentIntent))
 
-    self.goToApplePayPaymentAuthorization.assertValueCount(1)
-    let output = self.goToApplePayPaymentAuthorization.lastValue!
+    withEnvironment(apiService: mockService) {
+      self.vm.inputs.configure(with: data)
+      self.vm.inputs.viewDidLoad()
 
-    XCTAssertEqual(output.project, project)
-    XCTAssertEqual(output.hasNoReward, false)
-    XCTAssertEqual(output.subtotal, 18)
-    XCTAssertEqual(output.bonus, 0)
-    XCTAssertEqual(output.shipping, 0)
-    XCTAssertEqual(output.total, 18)
+      self.vm.inputs.applePayButtonTapped()
+
+      self.goToApplePayPaymentAuthorization.assertValueCount(1)
+      let output = self.goToApplePayPaymentAuthorization.lastValue!
+
+      XCTAssertEqual(output.project, project)
+      XCTAssertEqual(output.hasNoReward, false)
+      XCTAssertEqual(output.subtotal, 18)
+      XCTAssertEqual(output.bonus, 0)
+      XCTAssertEqual(output.shipping, 0)
+      XCTAssertEqual(output.total, 18)
+    }
   }
 
   func testApplePayAuthorization_rewardAndShipping_isCorrect() {
@@ -100,18 +117,25 @@ final class PostCampaignCheckoutViewModelTests: XCTestCase {
       checkoutId: "0"
     )
 
-    self.vm.configure(with: data)
-    self.vm.inputs.applePayButtonTapped()
+    let paymentIntent = PaymentIntentEnvelope(clientSecret: "foo")
+    let mockService = MockService(createPaymentIntentResult: .success(paymentIntent))
 
-    self.goToApplePayPaymentAuthorization.assertValueCount(1)
-    let output = self.goToApplePayPaymentAuthorization.lastValue!
+    withEnvironment(apiService: mockService) {
+      self.vm.inputs.configure(with: data)
+      self.vm.inputs.viewDidLoad()
 
-    XCTAssertEqual(output.project, project)
-    XCTAssertEqual(output.hasNoReward, false)
-    XCTAssertEqual(output.subtotal, 18)
-    XCTAssertEqual(output.bonus, 0)
-    XCTAssertEqual(output.shipping, 72)
-    XCTAssertEqual(output.total, 90)
+      self.vm.inputs.applePayButtonTapped()
+
+      self.goToApplePayPaymentAuthorization.assertValueCount(1)
+      let output = self.goToApplePayPaymentAuthorization.lastValue!
+
+      XCTAssertEqual(output.project, project)
+      XCTAssertEqual(output.hasNoReward, false)
+      XCTAssertEqual(output.subtotal, 18)
+      XCTAssertEqual(output.bonus, 0)
+      XCTAssertEqual(output.shipping, 72)
+      XCTAssertEqual(output.total, 90)
+    }
   }
 
   func testApplePayAuthorization_rewardAndShippingAndBonus_isCorrect() {
@@ -139,17 +163,123 @@ final class PostCampaignCheckoutViewModelTests: XCTestCase {
       checkoutId: "0"
     )
 
-    self.vm.configure(with: data)
-    self.vm.inputs.applePayButtonTapped()
+    let paymentIntent = PaymentIntentEnvelope(clientSecret: "foo")
+    let mockService = MockService(createPaymentIntentResult: .success(paymentIntent))
 
-    self.goToApplePayPaymentAuthorization.assertValueCount(1)
-    let output = self.goToApplePayPaymentAuthorization.lastValue!
+    withEnvironment(apiService: mockService) {
+      self.vm.inputs.configure(with: data)
+      self.vm.inputs.viewDidLoad()
 
-    XCTAssertEqual(output.project, project)
-    XCTAssertEqual(output.hasNoReward, false)
-    XCTAssertEqual(output.subtotal, 56)
-    XCTAssertEqual(output.bonus, 5)
-    XCTAssertEqual(output.shipping, 72)
-    XCTAssertEqual(output.total, 133)
+      self.vm.inputs.applePayButtonTapped()
+
+      self.goToApplePayPaymentAuthorization.assertValueCount(1)
+      let output = self.goToApplePayPaymentAuthorization.lastValue!
+
+      XCTAssertEqual(output.project, project)
+      XCTAssertEqual(output.hasNoReward, false)
+      XCTAssertEqual(output.subtotal, 56)
+      XCTAssertEqual(output.bonus, 5)
+      XCTAssertEqual(output.shipping, 72)
+      XCTAssertEqual(output.total, 133)
+    }
+  }
+
+  func testTapApplePayButton_createsPaymentIntent_beforePresentingAuthorizationController() {
+    let paymentIntent = PaymentIntentEnvelope(clientSecret: "foo")
+    let mockService = MockService(createPaymentIntentResult: .success(paymentIntent))
+
+    let project = Project.cosmicSurgery
+    let reward = Reward.noReward |> Reward.lens.minimum .~ 5
+
+    let data = PostCampaignCheckoutData(
+      project: project,
+      rewards: [reward],
+      selectedQuantities: [:],
+      bonusAmount: 0,
+      total: 5,
+      shipping: nil,
+      refTag: nil,
+      context: .pledge,
+      checkoutId: "0"
+    )
+
+    withEnvironment(apiService: mockService) {
+      self.vm.inputs.configure(with: data)
+      self.vm.inputs.viewDidLoad()
+      self.vm.inputs.applePayButtonTapped()
+      self.goToApplePayPaymentAuthorization.assertDidEmitValue()
+
+      let output = self.goToApplePayPaymentAuthorization.lastValue!
+      XCTAssertEqual(output.paymentIntent, "foo")
+    }
+  }
+
+  func testApplePay_completesCheckoutFlow() {
+    // Mock data for API requests
+    let paymentIntent = PaymentIntentEnvelope(clientSecret: "foo")
+    let completeSessionJsonString = """
+    {
+      "completeOnSessionCheckout": {
+        "__typename": "CompleteOnSessionCheckoutPayload",
+        "checkout": {
+          "__typename": "Checkout",
+          "id": "Q2hlY2tvdXQtMTk4MzM2OTIz",
+          "state": "successful",
+          "backing": {
+            "requiresAction": false,
+            "clientSecret": "super-secret",
+            "__typename": "Backing"
+          }
+        }
+      }
+    }
+    """
+    let completeSessionJson = try! JSONSerialization
+      .jsonObject(with: completeSessionJsonString.data(using: .utf8)!)
+    let completeSessionData = try! GraphAPI.CompleteOnSessionCheckoutMutation
+      .Data(jsonObject: completeSessionJson as! JSONObject)
+    let mockService = MockService(
+      completeOnSessionCheckoutResult: .success(completeSessionData),
+      createPaymentIntentResult: .success(paymentIntent)
+    )
+
+    let project = Project.cosmicSurgery
+    let reward = Reward.noReward |> Reward.lens.minimum .~ 5
+
+    let data = PostCampaignCheckoutData(
+      project: project,
+      rewards: [reward],
+      selectedQuantities: [:],
+      bonusAmount: 0,
+      total: 5,
+      shipping: nil,
+      refTag: nil,
+      context: .pledge,
+      checkoutId: "0"
+    )
+
+    withEnvironment(apiService: mockService) {
+      self.vm.configure(with: data)
+      self.vm.viewDidLoad()
+
+      self.vm.inputs.applePayButtonTapped()
+
+      self.goToApplePayPaymentAuthorization.assertDidEmitValue()
+
+      let params = ApplePayParams(
+        paymentInstrumentName: "Fake Instrument",
+        paymentNetwork: "Fake Payment Network",
+        transactionIdentifier: "Fake transaction identifier",
+        token: "tok_abc123def"
+      )
+
+      self.vm.inputs.applePayContextDidCreatePayment(params: params)
+
+      self.checkoutComplete.assertDidNotEmitValue()
+
+      self.vm.inputs.applePayContextDidComplete()
+
+      self.checkoutComplete.assertDidEmitValue()
+    }
   }
 }


### PR DESCRIPTION
# 📲 What

MBL-1285: Integrate ApplePay into Post-Campaign Checkout, using `STPApplePayContext`.

# 🤔 Why

This is the last remaining piece to complete the "happy path" for late-pledge payments.

# 🛠 How

I chose to swap from directly using `PKPaymentAuthorizationViewController` to `STPApplePayContext`, which is a Stripe wrapper around `PKPaymentAuthorizationViewController`. The advantage of `STPApplePayContext` is that it handles creating the payment method, associating it with the payment intent, _and_ confirming the payment, saving us from making extra calls to Stripe and adding extra complexity to our view model. See [their documentation here](https://docs.stripe.com/apple-pay).