### PR TITLE
Fix empty case in backings dashboard

### DIFF
--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOViewModel.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOViewModel.swift
@@ -113,7 +113,7 @@ final class PPOViewModel: ObservableObject, PPOViewModelInputs, PPOViewModelOutp
         }
       })
       .removeDuplicates(by: { left, right in
-        left.values == right.values
+        left.hasLoaded && right.hasLoaded && left.values == right.values
       })
       .receive(on: RunLoop.main)
       .sink(receiveValue: { results in

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOViewModel.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOViewModel.swift
@@ -112,6 +112,9 @@ final class PPOViewModel: ObservableObject, PPOViewModelInputs, PPOViewModelOutp
           return false
         }
       })
+      // SwiftUI List jumps around if reloading frequently. This code path prevents
+      // unnecessary reloads if the data has loaded. If the values are the same and
+      // both states have been loaded, then we can drop this change.
       .removeDuplicates(by: { left, right in
         left.hasLoaded && right.hasLoaded && left.values == right.values
       })

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOViewModelTests.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOViewModelTests.swift
@@ -53,7 +53,7 @@ class PPOViewModelTests: XCTestCase {
 
   func testInitialLoading_Twice() throws {
     let expectation = XCTestExpectation(description: "Initial loading twice")
-    expectation.expectedFulfillmentCount = 3
+    expectation.expectedFulfillmentCount = 5
 
     var values: [PPOViewModelPaginator.Results] = []
     self.viewModel.$results
@@ -72,12 +72,12 @@ class PPOViewModelTests: XCTestCase {
 
     wait(for: [expectation], timeout: 0.1)
 
-    XCTAssertEqual(values.count, 3)
+    XCTAssertEqual(values.count, 5)
 
     guard
       case .unloaded = values[0],
       case .loading = values[1],
-      case let .allLoaded(data, _) = values[2]
+      case let .allLoaded(data, _) = values[4]
     else {
       return XCTFail()
     }
@@ -88,7 +88,7 @@ class PPOViewModelTests: XCTestCase {
     let initialLoadExpectation = XCTestExpectation(description: "Initial load")
     initialLoadExpectation.expectedFulfillmentCount = 3
     let fullyLoadedExpectation = XCTestExpectation(description: "Pull to refresh")
-    fullyLoadedExpectation.expectedFulfillmentCount = 4
+    fullyLoadedExpectation.expectedFulfillmentCount = 5
 
     var values: [PPOViewModelPaginator.Results] = []
 
@@ -116,7 +116,7 @@ class PPOViewModelTests: XCTestCase {
 
     await fulfillment(of: [fullyLoadedExpectation], timeout: 0.1)
 
-    XCTAssertEqual(values.count, 4)
+    XCTAssertEqual(values.count, 5)
 
     guard
       case .unloaded = values[0],
@@ -128,7 +128,8 @@ class PPOViewModelTests: XCTestCase {
     XCTAssertEqual(firstData.count, 3)
 
     guard
-      case let .allLoaded(secondData, _) = values[3]
+      case .loading = values[3],
+      case let .allLoaded(secondData, _) = values[4]
     else {
       return XCTFail()
     }
@@ -139,7 +140,7 @@ class PPOViewModelTests: XCTestCase {
     let initialLoadExpectation = XCTestExpectation(description: "Initial load")
     initialLoadExpectation.expectedFulfillmentCount = 3
     let fullyLoadedExpectation = XCTestExpectation(description: "Pull to refresh twice")
-    fullyLoadedExpectation.expectedFulfillmentCount = 5
+    fullyLoadedExpectation.expectedFulfillmentCount = 7
 
     var values: [PPOViewModelPaginator.Results] = []
 
@@ -173,7 +174,7 @@ class PPOViewModelTests: XCTestCase {
 
     await fulfillment(of: [fullyLoadedExpectation], timeout: 0.1)
 
-    XCTAssertEqual(values.count, 5)
+    XCTAssertEqual(values.count, 7)
 
     guard
       case .unloaded = values[0],
@@ -185,14 +186,16 @@ class PPOViewModelTests: XCTestCase {
     XCTAssertEqual(firstData.count, 3)
 
     guard
-      case let .allLoaded(secondData, _) = values[3]
+      case .loading = values[3],
+      case let .allLoaded(secondData, _) = values[4]
     else {
       return XCTFail()
     }
     XCTAssertEqual(secondData.count, 2)
 
     guard
-      case let .allLoaded(thirdData, _) = values[4]
+      case .loading = values[5],
+      case let .allLoaded(thirdData, _) = values[6]
     else {
       return XCTFail()
     }
@@ -203,7 +206,7 @@ class PPOViewModelTests: XCTestCase {
     let initialLoadExpectation = XCTestExpectation(description: "Initial load")
     initialLoadExpectation.expectedFulfillmentCount = 3
     let fullyLoadedExpectation = XCTestExpectation(description: "Load more")
-    fullyLoadedExpectation.expectedFulfillmentCount = 4
+    fullyLoadedExpectation.expectedFulfillmentCount = 5
 
     var values: [PPOViewModelPaginator.Results] = []
 
@@ -234,7 +237,7 @@ class PPOViewModelTests: XCTestCase {
 
     await fulfillment(of: [fullyLoadedExpectation], timeout: 0.1)
 
-    XCTAssertEqual(values.count, 4)
+    XCTAssertEqual(values.count, 5)
 
     guard
       case .unloaded = values[0],
@@ -247,7 +250,8 @@ class PPOViewModelTests: XCTestCase {
     XCTAssertEqual(cursor, "4")
 
     guard
-      case let .allLoaded(secondData, _) = values[3]
+      case .loading = values[3],
+      case let .allLoaded(secondData, _) = values[4]
     else {
       return XCTFail()
     }


### PR DESCRIPTION
# 📲 What

Fixes an error in backings dashboard that prevents the list from loading when there are 0 items.

# 🛠 How

Changes in #2291 added a check for preventing the list from refreshing unnecessarily (which causes jumping in the list). The issue was caused by the deduplication code, which prevents the screen from reloading unless the values from the paginator are different. However, this returns an empty array for unloaded/loading/error states as well as an empty list of values from the API, which prevents the results from exiting the "loading" case.

Instead, we only do this check if the data has actually loaded. So the check also compares if the results enum is in a "hasLoaded" state, which is already defined for these cases. This fixes the "loading" -> "empty" transition which shows the view correctly.

Also, this undoes some unit test changes that were added in #2291, because apparently I should've listened to those. 😅 