### PR TITLE
[MBL-1712] No Reward Option Not Shown in Edit Reward Flow

### DIFF
--- a/Library/SharedFunctions.swift
+++ b/Library/SharedFunctions.swift
@@ -367,7 +367,7 @@ public func rewardsCarouselCanNavigateToReward(_ reward: Reward, in project: Pro
 
   let isBacking = userIsBacking(reward: reward, inProject: project)
   let isAvailableForNewBacker = rewardIsAvailable(reward) && !isBacking
-  let isAvailableForExistingBackerToEdit = (isBacking && reward.hasAddOns)
+  let isAvailableForExistingBackerToEdit = (isBacking && (reward.hasAddOns || featureNoShippingAtCheckout()))
 
   if featurePostCampaignPledgeEnabled(), project.isInPostCampaignPledgingPhase {
     return [

--- a/Library/ViewModels/NoShippingPledgeViewModel.swift
+++ b/Library/ViewModels/NoShippingPledgeViewModel.swift
@@ -1076,7 +1076,8 @@ private func amountValid(
    that is, in `RewardAddOnSelectionViewController` we don't navigate further unless the selection changes.
    */
   return [
-    pledgeAmountData.amount != initialAdditionalPledgeAmount || reward.hasAddOns,
+    pledgeAmountData
+      .amount != initialAdditionalPledgeAmount || (reward.hasAddOns || featureNoShippingAtCheckout()),
     pledgeAmountData.isValid
   ]
   .allSatisfy(isTrue)

--- a/Library/ViewModels/RewardCardContainerViewModel.swift
+++ b/Library/ViewModels/RewardCardContainerViewModel.swift
@@ -105,7 +105,7 @@ private func pledgeButtonTitle(project: Project, reward: Reward) -> String? {
   case (.backed(.live), false, true):
     return Strings.Select()
   case (.backed(.live), true, _), (.backed(.nonLive), true, _):
-    if reward.hasAddOns, project.state == .live {
+    if reward.hasAddOns || featureNoShippingAtCheckout(), project.state == .live {
       return Strings.Continue()
     }
     return Strings.Selected()
@@ -135,7 +135,7 @@ private func buttonStyleType(project: Project, reward: Reward) -> ButtonStyleTyp
     }
   case .backed(.live):
     if isBackingThisReward {
-      if reward.hasAddOns {
+      if reward.hasAddOns || featureNoShippingAtCheckout() {
         return .green
       }
       return .black

--- a/Library/ViewModels/WithShippingRewardsCollectionViewModel.swift
+++ b/Library/ViewModels/WithShippingRewardsCollectionViewModel.swift
@@ -476,8 +476,8 @@ private func filteredRewardsByLocation(
     let isUnrestrictedShippingReward = reward.isUnRestrictedShippingPreference
     let isRestrictedShippingReward = reward.isRestrictedShippingPreference
 
-    // return all rewards that are digital or ship anywhere in the world.
-    if isRewardLocalOrDigital || isUnrestrictedShippingReward {
+    // return all rewards that are, no reward, digital, or ship anywhere in the world.
+    if rewards.first?.id == reward.id || isRewardLocalOrDigital || isUnrestrictedShippingReward {
       shouldDisplayReward = true
 
       // if add on is local pickup, ensure locations are equal.


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Bug found in QA
- When pledging with a "no reward" selection this option wasn't being shown in the "Edit Reward" flow.
- It also wasn't selectable/editable

# 🤔 Why

- We should be showing the currently selected reward
- We also need them to be selectable so that backers can update their pledge/bonus amounts. Since those steppers were moved to the rewards screen we need to update this behavior.

# 🛠 How

Instead of only allowing rewards in the "Edit Rewards" flow to be editable if they have addons we should update this so that this condition is true if it has add ons _and/or_ the no shipping at checkout feature flag is on.

# 👀 See

![Simulator Screen Recording - iPhone 15 Pro 17 5 - 2024-09-06 at 13 22 31](https://github.com/user-attachments/assets/c9cfcb28-14b2-4471-9817-c57854a58529)

# ✅ Acceptance criteria

- [ ] Backers can select their current pledged reward and adjust their bonus/pledge amounts
- [ ] Backers can change rewards/add-ons etc. successfully
- [ ] When the feature flag is off, "edit reward" and "manage pledge" flows work as normal
