### PR TITLE
Add accent/gray/subtle and border/active to new design system colors

### DIFF
--- a/Kickstarter-iOS/Assets.xcassets/new design system/colors/background/accentGraySubtle.colorset/Contents.json
+++ b/Kickstarter-iOS/Assets.xcassets/new design system/colors/background/accentGraySubtle.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xF2",
+          "green" : "0xF2",
+          "red" : "0xF2"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Kickstarter-iOS/Assets.xcassets/new design system/colors/border/active.colorset/Contents.json
+++ b/Kickstarter-iOS/Assets.xcassets/new design system/colors/border/active.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x4D",
+          "green" : "0x4D",
+          "red" : "0x4D"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Library/Styles/Colors/NewDesignSystemColors.swift
+++ b/Library/Styles/Colors/NewDesignSystemColors.swift
@@ -6,6 +6,7 @@ public struct Colors {
     case accentGreenBold
     case accentGreenBoldPressed
     case accentGreenDisabled
+    case accentGraySubtle
     case accentRedSubtle
     case action
     case actionDisabled
@@ -22,6 +23,7 @@ public struct Colors {
 
   /// Border colors, mapped to `border/` namespace in Assets.
   public enum Border: String, AdaptiveColors {
+    case active
     case bold
     case dangerBold
     case subtle

--- a/Library/Styles/Fonts/CustomFont.swift
+++ b/Library/Styles/Fonts/CustomFont.swift
@@ -45,7 +45,7 @@ extension CustomFont {
   /// Converts the custom font to a SwiftUI `Font`.
   /// - Parameter size: The font size to apply. If `nil`, the default size for the font will be used.
   /// - Returns: A SwiftUI `Font` created from the custom `UIFont`.
-  public func swiftUIFont(size: CGFloat?) -> Font {
+  public func swiftUIFont(size: CGFloat? = nil) -> Font {
     return Font(self.font(size: size))
   }
 }


### PR DESCRIPTION
# 📲 What

* Add two colors to our design system
* Add a default size of `nil` to `swiftUIFont`, for convenience

# 🤔 Why

I need these for the search filter pill buttons.