### PR TITLE
[MBL-1738] iPadOS 18 - Navbar overlay issue in "Follow Friends" screen

### DIFF
--- a/Kickstarter-iOS/Features/FindFriends/Controller/FindFriendsViewController.swift
+++ b/Kickstarter-iOS/Features/FindFriends/Controller/FindFriendsViewController.swift
@@ -33,8 +33,8 @@ internal final class FindFriendsViewController: UITableViewController {
     self.viewModel.inputs.viewDidLoad()
   }
 
-  override func viewWillAppear(_ animated: Bool) {
-    super.viewWillAppear(animated)
+  override func viewDidAppear(_ animated: Bool) {
+    super.viewDidAppear(animated)
 
     self.navigationController?.setNavigationBarHidden(false, animated: animated)
   }


### PR DESCRIPTION
# 📲 What

- Moved the call to `setNavigationBarHidden` from `viewWillAppear` to `viewDidAppear` in the "Follow Friends" screen.

# 🤔 Why

The change was needed to fix an issue where the `UINavigationBar` was overlaying the content of the "Follow Friends" screen when running the app on a device with iPadOS 18 and Xcode 16.

This issue appears to be caused by layout changes introduced in iPadOS 18, where the tab bar is now at the top of the screen. By calling `setNavigationBarHidden` in `viewDidAppear` instead of `viewWillAppear`, we ensure that the layout has been fully constructed, which prevents the `UINavigationBar` from incorrectly overlaying the content.

# 🛠 How

The `setNavigationBarHidden` function was moved from `viewWillAppear` to `viewDidAppear` so that the layout is fully built before manipulating the visibility of the navigation bar. This change resolves the layout issue observed in iPadOS 18.

# 👀 See

[Jira issue](https://kickstarter.atlassian.net/browse/MBL-1738)

| Before 🐛 | After 🦋 |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/f6fd7faf-d174-45b8-a909-dae5af18d05b) | ![image](https://github.com/user-attachments/assets/939f2580-6e07-428b-a9b1-416cd843b038) |

# ✅ Acceptance criteria

- [ ] Ensure the `UINavigationBar` no longer overlays the "Follow Friends" screen on iPadOS 18.

