### PR TITLE
Secret reward icon - Dark Mode color

### DIFF
--- a/Kickstarter-iOS/Assets.xcassets/icons/Locked.imageset/Contents.json
+++ b/Kickstarter-iOS/Assets.xcassets/icons/Locked.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

This PR updates the image asset’s “Render as” setting to “Template Image”, allowing the image to correctly adopt the `tintColor` when rendered in the UI.

# 🛠 How

Set the "Render as" option in the asset catalog to "Template Image".

# 👀 See

Trello, screenshots, external resources?

| Before 🐛 | After 🦋 |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/bf5647e3-f5e8-4fa7-bc4a-646ff32bc634) | ![image](https://github.com/user-attachments/assets/820673f9-872d-46a9-b8f6-65fef0540391) |

# ✅ Acceptance criteria

- [ ] The **Locked** icon displays correctly with the appropriate tint color in both Dark mode and Light mode.
