### PR TITLE
[MBL-1690] Crash When Selecting 'Edit Reward' Option In Manage Pledge Flow

### DIFF
--- a/Library/ViewModels/WithShippingRewardsCollectionViewModel.swift
+++ b/Library/ViewModels/WithShippingRewardsCollectionViewModel.swift
@@ -66,9 +66,14 @@ public final class WithShippingRewardsCollectionViewModel: WithShippingRewardsCo
       .map(first)
       .map(titleForContext)
 
-    self.scrollToBackedRewardIndexPath = Signal.combineLatest(project, rewards)
+    self.scrollToBackedRewardIndexPath = Signal.combineLatest(project, rewards, filteredByLocationRewards)
       .takeWhen(self.viewDidLayoutSubviewsProperty.signal.ignoreValues())
-      .map(backedReward(_:rewards:))
+      .map { project, rewards, filteredRewardsByLocation in
+        backedReward(
+          project,
+          rewards: filteredRewardsByLocation.isEmpty ? rewards : filteredRewardsByLocation
+        )
+      }
       .skipNil()
       .take(first: 1)
 


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Uses the filtered rewards by location list to scroll to the selected reward via the 'Edit Reward' option in our Manage Pledge flow.

# 🤔 Why

this is the list the app uses when in our No Shipping At Checkout Flow.

# 🛠 How

Adds the `filteredByLocationRewards` list to the `scrollToBackedRewardIndexPath` signal and chooses the right list to use based on if that list is empty or not.

# 👀 See

![Simulator Screen Recording - iPhone 15 Pro 17 5 - 2024-09-03 at 14 31 03](https://github.com/user-attachments/assets/fff32ab8-6172-4786-9e93-c6b714a69c70)

# ✅ Acceptance criteria

- [x] Backers can edit their selected reward when the `No Shipping At Checkout` feature flag is on
- [x] Backers can edit their selected reward when the `No Shipping At Checkout` feature flag is off