### PR TITLE
Move all PPOProjectCard methods into one enum and callback

### DIFF
--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/CardView/PPOProjectCard.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/CardView/PPOProjectCard.swift
@@ -4,12 +4,35 @@ import Library
 import SwiftUI
 
 struct PPOProjectCard: View {
+  enum Action {
+    case confirmAddress
+    case editAddress
+    case completeSurvey
+    case fixPayment
+    case authenticateCard
+    case viewBackingDetails
+    case sendMessage
+
+    init(_ action: PPOProjectCardModel.Action) {
+      switch action {
+      case .confirmAddress:
+        self = .confirmAddress
+      case .editAddress:
+        self = .editAddress
+      case .completeSurvey:
+        self = .completeSurvey
+      case .fixPayment:
+        self = .fixPayment
+      case .authenticateCard:
+        self = .authenticateCard
+      }
+    }
+  }
+
   @StateObject var viewModel: PPOProjectCardViewModel
   var parentSize: CGSize
 
-  var onViewBackingDetails: ((PPOProjectCardModel) -> Void)? = nil
-  var onSendMessage: ((PPOProjectCardModel) -> Void)? = nil
-  var onPerformAction: ((PPOProjectCardModel, PPOProjectCardModel.Action) -> Void)? = nil
+  var onAction: ((PPOProjectCardModel, Action) -> Void)? = nil
 
   var body: some View {
     VStack(spacing: Constants.spacing) {
@@ -39,13 +62,13 @@ struct PPOProjectCard: View {
 
     // Handle actions
     .onReceive(self.viewModel.viewBackingDetailsTapped) {
-      self.onViewBackingDetails?(self.viewModel.card)
+      self.onAction?(self.viewModel.card, .viewBackingDetails)
     }
     .onReceive(self.viewModel.sendMessageTapped) {
-      self.onSendMessage?(self.viewModel.card)
+      self.onAction?(self.viewModel.card, .sendMessage)
     }
     .onReceive(self.viewModel.actionPerformed) { action in
-      self.onPerformAction?(self.viewModel.card, action)
+      self.onAction?(self.viewModel.card, .init(action))
     }
   }
 

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOView.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOView.swift
@@ -46,14 +46,12 @@ struct PPOView: View {
       PPOProjectCard(
         viewModel: card,
         parentSize: parentSize,
-        onViewBackingDetails: { card in
-          self.viewModel.viewBackingDetails(from: card)
-        },
-        onSendMessage: { card in
-          self.viewModel.contactCreator(from: card)
-        },
-        onPerformAction: { card, action in
+        onAction: { card, action in
           switch action {
+          case .viewBackingDetails:
+            self.viewModel.viewBackingDetails(from: card)
+          case .sendMessage:
+            self.viewModel.contactCreator(from: card)
           case .authenticateCard:
             self.viewModel.fix3DSChallenge(from: card)
           case .completeSurvey:


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

This PR refactors PPOProjectCard to use a single enum and callback for handling user actions.

# 🤔 Why

Follow up from #2186. We wanted to merge that PR but there was an outstanding comment about refactoring an action into a new enum, so this continues that discussion.

# 🛠 How

The initial suggestion was to extend `PPOProjectCardModel.Action` to include sending a creator message and viewing backing details. That enum is coming from GraphQL and relates specifically to button actions, so it doesn't strictly make sense to extend that.

Instead I created a new enum that handles all the actions, and replaced the existing APIs with this. This isn't the only choice, though. We could do any of the following:

1. We could leave the methods as is, and not make any changes like this.
2. We could make an enum that has cases for `viewBackerDetails`, `sendMessage`, and `buttonAction(PPOProjectCardModel.Action)`. Maybe renaming `PPOProjectCardModel.Action` to `PPOProjectCardModel.ButtonAction` in the process.
3. We could make a separate callback for each option. (I think this is probably not an ideal outcome especially since we will be adding more cases in the future.)

# ✅ Acceptance criteria

Tests should pass.