### PR TITLE
MBL-2212, MBL-2214: Add additional filter options and re-order to make Recommended first

### DIFF
--- a/Kickstarter-iOS/Features/Search/Extensions/DiscoveryParams_Sort+SortOption.swift
+++ b/Kickstarter-iOS/Features/Search/Extensions/DiscoveryParams_Sort+SortOption.swift
@@ -13,11 +13,15 @@ extension DiscoveryParams.Sort: SortOption {
     case .endingSoon:
       return Strings.discovery_sort_types_end_date()
     case .magic:
-      return Strings.discovery_sort_types_magic()
+      return Strings.Recommended()
     case .newest:
       return Strings.discovery_sort_types_newest()
     case .popular:
       return Strings.discovery_sort_types_popularity()
+    case .most_funded:
+      return Strings.discovery_sort_types_most_funded()
+    case .most_backed:
+      return Strings.discovery_sort_types_most_backed()
     }
   }
 }

--- a/KsApi/models/DiscoveryParams.swift
+++ b/KsApi/models/DiscoveryParams.swift
@@ -31,6 +31,8 @@ public struct DiscoveryParams {
     case magic
     case newest
     case popular = "popularity"
+    case most_funded
+    case most_backed
 
     public var trackingString: String {
       switch self {
@@ -38,6 +40,8 @@ public struct DiscoveryParams {
       case .magic: return "magic"
       case .newest: return "newest"
       case .popular: return "popular"
+      case .most_funded: return "most_funded"
+      case .most_backed: return "most_backed"
       }
     }
   }

--- a/Library/RefInfo.swift
+++ b/Library/RefInfo.swift
@@ -197,6 +197,10 @@ private func sortRefTagSuffix(_ sort: DiscoveryParams.Sort) -> String {
     return "_newest"
   case .popular:
     return "_popular"
+  case .most_backed:
+    return "_most_backed"
+  case .most_funded:
+    return "_most_funded"
   }
 }
 

--- a/Library/Styles/DiscoveryStyles.swift
+++ b/Library/Styles/DiscoveryStyles.swift
@@ -172,5 +172,17 @@ private func string(forSort sort: DiscoveryParams.Sort) -> String {
     return Strings.discovery_sort_types_newest()
   case .popular:
     return Strings.Popular()
+  case .most_backed:
+    assert(
+      false,
+      "most_backed was added for GraphQL compatibililty. It shouldn't actually be used in V1 Discover."
+    )
+    return Strings.discovery_sort_types_most_backed()
+  case .most_funded:
+    assert(
+      false,
+      "most_funded was added for GraphQL compatibililty. It shouldn't actually be used in V1 Discover."
+    )
+    return Strings.discovery_sort_types_most_funded()
   }
 }

--- a/Library/UseCases/SearchFiltersUseCase.swift
+++ b/Library/UseCases/SearchFiltersUseCase.swift
@@ -82,17 +82,19 @@ public final class SearchFiltersUseCase: SearchFiltersUseCaseType, SearchFilters
     self.tappedCategoryFilterObserver.send(value: ())
   }
 
-  fileprivate let selectedSortProperty = MutableProperty<DiscoveryParams.Sort>(.popular)
+  fileprivate let selectedSortProperty = MutableProperty<DiscoveryParams.Sort>(.magic)
   fileprivate let selectedCategoryProperty = MutableProperty<Category?>(nil)
 
   // Used for some extra sanity assertions.
   fileprivate let categoriesProperty = MutableProperty<[Category]>([])
 
   fileprivate let sortOptions = [
+    DiscoveryParams.Sort.magic, // aka Recommended
     DiscoveryParams.Sort.popular,
+    DiscoveryParams.Sort.newest,
     DiscoveryParams.Sort.endingSoon,
-    DiscoveryParams.Sort.magic,
-    DiscoveryParams.Sort.newest
+    DiscoveryParams.Sort.most_funded,
+    DiscoveryParams.Sort.most_backed
   ]
 
   public let showCategoryFilters: Signal<SearchFilterCategoriesSheet, Never>

--- a/Library/UseCases/SearchFiltersUseCaseTests.swift
+++ b/Library/UseCases/SearchFiltersUseCaseTests.swift
@@ -37,12 +37,12 @@ final class SearchFiltersUseCaseTests: TestCase {
     self.selectedCategory.assertLastValue(nil)
   }
 
-  func test_sort_onInitialSignal_isPopular() {
+  func test_sort_onInitialSignal_isRecommended() {
     self.selectedSort.assertDidNotEmitValue()
 
     self.initialObserver.send(value: ())
 
-    self.selectedSort.assertLastValue(.popular)
+    self.selectedSort.assertLastValue(.magic)
   }
 
   func test_tappedSort_showsSortOptions() {
@@ -57,8 +57,8 @@ final class SearchFiltersUseCaseTests: TestCase {
     if let sortOptions = self.showSort.lastValue {
       XCTAssertEqual(
         sortOptions.selectedOption,
-        .popular,
-        "First option, popular, should be selected by default"
+        .magic,
+        "First option, magic, should be selected by default"
       )
       XCTAssertGreaterThan(sortOptions.sortOptions.count, 0, "There should be multiple sort options")
     }
@@ -121,7 +121,7 @@ final class SearchFiltersUseCaseTests: TestCase {
     self.initialObserver.send(value: ())
 
     self.showSort.assertDidNotEmitValue()
-    self.selectedSort.assertLastValue(.popular)
+    self.selectedSort.assertLastValue(.magic)
 
     self.useCase.inputs.tappedSort()
     self.showSort.assertDidEmitValue()

--- a/Library/ViewModels/DiscoveryViewModel.swift
+++ b/Library/ViewModels/DiscoveryViewModel.swift
@@ -190,6 +190,12 @@ public final class DiscoveryViewModel: DiscoveryViewModelType, DiscoveryViewMode
     case .magic: return .magic
     case .newest: return .newest
     case .popular: return .popular
+    default:
+      assert(
+        false,
+        "The other sort types were added for GraphQL compatibility, and should never come up in V1 Discover."
+      )
+      return .magic
     }
   }
 

--- a/Library/ViewModels/SearchViewModel+GraphQL.swift
+++ b/Library/ViewModels/SearchViewModel+GraphQL.swift
@@ -11,6 +11,10 @@ extension GraphAPI.ProjectSort {
       return .newest
     case .popular:
       return .popularity
+    case .most_funded:
+      return .mostFunded
+    case .most_backed:
+      return .mostBacked
     }
   }
 }


### PR DESCRIPTION
# 📲 What

Add additional filtering options to `DiscoveryParams.Sort`.

# 🤔 Why

This adds a few extra sort options that are available in GraphQL. I also changed the default from Popularity to Recommended, to match Android.

<img width="531" alt="Screenshot 2025-03-21 at 4 50 40 PM" src="https://github.com/user-attachments/assets/1bea1d2f-6dde-42e1-a1ae-f9c217c7f391" />

# 🛠 How

Because the Search screen analytics are tightly coupled to `DiscoveryParams`, @Arkariang and I decided it makes the most sense to extend the existing `DiscoveryParams` model instead of creating a new one. However, it gets funny in this PR, because it means we're adding filter types that are really only in here for GraphQL - not for the actual V1 Discover endpoint.

I did my best to protect against those cases by adding `assert`s and sensible defaults everywhere I could. 