### PR TITLE
[MBL-2167] SPC - Page Control

### DIFF
--- a/Kickstarter-iOS/Features/ProjectPage/SimilarProjects/Cells/SimilarProjectsTableViewCell.swift
+++ b/Kickstarter-iOS/Features/ProjectPage/SimilarProjects/Cells/SimilarProjectsTableViewCell.swift
@@ -33,17 +33,15 @@ final class SimilarProjectsTableViewCell: UITableViewCell, ValueCell {
 
   private lazy var titleLabel: UILabel = { UILabel(frame: .zero) }()
 
+  private let pageControl: UIPageControl = { UIPageControl(frame: .zero) }()
+
   override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
     super.init(style: style, reuseIdentifier: reuseIdentifier)
-
-    self.collectionView.dataSource = self.dataSource
-    self.dataSource.delegate = self
-    self.collectionView.registerCellClass(SimilarProjectsCollectionViewCell.self)
-    self.collectionView.registerCellClass(SimilarProjectsLoadingCollectionViewCell.self)
 
     self.configureSubviews()
     self.bindStyles()
     self.updateConstraints()
+    self.setupCollectionView()
   }
 
   @available(*, unavailable)
@@ -58,6 +56,7 @@ final class SimilarProjectsTableViewCell: UITableViewCell, ValueCell {
     applyTitleLabelStyle(self.titleLabel)
     applyCollectionViewStyle(self.collectionView)
     applyCollectionViewLayoutStyle(self.layout)
+    applyPageControlStyle(self.pageControl)
   }
 
   /// UITableViewCells have a hard time adjusting to a nested UICollectionView's contentSize.
@@ -74,6 +73,7 @@ final class SimilarProjectsTableViewCell: UITableViewCell, ValueCell {
   }
 
   private func configureSubviews() {
+    self.contentView.addSubview(self.pageControl)
     self.contentView.addSubview(self.collectionView)
     self.contentView.addSubview(self.titleLabel)
   }
@@ -100,7 +100,13 @@ final class SimilarProjectsTableViewCell: UITableViewCell, ValueCell {
         equalTo: self.contentView.trailingAnchor,
         constant: -SimilarProjectsCellConstants.spacing
       ),
-      self.collectionView.bottomAnchor.constraint(equalTo: self.contentView.bottomAnchor)
+      self.collectionView.bottomAnchor.constraint(equalTo: self.contentView.bottomAnchor),
+      self.pageControl.topAnchor.constraint(
+        equalTo: self.contentView.topAnchor,
+        constant: SimilarProjectsCellConstants.spacing
+      ),
+      self.pageControl.trailingAnchor.constraint(equalTo: self.contentView.trailingAnchor),
+      self.pageControl.heightAnchor.constraint(equalToConstant: 30)
     ])
 
     super.updateConstraints()
@@ -112,19 +118,26 @@ final class SimilarProjectsTableViewCell: UITableViewCell, ValueCell {
     guard let state = value else { return }
 
     switch state {
-    case .hidden:
+    case .hidden, .error:
       self.dataSource.load([], isLoading: false)
     case .loading:
       self.dataSource.load([], isLoading: true)
     case let .loaded(projects):
+      self.pageControl.numberOfPages = projects.count
       self.dataSource.load(projects, isLoading: false)
       self.collectionView.isScrollEnabled = true
-    case let .error(error):
-      self.dataSource.load([], isLoading: false)
     }
 
     self.collectionView.reloadData()
     self.layoutIfNeeded()
+  }
+
+  private func setupCollectionView() {
+    self.collectionView.dataSource = self.dataSource
+    self.collectionView.delegate = self
+    self.dataSource.delegate = self
+    self.collectionView.registerCellClass(SimilarProjectsCollectionViewCell.self)
+    self.collectionView.registerCellClass(SimilarProjectsLoadingCollectionViewCell.self)
   }
 }
 
@@ -149,10 +162,26 @@ private func applyCollectionViewLayoutStyle(_ layout: UICollectionViewFlowLayout
   layout.itemSize = SimilarProjectsCellConstants.collectionViewItemSize
 }
 
+private func applyPageControlStyle(_ pageControl: UIPageControl) {
+  pageControl.currentPage = 0
+  pageControl.currentPageIndicatorTintColor = .ksr_support_700
+  pageControl.pageIndicatorTintColor = .ksr_support_300
+  pageControl.hidesForSinglePage = true
+  pageControl.isUserInteractionEnabled = false
+  pageControl.translatesAutoresizingMaskIntoConstraints = false
+}
+
 private func applyTitleLabelStyle(_ label: UILabel) {
   label.text = Strings.Similar_projects()
-  label.font = .ksr_title3()
+  label.font = .ksr_title3().bolded
   label.translatesAutoresizingMaskIntoConstraints = false
+}
+
+extension SimilarProjectsTableViewCell: UICollectionViewDelegate, UICollectionViewDelegateFlowLayout {
+  func scrollViewDidScroll(_ scrollView: UIScrollView) {
+    let pageIndex = Int(round(scrollView.contentOffset.x / scrollView.frame.width))
+    self.pageControl.currentPage = Int(pageIndex)
+  }
 }
 
 extension SimilarProjectsTableViewCell: SimilarProjectsCollectionViewDataSourceDelegate {


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

- Adds a UIPageControl to the Similar Projects Carousel 
- Implements custom collectionview cell paging logic.
   - I was having trouble using the built in paging logic without having the middle cells being cut off by the content view edges. This is likely due to the collection view no being the full width of the screen.
   - Rather than implement custom paging logic I opted to not have the collection page at all for now so we can get this out.

# 🤔 Why

- Design says and it's helpful UX

# 🛠 How

Add a UIPageControl based on the [designs](https://www.figma.com/design/a9GQ3iQn7XzRUxbpE3cVpE/Search-%26-Discover?node-id=270-49686&t=foaUor18uurLWZRR-4) and make sure it updates to the currently visible project cell.

# 👀 See

|  |  |
| --- | --- |
| ![Simulator Screen Recording - iPhone 15 Pro 17 5 - 2025-03-20 at 14 09 22](https://github.com/user-attachments/assets/2e6fa7e0-2d99-4c9c-98e3-c26d409361e9) |  |

# ✅ Acceptance criteria

- [x] Page Control appears based on the [designs](https://www.figma.com/design/a9GQ3iQn7XzRUxbpE3cVpE/Search-%26-Discover?node-id=270-49686&t=foaUor18uurLWZRR-4) and make sure it updates to the currently visible project cell
