### PR TITLE
Fix crash caused by tapping on title row in search results.

### DIFF
--- a/Kickstarter-iOS/Features/Search/Datasource/SearchDataSource.swift
+++ b/Kickstarter-iOS/Features/Search/Datasource/SearchDataSource.swift
@@ -1,6 +1,5 @@
 import KsApi
 import Library
-import Prelude
 import UIKit
 
 typealias TitleRow = Void
@@ -58,14 +57,26 @@ internal final class SearchDataSource: ValueCellDataSource {
       return nil
     }
 
-    if self.numberOfItems(in: Section.projects.rawValue) == 0 {
+    let projectsSectionCount = self.numberOfItems(in: Section.projects.rawValue)
+
+    if projectsSectionCount == 0 {
       // Projects are empty
+      return nil
+    }
+
+    guard indexPath.row < projectsSectionCount else {
+      // Out of bounds
       return nil
     }
 
     let firstIndex = IndexPath(row: 0, section: Section.projects.rawValue)
     let value = self[firstIndex]
     let hasTitleRow = value is TitleRow
+
+    if hasTitleRow && indexPath == firstIndex {
+      // Tapping on the title row does nothing.
+      return nil
+    }
 
     if hasTitleRow {
       // If there's a title row, the index of the actual project is one item less.

--- a/Kickstarter-iOS/Features/Search/Datasource/SearchDataSourceTests.swift
+++ b/Kickstarter-iOS/Features/Search/Datasource/SearchDataSourceTests.swift
@@ -1,0 +1,230 @@
+@testable import Kickstarter_Framework
+import KsApi
+import Library
+import XCTest
+
+class SearchDataSourceTests: XCTestCase {
+  func test_indexOfProject_withTitleRow_returnsCorrectProjectIndex() {
+    let datasource = SearchDataSource()
+
+    datasource.load(projects: threeTestProjects, withDiscoverTitle: true)
+
+    XCTAssertEqual(
+      datasource.numberOfItems(in: projectsSection),
+      4,
+      "Adding title row should add additional item to the top of the projects"
+    )
+
+    XCTAssertEqual(
+      datasource.numberOfItems(),
+      4,
+      "Datasource should have a total of 4 items - three projects and a title"
+    )
+
+    XCTAssertTrue(
+      datasource[IndexPath(row: 0, section: projectsSection)] is Void,
+      "First value in the data source should be a title row"
+    )
+
+    XCTAssertTrue(
+      datasource[IndexPath(row: 1, section: projectsSection)] is TestProject,
+      "Second value in the data source should be a project"
+    )
+
+    XCTAssertTrue(
+      datasource[IndexPath(row: 2, section: projectsSection)] is TestProject,
+      "Third value in the data source should be a project"
+    )
+
+    XCTAssertTrue(
+      datasource[IndexPath(row: 3, section: projectsSection)] is TestProject,
+      "Fourth value in the data source should be a project"
+    )
+
+    XCTAssertNil(
+      datasource.indexOfProject(forCellAtIndexPath: IndexPath(row: 0, section: projectsSection)),
+      "Tapping on title row should return nil index"
+    )
+
+    if let index = datasource.indexOfProject(forCellAtIndexPath: IndexPath(
+      row: 1,
+      section: projectsSection
+    )) {
+      let tappedProject = threeTestProjects[index]
+      XCTAssertEqual(tappedProject, threeTestProjects[0], "Tapping on second row should return first project")
+    } else {
+      XCTFail("Expected value for index")
+    }
+
+    if let index = datasource.indexOfProject(forCellAtIndexPath: IndexPath(
+      row: 2,
+      section: projectsSection
+    )) {
+      let tappedProject = threeTestProjects[index]
+      XCTAssertEqual(
+        tappedProject,
+        threeTestProjects[1],
+        "Tapping on second row should return second project"
+      )
+    } else {
+      XCTFail("Expected value for index")
+    }
+
+    if let index = datasource.indexOfProject(forCellAtIndexPath: IndexPath(
+      row: 3,
+      section: projectsSection
+    )) {
+      let tappedProject = threeTestProjects[index]
+      XCTAssertEqual(tappedProject, threeTestProjects[2], "Tapping on last row should return last project")
+    } else {
+      XCTFail("Expected value for index")
+    }
+
+    XCTAssertNil(
+      datasource.indexOfProject(forCellAtIndexPath: IndexPath(row: 4, section: projectsSection)),
+      "Requesting index for out-of-bounds project should return nil"
+    )
+  }
+
+  func test_indexOfProject_withoutTitleRow_returnsCorrectProjectIndex() {
+    let datasource = SearchDataSource()
+
+    datasource.load(projects: threeTestProjects, withDiscoverTitle: false)
+
+    XCTAssertEqual(
+      datasource.numberOfItems(in: projectsSection),
+      3,
+      "When no title row is set, number of items should equal the number of projects"
+    )
+
+    XCTAssertEqual(
+      datasource.numberOfItems(),
+      3,
+      "Datasource should have a total of 3 items - three projects"
+    )
+
+    XCTAssertTrue(
+      datasource[IndexPath(row: 0, section: projectsSection)] is TestProject,
+      "First value in the data source should be a project"
+    )
+
+    XCTAssertTrue(
+      datasource[IndexPath(row: 1, section: projectsSection)] is TestProject,
+      "Second value in the data source should be a project"
+    )
+
+    XCTAssertTrue(
+      datasource[IndexPath(row: 2, section: projectsSection)] is TestProject,
+      "Third value in the data source should be a project"
+    )
+
+    if let index = datasource.indexOfProject(forCellAtIndexPath: IndexPath(
+      row: 0,
+      section: projectsSection
+    )) {
+      let tappedProject = threeTestProjects[index]
+      XCTAssertEqual(tappedProject, threeTestProjects[0], "Tapping on first row should return first project")
+    } else {
+      XCTFail("Expected value for index")
+    }
+
+    if let index = datasource.indexOfProject(forCellAtIndexPath: IndexPath(
+      row: 1,
+      section: projectsSection
+    )) {
+      let tappedProject = threeTestProjects[index]
+      XCTAssertEqual(
+        tappedProject,
+        threeTestProjects[1],
+        "Tapping on second row should return second project"
+      )
+    } else {
+      XCTFail("Expected value for index")
+    }
+
+    if let index = datasource.indexOfProject(forCellAtIndexPath: IndexPath(
+      row: 2,
+      section: projectsSection
+    )) {
+      let tappedProject = threeTestProjects[index]
+      XCTAssertEqual(tappedProject, threeTestProjects[2], "Tapping on last row should return last project")
+    } else {
+      XCTFail("Expected value for index")
+    }
+
+    XCTAssertNil(
+      datasource.indexOfProject(forCellAtIndexPath: IndexPath(row: 3, section: projectsSection)),
+      "Requesting index for out-of-bounds project should return nil"
+    )
+  }
+
+  func test_indexOfProject_withEmptyState_returnsNil() {
+    let datasource = SearchDataSource()
+
+    datasource.load(params: DiscoveryParams.defaults, visible: true)
+
+    XCTAssertEqual(
+      datasource.numberOfItems(in: projectsSection),
+      0,
+      "No projects should be visible in empty state"
+    )
+    XCTAssertEqual(
+      datasource.numberOfItems(in: emptySection),
+      1,
+      "Adding visible empty state should have one item displayed"
+    )
+
+    XCTAssertTrue(
+      datasource[IndexPath(row: 0, section: emptySection)] is DiscoveryParams,
+      "First value in the empty section should be a DiscoveryParams"
+    )
+
+    XCTAssertNil(
+      datasource.indexOfProject(forCellAtIndexPath: IndexPath(row: 0, section: emptySection)),
+      "Tapping on empty state should return no project index"
+    )
+
+    XCTAssertNil(
+      datasource.indexOfProject(forCellAtIndexPath: IndexPath(row: 0, section: projectsSection)),
+      "Trying to tap on a project when the data source is in the empty state should return no project index"
+    )
+  }
+}
+
+struct TestProject: BackerDashboardProjectCellViewModel.ProjectCellModel, Equatable {
+  let name: String
+  let state: KsApi.Project.State
+  var fundingProgress: Float
+  let percentFunded: Int
+
+  let imageURL: String? = nil
+  let displayPrelaunch: Bool? = false
+  let prelaunchActivated: Bool? = false
+  let launchedAt: TimeInterval? = nil
+  let deadline: TimeInterval? = nil
+  let isStarred: Bool? = false
+}
+
+let threeTestProjects = [
+  TestProject(
+    name: "Test Project One",
+    state: .live,
+    fundingProgress: 0.5,
+    percentFunded: 50
+  ),
+  TestProject(
+    name: "Test Project Two",
+    state: .live,
+    fundingProgress: 0.5,
+    percentFunded: 50
+  ),
+  TestProject(
+    name: "Test Project Three",
+    state: .live,
+    fundingProgress: 0.5,
+    percentFunded: 50
+  )
+]
+
+let projectsSection = SearchDataSource.Section.projects.rawValue
+let emptySection = SearchDataSource.Section.noResults.rawValue

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -1627,6 +1627,7 @@
 		D7E20EA7228B4B7D00BA61A0 /* PledgeCTAContainerViewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7E20EA5228B4AC200BA61A0 /* PledgeCTAContainerViewViewModel.swift */; };
 		E10675642DA58AB4007CCA24 /* PillButtons.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10675632DA58AB4007CCA24 /* PillButtons.swift */; };
 		E10675662DA5A6E9007CCA24 /* SearchFilterPill.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10675652DA5A6E9007CCA24 /* SearchFilterPill.swift */; };
+		E108416C2DC27F24000E4F17 /* SearchDataSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E108416A2DC27F14000E4F17 /* SearchDataSourceTests.swift */; };
 		E10BE8D02B02975C00F73DC9 /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10BE8CF2B02975C00F73DC9 /* NotificationService.swift */; };
 		E10BE8D42B02975C00F73DC9 /* RichPushNotifications.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = E10BE8CD2B02975C00F73DC9 /* RichPushNotifications.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		E10BE8DC2B14F1C100F73DC9 /* BlockUser.graphql in Resources */ = {isa = PBXBuildFile; fileRef = E10BE8DB2B14F1C100F73DC9 /* BlockUser.graphql */; };
@@ -3425,6 +3426,7 @@
 		D7E20EA5228B4AC200BA61A0 /* PledgeCTAContainerViewViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PledgeCTAContainerViewViewModel.swift; sourceTree = "<group>"; };
 		E10675632DA58AB4007CCA24 /* PillButtons.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PillButtons.swift; sourceTree = "<group>"; };
 		E10675652DA5A6E9007CCA24 /* SearchFilterPill.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchFilterPill.swift; sourceTree = "<group>"; };
+		E108416A2DC27F14000E4F17 /* SearchDataSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchDataSourceTests.swift; sourceTree = "<group>"; };
 		E10BE8CD2B02975C00F73DC9 /* RichPushNotifications.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = RichPushNotifications.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		E10BE8CF2B02975C00F73DC9 /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
 		E10BE8D12B02975C00F73DC9 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -4448,6 +4450,7 @@
 			isa = PBXGroup;
 			children = (
 				A75CFA4E1CCDB322004CD5FA /* SearchDataSource.swift */,
+				E108416A2DC27F14000E4F17 /* SearchDataSourceTests.swift */,
 			);
 			path = Datasource;
 			sourceTree = "<group>";
@@ -9378,6 +9381,7 @@
 				A7ED20151E83229E00BFFA01 /* DiscoveryFiltersDataSourceTests.swift in Sources */,
 				39B850782C3EA5BB0045CBA5 /* MessageBannerViewTests.swift in Sources */,
 				77A3C53D219CCF1300824FC1 /* SettingsAccountDataSourceTests.swift in Sources */,
+				E108416C2DC27F24000E4F17 /* SearchDataSourceTests.swift in Sources */,
 				77E84E0C2166A8C600DA8891 /* MessageBannerViewControllerTests.swift in Sources */,
 				8A07CF052660344E00426B1C /* CommentRepliesViewControllerTests.swift in Sources */,
 				06AF78762710C970009587F1 /* ProjectPageViewControllerTests.swift in Sources */,

--- a/Library/ViewModels/SearchViewModel.swift
+++ b/Library/ViewModels/SearchViewModel.swift
@@ -252,7 +252,7 @@ public final class SearchViewModel: SearchViewModelType, SearchViewModelInputs, 
       .map { ($0.0, $0.1, $1) } // ((a, b) c) -> (a, b, c)
       .map { projects, query, index in
 
-        guard index < projects.count else {
+        guard index >= 0, index < projects.count else {
           let emptyResult: (Int, RefTag)? = nil
           assert(false, "Tapped card out of bounds.")
           return emptyResult
@@ -319,7 +319,7 @@ public final class SearchViewModel: SearchViewModelType, SearchViewModelInputs, 
       .map { ($0.0, $0.1, $1) } // ((a, b), c) -> (a, b, c)
       .observeValues { params, results, index in
 
-        guard index < results.count else {
+        guard index >= 0, index < results.count else {
           assert(false, "Tapped card out of bounds.")
           return
         }


### PR DESCRIPTION
# 📲 What

Fix crash caused by tapping on title row in search results.

# 🤔 Why

This crash occurred because I didn't checking for the title row in the method `indexOfProject(forCellAtIndexPath)`. If you tapped on the title row, this method returns `-1`, causing a crash when the view model tries to fetch `projects[-1]`. 
