### PR TITLE
[MBL-1855] Fix Estimated Shipping Conversion

### DIFF
--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/CardView/PPOProjectCardModel.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/CardView/PPOProjectCardModel.swift
@@ -396,7 +396,8 @@ extension PPOProjectCardModel {
 
     let projectAnalyticsFragment = backing?.project?.fragments.projectAnalyticsFragment
 
-    if let image, let title, let pledge, let creatorName, let projectAnalyticsFragment, let backingDetailsUrl {
+    if let image, let title, let pledge, let creatorName, let projectAnalyticsFragment,
+       let backingDetailsUrl {
       self.init(
         isUnread: true,
         alerts: alerts,

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/CardView/PPOProjectCardViewModel.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/CardView/PPOProjectCardViewModel.swift
@@ -61,7 +61,10 @@ final class PPOProjectCardViewModel: PPOProjectCardViewModelType {
 
   // MARK: - Outputs
 
-  var viewBackingDetailsTapped: AnyPublisher<(), Never> { self.viewBackingDetailsSubject.eraseToAnyPublisher() }
+  var viewBackingDetailsTapped: AnyPublisher<(), Never> {
+    self.viewBackingDetailsSubject.eraseToAnyPublisher()
+  }
+
   var sendMessageTapped: AnyPublisher<(), Never> { self.sendCreatorMessageSubject.eraseToAnyPublisher() }
   var actionPerformed: AnyPublisher<Action, Never> { self.actionPerformedSubject.eraseToAnyPublisher() }
 

--- a/Kickstarter-iOS/Library/SharedFunctionsTests.swift
+++ b/Kickstarter-iOS/Library/SharedFunctionsTests.swift
@@ -561,4 +561,27 @@ internal final class SharedFunctionsTests: TestCase {
       XCTAssertEqual(max, 10_000)
     }
   }
+
+  func testEstimatedShippingText() {
+    let mexicanCurrencyProjectTemplate = Project.template
+      |> Project.lens.stats.currency .~ Project.Country.mx.currencyCode
+
+    let backing = Backing.template
+
+    let shippingRule = ShippingRule.template
+      |> ShippingRule.lens.estimatedMin .~ Money(amount: 5.0)
+      |> ShippingRule.lens.estimatedMax .~ Money(amount: 10.0)
+    let reward = Reward.template
+      |> Reward.lens.shipping.enabled .~ true
+      |> Reward.lens.shippingRules .~ [shippingRule]
+
+    let estimatedShippingText = estimatedShippingText(
+      for: [reward],
+      project: mexicanCurrencyProjectTemplate,
+      locationId: shippingRule.location.id,
+      selectedQuantities: selectedRewardQuantities(in: backing) /// 2
+    )
+
+    XCTAssertEqual(estimatedShippingText, "$10-$20")
+  }
 }

--- a/Library/SharedFunctions.swift
+++ b/Library/SharedFunctions.swift
@@ -687,19 +687,15 @@ public func estimatedShippingText(
 
   guard estimatedMin > 0, estimatedMax > 0 else { return nil }
 
-  let currentCountry = project.stats.currentCountry ?? Project.Country.us
-
   let formattedMin = Format.currency(
     estimatedMin,
-    country: currentCountry,
-    omitCurrencyCode: project.stats.omitUSCurrencyCode,
+    country: project.country,
     roundingMode: .halfUp
   )
 
   let formattedMax = Format.currency(
     estimatedMax,
-    country: currentCountry,
-    omitCurrencyCode: project.stats.omitUSCurrencyCode,
+    country: project.country,
     roundingMode: .halfUp
   )
 

--- a/Library/ViewModels/RewardCardViewModel.swift
+++ b/Library/ViewModels/RewardCardViewModel.swift
@@ -132,7 +132,7 @@ public final class RewardCardViewModel: RewardCardViewModelType, RewardCardViewM
       .map { reward, project, shippingRule in
         guard let locationId = shippingRule?.location.id else { return nil }
 
-        return estimatedShippingText(for: [reward], project: project, locationId: locationId)
+        return estimatedShippingConversionText(for: [reward], project: project, locationId: locationId)
       }
 
     self.estimatedDeliveryDateLabelText = reward.map(estimatedDeliveryDateText(with:)).skipNil()

--- a/Library/ViewModels/RewardCardViewModel.swift
+++ b/Library/ViewModels/RewardCardViewModel.swift
@@ -132,7 +132,9 @@ public final class RewardCardViewModel: RewardCardViewModelType, RewardCardViewM
       .map { reward, project, shippingRule in
         guard let locationId = shippingRule?.location.id else { return nil }
 
-        return estimatedShippingConversionText(for: [reward], project: project, locationId: locationId)
+        return project.stats.needsConversion
+          ? estimatedShippingConversionText(for: [reward], project: project, locationId: locationId)
+          : estimatedShippingText(for: [reward], project: project, locationId: locationId)
       }
 
     self.estimatedDeliveryDateLabelText = reward.map(estimatedDeliveryDateText(with:)).skipNil()


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Fixes the estimated shipping text on reward cards so that it displays based on the user's selected currency settings and converts the values when the user's chosen currency differs from the project's currency configuration. 

# 🛠 How

- Updates our `estimatedShippingText` shared function to use the project's currency.
- Update the label to use the conversion if the user's chosen currency differs from the project's currency.

# 👀 See

In this example, my user settings have the British pound currency selected. The project is based in the US.

The expected behavior is that the estimated shipping on rewards cards is shown in/converted to pounds, and on the checkout screen's estimated shipping view, the range in the US is shown with the conversion to pounds displayed underneath it.

![Simulator Screen Recording - iPhone 15 Pro 17 5 - 2024-11-12 at 11 41 53](https://github.com/user-attachments/assets/87b013dd-1a2a-485b-a63a-c0fb404d0755)


# ✅ Acceptance criteria

- [ ] Estimated shipping on Reward cards and checkout are displayed as the expected behavior above and match [the designs](https://www.figma.com/design/z4faZM4BQwbyiDe7y8tbpP/Pledge-Redemption?node-id=0-1&node-type=canvas&t=W7XKlVYXEAq16uCY-0)
