### PR TITLE
MBL-2020: Use BorderlessButtonStyle for message creator button

### DIFF
--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/CardView/PPOProjectCard.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/CardView/PPOProjectCard.swift
@@ -79,27 +79,33 @@ struct PPOProjectCard: View {
 
   @ViewBuilder
   private func projectDetails(leadingColumnWidth: CGFloat) -> some View {
-    PPOProjectDetails(
-      image: self.viewModel.card.image,
-      title: self.viewModel.card.projectName,
-      pledge: self.viewModel.card.pledge,
-      leadingColumnWidth: leadingColumnWidth
-    )
-    .padding([.horizontal])
-    .onTapGesture {
+    Button {
       self.viewModel.viewBackingDetails()
+    } label: {
+      PPOProjectDetails(
+        image: self.viewModel.card.image,
+        title: self.viewModel.card.projectName,
+        pledge: self.viewModel.card.pledge,
+        leadingColumnWidth: leadingColumnWidth
+      )
+      .padding([.horizontal])
     }
+    // MBL-2020: Keeps the button action from being triggered by other taps in the card.
+    .buttonStyle(BorderlessButtonStyle())
   }
 
   @ViewBuilder
   private var projectCreator: some View {
-    PPOProjectCreator(
-      creatorName: self.viewModel.card.creatorName,
-      onSendMessage: { [weak viewModel] () in
-        viewModel?.sendCreatorMessage()
-      }
-    )
-    .padding([.horizontal])
+    Button {
+      self.viewModel.sendCreatorMessage()
+    } label: {
+      PPOProjectCreator(
+        creatorName: self.viewModel.card.creatorName
+      )
+      .padding([.horizontal])
+    }
+    // MBL-2020: Keeps the button action from being triggered by other taps in the card.
+    .buttonStyle(BorderlessButtonStyle())
   }
 
   @ViewBuilder

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/CardView/PPOProjectCreator.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/CardView/PPOProjectCreator.swift
@@ -4,7 +4,6 @@ import SwiftUI
 
 struct PPOProjectCreator: View {
   let creatorName: String
-  var onSendMessage: (() -> Void)? = nil
 
   var body: some View {
     HStack(alignment: .firstTextBaseline) {
@@ -18,17 +17,12 @@ struct PPOProjectCreator: View {
         )
         .lineLimit(Constants.textLineLimit)
 
-      Button(action: {
-        self.onSendMessage?()
-      }, label: {
-        Text(Strings.Send_a_message())
-      })
-      .font(Font(PPOStyles.subtitle.font))
-      .background(Color(PPOStyles.background))
-      .foregroundStyle(Color(Constants.sendMessageColor))
-      .frame(alignment: Constants.buttonAlignment)
-      .lineLimit(Constants.textLineLimit)
-      .buttonStyle(BorderlessButtonStyle())
+      Text(Strings.Send_a_message())
+        .font(Font(PPOStyles.subtitle.font))
+        .background(Color(PPOStyles.background))
+        .foregroundStyle(Color(Constants.sendMessageColor))
+        .frame(alignment: Constants.buttonAlignment)
+        .lineLimit(Constants.textLineLimit)
 
       Spacer()
         .frame(width: Constants.spacerWidth)

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/CardView/PPOProjectCreator.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/CardView/PPOProjectCreator.swift
@@ -28,6 +28,7 @@ struct PPOProjectCreator: View {
       .foregroundStyle(Color(Constants.sendMessageColor))
       .frame(alignment: Constants.buttonAlignment)
       .lineLimit(Constants.textLineLimit)
+      .buttonStyle(BorderlessButtonStyle())
 
       Spacer()
         .frame(width: Constants.spacerWidth)


### PR DESCRIPTION
# 📲 What
Use `BorderlessButtonStyle` for message creator button.

# 🤔 Why

Without this style, the button action hijacks other tap events in the same `HStack`. In our case, tapping anywhere that _wasn't_ a button in the card would open the Message Creator view. I was unable to find a satisfying explanation as to why this happens - a quirk of SwiftUI of some kind. However, this one liner conveniently solves the problem.

![send-message-bug](https://github.com/user-attachments/assets/fd403852-c3fa-4400-998d-8d277f4b8db8)