### PR TITLE
[MBL-1878] Add GraphAPI.MoneyFragment currency formatter

### DIFF
--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/CardView/PPOProjectCardModel.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/CardView/PPOProjectCardModel.swift
@@ -366,7 +366,7 @@ extension PPOProjectCardModel {
     let projectName = ppoProject?.name
     let projectId = ppoProject?.pid
     let pledgeFragment = backing?.amount.fragments.moneyFragment
-    let formattedPledge = pledgeFragment.flatMap({ Format.currency($0) })
+    let formattedPledge = pledgeFragment.flatMap { Format.currency($0) }
     let creatorName = ppoProject?.creator?.name
 
     let address: String? = backing?.deliveryAddress.flatMap { deliveryAddress in

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/CardView/PPOProjectCardModel.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/CardView/PPOProjectCardModel.swift
@@ -221,7 +221,7 @@ extension PPOProjectCardModel {
       .init(type: .warning, icon: .time, message: "Address locks in 8 hours")
     ],
     image: .network(URL(string: "https:///")!),
-    projectName: "Sugardew Island - Your cozy farm shop let's pretend this is a way way way longer title",
+    projectName: "Sugardew Island - Your cozy farm shop let’s pretend this is a way way way longer title",
     projectId: 12_345,
     pledge: "$50.00",
     creatorName: "rokaplay truncate if longer than",

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/CardView/PPOProjectCardModel.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/CardView/PPOProjectCardModel.swift
@@ -9,7 +9,7 @@ public struct PPOProjectCardModel: Identifiable, Equatable, Hashable {
   public let image: Kingfisher.Source
   public let projectName: String
   public let projectId: Int
-  public let pledge: GraphAPI.MoneyFragment
+  public let pledge: String
   public let creatorName: String
   public let address: String?
   public let actions: (Action, Action?)
@@ -221,9 +221,9 @@ extension PPOProjectCardModel {
       .init(type: .warning, icon: .time, message: "Address locks in 8 hours")
     ],
     image: .network(URL(string: "https:///")!),
-    projectName: "Sugardew Island - Your cozy farm shop let’s pretend this is a way way way longer title",
+    projectName: "Sugardew Island - Your cozy farm shop let's pretend this is a way way way longer title",
     projectId: 12_345,
-    pledge: .init(amount: "50.00", currency: .usd, symbol: "$"),
+    pledge: "$50.00",
     creatorName: "rokaplay truncate if longer than",
     address: """
       Firsty Lasty
@@ -246,7 +246,7 @@ extension PPOProjectCardModel {
     image: .network(URL(string: "https:///")!),
     projectName: "Sugardew Island - Your cozy farm shop let’s pretend this is a way way way longer title",
     projectId: 12_345,
-    pledge: .init(amount: "50.00", currency: .usd, symbol: "$"),
+    pledge: "$50.00",
     creatorName: "rokaplay truncate if longer than",
     address: nil,
     actions: (.completeSurvey, nil),
@@ -268,7 +268,7 @@ extension PPOProjectCardModel {
     image: .network(URL(string: "https:///")!),
     projectName: "Sugardew Island - Your cozy farm shop let’s pretend this is a way way way longer title",
     projectId: 12_345,
-    pledge: .init(amount: "50.00", currency: .usd, symbol: "$"),
+    pledge: "$50.00",
     creatorName: "rokaplay truncate if longer than",
     address: nil,
     actions: (.fixPayment, nil),
@@ -290,7 +290,7 @@ extension PPOProjectCardModel {
     image: .network(URL(string: "https:///")!),
     projectName: "Sugardew Island - Your cozy farm shop let’s pretend this is a way way way longer title",
     projectId: 12_345,
-    pledge: .init(amount: "50.00", currency: .usd, symbol: "$"),
+    pledge: "$50.00",
     creatorName: "rokaplay truncate if longer than",
     address: nil,
     actions: (.authenticateCard, nil),
@@ -307,7 +307,7 @@ extension PPOProjectCardModel {
     image: .network(URL(string: "https:///")!),
     projectName: "Sugardew Island - Your cozy farm shop let’s pretend this is a way way way longer title",
     projectId: 12_345,
-    pledge: .init(amount: "50.00", currency: .usd, symbol: "$"),
+    pledge: "$50.00",
     creatorName: "rokaplay truncate if longer than",
     address: nil,
     actions: (.completeSurvey, nil),
@@ -365,7 +365,8 @@ extension PPOProjectCardModel {
 
     let projectName = ppoProject?.name
     let projectId = ppoProject?.pid
-    let pledge = backing?.amount.fragments.moneyFragment
+    let pledgeFragment = backing?.amount.fragments.moneyFragment
+    let formattedPledge = pledgeFragment.flatMap({ Format.currency($0) })
     let creatorName = ppoProject?.creator?.name
 
     let address: String? = backing?.deliveryAddress.flatMap { deliveryAddress in
@@ -418,7 +419,7 @@ extension PPOProjectCardModel {
 
     let projectAnalyticsFragment = backing?.project?.fragments.projectAnalyticsFragment
 
-    if let image, let projectName, let projectId, let pledge, let creatorName,
+    if let image, let projectName, let projectId, let formattedPledge, let creatorName,
        let projectAnalyticsFragment, let backingDetailsUrl {
       self.init(
         isUnread: true,
@@ -426,7 +427,7 @@ extension PPOProjectCardModel {
         image: image,
         projectName: projectName,
         projectId: projectId,
-        pledge: pledge,
+        pledge: formattedPledge,
         creatorName: creatorName,
         address: address,
         actions: (primaryAction, secondaryAction),

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/CardView/PPOProjectDetails.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/CardView/PPOProjectDetails.swift
@@ -37,8 +37,8 @@ struct PPOProjectDetails: View {
             )
             .lineLimit(Constants.titleLineLimit)
         }
-        if let symbol = pledge.symbol, let amount = pledge.amount {
-          Text(Strings.Pledge_amount_pledged(pledge_amount: "\(symbol)\(amount)"))
+        if let amount = Format.currency(pledge) {
+          Text(Strings.Pledge_amount_pledged(pledge_amount: amount))
             .font(Font(PPOStyles.subtitle.font))
             .background(Color(PPOStyles.background))
             .foregroundStyle(Color(PPOStyles.subtitle.color))

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/CardView/PPOProjectDetails.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/CardView/PPOProjectDetails.swift
@@ -7,7 +7,7 @@ import SwiftUI
 struct PPOProjectDetails: View {
   let image: Source?
   let title: String?
-  let pledge: GraphAPI.MoneyFragment
+  let pledge: String
   let leadingColumnWidth: CGFloat
 
   var body: some View {
@@ -37,17 +37,15 @@ struct PPOProjectDetails: View {
             )
             .lineLimit(Constants.titleLineLimit)
         }
-        if let amount = Format.currency(pledge) {
-          Text(Strings.Pledge_amount_pledged(pledge_amount: amount))
-            .font(Font(PPOStyles.subtitle.font))
-            .background(Color(PPOStyles.background))
-            .foregroundStyle(Color(PPOStyles.subtitle.color))
-            .frame(
-              maxWidth: Constants.textMaxWidth,
-              alignment: Constants.textAlignment
-            )
-            .lineLimit(Constants.subtitleLineLimit)
-        }
+        Text(Strings.Pledge_amount_pledged(pledge_amount: self.pledge))
+          .font(Font(PPOStyles.subtitle.font))
+          .background(Color(PPOStyles.background))
+          .foregroundStyle(Color(PPOStyles.subtitle.color))
+          .frame(
+            maxWidth: Constants.textMaxWidth,
+            alignment: Constants.textAlignment
+          )
+          .lineLimit(Constants.subtitleLineLimit)
       }
     }
     .fixedSize(horizontal: false, vertical: true)
@@ -75,7 +73,7 @@ struct PPOProjectDetails: View {
       PPOProjectDetails(
         image: .network(URL(string: "http:///")!),
         title: "Sugardew Island - Your cozy farm shop let’s pretend this is a way way way longer title",
-        pledge: GraphAPI.MoneyFragment(amount: "50.00", currency: .usd, symbol: "$"),
+        pledge: "$50.00",
         leadingColumnWidth: geometry.size.width / 4
       )
     })
@@ -83,7 +81,7 @@ struct PPOProjectDetails: View {
       PPOProjectDetails(
         image: .network(URL(string: "http:///")!),
         title: "One line",
-        pledge: GraphAPI.MoneyFragment(amount: "50.00", currency: .usd, symbol: "$"),
+        pledge: "$50.00",
         leadingColumnWidth: geometry.size.width / 4
       )
     })

--- a/Library/Format.swift
+++ b/Library/Format.swift
@@ -413,20 +413,15 @@ public enum Format {
     env: Environment = AppEnvironment.current
   ) -> String? {
     guard
-      let symbol = money.symbol,
-      let amount = money.amount.flatMap(Double.init)
+      let currencyCode = money.currency?.rawValue,
+      let amountString = money.amount,
+      let decimal = try? Decimal(amountString, format: .number)
     else { return nil }
 
-    let formatter = NumberFormatterConfig.cachedFormatter(
-      forConfig: .defaultCurrencyConfig
-        |> NumberFormatterConfig.lens.locale .~ env.locale
-        |> NumberFormatterConfig.lens.currencySymbol .~ symbol
-        |> NumberFormatterConfig.lens.minimumFractionDigits .~ 2
-        |> NumberFormatterConfig.lens.maximumFractionDigits .~ 2
+    return decimal.formatted(
+      .currency(code: currencyCode)
+      .locale(env.locale)
     )
-
-    return formatter.string(for: amount)?
-      .trimmed()
   }
 }
 
@@ -544,6 +539,7 @@ extension NumberFormatterConfig: Hashable {
     hasher.combine(self.numberStyle)
     hasher.combine(self.roundingMode)
     hasher.combine(self.maximumFractionDigits)
+    hasher.combine(self.minimumFractionDigits)
     hasher.combine(self.generatesDecimalNumbers)
     hasher.combine(self.locale)
     hasher.combine(self.currencySymbol)
@@ -555,6 +551,7 @@ private func == (lhs: NumberFormatterConfig, rhs: NumberFormatterConfig) -> Bool
     lhs.numberStyle == rhs.numberStyle
       && lhs.roundingMode == rhs.roundingMode
       && lhs.maximumFractionDigits == rhs.maximumFractionDigits
+      && lhs.minimumFractionDigits == rhs.minimumFractionDigits
       && lhs.generatesDecimalNumbers == rhs.generatesDecimalNumbers
       && lhs.locale == rhs.locale
       && lhs.currencySymbol == rhs.currencySymbol

--- a/Library/Format.swift
+++ b/Library/Format.swift
@@ -420,7 +420,7 @@ public enum Format {
 
     return decimal.formatted(
       .currency(code: currencyCode)
-      .locale(env.locale)
+        .locale(env.locale)
     )
   }
 }

--- a/Library/Format.swift
+++ b/Library/Format.swift
@@ -399,6 +399,35 @@ public enum Format {
       return Strings.dates_right_now()
     }
   }
+
+  /**
+   Formats a GraphAPI.MoneyFragment into a formatted currency string.
+
+   - parameter money: The GraphAPI.MoneyFragment containing amount and currency symbol
+   - parameter env: (optional) An environment to use for locality
+
+   - returns: A formatted string with the appropriate currency symbol and amount, or nil if the fragment is incomplete
+   */
+  public static func currency(
+    _ money: GraphAPI.MoneyFragment,
+    env: Environment = AppEnvironment.current
+  ) -> String? {
+    guard
+      let amount = Double(money.amount),
+      let symbol = money.symbol
+    else { return nil }
+
+    let formatter = NumberFormatterConfig.cachedFormatter(
+      forConfig: .defaultCurrencyConfig
+        |> NumberFormatterConfig.lens.locale .~ env.locale
+        |> NumberFormatterConfig.lens.currencySymbol .~ symbol
+        |> NumberFormatterConfig.lens.minimumFractionDigits .~ 2
+        |> NumberFormatterConfig.lens.maximumFractionDigits .~ 2
+    )
+
+    return formatter.string(for: amount)?
+      .trimmed()
+  }
 }
 
 public let defaultThresholdInDays = 30 // days

--- a/Library/Format.swift
+++ b/Library/Format.swift
@@ -413,8 +413,8 @@ public enum Format {
     env: Environment = AppEnvironment.current
   ) -> String? {
     guard
-      let amount = Double(money.amount),
-      let symbol = money.symbol
+      let symbol = money.symbol,
+      let amount = money.amount.flatMap(Double.init)
     else { return nil }
 
     let formatter = NumberFormatterConfig.cachedFormatter(

--- a/Library/FormatTests.swift
+++ b/Library/FormatTests.swift
@@ -371,6 +371,19 @@ final class FormatTests: TestCase {
     }
   }
 
+  func testCurrencyMoneyFragment_USD_MoreThanTwoDecimals() {
+    withEnvironment(locale: Locale(identifier: "en_US")) {
+      let fragment = GraphAPI.MoneyFragment(amount: "1000.987", currency: .usd, symbol: "$")
+      XCTAssertEqual(Format.currency(fragment), "$1,000.99", "Should round to 2 decimal places")
+
+      let fragmentRoundDown = GraphAPI.MoneyFragment(amount: "1000.994", currency: .usd, symbol: "$")
+      XCTAssertEqual(Format.currency(fragmentRoundDown), "$1,000.99", "Should round down")
+
+      let fragmentRoundUp = GraphAPI.MoneyFragment(amount: "1000.995", currency: .usd, symbol: "$")
+      XCTAssertEqual(Format.currency(fragmentRoundUp), "$1,001.00", "Should round up")
+    }
+  }
+
   func testCurrencyMoneyFragment_EUR() {
     withEnvironment(locale: Locale(identifier: "de_DE")) {
       let fragment = GraphAPI.MoneyFragment(amount: "1000.00", currency: .eur, symbol: "€")
@@ -410,6 +423,20 @@ final class FormatTests: TestCase {
     withEnvironment(locale: Locale(identifier: "ja_JP")) {
       let fragment = GraphAPI.MoneyFragment(amount: "1000.00", currency: .jpy, symbol: "¥")
       XCTAssertEqual(Format.currency(fragment), "¥1,000")
+    }
+  }
+
+  func testCurrencyMoneyFragment_JPY_MoreThanTwoDecimals() {
+    withEnvironment(locale: Locale(identifier: "ja_JP")) {
+      let fragment = GraphAPI.MoneyFragment(amount: "1000.987", currency: .jpy, symbol: "¥")
+      XCTAssertEqual(Format.currency(fragment), "¥1,001", "JPY should round to whole numbers")
+
+      let fragmentRoundDown = GraphAPI.MoneyFragment(amount: "1000.499", currency: .jpy, symbol: "¥")
+      XCTAssertEqual(Format.currency(fragmentRoundDown), "¥1,000", "Should round down")
+
+      // for some reason the exact value of 1000.5 rounds down and not up
+      let fragmentRoundUp = GraphAPI.MoneyFragment(amount: "1000.501", currency: .jpy, symbol: "¥")
+      XCTAssertEqual(Format.currency(fragmentRoundUp), "¥1,001", "Should round up")
     }
   }
 

--- a/Library/FormatTests.swift
+++ b/Library/FormatTests.swift
@@ -358,30 +358,58 @@ final class FormatTests: TestCase {
   }
 
   func testCurrencyMoneyFragment_USD() {
-    withEnvironment(locale: Locale(identifier: "en")) {
+    withEnvironment(locale: Locale(identifier: "en_US")) {
       let fragment = GraphAPI.MoneyFragment(amount: "1000.00", currency: .usd, symbol: "$")
       XCTAssertEqual(Format.currency(fragment), "$1,000.00")
     }
   }
 
+  func testCurrencyMoneyFragment_USDCents() {
+    withEnvironment(locale: Locale(identifier: "en_US")) {
+      let fragment = GraphAPI.MoneyFragment(amount: "1000.33", currency: .usd, symbol: "$")
+      XCTAssertEqual(Format.currency(fragment), "$1,000.33")
+    }
+  }
+
   func testCurrencyMoneyFragment_EUR() {
-    withEnvironment(locale: Locale(identifier: "de")) {
+    withEnvironment(locale: Locale(identifier: "de_DE")) {
       let fragment = GraphAPI.MoneyFragment(amount: "1000.00", currency: .eur, symbol: "€")
       XCTAssertEqual(Format.currency(fragment), "1.000,00 €")
     }
   }
 
+  func testCurrencyMoneyFragment_EUREurocents() {
+    withEnvironment(locale: Locale(identifier: "de_DE")) {
+      let fragment = GraphAPI.MoneyFragment(amount: "1000.33", currency: .eur, symbol: "€")
+      XCTAssertEqual(Format.currency(fragment), "1.000,33 €")
+    }
+  }
+
+  func testCurrencyMoneyFragment_EuroInUS() {
+    withEnvironment(locale: Locale(identifier: "en_US")) {
+      let fragment = GraphAPI.MoneyFragment(amount: "1000.00", currency: .eur, symbol: "€")
+      XCTAssertEqual(Format.currency(fragment), "€1,000.00")
+    }
+  }
+
   func testCurrencyMoneyFragment_GBP() {
-    withEnvironment(locale: Locale(identifier: "en-GB")) {
+    withEnvironment(locale: Locale(identifier: "en_GB")) {
       let fragment = GraphAPI.MoneyFragment(amount: "1000.00", currency: .gbp, symbol: "£")
       XCTAssertEqual(Format.currency(fragment), "£1,000.00")
     }
   }
 
+  func testCurrencyMoneyFragment_GBPPence() {
+    withEnvironment(locale: Locale(identifier: "en_GB")) {
+      let fragment = GraphAPI.MoneyFragment(amount: "1000.33", currency: .gbp, symbol: "£")
+      XCTAssertEqual(Format.currency(fragment), "£1,000.33")
+    }
+  }
+
   func testCurrencyMoneyFragment_JPY() {
-    withEnvironment(locale: Locale(identifier: "ja")) {
+    withEnvironment(locale: Locale(identifier: "ja_JP")) {
       let fragment = GraphAPI.MoneyFragment(amount: "1000.00", currency: .jpy, symbol: "¥")
-      XCTAssertEqual(Format.currency(fragment), "¥1,000.00")
+      XCTAssertEqual(Format.currency(fragment), "¥1,000")
     }
   }
 
@@ -391,19 +419,19 @@ final class FormatTests: TestCase {
   }
 
   func testCurrencyMoneyFragment_MissingSymbol() {
-    let fragment = GraphAPI.MoneyFragment(amount: "1000.00", currency: .usd, symbol: nil)
+    let fragment = GraphAPI.MoneyFragment(amount: "1000.00", currency: nil, symbol: nil)
     XCTAssertNil(Format.currency(fragment))
   }
 
   func testCurrencyMoneyFragment_SmallAmount() {
-    withEnvironment(locale: Locale(identifier: "en")) {
+    withEnvironment(locale: Locale(identifier: "en_US")) {
       let fragment = GraphAPI.MoneyFragment(amount: "10.50", currency: .usd, symbol: "$")
       XCTAssertEqual(Format.currency(fragment), "$10.50")
     }
   }
 
   func testCurrencyMoneyFragment_ZeroAmount() {
-    withEnvironment(locale: Locale(identifier: "en")) {
+    withEnvironment(locale: Locale(identifier: "en_US")) {
       let fragment = GraphAPI.MoneyFragment(amount: "0.00", currency: .usd, symbol: "$")
       XCTAssertEqual(Format.currency(fragment), "$0.00")
     }

--- a/Library/FormatTests.swift
+++ b/Library/FormatTests.swift
@@ -357,6 +357,58 @@ final class FormatTests: TestCase {
     }
   }
 
+  func testCurrencyMoneyFragment_USD() {
+    withEnvironment(locale: Locale(identifier: "en")) {
+      let fragment = GraphAPI.MoneyFragment(amount: "1000.00", currency: .usd, symbol: "$")
+      XCTAssertEqual(Format.currency(fragment), "$1,000.00")
+    }
+  }
+
+  func testCurrencyMoneyFragment_EUR() {
+    withEnvironment(locale: Locale(identifier: "de")) {
+      let fragment = GraphAPI.MoneyFragment(amount: "1000.00", currency: .eur, symbol: "€")
+      XCTAssertEqual(Format.currency(fragment), "1.000,00 €")
+    }
+  }
+
+  func testCurrencyMoneyFragment_GBP() {
+    withEnvironment(locale: Locale(identifier: "en-GB")) {
+      let fragment = GraphAPI.MoneyFragment(amount: "1000.00", currency: .gbp, symbol: "£")
+      XCTAssertEqual(Format.currency(fragment), "£1,000.00")
+    }
+  }
+
+  func testCurrencyMoneyFragment_JPY() {
+    withEnvironment(locale: Locale(identifier: "ja")) {
+      let fragment = GraphAPI.MoneyFragment(amount: "1000.00", currency: .jpy, symbol: "¥")
+      XCTAssertEqual(Format.currency(fragment), "¥1,000.00")
+    }
+  }
+
+  func testCurrencyMoneyFragment_InvalidAmount() {
+    let fragment = GraphAPI.MoneyFragment(amount: "invalid", currency: .usd, symbol: "$")
+    XCTAssertNil(Format.currency(fragment))
+  }
+
+  func testCurrencyMoneyFragment_MissingSymbol() {
+    let fragment = GraphAPI.MoneyFragment(amount: "1000.00", currency: .usd, symbol: nil)
+    XCTAssertNil(Format.currency(fragment))
+  }
+
+  func testCurrencyMoneyFragment_SmallAmount() {
+    withEnvironment(locale: Locale(identifier: "en")) {
+      let fragment = GraphAPI.MoneyFragment(amount: "10.50", currency: .usd, symbol: "$")
+      XCTAssertEqual(Format.currency(fragment), "$10.50")
+    }
+  }
+
+  func testCurrencyMoneyFragment_ZeroAmount() {
+    withEnvironment(locale: Locale(identifier: "en")) {
+      let fragment = GraphAPI.MoneyFragment(amount: "0.00", currency: .usd, symbol: "$")
+      XCTAssertEqual(Format.currency(fragment), "$0.00")
+    }
+  }
+
   func testPlusSign() {
     withEnvironment(language: .de) {
       XCTAssertEqual(Format.attributedPlusSign().string, "+")


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Following up on PR comments in #2198, this PR adds a currency formatter to Format.swift to turn a `GraphAPI.MoneyFragment` into a localized string. 

# 🤔 Why

Being able to format the `GraphAPI.MoneyFragment` in a consistent and tested way is good

# 🛠 How

A new API was added which takes a `GraphAPI.MoneyFragment` and formats it using a `NumberFormatter` similar to our other currency formatters. Tests were added to generate a few strings from different fragments in different currencies and locales.

This API is nullable, because if the fragment is invalid, we should not show an incorrect string. Since this is the case, it made sense to update how this was used in backings dashboard. This check was moved to the `PPOProjectCardModel` constructor which already turns a bunch of other GraphQL data into the model object along with validation. Then the site where it's used already knows this field is valid.

# 👀 See

See #2198 for comments on why this ticket was created. 

# ♿️ Accessibility 

N/A, nothing user-facing changes

# ✅ Acceptance criteria

Tests should pass.