### PR TITLE
MBL-2581: Remove discoverable from LocationsByTermQuery

### DIFF
--- a/KsApi/GraphAPI.swift
+++ b/KsApi/GraphAPI.swift
@@ -14528,7 +14528,7 @@ public enum GraphAPI {
     public let operationDefinition: String =
       """
       query LocationsByTerm($term: String, $first: Int) {
-        locations(term: $term, first: $first, discoverable: true) {
+        locations(term: $term, first: $first) {
           __typename
           nodes {
             __typename
@@ -14563,7 +14563,7 @@ public enum GraphAPI {
 
       public static var selections: [GraphQLSelection] {
         return [
-          GraphQLField("locations", arguments: ["term": GraphQLVariable("term"), "first": GraphQLVariable("first"), "discoverable": true], type: .object(Location.selections)),
+          GraphQLField("locations", arguments: ["term": GraphQLVariable("term"), "first": GraphQLVariable("first")], type: .object(Location.selections)),
         ]
       }
 

--- a/KsApi/queries/LocationsByTermQuery.graphql
+++ b/KsApi/queries/LocationsByTermQuery.graphql
@@ -1,5 +1,5 @@
 query LocationsByTerm($term: String, $first: Int) {
-  locations(term: $term, first: $first, discoverable: true) {
+  locations(term: $term, first: $first) {
     nodes {
       ...LocationFragment
     }


### PR DESCRIPTION
# 📲 What

Remove `discoverable` from `LocationsByTermQuery`.

# 🤔 Why

This parameter was filtering out results which _technically_ have no projects (like "United States"), but which are valid filtering options. 

Projects are assigned on a city level, but users can search at a higher radius.