### PR TITLE
[MBL-2006] PLOT Terms of Use Button Disappearing On Manage Pledge Screen

### DIFF
--- a/Kickstarter-iOS/Features/ManagePledge/Controllers/PledgeOverTimePaymentScheduleViewController.swift
+++ b/Kickstarter-iOS/Features/ManagePledge/Controllers/PledgeOverTimePaymentScheduleViewController.swift
@@ -56,6 +56,7 @@ final class PledgeOverTimePaymentScheduleViewController: UIViewController {
     self.paymentsScheduleStackView.isHidden = true
     self.titleLabel.text = Strings.Payment_schedule()
 
+    self.termsOfUseButton.setContentCompressionResistancePriority(.required, for: .vertical)
     self.termsOfUseButton.setAttributedTitle(
       NSAttributedString(
         string: Strings.login_tout_help_sheet_terms(),


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Keeps the Terms of Use button on the Payment Schedule of the Manage Pledge screen from disappearing when the web view that it launches is dismissed.

# 🤔 Why

After launching the terms of use web view, this button disappears after dismissing it. 

This is only happening on a physical device, and the theory is that since the terms of use button is the only element that does not have a height constraint, it gets compressed (it's height set to 0) when the layout updates upon closing the web view.

# 🛠 How

This is difficult to verify, but the solution below seems to have resolved it.

Sets the `setContentCompressionResistancePriority` on the terms of use button.

# ✅ Acceptance criteria

- [x] Tested on my iphone 14 pro and the terms of use button remains visible and clickable as expected.
