### PR TITLE
[MBL-1616] Send backingId to CreatePaymentIntent for late pledges

### DIFF
--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -460,6 +460,7 @@
 		6021F66C2B97BCE200F76031 /* ConfirmDetailsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6021F66B2B97BCE200F76031 /* ConfirmDetailsViewModel.swift */; };
 		6021F66E2B98AF0C00F76031 /* ConfirmDetailsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6021F66D2B98AF0C00F76031 /* ConfirmDetailsViewModelTests.swift */; };
 		6031A8462AB2485800F8184D /* ReportProjectInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6031A8452AB2485800F8184D /* ReportProjectInfoView.swift */; };
+		6035AF992C46E03E007E28FC /* CreateCheckout.graphql in Resources */ = {isa = PBXBuildFile; fileRef = 6035AF982C46E03E007E28FC /* CreateCheckout.graphql */; };
 		60368E662AC334B9005EE9A5 /* ReportProjectFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60368E652AC334B9005EE9A5 /* ReportProjectFormView.swift */; };
 		60368E6A2AC35BD9005EE9A5 /* ReportProjectFormViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60368E692AC35BD9005EE9A5 /* ReportProjectFormViewModel.swift */; };
 		60368E6C2AC35BE3005EE9A5 /* ReportProjectFormViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60368E6B2AC35BE3005EE9A5 /* ReportProjectFormViewModelTests.swift */; };
@@ -473,7 +474,6 @@
 		6049D01C2AA0ECAC0015BB0D /* DemoShimmerLoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6049D01A2AA0EC700015BB0D /* DemoShimmerLoadingView.swift */; };
 		6049D0202AA776B40015BB0D /* DesignSystemColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6049D01E2AA774130015BB0D /* DesignSystemColors.swift */; };
 		6049D0242AA7940E0015BB0D /* DemoCTAContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6049D0232AA7940E0015BB0D /* DemoCTAContainerView.swift */; };
-		6051C6612B600E6000514202 /* CreateCheckout.graphql in Resources */ = {isa = PBXBuildFile; fileRef = 6051C6602B600E6000514202 /* CreateCheckout.graphql */; };
 		6051C6632B600E8000514202 /* CreateCheckoutMutation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6051C6622B600E8000514202 /* CreateCheckoutMutation.swift */; };
 		6051C6652B600F2000514202 /* CreateCheckoutInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6051C6642B600F2000514202 /* CreateCheckoutInput.swift */; };
 		6051C6672B600F3200514202 /* CreateCheckoutInputTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6051C6662B600F3200514202 /* CreateCheckoutInputTests.swift */; };
@@ -2076,6 +2076,7 @@
 		6021F66B2B97BCE200F76031 /* ConfirmDetailsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfirmDetailsViewModel.swift; sourceTree = "<group>"; };
 		6021F66D2B98AF0C00F76031 /* ConfirmDetailsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfirmDetailsViewModelTests.swift; sourceTree = "<group>"; };
 		6031A8452AB2485800F8184D /* ReportProjectInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportProjectInfoView.swift; sourceTree = "<group>"; };
+		6035AF982C46E03E007E28FC /* CreateCheckout.graphql */ = {isa = PBXFileReference; lastKnownFileType = text; path = CreateCheckout.graphql; sourceTree = "<group>"; };
 		60368E652AC334B9005EE9A5 /* ReportProjectFormView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportProjectFormView.swift; sourceTree = "<group>"; };
 		60368E692AC35BD9005EE9A5 /* ReportProjectFormViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportProjectFormViewModel.swift; sourceTree = "<group>"; };
 		60368E6B2AC35BE3005EE9A5 /* ReportProjectFormViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportProjectFormViewModelTests.swift; sourceTree = "<group>"; };
@@ -2089,7 +2090,6 @@
 		6049D01A2AA0EC700015BB0D /* DemoShimmerLoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoShimmerLoadingView.swift; sourceTree = "<group>"; };
 		6049D01E2AA774130015BB0D /* DesignSystemColors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignSystemColors.swift; sourceTree = "<group>"; };
 		6049D0232AA7940E0015BB0D /* DemoCTAContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoCTAContainerView.swift; sourceTree = "<group>"; };
-		6051C6602B600E6000514202 /* CreateCheckout.graphql */ = {isa = PBXFileReference; lastKnownFileType = text; path = CreateCheckout.graphql; sourceTree = "<group>"; };
 		6051C6622B600E8000514202 /* CreateCheckoutMutation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateCheckoutMutation.swift; sourceTree = "<group>"; };
 		6051C6642B600F2000514202 /* CreateCheckoutInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateCheckoutInput.swift; sourceTree = "<group>"; };
 		6051C6662B600F3200514202 /* CreateCheckoutInputTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateCheckoutInputTests.swift; sourceTree = "<group>"; };
@@ -5714,7 +5714,7 @@
 				475DEC0026B07BB9001B961B /* CancelBacking.graphql */,
 				39B5E1112B89120E00FFB720 /* CreateAttributionEvent.graphql */,
 				8AC3E0C1269E2ADC00168BF8 /* CreateBacking.graphql */,
-				6051C6602B600E6000514202 /* CreateCheckout.graphql */,
+				6035AF982C46E03E007E28FC /* CreateCheckout.graphql */,
 				60C996EB2AC1FF0C006BE4F4 /* CreateFlagging.graphql */,
 				6051C6742B67F2D600514202 /* CreatePaymentIntent.graphql */,
 				47C0BCD726C42135003658AC /* CreatePaymentSource.graphql */,
@@ -7576,11 +7576,11 @@
 				608F974A2B7522EF00DBE7D7 /* ValidateCheckout.graphql in Resources */,
 				6008632C29B8F64800B87B39 /* UserEmailFragment.graphql in Resources */,
 				47C0BCD826C42135003658AC /* CreatePaymentSource.graphql in Resources */,
+				6035AF992C46E03E007E28FC /* CreateCheckout.graphql in Resources */,
 				E12C88392C07CE16008AACCA /* CreateOrUpdateBackingAddressMutation.graphql in Resources */,
 				0655C72A2732FDE00087281F /* FetchCategory.graphql in Resources */,
 				E1B813C52BC8340700DF33CF /* FetchMySavedProjectsQuery.graphql in Resources */,
 				4778EE1F26A1E8230059EA69 /* FetchUser.graphql in Resources */,
-				6051C6612B600E6000514202 /* CreateCheckout.graphql in Resources */,
 				47D8619926B9E4F700A31F9A /* ClearUserUnseenActivity.graphql in Resources */,
 				06DAAE5726AA3CCD00194E58 /* CreditCardFragment.graphql in Resources */,
 				399DAD892ACD162C00238BA1 /* FetchProjectFriendsById.graphql in Resources */,

--- a/KsApi/GraphAPI.swift
+++ b/KsApi/GraphAPI.swift
@@ -4949,6 +4949,10 @@ public enum GraphAPI {
             __typename
             id
             paymentUrl
+            backing {
+              __typename
+              id
+            }
           }
         }
       }
@@ -5052,6 +5056,7 @@ public enum GraphAPI {
               GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
               GraphQLField("id", type: .nonNull(.scalar(GraphQLID.self))),
               GraphQLField("paymentUrl", type: .scalar(String.self)),
+              GraphQLField("backing", type: .nonNull(.object(Backing.selections))),
             ]
           }
 
@@ -5061,8 +5066,8 @@ public enum GraphAPI {
             self.resultMap = unsafeResultMap
           }
 
-          public init(id: GraphQLID, paymentUrl: String? = nil) {
-            self.init(unsafeResultMap: ["__typename": "Checkout", "id": id, "paymentUrl": paymentUrl])
+          public init(id: GraphQLID, paymentUrl: String? = nil, backing: Backing) {
+            self.init(unsafeResultMap: ["__typename": "Checkout", "id": id, "paymentUrl": paymentUrl, "backing": backing.resultMap])
           }
 
           public var __typename: String {
@@ -5089,6 +5094,55 @@ public enum GraphAPI {
             }
             set {
               resultMap.updateValue(newValue, forKey: "paymentUrl")
+            }
+          }
+
+          /// The backing that the checkout is modifying.
+          public var backing: Backing {
+            get {
+              return Backing(unsafeResultMap: resultMap["backing"]! as! ResultMap)
+            }
+            set {
+              resultMap.updateValue(newValue.resultMap, forKey: "backing")
+            }
+          }
+
+          public struct Backing: GraphQLSelectionSet {
+            public static let possibleTypes: [String] = ["Backing"]
+
+            public static var selections: [GraphQLSelection] {
+              return [
+                GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                GraphQLField("id", type: .nonNull(.scalar(GraphQLID.self))),
+              ]
+            }
+
+            public private(set) var resultMap: ResultMap
+
+            public init(unsafeResultMap: ResultMap) {
+              self.resultMap = unsafeResultMap
+            }
+
+            public init(id: GraphQLID) {
+              self.init(unsafeResultMap: ["__typename": "Backing", "id": id])
+            }
+
+            public var __typename: String {
+              get {
+                return resultMap["__typename"]! as! String
+              }
+              set {
+                resultMap.updateValue(newValue, forKey: "__typename")
+              }
+            }
+
+            public var id: GraphQLID {
+              get {
+                return resultMap["id"]! as! GraphQLID
+              }
+              set {
+                resultMap.updateValue(newValue, forKey: "id")
+              }
             }
           }
         }
@@ -7908,7 +7962,7 @@ public enum GraphAPI {
       }
 
       public struct Node: GraphQLSelectionSet {
-        public static let possibleTypes: [String] = ["Backing", "Reward", "Photo", "RewardItem", "Project", "Comment", "User", "Address", "Conversation", "Message", "CuratedPage", "Location", "Organization", "UserUrl", "Category", "AiDisclosure", "BusinessAddress", "Flagging", "Video", "VideoTrack", "VideoTrackCue", "ProjectProfile", "AttachedAudio", "AttachedVideo", "Tag", "CreatorInterview", "InterviewAnswer", "InterviewQuestion", "CreatorPrompt", "FreeformPost", "ShippingRule", "Checkout", "Order", "Survey"]
+        public static let possibleTypes: [String] = ["Backing", "Reward", "Photo", "RewardItem", "Project", "Comment", "User", "Address", "Conversation", "Message", "CuratedPage", "Location", "Organization", "UserUrl", "Category", "AiDisclosure", "BusinessAddress", "Flagging", "Video", "VideoTrack", "VideoTrackCue", "AttachedAudio", "AttachedVideo", "ProjectProfile", "Tag", "CreatorInterview", "InterviewAnswer", "InterviewQuestion", "CreatorPrompt", "FreeformPost", "ShippingRule", "Checkout", "Order", "Survey"]
 
         public static var selections: [GraphQLSelection] {
           return [
@@ -8007,16 +8061,16 @@ public enum GraphAPI {
           return Node(unsafeResultMap: ["__typename": "VideoTrackCue"])
         }
 
-        public static func makeProjectProfile() -> Node {
-          return Node(unsafeResultMap: ["__typename": "ProjectProfile"])
-        }
-
         public static func makeAttachedAudio() -> Node {
           return Node(unsafeResultMap: ["__typename": "AttachedAudio"])
         }
 
         public static func makeAttachedVideo() -> Node {
           return Node(unsafeResultMap: ["__typename": "AttachedVideo"])
+        }
+
+        public static func makeProjectProfile() -> Node {
+          return Node(unsafeResultMap: ["__typename": "ProjectProfile"])
         }
 
         public static func makeTag() -> Node {
@@ -8361,7 +8415,7 @@ public enum GraphAPI {
       }
 
       public struct Comment: GraphQLSelectionSet {
-        public static let possibleTypes: [String] = ["Backing", "Reward", "Photo", "RewardItem", "Project", "Comment", "User", "Address", "Conversation", "Message", "CuratedPage", "Location", "Organization", "UserUrl", "Category", "AiDisclosure", "BusinessAddress", "Flagging", "Video", "VideoTrack", "VideoTrackCue", "ProjectProfile", "AttachedAudio", "AttachedVideo", "Tag", "CreatorInterview", "InterviewAnswer", "InterviewQuestion", "CreatorPrompt", "FreeformPost", "ShippingRule", "Checkout", "Order", "Survey"]
+        public static let possibleTypes: [String] = ["Backing", "Reward", "Photo", "RewardItem", "Project", "Comment", "User", "Address", "Conversation", "Message", "CuratedPage", "Location", "Organization", "UserUrl", "Category", "AiDisclosure", "BusinessAddress", "Flagging", "Video", "VideoTrack", "VideoTrackCue", "AttachedAudio", "AttachedVideo", "ProjectProfile", "Tag", "CreatorInterview", "InterviewAnswer", "InterviewQuestion", "CreatorPrompt", "FreeformPost", "ShippingRule", "Checkout", "Order", "Survey"]
 
         public static var selections: [GraphQLSelection] {
           return [
@@ -8456,16 +8510,16 @@ public enum GraphAPI {
           return Comment(unsafeResultMap: ["__typename": "VideoTrackCue"])
         }
 
-        public static func makeProjectProfile() -> Comment {
-          return Comment(unsafeResultMap: ["__typename": "ProjectProfile"])
-        }
-
         public static func makeAttachedAudio() -> Comment {
           return Comment(unsafeResultMap: ["__typename": "AttachedAudio"])
         }
 
         public static func makeAttachedVideo() -> Comment {
           return Comment(unsafeResultMap: ["__typename": "AttachedVideo"])
+        }
+
+        public static func makeProjectProfile() -> Comment {
+          return Comment(unsafeResultMap: ["__typename": "ProjectProfile"])
         }
 
         public static func makeTag() -> Comment {

--- a/KsApi/graphql-schema.json
+++ b/KsApi/graphql-schema.json
@@ -1640,6 +1640,26 @@
             "deprecationReason": null
           },
           {
+            "name": "allowedCountries",
+            "description": "Countries that the backing's reward can be shipped to. If null, the backing's reward can be shipped to any country.",
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "CountryCode",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "amount",
             "description": "Total amount pledged by the backer to the project, including shipping.",
             "args": [],
@@ -2312,17 +2332,17 @@
           },
           {
             "kind": "OBJECT",
-            "name": "ProjectProfile",
-            "ofType": null
-          },
-          {
-            "kind": "OBJECT",
             "name": "AttachedAudio",
             "ofType": null
           },
           {
             "kind": "OBJECT",
             "name": "AttachedVideo",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "ProjectProfile",
             "ofType": null
           },
           {
@@ -3201,6 +3221,30 @@
               "kind": "ENUM",
               "name": "ShippingPreference",
               "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "shippingRates",
+            "description": "Shipping rates defined by the creator for this reward",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "ShippingRate",
+                    "ofType": null
+                  }
+                }
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -4613,6 +4657,18 @@
           {
             "name": "addressCollectionEnabled",
             "description": "Whether or not the creator has enabled address collection",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "addressCollectionForDigitalReward",
+            "description": "Whether or not the creator has enabled address collection for digital reward backers",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -6216,6 +6272,18 @@
             "deprecationReason": null
           },
           {
+            "name": "onBehalfOf",
+            "description": "A Stripe account identifier",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "paymentSource",
             "description": "Payment source on creator's account used to issue refunds.",
             "args": [],
@@ -6384,6 +6452,88 @@
               "ofType": {
                 "kind": "SCALAR",
                 "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "prelaunchStory",
+            "description": "The rich text story for a prelaunch campaign.",
+            "args": [
+              {
+                "name": "first",
+                "description": "The number of visible characters to fetch (does not include HTML markup).",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "assetWidth",
+                "description": "The width of embedded assets in pixels.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "SCALAR",
+              "name": "HTML",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "prelaunchStoryForEditor",
+            "description": "The rich text story for a prelaunch campaign in raw form.",
+            "args": [
+              {
+                "name": "first",
+                "description": "The number of visible characters to fetch (does not include HTML markup).",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "assetWidth",
+                "description": "The width of embedded assets in pixels.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "SCALAR",
+              "name": "HTML",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "prelaunchStoryRichText",
+            "description": "Return an itemized version of the prelaunch story. This feature is in BETA: types can change anytime!",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "RichText",
                 "ofType": null
               }
             },
@@ -8932,6 +9082,22 @@
           {
             "name": "isSuperbacker",
             "description": "Whether the user is a superbacker",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "isTrustedForOverlappingFulfillment",
+            "description": "Whether a user is trusted for overlapping fulfillment.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -13268,6 +13434,12 @@
             "deprecationReason": null
           },
           {
+            "name": "late_pledges_learn_more_cta",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "post_campaign_backings_2024",
             "description": null,
             "isDeprecated": false,
@@ -13365,6 +13537,12 @@
           },
           {
             "name": "address_collection_for_digital_rewards_2024",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "prelaunch_story_editor",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
@@ -21698,938 +21876,6 @@
         "possibleTypes": null
       },
       {
-        "kind": "OBJECT",
-        "name": "ProjectProfile",
-        "description": "A profile for after a project has ended.",
-        "fields": [
-          {
-            "name": "blurb",
-            "description": "The description of the projects from the project's profile.",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "featureImageUrl",
-            "description": "Featured image for this project profile.",
-            "args": [
-              {
-                "name": "width",
-                "description": "The width of the image in pixels.",
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null
-              }
-            ],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "id",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "ID",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "name",
-            "description": "The name from the project's profile.",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "state",
-            "description": "The project profile's current state.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "ENUM",
-                "name": "ProjectProfileState",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [
-          {
-            "kind": "INTERFACE",
-            "name": "Node",
-            "ofType": null
-          }
-        ],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "ENUM",
-        "name": "ProjectProfileState",
-        "description": "Various project profile states.",
-        "fields": null,
-        "inputFields": null,
-        "interfaces": null,
-        "enumValues": [
-          {
-            "name": "INACTIVE",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "ACTIVE",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "possibleTypes": null
-      },
-      {
-        "kind": "ENUM",
-        "name": "BitlyHashes",
-        "description": "The different bitly hashes for a project",
-        "fields": null,
-        "inputFields": null,
-        "interfaces": null,
-        "enumValues": [
-          {
-            "name": "SHARE",
-            "description": "A project's share link",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "TWEET",
-            "description": "A project's twitter share link",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "FACEBOOK",
-            "description": "A project's facebook share link",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "EMAIL",
-            "description": "A project's email share link",
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "ProjectStatus",
-        "description": "Project status set by user",
-        "fields": [
-          {
-            "name": "enabled",
-            "description": "Whether the project status is currently enabled or not (opted-in / opted-out)",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "id",
-            "description": "Id of a project status",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "nextDueDate",
-            "description": "The estimated due date for the next_status of the project",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "ISO8601DateTime",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "nextStatus",
-            "description": "The next_status of the project",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "nowStatus",
-            "description": "The now_status of the project",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "updatedAt",
-            "description": "When project status is updated",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "ISO8601DateTime",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "Question",
-        "description": "A question associated with one of the following: Project, RewardItem",
-        "fields": [
-          {
-            "name": "choiceSelectionLimit",
-            "description": "The question choice selection limit",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "choices",
-            "description": "The question choices",
-            "args": [],
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "id",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "ID",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "optional",
-            "description": "Whether the question is optional",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "prompt",
-            "description": "The question prompt",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "questionable",
-            "description": "The object associated with the question",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "UNION",
-                "name": "Questionable",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "type",
-            "description": "The question type",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "ENUM",
-                "name": "QuestionType",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "UNION",
-        "name": "Questionable",
-        "description": "An object that can be associated with a question",
-        "fields": null,
-        "inputFields": null,
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": [
-          {
-            "kind": "OBJECT",
-            "name": "Project",
-            "ofType": null
-          },
-          {
-            "kind": "OBJECT",
-            "name": "RewardItem",
-            "ofType": null
-          }
-        ]
-      },
-      {
-        "kind": "ENUM",
-        "name": "QuestionType",
-        "description": "Question types",
-        "fields": null,
-        "inputFields": null,
-        "interfaces": null,
-        "enumValues": [
-          {
-            "name": "text",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "choices",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "Recommendations",
-        "description": "Score and model from recommendations engine if a project was fetched via recommendations.",
-        "fields": [
-          {
-            "name": "modelName",
-            "description": "Model used for these recommendations.",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "rawScore",
-            "description": "Raw score from recommendations.",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "score",
-            "description": "Recommendations score.",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "RiskQuestion",
-        "description": "A category of risk. Each category corresponds to a question in the project Plan.",
-        "fields": [
-          {
-            "name": "inputType",
-            "description": "The input type of the risk category.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "ENUM",
-                "name": "RiskCategoryInput",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "question",
-            "description": "The question associated with the risk category.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "required",
-            "description": "Whether or not this is a required category.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "type",
-            "description": "The category identifier.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "ENUM",
-                "name": "RiskCategoryType",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "ENUM",
-        "name": "RiskCategoryInput",
-        "description": "Describes the expected input type for a risk category.",
-        "fields": null,
-        "inputFields": null,
-        "interfaces": null,
-        "enumValues": [
-          {
-            "name": "text",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "radio",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "possibleTypes": null
-      },
-      {
-        "kind": "ENUM",
-        "name": "RiskCategoryType",
-        "description": null,
-        "fields": null,
-        "inputFields": null,
-        "interfaces": null,
-        "enumValues": [
-          {
-            "name": "delays",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "unexpected_pledge_volume",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "previous_experience",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "fulfillment_plan",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "project_budget_contingency",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "alternative_fulfillment_path",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "RiskStrategy",
-        "description": null,
-        "fields": [
-          {
-            "name": "description",
-            "description": "Creator's answer for mitigating this particular risk category.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "id",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "ID",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "riskCategory",
-            "description": "The type of risk",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "ENUM",
-                "name": "RiskCategoryType",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "riskQuestion",
-            "description": "The question the creator is answering.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "RiskQuestion",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "Spreadsheet",
-        "description": "A project spreadsheet, including a url and row data",
-        "fields": [
-          {
-            "name": "data",
-            "description": "The data of the Google Sheet associated to this project",
-            "args": [],
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "SpreadsheetDatum",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "dataLastUpdatedAt",
-            "description": "When the data for the sheet was last fetched successfully",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "ISO8601DateTime",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "displayMode",
-            "description": "Can be `amount` or `percent` based on the creator's choice",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "hasDisplayableData",
-            "description": "Whether a spreadsheet contains the minimum information to render a graphic budget",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "public",
-            "description": "Whether the sheet is shareable with the public",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "url",
-            "description": "The URL of the Google Sheet associated to this project",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "SpreadsheetDatum",
-        "description": "A row of datum for a funding spreadsheet",
-        "fields": [
-          {
-            "name": "description",
-            "description": "Expanded description of the purpose of that row",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "name",
-            "description": "The name of the row",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "phase",
-            "description": "The funding category of the row",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "rowNum",
-            "description": "The spreadsheet row number",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "value",
-            "description": "The dollar value of the row",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "ENUM",
-        "name": "ProjectState",
-        "description": "Various project states.",
-        "fields": null,
-        "inputFields": null,
-        "interfaces": null,
-        "enumValues": [
-          {
-            "name": "STARTED",
-            "description": "Created and preparing for launch.",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "SUBMITTED",
-            "description": "Ready for launch with a draft submitted for auto-approval.",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "LIVE",
-            "description": "Active and accepting pledges.",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "CANCELED",
-            "description": "Canceled by creator.",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "SUSPENDED",
-            "description": "Suspended for investigation, visible.",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "PURGED",
-            "description": "Suspended and hidden.",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "SUCCESSFUL",
-            "description": "Successfully funded by deadline.",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "FAILED",
-            "description": "Failed to fund by deadline.",
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "possibleTypes": null
-      },
-      {
         "kind": "SCALAR",
         "name": "HTML",
         "description": "An HTML string.",
@@ -23742,6 +22988,938 @@
         "inputFields": null,
         "interfaces": [],
         "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ProjectProfile",
+        "description": "A profile for after a project has ended.",
+        "fields": [
+          {
+            "name": "blurb",
+            "description": "The description of the projects from the project's profile.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "featureImageUrl",
+            "description": "Featured image for this project profile.",
+            "args": [
+              {
+                "name": "width",
+                "description": "The width of the image in pixels.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "name",
+            "description": "The name from the project's profile.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "state",
+            "description": "The project profile's current state.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "ProjectProfileState",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "Node",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "ProjectProfileState",
+        "description": "Various project profile states.",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "INACTIVE",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ACTIVE",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "BitlyHashes",
+        "description": "The different bitly hashes for a project",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "SHARE",
+            "description": "A project's share link",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "TWEET",
+            "description": "A project's twitter share link",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "FACEBOOK",
+            "description": "A project's facebook share link",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "EMAIL",
+            "description": "A project's email share link",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ProjectStatus",
+        "description": "Project status set by user",
+        "fields": [
+          {
+            "name": "enabled",
+            "description": "Whether the project status is currently enabled or not (opted-in / opted-out)",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": "Id of a project status",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "nextDueDate",
+            "description": "The estimated due date for the next_status of the project",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ISO8601DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "nextStatus",
+            "description": "The next_status of the project",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "nowStatus",
+            "description": "The now_status of the project",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
+            "description": "When project status is updated",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ISO8601DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "Question",
+        "description": "A question associated with one of the following: Project, RewardItem",
+        "fields": [
+          {
+            "name": "choiceSelectionLimit",
+            "description": "The question choice selection limit",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "choices",
+            "description": "The question choices",
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "optional",
+            "description": "Whether the question is optional",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "prompt",
+            "description": "The question prompt",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "questionable",
+            "description": "The object associated with the question",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "UNION",
+                "name": "Questionable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type",
+            "description": "The question type",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "QuestionType",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "UNION",
+        "name": "Questionable",
+        "description": "An object that can be associated with a question",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": [
+          {
+            "kind": "OBJECT",
+            "name": "Project",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "RewardItem",
+            "ofType": null
+          }
+        ]
+      },
+      {
+        "kind": "ENUM",
+        "name": "QuestionType",
+        "description": "Question types",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "text",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "choices",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "Recommendations",
+        "description": "Score and model from recommendations engine if a project was fetched via recommendations.",
+        "fields": [
+          {
+            "name": "modelName",
+            "description": "Model used for these recommendations.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "rawScore",
+            "description": "Raw score from recommendations.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "score",
+            "description": "Recommendations score.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "RiskQuestion",
+        "description": "A category of risk. Each category corresponds to a question in the project Plan.",
+        "fields": [
+          {
+            "name": "inputType",
+            "description": "The input type of the risk category.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "RiskCategoryInput",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "question",
+            "description": "The question associated with the risk category.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "required",
+            "description": "Whether or not this is a required category.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type",
+            "description": "The category identifier.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "RiskCategoryType",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "RiskCategoryInput",
+        "description": "Describes the expected input type for a risk category.",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "text",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "radio",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "RiskCategoryType",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "delays",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "unexpected_pledge_volume",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "previous_experience",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "fulfillment_plan",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "project_budget_contingency",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "alternative_fulfillment_path",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "RiskStrategy",
+        "description": null,
+        "fields": [
+          {
+            "name": "description",
+            "description": "Creator's answer for mitigating this particular risk category.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "riskCategory",
+            "description": "The type of risk",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "RiskCategoryType",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "riskQuestion",
+            "description": "The question the creator is answering.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "RiskQuestion",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "Spreadsheet",
+        "description": "A project spreadsheet, including a url and row data",
+        "fields": [
+          {
+            "name": "data",
+            "description": "The data of the Google Sheet associated to this project",
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "SpreadsheetDatum",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "dataLastUpdatedAt",
+            "description": "When the data for the sheet was last fetched successfully",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "ISO8601DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "displayMode",
+            "description": "Can be `amount` or `percent` based on the creator's choice",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "hasDisplayableData",
+            "description": "Whether a spreadsheet contains the minimum information to render a graphic budget",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "public",
+            "description": "Whether the sheet is shareable with the public",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "url",
+            "description": "The URL of the Google Sheet associated to this project",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "SpreadsheetDatum",
+        "description": "A row of datum for a funding spreadsheet",
+        "fields": [
+          {
+            "name": "description",
+            "description": "Expanded description of the purpose of that row",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "name",
+            "description": "The name of the row",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "phase",
+            "description": "The funding category of the row",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "rowNum",
+            "description": "The spreadsheet row number",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "value",
+            "description": "The dollar value of the row",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "ProjectState",
+        "description": "Various project states.",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "STARTED",
+            "description": "Created and preparing for launch.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "SUBMITTED",
+            "description": "Ready for launch with a draft submitted for auto-approval.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "LIVE",
+            "description": "Active and accepting pledges.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "CANCELED",
+            "description": "Canceled by creator.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "SUSPENDED",
+            "description": "Suspended for investigation, visible.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "PURGED",
+            "description": "Suspended and hidden.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "SUCCESSFUL",
+            "description": "Successfully funded by deadline.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "FAILED",
+            "description": "Failed to fund by deadline.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
         "possibleTypes": null
       },
       {
@@ -26654,6 +26832,102 @@
       },
       {
         "kind": "OBJECT",
+        "name": "ShippingRate",
+        "description": "A shipping rate for a particular shippable and location",
+        "fields": [
+          {
+            "name": "cost",
+            "description": "The shipping cost for this location.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Money",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "location",
+            "description": "The shipping location for which this shipping rate is defined.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Location",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "shippable",
+            "description": "The item or reward for which this shipping rate is defined.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "UNION",
+                "name": "Shippable",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "UNION",
+        "name": "Shippable",
+        "description": "Types that can have shipping rates",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": [
+          {
+            "kind": "OBJECT",
+            "name": "Reward",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "RewardItem",
+            "ofType": null
+          }
+        ]
+      },
+      {
+        "kind": "OBJECT",
         "name": "ShippingRule",
         "description": "A project reward's shipping rule.",
         "fields": [
@@ -27202,6 +27476,22 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "shouldCollectAddress",
+            "description": "Whether or not this cart needs an address to be finalized",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -27212,7 +27502,7 @@
       {
         "kind": "OBJECT",
         "name": "Answer",
-        "description": "An answer associated with one of the following: LineItem, Project",
+        "description": "An answer associated with one of the following: LineItem, Cart, BackingAddon",
         "fields": [
           {
             "name": "answerable",
@@ -27308,7 +27598,12 @@
           },
           {
             "kind": "OBJECT",
-            "name": "Project",
+            "name": "Cart",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "BackingAddon",
             "ofType": null
           }
         ]
@@ -33775,6 +34070,33 @@
             "deprecationReason": null
           },
           {
+            "name": "confirmOrderAddress",
+            "description": "Confirm order address",
+            "args": [
+              {
+                "name": "input",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "ConfirmOrderAddressInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "ConfirmOrderAddressPayload",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "copyRewardItems",
             "description": "Copy Reward Items from one Project to another.",
             "args": [
@@ -37123,6 +37445,33 @@
             "deprecationReason": null
           },
           {
+            "name": "updateRewardShippingRates",
+            "description": "Update ShippingRates for a BackerReward",
+            "args": [
+              {
+                "name": "input",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "UpdateRewardShippingRatesInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "UpdateRewardShippingRatesPayload",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "updateSpreadsheetToggles",
             "description": "Updates the toggle-able options of the spreadsheet graph",
             "args": [
@@ -38478,8 +38827,8 @@
         "fields": null,
         "inputFields": [
           {
-            "name": "projectId",
-            "description": "kickstarter project id",
+            "name": "orderId",
+            "description": "The order id",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -38492,18 +38841,8 @@
             "defaultValue": null
           },
           {
-            "name": "orderId",
-            "description": "kickstarter order id (not required for now, but will be when this is refactored)",
-            "type": {
-              "kind": "SCALAR",
-              "name": "ID",
-              "ofType": null
-            },
-            "defaultValue": null
-          },
-          {
             "name": "stripeConfirmationTokenId",
-            "description": "the stripe confirmation token used to complete a payment (web only)",
+            "description": "The stripe confirmation token used to complete a payment (web only)",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -38513,7 +38852,7 @@
           },
           {
             "name": "stripePaymentMethodId",
-            "description": "the stripe payment method id, starting with either `card_` or `pm_` (mobile only)",
+            "description": "The stripe payment method id, starting with either `card_` or `pm_` (mobile only)",
             "type": {
               "kind": "SCALAR",
               "name": "String",
@@ -38593,7 +38932,7 @@
           },
           {
             "name": "clientSecret",
-            "description": "the stripe payment intent client secret used to complete a payment",
+            "description": "The stripe payment intent client secret used to complete a payment",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -38609,7 +38948,7 @@
           },
           {
             "name": "status",
-            "description": "the stripe payment intent status (if requires_action, it will be)",
+            "description": "The stripe payment intent status (if requires_action, it will be)",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -38617,6 +38956,94 @@
               "ofType": {
                 "kind": "SCALAR",
                 "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "ConfirmOrderAddressInput",
+        "description": "Autogenerated input type of ConfirmOrderAddress",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "orderId",
+            "description": "The order id",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "addressId",
+            "description": "The address id",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "clientMutationId",
+            "description": "A unique identifier for the client performing the mutation.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ConfirmOrderAddressPayload",
+        "description": "Autogenerated return type of ConfirmOrderAddress",
+        "fields": [
+          {
+            "name": "clientMutationId",
+            "description": "A unique identifier for the client performing the mutation.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "order",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Order",
                 "ofType": null
               }
             },
@@ -48698,6 +49125,18 @@
             "deprecationReason": null
           },
           {
+            "name": "deliveryAddress",
+            "description": "The delivery address attached to backing.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Address",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "success",
             "description": "Succeeds if cart is finalized.",
             "args": [],
@@ -51541,6 +51980,16 @@
             "defaultValue": null
           },
           {
+            "name": "prelaunchStory",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "HTML",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
             "name": "clientMutationId",
             "description": "A unique identifier for the client performing the mutation.",
             "type": {
@@ -52740,6 +53189,151 @@
               "kind": "OBJECT",
               "name": "RewardItem",
               "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "UpdateRewardShippingRatesInput",
+        "description": "Autogenerated input type of UpdateRewardShippingRates",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "rewardId",
+            "description": "Kickstarter BackerReward (base or addon) id",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "shippingRates",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "ShippingRateInput",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "clientMutationId",
+            "description": "A unique identifier for the client performing the mutation.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "ShippingRateInput",
+        "description": "Shipping rule for a reward",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "id",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "ID",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "cost",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "locationId",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "UpdateRewardShippingRatesPayload",
+        "description": "Autogenerated return type of UpdateRewardShippingRates",
+        "fields": [
+          {
+            "name": "clientMutationId",
+            "description": "A unique identifier for the client performing the mutation.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "reward",
+            "description": "The updated BackerReward",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Reward",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null

--- a/KsApi/models/CreateCheckoutEnvelope.swift
+++ b/KsApi/models/CreateCheckoutEnvelope.swift
@@ -7,6 +7,7 @@ public struct CreateCheckoutEnvelope: Decodable {
   public struct Checkout: Decodable {
     public var id: String
     public var paymentUrl: String
+    public var backingId: String
   }
 }
 
@@ -15,11 +16,12 @@ public struct CreateCheckoutEnvelope: Decodable {
 extension CreateCheckoutEnvelope {
   static func from(_ data: GraphAPI.CreateCheckoutMutation.Data) -> CreateCheckoutEnvelope? {
     guard let id = data.createCheckout?.checkout?.id,
-          let paymentUrl = data.createCheckout?.checkout?.paymentUrl else {
+          let paymentUrl = data.createCheckout?.checkout?.paymentUrl,
+          let backingId = data.createCheckout?.checkout?.backing.id else {
       return nil
     }
 
-    return CreateCheckoutEnvelope(checkout: Checkout(id: id, paymentUrl: paymentUrl))
+    return CreateCheckoutEnvelope(checkout: Checkout(id: id, paymentUrl: paymentUrl, backingId: backingId))
   }
 
   static func producer(from data: GraphAPI.CreateCheckoutMutation.Data)

--- a/KsApi/models/CreateCheckoutEnvelopeTests.swift
+++ b/KsApi/models/CreateCheckoutEnvelopeTests.swift
@@ -7,7 +7,8 @@ final class CreateCheckoutEnvelopeTests: XCTestCase {
     {
       "checkout": {
         "id": "2020",
-        "paymentUrl": "https://test-url.com"
+        "paymentUrl": "https://test-url.com",
+        "backingId": "backingId"
       }
     }
     """
@@ -18,6 +19,7 @@ final class CreateCheckoutEnvelopeTests: XCTestCase {
       let envelope = try JSONDecoder().decode(CreateCheckoutEnvelope.self, from: data)
       XCTAssertEqual(envelope.checkout.id, "2020")
       XCTAssertEqual(envelope.checkout.paymentUrl, "https://test-url.com")
+      XCTAssertEqual(envelope.checkout.backingId, "backingId")
     } catch {
       XCTFail("\(error)")
     }

--- a/KsApi/mutations/CreateCheckout.graphql
+++ b/KsApi/mutations/CreateCheckout.graphql
@@ -4,6 +4,9 @@ mutation CreateCheckout($input: CreateCheckoutInput!) {
     checkout {
       id
       paymentUrl
+      backing {
+        id
+      }
     }
   }
 }

--- a/KsApi/mutations/CreateCheckoutMutation.swift
+++ b/KsApi/mutations/CreateCheckoutMutation.swift
@@ -16,6 +16,9 @@ public struct CreateCheckoutMutation<T: GraphMutationInput>: GraphMutation {
           id
           paymentUrl
         }
+        backing {
+          id
+        }
       }
     }
     """

--- a/KsApi/mutations/inputs/CreatePaymentIntentInput.swift
+++ b/KsApi/mutations/inputs/CreatePaymentIntentInput.swift
@@ -2,6 +2,7 @@ import Foundation
 
 public struct CreatePaymentIntentInput: GraphMutationInput, Encodable {
   let projectId: String
+  let backingId: String
   let amountDollars: String
   let checkoutId: String
   let digitalMarketingAttributed: Bool?
@@ -11,6 +12,7 @@ public struct CreatePaymentIntentInput: GraphMutationInput, Encodable {
    Initializes a CreateCheckout.
 
    - parameter projectId: The GraphID of the Project.
+   - parameter backingId: The GraphID of the backing.
    - parameter amountDollars: The amount.
    - parameter checkoutId: The GraphID returned from our CreateCheckout mutation.
    - parameter digitalMarketingAttributed: The optional ID of the ShippingRule's Location.
@@ -18,11 +20,13 @@ public struct CreatePaymentIntentInput: GraphMutationInput, Encodable {
    */
   public init(
     projectId: String,
+    backingId: String,
     amountDollars: String,
     checkoutId: String,
     digitalMarketingAttributed: Bool?
   ) {
     self.projectId = projectId
+    self.backingId = backingId
     self.amountDollars = amountDollars
     self.checkoutId = checkoutId
     self.digitalMarketingAttributed = digitalMarketingAttributed

--- a/KsApi/mutations/inputs/CreatePaymentIntentInputTests.swift
+++ b/KsApi/mutations/inputs/CreatePaymentIntentInputTests.swift
@@ -6,6 +6,7 @@ final class CreatePaymentIntentInputTests: XCTestCase {
   func testCreateCheckoutInputDictionary() {
     let createCheckoutInput = CreatePaymentIntentInput(
       projectId: "projectId",
+      backingId: "backingId",
       amountDollars: "200.00",
       checkoutId: "checkoutId",
       digitalMarketingAttributed: false
@@ -14,6 +15,7 @@ final class CreatePaymentIntentInputTests: XCTestCase {
     let input = createCheckoutInput.toInputDictionary()
 
     XCTAssertEqual(input["projectId"] as? String, "projectId")
+    XCTAssertEqual(input["backingId"] as? String, "backingId")
     XCTAssertEqual(input["amountDollars"] as? String, "200.00")
     XCTAssertEqual(input["digitalMarketingAttributed"] as? Bool, false)
     XCTAssertEqual(input["checkoutId"] as? String, "checkoutId")

--- a/Library/StripeIntentService.swift
+++ b/Library/StripeIntentService.swift
@@ -5,6 +5,7 @@ import ReactiveSwift
 public protocol StripeIntentServiceType {
   func createPaymentIntent(
     for projectId: String,
+    backingId: String,
     checkoutId: String,
     pledgeTotal: Double
   ) -> SignalProducer<PaymentIntentEnvelope, ErrorEnvelope>
@@ -26,17 +27,20 @@ public class StripeIntentService: StripeIntentServiceType {
    - parameters:
      - projectId: The GraphID of a project
      - checkoutId: The GraphID returned from our CreateCheckout mutation.
+     - backingId: The current Backing ID used by the backend to reverse payments and rescue checkouts.
      - pledgeTotal: The final pledge total of the current pledge
    */
 
   public func createPaymentIntent(
     for projectId: String,
+    backingId: String,
     checkoutId: String,
     pledgeTotal: Double
   ) -> SignalProducer<PaymentIntentEnvelope, ErrorEnvelope> {
     AppEnvironment.current.apiService
       .createPaymentIntentInput(input: CreatePaymentIntentInput(
         projectId: projectId,
+        backingId: backingId,
         amountDollars: String(format: "%.2f", pledgeTotal),
         checkoutId: encodeToBase64("Checkout-\(checkoutId)"),
         digitalMarketingAttributed: nil

--- a/Library/TestHelpers/MockStripeIntentService.swift
+++ b/Library/TestHelpers/MockStripeIntentService.swift
@@ -10,6 +10,7 @@ public class MockStripeIntentService: StripeIntentServiceType {
 
   public func createPaymentIntent(
     for projectId: String,
+    backingId: String,
     checkoutId: String,
     pledgeTotal: Double
   ) -> SignalProducer<PaymentIntentEnvelope, ErrorEnvelope> {
@@ -23,6 +24,7 @@ public class MockStripeIntentService: StripeIntentServiceType {
     return AppEnvironment.current.apiService
       .createPaymentIntentInput(input: CreatePaymentIntentInput(
         projectId: projectId,
+        backingId: backingId,
         amountDollars: String(format: "%.2f", pledgeTotal),
         checkoutId: checkoutId,
         digitalMarketingAttributed: nil

--- a/Library/ViewModels/ConfirmDetailsViewModel.swift
+++ b/Library/ViewModels/ConfirmDetailsViewModel.swift
@@ -370,13 +370,14 @@ public class ConfirmDetailsViewModel: ConfirmDetailsViewModelType, ConfirmDetail
     let checkoutValues = createCheckoutEvents.values()
       .map { values in
         var checkoutId = values.checkout.id
+        var backingId = values.checkout.backingId
 
         if let decoded = decodeBase64(checkoutId), let range = decoded.range(of: "Checkout-") {
           let id = decoded[range.upperBound...]
           checkoutId = String(id)
         }
 
-        return checkoutId
+        return (checkoutId, backingId)
       }
 
     self.createCheckoutSuccess = checkoutValues.withLatestFrom(
@@ -388,7 +389,8 @@ public class ConfirmDetailsViewModel: ConfirmDetailsViewModelType, ConfirmDetail
         baseReward
       )
     )
-    .map { checkoutId, otherData -> PostCampaignCheckoutData in
+    .map { checkoutAndBackingId, otherData -> PostCampaignCheckoutData in
+      let (checkoutId, backingId) = checkoutAndBackingId
       let (initialData, bonusOrReward, shipping, pledgeTotal, baseReward) = otherData
       var rewards = initialData.rewards
       var bonus = bonusOrReward
@@ -409,11 +411,11 @@ public class ConfirmDetailsViewModel: ConfirmDetailsViewModelType, ConfirmDetail
         shipping: shipping,
         refTag: initialData.refTag,
         context: initialData.context,
-        checkoutId: checkoutId
+        checkoutId: checkoutId,
+        backingId: backingId
       )
     }
 
-    // TODO: [MBL-1217] Update string once translations are done
     self.showErrorBannerWithMessage = createCheckoutEvents.errors()
       .map { _ in Strings.Something_went_wrong_please_try_again() }
   }

--- a/Library/ViewModels/ConfirmDetailsViewModelTests.swift
+++ b/Library/ViewModels/ConfirmDetailsViewModelTests.swift
@@ -94,7 +94,11 @@ final class ConfirmDetailsViewModelTests: TestCase {
 
   func testGoToLoginSignup_doesNotEmitWhenLoggedIn_createCheckoutIsSuccessful() {
     let expectedId = "Q2hlY2tvdXQtMTk4MzM2NjQ2"
-    let createCheckout = CreateCheckoutEnvelope.Checkout(id: expectedId, paymentUrl: "paymentUrl")
+    let createCheckout = CreateCheckoutEnvelope.Checkout(
+      id: expectedId,
+      paymentUrl: "paymentUrl",
+      backingId: "backingId"
+    )
     let mockService = MockService(
       createCheckoutResult:
       Result.success(CreateCheckoutEnvelope(checkout: createCheckout))
@@ -886,7 +890,11 @@ final class ConfirmDetailsViewModelTests: TestCase {
 
   func testContinueButton_CallsCreateBackingMutation_Success() {
     let expectedId = "Q2hlY2tvdXQtMTk4MzM2NjQ2"
-    let createCheckout = CreateCheckoutEnvelope.Checkout(id: expectedId, paymentUrl: "paymentUrl")
+    let createCheckout = CreateCheckoutEnvelope.Checkout(
+      id: expectedId,
+      paymentUrl: "paymentUrl",
+      backingId: "backingId"
+    )
 
     let mockService = MockService(
       createCheckoutResult:
@@ -949,14 +957,19 @@ final class ConfirmDetailsViewModelTests: TestCase {
         shipping: expectedShipping,
         refTag: nil,
         context: .pledge,
-        checkoutId: "198336646"
+        checkoutId: "198336646",
+        backingId: "backingId"
       )
       self.createCheckoutSuccess.assertValue(expectedValue)
     }
   }
 
   func testContinueButton_CallsCreateBackingMutation_Failure_ShowsErrorMessageBanner() {
-    let createCheckout = CreateCheckoutEnvelope.Checkout(id: "id", paymentUrl: "paymentUrl")
+    let createCheckout = CreateCheckoutEnvelope.Checkout(
+      id: "id",
+      paymentUrl: "paymentUrl",
+      backingId: "backingId"
+    )
     let errorUnknown = ErrorEnvelope(
       errorMessages: ["Something went wrong yo."],
       ksrCode: .UnknownCode,

--- a/Library/ViewModels/PostCampaignCheckoutViewModelTests.swift
+++ b/Library/ViewModels/PostCampaignCheckoutViewModelTests.swift
@@ -108,7 +108,8 @@ final class PostCampaignCheckoutViewModelTests: TestCase {
         shipping: nil,
         refTag: nil,
         context: .pledge,
-        checkoutId: "0"
+        checkoutId: "0",
+        backingId: "backingId"
       )
 
       self.vm.inputs.configure(with: data)
@@ -138,7 +139,8 @@ final class PostCampaignCheckoutViewModelTests: TestCase {
         shipping: nil,
         refTag: nil,
         context: .pledge,
-        checkoutId: "0"
+        checkoutId: "0",
+        backingId: "backingId"
       )
 
       self.vm.inputs.configure(with: data)
@@ -165,7 +167,8 @@ final class PostCampaignCheckoutViewModelTests: TestCase {
       shipping: nil,
       refTag: nil,
       context: .pledge,
-      checkoutId: "0"
+      checkoutId: "0",
+      backingId: "backingId"
     )
 
     let paymentIntent = PaymentIntentEnvelope(clientSecret: "foo")
@@ -209,7 +212,8 @@ final class PostCampaignCheckoutViewModelTests: TestCase {
       shipping: nil,
       refTag: nil,
       context: .pledge,
-      checkoutId: "0"
+      checkoutId: "0",
+      backingId: "backingId"
     )
 
     let paymentIntent = PaymentIntentEnvelope(clientSecret: "foo")
@@ -259,7 +263,8 @@ final class PostCampaignCheckoutViewModelTests: TestCase {
       ),
       refTag: nil,
       context: .pledge,
-      checkoutId: "0"
+      checkoutId: "0",
+      backingId: "backingId"
     )
 
     let paymentIntent = PaymentIntentEnvelope(clientSecret: "foo")
@@ -311,7 +316,8 @@ final class PostCampaignCheckoutViewModelTests: TestCase {
       ),
       refTag: nil,
       context: .pledge,
-      checkoutId: "0"
+      checkoutId: "0",
+      backingId: "backingId"
     )
 
     let paymentIntent = PaymentIntentEnvelope(clientSecret: "foo")
@@ -357,7 +363,8 @@ final class PostCampaignCheckoutViewModelTests: TestCase {
       shipping: nil,
       refTag: nil,
       context: .pledge,
-      checkoutId: "0"
+      checkoutId: "0",
+      backingId: "backingId"
     )
 
     withEnvironment(apiService: mockService) {
@@ -417,7 +424,8 @@ final class PostCampaignCheckoutViewModelTests: TestCase {
       shipping: nil,
       refTag: nil,
       context: .pledge,
-      checkoutId: "0"
+      checkoutId: "0",
+      backingId: "backingId"
     )
 
     withEnvironment(apiService: mockService) {
@@ -467,7 +475,8 @@ final class PostCampaignCheckoutViewModelTests: TestCase {
       shipping: nil,
       refTag: nil,
       context: .pledge,
-      checkoutId: "0"
+      checkoutId: "0",
+      backingId: "backingId"
     )
 
     withEnvironment(apiService: mockService) {
@@ -536,7 +545,8 @@ final class PostCampaignCheckoutViewModelTests: TestCase {
       shipping: nil,
       refTag: nil,
       context: .latePledge,
-      checkoutId: "0"
+      checkoutId: "0",
+      backingId: "backingId"
     )
 
     withEnvironment(apiService: mockService) {
@@ -595,7 +605,8 @@ final class PostCampaignCheckoutViewModelTests: TestCase {
       shipping: nil,
       refTag: nil,
       context: .latePledge,
-      checkoutId: "0"
+      checkoutId: "0",
+      backingId: "backingId"
     )
 
     withEnvironment(apiService: mockService) {
@@ -645,7 +656,8 @@ final class PostCampaignCheckoutViewModelTests: TestCase {
       shipping: nil,
       refTag: nil,
       context: .latePledge,
-      checkoutId: "0"
+      checkoutId: "0",
+      backingId: "backingId"
     )
 
     withEnvironment(apiService: mockService) {
@@ -697,7 +709,8 @@ final class PostCampaignCheckoutViewModelTests: TestCase {
         shipping: nil,
         refTag: nil,
         context: .latePledge,
-        checkoutId: "0"
+        checkoutId: "0",
+        backingId: "backingId"
       )
 
       self.vm.inputs.configure(with: data)
@@ -731,7 +744,8 @@ final class PostCampaignCheckoutViewModelTests: TestCase {
         shipping: nil,
         refTag: nil,
         context: .latePledge,
-        checkoutId: "0"
+        checkoutId: "0",
+        backingId: "backingId"
       )
 
       self.vm.inputs.configure(with: data)


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Exposes `backingId` in our `CreateCheckout` GraphQL Mutation Response in order to pass it to `CreatePaymentIntent`.

# 🤔 Why

As a backer, if my late pledge checkout errors, the payment should be reversed or the checkout rescued asynchronously (handled by Rosie (backend) if `backingId` is present)

# 🛠 How

- Expose `backingId` in `CreateCheckout.graphql`
- Pass newly exposed `backingId` to `CreatePaymentIntent` GraphQl call

# 👀 See

No visible changes

# ✅ Acceptance criteria

- [x] backingId is successfully passed along to the backend in the CreatePaymentIntent call
- [x] Late pledge checkout flow works as normal. (creating new and using existing payment methods specifically) 
