### PR TITLE
MBL-2222: Add support to GraphQL, DiscoveryParams and view models for filtering by project state

### DIFF
--- a/KsApi/GraphAPI.swift
+++ b/KsApi/GraphAPI.swift
@@ -2611,6 +2611,73 @@ public enum GraphAPI {
     }
   }
 
+  /// Publically visible project states.
+  public enum PublicProjectState: RawRepresentable, Equatable, Hashable, CaseIterable, Apollo.JSONDecodable, Apollo.JSONEncodable {
+    public typealias RawValue = String
+    /// Active and accepting pledges.
+    case live
+    /// Successfully funded by deadline.
+    case successful
+    /// Failed to fund by deadline.
+    case failed
+    /// Project is submitted and in prelaunch state.
+    case submitted
+    /// Project that is in prelaunch.
+    case upcoming
+    /// Project that is successful and accepting late pledges.
+    case latePledge
+    /// Auto generated constant for unknown enum values
+    case __unknown(RawValue)
+
+    public init?(rawValue: RawValue) {
+      switch rawValue {
+        case "LIVE": self = .live
+        case "SUCCESSFUL": self = .successful
+        case "FAILED": self = .failed
+        case "SUBMITTED": self = .submitted
+        case "UPCOMING": self = .upcoming
+        case "LATE_PLEDGE": self = .latePledge
+        default: self = .__unknown(rawValue)
+      }
+    }
+
+    public var rawValue: RawValue {
+      switch self {
+        case .live: return "LIVE"
+        case .successful: return "SUCCESSFUL"
+        case .failed: return "FAILED"
+        case .submitted: return "SUBMITTED"
+        case .upcoming: return "UPCOMING"
+        case .latePledge: return "LATE_PLEDGE"
+        case .__unknown(let value): return value
+      }
+    }
+
+    public static func == (lhs: PublicProjectState, rhs: PublicProjectState) -> Bool {
+      switch (lhs, rhs) {
+        case (.live, .live): return true
+        case (.successful, .successful): return true
+        case (.failed, .failed): return true
+        case (.submitted, .submitted): return true
+        case (.upcoming, .upcoming): return true
+        case (.latePledge, .latePledge): return true
+        case (.__unknown(let lhsValue), .__unknown(let rhsValue)): return lhsValue == rhsValue
+        default: return false
+      }
+    }
+
+    public static var allCases: [PublicProjectState] {
+      return [
+        .live,
+        .successful,
+        .failed,
+        .submitted,
+        .upcoming,
+        .latePledge,
+      ]
+    }
+  }
+
   /// Various project states.
   public enum ProjectState: RawRepresentable, Equatable, Hashable, CaseIterable, Apollo.JSONDecodable, Apollo.JSONEncodable {
     public typealias RawValue = String
@@ -13977,11 +14044,12 @@ public enum GraphAPI {
     /// The raw GraphQL definition of this operation.
     public let operationDefinition: String =
       """
-      query Search($term: String, $sort: ProjectSort, $categoryId: String, $first: Int, $cursor: String) {
+      query Search($term: String, $sort: ProjectSort, $categoryId: String, $state: PublicProjectState, $first: Int, $cursor: String) {
         projects(
           term: $term
           sort: $sort
           categoryId: $categoryId
+          state: $state
           after: $cursor
           first: $first
         ) {
@@ -14014,19 +14082,21 @@ public enum GraphAPI {
     public var term: String?
     public var sort: ProjectSort?
     public var categoryId: String?
+    public var state: PublicProjectState?
     public var first: Int?
     public var cursor: String?
 
-    public init(term: String? = nil, sort: ProjectSort? = nil, categoryId: String? = nil, first: Int? = nil, cursor: String? = nil) {
+    public init(term: String? = nil, sort: ProjectSort? = nil, categoryId: String? = nil, state: PublicProjectState? = nil, first: Int? = nil, cursor: String? = nil) {
       self.term = term
       self.sort = sort
       self.categoryId = categoryId
+      self.state = state
       self.first = first
       self.cursor = cursor
     }
 
     public var variables: GraphQLMap? {
-      return ["term": term, "sort": sort, "categoryId": categoryId, "first": first, "cursor": cursor]
+      return ["term": term, "sort": sort, "categoryId": categoryId, "state": state, "first": first, "cursor": cursor]
     }
 
     public struct Data: GraphQLSelectionSet {
@@ -14034,7 +14104,7 @@ public enum GraphAPI {
 
       public static var selections: [GraphQLSelection] {
         return [
-          GraphQLField("projects", arguments: ["term": GraphQLVariable("term"), "sort": GraphQLVariable("sort"), "categoryId": GraphQLVariable("categoryId"), "after": GraphQLVariable("cursor"), "first": GraphQLVariable("first")], type: .object(Project.selections)),
+          GraphQLField("projects", arguments: ["term": GraphQLVariable("term"), "sort": GraphQLVariable("sort"), "categoryId": GraphQLVariable("categoryId"), "state": GraphQLVariable("state"), "after": GraphQLVariable("cursor"), "first": GraphQLVariable("first")], type: .object(Project.selections)),
         ]
       }
 

--- a/KsApi/Service.swift
+++ b/KsApi/Service.swift
@@ -394,6 +394,12 @@ public struct Service: ServiceType {
 
   public func fetchDiscovery(params: DiscoveryParams)
     -> SignalProducer<DiscoveryEnvelope, ErrorEnvelope> {
+    if !params.validForAPIV1() {
+      assert(
+        false,
+        "Using a field which was added for GraphQL support in API V1. This param may have unexpected effects on an API V1 call."
+      )
+    }
     return request(.discover(params))
   }
 

--- a/KsApi/models/DiscoveryParams.swift
+++ b/KsApi/models/DiscoveryParams.swift
@@ -24,6 +24,8 @@ public struct DiscoveryParams {
     case all
     case live
     case successful
+    case late_pledge
+    case upcoming
   }
 
   public enum Sort: String, Decodable {
@@ -164,4 +166,49 @@ private func stringIntToBool(_ string: String?) -> Bool? {
   return Int(string)
     .filter { $0 <= 1 && $0 >= -1 }
     .flatMap { ($0 == 0) ? nil : ($0 == 1) }
+}
+
+extension DiscoveryParams {
+  /// We're using `DiscoveryParams` in two places: Discover, which is powered by API V1,
+  /// and Search, which is now powered by GraphQL (using the `projects` query; see `SearchQuery.graphql`).
+  /// Search uses `DiscoveryParams` because our Search analytics is tightly coupled with `DiscoveryParams`,
+  /// and we haven't had the chance to fix that yet.
+  ///
+  /// This function validates that the params are only using enum values which are available in API V1, _not_ values
+  /// which were added for Search/GraphQL support.
+
+  func validForAPIV1() -> Bool {
+    if let sort = self.sort {
+      switch sort {
+      case .endingSoon:
+        break
+      case .magic:
+        break
+      case .newest:
+        break
+      case .popular:
+        break
+      case .most_funded:
+        return false
+      case .most_backed:
+        return false
+      }
+    }
+
+    if let state = self.state {
+      switch state {
+      case .all:
+        break
+      case .live:
+        break
+      case .successful:
+        break
+      case .late_pledge:
+        return false
+      case .upcoming:
+        return false
+      }
+    }
+    return true
+  }
 }

--- a/KsApi/queries/SearchQuery.graphql
+++ b/KsApi/queries/SearchQuery.graphql
@@ -1,5 +1,5 @@
-query Search($term: String, $sort: ProjectSort, $categoryId: String, $first: Int, $cursor: String) {
-  projects(term: $term, sort: $sort, categoryId: $categoryId, after: $cursor, first: $first) {
+query Search($term: String, $sort: ProjectSort, $categoryId: String, $state: PublicProjectState, $first: Int, $cursor: String) {
+  projects(term: $term, sort: $sort, categoryId: $categoryId, state: $state, after: $cursor, first: $first) {
     nodes {
       ...BackerDashboardProjectCellFragment
       ...ProjectAnalyticsFragment

--- a/Library/UseCases/SearchFiltersUseCase.swift
+++ b/Library/UseCases/SearchFiltersUseCase.swift
@@ -96,8 +96,6 @@ public final class SearchFiltersUseCase: SearchFiltersUseCaseType, SearchFilters
       self.selectedStateProperty.producer.takeWhen(initialSignal),
       self.selectedStateProperty.signal
     )
-
-      
   }
 
   fileprivate let (tappedSortSignal, tappedSortObserver) = Signal<Void, Never>.pipe()

--- a/Library/UseCases/SearchFiltersUseCaseTests.swift
+++ b/Library/UseCases/SearchFiltersUseCaseTests.swift
@@ -9,6 +9,7 @@ final class SearchFiltersUseCaseTests: TestCase {
 
   private let selectedSort = TestObserver<DiscoveryParams.Sort, Never>()
   private let selectedCategory = TestObserver<KsApi.Category?, Never>()
+  private let selectedState = TestObserver<DiscoveryParams.State, Never>()
   private let showCategoryFilters = TestObserver<SearchFilterCategoriesSheet, Never>()
   private let showSort = TestObserver<SearchSortSheet, Never>()
   private let pills = TestObserver<[SearchFilterPill], Never>()
@@ -28,6 +29,7 @@ final class SearchFiltersUseCaseTests: TestCase {
 
     self.useCase.dataOuputs.selectedCategory.observe(self.selectedCategory.observer)
     self.useCase.dataOuputs.selectedSort.observe(self.selectedSort.observer)
+    self.useCase.dataOuputs.selectedState.observe(self.selectedState.observer)
     self.useCase.uiOutputs.showCategoryFilters.observe(self.showCategoryFilters.observer)
     self.useCase.uiOutputs.showSort.observe(self.showSort.observer)
     self.useCase.uiOutputs.pills.observe(self.pills.observer)
@@ -53,6 +55,14 @@ final class SearchFiltersUseCaseTests: TestCase {
     self.initialObserver.send(value: ())
 
     self.selectedSort.assertLastValue(.magic)
+  }
+
+  func test_state_onInitialSignal_isAll() {
+    self.selectedState.assertDidNotEmitValue()
+
+    self.initialObserver.send(value: ())
+
+    self.selectedState.assertLastValue(.all)
   }
 
   func test_tappedSort_showsSortOptions() {
@@ -144,6 +154,21 @@ final class SearchFiltersUseCaseTests: TestCase {
     }
 
     XCTAssertEqual(newSelectedSort, .endingSoon, "Sort value should change when new sort is selected")
+  }
+
+  func test_selectingState_updatesState() {
+    self.initialObserver.send(value: ())
+
+    self.selectedState.assertLastValue(.all)
+
+    self.useCase.inputs.selectedProjectState(.late_pledge)
+
+    guard let newSelectedState = self.selectedState.lastValue else {
+      XCTFail("There should be a new selected state")
+      return
+    }
+
+    XCTAssertEqual(newSelectedState, .late_pledge, "State value should change when new state is selected")
   }
 
   func test_selectingSort_updatesSortPill() {

--- a/Library/ViewModels/SearchViewModel+GraphQL.swift
+++ b/Library/ViewModels/SearchViewModel+GraphQL.swift
@@ -19,6 +19,24 @@ extension GraphAPI.ProjectSort {
   }
 }
 
+extension GraphAPI.PublicProjectState {
+  static func from(discovery state: DiscoveryParams.State) -> GraphAPI.PublicProjectState? {
+    switch state {
+    case .all:
+      // Returning all results means we're not filtering to any particular state
+      return nil
+    case .live:
+      return GraphAPI.PublicProjectState.live
+    case .successful:
+      return GraphAPI.PublicProjectState.successful
+    case .late_pledge:
+      return GraphAPI.PublicProjectState.latePledge
+    case .upcoming:
+      return GraphAPI.PublicProjectState.upcoming
+    }
+  }
+}
+
 extension GraphAPI.SearchQuery {
   static func from(
     discoveryParams params: DiscoveryParams,
@@ -31,11 +49,13 @@ extension GraphAPI.SearchQuery {
     } else {
       categoryId = nil
     }
+    let state = GraphAPI.PublicProjectState.from(discovery: params.state ?? .all)
 
     return GraphAPI.SearchQuery(
       term: params.query,
       sort: sort,
       categoryId: categoryId,
+      state: state,
       first: params.perPage,
       cursor: cursor
     )
@@ -47,6 +67,7 @@ extension DiscoveryParams {
     var params = DiscoveryParams.defaults
     params.sort = .popular
     params.perPage = 15
+    params.state = .live
     return params
   }
 
@@ -56,6 +77,7 @@ extension DiscoveryParams {
     params.query = query
     params.category = category
     params.perPage = 15
+    params.state = .all
     return params
   }
 }

--- a/Library/ViewModels/SearchViewModel+GraphQL.swift
+++ b/Library/ViewModels/SearchViewModel+GraphQL.swift
@@ -67,17 +67,22 @@ extension DiscoveryParams {
     var params = DiscoveryParams.defaults
     params.sort = .popular
     params.perPage = 15
-    params.state = .live
+    params.state = .all
     return params
   }
 
-  static func withQuery(_ query: String, sort: DiscoveryParams.Sort, category: Category?) -> DiscoveryParams {
+  static func withQuery(
+    _ query: String,
+    sort: DiscoveryParams.Sort,
+    category: Category?,
+    state: DiscoveryParams.State?
+  ) -> DiscoveryParams {
     var params = DiscoveryParams.defaults
     params.sort = sort
     params.query = query
     params.category = category
     params.perPage = 15
-    params.state = .all
+    params.state = state
     return params
   }
 }

--- a/Library/ViewModels/SearchViewModel.swift
+++ b/Library/ViewModels/SearchViewModel.swift
@@ -122,13 +122,15 @@ public final class SearchViewModel: SearchViewModelType, SearchViewModelInputs, 
       )
 
     // DiscoveryParams using the users currently selected query text, sort and filters.
-    let queryParams: Signal<DiscoveryParams, Never> = queryText
-      .combineLatest(with: self.searchFiltersUseCase.selectedSort)
-      .combineLatest(with: self.searchFiltersUseCase.selectedCategory)
-      .map { ($0.0, $0.1, $1) } // ((a, b), c) -> (a, b, c)
-      .map { query, sort, category in
-        DiscoveryParams.withQuery(query, sort: sort, category: category)
-      }
+    let queryParams: Signal<DiscoveryParams, Never> = Signal.combineLatest(
+      queryText,
+      self.searchFiltersUseCase.selectedSort,
+      self.searchFiltersUseCase.selectedCategory,
+      self.searchFiltersUseCase.selectedState
+    )
+    .map { query, sort, category, state in
+      DiscoveryParams.withQuery(query, sort: sort, category: category, state: state)
+    }
 
     // Every time the user changes their query, sort or filters, we set an empty
     // results set to clear out the page. The user will just see the spinner.


### PR DESCRIPTION
# 📲 What

Add API and plumbing support for phase 2, filtering by project status.

# 🤔 Why

This change is effectively a no-op for the existing search - since it sets the default filters to `.all`. I split this out into its own PR for clarity's sake.