### PR TITLE
MBL-1390: Re-enable Stripe Link

### DIFF
--- a/Kickstarter.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Kickstarter.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -293,8 +293,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stripe/stripe-ios",
       "state" : {
-        "revision" : "e7bd9f65d40c20c1c84e6f335f60ff89f9f04a5d",
-        "version" : "23.10.0"
+        "revision" : "8a35266fab2e0ba116dec7d651ae69a0ca7bc7b7",
+        "version" : "23.27.2"
       }
     },
     {

--- a/Library/TestHelpers/Stripe+PaymentMethod.swift
+++ b/Library/TestHelpers/Stripe+PaymentMethod.swift
@@ -22,15 +22,15 @@ extension STPPaymentMethod {
   ])
 
   static let sampleStringPaymentOption: (STPPaymentMethod) -> PaymentSheet.PaymentOption = { paymentMethod in
-    PaymentSheet.PaymentOption.saved(paymentMethod: paymentMethod)
+    PaymentSheet.PaymentOption.saved(paymentMethod: paymentMethod, confirmParams: nil)
   }
 
   static let samplePaymentOptionsDisplayData: (PaymentSheet.PaymentOption)
     -> PaymentSheetPaymentOptionsDisplayData = { paymentOption in
       switch paymentOption {
-      case let .saved(paymentMethod):
+      case let .saved(paymentMethod, _):
         return PaymentSheetPaymentOptionsDisplayData(image: .add, label: "••••1234")
-      case .applePay, .new, .link:
+      case .applePay, .new, .link, .external:
         return PaymentSheetPaymentOptionsDisplayData(image: .add, label: "Unknown")
       }
     }

--- a/Library/ViewModels/PledgePaymentMethodsViewModel.swift
+++ b/Library/ViewModels/PledgePaymentMethodsViewModel.swift
@@ -325,6 +325,9 @@ public final class PledgePaymentMethodsViewModel: PledgePaymentMethodsViewModelT
           configuration.merchantDisplayName = Strings.general_accessibility_kickstarter()
           configuration.allowsDelayedPaymentMethods = true
 
+          // Enable Stripe Link
+          configuration.defaultBillingDetails.email = AppEnvironment.current.currentUserEmail
+
           let data = PaymentSheetSetupData(
             clientSecret: clientSecret,
             configuration: configuration


### PR DESCRIPTION
# 📲 What

Turn on Stripe Link.

# 🛠 How

This is _much_ simpler now that the payments sheet has been refactored, and since we also decided to nix feature flags for Stripe Link! All we need to do is upgrade the Stripe SDK and pass in the user's e-mail address.

# 👀 See
<img width="533" alt="Screenshot 2024-06-10 at 4 19 59 PM" src="https://github.com/kickstarter/ios-oss/assets/146007185/b8c8f6ce-7f93-4dd4-ad33-5e4dd4c0a81c">