### PR TITLE
DRAFT: Move CreateCheckout to final pledge page

### DIFF
--- a/Kickstarter-iOS/Features/ConfirmDetails/Controllers/ConfirmDetailsViewController.swift
+++ b/Kickstarter-iOS/Features/ConfirmDetails/Controllers/ConfirmDetailsViewController.swift
@@ -12,12 +12,10 @@ public enum ConfirmDetailsLayout {
 
 protocol ConfirmDetailsViewControllerDelegate: AnyObject {}
 
-final class ConfirmDetailsViewController: UIViewController, MessageBannerViewControllerPresenting {
+final class ConfirmDetailsViewController: UIViewController {
   // MARK: - Properties
 
   public weak var delegate: ConfirmDetailsViewControllerDelegate?
-
-  internal var messageBannerViewController: MessageBannerViewController?
 
   private lazy var titleLabel = UILabel(frame: .zero)
 
@@ -123,8 +121,6 @@ final class ConfirmDetailsViewController: UIViewController, MessageBannerViewCon
       |> \.title .~ Strings.Back_this_project()
 
     self.view.addGestureRecognizer(self.keyboardDimissingTapGestureRecognizer)
-
-    self.messageBannerViewController = self.configureMessageBannerViewController(on: self)
 
     self.configureChildViewControllers()
     self.setupConstraints()
@@ -263,16 +259,10 @@ final class ConfirmDetailsViewController: UIViewController, MessageBannerViewCon
         self?.rootScrollView.handleKeyboardVisibilityDidChange(change)
       }
 
-    self.viewModel.outputs.createCheckoutSuccess
+    self.viewModel.outputs.confirmSuccess
       .observeForUI()
       .observeValues { [weak self] data in
         self?.goToCheckout(data: data)
-      }
-
-    self.viewModel.outputs.showErrorBannerWithMessage
-      .observeForControllerAction()
-      .observeValues { [weak self] errorMessage in
-        self?.messageBannerViewController?.showBanner(with: .error, message: errorMessage)
       }
 
     self.pledgeAmountViewController.view.rac.hidden = self.viewModel.outputs.pledgeAmountViewHidden

--- a/Library/RemoteConfig/RemoteConfigFeature+Helpers.swift
+++ b/Library/RemoteConfig/RemoteConfigFeature+Helpers.swift
@@ -30,6 +30,7 @@ public func featureFacebookLoginInterstitialEnabled() -> Bool {
 }
 
 public func featurePostCampaignPledgeEnabled() -> Bool {
+  return true
   featureEnabled(feature: .postCampaignPledgeEnabled)
 }
 

--- a/Library/ViewModels/ConfirmDetailsViewModel.swift
+++ b/Library/ViewModels/ConfirmDetailsViewModel.swift
@@ -322,12 +322,14 @@ public class ConfirmDetailsViewModel: ConfirmDetailsViewModelType, ConfirmDetail
       initialData,
       bonusOrPledgeUpdatedAmount,
       optionalShippingSummaryData,
-      pledgeTotal
+      pledgeTotal,
+      baseReward
     )
     .takeWhen(self.continueCTATappedProperty.signal)
     .map { data -> PostCampaignCheckoutData in
-      let (initialData, bonusOrReward, shipping, pledgeTotal) = data
+      let (initialData, bonusOrReward, shipping, pledgeTotal, baseReward) = data
       var rewards = initialData.rewards
+
       var bonus = bonusOrReward
       if let reward = rewards.first, reward.isNoReward {
         rewards[0] = reward

--- a/Library/ViewModels/PostCampaignCheckoutViewModelTests.swift
+++ b/Library/ViewModels/PostCampaignCheckoutViewModelTests.swift
@@ -47,8 +47,7 @@ final class PostCampaignCheckoutViewModelTests: TestCase {
       total: 5,
       shipping: nil,
       refTag: nil,
-      context: .pledge,
-      checkoutId: "0"
+      context: .pledge
     )
 
     let paymentIntent = PaymentIntentEnvelope(clientSecret: "foo")
@@ -88,8 +87,7 @@ final class PostCampaignCheckoutViewModelTests: TestCase {
       total: 18,
       shipping: nil,
       refTag: nil,
-      context: .pledge,
-      checkoutId: "0"
+      context: .pledge
     )
 
     let paymentIntent = PaymentIntentEnvelope(clientSecret: "foo")
@@ -135,8 +133,7 @@ final class PostCampaignCheckoutViewModelTests: TestCase {
         total: 72
       ),
       refTag: nil,
-      context: .pledge,
-      checkoutId: "0"
+      context: .pledge
     )
 
     let paymentIntent = PaymentIntentEnvelope(clientSecret: "foo")
@@ -184,8 +181,7 @@ final class PostCampaignCheckoutViewModelTests: TestCase {
         total: 72
       ),
       refTag: nil,
-      context: .pledge,
-      checkoutId: "0"
+      context: .pledge
     )
 
     let paymentIntent = PaymentIntentEnvelope(clientSecret: "foo")
@@ -227,8 +223,7 @@ final class PostCampaignCheckoutViewModelTests: TestCase {
       total: 5,
       shipping: nil,
       refTag: nil,
-      context: .pledge,
-      checkoutId: "0"
+      context: .pledge
     )
 
     withEnvironment(apiService: mockService) {
@@ -282,8 +277,7 @@ final class PostCampaignCheckoutViewModelTests: TestCase {
       total: 5,
       shipping: nil,
       refTag: nil,
-      context: .pledge,
-      checkoutId: "0"
+      context: .pledge
     )
 
     withEnvironment(apiService: mockService) {
@@ -333,8 +327,7 @@ final class PostCampaignCheckoutViewModelTests: TestCase {
       total: 5,
       shipping: nil,
       refTag: nil,
-      context: .pledge,
-      checkoutId: "0"
+      context: .pledge
     )
 
     withEnvironment(apiService: mockService) {
@@ -393,8 +386,7 @@ final class PostCampaignCheckoutViewModelTests: TestCase {
       total: 5,
       shipping: nil,
       refTag: nil,
-      context: .latePledge,
-      checkoutId: "0"
+      context: .latePledge
     )
 
     withEnvironment(apiService: mockService) {
@@ -444,8 +436,7 @@ final class PostCampaignCheckoutViewModelTests: TestCase {
       total: 5,
       shipping: nil,
       refTag: nil,
-      context: .latePledge,
-      checkoutId: "0"
+      context: .latePledge
     )
 
     withEnvironment(apiService: mockService) {
@@ -490,8 +481,7 @@ final class PostCampaignCheckoutViewModelTests: TestCase {
       total: 5,
       shipping: nil,
       refTag: nil,
-      context: .latePledge,
-      checkoutId: "0"
+      context: .latePledge
     )
 
     withEnvironment(apiService: mockService) {
@@ -537,8 +527,7 @@ final class PostCampaignCheckoutViewModelTests: TestCase {
         total: 5,
         shipping: nil,
         refTag: nil,
-        context: .latePledge,
-        checkoutId: "0"
+        context: .latePledge
       )
 
       self.vm.inputs.configure(with: data)
@@ -570,8 +559,7 @@ final class PostCampaignCheckoutViewModelTests: TestCase {
         total: 5,
         shipping: nil,
         refTag: nil,
-        context: .latePledge,
-        checkoutId: "0"
+        context: .latePledge
       )
 
       self.vm.inputs.configure(with: data)

--- a/Library/ViewModels/PostCampaignCheckoutViewModelTests.swift
+++ b/Library/ViewModels/PostCampaignCheckoutViewModelTests.swift
@@ -241,23 +241,6 @@ final class PostCampaignCheckoutViewModelTests: TestCase {
   func testApplePay_completesCheckoutFlow() {
     // Mock data for API requests
     let paymentIntent = PaymentIntentEnvelope(clientSecret: "foo")
-    let completeSessionJsonString = """
-    {
-      "completeOnSessionCheckout": {
-        "__typename": "CompleteOnSessionCheckoutPayload",
-        "checkout": {
-          "__typename": "Checkout",
-          "id": "Q2hlY2tvdXQtMTk4MzM2OTIz",
-          "state": "successful",
-          "backing": {
-            "requiresAction": false,
-            "clientSecret": "super-secret",
-            "__typename": "Backing"
-          }
-        }
-      }
-    }
-    """
     let completeSessionData = try! GraphAPI.CompleteOnSessionCheckoutMutation
       .Data(jsonString: completeSessionJsonString)
     let mockService = MockService(
@@ -348,27 +331,8 @@ final class PostCampaignCheckoutViewModelTests: TestCase {
   func testPledge_completesCheckoutFlow() {
     // Mock data for API requests
     let validateCheckout = ValidateCheckoutEnvelope(valid: true, messages: ["message"])
-    let completeSessionJsonString = """
-    {
-      "completeOnSessionCheckout": {
-        "__typename": "CompleteOnSessionCheckoutPayload",
-        "checkout": {
-          "__typename": "Checkout",
-          "id": "Q2hlY2tvdXQtMTk4MzM2OTIz",
-          "state": "successful",
-          "backing": {
-            "requiresAction": false,
-            "clientSecret": "super-secret",
-            "__typename": "Backing"
-          }
-        }
-      }
-    }
-    """
-    let completeSessionJson = try! JSONSerialization
-      .jsonObject(with: completeSessionJsonString.data(using: .utf8)!)
     let completeSessionData = try! GraphAPI.CompleteOnSessionCheckoutMutation
-      .Data(jsonObject: completeSessionJson as! JSONObject)
+      .Data(jsonString: completeSessionJsonString)
     let mockService = MockService(
       completeOnSessionCheckoutResult: .success(completeSessionData),
       validateCheckoutResult: .success(validateCheckout)
@@ -571,3 +535,21 @@ final class PostCampaignCheckoutViewModelTests: TestCase {
     }
   }
 }
+
+private let completeSessionJsonString = """
+{
+  "completeOnSessionCheckout": {
+    "__typename": "CompleteOnSessionCheckoutPayload",
+    "checkout": {
+      "__typename": "Checkout",
+      "id": "Q2hlY2tvdXQtMTk4MzM2OTIz",
+      "state": "successful",
+      "backing": {
+        "requiresAction": false,
+        "clientSecret": "super-secret",
+        "__typename": "Backing"
+      }
+    }
+  }
+}
+"""


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

WIP: Move CreateCheckout to final pledge page.

# 🤔 Why

If you are logged out, we need to re-fetch a new `Checkout` for you. The original `Checkout` we create is not associated with your user.

# 🛠 How

This is an experimental/potential way to fix this problem. Right now, the code works, but tests are failing and will take some additional work to make them pass. Additionally, this adds yet another layer of complexity to `PostCampaignCheckoutViewModel`, which is already fairly complex. 

# 📓  TODO
- [ ] Update tests with `CreateCheckoutResult` mocks so that they pass correctly