### PR TITLE
[MBL-1362] If user cancels adding new card, don't show error banner

### DIFF
--- a/Kickstarter-iOS/Features/PaymentMethods/Controller/PaymentMethodSettingsViewController.swift
+++ b/Kickstarter-iOS/Features/PaymentMethods/Controller/PaymentMethodSettingsViewController.swift
@@ -214,8 +214,7 @@ internal final class PaymentMethodSettingsViewController: UIViewController,
           .paymentSheetDidAdd(newCard: paymentDisplayData, setupIntent: clientSecret)
       case .canceled:
         strongSelf.viewModel.inputs.failedToAddNewCard()
-        strongSelf.messageBannerViewController?
-          .showBanner(with: .error, message: Strings.general_error_something_wrong())
+      // User cancelled intentionally so don't show them an error banner.
       case let .failed(error):
         strongSelf.viewModel.inputs.failedToAddNewCard()
         strongSelf.messageBannerViewController?.showBanner(with: .error, message: error.localizedDescription)

--- a/Kickstarter-iOS/Features/PledgePaymentMethods/Controller/PledgePaymentMethodsViewController.swift
+++ b/Kickstarter-iOS/Features/PledgePaymentMethods/Controller/PledgePaymentMethodsViewController.swift
@@ -214,8 +214,8 @@ final class PledgePaymentMethodsViewController: UIViewController {
         strongSelf.viewModel.inputs
           .paymentSheetDidAdd(newCard: paymentDisplayData, clientSecret: clientSecret)
       case .canceled:
-        strongSelf.messageDisplayingDelegate?
-          .pledgeViewController(strongSelf, didErrorWith: Strings.general_error_something_wrong())
+        // User cancelled intentionally so do nothing.
+        break
       case let .failed(error):
         strongSelf.messageDisplayingDelegate?
           .pledgeViewController(strongSelf, didErrorWith: error.localizedDescription)

--- a/Kickstarter-iOS/Features/PledgeView/Controllers/PostCampaignCheckoutViewController.swift
+++ b/Kickstarter-iOS/Features/PledgeView/Controllers/PostCampaignCheckoutViewController.swift
@@ -282,8 +282,11 @@ final class PostCampaignCheckoutViewController: UIViewController,
     STPPaymentHandler.shared()
       .confirmPayment(paymentParams, with: self) { status, _, error in
         guard error == nil, status == .succeeded else {
-          self.messageBannerViewController?
-            .showBanner(with: .error, message: Strings.Something_went_wrong_please_try_again())
+          // Only show error banner if confirmation failed instead of being canceled.
+          if status == .failed {
+            self.messageBannerViewController?
+              .showBanner(with: .error, message: Strings.Something_went_wrong_please_try_again())
+          }
           self.viewModel.inputs.checkoutTerminated()
           return
         }


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

We currently show a "Something went wrong" error banner if a user decides to cancel adding a card through the 3DS prompt. This removes that banner.

Note: "Something went wrong" banner still shows as part of the payment flow if a user uses a saved 3DS card for checkout and cancels there. 

# 👀 See

[Jira](https://kickstarter.atlassian.net/browse/MBL-1362)

| Before 🐛 | After 🦋 |
| --- | --- |
| ![Simulator Screen Recording - iPhone 15 Pro Max - 2024-04-11 at 14 04 13](https://github.com/kickstarter/ios-oss/assets/6799207/efeb92da-4a3c-4f05-941e-8679e05c58b1) | ![Simulator Screen Recording - iPhone 15 Pro Max - 2024-04-11 at 14 11 51](https://github.com/kickstarter/ios-oss/assets/6799207/6a16e510-59d1-4a19-850f-bbc24638d89a) |

# ✅ Acceptance criteria

- [x] No error banner shows when user decides to cancel

# Todo

- [x] Update the payment methods from settings flow as well as the late pledge flow to stop showing banners on user cancellation as well
