### PR TITLE
[MBL-1608] Remove 'Update Pledge' From Manage Pledge Options Menu

### DIFF
--- a/Library/ViewModels/ManagePledgeViewModel.swift
+++ b/Library/ViewModels/ManagePledgeViewModel.swift
@@ -471,7 +471,15 @@ private func actionSheetMenuOptionsFor(
     return [.contactCreator]
   }
 
-  return ManagePledgeAlertAction.allCases.filter { $0 != .viewRewards }
+  let actions: [ManagePledgeAlertAction]
+
+  // TODO: Remove 'update pledge' from ManagePledgeAlertAction after feature rollout.
+  if featureNoShippingAtCheckout() {
+    actions = ManagePledgeAlertAction.allCases.filter { $0 != .viewRewards && $0 != .updatePledge }
+  } else {
+    actions = ManagePledgeAlertAction.allCases.filter { $0 != .viewRewards }
+  }
+  return actions
 }
 
 private func navigationBarTitle(


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Removes 'Update Pledge' From Manage Pledge Options Menu

# 🤔 Why

Users will be able to manage and make changes to their pledge in the pledge redemption flow now, rendering this menu option redundant. 

Taking this opportunity to clean it up.

# 🛠 How

When the menu options get collected in `ManagePledgeViewModel.actionSheetMenuOptionsFor(...)` we can filter out the `.updatePledge` option if the feature flag is on.

I added a `TODO` to remind us that we can remove this option from the options struct when the feature has completed and we start cleaning up the feature flag.

# 👀 See

Trello, screenshots, external resources?

|  flag **off** |  flag **on** |
| --- | --- |
| ![old](https://github.com/user-attachments/assets/5e1cf048-16e6-4eb4-94f8-68a2e50dc128) | ![new](https://github.com/user-attachments/assets/b229a911-20c9-4f90-b62a-5ef9479c0e34) |

# ✅ Acceptance criteria

- [x] when feature flag is **on** the `update pledge` option does not appear in the manage pledge popup sheet
- [x] when feature flag is **off** the `update pledge` option appears in the manage pledge popup sheet as normal
