### PR TITLE
Add RadioButtonList component

### DIFF
--- a/Kickstarter-iOS/Features/SortFilter/Components/RadioButtonList.swift
+++ b/Kickstarter-iOS/Features/SortFilter/Components/RadioButtonList.swift
@@ -1,0 +1,74 @@
+import Library
+import SwiftUI
+
+public struct RadioButtonList<Data: Identifiable>: View {
+  public struct Configuration {
+    let title: String
+    let isSelected: Bool
+  }
+
+  public let items: [Data]
+  public let didSelectItem: (Data) -> Void
+  public let itemConfiguration: (Data) -> (Configuration)
+
+  public var body: some View {
+    VStack(alignment: .leading, spacing: Constants.spacing) {
+      ForEach(self.items) { item in
+        let config = self.itemConfiguration(item)
+
+        Button {
+          self.didSelectItem(item)
+        } label: {
+          HStack(spacing: Constants.buttonLabelSpacing) {
+            RadioButton(isSelected: config.isSelected)
+            Text(config.title)
+              .font(InterFont.bodyLG.swiftUIFont())
+              .foregroundStyle(Colors.Text.primary.swiftUIColor())
+          }
+        }
+      }
+    }
+    .padding(Constants.padding)
+    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+  }
+}
+
+private enum Constants {
+  static let padding: CGFloat = 24.0
+  static let spacing: CGFloat = 24.0
+  static let buttonLabelSpacing: CGFloat = 8.0
+}
+
+private struct PreviewItem: Identifiable {
+  let id: Int
+  let title: String
+  let isSelected: Bool
+}
+
+#Preview {
+  RadioButtonList<PreviewItem>(
+    items: [
+      PreviewItem(
+        id: 1,
+        title: "Item One",
+        isSelected: false
+      ),
+      PreviewItem(
+        id: 2,
+        title: "Item Two",
+        isSelected: true
+      ),
+      PreviewItem(
+        id: 3,
+        title: "Item Three",
+        isSelected: false
+      )
+    ], didSelectItem: { _ in },
+    itemConfiguration: { item in
+      RadioButtonList.Configuration(
+        title: item.title,
+        isSelected: item.isSelected
+      )
+    }
+  )
+}

--- a/Kickstarter-iOS/Features/SortFilter/LocationView/LocationView.swift
+++ b/Kickstarter-iOS/Features/SortFilter/LocationView/LocationView.swift
@@ -3,7 +3,7 @@ import Library
 import SwiftUI
 
 public struct LocationView: View {
-  let defaultLocations: [Location]
+  let defaultLocations: [SearchFiltersDefaultLocation]
   let suggestedLocations: [Location]
   @Binding var selectedLocation: Location?
   let onSearchedForLocations: (String) -> Void
@@ -20,29 +20,31 @@ public struct LocationView: View {
   }
 
   @ViewBuilder var defaultLocationsList: some View {
-    VStack(alignment: .leading, spacing: Constants.spacing) {
-      Button {
-        self.selectedDefaultLocation(nil)
-      } label: {
-        // FIXME: MBL-2343 Add translations
-        self.buttonLabel(
-          title: "FPO: Anywhere",
-          isSelected: self.selectedLocation.isNil
-        )
-      }
-      ForEach(self.defaultLocations) { item in
-        Button {
-          self.selectedDefaultLocation(item)
-        } label: {
-          self.buttonLabel(
-            title: item.displayableName,
-            isSelected: self.selectedLocation?.id == item.id
+    RadioButtonList(
+      items: self.defaultLocations,
+      didSelectItem: { defaultLocation in
+        switch defaultLocation {
+        case .anywhere:
+          self.selectedDefaultLocation(nil)
+        case let .some(location):
+          self.selectedDefaultLocation(location)
+        }
+      },
+      itemConfiguration: { defaultLocation in
+        switch defaultLocation {
+        case .anywhere:
+          RadioButtonList.Configuration(
+            title: defaultLocation.title,
+            isSelected: self.selectedLocation == nil
+          )
+        case let .some(location):
+          RadioButtonList.Configuration(
+            title: defaultLocation.title,
+            isSelected: location == self.selectedLocation
           )
         }
       }
-    }
-    .padding(Constants.padding)
-    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    )
   }
 
   public var body: some View {

--- a/Kickstarter-iOS/Features/SortFilter/PercentRaisedView/PercentRaisedView.swift
+++ b/Kickstarter-iOS/Features/SortFilter/PercentRaisedView/PercentRaisedView.swift
@@ -7,28 +7,18 @@ public struct PercentRaisedView: View {
   @Binding var selectedBucket: DiscoveryParams.PercentRaisedBucket?
 
   public var body: some View {
-    VStack(alignment: .leading, spacing: Constants.spacing) {
-      ForEach(self.buckets) { bucket in
-        Button {
-          self.selectedBucket = bucket
-        } label: {
-          HStack(spacing: Constants.buttonLabelSpacing) {
-            RadioButton(isSelected: bucket == self.selectedBucket)
-            Text(bucket.title)
-              .font(InterFont.bodyLG.swiftUIFont())
-              .foregroundStyle(Colors.Text.primary.swiftUIColor())
-          }
-        }
+    RadioButtonList<DiscoveryParams.PercentRaisedBucket>(
+      items: self.buckets,
+      didSelectItem: { bucket in
+        self.selectedBucket = bucket
+      },
+      itemConfiguration: { bucket in
+        RadioButtonList.Configuration(
+          title: bucket.title,
+          isSelected: bucket == self.selectedBucket
+        )
       }
-    }
-    .padding(Constants.padding)
-    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-  }
-
-  internal enum Constants {
-    static let padding: CGFloat = 24.0
-    static let spacing: CGFloat = 24.0
-    static let buttonLabelSpacing: CGFloat = 8.0
+    )
   }
 }
 

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -1735,8 +1735,8 @@
 		E1BBB6722E035BE300291D48 /* FetchLocationsUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1BBB66E2E035BDD00291D48 /* FetchLocationsUseCaseTests.swift */; };
 		E1CFB5952D8E00C5004AB0D6 /* DiscoveryParams_Sort+SortOption.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1CFB5942D8E00C5004AB0D6 /* DiscoveryParams_Sort+SortOption.swift */; };
 		E1D569BB2E09D5CB00C78297 /* LocationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1D569B92E09D5CB00C78297 /* LocationView.swift */; };
-		E1D569BC2E09D5CB00C78297 /* DefaultLocationsList.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1D569B82E09D5CB00C78297 /* DefaultLocationsList.swift */; };
 		E1D569C32E0C720E00C78297 /* RadioButtonList.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1D569C22E0C720E00C78297 /* RadioButtonList.swift */; };
+		E1D569CA2E0DBB3700C78297 /* SearchFiltersDefaultLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1D569C92E0DBB2B00C78297 /* SearchFiltersDefaultLocation.swift */; };
 		E1DBB2372DAEBCE10050733F /* SearchFiltersHeaderViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1DBB2352DAEBCB60050733F /* SearchFiltersHeaderViewTests.swift */; };
 		E1EEED292B684AA7009976D9 /* PKCE.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1EEED282B684AA7009976D9 /* PKCE.swift */; };
 		E1F1DB3F2B7BC09C004EA80B /* Prelude in Frameworks */ = {isa = PBXBuildFile; productRef = E1F1DB3E2B7BC09C004EA80B /* Prelude */; };
@@ -3544,6 +3544,7 @@
 		E1CFB5942D8E00C5004AB0D6 /* DiscoveryParams_Sort+SortOption.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DiscoveryParams_Sort+SortOption.swift"; sourceTree = "<group>"; };
 		E1D569B92E09D5CB00C78297 /* LocationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationView.swift; sourceTree = "<group>"; };
 		E1D569C22E0C720E00C78297 /* RadioButtonList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadioButtonList.swift; sourceTree = "<group>"; };
+		E1D569C92E0DBB2B00C78297 /* SearchFiltersDefaultLocation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchFiltersDefaultLocation.swift; sourceTree = "<group>"; };
 		E1DBB2352DAEBCB60050733F /* SearchFiltersHeaderViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchFiltersHeaderViewTests.swift; sourceTree = "<group>"; };
 		E1EA34EE2AE1B28400942A04 /* Signal+Combine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Signal+Combine.swift"; sourceTree = "<group>"; };
 		E1EEED282B684AA7009976D9 /* PKCE.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PKCE.swift; sourceTree = "<group>"; };
@@ -7722,6 +7723,7 @@
 				E108416F2DCA7472000E4F17 /* SearchFiltersCategory.swift */,
 				E108416D2DCA6AC8000E4F17 /* SearchFiltersCategory.swift */,
 				AA7452A62D91BB8100DCB655 /* SearchFiltersUseCase.swift */,
+				E1D569C92E0DBB2B00C78297 /* SearchFiltersDefaultLocation.swift */,
 				AA7452A72D91BB8100DCB655 /* SearchFiltersUseCaseTests.swift */,
 				E182B7DA2DB2A80D000C4067 /* SearchFilters.swift */,
 				E182B7DC2DB2A845000C4067 /* SelectedSearchFilters+TestHelpers.swift */,
@@ -8558,6 +8560,7 @@
 				7705563B22BC03A600DCB062 /* TableViewStyles.swift in Sources */,
 				D6534D3A22E7878D00E9D279 /* CreditCard+Utils.swift in Sources */,
 				A75511601C8642C3005355CF /* GradientView.swift in Sources */,
+				E1D569CA2E0DBB3700C78297 /* SearchFiltersDefaultLocation.swift in Sources */,
 				A7CC13D31D00E6CF00035C52 /* FindFriendsFacebookConnectCellViewModel.swift in Sources */,
 				A75511611C8642C3005355CF /* Language.swift in Sources */,
 				373AB222222A058600769FC2 /* CreatePasswordViewModel.swift in Sources */,

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -1735,6 +1735,8 @@
 		E1BBB6722E035BE300291D48 /* FetchLocationsUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1BBB66E2E035BDD00291D48 /* FetchLocationsUseCaseTests.swift */; };
 		E1CFB5952D8E00C5004AB0D6 /* DiscoveryParams_Sort+SortOption.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1CFB5942D8E00C5004AB0D6 /* DiscoveryParams_Sort+SortOption.swift */; };
 		E1D569BB2E09D5CB00C78297 /* LocationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1D569B92E09D5CB00C78297 /* LocationView.swift */; };
+		E1D569BC2E09D5CB00C78297 /* DefaultLocationsList.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1D569B82E09D5CB00C78297 /* DefaultLocationsList.swift */; };
+		E1D569C32E0C720E00C78297 /* RadioButtonList.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1D569C22E0C720E00C78297 /* RadioButtonList.swift */; };
 		E1DBB2372DAEBCE10050733F /* SearchFiltersHeaderViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1DBB2352DAEBCB60050733F /* SearchFiltersHeaderViewTests.swift */; };
 		E1EEED292B684AA7009976D9 /* PKCE.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1EEED282B684AA7009976D9 /* PKCE.swift */; };
 		E1F1DB3F2B7BC09C004EA80B /* Prelude in Frameworks */ = {isa = PBXBuildFile; productRef = E1F1DB3E2B7BC09C004EA80B /* Prelude */; };
@@ -3541,6 +3543,7 @@
 		E1BBB66E2E035BDD00291D48 /* FetchLocationsUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchLocationsUseCaseTests.swift; sourceTree = "<group>"; };
 		E1CFB5942D8E00C5004AB0D6 /* DiscoveryParams_Sort+SortOption.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DiscoveryParams_Sort+SortOption.swift"; sourceTree = "<group>"; };
 		E1D569B92E09D5CB00C78297 /* LocationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationView.swift; sourceTree = "<group>"; };
+		E1D569C22E0C720E00C78297 /* RadioButtonList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadioButtonList.swift; sourceTree = "<group>"; };
 		E1DBB2352DAEBCB60050733F /* SearchFiltersHeaderViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchFiltersHeaderViewTests.swift; sourceTree = "<group>"; };
 		E1EA34EE2AE1B28400942A04 /* Signal+Combine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Signal+Combine.swift"; sourceTree = "<group>"; };
 		E1EEED282B684AA7009976D9 /* PKCE.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PKCE.swift; sourceTree = "<group>"; };
@@ -7756,6 +7759,7 @@
 		E19900A92DE634E20082F05E /* Components */ = {
 			isa = PBXGroup;
 			children = (
+				E1D569C22E0C720E00C78297 /* RadioButtonList.swift */,
 				E19900AA2DE634F10082F05E /* RadioButton.swift */,
 			);
 			path = Components;
@@ -9303,6 +9307,7 @@
 				E1BAA03B2C1A1CCD004F8B06 /* PPOView.swift in Sources */,
 				336194E32D8A95D200BED4BD /* SortView.swift in Sources */,
 				6049D0242AA7940E0015BB0D /* DemoCTAContainerView.swift in Sources */,
+				E1D569C32E0C720E00C78297 /* RadioButtonList.swift in Sources */,
 				778CCC5222822B5D00FB8D35 /* SheetOverlayTransitionAnimator.swift in Sources */,
 				D04F48D41E0313FB00EDC98A /* ActivityProjectStatusCell.swift in Sources */,
 				E10675642DA58AB4007CCA24 /* PillButtons.swift in Sources */,

--- a/Library/UseCases/SearchFilters/SearchFilters.swift
+++ b/Library/UseCases/SearchFilters/SearchFilters.swift
@@ -31,7 +31,7 @@ public class SearchFilters: ObservableObject {
   }
 
   public struct LocationOptions {
-    public var defaultLocations: [Location]
+    public var defaultLocations: [SearchFiltersDefaultLocation]
     public var suggestedLocations: [Location]
     public var selectedLocation: Location?
   }
@@ -132,7 +132,7 @@ public class SearchFilters: ObservableObject {
   }
 
   func update(
-    withDefaultSearchLocations locations: [Location]
+    withDefaultSearchLocations locations: [SearchFiltersDefaultLocation]
   ) {
     self.objectWillChange.send()
     self.location.defaultLocations = locations

--- a/Library/UseCases/SearchFilters/SearchFiltersDefaultLocation.swift
+++ b/Library/UseCases/SearchFilters/SearchFiltersDefaultLocation.swift
@@ -1,0 +1,36 @@
+import KsApi
+
+public enum SearchFiltersDefaultLocation: Identifiable, Equatable {
+  case anywhere
+  case some(KsApi.Location)
+
+  public var id: Int {
+    switch self {
+    case .anywhere:
+      -1
+    case let .some(location):
+      location.id
+    }
+  }
+
+  public var title: String {
+    switch self {
+    case .anywhere:
+      // FIXME: MBL-2343 Add translations
+      "FPO: Anywhere"
+    case let .some(location):
+      location.displayableName
+    }
+  }
+}
+
+public func == (lhs: SearchFiltersDefaultLocation, rhs: SearchFiltersDefaultLocation) -> Bool {
+  switch (lhs, rhs) {
+  case (.anywhere, .anywhere):
+    true
+  case let (.some(lhsLocation), .some(rhsLocation)):
+    lhsLocation.id == rhsLocation.id
+  default:
+    false
+  }
+}

--- a/Library/UseCases/SearchFilters/SearchFiltersUseCase.swift
+++ b/Library/UseCases/SearchFilters/SearchFiltersUseCase.swift
@@ -60,8 +60,12 @@ public final class SearchFiltersUseCase: SearchFiltersUseCaseType, SearchFilters
     suggestedLocations: Signal<[KsApi.Location], Never>
   ) {
     self.categoriesProperty <~ categories
-    self.defaultLocationsProperty <~ defaultLocations
     self.suggestedLocationsProperty <~ suggestedLocations
+    self.defaultLocationsProperty <~ defaultLocations
+      .map { locations in
+        let defaults = locations.map { SearchFiltersDefaultLocation.some($0) }
+        return [.anywhere] + defaults
+      }
 
     self.showFilters = self.tappedFilterTypeSignal
       .map { pill in
@@ -189,7 +193,7 @@ public final class SearchFiltersUseCase: SearchFiltersUseCaseType, SearchFilters
   fileprivate let selectedLocationProperty = MutableProperty<Location?>(nil)
 
   fileprivate let categoriesProperty = MutableProperty<[KsApi.Category]>([])
-  fileprivate let defaultLocationsProperty = MutableProperty<[KsApi.Location]>([])
+  fileprivate let defaultLocationsProperty = MutableProperty<[SearchFiltersDefaultLocation]>([])
   fileprivate let suggestedLocationsProperty = MutableProperty<[KsApi.Location]>([])
 
   internal static let defaultSortOption = DiscoveryParams.Sort.magic

--- a/Library/UseCases/SearchFilters/SearchFiltersUseCaseTests.swift
+++ b/Library/UseCases/SearchFilters/SearchFiltersUseCaseTests.swift
@@ -207,8 +207,13 @@ final class SearchFiltersUseCaseTests: TestCase {
       XCTAssertEqual(type, .location, "Tapping percent raised button should percent raised options")
       XCTAssertEqual(
         self.useCase.uiOutputs.searchFilters.location.defaultLocations.count,
-        3,
-        "There should be three default locations set"
+        4,
+        "There should be four default locations set"
+      )
+      XCTAssertEqual(
+        self.useCase.uiOutputs.searchFilters.location.defaultLocations[0],
+        .anywhere,
+        "The first default location should be 'anywhere'"
       )
       XCTAssertEqual(
         self.useCase.uiOutputs.searchFilters.location.suggestedLocations.count,


### PR DESCRIPTION
# 📲 What

* Add `RadioButtonList` component for search filters
* Refactor `LocationView` and `PercentRaisedView` to use `RadioButtonList`, instead of their own copies
* Refactor some plumbing so that the code to insert `Anywhere` as a default location happens in `SearchFiltersUseCase`, instead of in the UI.

# 🤔 Why

This consolidates some common UI in search filters. I wanted this `RadioButtonList` for Amount Raised.
