### PR TITLE
[MBL-2110] [MBL-2113] Fixes for PPO analytics events

### DIFF
--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/CardView/PPOProjectCardViewModel.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/CardView/PPOProjectCardViewModel.swift
@@ -102,6 +102,7 @@ final class PPOProjectCardViewModel: PPOProjectCardViewModelType {
 
 public enum PPOActionState {
   case processing
+  case confirmed
   case succeeded
   case cancelled
   case failed

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/CardView/PPOProjectCardViewModel.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/CardView/PPOProjectCardViewModel.swift
@@ -90,7 +90,7 @@ final class PPOProjectCardViewModel: PPOProjectCardViewModelType {
 
   func handle3DSState(_ state: PPOActionState) {
     switch state {
-    case .processing:
+    case .processing, .confirmed:
       self.buttonState = .loading
     case .succeeded:
       self.buttonState = .disabled

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOContainerViewController.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOContainerViewController.swift
@@ -80,7 +80,12 @@ public class PPOContainerViewController: PagedContainerViewController<PPOContain
       case let .fix3DSChallenge(clientSecret, onProgress):
         self?.handle3DSChallenge(clientSecret: clientSecret, onProgress: onProgress)
       case let .confirmAddress(backingId, addressId, address, onProgress):
-        self?.confirmAddress(backingId: backingId, addressId: addressId, address: address, onProgress: onProgress)
+        self?.confirmAddress(
+          backingId: backingId,
+          addressId: addressId,
+          address: address,
+          onProgress: onProgress
+        )
       }
     }.store(in: &self.subscriptions)
 
@@ -170,7 +175,12 @@ public class PPOContainerViewController: PagedContainerViewController<PPOContain
     self.present(nav, animated: true, completion: nil)
   }
 
-  private func confirmAddress(backingId: String, addressId: String, address: String, onProgress: @escaping (PPOActionState) -> Void) {
+  private func confirmAddress(
+    backingId: String,
+    addressId: String,
+    address: String,
+    onProgress: @escaping (PPOActionState) -> Void
+  ) {
     onProgress(.processing)
 
     let alert = UIAlertController(

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOContainerViewController.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOContainerViewController.swift
@@ -79,8 +79,8 @@ public class PPOContainerViewController: PagedContainerViewController<PPOContain
         self?.fixPayment(projectId: projectId, backingId: backingId)
       case let .fix3DSChallenge(clientSecret, onProgress):
         self?.handle3DSChallenge(clientSecret: clientSecret, onProgress: onProgress)
-      case let .confirmAddress(backingId, addressId, address):
-        self?.confirmAddress(backingId: backingId, addressId: addressId, address: address)
+      case let .confirmAddress(backingId, addressId, address, onProgress):
+        self?.confirmAddress(backingId: backingId, addressId: addressId, address: address, onProgress: onProgress)
       }
     }.store(in: &self.subscriptions)
 
@@ -170,18 +170,24 @@ public class PPOContainerViewController: PagedContainerViewController<PPOContain
     self.present(nav, animated: true, completion: nil)
   }
 
-  private func confirmAddress(backingId: String, addressId: String, address: String) {
+  private func confirmAddress(backingId: String, addressId: String, address: String, onProgress: @escaping (PPOActionState) -> Void) {
+    onProgress(.processing)
+
     let alert = UIAlertController(
       title: Strings.Confirm_your_address(),
       message: address,
       preferredStyle: .alert
     )
-    alert.addAction(UIAlertAction(title: Strings.Cancel(), style: .cancel))
+    alert.addAction(UIAlertAction(
+      title: Strings.Cancel(),
+      style: .cancel,
+      handler: { _ in onProgress(.cancelled) }
+    ))
     alert.addAction(UIAlertAction(
       title: Strings.Confirm(),
       style: .default,
       handler: { [weak self] _ in
-        self?.viewModel.confirmAddress(addressId: addressId, backingId: backingId)
+        self?.viewModel.confirmAddress(addressId: addressId, backingId: backingId, onProgress: onProgress)
       }
     ))
     self.present(alert, animated: true, completion: nil)

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOContainerViewModel.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOContainerViewModel.swift
@@ -76,7 +76,7 @@ final class PPOContainerViewModel: PPOContainerViewModelInputs, PPOContainerView
           )
         case .failed:
           return (.error, Strings.Something_went_wrong_please_try_again())
-        case .processing, .cancelled:
+        case .processing, .cancelled, .confirmed:
           return nil
         }
       }

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOContainerViewModel.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOContainerViewModel.swift
@@ -168,7 +168,6 @@ final class PPOContainerViewModel: PPOContainerViewModelInputs, PPOContainerView
   private let process3DSAuthenticationState = PassthroughSubject<PPOActionState, Never>()
   private let stripeConfigurationSubject = PassthroughSubject<PPOStripeConfiguration, Never>()
   private let confirmAddressSubject = PassthroughSubject<(addressId: String, backingId: String, onProgress: (PPOActionState) -> Void), Never>()
-  private let refreshSubject = PassthroughSubject<Void, Never>()
 
   private var cancellables: Set<AnyCancellable> = []
 }

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOContainerViewModel.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOContainerViewModel.swift
@@ -167,7 +167,10 @@ final class PPOContainerViewModel: PPOContainerViewModelInputs, PPOContainerView
   private let showBannerSubject = PassthroughSubject<MessageBannerConfiguration, Never>()
   private let process3DSAuthenticationState = PassthroughSubject<PPOActionState, Never>()
   private let stripeConfigurationSubject = PassthroughSubject<PPOStripeConfiguration, Never>()
-  private let confirmAddressSubject = PassthroughSubject<(addressId: String, backingId: String, onProgress: (PPOActionState) -> Void), Never>()
+  private let confirmAddressSubject = PassthroughSubject<
+    (addressId: String, backingId: String, onProgress: (PPOActionState) -> Void),
+    Never
+  >()
 
   private var cancellables: Set<AnyCancellable> = []
 }

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOViewModel.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOViewModel.swift
@@ -43,7 +43,12 @@ enum PPONavigationEvent: Equatable {
   case survey(url: String)
   case backingDetails(url: String)
   case editAddress(url: String)
-  case confirmAddress(backingId: String, addressId: String, address: String, onProgress: (PPOActionState) -> Void)
+  case confirmAddress(
+    backingId: String,
+    addressId: String,
+    address: String,
+    onProgress: (PPOActionState) -> Void
+  )
   case contactCreator(messageSubject: MessageSubject)
 
   static func == (lhs: PPONavigationEvent, rhs: PPONavigationEvent) -> Bool {
@@ -229,7 +234,7 @@ final class PPOViewModel: ObservableObject, PPOViewModelInputs, PPOViewModelOutp
 
     // Analytics: Finish confirming address
     self.confirmAddressProgressSubject
-      .filter({ $0.1 == .confirmed })
+      .filter { $0.1 == .confirmed }
       .flatMap { card in latestLoadedResults.map { (card.0, $0) } }
       .sink { card, overallProperties in
         AppEnvironment.current.ksrAnalytics.trackPPOSubmitAddressConfirmation(
@@ -330,7 +335,10 @@ final class PPOViewModel: ObservableObject, PPOViewModelInputs, PPOViewModelOutp
   private let viewBackingDetailsSubject = PassthroughSubject<PPOProjectCardModel, Never>()
   private let editAddressSubject = PassthroughSubject<PPOProjectCardModel, Never>()
   private let confirmAddressSubject = PassthroughSubject<(PPOProjectCardModel, String, String), Never>()
-  private let confirmAddressProgressSubject = PassthroughSubject<(PPOProjectCardModel, PPOActionState), Never>()
+  private let confirmAddressProgressSubject = PassthroughSubject<
+    (PPOProjectCardModel, PPOActionState),
+    Never
+  >()
   private let contactCreatorSubject = PassthroughSubject<PPOProjectCardModel, Never>()
   private var navigationEventSubject = PassthroughSubject<PPONavigationEvent, Never>()
 

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOViewModel.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOViewModel.swift
@@ -168,10 +168,12 @@ final class PPOViewModel: ObservableObject, PPOViewModelInputs, PPOViewModelOutp
         results.hasLoaded ? results.values
           .ppoAnalyticsProperties(total: results.total, page: results.page) : nil
       }
+      .first()
+      .eraseToAnyPublisher()
 
     // Analytics: When view appears, the next time it loads, send a PPO dashboard open
     self.viewDidAppearSubject
-      .combineLatest(latestLoadedResults)
+      .flatMap { card in latestLoadedResults.map { (card, $0) } }
       .sink { _, properties in
         AppEnvironment.current.ksrAnalytics.trackPPODashboardOpens(properties: properties)
       }
@@ -179,7 +181,7 @@ final class PPOViewModel: ObservableObject, PPOViewModelInputs, PPOViewModelOutp
 
     // Analytics: Tap messaging creator
     self.contactCreatorSubject
-      .combineLatest(latestLoadedResults)
+      .flatMap { card in latestLoadedResults.map { (card, $0) } }
       .sink { card, overallProperties in
         AppEnvironment.current.ksrAnalytics.trackPPOMessagingCreator(
           from: card.projectAnalytics,
@@ -190,7 +192,7 @@ final class PPOViewModel: ObservableObject, PPOViewModelInputs, PPOViewModelOutp
 
     // Analytics: Fixing payment failure
     self.fixPaymentMethodSubject
-      .combineLatest(latestLoadedResults)
+      .flatMap { card in latestLoadedResults.map { (card, $0) } }
       .sink { card, overallProperties in
         AppEnvironment.current.ksrAnalytics.trackPPOFixingPaymentFailure(
           project: card.projectAnalytics,
@@ -201,7 +203,7 @@ final class PPOViewModel: ObservableObject, PPOViewModelInputs, PPOViewModelOutp
 
     // Analytics: Opening survey
     self.openSurveySubject
-      .combineLatest(latestLoadedResults)
+      .flatMap { card in latestLoadedResults.map { (card, $0) } }
       .sink { card, overallProperties in
         AppEnvironment.current.ksrAnalytics.trackPPOOpeningSurvey(
           project: card.projectAnalytics,
@@ -212,7 +214,7 @@ final class PPOViewModel: ObservableObject, PPOViewModelInputs, PPOViewModelOutp
 
     // Analytics: Initiate confirming address
     self.confirmAddressSubject
-      .combineLatest(latestLoadedResults)
+      .flatMap { card in latestLoadedResults.map { (card, $0) } }
       .sink { cardProperties, overallProperties in
         let (card, _, _) = cardProperties
         AppEnvironment.current.ksrAnalytics.trackPPOInitiateConfirmingAddress(
@@ -224,7 +226,7 @@ final class PPOViewModel: ObservableObject, PPOViewModelInputs, PPOViewModelOutp
 
     // Analytics: Edit address
     self.editAddressSubject
-      .combineLatest(latestLoadedResults)
+      .flatMap { card in latestLoadedResults.map { (card, $0) } }
       .sink { card, overallProperties in
         AppEnvironment.current.ksrAnalytics.trackPPOEditAddress(
           project: card.projectAnalytics,

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOViewModelTests.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOViewModelTests.swift
@@ -332,7 +332,10 @@ class PPOViewModelTests: XCTestCase {
     appTrackingTransparency.updateAdvertisingIdentifier()
 
     let mockTrackingClient = MockTrackingClient()
-    let analytics = KSRAnalytics(segmentClient: mockTrackingClient, appTrackingTransparency: appTrackingTransparency)
+    let analytics = KSRAnalytics(
+      segmentClient: mockTrackingClient,
+      appTrackingTransparency: appTrackingTransparency
+    )
 
     let mockService = MockService(
       fetchPledgedProjectsResult: Result.success(try self.pledgedProjectsData(cursors: 1...3))

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOViewModelTests.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOViewModelTests.swift
@@ -1,6 +1,7 @@
 import Combine
 @testable import Kickstarter_Framework
 @testable import KsApi
+@testable import Library
 import XCTest
 
 class PPOViewModelTests: XCTestCase {
@@ -322,6 +323,70 @@ class PPOViewModelTests: XCTestCase {
       { self.viewModel.openSurvey(from: PPOProjectCardModel.fixPaymentTemplate) },
       event: .survey(url: PPOProjectCardModel.fixPaymentTemplate.backingDetailsUrl)
     )
+  }
+
+  func testAnalyticsEvents_NotTriggeredOnRefresh() async throws {
+    let appTrackingTransparency = MockAppTrackingTransparency()
+    appTrackingTransparency.requestAndSetAuthorizationStatusFlag = false
+    appTrackingTransparency.shouldRequestAuthStatus = true
+    appTrackingTransparency.updateAdvertisingIdentifier()
+
+    let mockTrackingClient = MockTrackingClient()
+    let analytics = KSRAnalytics(segmentClient: mockTrackingClient, appTrackingTransparency: appTrackingTransparency)
+
+    let mockService = MockService(
+      fetchPledgedProjectsResult: Result.success(try self.pledgedProjectsData(cursors: 1...3))
+    )
+
+    let reloadedMockService = MockService(
+      fetchPledgedProjectsResult: Result.success(try self.pledgedProjectsData(cursors: 4...6))
+    )
+
+    let initialLoadExpectation = XCTestExpectation(description: "Initial load")
+    initialLoadExpectation.expectedFulfillmentCount = 3
+    let refreshExpectation = XCTestExpectation(description: "Refresh complete")
+    refreshExpectation.expectedFulfillmentCount = 5
+
+    var values: [PPOViewModelPaginator.Results] = []
+    self.viewModel.$results
+      .sink { value in
+        values.append(value)
+        initialLoadExpectation.fulfill()
+        refreshExpectation.fulfill()
+      }
+      .store(in: &self.cancellables)
+
+    await withEnvironment(
+      apiService: mockService,
+      appTrackingTransparency: appTrackingTransparency,
+      ksrAnalytics: analytics
+    ) { () async in
+      self.viewModel.viewDidAppear()
+
+      // Trigger some actions that generate analytics
+      self.viewModel.openSurvey(from: PPOProjectCardModel.completeSurveyTemplate)
+      self.viewModel.fixPaymentMethod(from: PPOProjectCardModel.fixPaymentTemplate)
+      self.viewModel.contactCreator(from: PPOProjectCardModel.addressLockTemplate)
+
+      await fulfillment(of: [initialLoadExpectation], timeout: 0.1)
+
+      // Store analytics event counts before refresh
+      let trackCountBefore = mockTrackingClient.tracks.count
+      XCTAssertEqual(trackCountBefore, 4)
+
+      await withEnvironment(
+        apiService: reloadedMockService,
+        appTrackingTransparency: appTrackingTransparency,
+        ksrAnalytics: analytics
+      ) { () async in
+        await self.viewModel.refresh()
+      }
+
+      await fulfillment(of: [refreshExpectation], timeout: 0.1)
+
+      // Verify analytics events weren't triggered again
+      XCTAssertEqual(mockTrackingClient.tracks.count, trackCountBefore)
+    }
   }
 
   // Setup the view model to monitor navigation events, then run the closure, then check to make sure only that one event fired

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOViewModelTests.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOViewModelTests.swift
@@ -270,7 +270,8 @@ class PPOViewModelTests: XCTestCase {
       event: .confirmAddress(
         backingId: template.backingGraphId,
         addressId: addressId,
-        address: address
+        address: address,
+        onProgress: { _ in }
       )
     )
   }


### PR DESCRIPTION
# 📲 What

Two fixes:
1. Make sure that analytics events are only firing once; if the page reloads, they currently send all events another time.
2. Add a missing event for the user tapping "confirm" on the confirm address popup

# 🤔 Why

1. In order to support the counts properties we need, we use Combine to grab the most recent results from the Paginator. However, when the user pulls to refresh, this causes the Paginator's results publisher to fire again, triggering all analytics events a subsequent time.
2. This event was added but never connected.

# 🛠 How

1. Instead of using `combineLatest`, this was changed to a `flatMap` + `first`. This causes the Paginator's results method to fire immediately, and only one time. Since this is a flatMap, this process repeats every time the flatMap happens (e.g. every time the relevant button is clicked). This gets us the behavior we need.
2. The analytics for PPO are handled in PPOViewModel, but the confirm address button happens in the PPOContainerViewModel. So to support this, I added a PPOActionState closure to the confirmAddress case, similar to 3DS, and listen to it in the PPOViewModel. This also needed a new case added to PPOActionState, `confirmed`, when the user has confirmed their intent but processing is still happening.