### PR TITLE
[MBL-2166] SPC - Project Cards Loading Cell

### DIFF
--- a/Kickstarter-iOS/Features/ProjectPage/SimilarProjects/Cells/SimilarProjectsLoadingCollectionViewCell.swift
+++ b/Kickstarter-iOS/Features/ProjectPage/SimilarProjects/Cells/SimilarProjectsLoadingCollectionViewCell.swift
@@ -1,0 +1,113 @@
+import Foundation
+import Library
+import Prelude
+import UIKit
+
+private enum Constants {
+  static let imageAspectRatio = CGFloat(9.0 / 16.0)
+}
+
+final class SimilarProjectsLoadingCollectionViewCell: UICollectionViewCell, ValueCell {
+  // MARK: - Properties
+
+  private lazy var imagePlaceholder: UIView = { UIView(frame: .zero) }()
+  private lazy var titleLabelPlaceholder: UIView = { UIView(frame: .zero) }()
+  private lazy var subtitleLabelPlaceholder: UIView = { UIView(frame: .zero) }()
+
+  // MARK: - Lifecycle
+
+  override init(frame: CGRect) {
+    super.init(frame: frame)
+
+    self.configureViews()
+    self.setupConstraints()
+
+    self.startLoading()
+  }
+
+  @available(*, unavailable)
+  required init?(coder _: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  override func layoutSubviews() {
+    super.layoutSubviews()
+
+    self.layoutPlaceholderViews()
+    self.layoutGradientLayers()
+  }
+
+  private func layoutPlaceholderViews() {
+    self.imagePlaceholder.layoutIfNeeded()
+    self.titleLabelPlaceholder.layoutIfNeeded()
+    self.subtitleLabelPlaceholder.layoutIfNeeded()
+
+    self.titleLabelPlaceholder.layer.cornerRadius = self.titleLabelPlaceholder.bounds.height / 2
+    self.subtitleLabelPlaceholder.layer.cornerRadius = self.subtitleLabelPlaceholder.bounds.height / 2
+  }
+
+  override func bindStyles() {
+    super.bindStyles()
+
+    applyImageViewStyle(self.imagePlaceholder)
+
+    applyLabelViewStyle(self.titleLabelPlaceholder)
+    applyLabelViewStyle(self.subtitleLabelPlaceholder)
+  }
+
+  func configureWith(value _: Void) {}
+
+  // MARK: - Subviews
+
+  private func configureViews() {
+    self.contentView.addSubview(self.imagePlaceholder)
+    self.contentView.addSubview(self.titleLabelPlaceholder)
+    self.contentView.addSubview(self.subtitleLabelPlaceholder)
+  }
+
+  private func setupConstraints() {
+    NSLayoutConstraint.activate([
+      self.imagePlaceholder.heightAnchor.constraint(
+        equalTo: self.contentView.heightAnchor,
+        multiplier: Constants.imageAspectRatio
+      ),
+      self.imagePlaceholder.widthAnchor.constraint(equalTo: self.contentView.widthAnchor),
+      self.titleLabelPlaceholder.topAnchor.constraint(
+        equalTo: self.imagePlaceholder.bottomAnchor,
+        constant: Styles.grid(3)
+      ),
+      self.titleLabelPlaceholder.widthAnchor.constraint(equalTo: self.widthAnchor, multiplier: 0.75),
+      self.titleLabelPlaceholder.heightAnchor.constraint(equalToConstant: 20),
+      self.subtitleLabelPlaceholder.topAnchor.constraint(
+        equalTo: self.titleLabelPlaceholder.bottomAnchor,
+        constant: Styles.grid(3)
+      ),
+      self.subtitleLabelPlaceholder.widthAnchor.constraint(equalTo: self.widthAnchor, multiplier: 0.5),
+      self.subtitleLabelPlaceholder.heightAnchor.constraint(equalToConstant: 20)
+    ])
+  }
+}
+
+private func applyImageViewStyle(_ view: UIView) {
+  view.backgroundColor = .ksr_support_300
+  view.layer.cornerRadius = Styles.grid(2)
+  view.clipsToBounds = true
+  view.layer.masksToBounds = true
+  view.translatesAutoresizingMaskIntoConstraints = false
+}
+
+private func applyLabelViewStyle(_ view: UIView) {
+  view.backgroundColor = .ksr_support_300
+  view.clipsToBounds = true
+  view.layer.masksToBounds = true
+  view.insetsLayoutMarginsFromSafeArea = false
+  view.translatesAutoresizingMaskIntoConstraints = false
+}
+
+// MARK: - ShimmerLoading
+
+extension SimilarProjectsLoadingCollectionViewCell: ShimmerLoading {
+  func shimmerViews() -> [UIView] {
+    return [self.imagePlaceholder]
+  }
+}

--- a/Kickstarter-iOS/Features/ProjectPage/SimilarProjects/Cells/SimilarProjectsLoadingCollectionViewCell.swift
+++ b/Kickstarter-iOS/Features/ProjectPage/SimilarProjects/Cells/SimilarProjectsLoadingCollectionViewCell.swift
@@ -108,6 +108,6 @@ private func applyLabelViewStyle(_ view: UIView) {
 
 extension SimilarProjectsLoadingCollectionViewCell: ShimmerLoading {
   func shimmerViews() -> [UIView] {
-    return [self.imagePlaceholder]
+    return [self.imagePlaceholder, self.titleLabelPlaceholder, self.subtitleLabelPlaceholder]
   }
 }

--- a/Kickstarter-iOS/Features/ProjectPage/SimilarProjects/Cells/SimilarProjectsTableViewCell.swift
+++ b/Kickstarter-iOS/Features/ProjectPage/SimilarProjects/Cells/SimilarProjectsTableViewCell.swift
@@ -39,6 +39,7 @@ class SimilarProjectsTableViewCell: UITableViewCell, ValueCell {
     self.collectionView.dataSource = self.dataSource
     self.collectionView.delegate = self
     self.collectionView.registerCellClass(SimilarProjectsCollectionViewCell.self)
+    self.collectionView.registerCellClass(SimilarProjectsLoadingCollectionViewCell.self)
 
     self.configureSubviews()
     self.bindStyles()

--- a/Kickstarter-iOS/Features/ProjectPage/SimilarProjects/Datasource/SimilarProjectsCollectionViewDataSource.swift
+++ b/Kickstarter-iOS/Features/ProjectPage/SimilarProjects/Datasource/SimilarProjectsCollectionViewDataSource.swift
@@ -4,7 +4,16 @@ import Library
 import UIKit
 
 final class SimilarProjectsCollectionViewDataSource: ValueCellDataSource {
-  func load(_ values: [any SimilarProject]) {
+  func load(_ values: [any SimilarProject], isLoading: Bool = false) {
+    guard isLoading == false else {
+      /// Sets `[(), ()]` in values so that two cells display to indicate that a collection is loading.
+      return self.set(
+        values: [(), ()],
+        cellClass: SimilarProjectsLoadingCollectionViewCell.self,
+        inSection: 0
+      )
+    }
+
     self.set(
       values: values,
       cellClass: SimilarProjectsCollectionViewCell.self,
@@ -14,6 +23,8 @@ final class SimilarProjectsCollectionViewDataSource: ValueCellDataSource {
 
   override func configureCell(collectionCell cell: UICollectionViewCell, withValue value: Any) {
     switch (cell, value) {
+    case let (cell as SimilarProjectsLoadingCollectionViewCell, value as Void):
+      cell.configureWith(value: value)
     case let (cell as SimilarProjectsCollectionViewCell, value as any SimilarProject):
       cell.configureWith(value: value)
     default:

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -600,6 +600,7 @@
 		60EAD1C728D25A36009F9474 /* AppCenterDistribute in Frameworks */ = {isa = PBXBuildFile; productRef = 60EAD1C628D25A36009F9474 /* AppCenterDistribute */; };
 		60F03AC12D8AFCE300DB6C01 /* SimilarProjectsCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60F03AC02D8AFCE300DB6C01 /* SimilarProjectsCollectionViewCell.swift */; };
 		60F03AC42D8AFD6100DB6C01 /* SimilarProjectsCollectionViewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60F03AC32D8AFD6100DB6C01 /* SimilarProjectsCollectionViewDataSource.swift */; };
+		60F03AC62D8B0C1600DB6C01 /* SimilarProjectsLoadingCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60F03AC52D8B0C1600DB6C01 /* SimilarProjectsLoadingCollectionViewCell.swift */; };
 		701160D4291ECB9F0095BF24 /* LoadingBarButtonItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 701160D2291ECB250095BF24 /* LoadingBarButtonItem.swift */; };
 		70495690299D53ED00B273DF /* SnapshotTesting in Frameworks */ = {isa = PBXBuildFile; productRef = 7049568F299D53ED00B273DF /* SnapshotTesting */; };
 		7061848B29BE4CD8008F9941 /* MessageBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7061848829BE4C11008F9941 /* MessageBannerView.swift */; };
@@ -2310,6 +2311,7 @@
 		60E5FF0F2D78C9F800BE9942 /* SimilarProjectsCardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimilarProjectsCardViewModel.swift; sourceTree = "<group>"; };
 		60F03AC02D8AFCE300DB6C01 /* SimilarProjectsCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimilarProjectsCollectionViewCell.swift; sourceTree = "<group>"; };
 		60F03AC32D8AFD6100DB6C01 /* SimilarProjectsCollectionViewDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimilarProjectsCollectionViewDataSource.swift; sourceTree = "<group>"; };
+		60F03AC52D8B0C1600DB6C01 /* SimilarProjectsLoadingCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimilarProjectsLoadingCollectionViewCell.swift; sourceTree = "<group>"; };
 		701160D2291ECB250095BF24 /* LoadingBarButtonItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingBarButtonItem.swift; sourceTree = "<group>"; };
 		7061848829BE4C11008F9941 /* MessageBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageBannerView.swift; sourceTree = "<group>"; };
 		7061848C29BE577B008F9941 /* MessageBannerViewViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageBannerViewViewModel.swift; sourceTree = "<group>"; };
@@ -5993,6 +5995,7 @@
 			children = (
 				604E57212D7C8A4000133A91 /* SimilarProjectsTableViewCell.swift */,
 				60F03AC02D8AFCE300DB6C01 /* SimilarProjectsCollectionViewCell.swift */,
+				60F03AC52D8B0C1600DB6C01 /* SimilarProjectsLoadingCollectionViewCell.swift */,
 			);
 			path = Cells;
 			sourceTree = "<group>";
@@ -8859,6 +8862,7 @@
 				D63BBD392180BE5D007E01F0 /* PaymentMethodsFooterView.swift in Sources */,
 				774F8D5B22B1B0B300A1ACD5 /* FeatureFlagToolsViewController.swift in Sources */,
 				7754A0AE215A8361003AA36D /* ChangePasswordViewController.swift in Sources */,
+				60F03AC62D8B0C1600DB6C01 /* SimilarProjectsLoadingCollectionViewCell.swift in Sources */,
 				60C996E62ABCC002006BE4F4 /* ReportProjectCell.swift in Sources */,
 				A72C3AB71D00FB1F0075227E /* DiscoveryExpandedSelectableRow.swift in Sources */,
 				063D2D0A2846767F00CEDE33 /* PledgeLocalPickupView.swift in Sources */,


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Creates a UICollectionViewCell with our gray shimmer loading animator to replace the project cards while they load.

Just the initial class setup. This will be fully wired up when I implement this and the [collection view work](https://github.com/kickstarter/ios-oss/pull/2336) into the Project Page.

# 🤔 Why

Loading states are helpful and make sense.

# 🛠 How

- create `SimilarProjectsLoadingCollectionVIewCell`
- use this new cell instead of the main project card cell while they are loading in `SimilarProjectsCollectionViewDataSource`

**Not fully wired up yet. Used my test code to get a screen recording.**

# 👀 See

| isLoading == true | |
| --- | --- |
| ![Simulator Screen Recording - iPhone 15 Pro 17 5 - 2025-03-18 at 15 42 06](https://github.com/user-attachments/assets/9f07c761-731e-44c7-a936-00a6d1785c8d) |  |

# ✅ Acceptance criteria

- [x] Loading cell matches [designs](https://www.figma.com/design/a9GQ3iQn7XzRUxbpE3cVpE/Search-%26-Discover?node-id=1921-1055&t=gFTPrtriuDMSxi23-4) (it's since been decided that the page control won't be shown during the loading state. disregard from designs)

# ⏰ TODO

- [ ] page selector
