### PR TITLE
MBL-1371: Only show 'Coming Soon' if project is actually pre-launch

### DIFF
--- a/Kickstarter-iOS/Features/Search/Controller/SearchViewControllerTests.swift
+++ b/Kickstarter-iOS/Features/Search/Controller/SearchViewControllerTests.swift
@@ -114,6 +114,7 @@ internal final class SearchViewContollerTests: TestCase {
         |> Project.lens.photo.full .~ ""
         |> Project.lens.photo.med .~ ""
         |> Project.lens.displayPrelaunch .~ true
+        |> Project.lens.prelaunchActivated .~ true
     }
 
     let discoveryResponse = .template

--- a/Library/ViewModels/BackerDashboardProjectCellViewModel.swift
+++ b/Library/ViewModels/BackerDashboardProjectCellViewModel.swift
@@ -181,11 +181,14 @@ private func stateString(for project: Project) -> String {
 }
 
 private func isProjectPrelaunch(_ project: Project) -> Bool {
-  switch (project.displayPrelaunch, project.dates.launchedAt, project.prelaunchActivated) {
-  case (.some(true), _, _),
-       (_, _, .some(true)):
+  switch (project.displayPrelaunch, project.prelaunchActivated, project.dates.launchedAt) {
+  // GraphQL requests using ProjectFragment will populate displayPrelaunch and prelaunchActivated
+  case (.some(true), .some(true), _):
     return true
-  case let (_, .some(timeValue), _):
+
+  // V1 requests may not return displayPrelaunch and prelaunchActivated.
+  // But if no launch date is set, we can assume this is a prelaunch project.
+  case let (.none, .none, .some(timeValue)):
     return timeValue <= 0
   default:
     return false

--- a/Library/ViewModels/BackerDashboardProjectCellViewModelTests.swift
+++ b/Library/ViewModels/BackerDashboardProjectCellViewModelTests.swift
@@ -39,6 +39,8 @@ internal final class BackerDashboardProjectCellViewModelTests: TestCase {
       |> Project.lens.photo.full .~ "http://www.lazybathtubcat.com/vespa.jpg"
       |> Project.lens.stats.fundingProgress .~ 0.5
       |> Project.lens.dates.deadline .~ endingInDays
+      |> Project.lens.prelaunchActivated .~ false
+      |> Project.lens.displayPrelaunch .~ false
 
     self.vm.inputs.configureWith(project: project)
 
@@ -58,6 +60,8 @@ internal final class BackerDashboardProjectCellViewModelTests: TestCase {
       |> Project.lens.photo.full .~ "http://www.lazybathtubcat.com/vespa.jpg"
       |> Project.lens.stats.fundingProgress .~ 1.1
       |> Project.lens.state .~ .successful
+      |> Project.lens.prelaunchActivated .~ false
+      |> Project.lens.displayPrelaunch .~ false
 
     self.vm.inputs.configureWith(project: project)
 
@@ -77,6 +81,8 @@ internal final class BackerDashboardProjectCellViewModelTests: TestCase {
       |> Project.lens.photo.full .~ "http://www.lazybathtubcat.com/vespa.jpg"
       |> Project.lens.stats.fundingProgress .~ 0.2
       |> Project.lens.state .~ .failed
+      |> Project.lens.prelaunchActivated .~ false
+      |> Project.lens.displayPrelaunch .~ false
 
     self.vm.inputs.configureWith(project: project)
 
@@ -97,6 +103,8 @@ internal final class BackerDashboardProjectCellViewModelTests: TestCase {
       |> Project.lens.stats.fundingProgress .~ 1.1
       |> Project.lens.state .~ .successful
       |> Project.lens.personalization.isStarred .~ true
+      |> Project.lens.prelaunchActivated .~ false
+      |> Project.lens.displayPrelaunch .~ false
 
     self.vm.inputs.configureWith(project: project)
 
@@ -110,10 +118,11 @@ internal final class BackerDashboardProjectCellViewModelTests: TestCase {
     self.savedIconIsHidden.assertValues([false])
   }
 
-  func testProjectData_Prelaunch() {
+  func testProjectData_Prelaunch_Displayed() {
     let project = .template
       |> Project.lens.name .~ "Best of Lazy Bathtub Cat"
       |> Project.lens.photo.full .~ "http://www.lazybathtubcat.com/vespa.jpg"
+      |> Project.lens.prelaunchActivated .~ true
       |> Project.lens.displayPrelaunch .~ true
       |> Project.lens.personalization.isStarred .~ true
 
@@ -122,5 +131,41 @@ internal final class BackerDashboardProjectCellViewModelTests: TestCase {
     self.vm.inputs.configureWith(project: project)
 
     self.prelaunchProject.assertValues([true])
+    self.metadataText.assertValues(["Coming soon"])
+  }
+
+  func testProjectData_Prelaunch_ActivatedButNotDisplayed() {
+    let project = .template
+      |> Project.lens.name .~ "Best of Lazy Bathtub Cat"
+      |> Project.lens.photo.full .~ "http://www.lazybathtubcat.com/vespa.jpg"
+      |> Project.lens.prelaunchActivated .~ true
+      |> Project.lens.displayPrelaunch .~ false
+      |> Project.lens.personalization.isStarred .~ true
+      |> Project.lens.state .~ .successful
+
+    self.prelaunchProject.assertDidNotEmitValue()
+
+    self.vm.inputs.configureWith(project: project)
+
+    self.prelaunchProject.assertValues([false])
+    self.metadataText.assertValues(["Successful"])
+  }
+
+  func testProjectData_Prelaunch_DateIsZero() {
+    let project = .template
+      |> Project.lens.name .~ "Best of Lazy Bathtub Cat"
+      |> Project.lens.photo.full .~ "http://www.lazybathtubcat.com/vespa.jpg"
+      |> Project.lens.prelaunchActivated .~ nil
+      |> Project.lens.displayPrelaunch .~ nil
+      |> Project.lens.dates.launchedAt .~ 0
+      |> Project.lens.personalization.isStarred .~ true
+      |> Project.lens.state .~ .successful
+
+    self.prelaunchProject.assertDidNotEmitValue()
+
+    self.vm.inputs.configureWith(project: project)
+
+    self.prelaunchProject.assertValues([true])
+    self.metadataText.assertValues(["Coming soon"])
   }
 }


### PR DESCRIPTION
# 📲 What

Check both `displayPrelaunch` and `prelaunchActivated` flags on `Project` before showing `"Coming Soon"` in the project status.

# 🤔 Why

When I swapped this page to use GraphQL, it started returning values in `displayPrelaunch` and `prelaunchActivated` which were formerly `nil`. This caused the status badges to be incorrect.

On a little digging, the existing logic to check for prelaunch status didn't make sense:

- `prelaunchActivated` refers to whether the prelaunch page is available 
- `displayPrelaunch` is true if the project has not actually launched yet 

I surmised that checking for both, not either, is the correct behavior.

I kept the behavior that checks the launch date - turns out that is used for detecting prelaunch projects fetched via `/v1/discover` i.e. search.

# 👀 See

I checked this by comparing the status badges for my saved projects on prod with the badges in this version. I also created a prelaunch project on staging and verified that it shows "Coming soon" until I actually hit "launch".

![Screenshot 2024-04-18 at 5 14 51 PM](https://github.com/kickstarter/ios-oss/assets/146007185/bd9515eb-96f2-4d2d-af22-a32f4cc174b9)
![Screenshot 2024-04-18 at 5 16 13 PM](https://github.com/kickstarter/ios-oss/assets/146007185/cbde66c3-2dcb-4d3f-96c8-1926ece491ac)
