### PR TITLE
[MBL-1780] Remove deleted method from our beta changelog

### DIFF
--- a/.fastlane/beta-changelog.rb
+++ b/.fastlane/beta-changelog.rb
@@ -29,7 +29,7 @@ previous_changelog = current_builds.last['changelog']
 current_changelog_from_fastlane = File.read('.FASTLANE_RELEASE_NOTES.tmp')
 
 file_name = '.RELEASE_NOTES.tmp'
-File.delete(file_name) if File.exists?(file_name)
+File.delete(file_name) if File.exist?(file_name)
 File.open(file_name, 'w') do |f|
   f.write(current_changelog_from_fastlane)
   f.write(previous_changelog


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Update `beta-changelog.rb` to using `File.exist` instead of `File.exists`, as the latter no longer exists in Ruby 3.3. 

# 🤔 Why

I think this will unblock the beta build getting uploaded. The full Ruby error also includes a warning to aws-sdk-core about a change that's happening in Ruby 3.4, but I'm ignoring this for now. I think the fix for that warning is to update our aws gem versions, but I'd rather not do that without understanding what they're doing so I can test the changes properly, and I don't expect a ruby warning to break the script.

# 👀 See

[Jira](https://kickstarter.atlassian.net/browse/MBL-1780)

# ✅ Acceptance criteria

- [x] Tests pass
- I'm not testing that the beta build works before merging this pr, since I'm not sure how. (I tried creating a pr in the private repo instead, but it looks like the beta build only gets created after submit.) Plus, this pr is definitely part of the solution so I see no harm in confirming if it's the entire solution after it's submitted.
