### PR TITLE
[MBL-1994] Add tap gesture handler for PPO project details

### DIFF
--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/CardView/PPOProjectCard.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/CardView/PPOProjectCard.swift
@@ -86,6 +86,9 @@ struct PPOProjectCard: View {
       leadingColumnWidth: leadingColumnWidth
     )
     .padding([.horizontal])
+    .onTapGesture {
+      self.viewModel.viewBackingDetails()
+    }
   }
 
   @ViewBuilder


### PR DESCRIPTION
# 📲 What

Adds a tap handler for the project details view in PPO to show the project details. Must've gotten merged out at some point.