### PR TITLE
[MBL-2478] Fix badge overlap on Edit Reward screen when rotating device

### DIFF
--- a/Kickstarter-iOS/Features/RewardsCollection/Views/RewardCardContainerView.swift
+++ b/Kickstarter-iOS/Features/RewardsCollection/Views/RewardCardContainerView.swift
@@ -38,11 +38,6 @@ public final class RewardCardContainerView: UIView {
       |> \.translatesAutoresizingMaskIntoConstraints .~ false
   }()
 
-  /// Stores the top margin value to be applied to `rewardCardMaskView`.
-  /// This is dynamically adjusted based on whether the reward requires additional spacing
-  /// (e.g., to avoid overlapping badges like "Secret Reward" and "Your selection").
-  private var currentRewardCardMaskViewTopMarginInset = CGFloat.zero
-
   override init(frame: CGRect) {
     super.init(frame: frame)
 
@@ -66,8 +61,6 @@ public final class RewardCardContainerView: UIView {
     _ = self.rewardCardMaskView
       |> checkoutWhiteBackgroundStyle
       |> roundedStyle(cornerRadius: Styles.grid(3))
-
-    self.updateRewardCardMaskViewLayout()
   }
 
   public override func bindViewModel() {
@@ -123,21 +116,13 @@ public final class RewardCardContainerView: UIView {
       && data.reward.image == nil
       && userIsBacking(reward: data.reward, inProject: data.project)
 
-    self.currentRewardCardMaskViewTopMarginInset = requiresTopMarginInset ? Constants
-      .rewardCardMaskViewTopMarginInset : .zero
-
-    self.updateRewardCardMaskViewLayout()
-  }
-
-  private func updateRewardCardMaskViewLayout() {
-    let layoutMargins = UIEdgeInsets(
-      top: self.currentRewardCardMaskViewTopMarginInset,
+    let topMarginInset = requiresTopMarginInset ? Constants.rewardCardMaskViewTopMarginInset : .zero
+    self.rewardCardMaskView.layoutMargins = UIEdgeInsets(
+      top: topMarginInset,
       left: .zero,
       bottom: .zero,
       right: .zero
     )
-
-    self.rewardCardMaskView.layoutMargins = layoutMargins
   }
 
   // MARK: - Functions

--- a/Kickstarter-iOS/Features/RewardsCollection/Views/RewardCardContainerView.swift
+++ b/Kickstarter-iOS/Features/RewardsCollection/Views/RewardCardContainerView.swift
@@ -38,6 +38,11 @@ public final class RewardCardContainerView: UIView {
       |> \.translatesAutoresizingMaskIntoConstraints .~ false
   }()
 
+  /// Stores the top margin value to be applied to `rewardCardMaskView`.
+  /// This is dynamically adjusted based on whether the reward requires additional spacing
+  /// (e.g., to avoid overlapping badges like "Secret Reward" and "Your selection").
+  private var currentRewardCardMaskViewTopMarginInset = CGFloat.zero
+
   override init(frame: CGRect) {
     super.init(frame: frame)
 
@@ -60,8 +65,9 @@ public final class RewardCardContainerView: UIView {
 
     _ = self.rewardCardMaskView
       |> checkoutWhiteBackgroundStyle
-      |> \.layoutMargins .~ .zero
       |> roundedStyle(cornerRadius: Styles.grid(3))
+
+    self.updateRewardCardMaskViewLayout()
   }
 
   public override func bindViewModel() {
@@ -117,9 +123,21 @@ public final class RewardCardContainerView: UIView {
       && data.reward.image == nil
       && userIsBacking(reward: data.reward, inProject: data.project)
 
-    var margings = self.rewardCardMaskView.layoutMargins
-    margings.top = requiresTopMarginInset ? Constants.rewardCardMaskViewTopMarginInset : .zero
-    self.rewardCardMaskView.layoutMargins = margings
+    self.currentRewardCardMaskViewTopMarginInset = requiresTopMarginInset ? Constants
+      .rewardCardMaskViewTopMarginInset : .zero
+
+    self.updateRewardCardMaskViewLayout()
+  }
+
+  private func updateRewardCardMaskViewLayout() {
+    let layoutMargins = UIEdgeInsets(
+      top: self.currentRewardCardMaskViewTopMarginInset,
+      left: .zero,
+      bottom: .zero,
+      right: .zero
+    )
+
+    self.rewardCardMaskView.layoutMargins = layoutMargins
   }
 
   // MARK: - Functions


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Fixes a layout issue where the "Secret Reward" and "Your selection" badges overlap when rotating the device in the **Edit reward** screen.

# 🛠 How

- Introduced `currentRewardCardMaskViewTopMarginInset` property to store the current top margin value dynamically.
- Created `updateRewardCardMaskViewLayout()` to apply margin updates based on whether extra spacing is needed (e.g., when the reward is backed and is a secret reward).
- Called `updateRewardCardMaskViewLayout()` during `bindStyles()` to reflect layout changes.
- Removed hardcoded `.zero` margin.

# 👀 See

[Bug ticket](https://kickstarter.atlassian.net/browse/MBL-2479)

| Before 🐛 | After 🦋 |
| --- | --- |
| ![Simulator Screen Recording - iPhone 16 Pro - 2025-06-03 at 05 55 05](https://github.com/user-attachments/assets/13dcfa73-a067-4c73-a46b-2eb765a8c843) | ![Simulator Screen Recording - iPhone 16 Pro - 2025-06-03 at 06 27 34](https://github.com/user-attachments/assets/ac621229-4c97-4b34-b426-ce262c9bd05f) |

# ♿️ Accessibility 

- [ ] Tap targets use minimum of 44x44 pts dimensions
- [ ] Works with VoiceOver
- [ ] Supports Dynamic Type 

# 🏎 Performance

- [ ] Optimized Blended Layers (screenshots)

# ✅ Acceptance criteria

- [ ] On the Edit reward screen, "Secret Reward" and "Your selection" badges should not overlap.
- [ ] The spacing should adjust correctly when rotating the device.
- [ ] The fix should not affect rewards without both badges visible.

# ⏰ TODO

- [ ] Consider update the layout structure on the [cleanup ticket MBL-2478](https://kickstarter.atlassian.net/browse/MBL-2478)
