### PR TITLE
[MBL-2364] Fix facebook URL scheme

### DIFF
--- a/Kickstarter-iOS/Info.plist
+++ b/Kickstarter-iOS/Info.plist
@@ -31,6 +31,12 @@
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>fb69103156693</string>
+			</array>
+		</dict>
+		<dict>
 			<key>CFBundleTypeRole</key>
 			<string>Editor</string>
 			<key>CFBundleURLName</key>


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Fixes Facebook SDK login.

# 🛠 How

As part of #2356 I removed the URL scheme for AppCenter, not noticing that there was a Facebook SDK scheme there. The Facebook SDK scheme was deleted by accident, so now Facebook logins appear broken.

This change just re-adds the scheme.

# 👀 See

[Error events](https://console.firebase.google.com/u/0/project/kickstarter-ios/crashlytics/app/ios:com.kickstarter.kickstarter/issues/4775b110883a794b2702a61798310a48?time=last-twenty-four-hours&versions=5.24.1%20(1744776)&types=crash&sessionEventKey=23871d77925b4666b6e0a033abd7e07a_2074285278984436477)