### PR TITLE
Images on rewards aspect ratio

### DIFF
--- a/Kickstarter-iOS/Features/RewardAddOnSelection/Views/RewardAddOnCardView.swift
+++ b/Kickstarter-iOS/Features/RewardAddOnSelection/Views/RewardAddOnCardView.swift
@@ -1,6 +1,5 @@
 import KsApi
 import Library
-import Prelude
 import ReactiveSwift
 import UIKit
 
@@ -80,12 +79,9 @@ public final class RewardAddOnCardView: UIView {
   public override func bindStyles() {
     super.bindStyles()
 
-    _ = self
-      |> checkoutWhiteBackgroundStyle
+    _ = checkoutWhiteBackgroundStyle(self)
 
-    _ = self.addButton
-      |> UIButton.lens.title(for: .normal) .~ Strings.Add()
-      |> blackButtonStyle
+    applyAddButtonStyle(self.addButton)
 
     var stackViews = [
       self.detailsStackView,
@@ -95,110 +91,37 @@ public final class RewardAddOnCardView: UIView {
     ]
 
     stackViews.insert(self.estimatedShippingStackView, at: 3)
-
-    _ = stackViews
-      ||> { stackView in
-        stackView
-          |> sectionStackViewStyle
-      }
+    stackViews.forEach(applySectionStackViewStyle)
 
     applyRootStackViewStyle(self.rootStackView)
+    applyDetailsStackViewStyle(self.detailsStackView)
+    applyTitleAmountStackViewStyle(self.titleAmountStackView)
+    _ = separatorStyle(self.includedItemsSeparator)
+    applyIncludedItemsStackViewStyle(self.includedItemsStackView)
+    applyIncludedItemsTitleLabel(self.includedItemsTitleLabel)
+    applyIncludedItemsLabel(self.includedItemsLabel)
+    _ = separatorStyle(self.estimatedShippingSeparator)
+    applyIncludedItemsStackViewStyle(self.estimatedShippingStackView)
+    applyEstimatedShippingTitleLabel(self.estimatedShippingTitleLabel)
+    applyEstimatedShippingLabel(self.estimatedShippingLabel)
+    applyDescriptionLabelStyle(self.descriptionLabel)
+    applyRewardTitleLabelStyle(self.rewardTitleLabel)
+    applyAmountLabelStyle(self.amountLabel)
+    applyAmountConvertedLabelStyle(self.amountConversionLabel)
+    applyQuantityLabelContainerStyle(self.quantityLabelContainer)
+    applyQuantityLabelStyle(self.quantityLabel)
+    applyStepperStyle(self.stepper)
+    applyStepperStackViewStyle(self.stepperStackView)
 
-    _ = self.detailsStackView
-      |> detailsStackViewStyle
+    self.rewardLocationStackView
+      .addArrangedSubviews(
+        self.rewardLocationTitleLabel,
+        self.rewardLocationPickupLabel
+      )
 
-    _ = self.titleAmountStackView
-      |> titleAmountStackViewStyle
-
-    _ = self.includedItemsSeparator
-      |> separatorStyle
-
-    _ = self.includedItemsStackView
-      |> includedItemsStackViewStyle
-
-    _ = self.includedItemsTitleLabel
-      |> baseRewardLabelStyle
-      |> \.font .~ UIFont.ksr_callout().weighted(.semibold)
-      |> \.text %~ { _ in Strings.project_view_pledge_includes() }
-      |> \.textColor .~ UIColor.ksr_support_400
-
-    _ = self.includedItemsLabel
-      |> baseRewardLabelStyle
-      |> \.font .~ .ksr_callout()
-
-    _ = self.estimatedShippingSeparator
-      |> separatorStyle
-
-    _ = self.estimatedShippingStackView
-      |> includedItemsStackViewStyle
-
-    _ = self.estimatedShippingTitleLabel
-      |> baseRewardLabelStyle
-      |> \.font .~ UIFont.ksr_callout().weighted(.semibold)
-      |> \.text %~ { _ in Strings.Estimated_Shipping() }
-      |> \.textColor .~ UIColor.ksr_support_400
-
-    _ = self.estimatedShippingLabel
-      |> baseRewardLabelStyle
-      |> \.font .~ .ksr_callout()
-
-    _ = self.descriptionLabel
-      |> baseRewardLabelStyle
-      |> descriptionLabelStyle
-
-    _ = self.rewardTitleLabel
-      |> baseRewardLabelStyle
-      |> rewardTitleLabelStyle
-
-    _ = self.amountLabel
-      |> baseRewardLabelStyle
-      |> amountLabelStyle
-
-    _ = self.amountConversionLabel
-      |> baseRewardLabelStyle
-      |> convertedAmountLabelStyle
-
-    _ = self.quantityLabelContainer
-      |> \.layoutMargins .~ .init(topBottom: Styles.grid(1), leftRight: Styles.grid(2))
-      |> \.layer.borderColor .~ UIColor.ksr_support_300.cgColor
-      |> \.layer.borderWidth .~ 1
-      |> checkoutRoundedCornersStyle
-
-    _ = self.quantityLabel
-      |> \.font .~ UIFont.ksr_headline().monospaced
-
-    _ = self.stepper
-      |> checkoutStepperStyle
-      |> UIStepper.lens.decrementImage(for: .normal) .~ image(named: "stepper-decrement-normal-grey")
-      |> UIStepper.lens.incrementImage(for: .normal) .~ image(named: "stepper-increment-normal-grey")
-
-    _ = self.stepperStackView
-      |> \.alignment .~ .center
-
-    _ = ([self.rewardLocationTitleLabel, self.rewardLocationPickupLabel], self.rewardLocationStackView)
-      |> ksr_addArrangedSubviewsToStackView()
-
-    _ = self.rewardLocationStackView
-      |> includedItemsStackViewStyle
-
-    _ = self.rewardLocationTitleLabel
-      |> baseRewardLabelStyle
-      |> sectionTitleLabelStyle
-
-    _ = self.rewardLocationTitleLabel
-      |> \.text %~ { _ in Strings.Reward_location() }
-      |> \.textColor .~ UIColor.ksr_support_400
-
-    _ = self.rewardLocationPickupLabel
-      |> baseRewardLabelStyle
-      |> sectionBodyLabelStyle
-
-    _ = self.rewardLocationStackView.subviews
-      .dropFirst()
-      .compactMap { $0 as? UILabel }
-      ||> baseRewardLabelStyle
-      ||> sectionBodyLabelStyle
-
+    applyIncludedItemsStackViewStyle(self.rewardLocationStackView)
+    applyRewardLocationTitleLabelStyle(self.rewardLocationTitleLabel)
+    applySectionBodyLabelStyle(self.rewardLocationPickupLabel)
     applyRewardImageViewStyle(self.rewardImageView)
   }
 
@@ -274,51 +197,45 @@ public final class RewardAddOnCardView: UIView {
     self.rootStackView.addArrangedSubviews(self.rewardImageView, self.detailsStackView)
 
     self.rewardImageView.isHidden = true
-    var detailsSubviews = [
+
+    self.detailsStackView.addArrangedSubviews(
       self.rewardTitleLabel,
       self.titleAmountStackView,
       self.descriptionLabel,
+      self.estimatedShippingStackView,
       self.includedItemsStackView,
       self.rewardLocationStackView,
       self.pillsView,
       self.addButton,
       self.stepperStackView
-    ]
+    )
 
-    detailsSubviews.insert(self.estimatedShippingStackView, at: 4)
+    self.titleAmountStackView.addArrangedSubviews(
+      self.rewardTitleLabel,
+      self.amountLabel,
+      self.amountConversionLabel
+    )
 
-    _ = (detailsSubviews, self.detailsStackView)
-      |> ksr_addArrangedSubviewsToStackView()
-
-    let titleAmountViews = [self.rewardTitleLabel, self.amountLabel, self.amountConversionLabel]
-
-    _ = (titleAmountViews, self.titleAmountStackView)
-      |> ksr_addArrangedSubviewsToStackView()
-
-    let includedItemsViews = [
+    self.includedItemsStackView.addArrangedSubviews(
       self.includedItemsSeparator,
       self.includedItemsTitleLabel,
       self.includedItemsLabel
-    ]
+    )
 
-    let estimatedShippingViews = [
+    self.estimatedShippingStackView.addArrangedSubviews(
       self.estimatedShippingSeparator,
       self.estimatedShippingTitleLabel,
       self.estimatedShippingLabel
-    ]
+    )
 
-    _ = (includedItemsViews, self.includedItemsStackView)
-      |> ksr_addArrangedSubviewsToStackView()
+    self.quantityLabelContainer.addSubview(self.quantityLabel)
+    self.quantityLabel.constrainViewToMargins(in: self.quantityLabelContainer)
 
-    _ = (estimatedShippingViews, self.estimatedShippingStackView)
-      |> ksr_addArrangedSubviewsToStackView()
-
-    _ = (self.quantityLabel, self.quantityLabelContainer)
-      |> ksr_addSubviewToParent()
-      |> ksr_constrainViewToMarginsInParent()
-
-    _ = ([self.stepper, UIView(), self.quantityLabelContainer], self.stepperStackView)
-      |> ksr_addArrangedSubviewsToStackView()
+    self.stepperStackView.addArrangedSubviews(
+      self.stepper,
+      UIView(),
+      self.quantityLabelContainer
+    )
   }
 
   private func setupConstraints() {
@@ -388,69 +305,84 @@ public final class RewardAddOnCardView: UIView {
 
 // MARK: - Styles
 
-private let baseRewardLabelStyle: LabelStyle = { label in
-  label
-    |> \.numberOfLines .~ 0
-    |> \.textAlignment .~ .left
-    |> \.lineBreakMode .~ .byWordWrapping
+private func applyIncludedItemsTitleLabel(_ label: UILabel) {
+  applyBaseRewardLabelStyle(label)
+  label.font = .ksr_callout().weighted(.semibold)
+  label.text = Strings.project_view_pledge_includes()
+  label.textColor = .ksr_support_400
 }
 
-private let detailsStackViewStyle: StackViewStyle = { stackView in
-  stackView
-    |> \.isLayoutMarginsRelativeArrangement .~ true
-    |> \.layoutMargins .~ .init(all: Styles.grid(3))
-    |> \.spacing .~ Styles.grid(3)
+private func applyEstimatedShippingTitleLabel(_ label: UILabel) {
+  applyBaseRewardLabelStyle(label)
+  label.font = .ksr_callout().weighted(.semibold)
+  label.text = Strings.Estimated_Shipping()
+  label.textColor = .ksr_support_400
 }
 
-private let includedItemsStackViewStyle: StackViewStyle = { stackView in
-  stackView |> \.spacing .~ Styles.grid(2)
+private func applyEstimatedShippingLabel(_ label: UILabel) {
+  applyBaseRewardLabelStyle(label)
+  label.font = .ksr_callout()
 }
 
-private let amountLabelStyle: LabelStyle = { label in
-  label
-    |> \.textColor .~ .ksr_create_700
-    |> \.font .~ UIFont.ksr_title3().bolded
+private func applyIncludedItemsLabel(_ label: UILabel) {
+  applyBaseRewardLabelStyle(label)
+  label.font = .ksr_callout()
 }
 
-private let convertedAmountLabelStyle: LabelStyle = { label in
-  label
-    |> \.textColor .~ .ksr_support_400
-    |> \.font .~ UIFont.ksr_footnote().weighted(.medium)
+private func applyBaseRewardLabelStyle(_ label: UILabel) {
+  label.numberOfLines = 0
+  label.textAlignment = .left
+  label.lineBreakMode = .byWordWrapping
 }
 
-private let descriptionLabelStyle: LabelStyle = { label in
-  label
-    |> \.textColor .~ .ksr_support_700
-    |> \.font .~ UIFont.ksr_body()
+private func applyDetailsStackViewStyle(_ stackView: UIStackView) {
+  stackView.isLayoutMarginsRelativeArrangement = true
+  stackView.layoutMargins = .init(all: Styles.grid(3))
+  stackView.spacing = Styles.grid(3)
 }
 
-private let titleAmountStackViewStyle: StackViewStyle = { stackView in
-  stackView
-    |> \.axis .~ .vertical
-    |> \.spacing .~ Styles.gridHalf(1)
+private func applyIncludedItemsStackViewStyle(_ stackView: UIStackView) {
+  stackView.spacing = Styles.grid(2)
 }
 
-private let rewardTitleLabelStyle: LabelStyle = { label in
-  label
-    |> \.textColor .~ .ksr_support_700
-    |> \.font .~ UIFont.ksr_title3().bolded
+private func applyAmountLabelStyle(_ label: UILabel) {
+  applyBaseRewardLabelStyle(label)
+  label.textColor = .ksr_create_700
+  label.font = UIFont.ksr_title3().bolded
 }
 
-private let sectionStackViewStyle: StackViewStyle = { stackView in
-  stackView
-    |> \.axis .~ .vertical
-    |> \.spacing .~ Styles.grid(1)
+private func applyAmountConvertedLabelStyle(_ label: UILabel) {
+  applyBaseRewardLabelStyle(label)
+  label.textColor = .ksr_support_400
+  label.font = UIFont.ksr_footnote().weighted(.medium)
 }
 
-private let sectionBodyLabelStyle: LabelStyle = { label in
-  label
-    |> \.textColor .~ .ksr_support_700
-    |> \.font .~ UIFont.ksr_body()
+private func applyDescriptionLabelStyle(_ label: UILabel) {
+  applyBaseRewardLabelStyle(label)
+  label.textColor = .ksr_support_700
+  label.font = UIFont.ksr_body()
 }
 
-private let sectionTitleLabelStyle: LabelStyle = { label in
-  label
-    |> \.font .~ .ksr_headline()
+private func applyTitleAmountStackViewStyle(_ stackView: UIStackView) {
+  stackView.axis = .vertical
+  stackView.spacing = Styles.gridHalf(1)
+}
+
+private func applyRewardTitleLabelStyle(_ label: UILabel) {
+  applyBaseRewardLabelStyle(label)
+  label.textColor = .ksr_support_700
+  label.font = UIFont.ksr_title3().bolded
+}
+
+private func applySectionStackViewStyle(_ stackView: UIStackView) {
+  stackView.axis = .vertical
+  stackView.spacing = Styles.grid(1)
+}
+
+private func applySectionBodyLabelStyle(_ label: UILabel) {
+  applyBaseRewardLabelStyle(label)
+  label.textColor = .ksr_support_700
+  label.font = UIFont.ksr_body()
 }
 
 private func applyRootStackViewStyle(_ stackView: UIStackView) {
@@ -460,4 +392,37 @@ private func applyRootStackViewStyle(_ stackView: UIStackView) {
 private func applyRewardImageViewStyle(_ imageView: UIImageView) {
   imageView.contentMode = .scaleAspectFill
   imageView.clipsToBounds = true
+}
+
+private func applyQuantityLabelContainerStyle(_ view: UIView) {
+  _ = checkoutRoundedCornersStyle(view)
+  view.layoutMargins = .init(topBottom: Styles.grid(1), leftRight: Styles.grid(2))
+  view.layer.borderColor = UIColor.ksr_support_300.cgColor
+  view.layer.borderWidth = 1
+}
+
+private func applyQuantityLabelStyle(_ label: UILabel) {
+  label.font = UIFont.ksr_headline().monospaced
+}
+
+private func applyStepperStyle(_ stepper: UIStepper) {
+  _ = checkoutStepperStyle(stepper)
+  stepper.setDecrementImage(image(named: "stepper-decrement-normal-grey"), for: .normal)
+  stepper.setIncrementImage(image(named: "stepper-increment-normal-grey"), for: .normal)
+}
+
+private func applyStepperStackViewStyle(_ stackView: UIStackView) {
+  stackView.alignment = .center
+}
+
+private func applyAddButtonStyle(_ button: UIButton) {
+  _ = blackButtonStyle(button)
+  button.setTitle(Strings.Add(), for: .normal)
+}
+
+private func applyRewardLocationTitleLabelStyle(_ label: UILabel) {
+  applySectionBodyLabelStyle(label)
+  label.text = Strings.Reward_location()
+  label.textColor = UIColor.ksr_support_400
+  label.font = .ksr_headline()
 }

--- a/Kickstarter-iOS/Features/RewardAddOnSelection/Views/RewardAddOnCardView.swift
+++ b/Kickstarter-iOS/Features/RewardAddOnSelection/Views/RewardAddOnCardView.swift
@@ -198,6 +198,8 @@ public final class RewardAddOnCardView: UIView {
       .compactMap { $0 as? UILabel }
       ||> baseRewardLabelStyle
       ||> sectionBodyLabelStyle
+
+    applyRewardImageViewStyle(self.rewardImageView)
   }
 
   public override func bindViewModel() {
@@ -453,4 +455,9 @@ private let sectionTitleLabelStyle: LabelStyle = { label in
 
 private func applyRootStackViewStyle(_ stackView: UIStackView) {
   stackView.axis = .vertical
+}
+
+private func applyRewardImageViewStyle(_ imageView: UIImageView) {
+  imageView.contentMode = .scaleAspectFill
+  imageView.clipsToBounds = true
 }

--- a/Kickstarter-iOS/Features/RewardsCollection/Views/RewardCardView.swift
+++ b/Kickstarter-iOS/Features/RewardsCollection/Views/RewardCardView.swift
@@ -1,6 +1,5 @@
 import KsApi
 import Library
-import Prelude
 import ReactiveSwift
 import UIKit
 
@@ -63,133 +62,81 @@ public final class RewardCardView: UIView {
   public override func bindStyles() {
     super.bindStyles()
 
-    _ = self
-      |> checkoutWhiteBackgroundStyle
+    _ = checkoutWhiteBackgroundStyle(self)
 
-    var stackViews = [
+    let stackViews = [
       self.detailsStackView,
       self.priceStackView,
       self.descriptionStackView,
       self.includedItemsStackView,
+      self.estimatedShippingStackView,
       self.estimatedDeliveryStackView,
       self.rewardLocationStackView
     ]
 
-    stackViews.insert(self.estimatedShippingStackView, at: 4)
+    stackViews.forEach(applySectionStackViewStyle)
+    applyRootStackViewStyle(self.rootStackView)
+    applyDetailsStackViewStyle(self.detailsStackView)
+    applyPriceStackViewStyle(self.priceStackView)
+    applyIncludedItemsStackViewStyle(self.includedItemsStackView)
+    applyIncludedItemsTitleLabelStyle(self.includedItemsTitleLabel)
 
-    _ = stackViews
-      ||> { stackView in
-        stackView
-          |> sectionStackViewStyle
+    self.includedItemsStackView.subviews
+      .dropFirst()
+      .compactMap { $0 as? UILabel }
+      .forEach { label in
+        applyBaseRewardLabelStyle(label)
+        applySectionBodyLabelStyle(label)
       }
 
-    applyRootStackViewStyle(self.rootStackView)
+    applyBaseRewardLabelStyle(self.descriptionLabel)
+    applySectionBodyLabelStyle(self.descriptionLabel)
+    applyIncludedItemsStackViewStyle(self.estimatedDeliveryStackView)
+    applyEstimatedDeliveryTitleLabelStyle(self.estimatedDeliveryTitleLabel)
+    applyBaseRewardLabelStyle(self.estimatedDeliveryDateLabel)
+    applySectionBodyLabelStyle(self.estimatedDeliveryDateLabel)
 
-    _ = self.detailsStackView
-      |> detailsStackViewStyle
-
-    _ = self.priceStackView
-      |> priceStackViewStyle
-
-    _ = self.includedItemsStackView
-      |> includedItemsStackViewStyle
-
-    _ = self.includedItemsTitleLabel
-      |> baseRewardLabelStyle
-      |> sectionTitleLabelStyle
-
-    _ = self.includedItemsTitleLabel
-      |> \.text %~ { _ in Strings.project_view_pledge_includes() }
-      |> \.textColor .~ UIColor.ksr_support_400
-
-    _ = self.includedItemsStackView.subviews
+    self.estimatedDeliveryStackView.subviews
       .dropFirst()
       .compactMap { $0 as? UILabel }
-      ||> baseRewardLabelStyle
-      ||> sectionBodyLabelStyle
+      .forEach { label in
+        applyBaseRewardLabelStyle(label)
+        applySectionBodyLabelStyle(label)
+      }
 
-    _ = self.descriptionLabel
-      |> baseRewardLabelStyle
-      |> sectionBodyLabelStyle
+    applyIncludedItemsStackViewStyle(self.estimatedShippingStackView)
+    applyEstimatedShippingTitleLabelStyle(self.estimatedShippingTitleLabel)
+    applyBaseRewardLabelStyle(self.estimatedShippingLabel)
+    applySectionBodyLabelStyle(self.estimatedShippingLabel)
 
-    _ = self.estimatedDeliveryStackView
-      |> includedItemsStackViewStyle
-
-    _ = self.estimatedDeliveryTitleLabel
-      |> baseRewardLabelStyle
-      |> sectionTitleLabelStyle
-
-    _ = self.estimatedDeliveryTitleLabel
-      |> \.text %~ { _ in Strings.Estimated_delivery() }
-      |> \.textColor .~ UIColor.ksr_support_400
-
-    _ = self.estimatedDeliveryDateLabel
-      |> baseRewardLabelStyle
-      |> sectionBodyLabelStyle
-
-    _ = self.estimatedDeliveryStackView.subviews
+    self.estimatedShippingStackView.subviews
       .dropFirst()
       .compactMap { $0 as? UILabel }
-      ||> baseRewardLabelStyle
-      ||> sectionBodyLabelStyle
+      .forEach { label in
+        applyBaseRewardLabelStyle(label)
+        applySectionBodyLabelStyle(label)
+      }
 
-    _ = self.estimatedShippingStackView
-      |> includedItemsStackViewStyle
+    applyIncludedItemsStackViewStyle(self.rewardLocationStackView)
+    applyRewardLocationTitleLabelStyle(self.rewardLocationTitleLabel)
+    applyBaseRewardLabelStyle(self.rewardLocationPickupLabel)
+    applySectionBodyLabelStyle(self.rewardLocationPickupLabel)
 
-    _ = self.estimatedShippingTitleLabel
-      |> baseRewardLabelStyle
-      |> sectionTitleLabelStyle
-
-    _ = self.estimatedShippingTitleLabel
-      |> \.text .~ Strings.Estimated_Shipping()
-      |> \.textColor .~ UIColor.ksr_support_400
-
-    _ = self.estimatedShippingLabel
-      |> baseRewardLabelStyle
-      |> sectionBodyLabelStyle
-
-    _ = self.estimatedShippingStackView.subviews
+    self.rewardLocationStackView.subviews
       .dropFirst()
       .compactMap { $0 as? UILabel }
-      ||> baseRewardLabelStyle
-      ||> sectionBodyLabelStyle
+      .forEach { label in
+        applyBaseRewardLabelStyle(label)
+        applySectionBodyLabelStyle(label)
+      }
 
-    _ = self.rewardLocationStackView
-      |> includedItemsStackViewStyle
-
-    _ = self.rewardLocationTitleLabel
-      |> baseRewardLabelStyle
-      |> sectionTitleLabelStyle
-
-    _ = self.rewardLocationTitleLabel
-      |> \.text %~ { _ in Strings.Reward_location() }
-      |> \.textColor .~ UIColor.ksr_support_400
-
-    _ = self.rewardLocationPickupLabel
-      |> baseRewardLabelStyle
-      |> sectionBodyLabelStyle
-
-    _ = self.rewardLocationStackView.subviews
-      .dropFirst()
-      .compactMap { $0 as? UILabel }
-      ||> baseRewardLabelStyle
-      ||> sectionBodyLabelStyle
-
-    _ = self.rewardTitleLabel
-      |> baseRewardLabelStyle
-      |> rewardTitleLabelStyle
-
-    _ = self.minimumPriceLabel
-      |> baseRewardLabelStyle
-      |> minimumPriceLabelStyle
-
-    _ = self.minimumPriceConversionLabel
-      |> baseRewardLabelStyle
-      |> minimumPriceConversionLabelStyle
-
-    _ = self.pillsView
-      |> \.backgroundColor .~ self.backgroundColor
-
+    applyBaseRewardLabelStyle(self.rewardTitleLabel)
+    applyRewardTitleLabelStyle(self.rewardTitleLabel)
+    applyBaseRewardLabelStyle(self.minimumPriceLabel)
+    applyMinimumPriceLabelStyle(self.minimumPriceLabel)
+    applyBaseRewardLabelStyle(self.minimumPriceConversionLabel)
+    applyMinimumPriceConversionLabelStyle(self.minimumPriceConversionLabel)
+    applyPillsViewStyle(self.pillsView)
     applyRewardImageViewStyle(self.rewardImageView)
   }
 
@@ -226,8 +173,7 @@ public final class RewardCardView: UIView {
     self.viewModel.outputs.cardUserInteractionIsEnabled
       .observeForUI()
       .observeValues { [weak self] isUserInteractionEnabled in
-        _ = self
-          ?|> \.isUserInteractionEnabled .~ isUserInteractionEnabled
+        self?.isUserInteractionEnabled = isUserInteractionEnabled
       }
 
     self.viewModel.outputs.reloadPills
@@ -267,41 +213,41 @@ public final class RewardCardView: UIView {
 
     self.rewardImageView.isHidden = true
 
-    var detailsSubviews = [
+    self.detailsStackView.addArrangedSubviews(
       self.titleStackView,
       self.rewardTitleLabel,
       self.descriptionStackView,
       self.includedItemsStackView,
+      self.estimatedShippingStackView,
       self.estimatedDeliveryStackView,
       self.rewardLocationStackView,
       self.pillsView
-    ]
+    )
 
-    detailsSubviews.insert(self.estimatedShippingStackView, at: 4)
+    self.priceStackView.addArrangedSubviews(
+      self.minimumPriceLabel,
+      self.minimumPriceConversionLabel
+    )
 
-    _ = (detailsSubviews, self.detailsStackView)
-      |> ksr_addArrangedSubviewsToStackView()
+    self.includedItemsStackView.addArrangedSubview(self.includedItemsTitleLabel)
 
-    _ = ([self.minimumPriceLabel, self.minimumPriceConversionLabel], self.priceStackView)
-      |> ksr_addArrangedSubviewsToStackView()
+    self.estimatedShippingStackView.addArrangedSubviews(
+      self.estimatedShippingTitleLabel,
+      self.estimatedShippingLabel
+    )
 
-    _ = ([self.includedItemsTitleLabel], self.includedItemsStackView)
-      |> ksr_addArrangedSubviewsToStackView()
+    self.estimatedDeliveryStackView.addArrangedSubviews(
+      self.estimatedDeliveryTitleLabel,
+      self.estimatedDeliveryDateLabel
+    )
 
-    _ = ([self.estimatedShippingTitleLabel, self.estimatedShippingLabel], self.estimatedShippingStackView)
-      |> ksr_addArrangedSubviewsToStackView()
+    self.rewardLocationStackView.addArrangedSubviews(
+      self.rewardLocationTitleLabel,
+      self.rewardLocationPickupLabel
+    )
 
-    _ = ([self.estimatedDeliveryTitleLabel, self.estimatedDeliveryDateLabel], self.estimatedDeliveryStackView)
-      |> ksr_addArrangedSubviewsToStackView()
-
-    _ = ([self.rewardLocationTitleLabel, self.rewardLocationPickupLabel], self.rewardLocationStackView)
-      |> ksr_addArrangedSubviewsToStackView()
-
-    _ = ([self.descriptionLabel], self.descriptionStackView)
-      |> ksr_addArrangedSubviewsToStackView()
-
-    _ = ([self.priceStackView], self.titleStackView)
-      |> ksr_addArrangedSubviewsToStackView()
+    self.descriptionStackView.addArrangedSubview(self.descriptionLabel)
+    self.titleStackView.addArrangedSubview(self.priceStackView)
 
     let tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(self.rewardCardTapped))
     self.addGestureRecognizer(tapGestureRecognizer)
@@ -347,21 +293,20 @@ public final class RewardCardView: UIView {
   }
 
   fileprivate func load(items: [String]) {
-    _ = self.includedItemsStackView.subviews
-      ||> { $0.removeFromSuperview() }
+    self.includedItemsStackView.subviews
+      .forEach { $0.removeFromSuperview() }
 
     let includedItemViews = items.map { item -> UIView in
       let label = UILabel()
-        |> baseRewardLabelStyle
-        |> sectionBodyLabelStyle
-        |> \.text .~ item
-
+      applyBaseRewardLabelStyle(label)
+      applySectionBodyLabelStyle(label)
+      label.text = item
       return label
     }
 
     let separatedItemViews = includedItemViews.dropLast().map { view -> [UIView] in
       let separator = UIView()
-        |> separatorStyle
+      _ = separatorStyle(separator)
       separator.heightAnchor.constraint(equalToConstant: 1).isActive = true
 
       return [view, separator]
@@ -372,8 +317,7 @@ public final class RewardCardView: UIView {
       + separatedItemViews
       + [includedItemViews.last].compact()
 
-    _ = (allItemViews, self.includedItemsStackView)
-      |> ksr_addArrangedSubviewsToStackView()
+    self.includedItemsStackView.addArrangedSubviews(allItemViews)
   }
 
   // MARK: - Configuration
@@ -391,62 +335,85 @@ public final class RewardCardView: UIView {
 
 // MARK: - Styles
 
-private let baseRewardLabelStyle: LabelStyle = { label in
-  label
-    |> \.numberOfLines .~ 0
-    |> \.textAlignment .~ .left
-    |> \.lineBreakMode .~ .byWordWrapping
+private func applyBaseRewardLabelStyle(_ label: UILabel) {
+  label.numberOfLines = 0
+  label.textAlignment = .left
+  label.lineBreakMode = .byWordWrapping
 }
 
-private let detailsStackViewStyle: StackViewStyle = { stackView in
-  stackView
-    |> \.spacing .~ Styles.grid(3)
-    |> \.isLayoutMarginsRelativeArrangement .~ true
-    |> \.layoutMargins .~ .init(all: Styles.grid(3))
+private func applySectionTitleLabelStyle(_ label: UILabel) {
+  label.font = .ksr_headline()
 }
 
-private let includedItemsStackViewStyle: StackViewStyle = { stackView in
-  stackView |> \.spacing .~ Styles.grid(2)
+private func applyIncludedItemsTitleLabelStyle(_ label: UILabel) {
+  applyBaseRewardLabelStyle(label)
+  applySectionTitleLabelStyle(label)
+  label.text = Strings.project_view_pledge_includes()
+  label.textColor = UIColor.ksr_support_400
 }
 
-private let minimumPriceLabelStyle: LabelStyle = { label in
-  label
-    |> \.textColor .~ .ksr_create_700
-    |> \.font .~ UIFont.ksr_title3().bolded
+private func applyEstimatedDeliveryTitleLabelStyle(_ label: UILabel) {
+  applyBaseRewardLabelStyle(label)
+  applySectionTitleLabelStyle(label)
+  label.text = Strings.Estimated_delivery()
+  label.textColor = .ksr_support_400
 }
 
-private let minimumPriceConversionLabelStyle: LabelStyle = { label in
-  label
-    |> \.textColor .~ .ksr_create_700
-    |> \.font .~ UIFont.ksr_caption1().bolded
+private func applyEstimatedShippingTitleLabelStyle(_ label: UILabel) {
+  applyBaseRewardLabelStyle(label)
+  applySectionTitleLabelStyle(label)
+  label.text = Strings.Estimated_Shipping()
+  label.textColor = .ksr_support_400
 }
 
-private let priceStackViewStyle: StackViewStyle = { stackView in
-  stackView
-    |> \.spacing .~ Styles.gridHalf(1)
+private func applyRewardLocationTitleLabelStyle(_ label: UILabel) {
+  applyBaseRewardLabelStyle(label)
+  applySectionTitleLabelStyle(label)
+  label.text = Strings.Reward_location()
+  label.textColor = .ksr_support_400
 }
 
-private let rewardTitleLabelStyle: LabelStyle = { label in
-  label
-    |> \.textColor .~ .ksr_support_700
-    |> \.font .~ UIFont.ksr_title2().bolded
+private func applyPillsViewStyle(_ view: PillsView) {
+  view.backgroundColor = view.backgroundColor
 }
 
-private let sectionStackViewStyle: StackViewStyle = { stackView in
-  stackView
-    |> \.axis .~ .vertical
-    |> \.spacing .~ Styles.grid(1)
+private func applySectionStackViewStyle(_ stackView: UIStackView) {
+  stackView.axis = .vertical
+  stackView.spacing = Styles.grid(1)
 }
 
-private let sectionTitleLabelStyle: LabelStyle = { label in
-  label
-    |> \.font .~ .ksr_headline()
+private func applyDetailsStackViewStyle(_ stackView: UIStackView) {
+  stackView.spacing = Styles.grid(3)
+  stackView.isLayoutMarginsRelativeArrangement = true
+  stackView.layoutMargins = .init(all: Styles.grid(3))
 }
 
-private let sectionBodyLabelStyle: LabelStyle = { label in
-  label
-    |> \.textColor .~ .ksr_support_700
-    |> \.font .~ UIFont.ksr_body()
+private func applyPriceStackViewStyle(_ stackView: UIStackView) {
+  stackView.spacing = Styles.gridHalf(1)
+}
+
+private func applySectionBodyLabelStyle(_ label: UILabel) {
+  label.textColor = .ksr_support_700
+  label.font = UIFont.ksr_body()
+}
+
+private func applyIncludedItemsStackViewStyle(_ stackView: UIStackView) {
+  stackView.spacing = Styles.grid(2)
+}
+
+private func applyRewardTitleLabelStyle(_ label: UILabel) {
+  label.textColor = .ksr_support_700
+  label.font = UIFont.ksr_title2().bolded
+}
+
+private func applyMinimumPriceLabelStyle(_ label: UILabel) {
+  label.textColor = .ksr_create_700
+  label.font = UIFont.ksr_title3().bolded
+}
+
+private func applyMinimumPriceConversionLabelStyle(_ label: UILabel) {
+  label.textColor = .ksr_create_700
+  label.font = UIFont.ksr_caption1().bolded
 }
 
 private func applyRewardImageViewStyle(_ imageView: UIImageView) {
@@ -464,8 +431,7 @@ extension RewardCardView: UICollectionViewDelegate {
   ) {
     guard let pillCell = cell as? PillCell else { return }
 
-    _ = pillCell.label
-      |> \.preferredMaxLayoutWidth .~ collectionView.bounds.width
+    pillCell.label.preferredMaxLayoutWidth = collectionView.bounds.width
   }
 }
 

--- a/Kickstarter-iOS/Features/RewardsCollection/Views/RewardCardView.swift
+++ b/Kickstarter-iOS/Features/RewardsCollection/Views/RewardCardView.swift
@@ -189,6 +189,8 @@ public final class RewardCardView: UIView {
 
     _ = self.pillsView
       |> \.backgroundColor .~ self.backgroundColor
+
+    applyRewardImageViewStyle(self.rewardImageView)
   }
 
   public override func bindViewModel() {
@@ -445,6 +447,11 @@ private let sectionBodyLabelStyle: LabelStyle = { label in
   label
     |> \.textColor .~ .ksr_support_700
     |> \.font .~ UIFont.ksr_body()
+}
+
+private func applyRewardImageViewStyle(_ imageView: UIImageView) {
+  imageView.contentMode = .scaleAspectFill
+  imageView.clipsToBounds = true
 }
 
 // MARK: - UICollectionViewDelegate

--- a/Library/Extensions/UIStackView+Helper.swift
+++ b/Library/Extensions/UIStackView+Helper.swift
@@ -9,4 +9,13 @@ extension UIStackView {
   public func addArrangedSubviews(_ subviews: UIView...) {
     subviews.forEach(self.addArrangedSubview)
   }
+
+  /// Adds an array of views to the stack view as arranged subviews.
+  ///
+  /// - Parameter subviews: An array of `UIView` objects to be added as arranged subviews.
+  /// - Note: This method iterates through the provided views and calls `addArrangedSubview(_:)`
+  ///         on each, adding them to the stack view in the order they appear in the array.
+  public func addArrangedSubviews(_ subviews: [UIView]) {
+    subviews.forEach(self.addArrangedSubview)
+  }
 }

--- a/Library/Extensions/UIView+Helper.swift
+++ b/Library/Extensions/UIView+Helper.swift
@@ -32,6 +32,14 @@ extension UIView {
     NSLayoutConstraint.activate(constraints)
   }
 
+  /// Constrains the view to the layout margins of a parent view with an optional priority.
+  ///
+  /// This method adds constraints to make the view fill the layout margins of its parent view.
+  /// Layout margins respect the readable content area and can be useful for consistent spacing.
+  ///
+  /// - Parameters:
+  ///   - parentView: The parent `UIView` to which the current view will be constrained.
+  ///   - priority: The priority of the constraints. Defaults to `.required`.
   public func constrainViewToMargins(in parentView: UIView, priority: UILayoutPriority = .required) {
     self.translatesAutoresizingMaskIntoConstraints = false
 


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Fixes the aspect ratio issue for the add-on image shown on the pledge flow. The image was appearing compressed due to incorrect content mode configuration.

# 🛠 How

- Created a private `applyRewardImageViewStyle(_:)` helper method to apply consistent styling to the reward image view.
- Applied `.scaleAspectFill` and `clipsToBounds = true` to ensure images are rendered properly.
- Updated the following views:
  - `RewardAddOnCardView.swift`
  - `RewardCardView.swift`

# 👀 See

- [Ticket](https://kickstarter.atlassian.net/browse/MBL-2260)

| Before 🐛 | After 🦋 |
| --- | --- |
| ![IMG_5946](https://github.com/user-attachments/assets/755b84c1-63f4-491e-9bd2-2d84c16c7117) | ![image](https://github.com/user-attachments/assets/e5e90000-d3a4-485b-b2c9-01c818ae3095) |

# ✅ Acceptance criteria

- [x] The add-on image maintains the correct aspect ratio.
- [x] No compression or distortion is visible.
- [x] Consistent visual rendering across reward cards and add-on cards.
