### PR TITLE
[MBL-1721] Crowdfunding Checkout Pledge Summary Table View Refactor

### DIFF
--- a/Kickstarter-iOS/Features/PledgePaymentMethods/Controller/NoShippingPledgeRewardsSummaryViewController.swift
+++ b/Kickstarter-iOS/Features/PledgePaymentMethods/Controller/NoShippingPledgeRewardsSummaryViewController.swift
@@ -306,7 +306,9 @@ extension NoShippingPledgeRewardsSummaryViewController: UITableViewDelegate {
   }
 
   func tableView(_: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+    let section = PledgeRewardsSummarySection.allCases[section]
+
     /// Hides the first section header because we're using our own UITableCell here.
-    return section == 0 ? 0 : UITableView.automaticDimension
+    return section == .header || section == .bonusSupport ? 0 : UITableView.automaticDimension
   }
 }

--- a/Kickstarter-iOS/Features/PledgePaymentMethods/Controller/NoShippingPledgeRewardsSummaryViewController.swift
+++ b/Kickstarter-iOS/Features/PledgePaymentMethods/Controller/NoShippingPledgeRewardsSummaryViewController.swift
@@ -233,22 +233,20 @@ final class NoShippingPledgeRewardsSummaryViewController: UIViewController {
 
     // MARK: Reward Section
 
-    if rewardData.count > 0 {
-      let baseReward = rewardData[0]
-      snapshot.appendSections([.reward])
-      snapshot.appendItems([.reward(baseReward)], toSection: .reward)
+    let baseReward = rewardData[0]
+    snapshot.appendSections([.reward])
+    snapshot.appendItems([.reward(baseReward)], toSection: .reward)
 
-      // MARK: Add-Ons
+    // MARK: Add-Ons
 
-      let addOns = rewardData
-        .filter { reward in reward != baseReward && reward.text != Strings.Bonus_support() }
-        .map { PledgeRewardsSummaryRow.addOns($0) }
+    let addOns = rewardData
+      .filter { reward in reward != baseReward && reward.text != Strings.Bonus_support() }
+      .map { PledgeRewardsSummaryRow.addOns($0) }
 
-      /// We only want to add an add-ons section if any have been selected
-      if addOns.count > 0 {
-        snapshot.appendSections([.addOns])
-        snapshot.appendItems(addOns, toSection: .addOns)
-      }
+    /// We only want to add an add-ons section if any have been selected
+    if addOns.count > 0 {
+      snapshot.appendSections([.addOns])
+      snapshot.appendItems(addOns, toSection: .addOns)
     }
 
     // MARK: Bonus Support

--- a/Kickstarter-iOS/Features/PledgePaymentMethods/Controller/NoShippingPledgeRewardsSummaryViewController.swift
+++ b/Kickstarter-iOS/Features/PledgePaymentMethods/Controller/NoShippingPledgeRewardsSummaryViewController.swift
@@ -214,8 +214,6 @@ final class NoShippingPledgeRewardsSummaryViewController: UIViewController {
   private func applySnapshotToDataSource(from data: [PostCampaignRewardsSummaryItem]) {
     var snapshot = NSDiffableDataSourceSnapshot<PledgeRewardsSummarySection, PledgeRewardsSummaryRow>()
 
-    // MARK: Header + Reward Sections
-
     /// Decipher header vs reward objects from the `[PostCampaignRewardsSummaryItem]` data object.
     let headerItemData = data.compactMap { item -> PledgeExpandableHeaderRewardCellData? in
       guard case let .header(data) = item else { return nil }
@@ -227,26 +225,36 @@ final class NoShippingPledgeRewardsSummaryViewController: UIViewController {
       return data
     }
 
-    let baseReward = rewardData[0]
+    // MARK: Header Section
 
     /// Define the sections of the table and what data to use in each section.
-    snapshot.appendSections([.header, .reward])
+    snapshot.appendSections([.header])
     snapshot.appendItems([.header(headerItemData[0])], toSection: .header)
-    snapshot.appendItems([.reward(baseReward)], toSection: .reward)
 
-    // MARK: Add-Ons
+    // MARK: Reward Section
 
-    let addOns = rewardData.filter { $0 != baseReward || $0.text != Strings.Bonus_support() }
-      .map { PledgeRewardsSummaryRow.addOns($0) }
-    /// We only want to add an add-ons section if any have been selected
-    if addOns.isEmpty == false {
-      snapshot.appendSections([.addOns])
-      snapshot.appendItems(addOns, toSection: .addOns)
+    if rewardData.isEmpty == false {
+      let baseReward = rewardData[0]
+      snapshot.appendSections([.reward])
+      snapshot.appendItems([.reward(baseReward)], toSection: .reward)
+
+      // MARK: Add-Ons
+
+      let addOns = rewardData
+        .filter { reward in reward != baseReward && reward.text != Strings.Bonus_support() }
+        .map { PledgeRewardsSummaryRow.addOns($0) }
+
+      /// We only want to add an add-ons section if any have been selected
+      if addOns.isEmpty == false {
+        snapshot.appendSections([.addOns])
+        snapshot.appendItems(addOns, toSection: .addOns)
+      }
     }
 
     // MARK: Bonus Support
 
-    let bonusSupportReward = rewardData.filter { $0.text == Strings.Bonus_support() }
+    let bonusSupportReward = rewardData
+      .filter { reward in reward.text == Strings.Bonus_support() }
       .map { PledgeRewardsSummaryRow.bonusSupport($0) }
 
     if let bonusSupport = bonusSupportReward.first {
@@ -271,7 +279,6 @@ final class NoShippingPledgeRewardsSummaryViewController: UIViewController {
     case .header:
       break
     case .reward:
-      headerLabel.text = Strings.project_subpages_menu_buttons_rewards()
     case .addOns:
       headerLabel.text = Strings.Add_ons()
     case .bonusSupport:

--- a/Kickstarter-iOS/Features/PledgePaymentMethods/Controller/NoShippingPledgeRewardsSummaryViewController.swift
+++ b/Kickstarter-iOS/Features/PledgePaymentMethods/Controller/NoShippingPledgeRewardsSummaryViewController.swift
@@ -233,20 +233,21 @@ final class NoShippingPledgeRewardsSummaryViewController: UIViewController {
 
     // MARK: Reward Section
 
-    let baseReward = rewardData[0]
-    snapshot.appendSections([.reward])
-    snapshot.appendItems([.reward(baseReward)], toSection: .reward)
+    if let baseReward = rewardData.first {
+      snapshot.appendSections([.reward])
+      snapshot.appendItems([.reward(baseReward)], toSection: .reward)
 
-    // MARK: Add-Ons
+      // MARK: Add-Ons
 
-    let addOns = rewardData
-      .filter { reward in reward != baseReward && reward.text != Strings.Bonus_support() }
-      .map { PledgeRewardsSummaryRow.addOns($0) }
+      let addOns = rewardData
+        .filter { reward in reward != baseReward && reward.text != Strings.Bonus_support() }
+        .map { PledgeRewardsSummaryRow.addOns($0) }
 
-    /// We only want to add an add-ons section if any have been selected
-    if addOns.count > 0 {
-      snapshot.appendSections([.addOns])
-      snapshot.appendItems(addOns, toSection: .addOns)
+      /// We only want to add an add-ons section if any have been selected
+      if addOns.count > 0 {
+        snapshot.appendSections([.addOns])
+        snapshot.appendItems(addOns, toSection: .addOns)
+      }
     }
 
     // MARK: Bonus Support

--- a/Kickstarter-iOS/Features/PledgePaymentMethods/Controller/NoShippingPledgeRewardsSummaryViewController.swift
+++ b/Kickstarter-iOS/Features/PledgePaymentMethods/Controller/NoShippingPledgeRewardsSummaryViewController.swift
@@ -2,7 +2,7 @@ import Library
 import Prelude
 import UIKit
 
-final class NoShippingPledgeRewardsSummaryTotalViewController: UIViewController {
+final class NoShippingPledgeRewardsSummaryViewController: UIViewController {
   // MARK: - Properties
 
   private let dataSource = NoShippingPledgeRewardsSummaryDataSource()
@@ -188,7 +188,7 @@ final class NoShippingPledgeRewardsSummaryTotalViewController: UIViewController 
 
 // MARK: - UITableViewDelegate
 
-extension NoShippingPledgeRewardsSummaryTotalViewController: UITableViewDelegate {
+extension NoShippingPledgeRewardsSummaryViewController: UITableViewDelegate {
   func tableView(_: UITableView, willSelectRowAt _: IndexPath) -> IndexPath? {
     return nil
   }

--- a/Kickstarter-iOS/Features/PledgePaymentMethods/Controller/NoShippingPledgeRewardsSummaryViewController.swift
+++ b/Kickstarter-iOS/Features/PledgePaymentMethods/Controller/NoShippingPledgeRewardsSummaryViewController.swift
@@ -279,6 +279,7 @@ final class NoShippingPledgeRewardsSummaryViewController: UIViewController {
     case .header:
       break
     case .reward:
+      headerLabel.text = Strings.backer_modal_reward_title()
     case .addOns:
       headerLabel.text = Strings.Add_ons()
     case .bonusSupport:

--- a/Kickstarter-iOS/Features/PledgePaymentMethods/Controller/NoShippingPledgeRewardsSummaryViewController.swift
+++ b/Kickstarter-iOS/Features/PledgePaymentMethods/Controller/NoShippingPledgeRewardsSummaryViewController.swift
@@ -15,23 +15,14 @@ final class NoShippingPledgeRewardsSummaryViewController: UIViewController {
 
   private lazy var rootStackView: UIStackView = {
     UIStackView(frame: .zero)
-      |> \.translatesAutoresizingMaskIntoConstraints .~ false
   }()
 
   private lazy var tableViewContainer: UIView = {
     UIView(frame: .zero)
-      |> \.translatesAutoresizingMaskIntoConstraints .~ false
-      |> \.clipsToBounds .~ true
   }()
 
   private lazy var tableView: UITableView = {
     ContentSizeTableView(frame: .zero, style: .plain)
-      |> \.separatorInset .~ .zero
-      |> \.contentInsetAdjustmentBehavior .~ .never
-      |> \.isScrollEnabled .~ false
-      |> \.delegate .~ self
-      |> \.rowHeight .~ UITableView.automaticDimension
-      |> \.sectionHeaderTopPadding .~ 0
   }()
 
   private lazy var dataSource: NoShippingPledgeRewardsSummaryDiffableDataSource =
@@ -112,20 +103,16 @@ final class NoShippingPledgeRewardsSummaryViewController: UIViewController {
   override func bindStyles() {
     super.bindStyles()
 
-    _ = self.view
-      |> \.clipsToBounds .~ true
-      |> checkoutWhiteBackgroundStyle
+    self.view.backgroundColor = .ksr_white
+    self.view.clipsToBounds = true
 
-    _ = self.rootStackView
-      |> self.rootStackViewStyle
+    self.rootStackViewStyle(self.rootStackView)
 
-    _ = self.tableView
-      |> checkoutWhiteBackgroundStyle
-      |> \.translatesAutoresizingMaskIntoConstraints .~ false
+    self.tableViewStyle(self.tableView)
 
-    _ = self.separatorView
-      |> self.separatorViewStyle
+    self.separatorViewStyle(self.separatorView)
 
+    self.tableViewContainerStyle(self.tableViewContainer)
     self.tableViewContainerHeightConstraint?.constant = self.tableView.intrinsicContentSize.height
   }
 
@@ -169,17 +156,49 @@ final class NoShippingPledgeRewardsSummaryViewController: UIViewController {
 
   // MARK: Styles
 
-  private let rootStackViewStyle: StackViewStyle = { stackView in
-    stackView
-      |> \.axis .~ NSLayoutConstraint.Axis.vertical
-      |> \.spacing .~ Styles.grid(1)
-      |> \.isLayoutMarginsRelativeArrangement .~ true
+  private func tableViewStyle(_ tableView: UITableView) {
+    tableView.separatorInset = .zero
+    tableView.contentInsetAdjustmentBehavior = .never
+    tableView.isScrollEnabled = false
+    tableView.delegate = self
+    tableView.rowHeight = UITableView.automaticDimension
+    tableView.separatorStyle = .none
+    tableView.backgroundColor = .ksr_white
+    tableView.translatesAutoresizingMaskIntoConstraints = false
   }
 
-  private let separatorViewStyle: ViewStyle = { view in
-    view
-      |> \.backgroundColor .~ .ksr_support_200
-      |> \.translatesAutoresizingMaskIntoConstraints .~ false
+  private func rootStackViewStyle(_ stackView: UIStackView) {
+    stackView.axis = NSLayoutConstraint.Axis.vertical
+    stackView.spacing = Styles.grid(1)
+    stackView.isLayoutMarginsRelativeArrangement = true
+    stackView.translatesAutoresizingMaskIntoConstraints = false
+  }
+
+  private func separatorViewStyle(_ view: UIView) {
+    view.backgroundColor = .ksr_support_200
+    view.translatesAutoresizingMaskIntoConstraints = false
+  }
+
+  private func sectionHeaderViewStyle(_ view: UIView) {
+    view.translatesAutoresizingMaskIntoConstraints = false
+    view.frame = CGRectMake(0, 0, self.tableView.frame.size.width, self.tableView.frame.size.height)
+  }
+
+  private func sectionHeaderLabelStyle(_ label: UILabel) {
+    label.font = UIFont.ksr_subhead().bolded
+    label.textColor = UIColor.ksr_black
+    label.numberOfLines = 0
+    label.frame = CGRectMake(
+      CheckoutConstants.PledgeView.Inset.leftRight,
+      0,
+      self.tableView.frame.size.width,
+      PledgeRewardsSummaryStyles.Layout.sectionHeaderLabelHeight
+    )
+  }
+
+  private func tableViewContainerStyle(_ view: UIView) {
+    view.translatesAutoresizingMaskIntoConstraints = false
+    view.clipsToBounds = true
   }
 
   // MARK: - Helpers
@@ -189,6 +208,8 @@ final class NoShippingPledgeRewardsSummaryViewController: UIViewController {
     self.pledgeTotalViewController.view.isHidden = isHidden
     self.separatorView.isHidden = isHidden
   }
+
+  // MARK: Apply DataSource Snapshot
 
   private func applySnapshotToDataSource(from data: [PostCampaignRewardsSummaryItem]) {
     var snapshot = NSDiffableDataSourceSnapshot<PledgeRewardsSummarySection, PledgeRewardsSummaryRow>()
@@ -237,21 +258,14 @@ final class NoShippingPledgeRewardsSummaryViewController: UIViewController {
     self.dataSource.apply(snapshot, animatingDifferences: true)
   }
 
-  private func headerView(for section: PledgeRewardsSummarySection) -> UIView {
-    let headerView: UIView = UIView(
-      frame: CGRectMake(0, 0, tableView.frame.size.width, self.tableView.frame.size.height)
-    )
+  // MARK: Section Header View
+
+  private func sectionHeaderView(for section: PledgeRewardsSummarySection) -> UIView {
+    let headerView = UIView()
+    self.sectionHeaderViewStyle(headerView)
 
     let headerLabel: UILabel = UILabel(frame: .zero)
-    headerLabel.font = UIFont.ksr_subhead().bolded
-    headerLabel.textColor = UIColor.ksr_black
-    headerLabel.numberOfLines = 0
-    headerLabel.frame = CGRectMake(
-      CheckoutConstants.PledgeView.Inset.leftRight,
-      0,
-      self.tableView.frame.size.width,
-      PledgeRewardsSummaryStyles.Layout.sectionHeaderLabelHeight
-    )
+    self.sectionHeaderLabelStyle(headerLabel)
 
     switch section {
     case .header:
@@ -280,6 +294,11 @@ extension NoShippingPledgeRewardsSummaryViewController: UITableViewDelegate {
   func tableView(_: UITableView, viewForHeaderInSection section: Int) -> UIView? {
     let section = PledgeRewardsSummarySection.allCases[section]
 
-    return self.headerView(for: section)
+    return self.sectionHeaderView(for: section)
+  }
+
+  func tableView(_: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+    /// Hides the first section header because we're using our own UITableCell here.
+    return section == 0 ? 0 : UITableView.automaticDimension
   }
 }

--- a/Kickstarter-iOS/Features/PledgePaymentMethods/Controller/NoShippingPledgeRewardsSummaryViewController.swift
+++ b/Kickstarter-iOS/Features/PledgePaymentMethods/Controller/NoShippingPledgeRewardsSummaryViewController.swift
@@ -233,7 +233,7 @@ final class NoShippingPledgeRewardsSummaryViewController: UIViewController {
 
     // MARK: Reward Section
 
-    if rewardData.isEmpty == false {
+    if rewardData.count > 0 {
       let baseReward = rewardData[0]
       snapshot.appendSections([.reward])
       snapshot.appendItems([.reward(baseReward)], toSection: .reward)
@@ -245,7 +245,7 @@ final class NoShippingPledgeRewardsSummaryViewController: UIViewController {
         .map { PledgeRewardsSummaryRow.addOns($0) }
 
       /// We only want to add an add-ons section if any have been selected
-      if addOns.isEmpty == false {
+      if addOns.count > 0 {
         snapshot.appendSections([.addOns])
         snapshot.appendItems(addOns, toSection: .addOns)
       }
@@ -276,14 +276,12 @@ final class NoShippingPledgeRewardsSummaryViewController: UIViewController {
     self.sectionHeaderLabelStyle(headerLabel)
 
     switch section {
-    case .header:
+    case .header, .bonusSupport:
       break
     case .reward:
       headerLabel.text = Strings.backer_modal_reward_title()
     case .addOns:
       headerLabel.text = Strings.Add_ons()
-    case .bonusSupport:
-      break
     }
 
     headerView.addSubview(headerLabel)

--- a/Kickstarter-iOS/Features/PledgePaymentMethods/Datasource/NoShippingPledgeRewardsSummaryDiffableDataSource.swift
+++ b/Kickstarter-iOS/Features/PledgePaymentMethods/Datasource/NoShippingPledgeRewardsSummaryDiffableDataSource.swift
@@ -5,21 +5,33 @@ public enum PledgeRewardsSummarySection: CaseIterable {
   case header
   case reward
   case addOns
+  case bonusSupport
 }
 
 enum PledgeRewardsSummaryRow: Hashable {
   case header(PledgeExpandableHeaderRewardCellData)
   case reward(PledgeExpandableHeaderRewardCellData)
   case addOns(PledgeExpandableHeaderRewardCellData)
+  case bonusSupport(PledgeExpandableHeaderRewardCellData)
 }
+
+/**
+
+ A `UITableViewDiffableDataSource` that accepts two types.
+
+ - `PledgeRewardsSummarySection`: defines the section type of the table.
+ - `PledgeRewardsSummaryRow`: the model that represents the data to be displayed in each cell.
+
+ These types are defined above and each UITableViewCell is configured based on the current row being rendered.
+ */
 
 class NoShippingPledgeRewardsSummaryDiffableDataSource: UITableViewDiffableDataSource<
   PledgeRewardsSummarySection,
   PledgeRewardsSummaryRow
->, UITableViewDelegate {
+> {
   init(tableView: UITableView) {
-    super.init(tableView: tableView) { tableView, indexPath, item in
-      switch item {
+    super.init(tableView: tableView) { tableView, indexPath, row in
+      switch row {
       case let .header(model):
         let cell = tableView.dequeueReusableCell(
           withClass: PostCampaignPledgeRewardsSummaryHeaderCell.self,
@@ -29,16 +41,7 @@ class NoShippingPledgeRewardsSummaryDiffableDataSource: UITableViewDiffableDataS
         cell.configureWith(value: model)
 
         return cell
-      case let .reward(model):
-        let cell = tableView.dequeueReusableCell(
-          withClass: PostCampaignPledgeRewardsSummaryCell.self,
-          for: indexPath
-        ) as! PostCampaignPledgeRewardsSummaryCell
-
-        cell.configureWith(value: model)
-
-        return cell
-      case let .addOns(model):
+      case let .reward(model), let .addOns(model), let .bonusSupport(model):
         let cell = tableView.dequeueReusableCell(
           withClass: PostCampaignPledgeRewardsSummaryCell.self,
           for: indexPath

--- a/Kickstarter-iOS/Features/PledgePaymentMethods/Datasource/NoShippingPledgeRewardsSummaryDiffableDataSource.swift
+++ b/Kickstarter-iOS/Features/PledgePaymentMethods/Datasource/NoShippingPledgeRewardsSummaryDiffableDataSource.swift
@@ -1,0 +1,53 @@
+import Library
+import UIKit
+
+public enum PledgeRewardsSummarySection: CaseIterable {
+  case header
+  case reward
+  case addOns
+}
+
+enum PledgeRewardsSummaryRow: Hashable {
+  case header(PledgeExpandableHeaderRewardCellData)
+  case reward(PledgeExpandableHeaderRewardCellData)
+  case addOns(PledgeExpandableHeaderRewardCellData)
+}
+
+class NoShippingPledgeRewardsSummaryDiffableDataSource: UITableViewDiffableDataSource<
+  PledgeRewardsSummarySection,
+  PledgeRewardsSummaryRow
+>, UITableViewDelegate {
+  init(tableView: UITableView) {
+    super.init(tableView: tableView) { tableView, indexPath, item in
+      switch item {
+      case let .header(model):
+        let cell = tableView.dequeueReusableCell(
+          withClass: PostCampaignPledgeRewardsSummaryHeaderCell.self,
+          for: indexPath
+        ) as! PostCampaignPledgeRewardsSummaryHeaderCell
+
+        cell.configureWith(value: model)
+
+        return cell
+      case let .reward(model):
+        let cell = tableView.dequeueReusableCell(
+          withClass: PostCampaignPledgeRewardsSummaryCell.self,
+          for: indexPath
+        ) as! PostCampaignPledgeRewardsSummaryCell
+
+        cell.configureWith(value: model)
+
+        return cell
+      case let .addOns(model):
+        let cell = tableView.dequeueReusableCell(
+          withClass: PostCampaignPledgeRewardsSummaryCell.self,
+          for: indexPath
+        ) as! PostCampaignPledgeRewardsSummaryCell
+
+        cell.configureWith(value: model)
+
+        return cell
+      }
+    }
+  }
+}

--- a/Kickstarter-iOS/Features/PledgePaymentMethods/Datasource/PledgeExpandableRewardsHeaderDataSourceTests.swift
+++ b/Kickstarter-iOS/Features/PledgePaymentMethods/Datasource/PledgeExpandableRewardsHeaderDataSourceTests.swift
@@ -10,9 +10,9 @@ final class PledgeExpandableRewardsHeaderDataSourceTests: XCTestCase {
 
   func testLoadValues() {
     let items: [PledgeExpandableRewardsHeaderItem] = [
-      .header((nil, true, "Header title", NSAttributedString(string: "$800"))),
-      .reward((nil, true, "Reward title", NSAttributedString(string: "$400"))),
-      .reward((nil, true, "Reward title", NSAttributedString(string: "$400")))
+      .header(.init(text: "Header title", amount: NSAttributedString(string: "$800"))),
+      .reward(.init(text: "Reward title", amount: NSAttributedString(string: "$400"))),
+      .reward(.init(text: "Reward title", amount: NSAttributedString(string: "$400")))
     ]
 
     self.dataSource.load(items)

--- a/Kickstarter-iOS/Features/PledgePaymentMethods/Views/Cells/PostCampaignPledgeRewardsSummaryCell.swift
+++ b/Kickstarter-iOS/Features/PledgePaymentMethods/Views/Cells/PostCampaignPledgeRewardsSummaryCell.swift
@@ -8,7 +8,6 @@ final class PostCampaignPledgeRewardsSummaryCell: UITableViewCell, ValueCell {
   private lazy var amountLabel: UILabel = UILabel(frame: .zero)
   private lazy var rootStackView: UIStackView = UIStackView(frame: .zero)
   private lazy var labelsStackView: UIStackView = UIStackView(frame: .zero)
-  private lazy var headerLabel: UILabel = UILabel(frame: .zero)
   private lazy var titleLabel: UILabel = UILabel(frame: .zero)
 
   private let viewModel: PledgeExpandableHeaderRewardCellViewModelType
@@ -56,14 +55,6 @@ final class PostCampaignPledgeRewardsSummaryCell: UITableViewCell, ValueCell {
 
     self.amountLabel.rac.attributedText = self.viewModel.outputs.amountAttributedText
 
-    self.viewModel.outputs.headerLabelText
-      .observeForUI()
-      .observeValues { [weak self] text in
-        guard let self, text != nil else { return }
-        self.headerLabel.attributedText = text
-        self.headerLabel.setNeedsLayout()
-      }
-
     self.viewModel.outputs.labelText
       .observeForUI()
       .observeValues { [weak self] titleText in
@@ -88,7 +79,7 @@ final class PostCampaignPledgeRewardsSummaryCell: UITableViewCell, ValueCell {
     _ = ([self.labelsStackView, self.amountLabel], self.rootStackView)
       |> ksr_addArrangedSubviewsToStackView()
 
-    _ = ([self.headerLabel, self.titleLabel], self.labelsStackView)
+    _ = ([self.titleLabel], self.labelsStackView)
       |> ksr_addArrangedSubviewsToStackView()
   }
 
@@ -100,18 +91,11 @@ final class PostCampaignPledgeRewardsSummaryCell: UITableViewCell, ValueCell {
 
   override func layoutSubviews() {
     super.layoutSubviews()
-    self.headerLabel.preferredMaxLayoutWidth = self.titleLabel.frame.size.width
     self.titleLabel.preferredMaxLayoutWidth = self.titleLabel.frame.size.width
     super.layoutSubviews()
   }
 
   // MARK: - Styles
-
-  private func headerLabelStyle(_ label: UILabel) {
-    label.font = UIFont.ksr_subhead().bolded
-    label.textColor = UIColor.ksr_black
-    label.numberOfLines = 0
-  }
 
   private func labelStyle(_ label: UILabel) {
     label.font = UIFont.ksr_subhead().bolded

--- a/Kickstarter-iOS/Features/PledgePaymentMethods/Views/Cells/PostCampaignPledgeRewardsSummaryCell.swift
+++ b/Kickstarter-iOS/Features/PledgePaymentMethods/Views/Cells/PostCampaignPledgeRewardsSummaryCell.swift
@@ -39,14 +39,11 @@ final class PostCampaignPledgeRewardsSummaryCell: UITableViewCell, ValueCell {
 
     self.amountLabel.adjustsFontForContentSizeCategory = true
 
-    _ = self.rootStackView
-      |> rootStackViewStyle(self.traitCollection.preferredContentSizeCategory > .accessibilityLarge)
+    self.rootStackViewStyle(self.rootStackView)
 
-    _ = self.labelsStackView
-      |> labelStackViewStyle
+    self.labelStackViewStyle(self.labelsStackView)
 
-    _ = self.titleLabel
-      |> labelStyle
+    self.labelStyle(self.titleLabel)
 
     self.amountLabel.setContentHuggingPriority(.required, for: .horizontal)
     self.amountLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
@@ -107,29 +104,29 @@ final class PostCampaignPledgeRewardsSummaryCell: UITableViewCell, ValueCell {
     self.titleLabel.preferredMaxLayoutWidth = self.titleLabel.frame.size.width
     super.layoutSubviews()
   }
-}
 
-// MARK: - Styles
+  // MARK: - Styles
 
-private func headerLabelStyle(_ label: UILabel) {
-  label.font = UIFont.ksr_subhead().bolded
-  label.textColor = UIColor.ksr_black
-  label.numberOfLines = 0
-}
+  private func headerLabelStyle(_ label: UILabel) {
+    label.font = UIFont.ksr_subhead().bolded
+    label.textColor = UIColor.ksr_black
+    label.numberOfLines = 0
+  }
 
-private func labelStyle(_ label: UILabel) {
-  label.font = UIFont.ksr_subhead().bolded
-  label.textColor = label.text == Strings.Bonus_support() ? UIColor.ksr_black : UIColor.ksr_support_400
-  label.numberOfLines = 0
-}
+  private func labelStyle(_ label: UILabel) {
+    label.font = UIFont.ksr_subhead().bolded
+    label.textColor = label.text == Strings.Bonus_support() ? UIColor.ksr_black : UIColor.ksr_support_400
+    label.numberOfLines = 0
+  }
 
-private func rootStackViewStyle(_ isAccessibilityCategory: Bool) -> (StackViewStyle) {
-  let alignment: UIStackView.Alignment = (isAccessibilityCategory ? .center : .bottom)
-  let axis: NSLayoutConstraint.Axis = (isAccessibilityCategory ? .vertical : .horizontal)
-  let distribution: UIStackView.Distribution = (isAccessibilityCategory ? .equalSpacing : .fillProportionally)
-  let spacing: CGFloat = (isAccessibilityCategory ? Styles.grid(1) : 0)
+  private func rootStackViewStyle(_ stackView: UIStackView) {
+    let isAccessibilityCategory = self.traitCollection.preferredContentSizeCategory > .accessibilityLarge
+    let alignment: UIStackView.Alignment = (isAccessibilityCategory ? .center : .bottom)
+    let axis: NSLayoutConstraint.Axis = (isAccessibilityCategory ? .vertical : .horizontal)
+    let distribution: UIStackView
+      .Distribution = (isAccessibilityCategory ? .equalSpacing : .fillProportionally)
+    let spacing: CGFloat = (isAccessibilityCategory ? Styles.grid(1) : 0)
 
-  return { (stackView: UIStackView) in
     stackView.insetsLayoutMarginsFromSafeArea = false
     stackView.alignment = alignment
     stackView.axis = axis
@@ -137,18 +134,18 @@ private func rootStackViewStyle(_ isAccessibilityCategory: Bool) -> (StackViewSt
     stackView.spacing = spacing
     stackView.isLayoutMarginsRelativeArrangement = true
     stackView.layoutMargins = UIEdgeInsets(
-      topBottom: Styles.grid(3),
-      leftRight: CheckoutConstants.PledgeView.Inset.leftRight
+      top: 0,
+      left: CheckoutConstants.PledgeView.Inset.leftRight,
+      bottom: Styles.grid(3),
+      right: CheckoutConstants.PledgeView.Inset.leftRight
     )
-
-    return stackView
   }
-}
 
-private func labelStackViewStyle(_ stackView: UIStackView) {
-  stackView.axis = NSLayoutConstraint.Axis.vertical
-  stackView.distribution = .fill
-  stackView.alignment = .fill
-  stackView.spacing = Styles.grid(1)
-  stackView.isLayoutMarginsRelativeArrangement = true
+  private func labelStackViewStyle(_ stackView: UIStackView) {
+    stackView.axis = NSLayoutConstraint.Axis.vertical
+    stackView.distribution = .fill
+    stackView.alignment = .fill
+    stackView.spacing = Styles.grid(1)
+    stackView.isLayoutMarginsRelativeArrangement = true
+  }
 }

--- a/Kickstarter-iOS/Features/PledgePaymentMethods/Views/Cells/PostCampaignPledgeRewardsSummaryCell.swift
+++ b/Kickstarter-iOS/Features/PledgePaymentMethods/Views/Cells/PostCampaignPledgeRewardsSummaryCell.swift
@@ -134,10 +134,8 @@ final class PostCampaignPledgeRewardsSummaryCell: UITableViewCell, ValueCell {
     stackView.spacing = spacing
     stackView.isLayoutMarginsRelativeArrangement = true
     stackView.layoutMargins = UIEdgeInsets(
-      top: 0,
-      left: CheckoutConstants.PledgeView.Inset.leftRight,
-      bottom: Styles.grid(3),
-      right: CheckoutConstants.PledgeView.Inset.leftRight
+      topBottom: Styles.grid(1),
+      leftRight: CheckoutConstants.PledgeView.Inset.leftRight
     )
   }
 

--- a/Kickstarter-iOS/Features/PledgePaymentMethods/Views/Cells/PostCampaignPledgeRewardsSummaryCell.swift
+++ b/Kickstarter-iOS/Features/PledgePaymentMethods/Views/Cells/PostCampaignPledgeRewardsSummaryCell.swift
@@ -6,9 +6,11 @@ final class PostCampaignPledgeRewardsSummaryCell: UITableViewCell, ValueCell {
   // MARK: - Properties
 
   private lazy var amountLabel: UILabel = UILabel(frame: .zero)
+  private lazy var containerStackView: UIStackView = UIStackView(frame: .zero)
   private lazy var rootStackView: UIStackView = UIStackView(frame: .zero)
   private lazy var labelsStackView: UIStackView = UIStackView(frame: .zero)
   private lazy var titleLabel: UILabel = UILabel(frame: .zero)
+  private lazy var separatorView: UIView = { UIView(frame: .zero) }()
 
   private let viewModel: PledgeExpandableHeaderRewardCellViewModelType
     = PledgeExpandableHeaderRewardCellViewModel()
@@ -38,6 +40,8 @@ final class PostCampaignPledgeRewardsSummaryCell: UITableViewCell, ValueCell {
 
     self.amountLabel.adjustsFontForContentSizeCategory = true
 
+    self.containerStackViewStyle(self.containerStackView)
+
     self.rootStackViewStyle(self.rootStackView)
 
     self.labelStackViewStyle(self.labelsStackView)
@@ -46,6 +50,8 @@ final class PostCampaignPledgeRewardsSummaryCell: UITableViewCell, ValueCell {
 
     self.amountLabel.setContentHuggingPriority(.required, for: .horizontal)
     self.amountLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
+
+    self.separatorViewStyle(self.separatorView)
   }
 
   // MARK: - View model
@@ -72,9 +78,12 @@ final class PostCampaignPledgeRewardsSummaryCell: UITableViewCell, ValueCell {
   }
 
   private func configureViews() {
-    _ = (self.rootStackView, self.contentView)
+    _ = (self.containerStackView, self.contentView)
       |> ksr_addSubviewToParent()
       |> ksr_constrainViewToEdgesInParent()
+
+    _ = ([self.rootStackView, self.separatorView], self.containerStackView)
+      |> ksr_addArrangedSubviewsToStackView()
 
     _ = ([self.labelsStackView, self.amountLabel], self.rootStackView)
       |> ksr_addArrangedSubviewsToStackView()
@@ -85,7 +94,12 @@ final class PostCampaignPledgeRewardsSummaryCell: UITableViewCell, ValueCell {
 
   private func setupConstraints() {
     NSLayoutConstraint.activate([
-      self.amountLabel.topAnchor.constraint(equalTo: self.titleLabel.topAnchor)
+      self.amountLabel.topAnchor.constraint(equalTo: self.titleLabel.topAnchor),
+      self.separatorView.leftAnchor
+        .constraint(equalTo: self.rootStackView.leftAnchor, constant: Styles.grid(4)),
+      self.separatorView.rightAnchor
+        .constraint(equalTo: self.rootStackView.rightAnchor, constant: -Styles.grid(4)),
+      self.separatorView.heightAnchor.constraint(equalToConstant: 1)
     ])
   }
 
@@ -123,11 +137,21 @@ final class PostCampaignPledgeRewardsSummaryCell: UITableViewCell, ValueCell {
     )
   }
 
+  private func containerStackViewStyle(_ stackView: UIStackView) {
+    stackView.axis = NSLayoutConstraint.Axis.vertical
+    stackView.spacing = Styles.grid(1)
+  }
+
   private func labelStackViewStyle(_ stackView: UIStackView) {
     stackView.axis = NSLayoutConstraint.Axis.vertical
     stackView.distribution = .fill
     stackView.alignment = .fill
     stackView.spacing = Styles.grid(1)
     stackView.isLayoutMarginsRelativeArrangement = true
+  }
+
+  private func separatorViewStyle(_ view: UIView) {
+    view.backgroundColor = .ksr_support_200
+    view.translatesAutoresizingMaskIntoConstraints = false
   }
 }

--- a/Kickstarter-iOS/Features/PledgePaymentMethods/Views/Cells/PostCampaignPledgeRewardsSummaryHeaderCell.swift
+++ b/Kickstarter-iOS/Features/PledgePaymentMethods/Views/Cells/PostCampaignPledgeRewardsSummaryHeaderCell.swift
@@ -5,9 +5,11 @@ import UIKit
 final class PostCampaignPledgeRewardsSummaryHeaderCell: UITableViewCell, ValueCell {
   // MARK: - Properties
 
+  private lazy var containerStackView: UIStackView = UIStackView(frame: .zero)
   private lazy var rootStackView: UIStackView = UIStackView(frame: .zero)
   private lazy var subtitleLabel: UILabel = UILabel(frame: .zero)
   private lazy var titleLabel: UILabel = UILabel(frame: .zero)
+  private lazy var separatorView: UIView = { UIView(frame: .zero) }()
 
   private let viewModel: PledgeExpandableHeaderRewardCellViewModelType
     = PledgeExpandableHeaderRewardCellViewModel()
@@ -18,6 +20,7 @@ final class PostCampaignPledgeRewardsSummaryHeaderCell: UITableViewCell, ValueCe
     super.init(style: style, reuseIdentifier: reuseIdentifier)
 
     self.configureViews()
+    self.setupConstraints()
     self.bindViewModel()
   }
 
@@ -35,16 +38,20 @@ final class PostCampaignPledgeRewardsSummaryHeaderCell: UITableViewCell, ValueCe
       |> \.selectionStyle .~ .none
       |> \.separatorInset .~ .init(leftRight: CheckoutConstants.PledgeView.Inset.leftRight)
 
+    self.containerStackViewStyle(self.containerStackView)
+
     _ = self.rootStackView
-      |> rootStackViewStyle(self.traitCollection.preferredContentSizeCategory > .accessibilityLarge)
+      |> self.rootStackViewStyle(self.traitCollection.preferredContentSizeCategory > .accessibilityLarge)
       |> verticalStackViewStyle
       |> \.spacing .~ Styles.grid(1)
 
     _ = self.titleLabel
-      |> titleLabelStyle
+      |> self.titleLabelStyle
 
     _ = self.subtitleLabel
-      |> subtitleLabelStyle
+      |> self.subtitleLabelStyle
+
+    self.separatorViewStyle(self.separatorView)
   }
 
   // MARK: - View model
@@ -67,49 +74,72 @@ final class PostCampaignPledgeRewardsSummaryHeaderCell: UITableViewCell, ValueCe
   }
 
   private func configureViews() {
-    _ = (self.rootStackView, self.contentView)
+    _ = (self.containerStackView, self.contentView)
       |> ksr_addSubviewToParent()
       |> ksr_constrainViewToEdgesInParent()
+
+    _ = ([self.rootStackView, self.separatorView], self.containerStackView)
+      |> ksr_addArrangedSubviewsToStackView()
 
     _ = ([self.titleLabel, self.subtitleLabel], self.rootStackView)
       |> ksr_addArrangedSubviewsToStackView()
   }
-}
 
-// MARK: - Styles
+  private func setupConstraints() {
+    NSLayoutConstraint.activate([
+      self.separatorView.leftAnchor
+        .constraint(equalTo: self.rootStackView.leftAnchor, constant: Styles.grid(4)),
+      self.separatorView.rightAnchor
+        .constraint(equalTo: self.rootStackView.rightAnchor, constant: -Styles.grid(4)),
+      self.separatorView.heightAnchor.constraint(equalToConstant: 1)
+    ])
+  }
 
-private let subtitleLabelStyle: LabelStyle = { label in
-  label
-    |> \.font .~ UIFont.ksr_caption1()
-    |> \.textColor .~ UIColor.ksr_support_400
-    |> \.numberOfLines .~ 0
-}
+  // MARK: - Styles
 
-private let titleLabelStyle: LabelStyle = { label in
-  label
-    |> \.font .~ UIFont.ksr_headline().bolded
-    |> \.textColor .~ .ksr_support_700
-    |> \.numberOfLines .~ 0
-    |> \.text .~ Strings.Your_pledge()
-}
+  private let subtitleLabelStyle: LabelStyle = { label in
+    label
+      |> \.font .~ UIFont.ksr_caption1()
+      |> \.textColor .~ UIColor.ksr_support_400
+      |> \.numberOfLines .~ 0
+  }
 
-private func rootStackViewStyle(_ isAccessibilityCategory: Bool) -> (StackViewStyle) {
-  let alignment: UIStackView.Alignment = (isAccessibilityCategory ? .leading : .top)
-  let axis: NSLayoutConstraint.Axis = (isAccessibilityCategory ? .vertical : .horizontal)
-  let distribution: UIStackView.Distribution = (isAccessibilityCategory ? .equalSpacing : .fill)
-  let spacing: CGFloat = (isAccessibilityCategory ? Styles.grid(1) : 0)
+  private let titleLabelStyle: LabelStyle = { label in
+    label
+      |> \.font .~ UIFont.ksr_headline().bolded
+      |> \.textColor .~ .ksr_support_700
+      |> \.numberOfLines .~ 0
+      |> \.text .~ Strings.Your_pledge()
+  }
 
-  return { (stackView: UIStackView) in
-    stackView
-      |> \.insetsLayoutMarginsFromSafeArea .~ false
-      |> \.alignment .~ alignment
-      |> \.axis .~ axis
-      |> \.distribution .~ distribution
-      |> \.spacing .~ spacing
-      |> \.isLayoutMarginsRelativeArrangement .~ true
-      |> \.layoutMargins .~ .init(
-        topBottom: Styles.grid(1),
-        leftRight: CheckoutConstants.PledgeView.Inset.leftRight
-      )
+  private func containerStackViewStyle(_ stackView: UIStackView) {
+    stackView.axis = NSLayoutConstraint.Axis.vertical
+    stackView.spacing = Styles.grid(2)
+  }
+
+  private func rootStackViewStyle(_ isAccessibilityCategory: Bool) -> (StackViewStyle) {
+    let alignment: UIStackView.Alignment = (isAccessibilityCategory ? .leading : .top)
+    let axis: NSLayoutConstraint.Axis = (isAccessibilityCategory ? .vertical : .horizontal)
+    let distribution: UIStackView.Distribution = (isAccessibilityCategory ? .equalSpacing : .fill)
+    let spacing: CGFloat = (isAccessibilityCategory ? Styles.grid(1) : 0)
+
+    return { (stackView: UIStackView) in
+      stackView
+        |> \.insetsLayoutMarginsFromSafeArea .~ false
+        |> \.alignment .~ alignment
+        |> \.axis .~ axis
+        |> \.distribution .~ distribution
+        |> \.spacing .~ spacing
+        |> \.isLayoutMarginsRelativeArrangement .~ true
+        |> \.layoutMargins .~ .init(
+          topBottom: Styles.grid(1),
+          leftRight: CheckoutConstants.PledgeView.Inset.leftRight
+        )
+    }
+  }
+
+  private func separatorViewStyle(_ view: UIView) {
+    view.backgroundColor = .ksr_support_200
+    view.translatesAutoresizingMaskIntoConstraints = false
   }
 }

--- a/Kickstarter-iOS/Features/PledgePaymentMethods/Views/Cells/PostCampaignPledgeRewardsSummaryHeaderCell.swift
+++ b/Kickstarter-iOS/Features/PledgePaymentMethods/Views/Cells/PostCampaignPledgeRewardsSummaryHeaderCell.swift
@@ -108,7 +108,7 @@ private func rootStackViewStyle(_ isAccessibilityCategory: Bool) -> (StackViewSt
       |> \.spacing .~ spacing
       |> \.isLayoutMarginsRelativeArrangement .~ true
       |> \.layoutMargins .~ .init(
-        topBottom: Styles.grid(3),
+        topBottom: Styles.grid(1),
         leftRight: CheckoutConstants.PledgeView.Inset.leftRight
       )
   }

--- a/Kickstarter-iOS/Features/PledgeView/Controllers/NoShippingPledgeViewController.swift
+++ b/Kickstarter-iOS/Features/PledgeView/Controllers/NoShippingPledgeViewController.swift
@@ -78,7 +78,7 @@ final class NoShippingPledgeViewController: UIViewController,
   }()
 
   private lazy var pledgeRewardsSummaryViewController = {
-    NoShippingPledgeRewardsSummaryTotalViewController.instantiate()
+    NoShippingPledgeRewardsSummaryViewController.instantiate()
   }()
 
   private lazy var estimatedShippingViewContainer =

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -543,7 +543,7 @@
 		60DA510F28C7E04B002E2DF1 /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 60DA510E28C7E04B002E2DF1 /* Kingfisher */; };
 		60DA511428C96A65002E2DF1 /* SwiftSoup in Frameworks */ = {isa = PBXBuildFile; productRef = 60DA511328C96A65002E2DF1 /* SwiftSoup */; };
 		60E1BB272C6D230A007D723B /* NoShippingPledgeViewCTAContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60E1BB262C6D230A007D723B /* NoShippingPledgeViewCTAContainerView.swift */; };
-		60E1BB292C6E5C18007D723B /* NoShippingPledgeRewardsSummaryTotalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60E1BB282C6E5C18007D723B /* NoShippingPledgeRewardsSummaryTotalViewController.swift */; };
+		60E1BB292C6E5C18007D723B /* NoShippingPledgeRewardsSummaryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60E1BB282C6E5C18007D723B /* NoShippingPledgeRewardsSummaryViewController.swift */; };
 		60E1BB2B2C6E5C3D007D723B /* NoShippingPledgeRewardsSummaryDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60E1BB2A2C6E5C3D007D723B /* NoShippingPledgeRewardsSummaryDataSource.swift */; };
 		60E1BB352C74F7E4007D723B /* EstimatedShippingCheckoutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60E1BB342C74F7E4007D723B /* EstimatedShippingCheckoutView.swift */; };
 		60E1BB552C7670F6007D723B /* NoShippingPledgeViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60E1BB532C7670F1007D723B /* NoShippingPledgeViewControllerTests.swift */; };
@@ -2191,7 +2191,7 @@
 		60C996ED2AC2030C006BE4F4 /* CreateFlaggingInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateFlaggingInput.swift; sourceTree = "<group>"; };
 		60C996EF2AC20314006BE4F4 /* CreateFlaggingInputTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateFlaggingInputTests.swift; sourceTree = "<group>"; };
 		60E1BB262C6D230A007D723B /* NoShippingPledgeViewCTAContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoShippingPledgeViewCTAContainerView.swift; sourceTree = "<group>"; };
-		60E1BB282C6E5C18007D723B /* NoShippingPledgeRewardsSummaryTotalViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoShippingPledgeRewardsSummaryTotalViewController.swift; sourceTree = "<group>"; };
+		60E1BB282C6E5C18007D723B /* NoShippingPledgeRewardsSummaryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoShippingPledgeRewardsSummaryViewController.swift; sourceTree = "<group>"; };
 		60E1BB2A2C6E5C3D007D723B /* NoShippingPledgeRewardsSummaryDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoShippingPledgeRewardsSummaryDataSource.swift; sourceTree = "<group>"; };
 		60E1BB342C74F7E4007D723B /* EstimatedShippingCheckoutView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EstimatedShippingCheckoutView.swift; sourceTree = "<group>"; };
 		60E1BB532C7670F1007D723B /* NoShippingPledgeViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoShippingPledgeViewControllerTests.swift; sourceTree = "<group>"; };
@@ -5642,7 +5642,7 @@
 				8A13D15E249559CB007E2C0B /* PledgeExpandableRewardsHeaderViewController.swift */,
 				604453232BA08EEA00B8F485 /* PostCampaignPledgeRewardsSummaryViewController.swift */,
 				6044532B2BA08FE100B8F485 /* PostCampaignPledgeRewardsSummaryTotalViewController.swift */,
-				60E1BB282C6E5C18007D723B /* NoShippingPledgeRewardsSummaryTotalViewController.swift */,
+				60E1BB282C6E5C18007D723B /* NoShippingPledgeRewardsSummaryViewController.swift */,
 			);
 			path = Controller;
 			sourceTree = "<group>";
@@ -8626,7 +8626,7 @@
 				AAE7C9A82C75948B00800E03 /* PPOProjectCard.swift in Sources */,
 				A75AB2261C8B407F002FC3E6 /* ActivityFriendBackingCell.swift in Sources */,
 				19A97CE228C7DA7B0031B857 /* ActivitiesDataSource.swift in Sources */,
-				60E1BB292C6E5C18007D723B /* NoShippingPledgeRewardsSummaryTotalViewController.swift in Sources */,
+				60E1BB292C6E5C18007D723B /* NoShippingPledgeRewardsSummaryViewController.swift in Sources */,
 				4705D8982742E20900A13BBE /* ProjectHeaderCell.swift in Sources */,
 				A731BF901D1EE4CD00A734AC /* UpdateViewModel.swift in Sources */,
 				06232D3A2795D37600A81755 /* ProjectPageViewControllerDataSource.swift in Sources */,

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -522,6 +522,7 @@
 		6078106D2A0419170050D4F7 /* FirebasePerformance in Frameworks */ = {isa = PBXBuildFile; productRef = 6078106C2A0419170050D4F7 /* FirebasePerformance */; };
 		6078106F2A04191C0050D4F7 /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = 6078106E2A04191C0050D4F7 /* FirebaseAnalytics */; };
 		6080DA402AB366680088EF3D /* Text+HTML.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6080DA3F2AB366680088EF3D /* Text+HTML.swift */; };
+		608B5B212CADA6CD00BCC5F4 /* NoShippingPledgeRewardsSummaryDiffableDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 608B5B202CADA6CD00BCC5F4 /* NoShippingPledgeRewardsSummaryDiffableDataSource.swift */; };
 		608F974A2B7522EF00DBE7D7 /* ValidateCheckout.graphql in Resources */ = {isa = PBXBuildFile; fileRef = 608F97492B7522EF00DBE7D7 /* ValidateCheckout.graphql */; };
 		608F974C2B752C4900DBE7D7 /* ValidateCheckoutEnvelope.swift in Sources */ = {isa = PBXBuildFile; fileRef = 608F974B2B752C4900DBE7D7 /* ValidateCheckoutEnvelope.swift */; };
 		6093098D2A6054CB004297AF /* GraphAPI.TriggerThirdPartyEventInput+TriggerThirdPartyEventInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6093098C2A6054CB004297AF /* GraphAPI.TriggerThirdPartyEventInput+TriggerThirdPartyEventInput.swift */; };
@@ -2171,6 +2172,7 @@
 		606C45F629FACD94001BA067 /* RemoteConfigFeature+HelpersTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RemoteConfigFeature+HelpersTests.swift"; sourceTree = "<group>"; };
 		606C45F929FACE17001BA067 /* MockRemoteConfigClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockRemoteConfigClient.swift; sourceTree = "<group>"; };
 		6080DA3F2AB366680088EF3D /* Text+HTML.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Text+HTML.swift"; sourceTree = "<group>"; };
+		608B5B202CADA6CD00BCC5F4 /* NoShippingPledgeRewardsSummaryDiffableDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoShippingPledgeRewardsSummaryDiffableDataSource.swift; sourceTree = "<group>"; };
 		608F97492B7522EF00DBE7D7 /* ValidateCheckout.graphql */ = {isa = PBXFileReference; lastKnownFileType = text; path = ValidateCheckout.graphql; sourceTree = "<group>"; };
 		608F974B2B752C4900DBE7D7 /* ValidateCheckoutEnvelope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValidateCheckoutEnvelope.swift; sourceTree = "<group>"; };
 		6093098C2A6054CB004297AF /* GraphAPI.TriggerThirdPartyEventInput+TriggerThirdPartyEventInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GraphAPI.TriggerThirdPartyEventInput+TriggerThirdPartyEventInput.swift"; sourceTree = "<group>"; };
@@ -5630,6 +5632,7 @@
 				8A8C6135243FBA640092B682 /* PledgePaymentMethodsDataSourceTests.swift */,
 				604453252BA08F0500B8F485 /* PostCampaignPledgeRewardsSummaryDataSource.swift */,
 				60E1BB2A2C6E5C3D007D723B /* NoShippingPledgeRewardsSummaryDataSource.swift */,
+				608B5B202CADA6CD00BCC5F4 /* NoShippingPledgeRewardsSummaryDiffableDataSource.swift */,
 			);
 			path = Datasource;
 			sourceTree = "<group>";
@@ -8659,6 +8662,7 @@
 				8A13D163249566B8007E2C0B /* PledgeExpandableHeaderRewardHeaderCell.swift in Sources */,
 				8A13D1672495687E007E2C0B /* PledgeExpandableRewardsHeaderDataSource.swift in Sources */,
 				8A32FE0424D2336E00F79C72 /* EmpyStateView.swift in Sources */,
+				608B5B212CADA6CD00BCC5F4 /* NoShippingPledgeRewardsSummaryDiffableDataSource.swift in Sources */,
 				379CFFFB2242DADB00F6F0C2 /* MFMailComposeViewController.swift in Sources */,
 				D63BBCF9217F666B007E01F0 /* PaymentMethodsDataSource.swift in Sources */,
 				601342EC2C81414000B851FA /* NoShippingPostCampaignCheckoutViewController.swift in Sources */,

--- a/Library/ViewModels/PledgeExpandableHeaderRewardCellViewModel.swift
+++ b/Library/ViewModels/PledgeExpandableHeaderRewardCellViewModel.swift
@@ -4,8 +4,6 @@ import Prelude
 import ReactiveSwift
 
 public struct PledgeExpandableHeaderRewardCellData: Hashable {
-  public let headerText: NSAttributedString?
-  public let showHeader: Bool
   public let text: String
   public let amount: NSAttributedString
 }
@@ -16,7 +14,6 @@ public protocol PledgeExpandableHeaderRewardCellViewModelInputs {
 
 public protocol PledgeExpandableHeaderRewardCellViewModelOutputs {
   var amountAttributedText: Signal<NSAttributedString, Never> { get }
-  var headerLabelText: Signal<NSAttributedString?, Never> { get }
   var labelText: Signal<String, Never> { get }
 }
 
@@ -29,13 +26,8 @@ public final class PledgeExpandableHeaderRewardCellViewModel: PledgeExpandableHe
   PledgeExpandableHeaderRewardCellViewModelInputs, PledgeExpandableHeaderRewardCellViewModelOutputs {
   public init() {
     let data = self.configureWithDataProperty.signal.skipNil()
-    let showHeader = data.map(\.showHeader)
 
     self.amountAttributedText = data.map(\.amount)
-    self.headerLabelText = Signal.combineLatest(data, showHeader)
-      .map { data, showHeader in
-        showHeader == true ? data.headerText : nil
-      }
     self.labelText = data.map(\.text)
   }
 
@@ -45,7 +37,6 @@ public final class PledgeExpandableHeaderRewardCellViewModel: PledgeExpandableHe
   }
 
   public let amountAttributedText: Signal<NSAttributedString, Never>
-  public let headerLabelText: Signal<NSAttributedString?, Never>
   public let labelText: Signal<String, Never>
 
   public var inputs: PledgeExpandableHeaderRewardCellViewModelInputs { return self }

--- a/Library/ViewModels/PledgeExpandableHeaderRewardCellViewModel.swift
+++ b/Library/ViewModels/PledgeExpandableHeaderRewardCellViewModel.swift
@@ -3,12 +3,12 @@ import KsApi
 import Prelude
 import ReactiveSwift
 
-public typealias PledgeExpandableHeaderRewardCellData = (
-  headerText: NSAttributedString?,
-  showHeader: Bool,
-  text: String,
-  amount: NSAttributedString
-)
+public struct PledgeExpandableHeaderRewardCellData: Hashable {
+  public let headerText: NSAttributedString?
+  public let showHeader: Bool
+  public let text: String
+  public let amount: NSAttributedString
+}
 
 public protocol PledgeExpandableHeaderRewardCellViewModelInputs {
   func configure(with data: PledgeExpandableHeaderRewardCellData)

--- a/Library/ViewModels/PledgeExpandableHeaderRewardCellViewModelTests.swift
+++ b/Library/ViewModels/PledgeExpandableHeaderRewardCellViewModelTests.swift
@@ -23,7 +23,7 @@ final class PledgeExpandableHeaderRewardCellViewModelTests: TestCase {
     let text = "Text"
     let amount = NSAttributedString(string: "Test string")
 
-    self.vm.inputs.configure(with: (nil, true, text, amount))
+    self.vm.inputs.configure(with: .init(text: text, amount: amount))
 
     self.amountAttributedText.assertValues([amount])
     self.labelText.assertValues([text])

--- a/Library/ViewModels/PledgeExpandableRewardsHeaderViewModel.swift
+++ b/Library/ViewModels/PledgeExpandableRewardsHeaderViewModel.swift
@@ -143,8 +143,6 @@ private func items(
   ) else { return [] }
 
   let headerItem = PledgeExpandableRewardsHeaderItem.header(.init(
-    headerText: nil,
-    showHeader: true,
     text: estimatedDeliveryString,
     amount: totalAmountAttributedText
   ))
@@ -161,8 +159,6 @@ private func items(
     )
 
     return PledgeExpandableRewardsHeaderItem.reward(.init(
-      headerText: nil,
-      showHeader: true,
       text: itemString,
       amount: amountAttributedText
     ))

--- a/Library/ViewModels/PledgeExpandableRewardsHeaderViewModel.swift
+++ b/Library/ViewModels/PledgeExpandableRewardsHeaderViewModel.swift
@@ -142,7 +142,7 @@ private func items(
     with: data.projectCountry, amount: total, omitUSCurrencyCode: data.omitCurrencyCode
   ) else { return [] }
 
-  let headerItem = PledgeExpandableRewardsHeaderItem.header((
+  let headerItem = PledgeExpandableRewardsHeaderItem.header(.init(
     headerText: nil,
     showHeader: true,
     text: estimatedDeliveryString,
@@ -160,7 +160,7 @@ private func items(
       with: data.projectCountry, amount: amount, omitUSCurrencyCode: data.omitCurrencyCode
     )
 
-    return PledgeExpandableRewardsHeaderItem.reward((
+    return PledgeExpandableRewardsHeaderItem.reward(.init(
       headerText: nil,
       showHeader: true,
       text: itemString,

--- a/Library/ViewModels/PostCampaignPledgeRewardsSummaryViewModel.swift
+++ b/Library/ViewModels/PostCampaignPledgeRewardsSummaryViewModel.swift
@@ -150,8 +150,6 @@ private func items(
   // MARK: Header
 
   let headerItem = PostCampaignRewardsSummaryItem.header(.init(
-    headerText: nil,
-    showHeader: true,
     text: estimatedDeliveryString ?? "",
     amount: NSAttributedString(string: "")
   ))
@@ -164,27 +162,12 @@ private func items(
     let quantity = selectedQuantities[reward.id] ?? 0
     let itemString = quantity > 1 ? "\(Format.wholeNumber(quantity)) x \(title)" : title
 
-    var headerAttributedText: NSAttributedString?
-
-    if featureNoShippingAtCheckout() == true {
-      let headerText = reward == data.rewards.first ? Strings.backer_modal_reward_title() : Strings.Add_ons()
-      headerAttributedText = NSAttributedString(
-        string: headerText,
-        attributes: [
-          .foregroundColor: UIColor.ksr_black,
-          .font: UIFont.ksr_subhead().bolded
-        ]
-      )
-    }
-
     let amount = quantity > 1 ? reward.minimum * Double(quantity) : reward.minimum
     let amountAttributedText = attributedRewardCurrency(
       with: data.projectCountry, amount: amount, omitUSCurrencyCode: data.omitCurrencyCode
     )
 
     return PostCampaignRewardsSummaryItem.reward(.init(
-      headerText: headerAttributedText,
-      showHeader: false,
       text: itemString,
       amount: amountAttributedText
     ))
@@ -199,8 +182,6 @@ private func items(
     )
 
     let shippingItem = PostCampaignRewardsSummaryItem.reward(.init(
-      headerText: nil,
-      showHeader: true,
       text: Strings.Shipping_to_country(country: shipping.locationName),
       amount: shippingAmountAttributedText
     ))
@@ -216,8 +197,6 @@ private func items(
     )
 
     let bonusItem = PostCampaignRewardsSummaryItem.reward(.init(
-      headerText: nil,
-      showHeader: true,
       text: Strings.Bonus_support(),
       amount: bonusAmountAttributedText
     ))

--- a/Library/ViewModels/PostCampaignPledgeRewardsSummaryViewModel.swift
+++ b/Library/ViewModels/PostCampaignPledgeRewardsSummaryViewModel.swift
@@ -30,11 +30,11 @@ public enum PostCampaignRewardsSummaryItem {
 }
 
 public struct PostCampaignRewardsSummaryViewData {
-  public let rewards: [Reward]
-  public let selectedQuantities: SelectedRewardQuantities
-  public let projectCountry: Project.Country
-  public let omitCurrencyCode: Bool
-  public let shipping: PledgeShippingSummaryViewData?
+  let rewards: [Reward]
+  let selectedQuantities: SelectedRewardQuantities
+  let projectCountry: Project.Country
+  let omitCurrencyCode: Bool
+  let shipping: PledgeShippingSummaryViewData?
 }
 
 public protocol PostCampaignPledgeRewardsSummaryViewModelInputs {
@@ -149,7 +149,7 @@ private func items(
 ) -> [PostCampaignRewardsSummaryItem] {
   // MARK: Header
 
-  let headerItem = PostCampaignRewardsSummaryItem.header((
+  let headerItem = PostCampaignRewardsSummaryItem.header(.init(
     headerText: nil,
     showHeader: true,
     text: estimatedDeliveryString ?? "",
@@ -182,10 +182,9 @@ private func items(
       with: data.projectCountry, amount: amount, omitUSCurrencyCode: data.omitCurrencyCode
     )
 
-    return PostCampaignRewardsSummaryItem.reward((
+    return PostCampaignRewardsSummaryItem.reward(.init(
       headerText: headerAttributedText,
-      showHeader: data.rewards.firstIndex(of: reward)! < 2,
-      /// only show header text if the item is the base reward or the first add-on.
+      showHeader: false,
       text: itemString,
       amount: amountAttributedText
     ))
@@ -199,7 +198,7 @@ private func items(
       with: data.projectCountry, amount: shipping.total, omitUSCurrencyCode: data.omitCurrencyCode
     )
 
-    let shippingItem = PostCampaignRewardsSummaryItem.reward((
+    let shippingItem = PostCampaignRewardsSummaryItem.reward(.init(
       headerText: nil,
       showHeader: true,
       text: Strings.Shipping_to_country(country: shipping.locationName),
@@ -216,7 +215,7 @@ private func items(
       with: data.projectCountry, amount: bonus, omitUSCurrencyCode: data.omitCurrencyCode
     )
 
-    let bonusItem = PostCampaignRewardsSummaryItem.reward((
+    let bonusItem = PostCampaignRewardsSummaryItem.reward(.init(
       headerText: nil,
       showHeader: true,
       text: Strings.Bonus_support(),


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Instead of making the header text of each section a part of each cell, it'd be better to use actual table view header cells. We currently use a custom data source implementation that is overly complicated, somewhat difficult to understand, and not set up to easily define table view sections with UITableView headers.

After trying a couple of solutions, I built a new data source class that implements the `UITableViewDiffableDataSource` API. This approach comes with three main wins for us:
- Simplifies the UI State
- Removes the need for batch updates
- Setups up for automatic animations if we want to take advantage in the future.

By applying a snapshot of all of the table data at once, we can more easily define sections and configure specific cell types for each.

I've only implemented this to crowdfunding under the "No Shipping At Checkout" Feature Flag here, but I want to update late pledge to use this same table once we've decided that this is a good solution.

# 🛠 How

- Rename `NoShippingPledgeRewardsSummaryTotalViewController` to `NoShippingPledgeRewardsSummaryViewController` so i makes sense
- Creates `class NoShippingPledgeRewardsSummaryDiffableDataSource: UITableViewDiffableDataSource`
- Sets this new data source on the crowdfunding checkout table view
   - defines sections for the table as `header`, `reward`, `addOns`,  and `bonusSupport`

# 👀 See

| No Reward | Reward (no add-on) | Reward + add on | Reward + Bonus Support |
| --- | --- | --- | --- |
| ![No Reward](https://github.com/user-attachments/assets/ac5671d3-bb59-46a5-8c18-3a21852542c8) | ![reward (no addon)](https://github.com/user-attachments/assets/5dad293a-a9bb-4315-88a9-63c164063b44) | ![reward (addon)](https://github.com/user-attachments/assets/0f62f38a-c3ba-4058-8ff4-75ef2cc6bec8) | ![reward (addon + bonus support)](https://github.com/user-attachments/assets/ccd21caf-81a6-4a81-9d94-74efb5c095c7) |


# ✅ Acceptance criteria

- [x] crowdfunding pledges work as expected
- [x] crowdfunding pledge summary table matches [designs](https://www.figma.com/design/z4faZM4BQwbyiDe7y8tbpP/Pledge-Redemption?node-id=35-1532&node-type=frame&t=Gqnx64udPplFjYSb-0)

# ⏰ TODO
- [ ] Update late pledge to reuse this table and late pledge snapshots
- [ ] Add shipping section to data source
