### PR TITLE
[Part 4] Enable dark mode when featureDarkModeEnabled() is true

### DIFF
--- a/Kickstarter-iOS/AppDelegate.swift
+++ b/Kickstarter-iOS/AppDelegate.swift
@@ -238,6 +238,12 @@ internal final class AppDelegate: UIResponder, UIApplicationDelegate {
         enabled ? Analytics.shared().enable() : Analytics.shared().disable()
       }
 
+    self.viewModel.outputs.darkModeEnabled
+      .observeForUI()
+      .observeValues { [weak self] enabled in
+        self?.updateDarkMode(enabled)
+      }
+
     NotificationCenter.default
       .addObserver(
         forName: Notification.Name.ksr_configUpdated,
@@ -257,6 +263,14 @@ internal final class AppDelegate: UIResponder, UIApplicationDelegate {
     UNUserNotificationCenter.current().delegate = self
 
     return self.viewModel.outputs.applicationDidFinishLaunchingReturnValue
+  }
+
+  func updateDarkMode(_ isEnabled: Bool) {
+    if isEnabled {
+      self.window?.overrideUserInterfaceStyle = .unspecified
+    } else {
+      self.window?.overrideUserInterfaceStyle = .light
+    }
   }
 
   func applicationDidBecomeActive(_: UIApplication) {

--- a/Kickstarter-iOS/AppDelegateViewModel.swift
+++ b/Kickstarter-iOS/AppDelegateViewModel.swift
@@ -174,6 +174,8 @@ public protocol AppDelegateViewModelOutputs {
 
   /// Emits a config value that should be updated in the environment.
   var updateConfigInEnvironment: Signal<Config, Never> { get }
+
+  var darkModeEnabled: Signal<Bool, Never> { get }
 }
 
 public protocol AppDelegateViewModelType {
@@ -768,6 +770,14 @@ public final class AppDelegateViewModel: AppDelegateViewModelType, AppDelegateVi
       .flatMap { () in
         AppEnvironment.current.appTrackingTransparency.authorizationStatus
       }
+
+    self.darkModeEnabled = Signal.merge(
+      self.applicationWillEnterForegroundProperty.signal,
+      self.applicationLaunchOptionsProperty.signal.ignoreValues(),
+      self.didUpdateRemoteConfigClientProperty.signal.ignoreValues()
+    )
+    .map { _ in featureDarkModeEnabled() }
+    // .skipRepeats(==)
   }
 
   public var inputs: AppDelegateViewModelInputs { return self }
@@ -937,6 +947,7 @@ public final class AppDelegateViewModel: AppDelegateViewModelType, AppDelegateVi
   public let unregisterForRemoteNotifications: Signal<(), Never>
   public let updateCurrentUserInEnvironment: Signal<User, Never>
   public let updateConfigInEnvironment: Signal<Config, Never>
+  public let darkModeEnabled: Signal<Bool, Never>
 }
 
 /// Handles the deeplink route with both an id and text based name for a deeplink to categories.

--- a/Kickstarter-iOS/AppDelegateViewModel.swift
+++ b/Kickstarter-iOS/AppDelegateViewModel.swift
@@ -777,7 +777,7 @@ public final class AppDelegateViewModel: AppDelegateViewModelType, AppDelegateVi
       self.didUpdateRemoteConfigClientProperty.signal.ignoreValues()
     )
     .map { _ in featureDarkModeEnabled() }
-    // .skipRepeats(==)
+    .skipRepeats(==)
   }
 
   public var inputs: AppDelegateViewModelInputs { return self }

--- a/Kickstarter-iOS/Info.plist
+++ b/Kickstarter-iOS/Info.plist
@@ -137,8 +137,6 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>UIUserInterfaceStyle</key>
-	<string>Light</string>
 	<key>GOOGLE_ANALYTICS_DEFAULT_ALLOW_ANALYTICS_STORAGE</key>
 	<false/>
 	<key>GOOGLE_ANALYTICS_DEFAULT_ALLOW_AD_STORAGE</key>


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Turn on dark mode in the app.

![dark-mode-2](https://github.com/user-attachments/assets/a5502522-8a91-45a7-9803-0a9eb6d8b600)


# 🤔 Why

This is one of our most (if not _the_ most) requested features!

# 🛠 How

* Dynamically set `overrideUserInterfaceStyle` on the window depending on the value of `featureDarkModeEnabled()`
* Remove the interface style override from our `Info.plist`

📠 cc @jovaniks @stevestreza-ksr  📠 