### PR TITLE
Update Activity feed for dark mode

### DIFF
--- a/Kickstarter-iOS/Features/Activities/Storyboard/Activity.storyboard
+++ b/Kickstarter-iOS/Features/Activities/Storyboard/Activity.storyboard
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23094" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23084"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -24,42 +25,42 @@
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="H0b-7i-vhk">
-                                            <rect key="frame" x="19" y="11" width="362" height="299"/>
+                                            <rect key="frame" x="15" y="11" width="370" height="299"/>
                                         </view>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="XOw-uw-7h5" userLabel="Card View">
-                                            <rect key="frame" x="20" y="12" width="360" height="197"/>
-                                            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            <rect key="frame" x="16" y="12" width="368" height="197"/>
+                                            <color key="backgroundColor" name="white"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="197" id="IoR-Fk-p8l"/>
                                             </constraints>
                                         </view>
                                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="a69-hw-39E" userLabel="Project image">
-                                            <rect key="frame" x="20" y="12" width="360" height="197"/>
+                                            <rect key="frame" x="16" y="12" width="368" height="197"/>
                                         </imageView>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="AX7-E6-u6H">
-                                            <rect key="frame" x="28" y="-1" width="16.5" height="32.5"/>
+                                            <rect key="frame" x="24" y="-1" width="16.5" height="32.5"/>
                                             <color key="backgroundColor" red="0.1450980392" green="0.79607843140000001" blue="0.40784313729999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         </view>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ENh-bG-4l9">
-                                            <rect key="frame" x="34" y="5" width="4.5" height="20.5"/>
+                                            <rect key="frame" x="30" y="5" width="4.5" height="20.5"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <color key="textColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95294117649999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <view alpha="0.95999999999999996" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="xZe-M3-UVc" userLabel="Text Background View">
-                                            <rect key="frame" x="20" y="209" width="360" height="100"/>
+                                            <rect key="frame" x="16" y="209" width="368" height="100"/>
                                             <subviews>
                                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="YhF-yP-wuS">
-                                                    <rect key="frame" x="8" y="8" width="344" height="84"/>
+                                                    <rect key="frame" x="8" y="8" width="352" height="84"/>
                                                     <subviews>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalCompressionResistancePriority="1000" text="Bjork Swan Dress " lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2bd-l0-V3a" userLabel="Project name">
-                                                            <rect key="frame" x="0.0" y="0.0" width="344" height="26.5"/>
+                                                            <rect key="frame" x="0.0" y="0.0" width="352" height="26.5"/>
                                                             <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                             <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
                                                         <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="18" translatesAutoresizingMaskIntoConstraints="NO" id="CGg-rb-rXg" userLabel="Funding Stack View">
-                                                            <rect key="frame" x="0.0" y="38.5" width="344" height="45.5"/>
+                                                            <rect key="frame" x="0.0" y="38.5" width="352" height="45.5"/>
                                                             <subviews>
                                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="OZd-cW-cLB">
                                                                     <rect key="frame" x="0.0" y="21.5" width="50" height="3"/>
@@ -79,7 +80,7 @@
                                                                     </constraints>
                                                                 </view>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="249" horizontalCompressionResistancePriority="1000" text="120% funded" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jH5-2y-qF0">
-                                                                    <rect key="frame" x="68" y="12.5" width="276" height="20.5"/>
+                                                                    <rect key="frame" x="68" y="12.5" width="284" height="20.5"/>
                                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                     <nil key="highlightedColor"/>
@@ -89,7 +90,7 @@
                                                     </subviews>
                                                 </stackView>
                                             </subviews>
-                                            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            <color key="backgroundColor" name="white"/>
                                             <constraints>
                                                 <constraint firstAttribute="bottomMargin" secondItem="YhF-yP-wuS" secondAttribute="bottom" id="5IZ-tC-bZw"/>
                                                 <constraint firstAttribute="topMargin" secondItem="YhF-yP-wuS" secondAttribute="top" id="IBQ-p4-CpM"/>
@@ -158,14 +159,14 @@
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Vz1-ta-ikE">
-                                            <rect key="frame" x="20" y="16" width="360" height="68"/>
-                                            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            <rect key="frame" x="16" y="16" width="368" height="68"/>
+                                            <color key="backgroundColor" name="white"/>
                                         </view>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4ZS-Uj-4La">
-                                            <rect key="frame" x="21" y="17" width="358" height="66"/>
+                                            <rect key="frame" x="17" y="17" width="366" height="66"/>
                                             <subviews>
                                                 <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="kly-4t-f6l">
-                                                    <rect key="frame" x="8" y="8" width="342" height="50"/>
+                                                    <rect key="frame" x="8" y="8" width="350" height="50"/>
                                                     <subviews>
                                                         <imageView userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="O8h-S0-xe1" userLabel="Friend avatar" customClass="CircleAvatarImageView" customModule="Library">
                                                             <rect key="frame" x="0.0" y="12.5" width="25" height="25"/>
@@ -175,19 +176,19 @@
                                                             </constraints>
                                                         </imageView>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" " textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" minimumScaleFactor="0.69999999999999996" translatesAutoresizingMaskIntoConstraints="NO" id="eef-El-PXt" userLabel="Friend label">
-                                                            <rect key="frame" x="37" y="16" width="261" height="18"/>
+                                                            <rect key="frame" x="37" y="16" width="269" height="18"/>
                                                             <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                             <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
                                                         <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="1000" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="XtT-ao-aqM" userLabel="Follow button">
-                                                            <rect key="frame" x="310" y="8" width="32" height="34"/>
+                                                            <rect key="frame" x="318" y="8" width="32" height="34"/>
                                                             <inset key="contentEdgeInsets" minX="16" minY="8" maxX="16" maxY="8"/>
                                                         </button>
                                                     </subviews>
                                                 </stackView>
                                             </subviews>
-                                            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            <color key="backgroundColor" name="white"/>
                                             <constraints>
                                                 <constraint firstAttribute="bottomMargin" secondItem="kly-4t-f6l" secondAttribute="bottom" id="1YO-RO-wNC"/>
                                                 <constraint firstItem="kly-4t-f6l" firstAttribute="leading" secondItem="4ZS-Uj-4La" secondAttribute="leadingMargin" id="27B-iT-ucX"/>
@@ -236,10 +237,10 @@
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="qws-CN-NWM">
-                                            <rect key="frame" x="20" y="11" width="360" height="304"/>
+                                            <rect key="frame" x="16" y="11" width="368" height="304"/>
                                         </view>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bR1-hI-egB">
-                                            <rect key="frame" x="21" y="10" width="358" height="304"/>
+                                            <rect key="frame" x="17" y="10" width="366" height="304"/>
                                             <subviews>
                                                 <imageView userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="L5c-1Y-4qI" customClass="CircleAvatarImageView" customModule="Library">
                                                     <rect key="frame" x="8" y="8" width="24" height="24"/>
@@ -255,25 +256,25 @@
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <imageView userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="nnG-dK-ciq">
-                                                    <rect key="frame" x="0.0" y="45" width="358" height="197"/>
+                                                    <rect key="frame" x="0.0" y="45" width="366" height="197"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="197" id="SIV-De-YBZ"/>
                                                     </constraints>
                                                 </imageView>
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9kb-aJ-VGs">
-                                                    <rect key="frame" x="0.0" y="242" width="358" height="62"/>
+                                                    <rect key="frame" x="0.0" y="242" width="366" height="62"/>
                                                     <subviews>
                                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="aKf-SO-ukE">
-                                                            <rect key="frame" x="8" y="8" width="342" height="46"/>
+                                                            <rect key="frame" x="8" y="8" width="350" height="46"/>
                                                             <subviews>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalCompressionResistancePriority="1000" text=" " lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Wbb-oQ-LmI" userLabel="Project name">
-                                                                    <rect key="frame" x="0.0" y="0.0" width="342" height="26.5"/>
+                                                                    <rect key="frame" x="0.0" y="0.0" width="350" height="26.5"/>
                                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                     <nil key="highlightedColor"/>
                                                                 </label>
                                                                 <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="18" translatesAutoresizingMaskIntoConstraints="NO" id="FSZ-eM-Rwq" userLabel="Funding Stack View">
-                                                                    <rect key="frame" x="0.0" y="38.5" width="342" height="7.5"/>
+                                                                    <rect key="frame" x="0.0" y="38.5" width="350" height="7.5"/>
                                                                     <subviews>
                                                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="u08-la-LL2">
                                                                             <rect key="frame" x="0.0" y="2.5" width="50" height="3"/>
@@ -293,7 +294,7 @@
                                                                             </constraints>
                                                                         </view>
                                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="249" horizontalCompressionResistancePriority="1000" text=" " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Tad-xW-b6K">
-                                                                            <rect key="frame" x="68" y="0.0" width="274" height="7.5"/>
+                                                                            <rect key="frame" x="68" y="0.0" width="282" height="7.5"/>
                                                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                             <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                             <nil key="highlightedColor"/>
@@ -303,7 +304,7 @@
                                                             </subviews>
                                                         </stackView>
                                                     </subviews>
-                                                    <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <color key="backgroundColor" name="white"/>
                                                     <constraints>
                                                         <constraint firstAttribute="trailingMargin" secondItem="aKf-SO-ukE" secondAttribute="trailing" id="8p7-qc-WvI"/>
                                                         <constraint firstItem="aKf-SO-ukE" firstAttribute="leading" secondItem="9kb-aJ-VGs" secondAttribute="leadingMargin" id="IKw-q3-l30"/>
@@ -373,21 +374,21 @@
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="x1V-JC-eSG">
-                                            <rect key="frame" x="20" y="11" width="360" height="358"/>
-                                            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            <rect key="frame" x="16" y="11" width="368" height="358"/>
+                                            <color key="backgroundColor" name="white"/>
                                         </view>
                                         <view contentMode="scaleToFill" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="G9B-h5-vdo" userLabel="Container View">
                                             <rect key="frame" x="8" y="8" width="384" height="351.5"/>
                                             <subviews>
                                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="YEW-km-DyF">
-                                                    <rect key="frame" x="270" y="8" width="80" height="45"/>
+                                                    <rect key="frame" x="278" y="8" width="80" height="45"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" secondItem="YEW-km-DyF" secondAttribute="height" multiplier="16:9" id="f67-Ou-Bas"/>
                                                         <constraint firstAttribute="width" constant="80" id="vCB-Xb-z6f"/>
                                                     </constraints>
                                                 </imageView>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" " textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" minimumScaleFactor="0.69999999999999996" translatesAutoresizingMaskIntoConstraints="NO" id="peK-ts-qtm">
-                                                    <rect key="frame" x="8" y="21.5" width="250" height="18"/>
+                                                    <rect key="frame" x="8" y="21.5" width="258" height="18"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                     <color key="textColor" red="0.66666666666666663" green="0.66666666666666663" blue="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
@@ -397,35 +398,35 @@
                                                     </userDefinedRuntimeAttributes>
                                                 </label>
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="S1L-AK-J7o" userLabel="Divider">
-                                                    <rect key="frame" x="0.0" y="65" width="358" height="1"/>
+                                                    <rect key="frame" x="0.0" y="65" width="366" height="1"/>
                                                     <color key="backgroundColor" red="0.93725490196078431" green="0.93725490196078431" blue="0.95294117647058818" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="1" id="JSO-6o-MU1"/>
                                                     </constraints>
                                                 </view>
                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="kau-0I-djy" userLabel="Project image button">
-                                                    <rect key="frame" x="-21" y="0.0" width="400" height="65"/>
+                                                    <rect key="frame" x="-17" y="0.0" width="400" height="65"/>
                                                     <connections>
                                                         <action selector="tappedProjectImage" destination="Wv6-wT-OF6" eventType="touchUpInside" id="YQY-qk-5Bt"/>
                                                     </connections>
                                                 </button>
                                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="dQE-cC-7qh">
-                                                    <rect key="frame" x="8" y="84" width="342" height="93.5"/>
+                                                    <rect key="frame" x="8" y="84" width="350" height="93.5"/>
                                                     <subviews>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="752" text=" " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qj0-jB-Zve">
-                                                            <rect key="frame" x="0.0" y="0.0" width="342" height="14.5"/>
+                                                            <rect key="frame" x="0.0" y="0.0" width="350" height="14.5"/>
                                                             <fontDescription key="fontDescription" style="UICTFontTextStyleCaption1"/>
                                                             <color key="textColor" red="0.1450980392" green="0.79607843140000001" blue="0.40784313729999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalCompressionResistancePriority="751" text=" " textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" minimumScaleFactor="0.90000000000000002" translatesAutoresizingMaskIntoConstraints="NO" id="fef-3c-G8d">
-                                                            <rect key="frame" x="0.0" y="30.5" width="342" height="26.5"/>
+                                                            <rect key="frame" x="0.0" y="30.5" width="350" height="26.5"/>
                                                             <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                             <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" " textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2pH-Zs-dun">
-                                                            <rect key="frame" x="0.0" y="73" width="342" height="20.5"/>
+                                                            <rect key="frame" x="0.0" y="73" width="350" height="20.5"/>
                                                             <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                             <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                             <nil key="highlightedColor"/>
@@ -433,7 +434,7 @@
                                                     </subviews>
                                                 </stackView>
                                             </subviews>
-                                            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            <color key="backgroundColor" name="white"/>
                                             <constraints>
                                                 <constraint firstAttribute="trailingMargin" secondItem="YEW-km-DyF" secondAttribute="trailing" id="255-wa-bCx"/>
                                                 <constraint firstItem="S1L-AK-J7o" firstAttribute="leading" secondItem="G9B-h5-vdo" secondAttribute="leading" id="6gQ-ie-wnM"/>
@@ -497,26 +498,26 @@
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Ixh-Vp-gzP">
-                                            <rect key="frame" x="20" y="16" width="360" height="118"/>
-                                            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            <rect key="frame" x="16" y="16" width="368" height="118"/>
+                                            <color key="backgroundColor" name="white"/>
                                         </view>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Kgs-en-3FB">
-                                            <rect key="frame" x="21" y="17" width="358" height="116"/>
+                                            <rect key="frame" x="17" y="17" width="366" height="116"/>
                                             <subviews>
                                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="Z0r-XM-y2x">
-                                                    <rect key="frame" x="8" y="8" width="342" height="100"/>
+                                                    <rect key="frame" x="8" y="8" width="350" height="100"/>
                                                     <subviews>
                                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" alignment="center" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="hdi-fv-wM7">
-                                                            <rect key="frame" x="0.0" y="0.0" width="342" height="47"/>
+                                                            <rect key="frame" x="0.0" y="0.0" width="350" height="47"/>
                                                             <subviews>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" " textAlignment="center" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="H9b-Qe-5eB">
-                                                                    <rect key="frame" x="169" y="0.0" width="4.5" height="20.5"/>
+                                                                    <rect key="frame" x="173" y="0.0" width="4.5" height="20.5"/>
                                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                     <nil key="highlightedColor"/>
                                                                 </label>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text=" " textAlignment="center" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="c9R-7T-nhY">
-                                                                    <rect key="frame" x="169" y="26.5" width="4.5" height="20.5"/>
+                                                                    <rect key="frame" x="173" y="26.5" width="4.5" height="20.5"/>
                                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                     <nil key="highlightedColor"/>
@@ -524,7 +525,7 @@
                                                             </subviews>
                                                         </stackView>
                                                         <button opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="751" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="tailTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="X9G-oS-Rvz">
-                                                            <rect key="frame" x="0.0" y="59" width="342" height="41"/>
+                                                            <rect key="frame" x="0.0" y="59" width="350" height="41"/>
                                                             <state key="normal" title=" "/>
                                                         </button>
                                                     </subviews>
@@ -536,13 +537,13 @@
                                                     </constraints>
                                                 </stackView>
                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="9xM-7l-cFl">
-                                                    <rect key="frame" x="346" y="0.0" width="12" height="22"/>
+                                                    <rect key="frame" x="354" y="0.0" width="12" height="22"/>
                                                     <state key="normal" image="close-icon">
                                                         <color key="titleColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     </state>
                                                 </button>
                                             </subviews>
-                                            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                            <color key="backgroundColor" name="white"/>
                                             <constraints>
                                                 <constraint firstItem="9xM-7l-cFl" firstAttribute="top" secondItem="Kgs-en-3FB" secondAttribute="top" id="9GO-wX-NsA"/>
                                                 <constraint firstAttribute="topMargin" secondItem="Z0r-XM-y2x" secondAttribute="top" id="bLe-ZW-Rhm"/>
@@ -565,7 +566,7 @@
                                     </constraints>
                                     <edgeInsets key="layoutMargins" top="16" left="16" bottom="16" right="16"/>
                                 </tableViewCellContentView>
-                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <color key="backgroundColor" name="white"/>
                                 <connections>
                                     <outlet property="cardView" destination="Ixh-Vp-gzP" id="4ta-wz-cIx"/>
                                     <outlet property="closeButton" destination="9xM-7l-cFl" id="rSa-8D-LUI"/>
@@ -595,33 +596,33 @@
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="L2R-8a-1BF">
-                                            <rect key="frame" x="19" y="24" width="362" height="156"/>
-                                            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            <rect key="frame" x="15" y="24" width="370" height="156"/>
+                                            <color key="backgroundColor" name="white"/>
                                         </view>
                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="W0i-HA-ufe" userLabel="Top Stack View">
-                                            <rect key="frame" x="20" y="11" width="360" height="168"/>
+                                            <rect key="frame" x="16" y="11" width="368" height="168"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="249" text="4 Reward Surveys" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fIe-L6-SOz">
-                                                    <rect key="frame" x="0.0" y="0.0" width="360" height="0.0"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="368" height="0.0"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <view contentMode="scaleToFill" verticalCompressionResistancePriority="751" translatesAutoresizingMaskIntoConstraints="NO" id="9FR-kr-r2X">
-                                                    <rect key="frame" x="0.0" y="12" width="360" height="156"/>
+                                                    <rect key="frame" x="0.0" y="12" width="368" height="156"/>
                                                     <subviews>
                                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="U0K-GN-MuG" userLabel="Top Line">
-                                                            <rect key="frame" x="0.0" y="0.0" width="360" height="2"/>
+                                                            <rect key="frame" x="0.0" y="0.0" width="368" height="2"/>
                                                             <color key="backgroundColor" red="0.1450980392" green="0.79607843140000001" blue="0.40784313729999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="height" constant="2" id="e8S-o5-1ey"/>
                                                             </constraints>
                                                         </view>
                                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="24" translatesAutoresizingMaskIntoConstraints="NO" id="Biw-Cv-poS">
-                                                            <rect key="frame" x="8" y="20" width="344" height="124.5"/>
+                                                            <rect key="frame" x="8" y="20" width="352" height="124.5"/>
                                                             <subviews>
                                                                 <stackView opaque="NO" contentMode="scaleToFill" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="08U-ar-dhC">
-                                                                    <rect key="frame" x="0.0" y="0.0" width="344" height="24"/>
+                                                                    <rect key="frame" x="0.0" y="0.0" width="352" height="24"/>
                                                                     <subviews>
                                                                         <imageView userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="ait-r7-lig" customClass="CircleAvatarImageView" customModule="Library">
                                                                             <rect key="frame" x="0.0" y="0.0" width="24" height="24"/>
@@ -631,7 +632,7 @@
                                                                             </constraints>
                                                                         </imageView>
                                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.69999998807907104" translatesAutoresizingMaskIntoConstraints="NO" id="Yj4-xs-6Oi">
-                                                                            <rect key="frame" x="30" y="0.0" width="314" height="24"/>
+                                                                            <rect key="frame" x="30" y="0.0" width="322" height="24"/>
                                                                             <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                                             <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                             <nil key="highlightedColor"/>
@@ -639,13 +640,13 @@
                                                                     </subviews>
                                                                 </stackView>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="249" verticalCompressionResistancePriority="751" text=" " lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eM4-Bs-N5a">
-                                                                    <rect key="frame" x="0.0" y="48" width="344" height="20.5"/>
+                                                                    <rect key="frame" x="0.0" y="48" width="352" height="20.5"/>
                                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                     <nil key="highlightedColor"/>
                                                                 </label>
                                                                 <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="1000" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Op9-Hz-y39">
-                                                                    <rect key="frame" x="0.0" y="92.5" width="344" height="32"/>
+                                                                    <rect key="frame" x="0.0" y="92.5" width="352" height="32"/>
                                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleCallout"/>
                                                                     <state key="normal" title=" ">
                                                                         <color key="titleColor" red="0.031372549020000001" green="0.070588235289999995" blue="0.27058823529999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -661,7 +662,7 @@
                                                             </constraints>
                                                         </view>
                                                     </subviews>
-                                                    <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <color key="backgroundColor" name="white"/>
                                                     <constraints>
                                                         <constraint firstItem="7yF-Px-W1J" firstAttribute="leading" secondItem="9FR-kr-r2X" secondAttribute="leading" id="57Z-3z-N2p"/>
                                                         <constraint firstItem="U0K-GN-MuG" firstAttribute="leading" secondItem="9FR-kr-r2X" secondAttribute="leading" id="770-Zj-pE5"/>
@@ -736,5 +737,8 @@
     </scenes>
     <resources>
         <image name="close-icon" width="12" height="12"/>
+        <namedColor name="white">
+            <color red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+        </namedColor>
     </resources>
 </document>

--- a/Kickstarter-iOS/Features/Activities/Views/Cells/ActivityFriendBackingCell.swift
+++ b/Kickstarter-iOS/Features/Activities/Views/Cells/ActivityFriendBackingCell.swift
@@ -95,5 +95,7 @@ internal final class ActivityFriendBackingCell: UITableViewCell, ValueCell {
         topBottom: Styles.gridHalf(5),
         leftRight: Styles.grid(2)
       )
+
+    self.projectTextContainerView.backgroundColor = Colors.Background.Surface.primary.uiColor()
   }
 }

--- a/Kickstarter-iOS/Features/Activities/Views/Cells/ActivityFriendFollowCell.swift
+++ b/Kickstarter-iOS/Features/Activities/Views/Cells/ActivityFriendFollowCell.swift
@@ -45,6 +45,8 @@ internal final class ActivityFriendFollowCell: UITableViewCell, ValueCell {
     _ = self.containerView
       |> UIView.lens.layoutMargins .~ .init(topBottom: Styles.grid(3), leftRight: Styles.grid(2))
 
+    self.containerView.backgroundColor = Colors.Background.Surface.primary.uiColor()
+
     _ = self.friendImageView
       |> ignoresInvertColorsImageViewStyle
 

--- a/Kickstarter-iOS/Features/Activities/Views/Cells/ActivityProjectStatusCell.swift
+++ b/Kickstarter-iOS/Features/Activities/Views/Cells/ActivityProjectStatusCell.swift
@@ -70,6 +70,8 @@ internal final class ActivityProjectStatusCell: UITableViewCell, ValueCell {
           )
       }
 
+    self.cardView.backgroundColor = Colors.Background.Surface.primary.uiColor()
+
     _ = self.containerView
       |> cardStyle()
 

--- a/Kickstarter-iOS/Features/Activities/Views/Cells/ActivitySurveyResponseCell.swift
+++ b/Kickstarter-iOS/Features/Activities/Views/Cells/ActivitySurveyResponseCell.swift
@@ -49,6 +49,8 @@ internal final class ActivitySurveyResponseCell: UITableViewCell, ValueCell {
     _ = self.containerView
       |> UIView.lens.layoutMargins .~ .init(all: Styles.grid(2))
 
+    self.containerView.backgroundColor = Colors.Background.Surface.primary.uiColor()
+
     _ = self.creatorImageView
       |> ignoresInvertColorsImageViewStyle
 

--- a/Kickstarter-iOS/Features/Activities/Views/Cells/ActivityUpdateCell.swift
+++ b/Kickstarter-iOS/Features/Activities/Views/Cells/ActivityUpdateCell.swift
@@ -69,6 +69,8 @@ internal final class ActivityUpdateCell: UITableViewCell, ValueCell {
     _ = self.containerView
       |> UIView.lens.layoutMargins .~ .init(all: Styles.grid(2))
 
+    self.containerView.backgroundColor = Colors.Background.Surface.primary.uiColor()
+
     _ = self.bodyLabel
       |> UILabel.lens.font .~ .ksr_subhead()
       |> UILabel.lens.textColor .~ LegacyColors.ksr_support_400.uiColor()

--- a/Kickstarter-iOS/Features/Activities/Views/Cells/FindFriendsFacebookConnectCell.swift
+++ b/Kickstarter-iOS/Features/Activities/Views/Cells/FindFriendsFacebookConnectCell.swift
@@ -85,6 +85,8 @@ internal final class FindFriendsFacebookConnectCell: UITableViewCell, ValueCell 
     _ = self.containerView
       |> UIView.lens.layoutMargins .~ .init(all: Styles.grid(2))
 
+    self.containerView.backgroundColor = Colors.Background.Surface.primary.uiColor()
+
     _ = self.titleLabel
       |> UILabel.lens.font .~ .ksr_headline(size: 14)
       |> UILabel.lens.textColor .~ LegacyColors.ksr_support_700.uiColor()

--- a/Kickstarter-iOS/Features/Discovery/Storyboard/DiscoveryPage.storyboard
+++ b/Kickstarter-iOS/Features/Discovery/Storyboard/DiscoveryPage.storyboard
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23094" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
-        <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
-        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23084"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -21,26 +18,26 @@
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="DiscoveryOnboardingCell" rowHeight="170" id="WoX-KF-8JK" customClass="DiscoveryOnboardingCell" customModule="Kickstarter_Framework" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="28" width="400" height="170"/>
+                                <rect key="frame" x="0.0" y="50" width="400" height="170"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" tableViewCell="WoX-KF-8JK" id="lbd-MY-b3u">
                                     <rect key="frame" x="0.0" y="0.0" width="400" height="170"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="mTa-Hu-hCu">
-                                            <rect key="frame" x="20" y="32" width="360" height="97"/>
+                                            <rect key="frame" x="16" y="32" width="368" height="97"/>
                                             <subviews>
                                                 <imageView userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="kickstarter-logo" translatesAutoresizingMaskIntoConstraints="NO" id="bjX-R6-UNK">
-                                                    <rect key="frame" x="0.0" y="0.0" width="360" height="17"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="368" height="17"/>
                                                 </imageView>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" " textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xSL-8E-DPW">
-                                                    <rect key="frame" x="0.0" y="29" width="360" height="24"/>
+                                                    <rect key="frame" x="0.0" y="29" width="368" height="24"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="epB-3O-SOe">
-                                                    <rect key="frame" x="0.0" y="65" width="360" height="32"/>
+                                                    <rect key="frame" x="0.0" y="65" width="368" height="32"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleCallout"/>
                                                     <state key="normal">
                                                         <color key="titleColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -68,46 +65,46 @@
                                 </connections>
                             </tableViewCell>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="ActivitySampleProjectCell" rowHeight="220" id="lNn-Nz-wRa" customClass="ActivitySampleProjectCell" customModule="Kickstarter_Framework" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="198" width="400" height="220"/>
+                                <rect key="frame" x="0.0" y="220" width="400" height="220"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="lNn-Nz-wRa" id="Oy4-Ns-xfA">
                                     <rect key="frame" x="0.0" y="0.0" width="400" height="220"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="V7j-Aj-bqC">
-                                            <rect key="frame" x="20" y="18" width="360" height="125"/>
-                                            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            <rect key="frame" x="16" y="18" width="368" height="124"/>
+                                            <color key="backgroundColor" name="white"/>
                                         </view>
                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="Wwb-l7-geO">
-                                            <rect key="frame" x="20" y="18" width="360" height="124.5"/>
+                                            <rect key="frame" x="16" y="18" width="368" height="124"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QrT-7O-dh0">
-                                                    <rect key="frame" x="0.0" y="0.0" width="360" height="20.5"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="368" height="20.5"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <stackView opaque="NO" contentMode="scaleToFill" alignment="top" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="H0I-yI-6qt">
-                                                    <rect key="frame" x="0.0" y="32.5" width="360" height="50"/>
+                                                    <rect key="frame" x="0.0" y="32.5" width="368" height="49.5"/>
                                                     <subviews>
                                                         <imageView userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="tvi-AI-Dgu">
-                                                            <rect key="frame" x="0.0" y="0.0" width="88" height="50"/>
+                                                            <rect key="frame" x="0.0" y="0.0" width="88" height="49.5"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="width" constant="88" id="bSq-6d-t63" userLabel="width = 88"/>
                                                                 <constraint firstAttribute="width" secondItem="tvi-AI-Dgu" secondAttribute="height" multiplier="16:9" id="miz-hW-qqt"/>
                                                             </constraints>
                                                         </imageView>
                                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="Anq-O4-DJn">
-                                                            <rect key="frame" x="100" y="0.0" width="260" height="41"/>
+                                                            <rect key="frame" x="100" y="0.0" width="268" height="41"/>
                                                             <subviews>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" text=" " textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gQE-6Q-Edr">
-                                                                    <rect key="frame" x="0.0" y="0.0" width="260" height="20.5"/>
+                                                                    <rect key="frame" x="0.0" y="0.0" width="268" height="20.5"/>
                                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                     <nil key="highlightedColor"/>
                                                                 </label>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" " textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rem-eD-fYK">
-                                                                    <rect key="frame" x="0.0" y="20.5" width="260" height="20.5"/>
+                                                                    <rect key="frame" x="0.0" y="20.5" width="268" height="20.5"/>
                                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                     <nil key="highlightedColor"/>
@@ -116,8 +113,8 @@
                                                         </stackView>
                                                     </subviews>
                                                 </stackView>
-                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="9iW-q8-4Of">
-                                                    <rect key="frame" x="0.0" y="94.5" width="360" height="30"/>
+                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="9iW-q8-4Of">
+                                                    <rect key="frame" x="0.0" y="94" width="368" height="30"/>
                                                 </button>
                                             </subviews>
                                         </stackView>
@@ -147,27 +144,27 @@
                                 </connections>
                             </tableViewCell>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="ActivitySampleFollowCell" rowHeight="190" id="MPs-b9-04p" customClass="ActivitySampleFollowCell" customModule="Kickstarter_Framework" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="418" width="400" height="190"/>
+                                <rect key="frame" x="0.0" y="440" width="400" height="190"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="MPs-b9-04p" id="hcC-bj-V2I">
                                     <rect key="frame" x="0.0" y="0.0" width="400" height="190"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="JO5-vV-TxX">
-                                            <rect key="frame" x="20" y="30" width="360" height="119"/>
-                                            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            <rect key="frame" x="18" y="30" width="364" height="118.5"/>
+                                            <color key="backgroundColor" name="white"/>
                                         </view>
                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="wDz-2O-hfm">
-                                            <rect key="frame" x="20" y="30" width="360" height="118.5"/>
+                                            <rect key="frame" x="18" y="30" width="364" height="118.5"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TgG-4T-ymU">
-                                                    <rect key="frame" x="0.0" y="0.0" width="360" height="20.5"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="364" height="20.5"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="5p0-HX-9JA">
-                                                    <rect key="frame" x="0.0" y="32.5" width="360" height="44"/>
+                                                    <rect key="frame" x="0.0" y="32.5" width="364" height="44"/>
                                                     <subviews>
                                                         <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="9Ka-06-bwe" customClass="CircleAvatarImageView" customModule="Library">
                                                             <rect key="frame" x="0.0" y="0.0" width="44" height="44"/>
@@ -177,15 +174,15 @@
                                                             </constraints>
                                                         </imageView>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="251" text=" " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jP5-Ue-8Fq">
-                                                            <rect key="frame" x="60" y="0.0" width="300" height="44"/>
+                                                            <rect key="frame" x="60" y="0.0" width="304" height="44"/>
                                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                             <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
                                                     </subviews>
                                                 </stackView>
-                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="SdI-n7-3Ro">
-                                                    <rect key="frame" x="0.0" y="88.5" width="360" height="30"/>
+                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="SdI-n7-3Ro">
+                                                    <rect key="frame" x="0.0" y="88.5" width="364" height="30"/>
                                                 </button>
                                             </subviews>
                                         </stackView>
@@ -214,27 +211,27 @@
                                 </connections>
                             </tableViewCell>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="ActivitySampleBackingCell" rowHeight="190" id="1pr-e4-YOQ" customClass="ActivitySampleBackingCell" customModule="Kickstarter_Framework" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="608" width="400" height="190"/>
+                                <rect key="frame" x="0.0" y="630" width="400" height="190"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="1pr-e4-YOQ" id="CAL-n5-woQ">
                                     <rect key="frame" x="0.0" y="0.0" width="400" height="190"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4jN-iz-tJS">
-                                            <rect key="frame" x="20" y="32" width="360" height="119"/>
-                                            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            <rect key="frame" x="16" y="32" width="368" height="118.5"/>
+                                            <color key="backgroundColor" name="white"/>
                                         </view>
                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="Qac-NN-Hbl">
-                                            <rect key="frame" x="20" y="32" width="360" height="118.5"/>
+                                            <rect key="frame" x="16" y="32" width="368" height="118.5"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Dhh-fc-Urq">
-                                                    <rect key="frame" x="0.0" y="0.0" width="360" height="20.5"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="368" height="20.5"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="QqK-HW-yaJ">
-                                                    <rect key="frame" x="0.0" y="32.5" width="360" height="44"/>
+                                                    <rect key="frame" x="0.0" y="32.5" width="368" height="44"/>
                                                     <subviews>
                                                         <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="SEq-2l-lfW" customClass="CircleAvatarImageView" customModule="Library">
                                                             <rect key="frame" x="0.0" y="0.0" width="44" height="44"/>
@@ -244,15 +241,15 @@
                                                             </constraints>
                                                         </imageView>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="v9O-8V-rER">
-                                                            <rect key="frame" x="60" y="0.0" width="300" height="44"/>
+                                                            <rect key="frame" x="60" y="0.0" width="308" height="44"/>
                                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                             <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
                                                     </subviews>
                                                 </stackView>
-                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="7dU-pZ-UnW">
-                                                    <rect key="frame" x="0.0" y="88.5" width="360" height="30"/>
+                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="7dU-pZ-UnW">
+                                                    <rect key="frame" x="0.0" y="88.5" width="368" height="30"/>
                                                 </button>
                                             </subviews>
                                         </stackView>
@@ -295,6 +292,9 @@
         </scene>
     </scenes>
     <resources>
-        <image name="kickstarter-logo" width="164" height="17"/>
+        <image name="kickstarter-logo" width="163" height="17"/>
+        <namedColor name="white">
+            <color red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+        </namedColor>
     </resources>
 </document>

--- a/Kickstarter-iOS/Features/Discovery/Views/Cells/ActivitySampleBackingCell.swift
+++ b/Kickstarter-iOS/Features/Discovery/Views/Cells/ActivitySampleBackingCell.swift
@@ -40,6 +40,8 @@ internal final class ActivitySampleBackingCell: UITableViewCell, ValueCell {
         Strings.dashboard_tout_accessibility_hint_opens_project()
       }
 
+    self.cardView.backgroundColor = Colors.Background.Surface.primary.uiColor()
+
     _ = self.activityStackView
       |> activitySampleStackViewStyle
 

--- a/Kickstarter-iOS/Features/Discovery/Views/Cells/ActivitySampleFollowCell.swift
+++ b/Kickstarter-iOS/Features/Discovery/Views/Cells/ActivitySampleFollowCell.swift
@@ -46,6 +46,8 @@ internal final class ActivitySampleFollowCell: UITableViewCell, ValueCell {
     _ = self.cardView
       |> dropShadowStyleMedium()
 
+    self.cardView.backgroundColor = Colors.Background.Surface.primary.uiColor()
+
     _ = self.friendFollowLabel
       |> activitySampleFriendFollowLabelStyle
 

--- a/Kickstarter-iOS/Features/Discovery/Views/Cells/ActivitySampleProjectCell.swift
+++ b/Kickstarter-iOS/Features/Discovery/Views/Cells/ActivitySampleProjectCell.swift
@@ -47,6 +47,8 @@ internal final class ActivitySampleProjectCell: UITableViewCell, ValueCell {
     _ = self.cardView
       |> dropShadowStyleMedium()
 
+    self.cardView.backgroundColor = Colors.Background.Surface.primary.uiColor()
+
     _ = self.projectImageAndInfoStackView
       |> UIStackView.lens.spacing .~ Styles.grid(2)
 


### PR DESCRIPTION
# 📲 What

- Replace custom white color value in Storyboards for Activity and Activity preview cells with semantic `white` color from asset catalog
- Add programmatic background colors to Activity cells, wherever they were missing. I specifically used `background/surface/primary` so that the dark mode version looks a little nicer, instead of using `legacy/white`. 

| Before 🐛 | After 🦋 |
| --- | --- |
| <img width="200" src="https://github.com/user-attachments/assets/0d3ddfcb-40d0-4b2c-8fa2-f7b324efbe94" /> | <img width="200" src="https://github.com/user-attachments/assets/7c817af4-2506-4b0f-ae59-b2ae87fc708b" /> 
| <img width="200" src="https://github.com/user-attachments/assets/e001adbc-153e-4583-9406-432bc0b70b49" /> | <img width="200" src="https://github.com/user-attachments/assets/5a53522b-9c7b-4b27-8931-bba41c881875" /> |