### PR TITLE
MBL-2222: Add project state filters to Search

### DIFF
--- a/Library/UseCases/SearchFilterPill.swift
+++ b/Library/UseCases/SearchFilterPill.swift
@@ -12,10 +12,13 @@ public struct SearchFilterPill: Identifiable {
   public let filterType: FilterType
   public let buttonType: ButtonType
 
-  /// What kind of option the pill represents.
+  /// Which filter the pill represents.
+  /// Only one pill of each type will be shown, since this powers the id of the pill.
   public enum FilterType {
-    case sort
+    case all
     case category
+    case sort
+    case projectState
   }
 
   /// How the pill should be rendered.
@@ -24,7 +27,7 @@ public struct SearchFilterPill: Identifiable {
     case dropdown(String)
   }
 
-  public init(isHighlighted: Bool, filterType: FilterType, buttonType: ButtonType) {
+  public init(isHighlighted: Bool, filterType: SearchFilterPill.FilterType, buttonType: ButtonType) {
     self.isHighlighted = isHighlighted
     self.filterType = filterType
     self.buttonType = buttonType

--- a/Library/UseCases/SearchFiltersUseCase.swift
+++ b/Library/UseCases/SearchFiltersUseCase.swift
@@ -9,10 +9,8 @@ public protocol SearchFiltersUseCaseType {
 }
 
 public protocol SearchFiltersUseCaseInputs {
-  /// Call this when the user taps on a button to show the sort options.
-  func tappedSort()
-  /// Call this when the user taps on a button to show the category filters.
-  func tappedCategoryFilter()
+  /// Call this when the user taps on a button to show one of the sort options.
+  func tappedButton(forFilterType: SearchFilterPill.FilterType)
   /// Call this when the user selects a new sort option.
   func selectedSortOption(_ sort: DiscoveryParams.Sort)
   /// Call this when the user selects a new category.
@@ -24,10 +22,8 @@ public protocol SearchFiltersUseCaseInputs {
 }
 
 public protocol SearchFiltersUseCaseUIOutputs {
-  /// Sends a model object which can be used to display category filter options. Only sends if `categories` have also been sent.
-  var showCategoryFilters: Signal<SearchFilterCategoriesSheet, Never> { get }
-  /// Sends a model object which can be used to display sort options.
-  var showSort: Signal<SearchSortSheet, Never> { get }
+  /// Sends a model object which can be used to display all filter options, and a type describing which filters to display.
+  var showFilters: Signal<(SearchFilterOptions, SearchFilterModalType), Never> { get }
   /// Sends an array of model objects which represent filter options, to be displayed in the search filter header.
   var pills: Signal<[SearchFilterPill], Never> { get }
 }
@@ -49,22 +45,34 @@ public final class SearchFiltersUseCase: SearchFiltersUseCaseType, SearchFilters
   public init(initialSignal: Signal<Void, Never>, categories: Signal<[KsApi.Category], Never>) {
     self.categoriesProperty <~ categories
 
-    self.showCategoryFilters = self.selectedCategoryProperty.producer
-      .takeWhen(self.tappedCategoryFilterSignal)
-      .combineLatest(with: categories)
-      .map { selectedCategory, categories -> SearchFilterCategoriesSheet in
-
-        SearchFilterCategoriesSheet(
+    self.showFilters = SignalProducer.combineLatest(
+      self.categoriesProperty.producer,
+      self.selectedCategoryProperty.producer,
+      self.selectedSortProperty.producer,
+      self.selectedStateProperty.producer
+    )
+    .takePairWhen(self.tappedFilterTypeSignal)
+    .map { a, b in (a.0, a.1, a.2, a.3, b) }
+    .map { [sortOptions, stateOptions] categories, category, sort, state, pill in
+      let options = SearchFilterOptions(
+        category: SearchFilterOptions.CategoryOptions(
           categories: categories,
-          selectedCategory: selectedCategory
+          selectedCategory: category
+        ),
+        sort: SearchFilterOptions.SortOptions(
+          sortOptions: sortOptions,
+          selectedOption: sort
+        ),
+        projectState: SearchFilterOptions.ProjectStateOptions(
+          stateOptions: stateOptions,
+          selectedOption: state
         )
-      }
+      )
 
-    self.showSort = self.selectedSortProperty.producer
-      .takeWhen(self.tappedSortSignal)
-      .map { [sortOptions] sort -> SearchSortSheet in
-        SearchSortSheet(sortOptions: sortOptions, selectedOption: sort)
-      }
+      let modalType = filterModal(toShowForPill: pill)
+
+      return (options, modalType)
+    }
 
     self.selectedSort = Signal.merge(
       self.selectedSortProperty.producer.takeWhen(initialSignal),
@@ -76,40 +84,24 @@ public final class SearchFiltersUseCase: SearchFiltersUseCaseType, SearchFilters
       self.selectedCategoryProperty.signal
     )
 
-    self.pills = Signal.combineLatest(self.selectedSort, self.selectedCategory)
-      .map { sort, category in
-        [
-          SearchFilterPill(
-            isHighlighted: sort != SearchFiltersUseCase.defaultSortOption,
-            filterType: .sort,
-            buttonType: .image("icon-sort")
-          ),
-          SearchFilterPill(
-            isHighlighted: category != nil,
-            filterType: .category,
-            buttonType: .dropdown(category?.name ?? Strings.Category())
-          )
-        ]
-      }
-
     self.selectedState = Signal.merge(
       self.selectedStateProperty.producer.takeWhen(initialSignal),
       self.selectedStateProperty.signal
     )
+
+    self.pills = Signal.combineLatest(self.selectedSort, self.selectedCategory, self.selectedState)
+      .map { sort, category, state in
+        filterPills(fromSelectedSort: sort, category: category, state: state)
+      }
   }
 
-  fileprivate let (tappedSortSignal, tappedSortObserver) = Signal<Void, Never>.pipe()
-  public func tappedSort() {
-    self.tappedSortObserver.send(value: ())
-  }
-
-  fileprivate let (tappedCategoryFilterSignal, tappedCategoryFilterObserver) = Signal<Void, Never>.pipe()
-  public func tappedCategoryFilter() {
-    if self.categoriesProperty.value.isEmpty {
-      assert(false, "Tried to show category filter before categories have downloaded.")
-      return
-    }
-    self.tappedCategoryFilterObserver.send(value: ())
+  fileprivate let (tappedFilterTypeSignal, tappedFilterTypeObserver) = Signal<
+    SearchFilterPill.FilterType,
+    Never
+  >
+  .pipe()
+  public func tappedButton(forFilterType type: SearchFilterPill.FilterType) {
+    self.tappedFilterTypeObserver.send(value: type)
   }
 
   fileprivate let selectedSortProperty = MutableProperty<DiscoveryParams.Sort>(
@@ -146,9 +138,7 @@ public final class SearchFiltersUseCase: SearchFiltersUseCaseType, SearchFilters
     DiscoveryParams.State.successful
   ]
 
-  public let showCategoryFilters: Signal<SearchFilterCategoriesSheet, Never>
-  public let showSort: Signal<SearchSortSheet, Never>
-
+  public var showFilters: Signal<(SearchFilterOptions, SearchFilterModalType), Never>
   public let pills: Signal<[SearchFilterPill], Never>
 
   public var selectedSort: Signal<DiscoveryParams.Sort, Never>
@@ -198,12 +188,89 @@ public final class SearchFiltersUseCase: SearchFiltersUseCaseType, SearchFilters
   public var dataOuputs: SearchFiltersUseCaseDataOutputs { return self }
 }
 
-public struct SearchFilterCategoriesSheet {
-  public let categories: [KsApi.Category]
-  public let selectedCategory: KsApi.Category?
+private func filterPills(
+  fromSelectedSort sort: DiscoveryParams.Sort,
+  category: KsApi.Category?,
+  state: DiscoveryParams.State
+) -> [SearchFilterPill] {
+  let hasCategory = category != nil
+  let hasState = state != SearchFiltersUseCase.defaultStateOption
+
+  var pills: [SearchFilterPill] = []
+
+  pills.append(SearchFilterPill(
+    isHighlighted: sort != SearchFiltersUseCase.defaultSortOption,
+    filterType: .sort,
+    buttonType: .image("icon-sort")
+  ))
+
+  if featureSearchFilterByProjectStatusEnabled() {
+    pills.append(SearchFilterPill(
+      isHighlighted: hasCategory || hasState,
+      filterType: .all,
+      // FIXME: MBL-2218 Use the real filter icon.
+      buttonType: .image("star-small-icon")
+    ))
+  }
+
+  pills.append(SearchFilterPill(
+    isHighlighted: category != nil,
+    filterType: .category,
+    buttonType: .dropdown(category?.name ?? Strings.Category())
+  ))
+
+  if featureSearchFilterByProjectStatusEnabled() {
+    pills.append(
+      SearchFilterPill(
+        isHighlighted: state != SearchFiltersUseCase.defaultStateOption,
+        filterType: .projectState,
+        // FIXME: MBL-2218 Turn the state into a user-readable title.
+        buttonType: .dropdown(state.rawValue)
+      )
+    )
+  }
+
+  return pills
 }
 
-public struct SearchSortSheet {
-  public let sortOptions: [DiscoveryParams.Sort]
-  public let selectedOption: DiscoveryParams.Sort
+private func filterModal(toShowForPill pill: SearchFilterPill.FilterType) -> SearchFilterModalType {
+  let modalType: SearchFilterModalType
+  switch pill {
+  case .all:
+    modalType = .all
+  case .category:
+    modalType = .category
+  case .sort:
+    modalType = .sort
+  case .projectState:
+    modalType = .all
+  }
+  return modalType
+}
+
+public enum SearchFilterModalType {
+  case all
+  case category
+  case sort
+}
+
+public struct SearchFilterOptions {
+  public struct CategoryOptions {
+    public let categories: [KsApi.Category]
+    public let selectedCategory: KsApi.Category?
+  }
+
+  public struct SortOptions {
+    public let sortOptions: [DiscoveryParams.Sort]
+    public let selectedOption: DiscoveryParams.Sort
+  }
+
+  public struct ProjectStateOptions {
+    public let stateOptions: [DiscoveryParams.State]
+    public let selectedOption: DiscoveryParams.State
+  }
+
+  public let category: CategoryOptions
+  public let sort: SortOptions
+  public let projectState: ProjectStateOptions
 }

--- a/Library/UseCases/SearchFiltersUseCaseTests.swift
+++ b/Library/UseCases/SearchFiltersUseCaseTests.swift
@@ -143,7 +143,7 @@ final class SearchFiltersUseCaseTests: TestCase {
     self.showFilters.assertDidEmitValue()
 
     if let (_, type) = self.showFilters.lastValue {
-      XCTAssertEqual(type, .sort, "Tapping all filter button should show filters")
+      XCTAssertEqual(type, .all, "Tapping all filter button should show all filters")
     }
   }
 

--- a/Library/UseCases/SearchFiltersUseCaseTests.swift
+++ b/Library/UseCases/SearchFiltersUseCaseTests.swift
@@ -10,8 +10,7 @@ final class SearchFiltersUseCaseTests: TestCase {
   private let selectedSort = TestObserver<DiscoveryParams.Sort, Never>()
   private let selectedCategory = TestObserver<KsApi.Category?, Never>()
   private let selectedState = TestObserver<DiscoveryParams.State, Never>()
-  private let showCategoryFilters = TestObserver<SearchFilterCategoriesSheet, Never>()
-  private let showSort = TestObserver<SearchSortSheet, Never>()
+  private let showFilters = TestObserver<(SearchFilterOptions, SearchFilterModalType), Never>()
   private let pills = TestObserver<[SearchFilterPill], Never>()
   private let categoryPill = TestObserver<SearchFilterPill, Never>()
   private let sortPill = TestObserver<SearchFilterPill, Never>()
@@ -30,8 +29,7 @@ final class SearchFiltersUseCaseTests: TestCase {
     self.useCase.dataOuputs.selectedCategory.observe(self.selectedCategory.observer)
     self.useCase.dataOuputs.selectedSort.observe(self.selectedSort.observer)
     self.useCase.dataOuputs.selectedState.observe(self.selectedState.observer)
-    self.useCase.uiOutputs.showCategoryFilters.observe(self.showCategoryFilters.observer)
-    self.useCase.uiOutputs.showSort.observe(self.showSort.observer)
+    self.useCase.uiOutputs.showFilters.observe(self.showFilters.observer)
     self.useCase.uiOutputs.pills.observe(self.pills.observer)
     self.useCase.uiOutputs.pills.map { pills in
       pills.first(where: { $0.filterType == .sort })
@@ -68,19 +66,20 @@ final class SearchFiltersUseCaseTests: TestCase {
   func test_tappedSort_showsSortOptions() {
     self.initialObserver.send(value: ())
 
-    self.showSort.assertDidNotEmitValue()
+    self.showFilters.assertDidNotEmitValue()
 
-    self.useCase.inputs.tappedSort()
+    self.useCase.inputs.tappedButton(forFilterType: .sort)
 
-    self.showSort.assertDidEmitValue()
+    self.showFilters.assertDidEmitValue()
 
-    if let sortOptions = self.showSort.lastValue {
+    if let (options, type) = self.showFilters.lastValue {
+      XCTAssertEqual(type, .sort, "Tapping sort button should show sort options")
       XCTAssertEqual(
-        sortOptions.selectedOption,
+        options.sort.selectedOption,
         .magic,
         "First option, magic, should be selected by default"
       )
-      XCTAssertGreaterThan(sortOptions.sortOptions.count, 0, "There should be multiple sort options")
+      XCTAssertGreaterThan(options.sort.sortOptions.count, 0, "There should be multiple sort options")
     }
   }
 
@@ -93,19 +92,58 @@ final class SearchFiltersUseCaseTests: TestCase {
       .tabletopGames
     ])
 
-    self.showCategoryFilters.assertDidNotEmitValue()
+    self.showFilters.assertDidNotEmitValue()
 
-    self.useCase.inputs.tappedCategoryFilter()
+    self.useCase.inputs.tappedButton(forFilterType: .category)
 
-    self.showCategoryFilters.assertDidEmitValue()
+    self.showFilters.assertDidEmitValue()
 
-    if let categoryOptions = self.showCategoryFilters.lastValue {
-      XCTAssertEqual(categoryOptions.selectedCategory, nil, "No category should be selected by default")
+    if let (options, type) = self.showFilters.lastValue {
+      XCTAssertEqual(type, .category, "Tapping category button should show category filters")
+      XCTAssertEqual(options.category.selectedCategory, nil, "No category should be selected by default")
       XCTAssertEqual(
-        categoryOptions.categories.count,
+        options.category.categories.count,
         4,
         "The sheet should show categories that were loaded"
       )
+    }
+  }
+
+  func test_tappedProjectState_showsAllOptions() {
+    self.initialObserver.send(value: ())
+
+    self.showFilters.assertDidNotEmitValue()
+
+    self.useCase.inputs.tappedButton(forFilterType: .projectState)
+
+    self.showFilters.assertDidEmitValue()
+
+    if let (options, type) = self.showFilters.lastValue {
+      XCTAssertEqual(type, .all, "Tapping project state button should show all options")
+      XCTAssertEqual(
+        options.projectState.selectedOption,
+        .all,
+        "First option, All, should be selected by default"
+      )
+      XCTAssertGreaterThan(
+        options.projectState.stateOptions.count,
+        0,
+        "There should be multiple project state options"
+      )
+    }
+  }
+
+  func test_tappedAllFilters_showsAllOptions() {
+    self.initialObserver.send(value: ())
+
+    self.showFilters.assertDidNotEmitValue()
+
+    self.useCase.inputs.tappedButton(forFilterType: .all)
+
+    self.showFilters.assertDidEmitValue()
+
+    if let (_, type) = self.showFilters.lastValue {
+      XCTAssertEqual(type, .sort, "Tapping all filter button should show filters")
     }
   }
 
@@ -121,11 +159,11 @@ final class SearchFiltersUseCaseTests: TestCase {
 
     self.categoriesObserver.send(value: categories)
 
-    self.showCategoryFilters.assertDidNotEmitValue()
+    self.showFilters.assertDidNotEmitValue()
     self.selectedCategory.assertLastValue(nil)
 
-    self.useCase.inputs.tappedCategoryFilter()
-    self.showCategoryFilters.assertDidEmitValue()
+    self.useCase.inputs.tappedButton(forFilterType: .category)
+    self.showFilters.assertDidEmitValue()
 
     self.useCase.inputs.selectedCategory(.art)
 
@@ -140,11 +178,11 @@ final class SearchFiltersUseCaseTests: TestCase {
   func test_selectingSort_updatesSort() {
     self.initialObserver.send(value: ())
 
-    self.showSort.assertDidNotEmitValue()
+    self.showFilters.assertDidNotEmitValue()
     self.selectedSort.assertLastValue(.magic)
 
-    self.useCase.inputs.tappedSort()
-    self.showSort.assertDidEmitValue()
+    self.useCase.inputs.tappedButton(forFilterType: .sort)
+    self.showFilters.assertDidEmitValue()
 
     self.useCase.inputs.selectedSortOption(.endingSoon)
 

--- a/Library/ViewModels/SearchViewModel.swift
+++ b/Library/ViewModels/SearchViewModel.swift
@@ -31,17 +31,15 @@ public protocol SearchViewModelInputs {
   /// Call when a project is tapped.
   func tapped(projectAtIndex index: Int)
 
-  /// Call when the sort button is tapped.
-  func tappedSort()
+  /// Call this when the user taps on a button to show one of the sort options.
+  func tappedButton(forFilterType type: SearchFilterPill.FilterType)
 
-  /// Call when the category filter button is tapped.
-  func tappedCategoryFilter()
-
-  /// Call when a new sort option has been selected.
+  /// Call this when the user selects a new sort option.
   func selectedSortOption(_ sort: DiscoveryParams.Sort)
-
-  /// Call when a new category is selected.
+  /// Call this when the user selects a new category.
   func selectedCategory(_ category: KsApi.Category?)
+  /// Call this when the user selects a new project state filter.
+  func selectedProjectState(_ state: DiscoveryParams.State)
 
   /**
    Call from the controller's `tableView:willDisplayCell:forRowAtIndexPath` method.
@@ -84,11 +82,8 @@ public protocol SearchViewModelOutputs {
   /// Emits true when there are search or discover results, and we should show the UI to sort and filter those results.
   var showSortAndFilterHeader: Signal<Bool, Never> { get }
 
-  /// Emits a model object with possible category options when the category filter button is tapped.
-  var showCategoryFilters: Signal<SearchFilterCategoriesSheet, Never> { get }
-
-  /// Emits a model object with possible sort options when the sort button is tapped.
-  var showSort: Signal<SearchSortSheet, Never> { get }
+  /// Sends a model object which can be used to display all filter options, and a type describing which filters to display.
+  var showFilters: Signal<(SearchFilterOptions, SearchFilterModalType), Never> { get }
 
   /// Sends an array of model objects which represent filter options, to be displayed in the search filter header.
   var pills: Signal<[SearchFilterPill], Never> { get }
@@ -397,20 +392,8 @@ public final class SearchViewModel: SearchViewModelType, SearchViewModelInputs, 
     self.willDisplayRowProperty.value = (row, totalRows)
   }
 
-  public func tappedSort() {
-    self.searchFiltersUseCase.tappedSort()
-  }
-
-  public func tappedCategoryFilter() {
-    self.searchFiltersUseCase.tappedCategoryFilter()
-  }
-
-  public func selectedSortOption(_ sort: DiscoveryParams.Sort) {
-    self.searchFiltersUseCase.inputs.selectedSortOption(sort)
-  }
-
-  public func selectedCategory(_ category: KsApi.Category?) {
-    self.searchFiltersUseCase.inputs.selectedCategory(category)
+  public func tappedButton(forFilterType type: SearchFilterPill.FilterType) {
+    self.searchFiltersUseCase.inputs.tappedButton(forFilterType: type)
   }
 
   private let categoriesUseCase: FetchCategoriesUseCase
@@ -427,12 +410,20 @@ public final class SearchViewModel: SearchViewModelType, SearchViewModelInputs, 
   public let showSortAndFilterHeader: Signal<Bool, Never>
   public let projectsAndTitle: Signal<(Bool, [SearchResultCard]), Never>
 
-  public var showSort: Signal<SearchSortSheet, Never> {
-    return self.searchFiltersUseCase.showSort
+  public var showFilters: Signal<(SearchFilterOptions, SearchFilterModalType), Never> {
+    return self.searchFiltersUseCase.showFilters
   }
 
-  public var showCategoryFilters: Signal<SearchFilterCategoriesSheet, Never> {
-    return self.searchFiltersUseCase.showCategoryFilters
+  public func selectedCategory(_ category: KsApi.Category?) {
+    self.searchFiltersUseCase.selectedCategory(category)
+  }
+
+  public func selectedSortOption(_ sort: DiscoveryParams.Sort) {
+    self.searchFiltersUseCase.selectedSortOption(sort)
+  }
+
+  public func selectedProjectState(_ state: DiscoveryParams.State) {
+    self.searchFiltersUseCase.selectedProjectState(state)
   }
 
   public var pills: Signal<[SearchFilterPill], Never> {

--- a/Library/ViewModels/SearchViewModelTests.swift
+++ b/Library/ViewModels/SearchViewModelTests.swift
@@ -22,8 +22,7 @@ internal final class SearchViewModelTests: TestCase {
   fileprivate let searchLoaderIndicatorIsAnimating = TestObserver<Bool, Never>()
   fileprivate let showEmptyState = TestObserver<Bool, Never>()
   fileprivate let showEmptyStateParams = TestObserver<DiscoveryParams, Never>()
-  fileprivate let showSort = TestObserver<SearchSortSheet, Never>()
-  fileprivate let showCategoryFilters = TestObserver<SearchFilterCategoriesSheet, Never>()
+  fileprivate let showFilters = TestObserver<(SearchFilterOptions, SearchFilterModalType), Never>()
   fileprivate let showSortAndFilterHeader = TestObserver<Bool, Never>()
   fileprivate let categoryPill = TestObserver<SearchFilterPill, Never>()
   fileprivate let sortPill = TestObserver<SearchFilterPill, Never>()
@@ -50,8 +49,7 @@ internal final class SearchViewModelTests: TestCase {
       .observe(self.hasAddedProjects.observer)
 
     self.vm.outputs.showSortAndFilterHeader.observe(self.showSortAndFilterHeader.observer)
-    self.vm.outputs.showSort.observe(self.showSort.observer)
-    self.vm.outputs.showCategoryFilters.observe(self.showCategoryFilters.observer)
+    self.vm.outputs.showFilters.observe(self.showFilters.observer)
 
     self.vm.outputs.pills.map { pills in
       pills.first(where: { $0.filterType == .sort })
@@ -687,20 +685,19 @@ internal final class SearchViewModelTests: TestCase {
         "Selected sort should be in tracking properties"
       )
 
-      self.showSort.assertDidNotEmitValue()
-      self.showCategoryFilters.assertDidNotEmitValue()
+      self.showFilters.assertDidNotEmitValue()
 
-      self.vm.inputs.tappedSort()
-      self.showSort.assertDidEmitValue()
+      self.vm.inputs.tappedButton(forFilterType: .sort)
+      self.showFilters.assertDidEmitValue()
 
-      guard let sortSheet = self.showSort.lastValue else {
-        XCTFail("Sort sheet should have been shown after tappedSort was called")
+      guard let (options, type) = self.showFilters.lastValue else {
+        XCTFail("Sort sheet should have been shown after sort button was tapped")
         return
       }
 
-      XCTAssertTrue(sortSheet.sortOptions.count > 1, "Sort sheet should have multiple sort options")
+      XCTAssertTrue(options.sort.sortOptions.count > 1, "Sort sheet should have multiple sort options")
       XCTAssertTrue(
-        sortSheet.selectedOption == .magic,
+        options.sort.selectedOption == .magic,
         "Sort sheet should have first option selected by default"
       )
 
@@ -813,20 +810,19 @@ internal final class SearchViewModelTests: TestCase {
         "Selected category should be in tracking properties, but it should be nil because no category was selected yet"
       )
 
-      self.showSort.assertDidNotEmitValue()
-      self.showCategoryFilters.assertDidNotEmitValue()
+      self.showFilters.assertDidNotEmitValue()
 
-      self.vm.inputs.tappedCategoryFilter()
-      self.showCategoryFilters.assertDidEmitValue()
+      self.vm.inputs.tappedButton(forFilterType: .category)
+      self.showFilters.assertDidEmitValue()
 
-      guard let categorySheet = self.showCategoryFilters.lastValue else {
+      guard let (options, type) = self.showFilters.lastValue else {
         XCTFail("Category sheet should have been shown after tappedCategoryFilters was called")
         return
       }
 
-      XCTAssertTrue(categorySheet.categories.count == 4, "Category sheet should have 4 options")
+      XCTAssertTrue(options.category.categories.count == 4, "Category sheet should have 4 options")
       XCTAssertTrue(
-        categorySheet.selectedCategory.isNil,
+        options.category.selectedCategory.isNil,
         "Category sheet should have empty option selected by default"
       )
 


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Implement project state filters for Phase 2 of the sort & filters project.

![project-state-filters](https://github.com/user-attachments/assets/3e2e5b3d-9f31-41f5-85bd-49ff919a01c8)

* Added project state filters to `SearchFiltersUseCase` and `SearchViewModel`
* Show placeholder pills for 'All' filters and project state filters
* Show placeholder UI for choosing project filters
* Refactor `SearchFiltersUseCase` to make it easier to add more filter types in the future
* Refactor the data types used to show the filter modals

# 🤔 Why

I like to implement scaffolding like this before I go in and write the UI - it makes it easier for me to hook everything up later. Might as well sort out the hard problems first before making it pretty.