### PR TITLE
Hotfix: Preselect the original payment plan when editing a Pledge Over Time

### DIFF
--- a/Kickstarter-iOS/Features/PledgeView/Controllers/PledgeViewController.swift
+++ b/Kickstarter-iOS/Features/PledgeView/Controllers/PledgeViewController.swift
@@ -377,6 +377,7 @@ final class PledgeViewController: UIViewController,
 
     self.localPickupLocationView.rac.hidden = self.viewModel.outputs.localPickupViewHidden
     self.paymentMethodsViewController.view.rac.hidden = self.viewModel.outputs.paymentMethodsViewHidden
+    self.paymentSectionLabel.rac.hidden = self.viewModel.outputs.paymentMethodsViewHidden
 
     self.viewModel.outputs.title
       .observeForUI()

--- a/Library/ViewModels/PaymentMethodsUseCase.swift
+++ b/Library/ViewModels/PaymentMethodsUseCase.swift
@@ -77,7 +77,7 @@ public final class PaymentMethodsUseCase: PaymentMethodsUseCaseType, PaymentMeth
 
     let notChangingPaymentMethod = context.map { context in
       if context.isUpdating {
-        return context == .updateReward
+        return context == .updateReward || context == .editPledgeOverTime
       }
 
       return false

--- a/Library/ViewModels/PledgeOverTimeUseCase.swift
+++ b/Library/ViewModels/PledgeOverTimeUseCase.swift
@@ -113,15 +113,17 @@ public final class PledgeOverTimeUseCase: PledgeOverTimeUseCaseType, PledgeOverT
         pledgeOverTimeApiValues: GraphAPI.BuildPaymentPlanQuery.Data?
       ) -> PledgePaymentPlansAndSelectionData? in
 
-        let isPledgeOverTimePreSelected = project.personalization.backing?.paymentIncrements.isEmpty == false
-
-        let defaultPlan = isPledgeOverTimePreSelected ?
-          PledgePaymentPlansType.pledgeOverTime :
-          PledgePaymentPlansType.pledgeInFull
-
         // Wrap the value in `nil` to ensure the Signal emits consistently,
         // even when the API request fails or Pledge Over Time is disabled.
         guard let paymentPlan = pledgeOverTimeApiValues?.project?.paymentPlan else { return nil }
+
+        let isPledgeOverTimePreSelected = project.personalization.backing?.paymentIncrements.isEmpty == false
+        let isPledgeOverTimeEligible = paymentPlan.amountIsPledgeOverTimeEligible
+
+        // Retain PLOT pre-selection only if the new pledge amount meets the eligibility threshold (amountIsPledgeOverTimeEligible)
+        let defaultPlan = isPledgeOverTimePreSelected && isPledgeOverTimeEligible ?
+          PledgePaymentPlansType.pledgeOverTime :
+          PledgePaymentPlansType.pledgeInFull
 
         return PledgePaymentPlansAndSelectionData(
           withPaymentPlanFragment: paymentPlan,

--- a/Library/ViewModels/PledgeOverTimeUseCase.swift
+++ b/Library/ViewModels/PledgeOverTimeUseCase.swift
@@ -47,21 +47,21 @@ public final class PledgeOverTimeUseCase: PledgeOverTimeUseCaseType, PledgeOverT
       .map { ($0.isPledgeOverTimeAllowed ?? false) && featurePledgeOverTimeEnabled() }
 
     self.buildPaymentPlanInputs = Signal.combineLatest(
-        project,
-        // just re-evaluate if the total is changed
-        pledgeTotal.skipRepeats()
-      )
-      .map { (project: Project, pledgeTotal: Double) -> (
-        String,
-        String
-      ) in
-        let amountFormatter = NumberFormatter()
-        amountFormatter.minimumFractionDigits = 2
-        amountFormatter.maximumFractionDigits = 2
-        let amount = amountFormatter.string(from: NSNumber(value: pledgeTotal)) ?? ""
+      project,
+      // just re-evaluate if the total is changed
+      pledgeTotal.skipRepeats()
+    )
+    .map { (project: Project, pledgeTotal: Double) -> (
+      String,
+      String
+    ) in
+      let amountFormatter = NumberFormatter()
+      amountFormatter.minimumFractionDigits = 2
+      amountFormatter.maximumFractionDigits = 2
+      let amount = amountFormatter.string(from: NSNumber(value: pledgeTotal)) ?? ""
 
-        return (project.slug, amount)
-      }
+      return (project.slug, amount)
+    }
 
     let pledgeOverTimeQuery = self.buildPaymentPlanInputs
       .switchMap { (
@@ -112,13 +112,13 @@ public final class PledgeOverTimeUseCase: PledgeOverTimeUseCaseType, PledgeOverT
         project: Project,
         pledgeOverTimeApiValues: GraphAPI.BuildPaymentPlanQuery.Data?
       ) -> PledgePaymentPlansAndSelectionData? in
-        
+
         let isPledgeOverTimePreSelected = project.personalization.backing?.paymentIncrements.isEmpty == false
 
         let defaultPlan = isPledgeOverTimePreSelected ?
           PledgePaymentPlansType.pledgeOverTime :
           PledgePaymentPlansType.pledgeInFull
-        
+
         // Wrap the value in `nil` to ensure the Signal emits consistently,
         // even when the API request fails or Pledge Over Time is disabled.
         guard let paymentPlan = pledgeOverTimeApiValues?.project?.paymentPlan else { return nil }

--- a/Library/ViewModels/PledgeViewModel.swift
+++ b/Library/ViewModels/PledgeViewModel.swift
@@ -603,7 +603,7 @@ public class PledgeViewModel: PledgeViewModelType, PledgeViewModelInputs,
         context,
         selectedPaymentPlan
         -> UpdateBackingData in
-      var paymentSourceId = selectedPaymentSource?.savedCreditCardId
+      let paymentSourceId = selectedPaymentSource?.savedCreditCardId
 
       return (
         backing: backing,


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

This PR improves the default selection logic for the payment plan in the "Edit Pledge Over Time" flow.

Specifically:
	- The default selected plan will now reflect the backer's original selection (i.e., if they selected **Pledge In Full** originally, that will remain selected when editing).
	- Previously, the default was always **Pledge In Full**, regardless of the backer's choice.


# 🛠 How

This change uses `backing.paymentIncrements.isEmpty` to determine whether **Pledge Over Time** or **Pledge In Full** should be preselected.

- Retain PLOT pre-selection only if the new pledge amount meets the eligibility threshold (amountIsPledgeOverTimeEligible)

Added a new variable:

```swift
let isPledgeOverTimePreSelected = project.personalization.backing?.paymentIncrements.isEmpty == false
let isPledgeOverTimeEligible = paymentPlan.amountIsPledgeOverTimeEligible

let defaultPlan = isPledgeOverTimePreSelected && isPledgeOverTimeEligible ? 
    PledgePaymentPlansType.pledgeOverTime :
    PledgePaymentPlansType.pledgeInFull
```

- Also update `notChangingPaymentMethod` to include the `.editPledgeOverTime` context, this allow to the PLOT Edit Pledge to continue with the backing updates.

The `notChangingPaymentMethod` now looks like:
```swift
let notChangingPaymentMethod = context.map { context in
      if context.isUpdating {
        return context == .updateReward || context == .editPledgeOverTime
      }

      return false
    }
```

# 👀 See

![Simulator Screen Recording - iPhone 16 Pro - 2025-06-30 at 12 40 18](https://github.com/user-attachments/assets/3a6203ac-9396-47f5-87c8-2088a0328c52)

# ✅ Acceptance criteria

- [ ] Pre-selected option load as default
- [ ] Retain PLOT pre-selection only if the new pledge amount meets the eligibility threshold (amountIsPledgeOverTimeEligible)

