### PR TITLE
[NO TICKET] Shipping Dropdown Loading State

### DIFF
--- a/Library/RemoteConfig/RemoteConfigFeature+Helpers.swift
+++ b/Library/RemoteConfig/RemoteConfigFeature+Helpers.swift
@@ -18,7 +18,7 @@ public func featureDarkModeEnabled() -> Bool {
 }
 
 public func featureNoShippingAtCheckout() -> Bool {
-  true
+  return featureEnabled(feature: .noShippingAtCheckout)
 }
 
 public func featurePostCampaignPledgeEnabled() -> Bool {

--- a/Library/RemoteConfig/RemoteConfigFeature+Helpers.swift
+++ b/Library/RemoteConfig/RemoteConfigFeature+Helpers.swift
@@ -18,7 +18,7 @@ public func featureDarkModeEnabled() -> Bool {
 }
 
 public func featureNoShippingAtCheckout() -> Bool {
-  return featureEnabled(feature: .noShippingAtCheckout)
+  true
 }
 
 public func featurePostCampaignPledgeEnabled() -> Bool {

--- a/Library/ViewModels/PledgeShippingLocationViewModel.swift
+++ b/Library/ViewModels/PledgeShippingLocationViewModel.swift
@@ -54,7 +54,7 @@ public final class PledgeShippingLocationViewModel: PledgeShippingLocationViewMo
       .map { $0.3 }
 
     let shippingShouldBeginLoading = reward
-    .map { featureNoShippingAtCheckout() ? true : $0.shipping.enabled }
+      .map { featureNoShippingAtCheckout() ? true : $0.shipping.enabled }
 
     let shippingRulesEvent = Signal.zip(project, reward)
       .filter { _, reward in featureNoShippingAtCheckout() ? true : reward.shipping.enabled }

--- a/Library/ViewModels/PledgeShippingLocationViewModel.swift
+++ b/Library/ViewModels/PledgeShippingLocationViewModel.swift
@@ -54,7 +54,7 @@ public final class PledgeShippingLocationViewModel: PledgeShippingLocationViewMo
       .map { $0.3 }
 
     let shippingShouldBeginLoading = reward
-      .map { $0.shipping.enabled }
+    .map { featureNoShippingAtCheckout() ? true : $0.shipping.enabled }
 
     let shippingRulesEvent = Signal.zip(project, reward)
       .filter { _, reward in featureNoShippingAtCheckout() ? true : reward.shipping.enabled }


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Makes sure the shimmer view loads while the shipping dropdown fetches it's locations.

# 🤔 Why

Without this the dropdown appears empty and visually stutters once the locations have loaded.

# 🛠 How

- Update the view model's isLoading property so that it automatically starts loading when the no checkout at shipping feature flag is enabled.

- The current behavior will start loading if the passed in reward has shipping enabled. 
This only applies to the existing flow where the dropdown is on the AddOns screen. 
Not that it's on the Rewards screen the behavior is different in that we aren't passing in a reward.

# 👀 See

hard to see the before, but with slower internet it's pretty bad.

| Before 🐛 | After 🦋 |
| --- | --- |
| ![no-shimmer](https://github.com/user-attachments/assets/34c3cfc5-9544-4076-91d0-50678f2a1408) | ![with-shimmer](https://github.com/user-attachments/assets/e46ae5ce-0250-4a88-8b37-0d47942ff56b) |

# ✅ Acceptance criteria

- [x] Shimmer view shows until shipping dropdown has finished loading
