### PR TITLE
[MBL-2547] Show "Go to Pledge Manager" button for existing backers

### DIFF
--- a/KsApi/models/Project.swift
+++ b/KsApi/models/Project.swift
@@ -510,11 +510,11 @@ extension Project: GraphIDBridging {
 extension Project.Video: Decodable {}
 
 extension Project {
-  public var acceptsNetNewBackersForPM: Bool {
+  public var pledgeManagementAvailable: Bool {
     let isBacking = self.personalizationIsBacking ?? false
     let lastWaveActive = self.lastWave?.active ?? false
     let pmAcceptsNewBackers = self.pledgeManager?.acceptsNewBackers ?? false
 
-    return !isBacking && lastWaveActive && pmAcceptsNewBackers
+    return lastWaveActive && (pmAcceptsNewBackers || isBacking)
   }
 }

--- a/Library/ViewModels/PledgeCTAContainerViewViewModel.swift
+++ b/Library/ViewModels/PledgeCTAContainerViewViewModel.swift
@@ -211,15 +211,15 @@ private func pledgeCTA(project: Project, backing: Backing?) -> PledgeStateCTATyp
     return .prelaunch(saved: projectIsSaved, watchCount: project.watchesCount ?? 0)
   }
 
+  if featureNetNewBackersGoToPMEnabled() && project.pledgeManagementAvailable {
+    return PledgeStateCTAType.pledgeManager
+  }
+
   let isInPostCampaign = featurePostCampaignPledgeEnabled() && project.isInPostCampaignPledgingPhase
 
   guard let projectBacking = backing, project.personalization.isBacking == .some(true) else {
     if currentUserIsCreator(of: project) {
       return PledgeStateCTAType.viewYourRewards
-    }
-
-    if featureNetNewBackersGoToPMEnabled() && project.acceptsNetNewBackersForPM {
-      return PledgeStateCTAType.pledgeManager
     }
 
     if isInPostCampaign {

--- a/Library/ViewModels/PledgeCTAContainerViewViewModelTests.swift
+++ b/Library/ViewModels/PledgeCTAContainerViewViewModelTests.swift
@@ -136,7 +136,7 @@ internal final class PledgeCTAContainerViewViewModelTests: TestCase {
     }
   }
 
-  func testPledgeCTA_ExistingBackerBackerGoToPM() {
+  func testPledgeCTA_ExistingBackerGoToPM() {
     let mockConfigClient = MockRemoteConfigClient()
 
     mockConfigClient.features = [

--- a/Library/ViewModels/PledgeCTAContainerViewViewModelTests.swift
+++ b/Library/ViewModels/PledgeCTAContainerViewViewModelTests.swift
@@ -136,6 +136,27 @@ internal final class PledgeCTAContainerViewViewModelTests: TestCase {
     }
   }
 
+  func testPledgeCTA_ExistingBackerBackerGoToPM() {
+    let mockConfigClient = MockRemoteConfigClient()
+
+    mockConfigClient.features = [
+      RemoteConfigFeature.netNewBackersGoToPM.rawValue: true
+    ]
+
+    withEnvironment(remoteConfigClient: mockConfigClient) {
+      let project = Project.netNewBacker
+        |> Project.lens.personalization.backing .~ Backing.template
+        |> Project.lens.personalization.isBacking .~ true
+        |> Project.lens.pledgeManager .~ nil
+
+      self.vm.inputs.configureWith(value: (.left((project, nil)), false))
+      self.buttonStyleType.assertValues([ButtonStyleType.black])
+      self.buttonTitleText.assertValues([Strings.Go_to_pledge_manager()])
+      self.spacerIsHidden.assertValues([true])
+      self.stackViewIsHidden.assertValues([true])
+    }
+  }
+
   func testPledgeCTA_NonBacker_LiveProject_loggedOut() {
     let project = Project.template
       |> Project.lens.personalization.isBacking .~ nil


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Currently, we only show the go to pledge manager button on the project page for net new backers. We should also show it for existing backers!

# 🛠 How

Show go to pledge manager flow for net-new backers || existing backers.

# 👀 See

- [MBL-2547](https://kickstarter.atlassian.net/browse/MBL-2547)

![Simulator Screen Recording - iPhone 16 Pro - 2025-07-01 at 12 47 06](https://github.com/user-attachments/assets/d464ded0-dbb6-490a-b0ff-f3eb76413c65)

# ✅ Acceptance criteria

- [x] "Go to Pledge Manager" should show for both **Net New backers** and **Existing Backers**



[MBL-2547]: https://kickstarter.atlassian.net/browse/MBL-2547?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ