### PR TITLE
Pledge Over Time feature flag

### DIFF
--- a/Library/RemoteConfig/RemoteConfigFeature+Helpers.swift
+++ b/Library/RemoteConfig/RemoteConfigFeature+Helpers.swift
@@ -32,3 +32,7 @@ public func featureUseKeychainForOAuthTokenEnabled() -> Bool {
 public func featurePledgedProjectsOverviewEnabled() -> Bool {
   featureEnabled(feature: .pledgedProjectsOverviewEnabled)
 }
+
+public func featurePledgeOverTimeEnabled() -> Bool {
+  featureEnabled(feature: .pledgeOverTime)
+}

--- a/Library/RemoteConfig/RemoteConfigFeature.swift
+++ b/Library/RemoteConfig/RemoteConfigFeature.swift
@@ -6,6 +6,7 @@ public enum RemoteConfigFeature: String, CaseIterable {
   case postCampaignPledgeEnabled = "post_campaign_pledge"
   case useKeychainForOAuthToken = "use_keychain_for_oauth_token"
   case pledgedProjectsOverviewEnabled = "pledged_projects_overview"
+  case pledgeOverTime = "pledge_over_time"
 }
 
 extension RemoteConfigFeature: CustomStringConvertible {
@@ -16,6 +17,7 @@ extension RemoteConfigFeature: CustomStringConvertible {
     case .postCampaignPledgeEnabled: return "Post Campaign Pledging"
     case .useKeychainForOAuthToken: return "Use Keychain for OAuth token"
     case .pledgedProjectsOverviewEnabled: return "Pledged Projects Overview"
+    case .pledgeOverTime: return "Pledge Over Time"
     }
   }
 }

--- a/Library/ViewModels/RemoteConfigFeatureFlagToolsViewModel.swift
+++ b/Library/ViewModels/RemoteConfigFeatureFlagToolsViewModel.swift
@@ -95,6 +95,8 @@ private func isFeatureEnabled(_ feature: RemoteConfigFeature) -> Bool {
     return featureUseKeychainForOAuthTokenEnabled()
   case .pledgedProjectsOverviewEnabled:
     return featurePledgedProjectsOverviewEnabled()
+  case .pledgeOverTime:
+    return featurePledgeOverTimeEnabled()
   }
 }
 


### PR DESCRIPTION
# 📲 What

We need to add a new RemoteConfig feature flag so that we can work on the new Pledge Over Time feature.

# 🛠 How

Adding a new case `pledgeOverTime`  into the `RemoteConfigFeature` enum and the necessary configurations.

# 👀 See

[Jira](https://kickstarter.atlassian.net/browse/MBL-1811)

| Feature Flags screen |
 | --- |
| ![output](https://github.com/user-attachments/assets/08f7197e-c63f-47d5-a67c-ab243810c3ed) |

# ✅ Acceptance criteria

- [x] The public function `featurePledgeOverTimeEnabled` should be created in the `RemoteConfigFeature+Helpers.swift` helper.
- [x] The new feature flag is displayed in the **Remote Config Feature Flags** screen

