### PR TITLE
MBL-1372: Don't call createToken after ApplePayContext completes

### DIFF
--- a/Library/ViewModels/PostCampaignCheckoutViewModel.swift
+++ b/Library/ViewModels/PostCampaignCheckoutViewModel.swift
@@ -345,13 +345,13 @@ public class PostCampaignCheckoutViewModel: PostCampaignCheckoutViewModelType,
       }
 
     let completeCheckoutWithApplePayInput: Signal<GraphAPI.CompleteOnSessionCheckoutInput, Never> = Signal
-      .combineLatest(newPaymentIntentForApplePay, checkoutId, self.applePayParamsSignal)
+      .combineLatest(newPaymentIntentForApplePay, checkoutId, self.applePayParamsSignal.mapConst(true))
       .takeWhen(self.applePayContextDidCompleteSignal)
       .map {
         (
           clientSecret: String,
           checkoutId: String,
-          applePayParams: ApplePayParams
+          _: Bool
         ) -> GraphAPI.CompleteOnSessionCheckoutInput in
         GraphAPI
           .CompleteOnSessionCheckoutInput(
@@ -359,7 +359,13 @@ public class PostCampaignCheckoutViewModel: PostCampaignCheckoutViewModelType,
             paymentIntentClientSecret: clientSecret,
             paymentSourceId: nil,
             paymentSourceReusable: false,
-            applePay: GraphAPI.ApplePayInput.from(applePayParams)
+            /* We are no longer sending ApplePay parameters to the backend, because Stripe Tokens are
+              considered deprecated and are incompatible with PaymentIntent-based payments.
+
+              In the future, we may use the other parameters in the ApplePayParams object, but for now,
+              send nil.
+              */
+            applePay: nil
           )
       }
 


### PR DESCRIPTION
# 📲 What

Do not create a Stripe token after `ApplePayContext` creates a Stripe PaymentMethod.

# 🤔 Why

In production, this causes Stripe to return an error in the `createToken` endpoint, which breaks our ApplePay flow. Instead, we will ignore the `token` field and `applePayParams` field in our mutation, treating an ApplePay transaction like a regular credit card transaction. 