### PR TITLE
Add GraphAPI.swift and graphql-schema.json to gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
 *.pbxproj merge=union
 Frameworks/* linguist-vendored
+KsApi/GraphAPI.swift linguist-generated
+KsApi/graphql-schema.json linguist-vendored


### PR DESCRIPTION
# 📲 What

This PR adds some git attributes to `GraphAPI.swift` and `graphql-schema.json` which will hide their diffs and stats respectively.

Nothing about the code or build process changes with this PR.

# 🤔 Why

Some PRs regenerate these generated files, and that makes the PR appear massive compared to the actual changes included. By hiding the generated changes from the diff and/or the stats, we can hopefully reduce the cognitive overhead of reviewing a "large" PR.

# 🛠 How

I tagged these files with the relevant git attributes per GitHub's documentation.

# 👀 See

[GitHub documentation](https://github.com/github-linguist/linguist/blob/main/docs/overrides.md)
