### PR TITLE
[MBL-2317] View Your Pledge Web View

### DIFF
--- a/Kickstarter-iOS/Features/PledgeManagement/Controllers/PledgeManagementViewPledgeViewController.swift
+++ b/Kickstarter-iOS/Features/PledgeManagement/Controllers/PledgeManagementViewPledgeViewController.swift
@@ -1,0 +1,45 @@
+import KsApi
+import Library
+import Prelude
+import UIKit
+
+internal final class PledgeManagementViewPledgeViewController: WebViewController {
+  private let viewModel: PledgeManagementViewPledgeViewModelType = PledgeManagementViewPledgeViewModel()
+
+  internal static func configuredWith(project: Project) -> PledgeManagementViewPledgeViewController {
+    let vc = PledgeManagementViewPledgeViewController()
+    vc.viewModel.inputs.configureWith(project: project)
+    return vc
+  }
+
+  internal override func viewDidLoad() {
+    super.viewDidLoad()
+    
+    self.navigationItem.title = Strings.Backing_details()
+
+    if self.navigationController?.viewControllers.count == .some(1) {
+      self.navigationItem.leftBarButtonItem = UIBarButtonItem(
+        title: Strings.general_navigation_buttons_close(),
+        style: .plain,
+        target: self,
+        action: #selector(self.closeButtonTapped)
+      )
+    }
+
+    self.viewModel.inputs.viewDidLoad()
+  }
+
+  override func bindStyles() {
+    super.bindStyles()
+  }
+
+  internal override func bindViewModel() {
+    self.viewModel.outputs.webViewLoadRequest
+      .observeForControllerAction()
+      .observeValues { [weak self] in _ = self?.webView.load($0) }
+  }
+
+  @objc fileprivate func closeButtonTapped() {
+    self.dismiss(animated: true, completion: nil)
+  }
+}

--- a/Kickstarter-iOS/Features/PledgeManagement/Controllers/PledgeManagementViewPledgeViewController.swift
+++ b/Kickstarter-iOS/Features/PledgeManagement/Controllers/PledgeManagementViewPledgeViewController.swift
@@ -14,7 +14,7 @@ internal final class PledgeManagementViewPledgeViewController: WebViewController
 
   internal override func viewDidLoad() {
     super.viewDidLoad()
-    
+
     self.navigationItem.title = Strings.Backing_details()
 
     if self.navigationController?.viewControllers.count == .some(1) {

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -621,6 +621,9 @@
 		60F03AC12D8AFCE300DB6C01 /* SimilarProjectsCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60F03AC02D8AFCE300DB6C01 /* SimilarProjectsCollectionViewCell.swift */; };
 		60F03AC42D8AFD6100DB6C01 /* SimilarProjectsCollectionViewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60F03AC32D8AFD6100DB6C01 /* SimilarProjectsCollectionViewDataSource.swift */; };
 		60F03AC62D8B0C1600DB6C01 /* SimilarProjectsLoadingCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60F03AC52D8B0C1600DB6C01 /* SimilarProjectsLoadingCollectionViewCell.swift */; };
+		60FF346B2DA7FC3C003598A9 /* PledgeManagementViewPledgeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60FF34692DA7F97D003598A9 /* PledgeManagementViewPledgeViewModel.swift */; };
+		60FF346E2DA802DB003598A9 /* PledgeManagementViewPledgeViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60FF346C2DA802DB003598A9 /* PledgeManagementViewPledgeViewModelTests.swift */; };
+		60FF346F2DA803C5003598A9 /* PledgeManagementViewPledgeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60FF34692DA7F97D003598A9 /* PledgeManagementViewPledgeViewModel.swift */; };
 		701160D4291ECB9F0095BF24 /* LoadingBarButtonItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 701160D2291ECB250095BF24 /* LoadingBarButtonItem.swift */; };
 		70495690299D53ED00B273DF /* SnapshotTesting in Frameworks */ = {isa = PBXBuildFile; productRef = 7049568F299D53ED00B273DF /* SnapshotTesting */; };
 		7061848B29BE4CD8008F9941 /* MessageBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7061848829BE4C11008F9941 /* MessageBannerView.swift */; };
@@ -2370,6 +2373,8 @@
 		60F03AC02D8AFCE300DB6C01 /* SimilarProjectsCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimilarProjectsCollectionViewCell.swift; sourceTree = "<group>"; };
 		60F03AC32D8AFD6100DB6C01 /* SimilarProjectsCollectionViewDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimilarProjectsCollectionViewDataSource.swift; sourceTree = "<group>"; };
 		60F03AC52D8B0C1600DB6C01 /* SimilarProjectsLoadingCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimilarProjectsLoadingCollectionViewCell.swift; sourceTree = "<group>"; };
+		60FF34692DA7F97D003598A9 /* PledgeManagementViewPledgeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PledgeManagementViewPledgeViewModel.swift; sourceTree = "<group>"; };
+		60FF346C2DA802DB003598A9 /* PledgeManagementViewPledgeViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PledgeManagementViewPledgeViewModelTests.swift; sourceTree = "<group>"; };
 		701160D2291ECB250095BF24 /* LoadingBarButtonItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingBarButtonItem.swift; sourceTree = "<group>"; };
 		7061848829BE4C11008F9941 /* MessageBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageBannerView.swift; sourceTree = "<group>"; };
 		7061848C29BE577B008F9941 /* MessageBannerViewViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageBannerViewViewModel.swift; sourceTree = "<group>"; };
@@ -3472,6 +3477,10 @@
 		E1EEED2A2B686829009976D9 /* PKCETest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PKCETest.swift; sourceTree = "<group>"; };
 		E1FDB1E72AEAAC6100285F93 /* CombineTestObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CombineTestObserver.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		60FF34652DA7F904003598A9 /* PledgeManagement */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = PledgeManagement; sourceTree = "<group>"; };
+/* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
 		A75511381C8642B3005355CF /* Frameworks */ = {
@@ -5045,6 +5054,7 @@
 				19A97D3828C801AB0031B857 /* PillCollectionView_DEPRECATED_09_06_2022 */,
 				1937A6F128C92F0C00DD732D /* PledgeAmount */,
 				1937A6F028C92F0000DD732D /* PledgeAmountSummary */,
+				60FF34652DA7F904003598A9 /* PledgeManagement */,
 				33785F712CD9ADB8004B148E /* PledgeOverTime */,
 				19A97D3928C802230031B857 /* PledgePaymentMethods */,
 				1937A70428C9392600DD732D /* PledgeShippingLocation */,
@@ -7003,6 +7013,8 @@
 				8A13D16D24985411007E2C0B /* PledgeExpandableHeaderRewardCellViewModelTests.swift */,
 				8A13D16024955A2E007E2C0B /* PledgeExpandableRewardsHeaderViewModel.swift */,
 				8A13D16F24985550007E2C0B /* PledgeExpandableRewardsHeaderViewModelTests.swift */,
+				60FF34692DA7F97D003598A9 /* PledgeManagementViewPledgeViewModel.swift */,
+				60FF346C2DA802DB003598A9 /* PledgeManagementViewPledgeViewModelTests.swift */,
 				33AF01B92D2CBD6E0085A153 /* PledgeOverTimePaymentScheduleViewModel.swift */,
 				33AF01BD2D2E71E30085A153 /* PledgeOverTimePaymentScheduleViewModelTest.swift */,
 				8A73EACE2339528000FF9051 /* PledgePaymentMethodCellViewModel.swift */,
@@ -7761,6 +7773,9 @@
 			dependencies = (
 				A76E0A4C1D00C00500EC525A /* PBXTargetDependency */,
 			);
+			fileSystemSynchronizedGroups = (
+				60FF34652DA7F904003598A9 /* PledgeManagement */,
+			);
 			name = "Kickstarter-Framework-iOS";
 			packageProductDependencies = (
 				E1F1DB3E2B7BC09C004EA80B /* Prelude */,
@@ -8328,6 +8343,7 @@
 				A73378FB1D0AE33B00C91445 /* BaseStyles.swift in Sources */,
 				A755115C1C8642C3005355CF /* AssetImageGeneratorType.swift in Sources */,
 				D79A01A52242E91E004BC6A8 /* PushNotificationDialogType.swift in Sources */,
+				60FF346F2DA803C5003598A9 /* PledgeManagementViewPledgeViewModel.swift in Sources */,
 				A72C3A971D00F6C70075227E /* SortPagerViewModel.swift in Sources */,
 				E158020E2D7F53220000BAB3 /* Project+ProjectCellModel.swift in Sources */,
 				9DC572E51D36CA9800AE209C /* ProjectActivityStyles.swift in Sources */,
@@ -8864,6 +8880,7 @@
 				33F55B412D4A6DDD0007E50E /* PledgePaymentIncrementFormattedTest.swift in Sources */,
 				A7ED1FE51E831C5C00BFFA01 /* MessageDialogViewModelTests.swift in Sources */,
 				776B1A1124193C2500B03098 /* CategoryPillCellViewModelTests.swift in Sources */,
+				60FF346E2DA802DB003598A9 /* PledgeManagementViewPledgeViewModelTests.swift in Sources */,
 				A7ED1FB11E831C5C00BFFA01 /* ActivitySampleProjectCellViewModelTests.swift in Sources */,
 				60368E6C2AC35BE3005EE9A5 /* ReportProjectFormViewModelTests.swift in Sources */,
 				A7ED1F371E830FDC00BFFA01 /* String+WhitespaceTests.swift in Sources */,
@@ -9100,6 +9117,7 @@
 				6049D0242AA7940E0015BB0D /* DemoCTAContainerView.swift in Sources */,
 				778CCC5222822B5D00FB8D35 /* SheetOverlayTransitionAnimator.swift in Sources */,
 				D04F48D41E0313FB00EDC98A /* ActivityProjectStatusCell.swift in Sources */,
+				60FF346B2DA7FC3C003598A9 /* PledgeManagementViewPledgeViewModel.swift in Sources */,
 				0616458E26696847007D8D96 /* CommentRepliesDataSource.swift in Sources */,
 				E1CFB5972D8E0107004AB0D6 /* Category+FilterCategory.swift in Sources */,
 				D6600786240EFD6300AC1EDB /* CuratedProjectsViewController.swift in Sources */,

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -281,6 +281,8 @@
 		336195002D8AB5E100BED4BD /* SortViewTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 336194FE2D8AB5AC00BED4BD /* SortViewTest.swift */; };
 		336195032D8AB96000BED4BD /* SortViewModelTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 336195012D8AB7F200BED4BD /* SortViewModelTest.swift */; };
 		336195112D8B441500BED4BD /* BottomSheetPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 336195102D8B440F00BED4BD /* BottomSheetPresenter.swift */; };
+		3362A3CB2DA883F700E5E85D /* ProjectURLBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3362A3CA2DA883E200E5E85D /* ProjectURLBuilder.swift */; };
+		3362A3CE2DA8858400E5E85D /* ProjectURLBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3362A3CC2DA8856600E5E85D /* ProjectURLBuilderTests.swift */; };
 		336D378B2CDAF81200FA99F5 /* PledgePaymentPlansViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 336D378A2CDAF80300FA99F5 /* PledgePaymentPlansViewModel.swift */; };
 		33785F752CD9B0C2004B148E /* PledgePaymentPlansViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33785F742CD9B0C2004B148E /* PledgePaymentPlansViewController.swift */; };
 		3385CF012CF6116B00A33D86 /* UIStackView+Helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3385CF002CF6115D00A33D86 /* UIStackView+Helper.swift */; };
@@ -2036,6 +2038,8 @@
 		336194FE2D8AB5AC00BED4BD /* SortViewTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SortViewTest.swift; sourceTree = "<group>"; };
 		336195012D8AB7F200BED4BD /* SortViewModelTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SortViewModelTest.swift; sourceTree = "<group>"; };
 		336195102D8B440F00BED4BD /* BottomSheetPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetPresenter.swift; sourceTree = "<group>"; };
+		3362A3CA2DA883E200E5E85D /* ProjectURLBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectURLBuilder.swift; sourceTree = "<group>"; };
+		3362A3CC2DA8856600E5E85D /* ProjectURLBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectURLBuilderTests.swift; sourceTree = "<group>"; };
 		336D378A2CDAF80300FA99F5 /* PledgePaymentPlansViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PledgePaymentPlansViewModel.swift; sourceTree = "<group>"; };
 		33785F742CD9B0C2004B148E /* PledgePaymentPlansViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PledgePaymentPlansViewController.swift; sourceTree = "<group>"; };
 		3385CF002CF6115D00A33D86 /* UIStackView+Helper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIStackView+Helper.swift"; sourceTree = "<group>"; };
@@ -6636,6 +6640,8 @@
 				9DD1E3871D50035E00D4829E /* ProjectActivityData.swift */,
 				A75C811A1D210C4700B5AD03 /* ProjectActivityItemProvider.swift */,
 				D64850541FD879AB00B6AB91 /* ProjectActivityItemProviderTests.swift */,
+				3362A3CA2DA883E200E5E85D /* ProjectURLBuilder.swift */,
+				3362A3CC2DA8856600E5E85D /* ProjectURLBuilderTests.swift */,
 				D6089E572090D5B40032CC99 /* PushNotificationDialog.swift */,
 				D6B4D9BE209B88F3002C7B68 /* PushNotificationDialogTests.swift */,
 				D76437782241500600DAFC9E /* PushNotificationDialogType.swift */,
@@ -8467,6 +8473,7 @@
 				776B1A0F24192CA900B03098 /* CategoryPillCellViewModel.swift in Sources */,
 				A75511651C8642C3005355CF /* String+SimpleHTML.swift in Sources */,
 				A7F441C31D005A9400FE6FC5 /* FacebookConfirmationViewModel.swift in Sources */,
+				3362A3CB2DA883F700E5E85D /* ProjectURLBuilder.swift in Sources */,
 				D0200A5621935F2900F5CC27 /* MessageBannerType.swift in Sources */,
 				E15802102D7F536A0000BAB3 /* BackerDashboardProjectCellFragment+ProjectCellModel.swift in Sources */,
 				064B007A27A469C8007B21FE /* HTMLViewElementStyles.swift in Sources */,
@@ -8762,6 +8769,7 @@
 				3706409022A9BE9400889CBD /* DateFormatterTests.swift in Sources */,
 				778F891E22D5414F00D095C5 /* Feature+HelpersTests.swift in Sources */,
 				A7ED1F2C1E830FDC00BFFA01 /* KSCacheTests.swift in Sources */,
+				3362A3CE2DA8858400E5E85D /* ProjectURLBuilderTests.swift in Sources */,
 				D7237096211A1593001EA4CA /* SettingsFollowCellViewModelTests.swift in Sources */,
 				D79970B723EC88CB00584911 /* ThanksCategoryCellViewModelTests.swift in Sources */,
 				8A8099F522E2143000373E66 /* RewardCardContainerViewModelTests.swift in Sources */,

--- a/Library/ProjectURLBuilder.swift
+++ b/Library/ProjectURLBuilder.swift
@@ -1,5 +1,5 @@
-import KsApi
 import Foundation
+import KsApi
 
 public func getProjectBackingDetailsURL(with project: Project) -> URL? {
   let urlString =

--- a/Library/ProjectURLBuilder.swift
+++ b/Library/ProjectURLBuilder.swift
@@ -1,0 +1,9 @@
+import KsApi
+import Foundation
+
+public func getProjectBackingDetailsURL(with project: Project) -> URL? {
+  let urlString =
+    "\(AppEnvironment.current.apiService.serverConfig.webBaseUrl)/projects/\(project.creator.id)/\(project.slug)/backing/details"
+
+  return URL(string: urlString)
+}

--- a/Library/ProjectURLBuilderTests.swift
+++ b/Library/ProjectURLBuilderTests.swift
@@ -1,0 +1,15 @@
+@testable import KsApi
+@testable import Library
+import XCTest
+
+class ProjectURLBuilderTests: XCTestCase {
+  
+  func testGetProjectBackingDetailsURL() {
+    
+    let backingDetailsURL = getProjectBackingDetailsURL(with: Project.template)
+    let url = "https://www.kickstarter.com/projects/1/a-fun-project/backing/details"
+    
+    XCTAssertNotNil(backingDetailsURL)
+    XCTAssertEqual(backingDetailsURL?.absoluteString, url)
+  }
+}

--- a/Library/ProjectURLBuilderTests.swift
+++ b/Library/ProjectURLBuilderTests.swift
@@ -3,12 +3,10 @@
 import XCTest
 
 class ProjectURLBuilderTests: XCTestCase {
-  
   func testGetProjectBackingDetailsURL() {
-    
     let backingDetailsURL = getProjectBackingDetailsURL(with: Project.template)
     let url = "https://www.kickstarter.com/projects/1/a-fun-project/backing/details"
-    
+
     XCTAssertNotNil(backingDetailsURL)
     XCTAssertEqual(backingDetailsURL?.absoluteString, url)
   }

--- a/Library/ViewModels/PledgeManagementViewPledgeViewModel.swift
+++ b/Library/ViewModels/PledgeManagementViewPledgeViewModel.swift
@@ -28,11 +28,7 @@ internal final class PledgeManagementViewPledgeViewModel: PledgeManagementViewPl
     let project = Signal.combineLatest(self.projectProperty.signal.skipNil(), self.viewDidLoadProperty.signal)
       .map(first)
 
-    self.webViewLoadRequest = project.map {
-      let urlString =
-        "\(AppEnvironment.current.apiService.serverConfig.webBaseUrl)/projects/\($0.creator.id)/\($0.slug)/backing/details"
-      return URL(string: urlString)
-    }
+    self.webViewLoadRequest = project.map(getProjectBackingDetailsURL(with:))
     .skipNil()
     .map { AppEnvironment.current.apiService.preparedRequest(forURL: $0) }
   }

--- a/Library/ViewModels/PledgeManagementViewPledgeViewModel.swift
+++ b/Library/ViewModels/PledgeManagementViewPledgeViewModel.swift
@@ -29,8 +29,8 @@ internal final class PledgeManagementViewPledgeViewModel: PledgeManagementViewPl
       .map(first)
 
     self.webViewLoadRequest = project.map(getProjectBackingDetailsURL(with:))
-    .skipNil()
-    .map { AppEnvironment.current.apiService.preparedRequest(forURL: $0) }
+      .skipNil()
+      .map { AppEnvironment.current.apiService.preparedRequest(forURL: $0) }
   }
 
   internal var inputs: PledgeManagementViewPledgeViewModelInputs { return self }

--- a/Library/ViewModels/PledgeManagementViewPledgeViewModel.swift
+++ b/Library/ViewModels/PledgeManagementViewPledgeViewModel.swift
@@ -1,0 +1,54 @@
+import Foundation
+import KsApi
+import Library
+import Prelude
+import ReactiveSwift
+
+internal protocol PledgeManagementViewPledgeViewModelInputs {
+  /// Configure this webview using a `Project`.
+  func configureWith(project: Project)
+
+  /// Call when the view loads.
+  func viewDidLoad()
+}
+
+internal protocol PledgeManagementViewPledgeViewModelOutputs {
+  /// Emits a request that should be loaded into the webview.
+  var webViewLoadRequest: Signal<URLRequest, Never> { get }
+}
+
+internal protocol PledgeManagementViewPledgeViewModelType {
+  var inputs: PledgeManagementViewPledgeViewModelInputs { get }
+  var outputs: PledgeManagementViewPledgeViewModelOutputs { get }
+}
+
+internal final class PledgeManagementViewPledgeViewModel: PledgeManagementViewPledgeViewModelType,
+  PledgeManagementViewPledgeViewModelInputs, PledgeManagementViewPledgeViewModelOutputs {
+  internal init() {
+    let project = Signal.combineLatest(self.projectProperty.signal.skipNil(), self.viewDidLoadProperty.signal)
+      .map(first)
+
+    self.webViewLoadRequest = project.map {
+      let urlString =
+        "\(AppEnvironment.current.apiService.serverConfig.webBaseUrl)/projects/\($0.creator.id)/\($0.slug)/backing/details"
+      return URL(string: urlString)
+    }
+    .skipNil()
+    .map { AppEnvironment.current.apiService.preparedRequest(forURL: $0) }
+  }
+
+  internal var inputs: PledgeManagementViewPledgeViewModelInputs { return self }
+  internal var outputs: PledgeManagementViewPledgeViewModelOutputs { return self }
+
+  internal let webViewLoadRequest: Signal<URLRequest, Never>
+
+  fileprivate let projectProperty = MutableProperty<Project?>(nil)
+  public func configureWith(project: Project) {
+    self.projectProperty.value = project
+  }
+
+  fileprivate let viewDidLoadProperty = MutableProperty(())
+  func viewDidLoad() {
+    self.viewDidLoadProperty.value = ()
+  }
+}

--- a/Library/ViewModels/PledgeManagementViewPledgeViewModelTests.swift
+++ b/Library/ViewModels/PledgeManagementViewPledgeViewModelTests.swift
@@ -1,0 +1,30 @@
+@testable import KsApi
+@testable import Library
+import ReactiveExtensions_TestHelpers
+import ReactiveSwift
+import XCTest
+
+final class PledgeManagementViewPledgeViewModelTests: TestCase {
+  private let vm: PledgeManagementViewPledgeViewModelType = PledgeManagementViewPledgeViewModel()
+  private let webViewLoadRequest = TestObserver<URLRequest, Never>()
+
+  override func setUp() {
+    super.setUp()
+
+    self.vm.outputs.webViewLoadRequest.observe(self.webViewLoadRequest.observer)
+  }
+
+  func testLoadWebViewRequest() {
+    let project = Project.template
+    let urlString =
+      "\(AppEnvironment.current.apiService.serverConfig.webBaseUrl)/projects/\(project.creator.id)/\(project.slug)/backing/details"
+    let request = AppEnvironment.current.apiService.preparedRequest(
+      forURL: URL(string: urlString)!
+    )
+
+    self.vm.inputs.configureWith(project: project)
+    self.vm.inputs.viewDidLoad()
+
+    self.webViewLoadRequest.assertValues([request])
+  }
+}

--- a/Library/ViewModels/PledgeStatusLabelViewModel.swift
+++ b/Library/ViewModels/PledgeStatusLabelViewModel.swift
@@ -274,10 +274,3 @@ private func attributedPlotErroredString(
 
   return attributedString
 }
-
-private func getProjectBackingDetailsURL(with project: Project) -> URL? {
-  let urlString =
-    "\(AppEnvironment.current.apiService.serverConfig.webBaseUrl)/projects/\(project.creator.id)/\(project.slug)/backing/details"
-
-  return URL(string: urlString)
-}


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Creates a new web view controller that will display a user's backing details.

# 🤔 Why

For backers who pledged to a campaign and completed PM or who just completed PM, we'll show a web view when they want to see their backing details. 

This is a crunch time approach. There are plans to update our native screen with PM backing details, etc., once we're out of crunch time 🤞.

# 🛠 How

- Creates a new ViewController that inherits from our WebViewController class.
- Load the existing backing details URL on viewDidLoad using a passed in `Project`.

This is just the view controller. The next PR will wire it up and use the new `Backing.Order` object, and the feature flag, to determine when to show this web view and when to show the existing native screen.

The entry points will include the Project Page and Messages.

**[Checkout the SPIKE for more details](https://kickstarter.atlassian.net/wiki/spaces/NT/pages/3627319298/Net+New+Backers+Crunch+Time+SPIKE)**

# 👀 See

I replaced the creator profile webview with this new one for testing purposes.

|  |  |
| --- | --- |
| ![Simulator Screen Recording - iPhone 15 Pro 17 5 - 2025-04-10 at 09 43 52](https://github.com/user-attachments/assets/f9485b93-94ea-45bc-9f1b-52fa3d356b9d) |  |

# ✅ Acceptance criteria

- [x] when presented this new web view controller loads the backing details page.

# ⏰ TODO

- [ ] wire this up using the A/C I mentioned above.
