### PR TITLE
[MBL-1305] Revert banner changes

### DIFF
--- a/Kickstarter-iOS/Features/PledgeView/Controllers/PostCampaignCheckoutViewController.swift
+++ b/Kickstarter-iOS/Features/PledgeView/Controllers/PostCampaignCheckoutViewController.swift
@@ -404,6 +404,8 @@ extension PostCampaignCheckoutViewController: MessageBannerViewControllerDelegat
   func messageBannerViewDidHide(type: MessageBannerType) {
     switch type {
     case .error:
+      // Pop view controller in order to start checkout flow from the beginning,
+      // starting with generating a new checkout id.
       self.navigationController?.popViewController(animated: true)
     default:
       break

--- a/Kickstarter-iOS/Features/PledgeView/Controllers/PostCampaignCheckoutViewController.swift
+++ b/Kickstarter-iOS/Features/PledgeView/Controllers/PostCampaignCheckoutViewController.swift
@@ -77,6 +77,7 @@ final class PostCampaignCheckoutViewController: UIViewController, MessageBannerV
     self.title = Strings.Back_this_project()
 
     self.messageBannerViewController = self.configureMessageBannerViewController(on: self)
+    self.messageBannerViewController?.delegate = self
 
     self.configureChildViewControllers()
     self.setupConstraints()
@@ -398,6 +399,17 @@ extension PostCampaignCheckoutViewController: PledgeViewControllerMessageDisplay
 }
 
 // MARK: - MessageBannerViewControllerDelegate
+
+extension PostCampaignCheckoutViewController: MessageBannerViewControllerDelegate {
+  func messageBannerViewDidHide(type: MessageBannerType) {
+    switch type {
+    case .error:
+      self.navigationController?.popViewController(animated: true)
+    default:
+      break
+    }
+  }
+}
 
 extension PostCampaignCheckoutViewController: PKPaymentAuthorizationViewControllerDelegate {
   func paymentAuthorizationViewControllerDidFinish(_ controller: PKPaymentAuthorizationViewController) {


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Revert banner changes as we want to start the checkout flow over from the beginning if checkout goes wrong, and the confirm checkout VC is designed to create the checkout id.

Hopefully we'll restructure this for a better user experience in the future, but for now, this was the flow that eng across platforms decided on.

# 👀 See

[Jira](https://kickstarter.atlassian.net/browse/MBL-1305)
