### PR TITLE
Refactor BackerDashboardProjectCell to support GraphQL

### DIFF
--- a/Kickstarter-iOS/Features/BackerDashboardProjects/Views/Cells/BackerDashboardProjectCell.swift
+++ b/Kickstarter-iOS/Features/BackerDashboardProjects/Views/Cells/BackerDashboardProjectCell.swift
@@ -20,7 +20,7 @@ internal final class BackerDashboardProjectCell: UITableViewCell, ValueCell {
   @IBOutlet fileprivate var progressBarView: UIView!
   @IBOutlet fileprivate var savedIconImageView: UIImageView!
 
-  internal func configureWith(value: Project) {
+  internal func configureWith(value: any BackerDashboardProjectCellViewModel.ProjectCellModel) {
     self.viewModel.inputs.configureWith(project: value)
   }
 

--- a/Kickstarter-iOS/Features/Search/Views/Cell/MostPopularSearchProjectCell.swift
+++ b/Kickstarter-iOS/Features/Search/Views/Cell/MostPopularSearchProjectCell.swift
@@ -22,7 +22,7 @@ internal final class MostPopularSearchProjectCell: UITableViewCell, ValueCell {
   @IBOutlet fileprivate var separateView: UIView!
   @IBOutlet fileprivate var statsStackView: UIStackView!
 
-  internal func configureWith(value: Project) {
+  internal func configureWith(value: any BackerDashboardProjectCellViewModel.ProjectCellModel) {
     self.viewModel.inputs.configureWith(project: value)
   }
 

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -1184,7 +1184,6 @@
 		AAB4CBDF2D42F3860057BADB /* PPOProjectCardModel+Templates.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB4CBDE2D42F3810057BADB /* PPOProjectCardModel+Templates.swift */; };
 		AAB4CBE12D42F4AE0057BADB /* PPOProjectCardModel+Parsing.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB4CBE02D42F4AA0057BADB /* PPOProjectCardModel+Parsing.swift */; };
 		AAD759F42D2FA1F200A4E003 /* Publisher+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAD759F32D2FA1E900A4E003 /* Publisher+Helpers.swift */; };
-		AADDA7142CB6043D00E7112E /* ProjectAnalyticsProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = AADDA7132CB6043D00E7112E /* ProjectAnalyticsProperties.swift */; };
 		AADDA7162CB60B8B00E7112E /* ProjectAnalyticsFragment.graphql in Resources */ = {isa = PBXBuildFile; fileRef = AADDA7152CB60B8B00E7112E /* ProjectAnalyticsFragment.graphql */; };
 		AAE7C9A22C75142A00800E03 /* PPOStyles.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAE7C9A12C75142A00800E03 /* PPOStyles.swift */; };
 		AAE7C9A42C7527E000800E03 /* PagedTabBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAE7C9A32C7527E000800E03 /* PagedTabBar.swift */; };
@@ -1591,6 +1590,8 @@
 		E118351F2B75639F007B42E6 /* PaginationExampleViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E118351E2B75639F007B42E6 /* PaginationExampleViewModel.swift */; };
 		E11CFE4B2B6C42CE00497375 /* OAuth.swift in Sources */ = {isa = PBXBuildFile; fileRef = E11CFE492B6C41B400497375 /* OAuth.swift */; };
 		E11DE11A2D70C02200DD2ECA /* UIViewController+Children.swift in Sources */ = {isa = PBXBuildFile; fileRef = E11DE1192D70C02200DD2ECA /* UIViewController+Children.swift */; };
+		E11DE11E2D79F33500DD2ECA /* BackerDashboardProjectCellFragment.graphql in Sources */ = {isa = PBXBuildFile; fileRef = E11DE11D2D79F32900DD2ECA /* BackerDashboardProjectCellFragment.graphql */; };
+		E11DE1212D7A041600DD2ECA /* ProjectAnalyticsProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = AADDA7132CB6043D00E7112E /* ProjectAnalyticsProperties.swift */; };
 		E12420A22BA8921800037DB5 /* CompleteOnSessionCheckoutMutation.graphql in Resources */ = {isa = PBXBuildFile; fileRef = E12420A12BA8921800037DB5 /* CompleteOnSessionCheckoutMutation.graphql */; };
 		E12C88392C07CE16008AACCA /* CreateOrUpdateBackingAddressMutation.graphql in Resources */ = {isa = PBXBuildFile; fileRef = E12C88382C07CE16008AACCA /* CreateOrUpdateBackingAddressMutation.graphql */; };
 		E12C883B2C08B8DA008AACCA /* ConfirmBackingAddressMutationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E12C883A2C08B8DA008AACCA /* ConfirmBackingAddressMutationTests.swift */; };
@@ -1603,6 +1604,9 @@
 		E13D76802D42C55C00FB58CE /* PledgeOverTimeUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1A310272D2845CB0062646C /* PledgeOverTimeUseCaseTests.swift */; };
 		E13D76812D42CBA400FB58CE /* LoginSignupUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E13D767E2D42C52900FB58CE /* LoginSignupUseCaseTests.swift */; };
 		E15802442D7F72390000BAB3 /* SearchLegacyDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = E15802432D7F72390000BAB3 /* SearchLegacyDataSource.swift */; };
+		E158020E2D7F53220000BAB3 /* Project+ProjectCellModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E158020D2D7F53220000BAB3 /* Project+ProjectCellModel.swift */; };
+		E15802102D7F536A0000BAB3 /* BackerDashboardProjectCellFragment+ProjectCellModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E158020F2D7F536A0000BAB3 /* BackerDashboardProjectCellFragment+ProjectCellModel.swift */; };
+		E15802502D7F784F0000BAB3 /* BackerDashboardProjectCellViewModel+Utilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = E158024F2D7F784F0000BAB3 /* BackerDashboardProjectCellViewModel+Utilities.swift */; };
 		E16794282B7EAA5200064063 /* OAuthTokenExchange.swift in Sources */ = {isa = PBXBuildFile; fileRef = E16794272B7EAA5200064063 /* OAuthTokenExchange.swift */; };
 		E167942A2B85136900064063 /* OAuthTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E16794292B85136900064063 /* OAuthTests.swift */; };
 		E16ECA702C245A34002A1D25 /* PagedContainerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E16ECA6F2C245A34002A1D25 /* PagedContainerViewController.swift */; };
@@ -3310,6 +3314,7 @@
 		E11CFE492B6C41B400497375 /* OAuth.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuth.swift; sourceTree = "<group>"; };
 		E11CFE4E2B7162A400497375 /* PaginationExampleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginationExampleView.swift; sourceTree = "<group>"; };
 		E11DE1192D70C02200DD2ECA /* UIViewController+Children.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Children.swift"; sourceTree = "<group>"; };
+		E11DE11D2D79F32900DD2ECA /* BackerDashboardProjectCellFragment.graphql */ = {isa = PBXFileReference; lastKnownFileType = text; path = BackerDashboardProjectCellFragment.graphql; sourceTree = "<group>"; };
 		E12420A12BA8921800037DB5 /* CompleteOnSessionCheckoutMutation.graphql */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = CompleteOnSessionCheckoutMutation.graphql; sourceTree = "<group>"; };
 		E12C88382C07CE16008AACCA /* CreateOrUpdateBackingAddressMutation.graphql */ = {isa = PBXFileReference; lastKnownFileType = text; path = CreateOrUpdateBackingAddressMutation.graphql; sourceTree = "<group>"; };
 		E12C883A2C08B8DA008AACCA /* ConfirmBackingAddressMutationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfirmBackingAddressMutationTests.swift; sourceTree = "<group>"; };
@@ -3321,6 +3326,9 @@
 		E13D767C2D42C36900FB58CE /* LoginSignupUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginSignupUseCase.swift; sourceTree = "<group>"; };
 		E13D767E2D42C52900FB58CE /* LoginSignupUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginSignupUseCaseTests.swift; sourceTree = "<group>"; };
 		E15802432D7F72390000BAB3 /* SearchLegacyDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchLegacyDataSource.swift; sourceTree = "<group>"; };
+		E158020D2D7F53220000BAB3 /* Project+ProjectCellModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Project+ProjectCellModel.swift"; sourceTree = "<group>"; };
+		E158020F2D7F536A0000BAB3 /* BackerDashboardProjectCellFragment+ProjectCellModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BackerDashboardProjectCellFragment+ProjectCellModel.swift"; sourceTree = "<group>"; };
+		E158024F2D7F784F0000BAB3 /* BackerDashboardProjectCellViewModel+Utilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BackerDashboardProjectCellViewModel+Utilities.swift"; sourceTree = "<group>"; };
 		E16794272B7EAA5200064063 /* OAuthTokenExchange.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthTokenExchange.swift; sourceTree = "<group>"; };
 		E16794292B85136900064063 /* OAuthTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthTests.swift; sourceTree = "<group>"; };
 		E16ECA6F2C245A34002A1D25 /* PagedContainerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PagedContainerViewController.swift; sourceTree = "<group>"; };
@@ -6103,6 +6111,7 @@
 		8ADCCDAA2656BC020079D308 /* fragments */ = {
 			isa = PBXGroup;
 			children = (
+				E11DE11D2D79F32900DD2ECA /* BackerDashboardProjectCellFragment.graphql */,
 				8A1556D7269394A400017845 /* BackingFragment.graphql */,
 				8A1556EE269398CA00017845 /* CategoryFragment.graphql */,
 				8AC3E0EC269F485100168BF8 /* CheckoutFragment.graphql */,
@@ -6643,7 +6652,10 @@
 				E13D76752D41698000FB58CE /* ApplePayTokenUseCase.swift */,
 				E13D76772D4195E700FB58CE /* ApplePayTokenUseCaseTests.swift */,
 				015572721E79C4FF005FB8CC /* BackerDashboardProjectCellViewModel.swift */,
+				E158024F2D7F784F0000BAB3 /* BackerDashboardProjectCellViewModel+Utilities.swift */,
 				A7A627161E85BA5F004C931A /* BackerDashboardProjectCellViewModelTests.swift */,
+				E158020D2D7F53220000BAB3 /* Project+ProjectCellModel.swift */,
+				E158020F2D7F536A0000BAB3 /* BackerDashboardProjectCellFragment+ProjectCellModel.swift */,
 				014D629A1E6E31790033D2BD /* BackerDashboardProjectsViewModel.swift */,
 				A7A626181E85B936004C931A /* BackerDashboardProjectsViewModelTests.swift */,
 				015706541E64BFC80087DD68 /* BackerDashboardViewModel.swift */,
@@ -8044,6 +8056,7 @@
 				A755115C1C8642C3005355CF /* AssetImageGeneratorType.swift in Sources */,
 				D79A01A52242E91E004BC6A8 /* PushNotificationDialogType.swift in Sources */,
 				A72C3A971D00F6C70075227E /* SortPagerViewModel.swift in Sources */,
+				E158020E2D7F53220000BAB3 /* Project+ProjectCellModel.swift in Sources */,
 				9DC572E51D36CA9800AE209C /* ProjectActivityStyles.swift in Sources */,
 				A7F441C91D005A9400FE6FC5 /* MessageDialogViewModel.swift in Sources */,
 				8A3BF51E23F5DB52002AD818 /* MockCoreTelephonyNetworkInfo.swift in Sources */,
@@ -8057,7 +8070,6 @@
 				A757EB2B1D1AD89E00A5C978 /* DiscoveryStyles.swift in Sources */,
 				80E8EAC81D3EC65A007BDA4B /* Image.swift in Sources */,
 				4751A677272B31D000F81DD5 /* ProjectTabCategoryDescriptionCellViewModel.swift in Sources */,
-				AADDA7142CB6043D00E7112E /* ProjectAnalyticsProperties.swift in Sources */,
 				8A6C58932475E5950098D5A2 /* UIRefreshControl+StartRefreshing.swift in Sources */,
 				D7A37CCF1E2FF93D00EA066D /* SearchEmptyStateCellViewModel.swift in Sources */,
 				80D73AF61D50F1A60099231F /* Navigation.swift in Sources */,
@@ -8162,6 +8174,7 @@
 				A75511651C8642C3005355CF /* String+SimpleHTML.swift in Sources */,
 				A7F441C31D005A9400FE6FC5 /* FacebookConfirmationViewModel.swift in Sources */,
 				D0200A5621935F2900F5CC27 /* MessageBannerType.swift in Sources */,
+				E15802102D7F536A0000BAB3 /* BackerDashboardProjectCellFragment+ProjectCellModel.swift in Sources */,
 				064B007A27A469C8007B21FE /* HTMLViewElementStyles.swift in Sources */,
 				8A213CEF239EAEA400BBB4C7 /* KSRAnalytics.swift in Sources */,
 				D70347901DBAABC30099C668 /* DiscoveryExpandableRowCellViewModel.swift in Sources */,
@@ -8188,6 +8201,7 @@
 				D04AAC24218BB70D00CF713E /* DiscoveryProjectCategoryViewModel.swift in Sources */,
 				A7F441E91D005A9400FE6FC5 /* TwoFactorViewModel.swift in Sources */,
 				8A417DF025AE37D200A2C406 /* Segment.swift in Sources */,
+				E15802502D7F784F0000BAB3 /* BackerDashboardProjectCellViewModel+Utilities.swift in Sources */,
 				D6534D3C22E7898B00E9D279 /* PledgePaymentMethodsViewModel.swift in Sources */,
 				A78537F81CB5803B00385B73 /* NSHTTPCookieStorageType.swift in Sources */,
 				3385CF012CF6116B00A33D86 /* UIStackView+Helper.swift in Sources */,
@@ -9226,6 +9240,7 @@
 				AA7BB45F2CF67DC200E2B2D4 /* GraphUserSetup.swift in Sources */,
 				19047FC92889BD8100BDD1A8 /* ClientSecretEnvelope+CreateSetupIntentMutation.Data.swift in Sources */,
 				77CD894921791B05003066DA /* ProjectStatsTemplate.swift in Sources */,
+				E11DE1212D7A041600DD2ECA /* ProjectAnalyticsProperties.swift in Sources */,
 				D01588B11EEB2ED7006E7684 /* ProjectLenses.swift in Sources */,
 				D777442F217A3382008D679F /* ChangeCurrencyInput.swift in Sources */,
 				D01588531EEB2ED7006E7684 /* ChangePaymentMethodEnvelope.swift in Sources */,
@@ -9284,6 +9299,7 @@
 				D01588F31EEB2ED7006E7684 /* MessageThreadsEnvelope.swift in Sources */,
 				8A07CFF426657E2400426B1C /* CommentRepliesEnvelope.swift in Sources */,
 				47D7D09826C2ECB300D2BAB5 /* GraphAPI.SignInWithAppleInput+SignInWithAppleInput.swift in Sources */,
+				E11DE11E2D79F33500DD2ECA /* BackerDashboardProjectCellFragment.graphql in Sources */,
 				D6C9A2561F75921500981E64 /* CategoryTemplates.swift in Sources */,
 				D015882D1EEB2ED7006E7684 /* BasicHTTPAuth.swift in Sources */,
 				D0851010219500F200BC418B /* PaymentSourceDeleteMutation.swift in Sources */,

--- a/KsApi/GraphAPI.swift
+++ b/KsApi/GraphAPI.swift
@@ -2545,6 +2545,85 @@ public enum GraphAPI {
     }
   }
 
+  /// Various project states.
+  public enum ProjectState: RawRepresentable, Equatable, Hashable, CaseIterable, Apollo.JSONDecodable, Apollo.JSONEncodable {
+    public typealias RawValue = String
+    /// Created and preparing for launch.
+    case started
+    /// Ready for launch with a draft submitted for auto-approval.
+    case submitted
+    /// Active and accepting pledges.
+    case live
+    /// Canceled by creator.
+    case canceled
+    /// Suspended for investigation, visible.
+    case suspended
+    /// Suspended and hidden.
+    case purged
+    /// Successfully funded by deadline.
+    case successful
+    /// Failed to fund by deadline.
+    case failed
+    /// Auto generated constant for unknown enum values
+    case __unknown(RawValue)
+
+    public init?(rawValue: RawValue) {
+      switch rawValue {
+        case "STARTED": self = .started
+        case "SUBMITTED": self = .submitted
+        case "LIVE": self = .live
+        case "CANCELED": self = .canceled
+        case "SUSPENDED": self = .suspended
+        case "PURGED": self = .purged
+        case "SUCCESSFUL": self = .successful
+        case "FAILED": self = .failed
+        default: self = .__unknown(rawValue)
+      }
+    }
+
+    public var rawValue: RawValue {
+      switch self {
+        case .started: return "STARTED"
+        case .submitted: return "SUBMITTED"
+        case .live: return "LIVE"
+        case .canceled: return "CANCELED"
+        case .suspended: return "SUSPENDED"
+        case .purged: return "PURGED"
+        case .successful: return "SUCCESSFUL"
+        case .failed: return "FAILED"
+        case .__unknown(let value): return value
+      }
+    }
+
+    public static func == (lhs: ProjectState, rhs: ProjectState) -> Bool {
+      switch (lhs, rhs) {
+        case (.started, .started): return true
+        case (.submitted, .submitted): return true
+        case (.live, .live): return true
+        case (.canceled, .canceled): return true
+        case (.suspended, .suspended): return true
+        case (.purged, .purged): return true
+        case (.successful, .successful): return true
+        case (.failed, .failed): return true
+        case (.__unknown(let lhsValue), .__unknown(let rhsValue)): return lhsValue == rhsValue
+        default: return false
+      }
+    }
+
+    public static var allCases: [ProjectState] {
+      return [
+        .started,
+        .submitted,
+        .live,
+        .canceled,
+        .suspended,
+        .purged,
+        .successful,
+        .failed,
+      ]
+    }
+  }
+
   /// All available states for a checkout
   public enum CheckoutState: RawRepresentable, Equatable, Hashable, CaseIterable, Apollo.JSONDecodable, Apollo.JSONEncodable {
     public typealias RawValue = String
@@ -4070,85 +4149,6 @@ public enum GraphAPI {
     public static var allCases: [PaymentIncrementStateReason] {
       return [
         .requiresAction,
-      ]
-    }
-  }
-
-  /// Various project states.
-  public enum ProjectState: RawRepresentable, Equatable, Hashable, CaseIterable, Apollo.JSONDecodable, Apollo.JSONEncodable {
-    public typealias RawValue = String
-    /// Created and preparing for launch.
-    case started
-    /// Ready for launch with a draft submitted for auto-approval.
-    case submitted
-    /// Active and accepting pledges.
-    case live
-    /// Canceled by creator.
-    case canceled
-    /// Suspended for investigation, visible.
-    case suspended
-    /// Suspended and hidden.
-    case purged
-    /// Successfully funded by deadline.
-    case successful
-    /// Failed to fund by deadline.
-    case failed
-    /// Auto generated constant for unknown enum values
-    case __unknown(RawValue)
-
-    public init?(rawValue: RawValue) {
-      switch rawValue {
-        case "STARTED": self = .started
-        case "SUBMITTED": self = .submitted
-        case "LIVE": self = .live
-        case "CANCELED": self = .canceled
-        case "SUSPENDED": self = .suspended
-        case "PURGED": self = .purged
-        case "SUCCESSFUL": self = .successful
-        case "FAILED": self = .failed
-        default: self = .__unknown(rawValue)
-      }
-    }
-
-    public var rawValue: RawValue {
-      switch self {
-        case .started: return "STARTED"
-        case .submitted: return "SUBMITTED"
-        case .live: return "LIVE"
-        case .canceled: return "CANCELED"
-        case .suspended: return "SUSPENDED"
-        case .purged: return "PURGED"
-        case .successful: return "SUCCESSFUL"
-        case .failed: return "FAILED"
-        case .__unknown(let value): return value
-      }
-    }
-
-    public static func == (lhs: ProjectState, rhs: ProjectState) -> Bool {
-      switch (lhs, rhs) {
-        case (.started, .started): return true
-        case (.submitted, .submitted): return true
-        case (.live, .live): return true
-        case (.canceled, .canceled): return true
-        case (.suspended, .suspended): return true
-        case (.purged, .purged): return true
-        case (.successful, .successful): return true
-        case (.failed, .failed): return true
-        case (.__unknown(let lhsValue), .__unknown(let rhsValue)): return lhsValue == rhsValue
-        default: return false
-      }
-    }
-
-    public static var allCases: [ProjectState] {
-      return [
-        .started,
-        .submitted,
-        .live,
-        .canceled,
-        .suspended,
-        .purged,
-        .successful,
-        .failed,
       ]
     }
   }
@@ -13926,6 +13926,346 @@ public enum GraphAPI {
             set {
               resultMap.updateValue(newValue, forKey: "messages")
             }
+          }
+        }
+      }
+    }
+  }
+
+  public struct BackerDashboardProjectCellFragment: GraphQLFragment {
+    /// The raw GraphQL definition of this fragment.
+    public static let fragmentDefinition: String =
+      """
+      fragment BackerDashboardProjectCellFragment on Project {
+        __typename
+        projectId: id
+        name
+        projectState: state
+        image {
+          __typename
+          id
+          url(width: 1024)
+        }
+        goal {
+          __typename
+          ...MoneyFragment
+        }
+        pledged {
+          __typename
+          ...MoneyFragment
+        }
+        isLaunched
+        projectPrelaunchActivated: prelaunchActivated
+        deadlineAt
+        projectLaunchedAt: launchedAt
+        isWatched
+      }
+      """
+
+    public static let possibleTypes: [String] = ["Project"]
+
+    public static var selections: [GraphQLSelection] {
+      return [
+        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+        GraphQLField("id", alias: "projectId", type: .nonNull(.scalar(GraphQLID.self))),
+        GraphQLField("name", type: .nonNull(.scalar(String.self))),
+        GraphQLField("state", alias: "projectState", type: .nonNull(.scalar(ProjectState.self))),
+        GraphQLField("image", type: .object(Image.selections)),
+        GraphQLField("goal", type: .object(Goal.selections)),
+        GraphQLField("pledged", type: .nonNull(.object(Pledged.selections))),
+        GraphQLField("isLaunched", type: .nonNull(.scalar(Bool.self))),
+        GraphQLField("prelaunchActivated", alias: "projectPrelaunchActivated", type: .nonNull(.scalar(Bool.self))),
+        GraphQLField("deadlineAt", type: .scalar(String.self)),
+        GraphQLField("launchedAt", alias: "projectLaunchedAt", type: .scalar(String.self)),
+        GraphQLField("isWatched", type: .nonNull(.scalar(Bool.self))),
+      ]
+    }
+
+    public private(set) var resultMap: ResultMap
+
+    public init(unsafeResultMap: ResultMap) {
+      self.resultMap = unsafeResultMap
+    }
+
+    public init(projectId: GraphQLID, name: String, projectState: ProjectState, image: Image? = nil, goal: Goal? = nil, pledged: Pledged, isLaunched: Bool, projectPrelaunchActivated: Bool, deadlineAt: String? = nil, projectLaunchedAt: String? = nil, isWatched: Bool) {
+      self.init(unsafeResultMap: ["__typename": "Project", "projectId": projectId, "name": name, "projectState": projectState, "image": image.flatMap { (value: Image) -> ResultMap in value.resultMap }, "goal": goal.flatMap { (value: Goal) -> ResultMap in value.resultMap }, "pledged": pledged.resultMap, "isLaunched": isLaunched, "projectPrelaunchActivated": projectPrelaunchActivated, "deadlineAt": deadlineAt, "projectLaunchedAt": projectLaunchedAt, "isWatched": isWatched])
+    }
+
+    public var __typename: String {
+      get {
+        return resultMap["__typename"]! as! String
+      }
+      set {
+        resultMap.updateValue(newValue, forKey: "__typename")
+      }
+    }
+
+    public var projectId: GraphQLID {
+      get {
+        return resultMap["projectId"]! as! GraphQLID
+      }
+      set {
+        resultMap.updateValue(newValue, forKey: "projectId")
+      }
+    }
+
+    /// The project's name.
+    public var name: String {
+      get {
+        return resultMap["name"]! as! String
+      }
+      set {
+        resultMap.updateValue(newValue, forKey: "name")
+      }
+    }
+
+    /// The project's current state.
+    public var projectState: ProjectState {
+      get {
+        return resultMap["projectState"]! as! ProjectState
+      }
+      set {
+        resultMap.updateValue(newValue, forKey: "projectState")
+      }
+    }
+
+    /// The project's primary image.
+    public var image: Image? {
+      get {
+        return (resultMap["image"] as? ResultMap).flatMap { Image(unsafeResultMap: $0) }
+      }
+      set {
+        resultMap.updateValue(newValue?.resultMap, forKey: "image")
+      }
+    }
+
+    /// The minimum amount to raise for the project to be successful.
+    public var goal: Goal? {
+      get {
+        return (resultMap["goal"] as? ResultMap).flatMap { Goal(unsafeResultMap: $0) }
+      }
+      set {
+        resultMap.updateValue(newValue?.resultMap, forKey: "goal")
+      }
+    }
+
+    /// How much money is pledged to the project.
+    public var pledged: Pledged {
+      get {
+        return Pledged(unsafeResultMap: resultMap["pledged"]! as! ResultMap)
+      }
+      set {
+        resultMap.updateValue(newValue.resultMap, forKey: "pledged")
+      }
+    }
+
+    /// The project has launched
+    public var isLaunched: Bool {
+      get {
+        return resultMap["isLaunched"]! as! Bool
+      }
+      set {
+        resultMap.updateValue(newValue, forKey: "isLaunched")
+      }
+    }
+
+    /// Whether a project has activated prelaunch.
+    public var projectPrelaunchActivated: Bool {
+      get {
+        return resultMap["projectPrelaunchActivated"]! as! Bool
+      }
+      set {
+        resultMap.updateValue(newValue, forKey: "projectPrelaunchActivated")
+      }
+    }
+
+    /// When is the project scheduled to end?
+    public var deadlineAt: String? {
+      get {
+        return resultMap["deadlineAt"] as? String
+      }
+      set {
+        resultMap.updateValue(newValue, forKey: "deadlineAt")
+      }
+    }
+
+    /// When the project launched
+    public var projectLaunchedAt: String? {
+      get {
+        return resultMap["projectLaunchedAt"] as? String
+      }
+      set {
+        resultMap.updateValue(newValue, forKey: "projectLaunchedAt")
+      }
+    }
+
+    /// Is the current user watching this project?
+    public var isWatched: Bool {
+      get {
+        return resultMap["isWatched"]! as! Bool
+      }
+      set {
+        resultMap.updateValue(newValue, forKey: "isWatched")
+      }
+    }
+
+    public struct Image: GraphQLSelectionSet {
+      public static let possibleTypes: [String] = ["Photo"]
+
+      public static var selections: [GraphQLSelection] {
+        return [
+          GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+          GraphQLField("id", type: .nonNull(.scalar(GraphQLID.self))),
+          GraphQLField("url", arguments: ["width": 1024], type: .scalar(String.self)),
+        ]
+      }
+
+      public private(set) var resultMap: ResultMap
+
+      public init(unsafeResultMap: ResultMap) {
+        self.resultMap = unsafeResultMap
+      }
+
+      public init(id: GraphQLID, url: String? = nil) {
+        self.init(unsafeResultMap: ["__typename": "Photo", "id": id, "url": url])
+      }
+
+      public var __typename: String {
+        get {
+          return resultMap["__typename"]! as! String
+        }
+        set {
+          resultMap.updateValue(newValue, forKey: "__typename")
+        }
+      }
+
+      public var id: GraphQLID {
+        get {
+          return resultMap["id"]! as! GraphQLID
+        }
+        set {
+          resultMap.updateValue(newValue, forKey: "id")
+        }
+      }
+
+      /// URL of the photo
+      public var url: String? {
+        get {
+          return resultMap["url"] as? String
+        }
+        set {
+          resultMap.updateValue(newValue, forKey: "url")
+        }
+      }
+    }
+
+    public struct Goal: GraphQLSelectionSet {
+      public static let possibleTypes: [String] = ["Money"]
+
+      public static var selections: [GraphQLSelection] {
+        return [
+          GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+          GraphQLFragmentSpread(MoneyFragment.self),
+        ]
+      }
+
+      public private(set) var resultMap: ResultMap
+
+      public init(unsafeResultMap: ResultMap) {
+        self.resultMap = unsafeResultMap
+      }
+
+      public init(amount: String? = nil, currency: CurrencyCode? = nil, symbol: String? = nil) {
+        self.init(unsafeResultMap: ["__typename": "Money", "amount": amount, "currency": currency, "symbol": symbol])
+      }
+
+      public var __typename: String {
+        get {
+          return resultMap["__typename"]! as! String
+        }
+        set {
+          resultMap.updateValue(newValue, forKey: "__typename")
+        }
+      }
+
+      public var fragments: Fragments {
+        get {
+          return Fragments(unsafeResultMap: resultMap)
+        }
+        set {
+          resultMap += newValue.resultMap
+        }
+      }
+
+      public struct Fragments {
+        public private(set) var resultMap: ResultMap
+
+        public init(unsafeResultMap: ResultMap) {
+          self.resultMap = unsafeResultMap
+        }
+
+        public var moneyFragment: MoneyFragment {
+          get {
+            return MoneyFragment(unsafeResultMap: resultMap)
+          }
+          set {
+            resultMap += newValue.resultMap
+          }
+        }
+      }
+    }
+
+    public struct Pledged: GraphQLSelectionSet {
+      public static let possibleTypes: [String] = ["Money"]
+
+      public static var selections: [GraphQLSelection] {
+        return [
+          GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+          GraphQLFragmentSpread(MoneyFragment.self),
+        ]
+      }
+
+      public private(set) var resultMap: ResultMap
+
+      public init(unsafeResultMap: ResultMap) {
+        self.resultMap = unsafeResultMap
+      }
+
+      public init(amount: String? = nil, currency: CurrencyCode? = nil, symbol: String? = nil) {
+        self.init(unsafeResultMap: ["__typename": "Money", "amount": amount, "currency": currency, "symbol": symbol])
+      }
+
+      public var __typename: String {
+        get {
+          return resultMap["__typename"]! as! String
+        }
+        set {
+          resultMap.updateValue(newValue, forKey: "__typename")
+        }
+      }
+
+      public var fragments: Fragments {
+        get {
+          return Fragments(unsafeResultMap: resultMap)
+        }
+        set {
+          resultMap += newValue.resultMap
+        }
+      }
+
+      public struct Fragments {
+        public private(set) var resultMap: ResultMap
+
+        public init(unsafeResultMap: ResultMap) {
+          self.resultMap = unsafeResultMap
+        }
+
+        public var moneyFragment: MoneyFragment {
+          get {
+            return MoneyFragment(unsafeResultMap: resultMap)
+          }
+          set {
+            resultMap += newValue.resultMap
           }
         }
       }

--- a/KsApi/GraphQLFiles.xcfilelist
+++ b/KsApi/GraphQLFiles.xcfilelist
@@ -12,6 +12,7 @@ $(PROJECT_DIR)/KsApi/fragments/UserStoredCardsFragment.graphql
 $(PROJECT_DIR)/KsApi/fragments/UserEmailFragment.graphql
 $(PROJECT_DIR)/KsApi/fragments/MoneyFragment.graphql
 $(PROJECT_DIR)/KsApi/fragments/ProjectFragment.graphql
+$(PROJECT_DIR)/KsApi/fragments/BackerDashboardProjectCellFragment.graphql
 $(PROJECT_DIR)/KsApi/fragments/CountryFragment.graphql
 $(PROJECT_DIR)/KsApi/fragments/CategoryFragment.graphql
 $(PROJECT_DIR)/KsApi/fragments/ShippingRuleFragment.graphql

--- a/KsApi/fragments/BackerDashboardProjectCellFragment.graphql
+++ b/KsApi/fragments/BackerDashboardProjectCellFragment.graphql
@@ -1,0 +1,20 @@
+fragment BackerDashboardProjectCellFragment on Project {
+  projectId: id
+  name
+  projectState: state
+  image {
+    id
+    url(width: 1024)
+  }
+  goal {
+    ...MoneyFragment
+  }
+  pledged {
+    ...MoneyFragment
+  }
+  isLaunched
+  projectPrelaunchActivated: prelaunchActivated
+  deadlineAt
+  projectLaunchedAt: launchedAt
+  isWatched
+}

--- a/Library/ViewModels/BackerDashboardProjectCellFragment+ProjectCellModel.swift
+++ b/Library/ViewModels/BackerDashboardProjectCellFragment+ProjectCellModel.swift
@@ -2,10 +2,6 @@ import Foundation
 import KsApi
 
 extension GraphAPI.BackerDashboardProjectCellFragment: BackerDashboardProjectCellViewModel.ProjectCellModel {
-  public var id: Int {
-    return Int(self.projectId) ?? -1
-  }
-
   public var prelaunchActivated: Bool? {
     return Optional.some(self.projectPrelaunchActivated)
   }

--- a/Library/ViewModels/BackerDashboardProjectCellFragment+ProjectCellModel.swift
+++ b/Library/ViewModels/BackerDashboardProjectCellFragment+ProjectCellModel.swift
@@ -10,8 +10,8 @@ extension GraphAPI.BackerDashboardProjectCellFragment: BackerDashboardProjectCel
     return Project.State(rawValue: self.projectState.rawValue.lowercased()) ?? Project.State.live
   }
 
-  public var imageURL: String {
-    self.image?.url ?? ""
+  public var imageURL: String? {
+    self.image?.url
   }
 
   public var fundingProgress: Float {

--- a/Library/ViewModels/BackerDashboardProjectCellFragment+ProjectCellModel.swift
+++ b/Library/ViewModels/BackerDashboardProjectCellFragment+ProjectCellModel.swift
@@ -1,0 +1,48 @@
+import Foundation
+import KsApi
+
+extension GraphAPI.BackerDashboardProjectCellFragment: BackerDashboardProjectCellViewModel.ProjectCellModel {
+  public var id: Int {
+    return Int(self.projectId) ?? -1
+  }
+
+  public var prelaunchActivated: Bool? {
+    return Optional.some(self.projectPrelaunchActivated)
+  }
+
+  public var state: KsApi.Project.State {
+    return Project.State(rawValue: self.projectState.rawValue.lowercased()) ?? Project.State.live
+  }
+
+  public var imageURL: String {
+    self.image?.url ?? ""
+  }
+
+  public var fundingProgress: Float {
+    let pledged = self.pledged.fragments.moneyFragment.amount.flatMap(Float.init) ?? 0
+
+    let goal = self.goal?.fragments.moneyFragment.amount.flatMap(Float.init).flatMap(Int.init) ?? 0
+
+    return goal == 0 ? 0.0 : Float(pledged) / Float(goal)
+  }
+
+  public var percentFunded: Int {
+    return Int(floor(self.fundingProgress * 100.0))
+  }
+
+  public var displayPrelaunch: Bool? {
+    return !self.isLaunched
+  }
+
+  public var launchedAt: TimeInterval? {
+    return self.projectLaunchedAt.flatMap(TimeInterval.init)
+  }
+
+  public var deadline: TimeInterval? {
+    return self.deadlineAt.flatMap(TimeInterval.init)
+  }
+
+  public var isStarred: Bool? {
+    return self.isWatched
+  }
+}

--- a/Library/ViewModels/BackerDashboardProjectCellViewModel+Utilities.swift
+++ b/Library/ViewModels/BackerDashboardProjectCellViewModel+Utilities.swift
@@ -1,0 +1,114 @@
+import Foundation
+import UIKit
+
+func metadataString(for project: any BackerDashboardProjectCellViewModel.ProjectCellModel) -> String {
+  guard !isProjectPrelaunch(project) else { return Strings.Coming_soon() }
+
+  switch project.state {
+  case .live:
+    guard let deadline = project.deadline else {
+      return ""
+    }
+
+    let duration = Format.duration(secondsInUTC: deadline, abbreviate: true, useToGo: false)
+    return "\(duration.time) \(duration.unit)"
+  default:
+    return stateString(for: project)
+  }
+}
+
+func percentFundedString(
+  for project: any BackerDashboardProjectCellViewModel
+    .ProjectCellModel
+) -> NSAttributedString {
+  let percentage = Format.percentage(project.percentFunded)
+
+  switch project.state {
+  case .live, .successful:
+    return NSAttributedString(string: percentage, attributes: [
+      NSAttributedString.Key.font: UIFont.ksr_caption1(size: 10),
+      NSAttributedString.Key.foregroundColor: UIColor.ksr_create_700
+    ])
+  default:
+    return NSAttributedString(string: percentage, attributes: [
+      NSAttributedString.Key.font: UIFont.ksr_caption1(size: 10),
+      NSAttributedString.Key.foregroundColor: UIColor.ksr_support_400
+    ])
+  }
+}
+
+func progressBarColorForProject(
+  _ project: any BackerDashboardProjectCellViewModel
+    .ProjectCellModel
+) -> UIColor {
+  switch project.state {
+  case .live, .successful:
+    return .ksr_create_700
+  default:
+    return .ksr_support_300
+  }
+}
+
+func metadataBackgroundColorForProject(
+  _ project: any BackerDashboardProjectCellViewModel
+    .ProjectCellModel
+) -> UIColor {
+  guard !isProjectPrelaunch(project) else {
+    return .ksr_create_700
+  }
+
+  switch project.state {
+  case .live, .successful:
+    return .ksr_create_700
+  default:
+    return .ksr_support_700
+  }
+}
+
+func titleString(
+  for project: any BackerDashboardProjectCellViewModel
+    .ProjectCellModel
+) -> NSAttributedString {
+  switch project.state {
+  case .live, .successful:
+    return NSAttributedString(string: project.name, attributes: [
+      NSAttributedString.Key.font: UIFont.ksr_caption1(size: 13),
+      NSAttributedString.Key.foregroundColor: UIColor.ksr_support_700
+    ])
+  default:
+    return NSAttributedString(string: project.name, attributes: [
+      NSAttributedString.Key.font: UIFont.ksr_caption1(size: 13),
+      NSAttributedString.Key.foregroundColor: UIColor.ksr_support_400
+    ])
+  }
+}
+
+private func stateString(for project: any BackerDashboardProjectCellViewModel.ProjectCellModel) -> String {
+  switch project.state {
+  case .canceled:
+    return Strings.profile_projects_status_canceled()
+  case .successful:
+    return Strings.profile_projects_status_successful()
+  case .suspended:
+    return Strings.profile_projects_status_suspended()
+  case .failed:
+    return Strings.profile_projects_status_unsuccessful()
+  default:
+    return ""
+  }
+}
+
+func isProjectPrelaunch(_ project: any BackerDashboardProjectCellViewModel.ProjectCellModel) -> Bool {
+  switch (project.displayPrelaunch, project.prelaunchActivated, project.launchedAt) {
+  // GraphQL requests using ProjectFragment will populate displayPrelaunch and prelaunchActivated
+  case (.some(true), .some(true), _):
+    return true
+
+  // V1 requests may not return displayPrelaunch and prelaunchActivated.
+  // But if no launch date is set, we can assume this is a prelaunch project.
+  case let (.none, .none, .some(timeValue)):
+    return timeValue <= 0
+  default:
+    return false
+  }
+}

--- a/Library/ViewModels/BackerDashboardProjectCellViewModel+Utilities.swift
+++ b/Library/ViewModels/BackerDashboardProjectCellViewModel+Utilities.swift
@@ -19,33 +19,22 @@ func metadataString(for project: any BackerDashboardProjectCellViewModel.Project
 
 func percentFundedString(
   for project: any BackerDashboardProjectCellViewModel
-    .ProjectCellModel
+    .ProjectCellModel,
+  fontSize: CGFloat? = nil
 ) -> NSAttributedString {
   let percentage = Format.percentage(project.percentFunded)
 
   switch project.state {
   case .live, .successful:
     return NSAttributedString(string: percentage, attributes: [
-      NSAttributedString.Key.font: UIFont.ksr_caption1(size: 10),
+      NSAttributedString.Key.font: UIFont.ksr_caption1(size: fontSize),
       NSAttributedString.Key.foregroundColor: UIColor.ksr_create_700
     ])
   default:
     return NSAttributedString(string: percentage, attributes: [
-      NSAttributedString.Key.font: UIFont.ksr_caption1(size: 10),
+      NSAttributedString.Key.font: UIFont.ksr_caption1(size: fontSize),
       NSAttributedString.Key.foregroundColor: UIColor.ksr_support_400
     ])
-  }
-}
-
-func progressBarColorForProject(
-  _ project: any BackerDashboardProjectCellViewModel
-    .ProjectCellModel
-) -> UIColor {
-  switch project.state {
-  case .live, .successful:
-    return .ksr_create_700
-  default:
-    return .ksr_support_300
   }
 }
 

--- a/Library/ViewModels/BackerDashboardProjectCellViewModel.swift
+++ b/Library/ViewModels/BackerDashboardProjectCellViewModel.swift
@@ -48,7 +48,6 @@ public protocol BackerDashboardProjectCellViewModelType {
 public final class BackerDashboardProjectCellViewModel: BackerDashboardProjectCellViewModelType,
   BackerDashboardProjectCellViewModelInputs, BackerDashboardProjectCellViewModelOutputs {
   public protocol ProjectCellModel {
-    var id: Int { get }
     var name: String { get }
     var state: Project.State { get }
     var imageURL: String { get }

--- a/Library/ViewModels/BackerDashboardProjectCellViewModel.swift
+++ b/Library/ViewModels/BackerDashboardProjectCellViewModel.swift
@@ -50,7 +50,7 @@ public final class BackerDashboardProjectCellViewModel: BackerDashboardProjectCe
   public protocol ProjectCellModel {
     var name: String { get }
     var state: Project.State { get }
-    var imageURL: String { get }
+    var imageURL: String? { get }
     var fundingProgress: Float { get }
     var percentFunded: Int { get }
     var displayPrelaunch: Bool? { get }
@@ -65,7 +65,13 @@ public final class BackerDashboardProjectCellViewModel: BackerDashboardProjectCe
 
     self.projectTitleText = project.map(titleString(for:))
 
-    self.photoURL = project.map { URL(string: $0.imageURL) }
+    self.photoURL = project.map { project in
+      guard let urlString = project.imageURL else {
+        return nil
+      }
+
+      return URL(string: urlString)
+    }
 
     self.progress = project.map { $0.fundingProgress }
 

--- a/Library/ViewModels/BackerDashboardProjectCellViewModel.swift
+++ b/Library/ViewModels/BackerDashboardProjectCellViewModel.swift
@@ -85,7 +85,7 @@ public final class BackerDashboardProjectCellViewModel: BackerDashboardProjectCe
       return project.state != .live
     }
 
-    self.percentFundedText = project.map(percentFundedString(for:))
+    self.percentFundedText = project.map { percentFundedString(for: $0, fontSize: 10.0) }
 
     self.progressBarColor = project.map(progressBarColorForProject)
 
@@ -112,4 +112,16 @@ public final class BackerDashboardProjectCellViewModel: BackerDashboardProjectCe
 
   public var inputs: BackerDashboardProjectCellViewModelInputs { return self }
   public var outputs: BackerDashboardProjectCellViewModelOutputs { return self }
+}
+
+private func progressBarColorForProject(
+  _ project: any BackerDashboardProjectCellViewModel
+    .ProjectCellModel
+) -> UIColor {
+  switch project.state {
+  case .live, .successful:
+    return .ksr_create_700
+  default:
+    return .ksr_support_300
+  }
 }

--- a/Library/ViewModels/BackerDashboardProjectCellViewModelTests.swift
+++ b/Library/ViewModels/BackerDashboardProjectCellViewModelTests.swift
@@ -32,7 +32,7 @@ internal final class BackerDashboardProjectCellViewModelTests: TestCase {
   }
 
   func testProjectData_Live() {
-    let endingInDays = self.dateType.init().timeIntervalSince1970 + 60.0 * 60.0 * 24.0 * 14.0
+    let endingInDays = self.endingIn(days: 14)
 
     let project = .template
       |> Project.lens.name .~ "Best of Lazy Bathtub Cat"
@@ -167,5 +167,277 @@ internal final class BackerDashboardProjectCellViewModelTests: TestCase {
 
     self.prelaunchProject.assertValues([true])
     self.metadataText.assertValues(["Coming soon"])
+  }
+
+  func testProjectData_GraphQL_Live() {
+    let endingInDays = self.endingIn(days: 10)
+
+    let jsonString = """
+      {
+              "__typename": "Project",
+              "projectId": "pid",
+              "name": "Test Project Data Live",
+              "projectState": "LIVE",
+              "image": {
+                "__typename": "Image",
+                "id": "placeholder",
+                "url": "https://www.kickerstart.com/image.png"
+              },
+              "goal": {
+                "__typename": "Money",
+                "amount": "500.0",
+                "currency": "USD",
+                "symbol": "$"
+              },
+              "pledged": {
+                "__typename": "Money",
+                "amount": "250.0",
+                "currency": "USD",
+                "symbol": "$"
+              },
+              "isLaunched": true,
+              "projectPrelaunchActivated": false,
+              "deadlineAt": \(endingInDays),
+              "projectLaunchedAt": 1706727593,
+              "isWatched": false
+    }
+    """
+
+    let fragment = try! GraphAPI.BackerDashboardProjectCellFragment(jsonString: jsonString)
+
+    self.vm.inputs.configureWith(project: fragment)
+
+    self.metadataIconIsHidden.assertValues([false])
+    self.metadataText.assertValues(["10 days"])
+    self.percentFundedText.assertValues(["50%"])
+    self.photoURL.assertValues(["https://www.kickerstart.com/image.png"])
+    self.progress.assertValues([0.5])
+    self.progressBarColor.assertValues([UIColor.ksr_create_700])
+    self.projectTitleText.assertValues(["Test Project Data Live"])
+    self.savedIconIsHidden.assertValues([true])
+  }
+
+  func testProjectData_GraphQL_Successful() {
+    let jsonString = """
+        {
+          "__typename": "Project",
+          "projectId": "pid",
+          "name": "Test Project Data Successful",
+          "projectState": "SUCCESSFUL",
+          "image": {
+            "__typename": "Image",
+            "id": "id",
+            "url": "https://www.kickerstart.com/image.png"
+          },
+          "goal": {
+            "__typename": "Money",
+            "amount": "500.0",
+            "currency": "CAD",
+            "symbol": "$"
+          },
+          "pledged": {
+            "__typename": "Money",
+            "amount": "2000.00",
+            "currency": "CAD",
+            "symbol": "$"
+          },
+          "isLaunched": true,
+          "projectPrelaunchActivated": false,
+          "deadlineAt": 1625071247,
+          "projectLaunchedAt": 1622479247,
+          "isWatched": false
+        }
+    """
+
+    let fragment = try! GraphAPI.BackerDashboardProjectCellFragment(jsonString: jsonString)
+
+    self.vm.inputs.configureWith(project: fragment)
+
+    self.metadataIconIsHidden.assertValues([true])
+    self.metadataText.assertValues(["Successful"])
+    self.percentFundedText.assertValues(["400%"])
+    self.photoURL.assertValues(["https://www.kickerstart.com/image.png"])
+    self.progress.assertValues([4.0])
+    self.progressBarColor.assertValues([UIColor.ksr_create_700])
+    self.projectTitleText.assertValues(["Test Project Data Successful"])
+    self.savedIconIsHidden.assertValues([true])
+  }
+
+  func testProjectData_GraphQL_Failed() {
+    let jsonString = """
+        {
+          "__typename": "Project",
+          "projectId": "pid",
+          "name": "Test Project Data Failed",
+          "projectState": "FAILED",
+          "image": {
+            "__typename": "Image",
+            "id": "id",
+            "url": "https://www.kickerstart.com/image.png"
+          },
+          "goal": {
+            "__typename": "Money",
+            "amount": "500.0",
+            "currency": "CAD",
+            "symbol": "$"
+          },
+          "pledged": {
+            "__typename": "Money",
+            "amount": "50.0",
+            "currency": "CAD",
+            "symbol": "$"
+          },
+          "isLaunched": true,
+          "projectPrelaunchActivated": false,
+          "deadlineAt": 1625071247,
+          "projectLaunchedAt": 1622479247,
+          "isWatched": false
+        }
+    """
+
+    let fragment = try! GraphAPI.BackerDashboardProjectCellFragment(jsonString: jsonString)
+
+    self.vm.inputs.configureWith(project: fragment)
+
+    self.metadataIconIsHidden.assertValues([true])
+    self.metadataText.assertValues(["Unsuccessful"])
+    self.percentFundedText.assertValues(["10%"])
+    self.photoURL.assertValues(["https://www.kickerstart.com/image.png"])
+    self.progress.assertValues([0.1])
+    self.progressBarColor.assertValues([UIColor.ksr_support_300])
+    self.projectTitleText.assertValues(["Test Project Data Failed"])
+    self.savedIconIsHidden.assertValues([true])
+  }
+
+  func testProjectData_GraphQL_Saved() {
+    let endingInDays = self.endingIn(days: 94)
+
+    let jsonString = """
+      {
+              "__typename": "Project",
+              "projectId": "pid",
+              "name": "Test Project Data Live",
+              "projectState": "LIVE",
+              "image": {
+                "__typename": "Image",
+                "id": "placeholder",
+                "url": "https://www.kickerstart.com/image.png"
+              },
+              "goal": {
+                "__typename": "Money",
+                "amount": "500.0",
+                "currency": "USD",
+                "symbol": "$"
+              },
+              "pledged": {
+                "__typename": "Money",
+                "amount": "250.0",
+                "currency": "USD",
+                "symbol": "$"
+              },
+              "isLaunched": true,
+              "projectPrelaunchActivated": false,
+              "deadlineAt": \(endingInDays),
+              "projectLaunchedAt": 1706727593,
+              "isWatched": true
+    }
+    """
+
+    let fragment = try! GraphAPI.BackerDashboardProjectCellFragment(jsonString: jsonString)
+
+    self.vm.inputs.configureWith(project: fragment)
+
+    self.metadataIconIsHidden.assertValues([false])
+    self.metadataText.assertValues(["94 days"])
+    self.percentFundedText.assertValues(["50%"])
+    self.photoURL.assertValues(["https://www.kickerstart.com/image.png"])
+    self.progress.assertValues([0.5])
+    self.progressBarColor.assertValues([UIColor.ksr_create_700])
+    self.projectTitleText.assertValues(["Test Project Data Live"])
+    self.savedIconIsHidden.assertValues([false])
+  }
+
+  func testProjectData_GraphQL_Prelaunch_Displayed() {
+    let jsonString = """
+        {
+          "__typename": "Project",
+          "projectId": "pid",
+          "name": "Test Project Data Prelaunch",
+          "projectState": "SUBMITTED",
+          "image": {
+            "__typename": "Photo",
+            "id": "imageid",
+            "url": "https://www.kickstarter.com/image.png"
+          },
+          "goal": {
+            "__typename": "Money",
+            "amount": "100000.0",
+            "currency": "CAD",
+            "symbol": "$"
+          },
+          "pledged": {
+            "__typename": "Money",
+            "amount": "0.0",
+            "currency": "CAD",
+            "symbol": "$"
+          },
+          "isLaunched": false,
+          "projectPrelaunchActivated": true,
+          "deadlineAt": null,
+          "projectLaunchedAt": null,
+          "isWatched": false
+        }
+    """
+
+    let fragment = try! GraphAPI.BackerDashboardProjectCellFragment(jsonString: jsonString)
+
+    self.vm.inputs.configureWith(project: fragment)
+
+    self.prelaunchProject.assertValues([true])
+    self.metadataText.assertValues(["Coming soon"])
+  }
+
+  func testProjectData_GraphQL_Prelaunch_ActivatedButNotDisplayed() {
+    let jsonString = """
+        {
+          "__typename": "Project",
+          "projectId": "pid",
+          "name": "Test Project Data Successful",
+          "projectState": "SUCCESSFUL",
+          "image": {
+            "__typename": "Image",
+            "id": "id",
+            "url": "https://www.kickerstart.com/image.png"
+          },
+          "goal": {
+            "__typename": "Money",
+            "amount": "500.0",
+            "currency": "CAD",
+            "symbol": "$"
+          },
+          "pledged": {
+            "__typename": "Money",
+            "amount": "2000.00",
+            "currency": "CAD",
+            "symbol": "$"
+          },
+          "isLaunched": true,
+          "projectPrelaunchActivated": true,
+          "deadlineAt": 1625071247,
+          "projectLaunchedAt": 1622479247,
+          "isWatched": false
+        }
+    """
+
+    let fragment = try! GraphAPI.BackerDashboardProjectCellFragment(jsonString: jsonString)
+
+    self.vm.inputs.configureWith(project: fragment)
+
+    self.prelaunchProject.assertValues([false])
+    self.metadataText.assertValues(["Successful"])
+  }
+
+  private func endingIn(days: Int) -> TimeInterval {
+    self.dateType.init().timeIntervalSince1970 + 60.0 * 60.0 * 24.0 * Double(days)
   }
 }

--- a/Library/ViewModels/MostPopularSearchProjectCellViewModel.swift
+++ b/Library/ViewModels/MostPopularSearchProjectCellViewModel.swift
@@ -54,7 +54,7 @@ public final class MostPopularSearchProjectCellViewModel: MostPopularSearchProje
 
     self.progressBarColor = project.map(progressBarColorForProject)
 
-    self.percentFundedText = project.map(percentFundedString(for:))
+    self.percentFundedText = project.map { percentFundedString(for: $0) }
 
     self.metadataText = project.map(metadataString(for:))
 
@@ -77,4 +77,18 @@ public final class MostPopularSearchProjectCellViewModel: MostPopularSearchProje
 
   public var inputs: MostPopularSearchProjectCellViewModelInputs { return self }
   public var outputs: MostPopularSearchProjectCellViewModelOutputs { return self }
+}
+
+private func progressBarColorForProject(
+  _ project: any BackerDashboardProjectCellViewModel
+    .ProjectCellModel
+) -> UIColor {
+  guard !isProjectPrelaunch(project) else { return .ksr_create_700 }
+
+  switch project.state {
+  case .live, .successful:
+    return .ksr_create_700
+  default:
+    return .ksr_support_400
+  }
 }

--- a/Library/ViewModels/MostPopularSearchProjectCellViewModel.swift
+++ b/Library/ViewModels/MostPopularSearchProjectCellViewModel.swift
@@ -40,7 +40,13 @@ public final class MostPopularSearchProjectCellViewModel: MostPopularSearchProje
   public init() {
     let project = self.projectProperty.signal.skipNil()
 
-    self.projectImageUrl = project.map { URL(string: $0.imageURL) }
+    self.projectImageUrl = project.map { project in
+      guard let urlString = project.imageURL else {
+        return nil
+      }
+
+      return URL(string: urlString)
+    }
 
     self.projectName = project.map(titleString(for:))
 

--- a/Library/ViewModels/MostPopularSearchProjectCellViewModelTests.swift
+++ b/Library/ViewModels/MostPopularSearchProjectCellViewModelTests.swift
@@ -95,6 +95,7 @@ internal final class MostPopularSearchProjectCellViewModelTests: TestCase {
       |> Project.lens.name .~ "Best of Lazy Bathtub Cat"
       |> Project.lens.photo.full .~ "http://www.lazybathtubcat.com/vespa.jpg"
       |> Project.lens.displayPrelaunch .~ true
+      |> Project.lens.prelaunchActivated .~ true
       |> Project.lens.personalization.isStarred .~ true
 
     self.prelaunchProject.assertDidNotEmitValue()

--- a/Library/ViewModels/Project+ProjectCellModel.swift
+++ b/Library/ViewModels/Project+ProjectCellModel.swift
@@ -1,0 +1,28 @@
+import Foundation
+import KsApi
+
+extension Project: BackerDashboardProjectCellViewModel.ProjectCellModel {
+  public var fundingProgress: Float {
+    return self.stats.fundingProgress
+  }
+
+  public var percentFunded: Int {
+    return self.stats.percentFunded
+  }
+
+  public var imageURL: String {
+    return self.photo.full
+  }
+
+  public var launchedAt: TimeInterval? {
+    return self.dates.launchedAt
+  }
+
+  public var deadline: TimeInterval? {
+    return self.dates.deadline
+  }
+
+  public var isStarred: Bool? {
+    self.personalization.isStarred
+  }
+}

--- a/Library/ViewModels/Project+ProjectCellModel.swift
+++ b/Library/ViewModels/Project+ProjectCellModel.swift
@@ -10,7 +10,7 @@ extension Project: BackerDashboardProjectCellViewModel.ProjectCellModel {
     return self.stats.percentFunded
   }
 
-  public var imageURL: String {
+  public var imageURL: String? {
     return self.photo.full
   }
 


### PR DESCRIPTION

<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

- Add the protocol `ProjectCellModel`
- Use a `ProjectCellModel` as input to `BackerDashboardProjectCellViewModel`
- Implement an extension on `Project` to implement `ProjectCellModel`
- Add a GraphQL fragment, `BackerDashboardProjectCellFragment`, which also implements `ProjectCellModel`
- Share UI code between `BackerDashboardProjectCell` and `MostPopularSearchProjectCell`

# 🤔 Why

This is one of the pieces that's been blocking us from using GraphQL in the Search flow. This refactoring will allow us to use a short fragment, `BackerDashboardProjectCellFragment`, to power our old Search UI, instead of the Project page fragment `ProjectFragment`.

# 🛠 How

I did my best to minimize collateral damage with this refactoring:

1. I made the protocol first, and made it match `Project` whenever possible.
2. Then I refactored the cell to use the protocol.
3. Then I added the new fragment, and implemented the protocol.
