### PR TITLE
Add FetchLocationsUseCase

### DIFF
--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -1723,6 +1723,9 @@
 		E1BBB65D2E00724100291D48 /* GraphAPI+TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1BBB65B2E00718C00291D48 /* GraphAPI+TestHelpers.swift */; };
 		E1BBB65E2E00724100291D48 /* GraphAPI+TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1BBB65B2E00718C00291D48 /* GraphAPI+TestHelpers.swift */; };
 		E1BBB65F2E00724100291D48 /* GraphAPI+TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1BBB65B2E00718C00291D48 /* GraphAPI+TestHelpers.swift */; };
+		E1BBB6712E035BDD00291D48 /* FetchLocationsUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1BBB66D2E035BDD00291D48 /* FetchLocationsUseCase.swift */; };
+		E1BBB6722E035BE300291D48 /* FetchLocationsUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1BBB66E2E035BDD00291D48 /* FetchLocationsUseCaseTests.swift */; };
+		E1C880AF2BBC6CDA008B9612 /* GraphQLSelectionSet+String.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1C880AE2BBC6CDA008B9612 /* GraphQLSelectionSet+String.swift */; };
 		E1CFB5952D8E00C5004AB0D6 /* DiscoveryParams_Sort+SortOption.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1CFB5942D8E00C5004AB0D6 /* DiscoveryParams_Sort+SortOption.swift */; };
 		E1DBB2372DAEBCE10050733F /* SearchFiltersHeaderViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1DBB2352DAEBCB60050733F /* SearchFiltersHeaderViewTests.swift */; };
 		E1EEED292B684AA7009976D9 /* PKCE.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1EEED282B684AA7009976D9 /* PKCE.swift */; };
@@ -3518,6 +3521,9 @@
 		E1BAA03D2C1A1CE4004F8B06 /* PPOViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PPOViewModelTests.swift; sourceTree = "<group>"; };
 		E1BB25632B1E81AA000BD2D6 /* Publisher+Service.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Publisher+Service.swift"; sourceTree = "<group>"; };
 		E1BBB65B2E00718C00291D48 /* GraphAPI+TestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GraphAPI+TestHelpers.swift"; sourceTree = "<group>"; };
+		E1BBB66D2E035BDD00291D48 /* FetchLocationsUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchLocationsUseCase.swift; sourceTree = "<group>"; };
+		E1BBB66E2E035BDD00291D48 /* FetchLocationsUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchLocationsUseCaseTests.swift; sourceTree = "<group>"; };
+		E1C880AE2BBC6CDA008B9612 /* GraphQLSelectionSet+String.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GraphQLSelectionSet+String.swift"; sourceTree = "<group>"; };
 		E1CFB5942D8E00C5004AB0D6 /* DiscoveryParams_Sort+SortOption.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DiscoveryParams_Sort+SortOption.swift"; sourceTree = "<group>"; };
 		E1DBB2352DAEBCB60050733F /* SearchFiltersHeaderViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchFiltersHeaderViewTests.swift; sourceTree = "<group>"; };
 		E1EA34EE2AE1B28400942A04 /* Signal+Combine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Signal+Combine.swift"; sourceTree = "<group>"; };
@@ -7241,6 +7247,7 @@
 		AA7452A82D91BB8100DCB655 /* UseCases */ = {
 			isa = PBXGroup;
 			children = (
+				E1BBB66F2E035BDD00291D48 /* FetchLocations */,
 				AA7452A32D91BB8100DCB655 /* SimilarProjects */,
 				E182B7E32DB2AB98000C4067 /* FetchCategories */,
 				E182B7DE2DB2A88D000C4067 /* SearchFilters */,
@@ -7770,6 +7777,15 @@
 				E1BAA03D2C1A1CE4004F8B06 /* PPOViewModelTests.swift */,
 			);
 			path = PledgedProjectsOverview;
+			sourceTree = "<group>";
+		};
+		E1BBB66F2E035BDD00291D48 /* FetchLocations */ = {
+			isa = PBXGroup;
+			children = (
+				E1BBB66D2E035BDD00291D48 /* FetchLocationsUseCase.swift */,
+				E1BBB66E2E035BDD00291D48 /* FetchLocationsUseCaseTests.swift */,
+			);
+			path = FetchLocations;
 			sourceTree = "<group>";
 		};
 		E1CFB5932D8E00A6004AB0D6 /* Extensions */ = {
@@ -8657,6 +8673,7 @@
 				A75C81171D210BD700B5AD03 /* ShareViewModel.swift in Sources */,
 				6049D0202AA776B40015BB0D /* DesignSystemColors.swift in Sources */,
 				A757EAF01D1ABE7400A5C978 /* ActivitySurveyResponseCellViewModel.swift in Sources */,
+				E1BBB6712E035BDD00291D48 /* FetchLocationsUseCase.swift in Sources */,
 				E13D76712D4011BF00FB58CE /* PaymentMethodsUseCase.swift in Sources */,
 				A7CC13D91D00E6CF00035C52 /* FindFriendsStatsCellViewModel.swift in Sources */,
 				D08CD1FF21913166009F89F0 /* WatchProjectViewModel.swift in Sources */,
@@ -8793,6 +8810,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E1BBB6722E035BE300291D48 /* FetchLocationsUseCaseTests.swift in Sources */,
 				1611EF6923B275700051CDCC /* MockUUID.swift in Sources */,
 				D723708C2118CAD8001EA4CA /* SettingsDeleteOrRequestCellViewModelTests.swift in Sources */,
 				A7ED1FAC1E831C5C00BFFA01 /* ActivitySampleFollowCellViewModelTests.swift in Sources */,

--- a/KsApi/models/graphql/adapters/Location+LocationFragment.swift
+++ b/KsApi/models/graphql/adapters/Location+LocationFragment.swift
@@ -20,11 +20,8 @@ extension Location {
     }
 
     return nodes.compactMap { node in
-      if let fragment = node?.fragments.locationFragment {
-        KsApi.Location.location(from: fragment)
-      } else {
-        nil
-      }
+      guard let fragment = node?.fragments.locationFragment else { return nil }
+      return KsApi.Location.location(from: fragment)
     }
   }
 
@@ -34,11 +31,8 @@ extension Location {
     }
 
     return nodes.compactMap { node in
-      if let fragment = node?.fragments.locationFragment {
-        KsApi.Location.location(from: fragment)
-      } else {
-        nil
-      }
+      guard let fragment = node?.fragments.locationFragment else { return nil }
+      return KsApi.Location.location(from: fragment)
     }
   }
 }

--- a/KsApi/models/graphql/adapters/Location+LocationFragment.swift
+++ b/KsApi/models/graphql/adapters/Location+LocationFragment.swift
@@ -13,4 +13,32 @@ extension Location {
       name: locationFragment.name
     )
   }
+
+  public static func locations(from data: GraphAPI.DefaultLocationsQuery.Data) -> [Location] {
+    guard let nodes = data.locations?.nodes else {
+      return []
+    }
+
+    return nodes.compactMap { node in
+      if let fragment = node?.fragments.locationFragment {
+        KsApi.Location.location(from: fragment)
+      } else {
+        nil
+      }
+    }
+  }
+
+  public static func locations(from data: GraphAPI.LocationsByTermQuery.Data) -> [Location] {
+    guard let nodes = data.locations?.nodes else {
+      return []
+    }
+
+    return nodes.compactMap { node in
+      if let fragment = node?.fragments.locationFragment {
+        KsApi.Location.location(from: fragment)
+      } else {
+        nil
+      }
+    }
+  }
 }

--- a/Library/UseCases/FetchLocations/FetchLocationsUseCase.swift
+++ b/Library/UseCases/FetchLocations/FetchLocationsUseCase.swift
@@ -1,0 +1,72 @@
+import KsApi
+import ReactiveSwift
+
+public protocol FetchLocationsUseCaseType {
+  var inputs: FetchLocationsUseCaseInputs { get }
+  var dataOutputs: FetchLocationsUseCaseDataOutputs { get }
+}
+
+public protocol FetchLocationsUseCaseInputs {
+  /// Call this when the user types a location query string in the location filter
+  func searchedForLocations(_ query: String)
+}
+
+public protocol FetchLocationsUseCaseDataOutputs {
+  /// Emits the list of default locations. Emits empty array on initial signal.
+  var defaultLocations: Signal<[Location], Never> { get }
+
+  /// Emits locations related to the query inputted with `searchedForLocations`. Emits empty array on initial signal.
+  var suggestedLocations: Signal<[Location], Never> { get }
+}
+
+/// A use case for fetching locations for the purpose of filtering projects.
+public final class FetchLocationsUseCase: FetchLocationsUseCaseType, FetchLocationsUseCaseInputs,
+  FetchLocationsUseCaseDataOutputs {
+  public init(initialSignal: Signal<Void, Never>) {
+    let emptyArrayOnInitialSignal: Signal<[KsApi.Location], Never>
+      = initialSignal.mapConst([])
+
+    let defaultLocationsQuery = initialSignal
+      .switchMap {
+        let defaultLocations = GraphAPI.DefaultLocationsQuery(first: 1)
+        return AppEnvironment.current.apiService.fetch(query: defaultLocations).materialize()
+      }
+      .values()
+      .map { data in
+        KsApi.Location.locations(from: data)
+      }
+
+    self.defaultLocations = Signal.merge(emptyArrayOnInitialSignal, defaultLocationsQuery)
+
+    let locationQuery = self.locationQuerySignal.filter { !$0.isEmpty }
+    let emptyLocationQuery: Signal<[Location], Never> = self.locationQuerySignal.filter { $0.isEmpty }
+      .mapConst([])
+
+    let suggestedLocationsQuery = locationQuery
+      .switchMap { queryText in
+        let query = GraphAPI.LocationsByTermQuery(term: queryText, first: 10)
+        return AppEnvironment.current.apiService.fetch(query: query).materialize()
+      }
+      .values()
+      .map { data in
+        KsApi.Location.locations(from: data)
+      }
+
+    self.suggestedLocations = Signal.merge(
+      emptyArrayOnInitialSignal,
+      suggestedLocationsQuery,
+      emptyLocationQuery
+    )
+  }
+
+  private let (locationQuerySignal, locationQueryObserver) = Signal<String, Never>.pipe()
+  public func searchedForLocations(_ query: String) {
+    self.locationQueryObserver.send(value: query)
+  }
+
+  public let defaultLocations: Signal<[Location], Never>
+  public let suggestedLocations: Signal<[Location], Never>
+
+  public var inputs: FetchLocationsUseCaseInputs { return self }
+  public var dataOutputs: FetchLocationsUseCaseDataOutputs { return self }
+}

--- a/Library/UseCases/FetchLocations/FetchLocationsUseCaseTests.swift
+++ b/Library/UseCases/FetchLocations/FetchLocationsUseCaseTests.swift
@@ -1,0 +1,112 @@
+@testable import KsApi
+import Library
+import ReactiveExtensions_TestHelpers
+import ReactiveSwift
+import XCTest
+
+final class FetchLocationsUseCaseTests: TestCase {
+  private var useCase: FetchLocationsUseCase!
+  private let defaultLocations = TestObserver<[KsApi.Location], Never>()
+  private let suggestedLocations = TestObserver<[KsApi.Location], Never>()
+  private let (initialSignal, initialObserver) = Signal<Void, Never>.pipe()
+
+  override func setUp() {
+    super.setUp()
+
+    self.useCase = FetchLocationsUseCase(initialSignal: self.initialSignal)
+    self.useCase.dataOutputs.defaultLocations.observe(self.defaultLocations.observer)
+    self.useCase.dataOutputs.suggestedLocations.observe(self.suggestedLocations.observer)
+  }
+
+  func test_initialSignal_triggersEmptyOutputs() {
+    self.defaultLocations.assertDidNotEmitValue()
+    self.suggestedLocations.assertDidNotEmitValue()
+
+    self.initialObserver.send(value: ())
+
+    self.defaultLocations.assertLastValue([])
+    self.suggestedLocations.assertLastValue([])
+  }
+
+  func test_initialSignal_triggersDefaultLocationsToLoad() {
+    let response = try! GraphAPI.DefaultLocationsQuery.Data(jsonString: threeLocationsResponseJSON)
+    let mockService = MockService(fetchGraphQLResponses: [(
+      GraphAPI.DefaultLocationsQuery.self,
+      response
+    )])
+
+    withEnvironment(apiService: mockService) {
+      self.initialObserver.send(value: ())
+
+      if let defaultLocations = self.defaultLocations.lastValue {
+        XCTAssertTrue(defaultLocations.count == 3)
+      } else {
+        XCTFail("Expected defaultLocations locations to be sent")
+      }
+    }
+  }
+
+  func test_settingQuery_triggersSuggestedLocationsToLoad() {
+    let response = try! GraphAPI.LocationsByTermQuery.Data(jsonString: threeLocationsResponseJSON)
+    let mockService = MockService(fetchGraphQLResponses: [(
+      GraphAPI.LocationsByTermQuery.self,
+      response
+    )])
+
+    withEnvironment(apiService: mockService) {
+      self.initialObserver.send(value: ())
+
+      self.suggestedLocations.assertLastValue([])
+
+      self.useCase.inputs.searchedForLocations("fairfax")
+
+      if let suggestedLocations = self.suggestedLocations.lastValue {
+        XCTAssertTrue(suggestedLocations.count == 3, "Search should have returned results from response")
+      } else {
+        XCTFail("Expected suggested locations to be sent")
+      }
+
+      self.useCase.inputs.searchedForLocations("")
+
+      if let suggestedLocations = self.suggestedLocations.lastValue {
+        XCTAssertTrue(suggestedLocations.isEmpty, "Triggering an empty search should return empty results")
+      } else {
+        XCTFail("Expected suggested locations to be sent")
+      }
+    }
+  }
+}
+
+private let threeLocationsResponseJSON = """
+{
+    "locations": {
+      "__typename": "LocationsConnection",
+      "nodes": [
+        {
+          "__typename": "Location",
+          "country": "US",
+          "countryName": "United States",
+          "displayableName": "Fairfax, VA",
+          "id": "TG9jYXRpb24tMjQwMTM0OA==",
+          "name": "Fairfax"
+        },
+        {
+          "__typename": "Location",
+          "country": "US",
+          "countryName": "United States",
+          "displayableName": "Fairfax, CA",
+          "id": "TG9jYXRpb24tMjQwMTM0OQ==",
+          "name": "Fairfax"
+        },
+        {
+          "__typename": "Location",
+          "country": "US",
+          "countryName": "United States",
+          "displayableName": "Fairfax, Jacksonville, FL",
+          "id": "TG9jYXRpb24tMjkyMjk5NTk=",
+          "name": "Fairfax"
+        }
+      ]
+    }
+}
+"""

--- a/Library/UseCases/FetchLocations/FetchLocationsUseCaseTests.swift
+++ b/Library/UseCases/FetchLocations/FetchLocationsUseCaseTests.swift
@@ -29,7 +29,8 @@ final class FetchLocationsUseCaseTests: TestCase {
   }
 
   func test_initialSignal_triggersDefaultLocationsToLoad() {
-    let response = try! GraphAPI.DefaultLocationsQuery.Data(jsonString: threeLocationsResponseJSON)
+    let response: GraphAPI.DefaultLocationsQuery.Data =
+      try! testGraphObject(jsonString: threeLocationsResponseJSON)
     let mockService = MockService(fetchGraphQLResponses: [(
       GraphAPI.DefaultLocationsQuery.self,
       response
@@ -47,7 +48,8 @@ final class FetchLocationsUseCaseTests: TestCase {
   }
 
   func test_settingQuery_triggersSuggestedLocationsToLoad() {
-    let response = try! GraphAPI.LocationsByTermQuery.Data(jsonString: threeLocationsResponseJSON)
+    let response: GraphAPI.LocationsByTermQuery.Data =
+      try! testGraphObject(jsonString: threeLocationsResponseJSON)
     let mockService = MockService(fetchGraphQLResponses: [(
       GraphAPI.LocationsByTermQuery.self,
       response


### PR DESCRIPTION
# 📲 What

Add `FetchLocationsUseCase`. 

This is a small use case for getting default and suggested locations from the server. It will be used by `SearchFiltersUseCase`.

# 🤔 Why

Pulling this behavior out into its own use case makes it easy to test these network calls, and easier to test and hook up `SearchFiltersUseCase`.