### PR TITLE
MBL-1390: Add Stripe Link

### DIFF
--- a/Kickstarter-iOS/Features/PledgePaymentMethods/Controller/PledgePaymentMethodsViewController.swift
+++ b/Kickstarter-iOS/Features/PledgePaymentMethods/Controller/PledgePaymentMethodsViewController.swift
@@ -282,37 +282,11 @@ final class PledgePaymentMethodsViewController: UIViewController {
       return nil
     }
 
-    let formattedLabel = self.formatLinkLabel(paymentMethod.label)
+    let formattedLabel = KSRStripeLink.formatLinkLabel(paymentMethod.label)
     return PaymentSheetPaymentOptionsDisplayData(
       image: paymentMethod.image,
       label: formattedLabel ?? paymentMethod.label
     )
-  }
-
-  private func formatLinkLabel(_ label: String) -> String? {
-    // Link gives us a label like "Visa 1234"; reformat it to match our UI
-    do {
-      // Find 4 digits in the string
-      let regex = try NSRegularExpression(pattern: "\\d{4}")
-      let matches = regex.matches(
-        in: label,
-        range: NSRange(location: 0, length: label.count)
-      )
-
-      guard let match = matches.first else {
-        return nil
-      }
-
-      guard let range = Range(match.range, in: label) else {
-        return nil
-      }
-
-      let lastFour = label[range]
-      return "•••• \(lastFour)"
-
-    } catch {
-      return nil
-    }
   }
 
   private func updateAddNewPaymentMethodButtonLoading(state: Bool) {

--- a/Kickstarter-iOS/Features/PledgePaymentMethods/Controller/PledgePaymentMethodsViewController.swift
+++ b/Kickstarter-iOS/Features/PledgePaymentMethods/Controller/PledgePaymentMethodsViewController.swift
@@ -292,6 +292,7 @@ final class PledgePaymentMethodsViewController: UIViewController {
   private func formatLinkLabel(_ label: String) -> String? {
     // Link gives us a label like "Visa 1234"; reformat it to match our UI
     do {
+      // Find 4 digits in the string
       let regex = try NSRegularExpression(pattern: "\\d{4}")
       let matches = regex.matches(
         in: label,

--- a/Kickstarter-iOS/Features/PledgePaymentMethods/Controller/PledgePaymentMethodsViewController.swift
+++ b/Kickstarter-iOS/Features/PledgePaymentMethods/Controller/PledgePaymentMethodsViewController.swift
@@ -167,7 +167,7 @@ final class PledgePaymentMethodsViewController: UIViewController {
         strongSelf.paymentSheetFlowController?.presentPaymentOptions(from: strongSelf) { [weak self] in
           guard let strongSelf = self else { return }
 
-          strongSelf.confirmPaymentResult(with: data.clientSecret)
+          strongSelf.confirmPaymentResult(with: data)
         }
         strongSelf.viewModel.inputs.stripePaymentSheetDidAppear()
       }
@@ -190,7 +190,7 @@ final class PledgePaymentMethodsViewController: UIViewController {
     }
   }
 
-  private func confirmPaymentResult(with clientSecret: String) {
+  private func confirmPaymentResult(with data: PaymentSheetSetupData) {
     guard self.paymentSheetFlowController?.paymentOption != nil else {
       self.viewModel.inputs.shouldCancelPaymentSheetAppearance(state: true)
 
@@ -207,12 +207,11 @@ final class PledgePaymentMethodsViewController: UIViewController {
 
       switch paymentResult {
       case .completed:
-        let paymentDisplayData = PaymentSheetPaymentOptionsDisplayData(
-          image: existingPaymentOption.image,
-          label: existingPaymentOption.label
+        strongSelf.didConfirmAddedPaymentOption(
+          paymentOption: existingPaymentOption,
+          forClientSecret: data.clientSecret,
+          forPaymentSheetType: data.paymentSheetType
         )
-        strongSelf.viewModel.inputs
-          .paymentSheetDidAdd(newCard: paymentDisplayData, clientSecret: clientSecret)
       case .canceled:
         // User cancelled intentionally so do nothing.
         break
@@ -220,6 +219,98 @@ final class PledgePaymentMethodsViewController: UIViewController {
         strongSelf.messageDisplayingDelegate?
           .pledgeViewController(strongSelf, didErrorWith: error.localizedDescription)
       }
+    }
+  }
+
+  private func didConfirmAddedPaymentOption(
+    paymentOption: PaymentSheet.FlowController.PaymentOptionDisplayData,
+    forClientSecret clientSecret: String,
+    forPaymentSheetType paymentSheetType: PledgePaymentSheetType
+  ) {
+    // Stripe also defines this constant, but it's defined internally to the Stripe SDK :(
+    let linkIdentifier = "link"
+
+    // For regular payment types, continue with the display information they gave us
+    if paymentOption.paymentMethodType != linkIdentifier {
+      let paymentDisplayData = PaymentSheetPaymentOptionsDisplayData(
+        image: paymentOption.image,
+        label: paymentOption.label
+      )
+
+      self.viewModel.inputs.paymentSheetDidAdd(newCard: paymentDisplayData, clientSecret: clientSecret)
+      return
+    }
+
+    // For link payment types, fetch the underlying payment method so we can get at the card type and label
+
+    switch paymentSheetType {
+    case .setupIntent:
+      STPAPIClient.shared
+        .retrieveSetupIntent(
+          withClientSecret: clientSecret,
+          expand: ["payment_method"]
+        ) { [weak self] intent, _ in
+          guard let strongSelf = self else { return }
+          guard let paymentDisplayData = strongSelf.paymentDisplayData(forLink: intent?.paymentMethod)
+          else { return }
+          strongSelf.viewModel.inputs.paymentSheetDidAdd(
+            newCard: paymentDisplayData,
+            clientSecret: clientSecret
+          )
+        }
+
+    case .paymentIntent:
+      STPAPIClient.shared
+        .retrievePaymentIntent(
+          withClientSecret: clientSecret,
+          expand: ["payment_method"]
+        ) { [weak self] intent, _ in
+          guard let strongSelf = self else { return }
+          guard let paymentDisplayData = strongSelf.paymentDisplayData(forLink: intent?.paymentMethod)
+          else { return }
+          strongSelf.viewModel.inputs.paymentSheetDidAdd(
+            newCard: paymentDisplayData,
+            clientSecret: clientSecret
+          )
+        }
+    }
+  }
+
+  private func paymentDisplayData(forLink optionalPaymentMethod: STPPaymentMethod?)
+    -> PaymentSheetPaymentOptionsDisplayData? {
+    guard let paymentMethod = optionalPaymentMethod else {
+      return nil
+    }
+
+    let formattedLabel = self.formatLinkLabel(paymentMethod.label)
+    return PaymentSheetPaymentOptionsDisplayData(
+      image: paymentMethod.image,
+      label: formattedLabel ?? paymentMethod.label
+    )
+  }
+
+  private func formatLinkLabel(_ label: String) -> String? {
+    // Link gives us a label like "Visa 1234"; reformat it to match our UI
+    do {
+      let regex = try NSRegularExpression(pattern: "\\d{4}")
+      let matches = regex.matches(
+        in: label,
+        range: NSRange(location: 0, length: label.count)
+      )
+
+      guard let match = matches.first else {
+        return nil
+      }
+
+      guard let range = Range(match.range, in: label) else {
+        return nil
+      }
+
+      let lastFour = label[range]
+      return "•••• \(lastFour)"
+
+    } catch {
+      return nil
     }
   }
 

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -1531,6 +1531,8 @@
 		E182E5BA2B8CDFDE0008DD69 /* AppEnvironmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7ED1F121E830FDC00BFFA01 /* AppEnvironmentTests.swift */; };
 		E182E5BC2B8D36FE0008DD69 /* AppEnvironmentTests+OAuthInKeychain.swift in Sources */ = {isa = PBXBuildFile; fileRef = E182E5BB2B8D36FE0008DD69 /* AppEnvironmentTests+OAuthInKeychain.swift */; };
 		E1972EA22BB4722D002517E6 /* PostCampaignCheckoutViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1972EA12BB4722D002517E6 /* PostCampaignCheckoutViewModelTests.swift */; };
+		E1982FE52BEABF8B0057BD09 /* KSRStripeLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1982FE32BEABF8B0057BD09 /* KSRStripeLink.swift */; };
+		E1982FE62BEABF8F0057BD09 /* KSRStripeLinkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1982FE22BEABF8B0057BD09 /* KSRStripeLinkTests.swift */; };
 		E1A149202ACDD7BF00F49709 /* FetchProjectsEnvelope+FetchBackerProjectsQueryData.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1A1491F2ACDD7BF00F49709 /* FetchProjectsEnvelope+FetchBackerProjectsQueryData.swift */; };
 		E1A149222ACE013100F49709 /* FetchProjectsEnvelope.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1A149212ACE013100F49709 /* FetchProjectsEnvelope.swift */; };
 		E1A149242ACE02B300F49709 /* FetchProjectsEnvelope+FetchBackerProjectsQueryDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1A149232ACE02B300F49709 /* FetchProjectsEnvelope+FetchBackerProjectsQueryDataTests.swift */; };
@@ -3162,6 +3164,8 @@
 		E182E5BB2B8D36FE0008DD69 /* AppEnvironmentTests+OAuthInKeychain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppEnvironmentTests+OAuthInKeychain.swift"; sourceTree = "<group>"; };
 		E1889D8D2B6065D6004FBE21 /* CombineTestObserverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CombineTestObserverTests.swift; sourceTree = "<group>"; };
 		E1972EA12BB4722D002517E6 /* PostCampaignCheckoutViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostCampaignCheckoutViewModelTests.swift; sourceTree = "<group>"; };
+		E1982FE22BEABF8B0057BD09 /* KSRStripeLinkTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = KSRStripeLinkTests.swift; path = Library/KSRStripeLinkTests.swift; sourceTree = SOURCE_ROOT; };
+		E1982FE32BEABF8B0057BD09 /* KSRStripeLink.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = KSRStripeLink.swift; path = Library/KSRStripeLink.swift; sourceTree = SOURCE_ROOT; };
 		E1A1491F2ACDD7BF00F49709 /* FetchProjectsEnvelope+FetchBackerProjectsQueryData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "FetchProjectsEnvelope+FetchBackerProjectsQueryData.swift"; sourceTree = "<group>"; };
 		E1A149212ACE013100F49709 /* FetchProjectsEnvelope.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FetchProjectsEnvelope.swift; sourceTree = "<group>"; };
 		E1A149232ACE02B300F49709 /* FetchProjectsEnvelope+FetchBackerProjectsQueryDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FetchProjectsEnvelope+FetchBackerProjectsQueryDataTests.swift"; sourceTree = "<group>"; };
@@ -6120,6 +6124,8 @@
 				A71404381CAF215900A2795B /* KeyValueStoreType.swift */,
 				A71F59E71D2424CA00909BE3 /* KSCache.swift */,
 				A7ED1F171E830FDC00BFFA01 /* KSCacheTests.swift */,
+				E1982FE32BEABF8B0057BD09 /* KSRStripeLink.swift */,
+				E1982FE22BEABF8B0057BD09 /* KSRStripeLinkTests.swift */,
 				A7C725821C85D36D005A016B /* Language.swift */,
 				A7ED1F181E830FDC00BFFA01 /* LanguageTests.swift */,
 				A7C725831C85D36D005A016B /* LaunchedCountries.swift */,
@@ -7945,6 +7951,7 @@
 				59B0E07E1D147F340081D2DC /* DashboardStyles.swift in Sources */,
 				470B771A26FCDC8900EBD5CA /* RiskMessagingViewModel.swift in Sources */,
 				0169F8C11D6CA27500C8D5C5 /* RootCategory.swift in Sources */,
+				E1982FE52BEABF8B0057BD09 /* KSRStripeLink.swift in Sources */,
 				D04AAC21218BB70D00CF713E /* ChangePasswordViewModel.swift in Sources */,
 				8A32FE0624D233F000F79C72 /* EmptyStateViewModel.swift in Sources */,
 				37FEFBC8222F1E4F00FCA608 /* ProcessInfoType.swift in Sources */,
@@ -8044,6 +8051,7 @@
 				A7ED1F281E830FDC00BFFA01 /* CircleAvatarImageViewTests.swift in Sources */,
 				606C45F829FACD9F001BA067 /* RemoteConfigFeature+HelpersTests.swift in Sources */,
 				A7ED1FB81E831C5C00BFFA01 /* BackingCellViewModelTests.swift in Sources */,
+				E1982FE62BEABF8F0057BD09 /* KSRStripeLinkTests.swift in Sources */,
 				A7ED1FFD1E831C5C00BFFA01 /* ProjectUpdatesViewModelTests.swift in Sources */,
 				191E60262A953E2B001413B2 /* ProjectTabCheckmarkListCellViewModelTests.swift in Sources */,
 				A7ED1F341E830FDC00BFFA01 /* SharedFunctionsTests.swift in Sources */,

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -10741,7 +10741,7 @@
 			repositoryURL = "https://github.com/stripe/stripe-ios";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 23.10.0;
+				minimumVersion = 23.27.1;
 			};
 		};
 		194C593E28F5E7FF00453249 /* XCRemoteSwiftPackageReference "Kickstarter-ReactiveExtensions" */ = {

--- a/Kickstarter.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Kickstarter.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -275,8 +275,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stripe/stripe-ios",
       "state" : {
-        "revision" : "e7bd9f65d40c20c1c84e6f335f60ff89f9f04a5d",
-        "version" : "23.10.0"
+        "revision" : "d0c607a3bce526f2fd27c87fa4822f285d378d3f",
+        "version" : "23.27.1"
       }
     },
     {

--- a/Library/KSRStripeLink.swift
+++ b/Library/KSRStripeLink.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+public class KSRStripeLink {
+  // Link gives us a label like "Visa 1234"; reformat it to match our UI
+  public static func formatLinkLabel(_ label: String) -> String? {
+    do {
+      // Find 4 digits in the string
+      let regex = try NSRegularExpression(pattern: "\\d{4}")
+      let matches = regex.matches(
+        in: label,
+        range: NSRange(location: 0, length: label.count)
+      )
+
+      guard let match = matches.first else {
+        return nil
+      }
+
+      guard let range = Range(match.range, in: label) else {
+        return nil
+      }
+
+      let lastFour = label[range]
+      return "•••• \(lastFour)"
+
+    } catch {
+      return nil
+    }
+  }
+}

--- a/Library/KSRStripeLinkTests.swift
+++ b/Library/KSRStripeLinkTests.swift
@@ -1,0 +1,10 @@
+@testable import Library
+import XCTest
+
+final class KSRStripeLinkTests: XCTestCase {
+  func testFormatLinkLabel() {
+    XCTAssertEqual(KSRStripeLink.formatLinkLabel("Visa 1234"), "•••• 1234")
+    XCTAssertEqual(KSRStripeLink.formatLinkLabel("1234 Visa"), "•••• 1234")
+    XCTAssertEqual(KSRStripeLink.formatLinkLabel("Foobar"), nil)
+  }
+}

--- a/Library/TestHelpers/Stripe+PaymentMethod.swift
+++ b/Library/TestHelpers/Stripe+PaymentMethod.swift
@@ -22,15 +22,15 @@ extension STPPaymentMethod {
   ])
 
   static let sampleStringPaymentOption: (STPPaymentMethod) -> PaymentSheet.PaymentOption = { paymentMethod in
-    PaymentSheet.PaymentOption.saved(paymentMethod: paymentMethod)
+    PaymentSheet.PaymentOption.saved(paymentMethod: paymentMethod, confirmParams: nil)
   }
 
   static let samplePaymentOptionsDisplayData: (PaymentSheet.PaymentOption)
     -> PaymentSheetPaymentOptionsDisplayData = { paymentOption in
       switch paymentOption {
-      case let .saved(paymentMethod):
+      case .saved:
         return PaymentSheetPaymentOptionsDisplayData(image: .add, label: "••••1234")
-      case .applePay, .new, .link:
+      case .applePay, .new, .link, .external:
         return PaymentSheetPaymentOptionsDisplayData(image: .add, label: "Unknown")
       }
     }

--- a/Library/ViewModels/PaymentMethodSettingsViewModel.swift
+++ b/Library/ViewModels/PaymentMethodSettingsViewModel.swift
@@ -157,6 +157,11 @@ public final class PaymentMethodSettingsViewModel: PaymentMethodsViewModelType,
             var configuration = PaymentSheet.Configuration()
             configuration.merchantDisplayName = Strings.general_accessibility_kickstarter()
             configuration.allowsDelayedPaymentMethods = true
+
+            if featureStripeLinkEnabled() {
+              configuration.defaultBillingDetails.email = AppEnvironment.current.currentUserEmail
+            }
+
             let data = PaymentSheetSetupData(
               clientSecret: envelope.clientSecret,
               configuration: configuration,

--- a/Library/ViewModels/PledgePaymentMethodsViewModel.swift
+++ b/Library/ViewModels/PledgePaymentMethodsViewModel.swift
@@ -346,6 +346,10 @@ public final class PledgePaymentMethodsViewModel: PledgePaymentMethodsViewModelT
           configuration.merchantDisplayName = Strings.general_accessibility_kickstarter()
           configuration.allowsDelayedPaymentMethods = paymentSheetType == .setupIntent
 
+          if featureStripeLinkEnabled() {
+            configuration.defaultBillingDetails.email = AppEnvironment.current.currentUserEmail
+          }
+
           let data = PaymentSheetSetupData(
             clientSecret: clientSecret,
             configuration: configuration,


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Implement Stripe Link for iOS.

# 🤔 Why

Stripe Link allows backers to store their card information with Stripe, and then auto-complete it when they use the Stripe payment sheet in Kickstarter. We're implementing this because it's a nicer user experience in checkout.

# 🛠 How

When Stripe Link returns, it gives us payment display information specific to Stripe Link - i.e. it was giving us a the Link icon and the label "Stripe Link". 

<img width="250" alt="Screenshot 2024-04-25 at 9 53 49 AM" src="https://github.com/kickstarter/ios-oss/assets/146007185/4b801fae-6999-4b96-9d88-8ca8033120e8">

To work around this, Stripe suggested we fetch the underlying payment method associated with the link, which allows us to grab the last four digits of the card and its card image. This makes Stripe Link function the way a manually added card does, and looks better in our UI.

<img width="250" alt="Screenshot 2024-05-06 at 11 37 03 AM" src="https://github.com/kickstarter/ios-oss/assets/146007185/cb84e9ec-fa44-4f56-be3f-6fa24464795e">

# 👀 See

https://github.com/kickstarter/ios-oss/assets/146007185/5c1f5b79-22ec-405f-9b23-0ddb8cef99bc

# ✅  Regression testing before merging
- [ ] Pay with Stripe Link in live pledge flow
- [ ] Pay with Stripe Link in late pledge flow
- [ ] Pay with manually added card in live pledge flow
- [ ] Pay with manually added card in late pledge flow
