### PR TITLE
MBL-1853: Send 'incremental' in CreateBacking if PLOT is selected

### DIFF
--- a/Library/ViewModels/NoShippingPledgeViewModel.swift
+++ b/Library/ViewModels/NoShippingPledgeViewModel.swift
@@ -486,7 +486,14 @@ public class NoShippingPledgeViewModel: NoShippingPledgeViewModelType, NoShippin
       applePayParams.wrapInOptional()
     )
 
+    // MARK: Pledge Over Time
+
+    self.plotViewModel = PLOTPledgeViewModel(project: project, pledgeTotal: pledgeTotal)
+
     // MARK: - Create Backing
+
+    let selectedPaymentPlan = self.plotViewModel.pledgeOverTimeConfigData
+      .map { $0?.selectedPlan ?? .pledgeInFull }
 
     let createBackingData = Signal.combineLatest(
       project,
@@ -496,6 +503,7 @@ public class NoShippingPledgeViewModel: NoShippingPledgeViewModelType, NoShippin
       selectedShippingRule,
       selectedPaymentSource,
       applePayParamsData,
+      selectedPaymentPlan,
       refTag
     )
     .map {
@@ -506,10 +514,11 @@ public class NoShippingPledgeViewModel: NoShippingPledgeViewModelType, NoShippin
         selectedShippingRule,
         selectedPaymentSource,
         applePayParams,
+        selectedPaymentPlan,
         refTag
         -> CreateBackingData in
 
-      var paymentSourceId = selectedPaymentSource?.savedCreditCardId
+      let paymentSourceId = selectedPaymentSource?.savedCreditCardId
 
       return (
         project: project,
@@ -521,7 +530,7 @@ public class NoShippingPledgeViewModel: NoShippingPledgeViewModelType, NoShippin
         setupIntentClientSecret: nil,
         applePayParams: applePayParams,
         refTag: refTag,
-        incremental: false // TODO: implementation in [mbl-1853](https://kickstarter.atlassian.net/browse/MBL-1853)
+        incremental: selectedPaymentPlan == .pledgeOverTime
       )
     }
 
@@ -637,10 +646,6 @@ public class NoShippingPledgeViewModel: NoShippingPledgeViewModelType, NoShippin
     )
 
     self.processingViewIsHidden = processingViewIsHidden.signal
-
-    // MARK: Pledge Over Time
-
-    self.plotViewModel = PLOTPledgeViewModel(project: project, pledgeTotal: pledgeTotal)
 
     // MARK: - Form Validation
 

--- a/Library/ViewModels/PLOTPledgeViewModelTests.swift
+++ b/Library/ViewModels/PLOTPledgeViewModelTests.swift
@@ -14,6 +14,7 @@ final class PLOTPledgeViewModelTests: TestCase {
   let buildPaymentPlanInputs = TestObserver<(String, String), Never>()
   let pledgeOverTimeIsLoading = TestObserver<Bool, Never>()
   let showPledgeOverTimeUI = TestObserver<Bool, Never>()
+  let selectedPlan = TestObserver<PledgePaymentPlansType?, Never>()
 
   override func setUp() {
     super.setUp()
@@ -22,6 +23,7 @@ final class PLOTPledgeViewModelTests: TestCase {
     self.vm!.outputs.buildPaymentPlanInputs.observe(self.buildPaymentPlanInputs.observer)
     self.vm!.outputs.pledgeOverTimeIsLoading.observe(self.pledgeOverTimeIsLoading.observer)
     self.vm!.outputs.showPledgeOverTimeUI.observe(self.showPledgeOverTimeUI.observer)
+    self.vm!.outputs.pledgeOverTimeConfigData.map { $0?.selectedPlan }.observe(self.selectedPlan.observer)
   }
 
   func testViewModel_callsBuildPaymentPlanQuery_withCorrectSlugAndPledgeTotal() {
@@ -70,6 +72,11 @@ final class PLOTPledgeViewModelTests: TestCase {
       self.pledgeTotalObserver.send(value: 1.0)
       self.pledgeTotalObserver.send(value: 2.0)
       self.pledgeTotalObserver.send(value: 3.0)
+
+      self.vm!.paymentPlanSelected(.pledgeInFull)
+      self.vm!.paymentPlanSelected(.pledgeOverTime)
+      self.vm!.paymentPlanSelected(.pledgeInFull)
+
       self.buildPaymentPlanInputs.assertValueCount(1)
     }
   }
@@ -139,6 +146,82 @@ final class PLOTPledgeViewModelTests: TestCase {
       self.pledgeOverTimeIsLoading.assertValues([true, false])
       self.buildPaymentPlanInputs.assertDidEmitValue()
       self.showPledgeOverTimeUI.assertValues([true, false])
+    }
+  }
+
+  func testViewModel_emitsNilPaymentPlan_andHidesUI_ifPledgeOverTimeIsDisabled() {
+    let mockConfigClient = MockRemoteConfigClient()
+    mockConfigClient.features = [
+      RemoteConfigFeature.pledgeOverTime.rawValue: true
+    ]
+
+    withEnvironment(remoteConfigClient: mockConfigClient) {
+      self.buildPaymentPlanInputs.assertDidNotEmitValue()
+
+      let project = Project.template
+        |> Project.lens.slug .~ "some-slug"
+        |> Project.lens.isPledgeOverTimeAllowed .~ false
+
+      self.projectObserver.send(value: project)
+      self.pledgeTotalObserver.send(value: 100.0)
+
+      self.showPledgeOverTimeUI.assertValues([false])
+      self.selectedPlan.assertValues([nil])
+    }
+  }
+
+  func testViewModel_emitsNilPaymentPlan_andHidesUI_ifPledgeOverQueryReturnsAnError() {
+    let mockConfigClient = MockRemoteConfigClient()
+    mockConfigClient.features = [
+      RemoteConfigFeature.pledgeOverTime.rawValue: true
+    ]
+    let mockService = MockService(buildPaymentPlanResult: .failure(.couldNotParseJSON))
+
+    withEnvironment(apiService: mockService, remoteConfigClient: mockConfigClient) {
+      self.buildPaymentPlanInputs.assertDidNotEmitValue()
+
+      let project = Project.template
+        |> Project.lens.slug .~ "some-slug"
+        |> Project.lens.isPledgeOverTimeAllowed .~ true
+
+      self.projectObserver.send(value: project)
+      self.pledgeTotalObserver.send(value: 100.0)
+
+      self.buildPaymentPlanInputs.assertDidEmitValue()
+      self.showPledgeOverTimeUI.assertValues([true, false])
+      self.selectedPlan.assertValues([nil])
+    }
+  }
+
+  func testViewModel_paymentPlanSelected_changesSelectedPaymentPlan() {
+    let mockConfigClient = MockRemoteConfigClient()
+    mockConfigClient.features = [
+      RemoteConfigFeature.pledgeOverTime.rawValue: true
+    ]
+
+    let result = try! GraphAPI.BuildPaymentPlanQuery
+      .Data(jsonString: buildPaymentPlanQueryJson(eligible: true))
+    let mockService = MockService(buildPaymentPlanResult: .success(result))
+
+    withEnvironment(apiService: mockService, remoteConfigClient: mockConfigClient) {
+      self.buildPaymentPlanInputs.assertDidNotEmitValue()
+
+      let project = Project.template
+        |> Project.lens.slug .~ "some-slug"
+        |> Project.lens.isPledgeOverTimeAllowed .~ true
+      let pledgeTotal = 928.66
+
+      self.projectObserver.send(value: project)
+      self.pledgeTotalObserver.send(value: pledgeTotal)
+
+      // Defaults to pledgeInFull
+      self.selectedPlan.assertValues([.pledgeInFull])
+
+      self.vm!.paymentPlanSelected(.pledgeOverTime)
+      self.selectedPlan.assertValues([.pledgeInFull, .pledgeOverTime])
+
+      self.vm!.paymentPlanSelected(.pledgeInFull)
+      self.selectedPlan.assertValues([.pledgeInFull, .pledgeOverTime, .pledgeInFull])
     }
   }
 }


### PR DESCRIPTION
# 📲 What

Set `incremental = true` in `CreateBacking` in `NoShippingPledgeViewModel` if pledge over time is selected. 

# 🤔 Why

Allows us to actually create a pledge-over-time pledge!

# 🛠 How

This change adds another required signal to `CreateBacking`. I wanted to be sure that the signal was pretty well understood - and that, in all the failure modes I could think of, it would default to `.pledgeInFull`.

Because of that, I did some refactoring in `PLOTPledgeViewModel` to simplify how and when the config data was created. See comments inline.