### PR TITLE
[MBL-1930] Delete ppoHasAction from UserFragment

### DIFF
--- a/KsApi/GraphAPI.swift
+++ b/KsApi/GraphAPI.swift
@@ -20206,7 +20206,6 @@ public enum GraphAPI {
           topic
         }
         optedOutOfRecommendations
-        ppoHasAction
         showPublicProfile
         savedProjects {
           __typename
@@ -20254,7 +20253,6 @@ public enum GraphAPI {
         GraphQLField("newsletterSubscriptions", type: .object(NewsletterSubscription.selections)),
         GraphQLField("notifications", type: .list(.nonNull(.object(Notification.selections)))),
         GraphQLField("optedOutOfRecommendations", type: .scalar(Bool.self)),
-        GraphQLField("ppoHasAction", type: .scalar(Bool.self)),
         GraphQLField("showPublicProfile", type: .scalar(Bool.self)),
         GraphQLField("savedProjects", type: .object(SavedProject.selections)),
         GraphQLBooleanCondition(variableName: "withStoredCards", inverted: false, selections: [
@@ -20271,8 +20269,8 @@ public enum GraphAPI {
       self.resultMap = unsafeResultMap
     }
 
-    public init(backings: Backing? = nil, backingsCount: Int, chosenCurrency: String? = nil, createdProjects: CreatedProject? = nil, email: String? = nil, hasPassword: Bool? = nil, hasUnreadMessages: Bool? = nil, hasUnseenActivity: Bool? = nil, id: GraphQLID, imageUrl: String, isAppleConnected: Bool? = nil, isBlocked: Bool? = nil, isCreator: Bool? = nil, isDeliverable: Bool? = nil, isEmailVerified: Bool? = nil, isFacebookConnected: Bool? = nil, isKsrAdmin: Bool? = nil, isFollowing: Bool, isSocializing: Bool? = nil, location: Location? = nil, name: String, needsFreshFacebookToken: Bool? = nil, newsletterSubscriptions: NewsletterSubscription? = nil, notifications: [Notification]? = nil, optedOutOfRecommendations: Bool? = nil, ppoHasAction: Bool? = nil, showPublicProfile: Bool? = nil, savedProjects: SavedProject? = nil, storedCards: StoredCard? = nil, surveyResponses: SurveyResponse? = nil, uid: String) {
-      self.init(unsafeResultMap: ["__typename": "User", "backings": backings.flatMap { (value: Backing) -> ResultMap in value.resultMap }, "backingsCount": backingsCount, "chosenCurrency": chosenCurrency, "createdProjects": createdProjects.flatMap { (value: CreatedProject) -> ResultMap in value.resultMap }, "email": email, "hasPassword": hasPassword, "hasUnreadMessages": hasUnreadMessages, "hasUnseenActivity": hasUnseenActivity, "id": id, "imageUrl": imageUrl, "isAppleConnected": isAppleConnected, "isBlocked": isBlocked, "isCreator": isCreator, "isDeliverable": isDeliverable, "isEmailVerified": isEmailVerified, "isFacebookConnected": isFacebookConnected, "isKsrAdmin": isKsrAdmin, "isFollowing": isFollowing, "isSocializing": isSocializing, "location": location.flatMap { (value: Location) -> ResultMap in value.resultMap }, "name": name, "needsFreshFacebookToken": needsFreshFacebookToken, "newsletterSubscriptions": newsletterSubscriptions.flatMap { (value: NewsletterSubscription) -> ResultMap in value.resultMap }, "notifications": notifications.flatMap { (value: [Notification]) -> [ResultMap] in value.map { (value: Notification) -> ResultMap in value.resultMap } }, "optedOutOfRecommendations": optedOutOfRecommendations, "ppoHasAction": ppoHasAction, "showPublicProfile": showPublicProfile, "savedProjects": savedProjects.flatMap { (value: SavedProject) -> ResultMap in value.resultMap }, "storedCards": storedCards.flatMap { (value: StoredCard) -> ResultMap in value.resultMap }, "surveyResponses": surveyResponses.flatMap { (value: SurveyResponse) -> ResultMap in value.resultMap }, "uid": uid])
+    public init(backings: Backing? = nil, backingsCount: Int, chosenCurrency: String? = nil, createdProjects: CreatedProject? = nil, email: String? = nil, hasPassword: Bool? = nil, hasUnreadMessages: Bool? = nil, hasUnseenActivity: Bool? = nil, id: GraphQLID, imageUrl: String, isAppleConnected: Bool? = nil, isBlocked: Bool? = nil, isCreator: Bool? = nil, isDeliverable: Bool? = nil, isEmailVerified: Bool? = nil, isFacebookConnected: Bool? = nil, isKsrAdmin: Bool? = nil, isFollowing: Bool, isSocializing: Bool? = nil, location: Location? = nil, name: String, needsFreshFacebookToken: Bool? = nil, newsletterSubscriptions: NewsletterSubscription? = nil, notifications: [Notification]? = nil, optedOutOfRecommendations: Bool? = nil, showPublicProfile: Bool? = nil, savedProjects: SavedProject? = nil, storedCards: StoredCard? = nil, surveyResponses: SurveyResponse? = nil, uid: String) {
+      self.init(unsafeResultMap: ["__typename": "User", "backings": backings.flatMap { (value: Backing) -> ResultMap in value.resultMap }, "backingsCount": backingsCount, "chosenCurrency": chosenCurrency, "createdProjects": createdProjects.flatMap { (value: CreatedProject) -> ResultMap in value.resultMap }, "email": email, "hasPassword": hasPassword, "hasUnreadMessages": hasUnreadMessages, "hasUnseenActivity": hasUnseenActivity, "id": id, "imageUrl": imageUrl, "isAppleConnected": isAppleConnected, "isBlocked": isBlocked, "isCreator": isCreator, "isDeliverable": isDeliverable, "isEmailVerified": isEmailVerified, "isFacebookConnected": isFacebookConnected, "isKsrAdmin": isKsrAdmin, "isFollowing": isFollowing, "isSocializing": isSocializing, "location": location.flatMap { (value: Location) -> ResultMap in value.resultMap }, "name": name, "needsFreshFacebookToken": needsFreshFacebookToken, "newsletterSubscriptions": newsletterSubscriptions.flatMap { (value: NewsletterSubscription) -> ResultMap in value.resultMap }, "notifications": notifications.flatMap { (value: [Notification]) -> [ResultMap] in value.map { (value: Notification) -> ResultMap in value.resultMap } }, "optedOutOfRecommendations": optedOutOfRecommendations, "showPublicProfile": showPublicProfile, "savedProjects": savedProjects.flatMap { (value: SavedProject) -> ResultMap in value.resultMap }, "storedCards": storedCards.flatMap { (value: StoredCard) -> ResultMap in value.resultMap }, "surveyResponses": surveyResponses.flatMap { (value: SurveyResponse) -> ResultMap in value.resultMap }, "uid": uid])
     }
 
     public var __typename: String {
@@ -20530,16 +20528,6 @@ public enum GraphAPI {
       }
       set {
         resultMap.updateValue(newValue, forKey: "optedOutOfRecommendations")
-      }
-    }
-
-    /// Whether backer has any action in PPO
-    public var ppoHasAction: Bool? {
-      get {
-        return resultMap["ppoHasAction"] as? Bool
-      }
-      set {
-        resultMap.updateValue(newValue, forKey: "ppoHasAction")
       }
     }
 

--- a/KsApi/fragments/UserFragment.graphql
+++ b/KsApi/fragments/UserFragment.graphql
@@ -47,7 +47,6 @@ fragment UserFragment on User {
     topic
   }
   optedOutOfRecommendations
-  ppoHasAction
   showPublicProfile
   savedProjects {
     totalCount

--- a/KsApi/models/graphql/adapters/Backing+BackingFragmentTests.swift
+++ b/KsApi/models/graphql/adapters/Backing+BackingFragmentTests.swift
@@ -609,7 +609,6 @@ private func backingDictionary() -> [String: Any] {
          "totalCount": 2
       },
       "optedOutOfRecommendations": true,
-      "ppoHasAction": false,
       "hasPassword": true,
       "id": "VXNlci0xMTA4OTI0NjQw",
       "imageUrl": "https://i.kickstarter.com/assets/014/148/024/902b3aee57c0325f82d93af888194c5e_original.png?anim=false&fit=crop&height=1024&origin=ugc-qa&q=92&width=1024&sig=R3eM4ky3JqjYS9y8bIqPAag33sV10pfZu16tveritQY%3D",
@@ -820,7 +819,6 @@ private func backingDictionary() -> [String: Any] {
           "totalCount": 2
         },
         "optedOutOfRecommendations": true,
-        "ppoHasAction": false,
         "storedCards": {
           "__typename": "UserCreditCardTypeConnection",
           "nodes": [

--- a/KsApi/models/graphql/adapters/Project+ProjectFragmentTests.swift
+++ b/KsApi/models/graphql/adapters/Project+ProjectFragmentTests.swift
@@ -235,7 +235,6 @@ final class Project_ProjectFragmentTests: XCTestCase {
              "alumniNewsletter":true
           },
           "optedOutOfRecommendations":true,
-          "ppoHasAction": false,
           "notifications":[
              {
                 "__typename":"Notification",

--- a/KsApi/models/graphql/adapters/User+UserFragment.swift
+++ b/KsApi/models/graphql/adapters/User+UserFragment.swift
@@ -37,7 +37,6 @@ extension User {
       newsletters: self.newsletterSubscriptions(userFragment: userFragment),
       notifications: self.notifications(userFragment: userFragment),
       optedOutOfRecommendations: userFragment.optedOutOfRecommendations,
-      ppoHasAction: userFragment.ppoHasAction,
       showPublicProfile: userFragment.showPublicProfile,
       social: userFragment.isSocializing,
       stats: self.userStats(userFragment: userFragment),

--- a/KsApi/mutations/templates/fragment/CommentFragmentTemplate.swift
+++ b/KsApi/mutations/templates/fragment/CommentFragmentTemplate.swift
@@ -59,7 +59,6 @@ public enum CommentFragmentTemplate {
            "totalCount": 2
         },
         "optedOutOfRecommendations":true,
-        "ppoHasAction": false,
         "email": "m@example.com",
         "isAppleConnected": true,
         "isBlocked": false,

--- a/KsApi/queries/templates/FetchMyBackedProjectsQuery.json
+++ b/KsApi/queries/templates/FetchMyBackedProjectsQuery.json
@@ -71,7 +71,6 @@
             "newsletterSubscriptions": null,
             "notifications": null,
             "optedOutOfRecommendations": null,
-            "ppoHasAction": false,
             "showPublicProfile": null,
             "savedProjects": null,
             "storedCards": {
@@ -231,7 +230,6 @@
             "newsletterSubscriptions": null,
             "notifications": null,
             "optedOutOfRecommendations": null,
-            "ppoHasAction": false,
             "showPublicProfile": null,
             "savedProjects": null,
             "storedCards": {
@@ -421,7 +419,6 @@
             "newsletterSubscriptions": null,
             "notifications": null,
             "optedOutOfRecommendations": null,
-            "ppoHasAction": false,
             "showPublicProfile": null,
             "savedProjects": null,
             "storedCards": {

--- a/KsApi/queries/templates/FetchMySavedProjectsQuery.json
+++ b/KsApi/queries/templates/FetchMySavedProjectsQuery.json
@@ -260,7 +260,6 @@
               }
             ],
             "optedOutOfRecommendations": null,
-            "ppoHasAction": false,
             "showPublicProfile": null,
             "savedProjects": {
               "__typename": "UserSavedProjectsConnection",
@@ -506,7 +505,6 @@
               }
             ],
             "optedOutOfRecommendations": null,
-            "ppoHasAction": false,
             "showPublicProfile": null,
             "savedProjects": {
               "__typename": "UserSavedProjectsConnection",
@@ -908,7 +906,6 @@
               }
             ],
             "optedOutOfRecommendations": null,
-            "ppoHasAction": false,
             "showPublicProfile": null,
             "savedProjects": {
               "__typename": "UserSavedProjectsConnection",
@@ -1243,7 +1240,6 @@
               }
             ],
             "optedOutOfRecommendations": null,
-            "ppoHasAction": false,
             "showPublicProfile": null,
             "savedProjects": {
               "__typename": "UserSavedProjectsConnection",


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

The `ppoHasAction` field caused basically all graphQL fetches to fail for logged out users. (They probably only fail if we're fetching a user, but ex fetching a project includes a user fetch because of the project creator.) In order to unblock the build, we'll just delete this field from graphQL.

# 👀 See

[Jira](https://kickstarter.atlassian.net/browse/MBL-1930)
[Jira for next steps (currently blocked since the notification dot is broken)](https://kickstarter.atlassian.net/browse/MBL-1931)

| Before 🐛 | After 🦋 |
| --- | --- |
| ![Simulator Screen Recording - iPhone 16 Pro Max - 2024-12-10 at 15 28 31](https://github.com/user-attachments/assets/645270b9-cd11-4ddb-af68-1a5e2ecb9fb9) | ![Simulator Screen Recording - iPhone 16 Pro Max - 2024-12-10 at 15 26 37](https://github.com/user-attachments/assets/607a47c7-cb9a-4b6e-8f9f-1002a8b2ddf7) |

# ✅ Acceptance criteria

- [x] Project pages load normally for logged out users

