### PR TITLE
[MBL-2235] SPC Doesn't Show When Project Is Loaded From Search

### DIFF
--- a/Library/ViewModels/ProjectPageViewModel.swift
+++ b/Library/ViewModels/ProjectPageViewModel.swift
@@ -496,7 +496,6 @@ public final class ProjectPageViewModel: ProjectPageViewModelType, ProjectPageVi
         .map(HelpType.helpType)
         .skipNil()
 
-    // We skip the first one here because on `viewDidLoad` we are setting .overview so we don't need a useless emission here
     let dataSourceUpdate = self.projectNavigationSelectorViewDidSelectProperty.signal
       .skipNil()
       .skipRepeats()
@@ -529,7 +528,6 @@ public final class ProjectPageViewModel: ProjectPageViewModelType, ProjectPageVi
 
         return dataSourceUpdate
       }
-      .skip(first: 1)
 
     let similarProjectsState = self.similarProjectsUseCase.similarProjects.signal
       .merge(

--- a/Library/ViewModels/ProjectPageViewModelTests.swift
+++ b/Library/ViewModels/ProjectPageViewModelTests.swift
@@ -1517,12 +1517,11 @@ final class ProjectPageViewModelTests: TestCase {
 
     self.vm.inputs.projectNavigationSelectorViewDidSelect(index: overviewSection)
 
-    // The view model skips the first emission
-    self.updateDataSourceNavigationSection.assertDidNotEmitValue()
+    self.updateDataSourceNavigationSection.assertValueCount(1)
 
     self.vm.inputs.projectNavigationSelectorViewDidSelect(index: environmentalCommitmentsSection)
 
-    self.updateDataSourceNavigationSection.assertValues([.environmentalCommitments])
+    self.updateDataSourceNavigationSection.assertValues([.overview, .environmentalCommitments])
   }
 
   func testOutput_UpdateDataSourceProject() {
@@ -1539,8 +1538,7 @@ final class ProjectPageViewModelTests: TestCase {
     self.updateDataSourceProject.assertDidNotEmitValue()
     self.vm.inputs.projectNavigationSelectorViewDidSelect(index: overviewSection)
 
-    // The view model skips the first emission
-    self.updateDataSourceProject.assertDidNotEmitValue()
+    self.updateDataSourceNavigationSection.assertValueCount(1)
 
     self.vm.inputs.projectNavigationSelectorViewDidSelect(index: environmentalCommitmentsSection)
 
@@ -1563,8 +1561,7 @@ final class ProjectPageViewModelTests: TestCase {
 
       self.vm.inputs.projectNavigationSelectorViewDidSelect(index: overviewSection)
 
-      // The view model skips the first emission
-      self.updateDataSourceProject.assertDidNotEmitValue()
+      self.updateDataSourceNavigationSection.assertValueCount(1)
 
       self.vm.inputs.projectNavigationSelectorViewDidSelect(index: environmentalCommitmentsSection)
 
@@ -1592,8 +1589,7 @@ final class ProjectPageViewModelTests: TestCase {
     self.updateDataSourceImageURLS.assertDidNotEmitValue()
     self.vm.inputs.projectNavigationSelectorViewDidSelect(index: overviewSection)
 
-    // The view model skips the first emission
-    self.updateDataSourceImageURLS.assertDidNotEmitValue()
+    self.updateDataSourceNavigationSection.assertValueCount(1)
 
     self.vm.inputs.projectNavigationSelectorViewDidSelect(index: campaignSection)
 
@@ -1633,8 +1629,7 @@ final class ProjectPageViewModelTests: TestCase {
     self.updateDataSourceImageURLS.assertDidNotEmitValue()
     self.vm.inputs.projectNavigationSelectorViewDidSelect(index: overviewSection)
 
-    // The view model skips the first emission
-    self.updateDataSourceImageURLS.assertDidNotEmitValue()
+    self.updateDataSourceNavigationSection.assertValueCount(1)
 
     self.vm.inputs.projectNavigationSelectorViewDidSelect(index: campaignSection)
 


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Removes `.skip(first: 1)` from one of the signals in ProjectPageViewModel that updates the table view data source.

# 🤔 Why

This `ProjectPageViewModel.dataSourceUpdate.skip(first: 1)` initially prevented an "unnecessary" signal emission when loading up ProjectPageViewController.
When loading a project page from Discover or Profile, `dataSourceUpdate` get's triggered twice but when loading one from Search or the SPC directly, it's called once.
   - This happens when `projectNavigationSelectorViewDidSelect` is called FYI

We need this signal to complete in order to load the SPC so removing the `.skip` is necessary.


I did some general testing to make sure that this wasn't added originally to also fix a bug. Looks it's all good. 

Having an extra signal emission isn't 

# 👀 See

|  |  |
| --- | --- |
| ![Simulator Screen Recording - iPhone 15 Pro 17 5 - 2025-03-24 at 14 24 47](https://github.com/user-attachments/assets/3153234a-3a08-4e38-b687-3206f0aff67e) |  |

# ✅ Acceptance criteria

- [x] SPC displays on Project page regardless of where it was opened from, when ff is enabled 
