### PR TITLE
MBL-1316: Use isAvailable to filter visible add-ons

### DIFF
--- a/Kickstarter-iOS/Features/RewardAddOnSelection/Controller/RewardAddOnSelectionViewControllerTests.swift
+++ b/Kickstarter-iOS/Features/RewardAddOnSelection/Controller/RewardAddOnSelectionViewControllerTests.swift
@@ -24,11 +24,13 @@ final class RewardAddOnSelectionViewControllerTests: TestCase {
     let reward = Reward.template
       |> Reward.lens.shipping.enabled .~ false
       |> Reward.lens.localPickup .~ nil
+      |> Reward.lens.isAvailable .~ true
 
     let noShippingAddOn = Reward.template
       |> Reward.lens.shipping.enabled .~ false
       |> Reward.lens.shipping.preference .~ Reward.Shipping.Preference.none
       |> Reward.lens.localPickup .~ nil
+      |> Reward.lens.isAvailable .~ true
 
     let project = Project.template
       |> Project.lens.rewardData.rewards .~ [reward]
@@ -77,12 +79,14 @@ final class RewardAddOnSelectionViewControllerTests: TestCase {
       |> Reward.lens.shipping.enabled .~ true
       |> Reward.lens.shipping.preference .~ .unrestricted
       |> Reward.lens.localPickup .~ nil
+      |> Reward.lens.isAvailable .~ true
 
     let shippingAddOn = Reward.template
       |> Reward.lens.shipping.enabled .~ true
       |> Reward.lens.shipping.preference .~ .unrestricted
       |> Reward.lens.shippingRulesExpanded .~ shippingRules
       |> Reward.lens.localPickup .~ nil
+      |> Reward.lens.isAvailable .~ true
 
     let project = Project.template
       |> Project.lens.rewardData.rewards .~ [reward]
@@ -145,6 +149,7 @@ final class RewardAddOnSelectionViewControllerTests: TestCase {
       |> Reward.lens.id .~ 99
       |> Reward.lens.shippingRules .~ [shippingRule]
       |> Reward.lens.localPickup .~ nil
+      |> Reward.lens.isAvailable .~ true
 
     let shippingAddOn1 = Reward.template
       |> Reward.lens.id .~ 2
@@ -153,6 +158,7 @@ final class RewardAddOnSelectionViewControllerTests: TestCase {
         shippingRule |> ShippingRule.lens.location .~ (.template |> Location.lens.id .~ 99)
       ]
       |> Reward.lens.localPickup .~ nil
+      |> Reward.lens.isAvailable .~ true
 
     let shippingAddOn2 = Reward.template
       |> Reward.lens.id .~ 3
@@ -161,6 +167,7 @@ final class RewardAddOnSelectionViewControllerTests: TestCase {
         shippingRule |> ShippingRule.lens.location .~ (.template |> Location.lens.id .~ 99)
       ]
       |> Reward.lens.localPickup .~ nil
+      |> Reward.lens.isAvailable .~ true
 
     let shippingAddOn3 = Reward.template
       |> Reward.lens.id .~ 4
@@ -169,6 +176,7 @@ final class RewardAddOnSelectionViewControllerTests: TestCase {
         shippingRule |> ShippingRule.lens.location .~ (.template |> Location.lens.id .~ 3)
       ]
       |> Reward.lens.localPickup .~ nil
+      |> Reward.lens.isAvailable .~ true
 
     let shippingAddOn4 = Reward.template
       |> Reward.lens.id .~ 5
@@ -177,6 +185,7 @@ final class RewardAddOnSelectionViewControllerTests: TestCase {
         shippingRule |> ShippingRule.lens.location .~ (.template |> Location.lens.id .~ 3)
       ]
       |> Reward.lens.localPickup .~ nil
+      |> Reward.lens.isAvailable .~ true
 
     let project = Project.template
       |> Project.lens.rewardData.rewards .~ [reward]
@@ -265,11 +274,13 @@ final class RewardAddOnSelectionViewControllerTests: TestCase {
       |> Reward.lens.shipping.enabled .~ false
       |> Reward.lens.localPickup .~ .australia
       |> Reward.lens.shipping.preference .~ .local
+      |> Reward.lens.isAvailable .~ true
 
     let noShippingAddOn = Reward.template
       |> Reward.lens.shipping.enabled .~ false
       |> Reward.lens.shipping.preference .~ .local
       |> Reward.lens.localPickup .~ .australia
+      |> Reward.lens.isAvailable .~ true
 
     let project = Project.template
       |> Project.lens.rewardData.rewards .~ [reward]

--- a/KsApi/GraphAPI.swift
+++ b/KsApi/GraphAPI.swift
@@ -15520,6 +15520,7 @@ public enum GraphAPI {
         estimatedDeliveryOn
         id
         isMaxPledge
+        available
         items {
           __typename
           edges {
@@ -15570,6 +15571,7 @@ public enum GraphAPI {
         GraphQLField("estimatedDeliveryOn", type: .scalar(String.self)),
         GraphQLField("id", type: .nonNull(.scalar(GraphQLID.self))),
         GraphQLField("isMaxPledge", type: .nonNull(.scalar(Bool.self))),
+        GraphQLField("available", type: .nonNull(.scalar(Bool.self))),
         GraphQLField("items", type: .object(Item.selections)),
         GraphQLField("limit", type: .scalar(Int.self)),
         GraphQLField("limitPerBacker", type: .scalar(Int.self)),
@@ -15595,8 +15597,8 @@ public enum GraphAPI {
       self.resultMap = unsafeResultMap
     }
 
-    public init(amount: Amount, backersCount: Int? = nil, convertedAmount: ConvertedAmount, allowedAddons: AllowedAddon, description: String, displayName: String, endsAt: String? = nil, estimatedDeliveryOn: String? = nil, id: GraphQLID, isMaxPledge: Bool, items: Item? = nil, limit: Int? = nil, limitPerBacker: Int? = nil, localReceiptLocation: LocalReceiptLocation? = nil, name: String? = nil, postCampaignPledgingEnabled: Bool, project: Project? = nil, remainingQuantity: Int? = nil, shippingPreference: ShippingPreference? = nil, shippingSummary: String? = nil, shippingRules: [ShippingRule?]? = nil, startsAt: String? = nil) {
-      self.init(unsafeResultMap: ["__typename": "Reward", "amount": amount.resultMap, "backersCount": backersCount, "convertedAmount": convertedAmount.resultMap, "allowedAddons": allowedAddons.resultMap, "description": description, "displayName": displayName, "endsAt": endsAt, "estimatedDeliveryOn": estimatedDeliveryOn, "id": id, "isMaxPledge": isMaxPledge, "items": items.flatMap { (value: Item) -> ResultMap in value.resultMap }, "limit": limit, "limitPerBacker": limitPerBacker, "localReceiptLocation": localReceiptLocation.flatMap { (value: LocalReceiptLocation) -> ResultMap in value.resultMap }, "name": name, "postCampaignPledgingEnabled": postCampaignPledgingEnabled, "project": project.flatMap { (value: Project) -> ResultMap in value.resultMap }, "remainingQuantity": remainingQuantity, "shippingPreference": shippingPreference, "shippingSummary": shippingSummary, "shippingRules": shippingRules.flatMap { (value: [ShippingRule?]) -> [ResultMap?] in value.map { (value: ShippingRule?) -> ResultMap? in value.flatMap { (value: ShippingRule) -> ResultMap in value.resultMap } } }, "startsAt": startsAt])
+    public init(amount: Amount, backersCount: Int? = nil, convertedAmount: ConvertedAmount, allowedAddons: AllowedAddon, description: String, displayName: String, endsAt: String? = nil, estimatedDeliveryOn: String? = nil, id: GraphQLID, isMaxPledge: Bool, available: Bool, items: Item? = nil, limit: Int? = nil, limitPerBacker: Int? = nil, localReceiptLocation: LocalReceiptLocation? = nil, name: String? = nil, postCampaignPledgingEnabled: Bool, project: Project? = nil, remainingQuantity: Int? = nil, shippingPreference: ShippingPreference? = nil, shippingSummary: String? = nil, shippingRules: [ShippingRule?]? = nil, startsAt: String? = nil) {
+      self.init(unsafeResultMap: ["__typename": "Reward", "amount": amount.resultMap, "backersCount": backersCount, "convertedAmount": convertedAmount.resultMap, "allowedAddons": allowedAddons.resultMap, "description": description, "displayName": displayName, "endsAt": endsAt, "estimatedDeliveryOn": estimatedDeliveryOn, "id": id, "isMaxPledge": isMaxPledge, "available": available, "items": items.flatMap { (value: Item) -> ResultMap in value.resultMap }, "limit": limit, "limitPerBacker": limitPerBacker, "localReceiptLocation": localReceiptLocation.flatMap { (value: LocalReceiptLocation) -> ResultMap in value.resultMap }, "name": name, "postCampaignPledgingEnabled": postCampaignPledgingEnabled, "project": project.flatMap { (value: Project) -> ResultMap in value.resultMap }, "remainingQuantity": remainingQuantity, "shippingPreference": shippingPreference, "shippingSummary": shippingSummary, "shippingRules": shippingRules.flatMap { (value: [ShippingRule?]) -> [ResultMap?] in value.map { (value: ShippingRule?) -> ResultMap? in value.flatMap { (value: ShippingRule) -> ResultMap in value.resultMap } } }, "startsAt": startsAt])
     }
 
     public var __typename: String {
@@ -15706,6 +15708,16 @@ public enum GraphAPI {
       }
       set {
         resultMap.updateValue(newValue, forKey: "isMaxPledge")
+      }
+    }
+
+    /// Whether or not the reward is available for new pledges
+    public var available: Bool {
+      get {
+        return resultMap["available"]! as! Bool
+      }
+      set {
+        resultMap.updateValue(newValue, forKey: "available")
       }
     }
 

--- a/KsApi/fragments/RewardFragment.graphql
+++ b/KsApi/fragments/RewardFragment.graphql
@@ -17,6 +17,7 @@ fragment RewardFragment on Reward {
   estimatedDeliveryOn
   id
   isMaxPledge
+  available
   items {
     edges {
       quantity

--- a/KsApi/models/Reward.swift
+++ b/KsApi/models/Reward.swift
@@ -21,6 +21,8 @@ public struct Reward {
   public let startsAt: TimeInterval?
   public let title: String?
   public let localPickup: Location?
+  /// isAvailable is provided by GraphQL but not by API V1.
+  public let isAvailable: Bool?
 
   /// Returns `true` is this is the "fake" "No reward" reward.
   public var isNoReward: Bool {
@@ -147,6 +149,7 @@ extension Reward: Decodable {
     self.title = try values.decodeIfPresent(String.self, forKey: .title)
     // NOTE: `v1` is deprecated and doesn't contain any location pickup information.
     self.localPickup = nil
+    self.isAvailable = nil
   }
 }
 

--- a/KsApi/models/graphql/adapters/Backing+BackingFragmentTests.swift
+++ b/KsApi/models/graphql/adapters/Backing+BackingFragmentTests.swift
@@ -35,6 +35,7 @@ final class Backing_BackingFragmentTests: XCTestCase {
       XCTAssertEqual(backing.projectId, 1_596_594_463)
       XCTAssertNotNil(backing.reward)
       XCTAssertEqual(backing.rewardId, decompose(id: "UmV3YXJkLTgxNzM5MDE="))
+      XCTAssertNotNil(backing.reward?.isAvailable)
       XCTAssertEqual(backing.sequence, 148)
       XCTAssertEqual(backing.shippingAmount, 10.0)
       XCTAssertEqual(backing.status, .pledged)
@@ -793,6 +794,7 @@ private func backingDictionary() -> [String: Any] {
       "estimatedDeliveryOn": "2021-12-01",
       "id": "UmV3YXJkLTgxNzM5MDE=",
       "isMaxPledge": false,
+            "available": false,
       "items": {
         "__typename": "RewardItemsConnection",
         "edges": [

--- a/KsApi/models/graphql/adapters/Reward+RewardFragment.swift
+++ b/KsApi/models/graphql/adapters/Reward+RewardFragment.swift
@@ -54,7 +54,8 @@ extension Reward {
       shippingRulesExpanded: expandedShippingRules,
       startsAt: rewardFragment.startsAt.flatMap(TimeInterval.init),
       title: rewardFragment.name,
-      localPickup: location
+      localPickup: location,
+      isAvailable: rewardFragment.available
     )
   }
 }

--- a/KsApi/models/graphql/adapters/Reward+RewardFragmentTests.swift
+++ b/KsApi/models/graphql/adapters/Reward+RewardFragmentTests.swift
@@ -44,6 +44,7 @@ final class Reward_RewardFragmentTests: XCTestCase {
       XCTAssertEqual(v1Reward.rewardsItems[1].item.id, 1_170_813)
       XCTAssertEqual(v1Reward.rewardsItems[1].item.name, "Custom Bookmark")
       XCTAssertEqual(v1Reward.rewardsItems[1].quantity, 1)
+      XCTAssertNotNil(v1Reward.isAvailable)
 
       XCTAssertEqual(v1Reward.shipping.enabled, true)
       XCTAssertEqual(v1Reward.shipping.preference, .unrestricted)
@@ -98,6 +99,7 @@ private func rewardDictionary() -> [String: Any] {
     "estimatedDeliveryOn": "2021-12-01",
     "id": "UmV3YXJkLTgxNzM5MDE=",
     "isMaxPledge": false,
+    "available": false,
     "items": {
       "__typename": "RewardItemsConnection",
       "edges": [

--- a/KsApi/models/lenses/RewardLenses.swift
+++ b/KsApi/models/lenses/RewardLenses.swift
@@ -24,7 +24,8 @@ extension Reward {
         shippingRulesExpanded: $1.shippingRulesExpanded,
         startsAt: $1.startsAt,
         title: $1.title,
-        localPickup: $1.localPickup
+        localPickup: $1.localPickup,
+        isAvailable: nil
       ) }
     )
 
@@ -49,7 +50,8 @@ extension Reward {
         shippingRulesExpanded: $1.shippingRulesExpanded,
         startsAt: $1.startsAt,
         title: $1.title,
-        localPickup: $0
+        localPickup: $0,
+        isAvailable: nil
       ) }
     )
 
@@ -74,7 +76,8 @@ extension Reward {
         shippingRulesExpanded: $1.shippingRulesExpanded,
         startsAt: $1.startsAt,
         title: $1.title,
-        localPickup: $1.localPickup
+        localPickup: $1.localPickup,
+        isAvailable: nil
       ) }
     )
 
@@ -99,7 +102,8 @@ extension Reward {
         shippingRulesExpanded: $1.shippingRulesExpanded,
         startsAt: $1.startsAt,
         title: $1.title,
-        localPickup: $1.localPickup
+        localPickup: $1.localPickup,
+        isAvailable: nil
       ) }
     )
 
@@ -124,7 +128,8 @@ extension Reward {
         shippingRulesExpanded: $1.shippingRulesExpanded,
         startsAt: $1.startsAt,
         title: $1.title,
-        localPickup: $1.localPickup
+        localPickup: $1.localPickup,
+        isAvailable: nil
       ) }
     )
 
@@ -149,7 +154,8 @@ extension Reward {
         shippingRulesExpanded: $1.shippingRulesExpanded,
         startsAt: $1.startsAt,
         title: $1.title,
-        localPickup: $1.localPickup
+        localPickup: $1.localPickup,
+        isAvailable: nil
       ) }
     )
 
@@ -174,7 +180,8 @@ extension Reward {
         shippingRulesExpanded: $1.shippingRulesExpanded,
         startsAt: $1.startsAt,
         title: $1.title,
-        localPickup: $1.localPickup
+        localPickup: $1.localPickup,
+        isAvailable: nil
       ) }
     )
 
@@ -199,7 +206,8 @@ extension Reward {
         shippingRulesExpanded: $1.shippingRulesExpanded,
         startsAt: $1.startsAt,
         title: $1.title,
-        localPickup: $1.localPickup
+        localPickup: $1.localPickup,
+        isAvailable: nil
       ) }
     )
 
@@ -224,7 +232,8 @@ extension Reward {
         shippingRulesExpanded: $1.shippingRulesExpanded,
         startsAt: $1.startsAt,
         title: $1.title,
-        localPickup: $1.localPickup
+        localPickup: $1.localPickup,
+        isAvailable: nil
       ) }
     )
 
@@ -249,7 +258,8 @@ extension Reward {
         shippingRulesExpanded: $1.shippingRulesExpanded,
         startsAt: $1.startsAt,
         title: $1.title,
-        localPickup: $1.localPickup
+        localPickup: $1.localPickup,
+        isAvailable: nil
       ) }
     )
 
@@ -274,7 +284,8 @@ extension Reward {
         shippingRulesExpanded: $1.shippingRulesExpanded,
         startsAt: $1.startsAt,
         title: $1.title,
-        localPickup: $1.localPickup
+        localPickup: $1.localPickup,
+        isAvailable: nil
       ) }
     )
 
@@ -299,7 +310,8 @@ extension Reward {
         shippingRulesExpanded: $1.shippingRulesExpanded,
         startsAt: $1.startsAt,
         title: $1.title,
-        localPickup: $1.localPickup
+        localPickup: $1.localPickup,
+        isAvailable: nil
       ) }
     )
 
@@ -324,7 +336,8 @@ extension Reward {
         shippingRulesExpanded: $1.shippingRulesExpanded,
         startsAt: $1.startsAt,
         title: $1.title,
-        localPickup: $1.localPickup
+        localPickup: $1.localPickup,
+        isAvailable: nil
       ) }
     )
 
@@ -349,7 +362,8 @@ extension Reward {
         shippingRulesExpanded: $1.shippingRulesExpanded,
         startsAt: $1.startsAt,
         title: $1.title,
-        localPickup: $1.localPickup
+        localPickup: $1.localPickup,
+        isAvailable: nil
       ) }
     )
 
@@ -374,7 +388,8 @@ extension Reward {
         shippingRulesExpanded: $1.shippingRulesExpanded,
         startsAt: $1.startsAt,
         title: $1.title,
-        localPickup: $1.localPickup
+        localPickup: $1.localPickup,
+        isAvailable: nil
       ) }
     )
 
@@ -399,7 +414,8 @@ extension Reward {
         shippingRulesExpanded: $1.shippingRulesExpanded,
         startsAt: $1.startsAt,
         title: $1.title,
-        localPickup: $1.localPickup
+        localPickup: $1.localPickup,
+        isAvailable: nil
       ) }
     )
 
@@ -424,7 +440,8 @@ extension Reward {
         shippingRulesExpanded: $0,
         startsAt: $1.startsAt,
         title: $1.title,
-        localPickup: $1.localPickup
+        localPickup: $1.localPickup,
+        isAvailable: nil
       ) }
     )
 
@@ -449,7 +466,8 @@ extension Reward {
         shippingRulesExpanded: $1.shippingRulesExpanded,
         startsAt: $0,
         title: $1.title,
-        localPickup: $1.localPickup
+        localPickup: $1.localPickup,
+        isAvailable: nil
       ) }
     )
 
@@ -474,7 +492,34 @@ extension Reward {
         shippingRulesExpanded: $1.shippingRulesExpanded,
         startsAt: $1.startsAt,
         title: $0,
-        localPickup: $1.localPickup
+        localPickup: $1.localPickup,
+        isAvailable: nil
+      ) }
+    )
+
+    public static let isAvailable = Lens<Reward, Bool?>(
+      view: { $0.isAvailable },
+      set: { Reward(
+        backersCount: $1.backersCount,
+        convertedMinimum: $1.convertedMinimum,
+        description: $1.description,
+        endsAt: $1.endsAt,
+        estimatedDeliveryOn: $1.estimatedDeliveryOn,
+        hasAddOns: $1.hasAddOns,
+        id: $1.id,
+        limit: $1.limit,
+        limitPerBacker: $1.limitPerBacker,
+        minimum: $1.minimum,
+        postCampaignPledgingEnabled: $1.postCampaignPledgingEnabled,
+        remaining: $1.remaining,
+        rewardsItems: $1.rewardsItems,
+        shipping: $1.shipping,
+        shippingRules: $1.shippingRules,
+        shippingRulesExpanded: $1.shippingRulesExpanded,
+        startsAt: $1.startsAt,
+        title: $1.title,
+        localPickup: $1.localPickup,
+        isAvailable: $0
       ) }
     )
   }

--- a/KsApi/models/templates/RewardTemplates.swift
+++ b/KsApi/models/templates/RewardTemplates.swift
@@ -29,7 +29,8 @@ extension Reward {
     shippingRulesExpanded: nil,
     startsAt: nil,
     title: "My Reward",
-    localPickup: nil
+    localPickup: nil,
+    isAvailable: nil
   )
 
   public static let noReward = Reward(
@@ -57,7 +58,8 @@ extension Reward {
     shippingRulesExpanded: nil,
     startsAt: nil,
     title: nil,
-    localPickup: nil
+    localPickup: nil,
+    isAvailable: nil
   )
 
   public static let otherReward = Reward(
@@ -85,7 +87,8 @@ extension Reward {
     shippingRulesExpanded: nil,
     startsAt: nil,
     title: nil,
-    localPickup: nil
+    localPickup: nil,
+    isAvailable: nil
   )
 
   public static let postcards = Reward.template

--- a/KsApi/mutations/templates/query/FetchAddOnsQueryTemplate.swift
+++ b/KsApi/mutations/templates/query/FetchAddOnsQueryTemplate.swift
@@ -83,6 +83,7 @@ public enum FetchAddsOnsQueryTemplate {
                 "estimatedDeliveryOn": "2021-06-01",
                 "id": "UmV3YXJkLTgxOTAzMjA=",
                 "isMaxPledge": false,
+                "available": false,
                 "items": {
                   "__typename": "RewardItemsConnection",
                   "edges": [
@@ -200,6 +201,7 @@ public enum FetchAddsOnsQueryTemplate {
                 "estimatedDeliveryOn": "2021-06-01",
                 "id": "UmV3YXJkLTgxOTc0NDQ=",
                 "isMaxPledge": false,
+                "available": false,
                 "items": {
                   "__typename": "RewardItemsConnection",
                   "edges": [

--- a/KsApi/mutations/templates/query/FetchProjectRewardsByIdQueryTemplate.swift
+++ b/KsApi/mutations/templates/query/FetchProjectRewardsByIdQueryTemplate.swift
@@ -50,6 +50,7 @@ public enum FetchProjectRewardsByIdQueryTemplate {
                    "estimatedDeliveryOn":"2021-09-01",
                    "id":"UmV3YXJkLTgzMzQzNTk=",
                    "isMaxPledge":false,
+    "available": false,
                    "items": {
                      "__typename": "RewardItemsConnection",
                      "edges": []
@@ -102,6 +103,7 @@ public enum FetchProjectRewardsByIdQueryTemplate {
                    "estimatedDeliveryOn":"2021-11-01",
                    "id":"UmV3YXJkLTgzMzc3MTI=",
                    "isMaxPledge":false,
+    "available": false,
                    "items": {
                      "__typename": "RewardItemsConnection",
                      "edges": [
@@ -208,6 +210,7 @@ public enum FetchProjectRewardsByIdQueryTemplate {
                    "estimatedDeliveryOn":"2021-11-01",
                    "id":"UmV3YXJkLTgzMzQzOTY=",
                    "isMaxPledge":false,
+    "available": false,
                    "items": {
                      "__typename": "RewardItemsConnection",
                      "edges": [
@@ -299,6 +302,7 @@ public enum FetchProjectRewardsByIdQueryTemplate {
                    "estimatedDeliveryOn":"2021-11-01",
                    "id":"UmV3YXJkLTgzMzA3MDQ=",
                    "isMaxPledge":false,
+        "available": false,
                    "items": {
                      "__typename": "RewardItemsConnection",
                      "edges": [
@@ -405,6 +409,7 @@ public enum FetchProjectRewardsByIdQueryTemplate {
                    "estimatedDeliveryOn":"2021-11-01",
                    "id":"UmV3YXJkLTgzMzQzNjU=",
                    "isMaxPledge":false,
+        "available": false,
                    "items": {
                      "__typename": "RewardItemsConnection",
                      "edges": [
@@ -496,6 +501,7 @@ public enum FetchProjectRewardsByIdQueryTemplate {
                    "estimatedDeliveryOn":"2021-11-01",
                    "id":"UmV3YXJkLTgzNDMwNDM=",
                    "isMaxPledge":false,
+        "available": false,
                    "items": {
                      "__typename": "RewardItemsConnection",
                      "edges": [
@@ -587,6 +593,7 @@ public enum FetchProjectRewardsByIdQueryTemplate {
                    "estimatedDeliveryOn":"2021-11-01",
                    "id":"UmV3YXJkLTgzMzQyNDk=",
                    "isMaxPledge":false,
+        "available": false,
                    "items": {
                      "__typename": "RewardItemsConnection",
                      "edges": [
@@ -687,6 +694,7 @@ public enum FetchProjectRewardsByIdQueryTemplate {
                    "estimatedDeliveryOn":"2021-11-01",
                    "id":"UmV3YXJkLTgzMzQyNTg=",
                    "isMaxPledge":false,
+        "available": false,
                    "items": {
                      "__typename": "RewardItemsConnection",
                      "edges": [
@@ -787,6 +795,7 @@ public enum FetchProjectRewardsByIdQueryTemplate {
                    "estimatedDeliveryOn":"2021-11-01",
                    "id":"UmV3YXJkLTgzNDExODg=",
                    "isMaxPledge":false,
+        "available": false,
                    "items": {
                      "__typename": "RewardItemsConnection",
                      "edges": [
@@ -887,6 +896,7 @@ public enum FetchProjectRewardsByIdQueryTemplate {
                    "estimatedDeliveryOn":"2021-11-01",
                    "id":"UmV3YXJkLTgzMzQyNDI=",
                    "isMaxPledge":false,
+        "available": false,
                    "items": {
                      "__typename": "RewardItemsConnection",
                      "edges": [
@@ -987,6 +997,7 @@ public enum FetchProjectRewardsByIdQueryTemplate {
                    "estimatedDeliveryOn":"2021-11-01",
                    "id":"UmV3YXJkLTgzMzQyNTY=",
                    "isMaxPledge":false,
+        "available": false,
                    "items": {
                      "__typename": "RewardItemsConnection",
                      "edges": [
@@ -1087,6 +1098,7 @@ public enum FetchProjectRewardsByIdQueryTemplate {
                    "estimatedDeliveryOn":"2021-11-01",
                    "id":"UmV3YXJkLTgzNDExODM=",
                    "isMaxPledge":false,
+        "available": false,
                    "items": {
                      "__typename": "RewardItemsConnection",
                      "edges": [
@@ -1187,6 +1199,7 @@ public enum FetchProjectRewardsByIdQueryTemplate {
                    "estimatedDeliveryOn":"2021-11-01",
                    "id":"UmV3YXJkLTgzNDExODU=",
                    "isMaxPledge":false,
+        "available": false,
                    "items": {
                      "__typename": "RewardItemsConnection",
                      "edges": [
@@ -1293,6 +1306,7 @@ public enum FetchProjectRewardsByIdQueryTemplate {
                    "estimatedDeliveryOn":"2021-11-01",
                    "id":"UmV3YXJkLTgzNDExODA=",
                    "isMaxPledge":false,
+        "available": false,
                    "items": {
                      "__typename": "RewardItemsConnection",
                      "edges": [

--- a/Library/ViewModels/RewardAddOnSelectionViewModel.swift
+++ b/Library/ViewModels/RewardAddOnSelectionViewModel.swift
@@ -467,19 +467,7 @@ private func addOnIsAvailable(_ addOn: Reward, in project: Project) -> Bool {
     return true
   }
 
-  let isUnlimitedOrAvailable = addOn.limit == nil || addOn.remaining ?? 0 > 0
-
-  // Assuming the user has not backed the addOn, we only display if it's within range of the start and end date
-  let hasNoTimeLimitOrIsWithinRange = isStartDateBeforeToday(for: addOn) && isEndDateAfterToday(for: addOn)
-
-  let isPostCampaign = project.isInPostCampaignPledgingPhase && featurePostCampaignPledgeEnabled()
-
-  return [
-    project.state == .live || isPostCampaign,
-    hasNoTimeLimitOrIsWithinRange,
-    isUnlimitedOrAvailable
-  ]
-  .allSatisfy(isTrue)
+  return addOn.isAvailable ?? false
 }
 
 private func filteredAddOns(

--- a/Library/ViewModels/RewardAddOnSelectionViewModel.swift
+++ b/Library/ViewModels/RewardAddOnSelectionViewModel.swift
@@ -108,7 +108,6 @@ public final class RewardAddOnSelectionViewModel: RewardAddOnSelectionViewModelT
     self.endRefreshing = projectEvent.filter { $0.isTerminating }.ignoreValues()
 
     let addOns = projectEvent.values().map(\.rewardData.addOns).skipNil()
-
     let requestErrored = projectEvent.map(\.error).map(isNotNil)
 
     // Quantities updated as the user selects them, merged with an empty initial value.
@@ -473,8 +472,10 @@ private func addOnIsAvailable(_ addOn: Reward, in project: Project) -> Bool {
   // Assuming the user has not backed the addOn, we only display if it's within range of the start and end date
   let hasNoTimeLimitOrIsWithinRange = isStartDateBeforeToday(for: addOn) && isEndDateAfterToday(for: addOn)
 
+  let isPostCampaign = project.isInPostCampaignPledgingPhase && featurePostCampaignPledgeEnabled()
+
   return [
-    project.state == .live,
+    project.state == .live || isPostCampaign,
     hasNoTimeLimitOrIsWithinRange,
     isUnlimitedOrAvailable
   ]

--- a/Library/ViewModels/RewardAddOnSelectionViewModelTests.swift
+++ b/Library/ViewModels/RewardAddOnSelectionViewModelTests.swift
@@ -162,6 +162,8 @@ final class RewardAddOnSelectionViewModelTests: TestCase {
     let reward = Reward.template
       |> Reward.lens.shipping.enabled .~ false
       |> Reward.lens.shipping.preference .~ Reward.Shipping.Preference.none
+      |> Reward.lens.isAvailable .~ true
+
     let project = Project.template
       |> Project.lens.rewardData.addOns .~ [reward]
 
@@ -274,6 +276,8 @@ final class RewardAddOnSelectionViewModelTests: TestCase {
     let reward = Reward.template
       |> Reward.lens.shipping.enabled .~ false
       |> Reward.lens.shipping.preference .~ Reward.Shipping.Preference.none
+      |> Reward.lens.isAvailable .~ true
+
     let project = Project.template
       |> Project.lens.rewardData.addOns .~ [reward]
 
@@ -341,21 +345,25 @@ final class RewardAddOnSelectionViewModelTests: TestCase {
       |> Reward.lens.id .~ 99
       |> Reward.lens.shipping.enabled .~ false
       |> Reward.lens.shipping.preference .~ Reward.Shipping.Preference.none
+      |> Reward.lens.isAvailable .~ true
 
     let noShippingAddOn = Reward.template
       |> Reward.lens.id .~ 1
       |> Reward.lens.shipping.enabled .~ false
       |> Reward.lens.shipping.preference .~ Reward.Shipping.Preference.none
+      |> Reward.lens.isAvailable .~ true
 
     let shippingAddOn1 = Reward.template
       |> Reward.lens.id .~ 2
       |> Reward.lens.shipping.enabled .~ true
       |> Reward.lens.shipping.preference .~ Reward.Shipping.Preference.restricted
+      |> Reward.lens.isAvailable .~ true
 
     let shippingAddOn2 = Reward.template
       |> Reward.lens.id .~ 3
       |> Reward.lens.shipping.enabled .~ true
       |> Reward.lens.shipping.preference .~ Reward.Shipping.Preference.restricted
+      |> Reward.lens.isAvailable .~ true
 
     let project = Project.template
       |> Project.lens.rewardData.rewards .~ [reward]
@@ -406,6 +414,7 @@ final class RewardAddOnSelectionViewModelTests: TestCase {
       |> Reward.lens.limit .~ nil
       |> Reward.lens.remaining .~ nil
       |> Reward.lens.endsAt .~ nil
+      |> Reward.lens.isAvailable .~ true
 
     // timebased add-on, ended 60 secs ago.
     let addOn2 = Reward.template
@@ -413,17 +422,20 @@ final class RewardAddOnSelectionViewModelTests: TestCase {
       |> Reward.lens.limit .~ nil
       |> Reward.lens.remaining .~ nil
       |> Reward.lens.endsAt .~ (MockDate().timeIntervalSince1970 - 60)
+      |> Reward.lens.isAvailable .~ false
 
     // timebased add-on, ended 60 secs ago (backed).
     let addOn3 = Reward.template
       |> Reward.lens.id .~ 3
       |> Reward.lens.endsAt .~ (MockDate().timeIntervalSince1970 - 60)
+      |> Reward.lens.isAvailable .~ false
 
     // limited, unavailable add-on.
     let addOn4 = Reward.template
       |> Reward.lens.id .~ 4
       |> Reward.lens.limit .~ 5
       |> Reward.lens.remaining .~ 0
+      |> Reward.lens.isAvailable .~ false
 
     // time-based, available add-on, ends in 60 secs.
     let addOn5 = Reward.template
@@ -431,12 +443,14 @@ final class RewardAddOnSelectionViewModelTests: TestCase {
       |> Reward.lens.limit .~ nil
       |> Reward.lens.remaining .~ nil
       |> Reward.lens.endsAt .~ (MockDate().timeIntervalSince1970 + 60)
+      |> Reward.lens.isAvailable .~ true
 
     // limited, available add-on.
     let addOn6 = Reward.template
       |> Reward.lens.id .~ 6
       |> Reward.lens.limit .~ 5
       |> Reward.lens.remaining .~ 2
+      |> Reward.lens.isAvailable .~ true
 
     // timebased add-on, starts in 60 seconds
     let addOn7 = Reward.template
@@ -444,6 +458,7 @@ final class RewardAddOnSelectionViewModelTests: TestCase {
       |> Reward.lens.limit .~ nil
       |> Reward.lens.remaining .~ nil
       |> Reward.lens.startsAt .~ (MockDate().timeIntervalSince1970 + 60)
+      |> Reward.lens.isAvailable .~ false
 
     // timebased add-on, started 60 seconds ago.
     let addOn8 = Reward.template
@@ -451,6 +466,7 @@ final class RewardAddOnSelectionViewModelTests: TestCase {
       |> Reward.lens.limit .~ nil
       |> Reward.lens.remaining .~ nil
       |> Reward.lens.startsAt .~ (MockDate().timeIntervalSince1970 - 60)
+      |> Reward.lens.isAvailable .~ true
 
     // timebased add-on, both startsAt and endsAt are within a valid range
     let addOn9 = Reward.template
@@ -459,6 +475,7 @@ final class RewardAddOnSelectionViewModelTests: TestCase {
       |> Reward.lens.remaining .~ nil
       |> Reward.lens.startsAt .~ (MockDate().timeIntervalSince1970 - 60)
       |> Reward.lens.endsAt .~ (MockDate().timeIntervalSince1970 + 60)
+      |> Reward.lens.isAvailable .~ true
 
     // timebased add-on, invalid range
     let addOn10 = Reward.template
@@ -467,6 +484,7 @@ final class RewardAddOnSelectionViewModelTests: TestCase {
       |> Reward.lens.remaining .~ nil
       |> Reward.lens.startsAt .~ (MockDate().timeIntervalSince1970 + 30)
       |> Reward.lens.endsAt .~ (MockDate().timeIntervalSince1970 + 60)
+      |> Reward.lens.isAvailable .~ false
 
     let project = Project.template
       |> Project.lens.rewardData.rewards .~ [baseReward]
@@ -529,6 +547,7 @@ final class RewardAddOnSelectionViewModelTests: TestCase {
       |> Reward.lens.id .~ 1
       |> Reward.lens.shipping.enabled .~ false
       |> Reward.lens.shipping.preference .~ Reward.Shipping.Preference.none
+      |> Reward.lens.isAvailable .~ true
 
     let shippingAddOn1 = Reward.template
       |> Reward.lens.id .~ 2
@@ -537,6 +556,7 @@ final class RewardAddOnSelectionViewModelTests: TestCase {
         shippingRule,
         shippingRule |> ShippingRule.lens.location .~ (.template |> Location.lens.id .~ 99)
       ]
+      |> Reward.lens.isAvailable .~ true
 
     let shippingAddOn2 = Reward.template
       |> Reward.lens.id .~ 3
@@ -545,6 +565,7 @@ final class RewardAddOnSelectionViewModelTests: TestCase {
         shippingRule,
         shippingRule |> ShippingRule.lens.location .~ (.template |> Location.lens.id .~ 99)
       ]
+      |> Reward.lens.isAvailable .~ true
 
     let shippingAddOn3 = Reward.template
       |> Reward.lens.id .~ 4
@@ -552,11 +573,13 @@ final class RewardAddOnSelectionViewModelTests: TestCase {
       |> Reward.lens.shippingRulesExpanded .~ [
         shippingRule |> ShippingRule.lens.location .~ (.template |> Location.lens.id .~ 3)
       ]
+      |> Reward.lens.isAvailable .~ true
 
     let shippingAddOn4 = Reward.template
       |> Reward.lens.id .~ 5
       |> Reward.lens.shipping.enabled .~ true
       |> Reward.lens.shippingRulesExpanded .~ [shippingRule]
+      |> Reward.lens.isAvailable .~ true
 
     let project = Project.template
       |> Project.lens.rewardData.rewards .~ [reward]
@@ -628,21 +651,26 @@ final class RewardAddOnSelectionViewModelTests: TestCase {
       |> Reward.lens.shipping.enabled .~ true
       |> Reward.lens.shipping.preference .~ .restricted
       |> Reward.lens.id .~ 99
+      |> Reward.lens.isAvailable .~ true
 
     let noShippingAddOn = Reward.template
       |> Reward.lens.id .~ 1
       |> Reward.lens.shipping.enabled .~ false
       |> Reward.lens.shipping.preference .~ Reward.Shipping.Preference.none
+      |> Reward.lens.isAvailable .~ true
 
     let shippingAddOn1 = Reward.template
       |> Reward.lens.id .~ 2
       |> Reward.lens.shipping.enabled .~ true
       |> Reward.lens.shippingRulesExpanded .~ [shippingRule]
+      |> Reward.lens.isAvailable .~ true
 
     let shippingAddOn2 = Reward.template
       |> Reward.lens.id .~ 3
       |> Reward.lens.shipping.enabled .~ true
       |> Reward.lens.shippingRulesExpanded .~ [shippingRule]
+      |> Reward.lens.isAvailable .~ true
+      |> Reward.lens.isAvailable .~ true
 
     let shippingAddOn3 = Reward.template
       |> Reward.lens.id .~ 4
@@ -650,10 +678,12 @@ final class RewardAddOnSelectionViewModelTests: TestCase {
       |> Reward.lens.shippingRulesExpanded .~ [
         shippingRule |> ShippingRule.lens.location .~ (.template |> Location.lens.id .~ 3)
       ]
+      |> Reward.lens.isAvailable .~ true
 
     let shippingAddOn4 = Reward.template
       |> Reward.lens.id .~ 5
       |> Reward.lens.shipping.enabled .~ true
+      |> Reward.lens.isAvailable .~ true
 
     let project = Project.template
       |> Project.lens.rewardData.rewards .~ [reward]
@@ -724,6 +754,7 @@ final class RewardAddOnSelectionViewModelTests: TestCase {
     let reward = Reward.template
       |> Reward.lens.shipping.enabled .~ true
       |> Reward.lens.shipping.preference .~ .restricted
+      |> Reward.lens.isAvailable .~ true
 
     let shippingAddOn1 = Reward.template
       |> Reward.lens.id .~ 2
@@ -731,6 +762,7 @@ final class RewardAddOnSelectionViewModelTests: TestCase {
       |> Reward.lens.shippingRulesExpanded .~ [
         shippingRule |> ShippingRule.lens.location .~ (.template |> Location.lens.id .~ 99)
       ]
+      |> Reward.lens.isAvailable .~ true
 
     let shippingAddOn2 = Reward.template
       |> Reward.lens.id .~ 3
@@ -738,6 +770,7 @@ final class RewardAddOnSelectionViewModelTests: TestCase {
       |> Reward.lens.shippingRulesExpanded .~ [
         shippingRule |> ShippingRule.lens.location .~ (.template |> Location.lens.id .~ 99)
       ]
+      |> Reward.lens.isAvailable .~ true
 
     let shippingAddOn3 = Reward.template
       |> Reward.lens.id .~ 4
@@ -745,6 +778,7 @@ final class RewardAddOnSelectionViewModelTests: TestCase {
       |> Reward.lens.shippingRulesExpanded .~ [
         shippingRule |> ShippingRule.lens.location .~ (.template |> Location.lens.id .~ 3)
       ]
+      |> Reward.lens.isAvailable .~ true
 
     let shippingAddOn4 = Reward.template
       |> Reward.lens.id .~ 5
@@ -752,6 +786,7 @@ final class RewardAddOnSelectionViewModelTests: TestCase {
       |> Reward.lens.shippingRulesExpanded .~ [
         shippingRule |> ShippingRule.lens.location .~ (.template |> Location.lens.id .~ 3)
       ]
+      |> Reward.lens.isAvailable .~ true
 
     let project = Project.template
       |> Project.lens.rewardData.rewards .~ [reward]
@@ -822,30 +857,35 @@ final class RewardAddOnSelectionViewModelTests: TestCase {
       |> Reward.lens.shipping.enabled .~ true
       |> Reward.lens.shipping.preference .~ .unrestricted
       |> Reward.lens.id .~ 99
+      |> Reward.lens.isAvailable .~ true
 
     let addOn1 = Reward.template
       |> Reward.lens.id .~ 1
       |> Reward.lens.shipping.enabled .~ true
       |> Reward.lens.shipping.preference .~ .unrestricted
       |> Reward.lens.shippingRulesExpanded .~ [shippingRule]
+      |> Reward.lens.isAvailable .~ true
 
     let addOn2 = Reward.template
       |> Reward.lens.id .~ 2
       |> Reward.lens.shipping.enabled .~ true
       |> Reward.lens.shipping.preference .~ .unrestricted
       |> Reward.lens.shippingRulesExpanded .~ [shippingRule]
+      |> Reward.lens.isAvailable .~ true
 
     let addOn3 = Reward.template
       |> Reward.lens.id .~ 3
       |> Reward.lens.shipping.enabled .~ true
       |> Reward.lens.shipping.preference .~ .unrestricted
       |> Reward.lens.shippingRulesExpanded .~ [shippingRule]
+      |> Reward.lens.isAvailable .~ true
 
     let addOn4 = Reward.template
       |> Reward.lens.id .~ 4
       |> Reward.lens.shipping.enabled .~ true
       |> Reward.lens.shipping.preference .~ .unrestricted
       |> Reward.lens.shippingRulesExpanded .~ [shippingRule]
+      |> Reward.lens.isAvailable .~ true
 
     let project = Project.template
       |> Project.lens.rewardData.rewards .~ [reward]
@@ -934,30 +974,35 @@ final class RewardAddOnSelectionViewModelTests: TestCase {
       |> Reward.lens.id .~ 99
       |> Reward.lens.shipping.enabled .~ true
       |> Reward.lens.shipping.preference .~ .unrestricted
+      |> Reward.lens.isAvailable .~ true
 
     let addOn1 = Reward.template
       |> Reward.lens.id .~ 1
       |> Reward.lens.shipping.enabled .~ true
       |> Reward.lens.shipping.preference .~ .unrestricted
       |> Reward.lens.shippingRulesExpanded .~ [shippingRule]
+      |> Reward.lens.isAvailable .~ true
 
     let addOn2 = Reward.template
       |> Reward.lens.id .~ 2
       |> Reward.lens.shipping.enabled .~ true
       |> Reward.lens.shipping.preference .~ .unrestricted
       |> Reward.lens.shippingRulesExpanded .~ [shippingRule]
+      |> Reward.lens.isAvailable .~ true
 
     let addOn3 = Reward.template
       |> Reward.lens.id .~ 3
       |> Reward.lens.shipping.enabled .~ true
       |> Reward.lens.shipping.preference .~ .unrestricted
       |> Reward.lens.shippingRulesExpanded .~ [shippingRule]
+      |> Reward.lens.isAvailable .~ true
 
     let addOn4 = Reward.template
       |> Reward.lens.id .~ 4
       |> Reward.lens.shipping.enabled .~ true
       |> Reward.lens.shipping.preference .~ .unrestricted
       |> Reward.lens.shippingRulesExpanded .~ [shippingRule]
+      |> Reward.lens.isAvailable .~ true
 
     let project = Project.template
       |> Project.lens.rewardData.rewards .~ [reward]
@@ -1193,24 +1238,28 @@ final class RewardAddOnSelectionViewModelTests: TestCase {
       |> Reward.lens.shipping.enabled .~ true
       |> Reward.lens.shipping.preference .~ .unrestricted
       |> Reward.lens.shippingRulesExpanded .~ [shippingRule]
+      |> Reward.lens.isAvailable .~ true
 
     let addOn2 = Reward.template
       |> Reward.lens.id .~ 2
       |> Reward.lens.shipping.enabled .~ true
       |> Reward.lens.shipping.preference .~ .unrestricted
       |> Reward.lens.shippingRulesExpanded .~ [shippingRule]
+      |> Reward.lens.isAvailable .~ true
 
     let addOn3 = Reward.template
       |> Reward.lens.id .~ 3
       |> Reward.lens.shipping.enabled .~ true
       |> Reward.lens.shipping.preference .~ .unrestricted
       |> Reward.lens.shippingRulesExpanded .~ [shippingRule]
+      |> Reward.lens.isAvailable .~ true
 
     let addOn4 = Reward.template
       |> Reward.lens.id .~ 4
       |> Reward.lens.shipping.enabled .~ true
       |> Reward.lens.shipping.preference .~ .unrestricted
       |> Reward.lens.shippingRulesExpanded .~ [shippingRule]
+      |> Reward.lens.isAvailable .~ true
 
     let project = Project.template
       |> Project.lens.rewardData.rewards .~ [reward]


### PR DESCRIPTION
# 📲 What

Use the GraphQL field `isAvailable` to filter visible add-ons

# 🤔 Why

Our existing implementation did not take late pledges into account, so it was filtering out add-ons that were actually still available for late pledges. I spoke with @zan-rosenthal and apparently the gold-standard solution is to use the `available` field from GraphQL.

Most of this PR is updating plumbing to get `available` into `Reward`.