### PR TITLE
[MBL-1687] Fix continue button on confirm details page not working #2147

### DIFF
--- a/Library/ViewModels/ConfirmDetailsViewModel.swift
+++ b/Library/ViewModels/ConfirmDetailsViewModel.swift
@@ -362,10 +362,14 @@ public class ConfirmDetailsViewModel: ConfirmDetailsViewModelType, ConfirmDetail
             return [String](repeating: reward.graphID, count: count)
           }
 
+        let locationId = selectedShippingRule == nil
+          ? nil
+          : String(selectedShippingRule!.location.id)
+
         return CreateCheckoutInput(
           projectId: project.graphID,
           amount: String(format: "%.2f", pledgeTotal),
-          locationId: "\(selectedShippingRule?.location.id)",
+          locationId: locationId,
           rewardIds: rewardsIDs,
           refParam: refTag?.stringTag
         )

--- a/Library/ViewModels/ConfirmDetailsViewModel.swift
+++ b/Library/ViewModels/ConfirmDetailsViewModel.swift
@@ -362,9 +362,7 @@ public class ConfirmDetailsViewModel: ConfirmDetailsViewModelType, ConfirmDetail
             return [String](repeating: reward.graphID, count: count)
           }
 
-        let locationId = selectedShippingRule == nil
-          ? nil
-          : String(selectedShippingRule!.location.id)
+        let locationId = selectedShippingRule.flatMap { String($0.location.id) }
 
         return CreateCheckoutInput(
           projectId: project.graphID,

--- a/Library/ViewModels/NoShippingConfirmDetailsViewModel.swift
+++ b/Library/ViewModels/NoShippingConfirmDetailsViewModel.swift
@@ -305,9 +305,7 @@ public class NoShippingConfirmDetailsViewModel: NoShippingConfirmDetailsViewMode
             return [String](repeating: reward.graphID, count: count)
           }
 
-        let locationId = selectedShippingRule == nil
-          ? nil
-          : String(selectedShippingRule!.location.id)
+        let locationId = selectedShippingRule.flatMap { String($0.location.id) }
 
         return CreateCheckoutInput(
           projectId: project.graphID,

--- a/Library/ViewModels/NoShippingConfirmDetailsViewModel.swift
+++ b/Library/ViewModels/NoShippingConfirmDetailsViewModel.swift
@@ -305,10 +305,14 @@ public class NoShippingConfirmDetailsViewModel: NoShippingConfirmDetailsViewMode
             return [String](repeating: reward.graphID, count: count)
           }
 
+        let locationId = selectedShippingRule == nil
+          ? nil
+          : String(selectedShippingRule!.location.id)
+
         return CreateCheckoutInput(
           projectId: project.graphID,
           amount: String(format: "%.2f", pledgeTotal),
-          locationId: "\(selectedShippingRule?.location.id)",
+          locationId: locationId,
           rewardIds: rewardsIDs,
           refParam: refTag?.stringTag
         )

--- a/Library/ViewModels/NoShippingConfirmDetailsViewModelTests.swift
+++ b/Library/ViewModels/NoShippingConfirmDetailsViewModelTests.swift
@@ -411,9 +411,7 @@ final class NoShippingConfirmDetailsViewModelTests: TestCase {
     ])
   }
 
-  // TODO(MBL-1687): This test should be fixed when the corresponding flow works.
-  func testContinueButton_CallsCreateBackingMutation_Success() throws {
-    throw XCTSkip()
+  func testContinueButton_CallsCreateBackingMutation_Success() {
     let expectedId = "Q2hlY2tvdXQtMTk4MzM2NjQ2"
     let createCheckout = CreateCheckoutEnvelope.Checkout(
       id: expectedId,
@@ -438,10 +436,26 @@ final class NoShippingConfirmDetailsViewModelTests: TestCase {
 
       let expectedRewards = [reward, addOnReward1]
       let selectedQuantities = [reward.id: 1, addOnReward1.id: 1]
+
+      let expectedShipping = PledgeShippingSummaryViewData(
+        locationName: "United States",
+        omitUSCurrencyCode: true,
+        projectCountry: .us,
+        total: 3
+      )
+
+      let selectedShippingRule = ShippingRule(
+        cost: expectedShipping.total,
+        id: 47,
+        location: .usa,
+        estimatedMin: Money(amount: 1.0),
+        estimatedMax: Money(amount: 10.0)
+      )
+
       let data = PledgeViewData(
         project: project,
         rewards: expectedRewards,
-        selectedShippingRule: nil,
+        selectedShippingRule: selectedShippingRule,
         selectedQuantities: selectedQuantities,
         selectedLocationId: ShippingRule.template.id,
         refTag: nil,
@@ -450,21 +464,6 @@ final class NoShippingConfirmDetailsViewModelTests: TestCase {
 
       self.vm.inputs.configure(with: data)
       self.vm.inputs.viewDidLoad()
-
-      let expectedShipping = PledgeShippingSummaryViewData(
-        locationName: "Los Angeles, CA",
-        omitUSCurrencyCode: true,
-        projectCountry: .us,
-        total: 3
-      )
-
-      let selectedShippingRule = ShippingRule(
-        cost: expectedShipping.total,
-        id: nil,
-        location: .losAngeles,
-        estimatedMin: Money(amount: 1.0),
-        estimatedMax: Money(amount: 10.0)
-      )
 
       let expectedBonus = 5.0
       self.vm.inputs.pledgeAmountViewControllerDidUpdate(


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

We accidentally introduced a bug where the late pledge flow can't be completed because the location id isn't correctly transformed to a string. This fixes that bug and the "no shipping" test that I thought might be related that ended up not being related after all.

# 👀 See

[Jira](https://kickstarter.atlassian.net/browse/MBL-1687)

| With flag off | With flag on |
| --- | --- |
| ![Simulator Screen Recording - iPhone 15 Plus - 2024-09-05 at 12 59 12](https://github.com/user-attachments/assets/ec882e5b-3380-4c38-9245-2e9e8a98823a) | ![Simulator Screen Recording - iPhone 15 Plus - 2024-09-05 at 13 01 18](https://github.com/user-attachments/assets/7a5fce77-f595-4341-bc7b-e626e07acde9) |

# ✅ Acceptance criteria

- [x] Checkout id is created successfully and user can navigate from confirm details to checkout screen. Tested with and without flag on and with and without shipping

