### PR TITLE
[MBL-1334] Bind styles when PostCampaignPledgeRewardsSummaryTotalViewController loads

### DIFF
--- a/Kickstarter-iOS/Features/PledgePaymentMethods/Controller/PostCampaignPledgeRewardsSummaryTotalViewController.swift
+++ b/Kickstarter-iOS/Features/PledgePaymentMethods/Controller/PostCampaignPledgeRewardsSummaryTotalViewController.swift
@@ -24,6 +24,7 @@ final class PostCampaignPledgeRewardsSummaryTotalViewController: UIViewControlle
     super.viewDidLoad()
 
     self.configureSubviews()
+    self.bindStyles()
 
     self.viewModel.inputs.viewDidLoad()
   }

--- a/Kickstarter-iOS/Features/PledgePaymentMethods/Controller/PostCampaignPledgeRewardsSummaryViewController.swift
+++ b/Kickstarter-iOS/Features/PledgePaymentMethods/Controller/PostCampaignPledgeRewardsSummaryViewController.swift
@@ -65,6 +65,9 @@ final class PostCampaignPledgeRewardsSummaryViewController: UIViewController {
     _ = (self.tableView, self.tableViewContainer)
       |> ksr_addSubviewToParent()
 
+    self.addChild(self.pledgeTotalViewController)
+    self.pledgeTotalViewController.didMove(toParent: self)
+
     self.tableView.registerCellClass(PostCampaignPledgeRewardsSummaryHeaderCell.self)
     self.tableView.registerCellClass(PostCampaignPledgeRewardsSummaryCell.self)
   }


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Call `bindStyles` in `viewDidLoad`. We usually swizzle view controllers to call `bindStyles` on `viewWillAppear` and `traitCollectionDidChange`, but for some reason, on iOS 16, neither of these trigger `bindStyles` for this class. I think embedding a view controller's view in a different view controller is preventing `viewWillAppear` from triggering it, but I'm not sure why `traitCollectionDidChange` calls `bindStyles` on iOS 17 but not on iOS 16. Regardless of why, calling `bindStyles` in `viewDidLoad` fixes the problem and seems significantly safer.

# 👀 See

[Jira](https://kickstarter.atlassian.net/browse/MBL-1334)

| Before 🐛 | After 🦋 |
| --- | --- |
| ![image](https://github.com/kickstarter/ios-oss/assets/6799207/6b865a36-3a81-43e3-aeb2-b6986f54c44a) | ![image](https://github.com/kickstarter/ios-oss/assets/6799207/ab262e5b-7cfd-400a-bca2-e7340a77eed4) |

# ✅ Acceptance criteria

- [x] Total row in the pledge summary table looks good on iOS 16 as well
