### PR TITLE
Disable PPO when logged out

### DIFF
--- a/Library/ViewModels/ActivitiesViewModel.swift
+++ b/Library/ViewModels/ActivitiesViewModel.swift
@@ -180,7 +180,7 @@ public final class ActivitiesViewModel: ActivitiesViewModelType, ActitiviesViewM
 
     let erroredBackingsEvent = currentUser
       // Only fetch/show errored backings in activity if PPO is not available.
-      .filter { _ in !featurePledgedProjectsOverviewEnabled() }
+      .filter { user in !(featurePledgedProjectsOverviewEnabled() && user != nil) }
       .skipNil()
       .switchMap { _ in
         AppEnvironment.current.apiService.fetchErroredUserBackings(status: .errored)

--- a/Library/ViewModels/RootViewModel.swift
+++ b/Library/ViewModels/RootViewModel.swift
@@ -149,16 +149,10 @@ public final class RootViewModel: RootViewModelType, RootViewModelInputs, RootVi
       }
       .skipRepeats(==)
 
-    let standardViewControllers = self.viewDidLoadProperty.signal
-      .combineLatest(with: loginState)
-      .map { _, loginState -> [RootViewControllerData] in
-        generateStandardViewControllers(isLoggedIn: loginState)
-      }
-    let personalizedViewControllers = loginState.map { loginState -> [RootViewControllerData] in
-      generatePersonalizedViewControllers(isLoggedIn: loginState)
+    let viewControllers = loginState.map { loginState -> [RootViewControllerData] in
+      generateStandardViewControllers(isLoggedIn: loginState) +
+        generatePersonalizedViewControllers(isLoggedIn: loginState)
     }
-
-    let viewControllers = Signal.combineLatest(standardViewControllers, personalizedViewControllers).map(+)
 
     let refreshedViewControllers = loginState.takeWhen(self.userLocalePreferencesChangedProperty.signal)
       .map { loginState -> [RootViewControllerData] in
@@ -448,7 +442,7 @@ private func currentUserActivitiesAndErroredPledgeCount() -> Int {
 }
 
 private func generateStandardViewControllers(isLoggedIn: Bool) -> [RootViewControllerData] {
-  if featurePledgedProjectsOverviewEnabled() && isLoggedIn {
+  if featurePledgedProjectsOverviewEnabled(), isLoggedIn {
     return [.discovery, .pledgedProjectsAndActivities, .search]
   }
   return [.discovery, .activities, .search]


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Disables PPO tab when the user is logged out.

# 🤔 Why

It shows an error when logged out, and not the CTA to log in.

# 🛠 How

Changes to RootViewModel to add "isLoggedIn" support to the signal that regenerates view controllers.

This does mean that the "personalizedViewControllers" function is maybe a little redundant but that's bigger than this PR change.

# ✅ Acceptance criteria

- When logged in (and after logging in), the activity tab should show PPO when the feature flag is enabled
- When logged out (and after logging out), the activity tab should NOT show PPO
