### PR TITLE
[MBL-1458 pt 2] Add address summary for PPO

### DIFF
--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/CardView/PPOAddressSummary.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/CardView/PPOAddressSummary.swift
@@ -3,6 +3,7 @@ import SwiftUI
 
 struct PPOAddressSummary: View {
   let address: String
+  let leadingColumnWidth: CGFloat
 
   var body: some View {
     HStack(alignment: .firstTextBaseline) {
@@ -11,7 +12,7 @@ struct PPOAddressSummary: View {
         .lineLimit(nil)
         .font(Font(Constants.labelFont))
         .foregroundStyle(Color(Constants.labelColor))
-        .frame(width: Constants.labelWidth, alignment: .leading)
+        .frame(width: self.leadingColumnWidth, alignment: .leading)
         .multilineTextAlignment(.leading)
 
       Text(self.address)
@@ -25,7 +26,6 @@ struct PPOAddressSummary: View {
   }
 
   private enum Constants {
-    static let labelWidth: CGFloat = 85
     static let labelFont = UIFont.ksr_caption1().bolded
     static let labelColor = UIColor.ksr_black
     static let addressFont = UIFont.ksr_caption1()
@@ -35,12 +35,17 @@ struct PPOAddressSummary: View {
 
 #Preview {
   VStack(spacing: 28) {
-    PPOAddressSummary(address: """
-      Firsty Lasty
-      123 First Street, Apt #5678
-      Los Angeles, CA 90025-1234
-      United States
-    """)
+    GeometryReader(content: { geometry in
+      PPOAddressSummary(
+        address: """
+          Firsty Lasty
+          123 First Street, Apt #5678
+          Los Angeles, CA 90025-1234
+          United States
+        """,
+        leadingColumnWidth: geometry.size.width / 4
+      )
+    })
   }
   .padding(28)
 }

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/CardView/PPOAddressSummary.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/CardView/PPOAddressSummary.swift
@@ -1,0 +1,46 @@
+import Foundation
+import SwiftUI
+
+struct PPOAddressSummary: View {
+  let address: String
+
+  var body: some View {
+    HStack(alignment: .firstTextBaseline) {
+      // TODO: Localize
+      Text("Shipping address")
+        .lineLimit(nil)
+        .font(Font(Constants.labelFont))
+        .foregroundStyle(Color(Constants.labelColor))
+        .frame(width: Constants.labelWidth, alignment: .leading)
+        .multilineTextAlignment(.leading)
+
+      Text(self.address)
+        .lineLimit(nil)
+        .multilineTextAlignment(.leading)
+        .font(Font(Constants.addressFont))
+        .foregroundStyle(Color(Constants.addressColor))
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+    .frame(maxWidth: .infinity)
+  }
+
+  private enum Constants {
+    static let labelWidth: CGFloat = 85
+    static let labelFont = UIFont.ksr_caption1().bolded
+    static let labelColor = UIColor.ksr_black
+    static let addressFont = UIFont.ksr_caption1()
+    static let addressColor = UIColor.ksr_black
+  }
+}
+
+#Preview {
+  VStack(spacing: 28) {
+    PPOAddressSummary(address: """
+      Firsty Lasty
+      123 First Street, Apt #5678
+      Los Angeles, CA 90025-1234
+      United States
+    """)
+  }
+  .padding(28)
+}

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/CardView/PPOAddressSummary.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/CardView/PPOAddressSummary.swift
@@ -9,20 +9,18 @@ struct PPOAddressSummary: View {
     HStack(alignment: .firstTextBaseline) {
       // TODO: Localize
       Text("Shipping address")
-        .lineLimit(nil)
         .font(Font(Constants.labelFont))
         .foregroundStyle(Color(Constants.labelColor))
-        .frame(width: self.leadingColumnWidth, alignment: .leading)
-        .multilineTextAlignment(.leading)
+        .frame(width: self.leadingColumnWidth, alignment: Constants.textAlignment)
+        .multilineTextAlignment(Constants.textAlignment)
 
       Text(self.address)
-        .lineLimit(nil)
-        .multilineTextAlignment(.leading)
+        .multilineTextAlignment(Constants.textAlignment)
         .font(Font(Constants.addressFont))
         .foregroundStyle(Color(Constants.addressColor))
-        .frame(maxWidth: .infinity, alignment: .leading)
+        .frame(maxWidth: Constants.maxWidth, alignment: Constants.textAlignment)
     }
-    .frame(maxWidth: .infinity)
+    .frame(maxWidth: Constants.maxWidth)
   }
 
   private enum Constants {
@@ -30,6 +28,8 @@ struct PPOAddressSummary: View {
     static let labelColor = UIColor.ksr_black
     static let addressFont = UIFont.ksr_caption1()
     static let addressColor = UIColor.ksr_black
+    static let textAlignment = Alignment.leadingLastTextBaseline
+    static let maxWidth = CGFloat.infinity
   }
 }
 

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/CardView/PPOAddressSummary.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/CardView/PPOAddressSummary.swift
@@ -9,25 +9,19 @@ struct PPOAddressSummary: View {
     HStack(alignment: .firstTextBaseline) {
       // TODO: Localize
       Text("Shipping address")
-        .font(Font(Constants.labelFont))
-        .foregroundStyle(Color(Constants.labelColor))
+        .font(Font(PPOCardStyles.title.font))
+        .foregroundStyle(Color(PPOCardStyles.title.color))
         .frame(width: self.leadingColumnWidth, alignment: Constants.textAlignment)
-        .multilineTextAlignment(Constants.textAlignment)
 
       Text(self.address)
-        .multilineTextAlignment(Constants.textAlignment)
-        .font(Font(Constants.addressFont))
-        .foregroundStyle(Color(Constants.addressColor))
+        .font(Font(PPOCardStyles.body.font))
+        .foregroundStyle(Color(PPOCardStyles.body.color))
         .frame(maxWidth: Constants.maxWidth, alignment: Constants.textAlignment)
     }
     .frame(maxWidth: Constants.maxWidth)
   }
 
   private enum Constants {
-    static let labelFont = UIFont.ksr_caption1().bolded
-    static let labelColor = UIColor.ksr_black
-    static let addressFont = UIFont.ksr_caption1()
-    static let addressColor = UIColor.ksr_black
     static let textAlignment = Alignment.leadingLastTextBaseline
     static let maxWidth = CGFloat.infinity
   }

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/CardView/PPOCardStyles.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/CardView/PPOCardStyles.swift
@@ -23,6 +23,11 @@ enum PPOCardStyles {
     color: UIColor.ksr_support_400
   )
 
+  static let body = (
+    font: UIFont.ksr_caption1(),
+    color: UIColor.ksr_black
+  )
+
   static let timeImage = ImageResource.iconLimitedTime
   static let alertImage = ImageResource.iconNotice
 }

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -1125,6 +1125,7 @@
 		A7F441E91D005A9400FE6FC5 /* TwoFactorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7F441AC1D005A9400FE6FC5 /* TwoFactorViewModel.swift */; };
 		A7F6F0C11DC7EBF7002C118C /* DateProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7F6F0C01DC7EBF7002C118C /* DateProtocol.swift */; };
 		A7FC8C061C8F1DEA00C3B49B /* CircleAvatarImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7FC8C051C8F1DEA00C3B49B /* CircleAvatarImageView.swift */; };
+		AA6E9E8A2C63EE78001543FC /* PPOAddressSummary.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA6E9E892C63EE78001543FC /* PPOAddressSummary.swift */; };
 		D002CAE1218CF8F1009783F2 /* WatchProjectMutation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D002CAE0218CF8F1009783F2 /* WatchProjectMutation.swift */; };
 		D002CAE3218CF91D009783F2 /* WatchProjectInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = D002CAE2218CF91D009783F2 /* WatchProjectInput.swift */; };
 		D002CAE5218CF951009783F2 /* WatchProjectResponseEnvelope.swift in Sources */ = {isa = PBXBuildFile; fileRef = D002CAE4218CF951009783F2 /* WatchProjectResponseEnvelope.swift */; };
@@ -2761,6 +2762,7 @@
 		A7F761741C85FA40005405ED /* ActivitiesViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActivitiesViewController.swift; sourceTree = "<group>"; };
 		A7F761761C85FACB005405ED /* LoginToutViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = LoginToutViewController.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		A7FC8C051C8F1DEA00C3B49B /* CircleAvatarImageView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CircleAvatarImageView.swift; sourceTree = "<group>"; };
+		AA6E9E892C63EE78001543FC /* PPOAddressSummary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PPOAddressSummary.swift; sourceTree = "<group>"; };
 		D002CAE0218CF8F1009783F2 /* WatchProjectMutation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WatchProjectMutation.swift; sourceTree = "<group>"; };
 		D002CAE2218CF91D009783F2 /* WatchProjectInput.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WatchProjectInput.swift; sourceTree = "<group>"; };
 		D002CAE4218CF951009783F2 /* WatchProjectResponseEnvelope.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WatchProjectResponseEnvelope.swift; sourceTree = "<group>"; };
@@ -6678,6 +6680,14 @@
 			path = ViewModels;
 			sourceTree = "<group>";
 		};
+		AAD2BEE72C59B964003D8B95 /* CardView */ = {
+			isa = PBXGroup;
+			children = (
+				AA6E9E892C63EE78001543FC /* PPOAddressSummary.swift */,
+			);
+			path = CardView;
+			sourceTree = "<group>";
+		};
 		D01587511EEB2DE4006E7684 /* KsApi */ = {
 			isa = PBXGroup;
 			children = (
@@ -7098,6 +7108,7 @@
 		E1BAA0332C1A18DA004F8B06 /* PledgedProjectsOverview */ = {
 			isa = PBXGroup;
 			children = (
+				AAD2BEE72C59B964003D8B95 /* CardView */,
 				392BB12B2C3C095200A5591B /* PPOEmptyStateViewTests.swift */,
 				392BB1292C3BEB5500A5591B /* PPOEmptyStateView.swift */,
 				E1BAA0382C1A1C56004F8B06 /* PPOContainerViewController.swift */,
@@ -8455,6 +8466,7 @@
 				06EB4E3127B5D32000D8BFCC /* PinchToZoom.swift in Sources */,
 				60C996E42ABCA5E5006BE4F4 /* ReportProjectLabelView.swift in Sources */,
 				60C996E42ABCA5E5006BE4F4 /* ReportProjectLabelView.swift in Sources */,
+				AA6E9E8A2C63EE78001543FC /* PPOAddressSummary.swift in Sources */,
 				A75CBDE81C8A26F800758C55 /* AppDelegateViewModel.swift in Sources */,
 				A72C3AA71D00F7A30075227E /* SortPagerViewController.swift in Sources */,
 				D764370A224040D100DAFC9E /* SharedFunctions.swift in Sources */,


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

This PR implements the address summary for the card view for pledged projects, as well as the relevant subviews. It adds a view model to cover handling actions like tapping buttons and sending the creator a message.

Connecting to real data will come in a future PR.

# 🛠 How

Views are implemented as SwiftUI views, broken up into a few pieces, including individual flags, a project details view, a creator summary view, an address summary view, and buttons. Where possible, views used existing styling functions but did not use Prelude.

Snapshot testing is already complete and will be included in the card view PR.

# 👀 See

[Figma](https://www.figma.com/design/r0WKSECmMTCJTSKQskt2SQ/Backed-Projects-Dashboard?node-id=722-8194&t=rpm5RzgK15wT9Peu-0)

# ♿️ Accessibility 

- [x] Tap targets use minimum of 44x44 pts dimensions

Should support Dynamic Type and VoiceOver, but that hasn't been confirmed

# 🏎 Performance

Performance will be validated when these are integrated into the pledged project list.

# ✅ Acceptance criteria

Feature will be more thoroughly tested against real data in a future PR after integrating. For now, all tests should pass.

# ⏰ TODO

Future PRs will integrate into the app UI itself and more testing can happen at that time.
