### PR TITLE
[MBL-1458 pt 3] Add project creator for PPO

### DIFF
--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/CardView/PPOProjectCreator.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/CardView/PPOProjectCreator.swift
@@ -11,8 +11,8 @@ struct PPOProjectCreator: View {
       Text("Created by **\(self.creatorName)**")
         .font(Font(Constants.createdByFont))
         .foregroundStyle(Color(Constants.createdByColor))
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .lineLimit(1)
+        .frame(maxWidth: Constants.labelMaxWidth, alignment: Constants.labelAlignment)
+        .lineLimit(Constants.textLineLimit)
 
       Button(action: {
         // TODO: Action
@@ -22,11 +22,11 @@ struct PPOProjectCreator: View {
       })
       .font(Font(Constants.sendMessageFont))
       .foregroundStyle(Color(Constants.sendMessageColor))
-      .frame(alignment: .trailing)
-      .lineLimit(1)
+      .frame(alignment: Constants.buttonAlignment)
+      .lineLimit(Constants.textLineLimit)
 
       Spacer()
-        .frame(width: Styles.grid(1))
+        .frame(width: Constants.spacerWidth)
 
       Image("chevron-right")
         .resizable()
@@ -45,6 +45,11 @@ struct PPOProjectCreator: View {
     static let sendMessageColor = UIColor.ksr_create_700
     static let chevronSize: CGFloat = 10
     static let chevronOffset = CGSize(width: 0, height: 2)
+    static let spacerWidth = Styles.grid(1)
+    static let textLineLimit = 1
+    static let labelMaxWidth = CGFloat.infinity
+    static let labelAlignment = Alignment.leading
+    static let buttonAlignment = Alignment.trailing
   }
 }
 

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/CardView/PPOProjectCreator.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/CardView/PPOProjectCreator.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Library
 import SwiftUI
 
 struct PPOProjectCreator: View {
@@ -13,21 +14,25 @@ struct PPOProjectCreator: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .lineLimit(1)
 
-      // TODO: Localize
-      Text("Send a message")
-        .font(Font(Constants.sendMessageFont))
-        .foregroundStyle(Color(Constants.sendMessageColor))
-        .frame(alignment: .trailing)
-        .lineLimit(1)
+      Button(action: {
+        // TODO: Action
+      }, label: {
+        // TODO: Localize
+        Text("Send a message")
+      })
+      .font(Font(Constants.sendMessageFont))
+      .foregroundStyle(Color(Constants.sendMessageColor))
+      .frame(alignment: .trailing)
+      .lineLimit(1)
 
       Spacer()
-        .frame(width: 6)
+        .frame(width: Styles.grid(1))
 
       Image("chevron-right")
         .resizable()
         .scaledToFit()
-        .frame(width: 10, height: 10)
-        .offset(y: 2)
+        .frame(width: Constants.chevronSize, height: Constants.chevronSize)
+        .offset(Constants.chevronOffset)
         .foregroundStyle(Color(Constants.sendMessageColor))
     }
     .frame(maxWidth: .infinity)
@@ -38,6 +43,8 @@ struct PPOProjectCreator: View {
     static let createdByColor = UIColor.ksr_support_400
     static let sendMessageFont = UIFont.ksr_caption2()
     static let sendMessageColor = UIColor.ksr_create_700
+    static let chevronSize: CGFloat = 10
+    static let chevronOffset = CGSize(width: 0, height: 2)
   }
 }
 

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/CardView/PPOProjectCreator.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/CardView/PPOProjectCreator.swift
@@ -1,0 +1,51 @@
+import Foundation
+import SwiftUI
+
+struct PPOProjectCreator: View {
+  let creatorName: String
+
+  var body: some View {
+    HStack(alignment: .firstTextBaseline) {
+      // TODO: Localize
+      Text("Created by **\(self.creatorName)**")
+        .font(Font(Constants.createdByFont))
+        .foregroundStyle(Color(Constants.createdByColor))
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .lineLimit(1)
+
+      // TODO: Localize
+      Text("Send a message")
+        .font(Font(Constants.sendMessageFont))
+        .foregroundStyle(Color(Constants.sendMessageColor))
+        .frame(alignment: .trailing)
+        .lineLimit(1)
+
+      Spacer()
+        .frame(width: 6)
+
+      Image("chevron-right")
+        .resizable()
+        .scaledToFit()
+        .frame(width: 10, height: 10)
+        .offset(y: 2)
+        .foregroundStyle(Color(Constants.sendMessageColor))
+    }
+    .frame(maxWidth: .infinity)
+  }
+
+  private enum Constants {
+    static let createdByFont = UIFont.ksr_caption2()
+    static let createdByColor = UIColor.ksr_support_400
+    static let sendMessageFont = UIFont.ksr_caption2()
+    static let sendMessageColor = UIColor.ksr_create_700
+  }
+}
+
+#Preview {
+  VStack(spacing: 28) {
+    PPOProjectCreator(creatorName: "Disco Dave")
+    PPOProjectCreator(creatorName: "A much longer name")
+    PPOProjectCreator(creatorName: "rokaplay truncate if longer than")
+  }
+  .padding(28)
+}

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -1125,6 +1125,7 @@
 		A7F441E91D005A9400FE6FC5 /* TwoFactorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7F441AC1D005A9400FE6FC5 /* TwoFactorViewModel.swift */; };
 		A7F6F0C11DC7EBF7002C118C /* DateProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7F6F0C01DC7EBF7002C118C /* DateProtocol.swift */; };
 		A7FC8C061C8F1DEA00C3B49B /* CircleAvatarImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7FC8C051C8F1DEA00C3B49B /* CircleAvatarImageView.swift */; };
+		AA6E9E882C63EAE9001543FC /* PPOProjectCreator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA6E9E862C63E7C3001543FC /* PPOProjectCreator.swift */; };
 		D002CAE1218CF8F1009783F2 /* WatchProjectMutation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D002CAE0218CF8F1009783F2 /* WatchProjectMutation.swift */; };
 		D002CAE3218CF91D009783F2 /* WatchProjectInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = D002CAE2218CF91D009783F2 /* WatchProjectInput.swift */; };
 		D002CAE5218CF951009783F2 /* WatchProjectResponseEnvelope.swift in Sources */ = {isa = PBXBuildFile; fileRef = D002CAE4218CF951009783F2 /* WatchProjectResponseEnvelope.swift */; };
@@ -2761,6 +2762,7 @@
 		A7F761741C85FA40005405ED /* ActivitiesViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActivitiesViewController.swift; sourceTree = "<group>"; };
 		A7F761761C85FACB005405ED /* LoginToutViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = LoginToutViewController.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		A7FC8C051C8F1DEA00C3B49B /* CircleAvatarImageView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CircleAvatarImageView.swift; sourceTree = "<group>"; };
+		AA6E9E862C63E7C3001543FC /* PPOProjectCreator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PPOProjectCreator.swift; sourceTree = "<group>"; };
 		D002CAE0218CF8F1009783F2 /* WatchProjectMutation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WatchProjectMutation.swift; sourceTree = "<group>"; };
 		D002CAE2218CF91D009783F2 /* WatchProjectInput.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WatchProjectInput.swift; sourceTree = "<group>"; };
 		D002CAE4218CF951009783F2 /* WatchProjectResponseEnvelope.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WatchProjectResponseEnvelope.swift; sourceTree = "<group>"; };
@@ -6678,6 +6680,14 @@
 			path = ViewModels;
 			sourceTree = "<group>";
 		};
+		AAD2BEE72C59B964003D8B95 /* CardView */ = {
+			isa = PBXGroup;
+			children = (
+				AA6E9E862C63E7C3001543FC /* PPOProjectCreator.swift */,
+			);
+			path = CardView;
+			sourceTree = "<group>";
+		};
 		D01587511EEB2DE4006E7684 /* KsApi */ = {
 			isa = PBXGroup;
 			children = (
@@ -7098,6 +7108,7 @@
 		E1BAA0332C1A18DA004F8B06 /* PledgedProjectsOverview */ = {
 			isa = PBXGroup;
 			children = (
+				AAD2BEE72C59B964003D8B95 /* CardView */,
 				392BB12B2C3C095200A5591B /* PPOEmptyStateViewTests.swift */,
 				392BB1292C3BEB5500A5591B /* PPOEmptyStateView.swift */,
 				E1BAA0382C1A1C56004F8B06 /* PPOContainerViewController.swift */,
@@ -8437,6 +8448,7 @@
 				0634C2F727CFEE40003A6D6E /* ExternalSourceViewElementCell.swift in Sources */,
 				47F95ED72672C594001365B2 /* ViewRepliesView.swift in Sources */,
 				37CA16AD23300376006044F9 /* ManageViewPledgeRewardReceivedViewController.swift in Sources */,
+				AA6E9E882C63EAE9001543FC /* PPOProjectCreator.swift in Sources */,
 				E1BAA03B2C1A1CCD004F8B06 /* PPOView.swift in Sources */,
 				6049D0242AA7940E0015BB0D /* DemoCTAContainerView.swift in Sources */,
 				778CCC5222822B5D00FB8D35 /* SheetOverlayTransitionAnimator.swift in Sources */,


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

This PR implements the project creator view for the card view for pledged projects, as well as the relevant subviews. It adds a view model to cover handling actions like tapping buttons and sending the creator a message.

Connecting to real data will come in a future PR.

# 🛠 How

Views are implemented as SwiftUI views, broken up into a few pieces, including individual flags, a project details view, a creator summary view, an address summary view, and buttons. Where possible, views used existing styling functions but did not use Prelude.

Snapshot testing is already complete and will be included in the card view PR.

# 👀 See

[Figma](https://www.figma.com/design/r0WKSECmMTCJTSKQskt2SQ/Backed-Projects-Dashboard?node-id=722-8194&t=rpm5RzgK15wT9Peu-0)

# ♿️ Accessibility 

- [x] Tap targets use minimum of 44x44 pts dimensions

Should support Dynamic Type and VoiceOver, but that hasn't been confirmed

# 🏎 Performance

Performance will be validated when these are integrated into the pledged project list.

# ✅ Acceptance criteria

Feature will be more thoroughly tested against real data in a future PR after integrating. For now, all tests should pass.

# ⏰ TODO

Future PRs will integrate into the app UI itself and more testing can happen at that time.
