### PR TITLE
[MBL-1824 Include shipping in apple pay charge

### DIFF
--- a/Kickstarter-iOS/Features/PledgeView/Controllers/NoShippingPledgeViewController.swift
+++ b/Kickstarter-iOS/Features/PledgeView/Controllers/NoShippingPledgeViewController.swift
@@ -392,14 +392,14 @@ final class NoShippingPledgeViewController: UIViewController,
       }
   }
 
-  private func goToPaymentAuthorization(_ paymentAuthorizationData: PaymentAuthorizationDataNoShipping) {
+  private func goToPaymentAuthorization(_ paymentAuthorizationData: PaymentAuthorizationData) {
     let request = PKPaymentRequest
       .paymentRequest(
         for: paymentAuthorizationData.project,
         reward: paymentAuthorizationData.reward,
         allRewardsTotal: paymentAuthorizationData.allRewardsTotal,
         additionalPledgeAmount: paymentAuthorizationData.additionalPledgeAmount,
-        allRewardsShippingTotal: 0,
+        allRewardsShippingTotal: paymentAuthorizationData.allRewardsShippingTotal,
         merchantIdentifier: paymentAuthorizationData.merchantIdentifier
       )
 

--- a/Library/ViewModels/NoShippingPledgeViewModel.swift
+++ b/Library/ViewModels/NoShippingPledgeViewModel.swift
@@ -13,14 +13,6 @@ public typealias NoShippingPledgeViewCTAContainerViewData = (
   willRetryPaymentMethod: Bool
 )
 
-public typealias PaymentAuthorizationDataNoShipping = (
-  project: Project,
-  reward: Reward,
-  allRewardsTotal: Double,
-  additionalPledgeAmount: Double,
-  merchantIdentifier: String
-)
-
 public protocol NoShippingPledgeViewModelInputs {
   func applePayButtonTapped()
   func configure(with data: PledgeViewData)
@@ -55,7 +47,7 @@ public protocol NoShippingPledgeViewModelOutputs {
   var configureStripeIntegration: Signal<StripeConfigurationData, Never> { get }
   var descriptionSectionSeparatorHidden: Signal<Bool, Never> { get }
   var estimatedShippingViewHidden: Signal<Bool, Never> { get }
-  var goToApplePayPaymentAuthorization: Signal<PaymentAuthorizationDataNoShipping, Never> { get }
+  var goToApplePayPaymentAuthorization: Signal<PaymentAuthorizationData, Never> { get }
   var goToThanks: Signal<ThanksPageData, Never> { get }
   var goToLoginSignup: Signal<(LoginIntent, Project, Reward), Never> { get }
   var localPickupViewHidden: Signal<Bool, Never> { get }
@@ -410,20 +402,22 @@ public class NoShippingPledgeViewModel: NoShippingPledgeViewModelType, NoShippin
       .takeWhen(self.applePayButtonTappedSignal)
       .filter(isFalse)
 
-    let paymentAuthorizationData: Signal<PaymentAuthorizationDataNoShipping, Never> = Signal.combineLatest(
+    let paymentAuthorizationData: Signal<PaymentAuthorizationData, Never> = Signal.combineLatest(
       project,
       baseReward,
       allRewardsTotal,
-      additionalPledgeAmount
+      additionalPledgeAmount,
+      allRewardsShippingTotal
     )
-    .map { project, reward, allRewardsTotal, additionalPledgeAmount -> PaymentAuthorizationDataNoShipping in
+    .map { project, reward, allRewardsTotal, additionalPledgeAmount, shippingTotal -> PaymentAuthorizationData in
       let r = (
         project,
         reward,
         allRewardsTotal,
         additionalPledgeAmount,
+        shippingTotal,
         Secrets.ApplePay.merchantIdentifier
-      ) as PaymentAuthorizationDataNoShipping
+      ) as PaymentAuthorizationData
 
       return r
     }
@@ -1095,7 +1089,7 @@ public class NoShippingPledgeViewModel: NoShippingPledgeViewModelType, NoShippin
   public let configureStripeIntegration: Signal<StripeConfigurationData, Never>
   public let descriptionSectionSeparatorHidden: Signal<Bool, Never>
   public let estimatedShippingViewHidden: Signal<Bool, Never>
-  public let goToApplePayPaymentAuthorization: Signal<PaymentAuthorizationDataNoShipping, Never>
+  public let goToApplePayPaymentAuthorization: Signal<PaymentAuthorizationData, Never>
   public let goToThanks: Signal<ThanksPageData, Never>
   public let goToLoginSignup: Signal<(LoginIntent, Project, Reward), Never>
   public let localPickupViewHidden: Signal<Bool, Never>

--- a/Library/ViewModels/NoShippingPledgeViewModelTests.swift
+++ b/Library/ViewModels/NoShippingPledgeViewModelTests.swift
@@ -49,6 +49,7 @@ final class NoShippingPledgeViewModelTests: TestCase {
   private let goToApplePayPaymentAuthorizationReward = TestObserver<Reward, Never>()
   private let goToApplePayPaymentAuthorizationAllRewardsTotal = TestObserver<Double, Never>()
   private let goToApplePayPaymentAuthorizationAdditionalPledgeAmount = TestObserver<Double, Never>()
+  private let goToApplePayPaymentAuthorizationAllRewardsShippingTotal = TestObserver<Double, Never>()
   private let goToApplePayPaymentAuthorizationMerchantId = TestObserver<String, Never>()
   private let goToThanksCheckoutData = TestObserver<KSRAnalytics.CheckoutPropertiesData?, Never>()
   private let goToThanksProject = TestObserver<Project, Never>()
@@ -120,6 +121,8 @@ final class NoShippingPledgeViewModelTests: TestCase {
       .observe(self.goToApplePayPaymentAuthorizationAllRewardsTotal.observer)
     self.vm.outputs.goToApplePayPaymentAuthorization.map { $0.additionalPledgeAmount }
       .observe(self.goToApplePayPaymentAuthorizationAdditionalPledgeAmount.observer)
+    self.vm.outputs.goToApplePayPaymentAuthorization.map { $0.allRewardsShippingTotal }
+      .observe(self.goToApplePayPaymentAuthorizationAllRewardsShippingTotal.observer)
     self.vm.outputs.goToApplePayPaymentAuthorization.map { $0.merchantIdentifier }
       .observe(self.goToApplePayPaymentAuthorizationMerchantId.observer)
 
@@ -920,6 +923,7 @@ final class NoShippingPledgeViewModelTests: TestCase {
     self.goToApplePayPaymentAuthorizationReward.assertDidNotEmitValue()
     self.goToApplePayPaymentAuthorizationAllRewardsTotal.assertDidNotEmitValue()
     self.goToApplePayPaymentAuthorizationAdditionalPledgeAmount.assertDidNotEmitValue()
+    self.goToApplePayPaymentAuthorizationAllRewardsShippingTotal.assertDidNotEmitValue()
     self.goToApplePayPaymentAuthorizationMerchantId.assertDidNotEmitValue()
 
     self.vm.inputs.applePayButtonTapped()
@@ -929,6 +933,7 @@ final class NoShippingPledgeViewModelTests: TestCase {
     self.goToApplePayPaymentAuthorizationReward.assertValues([reward])
     self.goToApplePayPaymentAuthorizationAllRewardsTotal.assertValues([0])
     self.goToApplePayPaymentAuthorizationAdditionalPledgeAmount.assertValues([5])
+    self.goToApplePayPaymentAuthorizationAllRewardsShippingTotal.assertValues([0])
     self.goToApplePayPaymentAuthorizationMerchantId.assertValues([Secrets.ApplePay.merchantIdentifier])
   }
 
@@ -958,6 +963,7 @@ final class NoShippingPledgeViewModelTests: TestCase {
     self.goToApplePayPaymentAuthorizationReward.assertDidNotEmitValue()
     self.goToApplePayPaymentAuthorizationAllRewardsTotal.assertDidNotEmitValue()
     self.goToApplePayPaymentAuthorizationAdditionalPledgeAmount.assertDidNotEmitValue()
+    self.goToApplePayPaymentAuthorizationAllRewardsShippingTotal.assertDidNotEmitValue()
     self.goToApplePayPaymentAuthorizationMerchantId.assertDidNotEmitValue()
 
     self.vm.inputs.pledgeAmountViewControllerDidUpdate(with: pledgeAmountData)
@@ -969,6 +975,7 @@ final class NoShippingPledgeViewModelTests: TestCase {
     self.goToApplePayPaymentAuthorizationReward.assertValues([reward])
     self.goToApplePayPaymentAuthorizationAllRewardsTotal.assertValues([20])
     self.goToApplePayPaymentAuthorizationAdditionalPledgeAmount.assertValues([25])
+    self.goToApplePayPaymentAuthorizationAllRewardsShippingTotal.assertValues([5])
     self.goToApplePayPaymentAuthorizationMerchantId.assertValues([Secrets.ApplePay.merchantIdentifier])
   }
 


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

We need to include shipping when paying with apple pay, even when the "no shipping at pledge" flag is on. This adds that back in.

I think the shipping was intentionally deleted back when we didn't understand how pledge redemption would work, and since there are so many different pledge flows (and apple pay is tricky to test) we missed it during testing.

# 👀 See

[Jira](https://kickstarter.atlassian.net/browse/MBL-1824)

| Before 🐛 | After 🦋 |
| --- | --- |
| ![Simulator Screen Recording - iPhone 16 Pro Max - 2024-10-23 at 15 02 03](https://github.com/user-attachments/assets/2090f5ef-48ab-4372-b73b-2170ab5057a5) | ![Simulator Screen Recording - iPhone 16 Pro Max - 2024-10-23 at 14 58 55](https://github.com/user-attachments/assets/76c78421-0455-48d3-8ad8-9ddda5aeb1ac) |

# ✅ Acceptance criteria

- [x] Apple pay amount is correct and the shipping charge is correctly listed.

