### PR TITLE
[MBL-2366] Fix update payment method for PLOT pledges

### DIFF
--- a/Library/UpdateBackingInput+Constructor.swift
+++ b/Library/UpdateBackingInput+Constructor.swift
@@ -18,13 +18,21 @@ extension UpdateBackingInput {
     // be changed; amount, locationId, and rewardIds.
     let isFixPledge = updateBackingData.pledgeContext == .fixPaymentMethod
 
+    // Check if this is a change payment method and PLOT pledge; if so, only include paymentSourceId or applePay.
+    let isChangePaymentMethodAndPlot = updateBackingData
+      .pledgeContext == .changePaymentMethod && updateBackingData.backing.paymentIncrements.count > 0
+
+    let shouldOmitAmount = updateBackingData.backing
+      .isLatePledge || isFixPledge || isChangePaymentMethodAndPlot
+    let shouldOmitLocationAndRewards = isFixPledge || isChangePaymentMethodAndPlot
+
     return UpdateBackingInput(
-      amount: (updateBackingData.backing.isLatePledge || isFixPledge) ? nil : pledgeTotal,
+      amount: shouldOmitAmount ? nil : pledgeTotal,
       applePay: isApplePay ? updateBackingData.applePayParams : nil,
       id: backingId,
-      locationId: isFixPledge ? nil : locationId,
+      locationId: shouldOmitLocationAndRewards ? nil : locationId,
       paymentSourceId: isApplePay ? nil : updateBackingData.paymentSourceId,
-      rewardIds: isFixPledge ? nil : rewardIds,
+      rewardIds: shouldOmitLocationAndRewards ? nil : rewardIds,
       setupIntentClientSecret: updateBackingData.setupIntentClientSecret
     )
   }

--- a/Library/UpdateBackingInput+ConstructorTests.swift
+++ b/Library/UpdateBackingInput+ConstructorTests.swift
@@ -96,9 +96,8 @@ final class UpdateBackingInput_ConstructorTests: TestCase {
     XCTAssertNil(input.paymentSourceId)
     XCTAssertEqual(input.rewardIds, ["UmV3YXJkLTE="])
   }
-  
-  func testUpdateBackingInput_UpdateBackingData_IsPLOT_IsPaymentSource() {
 
+  func testUpdateBackingInput_UpdateBackingData_IsPLOT_IsPaymentSource() {
     let reward = Reward.template
 
     let data: UpdateBackingData = (
@@ -122,7 +121,7 @@ final class UpdateBackingInput_ConstructorTests: TestCase {
     XCTAssertEqual(input.paymentSourceId, UserCreditCards.amex.id)
     XCTAssertNil(input.rewardIds)
   }
-  
+
   func testUpdateBackingInput_UpdateBackingData_IsPLOT_IsApplePay() {
     let applePayParams = ApplePayParams(
       paymentInstrumentName: "paymentInstrumentName",
@@ -130,7 +129,7 @@ final class UpdateBackingInput_ConstructorTests: TestCase {
       transactionIdentifier: "transactionIdentifier",
       token: "token"
     )
-    
+
     let reward = Reward.template
 
     let data: UpdateBackingData = (

--- a/Library/UpdateBackingInput+ConstructorTests.swift
+++ b/Library/UpdateBackingInput+ConstructorTests.swift
@@ -96,6 +96,64 @@ final class UpdateBackingInput_ConstructorTests: TestCase {
     XCTAssertNil(input.paymentSourceId)
     XCTAssertEqual(input.rewardIds, ["UmV3YXJkLTE="])
   }
+  
+  func testUpdateBackingInput_UpdateBackingData_IsPLOT_IsPaymentSource() {
+
+    let reward = Reward.template
+
+    let data: UpdateBackingData = (
+      backing: Backing.templatePlot,
+      rewards: [reward],
+      pledgeTotal: 105,
+      selectedQuantities: [reward.id: 1],
+      shippingRule: ShippingRule.template,
+      paymentSourceId: UserCreditCards.amex.id,
+      setupIntentClientSecret: nil,
+      applePayParams: nil,
+      pledgeContext: .changePaymentMethod
+    )
+
+    let input = UpdateBackingInput.input(from: data, isApplePay: false)
+
+    XCTAssertNil(input.amount)
+    XCTAssertNil(input.applePay)
+    XCTAssertEqual(input.id, "QmFja2luZy0x")
+    XCTAssertNil(input.locationId)
+    XCTAssertEqual(input.paymentSourceId, UserCreditCards.amex.id)
+    XCTAssertNil(input.rewardIds)
+  }
+  
+  func testUpdateBackingInput_UpdateBackingData_IsPLOT_IsApplePay() {
+    let applePayParams = ApplePayParams(
+      paymentInstrumentName: "paymentInstrumentName",
+      paymentNetwork: "paymentNetwork",
+      transactionIdentifier: "transactionIdentifier",
+      token: "token"
+    )
+    
+    let reward = Reward.template
+
+    let data: UpdateBackingData = (
+      backing: Backing.templatePlot,
+      rewards: [reward],
+      pledgeTotal: 105,
+      selectedQuantities: [reward.id: 1],
+      shippingRule: ShippingRule.template,
+      paymentSourceId: UserCreditCards.amex.id,
+      setupIntentClientSecret: nil,
+      applePayParams: applePayParams,
+      pledgeContext: .changePaymentMethod
+    )
+
+    let input = UpdateBackingInput.input(from: data, isApplePay: true)
+
+    XCTAssertNil(input.amount)
+    XCTAssertEqual(input.applePay, applePayParams)
+    XCTAssertEqual(input.id, "QmFja2luZy0x")
+    XCTAssertNil(input.locationId)
+    XCTAssertNil(input.paymentSourceId)
+    XCTAssertNil(input.rewardIds)
+  }
 
   func testUpdateBackingInput_UpdateBackingData_AmountIsNull_WhenLatePledge_isApplePay() {
     let applePayParams = ApplePayParams(


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Fixes the **Feature disabled** error shown when attempting to change the payment method for PLOT pledges by ensuring only the `paymentSourceId` or `applePay` field is sent, and excluding `rewardIds`, `amount`, and `locationId`.

# 🤔 Why

The backend expects only `paymentSourceId` or `applePay` to be present in the payload when updating payment method for PLOT pledges. Sending additional fields like `rewardIds` causes the endpoint to reject the request with a **Feature disabled** error.

# 🛠 How

- Introduced a new boolean condition `isChangePaymentMethodAndPlot`.
- Used this to conditionally exclude `amount`, `rewardIds`, and `locationId` from the `UpdateBackingInput` payload when the context is `.changePaymentMethod` and the pledge is a PLOT type.


# 👀 See

- [Ticket](https://kickstarter.atlassian.net/browse/MBL-2366)

| Before 🐛 | After 🦋 |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/89da7bf2-d22f-4686-9416-f21f096eba95) | ![image](https://github.com/user-attachments/assets/afd56cf4-2527-4d7b-aeff-6ead309314ec) |

# ✅ Acceptance criteria

- [ ] 	Able to update the payment method on a PLOT pledge without receiving a **Feature disabled** error.
- [ ]  Confirm correct behavior on both Apple Pay and card-based pledges.

# ⏰ TODO

- [ ] 	Confirm behavior with backend team across different pledge types if needed.
