### PR TITLE
Fix KSRButtonStyle is blank after orientation change

### DIFF
--- a/Library/Styles/Buttons/KSRButtonStyleConfiguration.swift
+++ b/Library/Styles/Buttons/KSRButtonStyleConfiguration.swift
@@ -72,6 +72,7 @@ extension UIButton {
     }
 
     self.configuration = buttonConfiguration
+    self.setNeedsUpdateConfiguration()
   }
 
   private func updateContentInsets() {


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Fixes an issue where buttons styled with `KSRButtonStyle` would appear blank (white background, no title or border) after device orientation changes.

# 🤔 Why

When `applyStyleConfiguration` is called multiple times — such as during a layout update on rotation — the style configuration was being reassigned, but visual changes (like `tintColor`, `backgroundColor`, and `border` styling) weren’t being immediately reflected. This happened because those updates were deferred until a state change (e.g., touch), via `configurationUpdateHandler`.

# 🛠 How

- Added `setNeedsUpdateConfiguration()` just after the button configuration is set.

# 👀 See

Trello, screenshots, external resources?

| Before 🐛 | After 🦋 |
| --- | --- |
| ![Simulator Screen Recording - iPhone 16 Pro - 2025-04-30 at 09 20 31](https://github.com/user-attachments/assets/03b2b9aa-7f99-4cd1-acc2-cb0745777423) | ![Simulator Screen Recording - iPhone 16 Pro - 2025-04-30 at 09 21 43](https://github.com/user-attachments/assets/8d9be845-4fcc-4464-90df-d63c832da413) |


# ✅ Acceptance criteria

- [ ] Button looks good after device orientation

