### PR TITLE
[MBL-1783 Unhide rewards immediately if there's no shippable rewards

### DIFF
--- a/Kickstarter-iOS/Features/RewardsCollection/Controller/WithShippingRewardsCollectionViewController.swift
+++ b/Kickstarter-iOS/Features/RewardsCollection/Controller/WithShippingRewardsCollectionViewController.swift
@@ -193,11 +193,10 @@ final class WithShippingRewardsCollectionViewController: UICollectionViewControl
 
     self.viewModel.outputs.rewardsCollectionViewIsHidden
       .observeForUI()
-      .observeValues { [weak self] shimmerLoadingViewIsHidden in
+      .observeValues { [weak self] rewardsCollectionViewIsHidden in
         guard let self else { return }
 
-        self.collectionView.isHidden = !shimmerLoadingViewIsHidden
-        self.collectionView.layoutIfNeeded()
+        self.collectionView.isHidden = rewardsCollectionViewIsHidden
       }
 
     self.viewModel.outputs.rewardsCollectionViewFooterIsHidden

--- a/Library/ViewModels/WithShippingRewardsCollectionViewModel.swift
+++ b/Library/ViewModels/WithShippingRewardsCollectionViewModel.swift
@@ -102,15 +102,14 @@ public final class WithShippingRewardsCollectionViewModel: WithShippingRewardsCo
 
     // MARK: Shipping Location
 
-    self.shippingLocationViewHidden = project
-      .map { project in
-        projectHasShippableRewards(project) == false
-      }
+    let hasShippableRewards = project.map(projectHasShippableRewards)
+
+    self.shippingLocationViewHidden = hasShippableRewards.map(negate)
 
     // Only shown for regular non-add-ons based rewards
     self.configureShippingLocationViewWithData = Signal.combineLatest(
       project,
-      self.shippingLocationViewHidden.filter(isFalse)
+      hasShippableRewards.filter(isTrue)
     )
     .map { project, _ in
       // TODO: Reward will be removed from  ShippingLocationViewData once we remove the selector from Add-Ons
@@ -210,8 +209,15 @@ public final class WithShippingRewardsCollectionViewModel: WithShippingRewardsCo
     )
 
     /// Temporary loading state solution. Proper designs will be explored in this ticket [mbl-1678](https://kickstarter.atlassian.net/browse/MBL-1678)
-    self.rewardsCollectionViewIsHidden = self.pledgeShippingLocationViewControllerDidUpdateProperty.signal
+    let locationShimmerHidden = self.pledgeShippingLocationViewControllerDidUpdateProperty.signal
       .map { $0 }
+
+    // Rewards collection view should only be hidden while the location shimmer is showing.
+    // If the project doesn't have shippable rewards, show immediately.
+    self.rewardsCollectionViewIsHidden = Signal.merge(
+      locationShimmerHidden.negate(),
+      hasShippableRewards.filter(isFalse).mapConst(false)
+    )
 
     self.rewardsCollectionViewFooterIsHidden = self.traitCollectionChangedProperty.signal
       .skipNil()


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

We currently hide all rewards until the shipping location selector is done loading. If there aren't any shippable rewards, unhide the rewards immediately.

# 👀 See

[Jira](https://kickstarter.atlassian.net/browse/MBL-1783)

# ✅ Acceptance criteria

- [x] Rewards without any shippable rewards show their rewards correctly

