### PR TITLE
[MBL-1554] Fix survey push notifications for new surveys

### DIFF
--- a/Kickstarter-iOS/AppDelegateViewModel.swift
+++ b/Kickstarter-iOS/AppDelegateViewModel.swift
@@ -1066,7 +1066,9 @@ private func navigation(fromPushEnvelope envelope: PushEnvelope) -> Navigation? 
   }
 
   if let survey = envelope.survey {
-    return .user(.slug("self"), .survey(survey.id))
+    let path = survey.urls.web.survey
+    let url = AppEnvironment.current.apiService.serverConfig.webBaseUrl.absoluteString + path
+    return .project(.id(survey.projectId), .survey(url), refInfo: RefInfo(.push))
   }
 
   if let update = envelope.update {

--- a/Kickstarter-iOS/AppDelegateViewModelTests.swift
+++ b/Kickstarter-iOS/AppDelegateViewModelTests.swift
@@ -2504,7 +2504,12 @@ private let surveyResponsePushData = [
   ],
   "survey": [
     "id": 1,
-    "project_id": 1
+    "project_id": 1,
+    "urls": [
+      "web": [
+        "survey": "/projects/fakeCreatorId/1/surveys/0"
+      ]
+    ]
   ]
 ]
 

--- a/KsApi/models/PushEnvelope.swift
+++ b/KsApi/models/PushEnvelope.swift
@@ -42,6 +42,17 @@ public struct PushEnvelope {
   public struct Survey {
     public let id: Int
     public let projectId: Int
+
+    // urls.web.survey is the survey path.
+    public struct Urls: Decodable {
+      public struct Web: Decodable {
+        public let survey: String
+      }
+
+      public let web: Web
+    }
+
+    public let urls: Urls
   }
 
   public struct Update {
@@ -123,6 +134,7 @@ extension PushEnvelope.Survey: Decodable {
   enum CodingKeys: String, CodingKey {
     case id
     case projectId = "project_id"
+    case urls
   }
 }
 

--- a/KsApi/models/lenses/PushEnvelopeLenses.swift
+++ b/KsApi/models/lenses/PushEnvelopeLenses.swift
@@ -177,12 +177,17 @@ extension PushEnvelope.Survey {
   public enum lens {
     public static let id = Lens<PushEnvelope.Survey, Int>(
       view: { $0.id },
-      set: { .init(id: $0, projectId: $1.projectId) }
+      set: { .init(id: $0, projectId: $1.projectId, urls: $1.urls) }
     )
 
     public static let projectId = Lens<PushEnvelope.Survey, Int>(
       view: { $0.projectId },
-      set: { .init(id: $1.id, projectId: $0) }
+      set: { .init(id: $1.id, projectId: $0, urls: $1.urls) }
+    )
+
+    public static let urls = Lens<PushEnvelope.Survey, PushEnvelope.Survey.Urls>(
+      view: { $0.urls },
+      set: { .init(id: $1.id, projectId: $1.projectId, urls: $0) }
     )
   }
 }


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Allow new surveys to be opened from push notifications by using the url path provided instead of relying on the survey response id.

# 🤔 Why

New surveys don't have a unique id.

# 👀 See

[Jira](https://kickstarter.atlassian.net/browse/MBL-1554)

No screen recording of this because push notifications are a pain to work with, but I've verified that it works for new surveys and that push notification for old surveys have the exact same data format.

# ✅ Acceptance criteria

- [x] Clicking a push notification for a new survey opens the survey in the app.

