### PR TITLE
MBL-915: Replace LegacyInterceptorProvider

### DIFF
--- a/KsApi/extensions/ApolloInterceptors.swift
+++ b/KsApi/extensions/ApolloInterceptors.swift
@@ -1,27 +1,60 @@
 import Apollo
+import Foundation
 
-// MARK: - NetworkInterceptorProvider
-
-class NetworkInterceptorProvider: LegacyInterceptorProvider {
+/// This is based on `LegacyInterceptorProvider` from Apollo version 0.x.
+/// That's provider is longer included in Apollo 1.x, but we want to continue to have the same
+/// behavior. This could, potentailly, be cleaned up to remove unnecessary interceptors.
+class
+NetworkInterceptorProvider: InterceptorProvider {
   private let additionalHeaders: () -> [String: String]
+  private let client: URLSessionClient
+  private let store: ApolloStore
 
-  override func interceptors<Operation: GraphQLOperation>(for operation: Operation) -> [ApolloInterceptor] {
-    return [HeadersInterceptor(self.additionalHeaders)] + super.interceptors(for: operation)
+  /// Designated initializer
+  ///
+  /// - Parameters:
+  ///   - store: The `ApolloStore` to use when reading from or writing to the cache. Make sure you pass the same store to the `ApolloClient` instance you're planning to use.
+  public init(
+    store: ApolloStore,
+    additionalHeaders: @escaping () -> [String: String]
+  ) {
+    self.additionalHeaders = additionalHeaders
+    self.client = URLSessionClient()
+    self.store = store
   }
 
-  init(store: ApolloStore, additionalHeaders: @escaping () -> [String: String]) {
-    self.additionalHeaders = additionalHeaders
-    super.init(store: store)
+  deinit {
+    self.client.invalidate()
+  }
+
+  func interceptors<Operation: GraphQLOperation>(for _: Operation) -> [any ApolloInterceptor] {
+    return [
+      HeadersInterceptor(self.additionalHeaders),
+      MaxRetryInterceptor(),
+      LegacyCacheReadInterceptor(store: self.store),
+      NetworkFetchInterceptor(client: self.client),
+      ResponseCodeInterceptor(),
+      LegacyParsingInterceptor(cacheKeyForObject: self.store.cacheKeyForObject),
+      AutomaticPersistedQueryInterceptor(),
+      LegacyCacheReadInterceptor(store: self.store)
+    ]
+  }
+
+  func additionalErrorInterceptor<Operation: GraphQLOperation>(for _: Operation) -> ApolloErrorInterceptor? {
+    return nil
   }
 }
 
 // MARK: - HeadersInterceptor
 
 class HeadersInterceptor: ApolloInterceptor {
+  let id: String
+
   private let additionalHeaders: () -> [String: String]
 
   init(_ additionalHeaders: @escaping () -> [String: String]) {
     self.additionalHeaders = additionalHeaders
+    self.id = UUID().uuidString
   }
 
   func interceptAsync<Operation: GraphQLOperation>(


### PR DESCRIPTION


<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Apollo 1.0 and beyond remove the LegacyInterceptorProvider class. This replaces it, and also removes LegacyParsingInterceptor from our interceptor chain, which has no equivalent in 1.0.

# 🤔 Why

Some background context on why the change is needed.

# 🛠 How

More in-depth discussion of the change or implementation.

# 👀 See

Trello, screenshots, external resources?

| Before 🐛 | After 🦋 |
| --- | --- |
|  |  |

# ♿️ Accessibility 

- [ ] Tap targets use minimum of 44x44 pts dimensions
- [ ] Works with VoiceOver
- [ ] Supports Dynamic Type 

# 🏎 Performance

- [ ] Optimized Blended Layers (screenshots)

# ✅ Acceptance criteria

- [ ] Steps to test this feature
- [ ] Environment to test on
- [ ] Issues to look out for

# ⏰ TODO

- [ ] Got planned refactors to come
- [ ] Will add more tests
- [ ] Need feedback on a design
