### PR TITLE
Disable flaky test in ProjectPageViewControllerTests

### DIFF
--- a/Kickstarter-iOS/Features/ProjectPage/Controller/ProjectPageViewControllerTests.swift
+++ b/Kickstarter-iOS/Features/ProjectPage/Controller/ProjectPageViewControllerTests.swift
@@ -960,7 +960,8 @@ internal final class ProjectPageViewControllerTests: TestCase {
 
   // MARK: - Tab Content Tests
 
-  func testLoggedOut_NonBacker_LiveProjectSwitchedToCampaignTab_Success() {
+  // FIXME: MBL-2463 This test is flaky and frequently times out. Disabling it for the moment.
+  func disabled_testLoggedOut_NonBacker_LiveProjectSwitchedToCampaignTab_Success() {
     let config = Config.template
     let project = Project.cosmicSurgery
       |> Project.lens.photo.full .~ ""


### PR DESCRIPTION
# 📲 What

Disable a flaky snapshot test, `testLoggedOut_NonBacker_LiveProjectSwitchedToCampaignTab_Success`.

# 🤔 Why

This snapshot test regularly times out. There's nothing I can find that's obviously causing the timeout. By disabling this test, we can see if it's an issue with the overall suite timing out (in which case, _another_ test will become flaky), or if it's isolated to this one.

Either way, hopefully this moves us towards not being annoyed by this one any more.