### PR TITLE
Fix Stripe Link remote configuration flag

### DIFF
--- a/Library/ViewModels/PaymentMethodSettingsViewModel.swift
+++ b/Library/ViewModels/PaymentMethodSettingsViewModel.swift
@@ -159,10 +159,6 @@ public final class PaymentMethodSettingsViewModel: PaymentMethodsViewModelType,
             configuration.merchantDisplayName = Strings.general_accessibility_kickstarter()
             configuration.allowsDelayedPaymentMethods = true
 
-            if featureStripeLinkEnabled() {
-              configuration.defaultBillingDetails.email = AppEnvironment.current.currentUserEmail
-            }
-
             let data = PaymentSheetSetupData(
               clientSecret: envelope.clientSecret,
               configuration: configuration,

--- a/Library/ViewModels/PledgePaymentMethodsViewModel.swift
+++ b/Library/ViewModels/PledgePaymentMethodsViewModel.swift
@@ -354,6 +354,9 @@ public final class PledgePaymentMethodsViewModel: PledgePaymentMethodsViewModelT
 
           if featureStripeLinkEnabled() {
             configuration.defaultBillingDetails.email = AppEnvironment.current.currentUserEmail
+            configuration.billingDetailsCollectionConfiguration.email = .automatic
+          } else {
+            configuration.billingDetailsCollectionConfiguration.email = .always
           }
 
           let data = PaymentSheetSetupData(


### PR DESCRIPTION
# 📲 What

Fix the Stripe Link remote configuration flag, so that it _actually_ controls whether or not Stripe Link is enabled.

# 🤔 Why

Apparently setting the email address was insufficient to control the appearance of Stripe Link. 🤷‍♀️ 

