### PR TITLE
[MBL-1328] Update Pledge Button Enabled Signals

### DIFF
--- a/Library/ViewModels/PostCampaignCheckoutViewModel.swift
+++ b/Library/ViewModels/PostCampaignCheckoutViewModel.swift
@@ -86,7 +86,6 @@ public class PostCampaignCheckoutViewModel: PostCampaignCheckoutViewModelType,
     .skipNil()
 
     let context = initialData.map(\.context)
-    let project = initialData.map(\.project)
     let checkoutId = initialData.map(\.checkoutId)
     let baseReward = initialData.map(\.rewards).map(\.first)
 

--- a/Library/ViewModels/PostCampaignCheckoutViewModel.swift
+++ b/Library/ViewModels/PostCampaignCheckoutViewModel.swift
@@ -196,7 +196,7 @@ public class PostCampaignCheckoutViewModel: PostCampaignCheckoutViewModelType,
 
     let paymentIntentClientSecretForExistingCards = newPaymentIntentForExistingCards.values()
       .map { $0.clientSecret }
-    
+
     let validateCheckoutExistingCardInput = Signal
       .combineLatest(
         checkoutId,
@@ -204,9 +204,6 @@ public class PostCampaignCheckoutViewModel: PostCampaignCheckoutViewModelType,
         paymentIntentClientSecretForExistingCards,
         storedCardsValues
       )
-      .filter { _, selectedCard, _, _ in
-        selectedCard.isNewPaymentMethod == false
-      }
 
     // Runs validation for pre-existing cards that were created with setup intents originally but require payment intents for late pledges.
     let validateCheckoutExistingCard = validateCheckoutExistingCardInput
@@ -245,11 +242,8 @@ public class PostCampaignCheckoutViewModel: PostCampaignCheckoutViewModelType,
       }
 
     // MARK: - Validate New Cards
-    
+
     let validateCheckoutNewCardInput = Signal.combineLatest(checkoutId, selectedCard)
-      .filter { _, selectedCard in
-        selectedCard.isNewPaymentMethod == true
-      }
 
     // Runs validation for new cards that were created with payment intents.
     let validateCheckoutNewCard = validateCheckoutNewCardInput
@@ -414,13 +408,25 @@ public class PostCampaignCheckoutViewModel: PostCampaignCheckoutViewModelType,
       .map { $0 }
 
     self.checkoutError = checkoutCompleteSignal.signal.errors()
-    
+
     // MARK: - UI related to checkout flow
+
+    let newCardActivatesPledgeButton = validateCheckoutNewCardInput
+      .filter { _, selectedCard in
+        selectedCard.isNewPaymentMethod == true
+      }
+      .mapConst(true)
+
+    let existingCardActivatesPledgeButton = validateCheckoutExistingCardInput
+      .filter { _, selectedCard, _, _ in
+        selectedCard.isNewPaymentMethod == false
+      }
+      .mapConst(true)
 
     let pledgeButtonEnabled = Signal.merge(
       self.viewDidLoadProperty.signal.mapConst(false),
-      validateCheckoutNewCardInput.mapConst(true),
-      validateCheckoutExistingCardInput.mapConst(true)
+      newCardActivatesPledgeButton,
+      existingCardActivatesPledgeButton
     )
     .skipRepeats()
 

--- a/Library/ViewModels/PostCampaignCheckoutViewModel.swift
+++ b/Library/ViewModels/PostCampaignCheckoutViewModel.swift
@@ -110,28 +110,6 @@ public class PostCampaignCheckoutViewModel: PostCampaignCheckoutViewModelType,
       .map { _ in AppEnvironment.current.currentUser }
       .map(isNotNil)
 
-    let shouldEnablePledgeButton = self.creditCardSelectedProperty.signal.skipNil().mapConst(true)
-
-    let pledgeButtonEnabled = Signal.merge(
-      self.viewDidLoadProperty.signal.mapConst(false),
-      shouldEnablePledgeButton
-    )
-    .skipRepeats()
-
-    self.configurePledgeViewCTAContainerView = Signal.combineLatest(
-      isLoggedIn,
-      pledgeButtonEnabled,
-      context
-    )
-    .map { isLoggedIn, pledgeButtonEnabled, context in
-      PledgeViewCTAContainerViewData(
-        isLoggedIn: isLoggedIn,
-        isEnabled: pledgeButtonEnabled,
-        context: context,
-        willRetryPaymentMethod: false // Only retry in the `fixPaymentMethod` context.
-      )
-    }
-
     self.paymentMethodsViewHidden = Signal.combineLatest(isLoggedIn, context)
       .map { isLoggedIn, context in
         !isLoggedIn || context.paymentMethodsViewHidden
@@ -218,10 +196,20 @@ public class PostCampaignCheckoutViewModel: PostCampaignCheckoutViewModelType,
 
     let paymentIntentClientSecretForExistingCards = newPaymentIntentForExistingCards.values()
       .map { $0.clientSecret }
+    
+    let validateCheckoutExistingCardInput = Signal
+      .combineLatest(
+        checkoutId,
+        selectedCard,
+        paymentIntentClientSecretForExistingCards,
+        storedCardsValues
+      )
+      .filter { _, selectedCard, _, _ in
+        selectedCard.isNewPaymentMethod == false
+      }
 
     // Runs validation for pre-existing cards that were created with setup intents originally but require payment intents for late pledges.
-    let validateCheckoutExistingCard = Signal
-      .combineLatest(checkoutId, selectedCard, paymentIntentClientSecretForExistingCards, storedCardsValues)
+    let validateCheckoutExistingCard = validateCheckoutExistingCardInput
       .takeWhen(self.submitButtonTappedProperty.signal)
       .filter { _, selectedCard, _, _ in
         selectedCard.isNewPaymentMethod == false
@@ -257,9 +245,14 @@ public class PostCampaignCheckoutViewModel: PostCampaignCheckoutViewModelType,
       }
 
     // MARK: - Validate New Cards
+    
+    let validateCheckoutNewCardInput = Signal.combineLatest(checkoutId, selectedCard)
+      .filter { _, selectedCard in
+        selectedCard.isNewPaymentMethod == true
+      }
 
     // Runs validation for new cards that were created with payment intents.
-    let validateCheckoutNewCard = Signal.combineLatest(checkoutId, selectedCard)
+    let validateCheckoutNewCard = validateCheckoutNewCardInput
       .takeWhen(self.submitButtonTappedProperty.signal)
       .filter { _, selectedCard in
         selectedCard.isNewPaymentMethod == true
@@ -421,6 +414,29 @@ public class PostCampaignCheckoutViewModel: PostCampaignCheckoutViewModelType,
       .map { $0 }
 
     self.checkoutError = checkoutCompleteSignal.signal.errors()
+    
+    // MARK: - UI related to checkout flow
+
+    let pledgeButtonEnabled = Signal.merge(
+      self.viewDidLoadProperty.signal.mapConst(false),
+      validateCheckoutNewCardInput.mapConst(true),
+      validateCheckoutExistingCardInput.mapConst(true)
+    )
+    .skipRepeats()
+
+    self.configurePledgeViewCTAContainerView = Signal.combineLatest(
+      isLoggedIn,
+      pledgeButtonEnabled,
+      context
+    )
+    .map { isLoggedIn, pledgeButtonEnabled, context in
+      PledgeViewCTAContainerViewData(
+        isLoggedIn: isLoggedIn,
+        isEnabled: pledgeButtonEnabled,
+        context: context,
+        willRetryPaymentMethod: false // Only retry in the `fixPaymentMethod` context.
+      )
+    }
 
     self.processingViewIsHidden = Signal.merge(
       // Processing view starts hidden, so show at the start of a pledge flow.

--- a/Library/ViewModels/PostCampaignCheckoutViewModelTests.swift
+++ b/Library/ViewModels/PostCampaignCheckoutViewModelTests.swift
@@ -511,7 +511,7 @@ final class PostCampaignCheckoutViewModelTests: TestCase {
     }
   }
 
-  func testPledgeViewCTA_LoggedIn_State() {
+  func testPledgeViewCTAEnabled_afterSelectingNewPaymentMethod_LoggedIn() {
     let mockService = MockService(serverConfig: ServerConfig.staging)
 
     withEnvironment(apiService: mockService, currentUser: .template) {
@@ -540,6 +540,34 @@ final class PostCampaignCheckoutViewModelTests: TestCase {
       self.configurePledgeViewCTAContainerViewIsLoggedIn.assertValues([true, true])
       self.configurePledgeViewCTAContainerViewIsEnabled.assertValues([false, true])
       self.configurePledgeViewCTAContainerViewContext.assertValues([.latePledge, .latePledge])
+    }
+  }
+
+  func testPledgeViewCTADisabled_onViewDidLoad_LoggedIn() {
+    let mockService = MockService(serverConfig: ServerConfig.staging)
+
+    withEnvironment(apiService: mockService, currentUser: .template) {
+      let project = Project.cosmicSurgery
+      let reward = Reward.noReward |> Reward.lens.minimum .~ 5
+
+      let data = PostCampaignCheckoutData(
+        project: project,
+        rewards: [reward],
+        selectedQuantities: [:],
+        bonusAmount: 0,
+        total: 5,
+        shipping: nil,
+        refTag: nil,
+        context: .latePledge,
+        checkoutId: "0"
+      )
+
+      self.vm.inputs.configure(with: data)
+      self.vm.inputs.viewDidLoad()
+
+      self.configurePledgeViewCTAContainerViewIsLoggedIn.assertValues([true])
+      self.configurePledgeViewCTAContainerViewIsEnabled.assertValues([false])
+      self.configurePledgeViewCTAContainerViewContext.assertValues([.latePledge])
     }
   }
 }


### PR DESCRIPTION
Pledge Button enabled state needs to rely on successfully creating a new payment intent for pre-existing cards or when a new card is successfully created and selected.

# 🛠 How

Creates separate inputs for existing and new cards allowing the pledge button to respond to either scenario mentioned above.

# 👀 See

![Simulator Screen Recording - iPhone 15 Pro Max - 2024-04-03 at 14 33 00](https://github.com/kickstarter/ios-oss/assets/110618242/e8751a1d-49ea-4094-ba13-08c9f6529e4f)

# ✅ Acceptance criteria

- [x] Processing view doesn't hang when pledging with a new or existing card
