### PR TITLE
[MBL-1852] Update CreateBackingInput

### DIFF
--- a/KsApi/graphql-schema.json
+++ b/KsApi/graphql-schema.json
@@ -22061,7 +22061,7 @@
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
-                "name": "DateTime",
+                "name": "ISO8601DateTime",
                 "ofType": null
               }
             },

--- a/KsApi/graphql-schema.json
+++ b/KsApi/graphql-schema.json
@@ -691,9 +691,13 @@
               }
             ],
             "type": {
-              "kind": "OBJECT",
-              "name": "Order",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Order",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -14232,7 +14236,19 @@
             "deprecationReason": null
           },
           {
+            "name": "pledge_redemption_unified_creator_ui",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "react_backed_projects",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "copy_addons",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
@@ -30535,12 +30551,12 @@
             "deprecationReason": null
           },
           {
-            "name": "shippingAmount",
-            "description": "The cost of shipping",
+            "name": "shippingAmountFormatted",
+            "description": "The cost of shipping, formatted",
             "args": [],
             "type": {
               "kind": "SCALAR",
-              "name": "Int",
+              "name": "String",
               "ofType": null
             },
             "isDeprecated": false,
@@ -30575,12 +30591,24 @@
             "deprecationReason": null
           },
           {
-            "name": "totalTax",
-            "description": "The total tax amount for the order",
+            "name": "totalFormatted",
+            "description": "The total cost for the order including taxes and shipping, formatted",
             "args": [],
             "type": {
               "kind": "SCALAR",
-              "name": "Int",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalTaxFormatted",
+            "description": "The total tax amount for the order, formatted",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
               "ofType": null
             },
             "isDeprecated": false,
@@ -30633,38 +30661,6 @@
         "description": "An add-on reward included in an Order during Pledge Redemption as a Cross Sell.",
         "fields": [
           {
-            "name": "contentsType",
-            "description": "The content type of the reward",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "description",
-            "description": "Description of the add-on",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "id",
             "description": null,
             "args": [],
@@ -30681,18 +30677,6 @@
             "deprecationReason": null
           },
           {
-            "name": "name",
-            "description": "The add-on name.",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "orderable",
             "description": "The orderable of the cross sell",
             "args": [],
@@ -30702,38 +30686,6 @@
               "ofType": {
                 "kind": "UNION",
                 "name": "Orderable",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "orderableConfig",
-            "description": "Configuration for the add-on",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "OrderableConfig",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "orderableId",
-            "description": "The ID of the orderable",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
                 "ofType": null
               }
             },
@@ -30757,8 +30709,8 @@
             "deprecationReason": null
           },
           {
-            "name": "shippingPreference",
-            "description": "The shipping preference of the reward",
+            "name": "totalPriceFormatted",
+            "description": "The total price of the cross-sell",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -30773,31 +30725,7 @@
             "deprecationReason": null
           },
           {
-            "name": "shippingRatesExpanded",
-            "description": "Shipping rates for all shippable countries,\n        including those that are children of superregions",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "ShippingRate",
-                    "ofType": null
-                  }
-                }
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "unitPrice",
+            "name": "unitPriceFormatted",
             "description": "The price of one unit of the cross-sell",
             "args": [],
             "type": {
@@ -30805,7 +30733,7 @@
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
-                "name": "Int",
+                "name": "String",
                 "ofType": null
               }
             },
@@ -47920,22 +47848,6 @@
         "description": "Autogenerated return type of CreateWave",
         "fields": [
           {
-            "name": "checkoutWave",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "CheckoutWave",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "clientMutationId",
             "description": "A unique identifier for the client performing the mutation.",
             "args": [],
@@ -47943,6 +47855,22 @@
               "kind": "SCALAR",
               "name": "String",
               "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "project",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Project",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null

--- a/KsApi/models/graphql/adapters/GraphAPI.CreateBackingInput+CreateBackingInput.swift
+++ b/KsApi/models/graphql/adapters/GraphAPI.CreateBackingInput+CreateBackingInput.swift
@@ -10,7 +10,8 @@ extension GraphAPI.CreateBackingInput {
       refParam: input.refParam,
       paymentSourceId: input.paymentSourceId,
       setupIntentClientSecret: input.setupIntentClientSecret,
-      applePay: GraphAPI.ApplePayInput.from(input.applePay)
+      applePay: GraphAPI.ApplePayInput.from(input.applePay),
+      incremental: input.incremental
     )
   }
 }

--- a/KsApi/models/graphql/adapters/GraphAPI.CreateBackingInput+CreateBackingInputTests.swift
+++ b/KsApi/models/graphql/adapters/GraphAPI.CreateBackingInput+CreateBackingInputTests.swift
@@ -6,6 +6,7 @@ final class GraphAPI_CreateBackingInput_CreateBackingInputTests: XCTestCase {
     let input = CreateBackingInput(
       amount: "50.00",
       applePay: nil,
+      incremental: false,
       locationId: "1234",
       paymentSourceId: "1111",
       projectId: "5555",
@@ -18,6 +19,7 @@ final class GraphAPI_CreateBackingInput_CreateBackingInputTests: XCTestCase {
 
     XCTAssertEqual(graphInput.amount, input.amount)
     XCTAssertNil(graphInput.applePay??.token)
+    XCTAssertEqual(graphInput.incremental, input.incremental)
     XCTAssertEqual(graphInput.locationId, input.locationId)
     XCTAssertEqual(graphInput.paymentSourceId, input.paymentSourceId)
     XCTAssertEqual(graphInput.projectId, input.projectId)
@@ -35,6 +37,7 @@ final class GraphAPI_CreateBackingInput_CreateBackingInputTests: XCTestCase {
         transactionIdentifier: "transaction-identifier",
         token: "token"
       ),
+      incremental: false,
       locationId: "1234",
       paymentSourceId: "1111",
       projectId: "5555",
@@ -50,6 +53,7 @@ final class GraphAPI_CreateBackingInput_CreateBackingInputTests: XCTestCase {
     XCTAssertEqual(graphInput.applePay??.paymentInstrumentName, "instrument-name")
     XCTAssertEqual(graphInput.applePay??.paymentNetwork, "payment-network")
     XCTAssertEqual(graphInput.applePay??.transactionIdentifier, "transaction-identifier")
+    XCTAssertEqual(graphInput.incremental, input.incremental)
     XCTAssertEqual(graphInput.locationId, input.locationId)
     XCTAssertEqual(graphInput.paymentSourceId, input.paymentSourceId)
     XCTAssertEqual(graphInput.projectId, input.projectId)

--- a/KsApi/mutations/inputs/CreateBackingInput.swift
+++ b/KsApi/mutations/inputs/CreateBackingInput.swift
@@ -16,7 +16,7 @@ public struct CreateBackingInput: GraphMutationInput, Encodable {
 
    - parameter amount: The amount.
    - parameter applePay: The optional ApplePayParams.
-   - parameter incremental: The optional Bool indicating whether pledge over time has been selected..
+   - parameter incremental: The optional Bool indicating whether pledge over time has been selected.
    - parameter locationId: The optional ID of the ShippingRule's Location.
    - parameter paymentSourceId: The optional ID of the PaymentSource.
    - parameter projectId: The GraphID of the Project.

--- a/KsApi/mutations/inputs/CreateBackingInput.swift
+++ b/KsApi/mutations/inputs/CreateBackingInput.swift
@@ -3,6 +3,7 @@ import Foundation
 public struct CreateBackingInput: GraphMutationInput, Encodable {
   let amount: String
   let applePay: ApplePayParams?
+  let incremental: Bool?
   let locationId: String?
   let paymentSourceId: String?
   let projectId: String
@@ -15,6 +16,7 @@ public struct CreateBackingInput: GraphMutationInput, Encodable {
 
    - parameter amount: The amount.
    - parameter applePay: The optional ApplePayParams.
+   - parameter incremental: The optional Bool indicating whether pledge over time has been selected..
    - parameter locationId: The optional ID of the ShippingRule's Location.
    - parameter paymentSourceId: The optional ID of the PaymentSource.
    - parameter projectId: The GraphID of the Project.
@@ -25,6 +27,7 @@ public struct CreateBackingInput: GraphMutationInput, Encodable {
   public init(
     amount: String,
     applePay: ApplePayParams?,
+    incremental: Bool?,
     locationId: String?,
     paymentSourceId: String?,
     projectId: String,
@@ -34,6 +37,7 @@ public struct CreateBackingInput: GraphMutationInput, Encodable {
   ) {
     self.amount = amount
     self.applePay = applePay
+    self.incremental = incremental
     self.locationId = locationId
     self.paymentSourceId = paymentSourceId
     self.projectId = projectId

--- a/KsApi/mutations/inputs/CreateBackingInputTests.swift
+++ b/KsApi/mutations/inputs/CreateBackingInputTests.swift
@@ -12,6 +12,7 @@ final class CreateBackingInputTests: XCTestCase {
         transactionIdentifier: "tx-identifier",
         token: "token"
       ),
+      incremental: false,
       locationId: "NY",
       paymentSourceId: "paymentSourceId",
       projectId: "projectId",
@@ -28,6 +29,7 @@ final class CreateBackingInputTests: XCTestCase {
     XCTAssertEqual(applePayDictionary?["paymentNetwork"] as? String, "payment-network")
     XCTAssertEqual(applePayDictionary?["transactionIdentifier"] as? String, "tx-identifier")
     XCTAssertEqual(applePayDictionary?["token"] as? String, "token")
+    XCTAssertEqual(input["incremental"] as? Bool, false)
     XCTAssertEqual(input["locationId"] as? String, "NY")
     XCTAssertEqual(input["paymentSourceId"] as? String, "paymentSourceId")
     XCTAssertEqual(input["projectId"] as? String, "projectId")
@@ -43,6 +45,7 @@ final class CreateBackingInputTests: XCTestCase {
     let createBackingInput = CreateBackingInput(
       amount: "200.00",
       applePay: nil,
+      incremental: false,
       locationId: "NY",
       paymentSourceId: "paymentSourceId",
       projectId: "projectId",
@@ -56,6 +59,7 @@ final class CreateBackingInputTests: XCTestCase {
     XCTAssertFalse(input.keys.contains("applePay"))
 
     XCTAssertEqual(input["amount"] as? String, "200.00")
+    XCTAssertEqual(input["incremental"] as? Bool, false)
     XCTAssertEqual(input["locationId"] as? String, "NY")
     XCTAssertEqual(input["paymentSourceId"] as? String, "paymentSourceId")
     XCTAssertEqual(input["projectId"] as? String, "projectId")
@@ -73,6 +77,7 @@ final class CreateBackingInputTests: XCTestCase {
         transactionIdentifier: "tx-identifier",
         token: "token"
       ),
+      incremental: false,
       locationId: nil,
       paymentSourceId: "paymentSourceId",
       projectId: "projectId",
@@ -84,6 +89,7 @@ final class CreateBackingInputTests: XCTestCase {
     let input = createBackingInput.toInputDictionary()
 
     XCTAssertEqual(input["amount"] as? String, "200.00")
+    XCTAssertEqual(input["incremental"] as? Bool, false)
     XCTAssertNil(input["locationId"])
     XCTAssertEqual(input["paymentSourceId"] as? String, "paymentSourceId")
     XCTAssertEqual(input["projectId"] as? String, "projectId")

--- a/Library/CreateBackingConstructorTests.swift
+++ b/Library/CreateBackingConstructorTests.swift
@@ -25,7 +25,8 @@ final class CreateBackingInputConstructorTests: XCTestCase {
       paymentSourceId: UserCreditCards.amex.id,
       setupIntentClientSecret: nil,
       applePayParams: applePayParams,
-      refTag: RefTag.projectPage
+      refTag: RefTag.projectPage,
+      incremental: false
     )
 
     let input = CreateBackingInput.input(from: data, isApplePay: false)
@@ -37,6 +38,7 @@ final class CreateBackingInputConstructorTests: XCTestCase {
     XCTAssertEqual(input.rewardIds, ["UmV3YXJkLTA="])
     XCTAssertEqual(input.paymentSourceId, "6")
     XCTAssertEqual(input.refParam, "project_page")
+    XCTAssertEqual(input.incremental, false)
   }
 
   func testCreateBackingInput_WithShipping_RefTagNil_IsApplePay() {
@@ -62,7 +64,8 @@ final class CreateBackingInputConstructorTests: XCTestCase {
       paymentSourceId: "123",
       setupIntentClientSecret: "xyz",
       applePayParams: applePayParams,
-      refTag: nil
+      refTag: nil,
+      incremental: false
     )
 
     let input = CreateBackingInput.input(from: data, isApplePay: true)
@@ -74,6 +77,7 @@ final class CreateBackingInputConstructorTests: XCTestCase {
     XCTAssertEqual(input.rewardIds, ["UmV3YXJkLTE="])
     XCTAssertNil(input.paymentSourceId)
     XCTAssertNil(input.refParam)
+    XCTAssertEqual(input.incremental, false)
   }
 
   func testCreateBackingInput_WithShipping_RefTag_HasAddOns() {
@@ -104,7 +108,8 @@ final class CreateBackingInputConstructorTests: XCTestCase {
       paymentSourceId: "123",
       setupIntentClientSecret: "xyz",
       applePayParams: applePayParams,
-      refTag: .discovery
+      refTag: .discovery,
+      incremental: false
     )
 
     let input = CreateBackingInput.input(from: data, isApplePay: true)
@@ -119,6 +124,7 @@ final class CreateBackingInputConstructorTests: XCTestCase {
     )
     XCTAssertNil(input.paymentSourceId)
     XCTAssertEqual(input.refParam, "discovery")
+    XCTAssertEqual(input.incremental, false)
   }
 
   func testCreateBackingInput_WithApplePay_AndPaymentSource_AndSetupIntentClientSecret_OnlyApplePayIsValid_Success(
@@ -139,7 +145,8 @@ final class CreateBackingInputConstructorTests: XCTestCase {
       paymentSourceId: UserCreditCards.amex.id,
       setupIntentClientSecret: "xyz",
       applePayParams: applePayParams,
-      refTag: RefTag.projectPage
+      refTag: RefTag.projectPage,
+      incremental: false
     )
 
     let input = CreateBackingInput.input(from: data, isApplePay: true)
@@ -147,6 +154,7 @@ final class CreateBackingInputConstructorTests: XCTestCase {
     XCTAssertNotNil(input.applePay)
     XCTAssertNil(input.paymentSourceId)
     XCTAssertNil(input.setupIntentClientSecret)
+    XCTAssertEqual(input.incremental, false)
   }
 
   func testCreateBackingInput_WithNoApplePay_AndPaymentSource_AndSetupIntentClientSecret_OnlyPaymentSourceIsValid_Success(
@@ -160,7 +168,8 @@ final class CreateBackingInputConstructorTests: XCTestCase {
       paymentSourceId: UserCreditCards.amex.id,
       setupIntentClientSecret: nil,
       applePayParams: nil,
-      refTag: RefTag.projectPage
+      refTag: RefTag.projectPage,
+      incremental: false
     )
 
     let input = CreateBackingInput.input(from: data, isApplePay: false)
@@ -168,6 +177,7 @@ final class CreateBackingInputConstructorTests: XCTestCase {
     XCTAssertNil(input.applePay)
     XCTAssertEqual(input.paymentSourceId, UserCreditCards.amex.id)
     XCTAssertNil(input.setupIntentClientSecret)
+    XCTAssertEqual(input.incremental, false)
   }
 
   func testCreateBackingInput_WithNoApplePay_NoPaymentSource_AndSetupIntentClientSecret_OnlySetupIntentClientSecretIsValid_Success(
@@ -181,7 +191,8 @@ final class CreateBackingInputConstructorTests: XCTestCase {
       paymentSourceId: nil,
       setupIntentClientSecret: "xyz",
       applePayParams: nil,
-      refTag: RefTag.projectPage
+      refTag: RefTag.projectPage,
+      incremental: false
     )
 
     let input = CreateBackingInput.input(from: data, isApplePay: false)
@@ -189,5 +200,6 @@ final class CreateBackingInputConstructorTests: XCTestCase {
     XCTAssertNil(input.applePay)
     XCTAssertNil(input.paymentSourceId)
     XCTAssertEqual(input.setupIntentClientSecret, "xyz")
+    XCTAssertEqual(input.incremental, false)
   }
 }

--- a/Library/CreateBackingInput+Constructor.swift
+++ b/Library/CreateBackingInput+Constructor.swift
@@ -21,6 +21,7 @@ extension CreateBackingInput {
     return CreateBackingInput(
       amount: pledgeParams.pledgeTotal,
       applePay: isApplePay ? createBackingData.applePayParams : nil,
+      incremental: createBackingData.incremental,
       locationId: pledgeParams.locationId,
       paymentSourceId: paymentSourceId,
       projectId: createBackingData.project.graphID,

--- a/Library/ViewModels/NoShippingPledgeViewModel.swift
+++ b/Library/ViewModels/NoShippingPledgeViewModel.swift
@@ -529,7 +529,8 @@ public class NoShippingPledgeViewModel: NoShippingPledgeViewModelType, NoShippin
         paymentSourceId: paymentSourceId,
         setupIntentClientSecret: nil,
         applePayParams: applePayParams,
-        refTag: refTag
+        refTag: refTag,
+        incremental: false // TODO: implementation in [mbl-1853](https://kickstarter.atlassian.net/browse/MBL-1853)
       )
     }
 

--- a/Library/ViewModels/PledgeViewModel.swift
+++ b/Library/ViewModels/PledgeViewModel.swift
@@ -14,7 +14,8 @@ public typealias CreateBackingData = (
   paymentSourceId: String?,
   setupIntentClientSecret: String?,
   applePayParams: ApplePayParams?,
-  refTag: RefTag?
+  refTag: RefTag?,
+  incremental: Bool?
 )
 public typealias UpdateBackingData = (
   backing: Backing,
@@ -581,7 +582,8 @@ public class PledgeViewModel: PledgeViewModelType, PledgeViewModelInputs, Pledge
         paymentSourceId: paymentSourceId,
         setupIntentClientSecret: nil,
         applePayParams: applePayParams,
-        refTag: refTag
+        refTag: refTag,
+        incremental: false /// This will always be false for our old "shipping included" crowdfunding checkout flow. Pledge Over Time will only be available in our "no shipping at checkout" flow.
       )
     }
 


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Updates the `CreateBackingInput` GraphQL object to support its new `incremental: Bool?` property.

Actual implementation will be done separately in [mbl-1853](https://kickstarter.atlassian.net/browse/MBL-1853).


# 🤔 Why

This flag will let the backend know if backers have selected the Pledge Over Time option at checkout. 

# 🛠 How

- Updated GraphAPI.swift via our apollo script
- Updates the existing adapters and structs to include this new property.
- Passes `false` to call points for now since implementation will be done in [mbl-1853](https://kickstarter.atlassian.net/browse/MBL-1853)

# 👀 See

Tested that the new property is being sent as false in when attempting a crowdfund pledging:

<img width="542" alt="Screenshot 2024-11-25 at 10 23 49 AM" src="https://github.com/user-attachments/assets/b6bd66f4-365d-4762-99ca-fd62d1ef2dc2">


# ✅ Acceptance criteria

- [x] All checkout flows work as expected
- [x] `incremental` is being added to the `CreateBackingInput` and is false for now.
- [x] Late pledge flow experiences no change and is unaware of this new property.
