### PR TITLE
[MBL-1684] Remove Redundant No Shipping At Checkout Feature Flag Checks

### DIFF
--- a/Kickstarter-iOS/Features/PledgePaymentMethods/Controller/PledgePaymentMethodsViewController.swift
+++ b/Kickstarter-iOS/Features/PledgePaymentMethods/Controller/PledgePaymentMethodsViewController.swift
@@ -159,6 +159,7 @@ final class PledgePaymentMethodsViewController: UIViewController {
 
         assert(
           topViewController is PledgeViewController ||
+            topViewController is NoShippingPledgeViewController ||
             topViewController is PostCampaignCheckoutViewController,
           "PledgePaymentMethodsViewController is only intended to be presented as part of a pledge flow."
         )

--- a/Kickstarter-iOS/Features/RewardAddOnSelection/Controller/RewardAddOnSelectionNoShippingViewController.swift
+++ b/Kickstarter-iOS/Features/RewardAddOnSelection/Controller/RewardAddOnSelectionNoShippingViewController.swift
@@ -217,7 +217,7 @@ final class RewardAddOnSelectionNoShippingViewController: UIViewController {
     let vc = NoShippingConfirmDetailsViewController.instantiate()
     vc.configure(with: data)
     vc.title = self.title
-    
+
     self.navigationController?.pushViewController(vc, animated: true)
   }
 

--- a/Kickstarter-iOS/Features/RewardAddOnSelection/Controller/RewardAddOnSelectionNoShippingViewController.swift
+++ b/Kickstarter-iOS/Features/RewardAddOnSelection/Controller/RewardAddOnSelectionNoShippingViewController.swift
@@ -214,35 +214,19 @@ final class RewardAddOnSelectionNoShippingViewController: UIViewController {
   // MARK: Functions
 
   private func goToConfirmDetails(data: PledgeViewData) {
-    if featureNoShippingAtCheckout() {
-      let vc = NoShippingConfirmDetailsViewController.instantiate()
-      vc.configure(with: data)
-      vc.title = self.title
-
-      self.navigationController?.pushViewController(vc, animated: true)
-    } else {
-      let vc = ConfirmDetailsViewController.instantiate()
-      vc.configure(with: data)
-      vc.title = self.title
-
-      self.navigationController?.pushViewController(vc, animated: true)
-    }
+    let vc = NoShippingConfirmDetailsViewController.instantiate()
+    vc.configure(with: data)
+    vc.title = self.title
+    
+    self.navigationController?.pushViewController(vc, animated: true)
   }
 
   private func goToPledge(data: PledgeViewData) {
-    if featureNoShippingAtCheckout() {
-      let vc = NoShippingPledgeViewController.instantiate()
-      vc.delegate = self.noShippingPledgeViewDelegate
-      vc.configure(with: data)
+    let vc = NoShippingPledgeViewController.instantiate()
+    vc.delegate = self.noShippingPledgeViewDelegate
+    vc.configure(with: data)
 
-      self.navigationController?.pushViewController(vc, animated: true)
-    } else {
-      let vc = PledgeViewController.instantiate()
-      vc.delegate = self.pledgeViewDelegate
-      vc.configure(with: data)
-
-      self.navigationController?.pushViewController(vc, animated: true)
-    }
+    self.navigationController?.pushViewController(vc, animated: true)
   }
 }
 

--- a/Kickstarter-iOS/Features/RewardAddOnSelection/Controller/RewardAddOnSelectionViewController.swift
+++ b/Kickstarter-iOS/Features/RewardAddOnSelection/Controller/RewardAddOnSelectionViewController.swift
@@ -215,16 +215,16 @@ final class RewardAddOnSelectionViewController: UIViewController {
     let vc = ConfirmDetailsViewController.instantiate()
     vc.configure(with: data)
     vc.title = self.title
-    
+
     self.navigationController?.pushViewController(vc, animated: true)
   }
 
   private func goToPledge(data: PledgeViewData) {
-      let vc = PledgeViewController.instantiate()
-      vc.delegate = self.pledgeViewDelegate
-      vc.configure(with: data)
+    let vc = PledgeViewController.instantiate()
+    vc.delegate = self.pledgeViewDelegate
+    vc.configure(with: data)
 
-      self.navigationController?.pushViewController(vc, animated: true)
+    self.navigationController?.pushViewController(vc, animated: true)
   }
 }
 

--- a/Kickstarter-iOS/Features/RewardAddOnSelection/Controller/RewardAddOnSelectionViewController.swift
+++ b/Kickstarter-iOS/Features/RewardAddOnSelection/Controller/RewardAddOnSelectionViewController.swift
@@ -22,7 +22,6 @@ final class RewardAddOnSelectionViewController: UIViewController {
   }()
 
   public weak var pledgeViewDelegate: PledgeViewControllerDelegate?
-  public weak var noShippingPledgeViewDelegate: NoShippingPledgeViewControllerDelegate?
 
   private lazy var refreshControl: UIRefreshControl = { UIRefreshControl() }()
 
@@ -213,35 +212,19 @@ final class RewardAddOnSelectionViewController: UIViewController {
   // MARK: Functions
 
   private func goToConfirmDetails(data: PledgeViewData) {
-    if featureNoShippingAtCheckout() {
-      let vc = NoShippingConfirmDetailsViewController.instantiate()
-      vc.configure(with: data)
-      vc.title = self.title
-
-      self.navigationController?.pushViewController(vc, animated: true)
-    } else {
-      let vc = ConfirmDetailsViewController.instantiate()
-      vc.configure(with: data)
-      vc.title = self.title
-
-      self.navigationController?.pushViewController(vc, animated: true)
-    }
+    let vc = ConfirmDetailsViewController.instantiate()
+    vc.configure(with: data)
+    vc.title = self.title
+    
+    self.navigationController?.pushViewController(vc, animated: true)
   }
 
   private func goToPledge(data: PledgeViewData) {
-    if featureNoShippingAtCheckout() {
-      let vc = NoShippingPledgeViewController.instantiate()
-      vc.delegate = self.noShippingPledgeViewDelegate
-      vc.configure(with: data)
-
-      self.navigationController?.pushViewController(vc, animated: true)
-    } else {
       let vc = PledgeViewController.instantiate()
       vc.delegate = self.pledgeViewDelegate
       vc.configure(with: data)
 
       self.navigationController?.pushViewController(vc, animated: true)
-    }
   }
 }
 

--- a/Kickstarter-iOS/Features/RewardsCollection/Controller/RewardsCollectionViewController.swift
+++ b/Kickstarter-iOS/Features/RewardsCollection/Controller/RewardsCollectionViewController.swift
@@ -33,7 +33,6 @@ final class RewardsCollectionViewController: UICollectionViewController {
   }()
 
   public weak var pledgeViewDelegate: PledgeViewControllerDelegate?
-  public weak var noShippingPledgeViewDelegate: NoShippingPledgeViewControllerDelegate?
 
   private lazy var rewardsCollectionFooterView: RewardsCollectionViewFooter = {
     RewardsCollectionViewFooter(frame: .zero)
@@ -287,35 +286,19 @@ final class RewardsCollectionViewController: UICollectionViewController {
   }
 
   private func goToPledge(data: PledgeViewData) {
-    if featureNoShippingAtCheckout() {
-      let pledgeViewController = NoShippingPledgeViewController.instantiate()
-      pledgeViewController.delegate = self.noShippingPledgeViewDelegate
-      pledgeViewController.configure(with: data)
+    let pledgeViewController = PledgeViewController.instantiate()
+    pledgeViewController.delegate = self.pledgeViewDelegate
+    pledgeViewController.configure(with: data)
 
-      self.navigationController?.pushViewController(pledgeViewController, animated: true)
-    } else {
-      let pledgeViewController = PledgeViewController.instantiate()
-      pledgeViewController.delegate = self.pledgeViewDelegate
-      pledgeViewController.configure(with: data)
-
-      self.navigationController?.pushViewController(pledgeViewController, animated: true)
-    }
+    self.navigationController?.pushViewController(pledgeViewController, animated: true)
   }
 
   private func goToConfirmDetails(data: PledgeViewData) {
-    if featureNoShippingAtCheckout() {
-      let vc = NoShippingConfirmDetailsViewController.instantiate()
-      vc.configure(with: data)
-      vc.title = self.title
+    let vc = ConfirmDetailsViewController.instantiate()
+    vc.configure(with: data)
+    vc.title = self.title
 
-      self.navigationController?.pushViewController(vc, animated: true)
-    } else {
-      let vc = ConfirmDetailsViewController.instantiate()
-      vc.configure(with: data)
-      vc.title = self.title
-
-      self.navigationController?.pushViewController(vc, animated: true)
-    }
+    self.navigationController?.pushViewController(vc, animated: true)
   }
 
   private func showEditRewardConfirmationPrompt(title: String, message: String) {

--- a/Kickstarter-iOS/Features/RewardsCollection/Controller/WithShippingRewardsCollectionViewController.swift
+++ b/Kickstarter-iOS/Features/RewardsCollection/Controller/WithShippingRewardsCollectionViewController.swift
@@ -180,25 +180,15 @@ final class WithShippingRewardsCollectionViewController: UICollectionViewControl
     self.viewModel.outputs.goToAddOnSelection
       .observeForControllerAction()
       .observeValues { [weak self] data in
-        if featureNoShippingAtCheckout() {
-          self?.goToNoShippingAddOnSelection(data: data)
-        } else {
-          self?.goToAddOnSelection(data: data)
-        }
+        self?.goToNoShippingAddOnSelection(data: data)
       }
 
-    self.viewModel.outputs.goToPledge
+    self.viewModel.outputs.goToCustomizeYourReward
       .observeForControllerAction()
       .observeValues { [weak self] data in
         guard let self else { return }
-
-        if featureNoShippingAtCheckout() {
-          self.goToNoShippingAddOnSelection(data: data)
-        } else if data.context == .latePledge {
-          self.goToConfirmDetails(data: data)
-        } else {
-          self.goToPledge(data: data)
-        }
+        /// Goes to screen that only has the pledge amount or bonus amount selectors
+        self.goToNoShippingAddOnSelection(data: data)
       }
 
     self.viewModel.outputs.rewardsCollectionViewIsHidden
@@ -316,30 +306,6 @@ final class WithShippingRewardsCollectionViewController: UICollectionViewControl
     vc.pledgeViewDelegate = self.pledgeViewDelegate
     vc.configure(with: data)
     vc.navigationItem.title = self.title
-    self.navigationController?.pushViewController(vc, animated: true)
-  }
-
-  private func goToAddOnSelection(data: PledgeViewData) {
-    let vc = RewardAddOnSelectionViewController.instantiate()
-    vc.pledgeViewDelegate = self.pledgeViewDelegate
-    vc.configure(with: data)
-    vc.navigationItem.title = self.title
-    self.navigationController?.pushViewController(vc, animated: true)
-  }
-
-  private func goToPledge(data: PledgeViewData) {
-    let pledgeViewController = PledgeViewController.instantiate()
-    pledgeViewController.delegate = self.pledgeViewDelegate
-    pledgeViewController.configure(with: data)
-
-    self.navigationController?.pushViewController(pledgeViewController, animated: true)
-  }
-
-  private func goToConfirmDetails(data: PledgeViewData) {
-    let vc = ConfirmDetailsViewController.instantiate()
-    vc.configure(with: data)
-    vc.title = self.title
-
     self.navigationController?.pushViewController(vc, animated: true)
   }
 

--- a/Library/ViewModels/RewardAddOnSelectionNoShippingViewModel.swift
+++ b/Library/ViewModels/RewardAddOnSelectionNoShippingViewModel.swift
@@ -282,7 +282,7 @@ public final class RewardAddOnSelectionNoShippingViewModel: RewardAddOnSelection
       project.map { $0.personalization.backing }.skipNil().map(\.amount),
       combinedPledgeTotal
     )
-
+    
     // MARK: - Tracking
 
     // shippingRule needs to be set for the event is fired

--- a/Library/ViewModels/RewardAddOnSelectionNoShippingViewModel.swift
+++ b/Library/ViewModels/RewardAddOnSelectionNoShippingViewModel.swift
@@ -282,7 +282,7 @@ public final class RewardAddOnSelectionNoShippingViewModel: RewardAddOnSelection
       project.map { $0.personalization.backing }.skipNil().map(\.amount),
       combinedPledgeTotal
     )
-    
+
     // MARK: - Tracking
 
     // shippingRule needs to be set for the event is fired

--- a/Library/ViewModels/WithShippingRewardsCollectionViewModel.swift
+++ b/Library/ViewModels/WithShippingRewardsCollectionViewModel.swift
@@ -23,7 +23,7 @@ public protocol WithShippingRewardsCollectionViewModelOutputs {
   var configureShippingLocationViewWithData: Signal<PledgeShippingLocationViewData, Never> { get }
   var flashScrollIndicators: Signal<Void, Never> { get }
   var goToAddOnSelection: Signal<PledgeViewData, Never> { get }
-  var goToPledge: Signal<PledgeViewData, Never> { get }
+  var goToCustomizeYourReward: Signal<PledgeViewData, Never> { get }
   var navigationBarShadowImageHidden: Signal<Bool, Never> { get }
   var reloadDataWithValues: Signal<[RewardCardViewData], Never> { get }
   var rewardsCollectionViewIsHidden: Signal<Bool, Never> { get }
@@ -198,7 +198,8 @@ public final class WithShippingRewardsCollectionViewModel: WithShippingRewardsCo
       goToAddOnSelectionNotBackedWithAddOns,
       goToAddOnSelectionBackedConfirmed
     )
-    self.goToPledge = Signal.merge(
+
+    self.goToCustomizeYourReward = Signal.merge(
       goToPledgeNotBackedWithAddOns,
       goToPledgeBackedConfirmed
     )
@@ -383,7 +384,7 @@ public final class WithShippingRewardsCollectionViewModel: WithShippingRewardsCo
   public let configureRewardsCollectionViewFooterWithCount: Signal<Int, Never>
   public let flashScrollIndicators: Signal<Void, Never>
   public let goToAddOnSelection: Signal<PledgeViewData, Never>
-  public let goToPledge: Signal<PledgeViewData, Never>
+  public let goToCustomizeYourReward: Signal<PledgeViewData, Never>
   public let navigationBarShadowImageHidden: Signal<Bool, Never>
   public let reloadDataWithValues: Signal<[RewardCardViewData], Never>
   public let rewardsCollectionViewIsHidden: Signal<Bool, Never>


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Removes Redundant `featureNoShippingAtCheckout` Checks

Also does a quick fix for an issue found in QA for the Stripe Sheet not showing on `NoShippingPledgeViewController`.

# 🤔 Why

The `ProjectPageVIewController` determines whether to start the "No Shipping At Checkout" flow or the current flow in Production. 

We have unnecessary `if featureNoShippingAtCheckout()` conditions in the "No Shipping At Checkout" View Controllers. 

Since they'll never be shown when the flag is disabled, I'm removing them. They should never have been here tbh. 
This all cleanup work. 

# 🛠 How

Goes through each of these VCs and removes unused code and unnecessary feature flag checks:
- WithShippingRewardsCollectionVC + RewardsCollectionVC
- RewardAddOnSelectionNoShippingVC + RewardAddOnSelectionVC

# ✅ Acceptance criteria

- [x] Both Checkout flows function as expected when `featureNoShippingAtCheckout` is **OFF**
- [x] Both Checkout flows function as expected when `featureNoShippingAtCheckout` is **ON**
- [x] All tests pass
