### PR TITLE
[MBL-1491] [MBL-1663] Handle 3DS authentication with informational snackbar

### DIFF
--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/CardView/PPOProjectCard.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/CardView/PPOProjectCard.swift
@@ -116,17 +116,25 @@ struct PPOProjectCard: View {
 
   @ViewBuilder
   private func button(for action: PPOProjectCardViewModel.Action) -> some View {
-    switch action.style {
-    case .green:
-      self.baseButton(for: action)
-        .buttonStyle(GreenButtonStyle())
-    case .red:
-      self.baseButton(for: action)
-        .buttonStyle(RedButtonStyle())
-    case .black:
-      self.baseButton(for: action)
-        .buttonStyle(BlackButtonStyle())
+    ZStack {
+      switch action.style {
+      case .green:
+        self.baseButton(for: action)
+          .buttonStyle(GreenButtonStyle())
+      case .red:
+        self.baseButton(for: action)
+          .buttonStyle(RedButtonStyle())
+      case .black:
+        self.baseButton(for: action)
+          .buttonStyle(BlackButtonStyle())
+      }
+
+      if self.viewModel.isLoading {
+        ProgressView()
+          .progressViewStyle(CircularProgressViewStyle(tint: .white))
+      }
     }
+    .disabled(self.viewModel.isLoading)
   }
 
   @ViewBuilder

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/CardView/PPOProjectCardModel.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/CardView/PPOProjectCardModel.swift
@@ -64,7 +64,7 @@ public struct PPOProjectCardModel: Identifiable, Equatable, Hashable {
     case editAddress
     case completeSurvey
     case fixPayment
-    case authenticateCard
+    case authenticateCard(clientSecret: String)
 
     public var label: String {
       switch self {
@@ -297,7 +297,7 @@ extension PPOProjectCardModel {
     pledge: "$50.00",
     creatorName: "rokaplay truncate if longer than",
     address: nil,
-    actions: (.authenticateCard, nil),
+    actions: (.authenticateCard(clientSecret: ""), nil),
     tierType: .authenticateCard,
     backingDetailsUrl: "fakeBackingDetailsUrl",
     backingId: 47,
@@ -403,24 +403,25 @@ extension PPOProjectCardModel {
     let backingDetailsUrl = backing?.backingDetailsPageRoute
     let backingId = backing.flatMap { decompose(id: $0.id) }
 
-    switch card.tierType {
-    case PPOProjectCardModelConstants.paymentFailed:
+    switch (card.tierType, backing?.clientSecret) {
+    case (PPOProjectCardModelConstants.paymentFailed, _):
       primaryAction = .fixPayment
       secondaryAction = nil
       tierType = .fixPayment
-    case PPOProjectCardModelConstants.confirmAddress:
+    case (PPOProjectCardModelConstants.confirmAddress, _):
       primaryAction = .confirmAddress
       secondaryAction = .editAddress
       tierType = .confirmAddress
-    case PPOProjectCardModelConstants.completeSurvey:
+    case (PPOProjectCardModelConstants.completeSurvey, _):
       primaryAction = .completeSurvey
       secondaryAction = nil
       tierType = .openSurvey
-    case PPOProjectCardModelConstants.authenticationRequired:
-      primaryAction = .authenticateCard
+    case let (PPOProjectCardModelConstants.authenticationRequired, .some(clientSecret)):
+      primaryAction = .authenticateCard(clientSecret: clientSecret)
       secondaryAction = nil
       tierType = .authenticateCard
-    case .some(_), .none:
+    case (PPOProjectCardModelConstants.authenticationRequired, .none),
+         _:
       return nil
     }
 

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/CardView/PPOProjectCardModelTests.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/CardView/PPOProjectCardModelTests.swift
@@ -171,7 +171,8 @@ final class PPOProjectCardModelTests: XCTestCase {
                   "slug": "2071399561/ppo-failed-payment-0"
                 },
                 "backingDetailsPageRoute": "https://staging.kickstarter.com/projects/2071399561/ppo-failed-payment-0/backing/survey_responses",
-                "deliveryAddress": \(addressJSON)
+                "deliveryAddress": \(addressJSON),
+                "clientSecret": null
               },
               "tierType": "Tier1PaymentFailed",
               "flags": [

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/CardView/PPOProjectCardViewModel.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/CardView/PPOProjectCardViewModel.swift
@@ -87,4 +87,24 @@ final class PPOProjectCardViewModel: PPOProjectCardViewModelType {
   func setLoading(_ loading: Bool) {
     self.isLoading = loading
   }
+
+  func fix3DSChallenge(clientSecret: String) {
+    self.performAction(action: .authenticateCard(clientSecret: clientSecret))
+  }
+
+  func handle3DSState(_ state: PPOActionState) {
+    switch state {
+    case .processing:
+      self.isLoading = true
+    case .succeeded, .cancelled, .failed:
+      self.isLoading = false
+    }
+  }
+}
+
+public enum PPOActionState {
+  case processing
+  case succeeded
+  case cancelled
+  case failed
 }

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/CardView/PPOProjectCardViewModel.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/CardView/PPOProjectCardViewModel.swift
@@ -34,6 +34,7 @@ typealias PPOProjectCardViewModelType = Equatable & Hashable & Identifiable & Ob
 
 final class PPOProjectCardViewModel: PPOProjectCardViewModelType {
   @Published private(set) var card: PPOProjectCardModel
+  @Published var isLoading: Bool = false
 
   func hash(into hasher: inout Hasher) {
     hasher.combine(self.card)
@@ -81,5 +82,9 @@ final class PPOProjectCardViewModel: PPOProjectCardViewModelType {
 
   static func == (lhs: PPOProjectCardViewModel, rhs: PPOProjectCardViewModel) -> Bool {
     lhs.card == rhs.card
+  }
+
+  func setLoading(_ loading: Bool) {
+    self.isLoading = loading
   }
 }

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/CardView/PPOProjectCardViewModelTests.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/CardView/PPOProjectCardViewModelTests.swift
@@ -19,10 +19,10 @@ final class PPOProjectCardViewModelTests: XCTestCase {
       }
       .store(in: &cancellables)
 
-    viewModel.performAction(action: .authenticateCard)
+    viewModel.performAction(action: .authenticateCard(clientSecret: "test123"))
     waitForExpectations(timeout: 0.1)
 
-    XCTAssertEqual(actions, [.authenticateCard])
+    XCTAssertEqual(actions, [.authenticateCard(clientSecret: "test123")])
   }
 
   func testSendMessage() throws {

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOContainerViewController.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOContainerViewController.swift
@@ -14,6 +14,7 @@ public class PPOContainerViewController: PagedContainerViewController<PPOContain
     self.title = Strings.tabbar_activity()
 
     let ppoView = PPOView(
+      authenticationContext: self,
       onCountChange: { [weak self] count in
         self?.viewModel.projectAlertsCountChanged(count)
       },
@@ -132,32 +133,6 @@ public class PPOContainerViewController: PagedContainerViewController<PPOContain
     nav.modalPresentationStyle = .formSheet
     vc.delegate = self
     self.present(nav, animated: true, completion: nil)
-  }
-
-  private func handle3DSChallenge(setupIntent: String, setLoading: @escaping (Bool) -> Void) {
-    let confirmParams = STPSetupIntentConfirmParams(clientSecret: setupIntent)
-
-    // Set initial loading state
-    setLoading(true)
-
-    STPPaymentHandler.shared().confirmSetupIntent(
-      confirmParams,
-      with: self,
-      completion: { status, _, error in
-        switch (status, error) {
-        case (.succeeded, _):
-          setLoading(false)
-        case (.canceled, _):
-          setLoading(false)
-        case let (.failed, .some(error)):
-          print("Error \(error)")
-          setLoading(false)
-        case (.failed, .none):
-          // failed without an error? shouldn't happen but use a generic error here
-          setLoading(false)
-        }
-      }
-    )
   }
 }
 

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOContainerViewController.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOContainerViewController.swift
@@ -15,7 +15,6 @@ public class PPOContainerViewController: PagedContainerViewController<PPOContain
     self.title = Strings.tabbar_activity()
 
     let ppoView = PPOView(
-      authenticationContext: self,
       onCountChange: { [weak self] count in
         self?.viewModel.projectAlertsCountChanged(count)
       },

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOContainerViewController.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOContainerViewController.swift
@@ -67,8 +67,8 @@ public class PPOContainerViewController: PagedContainerViewController<PPOContain
         self?.messageCreator(messageSubject)
       case let .fixPaymentMethod(projectId, backingId):
         self?.fixPayment(projectId: projectId, backingId: backingId)
-      case let .fix3DSChallenge(clientSecret):
-        self?.handle3DSChallenge(setupIntent: clientSecret)
+      case let .fix3DSChallenge(clientSecret, setLoading):
+        self?.handle3DSChallenge(setupIntent: clientSecret, setLoading: setLoading)
       case .confirmAddress:
         // TODO: MBL-1451
         break
@@ -134,14 +134,28 @@ public class PPOContainerViewController: PagedContainerViewController<PPOContain
     self.present(nav, animated: true, completion: nil)
   }
 
-  private func handle3DSChallenge(setupIntent: String) {
+  private func handle3DSChallenge(setupIntent: String, setLoading: @escaping (Bool) -> Void) {
     let confirmParams = STPSetupIntentConfirmParams(clientSecret: setupIntent)
+
+    // Set initial loading state
+    setLoading(true)
 
     STPPaymentHandler.shared().confirmSetupIntent(
       confirmParams,
       with: self,
-      completion: { _, _, _ in
-        // Routing will be handled separately
+      completion: { status, _, error in
+        switch (status, error) {
+        case (.succeeded, _):
+          setLoading(false)
+        case (.canceled, _):
+          setLoading(false)
+        case let (.failed, .some(error)):
+          print("Error \(error)")
+          setLoading(false)
+        case (.failed, .none):
+          // failed without an error? shouldn't happen but use a generic error here
+          setLoading(false)
+        }
       }
     )
   }

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOContainerViewModel.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOContainerViewModel.swift
@@ -2,6 +2,7 @@ import Combine
 import Foundation
 import KsApi
 import Library
+import UIKit
 
 protocol PPOContainerViewModelInputs {
   func viewWillAppear()

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOContainerViewModel.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOContainerViewModel.swift
@@ -57,7 +57,10 @@ final class PPOContainerViewModel: PPOContainerViewModelInputs, PPOContainerView
       .compactMap { state -> MessageBannerConfiguration? in
         switch state {
         case .succeeded:
-          return (.success, "Your payment has been processed.")
+          return (
+            .success,
+            Strings.Youve_been_authenticated_successfully_pull_to_refresh()
+          )
         case .failed:
           return (.error, Strings.Something_went_wrong_please_try_again())
         case .processing, .cancelled:

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOContainerViewModel.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOContainerViewModel.swift
@@ -31,7 +31,7 @@ final class PPOContainerViewModel: PPOContainerViewModelInputs, PPOContainerView
       .map { _ in () }
 
     let currentUser = Publishers.Merge4(
-      self.viewWillAppearSubject,
+      self.viewWillAppearSubject.map { _ in () },
       userUpdated,
       sessionStarted,
       sessionEnded

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOContainerViewModel.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOContainerViewModel.swift
@@ -20,18 +20,18 @@ final class PPOContainerViewModel: PPOContainerViewModelInputs, PPOContainerView
   init() {
     let sessionStarted = NotificationCenter.default
       .publisher(for: .ksr_sessionStarted)
-      .map { _ in () }
+      .withEmptyValues()
 
     let sessionEnded = NotificationCenter.default
       .publisher(for: .ksr_sessionEnded)
-      .map { _ in () }
+      .withEmptyValues()
 
     let userUpdated = NotificationCenter.default
       .publisher(for: .ksr_userUpdated)
-      .map { _ in () }
+      .withEmptyValues()
 
     let currentUser = Publishers.Merge4(
-      self.viewWillAppearSubject.map { _ in () },
+      self.viewWillAppearSubject.withEmptyValues(),
       userUpdated,
       sessionStarted,
       sessionEnded

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOStyles.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOStyles.swift
@@ -48,6 +48,8 @@ enum PPOStyles {
     color: UIColor.ksr_black
   )
 
+  static let bannerPadding = 7
+
   static let background = UIColor.ksr_white
 
   static let timeImage = ImageResource.iconLimitedTime

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOView.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOView.swift
@@ -58,7 +58,7 @@ struct PPOView: View {
             self.viewModel.fix3DSChallenge(
               from: model,
               clientSecret: clientSecret,
-              completion: { status in
+              onProgress: { status in
                 switch status {
                 case .processing:
                   card.setLoading(true)

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOView.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOView.swift
@@ -104,6 +104,7 @@ struct PPOView: View {
     PPOEmptyStateView {
       self.onNavigate?(.backedProjects)
     }
+    .frame(maxHeight: .infinity)
   }
 
   @ViewBuilder var errorView: some View {

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOView.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOView.swift
@@ -52,18 +52,24 @@ struct PPOView: View {
         onSendMessage: { card in
           self.viewModel.contactCreator(from: card)
         },
-        onPerformAction: { card, action in
+        onPerformAction: { model, action in
           switch action {
           case let .authenticateCard(clientSecret):
-            self.viewModel.fix3DSChallenge(from: card, clientSecret: clientSecret)
+            self.viewModel.fix3DSChallenge(
+              from: model,
+              clientSecret: clientSecret,
+              setLoading: { loading in
+                card.setLoading(loading)
+              }
+            )
           case .completeSurvey:
-            self.viewModel.openSurvey(from: card)
+            self.viewModel.openSurvey(from: model)
           case .confirmAddress:
-            self.viewModel.confirmAddress(from: card)
+            self.viewModel.confirmAddress(from: model)
           case .editAddress:
-            self.viewModel.editAddress(from: card)
+            self.viewModel.editAddress(from: model)
           case .fixPayment:
-            self.viewModel.fixPaymentMethod(from: card)
+            self.viewModel.fixPaymentMethod(from: model)
           }
         }
       )

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOView.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOView.swift
@@ -136,24 +136,8 @@ struct PPOView: View {
     GeometryReader { reader in
       self.contentView(parentSize: reader.size)
         .frame(maxWidth: .infinity, alignment: .center)
-        .overlay(alignment: .bottom) {
-          MessageBannerView(viewModel: self.$viewModel.bannerViewModel)
-            .padding(.horizontal.union(.bottom), CGFloat(PPOStyles.bannerPadding))
-            .frame(
-              minWidth: reader.size.width,
-              idealWidth: reader.size.width,
-              alignment: .bottom
-            )
-            .animation(.easeInOut, value: self.viewModel.bannerViewModel != nil)
-            .accessibilityFocused(self.$isBannerFocused)
-        }
-        .onChange(of: self.viewModel.bannerViewModel, perform: { _ in
-          DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-            self.isBannerFocused = self.viewModel.bannerViewModel != nil
-          }
-        })
         .onAppear(perform: {
-          self.viewModel.viewDidAppear(authenticationContext: self.authenticationContext)
+          self.viewModel.viewDidAppear()
         })
         .onChange(of: self.viewModel.results.values.count, perform: { value in
           self.onCountChange?(value)

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOView.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOView.swift
@@ -60,8 +60,13 @@ struct PPOView: View {
             self.viewModel.fix3DSChallenge(
               from: model,
               clientSecret: clientSecret,
-              setLoading: { loading in
-                card.setLoading(loading)
+              completion: { status in
+                switch status {
+                case .processing:
+                  card.setLoading(true)
+                case .succeeded, .cancelled, .failed:
+                  card.setLoading(false)
+                }
               }
             )
           case .completeSurvey:

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOView.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOView.swift
@@ -54,8 +54,8 @@ struct PPOView: View {
         },
         onPerformAction: { card, action in
           switch action {
-          case .authenticateCard:
-            self.viewModel.fix3DSChallenge(from: card)
+          case let .authenticateCard(clientSecret):
+            self.viewModel.fix3DSChallenge(from: card, clientSecret: clientSecret)
           case .completeSurvey:
             self.viewModel.openSurvey(from: card)
           case .confirmAddress:

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOView.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOView.swift
@@ -1,10 +1,8 @@
 import Library
-import Stripe
 import SwiftUI
 
 struct PPOView: View {
   @StateObject var viewModel = PPOViewModel()
-  var authenticationContext: any STPAuthenticationContext
   var onCountChange: ((Int?) -> Void)?
   var onNavigate: ((PPONavigationEvent) -> Void)?
 
@@ -150,13 +148,5 @@ struct PPOView: View {
 }
 
 #Preview {
-  PPOView(authenticationContext: PreviewAuthenticationContext())
+  PPOView()
 }
-
-#if targetEnvironment(simulator)
-  fileprivate class PreviewAuthenticationContext: NSObject, STPAuthenticationContext {
-    func authenticationPresentingViewController() -> UIViewController {
-      fatalError()
-    }
-  }
-#endif

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOViewModel.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOViewModel.swift
@@ -139,7 +139,10 @@ final class PPOViewModel: ObservableObject, PPOViewModelInputs, PPOViewModelOutp
         let messageSubject = MessageSubject.project(id: viewModel.projectId, name: viewModel.projectName)
         return PPONavigationEvent.contactCreator(messageSubject: messageSubject)
       },
-      self.fixPaymentMethodSubject.map { model in PPONavigationEvent.fixPaymentMethod(projectId: model.projectId, backingId: model.backingId) },
+      self.fixPaymentMethodSubject.map { model in PPONavigationEvent.fixPaymentMethod(
+        projectId: model.projectId,
+        backingId: model.backingId
+      ) },
       self.fix3DSChallengeSubject.map { model, clientSecret, completion in
         PPONavigationEvent.fix3DSChallenge(
           clientSecret: clientSecret,
@@ -338,7 +341,6 @@ final class PPOViewModel: ObservableObject, PPOViewModelInputs, PPOViewModelOutp
   private enum Constants {
     static let pageSize = 20
   }
-
 }
 
 extension Sequence where Element == PPOProjectCardViewModel {

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOViewModel.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOViewModel.swift
@@ -139,7 +139,7 @@ final class PPOViewModel: ObservableObject, PPOViewModelInputs, PPOViewModelOutp
         projectId: model.projectId,
         backingId: model.backingId
       ) },
-      self.fix3DSChallengeSubject.map { model, clientSecret, onProgress in
+      self.fix3DSChallengeSubject.map { _, clientSecret, onProgress in
         PPONavigationEvent.fix3DSChallenge(
           clientSecret: clientSecret,
           onProgress: onProgress

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOViewModel.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOViewModel.swift
@@ -18,7 +18,7 @@ protocol PPOViewModelInputs {
 
   func openBackedProjects()
   func fixPaymentMethod(from: PPOProjectCardModel)
-  func fix3DSChallenge(from: PPOProjectCardModel)
+  func fix3DSChallenge(from: PPOProjectCardModel, clientSecret: String)
   func openSurvey(from: PPOProjectCardModel)
   func viewBackingDetails(from: PPOProjectCardModel)
   func editAddress(from: PPOProjectCardModel)
@@ -34,7 +34,7 @@ protocol PPOViewModelOutputs {
 enum PPONavigationEvent: Equatable {
   case backedProjects
   case fixPaymentMethod(projectId: Int, backingId: Int)
-  case fix3DSChallenge
+  case fix3DSChallenge(clientSecret: String)
   case survey(url: String)
   case backingDetails(url: String)
   case editAddress(url: String)
@@ -92,11 +92,20 @@ final class PPOViewModel: ObservableObject, PPOViewModelInputs, PPOViewModelOutp
     // Route navigation events
     Publishers.Merge8(
       self.openBackedProjectsSubject.map { PPONavigationEvent.backedProjects },
+<<<<<<< HEAD
       self.fixPaymentMethodSubject
         .map { viewModel in
           PPONavigationEvent.fixPaymentMethod(projectId: viewModel.projectId, backingId: viewModel.backingId)
         },
       self.fix3DSChallengeSubject.map { _ in PPONavigationEvent.fix3DSChallenge },
+=======
+      self.fixPaymentMethodSubject.map { _ in PPONavigationEvent.fixPaymentMethod },
+      self.fix3DSChallengeSubject.map { secret in
+        PPONavigationEvent.fix3DSChallenge(
+          clientSecret: secret
+        )
+      },
+>>>>>>> ccf05dbeb (Propagate client secret through PPOProjectCardModel action and bubble it up through to PPOContainerViewController)
       self.openSurveySubject.map { viewModel in PPONavigationEvent.survey(url: viewModel.backingDetailsUrl) },
       self.viewBackingDetailsSubject
         .map { viewModel in PPONavigationEvent.survey(url: viewModel.backingDetailsUrl) },
@@ -222,8 +231,8 @@ final class PPOViewModel: ObservableObject, PPOViewModelInputs, PPOViewModelOutp
     self.fixPaymentMethodSubject.send(from)
   }
 
-  func fix3DSChallenge(from: PPOProjectCardModel) {
-    self.fix3DSChallengeSubject.send(from)
+  func fix3DSChallenge(from _: PPOProjectCardModel, clientSecret: String) {
+    self.fix3DSChallengeSubject.send(clientSecret)
   }
 
   func openSurvey(from: PPOProjectCardModel) {
@@ -265,7 +274,7 @@ final class PPOViewModel: ObservableObject, PPOViewModelInputs, PPOViewModelOutp
   private let shouldSendSampleMessageSubject = PassthroughSubject<Void, Never>()
   private let openBackedProjectsSubject = PassthroughSubject<Void, Never>()
   private let fixPaymentMethodSubject = PassthroughSubject<PPOProjectCardModel, Never>()
-  private let fix3DSChallengeSubject = PassthroughSubject<PPOProjectCardModel, Never>()
+  private let fix3DSChallengeSubject = PassthroughSubject<String, Never>()
   private let openSurveySubject = PassthroughSubject<PPOProjectCardModel, Never>()
   private let viewBackingDetailsSubject = PassthroughSubject<PPOProjectCardModel, Never>()
   private let editAddressSubject = PassthroughSubject<PPOProjectCardModel, Never>()

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOViewModel.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOViewModel.swift
@@ -111,7 +111,7 @@ final class PPOViewModel: ObservableObject, PPOViewModelInputs, PPOViewModelOutp
 
     Publishers.Merge(
       self.viewDidAppearSubject
-        .map { _ in () }
+        .withEmptyValues()
         .first(),
       self.pullToRefreshSubject
     )

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOViewModel.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOViewModel.swift
@@ -99,14 +99,6 @@ final class PPOViewModel: ObservableObject, PPOViewModelInputs, PPOViewModelOutp
           return false
         }
       })
-      .combineLatest(self.filteredResultsSubject) { results, filteredIds in
-        // Filter out any values that are in the filtered set
-        results.mapValues { values in
-          values.filter { value in
-            !filteredIds.contains(value.card.id)
-          }
-        }
-      }
       .receive(on: RunLoop.main)
       .sink(receiveValue: { results in
         self.results = results
@@ -150,12 +142,7 @@ final class PPOViewModel: ObservableObject, PPOViewModelInputs, PPOViewModelOutp
       self.fix3DSChallengeSubject.map { model, clientSecret, onProgress in
         PPONavigationEvent.fix3DSChallenge(
           clientSecret: clientSecret,
-          onProgress: { state in
-            if case .succeeded = state {
-              self.filteredResultsSubject.value.insert(model.id)
-            }
-            onProgress(state)
-          }
+          onProgress: onProgress
         )
       }
     )
@@ -313,7 +300,6 @@ final class PPOViewModel: ObservableObject, PPOViewModelInputs, PPOViewModelOutp
   private let confirmAddressSubject = PassthroughSubject<PPOProjectCardModel, Never>()
   private let contactCreatorSubject = PassthroughSubject<PPOProjectCardModel, Never>()
   private var navigationEventSubject = PassthroughSubject<PPONavigationEvent, Never>()
-  private let filteredResultsSubject = CurrentValueSubject<Set<UUID>, Never>([])
 
   private var cancellables: Set<AnyCancellable> = []
 

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOViewModel.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOViewModel.swift
@@ -22,7 +22,7 @@ protocol PPOViewModelInputs {
   func fix3DSChallenge(
     from: PPOProjectCardModel,
     clientSecret: String,
-    completion: @escaping (PPOActionState) -> Void
+    onProgress: @escaping (PPOActionState) -> Void
   )
   func openSurvey(from: PPOProjectCardModel)
   func viewBackingDetails(from: PPOProjectCardModel)
@@ -39,7 +39,7 @@ protocol PPOViewModelOutputs {
 enum PPONavigationEvent: Equatable {
   case backedProjects
   case fixPaymentMethod(projectId: Int, backingId: Int)
-  case fix3DSChallenge(clientSecret: String, completion: (PPOActionState) -> Void)
+  case fix3DSChallenge(clientSecret: String, onProgress: (PPOActionState) -> Void)
   case survey(url: String)
   case backingDetails(url: String)
   case editAddress(url: String)
@@ -57,8 +57,8 @@ enum PPONavigationEvent: Equatable {
     case let (.contactCreator(lhsSubject), .contactCreator(rhsSubject)):
       return lhsSubject == rhsSubject
     case let (
-      .fix3DSChallenge(clientSecret: lhsSecret, completion: _),
-      .fix3DSChallenge(clientSecret: rhsSecret, completion: _)
+      .fix3DSChallenge(clientSecret: lhsSecret, onProgress: _),
+      .fix3DSChallenge(clientSecret: rhsSecret, onProgress: _)
     ):
       return lhsSecret == rhsSecret
     case (.backedProjects, .backedProjects),
@@ -147,14 +147,14 @@ final class PPOViewModel: ObservableObject, PPOViewModelInputs, PPOViewModelOutp
         projectId: model.projectId,
         backingId: model.backingId
       ) },
-      self.fix3DSChallengeSubject.map { model, clientSecret, completion in
+      self.fix3DSChallengeSubject.map { model, clientSecret, onProgress in
         PPONavigationEvent.fix3DSChallenge(
           clientSecret: clientSecret,
-          completion: { state in
+          onProgress: { state in
             if case .succeeded = state {
               self.filteredResultsSubject.value.insert(model.id)
             }
-            completion(state)
+            onProgress(state)
           }
         )
       }
@@ -261,9 +261,9 @@ final class PPOViewModel: ObservableObject, PPOViewModelInputs, PPOViewModelOutp
   func fix3DSChallenge(
     from: PPOProjectCardModel,
     clientSecret: String,
-    completion: @escaping (PPOActionState) -> Void
+    onProgress: @escaping (PPOActionState) -> Void
   ) {
-    self.fix3DSChallengeSubject.send((from, clientSecret, completion))
+    self.fix3DSChallengeSubject.send((from, clientSecret, onProgress))
   }
 
   func openSurvey(from: PPOProjectCardModel) {

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOViewModel.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOViewModel.swift
@@ -56,6 +56,11 @@ enum PPONavigationEvent: Equatable {
       return lhsUrl == rhsUrl
     case let (.contactCreator(lhsSubject), .contactCreator(rhsSubject)):
       return lhsSubject == rhsSubject
+    case let (
+      .fix3DSChallenge(clientSecret: lhsSecret, completion: _),
+      .fix3DSChallenge(clientSecret: rhsSecret, completion: _)
+    ):
+      return lhsSecret == rhsSecret
     case (.backedProjects, .backedProjects),
          (.confirmAddress, .confirmAddress),
          (.fixPaymentMethod, .fixPaymentMethod):

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOViewModelTests.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOViewModelTests.swift
@@ -280,8 +280,11 @@ class PPOViewModelTests: XCTestCase {
 
   func testNavigationFix3DSChallenge() {
     self.verifyNavigationEvent(
-      { self.viewModel.fix3DSChallenge(from: PPOProjectCardModel.authenticateCardTemplate) },
-      event: .fix3DSChallenge
+      { self.viewModel.fix3DSChallenge(
+        from: PPOProjectCardModel.authenticateCardTemplate,
+        clientSecret: "test123"
+      ) },
+      event: .fix3DSChallenge(clientSecret: "test123")
     )
   }
 
@@ -395,6 +398,7 @@ class PPOViewModelTests: XCTestCase {
           "symbol": "$"
         },
         "deliveryAddress": null,
+        "clientSecret": null,
         "backingDetailsPageRoute": "fake-backings-route",
         "project": {
           "__typename": "Project",

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOViewModelTests.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOViewModelTests.swift
@@ -278,6 +278,19 @@ class PPOViewModelTests: XCTestCase {
     )
   }
 
+  func testNavigationFix3DSChallenge() {
+    let clientSecret = "xyz"
+    let completion: (PPOActionState) -> Void = { _ in }
+    self.verifyNavigationEvent(
+      { self.viewModel.fix3DSChallenge(
+        from: PPOProjectCardModel.authenticateCardTemplate,
+        clientSecret: clientSecret,
+        completion: completion
+      ) },
+      event: .fix3DSChallenge(clientSecret: clientSecret, completion: completion)
+    )
+  }
+
   func testNavigationFixPaymentMethod() {
     self.verifyNavigationEvent(
       { self.viewModel.fixPaymentMethod(from: PPOProjectCardModel.fixPaymentTemplate) },

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOViewModelTests.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOViewModelTests.swift
@@ -280,14 +280,14 @@ class PPOViewModelTests: XCTestCase {
 
   func testNavigationFix3DSChallenge() {
     let clientSecret = "xyz"
-    let completion: (PPOActionState) -> Void = { _ in }
+    let onProgress: (PPOActionState) -> Void = { _ in }
     self.verifyNavigationEvent(
       { self.viewModel.fix3DSChallenge(
         from: PPOProjectCardModel.authenticateCardTemplate,
         clientSecret: clientSecret,
-        completion: completion
+        onProgress: onProgress
       ) },
-      event: .fix3DSChallenge(clientSecret: clientSecret, completion: completion)
+      event: .fix3DSChallenge(clientSecret: clientSecret, onProgress: onProgress)
     )
   }
 

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOViewModelTests.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOViewModelTests.swift
@@ -68,7 +68,11 @@ class PPOViewModelTests: XCTestCase {
       fetchPledgedProjectsResult: Result.success(try self.pledgedProjectsData())
     )) {
       self.viewModel.viewDidAppear(authenticationContext: self.mockAuthenticationContext)
-      self.viewModel.viewDidAppear(authenticationContext: self.mockAuthenticationContext) // This should not trigger another load
+      self.viewModel
+        .viewDidAppear(
+          authenticationContext: self
+            .mockAuthenticationContext
+        ) // This should not trigger another load
     }
 
     wait(for: [expectation], timeout: 0.1)

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOViewModelTests.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOViewModelTests.swift
@@ -1,13 +1,11 @@
 import Combine
 @testable import Kickstarter_Framework
 @testable import KsApi
-import Stripe
 import XCTest
 
 class PPOViewModelTests: XCTestCase {
   var viewModel: PPOViewModel!
   var cancellables: Set<AnyCancellable>!
-  fileprivate let mockAuthenticationContext = MockAuthenticationContext()
 
   override func setUp() {
     super.setUp()
@@ -36,7 +34,7 @@ class PPOViewModelTests: XCTestCase {
     withEnvironment(apiService: MockService(
       fetchPledgedProjectsResult: Result.success(try self.pledgedProjectsData())
     )) {
-      self.viewModel.viewDidAppear(authenticationContext: self.mockAuthenticationContext)
+      self.viewModel.viewDidAppear()
     }
 
     wait(for: [expectation], timeout: 0.1)
@@ -67,12 +65,8 @@ class PPOViewModelTests: XCTestCase {
     withEnvironment(apiService: MockService(
       fetchPledgedProjectsResult: Result.success(try self.pledgedProjectsData())
     )) {
-      self.viewModel.viewDidAppear(authenticationContext: self.mockAuthenticationContext)
-      self.viewModel
-        .viewDidAppear(
-          authenticationContext: self
-            .mockAuthenticationContext
-        ) // This should not trigger another load
+      self.viewModel.viewDidAppear()
+      self.viewModel.viewDidAppear() // This should not trigger another load
     }
 
     wait(for: [expectation], timeout: 0.1)
@@ -108,7 +102,7 @@ class PPOViewModelTests: XCTestCase {
     withEnvironment(apiService: MockService(
       fetchPledgedProjectsResult: Result.success(try self.pledgedProjectsData(cursors: 1...3))
     )) {
-      self.viewModel.viewDidAppear(authenticationContext: self.mockAuthenticationContext) // Initial load
+      self.viewModel.viewDidAppear() // Initial load
     }
 
     await fulfillment(of: [initialLoadExpectation], timeout: 0.1)
@@ -160,7 +154,7 @@ class PPOViewModelTests: XCTestCase {
     withEnvironment(apiService: MockService(
       fetchPledgedProjectsResult: Result.success(try self.pledgedProjectsData(cursors: 1...3))
     )) {
-      self.viewModel.viewDidAppear(authenticationContext: self.mockAuthenticationContext) // Initial load
+      self.viewModel.viewDidAppear() // Initial load
     }
 
     await fulfillment(of: [initialLoadExpectation], timeout: 0.1)
@@ -229,7 +223,7 @@ class PPOViewModelTests: XCTestCase {
         hasNextPage: true
       ))
     )) {
-      self.viewModel.viewDidAppear(authenticationContext: self.mockAuthenticationContext) // Initial load
+      self.viewModel.viewDidAppear() // Initial load
     }
 
     await fulfillment(of: [initialLoadExpectation], timeout: 0.1)
@@ -492,11 +486,5 @@ class PPOViewModelTests: XCTestCase {
       "tierType": "Tier1PaymentFailed"
     }
     """
-  }
-}
-
-private class MockAuthenticationContext: NSObject, STPAuthenticationContext {
-  func authenticationPresentingViewController() -> UIViewController {
-    fatalError("Not implemented in tests")
   }
 }

--- a/Kickstarter-iOS/Locales/Base.lproj/Localizable.strings
+++ b/Kickstarter-iOS/Locales/Base.lproj/Localizable.strings
@@ -881,6 +881,7 @@
 "Youve_canceled_your_pledge_of_pledge_amount_for_project_name" = "You’ve canceled your pledge of <b>%{pledge_amount}</b> for <b>%{project_name}</b>.";
 "Youve_pledged_to_support_this_project" = "You’ve pledged to support this project and it’s currently still funding.";
 "Youve_successfully_updated_your_pledge_to_amount_for_project_name" = "You’ve successfully updated your pledge to %{amount} for %{project_name}. If the project reaches its funding goal, your card will be charged on %{project_deadline}. Check your email for details.";
+"Youve_been_authenticated_successfully_pull_to_refresh" = "You’ve been authenticated successfully! Pull to refresh.";
 "Zip_code" = "Zip code";
 "accessibility.dashboard.buttons.activity" = "Activity";
 "accessibility.dashboard.buttons.activity_hint" = "Opens activity.";

--- a/Kickstarter-iOS/Locales/de.lproj/Localizable.strings
+++ b/Kickstarter-iOS/Locales/de.lproj/Localizable.strings
@@ -881,6 +881,7 @@
 "Youve_canceled_your_pledge_of_pledge_amount_for_project_name" = "Du hast den Finanzierungsbeitrag in Höhe von <b>%{pledge_amount}</b> für das Projekt <b>%{project_name}</b> zurückgezogen.";
 "Youve_pledged_to_support_this_project" = "Du hast einen Finazierungsbeitrag zu diesem Projekt geleistet. Die Frist für die Finanzierung ist noch nicht abgelaufen.";
 "Youve_successfully_updated_your_pledge_to_amount_for_project_name" = "Dein Finanzierungsbeitrag für or %{project_name} wurde erfolgreich auf %{amount} geändert. Wenn das Projekt sein Finanzierungsziel erreicht, wird deine Karte am %{project_deadline} belastet. Wir haben dir eine E-Mail mit genaueren Angaben gesendet.";
+"Youve_been_authenticated_successfully_pull_to_refresh" = "Du wurdest erfolgreich authentifiziert! Ziehe, um die Seite zu aktualisieren.";
 "Zip_code" = "Postleitzahl";
 "accessibility.dashboard.buttons.activity" = "Aktivität";
 "accessibility.dashboard.buttons.activity_hint" = "Öffnet Sparte Aktivität.";

--- a/Kickstarter-iOS/Locales/es.lproj/Localizable.strings
+++ b/Kickstarter-iOS/Locales/es.lproj/Localizable.strings
@@ -881,6 +881,7 @@
 "Youve_canceled_your_pledge_of_pledge_amount_for_project_name" = "Has cancelado tu contribución de <b>%{pledge_amount}</b> para el proyecto <b>%{project_name}</b>.";
 "Youve_pledged_to_support_this_project" = "Hiciste una contribución a este proyecto. El plazo de financiamiento todavía no ha terminado.";
 "Youve_successfully_updated_your_pledge_to_amount_for_project_name" = "Has actualizado con éxito tu contribución a %{amount} para %{project_name}. Si el proyecto alcanza su meta de financiamiento, se efectuará un cargo en tu tarjeta el %{project_deadline}. Consulta tu correo electrónico para obtener más detalles.";
+"Youve_been_authenticated_successfully_pull_to_refresh" = "La autenticación se completó con éxito. Desliza para actualizar.";
 "Zip_code" = "Código postal";
 "accessibility.dashboard.buttons.activity" = "Actividad";
 "accessibility.dashboard.buttons.activity_hint" = "Abre actividades.";

--- a/Kickstarter-iOS/Locales/fr.lproj/Localizable.strings
+++ b/Kickstarter-iOS/Locales/fr.lproj/Localizable.strings
@@ -881,6 +881,7 @@
 "Youve_canceled_your_pledge_of_pledge_amount_for_project_name" = "Vous avez annulé votre engagement de <b>%{pledge_amount}</b> pour le projet <b>%{project_name}</b>.";
 "Youve_pledged_to_support_this_project" = "Vous vous êtes engagé à soutenir ce projet et sa campagne de financement n'est pas terminée.";
 "Youve_successfully_updated_your_pledge_to_amount_for_project_name" = "Votre engagement de %{amount} en soutien du projet %{project_name} a bien été mis à jour. Si le créateur atteint son objectif de financement, votre carte sera débitée le %{project_deadline}. Veuillez consulter votre messagerie pour plus d'informations.";
+"Youve_been_authenticated_successfully_pull_to_refresh" = "Vous avez été authentifié ! Veuillez tirer l\'écran vers le bas pour l\'actualiser.";
 "Zip_code" = "Code postal";
 "accessibility.dashboard.buttons.activity" = "Activité";
 "accessibility.dashboard.buttons.activity_hint" = "Ouvre l'activité.";

--- a/Kickstarter-iOS/Locales/ja.lproj/Localizable.strings
+++ b/Kickstarter-iOS/Locales/ja.lproj/Localizable.strings
@@ -881,6 +881,7 @@
 "Youve_canceled_your_pledge_of_pledge_amount_for_project_name" = "<b>%{project_name}</b> への <b>%{pledge_amount}</b> のプレッジを取り消しました。";
 "Youve_pledged_to_support_this_project" = "このプレッジ済のプロジェクトは、現在もファンド中";
 "Youve_successfully_updated_your_pledge_to_amount_for_project_name" = "%{project_name} へのプレッジを %{amount} に更新しました。プロジェクトがファンディングゴールに達成した場合には、%{project_deadline} 付けでご登録いただいたクレジットカードに請求されます。";
+"Youve_been_authenticated_successfully_pull_to_refresh" = "認証が成功しました！画面をプルダウンして更新してください。";
 "Zip_code" = "郵便番号";
 "accessibility.dashboard.buttons.activity" = "アクティビティ";
 "accessibility.dashboard.buttons.activity_hint" = "アクティビティをみる";

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -1175,6 +1175,7 @@
 		AA7BB4612CF67E5200E2B2D4 /* FetchUserSetup.graphql in Resources */ = {isa = PBXBuildFile; fileRef = AA7BB4602CF67E5200E2B2D4 /* FetchUserSetup.graphql */; };
 		AA7BB4632CF67E7900E2B2D4 /* UserFeaturesFragment.graphql in Resources */ = {isa = PBXBuildFile; fileRef = AA7BB4622CF67E7900E2B2D4 /* UserFeaturesFragment.graphql */; };
 		AA89B2562D010DA100B4D52E /* PPOProjectCardModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA89B2552D010DA100B4D52E /* PPOProjectCardModelTests.swift */; };
+		AAD759F42D2FA1F200A4E003 /* Publisher+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAD759F32D2FA1E900A4E003 /* Publisher+Helpers.swift */; };
 		AADDA7142CB6043D00E7112E /* ProjectAnalyticsProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = AADDA7132CB6043D00E7112E /* ProjectAnalyticsProperties.swift */; };
 		AADDA7162CB60B8B00E7112E /* ProjectAnalyticsFragment.graphql in Resources */ = {isa = PBXBuildFile; fileRef = AADDA7152CB60B8B00E7112E /* ProjectAnalyticsFragment.graphql */; };
 		AAE7C9A22C75142A00800E03 /* PPOStyles.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAE7C9A12C75142A00800E03 /* PPOStyles.swift */; };
@@ -2873,6 +2874,7 @@
 		AA89B2552D010DA100B4D52E /* PPOProjectCardModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PPOProjectCardModelTests.swift; sourceTree = "<group>"; };
 		AAA592782C5C708000482087 /* PPOProjectDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PPOProjectDetails.swift; sourceTree = "<group>"; };
 		AAD2BEE82C59B981003D8B95 /* PPOAlertFlag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PPOAlertFlag.swift; sourceTree = "<group>"; };
+		AAD759F32D2FA1E900A4E003 /* Publisher+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Publisher+Helpers.swift"; sourceTree = "<group>"; };
 		AADDA7132CB6043D00E7112E /* ProjectAnalyticsProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectAnalyticsProperties.swift; sourceTree = "<group>"; };
 		AADDA7152CB60B8B00E7112E /* ProjectAnalyticsFragment.graphql */ = {isa = PBXFileReference; lastKnownFileType = text; path = ProjectAnalyticsFragment.graphql; sourceTree = "<group>"; };
 		AAE7C9A12C75142A00800E03 /* PPOStyles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PPOStyles.swift; sourceTree = "<group>"; };
@@ -5925,6 +5927,7 @@
 		778F891A22D3E35600D095C5 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				AAD759F32D2FA1E900A4E003 /* Publisher+Helpers.swift */,
 				33914D6C2D07D23B00A67C47 /* UIView+Helper.swift */,
 				3385CF002CF6115D00A33D86 /* UIStackView+Helper.swift */,
 				77C9122623C4F99400F3D2C9 /* Double+Currency.swift */,
@@ -8069,6 +8072,7 @@
 				771E630C23426B27005967E8 /* CancelPledgeViewModel.swift in Sources */,
 				A7F441C51D005A9400FE6FC5 /* LoginToutViewModel.swift in Sources */,
 				D7E20EA7228B4B7D00BA61A0 /* PledgeCTAContainerViewViewModel.swift in Sources */,
+				AAD759F42D2FA1F200A4E003 /* Publisher+Helpers.swift in Sources */,
 				A75C811E1D210C4700B5AD03 /* ProjectActivityItemProvider.swift in Sources */,
 				370C8B6623590CA500DE75DD /* LoadingButtonViewModel.swift in Sources */,
 				606C45FA29FACE17001BA067 /* MockRemoteConfigClient.swift in Sources */,

--- a/KsApi/GraphAPI.swift
+++ b/KsApi/GraphAPI.swift
@@ -16240,6 +16240,7 @@ public enum GraphAPI {
           recipientName
           countryCode
         }
+        clientSecret
       }
       """
 
@@ -16253,6 +16254,7 @@ public enum GraphAPI {
         GraphQLField("project", type: .object(Project.selections)),
         GraphQLField("backingDetailsPageRoute", arguments: ["type": "url", "tab": "survey_responses"], type: .nonNull(.scalar(String.self))),
         GraphQLField("deliveryAddress", type: .object(DeliveryAddress.selections)),
+        GraphQLField("clientSecret", type: .scalar(String.self)),
       ]
     }
 
@@ -16262,8 +16264,8 @@ public enum GraphAPI {
       self.resultMap = unsafeResultMap
     }
 
-    public init(amount: Amount, id: GraphQLID, project: Project? = nil, backingDetailsPageRoute: String, deliveryAddress: DeliveryAddress? = nil) {
-      self.init(unsafeResultMap: ["__typename": "Backing", "amount": amount.resultMap, "id": id, "project": project.flatMap { (value: Project) -> ResultMap in value.resultMap }, "backingDetailsPageRoute": backingDetailsPageRoute, "deliveryAddress": deliveryAddress.flatMap { (value: DeliveryAddress) -> ResultMap in value.resultMap }])
+    public init(amount: Amount, id: GraphQLID, project: Project? = nil, backingDetailsPageRoute: String, deliveryAddress: DeliveryAddress? = nil, clientSecret: String? = nil) {
+      self.init(unsafeResultMap: ["__typename": "Backing", "amount": amount.resultMap, "id": id, "project": project.flatMap { (value: Project) -> ResultMap in value.resultMap }, "backingDetailsPageRoute": backingDetailsPageRoute, "deliveryAddress": deliveryAddress.flatMap { (value: DeliveryAddress) -> ResultMap in value.resultMap }, "clientSecret": clientSecret])
     }
 
     public var __typename: String {
@@ -16321,6 +16323,16 @@ public enum GraphAPI {
       }
       set {
         resultMap.updateValue(newValue?.resultMap, forKey: "deliveryAddress")
+      }
+    }
+
+    /// If `requires_action` is true, `client_secret` should be used to initiate additional client-side authentication steps
+    public var clientSecret: String? {
+      get {
+        return resultMap["clientSecret"] as? String
+      }
+      set {
+        resultMap.updateValue(newValue, forKey: "clientSecret")
       }
     }
 

--- a/KsApi/fragments/PPOBackingFragment.graphql
+++ b/KsApi/fragments/PPOBackingFragment.graphql
@@ -22,4 +22,7 @@ fragment PPOBackingFragment on Backing {
     recipientName
     countryCode
   }
+
+  # For Stripe
+  clientSecret
 }

--- a/Library/Extensions/Publisher+Helpers.swift
+++ b/Library/Extensions/Publisher+Helpers.swift
@@ -1,0 +1,11 @@
+import Combine
+
+extension Publisher {
+  /// Transforms the publisher's output into `Void`, discarding the original values
+  /// while preserving the timing and completion/error events.
+  ///
+  /// - Returns: A publisher that emits `Void` for each value from the upstream publisher.
+  public func withEmptyValues() -> Publishers.Map<Self, Void> {
+    map { _ in () }
+  }
+}

--- a/Library/Paginator.swift
+++ b/Library/Paginator.swift
@@ -140,6 +140,23 @@ public class Paginator<Envelope, Value: Equatable, Cursor: Equatable, SomeError:
         nil
       }
     }
+
+    public func mapValues(_ transform: ([Value]) -> [Value]) -> Results {
+      switch self {
+      case .unloaded:
+        return .unloaded
+      case let .someLoaded(values, cursor, total, page):
+        return .someLoaded(values: transform(values), cursor: cursor, total: total, page: page)
+      case let .allLoaded(values, page):
+        return .allLoaded(values: transform(values), page: page)
+      case .empty:
+        return .empty
+      case let .error(error):
+        return .error(error)
+      case let .loading(previous):
+        return .loading(previous: previous.mapValues(transform))
+      }
+    }
   }
 
   @Published public var results: Results

--- a/Library/Paginator.swift
+++ b/Library/Paginator.swift
@@ -141,6 +141,12 @@ public class Paginator<Envelope, Value: Equatable, Cursor: Equatable, SomeError:
       }
     }
 
+    /**
+     Transforms the values array within the current Results state while preserving the case and other properties.
+
+     - Parameter transform: A closure that takes an array of Values and returns a transformed array of Values
+     - Returns: A new Results instance with the transformed values (if the case has values)
+     */
     public func mapValues(_ transform: ([Value]) -> [Value]) -> Results {
       switch self {
       case .unloaded:


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

This PR adds support for letting a user handle 3DS authentication via Stripe.

# 🤔 Why

Stripe won't process some transactions otherwise.

# 🛠 How

When the user taps the "authorize card" button, I added a loading indicator to the button and updated the enum cases to include a way to turn that loading indicator off.

Then I added fetching the client secret from GraphQL and passing that through the enum case for triggering 3DS authentication.

With those pieces in place, I updated PPOViewModel to call Stripe's authentication check. In debug mode, this is simulated for ease of testing. When the callback completes, the app informs the user that the call has either succeeded or failed. This was done with a touched up version of the MessageBannerView that already existed and had some basic hookups in the PPOViewModel.

If successful, the item is hidden. This was done by adding filtering capability to PPOViewModel and tying it to the existing Publisher chain for populating results.

I also added some convenience helpers for clarity, such as `withEmptyValues()` on Publisher, a pattern that I was using in a few places, and a way to map the values of a Paginator's Results (in this case, to facilitate filtering).

# 👀 See

![Screen Recording 2025-01-08 at 23 01 46](https://github.com/user-attachments/assets/7231cdb0-4061-4451-a58b-e92f453831f8)

[Figma](https://www.figma.com/design/r0WKSECmMTCJTSKQskt2SQ/Backed-Projects-Dashboard?node-id=1496-31218&t=AiNoD7dHaEdTt6hT-0)

# ✅ Acceptance criteria

Tests should pass.

End-to-end testing should succeed.

