### PR TITLE
Allow js requests from stripe

### DIFF
--- a/Library/ViewModels/SurveyResponseViewModel.swift
+++ b/Library/ViewModels/SurveyResponseViewModel.swift
@@ -110,6 +110,10 @@ public final class SurveyResponseViewModel: SurveyResponseViewModelType {
 
     self.policyDecisionProperty <~ newRequest
       .map { request in
+        if isStripeElement(request) {
+          return true
+        }
+
         if !AppEnvironment.current.apiService.isPrepared(request: request) {
           return false
         }
@@ -165,4 +169,8 @@ private func isUnpreparedSurvey(request: URLRequest) -> Bool {
 private func isSurvey(request: URLRequest) -> Bool {
   guard case (.project(_, .survey, _))? = Navigation.match(request) else { return false }
   return true
+}
+
+private func isStripeElement(_ request: URLRequest) -> Bool {
+  return request.url?.host == "js.stripe.com"
 }


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Allow js requests to render in our survey webview. This is needed in order for users to be able to add new addresses.

# 👀 See

Trello, screenshots, external resources?

| Before 🐛 | After 🦋 | Entire flow |
| --- | --- | --- |
| ![Simulator Screen Recording - iPhone 15 Pro Max - 2024-06-25 at 12 34 21](https://github.com/kickstarter/ios-oss/assets/6799207/f521ac56-9483-4c4e-8546-1575d59309a2) | ![Simulator Screen Recording - iPhone 15 Pro Max - 2024-06-25 at 12 30 28](https://github.com/kickstarter/ios-oss/assets/6799207/b73088b8-e877-4b8e-b578-63a1f8a39847) | ![Simulator Screen Recording - iPhone 15 Pro Max - 2024-06-25 at 12 36 13](https://github.com/kickstarter/ios-oss/assets/6799207/f59b85c0-c3df-4753-97c8-94f2b0e1027e)|


# ✅ Acceptance criteria

- [x] New addresses can be added in the survey web view

