### PR TITLE
[MBL-1687] Fix continue button on confirm details page not working

### DIFF
--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -368,6 +368,7 @@
 		39B8507C2C3EC52D0045CBA5 /* ButtonStyles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39B8507B2C3EC52D0045CBA5 /* ButtonStyles.swift */; };
 		39C6169E2BC83DB000732410 /* PostCampaignPledgeRewardsSummaryViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39C6169D2BC83DB000732410 /* PostCampaignPledgeRewardsSummaryViewModelTests.swift */; };
 		39E436F52C7FA5F3009707BE /* SharedPledgeViewStyles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39E436F42C7FA5F3009707BE /* SharedPledgeViewStyles.swift */; };
+		39E436F72C88D7D2009707BE /* NoShippingConfirmDetailsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39E436F62C88D7D2009707BE /* NoShippingConfirmDetailsViewModelTests.swift */; };
 		4705D8982742E20900A13BBE /* ProjectHeaderCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4705D8972742E20900A13BBE /* ProjectHeaderCell.swift */; };
 		471235F7274450AC0035527F /* ProjectPamphletMainCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 471235F6274450AC0035527F /* ProjectPamphletMainCell.xib */; };
 		471235F9274457460035527F /* ProjectPamphletSubpageCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 471235F8274457460035527F /* ProjectPamphletSubpageCell.xib */; };
@@ -2005,6 +2006,7 @@
 		39B8507B2C3EC52D0045CBA5 /* ButtonStyles.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ButtonStyles.swift; sourceTree = "<group>"; };
 		39C6169D2BC83DB000732410 /* PostCampaignPledgeRewardsSummaryViewModelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostCampaignPledgeRewardsSummaryViewModelTests.swift; sourceTree = "<group>"; };
 		39E436F42C7FA5F3009707BE /* SharedPledgeViewStyles.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SharedPledgeViewStyles.swift; sourceTree = "<group>"; };
+		39E436F62C88D7D2009707BE /* NoShippingConfirmDetailsViewModelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NoShippingConfirmDetailsViewModelTests.swift; sourceTree = "<group>"; };
 		3D1363951F0191FB00B53420 /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/Localizable.strings; sourceTree = "<group>"; };
 		4705D8972742E20900A13BBE /* ProjectHeaderCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectHeaderCell.swift; sourceTree = "<group>"; };
 		471235F6274450AC0035527F /* ProjectPamphletMainCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ProjectPamphletMainCell.xib; sourceTree = "<group>"; };
@@ -6503,6 +6505,7 @@
 				6021F66B2B97BCE200F76031 /* ConfirmDetailsViewModel.swift */,
 				6021F66D2B98AF0C00F76031 /* ConfirmDetailsViewModelTests.swift */,
 				6035AFBD2C598442007E28FC /* NoShippingConfirmDetailsViewModel.swift */,
+				39E436F62C88D7D2009707BE /* NoShippingConfirmDetailsViewModelTests.swift */,
 				373AB221222A058600769FC2 /* CreatePasswordViewModel.swift */,
 				373AB25A222A063500769FC2 /* CreatePasswordViewModelTests.swift */,
 				D63BBD36217FC224007E01F0 /* CreditCardCellViewModel.swift */,
@@ -8149,6 +8152,7 @@
 				3777F2F92343C7AB0030BEF5 /* ManageViewPledgeRewardReceivedViewModelTests.swift in Sources */,
 				47AC2139264AD5430090AEDF /* CommentsViewModelTests.swift in Sources */,
 				A7ED1FE31E831C5C00BFFA01 /* FindFriendsFaceookConnectCellViewModelTests.swift in Sources */,
+				39E436F72C88D7D2009707BE /* NoShippingConfirmDetailsViewModelTests.swift in Sources */,
 				A7ED1FFB1E831C5C00BFFA01 /* ProjectPamphletMainCellViewModelTests.swift in Sources */,
 				A7ED1FE41E831C5C00BFFA01 /* EmptyStatesViewModelTests.swift in Sources */,
 				D04AACA8218BB72100CF713E /* FindFriendsCellViewModelTests.swift in Sources */,

--- a/Library/ViewModels/ConfirmDetailsViewModel.swift
+++ b/Library/ViewModels/ConfirmDetailsViewModel.swift
@@ -362,10 +362,14 @@ public class ConfirmDetailsViewModel: ConfirmDetailsViewModelType, ConfirmDetail
             return [String](repeating: reward.graphID, count: count)
           }
 
+        let locationId = selectedShippingRule == nil
+          ? nil
+          : String(selectedShippingRule!.location.id)
+
         return CreateCheckoutInput(
           projectId: project.graphID,
           amount: String(format: "%.2f", pledgeTotal),
-          locationId: "\(selectedShippingRule?.location.id)",
+          locationId: locationId,
           rewardIds: rewardsIDs,
           refParam: refTag?.stringTag
         )

--- a/Library/ViewModels/NoShippingConfirmDetailsViewModel.swift
+++ b/Library/ViewModels/NoShippingConfirmDetailsViewModel.swift
@@ -93,12 +93,14 @@ public class NoShippingConfirmDetailsViewModel: NoShippingConfirmDetailsViewMode
       calculatedShippingTotal
     )
 
-    /// Initial pledge amount is zero if not backed.
-    let initialPledgeAmount = Signal.merge(
-      initialData.filter { $0.project.personalization.backing == nil }.mapConst(0.0),
-      backing.map(\.bonusAmount)
-    )
-    .take(first: 1)
+    /// If initial data includes a custom pledge amount, use that.
+    /// If not, bonus amount is 0 if there's no backing.
+    let initialPledgeAmount = Signal.zip(initialData.map(\.bonusSupport), project)
+      .map { bonusSupport, project in
+        if let bonusSupport { return bonusSupport }
+        if let backing = project.personalization.backing { return backing.bonusAmount }
+        return 0.0
+      }
 
     /// Called when pledge or bonus is updated by backer
     let additionalPledgeAmount = Signal.merge(

--- a/Library/ViewModels/NoShippingConfirmDetailsViewModel.swift
+++ b/Library/ViewModels/NoShippingConfirmDetailsViewModel.swift
@@ -305,10 +305,14 @@ public class NoShippingConfirmDetailsViewModel: NoShippingConfirmDetailsViewMode
             return [String](repeating: reward.graphID, count: count)
           }
 
+        let locationId = selectedShippingRule == nil
+          ? nil
+          : String(selectedShippingRule!.location.id)
+
         return CreateCheckoutInput(
           projectId: project.graphID,
           amount: String(format: "%.2f", pledgeTotal),
-          locationId: "\(selectedShippingRule?.location.id)",
+          locationId: locationId,
           rewardIds: rewardsIDs,
           refParam: refTag?.stringTag
         )

--- a/Library/ViewModels/NoShippingConfirmDetailsViewModelTests.swift
+++ b/Library/ViewModels/NoShippingConfirmDetailsViewModelTests.swift
@@ -1,0 +1,546 @@
+import Foundation
+@testable import KsApi
+@testable import Library
+import PassKit
+import Prelude
+import ReactiveExtensions
+import ReactiveExtensions_TestHelpers
+import ReactiveSwift
+import XCTest
+
+final class NoShippingConfirmDetailsViewModelTests: TestCase {
+  private let vm: NoShippingConfirmDetailsViewModelType = NoShippingConfirmDetailsViewModel()
+
+  private let configurePledgeSummaryViewControllerWithDataConfirmationLabelHidden = TestObserver<
+    Bool,
+    Never
+  >()
+  private let configurePledgeSummaryViewControllerWithDataPledgeTotal = TestObserver<Double, Never>()
+  private let configurePledgeSummaryViewControllerWithDataProject = TestObserver<Project, Never>()
+
+  private let configureLocalPickupViewWithData = TestObserver<PledgeLocalPickupViewData, Never>()
+
+  private let createCheckoutSuccess = TestObserver<PostCampaignCheckoutData, Never>()
+
+  private let goToLoginSignup = TestObserver<(LoginIntent, Project, Reward?), Never>()
+
+  private let localPickupViewHidden = TestObserver<Bool, Never>()
+  private let pledgeAmountViewHidden = TestObserver<Bool, Never>()
+
+  private let showErrorBannerWithMessage = TestObserver<String, Never>()
+
+  override func setUp() {
+    super.setUp()
+
+    self.vm.outputs.configureLocalPickupViewWithData.observe(self.configureLocalPickupViewWithData.observer)
+
+    self.vm.outputs.configurePledgeSummaryViewControllerWithData.map { $0.2 }
+      .observe(self.configurePledgeSummaryViewControllerWithDataConfirmationLabelHidden.observer)
+    self.vm.outputs.configurePledgeSummaryViewControllerWithData.map { $0.1 }
+      .observe(self.configurePledgeSummaryViewControllerWithDataPledgeTotal.observer)
+    self.vm.outputs.configurePledgeSummaryViewControllerWithData.map { $0.0 }
+      .observe(self.configurePledgeSummaryViewControllerWithDataProject.observer)
+
+    self.vm.outputs.createCheckoutSuccess.observe(self.createCheckoutSuccess.observer)
+
+    self.vm.outputs.goToLoginSignup.observe(self.goToLoginSignup.observer)
+
+    self.vm.outputs.localPickupViewHidden.observe(self.localPickupViewHidden.observer)
+    self.vm.outputs.pledgeAmountViewHidden.observe(self.pledgeAmountViewHidden.observer)
+
+    self.vm.outputs.showErrorBannerWithMessage.observe(self.showErrorBannerWithMessage.observer)
+  }
+
+  // MARK: - Login/Signup
+
+  func testGoToLoginSignup_emitsWhenLoggedOut_createCheckoutSuccessDoesNotEmit() {
+    withEnvironment(currentUser: nil) {
+      let data = PledgeViewData(
+        project: Project.template,
+        rewards: [Reward.template],
+        selectedShippingRule: nil,
+        selectedQuantities: [Reward.template.id: 1],
+        selectedLocationId: nil,
+        refTag: .projectPage,
+        context: .latePledge
+      )
+
+      self.vm.inputs.configure(with: data)
+      self.vm.inputs.viewDidLoad()
+
+      self.vm.inputs.continueCTATapped()
+
+      self.goToLoginSignup.assertDidEmitValue()
+      self.createCheckoutSuccess.assertDidNotEmitValue()
+    }
+  }
+
+  func testGoToLoginSignup_doesNotEmitWhenLoggedIn_createCheckoutIsSuccessful() {
+    let expectedId = "Q2hlY2tvdXQtMTk4MzM2NjQ2"
+    let createCheckout = CreateCheckoutEnvelope.Checkout(
+      id: expectedId,
+      paymentUrl: "paymentUrl",
+      backingId: "backingId"
+    )
+    let mockService = MockService(
+      createCheckoutResult:
+      Result.success(CreateCheckoutEnvelope(checkout: createCheckout))
+    )
+
+    withEnvironment(apiService: mockService, currentUser: User.template) {
+      let data = PledgeViewData(
+        project: Project.template,
+        rewards: [Reward.template],
+        selectedShippingRule: nil,
+        selectedQuantities: [Reward.template.id: 1],
+        selectedLocationId: nil,
+        refTag: .projectPage,
+        context: .latePledge
+      )
+
+      self.vm.inputs.configure(with: data)
+      self.vm.inputs.viewDidLoad()
+
+      self.vm.inputs.userSessionStarted()
+
+      let expectedShipping = PledgeShippingSummaryViewData(
+        locationName: "Los Angeles, CA",
+        omitUSCurrencyCode: true,
+        projectCountry: .us,
+        total: 3
+      )
+
+      let expectedBonus = 5.0
+      self.vm.inputs.pledgeAmountViewControllerDidUpdate(
+        with: (amount: expectedBonus, min: 0, max: 100, isValid: true)
+      )
+
+      self.vm.inputs.continueCTATapped()
+
+      self.scheduler.run()
+
+      self.goToLoginSignup.assertDidNotEmitValue()
+
+      self.createCheckoutSuccess.assertDidEmitValue()
+    }
+  }
+
+  func testPledgeContext_LoggedIn() {
+    let mockService = MockService(serverConfig: ServerConfig.staging)
+
+    withEnvironment(apiService: mockService, currentUser: .template) {
+      let project = Project.template
+      let reward = Reward.template
+        |> Reward.lens.shipping.enabled .~ true
+
+      let data = PledgeViewData(
+        project: project,
+        rewards: [reward],
+        selectedShippingRule: nil,
+        selectedQuantities: [reward.id: 1],
+        selectedLocationId: nil,
+        refTag: .projectPage,
+        context: .pledge
+      )
+
+      self.vm.inputs.configure(with: data)
+      self.vm.inputs.viewDidLoad()
+
+      self.configurePledgeSummaryViewControllerWithDataConfirmationLabelHidden.assertValues([false])
+      self.configurePledgeSummaryViewControllerWithDataPledgeTotal.assertValues([reward.minimum])
+      self.configurePledgeSummaryViewControllerWithDataProject.assertValues([project])
+
+      self.pledgeAmountViewHidden.assertValues([false])
+    }
+  }
+
+  func testPledgeContext_LoggedOut() {
+    let mockService = MockService(serverConfig: ServerConfig.staging)
+
+    withEnvironment(apiService: mockService, currentUser: nil) {
+      let project = Project.template
+      let reward = Reward.template
+        |> Reward.lens.shipping.enabled .~ true
+
+      let data = PledgeViewData(
+        project: project,
+        rewards: [reward],
+        selectedShippingRule: nil,
+        selectedQuantities: [reward.id: 1],
+        selectedLocationId: nil,
+        refTag: .projectPage,
+        context: .pledge
+      )
+
+      self.vm.inputs.configure(with: data)
+      self.vm.inputs.viewDidLoad()
+
+      self.configurePledgeSummaryViewControllerWithDataConfirmationLabelHidden.assertValues([false])
+      self.configurePledgeSummaryViewControllerWithDataPledgeTotal.assertValues([reward.minimum])
+      self.configurePledgeSummaryViewControllerWithDataProject.assertValues([project])
+
+      self.pledgeAmountViewHidden.assertValues([false])
+    }
+  }
+
+  func testPledgeView_Logged_Out_Shipping_Disabled() {
+    withEnvironment(currentUser: nil) {
+      let project = Project.template
+      let reward = Reward.template
+        |> Reward.lens.shipping.enabled .~ false
+
+      let data = PledgeViewData(
+        project: project,
+        rewards: [reward],
+        selectedShippingRule: nil,
+        selectedQuantities: [reward.id: 1],
+        selectedLocationId: nil,
+        refTag: .projectPage,
+        context: .pledge
+      )
+
+      self.vm.inputs.configure(with: data)
+      self.vm.inputs.viewDidLoad()
+
+      self.configurePledgeSummaryViewControllerWithDataPledgeTotal.assertValues([reward.minimum])
+      self.configurePledgeSummaryViewControllerWithDataProject.assertValues([project])
+
+      self.pledgeAmountViewHidden.assertValues([false])
+    }
+  }
+
+  func testPledgeView_Logged_Out_Shipping_Enabled() {
+    withEnvironment(currentUser: nil) {
+      let project = Project.template
+      let reward = Reward.template
+        |> Reward.lens.shipping.enabled .~ true
+
+      let data = PledgeViewData(
+        project: project,
+        rewards: [reward],
+        selectedShippingRule: nil,
+        selectedQuantities: [reward.id: 1],
+        selectedLocationId: nil,
+        refTag: .projectPage,
+        context: .pledge
+      )
+
+      self.vm.inputs.configure(with: data)
+      self.vm.inputs.viewDidLoad()
+
+      self.configurePledgeSummaryViewControllerWithDataPledgeTotal.assertValues([reward.minimum])
+      self.configurePledgeSummaryViewControllerWithDataProject.assertValues([project])
+    }
+  }
+
+  func testPledgeView_Logged_In_Shipping_Disabled() {
+    let project = Project.template
+    let reward = Reward.template
+      |> Reward.lens.shipping.enabled .~ false
+
+    withEnvironment(currentUser: .template) {
+      let data = PledgeViewData(
+        project: project,
+        rewards: [reward],
+        selectedShippingRule: nil,
+        selectedQuantities: [reward.id: 1],
+        selectedLocationId: nil,
+        refTag: .projectPage,
+        context: .pledge
+      )
+
+      self.vm.inputs.configure(with: data)
+      self.vm.inputs.viewDidLoad()
+
+      self.configurePledgeSummaryViewControllerWithDataPledgeTotal.assertValues([reward.minimum])
+      self.configurePledgeSummaryViewControllerWithDataProject.assertValues([project])
+    }
+  }
+
+  func testPledgeView_Logged_In_Shipping_Enabled() {
+    let project = Project.template
+    let reward = Reward.template
+      |> Reward.lens.shipping.enabled .~ true
+
+    withEnvironment(currentUser: .template) {
+      let data = PledgeViewData(
+        project: project,
+        rewards: [reward],
+        selectedShippingRule: nil,
+        selectedQuantities: [reward.id: 1],
+        selectedLocationId: nil,
+        refTag: .projectPage,
+        context: .pledge
+      )
+
+      self.vm.inputs.configure(with: data)
+      self.vm.inputs.viewDidLoad()
+
+      self.configurePledgeSummaryViewControllerWithDataPledgeTotal.assertValues([reward.minimum])
+      self.configurePledgeSummaryViewControllerWithDataProject.assertValues([project])
+    }
+  }
+
+  func testPledgeAmountUpdates() {
+    let project = Project.template
+    let reward = Reward.template
+      |> Reward.lens.shipping.enabled .~ true
+
+    withEnvironment(currentUser: .template) {
+      let data = PledgeViewData(
+        project: project,
+        rewards: [reward],
+        bonusSupport: 10.0,
+        selectedShippingRule: nil,
+        selectedQuantities: [reward.id: 1],
+        selectedLocationId: nil,
+        refTag: .projectPage,
+        context: .pledge
+      )
+
+      self.vm.inputs.configure(with: data)
+      self.vm.inputs.viewDidLoad()
+
+      self.configurePledgeSummaryViewControllerWithDataPledgeTotal.assertValues([reward.minimum + 10.0])
+      self.configurePledgeSummaryViewControllerWithDataProject.assertValues([project])
+
+      self.pledgeAmountViewHidden.assertValues([false])
+
+      let data1 = (amount: 66.0, min: 10.0, max: 10_000.0, isValid: true)
+
+      self.vm.inputs.pledgeAmountViewControllerDidUpdate(with: data1)
+
+      self.configurePledgeSummaryViewControllerWithDataPledgeTotal.assertValues([20, 76])
+      self.configurePledgeSummaryViewControllerWithDataProject.assertValues([project, project])
+
+      let data2 = (amount: 93.0, min: 10.0, max: 10_000.0, isValid: true)
+
+      self.vm.inputs.pledgeAmountViewControllerDidUpdate(with: data2)
+
+      self.configurePledgeSummaryViewControllerWithDataPledgeTotal.assertValues([20, 76, 103])
+      self.configurePledgeSummaryViewControllerWithDataProject.assertValues([project, project, project])
+    }
+  }
+
+  func testLocalRewardViewHidden_IsVisible_RegularReward_Shipping_NoAddOns_RewardIsLocalPckup() {
+    self.localPickupViewHidden.assertDidNotEmitValue()
+
+    let reward = Reward.template
+      |> Reward.lens.shipping.enabled .~ false
+      |> Reward.lens.shipping.preference .~ .local
+      |> Reward.lens.localPickup .~ .losAngeles
+    let project = Project.template
+      |> Project.lens.rewardData.rewards .~ [reward]
+
+    let data = PledgeViewData(
+      project: project,
+      rewards: [reward],
+      selectedShippingRule: nil,
+      selectedQuantities: [reward.id: 1],
+      selectedLocationId: nil,
+      refTag: nil,
+      context: .pledge
+    )
+
+    self.vm.inputs.configure(with: data)
+    self.vm.inputs.viewDidLoad()
+
+    self.localPickupViewHidden.assertValues([false])
+  }
+
+  func testLocalRewardView_IsHidden_RegularReward_Shipping_HasAddOns_RewardIsNotLocalPickup() {
+    self.localPickupViewHidden.assertDidNotEmitValue()
+
+    let reward = Reward.template
+      |> Reward.lens.shipping.enabled .~ true
+      |> Reward.lens.shipping.preference .~ .unrestricted
+      |> Reward.lens.localPickup .~ .losAngeles
+    let addOnReward1 = Reward.template
+      |> Reward.lens.id .~ 2
+    let project = Project.template
+      |> Project.lens.rewardData.rewards .~ [reward]
+
+    let data = PledgeViewData(
+      project: project,
+      rewards: [reward, addOnReward1],
+      selectedShippingRule: nil,
+      selectedQuantities: [reward.id: 1, addOnReward1.id: 1],
+      selectedLocationId: nil,
+      refTag: nil,
+      context: .pledge
+    )
+
+    self.vm.inputs.configure(with: data)
+    self.vm.inputs.viewDidLoad()
+
+    self.localPickupViewHidden.assertValues([true])
+  }
+
+  func testConfigureLocalPickupViewWithData_Success() {
+    self.configureLocalPickupViewWithData.assertDidNotEmitValue()
+
+    let reward = Reward.template
+      |> Reward.lens.shipping.enabled .~ false
+      |> Reward.lens.localPickup .~ .losAngeles
+      |> Reward.lens.shipping.preference .~ .local
+
+    let addOnReward1 = Reward.template
+      |> Reward.lens.id .~ 2
+      |> Reward.lens.shipping.enabled .~ false
+
+    let project = Project.template
+      |> Project.lens.rewardData.rewards .~ [reward]
+
+    let shippingRule = ShippingRule.template
+
+    let data = PledgeViewData(
+      project: project,
+      rewards: [reward, addOnReward1],
+      selectedShippingRule: nil,
+      selectedQuantities: [reward.id: 1, addOnReward1.id: 1],
+      selectedLocationId: shippingRule.id,
+      refTag: nil,
+      context: .pledge
+    )
+
+    self.vm.inputs.configure(with: data)
+    self.vm.inputs.viewDidLoad()
+
+    self.configureLocalPickupViewWithData.assertValues([
+      PledgeLocalPickupViewData(locationName: "Los Angeles, CA")
+    ])
+  }
+
+  // TODO(MBL-1687): This test should be fixed when the corresponding flow works.
+  func testContinueButton_CallsCreateBackingMutation_Success() throws {
+    throw XCTSkip()
+    let expectedId = "Q2hlY2tvdXQtMTk4MzM2NjQ2"
+    let createCheckout = CreateCheckoutEnvelope.Checkout(
+      id: expectedId,
+      paymentUrl: "paymentUrl",
+      backingId: "backingId"
+    )
+
+    let mockService = MockService(
+      createCheckoutResult:
+      Result.success(CreateCheckoutEnvelope(checkout: createCheckout))
+    )
+
+    withEnvironment(apiService: mockService, currentUser: .template) {
+      let reward = Reward.template
+        |> Reward.lens.shipping.enabled .~ true
+        |> Reward.lens.shipping.preference .~ .unrestricted
+        |> Reward.lens.localPickup .~ .losAngeles
+      let addOnReward1 = Reward.template
+        |> Reward.lens.id .~ 2
+      let project = Project.template
+        |> Project.lens.rewardData.rewards .~ [reward]
+
+      let expectedRewards = [reward, addOnReward1]
+      let selectedQuantities = [reward.id: 1, addOnReward1.id: 1]
+      let data = PledgeViewData(
+        project: project,
+        rewards: expectedRewards,
+        selectedShippingRule: nil,
+        selectedQuantities: selectedQuantities,
+        selectedLocationId: ShippingRule.template.id,
+        refTag: nil,
+        context: .pledge
+      )
+
+      self.vm.inputs.configure(with: data)
+      self.vm.inputs.viewDidLoad()
+
+      let expectedShipping = PledgeShippingSummaryViewData(
+        locationName: "Los Angeles, CA",
+        omitUSCurrencyCode: true,
+        projectCountry: .us,
+        total: 3
+      )
+
+      let selectedShippingRule = ShippingRule(
+        cost: expectedShipping.total,
+        id: nil,
+        location: .losAngeles,
+        estimatedMin: Money(amount: 1.0),
+        estimatedMax: Money(amount: 10.0)
+      )
+
+      let expectedBonus = 5.0
+      self.vm.inputs.pledgeAmountViewControllerDidUpdate(
+        with: (amount: expectedBonus, min: 0, max: 100, isValid: true)
+      )
+
+      self.vm.inputs.continueCTATapped()
+
+      self.scheduler.run()
+
+      self.showErrorBannerWithMessage.assertDidNotEmitValue()
+
+      self.createCheckoutSuccess.assertDidEmitValue()
+      let expectedValue = PostCampaignCheckoutData(
+        project: project,
+        baseReward: reward,
+        rewards: expectedRewards,
+        selectedQuantities: selectedQuantities,
+        bonusAmount: expectedBonus,
+        total: 28,
+        shipping: expectedShipping,
+        refTag: nil,
+        context: .pledge,
+        checkoutId: "198336646",
+        backingId: "backingId",
+        selectedShippingRule: selectedShippingRule
+      )
+      self.createCheckoutSuccess.assertValue(expectedValue)
+    }
+  }
+
+  func testContinueButton_CallsCreateBackingMutation_Failure_ShowsErrorMessageBanner() {
+    let createCheckout = CreateCheckoutEnvelope.Checkout(
+      id: "id",
+      paymentUrl: "paymentUrl",
+      backingId: "backingId"
+    )
+    let errorUnknown = ErrorEnvelope(
+      errorMessages: ["Something went wrong yo."],
+      ksrCode: .UnknownCode,
+      httpCode: 400,
+      exception: nil
+    )
+
+    let mockService = MockService(createCheckoutResult: Result.failure(errorUnknown))
+
+    withEnvironment(apiService: mockService, currentUser: .template) {
+      let reward = Reward.template
+        |> Reward.lens.shipping.enabled .~ true
+        |> Reward.lens.shipping.preference .~ .unrestricted
+        |> Reward.lens.localPickup .~ .losAngeles
+      let addOnReward1 = Reward.template
+        |> Reward.lens.id .~ 2
+      let project = Project.template
+        |> Project.lens.rewardData.rewards .~ [reward]
+
+      let data = PledgeViewData(
+        project: project,
+        rewards: [reward, addOnReward1],
+        selectedShippingRule: nil,
+        selectedQuantities: [reward.id: 1, addOnReward1.id: 1],
+        selectedLocationId: ShippingRule.template.id,
+        refTag: nil,
+        context: .pledge
+      )
+
+      self.vm.inputs.configure(with: data)
+      self.vm.inputs.viewDidLoad()
+
+      self.vm.inputs.continueCTATapped()
+
+      self.scheduler.run()
+
+      self.createCheckoutSuccess.assertDidNotEmitValue()
+
+      self.showErrorBannerWithMessage.assertValue(Strings.Something_went_wrong_please_try_again())
+    }
+  }
+}

--- a/Library/ViewModels/NoShippingConfirmDetailsViewModelTests.swift
+++ b/Library/ViewModels/NoShippingConfirmDetailsViewModelTests.swift
@@ -411,9 +411,7 @@ final class NoShippingConfirmDetailsViewModelTests: TestCase {
     ])
   }
 
-  // TODO(MBL-1687): This test should be fixed when the corresponding flow works.
-  func testContinueButton_CallsCreateBackingMutation_Success() throws {
-    throw XCTSkip()
+  func testContinueButton_CallsCreateBackingMutation_Success() {
     let expectedId = "Q2hlY2tvdXQtMTk4MzM2NjQ2"
     let createCheckout = CreateCheckoutEnvelope.Checkout(
       id: expectedId,
@@ -438,10 +436,26 @@ final class NoShippingConfirmDetailsViewModelTests: TestCase {
 
       let expectedRewards = [reward, addOnReward1]
       let selectedQuantities = [reward.id: 1, addOnReward1.id: 1]
+
+      let expectedShipping = PledgeShippingSummaryViewData(
+        locationName: "United States",
+        omitUSCurrencyCode: true,
+        projectCountry: .us,
+        total: 3
+      )
+
+      let selectedShippingRule = ShippingRule(
+        cost: expectedShipping.total,
+        id: 47,
+        location: .usa,
+        estimatedMin: Money(amount: 1.0),
+        estimatedMax: Money(amount: 10.0)
+      )
+
       let data = PledgeViewData(
         project: project,
         rewards: expectedRewards,
-        selectedShippingRule: nil,
+        selectedShippingRule: selectedShippingRule,
         selectedQuantities: selectedQuantities,
         selectedLocationId: ShippingRule.template.id,
         refTag: nil,
@@ -450,21 +464,6 @@ final class NoShippingConfirmDetailsViewModelTests: TestCase {
 
       self.vm.inputs.configure(with: data)
       self.vm.inputs.viewDidLoad()
-
-      let expectedShipping = PledgeShippingSummaryViewData(
-        locationName: "Los Angeles, CA",
-        omitUSCurrencyCode: true,
-        projectCountry: .us,
-        total: 3
-      )
-
-      let selectedShippingRule = ShippingRule(
-        cost: expectedShipping.total,
-        id: nil,
-        location: .losAngeles,
-        estimatedMin: Money(amount: 1.0),
-        estimatedMax: Money(amount: 10.0)
-      )
 
       let expectedBonus = 5.0
       self.vm.inputs.pledgeAmountViewControllerDidUpdate(

--- a/Library/ViewModels/PostCampaignPledgeRewardsSummaryViewModel.swift
+++ b/Library/ViewModels/PostCampaignPledgeRewardsSummaryViewModel.swift
@@ -189,22 +189,20 @@ private func items(
   }
   var items = [headerItem] + rewardItems
 
-  if featureNoShippingAtCheckout() == false {
-    // MARK: Shipping
+  // MARK: Shipping
 
-    if let shipping = data.shipping {
-      let shippingAmountAttributedText = attributedRewardCurrency(
-        with: data.projectCountry, amount: shipping.total, omitUSCurrencyCode: data.omitCurrencyCode
-      )
+  if let shipping = data.shipping, shipping.total > 0 {
+    let shippingAmountAttributedText = attributedRewardCurrency(
+      with: data.projectCountry, amount: shipping.total, omitUSCurrencyCode: data.omitCurrencyCode
+    )
 
-      let shippingItem = PostCampaignRewardsSummaryItem.reward((
-        headerText: nil,
-        text: Strings.Shipping_to_country(country: shipping.locationName),
-        amount: shippingAmountAttributedText
-      ))
+    let shippingItem = PostCampaignRewardsSummaryItem.reward((
+      headerText: nil,
+      text: Strings.Shipping_to_country(country: shipping.locationName),
+      amount: shippingAmountAttributedText
+    ))
 
-      items.append(shippingItem)
-    }
+    items.append(shippingItem)
   }
 
   // MARK: Bonus

--- a/Library/ViewModels/WithShippingRewardsCollectionViewModel.swift
+++ b/Library/ViewModels/WithShippingRewardsCollectionViewModel.swift
@@ -66,9 +66,14 @@ public final class WithShippingRewardsCollectionViewModel: WithShippingRewardsCo
       .map(first)
       .map(titleForContext)
 
-    self.scrollToBackedRewardIndexPath = Signal.combineLatest(project, rewards)
+    self.scrollToBackedRewardIndexPath = Signal.combineLatest(project, rewards, filteredByLocationRewards)
       .takeWhen(self.viewDidLayoutSubviewsProperty.signal.ignoreValues())
-      .map(backedReward(_:rewards:))
+      .map { project, rewards, filteredRewardsByLocation in
+        backedReward(
+          project,
+          rewards: filteredRewardsByLocation.isEmpty ? rewards : filteredRewardsByLocation
+        )
+      }
       .skipNil()
       .take(first: 1)
 


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

We accidentally introduced a bug where the late pledge flow can't be completed because the location id isn't correctly transformed to a string. This fixes that bug and the "no shipping" test that I thought might be related that ended up not being related after all.

# 👀 See

[Jira](https://kickstarter.atlassian.net/browse/MBL-1687)

| With flag off | With flag on |
| --- | --- |
| ![Simulator Screen Recording - iPhone 15 Plus - 2024-09-05 at 12 59 12](https://github.com/user-attachments/assets/ec882e5b-3380-4c38-9245-2e9e8a98823a) | ![Simulator Screen Recording - iPhone 15 Plus - 2024-09-05 at 13 01 18](https://github.com/user-attachments/assets/7a5fce77-f595-4341-bc7b-e626e07acde9) |

# ✅ Acceptance criteria

- [x] Checkout id is created successfully and user can navigate from confirm details to checkout screen. Tested with and without flag on and with and without shipping

