### PR TITLE
Use new redirect address to detect survey has been answered

### DIFF
--- a/Library/Navigation.swift
+++ b/Library/Navigation.swift
@@ -48,6 +48,7 @@ public enum Navigation: Equatable {
     case updates
     case update(Int, Navigation.Project.Update)
     case survey(Int)
+    case surveyResponse
 
     public enum Checkout: Equatable {
       case thanks(racing: Bool?)
@@ -131,6 +132,7 @@ private let allRoutes: [String: (RouteParamsDecoded) -> Navigation?] = [
   "/search": search,
   "/signup": signup,
   "/projects/:creator_param/:project_param": project,
+  "/projects/:creator_param/:project_param/backing/survey_responses": surveyResponse,
   "/projects/:creator_param/:project_param/checkouts/:checkout_param/thanks": thanks,
   "/projects/:creator_param/:project_param/comments": projectComments,
   "/projects/:creator_param/:project_param/creator_bio": creatorBio,
@@ -291,6 +293,15 @@ private func project(_ params: RouteParamsDecoded) -> Navigation? {
   } else if let projectParam = params.projectParam() {
     let refInfo = refInfoFromParams(params)
     return Navigation.project(projectParam, .root, refInfo: refInfo)
+  }
+
+  return nil
+}
+
+private func surveyResponse(_ params: RouteParamsDecoded) -> Navigation? {
+  if let projectParam = params.projectParam() {
+    let refInfo = refInfoFromParams(params)
+    return Navigation.project(projectParam, .surveyResponse, refInfo: refInfo)
   }
 
   return nil

--- a/Library/ViewModels/SurveyResponseViewModel.swift
+++ b/Library/ViewModels/SurveyResponseViewModel.swift
@@ -74,8 +74,11 @@ public final class SurveyResponseViewModel: SurveyResponseViewModelType {
       .map { request, _ in request }
 
     let redirectAfterPostRequest = requestAndNavigationType
-      .filter { request, navigationType in
-        isUnpreparedSurvey(request: request) && navigationType == .other
+      .filter { request, _ -> Bool in
+        if case (.project(_, .surveyResponse, _))? = Navigation.match(request) {
+          return true
+        }
+        return false
       }
       .map { request, _ in request }
 


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Change what redirect we're looking for in the survey web view in order to know that survey answers have been submitted.

Note: I don't think this PR should be submitted until we can verify that this won't negatively impact the new survey experience.

# 👀 See

[Main jira ticket](https://kickstarter.atlassian.net/browse/MBL-1387)
[Expired survey jira ticket](https://kickstarter.atlassian.net/browse/MBL-1389)

| Before 🐛 | After 🦋 |
| --- | --- |
| submission | ![Simulator Screen Recording - iPhone 15 Pro Max - 2024-05-08 at 16 46 52](https://github.com/kickstarter/ios-oss/assets/6799207/5df3d647-7b88-436c-824d-a6229b33a492) |
| expired | ![Simulator Screen Recording - iPhone 15 Pro Max - 2024-05-08 at 16 44 08](https://github.com/kickstarter/ios-oss/assets/6799207/6f298a1d-d469-4e1f-a355-77f855309351) |

# ✅ Acceptance criteria

- [ ] Surveys dismiss or at least tell user when a survey has been submitted
- [ ] Expired surveys have a better UX than a blank page

# ⏰ TODO

- [ ] Test that this changed redirect doesn't negatively influence new surveys
