### PR TITLE
Secret reward's autoscrolling

### DIFF
--- a/Kickstarter-iOS/Features/ProjectPage/Controller/ProjectPageViewController.swift
+++ b/Kickstarter-iOS/Features/ProjectPage/Controller/ProjectPageViewController.swift
@@ -322,9 +322,9 @@ public final class ProjectPageViewController: UIViewController, MessageBannerVie
     self.viewModel.outputs.goToRewards
       .observeForControllerAction()
       .observeValues { [weak self] params in
-        let (project, refTag) = params
+        let (project, refTag, secretRewardToken) = params
 
-        self?.goToRewards(project: project, refTag: refTag)
+        self?.goToRewards(project: project, refTag: refTag, secretRewardToken: secretRewardToken)
       }
 
     self.viewModel.outputs.goToManagePledge
@@ -688,8 +688,12 @@ public final class ProjectPageViewController: UIViewController, MessageBannerVie
     self.present(nav, animated: true, completion: nil)
   }
 
-  private func goToRewards(project: Project, refTag: RefTag?) {
-    let vc = RewardsCollectionViewController.controller(with: project, refTag: refTag)
+  private func goToRewards(project: Project, refTag: RefTag?, secretRewardToken: String?) {
+    let vc = RewardsCollectionViewController.controller(
+      with: project,
+      refTag: refTag,
+      secretRewardToken: secretRewardToken
+    )
     self.present(vc, animated: true)
   }
 

--- a/Kickstarter-iOS/Features/RewardsCollection/Controller/RewardsCollectionViewController.swift
+++ b/Kickstarter-iOS/Features/RewardsCollection/Controller/RewardsCollectionViewController.swift
@@ -51,10 +51,16 @@ final class RewardsCollectionViewController: UICollectionViewController {
   static func instantiate(
     with project: Project,
     refTag: RefTag?,
-    context: RewardsCollectionViewContext
+    context: RewardsCollectionViewContext,
+    secretRewardToken: String? = nil
   ) -> RewardsCollectionViewController {
     let rewardsCollectionVC = RewardsCollectionViewController()
-    rewardsCollectionVC.viewModel.inputs.configure(with: project, refTag: refTag, context: context)
+    rewardsCollectionVC.viewModel.inputs.configure(
+      with: project,
+      refTag: refTag,
+      context: context,
+      secretRewardToken: secretRewardToken
+    )
 
     return rewardsCollectionVC
   }
@@ -170,7 +176,7 @@ final class RewardsCollectionViewController: UICollectionViewController {
         self?.collectionView.reloadData()
       }
 
-    self.viewModel.outputs.scrollToBackedRewardIndexPath
+    self.viewModel.outputs.scrollToRewardIndexPath
       .observeForUI()
       .observeValues { [weak self] indexPath in
         self?.collectionView.scrollToItem(at: indexPath, at: .centeredHorizontally, animated: false)
@@ -407,10 +413,16 @@ private var collectionViewStyle: CollectionViewStyle = { collectionView -> UICol
 extension RewardsCollectionViewController {
   public static func controller(
     with project: Project,
-    refTag: RefTag?
+    refTag: RefTag?,
+    secretRewardToken: String?
   ) -> UINavigationController {
     let rewardsCollectionViewController = RewardsCollectionViewController
-      .instantiate(with: project, refTag: refTag, context: .createPledge)
+      .instantiate(
+        with: project,
+        refTag: refTag,
+        context: .createPledge,
+        secretRewardToken: secretRewardToken
+      )
 
     let closeButton = UIBarButtonItem(
       image: image(named: "icon--cross"),

--- a/Library/ViewModels/ProjectPageViewModel.swift
+++ b/Library/ViewModels/ProjectPageViewModel.swift
@@ -154,7 +154,7 @@ public protocol ProjectPageViewModelOutputs {
   var goToReportProject: Signal<(Bool, String, String), Never> { get }
 
   /// Emits a project and refTag to be used to navigate to the reward selection screen.
-  var goToRewards: Signal<(Project, RefTag?), Never> { get }
+  var goToRewards: Signal<(Project, RefTag?, String?), Never> { get }
 
   /// Emits a URL that will be opened by an external Safari browser.
   var goToURL: Signal<URL, Never> { get }
@@ -682,6 +682,8 @@ public final class ProjectPageViewModel: ProjectPageViewModelType, ProjectPageVi
     )
 
     self.goToRewards = freshProjectAndRefTag
+      .combineLatest(with: secretRewardToken)
+      .map(unpack)
       .takeWhen(
         self.rewardsUseCase.goToRewards
       )
@@ -866,7 +868,7 @@ public final class ProjectPageViewModel: ProjectPageViewModelType, ProjectPageVi
   }
 
   public let goToRestrictedCreator: Signal<String, Never>
-  public let goToRewards: Signal<(Project, RefTag?), Never>
+  public let goToRewards: Signal<(Project, RefTag?, String?), Never>
   public let goToUpdates: Signal<Project, Never>
   public let goToReportProject: Signal<(Bool, String, String), Never>
   public let goToURL: Signal<URL, Never>

--- a/Library/ViewModels/RewardsCollectionViewModelTests.swift
+++ b/Library/ViewModels/RewardsCollectionViewModelTests.swift
@@ -33,7 +33,7 @@ final class RewardsCollectionViewModelTests: TestCase {
     let testProject = Project.template
       |> Project.lens.rewardData.rewards .~ rewards
 
-    self.vm.configure(with: testProject, refTag: nil, context: .createPledge)
+    self.vm.configure(with: testProject, refTag: nil, context: .createPledge, secretRewardToken: "34342")
     self.vm.shippingRuleSelected(nil)
     self.vm.viewDidLoad()
 


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Add support for automatic scroll to the first secret reward when opening the project via a deeplink that includes a `secretRewardToken`.

# 🛠 How

- Extended `goToRewards` output from `ProjectPageViewModel` to include `secretRewardToken`.
- Propagated the token through `ProjectPageViewController` → `RewardsCollectionViewController` → `RewardsCollectionViewModel`.
- Replaced `scrollToBackedRewardIndexPath` with a more general-purpose `scrollToRewardIndexPath`.
- Modified the scroll logic to prioritize secret reward index if a token is present; otherwise fall back to previously backed reward (existing behaviour).

# 👀 See

- [MBL-2451](https://kickstarter.atlassian.net/browse/MBL-2451)

![Simulator Screen Recording - iPhone 16 Pro - 2025-06-12 at 09 34 07](https://github.com/user-attachments/assets/748615e0-46d0-4172-901d-29b843a94eaf)

# ✅ Acceptance criteria

- [x] Scrolling occurs automatically when `secretRewardToken` is passed
- [x] Only triggers if project has at least one secret reward
- [x] Defaults to existing scroll-to-backed-reward behavior otherwise

