### PR TITLE
[MBL-1995] Disable server feature flag and only rely on remote config

### DIFF
--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOContainerViewController.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOContainerViewController.swift
@@ -179,7 +179,6 @@ public class PPOContainerViewController: PagedContainerViewController<PPOContain
     clientSecret: String,
     onProgress: @escaping (PPOActionState) -> Void
   ) {
-
     if clientSecret.hasPrefix("seti_") {
       onProgress(.processing)
 
@@ -224,7 +223,7 @@ public class PPOContainerViewController: PagedContainerViewController<PPOContain
     STPPaymentHandler.shared().confirmPayment(
       paymentParams,
       with: self,
-      completion: { [weak self] status, _, y in
+      completion: { [weak self] status, _, _ in
         switch status {
         case .succeeded:
           self?.viewModel.process3DSAuthentication(state: .succeeded)

--- a/Library/Extensions/ServerFeature+Helpers.swift
+++ b/Library/Extensions/ServerFeature+Helpers.swift
@@ -1,17 +1,13 @@
 import Foundation
 import KsApi
 
-public func serverFeaturePledgedProjectsOverviewIsEnabled() -> Bool {
-  return ServerFeature.pledgeProjectsOverviewIos_2024.isEnabled()
-}
-
 extension ServerFeature {
   fileprivate func isEnabled(in environment: Environment = AppEnvironment.current) -> Bool {
     environment.currentUserServerFeatures?.contains(self) ?? false
   }
 }
 
-extension Set: EncodableType where Element == ServerFeature {
+extension Set: KsApi.EncodableType where Element == ServerFeature {
   public func encode() -> [String: Any] {
     ["features": Array(self).map { $0.rawValue }]
   }

--- a/Library/Extensions/ServerFeature+Helpers.swift
+++ b/Library/Extensions/ServerFeature+Helpers.swift
@@ -2,7 +2,7 @@ import Foundation
 import KsApi
 
 extension ServerFeature {
-  fileprivate func isEnabled(in environment: Environment = AppEnvironment.current) -> Bool {
+  private func isEnabled(in environment: Environment = AppEnvironment.current) -> Bool {
     environment.currentUserServerFeatures?.contains(self) ?? false
   }
 }

--- a/Library/ViewModels/RootViewModel.swift
+++ b/Library/ViewModels/RootViewModel.swift
@@ -443,12 +443,8 @@ private func currentUserActivitiesAndErroredPledgeCount() -> Int {
     (AppEnvironment.current.currentUser?.erroredBackingsCount ?? 0)
 }
 
-private func isPledgedProjectsOverviewEnabled() -> Bool {
-  featurePledgedProjectsOverviewEnabled() && serverFeaturePledgedProjectsOverviewIsEnabled()
-}
-
 private func generateStandardViewControllers() -> [RootViewControllerData] {
-  if isPledgedProjectsOverviewEnabled() {
+  if featurePledgedProjectsOverviewEnabled() {
     return [.discovery, .pledgedProjectsAndActivities, .search]
   }
   return [.discovery, .activities, .search]
@@ -475,7 +471,7 @@ extension TabBarItemsData: Equatable {}
 extension TabBarItem: Equatable {}
 
 private func activitiesBadgeValue(with value: Int?, hasPPOAction: Bool) -> String? {
-  guard !(hasPPOAction && isPledgedProjectsOverviewEnabled()) else {
+  guard !(hasPPOAction && featurePledgedProjectsOverviewEnabled()) else {
     // an empty string will show a dot as badge
     return ""
   }

--- a/Library/ViewModels/RootViewModelTests.swift
+++ b/Library/ViewModels/RootViewModelTests.swift
@@ -664,32 +664,6 @@ final class RootViewModelTests: TestCase {
       self.setBadgeValueAtIndexIndex.assertValues([1, 1])
     }
   }
-
-  func testPPOTabBarBadging_ServerFeatureFlagDisabled() {
-    let user = User.template
-      |> \.unseenActivityCount .~ 50
-      |> \.erroredBackingsCount .~ 4
-      |> \.ppoHasAction .~ true
-
-    let remoteConfig = MockRemoteConfigClient()
-    remoteConfig.features = [
-      RemoteConfigFeature.pledgedProjectsOverviewEnabled.rawValue: true
-    ]
-    let currentUserServerFeatures: Set<ServerFeature> = Set()
-
-    self.setBadgeValueAtIndexValue.assertValues([])
-    self.setBadgeValueAtIndexIndex.assertValues([])
-
-    withEnvironment(currentUserServerFeatures: currentUserServerFeatures, remoteConfigClient: remoteConfig) {
-      self.vm.inputs.viewDidLoad()
-
-      AppEnvironment.login(.init(accessToken: "deadbeef", user: user))
-      self.vm.inputs.currentUserUpdated()
-
-      self.setBadgeValueAtIndexValue.assertValues([nil, "54"])
-      self.setBadgeValueAtIndexIndex.assertValues([1, 1])
-    }
-  }
 }
 
 private func extractRootNames(_ vcs: [RootViewControllerData]) -> [String] {


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

We're no longer using server features to control PPO, and only relying on Remote Config. This PR removes the server feature check and code that implements it.