### PR TITLE
[MBL-1422] Handle errors without always dismissing

### DIFF
--- a/Kickstarter-iOS/Features/MessageBanner/Controller/MessageBannerViewController.swift
+++ b/Kickstarter-iOS/Features/MessageBanner/Controller/MessageBannerViewController.swift
@@ -29,7 +29,7 @@ public final class MessageBannerViewController: UIViewController, NibLoading {
     case bannerOnly
     // Banner can be dismissed by the user and will be dismissed automatically.
     // Once the banner is dismissed, the presenting view controller is popped.
-    case bannerAndParentVC
+    case bannerAndViewController
   }
 
   private var dismissType: DismissType = .bannerOnly
@@ -182,7 +182,7 @@ public final class MessageBannerViewController: UIViewController, NibLoading {
             )
           }
         } else {
-          if self?.dismissType == .bannerAndParentVC {
+          if self?.dismissType == .bannerAndViewController {
             self?.navigationController?.popViewController(animated: true)
             return
           }

--- a/Kickstarter-iOS/Features/MessageBanner/Controller/MessageBannerViewController.swift
+++ b/Kickstarter-iOS/Features/MessageBanner/Controller/MessageBannerViewController.swift
@@ -10,6 +10,7 @@ public protocol MessageBannerViewControllerPresenting {
 }
 
 public protocol MessageBannerViewControllerDelegate: AnyObject {
+  // Called when banner view hides if dismissType is `.bannerOnly`.
   func messageBannerViewDidHide(type: MessageBannerType)
 }
 
@@ -19,7 +20,19 @@ public final class MessageBannerViewController: UIViewController, NibLoading {
   @IBOutlet fileprivate var messageLabel: UILabel!
 
   private var bannerType: MessageBannerType?
-  private var dismissible: Bool = true
+
+  public enum DismissType {
+    // Banner cannot be dismissed and will not be dismissed automatically.
+    case persist
+    // Banner can be dismissed by the user and will be dismissed automatically.
+    // Once the banner is dismissed, the delegate method `messageBannerViewDidHide` is called.
+    case bannerOnly
+    // Banner can be dismissed by the user and will be dismissed automatically.
+    // Once the banner is dismissed, the presenting view controller is popped.
+    case bannerAndParentVC
+  }
+
+  private var dismissType: DismissType = .bannerOnly
 
   internal var bottomConstraint: NSLayoutConstraint?
   private let viewModel: MessageBannerViewModelType = MessageBannerViewModel()
@@ -70,7 +83,7 @@ public final class MessageBannerViewController: UIViewController, NibLoading {
       .observeValues { [weak self] isHidden in
         guard let self else { return }
 
-        if isHidden, !self.dismissible {
+        if isHidden, self.dismissType == .persist {
           return
         }
 
@@ -103,15 +116,19 @@ public final class MessageBannerViewController: UIViewController, NibLoading {
       }
   }
 
-  public func showBanner(with type: MessageBannerType, message: String, dismissible: Bool = true) {
+  public func showBanner(
+    with type: MessageBannerType,
+    message: String,
+    dismissType: DismissType = .bannerOnly
+  ) {
     self.bannerType = type
-    self.dismissible = dismissible
+    self.dismissType = dismissType
     self.viewModel.inputs.update(with: (type, message))
     self.viewModel.inputs.bannerViewWillShow(true)
   }
 
   private func showViewAndAnimate(_ isHidden: Bool) {
-    if !isHidden, !self.view.isHidden, !self.dismissible { return }
+    if !isHidden, !self.view.isHidden, self.dismissType == .persist { return }
 
     let duration = isHidden ? AnimationConstants.hideDuration : AnimationConstants.showDuration
 
@@ -120,7 +137,7 @@ public final class MessageBannerViewController: UIViewController, NibLoading {
     if !isHidden {
       self.view.superview?.bringSubviewToFront(self.view)
 
-      if self.dismissible {
+      if self.dismissType != .persist {
         self.view.superview?.isUserInteractionEnabled = false
       }
 
@@ -165,6 +182,11 @@ public final class MessageBannerViewController: UIViewController, NibLoading {
             )
           }
         } else {
+          if self?.dismissType == .bannerAndParentVC {
+            self?.navigationController?.popViewController(animated: true)
+            return
+          }
+
           self?.view.superview?.isUserInteractionEnabled = true
 
           if let type = self?.bannerType {
@@ -176,7 +198,7 @@ public final class MessageBannerViewController: UIViewController, NibLoading {
   }
 
   @IBAction private func bannerViewPanned(_ sender: UIPanGestureRecognizer) {
-    guard self.dismissible, let view = sender.view else {
+    guard self.dismissType != .persist, let view = sender.view else {
       return
     }
 
@@ -205,7 +227,7 @@ public final class MessageBannerViewController: UIViewController, NibLoading {
   }
 
   @IBAction private func bannerViewTapped(_: Any) {
-    guard self.dismissible else { return }
+    guard self.dismissType != .persist else { return }
 
     self.viewModel.inputs.bannerViewWillShow(false)
   }

--- a/Kickstarter-iOS/Features/Messages/Controller/MessagesViewController.swift
+++ b/Kickstarter-iOS/Features/Messages/Controller/MessagesViewController.swift
@@ -98,7 +98,7 @@ internal final class MessagesViewController: UITableViewController, MessageBanne
         guard let self, isBlocked == true else { return }
 
         self.messageBannerViewController?
-          .showBanner(with: .error, message: Strings.This_user_has_been_blocked(), dismissible: false)
+          .showBanner(with: .error, message: Strings.This_user_has_been_blocked(), dismissType: .persist)
       }
 
     self.viewModel.outputs.presentMessageDialog

--- a/Kickstarter-iOS/Features/PledgePaymentMethods/Controller/PledgePaymentMethodsViewController.swift
+++ b/Kickstarter-iOS/Features/PledgePaymentMethods/Controller/PledgePaymentMethodsViewController.swift
@@ -109,7 +109,7 @@ final class PledgePaymentMethodsViewController: UIViewController {
       .observeForUI()
       .observeValues { [weak self] errorMessage in
         guard let self = self else { return }
-        self.messageDisplayingDelegate?.pledgeViewController(self, didErrorWith: errorMessage)
+        self.messageDisplayingDelegate?.pledgeViewController(self, didErrorWith: errorMessage, error: nil)
       }
 
     self.viewModel.outputs.notifyDelegateCreditCardSelected
@@ -153,7 +153,7 @@ final class PledgePaymentMethodsViewController: UIViewController {
       case let .failure(error):
         strongSelf.viewModel.inputs.shouldCancelPaymentSheetAppearance(state: true)
         strongSelf.messageDisplayingDelegate?
-          .pledgeViewController(strongSelf, didErrorWith: error.localizedDescription)
+          .pledgeViewController(strongSelf, didErrorWith: error.localizedDescription, error: error)
       case let .success(paymentSheetFlowController):
         let topViewController = strongSelf.navigationController?.topViewController
 
@@ -211,7 +211,7 @@ final class PledgePaymentMethodsViewController: UIViewController {
       case let .failed(error):
         strongSelf.viewModel.inputs.shouldCancelPaymentSheetAppearance(state: true)
         strongSelf.messageDisplayingDelegate?
-          .pledgeViewController(strongSelf, didErrorWith: error.localizedDescription)
+          .pledgeViewController(strongSelf, didErrorWith: error.localizedDescription, error: error)
       }
     }
   }

--- a/Kickstarter-iOS/Features/PledgeView/Controllers/PledgeViewController.swift
+++ b/Kickstarter-iOS/Features/PledgeView/Controllers/PledgeViewController.swift
@@ -643,7 +643,7 @@ extension PledgeViewController: PledgeShippingLocationViewControllerDelegate {
 // MARK: - PledgeViewControllerMessageDisplaying
 
 extension PledgeViewController: PledgeViewControllerMessageDisplaying {
-  func pledgeViewController(_: UIViewController, didErrorWith message: String) {
+  func pledgeViewController(_: UIViewController, didErrorWith message: String, error _: Error?) {
     self.messageBannerViewController?.showBanner(with: .error, message: message)
   }
 

--- a/Kickstarter-iOS/Features/PledgeView/Controllers/PostCampaignCheckoutViewController.swift
+++ b/Kickstarter-iOS/Features/PledgeView/Controllers/PostCampaignCheckoutViewController.swift
@@ -82,7 +82,6 @@ final class PostCampaignCheckoutViewController: UIViewController,
     self.title = Strings.Back_this_project()
 
     self.messageBannerViewController = self.configureMessageBannerViewController(on: self)
-    self.messageBannerViewController?.delegate = self
 
     self.configureChildViewControllers()
     self.setupConstraints()
@@ -226,7 +225,11 @@ final class PostCampaignCheckoutViewController: UIViewController,
     self.viewModel.outputs.showErrorBannerWithMessage
       .observeForControllerAction()
       .observeValues { [weak self] errorMessage in
-        self?.messageBannerViewController?.showBanner(with: .error, message: errorMessage)
+        self?.messageBannerViewController?.showBanner(
+          with: .error,
+          message: errorMessage,
+          dismissType: .bannerAndParentVC
+        )
       }
 
     self.viewModel.outputs.configureStripeIntegration
@@ -261,7 +264,7 @@ final class PostCampaignCheckoutViewController: UIViewController,
         #endif
 
         self?.messageBannerViewController?
-          .showBanner(with: .error, message: message)
+          .showBanner(with: .error, message: message, dismissType: .bannerAndParentVC)
       }
   }
 
@@ -286,7 +289,11 @@ final class PostCampaignCheckoutViewController: UIViewController,
           // Only show error banner if confirmation failed instead of being canceled.
           if status == .failed {
             self.messageBannerViewController?
-              .showBanner(with: .error, message: Strings.Something_went_wrong_please_try_again())
+              .showBanner(
+                with: .error,
+                message: Strings.Something_went_wrong_please_try_again(),
+                dismissType: .bannerAndParentVC
+              )
           }
           self.viewModel.inputs.checkoutTerminated()
           return
@@ -361,27 +368,22 @@ extension PostCampaignCheckoutViewController: PledgePaymentMethodsViewController
 // MARK: - PledgeViewControllerMessageDisplaying
 
 extension PostCampaignCheckoutViewController: PledgeViewControllerMessageDisplaying {
-  func pledgeViewController(_: UIViewController, didErrorWith message: String) {
-    self.messageBannerViewController?.showBanner(with: .error, message: message)
+  func pledgeViewController(_: UIViewController, didErrorWith message: String, error: Error?) {
+    // If the error is a stripe error from attempting to add a new card, dismiss the banner only
+    // instead of restarting the checkout flow.
+    let stripeError = error as? NSError
+    let dismissBannerOnly = stripeError?.domain == STPError.stripeDomain &&
+      stripeError?.code == STPErrorCode.cardError.rawValue
+
+    self.messageBannerViewController?.showBanner(
+      with: .error,
+      message: message,
+      dismissType: dismissBannerOnly ? .bannerOnly : .bannerAndParentVC
+    )
   }
 
   func pledgeViewController(_: UIViewController, didSucceedWith message: String) {
     self.messageBannerViewController?.showBanner(with: .success, message: message)
-  }
-}
-
-// MARK: - MessageBannerViewControllerDelegate
-
-extension PostCampaignCheckoutViewController: MessageBannerViewControllerDelegate {
-  func messageBannerViewDidHide(type: MessageBannerType) {
-    switch type {
-    case .error:
-      // Pop view controller in order to start checkout flow from the beginning,
-      // starting with generating a new checkout id.
-      self.navigationController?.popViewController(animated: true)
-    default:
-      break
-    }
   }
 }
 
@@ -422,7 +424,11 @@ extension PostCampaignCheckoutViewController: STPApplePayContextDelegate {
     case .error:
       self.viewModel.inputs.checkoutTerminated()
       self.messageBannerViewController?
-        .showBanner(with: .error, message: Strings.Something_went_wrong_please_try_again())
+        .showBanner(
+          with: .error,
+          message: Strings.Something_went_wrong_please_try_again(),
+          dismissType: .bannerAndParentVC
+        )
     case .userCancellation:
       // User canceled the payment
       self.viewModel.inputs.checkoutTerminated()

--- a/Kickstarter-iOS/Features/PledgeView/Controllers/PostCampaignCheckoutViewController.swift
+++ b/Kickstarter-iOS/Features/PledgeView/Controllers/PostCampaignCheckoutViewController.swift
@@ -228,7 +228,7 @@ final class PostCampaignCheckoutViewController: UIViewController,
         self?.messageBannerViewController?.showBanner(
           with: .error,
           message: errorMessage,
-          dismissType: .bannerAndParentVC
+          dismissType: .bannerAndViewController
         )
       }
 
@@ -264,7 +264,7 @@ final class PostCampaignCheckoutViewController: UIViewController,
         #endif
 
         self?.messageBannerViewController?
-          .showBanner(with: .error, message: message, dismissType: .bannerAndParentVC)
+          .showBanner(with: .error, message: message, dismissType: .bannerAndViewController)
       }
   }
 
@@ -292,7 +292,7 @@ final class PostCampaignCheckoutViewController: UIViewController,
               .showBanner(
                 with: .error,
                 message: Strings.Something_went_wrong_please_try_again(),
-                dismissType: .bannerAndParentVC
+                dismissType: .bannerAndViewController
               )
           }
           self.viewModel.inputs.checkoutTerminated()
@@ -378,7 +378,7 @@ extension PostCampaignCheckoutViewController: PledgeViewControllerMessageDisplay
     self.messageBannerViewController?.showBanner(
       with: .error,
       message: message,
-      dismissType: dismissBannerOnly ? .bannerOnly : .bannerAndParentVC
+      dismissType: dismissBannerOnly ? .bannerOnly : .bannerAndViewController
     )
   }
 
@@ -427,7 +427,7 @@ extension PostCampaignCheckoutViewController: STPApplePayContextDelegate {
         .showBanner(
           with: .error,
           message: Strings.Something_went_wrong_please_try_again(),
-          dismissType: .bannerAndParentVC
+          dismissType: .bannerAndViewController
         )
     case .userCancellation:
       // User canceled the payment

--- a/Kickstarter-iOS/Library/PledgeViewControllerMessageDisplaying.swift
+++ b/Kickstarter-iOS/Library/PledgeViewControllerMessageDisplaying.swift
@@ -2,6 +2,10 @@ import Foundation
 import UIKit
 
 protocol PledgeViewControllerMessageDisplaying: AnyObject {
-  func pledgeViewController(_ pledgeViewController: UIViewController, didErrorWith message: String)
+  func pledgeViewController(
+    _ pledgeViewController: UIViewController,
+    didErrorWith message: String,
+    error: Error?
+  )
   func pledgeViewController(_ pledgeViewController: UIViewController, didSucceedWith message: String)
 }


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Don't dismiss the post campaign VC if there's an error caused by trying to add a new card.

Note: There are other categories of errors that also don't need to dismiss the VC (for example, if a user fails to authenticate a 3DS card). However, because we're currently planning to combine our checkout flows and get rid of the "confirm details" page, I didn't think it was worth spending a lot of extra time on this now. 

# 🤔 Why

Needing to restart checkout in these cases is a little annoying.

# 🛠 How

I refactored the messageBannerView to optionally be in charge of dismissing the vc. That way, we can decide if the error should lead to dismissing the VC when a specific error is displayed to the user.

# 👀 See

[Jira](https://kickstarter.atlassian.net/browse/MBL-1422)

| Before 🐛 | After 🦋 |
| --- | --- |
| ![Simulator Screen Recording - iPhone 15 Pro Max - 2024-06-26 at 11 42 14](https://github.com/kickstarter/ios-oss/assets/6799207/f412078f-eb26-4235-805d-275844c0015e) | ![Simulator Screen Recording - iPhone 15 Pro Max - 2024-06-26 at 11 38 05](https://github.com/kickstarter/ios-oss/assets/6799207/8e8b6a1e-b664-4586-bb0a-807b7cca3116) |

# ✅ Acceptance criteria

- [x] Errors while adding a new card don't restart checkout
- [x] All other errors during late pledge will still restart checkout

