### PR TITLE
MBL-1946: Disable pledge button while PLOT is loading

### DIFF
--- a/Library/ViewModels/NoShippingPledgeViewModel.swift
+++ b/Library/ViewModels/NoShippingPledgeViewModel.swift
@@ -638,6 +638,10 @@ public class NoShippingPledgeViewModel: NoShippingPledgeViewModelType, NoShippin
 
     self.processingViewIsHidden = processingViewIsHidden.signal
 
+    // MARK: Pledge Over Time
+
+    self.plotViewModel = PLOTPledgeViewModel(project: project, pledgeTotal: pledgeTotal)
+
     // MARK: - Form Validation
 
     let amountChangedAndValid = Signal.combineLatest(
@@ -695,6 +699,7 @@ public class NoShippingPledgeViewModel: NoShippingPledgeViewModelType, NoShippin
     let valuesChangedAndValid = Signal.combineLatest(
       amountChangedAndValid,
       paymentMethodChangedAndValid,
+      self.plotViewModel.pledgeOverTimeIsLoading,
       context
     )
     .map(allValuesChangedAndValid)
@@ -985,8 +990,6 @@ public class NoShippingPledgeViewModel: NoShippingPledgeViewModelType, NoShippin
           refTag: refTag
         )
       }
-
-    self.plotViewModel = PLOTPledgeViewModel(project: project, pledgeTotal: pledgeTotal)
   }
 
   // MARK: - Inputs
@@ -1214,13 +1217,14 @@ private func paymentMethodValid(
 private func allValuesChangedAndValid(
   amountValid: Bool,
   paymentSourceValid: Bool,
+  pledgeOverTimeIsLoading: Bool,
   context: PledgeViewContext
 ) -> Bool {
   if context.isUpdating, context != .updateReward {
     return amountValid || paymentSourceValid
   }
 
-  return amountValid
+  return amountValid && !pledgeOverTimeIsLoading
 }
 
 // MARK: - Helper Functions

--- a/Library/ViewModels/PLOTPledgeViewModel.swift
+++ b/Library/ViewModels/PLOTPledgeViewModel.swift
@@ -23,7 +23,7 @@ public protocol PLOTPledgeViewModelOutputs {
   - `project`: A project.
   - `pledgeTotal`: Total amount to pledge, a double.
   - `paymentPlanSelected:`: The payment plan selected by the user.
- 
+
  A `project` and `pledgeTotal` are required for `showPledgeOverTimeUI` or `pledgeOverTimeIsLoading` to send.
  In addition, `paymentPlanSelected:` must be called before `pledgeOverTimeConfigData` sends.
 
@@ -33,7 +33,7 @@ public protocol PLOTPledgeViewModelOutputs {
   - `pledgeOverTimeIsLoading`: Whether the PLOT module is loading. Sends one or more events, since loading can start and stop.
  */
 
-  public final class PLOTPledgeViewModel: PLOTPledgeViewModelInputs, PLOTPledgeViewModelOutputs {
+public final class PLOTPledgeViewModel: PLOTPledgeViewModelInputs, PLOTPledgeViewModelOutputs {
   init(project: Signal<Project, Never>, pledgeTotal: Signal<Double, Never>) {
     let pledgeOverTimeUIEnabled = project.signal
       .map { ($0.isPledgeOverTimeAllowed ?? false) && featurePledgeOverTimeEnabled() }
@@ -85,7 +85,7 @@ public protocol PLOTPledgeViewModelOutputs {
       // Hide PLOT if an error occurs
       pledgeOverTimeQuery.errors().map(value: false)
     )
-    
+
     self.pledgeOverTimeIsLoading = Signal.merge(
       pledgeOverTimeUIEnabled,
       pledgeOverTimeQuery.values().map(value: false),
@@ -137,5 +137,4 @@ public protocol PLOTPledgeViewModelOutputs {
   }
 
   // MARK: - Outputs
-
 }

--- a/Library/ViewModels/PLOTPledgeViewModel.swift
+++ b/Library/ViewModels/PLOTPledgeViewModel.swift
@@ -9,12 +9,31 @@ public protocol PLOTPledgeViewModelInputs {
 public protocol PLOTPledgeViewModelOutputs {
   var showPledgeOverTimeUI: Signal<Bool, Never> { get }
   var pledgeOverTimeConfigData: Signal<PledgePaymentPlansAndSelectionData?, Never> { get }
+  var pledgeOverTimeIsLoading: Signal<Bool, Never> { get }
 
   // Visible only for testing
   var buildPaymentPlanInputs: Signal<(String, String), Never> { get }
 }
 
-public final class PLOTPledgeViewModel: PLOTPledgeViewModelInputs, PLOTPledgeViewModelOutputs {
+/**
+ A component view model for Pledge Over Time in the pledge checkout flow.
+ Creates one BuildPaymentPlanQuery and uses those results to create data for the UI.
+
+ Inputs:
+  - `project`: A project.
+  - `pledgeTotal`: Total amount to pledge, a double.
+  - `paymentPlanSelected:`: The payment plan selected by the user.
+ 
+ A `project` and `pledgeTotal` are required for `showPledgeOverTimeUI` or `pledgeOverTimeIsLoading` to send.
+ In addition, `paymentPlanSelected:` must be called before `pledgeOverTimeConfigData` sends.
+
+ Outputs:
+  - `showPledgeOverTimeUI`:  Whether the PLOT module should be shown. Sends one or more events; the PLOT module should disappear if an error occurs in the BuildPaymentPlanQuery. Requires
+  - `pledgeOverTimeConfigData`: Info needed to display the PLOT module. Sends one or more events.
+  - `pledgeOverTimeIsLoading`: Whether the PLOT module is loading. Sends one or more events, since loading can start and stop.
+ */
+
+  public final class PLOTPledgeViewModel: PLOTPledgeViewModelInputs, PLOTPledgeViewModelOutputs {
   init(project: Signal<Project, Never>, pledgeTotal: Signal<Double, Never>) {
     let pledgeOverTimeUIEnabled = project.signal
       .map { ($0.isPledgeOverTimeAllowed ?? false) && featurePledgeOverTimeEnabled() }
@@ -66,6 +85,13 @@ public final class PLOTPledgeViewModel: PLOTPledgeViewModelInputs, PLOTPledgeVie
       // Hide PLOT if an error occurs
       pledgeOverTimeQuery.errors().map(value: false)
     )
+    
+    self.pledgeOverTimeIsLoading = Signal.merge(
+      pledgeOverTimeUIEnabled,
+      pledgeOverTimeQuery.values().map(value: false),
+      pledgeOverTimeQuery.errors().map(value: false)
+    )
+    .skipRepeats()
 
     let pledgeOverTimeApiValues = pledgeOverTimeQuery
       .values()
@@ -95,6 +121,11 @@ public final class PLOTPledgeViewModel: PLOTPledgeViewModelInputs, PLOTPledgeVie
       }
   }
 
+  public let showPledgeOverTimeUI: Signal<Bool, Never>
+  public let pledgeOverTimeConfigData: Signal<PledgePaymentPlansAndSelectionData?, Never>
+  public let pledgeOverTimeIsLoading: Signal<Bool, Never>
+  public let buildPaymentPlanInputs: Signal<(String, String), Never>
+
   public var outputs: PLOTPledgeViewModelOutputs { return self }
   public var inputs: PLOTPledgeViewModelInputs { return self }
 
@@ -107,7 +138,4 @@ public final class PLOTPledgeViewModel: PLOTPledgeViewModelInputs, PLOTPledgeVie
 
   // MARK: - Outputs
 
-  public let showPledgeOverTimeUI: Signal<Bool, Never>
-  public let pledgeOverTimeConfigData: Signal<PledgePaymentPlansAndSelectionData?, Never>
-  public let buildPaymentPlanInputs: Signal<(String, String), Never>
 }

--- a/Library/ViewModels/PLOTPledgeViewModelTests.swift
+++ b/Library/ViewModels/PLOTPledgeViewModelTests.swift
@@ -12,12 +12,16 @@ final class PLOTPledgeViewModelTests: TestCase {
   var vm: PLOTPledgeViewModel?
 
   let buildPaymentPlanInputs = TestObserver<(String, String), Never>()
+  let pledgeOverTimeIsLoading = TestObserver<Bool, Never>()
+  let showPledgeOverTimeUI = TestObserver<Bool, Never>()
 
   override func setUp() {
     super.setUp()
 
     self.vm = PLOTPledgeViewModel(project: self.projectSignal, pledgeTotal: self.pledgeTotalSignal)
     self.vm!.outputs.buildPaymentPlanInputs.observe(self.buildPaymentPlanInputs.observer)
+    self.vm!.outputs.pledgeOverTimeIsLoading.observe(self.pledgeOverTimeIsLoading.observer)
+    self.vm!.outputs.showPledgeOverTimeUI.observe(self.showPledgeOverTimeUI.observer)
   }
 
   func testViewModel_callsBuildPaymentPlanQuery_withCorrectSlugAndPledgeTotal() {
@@ -67,6 +71,74 @@ final class PLOTPledgeViewModelTests: TestCase {
       self.pledgeTotalObserver.send(value: 2.0)
       self.pledgeTotalObserver.send(value: 3.0)
       self.buildPaymentPlanInputs.assertValueCount(1)
+    }
+  }
+
+  func testViewModel_sendsLoadingEvent_whenPledgeOverTimeIsEnabled() {
+    let queryData = try! GraphAPI.BuildPaymentPlanQuery
+      .Data(jsonString: buildPaymentPlanQueryJson(eligible: true))
+    let mockApiService = MockService(buildPaymentPlanResult: .success(queryData))
+
+    let mockConfigClient = MockRemoteConfigClient()
+    mockConfigClient.features = [
+      RemoteConfigFeature.pledgeOverTime.rawValue: true
+    ]
+
+    withEnvironment(apiService: mockApiService, remoteConfigClient: mockConfigClient) {
+      let project = Project.template
+        |> Project.lens.slug .~ "some-slug"
+        |> Project.lens.isPledgeOverTimeAllowed .~ true
+
+      self.projectObserver.send(value: project)
+      self.pledgeTotalObserver.send(value: 100.0)
+
+      self.showPledgeOverTimeUI.assertValues([true])
+      self.pledgeOverTimeIsLoading.assertValues([true, false])
+    }
+  }
+
+  func testViewModel_doesntLoad_whenPledgeOverTimeIsDisabled() {
+    let queryData = try! GraphAPI.BuildPaymentPlanQuery
+      .Data(jsonString: buildPaymentPlanQueryJson(eligible: true))
+    let mockApiService = MockService(buildPaymentPlanResult: .success(queryData))
+
+    let mockConfigClient = MockRemoteConfigClient()
+    mockConfigClient.features = [
+      RemoteConfigFeature.pledgeOverTime.rawValue: false
+    ]
+
+    withEnvironment(apiService: mockApiService, remoteConfigClient: mockConfigClient) {
+      let project = Project.template
+        |> Project.lens.slug .~ "some-slug"
+        |> Project.lens.isPledgeOverTimeAllowed .~ false
+
+      self.projectObserver.send(value: project)
+      self.pledgeTotalObserver.send(value: 100.0)
+
+      self.pledgeOverTimeIsLoading.assertValues([false])
+      self.showPledgeOverTimeUI.assertValues([false])
+    }
+  }
+
+  func testViewModel_hidesUIAndStopsLoading_whenBuildPaymentPlanQueryFails() {
+    let mockApiService = MockService(buildPaymentPlanResult: .failure(.couldNotParseJSON))
+
+    let mockConfigClient = MockRemoteConfigClient()
+    mockConfigClient.features = [
+      RemoteConfigFeature.pledgeOverTime.rawValue: true
+    ]
+
+    withEnvironment(apiService: mockApiService, remoteConfigClient: mockConfigClient) {
+      let project = Project.template
+        |> Project.lens.slug .~ "some-slug"
+        |> Project.lens.isPledgeOverTimeAllowed .~ true
+
+      self.projectObserver.send(value: project)
+      self.pledgeTotalObserver.send(value: 100.0)
+
+      self.pledgeOverTimeIsLoading.assertValues([true, false])
+      self.buildPaymentPlanInputs.assertDidEmitValue()
+      self.showPledgeOverTimeUI.assertValues([true, false])
     }
   }
 }


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Disable pledge button while PLOT is loading, for projects that have PLOT enabled.

# 🤔 Why

Prevents people from pledging with the default option (pledge in full) until they have the option of selecting PLOT. Seems likely to cause bugs if we don't do this.