### PR TITLE
MBL-1374: Handle long add-on names on late pledge confirmation page

### DIFF
--- a/Kickstarter-iOS/Features/PledgePaymentMethods/Controller/PostCampaignPledgeRewardsSummaryViewController.swift
+++ b/Kickstarter-iOS/Features/PledgePaymentMethods/Controller/PostCampaignPledgeRewardsSummaryViewController.swift
@@ -72,6 +72,12 @@ final class PostCampaignPledgeRewardsSummaryViewController: UIViewController {
     self.tableView.registerCellClass(PostCampaignPledgeRewardsSummaryCell.self)
   }
 
+  override func viewWillLayoutSubviews() {
+    super.viewWillLayoutSubviews()
+
+    self.tableViewContainerHeightConstraint?.constant = self.tableView.intrinsicContentSize.height
+  }
+
   private func setupConstraints() {
     let tableViewContainerHeightConstraint = self.tableViewContainer.heightAnchor
       .constraint(equalToConstant: 0)

--- a/Kickstarter-iOS/Features/PledgePaymentMethods/Views/Cells/PostCampaignPledgeRewardsSummaryCell.swift
+++ b/Kickstarter-iOS/Features/PledgePaymentMethods/Views/Cells/PostCampaignPledgeRewardsSummaryCell.swift
@@ -31,13 +31,12 @@ final class PostCampaignPledgeRewardsSummaryCell: UITableViewCell, ValueCell {
   override func bindStyles() {
     super.bindStyles()
 
-    _ = self
-      |> \.selectionStyle .~ .none
-      |> \.separatorInset .~ .init(leftRight: CheckoutConstants.PledgeView.Inset.leftRight)
+    self.selectionStyle = .none
+    self.separatorInset = UIEdgeInsets(leftRight: CheckoutConstants.PledgeView.Inset.leftRight)
 
-    _ = self.amountLabel
-      |> UILabel.lens.contentHuggingPriority(for: .horizontal) .~ .required
-      |> \.adjustsFontForContentSizeCategory .~ true
+    self.amountLabel.setContentHuggingPriority(.required, for: .horizontal)
+
+    self.amountLabel.adjustsFontForContentSizeCategory = true
 
     _ = self.rootStackView
       |> rootStackViewStyle(self.traitCollection.preferredContentSizeCategory > .accessibilityLarge)
@@ -82,10 +81,11 @@ final class PostCampaignPledgeRewardsSummaryCell: UITableViewCell, ValueCell {
 // MARK: - Styles
 
 private let titleLabelStyle: LabelStyle = { label in
-  label
-    |> \.font .~ UIFont.ksr_subhead().bolded
-    |> \.textColor .~ .ksr_support_400
-    |> \.numberOfLines .~ 0
+  label.font = UIFont.ksr_subhead().bolded
+  label.textColor = UIColor.ksr_support_400
+  label.numberOfLines = 0
+
+  return label
 }
 
 private func rootStackViewStyle(_ isAccessibilityCategory: Bool) -> (StackViewStyle) {
@@ -95,16 +95,17 @@ private func rootStackViewStyle(_ isAccessibilityCategory: Bool) -> (StackViewSt
   let spacing: CGFloat = (isAccessibilityCategory ? Styles.grid(1) : 0)
 
   return { (stackView: UIStackView) in
-    stackView
-      |> \.insetsLayoutMarginsFromSafeArea .~ false
-      |> \.alignment .~ alignment
-      |> \.axis .~ axis
-      |> \.distribution .~ distribution
-      |> \.spacing .~ spacing
-      |> \.isLayoutMarginsRelativeArrangement .~ true
-      |> \.layoutMargins .~ .init(
-        topBottom: Styles.grid(3),
-        leftRight: CheckoutConstants.PledgeView.Inset.leftRight
-      )
+    stackView.insetsLayoutMarginsFromSafeArea = false
+    stackView.alignment = alignment
+    stackView.axis = axis
+    stackView.distribution = distribution
+    stackView.spacing = spacing
+    stackView.isLayoutMarginsRelativeArrangement = true
+    stackView.layoutMargins = UIEdgeInsets(
+      topBottom: Styles.grid(3),
+      leftRight: CheckoutConstants.PledgeView.Inset.leftRight
+    )
+
+    return stackView
   }
 }

--- a/Kickstarter-iOS/Features/PledgePaymentMethods/Views/Cells/PostCampaignPledgeRewardsSummaryCell.swift
+++ b/Kickstarter-iOS/Features/PledgePaymentMethods/Views/Cells/PostCampaignPledgeRewardsSummaryCell.swift
@@ -34,8 +34,6 @@ final class PostCampaignPledgeRewardsSummaryCell: UITableViewCell, ValueCell {
     self.selectionStyle = .none
     self.separatorInset = UIEdgeInsets(leftRight: CheckoutConstants.PledgeView.Inset.leftRight)
 
-    self.amountLabel.setContentHuggingPriority(.required, for: .horizontal)
-
     self.amountLabel.adjustsFontForContentSizeCategory = true
 
     _ = self.rootStackView
@@ -43,6 +41,9 @@ final class PostCampaignPledgeRewardsSummaryCell: UITableViewCell, ValueCell {
 
     _ = self.titleLabel
       |> titleLabelStyle
+
+    self.amountLabel.setContentHuggingPriority(.required, for: .horizontal)
+    self.amountLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
   }
 
   // MARK: - View model
@@ -76,6 +77,12 @@ final class PostCampaignPledgeRewardsSummaryCell: UITableViewCell, ValueCell {
     _ = ([self.titleLabel, self.amountLabel], self.rootStackView)
       |> ksr_addArrangedSubviewsToStackView()
   }
+
+  override func layoutSubviews() {
+    super.layoutSubviews()
+    self.titleLabel.preferredMaxLayoutWidth = self.titleLabel.frame.size.width
+    super.layoutSubviews()
+  }
 }
 
 // MARK: - Styles
@@ -91,7 +98,7 @@ private let titleLabelStyle: LabelStyle = { label in
 private func rootStackViewStyle(_ isAccessibilityCategory: Bool) -> (StackViewStyle) {
   let alignment: UIStackView.Alignment = (isAccessibilityCategory ? .center : .top)
   let axis: NSLayoutConstraint.Axis = (isAccessibilityCategory ? .vertical : .horizontal)
-  let distribution: UIStackView.Distribution = (isAccessibilityCategory ? .equalSpacing : .fill)
+  let distribution: UIStackView.Distribution = (isAccessibilityCategory ? .equalSpacing : .fillProportionally)
   let spacing: CGFloat = (isAccessibilityCategory ? Styles.grid(1) : 0)
 
   return { (stackView: UIStackView) in


### PR DESCRIPTION
# 📲 What

In the summary view for late pledge confirmation,
- Fix missing price information when the title ran over
- Fix multi-line title tables 
- Clean up some Prelude

# 🤔 Why

Long add-on names would break the summary view:
<img src="https://github.com/kickstarter/ios-oss/assets/146007185/cbcb26b4-d87d-4ad0-b394-47c5f610b344" width="250"/>

# 👀 See

Here's the same project, fixed:
<img width="250" alt="Screenshot 2024-05-08 at 3 04 05 PM" src="https://github.com/kickstarter/ios-oss/assets/146007185/21f5817e-aac4-4630-b53c-a973f5429171">


Here's an example of it working, with a very long hard-coded string:
<img width="250" alt="Screenshot 2024-05-08 at 2 20 28 PM" src="https://github.com/kickstarter/ios-oss/assets/146007185/eed290ba-84d5-4f83-8b09-742ddc9c9adc">

As well as working with the largest font size:
<img width="250" alt="Screenshot 2024-05-08 at 2 23 28 PM" src="https://github.com/kickstarter/ios-oss/assets/146007185/0f83924a-5dbe-4ab3-9c8f-1707c37934ac">

