### PR TITLE
[MBL-1553] Make sure surveyVC is created on the main thread

### DIFF
--- a/Kickstarter-iOS/AppDelegateViewModel.swift
+++ b/Kickstarter-iOS/AppDelegateViewModel.swift
@@ -588,7 +588,6 @@ public final class AppDelegateViewModel: AppDelegateViewModelType, AppDelegateVi
       .switchMap { surveyResponseId in
         AppEnvironment.current.apiService.fetchSurveyResponse(surveyResponseId: surveyResponseId)
           .demoteErrors()
-          .observeForUI()
           .map { surveyResponse -> String in
             surveyResponse.urls.web.survey
           }
@@ -604,6 +603,7 @@ public final class AppDelegateViewModel: AppDelegateViewModelType, AppDelegateVi
       .skipNil()
 
     let surveyResponseLink = Signal.merge(surveyUrlFromProjectLink, surveyUrlFromUserLink)
+      .observeForUI()
       .map { url -> [UIViewController] in
         [SurveyResponseViewController.configuredWith(surveyUrl: url)]
       }


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Make sure the survey view controller is created on the main thread. When I added the url support, I accidentally skipped this step when we created the view controller directly from the url. I'm not sure why this crash didn't show up in the simulator 🤷 

# ✅ Acceptance criteria

- [x] Opening a deeplink to the survey doesn't cause the app to crash
