### PR TITLE
[MBL-1307] Show processing view while payment is processing

### DIFF
--- a/Kickstarter-iOS/Features/PledgeView/Controllers/PostCampaignCheckoutViewController.swift
+++ b/Kickstarter-iOS/Features/PledgeView/Controllers/PostCampaignCheckoutViewController.swift
@@ -447,7 +447,6 @@ extension PostCampaignCheckoutViewController: STPApplePayContextDelegate {
     completion: @escaping StripeApplePay.STPIntentClientSecretCompletionBlock
   ) {
     guard let paymentIntentClientSecret = self.applePayPaymentIntent else {
-      self.viewModel.inputs.checkoutTerminated()
       completion(
         nil,
         PostCampaignCheckoutApplePayError.missingPaymentIntent("Missing PaymentIntent")
@@ -457,7 +456,6 @@ extension PostCampaignCheckoutViewController: STPApplePayContextDelegate {
 
     guard let paymentDisplayName = payment.token.paymentMethod.displayName,
       let paymentNetworkName = payment.token.paymentMethod.network?.rawValue else {
-      self.viewModel.inputs.checkoutTerminated()
       completion(
         nil,
         PostCampaignCheckoutApplePayError
@@ -475,7 +473,6 @@ extension PostCampaignCheckoutViewController: STPApplePayContextDelegate {
       }
 
       guard let tokenId = token?.tokenId else {
-        self.viewModel.inputs.checkoutTerminated()
         completion(
           nil,
           PostCampaignCheckoutApplePayError.missingToken("Unable to retrieve token from Stripe")

--- a/Library/ViewModels/PostCampaignCheckoutViewModel.swift
+++ b/Library/ViewModels/PostCampaignCheckoutViewModel.swift
@@ -310,6 +310,7 @@ public class PostCampaignCheckoutViewModel: PostCampaignCheckoutViewModelType,
               amountDollars: String(format: "%.2f", pledgeTotal),
               digitalMarketingAttributed: nil
             ))
+            .ksr_delay(AppEnvironment.current.apiDelayInterval, on: AppEnvironment.current.scheduler)
             .materialize()
         }
 
@@ -405,13 +406,14 @@ public class PostCampaignCheckoutViewModel: PostCampaignCheckoutViewModelType,
     self.checkoutError = checkoutCompleteSignal.signal.errors()
 
     self.processingViewIsHidden = Signal.merge(
-      initialData.mapConst(true),
+      // Processing view starts hidden, so show at the start of a pledge flow.
       self.submitButtonTappedProperty.signal.mapConst(false),
       self.applePayButtonTappedSignal.mapConst(false),
-      newPaymentIntentForApplePayError.mapConst(true), // Apple pay payment intent error.
-      validateCheckoutError.mapConst(true), // Card validation error terminates flow.
-      self.checkoutTerminatedProperty.signal.mapConst(true), // Error/cancellation in VC.
-      checkoutCompleteSignal.signal.mapConst(true) // Checkout completed.
+      // Hide view again whenever pledge flow is completed/cancelled/errors.
+      newPaymentIntentForApplePayError.mapConst(true),
+      validateCheckoutError.mapConst(true),
+      self.checkoutTerminatedProperty.signal.mapConst(true),
+      checkoutCompleteSignal.signal.mapConst(true)
     )
   }
 

--- a/Library/ViewModels/PostCampaignCheckoutViewModelTests.swift
+++ b/Library/ViewModels/PostCampaignCheckoutViewModelTests.swift
@@ -12,11 +12,14 @@ final class PostCampaignCheckoutViewModelTests: XCTestCase {
     Never
   >()
   fileprivate let checkoutComplete = TestObserver<ThanksPageData, Never>()
+  
+  fileprivate let processingViewIsHidden = TestObserver<Bool, Never>()
 
   override func setUp() {
     super.setUp()
     self.vm.goToApplePayPaymentAuthorization.observe(self.goToApplePayPaymentAuthorization.observer)
     self.vm.checkoutComplete.observe(self.checkoutComplete.observer)
+    self.vm.processingViewIsHidden.observe(self.processingViewIsHidden.observer)
   }
 
   func testApplePayAuthorization_noReward_isCorrect() {
@@ -263,6 +266,8 @@ final class PostCampaignCheckoutViewModelTests: XCTestCase {
       self.vm.viewDidLoad()
 
       self.vm.inputs.applePayButtonTapped()
+      
+      self.processingViewIsHidden.assertLastValue(false)
 
       self.goToApplePayPaymentAuthorization.assertDidEmitValue()
 
@@ -280,6 +285,8 @@ final class PostCampaignCheckoutViewModelTests: XCTestCase {
       self.vm.inputs.applePayContextDidComplete()
 
       self.checkoutComplete.assertDidEmitValue()
+      
+      self.processingViewIsHidden.assertLastValue(true)
     }
   }
 }


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Show processing view while payment is processing. This prevents further user interaction until it's dismissed.

Note: It's very important that we make sure that regardless of how checkout goes/where it fails, the processing view will get dismissed. It will lock the app otherwise. The original pledge VC ties the processing view to specific API calls, but we can't do that for post campaign pledges, since we require multiple different API calls to finish the payment flow. Please help me double check that there aren't edge cases that would leave the processing screen up indefinitely!

Note: The processing screen does hide immediately once apple pay is dismissed - I have no idea why the gif is showing it weird.

# 👀 See

[Jira](https://kickstarter.atlassian.net/browse/MBL-1307)

| Pledge flow | Apple pay flow |
| --- | --- |
| ![Simulator Screen Recording - iPhone 15 Pro Max - 2024-04-01 at 16 01 41](https://github.com/kickstarter/ios-oss/assets/6799207/8756e9b8-264f-4e3a-9bf2-384315265833) | ![Simulator Screen Recording - iPhone 15 Pro Max - 2024-04-01 at 16 04 20](https://github.com/kickstarter/ios-oss/assets/6799207/bdc72ee9-ab06-48c9-a8a2-c8fe2885024f) |

# ✅ Acceptance criteria

- [x] Processing overlay shows when it should and hides again when it should

# ⏰ TODO

- [x] Add tests
