### PR TITLE
[MBL-1996] Don't fetch errored pledges if PPO is enabled

### DIFF
--- a/Library/ViewModels/ActivitiesViewModel.swift
+++ b/Library/ViewModels/ActivitiesViewModel.swift
@@ -235,8 +235,7 @@ public final class ActivitiesViewModel: ActivitiesViewModelType, ActitiviesViewM
           self.surveyResponseViewControllerDismissedProperty.signal
         )
       )
-      // Only fetch survey events if there's a logged-in user and PPO is not available.
-      .filter { $0 != nil && !featurePledgedProjectsOverviewEnabled() }
+      .filter { $0 != nil }
       .switchMap { _ in
         AppEnvironment.current.apiService.fetchUnansweredSurveyResponses()
           .materialize()

--- a/Library/ViewModels/ActivitiesViewModel.swift
+++ b/Library/ViewModels/ActivitiesViewModel.swift
@@ -179,6 +179,8 @@ public final class ActivitiesViewModel: ActivitiesViewModelType, ActitiviesViewM
       .map { _ in AppEnvironment.current.currentUser }
 
     let erroredBackingsEvent = currentUser
+      // Only fetch/show errored backings in activity if PPO is not available.
+      .filter { _ in !featurePledgedProjectsOverviewEnabled() }
       .skipNil()
       .switchMap { _ in
         AppEnvironment.current.apiService.fetchErroredUserBackings(status: .errored)
@@ -233,7 +235,8 @@ public final class ActivitiesViewModel: ActivitiesViewModelType, ActitiviesViewM
           self.surveyResponseViewControllerDismissedProperty.signal
         )
       )
-      .filter { $0 != nil }
+      // Only fetch survey events if there's a logged-in user and PPO is not available.
+      .filter { $0 != nil && !featurePledgedProjectsOverviewEnabled() }
       .switchMap { _ in
         AppEnvironment.current.apiService.fetchUnansweredSurveyResponses()
           .materialize()

--- a/Library/ViewModels/RootViewModel.swift
+++ b/Library/ViewModels/RootViewModel.swift
@@ -440,7 +440,7 @@ public final class RootViewModel: RootViewModelType, RootViewModelInputs, RootVi
 
 private func currentUserActivitiesAndErroredPledgeCount() -> Int {
   // Do not include errored pledges if PPO is enabled.
-  let errorCount = isPledgedProjectsOverviewEnabled()
+  let errorCount = featurePledgedProjectsOverviewEnabled()
     ? 0
     : AppEnvironment.current.currentUser?.erroredBackingsCount ?? 0
   return (AppEnvironment.current.currentUser?.unseenActivityCount ?? 0) + errorCount

--- a/Library/ViewModels/RootViewModel.swift
+++ b/Library/ViewModels/RootViewModel.swift
@@ -439,8 +439,11 @@ public final class RootViewModel: RootViewModelType, RootViewModelInputs, RootVi
 }
 
 private func currentUserActivitiesAndErroredPledgeCount() -> Int {
-  (AppEnvironment.current.currentUser?.unseenActivityCount ?? 0) +
-    (AppEnvironment.current.currentUser?.erroredBackingsCount ?? 0)
+  // Do not include errored pledges if PPO is enabled.
+  let errorCount = isPledgedProjectsOverviewEnabled()
+    ? 0
+    : AppEnvironment.current.currentUser?.erroredBackingsCount ?? 0
+  return (AppEnvironment.current.currentUser?.unseenActivityCount ?? 0) + errorCount
 }
 
 private func isPledgedProjectsOverviewEnabled() -> Bool {


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Since PPO will live right next to activities, it feels redundant to show the same information in both places. We will still show surveys in both places, however, at least while some surveys show in Activity without being available in PPO.

# 👀 See

[Jira](https://kickstarter.atlassian.net/browse/MBL-1996)

| Before 🐛 | After 🦋 |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/ca758108-f062-4f4b-baef-3984074bf559) | ![image](https://github.com/user-attachments/assets/6f32d945-c158-417e-b13d-908cd33a0551) |

# ✅ Acceptance criteria

- [x] When PPO flag is on, errored pledges are not included in the activity count and errored pledges don't show in Activity
- [x] When PPO flag is off, errored pledges are included in both

# ⏰ TODO

- We will likely want to hide surveys as well, once all surveys are available as part of PPO, but that's been removed from this ticket.
- If we decide to only roll out to superbackers after all, this change will need to be rolled back, too.
