### PR TITLE
[MBL-2117] Add minimal large font support

### DIFF
--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/CardView/PPOProjectCreator.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/CardView/PPOProjectCreator.swift
@@ -4,6 +4,7 @@ import SwiftUI
 
 struct PPOProjectCreator: View {
   let creatorName: String
+  @SwiftUI.Environment(\.sizeCategory) var sizeCategory
 
   var body: some View {
     HStack(alignment: .firstTextBaseline) {
@@ -15,14 +16,18 @@ struct PPOProjectCreator: View {
           maxWidth: Constants.labelMaxWidth,
           alignment: Constants.labelAlignment
         )
-        .lineLimit(Constants.textLineLimit)
+        .lineLimit(
+          self.sizeCategory > .extraExtraExtraLarge ?
+            Constants.largeTextLineLimit :
+            Constants.textLineLimit
+        )
 
       Text(Strings.Send_a_message())
         .font(Font(PPOStyles.subtitle.font))
         .background(Color(PPOStyles.background))
         .foregroundStyle(Color(Constants.sendMessageColor))
         .frame(alignment: Constants.buttonAlignment)
-        .lineLimit(Constants.textLineLimit)
+        .lineLimit(nil)
 
       Spacer()
         .frame(width: Constants.spacerWidth)
@@ -43,6 +48,7 @@ struct PPOProjectCreator: View {
     static let chevronOffset = CGSize(width: 0, height: 2)
     static let spacerWidth = Styles.grid(1)
     static let textLineLimit = 1
+    static let largeTextLineLimit = 3
     static let labelMaxWidth = CGFloat.infinity
     static let labelAlignment = Alignment.leading
     static let buttonAlignment = Alignment.trailing

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/CardView/PPOProjectDetails.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/CardView/PPOProjectDetails.swift
@@ -62,7 +62,7 @@ struct PPOProjectDetails: View {
     static let imageContentMode = ContentMode.fit
 
     static let titleLineLimit = 2
-    static let subtitleLineLimit = 1
+    static let subtitleLineLimit: Int? = nil
 
     static let textMaxWidth = CGFloat.infinity
     static let textAlignment = Alignment.leading

--- a/Library/PagedContainer/PagedContainerViewController.swift
+++ b/Library/PagedContainer/PagedContainerViewController.swift
@@ -29,6 +29,10 @@ open class PagedContainerViewController<Page: TabBarPage>: UIViewController {
     self.toggle.view.topAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.topAnchor).isActive = true
     self.toggle.view.widthAnchor.constraint(equalTo: self.view.widthAnchor).isActive = true
 
+    // Prevent tab bar text from being set based on user preferences, since the UI isn't designed
+    // to handle larger font sizes.
+    self.toggle.view.maximumContentSizeCategory = .medium
+
     self.viewModel.$displayPage.receive(on: RunLoop.main)
       .compactMap { $0 }
       .sink { [weak self] _, controller in


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Prevent hardcoded strings from truncating at all and add more reasonable line limits to strings with user provided content where needed. Also, prevent tab bar titles from growing dynamically at all.

Note: This does NOT change layouts or add tests. I spent some time trying to do each of these things with limited success, so I'm going to submit this pr as is, and hope we'll have time to make this better as a fast follow.

# 👀 See

[Jira](https://kickstarter.atlassian.net/browse/MBL-2117)

| Default font size | Largest normal size | Largest accessible size |
| --- | --- | --- |
| <img width="401" alt="image" src="https://github.com/user-attachments/assets/88ebc2ad-1de8-4073-8e9d-985b3ec41560" /> | <img width="397" alt="image" src="https://github.com/user-attachments/assets/9efaf1ab-ef8c-4b52-9fe3-e42246c12862" /> | ![Simulator Screen Recording - iPhone 16 - 2025-02-18 at 17 00 53](https://github.com/user-attachments/assets/eb124841-6b8f-4c6a-8cc2-a08ae6e330ee) |
| <img width="400" alt="image" src="https://github.com/user-attachments/assets/04675e26-f8f8-4389-84ad-2632f16e5387" /> | <img width="405" alt="image" src="https://github.com/user-attachments/assets/c9cfdd4f-27df-4ac4-8ba7-b397b5d0765d" /> | ![Simulator Screen Recording - iPhone 15 Pro - 2025-02-18 at 17 05 23](https://github.com/user-attachments/assets/e49049f9-f902-44ee-b800-87a721b55c94) |

# ♿️ Accessibility 

- [x] Supports Dynamic Type 

# ✅ Acceptance criteria

- [x] Tests pass
- [x] Large font experience is better than it was before (tested the cards that showed up for me, which is survey (incl one with an address showing) and fix payment) 

# ⏰ TODO

In a follow-up pr (possibly a separate ticket), I'd like to:
- Work with UX to figure out what we want accessible layouts to be (I'm thinking fewer hstacks) and implement these. 
- Add snapshot tests for dynamic sizes (neither the sizeCategory env variable nor the `dynamicTypeSize` modifiers did anything, so we'll need to do some framework level work to implement dynamic type support in our UI tests - possibly by explicitly use a hosting view controller and setting the size in UIKit.)
- I'd like us to have font size actually update dynamically instead of needing to restart the app to see changes in this view. Not sure if it's worth our time to implement if it ends up being tricky, but definitely worth looking into for an hour or so.
