### PR TITLE
[MBL-1329 Calculate total cost for each add-on

### DIFF
--- a/Library/ViewModels/PledgeExpandableRewardsHeaderViewModel.swift
+++ b/Library/ViewModels/PledgeExpandableRewardsHeaderViewModel.swift
@@ -151,11 +151,11 @@ private func items(
     guard let title = reward.title else { return nil }
 
     let quantity = selectedQuantities[reward.id] ?? 0
-
     let itemString = quantity > 1 ? "\(Format.wholeNumber(quantity)) x \(title)" : title
 
+    let amount = quantity > 1 ? reward.minimum * Double(quantity) : reward.minimum
     let amountAttributedText = attributedRewardCurrency(
-      with: data.projectCountry, amount: reward.minimum, omitUSCurrencyCode: data.omitCurrencyCode
+      with: data.projectCountry, amount: amount, omitUSCurrencyCode: data.omitCurrencyCode
     )
 
     return PledgeExpandableRewardsHeaderItem.reward((

--- a/Library/ViewModels/PostCampaignPledgeRewardsSummaryViewModel.swift
+++ b/Library/ViewModels/PostCampaignPledgeRewardsSummaryViewModel.swift
@@ -160,11 +160,11 @@ private func items(
     guard let title = reward.title else { return nil }
 
     let quantity = selectedQuantities[reward.id] ?? 0
-
     let itemString = quantity > 1 ? "\(Format.wholeNumber(quantity)) x \(title)" : title
 
+    let amount = quantity > 1 ? reward.minimum * Double(quantity) : reward.minimum
     let amountAttributedText = attributedRewardCurrency(
-      with: data.projectCountry, amount: reward.minimum, omitUSCurrencyCode: data.omitCurrencyCode
+      with: data.projectCountry, amount: amount, omitUSCurrencyCode: data.omitCurrencyCode
     )
 
     return PostCampaignRewardsSummaryItem.reward((


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

When users add multiple copies of an add-on, whether in the standard pledge flow or in the late pledge flow, multiply the line item cost for that add-on by the count.

# 👀 See

[Jira](https://kickstarter.atlassian.net/browse/MBL-1329)

| Before 🐛 | After 🦋 |
| --- | --- |
| todo | todo |
| todo | todo |

# ✅ Acceptance criteria

- [ ] Line item cost matches multiplier
- [ ] Items with just one copy are unchanged
