### PR TITLE
MBL-2227: Support navigation for filters and add placeholder root filter view

### DIFF
--- a/Kickstarter-iOS/Features/SortFilter/FilterCategory/FilterCategoryView.swift
+++ b/Kickstarter-iOS/Features/SortFilter/FilterCategory/FilterCategoryView.swift
@@ -9,7 +9,11 @@ struct FilterCategoryView<T: FilterCategory>: View {
 
   var body: some View {
     VStack(spacing: 0) {
-      self.headerView
+      if !featureSearchFilterByProjectStatusEnabled() {
+        // When status filters are enabled, this is presented in a NavigationStack
+        // and has a built-in navigation title view.
+        self.headerView
+      }
 
       if self.viewModel.isLoading {
         ProgressView()

--- a/Kickstarter-iOS/Features/SortFilter/FilterRootView.swift
+++ b/Kickstarter-iOS/Features/SortFilter/FilterRootView.swift
@@ -1,0 +1,129 @@
+import KsApi
+import Library
+import SwiftUI
+
+struct FilterRootView: View {
+  @State var filterOptions: SearchFilterOptions
+  @State var navigationState: [SearchFilterModalType]
+
+  @ObservedObject var selectedFilters: SelectedSearchFilters
+
+  var onSelectedCategory: ((KsApi.Category?) -> Void)? = nil
+  var onSelectedProjectState: ((DiscoveryParams.State) -> Void)? = nil
+  var onResults: (() -> Void)? = nil
+  var onClose: (() -> Void)? = nil
+
+  @ViewBuilder
+  private var separator: some View {
+    Rectangle()
+      .fill(Colors.Border.subtle.swiftUIColor())
+      .frame(height: 1)
+      .frame(maxWidth: .infinity)
+  }
+
+  @ViewBuilder
+  var categorySection: some View {
+    Text(Strings.Category())
+      .fontWeight(.bold)
+    NavigationLink(value: SearchFilterModalType.category) {
+      Text("Pick a category >")
+    }
+    if let selectedCategory = self.selectedFilters.category?.name {
+      Text("Selected category: \(selectedCategory)")
+        .font(InterFont.body.swiftUIFont())
+        .foregroundStyle(Colors.Text.disabled.swiftUIColor())
+    }
+  }
+
+  @ViewBuilder
+  var projectStateSection: some View {
+    Text(Strings.Project_status())
+      .fontWeight(.bold)
+    VStack {
+      ForEach(self.filterOptions.projectState.stateOptions) { state in
+        Button(action: {
+          if let action = onSelectedProjectState {
+            action(state)
+          }
+        }, label: {
+          Text(state.title)
+            .lineLimit(1)
+        })
+        .buttonStyle(BorderedProminentButtonStyle())
+        .tint(state == self.selectedFilters.projectState ? .red : .blue)
+      }
+    }
+  }
+
+  @ViewBuilder
+  var categoryModal: some View {
+    FilterCategoryView(
+      viewModel: FilterCategoryViewModel<KsApi.Category>(
+        with: self.filterOptions.category.categories,
+        selectedCategory: self.selectedFilters.category
+      ),
+      onSelectedCategory: self.onSelectedCategory,
+      onResults: self.onResults,
+      onClose: self.onClose
+    )
+    .navigationTitle(Strings.Category())
+  }
+
+  init(
+    filterOptions: SearchFilterOptions,
+    filterType: SearchFilterModalType,
+    selectedFilters: SelectedSearchFilters
+  ) {
+    self.filterOptions = filterOptions
+    if filterType == .all {
+      // Show the root view
+      self.navigationState = []
+    } else {
+      self.navigationState = [filterType]
+    }
+
+    self.selectedFilters = selectedFilters
+  }
+
+  public var body: some View {
+    NavigationStack(path: self.$navigationState) {
+      VStack(spacing: 20) {
+        self.categorySection
+        self.separator
+        self.projectStateSection
+      }
+      .navigationDestination(for: SearchFilterModalType.self, destination: { modalType in
+        if modalType == .category {
+          self.categoryModal
+            .modalHeader(withTitle: Strings.Category(), onClose: self.onClose)
+        } else {
+          EmptyView()
+        }
+      })
+      .modalHeader(withTitle: Strings.Filter(), onClose: self.onClose)
+    }
+  }
+}
+
+extension View {
+  func modalHeader(withTitle _: String, onClose: (() -> Void)?) -> some View {
+    self
+      .navigationTitle(Strings.Filter())
+      .navigationBarTitleDisplayMode(.inline)
+      .toolbar {
+        Button {
+          if let action = onClose {
+            action()
+          }
+        } label: {
+          Text("X")
+        }
+      }
+  }
+}
+
+extension DiscoveryParams.State: @retroactive Identifiable {
+  public var id: Int {
+    return self.rawValue.hashValue
+  }
+}

--- a/Kickstarter-iOS/Features/SortFilter/FilterRootView.swift
+++ b/Kickstarter-iOS/Features/SortFilter/FilterRootView.swift
@@ -2,6 +2,8 @@ import KsApi
 import Library
 import SwiftUI
 
+// FIXME: MBL-2220: All of this UI is placeholder UI.
+// It's functional, but not up to spec, and includes no translations.
 struct FilterRootView: View {
   @State var filterOptions: SearchFilterOptions
   @State var navigationState: [SearchFilterModalType]

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -1679,6 +1679,7 @@
 		E17611E62B75242A00DF2F50 /* PaginatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E17611E52B75242A00DF2F50 /* PaginatorTests.swift */; };
 		E1801FA72BA8EDB500EBB533 /* PaginatingList.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1801FA62BA8EDB500EBB533 /* PaginatingList.swift */; };
 		E1801FAA2BAB6D0900EBB533 /* PaymentSourceSelected.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1801FA82BAB6CD400EBB533 /* PaymentSourceSelected.swift */; };
+		E182B7CA2DAFF529000C4067 /* FilterRootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E182B7C92DAFF525000C4067 /* FilterRootView.swift */; };
 		E182B7DF2DB2A89D000C4067 /* SelectedSearchFilters.swift in Sources */ = {isa = PBXBuildFile; fileRef = E182B7DA2DB2A80D000C4067 /* SelectedSearchFilters.swift */; };
 		E182B7E02DB2A8A3000C4067 /* SelectedSearchFilters+TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = E182B7DC2DB2A845000C4067 /* SelectedSearchFilters+TestHelpers.swift */; };
 		E182B7E22DB2AAC9000C4067 /* SearchFilterOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E182B7E12DB2AAC9000C4067 /* SearchFilterOptions.swift */; };
@@ -3465,6 +3466,7 @@
 		E17611E52B75242A00DF2F50 /* PaginatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginatorTests.swift; sourceTree = "<group>"; };
 		E1801FA62BA8EDB500EBB533 /* PaginatingList.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PaginatingList.swift; sourceTree = "<group>"; };
 		E1801FA82BAB6CD400EBB533 /* PaymentSourceSelected.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentSourceSelected.swift; sourceTree = "<group>"; };
+		E182B7C92DAFF525000C4067 /* FilterRootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterRootView.swift; sourceTree = "<group>"; };
 		E182B7DA2DB2A80D000C4067 /* SelectedSearchFilters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectedSearchFilters.swift; sourceTree = "<group>"; };
 		E182B7DC2DB2A845000C4067 /* SelectedSearchFilters+TestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SelectedSearchFilters+TestHelpers.swift"; sourceTree = "<group>"; };
 		E182B7E12DB2AAC9000C4067 /* SearchFilterOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchFilterOptions.swift; sourceTree = "<group>"; };
@@ -5918,6 +5920,7 @@
 		336193ED2D825C4F00BED4BD /* SortFilter */ = {
 			isa = PBXGroup;
 			children = (
+				E182B7C92DAFF525000C4067 /* FilterRootView.swift */,
 				E1CFB6B62D91E99F004AB0D6 /* HeaderView */,
 				336194E12D8A95BB00BED4BD /* SortView */,
 				336193EE2D825C6500BED4BD /* FilterCategory */,
@@ -9072,6 +9075,7 @@
 				4751A679272B56C400F81DD5 /* ProjectTabDisclaimerCell.swift in Sources */,
 				94114D602653135E0063E8F6 /* CommentRemovedCell.swift in Sources */,
 				D6CCD8A523A94C6200CFD5FF /* ActivityErroredBackingsCell.swift in Sources */,
+				E182B7CA2DAFF529000C4067 /* FilterRootView.swift in Sources */,
 				D6B6766B20FF8F890082717D /* SettingsNewslettersCell.swift in Sources */,
 				77320F8A24411459004C631E /* SettingsAccountHeaderView.swift in Sources */,
 				4724A0A4268F6123000EB7A9 /* ViewMoreRepliesCell.swift in Sources */,


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

* Add `FilterRootView` with placeholder, but functional, UI
* Use `NavigationStack` so that tapping on "Category" button links you to a `FilterCategoryView` pushed on top of a `FilterRootView`

![filter-navigation-new](https://github.com/user-attachments/assets/0b91ccea-a442-45c8-aa66-03a20c61b04c)


# 🤔 Why

This is the last big leap from Phase 1 of search into Phase 2!