### PR TITLE
[NO TICKET] Privacy Manifest Fix

### DIFF
--- a/Kickstarter-iOS/PrivacyInfo.xcprivacy
+++ b/Kickstarter-iOS/PrivacyInfo.xcprivacy
@@ -12,7 +12,6 @@
 				<string>CA92.1</string>
 			</array>
 		</dict>
-		<dict/>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
Removes an extra, empty, item key from the new privacy manifest.