### PR TITLE
Turn guard statement into if statement

### DIFF
--- a/Library/UseCases/SearchFiltersUseCase.swift
+++ b/Library/UseCases/SearchFiltersUseCase.swift
@@ -119,7 +119,7 @@ public final class SearchFiltersUseCase: SearchFiltersUseCaseType, SearchFilters
     }
 
     let index = self.categoriesProperty.value.firstIndex(of: category)
-    guard index != nil else {
+    if index == nil {
       assert(false, "Selected category should be one of the categories set in SearchFiltersUseCase.")
     }
 


### PR DESCRIPTION
# 📲 What

Turn `guard` statement into `if` statement.

# 🤔 Why

It doesn't need to eject on failure, just throw an assert. Also it was breaking the build.
