### PR TITLE
Fix "Continue with Apple" style when New Design System is enabled

### DIFF
--- a/Kickstarter-iOS/Features/LoginTout/Controller/LoginToutViewController.swift
+++ b/Kickstarter-iOS/Features/LoginTout/Controller/LoginToutViewController.swift
@@ -109,8 +109,7 @@ public final class LoginToutViewController: UIViewController, MFMailComposeViewC
     _ = self.backgroundImageView
       |> backgroundImageViewStyle
 
-    _ = self.appleLoginButton
-      |> roundedStyle(cornerRadius: Styles.grid(2))
+    applyAppleLoginButtonStyle(self.appleLoginButton)
 
     _ = self.bringCreativeProjectsToLifeLabel
       |> baseLabelStyle
@@ -531,6 +530,12 @@ private let separatorViewStyle: ViewStyle = { view in
   view
     |> \.backgroundColor .~ LegacyColors.ksr_support_300.uiColor()
     |> \.translatesAutoresizingMaskIntoConstraints .~ false
+}
+
+private func applyAppleLoginButtonStyle(_ button: AdaptiveAppleIDButton) {
+  let cornerRadius: CGFloat = featureNewDesignSystemEnabled() ? Styles.cornerRadius : Styles.grid(2)
+
+  button.rounded(with: cornerRadius)
 }
 
 // MARK: - ASAuthorizationControllerDelegate


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

This PR updates the corner radius of the "Continue with Apple" button to match the style defined for the new Design System, ensuring consistency across all login buttons.

# 🛠 How

- Refactored the `LoginToutViewController` to apply the corner radius, if the feature is enabled, uses `Styles.cornerRadius`; otherwise, falls back to `Styles.grid(2)`.

# 👀 See

| Before 🐛 | After 🦋 |
| --- | --- |
| ![Simulator Screenshot - iPhone 16 Pro - 2025-06-04 at 17 42 35](https://github.com/user-attachments/assets/59b9819b-d59b-49a5-a87f-905363f8e6e7) | ![Simulator Screenshot - iPhone 16 Pro - 2025-06-04 at 17 37 44](https://github.com/user-attachments/assets/ec179afc-b02c-40b4-990d-f52ff80aebf2) |

# ✅ Acceptance criteria

- [ ] The style is applied conditionally based on the feature flag `featureNewDesignSystemEnabled()`.
