### PR TITLE
Create ApplePayTokenUseCase and tests

### DIFF
--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -1595,6 +1595,8 @@
 		E13D76812D42CBA400FB58CE /* LoginSignupUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E13D767E2D42C52900FB58CE /* LoginSignupUseCaseTests.swift */; };
 		E13D76712D4011BF00FB58CE /* PaymentMethodsUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = E13D76702D4011BF00FB58CE /* PaymentMethodsUseCase.swift */; };
 		E13D76742D404F1600FB58CE /* PaymentMethodsUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E13D76722D40438100FB58CE /* PaymentMethodsUseCaseTests.swift */; };
+		E13D76762D41698500FB58CE /* ApplePayTokenUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = E13D76752D41698000FB58CE /* ApplePayTokenUseCase.swift */; };
+		E13D76792D419A5900FB58CE /* ApplePayTokenUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E13D76772D4195E700FB58CE /* ApplePayTokenUseCaseTests.swift */; };
 		E16794282B7EAA5200064063 /* OAuthTokenExchange.swift in Sources */ = {isa = PBXBuildFile; fileRef = E16794272B7EAA5200064063 /* OAuthTokenExchange.swift */; };
 		E167942A2B85136900064063 /* OAuthTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E16794292B85136900064063 /* OAuthTests.swift */; };
 		E16ECA702C245A34002A1D25 /* PagedContainerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E16ECA6F2C245A34002A1D25 /* PagedContainerViewController.swift */; };
@@ -3314,6 +3316,8 @@
 		E13D767E2D42C52900FB58CE /* LoginSignupUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginSignupUseCaseTests.swift; sourceTree = "<group>"; };
 		E13D76702D4011BF00FB58CE /* PaymentMethodsUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentMethodsUseCase.swift; sourceTree = "<group>"; };
 		E13D76722D40438100FB58CE /* PaymentMethodsUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentMethodsUseCaseTests.swift; sourceTree = "<group>"; };
+		E13D76752D41698000FB58CE /* ApplePayTokenUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplePayTokenUseCase.swift; sourceTree = "<group>"; };
+		E13D76772D4195E700FB58CE /* ApplePayTokenUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplePayTokenUseCaseTests.swift; sourceTree = "<group>"; };
 		E16794272B7EAA5200064063 /* OAuthTokenExchange.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthTokenExchange.swift; sourceTree = "<group>"; };
 		E16794292B85136900064063 /* OAuthTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthTests.swift; sourceTree = "<group>"; };
 		E16ECA6F2C245A34002A1D25 /* PagedContainerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PagedContainerViewController.swift; sourceTree = "<group>"; };
@@ -6608,6 +6612,8 @@
 				A757EAEF1D1ABE7400A5C978 /* ActivitySurveyResponseCellViewModel.swift */,
 				A7F441921D005A9400FE6FC5 /* ActivityUpdateViewModel.swift */,
 				A7ED1F7A1E831C5C00BFFA01 /* ActivityUpdateViewModelTests.swift */,
+				E13D76752D41698000FB58CE /* ApplePayTokenUseCase.swift */,
+				E13D76772D4195E700FB58CE /* ApplePayTokenUseCaseTests.swift */,
 				015572721E79C4FF005FB8CC /* BackerDashboardProjectCellViewModel.swift */,
 				A7A627161E85BA5F004C931A /* BackerDashboardProjectCellViewModelTests.swift */,
 				014D629A1E6E31790033D2BD /* BackerDashboardProjectsViewModel.swift */,
@@ -8259,6 +8265,7 @@
 				606C45F529FACD78001BA067 /* RemoteConfigFeature+Helpers.swift in Sources */,
 				598D96C21D429756003F3F66 /* ActivitySampleStyles.swift in Sources */,
 				8AE8D86623466EB9005860C6 /* UpdateBackingInput+Constructor.swift in Sources */,
+				E13D76762D41698500FB58CE /* ApplePayTokenUseCase.swift in Sources */,
 				59B0E07E1D147F340081D2DC /* DashboardStyles.swift in Sources */,
 				0169F8C11D6CA27500C8D5C5 /* RootCategory.swift in Sources */,
 				D04AAC21218BB70D00CF713E /* ChangePasswordViewModel.swift in Sources */,
@@ -8507,6 +8514,7 @@
 				8AE8D86823466EDB005860C6 /* UpdateBackingInput+ConstructorTests.swift in Sources */,
 				D04AACAD218BB72100CF713E /* SettingsNotificationPickerViewModelTests.swift in Sources */,
 				E13D76812D42CBA400FB58CE /* LoginSignupUseCaseTests.swift in Sources */,
+				E13D76792D419A5900FB58CE /* ApplePayTokenUseCaseTests.swift in Sources */,
 				A7ED1FBF1E831C5C00BFFA01 /* SortPagerViewModelTests.swift in Sources */,
 				D6AE53161FD1E05E00BEC788 /* String+Base64Tests.swift in Sources */,
 				A7ED1FCB1E831C5C00BFFA01 /* ActivityFriendBackingViewModelTests.swift in Sources */,

--- a/Library/ViewModels/ApplePayTokenUseCase.swift
+++ b/Library/ViewModels/ApplePayTokenUseCase.swift
@@ -1,0 +1,160 @@
+import Foundation
+import KsApi
+import PassKit
+import ReactiveSwift
+
+public protocol ApplePayTokenUseCaseInputs {
+  func applePayButtonTapped()
+  func paymentAuthorizationDidAuthorizePayment(paymentData: (
+    displayName: String?,
+    network: String?,
+    transactionIdentifier: String
+  ))
+  func paymentAuthorizationViewControllerDidFinish()
+  func stripeTokenCreated(token: String?, error: Error?) -> PKPaymentAuthorizationStatus
+}
+
+public protocol ApplePayTokenUseCaseOutputs {
+  var goToApplePayPaymentAuthorization: Signal<PKPaymentRequest, Never> { get }
+  var applePayParams: Signal<ApplePayParams?, Never> { get }
+  var applePayAuthorizationStatus: Signal<PKPaymentAuthorizationStatus, Never> { get }
+}
+
+/**
+ A use case for ApplePay transactions in the regular (not post!) pledge flow.
+
+ To complete an ApplePay payment, the use case should be used in this order:
+ - `input.applePayButtonTapped()` - The ApplePay button has been tapped
+ - `output.goToApplePayPaymentAuthorization` - The view controller should display a `PKPaymentAuthorizationViewController` with the sent `PKPaymentRequest`
+ - `input.paymentAuthorizationDidAuthorizePayment(paymentData:)` - The `PKPaymentAuthorizationViewController` successfully authorized a payment
+ - `input.stripeTokenCreated(token:error:)` - Stripe successfully turned the `PKPayment` into a Stripe token. Returns a status, which is also sent by the `applePayAuthorizationStatus` signal.
+ - `input.paymentAuthorizationViewControllerDidFinish()` - The `PKPaymentAuthorizationViewController` was dismissed
+ - `output.applePayParams` - Sends parameters which can be used in `CreateBacking` or `UpdateBacking`. Sends an initial `nil`value, by default.
+
+ Other inputs and outputs:
+
+ Inputs:
+ - `initialData` - An `initialData` event is required for any other signals to send.
+
+ Outputs:
+ - `applePayAuthorizationStatus` - Sends an event indicating whether the ApplePay flow succeeded or failed.
+  */
+
+public final class ApplePayTokenUseCase: ApplePayTokenUseCaseInputs, ApplePayTokenUseCaseOutputs {
+  init(initialData: Signal<PaymentAuthorizationData, Never>) {
+    let paymentAuthorizationData: Signal<PKPaymentRequest, Never> =
+      initialData
+        .map { project, reward, allRewardsTotal, additionalPledgeAmount, shippingTotal, merchantIdentifier -> PKPaymentRequest in
+          PKPaymentRequest
+            .paymentRequest(
+              for: project,
+              reward: reward,
+              allRewardsTotal: allRewardsTotal,
+              additionalPledgeAmount: additionalPledgeAmount,
+              allRewardsShippingTotal: shippingTotal,
+              merchantIdentifier: merchantIdentifier
+            )
+        }
+
+    self.goToApplePayPaymentAuthorization = paymentAuthorizationData
+      .takeWhen(self.applePayButtonTappedSignal)
+
+    let pkPaymentData = self.pkPaymentSignal
+      .map { pkPayment -> PKPaymentData? in
+        guard let displayName = pkPayment.displayName, let network = pkPayment.network else {
+          return nil
+        }
+
+        return (displayName, network, pkPayment.transactionIdentifier)
+      }
+
+    let applePayStatusSuccess = Signal.combineLatest(
+      self.stripeTokenSignal.skipNil(),
+      self.stripeErrorSignal.filter { $0 == nil },
+      pkPaymentData.skipNil()
+    )
+    .mapConst(PKPaymentAuthorizationStatus.success)
+
+    let applePayStatusFailure = Signal.merge(
+      self.stripeErrorSignal.skipNil().ignoreValues(),
+      self.stripeTokenSignal.filter { $0 == nil }.ignoreValues(),
+      pkPaymentData.filter { $0 == nil }.ignoreValues()
+    )
+    .mapConst(PKPaymentAuthorizationStatus.failure)
+
+    self.createApplePayBackingStatusProperty <~ Signal.merge(
+      applePayStatusSuccess,
+      applePayStatusFailure
+    )
+
+    let applePayParams = Signal.combineLatest(
+      pkPaymentData.skipNil(),
+      self.stripeTokenSignal.skipNil()
+    )
+    .map { paymentData, token in
+      (
+        paymentData.displayName,
+        paymentData.network,
+        paymentData.transactionIdentifier,
+        token
+      )
+    }
+    .map(ApplePayParams.init)
+    .takeWhen(self.paymentAuthorizationDidFinishSignal)
+
+    self.applePayParams = Signal.merge(
+      initialData.mapConst(nil),
+      applePayParams.wrapInOptional()
+    )
+
+    self.applePayAuthorizationStatus = self.createApplePayBackingStatusProperty.signal
+  }
+
+  // MARK: - Inputs
+
+  private let (applePayButtonTappedSignal, applePayButtonTappedObserver) = Signal<Void, Never>.pipe()
+  public func applePayButtonTapped() {
+    self.applePayButtonTappedObserver.send(value: ())
+  }
+
+  private let (pkPaymentSignal, pkPaymentObserver) = Signal<(
+    displayName: String?,
+    network: String?,
+    transactionIdentifier: String
+  ), Never>.pipe()
+  public func paymentAuthorizationDidAuthorizePayment(paymentData: (
+    displayName: String?,
+    network: String?,
+    transactionIdentifier: String
+  )) {
+    self.pkPaymentObserver.send(value: paymentData)
+  }
+
+  private let (paymentAuthorizationDidFinishSignal, paymentAuthorizationDidFinishObserver)
+    = Signal<Void, Never>.pipe()
+  public func paymentAuthorizationViewControllerDidFinish() {
+    self.paymentAuthorizationDidFinishObserver.send(value: ())
+  }
+
+  private let (stripeTokenSignal, stripeTokenObserver) = Signal<String?, Never>.pipe()
+  private let (stripeErrorSignal, stripeErrorObserver) = Signal<Error?, Never>.pipe()
+
+  private let createApplePayBackingStatusProperty = MutableProperty<PKPaymentAuthorizationStatus>(.failure)
+  public func stripeTokenCreated(token: String?, error: Error?) -> PKPaymentAuthorizationStatus {
+    self.stripeTokenObserver.send(value: token)
+    self.stripeErrorObserver.send(value: error)
+
+    return self.createApplePayBackingStatusProperty.value
+  }
+
+  // MARK: - Outputs
+
+  public let goToApplePayPaymentAuthorization: Signal<PKPaymentRequest, Never>
+  public let applePayParams: Signal<ApplePayParams?, Never>
+  public let applePayAuthorizationStatus: Signal<PKPaymentAuthorizationStatus, Never>
+
+  // MARK: - Interface
+
+  public var inputs: ApplePayTokenUseCaseInputs { return self }
+  public var outputs: ApplePayTokenUseCaseOutputs { return self }
+}

--- a/Library/ViewModels/ApplePayTokenUseCase.swift
+++ b/Library/ViewModels/ApplePayTokenUseCase.swift
@@ -3,7 +3,13 @@ import KsApi
 import PassKit
 import ReactiveSwift
 
-public protocol ApplePayTokenUseCaseInputs {
+public protocol ApplePayTokenUseCaseType {
+  var uiInputs: ApplePayTokenUseCaseUIInputs { get }
+  var uiOutputs: ApplePayTokenUseCaseUIOutputs { get }
+  var dataOutputs: ApplePayTokenUseCaseDataOutputs { get }
+}
+
+public protocol ApplePayTokenUseCaseUIInputs {
   func applePayButtonTapped()
   func paymentAuthorizationDidAuthorizePayment(paymentData: (
     displayName: String?,
@@ -14,8 +20,11 @@ public protocol ApplePayTokenUseCaseInputs {
   func stripeTokenCreated(token: String?, error: Error?) -> PKPaymentAuthorizationStatus
 }
 
-public protocol ApplePayTokenUseCaseOutputs {
+public protocol ApplePayTokenUseCaseUIOutputs {
   var goToApplePayPaymentAuthorization: Signal<PKPaymentRequest, Never> { get }
+}
+
+public protocol ApplePayTokenUseCaseDataOutputs {
   var applePayParams: Signal<ApplePayParams?, Never> { get }
   var applePayAuthorizationStatus: Signal<PKPaymentAuthorizationStatus, Never> { get }
 }
@@ -33,14 +42,15 @@ public protocol ApplePayTokenUseCaseOutputs {
 
  Other inputs and outputs:
 
- Inputs:
+ Data Inputs:
  - `initialData` - An `initialData` event is required for any other signals to send.
 
- Outputs:
+ Data Outputs:
  - `applePayAuthorizationStatus` - Sends an event indicating whether the ApplePay flow succeeded or failed.
   */
 
-public final class ApplePayTokenUseCase: ApplePayTokenUseCaseInputs, ApplePayTokenUseCaseOutputs {
+public final class ApplePayTokenUseCase: ApplePayTokenUseCaseType, ApplePayTokenUseCaseUIInputs,
+  ApplePayTokenUseCaseUIOutputs, ApplePayTokenUseCaseDataOutputs {
   init(initialData: Signal<PaymentAuthorizationData, Never>) {
     let paymentAuthorizationData: Signal<PKPaymentRequest, Never> =
       initialData
@@ -155,6 +165,7 @@ public final class ApplePayTokenUseCase: ApplePayTokenUseCaseInputs, ApplePayTok
 
   // MARK: - Interface
 
-  public var inputs: ApplePayTokenUseCaseInputs { return self }
-  public var outputs: ApplePayTokenUseCaseOutputs { return self }
+  public var uiInputs: ApplePayTokenUseCaseUIInputs { return self }
+  public var uiOutputs: ApplePayTokenUseCaseUIOutputs { return self }
+  public var dataOutputs: ApplePayTokenUseCaseDataOutputs { return self }
 }

--- a/Library/ViewModels/ApplePayTokenUseCaseTests.swift
+++ b/Library/ViewModels/ApplePayTokenUseCaseTests.swift
@@ -13,7 +13,7 @@ final class ApplePayTokenUseCaseTests: TestCase {
 
   var useCase: ApplePayTokenUseCase!
 
-  let goToApplePayPaymentAuthorization = TestObserver<PKPaymentRequest, Never>()
+  let goToApplePayPaymentAuthorization = TestObserver<PaymentAuthorizationData, Never>()
   let applePayParams = TestObserver<ApplePayParams?, Never>()
   let applePayAuthorizationStatus = TestObserver<PKPaymentAuthorizationStatus, Never>()
 

--- a/Library/ViewModels/ApplePayTokenUseCaseTests.swift
+++ b/Library/ViewModels/ApplePayTokenUseCaseTests.swift
@@ -24,10 +24,10 @@ final class ApplePayTokenUseCaseTests: TestCase {
       initialData: self.initialDataSignal
     )
 
-    self.useCase.outputs.goToApplePayPaymentAuthorization
+    self.useCase.uiOutputs.goToApplePayPaymentAuthorization
       .observe(self.goToApplePayPaymentAuthorization.observer)
-    self.useCase.outputs.applePayAuthorizationStatus.observe(self.applePayAuthorizationStatus.observer)
-    self.useCase.outputs.applePayParams.observe(self.applePayParams.observer)
+    self.useCase.dataOutputs.applePayAuthorizationStatus.observe(self.applePayAuthorizationStatus.observer)
+    self.useCase.dataOutputs.applePayParams.observe(self.applePayParams.observer)
   }
 
   func testUseCase_GoesToPaymentAuthorization_WhenApplePayButtonIsTapped() {
@@ -44,7 +44,7 @@ final class ApplePayTokenUseCaseTests: TestCase {
 
     self.goToApplePayPaymentAuthorization.assertDidNotEmitValue()
 
-    self.useCase.inputs.applePayButtonTapped()
+    self.useCase.uiInputs.applePayButtonTapped()
 
     self.goToApplePayPaymentAuthorization.assertDidEmitValue()
   }
@@ -75,22 +75,22 @@ final class ApplePayTokenUseCaseTests: TestCase {
 
     self.initialDataObserver.send(value: data)
 
-    self.useCase.inputs.applePayButtonTapped()
+    self.useCase.uiInputs.applePayButtonTapped()
     self.goToApplePayPaymentAuthorization.assertDidEmitValue()
 
-    self.useCase.inputs.paymentAuthorizationDidAuthorizePayment(paymentData: (
+    self.useCase.uiInputs.paymentAuthorizationDidAuthorizePayment(paymentData: (
       "Display Name",
       "Network",
       "Transaction Identifier"
     ))
     self.applePayParams.assertLastValue(nil, "Params shouldn't emit until transaction is finished")
 
-    let status = self.useCase.inputs.stripeTokenCreated(token: "some_stripe_token", error: nil)
+    let status = self.useCase.uiInputs.stripeTokenCreated(token: "some_stripe_token", error: nil)
     XCTAssertEqual(status, PKPaymentAuthorizationStatus.success)
 
     self.applePayParams.assertLastValue(nil, "Params shouldn't emit until transaction is finished")
 
-    self.useCase.inputs.paymentAuthorizationViewControllerDidFinish()
+    self.useCase.uiInputs.paymentAuthorizationViewControllerDidFinish()
 
     self.applePayAuthorizationStatus.assertLastValue(PKPaymentAuthorizationStatus.success)
     self.applePayParams.assertDidEmitValue()
@@ -116,17 +116,17 @@ final class ApplePayTokenUseCaseTests: TestCase {
 
     self.initialDataObserver.send(value: data)
 
-    self.useCase.inputs.applePayButtonTapped()
-    self.useCase.inputs.paymentAuthorizationDidAuthorizePayment(paymentData: (
+    self.useCase.uiInputs.applePayButtonTapped()
+    self.useCase.uiInputs.paymentAuthorizationDidAuthorizePayment(paymentData: (
       "Display Name",
       "Network",
       "Transaction Identifier"
     ))
 
-    let status = self.useCase.inputs.stripeTokenCreated(token: nil, error: TestError())
+    let status = self.useCase.uiInputs.stripeTokenCreated(token: nil, error: TestError())
     XCTAssertEqual(status, PKPaymentAuthorizationStatus.failure)
 
-    self.useCase.inputs.paymentAuthorizationViewControllerDidFinish()
+    self.useCase.uiInputs.paymentAuthorizationViewControllerDidFinish()
 
     self.applePayAuthorizationStatus.assertLastValue(PKPaymentAuthorizationStatus.failure)
     self.applePayParams.assertLastValue(nil, "Params shouldn't emit when Stripe fails")
@@ -144,8 +144,8 @@ final class ApplePayTokenUseCaseTests: TestCase {
 
     self.initialDataObserver.send(value: data)
 
-    self.useCase.inputs.applePayButtonTapped()
-    self.useCase.inputs.paymentAuthorizationViewControllerDidFinish()
+    self.useCase.uiInputs.applePayButtonTapped()
+    self.useCase.uiInputs.paymentAuthorizationViewControllerDidFinish()
 
     self.applePayAuthorizationStatus.assertDidNotEmitValue()
     self.applePayParams.assertLastValue(nil, "Params shouldn't emit when ApplePay is canceled")

--- a/Library/ViewModels/ApplePayTokenUseCaseTests.swift
+++ b/Library/ViewModels/ApplePayTokenUseCaseTests.swift
@@ -1,0 +1,155 @@
+@testable import KsApi
+@testable import Library
+import PassKit
+import ReactiveExtensions_TestHelpers
+import ReactiveSwift
+import XCTest
+
+final class ApplePayTokenUseCaseTests: TestCase {
+  let (initialDataSignal, initialDataObserver) = Signal<PaymentAuthorizationData, Never>.pipe()
+  let (allRewardsTotalSignal, allRewardsTotalObserver) = Signal<Double, Never>.pipe()
+  let (additionalPledgeAmountSignal, additionalPledgeAmountObserver) = Signal<Double, Never>.pipe()
+  let (allRewardsShippingTotalSignal, allRewardsShippingTotalObserver) = Signal<Double, Never>.pipe()
+
+  var useCase: ApplePayTokenUseCase!
+
+  let goToApplePayPaymentAuthorization = TestObserver<PKPaymentRequest, Never>()
+  let applePayParams = TestObserver<ApplePayParams?, Never>()
+  let applePayAuthorizationStatus = TestObserver<PKPaymentAuthorizationStatus, Never>()
+
+  override func setUp() {
+    super.setUp()
+
+    self.useCase = ApplePayTokenUseCase(
+      initialData: self.initialDataSignal
+    )
+
+    self.useCase.outputs.goToApplePayPaymentAuthorization
+      .observe(self.goToApplePayPaymentAuthorization.observer)
+    self.useCase.outputs.applePayAuthorizationStatus.observe(self.applePayAuthorizationStatus.observer)
+    self.useCase.outputs.applePayParams.observe(self.applePayParams.observer)
+  }
+
+  func testUseCase_GoesToPaymentAuthorization_WhenApplePayButtonIsTapped() {
+    let data = PaymentAuthorizationData(
+      project: Project.template,
+      reward: Reward.template,
+      allRewardsTotal: 92.0,
+      additionalPledgeAmount: 15.0,
+      allRewardsShippingTotal: 33.0,
+      merchantIdentifier: "foo.bar.baz"
+    )
+
+    self.initialDataObserver.send(value: data)
+
+    self.goToApplePayPaymentAuthorization.assertDidNotEmitValue()
+
+    self.useCase.inputs.applePayButtonTapped()
+
+    self.goToApplePayPaymentAuthorization.assertDidEmitValue()
+  }
+
+  func testUseCase_ApplePayParams_DefaultToNil() {
+    let data = PaymentAuthorizationData(
+      project: Project.template,
+      reward: Reward.template,
+      allRewardsTotal: 92.0,
+      additionalPledgeAmount: 15.0,
+      allRewardsShippingTotal: 33.0,
+      merchantIdentifier: "foo.bar.baz"
+    )
+
+    self.initialDataObserver.send(value: data)
+    self.applePayParams.assertLastValue(nil)
+  }
+
+  func testUseCase_CompletingApplePayFlow_SendsApplePayParamsAndStatus() {
+    let data = PaymentAuthorizationData(
+      project: Project.template,
+      reward: Reward.template,
+      allRewardsTotal: 92.0,
+      additionalPledgeAmount: 15.0,
+      allRewardsShippingTotal: 33.0,
+      merchantIdentifier: "foo.bar.baz"
+    )
+
+    self.initialDataObserver.send(value: data)
+
+    self.useCase.inputs.applePayButtonTapped()
+    self.goToApplePayPaymentAuthorization.assertDidEmitValue()
+
+    self.useCase.inputs.paymentAuthorizationDidAuthorizePayment(paymentData: (
+      "Display Name",
+      "Network",
+      "Transaction Identifier"
+    ))
+    self.applePayParams.assertLastValue(nil, "Params shouldn't emit until transaction is finished")
+
+    let status = self.useCase.inputs.stripeTokenCreated(token: "some_stripe_token", error: nil)
+    XCTAssertEqual(status, PKPaymentAuthorizationStatus.success)
+
+    self.applePayParams.assertLastValue(nil, "Params shouldn't emit until transaction is finished")
+
+    self.useCase.inputs.paymentAuthorizationViewControllerDidFinish()
+
+    self.applePayAuthorizationStatus.assertLastValue(PKPaymentAuthorizationStatus.success)
+    self.applePayParams.assertDidEmitValue()
+
+    XCTAssertNotNil(self.applePayParams.lastValue as Any)
+
+    let params = self.applePayParams.lastValue!!
+    XCTAssertEqual(params.token, "some_stripe_token")
+    XCTAssertEqual(params.paymentInstrumentName, "Display Name")
+    XCTAssertEqual(params.paymentNetwork, "Network")
+    XCTAssertEqual(params.transactionIdentifier, "Transaction Identifier")
+  }
+
+  func testUseCase_StripeError_SendsFailedStatus() {
+    let data = PaymentAuthorizationData(
+      project: Project.template,
+      reward: Reward.template,
+      allRewardsTotal: 92.0,
+      additionalPledgeAmount: 15.0,
+      allRewardsShippingTotal: 33.0,
+      merchantIdentifier: "foo.bar.baz"
+    )
+
+    self.initialDataObserver.send(value: data)
+
+    self.useCase.inputs.applePayButtonTapped()
+    self.useCase.inputs.paymentAuthorizationDidAuthorizePayment(paymentData: (
+      "Display Name",
+      "Network",
+      "Transaction Identifier"
+    ))
+
+    let status = self.useCase.inputs.stripeTokenCreated(token: nil, error: TestError())
+    XCTAssertEqual(status, PKPaymentAuthorizationStatus.failure)
+
+    self.useCase.inputs.paymentAuthorizationViewControllerDidFinish()
+
+    self.applePayAuthorizationStatus.assertLastValue(PKPaymentAuthorizationStatus.failure)
+    self.applePayParams.assertLastValue(nil, "Params shouldn't emit when Stripe fails")
+  }
+
+  func testUseCase_ApplePayIsCanceled_DoesNotSendParams() {
+    let data = PaymentAuthorizationData(
+      project: Project.template,
+      reward: Reward.template,
+      allRewardsTotal: 92.0,
+      additionalPledgeAmount: 15.0,
+      allRewardsShippingTotal: 33.0,
+      merchantIdentifier: "foo.bar.baz"
+    )
+
+    self.initialDataObserver.send(value: data)
+
+    self.useCase.inputs.applePayButtonTapped()
+    self.useCase.inputs.paymentAuthorizationViewControllerDidFinish()
+
+    self.applePayAuthorizationStatus.assertDidNotEmitValue()
+    self.applePayParams.assertLastValue(nil, "Params shouldn't emit when ApplePay is canceled")
+  }
+}
+
+private class TestError: Error {}


### PR DESCRIPTION
# 📲 What

Create a use case that will handle ApplePay in the regular (live) pledge flow.

# 🤔 Why

This puts a lot of ApplePay code in one place, so we can pull it out of `NoShippingPledgeViewModel` in the next release.

More broadly: our goal is to simplify our checkout code. One way we can do this is by breaking it down into smaller, more understandable parts. We're following Android's lead here and building 'Use Cases', which are small chunks of code related to a single behavior or feature. These little pieces are much easier to understand, debug, and test.

It's worth noting that ApplePay in late + live pledges is fundamentally different - they use different Stripe APIs. It would be nice to consolidate that, but that would be out of scope without further API changes. This is just a refactoring for niceness and modularity, instead of code re-use.