### PR TITLE
[MBL-1553] Configure survey webview with url instead of SurveyResponse object

### DIFF
--- a/Kickstarter-iOS/AppDelegateViewModel.swift
+++ b/Kickstarter-iOS/AppDelegateViewModel.swift
@@ -596,7 +596,7 @@ public final class AppDelegateViewModel: AppDelegateViewModelType, AppDelegateVi
 
     let surveyUrlFromProjectLink = deepLink
       .map { link -> String? in
-        if case let .project(_, .survey(surveyResponseId, surveyUrl), _) = link {
+        if case let .project(_, .survey(surveyUrl), _) = link {
           return surveyUrl
         }
         return nil

--- a/Kickstarter-iOS/AppDelegateViewModel.swift
+++ b/Kickstarter-iOS/AppDelegateViewModel.swift
@@ -579,10 +579,9 @@ public final class AppDelegateViewModel: AppDelegateViewModelType, AppDelegateVi
           }
       }
 
-    let surveyResponseLink = deepLink
+    let surveyUrlFromUserLink = deepLink
       .map { link -> Int? in
         if case let .user(_, .survey(surveyResponseId)) = link { return surveyResponseId }
-        if case let .project(_, .survey(surveyResponseId), _) = link { return surveyResponseId }
         return nil
       }
       .skipNil()
@@ -590,9 +589,23 @@ public final class AppDelegateViewModel: AppDelegateViewModelType, AppDelegateVi
         AppEnvironment.current.apiService.fetchSurveyResponse(surveyResponseId: surveyResponseId)
           .demoteErrors()
           .observeForUI()
-          .map { surveyResponse -> [UIViewController] in
-            [SurveyResponseViewController.configuredWith(surveyResponse: surveyResponse)]
+          .map { surveyResponse -> String in
+            surveyResponse.urls.web.survey
           }
+      }
+
+    let surveyUrlFromProjectLink = deepLink
+      .map { link -> String? in
+        if case let .project(_, .survey(surveyResponseId, surveyUrl), _) = link {
+          return surveyUrl
+        }
+        return nil
+      }
+      .skipNil()
+
+    let surveyResponseLink = Signal.merge(surveyUrlFromProjectLink, surveyUrlFromUserLink)
+      .map { url -> [UIViewController] in
+        [SurveyResponseViewController.configuredWith(surveyUrl: url)]
       }
 
     let updatesLink = projectLink

--- a/Kickstarter-iOS/Features/Activities/Controller/ActivitiesViewController.swift
+++ b/Kickstarter-iOS/Features/Activities/Controller/ActivitiesViewController.swift
@@ -210,7 +210,8 @@ internal final class ActivitiesViewController: UITableViewController {
   }
 
   fileprivate func goToSurveyResponse(surveyResponse: SurveyResponse) {
-    let vc = SurveyResponseViewController.configuredWith(surveyResponse: surveyResponse)
+    let url = surveyResponse.urls.web.survey
+    let vc = SurveyResponseViewController.configuredWith(surveyUrl: url)
     vc.delegate = self
 
     let nav = UINavigationController(rootViewController: vc)

--- a/Kickstarter-iOS/Features/SurveyResponse/Controller/SurveyResponseViewController.swift
+++ b/Kickstarter-iOS/Features/SurveyResponse/Controller/SurveyResponseViewController.swift
@@ -13,10 +13,10 @@ internal final class SurveyResponseViewController: WebViewController {
   internal weak var delegate: SurveyResponseViewControllerDelegate?
   fileprivate let viewModel: SurveyResponseViewModelType = SurveyResponseViewModel()
 
-  internal static func configuredWith(surveyResponse: SurveyResponse)
+  internal static func configuredWith(surveyUrl: String)
     -> SurveyResponseViewController {
     let vc = SurveyResponseViewController()
-    vc.viewModel.inputs.configureWith(surveyResponse: surveyResponse)
+    vc.viewModel.inputs.configureWith(surveyUrl: surveyUrl)
     return vc
   }
 

--- a/Library/Navigation.swift
+++ b/Library/Navigation.swift
@@ -47,7 +47,7 @@ public enum Navigation: Equatable {
     case pledge(Navigation.Project.Pledge)
     case updates
     case update(Int, Navigation.Project.Update)
-    case survey(Int)
+    case survey(Int, String)
 
     public enum Checkout: Equatable {
       case thanks(racing: Bool?)
@@ -422,9 +422,11 @@ private func posts(_ params: RouteParamsDecoded) -> Navigation? {
 
 private func projectSurvey(_ params: RouteParamsDecoded) -> Navigation? {
   if let projectParam = params.projectParam(),
-     let surveyParam = params.surveyParam() {
+     let surveyParam = params.surveyParam(),
+     let path = params.path() {
+    let url = AppEnvironment.current.apiService.serverConfig.webBaseUrl.absoluteString + path
     let refInfo = refInfoFromParams(params)
-    let survey = Navigation.Project.survey(surveyParam)
+    let survey = Navigation.Project.survey(surveyParam, url)
     return Navigation.project(projectParam, survey, refInfo: refInfo)
   }
 
@@ -559,6 +561,7 @@ private func parsedParams(url: URL, fromTemplate template: String) -> RouteParam
   // If the deeplink opens the project page, track the url.
   if urlComponents.first == "projects" {
     object[RouteParamsDecoded.CodingKeys.deeplinkUrl.rawValue] = url.absoluteString
+    object[RouteParamsDecoded.CodingKeys.path.rawValue] = url.path
   }
 
   return object
@@ -598,6 +601,7 @@ extension RouteParamsDecoded {
     case notificationParam = "notification_param"
     case checkoutParam = "checkout_param"
     case enabledParam = "enabled_param"
+    case path
     case payload
     case projectParam = "project_param"
     case ref
@@ -623,6 +627,11 @@ extension RouteParamsDecoded {
   public func enabledParam() -> Bool? {
     let key = CodingKeys.enabledParam.rawValue
     return self[key].flatMap(Bool.init)
+  }
+
+  public func path() -> String? {
+    let key = CodingKeys.path.rawValue
+    return self[key]
   }
 
   public func refTag() -> RefTag? {

--- a/Library/Navigation.swift
+++ b/Library/Navigation.swift
@@ -47,7 +47,7 @@ public enum Navigation: Equatable {
     case pledge(Navigation.Project.Pledge)
     case updates
     case update(Int, Navigation.Project.Update)
-    case survey(Int, String)
+    case survey(String)
 
     public enum Checkout: Equatable {
       case thanks(racing: Bool?)
@@ -422,11 +422,10 @@ private func posts(_ params: RouteParamsDecoded) -> Navigation? {
 
 private func projectSurvey(_ params: RouteParamsDecoded) -> Navigation? {
   if let projectParam = params.projectParam(),
-     let surveyParam = params.surveyParam(),
      let path = params.path() {
     let url = AppEnvironment.current.apiService.serverConfig.webBaseUrl.absoluteString + path
     let refInfo = refInfoFromParams(params)
-    let survey = Navigation.Project.survey(surveyParam, url)
+    let survey = Navigation.Project.survey(url)
     return Navigation.project(projectParam, survey, refInfo: refInfo)
   }
 

--- a/Library/NavigationTests.swift
+++ b/Library/NavigationTests.swift
@@ -126,7 +126,10 @@ public final class NavigationTests: XCTestCase {
       navigation: .update(2, .commentThread("dead", "beef"))
     )
 
-    self.assertProjectMatch(path: "/projects/creator/project/surveys/3", navigation: .survey(3))
+    self.assertProjectMatch(
+      path: "/projects/creator/project/surveys/3",
+      navigation: .survey(3, "https://www.kickstarter.com/projects/creator/project/surveys/3")
+    )
 
     KSRAssertMatch(
       .signup,

--- a/Library/NavigationTests.swift
+++ b/Library/NavigationTests.swift
@@ -1,4 +1,4 @@
-import KsApi
+@testable import KsApi
 @testable import Library
 import Prelude
 import XCTest
@@ -126,10 +126,12 @@ public final class NavigationTests: XCTestCase {
       navigation: .update(2, .commentThread("dead", "beef"))
     )
 
-    self.assertProjectMatch(
-      path: "/projects/creator/project/surveys/3",
-      navigation: .survey(3, "https://www.kickstarter.com/projects/creator/project/surveys/3")
-    )
+    withEnvironment(apiService: MockService(serverConfig: ServerConfig.production)) {
+      self.assertProjectMatch(
+        path: "/projects/creator/project/surveys/3",
+        navigation: .survey("https://www.kickstarter.com/projects/creator/project/surveys/3")
+      )
+    }
 
     KSRAssertMatch(
       .signup,

--- a/Library/ViewModels/SurveyResponseViewModel.swift
+++ b/Library/ViewModels/SurveyResponseViewModel.swift
@@ -8,8 +8,8 @@ public protocol SurveyResponseViewModelInputs {
   /// Call when the close button is tapped.
   func closeButtonTapped()
 
-  /// Call to configure with a survey response.
-  func configureWith(surveyResponse: SurveyResponse)
+  /// Call to configure with a survey url.
+  func configureWith(surveyUrl: String)
 
   /// Call when the webview needs to decide a policy for a navigation action. Returns the decision policy.
   func decidePolicyFor(navigationAction: WKNavigationActionData) -> WKNavigationActionPolicy
@@ -45,14 +45,14 @@ public protocol SurveyResponseViewModelType: SurveyResponseViewModelInputs, Surv
 public final class SurveyResponseViewModel: SurveyResponseViewModelType {
   public init() {
     let surveyResponse = Signal.combineLatest(
-      self.surveyResponseProperty.signal.skipNil(),
+      self.initialSurveyProperty.signal.skipNil(),
       self.viewDidLoadProperty.signal
     )
     .map(first)
 
     let initialRequest = surveyResponse
-      .map { surveyResponse -> URLRequest? in
-        guard let url = URL(string: surveyResponse.urls.web.survey) else { return nil }
+      .map { surveyUrlString -> URLRequest? in
+        guard let url = URL(string: surveyUrlString) else { return nil }
         return URLRequest(url: url)
       }
       .skipNil()
@@ -138,9 +138,9 @@ public final class SurveyResponseViewModel: SurveyResponseViewModelType {
     return self.policyDecisionProperty.value
   }
 
-  fileprivate let surveyResponseProperty = MutableProperty<SurveyResponse?>(nil)
-  public func configureWith(surveyResponse: SurveyResponse) {
-    self.surveyResponseProperty.value = surveyResponse
+  fileprivate let initialSurveyProperty = MutableProperty<String?>(nil)
+  public func configureWith(surveyUrl: String) {
+    self.initialSurveyProperty.value = surveyUrl
   }
 
   fileprivate let viewDidLoadProperty = MutableProperty(())

--- a/Library/ViewModels/SurveyResponseViewModelTests.swift
+++ b/Library/ViewModels/SurveyResponseViewModelTests.swift
@@ -33,7 +33,7 @@ final class SurveyResponseViewModelTests: TestCase {
   }
 
   func testDismissViewControllerOnCloseButtonTapped() {
-    self.vm.inputs.configureWith(surveyResponse: .template)
+    self.vm.inputs.configureWith(surveyUrl: SurveyResponse.template.urls.web.survey)
     self.vm.inputs.viewDidLoad()
     self.dismissViewController.assertDidNotEmitValue()
 
@@ -47,7 +47,7 @@ final class SurveyResponseViewModelTests: TestCase {
       |> SurveyResponse.lens.id .~ 123
       |> SurveyResponse.lens.project .~ project
 
-    self.vm.inputs.configureWith(surveyResponse: surveyResponse)
+    self.vm.inputs.configureWith(surveyUrl: surveyResponse.urls.web.survey)
     self.vm.inputs.viewDidLoad()
 
     // 1. Load survey.
@@ -121,7 +121,7 @@ final class SurveyResponseViewModelTests: TestCase {
   }
 
   func testTitle() {
-    self.vm.inputs.configureWith(surveyResponse: .template)
+    self.vm.inputs.configureWith(surveyUrl: SurveyResponse.template.urls.web.survey)
     self.title.assertValueCount(0)
 
     self.vm.inputs.viewDidLoad()
@@ -135,7 +135,7 @@ final class SurveyResponseViewModelTests: TestCase {
     let surveyResponse = .template
       |> SurveyResponse.lens.project .~ project
 
-    self.vm.inputs.configureWith(surveyResponse: surveyResponse)
+    self.vm.inputs.configureWith(surveyUrl: surveyResponse.urls.web.survey)
     self.vm.inputs.viewDidLoad()
 
     self.goToPledge.assertDidNotEmitValue()
@@ -160,7 +160,7 @@ final class SurveyResponseViewModelTests: TestCase {
     let surveyResponse = .template
       |> SurveyResponse.lens.project .~ project
 
-    self.vm.inputs.configureWith(surveyResponse: surveyResponse)
+    self.vm.inputs.configureWith(surveyUrl: surveyResponse.urls.web.survey)
     self.vm.inputs.viewDidLoad()
 
     self.goToProjectParam.assertDidNotEmitValue()
@@ -188,7 +188,7 @@ final class SurveyResponseViewModelTests: TestCase {
 
     let update = Update.template
 
-    self.vm.inputs.configureWith(surveyResponse: surveyResponse)
+    self.vm.inputs.configureWith(surveyUrl: surveyResponse.urls.web.survey)
     self.vm.inputs.viewDidLoad()
 
     withEnvironment(apiService: MockService(


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Configure survey webview using a url string instead of an entire SurveyResponse object. This allows us to open deeplinks to new surveys as well as old surveys.

# 🛠 How

I'm reconstructing the url here using the current host and the path from the deeplink; I thought this had a good balance of being clear as well as definitely working. (I often do `ksr:// `deeplinks for testing, for example, and these would not be displayable in the webview directly if we were just using `.absoluteString` on the raw deeplink.)

# 👀 See

[Jira](https://kickstarter.atlassian.net/browse/MBL-1553)

# ✅ Acceptance criteria

- [x] New surveys are openable from activity and deeplinks
- [x] Old surveys are openable from activity and deeplinks

# ⏰ TODO

Note: This pr does not fix push notifications, which will be fixed in a later pr.
Once push notifications depend on the url as well, I'll follow up to see if we can just delete the user survey path.
