### PR TITLE
MBL-1838: Wire up PLOT query to UI in no-shipping checkout flow

### DIFF
--- a/Kickstarter-iOS/Features/PledgeView/Controllers/NoShippingPledgeViewControllerTests.swift
+++ b/Kickstarter-iOS/Features/PledgeView/Controllers/NoShippingPledgeViewControllerTests.swift
@@ -298,8 +298,14 @@ final class NoShippingPledgeViewControllerTests: TestCase {
   }
 
   func testView_ShowCollectionPlans() {
-    let response = UserEnvelope<GraphUser>(me: self.userWithCards)
-    let mockService = MockService(fetchGraphUserResult: .success(response))
+    let userResponse = UserEnvelope<GraphUser>(me: self.userWithCards)
+    let paymentPlanResponse = try! GraphAPI.BuildPaymentPlanQuery
+      .Data(jsonString: buildPaymentPlanQueryJson_Eligible)
+    let mockService = MockService(
+      buildPaymentPlanResult: .success(paymentPlanResponse),
+      fetchGraphUserResult: .success(userResponse)
+    )
+
     let project = Project.template
       |> \.availableCardTypes .~ [CreditCardType.discover.rawValue]
       |> Project.lens.isPledgeOverTimeAllowed .~ true
@@ -346,8 +352,14 @@ final class NoShippingPledgeViewControllerTests: TestCase {
   }
 
   func testView_ShowCollectionPlans_Ineligible() {
-    let response = UserEnvelope<GraphUser>(me: self.userWithCards)
-    let mockService = MockService(fetchGraphUserResult: .success(response))
+    let userResponse = UserEnvelope<GraphUser>(me: self.userWithCards)
+    let paymentPlanResponse = try! GraphAPI.BuildPaymentPlanQuery
+      .Data(jsonString: buildPaymentPlanQueryJson_Ineligible)
+    let mockService = MockService(
+      buildPaymentPlanResult: .success(paymentPlanResponse),
+      fetchGraphUserResult: .success(userResponse)
+    )
+
     let project = Project.template
       |> \.availableCardTypes .~ [CreditCardType.discover.rawValue]
       |> Project.lens.isPledgeOverTimeAllowed .~ true
@@ -393,3 +405,51 @@ final class NoShippingPledgeViewControllerTests: TestCase {
       }
   }
 }
+
+private let buildPaymentPlanQueryJson_Eligible = """
+{
+    "project": {
+      "__typename": "Project",
+      "paymentPlan": {
+        "__typename": "PaymentPlan",
+        "projectIsPledgeOverTimeAllowed": true,
+        "amountIsPledgeOverTimeEligible": true,
+        "paymentIncrements": [
+          {
+            "__typename": "PaymentIncrement",
+            "amount": {
+              "__typename": "Money",
+              "amount": "933.23",
+              "currency": "USD"
+            },
+            "scheduledCollection": "2025-03-31T10:29:19-04:00",
+          }
+        ]
+      }
+    }
+}
+"""
+
+private let buildPaymentPlanQueryJson_Ineligible = """
+{
+    "project": {
+      "__typename": "Project",
+      "paymentPlan": {
+        "__typename": "PaymentPlan",
+        "projectIsPledgeOverTimeAllowed": true,
+        "amountIsPledgeOverTimeEligible": false,
+        "paymentIncrements": [
+          {
+            "__typename": "PaymentIncrement",
+            "amount": {
+              "__typename": "Money",
+              "amount": "933.23",
+              "currency": "USD"
+            },
+            "scheduledCollection": "2025-03-31T10:29:19-04:00",
+          }
+        ]
+      }
+    }
+}
+"""

--- a/Kickstarter-iOS/Features/PledgeView/Controllers/NoShippingPledgeViewControllerTests.swift
+++ b/Kickstarter-iOS/Features/PledgeView/Controllers/NoShippingPledgeViewControllerTests.swift
@@ -423,8 +423,9 @@ private let buildPaymentPlanQueryJson_Eligible = """
               "currency": "USD"
             },
             "scheduledCollection": "2025-03-31T10:29:19-04:00",
+            "state": "some state",
           }
-        ]
+        ],
       }
     }
 }
@@ -447,6 +448,7 @@ private let buildPaymentPlanQueryJson_Ineligible = """
               "currency": "USD"
             },
             "scheduledCollection": "2025-03-31T10:29:19-04:00",
+=           "state": "some state",
           }
         ]
       }

--- a/Kickstarter-iOS/Features/PledgeView/Controllers/NoShippingPledgeViewControllerTests.swift
+++ b/Kickstarter-iOS/Features/PledgeView/Controllers/NoShippingPledgeViewControllerTests.swift
@@ -300,7 +300,7 @@ final class NoShippingPledgeViewControllerTests: TestCase {
   func testView_ShowCollectionPlans() {
     let userResponse = UserEnvelope<GraphUser>(me: self.userWithCards)
     let paymentPlanResponse = try! GraphAPI.BuildPaymentPlanQuery
-      .Data(jsonString: buildPaymentPlanQueryJson_Eligible)
+      .Data(jsonString: buildPaymentPlanQueryJson(eligible: true))
     let mockService = MockService(
       buildPaymentPlanResult: .success(paymentPlanResponse),
       fetchGraphUserResult: .success(userResponse)
@@ -354,7 +354,7 @@ final class NoShippingPledgeViewControllerTests: TestCase {
   func testView_ShowCollectionPlans_Ineligible() {
     let userResponse = UserEnvelope<GraphUser>(me: self.userWithCards)
     let paymentPlanResponse = try! GraphAPI.BuildPaymentPlanQuery
-      .Data(jsonString: buildPaymentPlanQueryJson_Ineligible)
+      .Data(jsonString: buildPaymentPlanQueryJson(eligible: false))
     let mockService = MockService(
       buildPaymentPlanResult: .success(paymentPlanResponse),
       fetchGraphUserResult: .success(userResponse)
@@ -405,53 +405,3 @@ final class NoShippingPledgeViewControllerTests: TestCase {
       }
   }
 }
-
-private let buildPaymentPlanQueryJson_Eligible = """
-{
-    "project": {
-      "__typename": "Project",
-      "paymentPlan": {
-        "__typename": "PaymentPlan",
-        "projectIsPledgeOverTimeAllowed": true,
-        "amountIsPledgeOverTimeEligible": true,
-        "paymentIncrements": [
-          {
-            "__typename": "PaymentIncrement",
-            "amount": {
-              "__typename": "Money",
-              "amount": "933.23",
-              "currency": "USD"
-            },
-            "scheduledCollection": "2025-03-31T10:29:19-04:00",
-            "state": "some state",
-          }
-        ],
-      }
-    }
-}
-"""
-
-private let buildPaymentPlanQueryJson_Ineligible = """
-{
-    "project": {
-      "__typename": "Project",
-      "paymentPlan": {
-        "__typename": "PaymentPlan",
-        "projectIsPledgeOverTimeAllowed": true,
-        "amountIsPledgeOverTimeEligible": false,
-        "paymentIncrements": [
-          {
-            "__typename": "PaymentIncrement",
-            "amount": {
-              "__typename": "Money",
-              "amount": "933.23",
-              "currency": "USD"
-            },
-            "scheduledCollection": "2025-03-31T10:29:19-04:00",
-=           "state": "some state",
-          }
-        ]
-      }
-    }
-}
-"""

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -1593,6 +1593,8 @@
 		E1A149222ACE013100F49709 /* FetchProjectsEnvelope.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1A149212ACE013100F49709 /* FetchProjectsEnvelope.swift */; };
 		E1A149242ACE02B300F49709 /* FetchProjectsEnvelope+FetchBackerProjectsQueryDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1A149232ACE02B300F49709 /* FetchProjectsEnvelope+FetchBackerProjectsQueryDataTests.swift */; };
 		E1A149272ACE063400F49709 /* FetchBackerProjectsQueryDataTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1A149262ACE063400F49709 /* FetchBackerProjectsQueryDataTemplate.swift */; };
+		E1A310232D270CB00062646C /* BuildPaymentPlanQueryTestData.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1A310212D270C610062646C /* BuildPaymentPlanQueryTestData.swift */; };
+		E1A310242D270CB00062646C /* BuildPaymentPlanQueryTestData.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1A310212D270C610062646C /* BuildPaymentPlanQueryTestData.swift */; };
 		E1AA8ABF2AEABBB100AC98BF /* Signal+Combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1EA34EE2AE1B28400942A04 /* Signal+Combine.swift */; };
 		E1B214712BFD184500109961 /* KingfisherWebP in Frameworks */ = {isa = PBXBuildFile; productRef = E1B214702BFD184500109961 /* KingfisherWebP */; };
 		E1B813C32BC833D100DF33CF /* FetchMyBackedProjectsQuery.graphql in Resources */ = {isa = PBXBuildFile; fileRef = E1B813C22BC833D100DF33CF /* FetchMyBackedProjectsQuery.graphql */; };
@@ -3285,6 +3287,7 @@
 		E1A149212ACE013100F49709 /* FetchProjectsEnvelope.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FetchProjectsEnvelope.swift; sourceTree = "<group>"; };
 		E1A149232ACE02B300F49709 /* FetchProjectsEnvelope+FetchBackerProjectsQueryDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FetchProjectsEnvelope+FetchBackerProjectsQueryDataTests.swift"; sourceTree = "<group>"; };
 		E1A149262ACE063400F49709 /* FetchBackerProjectsQueryDataTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchBackerProjectsQueryDataTemplate.swift; sourceTree = "<group>"; };
+		E1A310212D270C610062646C /* BuildPaymentPlanQueryTestData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildPaymentPlanQueryTestData.swift; sourceTree = "<group>"; };
 		E1B813C22BC833D100DF33CF /* FetchMyBackedProjectsQuery.graphql */ = {isa = PBXFileReference; lastKnownFileType = text; path = FetchMyBackedProjectsQuery.graphql; sourceTree = "<group>"; };
 		E1B813C42BC8340700DF33CF /* FetchMySavedProjectsQuery.graphql */ = {isa = PBXFileReference; lastKnownFileType = text; path = FetchMySavedProjectsQuery.graphql; sourceTree = "<group>"; };
 		E1B813C62BC851CB00DF33CF /* FetchMyBackedProjectsQueryRequestForTests.graphql_test */ = {isa = PBXFileReference; lastKnownFileType = text; path = FetchMyBackedProjectsQueryRequestForTests.graphql_test; sourceTree = "<group>"; };
@@ -6558,6 +6561,7 @@
 				A7ED1F5C1E831C5C00BFFA01 /* BackingCellViewModelTests.swift */,
 				D04AAC12218BB70A00CF713E /* BetaToolsViewModel.swift */,
 				D04AAC1A218BB70B00CF713E /* BetaToolsViewModelTests.swift */,
+				E1A310212D270C610062646C /* BuildPaymentPlanQueryTestData.swift */,
 				771E6308234258D1005967E8 /* CancelPledgeViewModel.swift */,
 				771E630D23426B74005967E8 /* CancelPledgeViewModelTests.swift */,
 				77C26956240D711A009AD91E /* CategoryCollectionViewSectionHeaderViewModel.swift */,
@@ -8303,6 +8307,7 @@
 				4746FFF5272C588900EC3429 /* ProjectTabDisclaimerCellViewModelTests.swift in Sources */,
 				D6B6876E21937182005F5DA7 /* CreditCardCellViewModelTests.swift in Sources */,
 				8AA3DB39250AF692009AC8EA /* MockPushRegistration.swift in Sources */,
+				E1A310232D270CB00062646C /* BuildPaymentPlanQueryTestData.swift in Sources */,
 				A7ED1FFC1E831C5C00BFFA01 /* ProjectPamphletSubpageCellViewModelTests.swift in Sources */,
 				A7ED20031E831C5C00BFFA01 /* TwoFactorViewModelTests.swift in Sources */,
 				D09362B0225D803600E1411A /* UIViewController+URLTests.swift in Sources */,
@@ -8831,6 +8836,7 @@
 				37096C3022BC238C003D1F40 /* MockFeedbackGenerator.swift in Sources */,
 				D6E925CE211107CD00E13010 /* SettingsNewslettersDataSourceTests.swift in Sources */,
 				77FA6CD220F53E5E00809E31 /* SettingsDataSourceTests.swift in Sources */,
+				E1A310242D270CB00062646C /* BuildPaymentPlanQueryTestData.swift in Sources */,
 				339ED5602CE41015004B301D /* PledgePaymentPlansViewControllerTest.swift in Sources */,
 				A7ED204D1E8323E900BFFA01 /* FindFriendsViewControllerTests.swift in Sources */,
 				015102AE1F1947CB0006C0FC /* MessageThreadsDataSourceTests.swift in Sources */,

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -1578,6 +1578,8 @@
 		E170B9112B20E83B001BEDD7 /* MockGraphQLClient+CombineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E170B9102B20E83B001BEDD7 /* MockGraphQLClient+CombineTests.swift */; };
 		E171A5752D147CFD00AFE0EE /* PledgePaymentIncrement+GraphAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = E171A5742D147CFD00AFE0EE /* PledgePaymentIncrement+GraphAPI.swift */; };
 		E171A5782D147DF100AFE0EE /* PledgePaymentIncrement+GraphAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E171A5762D147DC200AFE0EE /* PledgePaymentIncrement+GraphAPITests.swift */; };
+		E171A57C2D14912B00AFE0EE /* PledgePaymentPlansAndSelectionData+GraphAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = E171A57B2D14912500AFE0EE /* PledgePaymentPlansAndSelectionData+GraphAPI.swift */; };
+		E171A57F2D14991100AFE0EE /* PledgePaymentPlansAndSelectionData+GraphAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E171A57D2D14985500AFE0EE /* PledgePaymentPlansAndSelectionData+GraphAPITests.swift */; };
 		E17611E02B7287CF00DF2F50 /* PaginationExampleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E11CFE4E2B7162A400497375 /* PaginationExampleView.swift */; };
 		E17611E22B73D9A400DF2F50 /* Data+PKCE.swift in Sources */ = {isa = PBXBuildFile; fileRef = E17611E12B73D9A400DF2F50 /* Data+PKCE.swift */; };
 		E17611E42B751E8100DF2F50 /* Paginator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E17611E32B751E8100DF2F50 /* Paginator.swift */; };
@@ -3269,6 +3271,8 @@
 		E170B9102B20E83B001BEDD7 /* MockGraphQLClient+CombineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MockGraphQLClient+CombineTests.swift"; sourceTree = "<group>"; };
 		E171A5742D147CFD00AFE0EE /* PledgePaymentIncrement+GraphAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PledgePaymentIncrement+GraphAPI.swift"; sourceTree = "<group>"; };
 		E171A5762D147DC200AFE0EE /* PledgePaymentIncrement+GraphAPITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PledgePaymentIncrement+GraphAPITests.swift"; sourceTree = "<group>"; };
+		E171A57B2D14912500AFE0EE /* PledgePaymentPlansAndSelectionData+GraphAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PledgePaymentPlansAndSelectionData+GraphAPI.swift"; sourceTree = "<group>"; };
+		E171A57D2D14985500AFE0EE /* PledgePaymentPlansAndSelectionData+GraphAPITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PledgePaymentPlansAndSelectionData+GraphAPITests.swift"; sourceTree = "<group>"; };
 		E17611E12B73D9A400DF2F50 /* Data+PKCE.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+PKCE.swift"; sourceTree = "<group>"; };
 		E17611E32B751E8100DF2F50 /* Paginator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Paginator.swift; sourceTree = "<group>"; };
 		E17611E52B75242A00DF2F50 /* PaginatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginatorTests.swift; sourceTree = "<group>"; };
@@ -6706,6 +6710,8 @@
 				339ED5642CE41AFC004B301D /* PledgePaymentPlansOptionViewModelTest.swift */,
 				E171A5742D147CFD00AFE0EE /* PledgePaymentIncrement+GraphAPI.swift */,
 				E171A5762D147DC200AFE0EE /* PledgePaymentIncrement+GraphAPITests.swift */,
+				E171A57B2D14912500AFE0EE /* PledgePaymentPlansAndSelectionData+GraphAPI.swift */,
+				E171A57D2D14985500AFE0EE /* PledgePaymentPlansAndSelectionData+GraphAPITests.swift */,
 				E1801FA82BAB6CD400EBB533 /* PaymentSourceSelected.swift */,
 				37DEC21F2257CA0A0051EF9B /* PledgeViewModelTests.swift */,
 				6035AFB02C5947D2007E28FC /* NoShippingPledgeViewModel.swift */,
@@ -7983,6 +7989,7 @@
 				203015582666FECF0063B629 /* CommentsViewModel.swift in Sources */,
 				8016BFE81D0F582D00067956 /* String+Whitespace.swift in Sources */,
 				A76126AD1C90C94000EDCCB9 /* ValueCellDataSource.swift in Sources */,
+				E171A57C2D14912B00AFE0EE /* PledgePaymentPlansAndSelectionData+GraphAPI.swift in Sources */,
 				4791BDE6271762E600DFE5D5 /* ProjectFAQsCellViewModel.swift in Sources */,
 				0634C2F927CFEEC2003A6D6E /* ExternalSourceViewElementCellViewModel.swift in Sources */,
 				94BA16E426698C8B0034CC3F /* CommentTableViewFooterViewModel.swift in Sources */,
@@ -8260,6 +8267,7 @@
 				8A13D17024985550007E2C0B /* PledgeExpandableRewardsHeaderViewModelTests.swift in Sources */,
 				8A00CCFF24BD439E00E12D49 /* RewardAddOnCardViewModelTests.swift in Sources */,
 				771E630E23426B74005967E8 /* CancelPledgeViewModelTests.swift in Sources */,
+				E171A57F2D14991100AFE0EE /* PledgePaymentPlansAndSelectionData+GraphAPITests.swift in Sources */,
 				8A73EAD12339732900FF9051 /* PledgePaymentMethodCellViewModelTests.swift in Sources */,
 				D04AABF7218BB2F700CF713E /* SettingsNotificationsViewModelTests.swift in Sources */,
 				D0A7880F2204EF93006AE4F4 /* SelectCurrencyViewModelTests.swift in Sources */,

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -1576,6 +1576,8 @@
 		E16ECA702C245A34002A1D25 /* PagedContainerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E16ECA6F2C245A34002A1D25 /* PagedContainerViewController.swift */; };
 		E16ECA722C245A51002A1D25 /* PagedContainerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E16ECA712C245A51002A1D25 /* PagedContainerViewModel.swift */; };
 		E170B9112B20E83B001BEDD7 /* MockGraphQLClient+CombineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E170B9102B20E83B001BEDD7 /* MockGraphQLClient+CombineTests.swift */; };
+		E171A5752D147CFD00AFE0EE /* PledgePaymentIncrement+GraphAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = E171A5742D147CFD00AFE0EE /* PledgePaymentIncrement+GraphAPI.swift */; };
+		E171A5782D147DF100AFE0EE /* PledgePaymentIncrement+GraphAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E171A5762D147DC200AFE0EE /* PledgePaymentIncrement+GraphAPITests.swift */; };
 		E17611E02B7287CF00DF2F50 /* PaginationExampleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E11CFE4E2B7162A400497375 /* PaginationExampleView.swift */; };
 		E17611E22B73D9A400DF2F50 /* Data+PKCE.swift in Sources */ = {isa = PBXBuildFile; fileRef = E17611E12B73D9A400DF2F50 /* Data+PKCE.swift */; };
 		E17611E42B751E8100DF2F50 /* Paginator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E17611E32B751E8100DF2F50 /* Paginator.swift */; };
@@ -3265,6 +3267,8 @@
 		E16ECA6F2C245A34002A1D25 /* PagedContainerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PagedContainerViewController.swift; sourceTree = "<group>"; };
 		E16ECA712C245A51002A1D25 /* PagedContainerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PagedContainerViewModel.swift; sourceTree = "<group>"; };
 		E170B9102B20E83B001BEDD7 /* MockGraphQLClient+CombineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MockGraphQLClient+CombineTests.swift"; sourceTree = "<group>"; };
+		E171A5742D147CFD00AFE0EE /* PledgePaymentIncrement+GraphAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PledgePaymentIncrement+GraphAPI.swift"; sourceTree = "<group>"; };
+		E171A5762D147DC200AFE0EE /* PledgePaymentIncrement+GraphAPITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PledgePaymentIncrement+GraphAPITests.swift"; sourceTree = "<group>"; };
 		E17611E12B73D9A400DF2F50 /* Data+PKCE.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+PKCE.swift"; sourceTree = "<group>"; };
 		E17611E32B751E8100DF2F50 /* Paginator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Paginator.swift; sourceTree = "<group>"; };
 		E17611E52B75242A00DF2F50 /* PaginatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginatorTests.swift; sourceTree = "<group>"; };
@@ -6700,6 +6704,8 @@
 				338654732CE3D17200AB16A9 /* PledgePaymentPlansViewModelTest.swift */,
 				3386546D2CE29AD500AB16A9 /* PledgePaymentPlansOptionViewModel.swift */,
 				339ED5642CE41AFC004B301D /* PledgePaymentPlansOptionViewModelTest.swift */,
+				E171A5742D147CFD00AFE0EE /* PledgePaymentIncrement+GraphAPI.swift */,
+				E171A5762D147DC200AFE0EE /* PledgePaymentIncrement+GraphAPITests.swift */,
 				E1801FA82BAB6CD400EBB533 /* PaymentSourceSelected.swift */,
 				37DEC21F2257CA0A0051EF9B /* PledgeViewModelTests.swift */,
 				6035AFB02C5947D2007E28FC /* NoShippingPledgeViewModel.swift */,
@@ -8126,6 +8132,7 @@
 				77F6E73521222E7C005A5C55 /* EmailFrequency.swift in Sources */,
 				D0237C2622BD7B540092C792 /* PledgeSummaryViewModel.swift in Sources */,
 				01A7A4C01C9690220036E553 /* UITextField+LocalizedPlaceholderKey.swift in Sources */,
+				E171A5752D147CFD00AFE0EE /* PledgePaymentIncrement+GraphAPI.swift in Sources */,
 				3777F2F72343C7900030BEF5 /* ManageViewPledgeRewardReceivedViewModel.swift in Sources */,
 				0176E13B1C9742FD009CA092 /* UIBarButtonItem.swift in Sources */,
 				395A3BC92BA8D43F0091A379 /* PostCampaignCheckoutViewModel.swift in Sources */,
@@ -8301,6 +8308,7 @@
 				D79970B723EC88CB00584911 /* ThanksCategoryCellViewModelTests.swift in Sources */,
 				8A8099F522E2143000373E66 /* RewardCardContainerViewModelTests.swift in Sources */,
 				D667C2BC2305F03300EC094A /* ExperimentName+HelpersTests.swift in Sources */,
+				E171A5782D147DF100AFE0EE /* PledgePaymentIncrement+GraphAPITests.swift in Sources */,
 				8A8099F622E2143400373E66 /* RewardCardViewModelTests.swift in Sources */,
 				06B9AF4F26AF79DF00735908 /* UserEnvelope+GraphUserEnvelopeTemplates.swift in Sources */,
 				D66850A323707CCC00EE9AC2 /* ProjectPamphletCreatorHeaderCellViewModelTests.swift in Sources */,

--- a/KsApi/GraphAPI.swift
+++ b/KsApi/GraphAPI.swift
@@ -7926,6 +7926,7 @@ public enum GraphAPI {
                 currency
               }
               scheduledCollection
+              state
             }
           }
         }
@@ -8082,6 +8083,7 @@ public enum GraphAPI {
                 GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
                 GraphQLField("amount", type: .nonNull(.object(Amount.selections))),
                 GraphQLField("scheduledCollection", type: .nonNull(.scalar(String.self))),
+                GraphQLField("state", type: .nonNull(.scalar(String.self))),
               ]
             }
 
@@ -8091,8 +8093,8 @@ public enum GraphAPI {
               self.resultMap = unsafeResultMap
             }
 
-            public init(amount: Amount, scheduledCollection: String) {
-              self.init(unsafeResultMap: ["__typename": "PaymentIncrement", "amount": amount.resultMap, "scheduledCollection": scheduledCollection])
+            public init(amount: Amount, scheduledCollection: String, state: String) {
+              self.init(unsafeResultMap: ["__typename": "PaymentIncrement", "amount": amount.resultMap, "scheduledCollection": scheduledCollection, "state": state])
             }
 
             public var __typename: String {
@@ -8119,6 +8121,15 @@ public enum GraphAPI {
               }
               set {
                 resultMap.updateValue(newValue, forKey: "scheduledCollection")
+              }
+            }
+
+            public var state: String {
+              get {
+                return resultMap["state"]! as! String
+              }
+              set {
+                resultMap.updateValue(newValue, forKey: "state")
               }
             }
 

--- a/KsApi/GraphAPI.swift
+++ b/KsApi/GraphAPI.swift
@@ -7925,12 +7925,7 @@ public enum GraphAPI {
                 amount
                 currency
               }
-              id
-              paymentIncrementableId
-              paymentIncrementableType
               scheduledCollection
-              state
-              stateReason
             }
           }
         }
@@ -8086,12 +8081,7 @@ public enum GraphAPI {
               return [
                 GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
                 GraphQLField("amount", type: .nonNull(.object(Amount.selections))),
-                GraphQLField("id", type: .scalar(GraphQLID.self)),
-                GraphQLField("paymentIncrementableId", type: .scalar(GraphQLID.self)),
-                GraphQLField("paymentIncrementableType", type: .scalar(String.self)),
                 GraphQLField("scheduledCollection", type: .nonNull(.scalar(String.self))),
-                GraphQLField("state", type: .nonNull(.scalar(String.self))),
-                GraphQLField("stateReason", type: .scalar(String.self)),
               ]
             }
 
@@ -8101,8 +8091,8 @@ public enum GraphAPI {
               self.resultMap = unsafeResultMap
             }
 
-            public init(amount: Amount, id: GraphQLID? = nil, paymentIncrementableId: GraphQLID? = nil, paymentIncrementableType: String? = nil, scheduledCollection: String, state: String, stateReason: String? = nil) {
-              self.init(unsafeResultMap: ["__typename": "PaymentIncrement", "amount": amount.resultMap, "id": id, "paymentIncrementableId": paymentIncrementableId, "paymentIncrementableType": paymentIncrementableType, "scheduledCollection": scheduledCollection, "state": state, "stateReason": stateReason])
+            public init(amount: Amount, scheduledCollection: String) {
+              self.init(unsafeResultMap: ["__typename": "PaymentIncrement", "amount": amount.resultMap, "scheduledCollection": scheduledCollection])
             }
 
             public var __typename: String {
@@ -8123,57 +8113,12 @@ public enum GraphAPI {
               }
             }
 
-            public var id: GraphQLID? {
-              get {
-                return resultMap["id"] as? GraphQLID
-              }
-              set {
-                resultMap.updateValue(newValue, forKey: "id")
-              }
-            }
-
-            public var paymentIncrementableId: GraphQLID? {
-              get {
-                return resultMap["paymentIncrementableId"] as? GraphQLID
-              }
-              set {
-                resultMap.updateValue(newValue, forKey: "paymentIncrementableId")
-              }
-            }
-
-            public var paymentIncrementableType: String? {
-              get {
-                return resultMap["paymentIncrementableType"] as? String
-              }
-              set {
-                resultMap.updateValue(newValue, forKey: "paymentIncrementableType")
-              }
-            }
-
             public var scheduledCollection: String {
               get {
                 return resultMap["scheduledCollection"]! as! String
               }
               set {
                 resultMap.updateValue(newValue, forKey: "scheduledCollection")
-              }
-            }
-
-            public var state: String {
-              get {
-                return resultMap["state"]! as! String
-              }
-              set {
-                resultMap.updateValue(newValue, forKey: "state")
-              }
-            }
-
-            public var stateReason: String? {
-              get {
-                return resultMap["stateReason"] as? String
-              }
-              set {
-                resultMap.updateValue(newValue, forKey: "stateReason")
               }
             }
 

--- a/KsApi/queries/BuildPaymentPlanQuery.graphql
+++ b/KsApi/queries/BuildPaymentPlanQuery.graphql
@@ -9,6 +9,7 @@ query BuildPaymentPlan($slug: String!, $amount: String!) {
           currency
         }
         scheduledCollection
+        state
       }
     }
   }

--- a/KsApi/queries/BuildPaymentPlanQuery.graphql
+++ b/KsApi/queries/BuildPaymentPlanQuery.graphql
@@ -8,12 +8,7 @@ query BuildPaymentPlan($slug: String!, $amount: String!) {
           amount
           currency
         }
-        id
-        paymentIncrementableId
-        paymentIncrementableType
         scheduledCollection
-        state
-        stateReason
       }
     }
   }

--- a/Library/TimeInterval+ISO8601Date.swift
+++ b/Library/TimeInterval+ISO8601Date.swift
@@ -4,4 +4,8 @@ public extension TimeInterval {
   func toISO8601DateTimeString() -> String {
     return ISO8601DateFormatter().string(from: Date(timeIntervalSince1970: self))
   }
+
+  static func from(ISO8601DateTimeString string: String) -> TimeInterval? {
+    return ISO8601DateFormatter().date(from: string)?.timeIntervalSince1970
+  }
 }

--- a/Library/TimeInterval+ISO8601DateTests.swift
+++ b/Library/TimeInterval+ISO8601DateTests.swift
@@ -13,4 +13,10 @@ class TimeInterval_ISO8601DateTests: XCTestCase {
 
     XCTAssertEqual(timeInterval.toISO8601DateTimeString(), "2023-03-29T08:30:55Z")
   }
+
+  func testFromISO8601DateTimeString() {
+    XCTAssertEqual(TimeInterval.from(ISO8601DateTimeString: "2017-10-01T22:35:15Z"), 1_506_897_315.0)
+    XCTAssertEqual(TimeInterval.from(ISO8601DateTimeString: "2023-03-29T08:30:55Z"), 1_680_078_655.0)
+    XCTAssertEqual(TimeInterval.from(ISO8601DateTimeString: "2025-03-31T10:29:19-04:00"), 1_743_431_359.0)
+  }
 }

--- a/Library/ViewModels/BuildPaymentPlanQueryTestData.swift
+++ b/Library/ViewModels/BuildPaymentPlanQueryTestData.swift
@@ -1,0 +1,27 @@
+// Some data for mocking a BuildPaymentPlanQuery response.
+public func buildPaymentPlanQueryJson(eligible: Bool) -> String {
+  return """
+  {
+      "project": {
+        "__typename": "Project",
+        "paymentPlan": {
+          "__typename": "PaymentPlan",
+          "projectIsPledgeOverTimeAllowed": true,
+          "amountIsPledgeOverTimeEligible": \(eligible ? "true" : "false"),
+          "paymentIncrements": [
+            {
+              "__typename": "PaymentIncrement",
+              "amount": {
+                "__typename": "Money",
+                "amount": "933.23",
+                "currency": "USD"
+              },
+              "scheduledCollection": "2025-03-31T10:29:19-04:00",
+              "state": "some state",
+            }
+          ],
+        }
+      }
+  }
+  """
+}

--- a/Library/ViewModels/ManagePledgeViewModel.swift
+++ b/Library/ViewModels/ManagePledgeViewModel.swift
@@ -1,3 +1,4 @@
+import Foundation
 import KsApi
 import Prelude
 import ReactiveExtensions
@@ -624,4 +625,21 @@ private func distinctRewards(_ rewards: [Reward]) -> [Reward] {
     defer { rewardIds.insert(reward.id) }
     return !rewardIds.contains(reward.id)
   }
+}
+
+// TODO: Remove this when implementing the API  [MBL-1851](https://kickstarter.atlassian.net/browse/MBL-1851)
+public func mockPledgePaymentIncrement() -> [PledgePaymentIncrement] {
+  var increments: [PledgePaymentIncrement] = []
+  #if DEBUG
+    var timeStamp = TimeInterval(1_733_931_903)
+    for _ in 1...4 {
+      timeStamp += 30 * 24 * 60 * 60
+      increments.append(PledgePaymentIncrement(
+        amount: PledgePaymentIncrementAmount(amount: 250.0, currency: "USD"),
+        scheduledCollection: timeStamp
+      ))
+    }
+  #endif
+
+  return increments
 }

--- a/Library/ViewModels/NoShippingPledgeViewModel.swift
+++ b/Library/ViewModels/NoShippingPledgeViewModel.swift
@@ -1001,8 +1001,8 @@ public class NoShippingPledgeViewModel: NoShippingPledgeViewModelType, NoShippin
         Signal<GraphAPI.BuildPaymentPlanQuery.Data, ErrorEnvelope>.Event,
         Never
       > in
-        let nf = NumberFormatter()
-        let amount = nf.string(from: NSNumber(value: pledgeTotal)) ?? ""
+        let amountFormatter = NumberFormatter()
+        let amount = amountFormatter.string(from: NSNumber(value: pledgeTotal)) ?? ""
         return AppEnvironment.current.apiService.buildPaymentPlan(
           projectSlug: project.slug,
           pledgeAmount: amount

--- a/Library/ViewModels/NoShippingPledgeViewModel.swift
+++ b/Library/ViewModels/NoShippingPledgeViewModel.swift
@@ -1285,20 +1285,3 @@ private func pledgeAmountSummaryViewData(
     rewardIsLocalPickup: rewardIsLocalPickup
   )
 }
-
-// TODO: Remove this when implementing the API [MBL-1838](https://kickstarter.atlassian.net/browse/MBL-1838)
-public func mockPledgePaymentIncrement() -> [PledgePaymentIncrement] {
-  var increments: [PledgePaymentIncrement] = []
-  #if DEBUG
-    var timeStamp = TimeInterval(1_733_931_903)
-    for _ in 1...4 {
-      timeStamp += 30 * 24 * 60 * 60
-      increments.append(PledgePaymentIncrement(
-        amount: PledgePaymentIncrementAmount(amount: 250.0, currency: "USD"),
-        scheduledCollection: timeStamp
-      ))
-    }
-  #endif
-
-  return increments
-}

--- a/Library/ViewModels/NoShippingPledgeViewModelTests.swift
+++ b/Library/ViewModels/NoShippingPledgeViewModelTests.swift
@@ -5311,6 +5311,7 @@ final class NoShippingPledgeViewModelTests: TestCase {
                   "currency": "USD"
                 },
                 "scheduledCollection": "2025-03-31T10:29:19-04:00",
+                "state": "some state",
               }
             ]
           }

--- a/Library/ViewModels/NoShippingPledgeViewModelTests.swift
+++ b/Library/ViewModels/NoShippingPledgeViewModelTests.swift
@@ -5294,32 +5294,8 @@ final class NoShippingPledgeViewModelTests: TestCase {
       RemoteConfigFeature.pledgeOverTime.rawValue: true
     ]
 
-    let jsonString = """
-    {
-        "project": {
-          "__typename": "Project",
-          "paymentPlan": {
-            "__typename": "PaymentPlan",
-            "projectIsPledgeOverTimeAllowed": true,
-            "amountIsPledgeOverTimeEligible": true,
-            "paymentIncrements": [
-              {
-                "__typename": "PaymentIncrement",
-                "amount": {
-                  "__typename": "Money",
-                  "amount": "933.23",
-                  "currency": "USD"
-                },
-                "scheduledCollection": "2025-03-31T10:29:19-04:00",
-                "state": "some state",
-              }
-            ]
-          }
-        }
-    }
-    """
-
-    let mockQuery = try! GraphAPI.BuildPaymentPlanQuery.Data(jsonString: jsonString)
+    let mockQuery = try! GraphAPI.BuildPaymentPlanQuery
+      .Data(jsonString: buildPaymentPlanQueryJson(eligible: true))
     let mockService = MockService(buildPaymentPlanResult: .success(mockQuery))
 
     withEnvironment(apiService: mockService, remoteConfigClient: mockConfigClient) {

--- a/Library/ViewModels/PledgePaymentIncrement+GraphAPI.swift
+++ b/Library/ViewModels/PledgePaymentIncrement+GraphAPI.swift
@@ -1,0 +1,22 @@
+import Foundation
+import KsApi
+
+extension PledgePaymentIncrement {
+  init?(
+    withGraphQLFragment fragment: GraphAPI.BuildPaymentPlanQuery.Data.Project.PaymentPlan
+      .PaymentIncrement
+  ) {
+    guard let amountAsString = fragment.amount.amount,
+          let amountAsDouble = Double(amountAsString),
+          let currency = fragment.amount.currency?.rawValue else {
+      return nil
+    }
+
+    guard let intervalAsTime = TimeInterval.from(ISO8601DateTimeString: fragment.scheduledCollection) else {
+      return nil
+    }
+
+    self.amount = PledgePaymentIncrementAmount(amount: amountAsDouble, currency: currency)
+    self.scheduledCollection = intervalAsTime
+  }
+}

--- a/Library/ViewModels/PledgePaymentIncrement+GraphAPITests.swift
+++ b/Library/ViewModels/PledgePaymentIncrement+GraphAPITests.swift
@@ -5,34 +5,19 @@ import XCTest
 final class PledgePaymentIncrementGraphAPITests: TestCase {
   func testPaymentIncrementViewModel_fromValidFragment_isCorrect() {
     let jsonString = """
-    {
-        "project": {
-          "__typename": "Project",
-          "paymentPlan": {
-            "__typename": "PaymentPlan",
-            "projectIsPledgeOverTimeAllowed": true,
-            "amountIsPledgeOverTimeEligible": true,
-            "paymentIncrements": [
-              {
-                "__typename": "PaymentIncrement",
-                "amount": {
-                  "__typename": "Money",
-                  "amount": "99.75",
-                  "currency": "USD"
-                },
-                "scheduledCollection": "2025-03-31T10:29:19-04:00",
-              }
-            ]
-          }
-        }
-    }
+      {
+        "__typename": "PaymentIncrement",
+        "amount": {
+          "__typename": "Money",
+          "amount": "99.75",
+          "currency": "USD"
+        },
+        "scheduledCollection": "2025-03-31T10:29:19-04:00",
+      }
     """
 
-    let mockGraphData = try! GraphAPI.BuildPaymentPlanQuery.Data(jsonString: jsonString)
-    guard let fragment = mockGraphData.project?.paymentPlan?.paymentIncrements?.first else {
-      XCTFail("Unable to create mock GraphQL fragment to test with")
-      return
-    }
+    let fragment = try! GraphAPI.BuildPaymentPlanQuery.Data.Project.PaymentPlan
+      .PaymentIncrement(jsonString: jsonString)
 
     let increment = PledgePaymentIncrement(withGraphQLFragment: fragment)
     XCTAssertNotNil(increment)
@@ -43,34 +28,19 @@ final class PledgePaymentIncrementGraphAPITests: TestCase {
 
   func testPaymentIncrementViewModel_fromInvalidFragment_isNil() {
     let jsonString = """
-    {
-        "project": {
-          "__typename": "Project",
-          "paymentPlan": {
-            "__typename": "PaymentPlan",
-            "projectIsPledgeOverTimeAllowed": true,
-            "amountIsPledgeOverTimeEligible": true,
-            "paymentIncrements": [
-              {
-                "__typename": "PaymentIncrement",
-                "amount": {
-                  "__typename": "Money",
-                  "amount": "99.75",
-                  "currency": "USD"
-                },
-                "scheduledCollection": "not a date :(",
-              }
-            ]
-          }
-        }
-    }
+      {
+        "__typename": "PaymentIncrement",
+        "amount": {
+          "__typename": "Money",
+          "amount": "99.75",
+          "currency": "USD"
+        },
+        "scheduledCollection": "not a date :(",
+      }
     """
 
-    let mockGraphData = try! GraphAPI.BuildPaymentPlanQuery.Data(jsonString: jsonString)
-    guard let fragment = mockGraphData.project?.paymentPlan?.paymentIncrements?.first else {
-      XCTFail("Unable to create mock GraphQL fragment to test with")
-      return
-    }
+    let fragment = try! GraphAPI.BuildPaymentPlanQuery.Data.Project.PaymentPlan
+      .PaymentIncrement(jsonString: jsonString)
 
     let increment = PledgePaymentIncrement(withGraphQLFragment: fragment)
     XCTAssertNil(increment)

--- a/Library/ViewModels/PledgePaymentIncrement+GraphAPITests.swift
+++ b/Library/ViewModels/PledgePaymentIncrement+GraphAPITests.swift
@@ -13,6 +13,7 @@ final class PledgePaymentIncrementGraphAPITests: TestCase {
           "currency": "USD"
         },
         "scheduledCollection": "2025-03-31T10:29:19-04:00",
+        "state": "some state"
       }
     """
 
@@ -36,6 +37,7 @@ final class PledgePaymentIncrementGraphAPITests: TestCase {
           "currency": "USD"
         },
         "scheduledCollection": "not a date :(",
+        "state": "some state"
       }
     """
 

--- a/Library/ViewModels/PledgePaymentIncrement+GraphAPITests.swift
+++ b/Library/ViewModels/PledgePaymentIncrement+GraphAPITests.swift
@@ -1,0 +1,78 @@
+@testable import KsApi
+@testable import Library
+import XCTest
+
+final class PledgePaymentIncrementGraphAPITests: TestCase {
+  func testPaymentIncrementViewModel_fromValidFragment_isCorrect() {
+    let jsonString = """
+    {
+        "project": {
+          "__typename": "Project",
+          "paymentPlan": {
+            "__typename": "PaymentPlan",
+            "projectIsPledgeOverTimeAllowed": true,
+            "amountIsPledgeOverTimeEligible": true,
+            "paymentIncrements": [
+              {
+                "__typename": "PaymentIncrement",
+                "amount": {
+                  "__typename": "Money",
+                  "amount": "99.75",
+                  "currency": "USD"
+                },
+                "scheduledCollection": "2025-03-31T10:29:19-04:00",
+              }
+            ]
+          }
+        }
+    }
+    """
+
+    let mockGraphData = try! GraphAPI.BuildPaymentPlanQuery.Data(jsonString: jsonString)
+    guard let fragment = mockGraphData.project?.paymentPlan?.paymentIncrements?.first else {
+      XCTFail("Unable to create mock GraphQL fragment to test with")
+      return
+    }
+
+    let increment = PledgePaymentIncrement(withGraphQLFragment: fragment)
+    XCTAssertNotNil(increment)
+    XCTAssertEqual(increment!.amount.currency, "USD")
+    XCTAssertEqual(increment!.amount.amount, Double(99.75))
+    XCTAssertEqual(increment!.scheduledCollection, 1_743_431_359.0)
+  }
+
+  func testPaymentIncrementViewModel_fromInvalidFragment_isNil() {
+    let jsonString = """
+    {
+        "project": {
+          "__typename": "Project",
+          "paymentPlan": {
+            "__typename": "PaymentPlan",
+            "projectIsPledgeOverTimeAllowed": true,
+            "amountIsPledgeOverTimeEligible": true,
+            "paymentIncrements": [
+              {
+                "__typename": "PaymentIncrement",
+                "amount": {
+                  "__typename": "Money",
+                  "amount": "99.75",
+                  "currency": "USD"
+                },
+                "scheduledCollection": "not a date :(",
+              }
+            ]
+          }
+        }
+    }
+    """
+
+    let mockGraphData = try! GraphAPI.BuildPaymentPlanQuery.Data(jsonString: jsonString)
+    guard let fragment = mockGraphData.project?.paymentPlan?.paymentIncrements?.first else {
+      XCTFail("Unable to create mock GraphQL fragment to test with")
+      return
+    }
+
+    let increment = PledgePaymentIncrement(withGraphQLFragment: fragment)
+    XCTAssertNil(increment)
+  }
+}

--- a/Library/ViewModels/PledgePaymentPlansAndSelectionData+GraphAPI.swift
+++ b/Library/ViewModels/PledgePaymentPlansAndSelectionData+GraphAPI.swift
@@ -1,0 +1,24 @@
+import KsApi
+
+extension PledgePaymentPlansAndSelectionData {
+  public init(
+    withPaymentPlanFragment paymentPlan: GraphAPI.BuildPaymentPlanQuery.Data.Project.PaymentPlan,
+    selectedPlan: PledgePaymentPlansType,
+    project: Project,
+    thresholdAmount: Double
+  ) {
+    var increments: [PledgePaymentIncrement] = []
+
+    if let fetchedIncrements = paymentPlan.paymentIncrements {
+      increments = fetchedIncrements.compactMap { PledgePaymentIncrement(withGraphQLFragment: $0) }
+    }
+
+    self.init(
+      selectedPlan: selectedPlan,
+      increments: increments,
+      ineligible: !paymentPlan.amountIsPledgeOverTimeEligible,
+      project: project,
+      thresholdAmount: thresholdAmount
+    )
+  }
+}

--- a/Library/ViewModels/PledgePaymentPlansAndSelectionData+GraphAPITests.swift
+++ b/Library/ViewModels/PledgePaymentPlansAndSelectionData+GraphAPITests.swift
@@ -21,6 +21,7 @@ final class PledgePaymentPlansAndSelectionDataGraphAPITests: TestCase {
                   "currency": "JPY"
                 },
                 "scheduledCollection": "2025-03-31T10:29:19-04:00",
+                "state": "some state",
               }
             ]
           }

--- a/Library/ViewModels/PledgePaymentPlansAndSelectionData+GraphAPITests.swift
+++ b/Library/ViewModels/PledgePaymentPlansAndSelectionData+GraphAPITests.swift
@@ -1,0 +1,50 @@
+@testable import KsApi
+@testable import Library
+import XCTest
+
+final class PledgePaymentPlansAndSelectionDataGraphAPITests: TestCase {
+  func testPaymentPlanViewModel_fromValidQuery_isCorrect() {
+    let jsonString = """
+    {
+        "project": {
+          "__typename": "Project",
+          "paymentPlan": {
+            "__typename": "PaymentPlan",
+            "projectIsPledgeOverTimeAllowed": true,
+            "amountIsPledgeOverTimeEligible": true,
+            "paymentIncrements": [
+              {
+                "__typename": "PaymentIncrement",
+                "amount": {
+                  "__typename": "Money",
+                  "amount": "974",
+                  "currency": "JPY"
+                },
+                "scheduledCollection": "2025-03-31T10:29:19-04:00",
+              }
+            ]
+          }
+        }
+    }
+    """
+
+    let mockGraphData = try! GraphAPI.BuildPaymentPlanQuery.Data(jsonString: jsonString)
+    guard let paymentPlan = mockGraphData.project?.paymentPlan else {
+      XCTFail("Unable to create mock GraphQL fragment to test with")
+      return
+    }
+
+    let selectionData = PledgePaymentPlansAndSelectionData(
+      withPaymentPlanFragment: paymentPlan,
+      selectedPlan: .pledgeInFull,
+      project: Project.template,
+      thresholdAmount: 125
+    )
+
+    XCTAssertFalse(selectionData.ineligible)
+    XCTAssertEqual(selectionData.paymentIncrements.count, 1)
+    XCTAssertEqual(selectionData.paymentIncrements.first!.amount.currency, "JPY")
+    XCTAssertEqual(selectionData.paymentIncrements.first!.amount.amount, Double(974))
+    XCTAssertEqual(selectionData.paymentIncrements.first!.scheduledCollection, 1_743_431_359.0)
+  }
+}


### PR DESCRIPTION
# 📲 What

Hook up the `BuildPaymentPlanQuery` to the new PLOT UI.

# 🤔 Why

This means PLOT will start showing live data, instead of mock data.

# 🛠 How

* I created some helpers (plus tests) to map between the GraphAPI response object and @jovaniks view model objects. While I didn't write an intermediary envelope object, those helpers serve a similar role. As an aside, I've been noticing that Apollo/GraphQL objects are painful to test, which is a downside to avoiding envelope objects. 
* I had to update our ISO8061 date formatter to work in both directions, since we need to parse dates.
* I removed some fields we weren't using from the `PledgePaymentIncrement` fragment.

# 👀 See
https://github.com/user-attachments/assets/d7eb3348-d5ce-4b18-b99a-2a7c03924b25

# 📓  Todos
- [ ] Fix failing screenshot tests
- [ ] Discuss loading states. Do we want to block pledge until the PLOT module loads? What should it look like while it's loading?