### PR TITLE
MBL-1390: Log in to Stripe Link on Payment settings page, too

### DIFF
--- a/Library/ViewModels/PaymentMethodSettingsViewModel.swift
+++ b/Library/ViewModels/PaymentMethodSettingsViewModel.swift
@@ -138,6 +138,10 @@ public final class PaymentMethodSettingsViewModel: PaymentMethodsViewModelType,
             var configuration = PaymentSheet.Configuration()
             configuration.merchantDisplayName = Strings.general_accessibility_kickstarter()
             configuration.allowsDelayedPaymentMethods = true
+
+            // Log in to Stripe Link
+            configuration.defaultBillingDetails.email = AppEnvironment.current.currentUserEmail
+
             let data = PaymentSheetSetupData(
               clientSecret: envelope.clientSecret,
               configuration: configuration

--- a/Library/ViewModels/PledgePaymentMethodsViewModel.swift
+++ b/Library/ViewModels/PledgePaymentMethodsViewModel.swift
@@ -325,7 +325,7 @@ public final class PledgePaymentMethodsViewModel: PledgePaymentMethodsViewModelT
           configuration.merchantDisplayName = Strings.general_accessibility_kickstarter()
           configuration.allowsDelayedPaymentMethods = true
 
-          // Enable Stripe Link
+          // Log in to Stripe Link
           configuration.defaultBillingDetails.email = AppEnvironment.current.currentUserEmail
 
           let data = PaymentSheetSetupData(


### PR DESCRIPTION
# 📲 What

Add e-mail address to log in to Stripe Link from the payment settings page.

# 🤔 Why

We made the decision that, since we can't turn Stripe Link off in the app at all, we will fully support it in both the Pledge flow, and in Account Settings. This is a slight divergence from the web, which doesn't show Link in Account Settings.

Without this change, Stripe Link is visible, but does not automatically log in the user if they have an existing Stripe Link account.