### PR TITLE
[MBL-2109] List refreshing when performing PPO actions

### DIFF
--- a/Kickstarter-iOS/Features/Activities/Controller/ActivitiesViewController.swift
+++ b/Kickstarter-iOS/Features/Activities/Controller/ActivitiesViewController.swift
@@ -287,5 +287,5 @@ extension ActivitiesViewController: ManagePledgeViewControllerDelegate {
     self.viewModel.inputs.managePledgeViewControllerDidFinish()
   }
 
-  func managePledgeViewControllerDidDismiss(_ viewController: ManagePledgeViewController) {}
+  func managePledgeViewControllerDidDismiss(_: ManagePledgeViewController) {}
 }

--- a/Kickstarter-iOS/Features/Activities/Controller/ActivitiesViewController.swift
+++ b/Kickstarter-iOS/Features/Activities/Controller/ActivitiesViewController.swift
@@ -286,4 +286,6 @@ extension ActivitiesViewController: ManagePledgeViewControllerDelegate {
   ) {
     self.viewModel.inputs.managePledgeViewControllerDidFinish()
   }
+
+  func managePledgeViewControllerDidDismiss(_ viewController: ManagePledgeViewController) {}
 }

--- a/Kickstarter-iOS/Features/ManagePledge/Controllers/ManagePledgeViewController.swift
+++ b/Kickstarter-iOS/Features/ManagePledge/Controllers/ManagePledgeViewController.swift
@@ -8,6 +8,8 @@ protocol ManagePledgeViewControllerDelegate: AnyObject {
     _ viewController: ManagePledgeViewController,
     managePledgeViewControllerFinishedWithMessage message: String?
   )
+
+  func managePledgeViewControllerDidDismiss(_ viewController: ManagePledgeViewController)
 }
 
 final class ManagePledgeViewController: UIViewController, MessageBannerViewControllerPresenting {
@@ -533,6 +535,7 @@ final class ManagePledgeViewController: UIViewController, MessageBannerViewContr
 
   @objc private func closeButtonTapped() {
     self.dismiss(animated: true)
+    self.delegate?.managePledgeViewControllerDidDismiss(self)
   }
 
   // MARK: - Functions

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/CardView/PPOProjectCardModel+Templates.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/CardView/PPOProjectCardModel+Templates.swift
@@ -102,7 +102,7 @@ import KsApi
       pledge: "$50.00",
       creatorName: "rokaplay truncate if longer than",
       address: nil,
-      actions: (.authenticateCard(clientSecret: ""), nil),
+      actions: (.authenticateCard(clientSecret: "seti_asdqwe_secret_x"), nil),
       tierType: .authenticateCard,
       backingDetailsUrl: "fakeBackingDetailsUrl",
       backingId: 47,

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOContainerViewController.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOContainerViewController.swift
@@ -289,7 +289,7 @@ extension PPOContainerViewController: STPAuthenticationContext {
     return self
   }
 
-  public func authenticationContextWillDismiss(_ viewController: UIViewController) {
+  public func authenticationContextWillDismiss(_: UIViewController) {
     self.viewModel.actionFinishedPerforming()
   }
 }
@@ -302,19 +302,19 @@ extension PPOContainerViewController: SurveyResponseViewControllerDelegate {
 
 extension PPOContainerViewController: ManagePledgeViewControllerDelegate {
   func managePledgeViewController(
-    _ viewController: ManagePledgeViewController,
-    managePledgeViewControllerFinishedWithMessage message: String?
+    _: ManagePledgeViewController,
+    managePledgeViewControllerFinishedWithMessage _: String?
   ) {
     self.viewModel.actionFinishedPerforming()
   }
 
-  func managePledgeViewControllerDidDismiss(_ viewController: ManagePledgeViewController) {
+  func managePledgeViewControllerDidDismiss(_: ManagePledgeViewController) {
     self.viewModel.actionFinishedPerforming()
   }
 }
 
 extension PPOContainerViewController: UIAdaptivePresentationControllerDelegate {
-  public func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
+  public func presentationControllerDidDismiss(_: UIPresentationController) {
     self.viewModel.actionFinishedPerforming()
   }
 }

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOContainerViewController.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOContainerViewController.swift
@@ -15,6 +15,7 @@ public class PPOContainerViewController: PagedContainerViewController<PPOContain
     self.title = Strings.tabbar_activity()
 
     let ppoView = PPOView(
+      shouldRefresh: self.viewModel.refresh,
       onCountChange: { [weak self] count in
         self?.viewModel.projectAlertsCountChanged(count)
       },

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOContainerViewController.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOContainerViewController.swift
@@ -15,7 +15,7 @@ public class PPOContainerViewController: PagedContainerViewController<PPOContain
     self.title = Strings.tabbar_activity()
 
     let ppoView = PPOView(
-      shouldRefresh: self.viewModel.refresh,
+      shouldRefresh: self.viewModel.shouldRefresh,
       onCountChange: { [weak self] count in
         self?.viewModel.projectAlertsCountChanged(count)
       },
@@ -156,23 +156,27 @@ public class PPOContainerViewController: PagedContainerViewController<PPOContain
 
   private func fixPayment(projectId: Int, backingId: Int) {
     let data = (projectParam: Param.id(projectId), backingParam: Param.id(backingId))
-    let vc = ManagePledgeViewController.controller(with: data, delegate: nil)
-    self.present(vc, animated: true)
+    let vc = ManagePledgeViewController.controller(with: data, delegate: self)
+    vc.presentationController?.delegate = self
+    self.navigationController?.present(vc, animated: true)
   }
 
   private func openSurvey(_ url: String) {
     let vc = SurveyResponseViewController.configuredWith(surveyUrl: url)
+    vc.delegate = self
     let nav = UINavigationController(rootViewController: vc)
     nav.modalPresentationStyle = .formSheet
+    nav.presentationController?.delegate = self
 
-    self.present(nav, animated: true, completion: nil)
+    self.navigationController?.present(nav, animated: true)
   }
 
   private func messageCreator(_ messageSubject: MessageSubject) {
     let vc = MessageDialogViewController.configuredWith(messageSubject: messageSubject, context: .backerModal)
     let nav = UINavigationController(rootViewController: vc)
     nav.modalPresentationStyle = .formSheet
-    vc.delegate = self
+    nav.presentationController?.delegate = self
+
     self.present(nav, animated: true, completion: nil)
   }
 
@@ -283,5 +287,34 @@ extension PPOContainerViewController: MessageDialogViewControllerDelegate {
 extension PPOContainerViewController: STPAuthenticationContext {
   public func authenticationPresentingViewController() -> UIViewController {
     return self
+  }
+
+  public func authenticationContextWillDismiss(_ viewController: UIViewController) {
+    self.viewModel.actionFinishedPerforming()
+  }
+}
+
+extension PPOContainerViewController: SurveyResponseViewControllerDelegate {
+  public func surveyResponseViewControllerDismissed() {
+    self.viewModel.actionFinishedPerforming()
+  }
+}
+
+extension PPOContainerViewController: ManagePledgeViewControllerDelegate {
+  func managePledgeViewController(
+    _ viewController: ManagePledgeViewController,
+    managePledgeViewControllerFinishedWithMessage message: String?
+  ) {
+    self.viewModel.actionFinishedPerforming()
+  }
+
+  func managePledgeViewControllerDidDismiss(_ viewController: ManagePledgeViewController) {
+    self.viewModel.actionFinishedPerforming()
+  }
+}
+
+extension PPOContainerViewController: UIAdaptivePresentationControllerDelegate {
+  public func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
+    self.viewModel.actionFinishedPerforming()
   }
 }

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOContainerViewModel.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOContainerViewModel.swift
@@ -19,6 +19,7 @@ protocol PPOContainerViewModelOutputs {
   var navigationEvents: AnyPublisher<PPONavigationEvent, Never> { get }
   var showBanner: AnyPublisher<MessageBannerConfiguration, Never> { get }
   var stripeConfiguration: AnyPublisher<PPOStripeConfiguration, Never> { get }
+  var refresh: AnyPublisher<Void, Never> { get }
 }
 
 final class PPOContainerViewModel: PPOContainerViewModelInputs, PPOContainerViewModelOutputs {
@@ -157,6 +158,10 @@ final class PPOContainerViewModel: PPOContainerViewModelInputs, PPOContainerView
     self.stripeConfigurationSubject.eraseToAnyPublisher()
   }
 
+  var refresh: AnyPublisher<Void, Never> {
+    self.refreshSubject.eraseToAnyPublisher()
+  }
+
   // MARK: - Private
 
   private var viewWillAppearSubject = PassthroughSubject<Void, Never>()
@@ -171,6 +176,7 @@ final class PPOContainerViewModel: PPOContainerViewModelInputs, PPOContainerView
     (addressId: String, backingId: String, onProgress: (PPOActionState) -> Void),
     Never
   >()
+  private let refreshSubject = PassthroughSubject<Void, Never>()
 
   private var cancellables: Set<AnyCancellable> = []
 }

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOContainerViewModel.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOContainerViewModel.swift
@@ -118,7 +118,7 @@ final class PPOContainerViewModel: PPOContainerViewModelInputs, PPOContainerView
     Publishers.Merge3(
       self.actionFinishedPerformingSubject,
       self.process3DSAuthenticationState
-        .filter({ $0 == .succeeded })
+        .filter { $0 == .succeeded }
         .withEmptyValues(),
       self.showBannerSubject
         .filter { $0.type == .success }

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOView.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOView.swift
@@ -142,7 +142,11 @@ struct PPOView: View {
         .onReceive(self.viewModel.navigationEvents, perform: { event in
           self.onNavigate?(event)
         })
-        .onReceive(self.shouldRefresh.throttle(for: .milliseconds(300), scheduler: RunLoop.main, latest: false)) { () in
+        .onReceive(self.shouldRefresh.throttle(
+          for: .milliseconds(300),
+          scheduler: RunLoop.main,
+          latest: false
+        )) { () in
           Task {
             await self.viewModel.refresh()
           }

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOView.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOView.swift
@@ -142,7 +142,7 @@ struct PPOView: View {
         .onReceive(self.viewModel.navigationEvents, perform: { event in
           self.onNavigate?(event)
         })
-        .onReceive(self.shouldRefresh) { () in
+        .onReceive(self.shouldRefresh.throttle(for: .milliseconds(300), scheduler: RunLoop.main, latest: false)) { () in
           Task {
             await self.viewModel.refresh()
           }

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOView.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOView.swift
@@ -1,8 +1,10 @@
+import Combine
 import Library
 import SwiftUI
 
 struct PPOView: View {
   @StateObject var viewModel = PPOViewModel()
+  var shouldRefresh: AnyPublisher<Void, Never>
   var onCountChange: ((Int?) -> Void)?
   var onNavigate: ((PPONavigationEvent) -> Void)?
 
@@ -140,10 +142,15 @@ struct PPOView: View {
         .onReceive(self.viewModel.navigationEvents, perform: { event in
           self.onNavigate?(event)
         })
+        .onReceive(self.shouldRefresh) { () in
+          Task {
+            await self.viewModel.refresh()
+          }
+        }
     }
   }
 }
 
 #Preview {
-  PPOView()
+  PPOView(shouldRefresh: Empty().eraseToAnyPublisher())
 }

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOViewModel.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOViewModel.swift
@@ -112,6 +112,9 @@ final class PPOViewModel: ObservableObject, PPOViewModelInputs, PPOViewModelOutp
           return false
         }
       })
+      .removeDuplicates(by: { left, right in
+        left.values == right.values
+      })
       .receive(on: RunLoop.main)
       .sink(receiveValue: { results in
         self.results = results
@@ -120,8 +123,7 @@ final class PPOViewModel: ObservableObject, PPOViewModelInputs, PPOViewModelOutp
 
     Publishers.Merge(
       self.viewDidAppearSubject
-        .withEmptyValues()
-        .first(),
+        .withEmptyValues(),
       self.pullToRefreshSubject
     )
     .sink { () in

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOViewModelTests.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOViewModelTests.swift
@@ -88,7 +88,7 @@ class PPOViewModelTests: XCTestCase {
     let initialLoadExpectation = XCTestExpectation(description: "Initial load")
     initialLoadExpectation.expectedFulfillmentCount = 3
     let fullyLoadedExpectation = XCTestExpectation(description: "Pull to refresh")
-    fullyLoadedExpectation.expectedFulfillmentCount = 5
+    fullyLoadedExpectation.expectedFulfillmentCount = 4
 
     var values: [PPOViewModelPaginator.Results] = []
 
@@ -116,7 +116,7 @@ class PPOViewModelTests: XCTestCase {
 
     await fulfillment(of: [fullyLoadedExpectation], timeout: 0.1)
 
-    XCTAssertEqual(values.count, 5)
+    XCTAssertEqual(values.count, 4)
 
     guard
       case .unloaded = values[0],
@@ -128,8 +128,7 @@ class PPOViewModelTests: XCTestCase {
     XCTAssertEqual(firstData.count, 3)
 
     guard
-      case .loading = values[3],
-      case let .allLoaded(secondData, _) = values[4]
+      case let .allLoaded(secondData, _) = values[3]
     else {
       return XCTFail()
     }
@@ -140,7 +139,7 @@ class PPOViewModelTests: XCTestCase {
     let initialLoadExpectation = XCTestExpectation(description: "Initial load")
     initialLoadExpectation.expectedFulfillmentCount = 3
     let fullyLoadedExpectation = XCTestExpectation(description: "Pull to refresh twice")
-    fullyLoadedExpectation.expectedFulfillmentCount = 7
+    fullyLoadedExpectation.expectedFulfillmentCount = 5
 
     var values: [PPOViewModelPaginator.Results] = []
 
@@ -174,7 +173,7 @@ class PPOViewModelTests: XCTestCase {
 
     await fulfillment(of: [fullyLoadedExpectation], timeout: 0.1)
 
-    XCTAssertEqual(values.count, 7)
+    XCTAssertEqual(values.count, 5)
 
     guard
       case .unloaded = values[0],
@@ -186,16 +185,14 @@ class PPOViewModelTests: XCTestCase {
     XCTAssertEqual(firstData.count, 3)
 
     guard
-      case .loading = values[3],
-      case let .allLoaded(secondData, _) = values[4]
+      case let .allLoaded(secondData, _) = values[3]
     else {
       return XCTFail()
     }
     XCTAssertEqual(secondData.count, 2)
 
     guard
-      case .loading = values[5],
-      case let .allLoaded(thirdData, _) = values[6]
+      case let .allLoaded(thirdData, _) = values[4]
     else {
       return XCTFail()
     }
@@ -206,7 +203,7 @@ class PPOViewModelTests: XCTestCase {
     let initialLoadExpectation = XCTestExpectation(description: "Initial load")
     initialLoadExpectation.expectedFulfillmentCount = 3
     let fullyLoadedExpectation = XCTestExpectation(description: "Load more")
-    fullyLoadedExpectation.expectedFulfillmentCount = 5
+    fullyLoadedExpectation.expectedFulfillmentCount = 4
 
     var values: [PPOViewModelPaginator.Results] = []
 
@@ -237,7 +234,7 @@ class PPOViewModelTests: XCTestCase {
 
     await fulfillment(of: [fullyLoadedExpectation], timeout: 0.1)
 
-    XCTAssertEqual(values.count, 5)
+    XCTAssertEqual(values.count, 4)
 
     guard
       case .unloaded = values[0],
@@ -250,8 +247,7 @@ class PPOViewModelTests: XCTestCase {
     XCTAssertEqual(cursor, "4")
 
     guard
-      case .loading = values[3],
-      case let .allLoaded(secondData, _) = values[4]
+      case let .allLoaded(secondData, _) = values[3]
     else {
       return XCTFail()
     }

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOViewModelTests.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOViewModelTests.swift
@@ -344,7 +344,7 @@ class PPOViewModelTests: XCTestCase {
     let initialLoadExpectation = XCTestExpectation(description: "Initial load")
     initialLoadExpectation.expectedFulfillmentCount = 3
     let refreshExpectation = XCTestExpectation(description: "Refresh complete")
-    refreshExpectation.expectedFulfillmentCount = 5
+    refreshExpectation.expectedFulfillmentCount = 4
 
     var values: [PPOViewModelPaginator.Results] = []
     self.viewModel.$results

--- a/Kickstarter-iOS/Features/ProjectPage/Controller/ProjectPageViewController.swift
+++ b/Kickstarter-iOS/Features/ProjectPage/Controller/ProjectPageViewController.swift
@@ -835,7 +835,7 @@ extension ProjectPageViewController: ManagePledgeViewControllerDelegate {
     self.viewModel.inputs.managePledgeViewControllerFinished(with: message)
   }
 
-  func managePledgeViewControllerDidDismiss(_ viewController: ManagePledgeViewController) {}
+  func managePledgeViewControllerDidDismiss(_: ManagePledgeViewController) {}
 }
 
 // MARK: - ProjectPageViewControllerDelegate

--- a/Kickstarter-iOS/Features/ProjectPage/Controller/ProjectPageViewController.swift
+++ b/Kickstarter-iOS/Features/ProjectPage/Controller/ProjectPageViewController.swift
@@ -834,6 +834,8 @@ extension ProjectPageViewController: ManagePledgeViewControllerDelegate {
   ) {
     self.viewModel.inputs.managePledgeViewControllerFinished(with: message)
   }
+
+  func managePledgeViewControllerDidDismiss(_ viewController: ManagePledgeViewController) {}
 }
 
 // MARK: - ProjectPageViewControllerDelegate


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

When the user performs an action in PPO, the list now refreshes.

# 🛠 How

There is a new `shouldRefresh` publisher which is passed into PPOView. When this emits, the PPOViewModel triggers a list refresh. A throttle is used to make sure it doesn't refresh the list multiple times in response to a single event.

This `shouldRefresh` publisher comes from `PPOContainerViewModel` which listens to a few different signals to determine when to reload, including the current user changing, a success banner being shown, when a presented view is dismissed, or when the relevant view controllers fire delegate methods that say they've completed.
