### PR TITLE
[MBL-2328] Fix image/audio element loading in campaign from search

### DIFF
--- a/Library/ViewModels/ProjectPageViewModel.swift
+++ b/Library/ViewModels/ProjectPageViewModel.swift
@@ -389,9 +389,7 @@ public final class ProjectPageViewModel: ProjectPageViewModelType, ProjectPageVi
       }
 
     let trackFreshProjectAndRefTagViewed: Signal<(Project, RefTag?), Never> = Signal.zip(
-      freshProjectAndRefTag
-        .filter { $0.0.extendedProjectProperties.isSome }
-        .take(first: 1),
+      freshProjectAndRefTag.skip(first: 1),
       self.viewDidAppearAnimatedProperty.signal.ignoreValues()
     )
     .map(unpack)

--- a/Library/ViewModels/ProjectPageViewModel.swift
+++ b/Library/ViewModels/ProjectPageViewModel.swift
@@ -233,15 +233,15 @@ public final class ProjectPageViewModel: ProjectPageViewModelType, ProjectPageVi
       .map { $0.flagging ?? false }
 
     self.prefetchImageURLs = project.signal
-      .skip(first: 1)
+      .compactMap { $0.extendedProjectProperties }
       .combineLatest(with: self.prepareImageAtProperty.signal.skipNil())
       .filterWhenLatestFrom(
         self.projectNavigationSelectorViewDidSelectProperty.signal.skipNil(),
         satisfies: { NavigationSection(rawValue: $0) == .campaign }
       )
-      .switchMap { project, indexPath -> SignalProducer<([URL], IndexPath)?, Never> in
-        let imageViewElements = project.extendedProjectProperties?.story.htmlViewElements
-          .compactMap { $0 as? ImageViewElement } ?? []
+      .switchMap { properties, indexPath -> SignalProducer<([URL], IndexPath)?, Never> in
+        let imageViewElements = properties.story.htmlViewElements
+          .compactMap { $0 as? ImageViewElement }
 
         if imageViewElements.count > 0 {
           let urlStrings = imageViewElements.map { $0.src }
@@ -255,19 +255,19 @@ public final class ProjectPageViewModel: ProjectPageViewModelType, ProjectPageVi
       .skipNil()
 
     self.prefetchImageURLsOnFirstLoad = project.signal
-      .skip(first: 1)
-      .switchMap { project -> SignalProducer<[ImageViewElement], Never> in
-        let imageViewElements = project.extendedProjectProperties?.story.htmlViewElements
-          .compactMap { $0 as? ImageViewElement } ?? []
+      .compactMap { $0.extendedProjectProperties }
+      .switchMap { properties -> SignalProducer<[ImageViewElement], Never> in
+        let imageViewElements = properties.story.htmlViewElements
+          .compactMap { $0 as? ImageViewElement }
 
         return SignalProducer(value: imageViewElements)
       }
 
     self.precreateAudioVideoURLsOnFirstLoad = project.signal
-      .skip(first: 1)
-      .switchMap { project -> SignalProducer<[AudioVideoViewElement], Never> in
-        let audioVideoViewElements = project.extendedProjectProperties?.story.htmlViewElements
-          .compactMap { $0 as? AudioVideoViewElement } ?? []
+      .compactMap { $0.extendedProjectProperties }
+      .switchMap { properties -> SignalProducer<[AudioVideoViewElement], Never> in
+        let audioVideoViewElements = properties.story.htmlViewElements
+          .compactMap { $0 as? AudioVideoViewElement }
 
         return SignalProducer(value: audioVideoViewElements)
       }
@@ -389,7 +389,9 @@ public final class ProjectPageViewModel: ProjectPageViewModelType, ProjectPageVi
       }
 
     let trackFreshProjectAndRefTagViewed: Signal<(Project, RefTag?), Never> = Signal.zip(
-      freshProjectAndRefTag.skip(first: 1),
+      freshProjectAndRefTag
+        .filter { $0.0.extendedProjectProperties.isSome }
+        .take(first: 1),
       self.viewDidAppearAnimatedProperty.signal.ignoreValues()
     )
     .map(unpack)


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Fixes image and audio loading when opening a project from search.

# 🤔 Why

So people can see images in search results.

# 🛠 How

Search loads without a Project instance, and instead passes a param (like an id or slug) of a project. The project page then loads that project one time.

The existing signal chain was assuming that the project page would be opened via a Project instance, so the signals would receive two projects. The first one being partial, the second one being complete.

Since it was making this assumption, it was skipping the first project returned. When opening via a param, this is the ONLY project being returned. So it was not doing the work to load images (and, it turns out, audio elements and I think page view events). So images and audio elements were not being shown.

This fixes by removing the `skip` call and replacing it with a `.compactMap({ project.extendedProjectProperties })`. This accomplishes the same thing when loading via a Project, but also makes it work when loading via a Param.

