### PR TITLE
[MBL-2484] Apply correct background to Facebook 2FA screen in Dark Mode

### DIFF
--- a/Kickstarter-iOS/Features/TwoFactorAuthentication/Controller/TwoFactorViewController.swift
+++ b/Kickstarter-iOS/Features/TwoFactorAuthentication/Controller/TwoFactorViewController.swift
@@ -32,6 +32,7 @@ internal final class TwoFactorViewController: UIViewController {
 
     _ = self
       |> twoFactorControllerStyle
+      |> UIViewController.lens.view.backgroundColor .~ LegacyColors.ksr_white.uiColor()
       |> UIViewController.lens.view.layoutMargins %~~ { _, _ in
         isPad ? .init(all: Styles.grid(20)) : .init(all: Styles.grid(3))
       }


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Fixing a visual issue on the 2FA screen used during Facebook login, where the background color appeared incorrectly in dark mode.

# 🛠 How

The issue was that the background behind the 2FA prompt was missing its intended color. This fix applies the same background color used by `formBackgroundView` in `TwoFactorViewController`.

- Color: `LegacyColors.ksr_white`

# 👀 See

- [MBL-2484](https://kickstarter.atlassian.net/browse/MBL-2484)

| Before 🐛 | After 🦋 |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/173aaf80-cda8-4381-89ed-1332696fe4f4) | ![Simulator Screenshot - iPhone 16 Pro - 2025-06-10 at 07 00 52](https://github.com/user-attachments/assets/1d5d9960-4fe4-4f36-91f1-1e0be1ca8506) |

# ✅ Acceptance criteria

- [ ] 2FA screen background color matches the rest of the form in dark mode


[MBL-2484]: https://kickstarter.atlassian.net/browse/MBL-2484?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ