### PR TITLE
Fix missing spinner on BackerDashboardProjectsViewController

### DIFF
--- a/Kickstarter-iOS/Features/BackerDashboardProjects/Controller/BackerDashboardProjectsViewController.swift
+++ b/Kickstarter-iOS/Features/BackerDashboardProjects/Controller/BackerDashboardProjectsViewController.swift
@@ -42,10 +42,20 @@ internal final class BackerDashboardProjectsViewController: UITableViewControlle
     self.userUpdatedObserver.doIfSome(NotificationCenter.default.removeObserver)
   }
 
-  internal override func viewWillAppear(_ animated: Bool) {
-    super.viewWillAppear(animated)
+  internal override func viewDidAppear(_ animated: Bool) {
+    super.viewDidAppear(animated)
 
-    self.viewModel.inputs.viewWillAppear(animated)
+    // The refresh control needs to be on screen when we call beginRefreshing, or else it won't show the spinner.
+    // So this is all done on didAppear instead of willAppear.
+    self.viewModel.inputs.viewDidAppear(animated)
+  }
+
+  internal override func viewDidDisappear(_ animated: Bool) {
+    super.viewDidDisappear(animated)
+
+    // Refresh control is sensitive to lifecycle methods - see https://stackoverflow.com/questions/24341192/uirefreshcontrol-stuck-after-switching-tabs-in-uitabbarcontroller.
+    // This fixes this issue.
+    self.refreshControl?.endRefreshing()
   }
 
   internal override func bindViewModel() {

--- a/Library/ViewModels/BackerDashboardProjectsViewModel.swift
+++ b/Library/ViewModels/BackerDashboardProjectsViewModel.swift
@@ -20,8 +20,8 @@ public protocol BackerDashboardProjectsViewModelInputs {
   /// Call when the view loads.
   func viewDidLoad()
 
-  /// Call when the view will appear.
-  func viewWillAppear(_ animated: Bool)
+  /// Call when the view did appear.
+  func viewDidAppear(_ animated: Bool)
 
   /// Call when a new row is displayed.
   func willDisplayRow(_ row: Int, outOf totalRows: Int)
@@ -53,7 +53,7 @@ public final class BackerDashboardProjectsViewModel: BackerDashboardProjectsView
     let projectsType = projectsTypeAndSort.map(first)
 
     let userUpdatedProjectsCount = Signal.merge(
-      self.viewWillAppearProperty.signal.ignoreValues(),
+      self.viewDidAppearProperty.signal.ignoreValues(),
       self.currentUserUpdatedProperty.signal
     )
     .map { _ -> (Int, Int) in
@@ -159,9 +159,9 @@ public final class BackerDashboardProjectsViewModel: BackerDashboardProjectsView
     self.refreshProperty.value = ()
   }
 
-  private let viewWillAppearProperty = MutableProperty(false)
-  public func viewWillAppear(_ animated: Bool) {
-    self.viewWillAppearProperty.value = animated
+  private let viewDidAppearProperty = MutableProperty(false)
+  public func viewDidAppear(_ animated: Bool) {
+    self.viewDidAppearProperty.value = animated
   }
 
   private let willDisplayRowProperty = MutableProperty<(row: Int, total: Int)?>(nil)

--- a/Library/ViewModels/BackerDashboardProjectsViewModelTests.swift
+++ b/Library/ViewModels/BackerDashboardProjectsViewModelTests.swift
@@ -46,7 +46,7 @@ internal final class BackerDashboardProjectsViewModelTests: TestCase {
 
     withEnvironment(apiService: MockService(fetchBackerBackedProjectsResponse: env), currentUser: .template) {
       self.vm.inputs.configureWith(projectsType: .backed, sort: .endingSoon)
-      self.vm.inputs.viewWillAppear(false)
+      self.vm.inputs.viewDidAppear(false)
       self.vm.inputs.currentUserUpdated()
 
       self.projects.assertValueCount(0)
@@ -63,7 +63,7 @@ internal final class BackerDashboardProjectsViewModelTests: TestCase {
       self.emptyStateProjectsType.assertValues([.backed])
       self.isRefreshing.assertValues([true, false])
 
-      self.vm.inputs.viewWillAppear(true)
+      self.vm.inputs.viewDidAppear(true)
       self.isRefreshing.assertValues([true, false], "Projects don't refresh.")
 
       self.scheduler.advance()
@@ -80,7 +80,7 @@ internal final class BackerDashboardProjectsViewModelTests: TestCase {
         currentUser: updatedUser
       ) {
         self.vm.inputs.currentUserUpdated()
-        self.vm.inputs.viewWillAppear(false)
+        self.vm.inputs.viewDidAppear(false)
 
         self.isRefreshing.assertValues([true, false, true])
 
@@ -114,7 +114,7 @@ internal final class BackerDashboardProjectsViewModelTests: TestCase {
 
     withEnvironment(apiService: MockService(fetchBackerSavedProjectsResponse: env), currentUser: .template) {
       self.vm.inputs.configureWith(projectsType: .saved, sort: .endingSoon)
-      self.vm.inputs.viewWillAppear(false)
+      self.vm.inputs.viewDidAppear(false)
 
       self.projects.assertValueCount(0)
       self.emptyStateIsVisible.assertValueCount(0)
@@ -130,7 +130,7 @@ internal final class BackerDashboardProjectsViewModelTests: TestCase {
       XCTAssertEqual([], self.segmentTrackingClient.events)
       XCTAssertEqual([], self.segmentTrackingClient.properties(forKey: "type", as: String.self))
 
-      self.vm.inputs.viewWillAppear(true)
+      self.vm.inputs.viewDidAppear(true)
 
       self.scheduler.advance()
 
@@ -146,7 +146,7 @@ internal final class BackerDashboardProjectsViewModelTests: TestCase {
 
     withEnvironment(apiService: MockService(fetchBackerBackedProjectsResponse: env), currentUser: .template) {
       self.vm.inputs.configureWith(projectsType: .backed, sort: .endingSoon)
-      self.vm.inputs.viewWillAppear(false)
+      self.vm.inputs.viewDidAppear(false)
 
       self.scheduler.advance()
 


### PR DESCRIPTION
# 📲 What

Fix a missing loading spinner on `BackerDashboardProjectsViewController`.

# 🤔 Why

I noticed this while fixing other bugs - the spinner was frequently missing, and it made the loading feel much slower than it effectively was.

# 🛠 How

- Change `viewWillAppear` to `viewDidAppear` to fix a warning about using the refresh controller while off screen
- Add extra `endRefreshing()` call to `viewDidDisappear`, per a suggestion from StackOverflow. Seems like the refresh controller is strangely sensitive to view lifecycle methods, and this fixes the problem.
