### PR TITLE
Add dark mode colors for background/accent/gray/subtle and border/active

### DIFF
--- a/Kickstarter-iOS/Assets.xcassets/new design system/colors/background/accentGraySubtle.colorset/Contents.json
+++ b/Kickstarter-iOS/Assets.xcassets/new design system/colors/background/accentGraySubtle.colorset/Contents.json
@@ -11,6 +11,24 @@
         }
       },
       "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x3C",
+          "green" : "0x3C",
+          "red" : "0x3C"
+        }
+      },
+      "idiom" : "universal"
     }
   ],
   "info" : {

--- a/Kickstarter-iOS/Assets.xcassets/new design system/colors/border/active.colorset/Contents.json
+++ b/Kickstarter-iOS/Assets.xcassets/new design system/colors/border/active.colorset/Contents.json
@@ -11,6 +11,24 @@
         }
       },
       "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFA",
+          "green" : "0xFA",
+          "red" : "0xFA"
+        }
+      },
+      "idiom" : "universal"
     }
   ],
   "info" : {


### PR DESCRIPTION
# 📲 What

Add dark mode colors for background/accent/gray/subtle and border/active

# 🤔 Why

I didn't add these earlier, and now I know what colors they are!
For reference, the main Figman board: https://www.figma.com/design/enEdulL4R1rsMcMttfxJRr/Kickstarter-Design-System---Mobile
