### PR TITLE
[MBL-1339] Include multiple copies of add-ons if selected

### DIFF
--- a/Library/ViewModels/ConfirmDetailsViewModel.swift
+++ b/Library/ViewModels/ConfirmDetailsViewModel.swift
@@ -314,14 +314,22 @@ public class ConfirmDetailsViewModel: ConfirmDetailsViewModelType, ConfirmDetail
     let pledgeDetailsData = Signal.combineLatest(
       project,
       rewards,
+      selectedQuantities,
       pledgeTotal,
       refTag
     )
 
     let createCheckoutEvents = pledgeDetailsData
       .takeWhen(self.continueCTATappedProperty.signal)
-      .map { project, rewards, pledgeTotal, refTag in
-        let rewardsIDs = rewards.first?.isNoReward == true ? [] : rewards.map { $0.graphID }
+      .map { project, rewards, selectedQuantities, pledgeTotal, refTag in
+        let rewardsIDs: [String] = rewards.first?.isNoReward == true
+          ? []
+          : rewards.flatMap { reward -> [String] in
+            guard let count = selectedQuantities[reward.id] else {
+              return []
+            }
+            return [String](repeating: reward.graphID, count: count)
+          }
 
         return CreateCheckoutInput(
           projectId: project.graphID,


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Send all copies of each reward to the backend. Note that this doesn't fix the bonus support being weird, but that matches a web bug that backend/web people are already working on.

# 👀 See

[Jira](https://kickstarter.atlassian.net/browse/MBL-1339)

| Before 🐛 | After 🦋 |
| --- | --- |
| ![Screenshot 2024-04-04 at 2 29 58 PM](https://github.com/kickstarter/ios-oss/assets/6799207/4e504de7-9f11-422a-9959-5441cd09836e) | ![Screenshot 2024-04-04 at 2 32 31 PM](https://github.com/kickstarter/ios-oss/assets/6799207/e95d1421-95ce-495c-885a-1b4561085341) |
| ![Screenshot 2024-04-04 at 2 30 06 PM](https://github.com/kickstarter/ios-oss/assets/6799207/1d17c891-e4ab-4356-9570-491db3158e41) | ![Screenshot 2024-04-04 at 2 32 40 PM](https://github.com/kickstarter/ios-oss/assets/6799207/c241b058-5aa0-4f4e-9c52-334671dc1376) |

# ✅ Acceptance criteria

- [x] Reward cards now match actual pledge
- [x] Total reward cost and total shipping cost is now correct in the pledge summary
