### PR TITLE
Allowlist all stripe requests, not just stripe elements

### DIFF
--- a/Library/ViewModels/SurveyResponseViewModel.swift
+++ b/Library/ViewModels/SurveyResponseViewModel.swift
@@ -164,10 +164,11 @@ private func isSurvey(request: URLRequest) -> Bool {
   return true
 }
 
-// Returns true if the url host is of the form *.stripe.com or *.stripe.network.
+// Returns true if the url host is of the form *.stripe.com, *.stripe.network, or *.stripecdn.com.
 private func isStripeRequest(_ request: URLRequest) -> Bool {
+  let stripeDomains = ["stripe.com", "stripe.network", "stripecdn.com"]
+
   guard let host = request.url?.host?.lowercased() else { return false }
-  let components = host.split(separator: ".")
-  return components.count == 3 && components[1] == "stripe" &&
-    (components[2] == "com" || components[2] == "network")
+  let withoutSubdomain = host.split(separator: ".").suffix(2).joined(separator: ".")
+  return stripeDomains.contains(withoutSubdomain)
 }

--- a/Library/ViewModels/SurveyResponseViewModel.swift
+++ b/Library/ViewModels/SurveyResponseViewModel.swift
@@ -107,7 +107,7 @@ public final class SurveyResponseViewModel: SurveyResponseViewModelType {
 
     self.policyDecisionProperty <~ newRequest
       .map { request in
-        if isStripeElement(request) {
+        if isStripeRequest(request) {
           return true
         }
 
@@ -164,6 +164,10 @@ private func isSurvey(request: URLRequest) -> Bool {
   return true
 }
 
-private func isStripeElement(_ request: URLRequest) -> Bool {
-  return request.url?.host == "js.stripe.com"
+// Returns true if the url host is of the form *.stripe.com or *.stripe.network.
+private func isStripeRequest(_ request: URLRequest) -> Bool {
+  guard let host = request.url?.host?.lowercased() else { return false }
+  let components = host.split(separator: ".")
+  return components.count == 3 && components[1] == "stripe" &&
+    (components[2] == "com" || components[2] == "network")
 }

--- a/Library/ViewModels/SurveyResponseViewModelTests.swift
+++ b/Library/ViewModels/SurveyResponseViewModelTests.swift
@@ -205,9 +205,61 @@ final class SurveyResponseViewModelTests: TestCase {
       XCTAssertEqual(update, updateResult, " Update is wrong.")
     }
   }
+
+  // MARK: - Decision policy tests
+
+  func testBadRequest() {
+    let navigationData = navigationData("https://www.fake.com/bad-url")
+    XCTAssertEqual(
+      self.vm.decidePolicyFor(navigationAction: navigationData),
+      WKNavigationActionPolicy.cancel
+    )
+  }
+
+  func testBadStripeRequest() {
+    let navigationData = navigationData("https://www.stripecdn.network")
+    XCTAssertEqual(
+      self.vm.decidePolicyFor(navigationAction: navigationData),
+      WKNavigationActionPolicy.cancel
+    )
+  }
+
+  func testStripeNetworkRequest() {
+    let navigationData = navigationData("https://m.stripe.network/inner.html#url=fake")
+    XCTAssertEqual(
+      self.vm.decidePolicyFor(navigationAction: navigationData),
+      WKNavigationActionPolicy.allow
+    )
+  }
+
+  func testStripeElementRequest() {
+    let navigationData = navigationData("https://js.stripe.com/v3/controller-fake.html")
+    XCTAssertEqual(
+      self.vm.decidePolicyFor(navigationAction: navigationData),
+      WKNavigationActionPolicy.allow
+    )
+  }
+
+  func testStripeCdnRequest() {
+    let navigationData = navigationData("https://b.stripecdn.com/assets/v21.19/Captcha.html")
+    XCTAssertEqual(
+      self.vm.decidePolicyFor(navigationAction: navigationData),
+      WKNavigationActionPolicy.allow
+    )
+  }
 }
 
 // MARK: - Helpers
+
+private func navigationData(_ url: String) -> WKNavigationActionData {
+  let request = URLRequest(url: URL.init(string: url)!)
+  return WKNavigationActionData(
+    navigationType: .other,
+    request: request,
+    sourceFrame: WKFrameInfoData(frameInfo: WKFrameInfo()),
+    targetFrame: nil
+  )
+}
 
 private func surveyRequest(project: Project, prepared: Bool, method: KsApi.Method) -> URLRequest {
   let url = "\(project.urls.web.project)/surveys/1"


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Allowlist all requests from `*.stripe.com`, `*.stripe.network`, or `stripecdn.com` in the survey/backing details webview.

# 🤔 Why

The webview got stuck in an infinite loading state earlier today. I'm not sure if it's related to our policy not allowing some of these requests through, but it definitely might be. I noticed `m.stripe.network` requests that we were blocking when I was debugging earlier. [Aidan did a little digging and found that there's also `m.stripe.com` and `r.stripe.com` domains on the checkout page](https://kickstarter.slack.com/archives/C06EKGN4MHU/p1729019704602539?thread_ts=1729007161.056579&cid=C06EKGN4MHU).

I let this idle for a while and noticed `stripecdn.com` requests as well, for invisible captchas, so I've added those as well. It required reformatting the helper function for this to make sure that each domain is only allowed if it has the correct tld.

# 🛠 How

I'm doing a general component match that allows all subdomains - I think that's safe since they all have to be owned by stripe, and being general in webviews is nice for backwards compatibility. If anyone has concerns about this approach, though, definitely let me know!

# ✅ Acceptance criteria

- [x] Tests pass
