### PR TITLE
[MBL-2385] Intersperse Tracking # Cards With Activities

### DIFF
--- a/Kickstarter-iOS/Features/Activities/Controller/ActivitiesViewController.swift
+++ b/Kickstarter-iOS/Features/Activities/Controller/ActivitiesViewController.swift
@@ -169,13 +169,6 @@ internal final class ActivitiesViewController: UITableViewController {
         NotificationCenter.default.post(.init(name: .ksr_userUpdated))
       }
 
-    self.viewModel.outputs.rewardTrackingData
-      .observeForUI()
-      .observeValues { [weak self] trackings in
-        self?.dataSource.load(rewardTrackingData: trackings)
-        self?.tableView.reloadData()
-      }
-
     self.viewModel.outputs.goToTrackShipping
       .observeForUI()
       .observeValues { [weak self] url in

--- a/Kickstarter-iOS/Features/Activities/Datasource/ActivitiesDataSource.swift
+++ b/Kickstarter-iOS/Features/Activities/Datasource/ActivitiesDataSource.swift
@@ -92,16 +92,14 @@ internal final class ActivitiesDataSource: ValueCellDataSource {
   private func rewardTrackingActivitiyData(from activity: Activity) -> RewardTrackingActivitiesCellData? {
     guard featureRewardShipmentTrackingEnabled() == true,
           let project = activity.project,
-          let trackingNumber = activity.trackingNumber,
-          let trackingUrl = activity.trackingUrl,
-          let trackingURL = URL(string: trackingUrl)
+          let trackingNumber = activity.trackingNumber
     else {
       return nil
     }
 
     let trackingData = RewardTrackingDetailsViewData(
       trackingNumber: trackingNumber,
-      trackingURL: trackingURL
+      trackingURL: URL(string: activity.trackingUrl ?? "")
     )
 
     return RewardTrackingActivitiesCellData(

--- a/Kickstarter-iOS/Features/RewardTracking/Views/RewardTrackingDetailsView.swift
+++ b/Kickstarter-iOS/Features/RewardTracking/Views/RewardTrackingDetailsView.swift
@@ -65,11 +65,14 @@ final class RewardTrackingDetailsView: UIView {
 
     self.trackingStatusLabel.rac.text = self.viewModel.outputs.rewardTrackingStatus
     self.trackingNumberLabel.rac.text = self.viewModel.outputs.rewardTrackingNumber
+    self.trackingButton.rac.hidden = self.viewModel.outputs.trackingButtonHidden
 
     self.viewModel.outputs.trackShipping
       .observeForUI()
       .observeValues { [weak self] trackingURL in
-        self?.delegate?.didTapTrackingButton(with: trackingURL)
+        guard let url = trackingURL else { return }
+
+        self?.delegate?.didTapTrackingButton(with: url)
       }
   }
 

--- a/Library/ViewModels/ActivitiesViewModel.swift
+++ b/Library/ViewModels/ActivitiesViewModel.swift
@@ -92,9 +92,6 @@ public protocol ActivitiesViewModelOutputs {
 
   /// Emits a User that can be used to replace the current user in the environment.
   var updateUserInEnvironment: Signal<User, Never> { get }
-
-  /// Emits an array of reward tracking data that should be displayed.
-  var rewardTrackingData: Signal<[RewardTrackingActivitiesCellData], Never> { get }
 }
 
 public protocol ActivitiesViewModelType {
@@ -282,35 +279,6 @@ public final class ActivitiesViewModel: ActivitiesViewModelType, ActitiviesViewM
       )
     }
 
-    // Track shipping feature
-
-    self.rewardTrackingData = self.activities.signal
-      .filter { _ in featureRewardShipmentTrackingEnabled() }
-      .map { activities in
-        activities
-          .filter { $0.category == .shipped }
-          .compactMap { activity -> RewardTrackingActivitiesCellData? in
-            guard
-              let project = activity.project,
-              let trackingNumber = activity.trackingNumber,
-              let trackingUrl = activity.trackingUrl,
-              let trackingURL = URL(string: trackingUrl)
-            else {
-              return nil
-            }
-
-            let trackingData = RewardTrackingDetailsViewData(
-              trackingNumber: trackingNumber,
-              trackingURL: trackingURL
-            )
-
-            return RewardTrackingActivitiesCellData(
-              trackingData: trackingData,
-              project: project
-            )
-          }
-      }
-
     self.goToTrackShipping = self.tappedTrackShippingProperty.signal.skipNil()
   }
 
@@ -398,7 +366,6 @@ public final class ActivitiesViewModel: ActivitiesViewModelType, ActitiviesViewM
   public let showEmptyStateIsLoggedIn: Signal<Bool, Never>
   public let unansweredSurveys: Signal<[SurveyResponse], Never>
   public let updateUserInEnvironment: Signal<User, Never>
-  public let rewardTrackingData: Signal<[RewardTrackingActivitiesCellData], Never>
 
   public var inputs: ActitiviesViewModelInputs { return self }
   public var outputs: ActivitiesViewModelOutputs { return self }

--- a/Library/ViewModels/ActivitiesViewModelTests.swift
+++ b/Library/ViewModels/ActivitiesViewModelTests.swift
@@ -224,13 +224,19 @@ final class ActivitiesViewModelTests: TestCase {
   }
 
   func testShippedActivities() {
+    let mockConfigClient = MockRemoteConfigClient()
+    mockConfigClient.features = [
+      RemoteConfigFeature.rewardShipmentTracking.rawValue: true
+    ]
+
     withEnvironment(
       apiService: MockService(fetchActivitiesResponse: [
         self.activity1,
         self.activity2,
         self.shippedActivity
       ]),
-      currentUser: .template
+      currentUser: .template,
+      remoteConfigClient: mockConfigClient
     ) {
       self.vm.inputs.viewDidLoad()
       self.vm.inputs.userSessionStarted()

--- a/Library/ViewModels/ActivitiesViewModelTests.swift
+++ b/Library/ViewModels/ActivitiesViewModelTests.swift
@@ -7,6 +7,7 @@ import XCTest
 final class ActivitiesViewModelTests: TestCase {
   fileprivate let vm: ActivitiesViewModelType! = ActivitiesViewModel()
 
+  fileprivate let activities = TestObserver<[Activity], Never>()
   fileprivate let activitiesPresent = TestObserver<Bool, Never>()
   fileprivate let clearBadgeValue = TestObserver<(), Never>()
   fileprivate let erroredBackings = TestObserver<[ProjectAndBackingEnvelope], Never>()
@@ -20,7 +21,6 @@ final class ActivitiesViewModelTests: TestCase {
   fileprivate let goToFriends = TestObserver<FriendsSource, Never>()
   fileprivate let goToManagePledgeProjectParam = TestObserver<Param, Never>()
   fileprivate let goToManagePledgeBackingParam = TestObserver<Param?, Never>()
-  fileprivate let rewardTrackingData = TestObserver<[RewardTrackingActivitiesCellData], Never>()
   fileprivate let showEmptyStateIsLoggedIn = TestObserver<Bool, Never>()
   fileprivate let showFacebookConnectSection = TestObserver<Bool, Never>()
   fileprivate let showFacebookConnectSectionSource = TestObserver<FriendsSource, Never>()
@@ -30,12 +30,10 @@ final class ActivitiesViewModelTests: TestCase {
   fileprivate let unansweredSurveyResponse = TestObserver<[SurveyResponse], Never>()
   fileprivate let updateUserInEnvironment = TestObserver<User, Never>()
 
-  fileprivate let testTrackingNumber = "test-tracking-number"
-  fileprivate let testTrackingURL = "test-tracking-number"
-
   override func setUp() {
     super.setUp()
 
+    self.vm.outputs.activities.observe(self.activities.observer)
     self.vm.outputs.activities.map { !$0.isEmpty }.observe(self.activitiesPresent.observer)
     self.vm.outputs.clearBadgeValue.observe(self.clearBadgeValue.observer)
     self.vm.outputs.erroredBackings.observe(self.erroredBackings.observer)
@@ -46,7 +44,6 @@ final class ActivitiesViewModelTests: TestCase {
     self.vm.outputs.goToSurveyResponse.observe(self.goToSurveyResponse.observer)
     self.vm.outputs.goToManagePledge.map(first).observe(self.goToManagePledgeProjectParam.observer)
     self.vm.outputs.goToManagePledge.map(second).observe(self.goToManagePledgeBackingParam.observer)
-    self.vm.outputs.rewardTrackingData.observe(self.rewardTrackingData.observer)
     self.vm.outputs.showEmptyStateIsLoggedIn.observe(self.showEmptyStateIsLoggedIn.observer)
     self.vm.outputs.unansweredSurveys.observe(self.unansweredSurveyResponse.observer)
     self.vm.outputs.updateUserInEnvironment.observe(self.updateUserInEnvironment.observer)
@@ -226,6 +223,25 @@ final class ActivitiesViewModelTests: TestCase {
     }
   }
 
+  func testShippedActivities() {
+    withEnvironment(
+      apiService: MockService(fetchActivitiesResponse: [
+        self.activity1,
+        self.activity2,
+        self.shippedActivity
+      ]),
+      currentUser: .template
+    ) {
+      self.vm.inputs.viewDidLoad()
+      self.vm.inputs.userSessionStarted()
+      self.vm.inputs.viewWillAppear(animated: false)
+      self.scheduler.advance()
+
+      self.activitiesPresent.assertValues([true], "Activities loaded.")
+      self.activities.assertValues([[self.shippedActivity, self.activity2, self.activity1]])
+    }
+  }
+
   func testClearBadgeValueOnRefreshActivities() {
     self.updateUserInEnvironment.assertValues([])
     self.clearBadgeValue.assertValueCount(0)
@@ -328,54 +344,6 @@ final class ActivitiesViewModelTests: TestCase {
       ["activity_feed"],
       self.segmentTrackingClient.properties(forKey: "context_page", as: String.self)
     )
-  }
-
-  func testShippedActivitiesArePresent_WhenThereIsRewardTrackingData() {
-    let mockConfigClient = MockRemoteConfigClient()
-    mockConfigClient.features = [
-      RemoteConfigFeature.rewardShipmentTracking.rawValue: true
-    ]
-
-    let activityWithShippedReward1 = .template
-      |> Activity.lens.id .~ 4
-      |> Activity.lens.category .~ .shipped
-      |> Activity.lens.trackingNumber .~ self.testTrackingNumber
-      |> Activity.lens.trackingUrl .~ self.testTrackingURL
-    let activityWithShippedReward2 = .template
-      |> Activity.lens.id .~ 5
-      |> Activity.lens.category .~ .shipped
-      |> Activity.lens.trackingNumber .~ self.testTrackingNumber
-      |> Activity.lens.trackingUrl .~ self.testTrackingURL
-
-    self.vm.inputs.viewWillAppear(animated: false)
-
-    self.activitiesPresent.assertValues([], "No activities shown for logged-out user.")
-
-    AppEnvironment.login(AccessTokenEnvelope(accessToken: "deadbeef", user: User.template))
-    withEnvironment(apiService: MockService(fetchActivitiesResponse: [
-      self.activity1,
-      self.activity2,
-      activityWithShippedReward1,
-      activityWithShippedReward2
-    ]), remoteConfigClient: mockConfigClient) {
-      self.vm.inputs.userSessionStarted()
-      self.vm.inputs.viewWillAppear(animated: false)
-
-      self.scheduler.advance()
-
-      self.activitiesPresent.assertValues([true], "Activities load after session starts and view appears.")
-
-      XCTAssertEqual(self.rewardTrackingData.values.first?.count, 2)
-
-      if let trackingCellData = self.rewardTrackingData.values.first, trackingCellData.isEmpty == false {
-        trackingCellData.forEach { data in
-          XCTAssertEqual(data.trackingData.trackingNumber, self.testTrackingNumber)
-          XCTAssertEqual(data.trackingData.trackingURL, URL(string: self.testTrackingURL)!)
-        }
-      } else {
-        XCTFail("rewardTrackingData is empty when it should have 2 values: \(self.rewardTrackingData.values)")
-      }
-    }
   }
 
   func testSurveys() {
@@ -506,4 +474,9 @@ final class ActivitiesViewModelTests: TestCase {
   fileprivate let activity1 = .template |> Activity.lens.id .~ 1
   fileprivate let activity2 = .template |> Activity.lens.id .~ 2
   fileprivate let activity3 = .template |> Activity.lens.id .~ 3
+  fileprivate let shippedActivity = .template
+    |> Activity.lens.id .~ 4
+    |> Activity.lens.category .~ .shipped
+    |> Activity.lens.trackingNumber .~ "test-tracking-number"
+    |> Activity.lens.trackingUrl .~ "https://example.com"
 }

--- a/Library/ViewModels/RewardTrackingDetailsViewModel.swift
+++ b/Library/ViewModels/RewardTrackingDetailsViewModel.swift
@@ -3,9 +3,9 @@ import ReactiveSwift
 
 public struct RewardTrackingDetailsViewData {
   public let trackingNumber: String
-  public let trackingURL: URL
+  public let trackingURL: URL?
 
-  public init(trackingNumber: String, trackingURL: URL) {
+  public init(trackingNumber: String, trackingURL: URL?) {
     self.trackingNumber = trackingNumber
     self.trackingURL = trackingURL
   }
@@ -19,7 +19,8 @@ public protocol RewardTrackingDetailsViewModelInputs {
 public protocol RewardTrackingDetailsViewModelOutputs {
   var rewardTrackingStatus: Signal<String, Never> { get }
   var rewardTrackingNumber: Signal<String, Never> { get }
-  var trackShipping: Signal<URL, Never> { get }
+  var trackingButtonHidden: Signal<Bool, Never> { get }
+  var trackShipping: Signal<URL?, Never> { get }
 }
 
 public protocol RewardTrackingDetailsViewModelType {
@@ -42,6 +43,8 @@ public final class RewardTrackingDetailsViewModel: RewardTrackingDetailsViewMode
         Strings.Your_reward_has_shipped()
       }
 
+    self.trackingButtonHidden = configData.map { $0.trackingURL == nil }
+
     self.trackShipping = configData
       .takeWhen(self.trackingButtonTappedSignal)
       .map { $0.trackingURL }
@@ -59,7 +62,8 @@ public final class RewardTrackingDetailsViewModel: RewardTrackingDetailsViewMode
 
   public var rewardTrackingStatus: Signal<String, Never>
   public var rewardTrackingNumber: Signal<String, Never>
-  public var trackShipping: Signal<URL, Never>
+  public var trackingButtonHidden: Signal<Bool, Never>
+  public var trackShipping: Signal<URL?, Never>
 
   public var inputs: RewardTrackingDetailsViewModelInputs { return self }
   public var outputs: RewardTrackingDetailsViewModelOutputs { return self }

--- a/Library/ViewModels/RewardTrackingDetailsViewModelTest.swift
+++ b/Library/ViewModels/RewardTrackingDetailsViewModelTest.swift
@@ -9,7 +9,8 @@ final class RewardTrackingDetailsViewModelTest: TestCase {
 
   private var rewardTrackingStatus = TestObserver<String, Never>()
   private var rewardTrackingNumber = TestObserver<String, Never>()
-  private var trackShipping = TestObserver<URL, Never>()
+  private var trackingButtonHidden = TestObserver<Bool, Never>()
+  private var trackShipping = TestObserver<URL?, Never>()
 
   private let testTrackingNumber = "1234567890"
   private let testURL = URL(string: "http://ksr.com")!
@@ -19,6 +20,7 @@ final class RewardTrackingDetailsViewModelTest: TestCase {
 
     self.vm.outputs.rewardTrackingStatus.observe(self.rewardTrackingStatus.observer)
     self.vm.outputs.rewardTrackingNumber.observe(self.rewardTrackingNumber.observer)
+    self.vm.outputs.trackingButtonHidden.observe(self.trackingButtonHidden.observer)
     self.vm.outputs.trackShipping.observe(self.trackShipping.observer)
   }
 
@@ -33,6 +35,7 @@ final class RewardTrackingDetailsViewModelTest: TestCase {
 
     self.rewardTrackingNumber.assertLastValue(Strings.Tracking_number(number: "1234567890"))
     self.rewardTrackingStatus.assertLastValue(Strings.Your_reward_has_shipped())
+    self.trackingButtonHidden.assertValues([false])
   }
 
   func testView_Activity_Style() {
@@ -46,6 +49,19 @@ final class RewardTrackingDetailsViewModelTest: TestCase {
 
     self.rewardTrackingNumber.assertLastValue(Strings.Tracking_number(number: "1234567890"))
     self.rewardTrackingStatus.assertLastValue(Strings.Your_reward_has_shipped())
+    self.trackingButtonHidden.assertValues([false])
+  }
+
+  func testTrackingButtonHidden() {
+    let data = RewardTrackingDetailsViewData(
+      trackingNumber: self.testTrackingNumber,
+      trackingURL: URL(string: "")
+    )
+
+    self.vm.inputs.configure(with: data)
+    self.vm.inputs.trackingButtonTapped()
+
+    self.trackingButtonHidden.assertValues([true])
   }
 
   func testTrackingButtonTapped() {
@@ -55,6 +71,9 @@ final class RewardTrackingDetailsViewModelTest: TestCase {
     )
 
     self.vm.inputs.configure(with: data)
+
+    self.trackingButtonHidden.assertValues([false])
+
     self.vm.inputs.trackingButtonTapped()
 
     self.trackShipping.assertValues([self.testURL])


### PR DESCRIPTION
…f being in their own section

<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

- Use the sort order of the `v1/activities` response so that the tracking # cards are interspersed among the other activities and next to their relevant project Activity.
- Also adds logic to only hide the "Track shipment" button if the `trackingURL` is nil.

# 🤔 Why

- It makes more sense for these cards to be paired with their relevant project activities. 
We also don't want to bury any surveys unnecessarily.
- If the `trackingURL` is nil, it will still be useful for backers to know their tracking numbers and that their rewards have shipped. Rather than hiding the entire view.

# 🛠 How

- Use the existing data source `.load` method, that is already populating the `activities` section of the table, to load up the shipped activities.
- Remove the code that handles loading these new activities into a separate `rewardTracking` section.

# 👀 See

| Before 🐛 | After 🦋 |
| --- | --- |
| ![Simulator Screen Recording - iPhone 15 Pro 17 5 - 2025-04-23 at 09 31 40](https://github.com/user-attachments/assets/2718cec4-090a-4b78-8a35-50fcf9c408cd) | ![Simulator Screen Recording - iPhone 15 Pro 17 5 - 2025-04-25 at 09 28 45](https://github.com/user-attachments/assets/79a9db9d-8dc9-4070-822f-dd839ebe8ea6) |


# ✅ Acceptance criteria

- [x] Reward tracking cards are interspersed amongst activities and are paired with their relevant projects
- [x] Tracking cards still display expected data, and the "track shipment" button functions as expected.
