### PR TITLE
[MBL-1891] Estimated Shipping Doesn't Update On Location Dropdown Change 

### DIFF
--- a/Kickstarter-iOS/Features/PledgeView/Controllers/NoShippingPledgeViewControllerTests.swift
+++ b/Kickstarter-iOS/Features/PledgeView/Controllers/NoShippingPledgeViewControllerTests.swift
@@ -172,7 +172,7 @@ final class NoShippingPledgeViewControllerTests: TestCase {
       |> ShippingRule.lens.estimatedMax .~ Money(amount: 10.0)
     let reward = Reward.template
       |> Reward.lens.shipping.enabled .~ true
-      |> Reward.lens.shippingRules .~ [shippingRule]
+      |> Reward.lens.shippingRulesExpanded .~ [shippingRule]
       |> Reward.lens.id .~ 99
     let mockConfigClient = MockRemoteConfigClient()
     mockConfigClient.features = [

--- a/Kickstarter-iOS/Features/PledgeView/Controllers/NoShippingPostCampaignViewControllerTests.swift
+++ b/Kickstarter-iOS/Features/PledgeView/Controllers/NoShippingPostCampaignViewControllerTests.swift
@@ -110,7 +110,7 @@ final class NoShippingPostCampaignViewControllerTests: TestCase {
       |> ShippingRule.lens.cost .~ 0.0
     let reward = Reward.template
       |> Reward.lens.shipping.enabled .~ true
-      |> Reward.lens.shippingRules .~ [shippingRule]
+      |> Reward.lens.shippingRulesExpanded .~ [shippingRule]
       |> Reward.lens.id .~ 99
 
     let mockConfigClient = MockRemoteConfigClient()

--- a/Kickstarter-iOS/Library/SharedFunctionsTests.swift
+++ b/Kickstarter-iOS/Library/SharedFunctionsTests.swift
@@ -574,7 +574,7 @@ internal final class SharedFunctionsTests: TestCase {
       |> ShippingRule.lens.estimatedMax .~ Money(amount: 10.0)
     let reward = Reward.template
       |> Reward.lens.shipping.enabled .~ true
-      |> Reward.lens.shippingRules .~ [shippingRule]
+      |> Reward.lens.shippingRulesExpanded .~ [shippingRule]
 
     let estimatedShippingText = estimatedShippingText(
       for: [reward],
@@ -597,7 +597,7 @@ internal final class SharedFunctionsTests: TestCase {
       |> ShippingRule.lens.estimatedMax .~ Money(amount: 10.0)
     let reward = Reward.template
       |> Reward.lens.shipping.enabled .~ true
-      |> Reward.lens.shippingRules .~ [shippingRule]
+      |> Reward.lens.shippingRulesExpanded .~ [shippingRule]
 
     let estimatedShippingText = estimatedShippingText(
       for: [reward],

--- a/Library/SharedFunctions.swift
+++ b/Library/SharedFunctions.swift
@@ -778,12 +778,18 @@ private func estimatedMinMax(
   var max: Double = 0
 
   rewards.forEach { reward in
-    guard reward.shipping.enabled, let shippingRules = reward.shippingRulesExpanded,
-          let shipping = shippingRules.first(where: { $0.location.id == locationId }) else { return }
+    guard reward.shipping.enabled,
+          let shippingRules = reward.shippingRulesExpanded ?? reward.shippingRules else { return }
+
+    var shipping: ShippingRule? = shippingRules.first(where: { $0.location.id == locationId })
+
+    if shipping == nil && reward.shipping.preference == .unrestricted {
+      shipping = shippingRules.first
+    }
 
     /// Verify there are estimated amounts greater than 0
-    guard let estimatedMin = shipping.estimatedMin?.amount,
-          let estimatedMax = shipping.estimatedMax?.amount,
+    guard let estimatedMin = shipping?.estimatedMin?.amount,
+          let estimatedMax = shipping?.estimatedMax?.amount,
           estimatedMin > 0 || estimatedMax > 0 else {
       return
     }

--- a/Library/SharedFunctions.swift
+++ b/Library/SharedFunctions.swift
@@ -778,22 +778,8 @@ private func estimatedMinMax(
   var max: Double = 0
 
   rewards.forEach { reward in
-    guard reward.shipping.enabled, let shippingRules = reward.shippingRules else {
-      return
-    }
-
-    var shippingRule: ShippingRule?
-
-    /// First check to see if the reward has a shipping rule that matches the selected location id.
-    /// If it doesn't AND the reward has an unrestricted shipping preference, grab the "Anywhere in the world' shipping rule by id. (id is always 1) .
-    /// Otherwise, we know that the reward doesn't have any shipping rule information associated with it.
-    if let matchingShippingRule = shippingRules.first(where: { $0.location.id == locationId }) {
-      shippingRule = matchingShippingRule
-    } else if reward.shipping.preference == .unrestricted {
-      shippingRule = shippingRules.first(where: { $0.location.id == 1 })
-    }
-
-    guard let shipping = shippingRule else { return }
+    guard reward.shipping.enabled, let shippingRules = reward.shippingRulesExpanded,
+          let shipping = shippingRules.first(where: { $0.location.id == locationId }) else { return }
 
     /// Verify there are estimated amounts greater than 0
     guard let estimatedMin = shipping.estimatedMin?.amount,

--- a/Library/SharedFunctions.swift
+++ b/Library/SharedFunctions.swift
@@ -778,16 +778,20 @@ private func estimatedMinMax(
   var max: Double = 0
 
   rewards.forEach { reward in
-    guard reward.shipping.enabled, let shippingRules = reward.shippingRules else { return }
+    guard reward.shipping.enabled, let shippingRules = reward.shippingRules else {
+      return
+    }
 
     var shippingRule: ShippingRule?
 
-    /// If the reward's shipping prefernce is Anywhere in the world, use its first and only shipping rule.
-    /// Else use the rule that  matches the selected shipping rule (from the locations dropdown).
-    shippingRule = reward.shipping.preference == .unrestricted
-      ? shippingRules.first
-      : shippingRules
-      .first(where: { $0.location.id == locationId })
+    /// First check to see if the reward has a shipping rule that matches the selected location id.
+    /// If it doesn't AND the reward has an unrestricted shipping preference, grab the "Anywhere in the world' shipping rule by id. (id is always 1) .
+    /// Otherwise, we know that the reward doesn't have any shipping rule information associated with it.
+    if let matchingShippingRule = shippingRules.first(where: { $0.location.id == locationId }) {
+      shippingRule = matchingShippingRule
+    } else if reward.shipping.preference == .unrestricted {
+      shippingRule = shippingRules.first(where: { $0.location.id == 1 })
+    }
 
     guard let shipping = shippingRule else { return }
 

--- a/Library/SharedFunctionsTests.swift
+++ b/Library/SharedFunctionsTests.swift
@@ -708,12 +708,12 @@ final class SharedFunctionsTests: TestCase {
 
     let reward = Reward.template
       |> Reward.lens.shipping .~ (.template |> Reward.Shipping.lens.enabled .~ true)
-      |> Reward.lens.shippingRules .~ [rewardShippingRule]
+      |> Reward.lens.shippingRulesExpanded .~ [rewardShippingRule]
       |> Reward.lens.id .~ 99
     let addOn = Reward.template
       |> Reward.lens.shipping .~ (.template |> Reward.Shipping.lens.enabled .~ true)
       |> Reward.lens.id .~ 5
-      |> Reward.lens.shippingRules .~ [addOnShippingRule]
+      |> Reward.lens.shippingRulesExpanded .~ [addOnShippingRule]
 
     let project = Project.template
 
@@ -736,12 +736,12 @@ final class SharedFunctionsTests: TestCase {
 
     let reward = Reward.template
       |> Reward.lens.shipping .~ (.template |> Reward.Shipping.lens.enabled .~ true)
-      |> Reward.lens.shippingRules .~ [rewardShippingRule]
+      |> Reward.lens.shippingRulesExpanded .~ [rewardShippingRule]
       |> Reward.lens.id .~ 99
     let addOn = Reward.template
       |> Reward.lens.shipping .~ (.template |> Reward.Shipping.lens.enabled .~ true)
       |> Reward.lens.id .~ 5
-      |> Reward.lens.shippingRules .~ [addOnShippingRule]
+      |> Reward.lens.shippingRulesExpanded .~ [addOnShippingRule]
 
     let project = Project.template
 


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

This PR makes sure that estimated shipping on reward cards is updated based on the selected shipping location. Specifically for when the reward has a "Ships anywhere in the world" preference _and_ has shipping rules set for specific countries.

# 🤔 Why

Existing logic was written assuming that unrestricted shipping rewards would only have shipping costs for the rest of the world. It turns out they can also have shipping costs for specific countries.

This means that a reward can have an "unrestricted" shipping preference with shipping rules for "Rest of World" _and_ other specific countries.

# 🛠 How

We need to check first to see if the reward has a shipping rule matching the selected location ID.
If it _doesn't _and_ the reward has an unrestricted shipping preference, use the shipping rule with an id of 1. This is always the  "Anywhere in the world" rule.
If that doesn't exist either, we know the reward has no shipping rule information.

# 👀 See

The test project I used has the following shipping config:
<img width="406" alt="Screenshot 2024-11-18 at 12 34 12 PM" src="https://github.com/user-attachments/assets/80ccdc11-117f-4a0e-972f-016b09f14039">

See that the estimated shipping values update as expected when the location changes.

![Simulator Screen Recording - iPhone 15 Pro 17 5 - 2024-11-18 at 12 26 40](https://github.com/user-attachments/assets/66375833-7c63-4921-9ccc-fd60392939ba)


# ✅ Acceptance criteria

- [x] Estimated shipping on rewards cards matches the selected location or the costs associated with "Rest of World" shipping rules if the reward has unrestricted shipping
