### PR TITLE
Move PLOT logic out of NoShippingPledgeViewModel and into its own VM

### DIFF
--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -1595,6 +1595,8 @@
 		E1A149272ACE063400F49709 /* FetchBackerProjectsQueryDataTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1A149262ACE063400F49709 /* FetchBackerProjectsQueryDataTemplate.swift */; };
 		E1A310232D270CB00062646C /* BuildPaymentPlanQueryTestData.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1A310212D270C610062646C /* BuildPaymentPlanQueryTestData.swift */; };
 		E1A310242D270CB00062646C /* BuildPaymentPlanQueryTestData.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1A310212D270C610062646C /* BuildPaymentPlanQueryTestData.swift */; };
+		E1A310262D28406F0062646C /* PLOTPledgeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1A310252D2840680062646C /* PLOTPledgeViewModel.swift */; };
+		E1A310292D2845E00062646C /* PLOTPledgeViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1A310272D2845CB0062646C /* PLOTPledgeViewModelTests.swift */; };
 		E1AA8ABF2AEABBB100AC98BF /* Signal+Combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1EA34EE2AE1B28400942A04 /* Signal+Combine.swift */; };
 		E1B214712BFD184500109961 /* KingfisherWebP in Frameworks */ = {isa = PBXBuildFile; productRef = E1B214702BFD184500109961 /* KingfisherWebP */; };
 		E1B813C32BC833D100DF33CF /* FetchMyBackedProjectsQuery.graphql in Resources */ = {isa = PBXBuildFile; fileRef = E1B813C22BC833D100DF33CF /* FetchMyBackedProjectsQuery.graphql */; };
@@ -3288,6 +3290,8 @@
 		E1A149232ACE02B300F49709 /* FetchProjectsEnvelope+FetchBackerProjectsQueryDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FetchProjectsEnvelope+FetchBackerProjectsQueryDataTests.swift"; sourceTree = "<group>"; };
 		E1A149262ACE063400F49709 /* FetchBackerProjectsQueryDataTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchBackerProjectsQueryDataTemplate.swift; sourceTree = "<group>"; };
 		E1A310212D270C610062646C /* BuildPaymentPlanQueryTestData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildPaymentPlanQueryTestData.swift; sourceTree = "<group>"; };
+		E1A310252D2840680062646C /* PLOTPledgeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PLOTPledgeViewModel.swift; sourceTree = "<group>"; };
+		E1A310272D2845CB0062646C /* PLOTPledgeViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PLOTPledgeViewModelTests.swift; sourceTree = "<group>"; };
 		E1B813C22BC833D100DF33CF /* FetchMyBackedProjectsQuery.graphql */ = {isa = PBXFileReference; lastKnownFileType = text; path = FetchMyBackedProjectsQuery.graphql; sourceTree = "<group>"; };
 		E1B813C42BC8340700DF33CF /* FetchMySavedProjectsQuery.graphql */ = {isa = PBXFileReference; lastKnownFileType = text; path = FetchMySavedProjectsQuery.graphql; sourceTree = "<group>"; };
 		E1B813C62BC851CB00DF33CF /* FetchMyBackedProjectsQueryRequestForTests.graphql_test */ = {isa = PBXFileReference; lastKnownFileType = text; path = FetchMyBackedProjectsQueryRequestForTests.graphql_test; sourceTree = "<group>"; };
@@ -6722,6 +6726,8 @@
 				6035AFB22C594817007E28FC /* NoShippingPledgeViewModelTests.swift */,
 				601342F02C8141F000B851FA /* NoShippingPostCampaignCheckoutViewModel.swift */,
 				601342F22C81420D00B851FA /* NoShippingPostCampaignCheckoutViewModelTests.swift */,
+				E1A310252D2840680062646C /* PLOTPledgeViewModel.swift */,
+				E1A310272D2845CB0062646C /* PLOTPledgeViewModelTests.swift */,
 				395A3BC82BA8D43F0091A379 /* PostCampaignCheckoutViewModel.swift */,
 				E1972EA12BB4722D002517E6 /* PostCampaignCheckoutViewModelTests.swift */,
 				6044532D2BA0905600B8F485 /* PostCampaignPledgeRewardsSummaryViewModel.swift */,
@@ -8036,6 +8042,7 @@
 				D04AAC29218BB70D00CF713E /* BetaToolsViewModel.swift in Sources */,
 				D093B49C21A86FD800910962 /* PushRegistration.swift in Sources */,
 				A7F441B31D005A9400FE6FC5 /* ActivityProjectStatusViewModel.swift in Sources */,
+				E1A310262D28406F0062646C /* PLOTPledgeViewModel.swift in Sources */,
 				AAE7C9A42C7527E000800E03 /* PagedTabBar.swift in Sources */,
 				370BE71622541C8100B44DB2 /* UIViewController+URL.swift in Sources */,
 				A75511641C8642C3005355CF /* NSBundleType.swift in Sources */,
@@ -8446,6 +8453,7 @@
 				D6600790241A7C0000AC1EDB /* CuratedProjectsViewModelTests.swift in Sources */,
 				A7ED1F4A1E831BA200BFFA01 /* MockBundle.swift in Sources */,
 				D04AACA5218BB72100CF713E /* BetaToolsViewModelTests.swift in Sources */,
+				E1A310292D2845E00062646C /* PLOTPledgeViewModelTests.swift in Sources */,
 				1996AA332A5F477B00AE2ED0 /* PaymentMethodSettingsViewModelTests.swift in Sources */,
 				473DE018273C74BA0033331D /* ProjectRisksCellViewModelTests.swift in Sources */,
 				84F3C492251C87B400AEF24D /* UpdateActivityItemProviderTests.swift in Sources */,

--- a/Library/ViewModels/PLOTPledgeViewModel.swift
+++ b/Library/ViewModels/PLOTPledgeViewModel.swift
@@ -1,0 +1,73 @@
+import Foundation
+import KsApi
+import ReactiveSwift
+
+public protocol PLOTPledgeViewModelOutputs {
+  var showPledgeOverTimeUI: Signal<Bool, Never> { get }
+  var pledgeOverTimeConfigData: Signal<PledgePaymentPlansAndSelectionData, Never> { get }
+
+  // Visible only for testing
+  var buildPaymentPlanInputs: Signal<(String, String), Never> { get }
+}
+
+public struct PLOTPledgeViewModel: PLOTPledgeViewModelOutputs {
+  init(project: Signal<Project, Never>, pledgeTotal: Signal<Double, Never>) {
+    let pledgeOverTimeUIEnabled = project.signal
+      .map { ($0.isPledgeOverTimeAllowed ?? false) && featurePledgeOverTimeEnabled() }
+
+    self.buildPaymentPlanInputs = Signal.combineLatest(project, pledgeTotal)
+      // Only call the query once
+      .take(first: 1)
+      // Only make the query when PLOT is enabled
+      .filterWhenLatestFrom(pledgeOverTimeUIEnabled, satisfies: {
+        $0 == true
+      })
+      .map { (project: Project, pledgeTotal: Double) -> (String, String) in
+        let amountFormatter = NumberFormatter()
+        amountFormatter.minimumFractionDigits = 2
+        amountFormatter.maximumFractionDigits = 2
+        let amount = amountFormatter.string(from: NSNumber(value: pledgeTotal)) ?? ""
+
+        return (project.slug, amount)
+      }
+
+    let pledgeOverTimeQuery = self.buildPaymentPlanInputs.switchMap { (slug: String, amount: String) in
+      AppEnvironment.current.apiService.buildPaymentPlan(
+        projectSlug: slug,
+        pledgeAmount: amount
+      ).materialize()
+    }
+
+    self.showPledgeOverTimeUI = Signal.merge(
+      // Hide PLOT if the feature flag is off on either client or server
+      pledgeOverTimeUIEnabled,
+      // Hide PLOT if an error occurs
+      pledgeOverTimeQuery.errors().map(value: false)
+    )
+
+    self.pledgeOverTimeConfigData = pledgeOverTimeQuery
+      .values()
+      .compactMap { $0.project?.paymentPlan }
+      .combineLatest(with: project)
+      .map { paymentPlan, project in
+
+        // TODO: Temporary placeholder to simulate the ineligible state for plans.
+        // The `thresholdAmount` will be retrieved from the API in the future.
+        // See [MBL-1838](https://kickstarter.atlassian.net/browse/MBL-1838) for implementation details.
+        let thresholdAmount = 125.0
+
+        return PledgePaymentPlansAndSelectionData(
+          withPaymentPlanFragment: paymentPlan,
+          selectedPlan: .pledgeInFull,
+          project: project,
+          thresholdAmount: thresholdAmount
+        )
+      }
+  }
+
+  public let showPledgeOverTimeUI: Signal<Bool, Never>
+  public let pledgeOverTimeConfigData: Signal<PledgePaymentPlansAndSelectionData, Never>
+  public let buildPaymentPlanInputs: Signal<(String, String), Never>
+
+  public var outputs: PLOTPledgeViewModelOutputs { return self }
+}

--- a/Library/ViewModels/PLOTPledgeViewModelTests.swift
+++ b/Library/ViewModels/PLOTPledgeViewModelTests.swift
@@ -1,0 +1,72 @@
+@testable import KsApi
+@testable import Library
+import Prelude
+import ReactiveExtensions_TestHelpers
+import ReactiveSwift
+import XCTest
+
+final class PLOTPledgeViewModelTests: TestCase {
+  let (projectSignal, projectObserver) = Signal<Project, Never>.pipe()
+  let (pledgeTotalSignal, pledgeTotalObserver) = Signal<Double, Never>.pipe()
+
+  var vm: PLOTPledgeViewModel?
+
+  let buildPaymentPlanInputs = TestObserver<(String, String), Never>()
+
+  override func setUp() {
+    super.setUp()
+
+    self.vm = PLOTPledgeViewModel(project: self.projectSignal, pledgeTotal: self.pledgeTotalSignal)
+    self.vm!.outputs.buildPaymentPlanInputs.observe(self.buildPaymentPlanInputs.observer)
+  }
+
+  func testViewModel_callsBuildPaymentPlanQuery_withCorrectSlugAndPledgeTotal() {
+    let mockConfigClient = MockRemoteConfigClient()
+    mockConfigClient.features = [
+      RemoteConfigFeature.pledgeOverTime.rawValue: true
+    ]
+
+    withEnvironment(remoteConfigClient: mockConfigClient) {
+      self.buildPaymentPlanInputs.assertDidNotEmitValue()
+
+      let project = Project.template
+        |> Project.lens.slug .~ "some-slug"
+        |> Project.lens.isPledgeOverTimeAllowed .~ true
+      let pledgeTotal = 928.66
+
+      self.projectObserver.send(value: project)
+      self.pledgeTotalObserver.send(value: pledgeTotal)
+
+      self.buildPaymentPlanInputs.assertValueCount(1)
+      XCTAssertEqual(self.buildPaymentPlanInputs.lastValue?.0, "some-slug")
+      XCTAssertEqual(self.buildPaymentPlanInputs.lastValue?.1, "928.66")
+    }
+  }
+
+  func testViewModel_callsBuildPaymentPlanQuery_onlyOnce() {
+    let mockConfigClient = MockRemoteConfigClient()
+    mockConfigClient.features = [
+      RemoteConfigFeature.pledgeOverTime.rawValue: true
+    ]
+
+    withEnvironment(remoteConfigClient: mockConfigClient) {
+      self.buildPaymentPlanInputs.assertDidNotEmitValue()
+
+      let project = Project.template
+        |> Project.lens.slug .~ "some-slug"
+        |> Project.lens.isPledgeOverTimeAllowed .~ true
+
+      self.projectObserver.send(value: project)
+      self.pledgeTotalObserver.send(value: 100.0)
+
+      self.buildPaymentPlanInputs.assertValueCount(1)
+      XCTAssertEqual(self.buildPaymentPlanInputs.lastValue?.0, "some-slug")
+      XCTAssertEqual(self.buildPaymentPlanInputs.lastValue?.1, "100.00")
+
+      self.pledgeTotalObserver.send(value: 1.0)
+      self.pledgeTotalObserver.send(value: 2.0)
+      self.pledgeTotalObserver.send(value: 3.0)
+      self.buildPaymentPlanInputs.assertValueCount(1)
+    }
+  }
+}


### PR DESCRIPTION
# 📲 What

Move all PLOT logic out of `NoShippingPledgeViewModel` and into its own view model, `PLOTPledgeViewModel`.

# 🤔 Why

The complexity of checkout is a significant thorn in our side. Moving the PLOT logic out of the main pledge VM and into its own accomplishes three things:

1. Moves us a small step closer to checkout being modular, shorter, and easier to understand.
2. Allows us to integrate PLOT into other branches of checkout, if necessary.
3. Makes PLOT easier to test.

# 🛠 How

The PLOT VM is fairly simple - this is mostly copy-pasted from `NoShippingPledgeViewModel`. It follows the same structure as our other view models, with one notable exception: it takes its inputs as signals passed during `init`, instead of having an input function like a view model linked directly to a View Controller. 

# 👀 See

Implementing this allowed me to uncover a gnarly little bug in PLOT, which I've called out below!