### PR TITLE
Fix 'coming soon' state on search results

### DIFF
--- a/Kickstarter-iOS/Features/ProjectCard/ProjectCardViewTests.swift
+++ b/Kickstarter-iOS/Features/ProjectCard/ProjectCardViewTests.swift
@@ -104,6 +104,7 @@ final class ProjectCardViewTests: TestCase {
       id: 1,
       name: "Project 1",
       state: "live",
+      isLaunched: false,
       prelaunchActivated: true,
       launchedAt: "-5"
     )

--- a/Library/UseCases/SimilarProjects/ProjectCardProperties.swift
+++ b/Library/UseCases/SimilarProjects/ProjectCardProperties.swift
@@ -66,7 +66,7 @@ public struct ProjectCardProperties {
   }
 
   public var shouldDisplayPrelaunch: Bool {
-    self.isPrelaunchActivated
+    self.isPrelaunchActivated && !self.isLaunched
   }
 
   public var projectPageParam: ProjectPageParam {


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Regression fix for search results so they no longer show "coming soon" unnecessarily. One of the tests was misconfigured to include `isLaunched: true` for the "coming soon" case, so when the original fix was built to keep the tests as-is, the `isLaunched` flag was no longer checked, causing the issue.

# 🛠 How

Add a check for `isLaunched` when determining if prelaunch, and update the test to not rely on the flag.

# 👀 See

<img src="https://github.com/user-attachments/assets/81bfbf01-2773-4ec0-b614-4fb32bf620db" width=250 />
<img src="https://github.com/user-attachments/assets/9ab69912-17c9-42b4-85de-bc5fc7e6a4f9" width=250 />
<img src="https://github.com/user-attachments/assets/9751f79b-8058-4c9c-af19-1785bdd51344" width=250 />
