### PR TITLE
[MBL-1358] Update Kingfisher

### DIFF
--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -10785,7 +10785,7 @@
 			repositoryURL = "https://github.com/onevcat/Kingfisher";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 7.3.2;
+				minimumVersion = 7.10.0;
 			};
 		};
 		60DA511028C96865002E2DF1 /* XCRemoteSwiftPackageReference "SwiftSoup" */ = {

--- a/Kickstarter.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Kickstarter.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -167,8 +167,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/onevcat/Kingfisher",
       "state" : {
-        "revision" : "3f6992b5cd3143e83b02300ea59c400d4cf0747a",
-        "version" : "7.8.0"
+        "revision" : "5b92f029fab2cce44386d28588098b5be0824ef5",
+        "version" : "7.11.0"
       }
     },
     {


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Updates min version to 7.10.0 up to next major version 7.11.0 (Latest).

# 🤔 Why

[Main reference for what's going on](https://github.com/kickstarter/ios-oss/pull/2045)

But, Apple requires us to give reasons for using certain APIs. Reasons that need to be added to a Privacy Manifest file (added in that PR ☝️ )

One of the APIs that our app is missing a reason for is `NSPrivacyAccessedAPICategoryFileTimestamp`. 
We aren't actually using this API internally, Kingfisher is.

Kingfisher added privacy support for Apple's new requirement in 7.10.0. So, by updating the version we're using we should now be meeting the requirement.
- I'm not certain that we don't still need to include a reason for how the 3rd party is using this API as well, but we've reached out to apple support for clarification. For now we're going to update anyway since it has minimal impact.

# 🛠 How

[set minimum version to 7.10.0 (version that they added privacy support) up to next major version (7.11.0)](https://github.com/kickstarter/ios-oss/commit/d3f06d36fc5bc5ab99d922bd344cb3afd407e6fd)

# 👀 See

Kingfisher's Privacy Manifest which contains the File Timestamp type and reason that Apple is warning us about.

<img width="1275" alt="Screenshot 2024-04-23 at 11 59 16 AM" src="https://github.com/kickstarter/ios-oss/assets/110618242/618e565c-193d-4d9e-b2f1-6693f0fdc6b1">

# ✅ Acceptance criteria

- [x] The app runs as normal. Specifically image loading. I ran through som regression test steps as well to cover more cases.
- [x] All tests pass
