### PR TITLE
[MBL-1613] Handle errors for late pledges without dismissing the view controller

### DIFF
--- a/Kickstarter-iOS/Features/PledgeView/Controllers/NoShippingPostCampaignCheckoutViewController.swift
+++ b/Kickstarter-iOS/Features/PledgeView/Controllers/NoShippingPostCampaignCheckoutViewController.swift
@@ -277,7 +277,7 @@ final class NoShippingPostCampaignCheckoutViewController: UIViewController,
         self.confirmPayment(with: validation)
       }
 
-    self.viewModel.outputs.showErrorBannerWithMessage
+    self.viewModel.outputs.showErrorBanner
       .observeForControllerAction()
       .observeValues { [weak self] errorMessage, shouldPersist in
         self?.messageBannerViewController?.showBanner(

--- a/Library/ViewModels/NoShippingPostCampaignCheckoutViewModel.swift
+++ b/Library/ViewModels/NoShippingPostCampaignCheckoutViewModel.swift
@@ -34,7 +34,7 @@ public protocol NoShippingPostCampaignCheckoutViewModelOutputs {
   var goToLoginSignup: Signal<(LoginIntent, Project, Reward), Never> { get }
   var paymentMethodsViewHidden: Signal<Bool, Never> { get }
   var processingViewIsHidden: Signal<Bool, Never> { get }
-  var showErrorBannerWithMessage: Signal<(String, /* persist: */ Bool), Never> { get }
+  var showErrorBanner: Signal<(message: String, persist: Bool), Never> { get }
   var showWebHelp: Signal<HelpType, Never> { get }
   var validateCheckoutSuccess: Signal<PaymentSourceValidation, Never> { get }
   var goToApplePayPaymentAuthorization: Signal<PostCampaignPaymentAuthorizationData, Never> { get }
@@ -516,14 +516,14 @@ public class NoShippingPostCampaignCheckoutViewModel: NoShippingPostCampaignChec
 
     // MARK: - Error handling
 
-    self.showErrorBannerWithMessage = Signal.merge(
+    self.showErrorBanner = Signal.merge(
       createCheckoutError.map { ($0, true) },
       validateCheckoutError.map { ($0, false) },
       checkoutError.map { ($0, false) }
     )
     .map { error, shouldPersist in
       if error.ksrCode == .ValidateCheckoutError, let message = error.errorMessages.first {
-        return (message, shouldPersist)
+        return (message: message, persist: shouldPersist)
       }
 
       #if DEBUG
@@ -533,7 +533,7 @@ public class NoShippingPostCampaignCheckoutViewModel: NoShippingPostCampaignChec
         let message = Strings.Something_went_wrong_please_try_again()
       #endif
 
-      return (message, shouldPersist)
+      return (message: message, persist: shouldPersist)
     }
 
     // MARK: - UI related to checkout flow
@@ -759,7 +759,7 @@ public class NoShippingPostCampaignCheckoutViewModel: NoShippingPostCampaignChec
   public let estimatedShippingViewHidden: Signal<Bool, Never>
   public let goToLoginSignup: Signal<(LoginIntent, Project, Reward), Never>
   public let processingViewIsHidden: Signal<Bool, Never>
-  public let showErrorBannerWithMessage: Signal<(String, /* persist: */ Bool), Never>
+  public let showErrorBanner: Signal<(message: String, persist: Bool), Never>
   public let showWebHelp: Signal<HelpType, Never>
   public let paymentMethodsViewHidden: Signal<Bool, Never>
   public let validateCheckoutSuccess: Signal<PaymentSourceValidation, Never>

--- a/Library/ViewModels/NoShippingPostCampaignCheckoutViewModel.swift
+++ b/Library/ViewModels/NoShippingPostCampaignCheckoutViewModel.swift
@@ -34,12 +34,11 @@ public protocol NoShippingPostCampaignCheckoutViewModelOutputs {
   var goToLoginSignup: Signal<(LoginIntent, Project, Reward), Never> { get }
   var paymentMethodsViewHidden: Signal<Bool, Never> { get }
   var processingViewIsHidden: Signal<Bool, Never> { get }
-  var showErrorBannerWithMessage: Signal<String, Never> { get }
+  var showErrorBannerWithMessage: Signal<(String, /* persist: */ Bool), Never> { get }
   var showWebHelp: Signal<HelpType, Never> { get }
   var validateCheckoutSuccess: Signal<PaymentSourceValidation, Never> { get }
   var goToApplePayPaymentAuthorization: Signal<PostCampaignPaymentAuthorizationData, Never> { get }
   var checkoutComplete: Signal<ThanksPageData, Never> { get }
-  var checkoutError: Signal<ErrorEnvelope, Never> { get }
 }
 
 public protocol NoShippingPostCampaignCheckoutViewModelType {
@@ -179,7 +178,7 @@ public class NoShippingPostCampaignCheckoutViewModel: NoShippingPostCampaignChec
 
     let backingId = createCheckoutEvents.values().map(\.checkout.backingId)
 
-    let createCheckoutErrors = createCheckoutEvents.errors()
+    let createCheckoutError = createCheckoutEvents.errors()
 
     // MARK: Configure views
 
@@ -454,6 +453,7 @@ public class NoShippingPostCampaignCheckoutViewModel: NoShippingPostCampaignChec
 
     let completeCheckoutWithCreditCardInput: Signal<GraphAPI.CompleteOnSessionCheckoutInput, Never> = Signal
       .combineLatest(self.confirmPaymentSuccessfulProperty.signal.skipNil(), checkoutId, selectedCard)
+      .takeWhen(self.confirmPaymentSuccessfulProperty.signal.skipNil())
       .map { (
         clientSecret: String,
         checkoutId: String,
@@ -512,19 +512,29 @@ public class NoShippingPostCampaignCheckoutViewModel: NoShippingPostCampaignChec
       .takeWhen(checkoutCompleteSignal.signal.values())
       .map { $0 }
 
-    self.checkoutError = checkoutCompleteSignal.signal.errors()
+    let checkoutError = checkoutCompleteSignal.signal.errors()
 
     // MARK: - Error handling
 
-    self.showErrorBannerWithMessage = Signal.merge(createCheckoutErrors, validateCheckoutError)
-      .map { error in
-        switch error.ksrCode {
-        case .ValidateCheckoutError:
-          return error.errorMessages.first ?? Strings.Something_went_wrong_please_try_again()
-        default:
-          return Strings.Something_went_wrong_please_try_again()
-        }
+    self.showErrorBannerWithMessage = Signal.merge(
+      createCheckoutError.map { ($0, true) },
+      validateCheckoutError.map { ($0, false) },
+      checkoutError.map { ($0, false) }
+    )
+    .map { error, shouldPersist in
+      if error.ksrCode == .ValidateCheckoutError, let message = error.errorMessages.first {
+        return (message, shouldPersist)
       }
+
+      #if DEBUG
+        let serverError = error.errorMessages.first ?? ""
+        let message = "\(Strings.Something_went_wrong_please_try_again())\n\(serverError)"
+      #else
+        let message = Strings.Something_went_wrong_please_try_again()
+      #endif
+
+      return (message, shouldPersist)
+    }
 
     // MARK: - UI related to checkout flow
 
@@ -567,7 +577,7 @@ public class NoShippingPostCampaignCheckoutViewModel: NoShippingPostCampaignChec
     // Use checkoutId in tracking, or default to nil if creating it errors.
     let checkoutIdOrNil = Signal.merge(
       checkoutId.wrapInOptional(),
-      createCheckoutErrors.mapConst(nil).take(first: 1)
+      createCheckoutError.mapConst(nil).take(first: 1)
     )
 
     let checkoutData = Signal.combineLatest(
@@ -749,13 +759,12 @@ public class NoShippingPostCampaignCheckoutViewModel: NoShippingPostCampaignChec
   public let estimatedShippingViewHidden: Signal<Bool, Never>
   public let goToLoginSignup: Signal<(LoginIntent, Project, Reward), Never>
   public let processingViewIsHidden: Signal<Bool, Never>
-  public let showErrorBannerWithMessage: Signal<String, Never>
+  public let showErrorBannerWithMessage: Signal<(String, /* persist: */ Bool), Never>
   public let showWebHelp: Signal<HelpType, Never>
   public let paymentMethodsViewHidden: Signal<Bool, Never>
   public let validateCheckoutSuccess: Signal<PaymentSourceValidation, Never>
   public let goToApplePayPaymentAuthorization: Signal<PostCampaignPaymentAuthorizationData, Never>
   public let checkoutComplete: Signal<ThanksPageData, Never>
-  public let checkoutError: Signal<ErrorEnvelope, Never>
 
   public var inputs: NoShippingPostCampaignCheckoutViewModelInputs { return self }
   public var outputs: NoShippingPostCampaignCheckoutViewModelOutputs { return self }

--- a/Library/ViewModels/NoShippingPostCampaignCheckoutViewModelTests.swift
+++ b/Library/ViewModels/NoShippingPostCampaignCheckoutViewModelTests.swift
@@ -20,7 +20,7 @@ final class NoShippingPostCampaignCheckoutViewModelTests: TestCase {
   private let checkoutComplete = TestObserver<ThanksPageData, Never>()
   private let processingViewIsHidden = TestObserver<Bool, Never>()
   private let validateCheckoutSuccess = TestObserver<PaymentSourceValidation, Never>()
-  private let showErrorBannerWithMessage = TestObserver<(String, Bool), Never>()
+  private let showErrorBanner = TestObserver<(message: String, persist: Bool), Never>()
   private let goToLoginSignup = TestObserver<(LoginIntent, Project, Reward), Never>()
 
   private let configurePaymentMethodsViewControllerWithUser = TestObserver<User, Never>()
@@ -47,7 +47,7 @@ final class NoShippingPostCampaignCheckoutViewModelTests: TestCase {
     self.vm.checkoutComplete.observe(self.checkoutComplete.observer)
     self.vm.processingViewIsHidden.observe(self.processingViewIsHidden.observer)
     self.vm.validateCheckoutSuccess.observe(self.validateCheckoutSuccess.observer)
-    self.vm.showErrorBannerWithMessage.observe(self.showErrorBannerWithMessage.observer)
+    self.vm.showErrorBanner.observe(self.showErrorBanner.observer)
     self.vm.goToLoginSignup.observe(self.goToLoginSignup.observer)
 
     self.vm.outputs.configurePaymentMethodsViewControllerWithValue.map { $0.0 }
@@ -813,7 +813,7 @@ final class NoShippingPostCampaignCheckoutViewModelTests: TestCase {
       self.vm.inputs.goToLoginSignupTapped()
 
       self.goToLoginSignup.assertDidEmitValue()
-      self.showErrorBannerWithMessage.assertDidNotEmitValue()
+      self.showErrorBanner.assertDidNotEmitValue()
     }
   }
 }

--- a/Library/ViewModels/NoShippingPostCampaignCheckoutViewModelTests.swift
+++ b/Library/ViewModels/NoShippingPostCampaignCheckoutViewModelTests.swift
@@ -20,7 +20,7 @@ final class NoShippingPostCampaignCheckoutViewModelTests: TestCase {
   private let checkoutComplete = TestObserver<ThanksPageData, Never>()
   private let processingViewIsHidden = TestObserver<Bool, Never>()
   private let validateCheckoutSuccess = TestObserver<PaymentSourceValidation, Never>()
-  private let checkoutError = TestObserver<ErrorEnvelope, Never>()
+  private let showErrorBannerWithMessage = TestObserver<(String, Bool), Never>()
   private let goToLoginSignup = TestObserver<(LoginIntent, Project, Reward), Never>()
 
   private let configurePaymentMethodsViewControllerWithUser = TestObserver<User, Never>()
@@ -47,7 +47,7 @@ final class NoShippingPostCampaignCheckoutViewModelTests: TestCase {
     self.vm.checkoutComplete.observe(self.checkoutComplete.observer)
     self.vm.processingViewIsHidden.observe(self.processingViewIsHidden.observer)
     self.vm.validateCheckoutSuccess.observe(self.validateCheckoutSuccess.observer)
-    self.vm.checkoutError.observe(self.checkoutError.observer)
+    self.vm.showErrorBannerWithMessage.observe(self.showErrorBannerWithMessage.observer)
     self.vm.goToLoginSignup.observe(self.goToLoginSignup.observer)
 
     self.vm.outputs.configurePaymentMethodsViewControllerWithValue.map { $0.0 }
@@ -813,7 +813,7 @@ final class NoShippingPostCampaignCheckoutViewModelTests: TestCase {
       self.vm.inputs.goToLoginSignupTapped()
 
       self.goToLoginSignup.assertDidEmitValue()
-      self.checkoutError.assertDidNotEmitValue()
+      self.showErrorBannerWithMessage.assertDidNotEmitValue()
     }
   }
 }


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Handle errors in the late pledge flow without a confirm details page by just showing an error banner (not dismissing the vc). The error banner will persist if the error happens when creating the checkout. If it's an error that happens in a part of the flow the user can retry (after hitting "pledge" or adding a new card) the banner disappears.

# 👀 See

[Jira](https://kickstarter.atlassian.net/browse/MBL-1613)

![Simulator Screen Recording - iPhone 16 Pro Max - 2024-10-09 at 15 37 42](https://github.com/user-attachments/assets/597febe7-1c9c-404d-b9ab-e65843a26e57)

# ✅ Acceptance criteria

- [x] The same errors show as before, but they no longer navigate backwards
- [x] If in debug, the server error always shows in addition to the general "Something went wrong"
- [x] I tested the "checkout error causes banner to persist" by hardcoding the view model to say it happened. So I've tested all the UI changes, but I haven't tried to generate new (real) errors.

