### PR TITLE
Add Assets.xcassets to Library-iOSTests and switch to image(named:) helper

### DIFF
--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -299,6 +299,7 @@
 		33D11D422D68C57300CC88A3 /* KSRButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33D11D412D68C56700CC88A3 /* KSRButtonStyle.swift */; };
 		33D11D462D6EFFB500CC88A3 /* KSRButtonStyleConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33D11D452D6EFF9F00CC88A3 /* KSRButtonStyleConfiguration.swift */; };
 		33F04B262D28A8090078AED1 /* PledgeOverTimeBadgeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33F04B252D28A7F50078AED1 /* PledgeOverTimeBadgeView.swift */; };
+		33F39E342D9DB086007099A6 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A7D1F9501C850B7C000D41D5 /* Assets.xcassets */; };
 		33F55B3A2D4143940007E50E /* BadgeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33F55B392D41438E0007E50E /* BadgeView.swift */; };
 		33F55B3C2D499CDB0007E50E /* PledgeOverTimeIncrementView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33F55B3B2D499CCA0007E50E /* PledgeOverTimeIncrementView.swift */; };
 		33F55B3E2D4A6D030007E50E /* PledgePaymentIncrementFormatted.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33F55B3D2D4A6CF30007E50E /* PledgePaymentIncrementFormatted.swift */; };
@@ -7983,6 +7984,7 @@
 				E158030B2D836C370000BAB3 /* SearchQuery_EmptyResults.json in Resources */,
 				33F55B582D59F3C10007E50E /* Inter-VariableFont.ttf in Resources */,
 				E15803092D836C2C0000BAB3 /* SearchQuery_FiveResults.json in Resources */,
+				33F39E342D9DB086007099A6 /* Assets.xcassets in Resources */,
 				E158030A2D836C320000BAB3 /* SearchQuery_AnotherFiveResults.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Library/ViewModels/CreditCardCellViewModelTests.swift
+++ b/Library/ViewModels/CreditCardCellViewModelTests.swift
@@ -25,42 +25,42 @@ internal final class CreditCardCellViewModelTests: TestCase {
   func testCardInfoForSupportedCards() {
     self.vm.inputs.configureWith(creditCard: UserCreditCards.amex)
 
-    self.cardImage.assertLastValue(UIImage(named: "icon--amex"))
+    self.cardImage.assertLastValue(image(named: "icon--amex"))
     self.cardNumberAccessibilityLabel.assertLastValue("Amex, Card ending in 8882")
     self.cardNumberTextLongStyle.assertLastValue("Card ending in 8882")
     self.expirationDateText.assertLastValue("Expires 01/2024")
 
     self.vm.inputs.configureWith(creditCard: UserCreditCards.discover)
 
-    self.cardImage.assertLastValue(UIImage(named: "icon--discover"))
+    self.cardImage.assertLastValue(image(named: "icon--discover"))
     self.cardNumberAccessibilityLabel.assertLastValue("Discover, Card ending in 4242")
     self.cardNumberTextLongStyle.assertLastValue("Card ending in 4242")
     self.expirationDateText.assertLastValue("Expires 03/2022")
 
     self.vm.inputs.configureWith(creditCard: UserCreditCards.jcb)
 
-    self.cardImage.assertLastValue(UIImage(named: "icon--jcb"))
+    self.cardImage.assertLastValue(image(named: "icon--jcb"))
     self.cardNumberAccessibilityLabel.assertLastValue("Jcb, Card ending in 2222")
     self.cardNumberTextLongStyle.assertLastValue("Card ending in 2222")
     self.expirationDateText.assertLastValue("Expires 01/2022")
 
     self.vm.inputs.configureWith(creditCard: UserCreditCards.masterCard)
 
-    self.cardImage.assertLastValue(UIImage(named: "icon--mastercard"))
+    self.cardImage.assertLastValue(image(named: "icon--mastercard"))
     self.cardNumberAccessibilityLabel.assertLastValue("Mastercard, Card ending in 0000")
     self.cardNumberTextLongStyle.assertLastValue("Card ending in 0000")
     self.expirationDateText.assertLastValue("Expires 10/2018")
 
     self.vm.inputs.configureWith(creditCard: UserCreditCards.visa)
 
-    self.cardImage.assertLastValue(UIImage(named: "icon--visa"))
+    self.cardImage.assertLastValue(image(named: "icon--visa"))
     self.cardNumberAccessibilityLabel.assertLastValue("Visa, Card ending in 1111")
     self.cardNumberTextLongStyle.assertLastValue("Card ending in 1111")
     self.expirationDateText.assertLastValue("Expires 09/2019")
 
     self.vm.inputs.configureWith(creditCard: UserCreditCards.diners)
 
-    self.cardImage.assertLastValue(UIImage(named: "icon--diners"))
+    self.cardImage.assertLastValue(image(named: "icon--diners"))
     self.cardNumberAccessibilityLabel.assertLastValue("Diners, Card ending in 1212")
     self.cardNumberTextLongStyle.assertLastValue("Card ending in 1212")
     self.expirationDateText.assertLastValue("Expires 09/2022")
@@ -69,7 +69,7 @@ internal final class CreditCardCellViewModelTests: TestCase {
   func testSelectedCard() {
     self.vm.inputs.configureWith(creditCard: UserCreditCards.generic)
 
-    self.cardImage.assertValue(UIImage(named: "icon--generic"))
+    self.cardImage.assertValue(image(named: "icon--generic"))
     self.cardNumberTextLongStyle.assertLastValue("Card ending in 1882")
     self.expirationDateText.assertValue("Expires 01/2024")
   }
@@ -77,7 +77,7 @@ internal final class CreditCardCellViewModelTests: TestCase {
   func testCardInfoForUnsupportedCards() {
     self.vm.inputs.configureWith(creditCard: UserCreditCards.generic)
 
-    self.cardImage.assertValue(UIImage(named: "icon--generic"))
+    self.cardImage.assertValue(image(named: "icon--generic"))
     self.cardNumberTextLongStyle.assertLastValue("Card ending in 1882")
     self.expirationDateText.assertValue("Expires 01/2024")
   }
@@ -87,7 +87,7 @@ internal final class CreditCardCellViewModelTests: TestCase {
 
     self.vm.inputs.configureWith(creditCard: unknownCard)
 
-    self.cardImage.assertValue(UIImage(named: "icon--generic"))
+    self.cardImage.assertValue(image(named: "icon--generic"))
     self.cardNumberAccessibilityLabel.assertLastValue("Card ending in 1882")
     self.cardNumberTextLongStyle.assertLastValue("Card ending in 1882")
     self.expirationDateText.assertValue("Expires 01/2024")


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Fix asset loading in `Library-iOSTests` by adding the `Assets.xcassets` to the test target and using the `image(named:)` helper for better asset resolution in unit tests.

# 🛠 How

- Added `Assets.xcassets` to the `Library-iOSTests` test target to ensure test cases can load images and colors from the asset catalog.
- Replaced instances of `UIImage(named:)` in tests with the `image(named:)` helper, which resolves assets using `AppEnvironment.current.mainBundle`.

# ✅ Acceptance criteria

- [x] image|color-based assertions pass in `Library-iOSTests`.
- [x] Assets resolve properly in test context.
- [x] Code uses the appropriate bundle context via `AppEnvironment.current.mainBundle`.

# ⏰ TODO

- [ ] Monitor for any missing asset coverage.
