### PR TITLE
[SPC] MBL-2165: Connect GraphQL query for similar projects

### DIFF
--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -1168,6 +1168,8 @@
 		A7FC8C061C8F1DEA00C3B49B /* CircleAvatarImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7FC8C051C8F1DEA00C3B49B /* CircleAvatarImageView.swift */; };
 		AA1023E42CABD2AE007800B5 /* PPOContainerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1023E32CABD2AE007800B5 /* PPOContainerViewModel.swift */; };
 		AA3EB8432CF687680018C880 /* ServerFeature+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA3EB8422CF687680018C880 /* ServerFeature+Helpers.swift */; };
+		AA5480E92D77ECB200EC2849 /* SimilarProjectQuery.graphql in Resources */ = {isa = PBXBuildFile; fileRef = AA5480E82D77ECB200EC2849 /* SimilarProjectQuery.graphql */; };
+		AA5480EB2D77F9DE00EC2849 /* ProjectCardFragment.graphql in Resources */ = {isa = PBXBuildFile; fileRef = AA5480EA2D77F9DA00EC2849 /* ProjectCardFragment.graphql */; };
 		AA59AFF22D39BD7B00644627 /* PPOUserSetupFragment.graphql in Resources */ = {isa = PBXBuildFile; fileRef = AA59AFF12D39BD7600644627 /* PPOUserSetupFragment.graphql */; };
 		AA645E972C770D620034705A /* DesignSystemViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6049D0102A9CF6840015BB0D /* DesignSystemViewController.swift */; };
 		AA645E9C2C7725FB0034705A /* PagedContainerViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA645E9A2C7725FB0034705A /* PagedContainerViewModelTests.swift */; };
@@ -2885,6 +2887,8 @@
 		A7FC8C051C8F1DEA00C3B49B /* CircleAvatarImageView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CircleAvatarImageView.swift; sourceTree = "<group>"; };
 		AA1023E32CABD2AE007800B5 /* PPOContainerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PPOContainerViewModel.swift; sourceTree = "<group>"; };
 		AA3EB8422CF687680018C880 /* ServerFeature+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ServerFeature+Helpers.swift"; sourceTree = "<group>"; };
+		AA5480E82D77ECB200EC2849 /* SimilarProjectQuery.graphql */ = {isa = PBXFileReference; lastKnownFileType = text; path = SimilarProjectQuery.graphql; sourceTree = "<group>"; };
+		AA5480EA2D77F9DA00EC2849 /* ProjectCardFragment.graphql */ = {isa = PBXFileReference; lastKnownFileType = text; path = ProjectCardFragment.graphql; sourceTree = "<group>"; };
 		AA59AFF12D39BD7600644627 /* PPOUserSetupFragment.graphql */ = {isa = PBXFileReference; lastKnownFileType = text; path = PPOUserSetupFragment.graphql; sourceTree = "<group>"; };
 		AA645E9A2C7725FB0034705A /* PagedContainerViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PagedContainerViewModelTests.swift; sourceTree = "<group>"; };
 		AA645E9D2C772C650034705A /* PagedTabBarTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PagedTabBarTests.swift; sourceTree = "<group>"; };
@@ -6010,6 +6014,7 @@
 		7798B5292174F3BC008BC50D /* queries */ = {
 			isa = PBXGroup;
 			children = (
+				AA5480E82D77ECB200EC2849 /* SimilarProjectQuery.graphql */,
 				604334DD2D08CF5E00819385 /* BuildPaymentPlanQuery.graphql */,
 				8AC3E0882698CC1900168BF8 /* FetchAddOnsQuery.graphql */,
 				06566372270BA8E000CE7EDF /* FetchProjectRewardsByIdQuery.graphql */,
@@ -6125,6 +6130,7 @@
 			isa = PBXGroup;
 			children = (
 				E11DE11D2D79F32900DD2ECA /* BackerDashboardProjectCellFragment.graphql */,
+				AA5480EA2D77F9DA00EC2849 /* ProjectCardFragment.graphql */,
 				8A1556D7269394A400017845 /* BackingFragment.graphql */,
 				8A1556EE269398CA00017845 /* CategoryFragment.graphql */,
 				8AC3E0EC269F485100168BF8 /* CheckoutFragment.graphql */,
@@ -7867,6 +7873,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AA5480EB2D77F9DE00EC2849 /* ProjectCardFragment.graphql in Resources */,
 				06DAAE5826AA3CCF00194E58 /* CountryFragment.graphql in Resources */,
 				06B3605C26E12288006CB9E4 /* FetchProjectByIdQuery.graphql in Resources */,
 				06566373270BA8E000CE7EDF /* FetchProjectRewardsByIdQuery.graphql in Resources */,
@@ -7921,6 +7928,7 @@
 				4758484E26B31CF8005AAC1C /* FetchUserBackings.graphql in Resources */,
 				06DAAE5426AA3CC600194E58 /* ProjectFragment.graphql in Resources */,
 				393E8DA72C5BF35B00AEA968 /* FetchPPOQuery.graphql in Resources */,
+				AA5480E92D77ECB200EC2849 /* SimilarProjectQuery.graphql in Resources */,
 				AA59AFF22D39BD7B00644627 /* PPOUserSetupFragment.graphql in Resources */,
 				475DEC0126B07BB9001B961B /* CancelBacking.graphql in Resources */,
 				8AC3E08E2698CE8200168BF8 /* ShippingRuleFragment.graphql in Resources */,

--- a/KsApi/GraphAPI.swift
+++ b/KsApi/GraphAPI.swift
@@ -13795,6 +13795,7 @@ public enum GraphAPI {
     public var queryDocument: String {
       var document: String = operationDefinition
       document.append("\n" + ProjectCardFragment.fragmentDefinition)
+      document.append("\n" + MoneyFragment.fragmentDefinition)
       return document
     }
 
@@ -18490,6 +18491,20 @@ public enum GraphAPI {
         }
         name
         pid
+        state
+        isLaunched
+        deadlineAt
+        percentFunded
+        prelaunchActivated
+        launchedAt
+        goal {
+          __typename
+          ...MoneyFragment
+        }
+        pledged {
+          __typename
+          ...MoneyFragment
+        }
       }
       """
 
@@ -18501,6 +18516,14 @@ public enum GraphAPI {
         GraphQLField("image", type: .object(Image.selections)),
         GraphQLField("name", type: .nonNull(.scalar(String.self))),
         GraphQLField("pid", type: .nonNull(.scalar(Int.self))),
+        GraphQLField("state", type: .nonNull(.scalar(ProjectState.self))),
+        GraphQLField("isLaunched", type: .nonNull(.scalar(Bool.self))),
+        GraphQLField("deadlineAt", type: .scalar(String.self)),
+        GraphQLField("percentFunded", type: .nonNull(.scalar(Int.self))),
+        GraphQLField("prelaunchActivated", type: .nonNull(.scalar(Bool.self))),
+        GraphQLField("launchedAt", type: .scalar(String.self)),
+        GraphQLField("goal", type: .object(Goal.selections)),
+        GraphQLField("pledged", type: .nonNull(.object(Pledged.selections))),
       ]
     }
 
@@ -18510,8 +18533,8 @@ public enum GraphAPI {
       self.resultMap = unsafeResultMap
     }
 
-    public init(image: Image? = nil, name: String, pid: Int) {
-      self.init(unsafeResultMap: ["__typename": "Project", "image": image.flatMap { (value: Image) -> ResultMap in value.resultMap }, "name": name, "pid": pid])
+    public init(image: Image? = nil, name: String, pid: Int, state: ProjectState, isLaunched: Bool, deadlineAt: String? = nil, percentFunded: Int, prelaunchActivated: Bool, launchedAt: String? = nil, goal: Goal? = nil, pledged: Pledged) {
+      self.init(unsafeResultMap: ["__typename": "Project", "image": image.flatMap { (value: Image) -> ResultMap in value.resultMap }, "name": name, "pid": pid, "state": state, "isLaunched": isLaunched, "deadlineAt": deadlineAt, "percentFunded": percentFunded, "prelaunchActivated": prelaunchActivated, "launchedAt": launchedAt, "goal": goal.flatMap { (value: Goal) -> ResultMap in value.resultMap }, "pledged": pledged.resultMap])
     }
 
     public var __typename: String {
@@ -18550,6 +18573,86 @@ public enum GraphAPI {
       }
       set {
         resultMap.updateValue(newValue, forKey: "pid")
+      }
+    }
+
+    /// The project's current state.
+    public var state: ProjectState {
+      get {
+        return resultMap["state"]! as! ProjectState
+      }
+      set {
+        resultMap.updateValue(newValue, forKey: "state")
+      }
+    }
+
+    /// The project has launched
+    public var isLaunched: Bool {
+      get {
+        return resultMap["isLaunched"]! as! Bool
+      }
+      set {
+        resultMap.updateValue(newValue, forKey: "isLaunched")
+      }
+    }
+
+    /// When is the project scheduled to end?
+    public var deadlineAt: String? {
+      get {
+        return resultMap["deadlineAt"] as? String
+      }
+      set {
+        resultMap.updateValue(newValue, forKey: "deadlineAt")
+      }
+    }
+
+    /// What percent the project has towards meeting its funding goal.
+    public var percentFunded: Int {
+      get {
+        return resultMap["percentFunded"]! as! Int
+      }
+      set {
+        resultMap.updateValue(newValue, forKey: "percentFunded")
+      }
+    }
+
+    /// Whether a project has activated prelaunch.
+    public var prelaunchActivated: Bool {
+      get {
+        return resultMap["prelaunchActivated"]! as! Bool
+      }
+      set {
+        resultMap.updateValue(newValue, forKey: "prelaunchActivated")
+      }
+    }
+
+    /// When the project launched
+    public var launchedAt: String? {
+      get {
+        return resultMap["launchedAt"] as? String
+      }
+      set {
+        resultMap.updateValue(newValue, forKey: "launchedAt")
+      }
+    }
+
+    /// The minimum amount to raise for the project to be successful.
+    public var goal: Goal? {
+      get {
+        return (resultMap["goal"] as? ResultMap).flatMap { Goal(unsafeResultMap: $0) }
+      }
+      set {
+        resultMap.updateValue(newValue?.resultMap, forKey: "goal")
+      }
+    }
+
+    /// How much money is pledged to the project.
+    public var pledged: Pledged {
+      get {
+        return Pledged(unsafeResultMap: resultMap["pledged"]! as! ResultMap)
+      }
+      set {
+        resultMap.updateValue(newValue.resultMap, forKey: "pledged")
       }
     }
 
@@ -18599,6 +18702,118 @@ public enum GraphAPI {
         }
         set {
           resultMap.updateValue(newValue, forKey: "url")
+        }
+      }
+    }
+
+    public struct Goal: GraphQLSelectionSet {
+      public static let possibleTypes: [String] = ["Money"]
+
+      public static var selections: [GraphQLSelection] {
+        return [
+          GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+          GraphQLFragmentSpread(MoneyFragment.self),
+        ]
+      }
+
+      public private(set) var resultMap: ResultMap
+
+      public init(unsafeResultMap: ResultMap) {
+        self.resultMap = unsafeResultMap
+      }
+
+      public init(amount: String? = nil, currency: CurrencyCode? = nil, symbol: String? = nil) {
+        self.init(unsafeResultMap: ["__typename": "Money", "amount": amount, "currency": currency, "symbol": symbol])
+      }
+
+      public var __typename: String {
+        get {
+          return resultMap["__typename"]! as! String
+        }
+        set {
+          resultMap.updateValue(newValue, forKey: "__typename")
+        }
+      }
+
+      public var fragments: Fragments {
+        get {
+          return Fragments(unsafeResultMap: resultMap)
+        }
+        set {
+          resultMap += newValue.resultMap
+        }
+      }
+
+      public struct Fragments {
+        public private(set) var resultMap: ResultMap
+
+        public init(unsafeResultMap: ResultMap) {
+          self.resultMap = unsafeResultMap
+        }
+
+        public var moneyFragment: MoneyFragment {
+          get {
+            return MoneyFragment(unsafeResultMap: resultMap)
+          }
+          set {
+            resultMap += newValue.resultMap
+          }
+        }
+      }
+    }
+
+    public struct Pledged: GraphQLSelectionSet {
+      public static let possibleTypes: [String] = ["Money"]
+
+      public static var selections: [GraphQLSelection] {
+        return [
+          GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+          GraphQLFragmentSpread(MoneyFragment.self),
+        ]
+      }
+
+      public private(set) var resultMap: ResultMap
+
+      public init(unsafeResultMap: ResultMap) {
+        self.resultMap = unsafeResultMap
+      }
+
+      public init(amount: String? = nil, currency: CurrencyCode? = nil, symbol: String? = nil) {
+        self.init(unsafeResultMap: ["__typename": "Money", "amount": amount, "currency": currency, "symbol": symbol])
+      }
+
+      public var __typename: String {
+        get {
+          return resultMap["__typename"]! as! String
+        }
+        set {
+          resultMap.updateValue(newValue, forKey: "__typename")
+        }
+      }
+
+      public var fragments: Fragments {
+        get {
+          return Fragments(unsafeResultMap: resultMap)
+        }
+        set {
+          resultMap += newValue.resultMap
+        }
+      }
+
+      public struct Fragments {
+        public private(set) var resultMap: ResultMap
+
+        public init(unsafeResultMap: ResultMap) {
+          self.resultMap = unsafeResultMap
+        }
+
+        public var moneyFragment: MoneyFragment {
+          get {
+            return MoneyFragment(unsafeResultMap: resultMap)
+          }
+          set {
+            resultMap += newValue.resultMap
+          }
         }
       }
     }

--- a/KsApi/GraphAPI.swift
+++ b/KsApi/GraphAPI.swift
@@ -13775,6 +13775,162 @@ public enum GraphAPI {
     }
   }
 
+  public final class FetchSimilarProjectsQuery: GraphQLQuery {
+    /// The raw GraphQL definition of this operation.
+    public let operationDefinition: String =
+      """
+      query FetchSimilarProjects($projectID: String!) {
+        projects(recommended: true, first: 4, similarToPid: $projectID, state: LIVE) {
+          __typename
+          nodes {
+            __typename
+            ...ProjectCardFragment
+          }
+        }
+      }
+      """
+
+    public let operationName: String = "FetchSimilarProjects"
+
+    public var queryDocument: String {
+      var document: String = operationDefinition
+      document.append("\n" + ProjectCardFragment.fragmentDefinition)
+      return document
+    }
+
+    public var projectID: String
+
+    public init(projectID: String) {
+      self.projectID = projectID
+    }
+
+    public var variables: GraphQLMap? {
+      return ["projectID": projectID]
+    }
+
+    public struct Data: GraphQLSelectionSet {
+      public static let possibleTypes: [String] = ["Query"]
+
+      public static var selections: [GraphQLSelection] {
+        return [
+          GraphQLField("projects", arguments: ["recommended": true, "first": 4, "similarToPid": GraphQLVariable("projectID"), "state": "LIVE"], type: .object(Project.selections)),
+        ]
+      }
+
+      public private(set) var resultMap: ResultMap
+
+      public init(unsafeResultMap: ResultMap) {
+        self.resultMap = unsafeResultMap
+      }
+
+      public init(projects: Project? = nil) {
+        self.init(unsafeResultMap: ["__typename": "Query", "projects": projects.flatMap { (value: Project) -> ResultMap in value.resultMap }])
+      }
+
+      /// Get some projects
+      public var projects: Project? {
+        get {
+          return (resultMap["projects"] as? ResultMap).flatMap { Project(unsafeResultMap: $0) }
+        }
+        set {
+          resultMap.updateValue(newValue?.resultMap, forKey: "projects")
+        }
+      }
+
+      public struct Project: GraphQLSelectionSet {
+        public static let possibleTypes: [String] = ["ProjectsConnectionWithTotalCount"]
+
+        public static var selections: [GraphQLSelection] {
+          return [
+            GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+            GraphQLField("nodes", type: .list(.object(Node.selections))),
+          ]
+        }
+
+        public private(set) var resultMap: ResultMap
+
+        public init(unsafeResultMap: ResultMap) {
+          self.resultMap = unsafeResultMap
+        }
+
+        public init(nodes: [Node?]? = nil) {
+          self.init(unsafeResultMap: ["__typename": "ProjectsConnectionWithTotalCount", "nodes": nodes.flatMap { (value: [Node?]) -> [ResultMap?] in value.map { (value: Node?) -> ResultMap? in value.flatMap { (value: Node) -> ResultMap in value.resultMap } } }])
+        }
+
+        public var __typename: String {
+          get {
+            return resultMap["__typename"]! as! String
+          }
+          set {
+            resultMap.updateValue(newValue, forKey: "__typename")
+          }
+        }
+
+        /// A list of nodes.
+        public var nodes: [Node?]? {
+          get {
+            return (resultMap["nodes"] as? [ResultMap?]).flatMap { (value: [ResultMap?]) -> [Node?] in value.map { (value: ResultMap?) -> Node? in value.flatMap { (value: ResultMap) -> Node in Node(unsafeResultMap: value) } } }
+          }
+          set {
+            resultMap.updateValue(newValue.flatMap { (value: [Node?]) -> [ResultMap?] in value.map { (value: Node?) -> ResultMap? in value.flatMap { (value: Node) -> ResultMap in value.resultMap } } }, forKey: "nodes")
+          }
+        }
+
+        public struct Node: GraphQLSelectionSet {
+          public static let possibleTypes: [String] = ["Project"]
+
+          public static var selections: [GraphQLSelection] {
+            return [
+              GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+              GraphQLFragmentSpread(ProjectCardFragment.self),
+            ]
+          }
+
+          public private(set) var resultMap: ResultMap
+
+          public init(unsafeResultMap: ResultMap) {
+            self.resultMap = unsafeResultMap
+          }
+
+          public var __typename: String {
+            get {
+              return resultMap["__typename"]! as! String
+            }
+            set {
+              resultMap.updateValue(newValue, forKey: "__typename")
+            }
+          }
+
+          public var fragments: Fragments {
+            get {
+              return Fragments(unsafeResultMap: resultMap)
+            }
+            set {
+              resultMap += newValue.resultMap
+            }
+          }
+
+          public struct Fragments {
+            public private(set) var resultMap: ResultMap
+
+            public init(unsafeResultMap: ResultMap) {
+              self.resultMap = unsafeResultMap
+            }
+
+            public var projectCardFragment: ProjectCardFragment {
+              get {
+                return ProjectCardFragment(unsafeResultMap: resultMap)
+              }
+              set {
+                resultMap += newValue.resultMap
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
   public final class ValidateCheckoutQuery: GraphQLQuery {
     /// The raw GraphQL definition of this operation.
     public let operationDefinition: String =
@@ -18316,6 +18472,133 @@ public enum GraphAPI {
         }
         set {
           resultMap.updateValue(newValue, forKey: "amount")
+        }
+      }
+    }
+  }
+
+  public struct ProjectCardFragment: GraphQLFragment {
+    /// The raw GraphQL definition of this fragment.
+    public static let fragmentDefinition: String =
+      """
+      fragment ProjectCardFragment on Project {
+        __typename
+        image {
+          __typename
+          id
+          url(width: 1024)
+        }
+        name
+        pid
+      }
+      """
+
+    public static let possibleTypes: [String] = ["Project"]
+
+    public static var selections: [GraphQLSelection] {
+      return [
+        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+        GraphQLField("image", type: .object(Image.selections)),
+        GraphQLField("name", type: .nonNull(.scalar(String.self))),
+        GraphQLField("pid", type: .nonNull(.scalar(Int.self))),
+      ]
+    }
+
+    public private(set) var resultMap: ResultMap
+
+    public init(unsafeResultMap: ResultMap) {
+      self.resultMap = unsafeResultMap
+    }
+
+    public init(image: Image? = nil, name: String, pid: Int) {
+      self.init(unsafeResultMap: ["__typename": "Project", "image": image.flatMap { (value: Image) -> ResultMap in value.resultMap }, "name": name, "pid": pid])
+    }
+
+    public var __typename: String {
+      get {
+        return resultMap["__typename"]! as! String
+      }
+      set {
+        resultMap.updateValue(newValue, forKey: "__typename")
+      }
+    }
+
+    /// The project's primary image.
+    public var image: Image? {
+      get {
+        return (resultMap["image"] as? ResultMap).flatMap { Image(unsafeResultMap: $0) }
+      }
+      set {
+        resultMap.updateValue(newValue?.resultMap, forKey: "image")
+      }
+    }
+
+    /// The project's name.
+    public var name: String {
+      get {
+        return resultMap["name"]! as! String
+      }
+      set {
+        resultMap.updateValue(newValue, forKey: "name")
+      }
+    }
+
+    /// The project's pid.
+    public var pid: Int {
+      get {
+        return resultMap["pid"]! as! Int
+      }
+      set {
+        resultMap.updateValue(newValue, forKey: "pid")
+      }
+    }
+
+    public struct Image: GraphQLSelectionSet {
+      public static let possibleTypes: [String] = ["Photo"]
+
+      public static var selections: [GraphQLSelection] {
+        return [
+          GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+          GraphQLField("id", type: .nonNull(.scalar(GraphQLID.self))),
+          GraphQLField("url", arguments: ["width": 1024], type: .scalar(String.self)),
+        ]
+      }
+
+      public private(set) var resultMap: ResultMap
+
+      public init(unsafeResultMap: ResultMap) {
+        self.resultMap = unsafeResultMap
+      }
+
+      public init(id: GraphQLID, url: String? = nil) {
+        self.init(unsafeResultMap: ["__typename": "Photo", "id": id, "url": url])
+      }
+
+      public var __typename: String {
+        get {
+          return resultMap["__typename"]! as! String
+        }
+        set {
+          resultMap.updateValue(newValue, forKey: "__typename")
+        }
+      }
+
+      public var id: GraphQLID {
+        get {
+          return resultMap["id"]! as! GraphQLID
+        }
+        set {
+          resultMap.updateValue(newValue, forKey: "id")
+        }
+      }
+
+      /// URL of the photo
+      public var url: String? {
+        get {
+          return resultMap["url"] as? String
+        }
+        set {
+          resultMap.updateValue(newValue, forKey: "url")
         }
       }
     }

--- a/KsApi/GraphQLFiles.xcfilelist
+++ b/KsApi/GraphQLFiles.xcfilelist
@@ -13,6 +13,7 @@ $(PROJECT_DIR)/KsApi/fragments/UserEmailFragment.graphql
 $(PROJECT_DIR)/KsApi/fragments/MoneyFragment.graphql
 $(PROJECT_DIR)/KsApi/fragments/ProjectFragment.graphql
 $(PROJECT_DIR)/KsApi/fragments/BackerDashboardProjectCellFragment.graphql
+$(PROJECT_DIR)/KsApi/fragments/ProjectCardFragment.graphql
 $(PROJECT_DIR)/KsApi/fragments/CountryFragment.graphql
 $(PROJECT_DIR)/KsApi/fragments/CategoryFragment.graphql
 $(PROJECT_DIR)/KsApi/fragments/ShippingRuleFragment.graphql
@@ -54,6 +55,7 @@ $(PROJECT_DIR)/KsApi/queries/BuildPaymentPlanQuery.graphql
 $(PROJECT_DIR)/KsApi/queries/ValidateCheckout.graphql
 $(PROJECT_DIR)/KsApi/queries/FetchCommentReplies.graphql
 $(PROJECT_DIR)/KsApi/queries/FetchUpdateComments.graphql
+$(PROJECT_DIR)/KsApi/queries/SimilarProjectQuery.graphql
 $(PROJECT_DIR)/KsApi/queries/FetchUserBackings.graphql
 $(PROJECT_DIR)/KsApi/queries/FetchProjectFriendsById.graphql
 $(PROJECT_DIR)/KsApi/queries/FetchProjectComments.graphql

--- a/KsApi/Service.swift
+++ b/KsApi/Service.swift
@@ -85,6 +85,10 @@ public struct Service: ServiceType {
     return request(Route.addImage(fileUrl: fileURL, toDraft: draft))
   }
 
+  public func fetch<Q: GraphQLQuery>(query: Q) -> SignalProducer<Q.Data, ErrorEnvelope> {
+    GraphQL.shared.client.fetch(query: query)
+  }
+
   public func addNewCreditCard(input: CreatePaymentSourceInput)
     -> SignalProducer<CreatePaymentSourceEnvelope, ErrorEnvelope> {
     return GraphQL.shared.client

--- a/KsApi/ServiceType.swift
+++ b/KsApi/ServiceType.swift
@@ -1,3 +1,4 @@
+import Apollo
 import Combine
 import Prelude
 import ReactiveSwift
@@ -32,6 +33,9 @@ public protocol ServiceType {
     deviceIdentifier: String,
     apolloClient: ApolloClientType?
   )
+
+  /// Fetches a GraphQL query and returns the data.
+  func fetch<Q: GraphQLQuery>(query: Q) -> SignalProducer<Q.Data, ErrorEnvelope>
 
   /// Returns a new service with the oauth token replaced.
   func login(_ oauthToken: OauthTokenAuthType) -> Self

--- a/KsApi/fragments/ProjectCardFragment.graphql
+++ b/KsApi/fragments/ProjectCardFragment.graphql
@@ -6,4 +6,16 @@ fragment ProjectCardFragment on Project {
   }
   name
   pid
+  state
+  isLaunched
+  deadlineAt
+  percentFunded
+  prelaunchActivated
+  launchedAt
+  goal {
+    ...MoneyFragment
+  }
+  pledged {
+    ...MoneyFragment
+  }
 }

--- a/KsApi/fragments/ProjectCardFragment.graphql
+++ b/KsApi/fragments/ProjectCardFragment.graphql
@@ -1,0 +1,9 @@
+# Minimal version of ProjectFragment, containing only the fields needed for showing project cards.
+fragment ProjectCardFragment on Project {
+  image {
+    id
+    url(width: 1024)
+  }
+  name
+  pid
+}

--- a/KsApi/models/Money.swift
+++ b/KsApi/models/Money.swift
@@ -46,3 +46,18 @@ extension Money {
     self.symbol = try values.decodeIfPresent(String.self, forKey: .symbol)
   }
 }
+
+extension Money {
+  public init?(_ fragment: GraphAPI.MoneyFragment) {
+    guard
+      let amount = fragment.amount.flatMap(Double.init),
+      let currencyCode = fragment.currency.flatMap({ Money.CurrencyCode(rawValue: $0.rawValue) })
+    else {
+      return nil
+    }
+
+    self.amount = amount
+    self.currency = currencyCode
+    self.symbol = fragment.symbol
+  }
+}

--- a/KsApi/models/graphql/adapters/Project+ProjectFragment.swift
+++ b/KsApi/models/graphql/adapters/Project+ProjectFragment.swift
@@ -426,3 +426,12 @@ private func extendedProjectAIDisclosure(
 
   return aiDisclosure
 }
+
+extension Project.State {
+  public init?(_ fragment: GraphAPI.ProjectState) {
+    guard let state = projectState(from: fragment) else {
+      return nil
+    }
+    self = state
+  }
+}

--- a/KsApi/queries/SimilarProjectQuery.graphql
+++ b/KsApi/queries/SimilarProjectQuery.graphql
@@ -1,0 +1,12 @@
+query FetchSimilarProjects($projectID: String!) {
+ projects(
+    recommended: true
+    first: 4
+    similarToPid: $projectID
+    state: LIVE
+  ) {
+    nodes {
+      ...ProjectCardFragment
+    }
+  }
+}

--- a/Library/UseCases/SimilarProjects/SimilarProject+Parsing.swift
+++ b/Library/UseCases/SimilarProjects/SimilarProject+Parsing.swift
@@ -1,0 +1,47 @@
+import Foundation
+import Kingfisher
+import KsApi
+
+internal struct SimilarProjectFragment: SimilarProject {
+  let projectID: String
+  let image: Kingfisher.Source
+  let name: String
+  let isLaunched: Bool
+  let isPrelaunchActivated: Bool
+  let launchedAt: Date?
+  let deadlineAt: Date?
+  let percentFunded: Int
+  let state: Project.State
+  let goal: Money?
+  let pledged: Money?
+
+  init?(_ fragment: GraphAPI.ProjectCardFragment) {
+    guard
+      let imageURL = fragment.image?.url.flatMap(URL.init),
+      let state = Project.State(fragment.state)
+    else {
+      return nil
+    }
+
+    func timestamp(from: String?) -> Date? {
+      from
+        .flatMap { timestamp in Int(timestamp) }
+        .flatMap { timestamp in Date(timeIntervalSince1970: TimeInterval(timestamp)) }
+    }
+
+    let launchedAt = timestamp(from: fragment.launchedAt)
+    let deadlineAt = timestamp(from: fragment.deadlineAt)
+
+    self.projectID = "\(fragment.pid)"
+    self.image = .network(imageURL)
+    self.name = fragment.name
+    self.isLaunched = fragment.isLaunched
+    self.isPrelaunchActivated = fragment.prelaunchActivated
+    self.launchedAt = launchedAt
+    self.deadlineAt = deadlineAt
+    self.percentFunded = fragment.percentFunded
+    self.state = state
+    self.goal = (fragment.goal?.fragments.moneyFragment).flatMap(Money.init)
+    self.pledged = Money(fragment.pledged.fragments.moneyFragment)
+  }
+}

--- a/Library/UseCases/SimilarProjects/SimilarProject.swift
+++ b/Library/UseCases/SimilarProjects/SimilarProject.swift
@@ -1,5 +1,5 @@
 /// Represents a project that is similar to the currently viewed project.
 public protocol SimilarProject {
   /// The identifier for the project.
-  var pid: String { get }
+  var projectID: String { get }
 }

--- a/Library/UseCases/SimilarProjects/SimilarProject.swift
+++ b/Library/UseCases/SimilarProjects/SimilarProject.swift
@@ -1,5 +1,24 @@
+import Foundation
+import Kingfisher
+import KsApi
+
 /// Represents a project that is similar to the currently viewed project.
 public protocol SimilarProject {
   /// The identifier for the project.
   var projectID: String { get }
+
+  var image: Kingfisher.Source { get }
+
+  var name: String { get }
+
+  var isLaunched: Bool { get }
+  var isPrelaunchActivated: Bool { get }
+
+  var launchedAt: Date? { get }
+  var deadlineAt: Date? { get }
+  var percentFunded: Int { get }
+
+  var state: Project.State { get }
+  var goal: Money? { get }
+  var pledged: Money? { get }
 }

--- a/Library/UseCases/SimilarProjects/SimilarProjectsUseCaseTests.swift
+++ b/Library/UseCases/SimilarProjects/SimilarProjectsUseCaseTests.swift
@@ -8,6 +8,7 @@ final class SimilarProjectsUseCaseTests: TestCase {
   private var useCase: SimilarProjectsUseCase!
   private let projectTappedObserver = TestObserver<SimilarProject, Never>()
   private let similarProjectsObserver = TestObserver<SimilarProjectsState, Never>()
+  private var mockService: MockService!
 
   override func setUp() {
     super.setUp()
@@ -16,6 +17,27 @@ final class SimilarProjectsUseCaseTests: TestCase {
     remoteConfig.features["similar_projects_carousel"] = true
     AppEnvironment.pushEnvironment(remoteConfigClient: remoteConfig)
 
+    // Create mock data for similar projects
+    let mockProjectNodes: [GraphAPI.FetchSimilarProjectsQuery.Data.Project.Node?] = [
+      self.createMockProjectNode(id: "1", name: "Project 1"),
+      self.createMockProjectNode(id: "2", name: "Project 2"),
+      self.createMockProjectNode(id: "3", name: "Project 3"),
+      self.createMockProjectNode(id: "4", name: "Project 4")
+    ]
+
+    // Create mock project data
+    let mockProjects = GraphAPI.FetchSimilarProjectsQuery.Data.Project(nodes: mockProjectNodes)
+
+    // Create mock query data
+    let mockData = GraphAPI.FetchSimilarProjectsQuery.Data(projects: mockProjects)
+
+    self.mockService = MockService(
+      fetchGraphQLResponses: [
+        (GraphAPI.FetchSimilarProjectsQuery.self, mockData)
+      ]
+    )
+
+    // Initialize the use case with our mock service
     self.useCase = SimilarProjectsUseCase()
     self.useCase.navigateToProject.observe(self.projectTappedObserver.observer)
     self.useCase.similarProjects.producer.start(self.similarProjectsObserver.observer)
@@ -23,60 +45,81 @@ final class SimilarProjectsUseCaseTests: TestCase {
 
   override func tearDown() {
     self.useCase = nil
+    self.mockService = nil
     AppEnvironment.popEnvironment()
     super.tearDown()
   }
 
   func testInitialState() {
-    // The useCase should start with a loading state
-    XCTAssertEqual(1, self.similarProjectsObserver.values.count)
+    withEnvironment(apiService: self.mockService) {
+      // The useCase should start with a loading state
+      XCTAssertEqual(1, self.similarProjectsObserver.values.count)
 
-    if case .loading = self.similarProjectsObserver.values[0] {
-      // Expected loading state
-    } else {
-      XCTFail("Expected initial loading state")
+      if case .loading = self.similarProjectsObserver.values[0] {
+        // Expected loading state
+      } else {
+        XCTFail("Expected initial loading state")
+      }
     }
   }
 
   func testProjectIDLoaded_emitsLoadedState() {
-    // When loading a project ID
-    self.useCase.projectIDLoaded(projectID: "project-123")
+    withEnvironment(apiService: self.mockService) {
+      // Verify we're in loading state
+      XCTAssertEqual(1, self.similarProjectsObserver.values.count)
+      if case .loading = self.similarProjectsObserver.values[0] {
+        // Expected loading state
+      } else {
+        XCTFail("Expected loading state")
+      }
 
-    // Verify we're in loading state
-    XCTAssertEqual(1, self.similarProjectsObserver.values.count)
-    if case .loading = self.similarProjectsObserver.values[0] {
-      // Expected loading state
-    } else {
-      XCTFail("Expected loading state")
-    }
+      // When loading a project ID
+      self.useCase.projectIDLoaded(projectID: "123")
 
-    // Advance scheduler to simulate network delay
-    self.scheduler.advance(by: .seconds(2))
+      // Verify we received loaded state with projects
+      XCTAssertEqual(2, self.similarProjectsObserver.values.count)
 
-    // Verify we received loaded state with projects
-    XCTAssertEqual(2, self.similarProjectsObserver.values.count)
-
-    if case let .loaded(projects) = similarProjectsObserver.values[1] {
-      XCTAssertEqual(4, projects.count, "Expected 4 similar projects")
-    } else {
-      XCTFail("Expected loaded state with projects")
+      if case let .loaded(projects) = similarProjectsObserver.values[1] {
+        XCTAssertEqual(4, projects.count, "Expected 4 similar projects")
+      } else {
+        XCTFail("Expected loaded state with projects")
+      }
     }
   }
 
   func testProjectTapped_emitsNavigateToProject() {
-    // Create a fake project
-    let project = TestSimilarProject(pid: "project-456")
+    withEnvironment(apiService: self.mockService) {
+      // When loading a project ID
+      self.useCase.projectIDLoaded(projectID: "123")
+      guard
+        case let .loaded(projects) = similarProjectsObserver.values[1],
+        let project = projects.first
+      else {
+        return XCTFail()
+      }
 
-    // Send project tapped event
-    self.useCase.projectTapped(project: project)
+      // Send project tapped event
+      self.useCase.projectTapped(project: project)
 
-    // Verify navigate signal fired
-    XCTAssertEqual(1, self.projectTappedObserver.values.count)
-    XCTAssertEqual("project-456", self.projectTappedObserver.values[0].pid)
+      // Verify navigate signal fired
+      XCTAssertEqual(1, self.projectTappedObserver.values.count)
+      XCTAssertEqual(project.projectID, self.projectTappedObserver.values[0].projectID)
+    }
   }
-}
 
-// Test helper
-private struct TestSimilarProject: SimilarProject {
-  let pid: String
+  // Helper method to create mock project nodes for testing
+  private func createMockProjectNode(id: String, name: String) -> GraphAPI.FetchSimilarProjectsQuery.Data
+    .Project.Node {
+    let resultMap: [String: Any] = [
+      "__typename": "Project",
+      "pid": Int(id)!,
+      "name": name,
+      "photo": [
+        "__typename": "Photo",
+        "url": "https://example.com/image.jpg"
+      ]
+    ]
+
+    return GraphAPI.FetchSimilarProjectsQuery.Data.Project.Node(unsafeResultMap: resultMap)
+  }
 }

--- a/Library/UseCases/SimilarProjects/SimilarProjectsUseCaseTests.swift
+++ b/Library/UseCases/SimilarProjects/SimilarProjectsUseCaseTests.swift
@@ -19,10 +19,10 @@ final class SimilarProjectsUseCaseTests: TestCase {
 
     // Create mock data for similar projects
     let mockProjectNodes: [GraphAPI.FetchSimilarProjectsQuery.Data.Project.Node?] = [
-      self.createMockProjectNode(id: "1", name: "Project 1"),
-      self.createMockProjectNode(id: "2", name: "Project 2"),
-      self.createMockProjectNode(id: "3", name: "Project 3"),
-      self.createMockProjectNode(id: "4", name: "Project 4")
+      self.createMockProjectNode(id: 1, name: "Project 1"),
+      self.createMockProjectNode(id: 2, name: "Project 2"),
+      self.createMockProjectNode(id: 3, name: "Project 3"),
+      self.createMockProjectNode(id: 4, name: "Project 4")
     ]
 
     // Create mock project data
@@ -74,7 +74,7 @@ final class SimilarProjectsUseCaseTests: TestCase {
       }
 
       // When loading a project ID
-      self.useCase.projectIDLoaded(projectID: "123")
+      self.useCase.projectIDLoaded(projectID: "1")
 
       // Verify we received loaded state with projects
       XCTAssertEqual(2, self.similarProjectsObserver.values.count)
@@ -107,18 +107,118 @@ final class SimilarProjectsUseCaseTests: TestCase {
     }
   }
 
+  // MARK: - SimilarProject Parsing Tests
+
+  func testSimilarProjectParsing_ValidData_Success() throws {
+    // Create a valid ProjectCardFragment with all required fields
+    let validProjectFragment = self.createMockProjectNode()
+
+    // Test the parsing constructor
+    let similarProject =
+      try XCTUnwrap(SimilarProjectFragment(validProjectFragment.fragments.projectCardFragment))
+
+    // Verify the parsing succeeded
+    XCTAssertNotNil(similarProject, "Parsing should succeed with valid data")
+
+    // Verify the parsed data is correct
+    XCTAssertEqual(similarProject.projectID, "123")
+    XCTAssertEqual(similarProject.name, "Test Project")
+    XCTAssertEqual(similarProject.isLaunched, true)
+    XCTAssertEqual(similarProject.isPrelaunchActivated, false)
+    XCTAssertEqual(similarProject.percentFunded, 75)
+    XCTAssertEqual(similarProject.state, .live)
+
+    // Verify dates are parsed correctly
+    XCTAssertEqual(
+      similarProject.launchedAt?.timeIntervalSince1970 ?? 0,
+      TimeInterval(1_741_737_648),
+      accuracy: 0.001
+    )
+    XCTAssertEqual(
+      similarProject.deadlineAt?.timeIntervalSince1970 ?? 0,
+      TimeInterval(1_742_737_648),
+      accuracy: 0.001
+    )
+
+    // Verify money is parsed correctly
+    XCTAssertEqual(similarProject.goal?.amount, 10_000)
+    XCTAssertEqual(similarProject.pledged?.amount, 7_500)
+  }
+
+  func testSimilarProjectParsing_InvalidData_ReturnsNil() {
+    // Test with missing image URL
+    let missingImageFragment = self.createMockProjectNode(imageURL: nil)
+
+    let missingImageProject = SimilarProjectFragment(missingImageFragment.fragments.projectCardFragment)
+    XCTAssertNil(missingImageProject, "Parsing should fail with missing image URL")
+
+    // Test with invalid image URL
+    let invalidImageFragment = self.createMockProjectNode(imageURL: "127.0.0.1:8000/test")
+
+    let invalidImageProject = SimilarProjectFragment(invalidImageFragment.fragments.projectCardFragment)
+    XCTAssertNil(invalidImageProject, "Parsing should fail with invalid image URL")
+
+    // Test with invalid state
+    let invalidStateNode = self.createMockProjectNode(state: "invalid_state")
+
+    let invalidStateProject = SimilarProjectFragment(invalidStateNode.fragments.projectCardFragment)
+    XCTAssertNil(invalidStateProject, "Parsing should fail with invalid state")
+  }
+
   // Helper method to create mock project nodes for testing
-  private func createMockProjectNode(id: String, name: String) -> GraphAPI.FetchSimilarProjectsQuery.Data
-    .Project.Node {
-    let resultMap: [String: Any] = [
+  private func createMockProjectNode(
+    id: Int = 123,
+    name: String = "Test Project",
+    imageURL: String? = "https://example.com/image.jpg",
+    state: String = "live",
+    isLaunched: Bool = true,
+    prelaunchActivated: Bool = false,
+    launchedAt: String? = "1741737648",
+    deadlineAt: String? = "1742737648",
+    percentFunded: Int = 75,
+    goal: Double? = 10_000,
+    pledged: Double = 7_500
+  ) -> GraphAPI.FetchSimilarProjectsQuery.Data.Project.Node {
+    var resultMap: [String: Any] = [
       "__typename": "Project",
-      "pid": Int(id)!,
+      "pid": id,
       "name": name,
-      "photo": [
-        "__typename": "Photo",
-        "url": "https://example.com/image.jpg"
+      "state": GraphAPI.ProjectState(rawValue: state) ?? GraphAPI.ProjectState.__unknown(state),
+      "isLaunched": isLaunched,
+      "prelaunchActivated": prelaunchActivated,
+      "percentFunded": percentFunded,
+      "pledged": [
+        "__typename": "Money",
+        "amount": String(pledged),
+        "currency": GraphAPI.CurrencyCode.usd,
+        "symbol": "$"
       ]
     ]
+
+    // Add optional fields
+    if let imageURL {
+      resultMap["image"] = [
+        "__typename": "Photo",
+        "url": imageURL
+      ]
+    }
+
+    if let launchedAt {
+      resultMap["launchedAt"] = launchedAt
+    }
+
+    if let deadlineAt {
+      resultMap["deadlineAt"] = deadlineAt
+    }
+
+    if let goal {
+      resultMap["goal"] = [
+        "__typename": "Money",
+        "amount": String(goal),
+        "currency": GraphAPI.CurrencyCode.usd,
+        "symbol": "$"
+      ]
+    }
 
     return GraphAPI.FetchSimilarProjectsQuery.Data.Project.Node(unsafeResultMap: resultMap)
   }

--- a/Library/ViewModels/ProjectPageViewModel.swift
+++ b/Library/ViewModels/ProjectPageViewModel.swift
@@ -603,7 +603,7 @@ public final class ProjectPageViewModel: ProjectPageViewModelType, ProjectPageVi
     // MARK: Similar Projects
 
     freshProjectAndRefTag
-      .map { "\($0.0.id)" }
+      .map { project, _ in "\(project.id)" }
       .skipRepeats()
       .observeForControllerAction()
       .observeValues { [weak self] projectID in

--- a/Library/ViewModels/ProjectPageViewModel.swift
+++ b/Library/ViewModels/ProjectPageViewModel.swift
@@ -599,6 +599,16 @@ public final class ProjectPageViewModel: ProjectPageViewModelType, ProjectPageVi
             targetUserId: "\(blockedUserId)"
           )
       }
+
+    // MARK: Similar Projects
+
+    freshProjectAndRefTag
+      .map { "\($0.0.id)" }
+      .skipRepeats()
+      .observeForControllerAction()
+      .observeValues { [weak self] projectID in
+        self?.similarProjectsUseCase.inputs.projectIDLoaded(projectID: projectID)
+      }
   }
 
   fileprivate let askAQuestionCellTappedProperty = MutableProperty(())


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->


# 📲 What

Adds a new GraphQL query for Similar Projects carousel, along with a basic ProjectCardFragment to populate it. Also adds new functions to ServiceType, Service, and MockService to support querying a GraphQL query directly.

# 🤔 Why

We need data for SPC and this is how we get it.

We also are adding more direct querying of GraphQL to prevent needing to add more endpoints to ServiceType.

# 🛠 How

A new standard GraphQL query was added which includes a fragment for loading similar projects, and hooked into the existing plumbing in SimilarProjectsUseCase.

To support calling this, I also added a method to Service which allows someone to call a GraphQL query directly, along with support in MockService for mocking responses. 

# ✅ Acceptance criteria

- Tests should pass
