### PR TITLE
Add init(jsonString:) to GraphQLSelectionSet

### DIFF
--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -1536,6 +1536,7 @@
 		E1A149272ACE063400F49709 /* FetchBackerProjectsQueryDataTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1A149262ACE063400F49709 /* FetchBackerProjectsQueryDataTemplate.swift */; };
 		E1AA8ABF2AEABBB100AC98BF /* Signal+Combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1EA34EE2AE1B28400942A04 /* Signal+Combine.swift */; };
 		E1BB25642B1E81AA000BD2D6 /* Publisher+Service.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1BB25632B1E81AA000BD2D6 /* Publisher+Service.swift */; };
+		E1C880AF2BBC6CDA008B9612 /* GraphQLSelectionSet+String.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1C880AE2BBC6CDA008B9612 /* GraphQLSelectionSet+String.swift */; };
 		E1EEED292B684AA7009976D9 /* PKCE.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1EEED282B684AA7009976D9 /* PKCE.swift */; };
 		E1F1DB3F2B7BC09C004EA80B /* Prelude in Frameworks */ = {isa = PBXBuildFile; productRef = E1F1DB3E2B7BC09C004EA80B /* Prelude */; };
 /* End PBXBuildFile section */
@@ -3160,6 +3161,7 @@
 		E1A149232ACE02B300F49709 /* FetchProjectsEnvelope+FetchBackerProjectsQueryDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FetchProjectsEnvelope+FetchBackerProjectsQueryDataTests.swift"; sourceTree = "<group>"; };
 		E1A149262ACE063400F49709 /* FetchBackerProjectsQueryDataTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchBackerProjectsQueryDataTemplate.swift; sourceTree = "<group>"; };
 		E1BB25632B1E81AA000BD2D6 /* Publisher+Service.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Publisher+Service.swift"; sourceTree = "<group>"; };
+		E1C880AE2BBC6CDA008B9612 /* GraphQLSelectionSet+String.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GraphQLSelectionSet+String.swift"; sourceTree = "<group>"; };
 		E1EA34EE2AE1B28400942A04 /* Signal+Combine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Signal+Combine.swift"; sourceTree = "<group>"; };
 		E1EEED282B684AA7009976D9 /* PKCE.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PKCE.swift; sourceTree = "<group>"; };
 		E1EEED2A2B686829009976D9 /* PKCETest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PKCETest.swift; sourceTree = "<group>"; };
@@ -6656,6 +6658,7 @@
 			children = (
 				D01587531EEB2DE4006E7684 /* Info.plist */,
 				8ADCCD4E2654281E0079D308 /* GraphAPI.swift */,
+				E1C880AE2BBC6CDA008B9612 /* GraphQLSelectionSet+String.swift */,
 				D08CD1BF21910C97009F89F0 /* GraphIDBridging.swift */,
 				775DFA9C215E758400620CED /* GraphMutation.swift */,
 				D67F29351F68333800E399A6 /* GraphSchema.swift */,
@@ -8708,6 +8711,7 @@
 				D01588AD1EEB2ED7006E7684 /* Project.StatsLenses.swift in Sources */,
 				D0158A211EEB30A2006E7684 /* ProjectStatsEnvelope.VideoStatsTemplates.swift in Sources */,
 				D0158A141EEB30A2006E7684 /* FindFriendsEnvelopeTemplates.swift in Sources */,
+				E1C880AF2BBC6CDA008B9612 /* GraphQLSelectionSet+String.swift in Sources */,
 				06BD75C126C42D5700A12D4E /* ActivityComment.swift in Sources */,
 				8ADCCD812655CA290079D308 /* ApolloInterceptors.swift in Sources */,
 				D79440902208970E00D0A747 /* CreatePaymentSourceTemplate.swift in Sources */,

--- a/KsApi/GraphQLSelectionSet+String.swift
+++ b/KsApi/GraphQLSelectionSet+String.swift
@@ -1,0 +1,17 @@
+import Apollo
+import Foundation
+
+public enum GraphQLSelectionSetStringError: Error {
+  case unableToInitData
+}
+
+public extension GraphQLSelectionSet {
+  init(jsonString: String) throws {
+    guard let data = jsonString.data(using: .utf8) else {
+      throw GraphQLSelectionSetStringError.unableToInitData
+    }
+
+    let json = try JSONSerialization.jsonObject(with: data)
+    try self.init(jsonObject: json as! JSONObject)
+  }
+}

--- a/Library/ViewModels/PostCampaignCheckoutViewModelTests.swift
+++ b/Library/ViewModels/PostCampaignCheckoutViewModelTests.swift
@@ -247,10 +247,8 @@ final class PostCampaignCheckoutViewModelTests: TestCase {
       }
     }
     """
-    let completeSessionJson = try! JSONSerialization
-      .jsonObject(with: completeSessionJsonString.data(using: .utf8)!)
     let completeSessionData = try! GraphAPI.CompleteOnSessionCheckoutMutation
-      .Data(jsonObject: completeSessionJson as! JSONObject)
+      .Data(jsonString: completeSessionJsonString)
     let mockService = MockService(
       completeOnSessionCheckoutResult: .success(completeSessionData),
       createPaymentIntentResult: .success(paymentIntent)


### PR DESCRIPTION
# 📲 What

Add a convenience initializer `init(jsonString:)` to `GraphQLSelectionSet`

# 🤔 Why

This makes it easier to create new GraphQL Data objects in test environments.