### PR TITLE
[MBL-1458 pt 4] Add project details for PPO

### DIFF
--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/CardView/PPOProjectDetails.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/CardView/PPOProjectDetails.swift
@@ -1,0 +1,64 @@
+import Foundation
+import Kingfisher
+import KsApi
+import SwiftUI
+
+struct PPOProjectDetails: View {
+  let imageUrl: URL?
+  let title: String?
+  let pledge: GraphAPI.MoneyFragment
+
+  var body: some View {
+    HStack {
+      KFImage(self.imageUrl)
+        .resizable()
+        .clipShape(Constants.imageShape)
+        .aspectRatio(Constants.imageAspectRatio, contentMode: .fit)
+        .frame(width: Constants.imageWidth)
+      Spacer()
+        .frame(width: Constants.spacing)
+      VStack {
+        if let title {
+          Text(title)
+            .font(Font(Constants.titleFont))
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .lineLimit(2)
+        }
+        // TODO: Localize
+        Text("\(self.pledge.symbol ?? "")\(self.pledge.amount ?? "") pledged")
+          .font(Font(Constants.subtitleFont))
+          .foregroundStyle(Color(Constants.subtitleTextColor))
+          .frame(maxWidth: .infinity, alignment: .leading)
+          .lineLimit(1)
+      }
+    }
+    .fixedSize(horizontal: false, vertical: true)
+    .frame(maxWidth: .infinity)
+  }
+
+  private enum Constants {
+    static let imageShape = RoundedRectangle(cornerRadius: 4)
+    static let imageAspectRatio: CGFloat = 16 / 9
+    static let imageWidth: CGFloat = 85
+    static let spacing: CGFloat = 8
+    static let titleFont = UIFont.ksr_caption1().bolded
+    static let subtitleFont = UIFont.ksr_footnote()
+    static let subtitleTextColor = UIColor.ksr_support_400
+  }
+}
+
+#Preview {
+  VStack {
+    PPOProjectDetails(
+      imageUrl: URL(string: "http:///")!,
+      title: "Sugardew Island - Your cozy farm shop let’s pretend this is a way way way longer title",
+      pledge: GraphAPI.MoneyFragment(amount: "50.00", currency: .usd, symbol: "$")
+    )
+    PPOProjectDetails(
+      imageUrl: URL(string: "http:///")!,
+      title: "One line",
+      pledge: GraphAPI.MoneyFragment(amount: "50.00", currency: .usd, symbol: "$")
+    )
+  }
+  .padding(28)
+}

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/CardView/PPOProjectDetails.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/CardView/PPOProjectDetails.swift
@@ -47,7 +47,6 @@ struct PPOProjectDetails: View {
     static let imageShape = RoundedRectangle(cornerRadius: Styles.cornerRadius)
     static let imageAspectRatio: CGFloat = 16 / 9
     static let imageContentMode = ContentMode.fit
-    static let imageWidth: CGFloat = 85
 
     static let titleFont = UIFont.ksr_caption1().bolded
     static let titleTextColor = UIColor.ksr_black

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/CardView/PPOProjectDetails.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/CardView/PPOProjectDetails.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Kingfisher
 import KsApi
+import Library
 import SwiftUI
 
 struct PPOProjectDetails: View {
@@ -13,7 +14,7 @@ struct PPOProjectDetails: View {
       KFImage(self.imageUrl)
         .resizable()
         .clipShape(Constants.imageShape)
-        .aspectRatio(Constants.imageAspectRatio, contentMode: .fit)
+        .aspectRatio(Constants.imageAspectRatio, contentMode: Constants.imageContentMode)
         .frame(width: Constants.imageWidth)
       Spacer()
         .frame(width: Constants.spacing)
@@ -21,15 +22,18 @@ struct PPOProjectDetails: View {
         if let title {
           Text(title)
             .font(Font(Constants.titleFont))
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .lineLimit(2)
+            .foregroundStyle(Color(Constants.titleTextColor))
+            .frame(maxWidth: Constants.textMaxWidth, alignment: Constants.textAlignment)
+            .lineLimit(Constants.titleLineLimit)
         }
-        // TODO: Localize
-        Text("\(self.pledge.symbol ?? "")\(self.pledge.amount ?? "") pledged")
-          .font(Font(Constants.subtitleFont))
-          .foregroundStyle(Color(Constants.subtitleTextColor))
-          .frame(maxWidth: .infinity, alignment: .leading)
-          .lineLimit(1)
+        if let symbol = pledge.symbol, let amount = pledge.amount {
+          // TODO: Localize
+          Text("\(symbol)\(amount) pledged")
+            .font(Font(Constants.subtitleFont))
+            .foregroundStyle(Color(Constants.subtitleTextColor))
+            .frame(maxWidth: Constants.textMaxWidth, alignment: Constants.textAlignment)
+            .lineLimit(Constants.subtitleLineLimit)
+        }
       }
     }
     .fixedSize(horizontal: false, vertical: true)
@@ -37,13 +41,23 @@ struct PPOProjectDetails: View {
   }
 
   private enum Constants {
-    static let imageShape = RoundedRectangle(cornerRadius: 4)
+    static let spacing: CGFloat = Styles.grid(1)
+
+    static let imageShape = RoundedRectangle(cornerRadius: Styles.cornerRadius)
     static let imageAspectRatio: CGFloat = 16 / 9
+    static let imageContentMode = ContentMode.fit
     static let imageWidth: CGFloat = 85
-    static let spacing: CGFloat = 8
+
     static let titleFont = UIFont.ksr_caption1().bolded
+    static let titleTextColor = UIColor.ksr_black
+    static let titleLineLimit = 2
+
     static let subtitleFont = UIFont.ksr_footnote()
     static let subtitleTextColor = UIColor.ksr_support_400
+    static let subtitleLineLimit = 1
+
+    static let textMaxWidth = CGFloat.infinity
+    static let textAlignment = Alignment.leading
   }
 }
 

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/CardView/PPOProjectDetails.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/CardView/PPOProjectDetails.swift
@@ -8,6 +8,7 @@ struct PPOProjectDetails: View {
   let imageUrl: URL?
   let title: String?
   let pledge: GraphAPI.MoneyFragment
+  let leadingColumnWidth: CGFloat
 
   var body: some View {
     HStack {
@@ -15,7 +16,7 @@ struct PPOProjectDetails: View {
         .resizable()
         .clipShape(Constants.imageShape)
         .aspectRatio(Constants.imageAspectRatio, contentMode: Constants.imageContentMode)
-        .frame(width: Constants.imageWidth)
+        .frame(width: self.leadingColumnWidth)
       Spacer()
         .frame(width: Constants.spacing)
       VStack {
@@ -63,16 +64,22 @@ struct PPOProjectDetails: View {
 
 #Preview {
   VStack {
-    PPOProjectDetails(
-      imageUrl: URL(string: "http:///")!,
-      title: "Sugardew Island - Your cozy farm shop let’s pretend this is a way way way longer title",
-      pledge: GraphAPI.MoneyFragment(amount: "50.00", currency: .usd, symbol: "$")
-    )
-    PPOProjectDetails(
-      imageUrl: URL(string: "http:///")!,
-      title: "One line",
-      pledge: GraphAPI.MoneyFragment(amount: "50.00", currency: .usd, symbol: "$")
-    )
+    GeometryReader(content: { geometry in
+      PPOProjectDetails(
+        imageUrl: URL(string: "http:///")!,
+        title: "Sugardew Island - Your cozy farm shop let’s pretend this is a way way way longer title",
+        pledge: GraphAPI.MoneyFragment(amount: "50.00", currency: .usd, symbol: "$"),
+        leadingColumnWidth: geometry.size.width / 4
+      )
+    })
+    GeometryReader(content: { geometry in
+      PPOProjectDetails(
+        imageUrl: URL(string: "http:///")!,
+        title: "One line",
+        pledge: GraphAPI.MoneyFragment(amount: "50.00", currency: .usd, symbol: "$"),
+        leadingColumnWidth: geometry.size.width / 4
+      )
+    })
   }
   .padding(28)
 }

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -1125,6 +1125,7 @@
 		A7F441E91D005A9400FE6FC5 /* TwoFactorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7F441AC1D005A9400FE6FC5 /* TwoFactorViewModel.swift */; };
 		A7F6F0C11DC7EBF7002C118C /* DateProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7F6F0C01DC7EBF7002C118C /* DateProtocol.swift */; };
 		A7FC8C061C8F1DEA00C3B49B /* CircleAvatarImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7FC8C051C8F1DEA00C3B49B /* CircleAvatarImageView.swift */; };
+		AA6E9E842C62B9DC001543FC /* PPOProjectDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA592782C5C708000482087 /* PPOProjectDetails.swift */; };
 		D002CAE1218CF8F1009783F2 /* WatchProjectMutation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D002CAE0218CF8F1009783F2 /* WatchProjectMutation.swift */; };
 		D002CAE3218CF91D009783F2 /* WatchProjectInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = D002CAE2218CF91D009783F2 /* WatchProjectInput.swift */; };
 		D002CAE5218CF951009783F2 /* WatchProjectResponseEnvelope.swift in Sources */ = {isa = PBXBuildFile; fileRef = D002CAE4218CF951009783F2 /* WatchProjectResponseEnvelope.swift */; };
@@ -2761,6 +2762,7 @@
 		A7F761741C85FA40005405ED /* ActivitiesViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActivitiesViewController.swift; sourceTree = "<group>"; };
 		A7F761761C85FACB005405ED /* LoginToutViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = LoginToutViewController.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		A7FC8C051C8F1DEA00C3B49B /* CircleAvatarImageView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CircleAvatarImageView.swift; sourceTree = "<group>"; };
+		AAA592782C5C708000482087 /* PPOProjectDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PPOProjectDetails.swift; sourceTree = "<group>"; };
 		D002CAE0218CF8F1009783F2 /* WatchProjectMutation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WatchProjectMutation.swift; sourceTree = "<group>"; };
 		D002CAE2218CF91D009783F2 /* WatchProjectInput.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WatchProjectInput.swift; sourceTree = "<group>"; };
 		D002CAE4218CF951009783F2 /* WatchProjectResponseEnvelope.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WatchProjectResponseEnvelope.swift; sourceTree = "<group>"; };
@@ -6678,6 +6680,14 @@
 			path = ViewModels;
 			sourceTree = "<group>";
 		};
+		AAD2BEE72C59B964003D8B95 /* CardView */ = {
+			isa = PBXGroup;
+			children = (
+				AAA592782C5C708000482087 /* PPOProjectDetails.swift */,
+			);
+			path = CardView;
+			sourceTree = "<group>";
+		};
 		D01587511EEB2DE4006E7684 /* KsApi */ = {
 			isa = PBXGroup;
 			children = (
@@ -7098,6 +7108,7 @@
 		E1BAA0332C1A18DA004F8B06 /* PledgedProjectsOverview */ = {
 			isa = PBXGroup;
 			children = (
+				AAD2BEE72C59B964003D8B95 /* CardView */,
 				392BB12B2C3C095200A5591B /* PPOEmptyStateViewTests.swift */,
 				392BB1292C3BEB5500A5591B /* PPOEmptyStateView.swift */,
 				E1BAA0382C1A1C56004F8B06 /* PPOContainerViewController.swift */,
@@ -8415,6 +8426,7 @@
 				473DE014273C551C0033331D /* ProjectRisksDisclaimerCell.swift in Sources */,
 				D6C3845B210B9AC400ADB671 /* SettingsNewslettersTopCell.swift in Sources */,
 				D6534D3822E784B500E9D279 /* PledgePaymentMethodCell.swift in Sources */,
+				AA6E9E842C62B9DC001543FC /* PPOProjectDetails.swift in Sources */,
 				777C67BB220A0FA5009F8D42 /* SettingsTableViewHeader.swift in Sources */,
 				A72C3AB01D00F9C10075227E /* DiscoveryFiltersDataSource.swift in Sources */,
 				A757EBB31D1B084F00A5C978 /* DiscoveryOnboardingCell.swift in Sources */,


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

This PR implements the project detail summary view for the card view for pledged projects, as well as the relevant subviews. It adds a view model to cover handling actions like tapping buttons and sending the creator a message.

Connecting to real data will come in a future PR.

# 🛠 How

Views are implemented as SwiftUI views, broken up into a few pieces, including individual flags, a project details view, a creator summary view, an address summary view, and buttons. Where possible, views used existing styling functions but did not use Prelude.

Snapshot testing is already complete and will be included in the card view PR.

# 👀 See

[Figma](https://www.figma.com/design/r0WKSECmMTCJTSKQskt2SQ/Backed-Projects-Dashboard?node-id=722-8194&t=rpm5RzgK15wT9Peu-0)

# ♿️ Accessibility 

- [x] Tap targets use minimum of 44x44 pts dimensions

Should support Dynamic Type and VoiceOver, but that hasn't been confirmed

# 🏎 Performance

Performance will be validated when these are integrated into the pledged project list.

# ✅ Acceptance criteria

Feature will be more thoroughly tested against real data in a future PR after integrating. For now, all tests should pass.

# ⏰ TODO

Future PRs will integrate into the app UI itself and more testing can happen at that time.
