### PR TITLE
Clear sort and filter options when search query is cleared

### DIFF
--- a/Library/UseCases/SearchFiltersUseCaseTests.swift
+++ b/Library/UseCases/SearchFiltersUseCaseTests.swift
@@ -187,4 +187,25 @@ final class SearchFiltersUseCaseTests: TestCase {
       "Category pill should have selected category title when category is selected"
     )
   }
+
+  func test_clearOptions_resetsSort_andClearsCategory() {
+    self.initialObserver.send(value: ())
+    self.categoriesObserver.send(value: [
+      .art
+    ])
+
+    self.selectedSort.assertLastValue(.magic)
+    self.selectedCategory.assertLastValue(nil)
+
+    self.useCase.inputs.selectedSortOption(.popular)
+    self.useCase.inputs.selectedCategory(.art)
+
+    self.selectedSort.assertLastValue(.popular)
+    self.selectedCategory.assertLastValue(.art)
+
+    self.useCase.inputs.clearOptions()
+
+    self.selectedSort.assertLastValue(.magic, "Sort should revert to default sort when options are cleared")
+    self.selectedCategory.assertLastValue(nil, "Category should revert to nil when options are cleared")
+  }
 }

--- a/Library/ViewModels/SearchViewModel.swift
+++ b/Library/ViewModels/SearchViewModel.swift
@@ -371,11 +371,13 @@ public final class SearchViewModel: SearchViewModelType, SearchViewModelInputs, 
   fileprivate let cancelButtonPressedProperty = MutableProperty(())
   public func cancelButtonPressed() {
     self.cancelButtonPressedProperty.value = ()
+    self.searchFiltersUseCase.inputs.clearOptions()
   }
 
   fileprivate let clearSearchTextProperty = MutableProperty(())
   public func clearSearchText() {
     self.clearSearchTextProperty.value = ()
+    self.searchFiltersUseCase.inputs.clearOptions()
   }
 
   fileprivate let searchFieldDidBeginEditingProperty = MutableProperty(())
@@ -386,6 +388,10 @@ public final class SearchViewModel: SearchViewModelType, SearchViewModelInputs, 
   fileprivate let searchTextChangedProperty = MutableProperty("")
   public func searchTextChanged(_ searchText: String) {
     self.searchTextChangedProperty.value = searchText
+
+    if searchText.isEmpty {
+      self.searchFiltersUseCase.inputs.clearOptions()
+    }
   }
 
   fileprivate let searchTextEditingDidEndProperty = MutableProperty(())


### PR DESCRIPTION
# 📲 What

Clear selected sort and filter options when the search query clears, is canceled, or is an empty string.

# 🤔 Why

This behavior feels a little more natural. Otherwise, you can get caught in a weird state where you have no search results, cancel the search, but then have 'retained' filters from your last failed query.
