### PR TITLE
[MBL-2141] Default pledge cta button and retry stack view to hidden

### DIFF
--- a/Kickstarter-iOS/SharedViews/PledgeCTAContainerView.swift
+++ b/Kickstarter-iOS/SharedViews/PledgeCTAContainerView.swift
@@ -27,37 +27,48 @@ final class PledgeCTAContainerView: UIView {
 
   private lazy var activityIndicator: UIActivityIndicatorView = {
     let indicator = UIActivityIndicatorView(frame: .zero)
-      |> \.translatesAutoresizingMaskIntoConstraints .~ false
+    indicator.translatesAutoresizingMaskIntoConstraints = false
     indicator.startAnimating()
     return indicator
   }()
 
   private lazy var activityIndicatorContainerView: UIView = {
-    UIView(frame: .zero)
-      |> \.translatesAutoresizingMaskIntoConstraints .~ false
+    let view = UIView(frame: .zero)
+    view.translatesAutoresizingMaskIntoConstraints = false
+    return view
   }()
 
   private(set) lazy var pledgeCTAButton: UIButton = {
-    UIButton(type: .custom)
-      |> \.translatesAutoresizingMaskIntoConstraints .~ false
+    let button = UIButton(type: .custom)
+    button.translatesAutoresizingMaskIntoConstraints = false
+    button.isHidden = true // Default to hidden until data is ready.
+    return button
   }()
 
   private(set) lazy var retryButton: UIButton = {
-    UIButton(type: .custom)
-      |> \.translatesAutoresizingMaskIntoConstraints .~ false
+    let button = UIButton(type: .custom)
+    button.translatesAutoresizingMaskIntoConstraints = false
+    return button
   }()
 
   private lazy var retryDescriptionLabel: UILabel = { UILabel(frame: .zero) }()
-  private lazy var retryStackView: UIStackView = { UIStackView(frame: .zero) }()
+
+  private lazy var retryStackView: UIStackView = {
+    let stackView = UIStackView(frame: .zero)
+    stackView.isHidden = true // Default to hidden until data is ready.
+    return stackView
+  }()
 
   private lazy var rootStackView: UIStackView = {
-    UIStackView(frame: .zero)
-      |> \.translatesAutoresizingMaskIntoConstraints .~ false
+    let stackView = UIStackView(frame: .zero)
+    stackView.translatesAutoresizingMaskIntoConstraints = false
+    return stackView
   }()
 
   private lazy var spacer: UIView = {
-    UIView(frame: .zero)
-      |> \.translatesAutoresizingMaskIntoConstraints .~ false
+    let view = UIView(frame: .zero)
+    view.translatesAutoresizingMaskIntoConstraints = false
+    return view
   }()
 
   private lazy var subtitleLabel: UILabel = { UILabel(frame: .zero) }()
@@ -65,13 +76,15 @@ final class PledgeCTAContainerView: UIView {
   private lazy var watchesLabel: UILabel = { UILabel(frame: .zero) }()
 
   private lazy var titleAndSubtitleStackView: UIStackView = {
-    UIStackView(frame: .zero)
-      |> \.translatesAutoresizingMaskIntoConstraints .~ false
+    let stackView = UIStackView(frame: .zero)
+    stackView.translatesAutoresizingMaskIntoConstraints = false
+    return stackView
   }()
 
   private lazy var pledgeButtonAndWatchesStackView: UIStackView = {
-    UIStackView(frame: .zero)
-      |> \.translatesAutoresizingMaskIntoConstraints .~ false
+    let stackView = UIStackView(frame: .zero)
+    stackView.translatesAutoresizingMaskIntoConstraints = false
+    return stackView
   }()
 
   private lazy var titleLabel: UILabel = { UILabel(frame: .zero) }()


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

When the pledge cta view is loaded but not yet configured with data, default the UI to show the loading indicator and nothing else.

I also updated all the lazy inits in this class to move away from Prelude while I was changing stuff here anyways.

# 🤔 Why

Before this change, whenever we'd open a project page with just the project id, the pledge cta would, by default, try to lay out all its possible UI states. Usually, this led to the loading indicator and the "retry" button showing. I considered updating the pledge cta config data to no longer require a project in the loading state, but this led to a lot of tedious test updates (and the pledge CTA still required a full `Project` class once loaded). Instead, I did this the quick and easy way, and set the pledge cta and the retry stack view to be hidden when they're initialized.

# 👀 See

[Jira](https://kickstarter.atlassian.net/browse/MBL-2141)

| Before 🐛 | After 🦋 |
| --- | --- |
| ![Simulator Screen Recording - iPhone 16 Pro - 2025-03-06 at 10 32 19](https://github.com/user-attachments/assets/eeeead33-f1c1-49ee-ab8f-2520082e0aa1) | ![Simulator Screen Recording - iPhone 16 Pro - 2025-03-06 at 10 41 18](https://github.com/user-attachments/assets/04135079-a05c-4b03-92c0-eb71cb85126a) |

# ✅ Acceptance criteria

- [x] Loading state looks reasonable when project page is opened with just a project id
- [x] Pledge CTA still functions as expected when project page is opened with a `Project`
