### PR TITLE
Remove swiftformat:disable directives that SwiftFormat was ignoring

### DIFF
--- a/Kickstarter-iOS/Library/Nib.swift
+++ b/Kickstarter-iOS/Library/Nib.swift
@@ -46,14 +46,12 @@ protocol NibLoading {
 
 extension NibLoading {
   static func fromNib(nib: Nib) -> Self? {
-    // swiftformat:disable indent
     guard let view = UINib(nibName: nib.rawValue, bundle: .framework)
       .instantiate(withOwner: self, options: nil)
       .first as? Self else {
-        assertionFailure("Nib not found")
-        return nil
-      }
-    // swiftformat:enable indent
+      assertionFailure("Nib not found")
+      return nil
+    }
 
     return view
   }

--- a/KsApi/ServiceTypeTests.swift
+++ b/KsApi/ServiceTypeTests.swift
@@ -319,14 +319,10 @@ final class ServiceTypeTests: XCTestCase {
   }
 }
 
-// swiftformat:disable wrap
 private func userAgent() -> String {
-  return """
-  xctest/\(testToolBuildNumber()) (\(UIDevice.current.model); iOS \(UIDevice.current.systemVersion) Scale/\(UIScreen.main.scale))
-  """
+  // swiftformat:disable:next wrap
+  return "xctest/\(testToolBuildNumber()) (\(UIDevice.current.model); iOS \(UIDevice.current.systemVersion) Scale/\(UIScreen.main.scale))"
 }
-
-// swiftformat:enable wrap
 
 private func testToolBuildNumber() -> String {
   return Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? ""

--- a/KsApi/models/Project.Country.swift
+++ b/KsApi/models/Project.Country.swift
@@ -16,39 +16,211 @@ extension Project {
      Ideally we should get the amounts from the API. But for now we have to update them manually.
      */
 
-    // swiftformat:disable wrap
-    // swiftformat:disable wrapArguments
-    public static let at = Country(countryCode: "AT", currencyCode: "EUR", currencySymbol: "€", maxPledge: eurMaxPledge, minPledge: eurMinPledge, trailingCode: false)
-    public static let au = Country(countryCode: "AU", currencyCode: "AUD", currencySymbol: "$", maxPledge: 13_000, minPledge: 1, trailingCode: true)
-    public static let be = Country(countryCode: "BE", currencyCode: "EUR", currencySymbol: "€", maxPledge: eurMaxPledge, minPledge: eurMinPledge, trailingCode: false)
-    public static let ca = Country(countryCode: "CA", currencyCode: "CAD", currencySymbol: "$", maxPledge: 13_000, minPledge: 1, trailingCode: true)
-    public static let ch = Country(countryCode: "CH", currencyCode: "CHF", currencySymbol: "Fr", maxPledge: 9_500, minPledge: 1, trailingCode: true)
-    public static let de = Country(countryCode: "DE", currencyCode: "EUR", currencySymbol: "€", maxPledge: eurMaxPledge, minPledge: eurMinPledge, trailingCode: false)
-    public static let dk = Country(countryCode: "DK", currencyCode: "DKK", currencySymbol: "kr", maxPledge: 65_000, minPledge: 5, trailingCode: true)
-    public static let es = Country(countryCode: "ES", currencyCode: "EUR", currencySymbol: "€", maxPledge: eurMaxPledge, minPledge: eurMinPledge, trailingCode: false)
-    public static let fr = Country(countryCode: "FR", currencyCode: "EUR", currencySymbol: "€", maxPledge: eurMaxPledge, minPledge: eurMinPledge, trailingCode: false)
-    public static let gb = Country(countryCode: "GB", currencyCode: "GBP", currencySymbol: "£", maxPledge: 8_000, minPledge: 1, trailingCode: false)
-    public static let gr = Country(countryCode: "GR", currencyCode: "EUR", currencySymbol: "€", maxPledge: eurMaxPledge, minPledge: eurMinPledge, trailingCode: false)
-    public static let hk = Country(countryCode: "HK", currencyCode: "HKD", currencySymbol: "$", maxPledge: 75_000, minPledge: 10, trailingCode: true)
-    public static let ie = Country(countryCode: "IE", currencyCode: "EUR", currencySymbol: "€", maxPledge: eurMaxPledge, minPledge: eurMinPledge, trailingCode: false)
-    public static let it = Country(countryCode: "IT", currencyCode: "EUR", currencySymbol: "€", maxPledge: eurMaxPledge, minPledge: eurMinPledge, trailingCode: false)
-    public static let jp = Country(countryCode: "JP", currencyCode: "JPY", currencySymbol: "¥", maxPledge: 1_200_000, minPledge: 100, trailingCode: false)
-    public static let lu = Country(countryCode: "LU", currencyCode: "EUR", currencySymbol: "€", maxPledge: eurMaxPledge, minPledge: eurMinPledge, trailingCode: false)
-    public static let mx = Country(countryCode: "MX", currencyCode: "MXN", currencySymbol: "$", maxPledge: 200_000, minPledge: 10, trailingCode: true)
-    public static let nl = Country(countryCode: "NL", currencyCode: "EUR", currencySymbol: "€", maxPledge: eurMaxPledge, minPledge: eurMinPledge, trailingCode: false)
-    public static let no = Country(countryCode: "NO", currencyCode: "NOK", currencySymbol: "kr", maxPledge: 80_000, minPledge: 5, trailingCode: true)
-    public static let nz = Country(countryCode: "NZ", currencyCode: "NZD", currencySymbol: "$", maxPledge: 14_000, minPledge: 1, trailingCode: true)
-    public static let pl = Country(countryCode: "PL", currencyCode: "PLN", currencySymbol: "zł", maxPledge: 37_250, minPledge: 5, trailingCode: false)
-    public static let se = Country(countryCode: "SE", currencyCode: "SEK", currencySymbol: "kr", maxPledge: 85_000, minPledge: 5, trailingCode: true)
-    public static let sg = Country(countryCode: "SG", currencyCode: "SGD", currencySymbol: "$", maxPledge: 13_000, minPledge: 2, trailingCode: true)
-    public static let si = Country(countryCode: "SI", currencyCode: "EUR", currencySymbol: "€", maxPledge: eurMaxPledge, minPledge: eurMinPledge, trailingCode: false)
-    public static let us = Country(countryCode: "US", currencyCode: "USD", currencySymbol: "$", maxPledge: 10_000, minPledge: 1, trailingCode: true)
+    public static let at = Country(
+      countryCode: "AT",
+      currencyCode: "EUR",
+      currencySymbol: "€",
+      maxPledge: eurMaxPledge,
+      minPledge: eurMinPledge,
+      trailingCode: false
+    )
+    public static let au = Country(
+      countryCode: "AU",
+      currencyCode: "AUD",
+      currencySymbol: "$",
+      maxPledge: 13_000,
+      minPledge: 1,
+      trailingCode: true
+    )
+    public static let be = Country(
+      countryCode: "BE",
+      currencyCode: "EUR",
+      currencySymbol: "€",
+      maxPledge: eurMaxPledge,
+      minPledge: eurMinPledge,
+      trailingCode: false
+    )
+    public static let ca = Country(
+      countryCode: "CA",
+      currencyCode: "CAD",
+      currencySymbol: "$",
+      maxPledge: 13_000,
+      minPledge: 1,
+      trailingCode: true
+    )
+    public static let ch = Country(
+      countryCode: "CH",
+      currencyCode: "CHF",
+      currencySymbol: "Fr",
+      maxPledge: 9_500,
+      minPledge: 1,
+      trailingCode: true
+    )
+    public static let de = Country(
+      countryCode: "DE",
+      currencyCode: "EUR",
+      currencySymbol: "€",
+      maxPledge: eurMaxPledge,
+      minPledge: eurMinPledge,
+      trailingCode: false
+    )
+    public static let dk = Country(
+      countryCode: "DK",
+      currencyCode: "DKK",
+      currencySymbol: "kr",
+      maxPledge: 65_000,
+      minPledge: 5,
+      trailingCode: true
+    )
+    public static let es = Country(
+      countryCode: "ES",
+      currencyCode: "EUR",
+      currencySymbol: "€",
+      maxPledge: eurMaxPledge,
+      minPledge: eurMinPledge,
+      trailingCode: false
+    )
+    public static let fr = Country(
+      countryCode: "FR",
+      currencyCode: "EUR",
+      currencySymbol: "€",
+      maxPledge: eurMaxPledge,
+      minPledge: eurMinPledge,
+      trailingCode: false
+    )
+    public static let gb = Country(
+      countryCode: "GB",
+      currencyCode: "GBP",
+      currencySymbol: "£",
+      maxPledge: 8_000,
+      minPledge: 1,
+      trailingCode: false
+    )
+    public static let gr = Country(
+      countryCode: "GR",
+      currencyCode: "EUR",
+      currencySymbol: "€",
+      maxPledge: eurMaxPledge,
+      minPledge: eurMinPledge,
+      trailingCode: false
+    )
+    public static let hk = Country(
+      countryCode: "HK",
+      currencyCode: "HKD",
+      currencySymbol: "$",
+      maxPledge: 75_000,
+      minPledge: 10,
+      trailingCode: true
+    )
+    public static let ie = Country(
+      countryCode: "IE",
+      currencyCode: "EUR",
+      currencySymbol: "€",
+      maxPledge: eurMaxPledge,
+      minPledge: eurMinPledge,
+      trailingCode: false
+    )
+    public static let it = Country(
+      countryCode: "IT",
+      currencyCode: "EUR",
+      currencySymbol: "€",
+      maxPledge: eurMaxPledge,
+      minPledge: eurMinPledge,
+      trailingCode: false
+    )
+    public static let jp = Country(
+      countryCode: "JP",
+      currencyCode: "JPY",
+      currencySymbol: "¥",
+      maxPledge: 1_200_000,
+      minPledge: 100,
+      trailingCode: false
+    )
+    public static let lu = Country(
+      countryCode: "LU",
+      currencyCode: "EUR",
+      currencySymbol: "€",
+      maxPledge: eurMaxPledge,
+      minPledge: eurMinPledge,
+      trailingCode: false
+    )
+    public static let mx = Country(
+      countryCode: "MX",
+      currencyCode: "MXN",
+      currencySymbol: "$",
+      maxPledge: 200_000,
+      minPledge: 10,
+      trailingCode: true
+    )
+    public static let nl = Country(
+      countryCode: "NL",
+      currencyCode: "EUR",
+      currencySymbol: "€",
+      maxPledge: eurMaxPledge,
+      minPledge: eurMinPledge,
+      trailingCode: false
+    )
+    public static let no = Country(
+      countryCode: "NO",
+      currencyCode: "NOK",
+      currencySymbol: "kr",
+      maxPledge: 80_000,
+      minPledge: 5,
+      trailingCode: true
+    )
+    public static let nz = Country(
+      countryCode: "NZ",
+      currencyCode: "NZD",
+      currencySymbol: "$",
+      maxPledge: 14_000,
+      minPledge: 1,
+      trailingCode: true
+    )
+    public static let pl = Country(
+      countryCode: "PL",
+      currencyCode: "PLN",
+      currencySymbol: "zł",
+      maxPledge: 37_250,
+      minPledge: 5,
+      trailingCode: false
+    )
+    public static let se = Country(
+      countryCode: "SE",
+      currencyCode: "SEK",
+      currencySymbol: "kr",
+      maxPledge: 85_000,
+      minPledge: 5,
+      trailingCode: true
+    )
+    public static let sg = Country(
+      countryCode: "SG",
+      currencyCode: "SGD",
+      currencySymbol: "$",
+      maxPledge: 13_000,
+      minPledge: 2,
+      trailingCode: true
+    )
+    public static let si = Country(
+      countryCode: "SI",
+      currencyCode: "EUR",
+      currencySymbol: "€",
+      maxPledge: eurMaxPledge,
+      minPledge: eurMinPledge,
+      trailingCode: false
+    )
+    public static let us = Country(
+      countryCode: "US",
+      currencyCode: "USD",
+      currencySymbol: "$",
+      maxPledge: 10_000,
+      minPledge: 1,
+      trailingCode: true
+    )
 
     public static let all: [Country] = [
-      .au, .at, .be, .ca, .ch, .de, .dk, .es, .fr, .gb, .gr, .hk, .ie, .it, .jp, .lu, .mx, .nl, .no, .nz, .pl, .se, .sg, .si, .us
+      .au, .at, .be, .ca, .ch, .de, .dk, .es, .fr, .gb, .gr, .hk, .ie, .it, .jp, .lu, .mx, .nl, .no, .nz, .pl,
+      .se, .sg, .si, .us
     ]
-    // swiftformat:enable wrap
-    // swiftformat:enable wrapArguments
   }
 }
 

--- a/KsApi/models/templates/ProjectTemplates.swift
+++ b/KsApi/models/templates/ProjectTemplates.swift
@@ -1,7 +1,6 @@
 import Foundation
 import Prelude
 
-// swiftformat:disable wrap
 extension Project {
   internal static let template = Project(
     availableCardTypes: [
@@ -26,7 +25,8 @@ extension Project {
     dates: Project.Dates(
       deadline: Date(timeIntervalSince1970: 1_475_361_315).timeIntervalSince1970 + 60.0 * 60.0 * 24.0 * 15.0,
       featuredAt: nil,
-      launchedAt: Date(timeIntervalSince1970: 1_475_361_315).timeIntervalSince1970 - 60.0 * 60.0 * 24.0 * 15.0,
+      launchedAt: Date(timeIntervalSince1970: 1_475_361_315)
+        .timeIntervalSince1970 - 60.0 * 60.0 * 24.0 * 15.0,
       stateChangedAt: Date(
         timeIntervalSince1970: 1_475_361_315
       ).timeIntervalSince1970 - 60.0 * 60.0 * 24.0 * 15.0
@@ -63,9 +63,15 @@ extension Project {
   )
 
   internal static let todayByScottThrift = Project.template
-    |> Project.lens.photo.full .~ "https://ksr-ugc.imgix.net/assets/012/224/660/847bc4da31e6863e9351bee4e55b8005_original.jpg?w=560&h=315&fit=fill&bg=FBFAF8&v=1464773625&auto=format&q=92&s=bb3773aebc4ad41e145ed8735cb3a221"
-    |> Project.lens.photo.med .~ "https://ksr-ugc.imgix.net/assets/012/224/660/847bc4da31e6863e9351bee4e55b8005_original.jpg?w=266&h=150&fit=fill&bg=FBFAF8&v=1464773625&auto=format&q=92&s=79a8051e6475e417ead9b0bfae63798b"
-    |> Project.lens.photo.small .~ "https://ksr-ugc.imgix.net/assets/012/224/660/847bc4da31e6863e9351bee4e55b8005_original.jpg?w=160&h=90&fit=fill&bg=FBFAF8&v=1464773625&auto=format&q=92&s=fc738d87d861a96333e9f93bee680c27"
+    |> Project.lens.photo
+    .full .~
+    "https://ksr-ugc.imgix.net/assets/012/224/660/847bc4da31e6863e9351bee4e55b8005_original.jpg?w=560&h=315&fit=fill&bg=FBFAF8&v=1464773625&auto=format&q=92&s=bb3773aebc4ad41e145ed8735cb3a221"
+    |> Project.lens.photo
+    .med .~
+    "https://ksr-ugc.imgix.net/assets/012/224/660/847bc4da31e6863e9351bee4e55b8005_original.jpg?w=266&h=150&fit=fill&bg=FBFAF8&v=1464773625&auto=format&q=92&s=79a8051e6475e417ead9b0bfae63798b"
+    |> Project.lens.photo
+    .small .~
+    "https://ksr-ugc.imgix.net/assets/012/224/660/847bc4da31e6863e9351bee4e55b8005_original.jpg?w=160&h=90&fit=fill&bg=FBFAF8&v=1464773625&auto=format&q=92&s=fc738d87d861a96333e9f93bee680c27"
     |> Project.lens.name .~ "Today"
     |> Project.lens.blurb .~ "A 24-hour timepiece beautifully designed to change the way you see your day."
     |> \.category.name .~ "Product Design"
@@ -74,11 +80,19 @@ extension Project {
     |> Project.lens.stats.goal .~ 24_000
 
   internal static let cosmicSurgery = .template
-    |> Project.lens.photo.full .~ "https://ksr-ugc.imgix.net/assets/012/347/230/2eddca8c4a06ecb69b8787b985201b92_original.jpg?w=460&fit=max&v=1463756137&auto=format&q=92&s=98a6df348751e8b325e48eb8f802fa7e"
-    |> Project.lens.photo.med .~ "https://ksr-ugc.imgix.net/assets/012/347/230/2eddca8c4a06ecb69b8787b985201b92_original.jpg?w=460&fit=max&v=1463756137&auto=format&q=92&s=98a6df348751e8b325e48eb8f802fa7e"
-    |> Project.lens.photo.small .~ "https://ksr-ugc.imgix.net/assets/012/347/230/2eddca8c4a06ecb69b8787b985201b92_original.jpg?w=460&fit=max&v=1463756137&auto=format&q=92&s=98a6df348751e8b325e48eb8f802fa7e"
+    |> Project.lens.photo
+    .full .~
+    "https://ksr-ugc.imgix.net/assets/012/347/230/2eddca8c4a06ecb69b8787b985201b92_original.jpg?w=460&fit=max&v=1463756137&auto=format&q=92&s=98a6df348751e8b325e48eb8f802fa7e"
+    |> Project.lens.photo
+    .med .~
+    "https://ksr-ugc.imgix.net/assets/012/347/230/2eddca8c4a06ecb69b8787b985201b92_original.jpg?w=460&fit=max&v=1463756137&auto=format&q=92&s=98a6df348751e8b325e48eb8f802fa7e"
+    |> Project.lens.photo
+    .small .~
+    "https://ksr-ugc.imgix.net/assets/012/347/230/2eddca8c4a06ecb69b8787b985201b92_original.jpg?w=460&fit=max&v=1463756137&auto=format&q=92&s=98a6df348751e8b325e48eb8f802fa7e"
     |> Project.lens.name .~ "Cosmic Surgery"
-    |> Project.lens.blurb .~ "Cosmic Surgery is a photo book, set in the not too distant future where the world of cosmetic surgery is about to be transformed."
+    |> Project.lens
+    .blurb .~
+    "Cosmic Surgery is a photo book, set in the not too distant future where the world of cosmetic surgery is about to be transformed."
     |> \.category.name .~ "Photo Books"
     |> Project.lens.stats.backersCount .~ 329
     |> Project.lens.stats.pledged .~ 22_318
@@ -93,19 +107,31 @@ extension Project {
       User.template
         |> \.id .~ "Alma Haser".hash
         |> \.name .~ "Alma Haser"
-        |> \.avatar.large .~ "https://ksr-ugc.imgix.net/assets/006/286/957/203502774070f5c0bf5ddcbb58e13000_original.jpg?w=80&h=80&fit=crop&v=1461378633&auto=format&q=92&s=68edc5b8d1b110634b59589253801ea1"
-        |> \.avatar.medium .~ "https://ksr-ugc.imgix.net/assets/006/286/957/203502774070f5c0bf5ddcbb58e13000_original.jpg?w=80&h=80&fit=crop&v=1461378633&auto=format&q=92&s=68edc5b8d1b110634b59589253801ea1"
-        |> \.avatar.small .~ "https://ksr-ugc.imgix.net/assets/006/286/957/203502774070f5c0bf5ddcbb58e13000_original.jpg?w=80&h=80&fit=crop&v=1461378633&auto=format&q=92&s=68edc5b8d1b110634b59589253801ea1"
+        |> \.avatar
+        .large .~
+        "https://ksr-ugc.imgix.net/assets/006/286/957/203502774070f5c0bf5ddcbb58e13000_original.jpg?w=80&h=80&fit=crop&v=1461378633&auto=format&q=92&s=68edc5b8d1b110634b59589253801ea1"
+        |> \.avatar
+        .medium .~
+        "https://ksr-ugc.imgix.net/assets/006/286/957/203502774070f5c0bf5ddcbb58e13000_original.jpg?w=80&h=80&fit=crop&v=1461378633&auto=format&q=92&s=68edc5b8d1b110634b59589253801ea1"
+        |> \.avatar
+        .small .~
+        "https://ksr-ugc.imgix.net/assets/006/286/957/203502774070f5c0bf5ddcbb58e13000_original.jpg?w=80&h=80&fit=crop&v=1461378633&auto=format&q=92&s=68edc5b8d1b110634b59589253801ea1"
     )
     |> Project.lens.urls.web.project .~ "https://www.kickstarter.com/projects/1171937901/cosmic-surgery"
     |> Project.lens.rewardData.rewards .~ cosmicSurgeryRewards
     |> Project.lens.displayPrelaunch .~ false
 
   internal static let anomalisa = .template
-    |> Project.lens.photo.full .~ "https://ksr-ugc.imgix.net/assets/011/388/954/25e113da402393de9de995619428d10d_original.png?w=1024&h=576&fit=fill&bg=000000&v=1463681956&auto=format&q=92&s=2a9b6a90e1f52b96d7cbdcad28319f9d"
-    |> Project.lens.photo.med .~ "https://ksr-ugc.imgix.net/assets/005/055/025/6e0d27710c9ae20d661e2974e99fe239_original.jpg?w=460&fit=max&v=1449722467&auto=format&q=92&s=cd67034e3ee1f363be0df4f5d3b5f728"
+    |> Project.lens.photo
+    .full .~
+    "https://ksr-ugc.imgix.net/assets/011/388/954/25e113da402393de9de995619428d10d_original.png?w=1024&h=576&fit=fill&bg=000000&v=1463681956&auto=format&q=92&s=2a9b6a90e1f52b96d7cbdcad28319f9d"
+    |> Project.lens.photo
+    .med .~
+    "https://ksr-ugc.imgix.net/assets/005/055/025/6e0d27710c9ae20d661e2974e99fe239_original.jpg?w=460&fit=max&v=1449722467&auto=format&q=92&s=cd67034e3ee1f363be0df4f5d3b5f728"
     |> Project.lens.name .~ "Charlie Kaufman's Anomalisa"
-    |> Project.lens.blurb .~ "From writer Charlie Kaufman (Being John Malkovich, Eternal Sunshine of the Spotless Mind) and Duke Johnson (Moral Orel, Frankenhole) comes Anomalisa."
+    |> Project.lens
+    .blurb .~
+    "From writer Charlie Kaufman (Being John Malkovich, Eternal Sunshine of the Spotless Mind) and Duke Johnson (Moral Orel, Frankenhole) comes Anomalisa."
     |> \.category.name .~ "Animation"
     |> Project.lens.stats.backersCount .~ 5_770
     |> Project.lens.stats.pledged .~ 406_237
@@ -132,7 +158,9 @@ private let cosmicSurgeryRewards: [Reward] = [
     |> Reward.lens.backersCount .~ 100
     |> Reward.lens.remaining .~ 0
     |> Reward.lens.title .~ "‘EARLYBIRD’ COSMIC SURGERY BOOK"
-    |> Reward.lens.description .~ "You will be the first to receive a copy of the book at this special ‘earlybird’ price. Limited to the first 100 copies."
+    |> Reward.lens
+    .description .~
+    "You will be the first to receive a copy of the book at this special ‘earlybird’ price. Limited to the first 100 copies."
     |> Reward.lens.localPickup .~ nil,
 
   .template
@@ -141,7 +169,9 @@ private let cosmicSurgeryRewards: [Reward] = [
     |> Reward.lens.convertedMinimum .~ 39.0
     |> Reward.lens.backersCount .~ 83
     |> Reward.lens.title .~ "COSMIC SURGERY BOOK"
-    |> Reward.lens.description .~ "You will be the first to receive a copy of the book at the special price of £30. The book will be sold for £35 in shops when released in July."
+    |> Reward.lens
+    .description .~
+    "You will be the first to receive a copy of the book at the special price of £30. The book will be sold for £35 in shops when released in July."
     |> Reward.lens.localPickup .~ nil,
 
   .template
@@ -151,7 +181,8 @@ private let cosmicSurgeryRewards: [Reward] = [
     |> Reward.lens.limit .~ 10
     |> Reward.lens.backersCount .~ 3
     |> Reward.lens.title .~ "‘PATIENT NO. 16’ PRINT"
-    |> Reward.lens.description .~ "This is a newly released print available in the Cosmic Surgery print series."
+    |> Reward.lens
+    .description .~ "This is a newly released print available in the Cosmic Surgery print series."
     |> Reward.lens.rewardsItems .~ [
       .template
         |> RewardsItem.lens.id .~ 1

--- a/KsApi/models/templates/UserTemplates.swift
+++ b/KsApi/models/templates/UserTemplates.swift
@@ -22,12 +22,16 @@ extension User {
     unseenActivityCount: nil
   )
 
-  // swiftformat:disable wrap
   internal static let brando = User.template
-    |> \.avatar.large .~ "https://ksr-ugc.imgix.net/assets/006/258/518/b9033f46095b83119188cf9a66d19356_original.jpg?w=160&h=160&fit=crop&v=1461376829&auto=format&q=92&s=8d7666f01ab6765c3cf09149751ff077"
-    |> \.avatar.medium .~ "https://ksr-ugc.imgix.net/assets/006/258/518/b9033f46095b83119188cf9a66d19356_original.jpg?w=40&h=40&fit=crop&v=1461376829&auto=format&q=92&s=0fcedf8888ca6990408ccde81888899b"
-    |> \.avatar.small .~ "https://ksr-ugc.imgix.net/assets/006/258/518/b9033f46095b83119188cf9a66d19356_original.jpg?w=40&h=40&fit=crop&v=1461376829&auto=format&q=92&s=0fcedf8888ca6990408ccde81888899b"
+    |> \.avatar
+    .large .~
+    "https://ksr-ugc.imgix.net/assets/006/258/518/b9033f46095b83119188cf9a66d19356_original.jpg?w=160&h=160&fit=crop&v=1461376829&auto=format&q=92&s=8d7666f01ab6765c3cf09149751ff077"
+    |> \.avatar
+    .medium .~
+    "https://ksr-ugc.imgix.net/assets/006/258/518/b9033f46095b83119188cf9a66d19356_original.jpg?w=40&h=40&fit=crop&v=1461376829&auto=format&q=92&s=0fcedf8888ca6990408ccde81888899b"
+    |> \.avatar
+    .small .~
+    "https://ksr-ugc.imgix.net/assets/006/258/518/b9033f46095b83119188cf9a66d19356_original.jpg?w=40&h=40&fit=crop&v=1461376829&auto=format&q=92&s=0fcedf8888ca6990408ccde81888899b"
     |> \.id .~ "brando".hash
     |> \.name .~ "Brandon Williams"
-  // swiftformat:enable wrap
 }

--- a/Library/AppEnvironment.swift
+++ b/Library/AppEnvironment.swift
@@ -452,8 +452,6 @@ public struct AppEnvironment: AppEnvironmentType {
   ) {
     var data: [String: Any] = [:]
 
-    // swiftformat:disable wrap
-
     if let oauthToken = env.apiService.oauthToken?.token {
       // Try to save to the keychain, but if that fails, save to user defaults
       if !self.storeOAuthTokenToKeychain(oauthToken) {
@@ -464,16 +462,18 @@ public struct AppEnvironment: AppEnvironmentType {
     }
 
     data["apiService.serverConfig.apiBaseUrl"] = env.apiService.serverConfig.apiBaseUrl.absoluteString
-    data["apiService.serverConfig.apiClientAuth.clientId"] = env.apiService.serverConfig.apiClientAuth.clientId
-    data["apiService.serverConfig.basicHTTPAuth.username"] = env.apiService.serverConfig.basicHTTPAuth?.username
-    data["apiService.serverConfig.basicHTTPAuth.password"] = env.apiService.serverConfig.basicHTTPAuth?.password
+    data["apiService.serverConfig.apiClientAuth.clientId"] = env.apiService.serverConfig.apiClientAuth
+      .clientId
+    data["apiService.serverConfig.basicHTTPAuth.username"] = env.apiService.serverConfig.basicHTTPAuth?
+      .username
+    data["apiService.serverConfig.basicHTTPAuth.password"] = env.apiService.serverConfig.basicHTTPAuth?
+      .password
     data["apiService.serverConfig.webBaseUrl"] = env.apiService.serverConfig.webBaseUrl.absoluteString
     data["apiService.serverConfig.environment"] = env.apiService.serverConfig.environment.description
     data["apiService.language"] = env.apiService.language
     data["apiService.currency"] = env.apiService.currency
     data["config"] = env.config?.encode()
     data["currentUser"] = env.currentUser?.encode()
-    // swiftformat:enable wrap
 
     userDefaults.set(data, forKey: self.environmentStorageKey)
   }

--- a/Library/KeyValueStoreType.swift
+++ b/Library/KeyValueStoreType.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 public enum AppKeys: String {
-  // swiftformat:disable wrap
   case closedFacebookConnectInActivity = "com.kickstarter.KeyValueStoreType.closedFacebookConnectInActivity"
   case closedFindFriendsInActivity = "com.kickstarter.KeyValueStoreType.closedFindFriendsInActivity"
   case deniedNotificationContexts = "com.kickstarter.KeyValueStoreType.deniedNotificationContexts"
   case favoriteCategoryIds = "favorite_category_ids"
-  case hasCompletedCategoryPersonalizationFlow = "com.kickstarter.KeyValueStoreType.hasCompletedCategoryPersonalizationFlow"
+  case hasCompletedCategoryPersonalizationFlow =
+    "com.kickstarter.KeyValueStoreType.hasCompletedCategoryPersonalizationFlow"
   case hasDismissedPersonalizationCard = "com.kickstarter.KeyValueStoreType.hasDismissedPersonalizationCard"
   case hasSeenFavoriteCategoryAlert = "com.kickstarter.KeyValueStoreType.hasSeenFavoriteCategoryAlert"
   case hasSeenSaveProjectAlert = "com.kickstarter.KeyValueStoreType.hasSeenSaveProjectAlert"
@@ -15,7 +15,6 @@ public enum AppKeys: String {
   case remoteConfigFeatureFlags = "com.kickstarter.KeyValueStoreType.remoteConfigFeatureFlags"
   case seenAppRating = "com.kickstarter.KeyValueStoreType.hasSeenAppRating"
   case seenGamesNewsletter = "com.kickstarter.KeyValueStoreType.hasSeenGamesNewsletter"
-  // swiftformat:enable wrap
 }
 
 public protocol KeyValueStoreType: AnyObject {

--- a/Library/NumberFormatter.swift
+++ b/Library/NumberFormatter.swift
@@ -1,4 +1,3 @@
-// swiftformat:disable wrap
 import Foundation
 
 final class AttributedNumberFormatter: NumberFormatter {
@@ -11,10 +10,14 @@ final class AttributedNumberFormatter: NumberFormatter {
 
   // MARK: - Attributed string
 
-  override func attributedString(for obj: Any, withDefaultAttributes _: [NSAttributedString.Key: Any]? = nil) -> NSAttributedString? {
+  override func attributedString(
+    for obj: Any,
+    withDefaultAttributes _: [NSAttributedString.Key: Any]? = nil
+  ) -> NSAttributedString? {
     guard
       let number = obj as? NSNumber,
-      let string = string(from: number)?.replacingOccurrences(of: String.nbsp + String.nbsp, with: String.nbsp)
+      let string = string(from: number)?
+      .replacingOccurrences(of: String.nbsp + String.nbsp, with: String.nbsp)
     else { return nil }
 
     let mutableAttributedString = NSMutableAttributedString(
@@ -22,21 +25,24 @@ final class AttributedNumberFormatter: NumberFormatter {
       attributes: self.defaultAttributes
     )
 
-    if let currencySymbolRange = self.currencySymbolRange(for: string), currencySymbolRange.location != NSNotFound {
+    if let currencySymbolRange = self.currencySymbolRange(for: string),
+      currencySymbolRange.location != NSNotFound {
       mutableAttributedString.addAttributes(
         self.currencySymbolAttributes,
         range: currencySymbolRange
       )
     }
 
-    if let decimalSeparatorRange = self.decimalSeparatorRange(for: string), decimalSeparatorRange.location != NSNotFound {
+    if let decimalSeparatorRange = self.decimalSeparatorRange(for: string),
+      decimalSeparatorRange.location != NSNotFound {
       mutableAttributedString.addAttributes(
         self.decimalSeparatorAttributes,
         range: decimalSeparatorRange
       )
     }
 
-    if let fractionDigitsRange = self.fractionDigitsRange(for: string), fractionDigitsRange.location != NSNotFound {
+    if let fractionDigitsRange = self.fractionDigitsRange(for: string),
+      fractionDigitsRange.location != NSNotFound {
       mutableAttributedString.addAttributes(
         self.fractionDigitsAttributes,
         range: fractionDigitsRange
@@ -58,7 +64,8 @@ final class AttributedNumberFormatter: NumberFormatter {
   }
 
   private func fractionDigitsRange(for string: String) -> NSRange? {
-    if let decimalSeparatorRange = self.decimalSeparatorRange(for: string), decimalSeparatorRange.location != NSNotFound {
+    if let decimalSeparatorRange = self.decimalSeparatorRange(for: string),
+      decimalSeparatorRange.location != NSNotFound {
       return NSRange(
         location: decimalSeparatorRange.location + 1,
         length: self.maximumFractionDigits

--- a/Library/ViewModels/ManagePledgeViewModel.swift
+++ b/Library/ViewModels/ManagePledgeViewModel.swift
@@ -301,9 +301,8 @@ public final class ManagePledgeViewModel:
     let attemptedDisallowedCancelBackingMessage = cancelBackingDisallowed
       .takeWhen(cancelPledgeSelected)
       .map { _ in
-        // swiftformat:disable wrap
-        Strings.We_dont_allow_cancelations_that_will_cause_a_project_to_fall_short_of_its_goal_within_the_last_24_hours()
-        // swiftformat:enable wrap
+        Strings
+          .We_dont_allow_cancelations_that_will_cause_a_project_to_fall_short_of_its_goal_within_the_last_24_hours()
       }
 
     let networkErrorMessage = Signal.merge(


### PR DESCRIPTION
# 📲 What

Remove `swiftformat:disable` directives that weren't working.

# 🤔 Why

When all of us upgraded our Macbooks to Sonoma 14.4, `swiftformat` suddenly ceased to respect all of our `disable` and `enable` statements. Frustratingly, one file `ServiceTypeTests.swift` would get trapped in an infinite loop, in which swiftformat _always_ insisted on editing it.

We've yet to find an actual fix for this issue, but to be blunt, the `ignore`s were mostly just there to make certain files that shouldn't be wrapped a bit prettier. In this PR I'm removing all of the `ignore`s that I can, and fixing the one in `ServiceTypeTest` that is actually broken. 

I'll file a follow-up ticket to investigate further, but it's more important that the team stops being blocked by these unnecessary/unwanted formatting changes than it is for us to have these files be beautiful.