### PR TITLE
[MBL-1501] PPO view model navigation events

### DIFF
--- a/Kickstarter-iOS/Features/PaginationExample/PaginationExampleViewModel.swift
+++ b/Kickstarter-iOS/Features/PaginationExample/PaginationExampleViewModel.swift
@@ -20,6 +20,7 @@ internal class PaginationExampleViewModel: ObservableObject {
       cursorFromEnvelope: {
         $0.urls.api.moreProjects
       },
+      totalFromEnvelope: { _ in nil },
       requestFromParams: {
         AppEnvironment.current.apiService.fetchDiscovery_combine(params: $0)
       },
@@ -49,7 +50,7 @@ internal class PaginationExampleViewModel: ObservableObject {
         return "Waiting to load"
       case .loading:
         return "Loading"
-      case let .someLoaded(values, _):
+      case let .someLoaded(values, _, _):
         return "Got \(values.count) results; more are available"
       case .allLoaded:
         return "Loaded all results"

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOContainerViewController.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOContainerViewController.swift
@@ -5,7 +5,6 @@ import SwiftUI
 
 public class PPOContainerViewController: PagedContainerViewController<PPOContainerViewController.Page> {
   private let viewModel = PPOContainerViewModel()
-  private var ppoViewModel = PPOViewModel()
 
   public override func viewDidLoad() {
     super.viewDidLoad()
@@ -13,9 +12,14 @@ public class PPOContainerViewController: PagedContainerViewController<PPOContain
     // TODO: Translate these strings (MBL-1558)
     self.title = "Activity"
 
-    let ppoView = PPOView(viewModel: self.ppoViewModel, onCountChange: { [weak self] count in
-      self?.viewModel.projectAlertsCountChanged(count)
-    })
+    let ppoView = PPOView(
+      onCountChange: { [weak self] count in
+        self?.viewModel.projectAlertsCountChanged(count)
+      },
+      onNavigate: { [weak self] event in
+        self?.viewModel.handle(navigationEvent: event)
+      }
+    )
     let ppoViewController = UIHostingController(rootView: ppoView)
     ppoViewController.title = "Project Alerts"
 
@@ -41,7 +45,7 @@ public class PPOContainerViewController: PagedContainerViewController<PPOContain
     }
     .store(in: &self.subscriptions)
 
-    ppoView.viewModel.navigationEvents.sink { nav in
+    self.viewModel.navigationEvents.sink { nav in
       switch nav {
       case .backingPage:
         tabBarController?.switchToProfile()

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOContainerViewController.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOContainerViewController.swift
@@ -4,7 +4,7 @@ import Library
 import SwiftUI
 
 public class PPOContainerViewController: PagedContainerViewController<PPOContainerViewController.Page> {
-  var ppoViewModel = PPOViewModel()
+  private var ppoViewModel = PPOViewModel()
 
   public override func viewDidLoad() {
     super.viewDidLoad()
@@ -12,11 +12,7 @@ public class PPOContainerViewController: PagedContainerViewController<PPOContain
     // TODO: Translate these strings (MBL-1558)
     self.title = "Activity"
 
-    let ppoView = PPOView(viewModel: Binding(get: {
-      self.ppoViewModel
-    }, set: {
-      self.ppoViewModel = $0
-    }))
+    let ppoView = PPOView(viewModel: self.ppoViewModel)
     let ppoViewController = UIHostingController(rootView: ppoView)
     ppoViewController.title = "Project Alerts"
 
@@ -30,7 +26,7 @@ public class PPOContainerViewController: PagedContainerViewController<PPOContain
 
     let tabBarController = self.tabBarController as? RootTabBarViewController
 
-    ppoViewModel.$results.sink { [weak self] results in
+    self.ppoViewModel.$results.sink { [weak self] results in
       let badge: TabBarBadge = results.values.count > 0 ? .count(results.values.count) : .none
       self?.setPagedViewControllers([
         (.projectAlerts(badge), ppoViewController),
@@ -43,7 +39,7 @@ public class PPOContainerViewController: PagedContainerViewController<PPOContain
       case .backingPage:
         tabBarController?.switchToProfile()
       case .confirmAddress, .contactCreator, .fix3DSChallenge, .fixPaymentMethod, .survey:
-        // TODO MBL-1451
+        // TODO: MBL-1451
         break
       }
     }.store(in: &self.subscriptions)

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOContainerViewController.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOContainerViewController.swift
@@ -1,3 +1,4 @@
+import Combine
 import Foundation
 import Library
 import SwiftUI
@@ -9,8 +10,8 @@ public class PPOContainerViewController: PagedContainerViewController<PPOContain
     // TODO: Translate these strings (MBL-1558)
     self.title = "Activity"
 
-    let tabBarController = self.tabBarController as? RootTabBarViewController
-    let ppoViewController = UIHostingController(rootView: PPOView(tabBarController: tabBarController))
+    let ppoView = PPOView()
+    let ppoViewController = UIHostingController(rootView: ppoView)
     ppoViewController.title = "Project Alerts"
 
     let activitiesViewController = ActivitiesViewController.instantiate()
@@ -20,6 +21,18 @@ public class PPOContainerViewController: PagedContainerViewController<PPOContain
       (.projectAlerts(.count(5)), ppoViewController),
       (.activityFeed(.dot), activitiesViewController)
     ])
+
+    let tabBarController = self.tabBarController as? RootTabBarViewController
+
+    ppoView.viewModel.navigationEvents.sink { nav in
+      switch nav {
+      case .backingPage:
+        tabBarController?.switchToProfile()
+      case .confirmAddress, .contactCreator, .fix3DSChallenge, .fixPaymentMethod, .survey:
+        // TODO MBL-1451
+        break
+      }
+    }.store(in: &self.subscriptions)
   }
 
   public enum Page: TabBarPage {
@@ -49,4 +62,6 @@ public class PPOContainerViewController: PagedContainerViewController<PPOContain
       self.name
     }
   }
+
+  private var subscriptions = Set<AnyCancellable>()
 }

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOContainerViewController.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOContainerViewController.swift
@@ -47,7 +47,7 @@ public class PPOContainerViewController: PagedContainerViewController<PPOContain
 
     self.viewModel.navigationEvents.sink { nav in
       switch nav {
-      case .backingPage:
+      case .backedProjects:
         tabBarController?.switchToProfile()
       case .confirmAddress, .contactCreator, .fix3DSChallenge, .fixPaymentMethod, .survey:
         // TODO: MBL-1451

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOContainerViewController.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOContainerViewController.swift
@@ -27,7 +27,7 @@ public class PPOContainerViewController: PagedContainerViewController<PPOContain
     let tabBarController = self.tabBarController as? RootTabBarViewController
 
     self.ppoViewModel.$results.sink { [weak self] results in
-      let badge: TabBarBadge = results.values.count > 0 ? .count(results.values.count) : .none
+      let badge: TabBarBadge = results.total.flatMap { count in .count(count) } ?? .none
       self?.setPagedViewControllers([
         (.projectAlerts(badge), ppoViewController),
         (.activityFeed(.dot), activitiesViewController)

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOContainerViewModel.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOContainerViewModel.swift
@@ -6,11 +6,13 @@ import Library
 protocol PPOContainerViewModelInputs {
   func viewWillAppear()
   func projectAlertsCountChanged(_ count: Int?)
+  func handle(navigationEvent: PPONavigationEvent)
 }
 
 protocol PPOContainerViewModelOutputs {
   var projectAlertsBadge: AnyPublisher<TabBarBadge, Never> { get }
   var activityBadge: AnyPublisher<TabBarBadge, Never> { get }
+  var navigationEvents: AnyPublisher<PPONavigationEvent, Never> { get }
 }
 
 final class PPOContainerViewModel: PPOContainerViewModelInputs, PPOContainerViewModelOutputs {
@@ -56,6 +58,10 @@ final class PPOContainerViewModel: PPOContainerViewModelInputs, PPOContainerView
     self.projectAlertsCountSubject.send(count)
   }
 
+  func handle(navigationEvent: PPONavigationEvent) {
+    self.handleNavigationEventSubject.send(navigationEvent)
+  }
+
   // MARK: - Outputs
 
   var projectAlertsBadge: AnyPublisher<TabBarBadge, Never> {
@@ -66,12 +72,17 @@ final class PPOContainerViewModel: PPOContainerViewModelInputs, PPOContainerView
     self.activityBadgeSubject.eraseToAnyPublisher()
   }
 
+  var navigationEvents: AnyPublisher<PPONavigationEvent, Never> {
+    self.handleNavigationEventSubject.eraseToAnyPublisher()
+  }
+
   // MARK: - Private
 
   private var viewWillAppearSubject = PassthroughSubject<Void, Never>()
   private var projectAlertsCountSubject = CurrentValueSubject<Int?, Never>(nil)
   private var projectAlertsBadgeSubject = CurrentValueSubject<TabBarBadge, Never>(.none)
   private var activityBadgeSubject = CurrentValueSubject<TabBarBadge, Never>(.none)
+  private var handleNavigationEventSubject = CurrentValueSubject<PPONavigationEvent, Never>(.none)
 
   private var cancellables: Set<AnyCancellable> = []
 }

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOContainerViewModel.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOContainerViewModel.swift
@@ -82,7 +82,7 @@ final class PPOContainerViewModel: PPOContainerViewModelInputs, PPOContainerView
   private var projectAlertsCountSubject = CurrentValueSubject<Int?, Never>(nil)
   private var projectAlertsBadgeSubject = CurrentValueSubject<TabBarBadge, Never>(.none)
   private var activityBadgeSubject = CurrentValueSubject<TabBarBadge, Never>(.none)
-  private var handleNavigationEventSubject = CurrentValueSubject<PPONavigationEvent, Never>(.none)
+  private var handleNavigationEventSubject = PassthroughSubject<PPONavigationEvent, Never>()
 
   private var cancellables: Set<AnyCancellable> = []
 }

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOContainerViewModel.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOContainerViewModel.swift
@@ -1,0 +1,69 @@
+import Combine
+import Foundation
+import KsApi
+import Library
+
+protocol PPOContainerViewModelInputs {
+  func viewWillAppear()
+}
+
+protocol PPOContainerViewModelOutputs {
+  var pledgedProjectsOverviewBadge: AnyPublisher<TabBarBadge, Never> { get }
+  var activityBadge: AnyPublisher<TabBarBadge, Never> { get }
+}
+
+final class PPOContainerViewModel: PPOContainerViewModelInputs, PPOContainerViewModelOutputs {
+  init() {
+    let sessionStarted = NotificationCenter.default
+      .publisher(for: .ksr_sessionStarted)
+      .map { _ in () }
+
+    let sessionEnded = NotificationCenter.default
+      .publisher(for: .ksr_sessionEnded)
+      .map { _ in () }
+
+    let userUpdated = NotificationCenter.default
+      .publisher(for: .ksr_userUpdated)
+      .map { _ in () }
+
+    let currentUser = Publishers.Merge4(
+      self.viewWillAppearSubject,
+      userUpdated,
+      sessionStarted,
+      sessionEnded
+    )
+    .map { _ in AppEnvironment.current.currentUser }
+
+    currentUser
+      .map { user -> TabBarBadge in
+        user?.unseenActivityCount
+          .flatMap { count -> TabBarBadge in count == 0 ? .none : .count(count) } ?? .none
+      }
+      .subscribe(self.activityBadgeSubject)
+      .store(in: &self.cancellables)
+  }
+
+  // MARK: - Inputs
+
+  func viewWillAppear() {
+    self.viewWillAppearSubject.send()
+  }
+
+  // MARK: - Outputs
+
+  var pledgedProjectsOverviewBadge: AnyPublisher<TabBarBadge, Never> {
+    self.pledgedProjectsOverviewBadgeSubject.eraseToAnyPublisher()
+  }
+
+  var activityBadge: AnyPublisher<TabBarBadge, Never> {
+    self.activityBadgeSubject.eraseToAnyPublisher()
+  }
+
+  // MARK: - Private
+
+  private var viewWillAppearSubject = PassthroughSubject<Void, Never>()
+  private var pledgedProjectsOverviewBadgeSubject = CurrentValueSubject<TabBarBadge, Never>(.none)
+  private var activityBadgeSubject = CurrentValueSubject<TabBarBadge, Never>(.none)
+
+  private var cancellables: Set<AnyCancellable> = []
+}

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOEmptyStateView.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOEmptyStateView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct PPOEmptyStateView: View {
-  let viewModel: PPOViewModel?
+  var onOpenBackedProjects: (() -> Void)? = nil
 
   private enum Constants {
     public static let largePadding = 24.0
@@ -28,7 +28,7 @@ struct PPOEmptyStateView: View {
           .multilineTextAlignment(.center)
 
         Button("See all backed projects") {
-          self.viewModel?.openBackedProjects()
+          self.onOpenBackedProjects?()
         }
         .buttonStyle(GreenButtonStyle())
       }
@@ -43,5 +43,5 @@ struct PPOEmptyStateView: View {
 }
 
 #Preview {
-  PPOEmptyStateView(viewModel: nil)
+  PPOEmptyStateView()
 }

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOEmptyStateView.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOEmptyStateView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct PPOEmptyStateView: View {
-  weak var tabBarController: RootTabBarViewController?
+  let viewModel: PPOViewModel?
 
   private enum Constants {
     public static let largePadding = 24.0
@@ -28,7 +28,7 @@ struct PPOEmptyStateView: View {
           .multilineTextAlignment(.center)
 
         Button("See all backed projects") {
-          self.tabBarController?.switchToProfile()
+          self.viewModel?.openBackedProjects()
         }
         .buttonStyle(GreenButtonStyle())
       }
@@ -43,5 +43,5 @@ struct PPOEmptyStateView: View {
 }
 
 #Preview {
-  PPOEmptyStateView()
+  PPOEmptyStateView(viewModel: nil)
 }

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOEmptyStateViewTests.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOEmptyStateViewTests.swift
@@ -5,7 +5,7 @@ import XCTest
 
 final class PPOEmptyStateViewTests: TestCase {
   func testEmptyStateView() {
-    let view = PPOEmptyStateView(viewModel: nil).frame(width: 320, height: 500)
+    let view = PPOEmptyStateView().frame(width: 320, height: 500)
     // TODO: Record multiple snapshots once translations are available (MBL-1558)
     assertSnapshot(matching: view, as: .image, named: "lang_en")
   }

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOEmptyStateViewTests.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOEmptyStateViewTests.swift
@@ -5,7 +5,7 @@ import XCTest
 
 final class PPOEmptyStateViewTests: TestCase {
   func testEmptyStateView() {
-    let view = PPOEmptyStateView().frame(width: 320, height: 500)
+    let view = PPOEmptyStateView(viewModel: nil).frame(width: 320, height: 500)
     // TODO: Record multiple snapshots once translations are available (MBL-1558)
     assertSnapshot(matching: view, as: .image, named: "lang_en")
   }

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOView.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct PPOView: View {
-  @Binding var viewModel: PPOViewModel
+  @ObservedObject var viewModel: PPOViewModel
 
   @AccessibilityFocusState private var isBannerFocused: Bool
 
@@ -39,5 +39,5 @@ struct PPOView: View {
 }
 
 #Preview {
-  PPOView(viewModel: Binding.constant(PPOViewModel()))
+  PPOView(viewModel: PPOViewModel())
 }

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOView.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOView.swift
@@ -1,8 +1,9 @@
 import SwiftUI
 
 struct PPOView: View {
-  @ObservedObject var viewModel: PPOViewModel
+  @ObservedObject var viewModel = PPOViewModel()
   var onCountChange: ((Int?) -> Void)?
+  var onNavigate: ((PPONavigationEvent) -> Void)?
 
   @AccessibilityFocusState private var isBannerFocused: Bool
 
@@ -37,6 +38,9 @@ struct PPOView: View {
       .onAppear(perform: { self.viewModel.viewDidAppear() })
       .onChange(of: self.viewModel.results.total, perform: { value in
         self.onCountChange?(value)
+      })
+      .onReceive(self.viewModel.navigationEvents, perform: { event in
+        self.onNavigate?(event)
       })
     }
   }

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOView.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct PPOView: View {
   @ObservedObject var viewModel: PPOViewModel
+  var onCountChange: ((Int?) -> Void)?
 
   @AccessibilityFocusState private var isBannerFocused: Bool
 
@@ -34,6 +35,9 @@ struct PPOView: View {
         }
       })
       .onAppear(perform: { self.viewModel.viewDidAppear() })
+      .onChange(of: self.viewModel.results.total, perform: { value in
+        self.onCountChange?(value)
+      })
     }
   }
 }

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOView.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOView.swift
@@ -1,8 +1,7 @@
 import SwiftUI
 
 struct PPOView: View {
-  weak var tabBarController: RootTabBarViewController?
-  @StateObject private var viewModel = PPOViewModel()
+  @StateObject var viewModel = PPOViewModel()
 
   @AccessibilityFocusState private var isBannerFocused: Bool
 

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOView.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct PPOView: View {
-  @StateObject var viewModel = PPOViewModel()
+  @Binding var viewModel: PPOViewModel
 
   @AccessibilityFocusState private var isBannerFocused: Bool
 
@@ -39,5 +39,5 @@ struct PPOView: View {
 }
 
 #Preview {
-  PPOView()
+  PPOView(viewModel: Binding.constant(PPOViewModel()))
 }

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOView.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct PPOView: View {
-  @ObservedObject var viewModel = PPOViewModel()
+  @StateObject var viewModel = PPOViewModel()
   var onCountChange: ((Int?) -> Void)?
   var onNavigate: ((PPONavigationEvent) -> Void)?
 
@@ -11,7 +11,9 @@ struct PPOView: View {
     GeometryReader { reader in
       ScrollView {
         // TODO: Show empty state view if user is logged in and has no PPO updates.
-        //      PPOEmptyStateView(tabBarController: self.tabBarController)
+        // PPOEmptyStateView {
+        //  self.onNavigate?(.backedProjects)
+        // }
 
         // TODO: Remove this button once we're showing cards instead.
         Button("Show banner") {

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOViewModel.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOViewModel.swift
@@ -53,6 +53,9 @@ final class PPOViewModel: ObservableObject, PPOViewModelInputs, PPOViewModelOutp
         }
         return data.pledgeProjectsOverview?.pledges?.pageInfo.endCursor
       },
+      totalFromEnvelope: { data in
+        data.pledgeProjectsOverview?.pledges?.totalCount
+      },
       requestFromParams: { () in
         AppEnvironment.current.apiService.fetchPledgedProjects(cursor: nil, limit: Constants.pageSize)
       },

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOViewModel.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOViewModel.swift
@@ -89,6 +89,18 @@ final class PPOViewModel: ObservableObject, PPOViewModelInputs, PPOViewModelOutp
       }
       .store(in: &self.cancellables)
 
+    // Route navigation events
+    Publishers.Merge6(
+      self.openBackedProjectsSubject.map { PPONavigationEvent.backingPage },
+      self.fixPaymentMethodSubject.map { PPONavigationEvent.fixPaymentMethod },
+      self.fix3DSChallengeSubject.map { PPONavigationEvent.fix3DSChallenge },
+      self.openSurveySubject.map { PPONavigationEvent.survey },
+      self.confirmAddressSubject.map { PPONavigationEvent.confirmAddress },
+      self.contactCreatorSubject.map { PPONavigationEvent.contactCreator }
+    )
+    .subscribe(self.navigationEventSubject)
+    .store(in: &self.cancellables)
+
     // TODO: Send actual banner messages in response to card actions instead.
     self.shouldSendSampleMessageSubject
       .sink { [weak self] _ in
@@ -119,28 +131,30 @@ final class PPOViewModel: ObservableObject, PPOViewModelInputs, PPOViewModelOutp
     self.pullToRefreshSubject.send(())
   }
 
+  // TODO: Add any additional properties for routing (MBL-1451)
+
   func openBackedProjects() {
-    self.navigationEventSubject.send(.backingPage)
+    self.openBackedProjectsSubject.send(())
   }
 
   func fixPaymentMethod() {
-    self.navigationEventSubject.send(.fixPaymentMethod)
+    self.fixPaymentMethodSubject.send(())
   }
 
   func fix3DSChallenge() {
-    self.navigationEventSubject.send(.fix3DSChallenge)
+    self.fix3DSChallengeSubject.send(())
   }
 
   func openSurvey() {
-    self.navigationEventSubject.send(.survey)
+    self.openSurveySubject.send(())
   }
 
   func confirmAddress() {
-    self.navigationEventSubject.send(.confirmAddress)
+    self.confirmAddressSubject.send(())
   }
 
   func contactCreator() {
-    self.navigationEventSubject.send(.contactCreator)
+    self.contactCreatorSubject.send(())
   }
 
   // MARK: - Outputs
@@ -149,7 +163,7 @@ final class PPOViewModel: ObservableObject, PPOViewModelInputs, PPOViewModelOutp
   @Published var results = PPOViewModelPaginator.Results.unloaded
 
   var navigationEvents: AnyPublisher<PPONavigationEvent, Never> {
-    navigationEventSubject.eraseToAnyPublisher()
+    self.navigationEventSubject.eraseToAnyPublisher()
   }
 
   // MARK: - Private
@@ -160,6 +174,12 @@ final class PPOViewModel: ObservableObject, PPOViewModelInputs, PPOViewModelOutp
   private let loadMoreSubject = PassthroughSubject<Void, Never>()
   private let pullToRefreshSubject = PassthroughSubject<Void, Never>()
   private let shouldSendSampleMessageSubject = PassthroughSubject<(), Never>()
+  private let openBackedProjectsSubject = PassthroughSubject<Void, Never>()
+  private let fixPaymentMethodSubject = PassthroughSubject<Void, Never>()
+  private let fix3DSChallengeSubject = PassthroughSubject<Void, Never>()
+  private let openSurveySubject = PassthroughSubject<Void, Never>()
+  private let confirmAddressSubject = PassthroughSubject<Void, Never>()
+  private let contactCreatorSubject = PassthroughSubject<Void, Never>()
 
   private var navigationEventSubject = PassthroughSubject<PPONavigationEvent, Never>()
 

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOViewModel.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOViewModel.swift
@@ -30,7 +30,7 @@ protocol PPOViewModelOutputs {
 }
 
 enum PPONavigationEvent {
-  case backingPage
+  case backedProjects
   case fixPaymentMethod
   case fix3DSChallenge
   case survey
@@ -94,7 +94,7 @@ final class PPOViewModel: ObservableObject, PPOViewModelInputs, PPOViewModelOutp
 
     // Route navigation events
     Publishers.Merge6(
-      self.openBackedProjectsSubject.map { PPONavigationEvent.backingPage },
+      self.openBackedProjectsSubject.map { PPONavigationEvent.backedProjects },
       self.fixPaymentMethodSubject.map { PPONavigationEvent.fixPaymentMethod },
       self.fix3DSChallengeSubject.map { PPONavigationEvent.fix3DSChallenge },
       self.openSurveySubject.map { PPONavigationEvent.survey },

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOViewModel.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOViewModel.swift
@@ -15,10 +15,27 @@ protocol PPOViewModelInputs {
   func viewDidAppear()
   func loadMore()
   func pullToRefresh()
+
+  func openBackedProjects()
+  func fixPaymentMethod()
+  func fix3DSChallenge()
+  func openSurvey()
+  func confirmAddress()
+  func contactCreator()
 }
 
 protocol PPOViewModelOutputs {
   var results: PPOViewModelPaginator.Results { get }
+  var navigationEvents: AnyPublisher<PPONavigationEvent, Never> { get }
+}
+
+enum PPONavigationEvent {
+  case backingPage
+  case fixPaymentMethod
+  case fix3DSChallenge
+  case survey
+  case confirmAddress
+  case contactCreator
 }
 
 final class PPOViewModel: ObservableObject, PPOViewModelInputs, PPOViewModelOutputs {
@@ -102,10 +119,38 @@ final class PPOViewModel: ObservableObject, PPOViewModelInputs, PPOViewModelOutp
     self.pullToRefreshSubject.send(())
   }
 
+  func openBackedProjects() {
+    self.navigationEventSubject.send(.backingPage)
+  }
+
+  func fixPaymentMethod() {
+    self.navigationEventSubject.send(.fixPaymentMethod)
+  }
+
+  func fix3DSChallenge() {
+    self.navigationEventSubject.send(.fix3DSChallenge)
+  }
+
+  func openSurvey() {
+    self.navigationEventSubject.send(.survey)
+  }
+
+  func confirmAddress() {
+    self.navigationEventSubject.send(.confirmAddress)
+  }
+
+  func contactCreator() {
+    self.navigationEventSubject.send(.contactCreator)
+  }
+
   // MARK: - Outputs
 
   @Published var bannerViewModel: MessageBannerViewViewModel? = nil
   @Published var results = PPOViewModelPaginator.Results.unloaded
+
+  var navigationEvents: AnyPublisher<PPONavigationEvent, Never> {
+    navigationEventSubject.eraseToAnyPublisher()
+  }
 
   // MARK: - Private
 
@@ -115,6 +160,8 @@ final class PPOViewModel: ObservableObject, PPOViewModelInputs, PPOViewModelOutp
   private let loadMoreSubject = PassthroughSubject<Void, Never>()
   private let pullToRefreshSubject = PassthroughSubject<Void, Never>()
   private let shouldSendSampleMessageSubject = PassthroughSubject<(), Never>()
+
+  private var navigationEventSubject = PassthroughSubject<PPONavigationEvent, Never>()
 
   private var cancellables: Set<AnyCancellable> = []
 

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOViewModelTests.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOViewModelTests.swift
@@ -225,7 +225,7 @@ class PPOViewModelTests: XCTestCase {
     guard
       case .unloaded = values[0],
       case .loading = values[1],
-      case let .someLoaded(firstData, cursor) = values[2]
+      case let .someLoaded(firstData, cursor, _) = values[2]
     else {
       return XCTFail()
     }

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOViewModelTests.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOViewModelTests.swift
@@ -242,7 +242,7 @@ class PPOViewModelTests: XCTestCase {
   }
 
   func testNavigationBackedProjects() {
-    self.verifyNavigationEvent({ self.viewModel.openBackedProjects() }, event: .backingPage)
+    self.verifyNavigationEvent({ self.viewModel.openBackedProjects() }, event: .backedProjects)
   }
 
   func testNavigationConfirmAddress() {

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOViewModelTests.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOViewModelTests.swift
@@ -241,6 +241,50 @@ class PPOViewModelTests: XCTestCase {
     XCTAssertEqual(secondData.count, 7)
   }
 
+  func testNavigationBackedProjects() {
+    verifyNavigationEvent({ self.viewModel.openBackedProjects() }, event: .backingPage)
+  }
+
+  func testNavigationConfirmAddress() {
+    verifyNavigationEvent({ self.viewModel.confirmAddress() }, event: .confirmAddress)
+  }
+
+  func testNavigationContactCreator() {
+    verifyNavigationEvent({ self.viewModel.contactCreator() }, event: .contactCreator)
+  }
+
+  func testNavigationFix3DSChallenge() {
+    verifyNavigationEvent({ self.viewModel.fix3DSChallenge() }, event: .fix3DSChallenge)
+  }
+
+  func testNavigationFixPaymentMethod() {
+    verifyNavigationEvent({ self.viewModel.fixPaymentMethod() }, event: .fixPaymentMethod)
+  }
+
+  func testNavigationOpenSurvey() {
+    verifyNavigationEvent({ self.viewModel.openSurvey() }, event: .survey)
+  }
+
+  private func verifyNavigationEvent(_ closure: () -> Void, event: PPONavigationEvent) {
+    let beforeResults: PPOViewModelPaginator.Results = self.viewModel.results
+
+    var values: [PPONavigationEvent] = []
+    self.viewModel.navigationEvents.first().collect()
+      .sink(receiveValue: { v in values = v })
+      .store(in: &self.cancellables)
+
+    closure()
+
+    let afterResults: PPOViewModelPaginator.Results = self.viewModel.results
+
+    XCTAssertEqual(values.count, 1)
+    guard case event = values[0] else {
+      return XCTFail()
+    }
+
+    XCTAssertEqual(beforeResults, afterResults)
+  }
+
   private func pledgedProjectsData(
     cursors: ClosedRange<Int> = 1...3,
     hasNextPage: Bool = false

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOViewModelTests.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOViewModelTests.swift
@@ -242,38 +242,47 @@ class PPOViewModelTests: XCTestCase {
   }
 
   func testNavigationBackedProjects() {
-    verifyNavigationEvent({ self.viewModel.openBackedProjects() }, event: .backingPage)
+    self.verifyNavigationEvent({ self.viewModel.openBackedProjects() }, event: .backingPage)
   }
 
   func testNavigationConfirmAddress() {
-    verifyNavigationEvent({ self.viewModel.confirmAddress() }, event: .confirmAddress)
+    self.verifyNavigationEvent({ self.viewModel.confirmAddress() }, event: .confirmAddress)
   }
 
   func testNavigationContactCreator() {
-    verifyNavigationEvent({ self.viewModel.contactCreator() }, event: .contactCreator)
+    self.verifyNavigationEvent({ self.viewModel.contactCreator() }, event: .contactCreator)
   }
 
   func testNavigationFix3DSChallenge() {
-    verifyNavigationEvent({ self.viewModel.fix3DSChallenge() }, event: .fix3DSChallenge)
+    self.verifyNavigationEvent({ self.viewModel.fix3DSChallenge() }, event: .fix3DSChallenge)
   }
 
   func testNavigationFixPaymentMethod() {
-    verifyNavigationEvent({ self.viewModel.fixPaymentMethod() }, event: .fixPaymentMethod)
+    self.verifyNavigationEvent({ self.viewModel.fixPaymentMethod() }, event: .fixPaymentMethod)
   }
 
   func testNavigationOpenSurvey() {
-    verifyNavigationEvent({ self.viewModel.openSurvey() }, event: .survey)
+    self.verifyNavigationEvent({ self.viewModel.openSurvey() }, event: .survey)
   }
 
+  // Setup the view model to monitor navigation events, then run the closure, then check to make sure only that one event fired
   private func verifyNavigationEvent(_ closure: () -> Void, event: PPONavigationEvent) {
     let beforeResults: PPOViewModelPaginator.Results = self.viewModel.results
 
+    let expectation = self.expectation(description: "VerifyNavigationEvent \(event)")
+
     var values: [PPONavigationEvent] = []
-    self.viewModel.navigationEvents.first().collect()
-      .sink(receiveValue: { v in values = v })
+    self.viewModel.navigationEvents
+      .collect(.byTime(DispatchQueue.main, 0.1))
+      .sink(receiveValue: { v in
+        values = v
+        expectation.fulfill()
+      })
       .store(in: &self.cancellables)
 
     closure()
+
+    self.wait(for: [expectation], timeout: 1)
 
     let afterResults: PPOViewModelPaginator.Results = self.viewModel.results
 

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -1137,11 +1137,12 @@
 		A7F441E91D005A9400FE6FC5 /* TwoFactorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7F441AC1D005A9400FE6FC5 /* TwoFactorViewModel.swift */; };
 		A7F6F0C11DC7EBF7002C118C /* DateProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7F6F0C01DC7EBF7002C118C /* DateProtocol.swift */; };
 		A7FC8C061C8F1DEA00C3B49B /* CircleAvatarImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7FC8C051C8F1DEA00C3B49B /* CircleAvatarImageView.swift */; };
-		AA645EA32C7D68FC0034705A /* PPOProjectCardView+GraphAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA645EA12C7D681F0034705A /* PPOProjectCardView+GraphAPI.swift */; };
+		AA1023E42CABD2AE007800B5 /* PPOContainerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1023E32CABD2AE007800B5 /* PPOContainerViewModel.swift */; };
 		AA645E972C770D620034705A /* DesignSystemViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6049D0102A9CF6840015BB0D /* DesignSystemViewController.swift */; };
 		AA645E9C2C7725FB0034705A /* PagedContainerViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA645E9A2C7725FB0034705A /* PagedContainerViewModelTests.swift */; };
 		AA645E9E2C772C650034705A /* PagedTabBarTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA645E9D2C772C650034705A /* PagedTabBarTests.swift */; };
 		AA645EA02C772DC90034705A /* SnapshotTesting in Frameworks */ = {isa = PBXBuildFile; productRef = AA645E9F2C772DC90034705A /* SnapshotTesting */; };
+		AA645EA32C7D68FC0034705A /* PPOProjectCardView+GraphAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA645EA12C7D681F0034705A /* PPOProjectCardView+GraphAPI.swift */; };
 		AA6E9E842C62B9DC001543FC /* PPOProjectDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA592782C5C708000482087 /* PPOProjectDetails.swift */; };
 		AA6E9E852C62B9DC001543FC /* PPOAlertFlag.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAD2BEE82C59B981003D8B95 /* PPOAlertFlag.swift */; };
 		AA6E9E882C63EAE9001543FC /* PPOProjectCreator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA6E9E862C63E7C3001543FC /* PPOProjectCreator.swift */; };
@@ -2801,9 +2802,10 @@
 		A7F761741C85FA40005405ED /* ActivitiesViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActivitiesViewController.swift; sourceTree = "<group>"; };
 		A7F761761C85FACB005405ED /* LoginToutViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = LoginToutViewController.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		A7FC8C051C8F1DEA00C3B49B /* CircleAvatarImageView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CircleAvatarImageView.swift; sourceTree = "<group>"; };
-		AA645EA12C7D681F0034705A /* PPOProjectCardView+GraphAPI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "PPOProjectCardView+GraphAPI.swift"; sourceTree = "<group>"; };
+		AA1023E32CABD2AE007800B5 /* PPOContainerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PPOContainerViewModel.swift; sourceTree = "<group>"; };
 		AA645E9A2C7725FB0034705A /* PagedContainerViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PagedContainerViewModelTests.swift; sourceTree = "<group>"; };
 		AA645E9D2C772C650034705A /* PagedTabBarTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PagedTabBarTests.swift; sourceTree = "<group>"; };
+		AA645EA12C7D681F0034705A /* PPOProjectCardView+GraphAPI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "PPOProjectCardView+GraphAPI.swift"; sourceTree = "<group>"; };
 		AA6E9E862C63E7C3001543FC /* PPOProjectCreator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PPOProjectCreator.swift; sourceTree = "<group>"; };
 		AA6E9E892C63EE78001543FC /* PPOAddressSummary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PPOAddressSummary.swift; sourceTree = "<group>"; };
 		AAA592782C5C708000482087 /* PPOProjectDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PPOProjectDetails.swift; sourceTree = "<group>"; };
@@ -7188,6 +7190,7 @@
 				AAD2BEE72C59B964003D8B95 /* CardView */,
 				392BB12B2C3C095200A5591B /* PPOEmptyStateViewTests.swift */,
 				392BB1292C3BEB5500A5591B /* PPOEmptyStateView.swift */,
+				AA1023E32CABD2AE007800B5 /* PPOContainerViewModel.swift */,
 				E1BAA0382C1A1C56004F8B06 /* PPOContainerViewController.swift */,
 				E1BAA0342C1A1907004F8B06 /* PPOView.swift */,
 				E1BAA0362C1A1B13004F8B06 /* PPOViewModel.swift */,
@@ -8640,6 +8643,7 @@
 				014D62991E6E22920033D2BD /* BackerDashboardEmptyStateCell.swift in Sources */,
 				D7237099211A3DA9001EA4CA /* SettingsFollowCell.swift in Sources */,
 				A7CC143E1D00E74F00035C52 /* FindFriendsFriendFollowCell.swift in Sources */,
+				AA1023E42CABD2AE007800B5 /* PPOContainerViewModel.swift in Sources */,
 				77E6440120F64F0B005F6B38 /* HelpDataSource.swift in Sources */,
 				1937A72328C9570A00DD732D /* ErroredBackingView.swift in Sources */,
 				77A7B67B21026F4F008D12C1 /* SettingsNotificationCell.swift in Sources */,

--- a/Library/PagedContainer/PagedContainerViewController.swift
+++ b/Library/PagedContainer/PagedContainerViewController.swift
@@ -52,7 +52,7 @@ open class PagedContainerViewController<Page: TabBarPage>: UIViewController {
     return false
   }
 
-  public override func viewWillAppear(_ animated: Bool) {
+  open override func viewWillAppear(_ animated: Bool) {
     super.viewWillAppear(animated)
 
     self.viewModel.viewWillAppear()
@@ -62,7 +62,7 @@ open class PagedContainerViewController<Page: TabBarPage>: UIViewController {
     }
   }
 
-  public override func viewDidAppear(_ animated: Bool) {
+  open override func viewDidAppear(_ animated: Bool) {
     super.viewDidAppear(animated)
 
     if let activeController = self.activeController {

--- a/Library/PagedContainer/PagedContainerViewModel.swift
+++ b/Library/PagedContainer/PagedContainerViewModel.swift
@@ -16,6 +16,19 @@ public enum TabBarBadge {
       nil
     }
   }
+
+  public init(count: Int?, convertZeroToNone: Bool = true) {
+    switch (count, convertZeroToNone) {
+    case (.none, _):
+      self = .none
+    case (.some(0), true):
+      self = .none
+    case (.some(0), false):
+      self = .count(0)
+    case let (.some(count), _):
+      self = .count(count)
+    }
+  }
 }
 
 public protocol TabBarPage: Identifiable {

--- a/Library/PagedContainer/PagedContainerViewModel.swift
+++ b/Library/PagedContainer/PagedContainerViewModel.swift
@@ -8,7 +8,7 @@ public enum TabBarBadge {
   case dot
   case count(Int)
 
-  var count: Int? {
+  public var count: Int? {
     switch self {
     case let .count(count):
       count

--- a/Library/PaginatorTests.swift
+++ b/Library/PaginatorTests.swift
@@ -18,6 +18,7 @@ struct ConcreteError: Error {}
 final class PaginatorTests: XCTestCase {
   let valuesFromEnvelope: (TestEnvelope) -> [Int] = { $0.values }
   let cursorFromEnvelope: (TestEnvelope) -> Int? = { $0.cursor }
+  let totalFromEnvelope: (TestEnvelope) -> Int? = { _ in 42 }
 
   func waitTinyInterval() {
     _ = XCTWaiter.wait(for: [expectation(description: "Wait a tiny interval of time.")], timeout: 0.05)
@@ -27,6 +28,7 @@ final class PaginatorTests: XCTestCase {
     let paginator = Paginator<TestEnvelope, Int, Int?, ConcreteError, Int>(
       valuesFromEnvelope: valuesFromEnvelope,
       cursorFromEnvelope: cursorFromEnvelope,
+      totalFromEnvelope: totalFromEnvelope,
       requestFromParams: { _ in TestEnvelope(values: [], cursor: nil).publisher },
       requestFromCursor: { _ in TestEnvelope(values: [], cursor: nil).publisher }
     )
@@ -40,6 +42,7 @@ final class PaginatorTests: XCTestCase {
     let paginator = Paginator<TestEnvelope, Int, Int, ConcreteError, Void>(
       valuesFromEnvelope: valuesFromEnvelope,
       cursorFromEnvelope: cursorFromEnvelope,
+      totalFromEnvelope: totalFromEnvelope,
       requestFromParams: { _ in TestEnvelope(values: [1, 2, 3], cursor: nil).publisher },
       requestFromCursor: { _ in TestEnvelope(values: [], cursor: nil).publisher }
     )
@@ -60,6 +63,7 @@ final class PaginatorTests: XCTestCase {
     let paginator = Paginator<TestEnvelope, Int, Int, ConcreteError, Void>(
       valuesFromEnvelope: valuesFromEnvelope,
       cursorFromEnvelope: cursorFromEnvelope,
+      totalFromEnvelope: totalFromEnvelope,
       requestFromParams: { _ in TestEnvelope(values: [], cursor: nil).publisher },
       requestFromCursor: { _ in TestEnvelope(values: [], cursor: nil).publisher }
     )
@@ -80,6 +84,7 @@ final class PaginatorTests: XCTestCase {
     let paginator = Paginator<TestEnvelope, Int, Int, ConcreteError, Void>(
       valuesFromEnvelope: valuesFromEnvelope,
       cursorFromEnvelope: cursorFromEnvelope,
+      totalFromEnvelope: totalFromEnvelope,
       requestFromParams: { _ in TestEnvelope(values: [1, 2, 3], cursor: 1).publisher },
       requestFromCursor: { cursor in
         if cursor == 1 {
@@ -97,7 +102,7 @@ final class PaginatorTests: XCTestCase {
 
     self.waitTinyInterval()
 
-    XCTAssertEqual(paginator.results, .someLoaded(values: [1, 2, 3], cursor: 1))
+    XCTAssertEqual(paginator.results, .someLoaded(values: [1, 2, 3], cursor: 1, total: 42))
     XCTAssertEqual(paginator.results.values, [1, 2, 3])
 
     paginator.requestNextPage()
@@ -107,7 +112,7 @@ final class PaginatorTests: XCTestCase {
     XCTAssertFalse(paginator.results.isLoading)
     XCTAssertEqual(paginator.results.values, [1, 2, 3, 4, 5, 6])
     XCTAssertNil(paginator.results.error)
-    XCTAssertEqual(paginator.results, .someLoaded(values: [1, 2, 3, 4, 5, 6], cursor: 2))
+    XCTAssertEqual(paginator.results, .someLoaded(values: [1, 2, 3, 4, 5, 6], cursor: 2, total: 42))
 
     paginator.requestNextPage()
     XCTAssertTrue(paginator.results.isLoading)
@@ -123,6 +128,7 @@ final class PaginatorTests: XCTestCase {
     let paginator = Paginator<TestEnvelope, Int, Int, ConcreteError, Void>(
       valuesFromEnvelope: valuesFromEnvelope,
       cursorFromEnvelope: cursorFromEnvelope,
+      totalFromEnvelope: totalFromEnvelope,
       requestFromParams: { _ in TestEnvelope(values: [1, 2, 3], cursor: 1).publisher },
       requestFromCursor: { cursor in
         if cursor == 1 {
@@ -138,7 +144,7 @@ final class PaginatorTests: XCTestCase {
 
     self.waitTinyInterval()
 
-    XCTAssertEqual(paginator.results, .someLoaded(values: [1, 2, 3], cursor: 1))
+    XCTAssertEqual(paginator.results, .someLoaded(values: [1, 2, 3], cursor: 1, total: 42))
     XCTAssertEqual(paginator.results.values, [1, 2, 3])
 
     paginator.requestNextPage()
@@ -162,6 +168,7 @@ final class PaginatorTests: XCTestCase {
     let paginator = Paginator<TestEnvelope, Int, Int, ConcreteError, Void>(
       valuesFromEnvelope: valuesFromEnvelope,
       cursorFromEnvelope: cursorFromEnvelope,
+      totalFromEnvelope: totalFromEnvelope,
       requestFromParams: { _ in TestEnvelope(values: [1, 2, 3], cursor: 1).publisher },
       requestFromCursor: { cursor in
         if cursor == 1 {
@@ -179,7 +186,7 @@ final class PaginatorTests: XCTestCase {
 
     self.waitTinyInterval()
 
-    XCTAssertEqual(paginator.results, .someLoaded(values: [1, 2, 3], cursor: 1))
+    XCTAssertEqual(paginator.results, .someLoaded(values: [1, 2, 3], cursor: 1, total: 42))
     XCTAssertEqual(paginator.results.values, [1, 2, 3])
 
     paginator.requestNextPage()
@@ -189,7 +196,7 @@ final class PaginatorTests: XCTestCase {
     XCTAssertFalse(paginator.results.isLoading)
     XCTAssertEqual(paginator.results.values, [1, 2, 3, 4, 5, 6])
     XCTAssertNil(paginator.results.error)
-    XCTAssertEqual(paginator.results, .someLoaded(values: [1, 2, 3, 4, 5, 6], cursor: 2))
+    XCTAssertEqual(paginator.results, .someLoaded(values: [1, 2, 3, 4, 5, 6], cursor: 2, total: 42))
 
     paginator.requestNextPage()
     self.waitTinyInterval()
@@ -203,6 +210,7 @@ final class PaginatorTests: XCTestCase {
     let paginator = Paginator<TestEnvelope, Int, Int, ConcreteError, Void>(
       valuesFromEnvelope: valuesFromEnvelope,
       cursorFromEnvelope: cursorFromEnvelope,
+      totalFromEnvelope: totalFromEnvelope,
       requestFromParams: { _ in TestEnvelope(values: [1, 2, 3], cursor: nil).publisher },
       requestFromCursor: { _ in TestEnvelope(values: [], cursor: nil).publisher }
     )
@@ -224,6 +232,7 @@ final class PaginatorTests: XCTestCase {
     let paginator = Paginator<TestEnvelope, Int, Int, ConcreteError, Void>(
       valuesFromEnvelope: valuesFromEnvelope,
       cursorFromEnvelope: cursorFromEnvelope,
+      totalFromEnvelope: totalFromEnvelope,
       requestFromParams: { _ in TestEnvelope(values: [1, 2, 3], cursor: 1).publisher },
       requestFromCursor: { _ in TestEnvelope(values: [4, 5, 6], cursor: nil).publisher }
     )
@@ -245,6 +254,7 @@ final class PaginatorTests: XCTestCase {
     let paginator = Paginator<TestEnvelope, Int, Int, ConcreteError, Void>(
       valuesFromEnvelope: valuesFromEnvelope,
       cursorFromEnvelope: cursorFromEnvelope,
+      totalFromEnvelope: totalFromEnvelope,
       requestFromParams: { _ in TestEnvelope(values: [1, 2, 3], cursor: 1).publisher },
       requestFromCursor: { _ in TestEnvelope(values: [4, 5, 6], cursor: nil).publisher }
     )
@@ -275,6 +285,7 @@ final class PaginatorTests: XCTestCase {
     let paginator = Paginator<TestEnvelope, Int, Int, ConcreteError, Void>(
       valuesFromEnvelope: valuesFromEnvelope,
       cursorFromEnvelope: cursorFromEnvelope,
+      totalFromEnvelope: totalFromEnvelope,
       requestFromParams: { _ in
         Fail(outputType: TestEnvelope.self, failure: ConcreteError())
           .delay(for: 0.01, tolerance: 0.01, scheduler: RunLoop.main)
@@ -297,6 +308,7 @@ final class PaginatorTests: XCTestCase {
     let paginator = Paginator<TestEnvelope, Int, Int, ConcreteError, Void>(
       valuesFromEnvelope: valuesFromEnvelope,
       cursorFromEnvelope: cursorFromEnvelope,
+      totalFromEnvelope: totalFromEnvelope,
       requestFromParams: { _ in TestEnvelope(values: [1, 2, 3], cursor: 1).publisher },
       requestFromCursor: { _ in
         Fail(outputType: TestEnvelope.self, failure: ConcreteError())

--- a/Library/PaginatorTests.swift
+++ b/Library/PaginatorTests.swift
@@ -5,6 +5,13 @@ import XCTest
 struct TestEnvelope {
   let values: [Int]
   let cursor: Int?
+  let total: Int
+
+  init(values: [Int], cursor: Int?, total: Int = 42) {
+    self.values = values
+    self.cursor = cursor
+    self.total = total
+  }
 
   var publisher: AnyPublisher<TestEnvelope, ConcreteError> {
     return Just(self).setFailureType(to: ConcreteError.self)
@@ -18,7 +25,7 @@ struct ConcreteError: Error {}
 final class PaginatorTests: XCTestCase {
   let valuesFromEnvelope: (TestEnvelope) -> [Int] = { $0.values }
   let cursorFromEnvelope: (TestEnvelope) -> Int? = { $0.cursor }
-  let totalFromEnvelope: (TestEnvelope) -> Int? = { _ in 42 }
+  let totalFromEnvelope: (TestEnvelope) -> Int? = { $0.total }
 
   func waitTinyInterval() {
     _ = XCTWaiter.wait(for: [expectation(description: "Wait a tiny interval of time.")], timeout: 0.05)
@@ -36,6 +43,7 @@ final class PaginatorTests: XCTestCase {
     XCTAssertEqual(paginator.results, .unloaded)
     XCTAssertFalse(paginator.results.isLoading)
     XCTAssertEqual(paginator.results.values, [])
+    XCTAssertEqual(paginator.results.total, nil)
   }
 
   func testPaginator_requestFirstPage_loadsFirstPage() {
@@ -43,13 +51,14 @@ final class PaginatorTests: XCTestCase {
       valuesFromEnvelope: valuesFromEnvelope,
       cursorFromEnvelope: cursorFromEnvelope,
       totalFromEnvelope: totalFromEnvelope,
-      requestFromParams: { _ in TestEnvelope(values: [1, 2, 3], cursor: nil).publisher },
-      requestFromCursor: { _ in TestEnvelope(values: [], cursor: nil).publisher }
+      requestFromParams: { _ in TestEnvelope(values: [1, 2, 3], cursor: nil, total: 3).publisher },
+      requestFromCursor: { _ in TestEnvelope(values: [], cursor: nil, total: 3).publisher }
     )
 
     paginator.requestFirstPage(withParams: ())
     XCTAssertTrue(paginator.results.isLoading)
     XCTAssertEqual(paginator.results.values, [], "Values should not have loaded yet")
+    XCTAssertEqual(paginator.results.total, nil)
 
     self.waitTinyInterval()
 
@@ -57,6 +66,7 @@ final class PaginatorTests: XCTestCase {
     XCTAssertEqual(paginator.results.values, [1, 2, 3])
     XCTAssertNil(paginator.results.error)
     XCTAssertEqual(paginator.results, .allLoaded(values: [1, 2, 3]))
+    XCTAssertEqual(paginator.results.total, 3)
   }
 
   func testPaginator_requestFirstPage_noResults_isEmpty() {
@@ -71,6 +81,7 @@ final class PaginatorTests: XCTestCase {
     paginator.requestFirstPage(withParams: ())
     XCTAssertTrue(paginator.results.isLoading)
     XCTAssertEqual(paginator.results.values, [], "Values should not have loaded yet")
+    XCTAssertEqual(paginator.results.total, nil)
 
     self.waitTinyInterval()
 
@@ -78,6 +89,7 @@ final class PaginatorTests: XCTestCase {
     XCTAssertEqual(paginator.results.values, [])
     XCTAssertNil(paginator.results.error)
     XCTAssertEqual(paginator.results, .empty)
+    XCTAssertEqual(paginator.results.total, 0)
   }
 
   func testPaginator_requestNextPage_hasCursor_loadsNextPage() {
@@ -85,12 +97,12 @@ final class PaginatorTests: XCTestCase {
       valuesFromEnvelope: valuesFromEnvelope,
       cursorFromEnvelope: cursorFromEnvelope,
       totalFromEnvelope: totalFromEnvelope,
-      requestFromParams: { _ in TestEnvelope(values: [1, 2, 3], cursor: 1).publisher },
+      requestFromParams: { _ in TestEnvelope(values: [1, 2, 3], cursor: 1, total: 9).publisher },
       requestFromCursor: { cursor in
         if cursor == 1 {
-          return TestEnvelope(values: [4, 5, 6], cursor: 2).publisher
+          return TestEnvelope(values: [4, 5, 6], cursor: 2, total: 9).publisher
         } else if cursor == 2 {
-          return TestEnvelope(values: [7, 8, 9], cursor: nil).publisher
+          return TestEnvelope(values: [7, 8, 9], cursor: nil, total: 9).publisher
         } else {
           XCTFail()
           return Empty(completeImmediately: true).eraseToAnyPublisher()
@@ -102,8 +114,9 @@ final class PaginatorTests: XCTestCase {
 
     self.waitTinyInterval()
 
-    XCTAssertEqual(paginator.results, .someLoaded(values: [1, 2, 3], cursor: 1, total: 42))
+    XCTAssertEqual(paginator.results, .someLoaded(values: [1, 2, 3], cursor: 1, total: 9))
     XCTAssertEqual(paginator.results.values, [1, 2, 3])
+    XCTAssertEqual(paginator.results.total, 9)
 
     paginator.requestNextPage()
     XCTAssertTrue(paginator.results.isLoading)
@@ -112,7 +125,8 @@ final class PaginatorTests: XCTestCase {
     XCTAssertFalse(paginator.results.isLoading)
     XCTAssertEqual(paginator.results.values, [1, 2, 3, 4, 5, 6])
     XCTAssertNil(paginator.results.error)
-    XCTAssertEqual(paginator.results, .someLoaded(values: [1, 2, 3, 4, 5, 6], cursor: 2, total: 42))
+    XCTAssertEqual(paginator.results, .someLoaded(values: [1, 2, 3, 4, 5, 6], cursor: 2, total: 9))
+    XCTAssertEqual(paginator.results.total, 9)
 
     paginator.requestNextPage()
     XCTAssertTrue(paginator.results.isLoading)
@@ -122,6 +136,7 @@ final class PaginatorTests: XCTestCase {
     XCTAssertEqual(paginator.results.values, [1, 2, 3, 4, 5, 6, 7, 8, 9])
     XCTAssertNil(paginator.results.error)
     XCTAssertEqual(paginator.results, .allLoaded(values: [1, 2, 3, 4, 5, 6, 7, 8, 9]))
+    XCTAssertEqual(paginator.results.total, 9)
   }
 
   func testPaginator_requestNextPage_returnsNoCursor_finishes() {
@@ -129,10 +144,10 @@ final class PaginatorTests: XCTestCase {
       valuesFromEnvelope: valuesFromEnvelope,
       cursorFromEnvelope: cursorFromEnvelope,
       totalFromEnvelope: totalFromEnvelope,
-      requestFromParams: { _ in TestEnvelope(values: [1, 2, 3], cursor: 1).publisher },
+      requestFromParams: { _ in TestEnvelope(values: [1, 2, 3], cursor: 1, total: 6).publisher },
       requestFromCursor: { cursor in
         if cursor == 1 {
-          return TestEnvelope(values: [4, 5, 6], cursor: nil).publisher
+          return TestEnvelope(values: [4, 5, 6], cursor: nil, total: 6).publisher
         } else {
           XCTFail()
           return Empty(completeImmediately: true).eraseToAnyPublisher()
@@ -144,8 +159,9 @@ final class PaginatorTests: XCTestCase {
 
     self.waitTinyInterval()
 
-    XCTAssertEqual(paginator.results, .someLoaded(values: [1, 2, 3], cursor: 1, total: 42))
+    XCTAssertEqual(paginator.results, .someLoaded(values: [1, 2, 3], cursor: 1, total: 6))
     XCTAssertEqual(paginator.results.values, [1, 2, 3])
+    XCTAssertEqual(paginator.results.total, 6)
 
     paginator.requestNextPage()
     XCTAssertTrue(paginator.results.isLoading)
@@ -155,13 +171,16 @@ final class PaginatorTests: XCTestCase {
     XCTAssertEqual(paginator.results.values, [1, 2, 3, 4, 5, 6])
     XCTAssertNil(paginator.results.error)
     XCTAssertEqual(paginator.results, .allLoaded(values: [1, 2, 3, 4, 5, 6]))
+    XCTAssertEqual(paginator.results.total, 6)
 
     paginator.requestNextPage()
     XCTAssertFalse(paginator.results.isLoading)
     XCTAssertEqual(paginator.results, .allLoaded(values: [1, 2, 3, 4, 5, 6]))
+    XCTAssertEqual(paginator.results.total, 6)
 
     self.waitTinyInterval()
     XCTAssertEqual(paginator.results.values, [1, 2, 3, 4, 5, 6])
+    XCTAssertEqual(paginator.results.total, 6)
   }
 
   func testPaginator_requestNextPage_returnsNoResults_finishes() {
@@ -169,12 +188,12 @@ final class PaginatorTests: XCTestCase {
       valuesFromEnvelope: valuesFromEnvelope,
       cursorFromEnvelope: cursorFromEnvelope,
       totalFromEnvelope: totalFromEnvelope,
-      requestFromParams: { _ in TestEnvelope(values: [1, 2, 3], cursor: 1).publisher },
+      requestFromParams: { _ in TestEnvelope(values: [1, 2, 3], cursor: 1, total: 6).publisher },
       requestFromCursor: { cursor in
         if cursor == 1 {
-          return TestEnvelope(values: [4, 5, 6], cursor: 2).publisher
+          return TestEnvelope(values: [4, 5, 6], cursor: 2, total: 6).publisher
         } else if cursor == 2 {
-          return TestEnvelope(values: [], cursor: 3).publisher
+          return TestEnvelope(values: [], cursor: 3, total: 6).publisher
         } else {
           XCTFail()
           return Empty(completeImmediately: true).eraseToAnyPublisher()
@@ -186,8 +205,9 @@ final class PaginatorTests: XCTestCase {
 
     self.waitTinyInterval()
 
-    XCTAssertEqual(paginator.results, .someLoaded(values: [1, 2, 3], cursor: 1, total: 42))
+    XCTAssertEqual(paginator.results, .someLoaded(values: [1, 2, 3], cursor: 1, total: 6))
     XCTAssertEqual(paginator.results.values, [1, 2, 3])
+    XCTAssertEqual(paginator.results.total, 6)
 
     paginator.requestNextPage()
     XCTAssertTrue(paginator.results.isLoading)
@@ -196,7 +216,8 @@ final class PaginatorTests: XCTestCase {
     XCTAssertFalse(paginator.results.isLoading)
     XCTAssertEqual(paginator.results.values, [1, 2, 3, 4, 5, 6])
     XCTAssertNil(paginator.results.error)
-    XCTAssertEqual(paginator.results, .someLoaded(values: [1, 2, 3, 4, 5, 6], cursor: 2, total: 42))
+    XCTAssertEqual(paginator.results, .someLoaded(values: [1, 2, 3, 4, 5, 6], cursor: 2, total: 6))
+    XCTAssertEqual(paginator.results.total, 6)
 
     paginator.requestNextPage()
     self.waitTinyInterval()
@@ -204,6 +225,7 @@ final class PaginatorTests: XCTestCase {
     XCTAssertFalse(paginator.results.isLoading)
     XCTAssertEqual(paginator.results, .allLoaded(values: [1, 2, 3, 4, 5, 6]))
     XCTAssertEqual(paginator.results.values, [1, 2, 3, 4, 5, 6])
+    XCTAssertEqual(paginator.results.total, 6)
   }
 
   func testPaginator_cancel_cancelsPendingRequests() {
@@ -233,8 +255,8 @@ final class PaginatorTests: XCTestCase {
       valuesFromEnvelope: valuesFromEnvelope,
       cursorFromEnvelope: cursorFromEnvelope,
       totalFromEnvelope: totalFromEnvelope,
-      requestFromParams: { _ in TestEnvelope(values: [1, 2, 3], cursor: 1).publisher },
-      requestFromCursor: { _ in TestEnvelope(values: [4, 5, 6], cursor: nil).publisher }
+      requestFromParams: { _ in TestEnvelope(values: [1, 2, 3], cursor: 1, total: 6).publisher },
+      requestFromCursor: { _ in TestEnvelope(values: [4, 5, 6], cursor: nil, total: 6).publisher }
     )
 
     paginator.requestFirstPage(withParams: ())
@@ -255,8 +277,8 @@ final class PaginatorTests: XCTestCase {
       valuesFromEnvelope: valuesFromEnvelope,
       cursorFromEnvelope: cursorFromEnvelope,
       totalFromEnvelope: totalFromEnvelope,
-      requestFromParams: { _ in TestEnvelope(values: [1, 2, 3], cursor: 1).publisher },
-      requestFromCursor: { _ in TestEnvelope(values: [4, 5, 6], cursor: nil).publisher }
+      requestFromParams: { _ in TestEnvelope(values: [1, 2, 3], cursor: 1, total: 6).publisher },
+      requestFromCursor: { _ in TestEnvelope(values: [4, 5, 6], cursor: nil, total: 6).publisher }
     )
 
     paginator.requestFirstPage(withParams: ())
@@ -265,6 +287,7 @@ final class PaginatorTests: XCTestCase {
     self.waitTinyInterval()
     XCTAssertEqual(paginator.results.values, [1, 2, 3])
     XCTAssertFalse(paginator.results.isLoading)
+    XCTAssertEqual(paginator.results.total, 6)
 
     paginator.requestNextPage()
     XCTAssertTrue(paginator.results.isLoading)


### PR DESCRIPTION
  # 📲 What
  
Implements most of the logic for navigation events in the PPO view model and the tab bar integration. 
  
  # 🛠 How
  
Each user interaction was added to the PPOViewModel separately, with separate subjects to represent each type of user interaction. This will let us handle navigation events and analytics separately. 

A `PPONavigationEvent` enum was added to represent different locations the user might navigate to. Then, the individual subjects are mapped to their respective navigation events, and those get merged into a navigationEvents publisher. 

Contextual information for routing locations (e.g. which project was backed) and handling of routing will be added once we connect this to a navigation service in MBL-1451).

Unit tests were added to cover these inputs and their navigation events.
  
  # ✅ Acceptance criteria
  
All tests should pass.