### PR TITLE
[MBL-1315] Move save button styling off prelude

### DIFF
--- a/Kickstarter-iOS/Features/Discovery/Views/Cells/DiscoveryPostcardCell.swift
+++ b/Kickstarter-iOS/Features/Discovery/Views/Cells/DiscoveryPostcardCell.swift
@@ -202,8 +202,7 @@ internal final class DiscoveryPostcardCell: UITableViewCell, ValueCell {
     _ = self.projectStatsStackView
       |> UIStackView.lens.spacing .~ Styles.grid(4)
 
-    _ = self.saveButton
-      |> discoverySaveButtonStyle
+    styleDiscoverySaveButton(self.saveButton)
 
     _ = self.socialAvatarImageView
       |> UIImageView.lens.layer.shouldRasterize .~ true

--- a/Kickstarter-iOS/Features/Discovery/Views/Cells/DiscoveryProjectCardCell.swift
+++ b/Kickstarter-iOS/Features/Discovery/Views/Cells/DiscoveryProjectCardCell.swift
@@ -124,8 +124,7 @@ final class DiscoveryProjectCardCell: UITableViewCell, ValueCell {
       |> verticalStackViewStyle
       |> \.spacing .~ 0
 
-    _ = self.saveButton
-      |> saveButtonStyle
+    styleDiscoverySaveButton(self.saveButton)
 
     _ = self.cardContainerView
       |> cardContainerViewStyle
@@ -747,11 +746,6 @@ private let projectDetailsStackViewStyle: StackViewStyle = { stackView in
     |> \.layoutMargins .~ .init(all: Styles.grid(3))
     |> \.isLayoutMarginsRelativeArrangement .~ true
     |> \.insetsLayoutMarginsFromSafeArea .~ false
-}
-
-private let saveButtonStyle: ButtonStyle = { button in
-  button
-    |> discoverySaveButtonStyle
 }
 
 private let youreABackerViewStyle: ViewStyle = { view in

--- a/Kickstarter-iOS/Features/ProjectPage/Views/ProjectPageNavigationBarView.swift
+++ b/Kickstarter-iOS/Features/ProjectPage/Views/ProjectPageNavigationBarView.swift
@@ -82,9 +82,8 @@ final class ProjectPageNavigationBarView: UIView {
       |> shareButtonStyle
       |> UIButton.lens.accessibilityLabel %~ { _ in Strings.dashboard_accessibility_label_share_project() }
 
-    _ = self.navigationSaveButton
-      |> saveButtonStyle
-      |> UIButton.lens.accessibilityLabel %~ { _ in Strings.Toggle_saving_this_project() }
+    styleSaveButton(self.navigationSaveButton)
+    self.navigationSaveButton.accessibilityLabel = Strings.Toggle_saving_this_project()
   }
 
   // MARK: - View Model

--- a/Library/Styles/ButtonStyles.swift
+++ b/Library/Styles/ButtonStyles.swift
@@ -111,12 +111,13 @@ public let fbFollowButtonStyle = facebookButtonStyle
 
 // MARK: - Save
 
-public let saveButtonStyle =
-  UIButton.lens.title(for: .normal) .~ nil
-    <> UIButton.lens.tintColor .~ .ksr_support_700
-    <> UIButton.lens.image(for: .normal) .~ image(named: "icon--heart-outline")
-    <> UIButton.lens.image(for: .selected) .~ image(named: "icon--heart")
-    <> UIButton.lens.accessibilityLabel %~ { _ in Strings.Save_this_project() }
+public func styleSaveButton(_ button: UIButton) {
+  button.setTitle(nil, for: .normal)
+  button.tintColor = .ksr_support_700
+  button.setImage(image(named: "icon--heart-outline"), for: .normal)
+  button.setImage(image(named: "icon--heart"), for: .selected)
+  button.accessibilityLabel = Strings.Save_this_project()
+}
 
 // MARK: - Share
 

--- a/Library/Styles/DiscoveryStyles.swift
+++ b/Library/Styles/DiscoveryStyles.swift
@@ -24,10 +24,12 @@ public let discoveryNavTitleStackViewStyle =
 
   <> UIStackView.lens.isLayoutMarginsRelativeArrangement .~ true
 
-public let discoverySaveButtonStyle = saveButtonStyle
-  <> UIButton.lens.image(for: .normal) .~ image(named: "icon--heart-outline-circle")
-  <> UIButton.lens.image(for: .selected) .~ image(named: "icon--heart-circle")
-  <> UIButton.lens.tintColor .~ .ksr_white
+public func styleDiscoverySaveButton(_ button: UIButton) {
+  styleSaveButton(button)
+  button.setImage(image(named: "icon--heart-outline-circle"), for: .normal)
+  button.setImage(image(named: "icon--heart-circle"), for: .selected)
+  button.tintColor = .ksr_white
+}
 
 public func discoveryFilterLabelFontStyle<L: UILabelProtocol>(isSelected: Bool) -> ((L) -> L) {
   return L.lens.font %~~ { _, label in


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Neither Scott nor I have been able to reproduce this crash. However, according to the crash logs, it's happening when the `DiscoveryPostcardCell`'s save button's accessibility label is set using prelude. I'm not sure if this change will actually fix the crash, but hopefully if it doesn't, it'll get us more info.

Note: if prelude accessibility labels + iPads + iOS 17.4 is actually the problem, we should start seeing this crash other places in our codebase once this version of it is fixed. If that happens, we'll at least know how to fix it going forward.

# 👀 See

[Jira](https://kickstarter.atlassian.net/browse/MBL-1315)


# ✅ Acceptance criteria

- [x] UI looks the same and tests pass
