### PR TITLE
Refactor interface to SearchFiltersUseCase

### DIFF
--- a/Kickstarter-iOS/Features/Search/Controller/SearchViewController.swift
+++ b/Kickstarter-iOS/Features/Search/Controller/SearchViewController.swift
@@ -207,7 +207,7 @@ internal final class SearchViewController: UITableViewController {
     let sortView = SortView(
       viewModel: sortViewModel,
       onSelectedSort: { [weak self] sortOption in
-        self?.viewModel.inputs.selectedSortOption(sortOption)
+        self?.viewModel.inputs.selectedFilter(.sort(sortOption))
       },
       onClosed: { [weak self] in
         self?.dismiss(animated: true)
@@ -223,23 +223,11 @@ internal final class SearchViewController: UITableViewController {
       filterType: filterType,
       searchFilters: self.viewModel.outputs.searchFilters
     )
-    filterView.onSelectedProjectState = { [weak self] state in
-      self?.viewModel.inputs.selectedProjectState(state)
-    }
-    filterView.onSelectedCategory = { [weak self] category in
-      self?.viewModel.inputs.selectedCategory(category)
-    }
-    filterView.onSelectedPercentRaisedBucket = { [weak self] bucket in
-      self?.viewModel.inputs.selectedPercentRaisedBucket(bucket)
-    }
-    filterView.onSelectedLocation = { [weak self] location in
-      self?.viewModel.inputs.filteredLocation(location)
+    filterView.onFilter = { [weak self] filterEvent in
+      self?.viewModel.inputs.selectedFilter(filterEvent)
     }
     filterView.onSearchedForLocations = { [weak self] locationQuery in
       self?.viewModel.inputs.searchedForLocations(locationQuery)
-    }
-    filterView.onSelectedAmountRaisedBucket = { [weak self] bucket in
-      self?.viewModel.inputs.selectedAmountRaisedBucket(bucket)
     }
     filterView.onReset = { [weak self] type in
       self?.viewModel.inputs.resetFilters(for: type)

--- a/Kickstarter-iOS/Features/SortFilter/FilterRootView/FilterRootView.swift
+++ b/Kickstarter-iOS/Features/SortFilter/FilterRootView/FilterRootView.swift
@@ -6,11 +6,7 @@ struct FilterRootView: View {
   @State var navigationState: [SearchFilterModalType]
   @ObservedObject var searchFilters: SearchFilters
 
-  var onSelectedCategory: ((SearchFiltersCategory) -> Void)? = nil
-  var onSelectedProjectState: ((DiscoveryParams.State) -> Void)? = nil
-  var onSelectedPercentRaisedBucket: ((DiscoveryParams.PercentRaisedBucket) -> Void)? = nil
-  var onSelectedLocation: ((Location?) -> Void)? = nil
-  var onSelectedAmountRaisedBucket: ((DiscoveryParams.AmountRaisedBucket) -> Void)? = nil
+  var onFilter: ((SearchFilterEvent) -> Void)? = nil
   var onSearchedForLocations: ((String) -> Void)? = nil
   var onReset: ((SearchFilterModalType) -> Void)? = nil
   var onResults: (() -> Void)? = nil
@@ -20,8 +16,8 @@ struct FilterRootView: View {
     Binding {
       self.searchFilters.category.selectedCategory
     } set: { newValue in
-      if let action = self.onSelectedCategory {
-        action(newValue)
+      if let action = self.onFilter {
+        action(.category(newValue))
       }
     }
   }
@@ -30,9 +26,9 @@ struct FilterRootView: View {
     Binding {
       self.searchFilters.percentRaised.selectedBucket
     } set: { newValue in
-      if let action = self.onSelectedPercentRaisedBucket,
+      if let action = self.onFilter,
          let bucket = newValue {
-        action(bucket)
+        action(.percentRaised(bucket))
       }
     }
   }
@@ -41,8 +37,8 @@ struct FilterRootView: View {
     Binding {
       self.searchFilters.location.selectedLocation
     } set: { newValue in
-      if let action = self.onSelectedLocation {
-        action(newValue)
+      if let action = self.onFilter {
+        action(.location(newValue))
       }
     }
   }
@@ -51,9 +47,9 @@ struct FilterRootView: View {
     Binding {
       self.searchFilters.amountRaised.selectedBucket
     } set: { newValue in
-      if let action = self.onSelectedAmountRaisedBucket,
+      if let action = self.onFilter,
          let bucket = newValue {
-        action(bucket)
+        action(.amountRaised(bucket))
       }
     }
   }
@@ -85,8 +81,8 @@ struct FilterRootView: View {
       FlowLayout(spacing: Constants.flowLayoutSpacing) {
         ForEach(self.searchFilters.projectState.stateOptions) { state in
           Button(action: {
-            if let action = onSelectedProjectState {
-              action(state)
+            if let action = self.onFilter {
+              action(.projectState(state))
             }
           }, label: {
             Text(state.title)

--- a/Library/UseCases/SearchFilters/SearchFiltersUseCase.swift
+++ b/Library/UseCases/SearchFilters/SearchFiltersUseCase.swift
@@ -64,35 +64,14 @@ public final class SearchFiltersUseCase: SearchFiltersUseCaseType, SearchFilters
         return modalType
       }
 
-    self.selectedSort = Signal.merge(
-      self.selectedSortProperty.producer.takeWhen(initialSignal),
-      self.selectedSortProperty.signal
-    )
-
-    self.selectedCategory = Signal.merge(
-      self.selectedCategoryProperty.producer.takeWhen(initialSignal),
-      self.selectedCategoryProperty.signal
-    )
-
-    self.selectedState = Signal.merge(
-      self.selectedStateProperty.producer.takeWhen(initialSignal),
-      self.selectedStateProperty.signal
-    )
-
-    self.selectedPercentRaisedBucket = Signal.merge(
-      self.selectedPercentRaisedBucketProperty.producer.takeWhen(initialSignal),
-      self.selectedPercentRaisedBucketProperty.signal
-    )
-
-    self.selectedLocation = Signal.merge(
-      self.selectedLocationProperty.producer.takeWhen(initialSignal),
-      self.selectedLocationProperty.signal
-    )
-
-    self.selectedAmountRaisedBucket = Signal.merge(
-      self.selectedAmountRaisedBucketProperty.producer.takeWhen(initialSignal),
-      self.selectedAmountRaisedBucketProperty.signal
-    )
+    self.selectedSort = self.selectedSortProperty.signal(takeInitialValueWhen: initialSignal)
+    self.selectedCategory = self.selectedCategoryProperty.signal(takeInitialValueWhen: initialSignal)
+    self.selectedState = self.selectedStateProperty.signal(takeInitialValueWhen: initialSignal)
+    self.selectedPercentRaisedBucket = self.selectedPercentRaisedBucketProperty
+      .signal(takeInitialValueWhen: initialSignal)
+    self.selectedLocation = self.selectedLocationProperty.signal(takeInitialValueWhen: initialSignal)
+    self.selectedAmountRaisedBucket = self.selectedAmountRaisedBucketProperty
+      .signal(takeInitialValueWhen: initialSignal)
 
     let sortOptions = SearchFilters.SortOptions(
       sortOptions: self.sortOptions,
@@ -324,3 +303,14 @@ public enum SearchFilterEvent {
 }
 
 private extension GraphAPI.LocationsByTermQuery.Data.Location {}
+
+private extension MutableProperty {
+  /// Emits its current value when `takeInitialValueWhen` is sent, and whenever the value changes, too.
+  /// Useful for turning a `MutableProperty` with a default value into a `signal`.
+  func signal(takeInitialValueWhen initialSignal: Signal<Void, Never>) -> Signal<Value, Never> {
+    return Signal.merge(
+      self.producer.takeWhen(initialSignal),
+      self.signal
+    )
+  }
+}

--- a/Library/UseCases/SearchFilters/SearchFiltersUseCase.swift
+++ b/Library/UseCases/SearchFilters/SearchFiltersUseCase.swift
@@ -73,41 +73,29 @@ public final class SearchFiltersUseCase: SearchFiltersUseCaseType, SearchFilters
     self.selectedAmountRaisedBucket = self.selectedAmountRaisedBucketProperty
       .signal(takeInitialValueWhen: initialSignal)
 
-    let sortOptions = SearchFilters.SortOptions(
-      sortOptions: self.sortOptions,
-      selectedSort: self.selectedSortProperty.value
-    )
-
-    let categoryOptions = SearchFilters.CategoryOptions(
-      categories: self.categoriesProperty.value,
-      selectedCategory: self.selectedCategoryProperty.value
-    )
-
-    let projectStateOptions = SearchFilters.ProjectStateOptions(
-      stateOptions: self.stateOptions,
-      selectedProjectState: self.selectedStateProperty.value
-    )
-
-    let percentRaisedOptions = SearchFilters.PercentRaisedOptions(
-      buckets: DiscoveryParams.PercentRaisedBucket.allCases
-    )
-
-    let locationOptions = SearchFilters.LocationOptions(
-      defaultLocations: self.defaultLocationsProperty.value,
-      suggestedLocations: self.suggestedLocationsProperty.value
-    )
-
-    let amountRaisedOptions = SearchFilters.AmountRaisedOptions(
-      buckets: DiscoveryParams.AmountRaisedBucket.allCases
-    )
-
     self.searchFilters = SearchFilters(
-      sort: sortOptions,
-      category: categoryOptions,
-      projectState: projectStateOptions,
-      percentRaised: percentRaisedOptions,
-      location: locationOptions,
-      amountRaised: amountRaisedOptions
+      sort: SearchFilters.SortOptions(
+        sortOptions: self.sortOptions,
+        selectedSort: self.selectedSortProperty.value
+      ),
+      category: SearchFilters.CategoryOptions(
+        categories: self.categoriesProperty.value,
+        selectedCategory: self.selectedCategoryProperty.value
+      ),
+      projectState: SearchFilters.ProjectStateOptions(
+        stateOptions: self.stateOptions,
+        selectedProjectState: self.selectedStateProperty.value
+      ),
+      percentRaised: SearchFilters.PercentRaisedOptions(
+        buckets: DiscoveryParams.PercentRaisedBucket.allCases
+      ),
+      location: SearchFilters.LocationOptions(
+        defaultLocations: self.defaultLocationsProperty.value,
+        suggestedLocations: self.suggestedLocationsProperty.value
+      ),
+      amountRaised: SearchFilters.AmountRaisedOptions(
+        buckets: DiscoveryParams.AmountRaisedBucket.allCases
+      )
     )
 
     Signal.combineLatest(

--- a/Library/UseCases/SearchFilters/SearchFiltersUseCaseTests.swift
+++ b/Library/UseCases/SearchFilters/SearchFiltersUseCaseTests.swift
@@ -276,7 +276,7 @@ final class SearchFiltersUseCaseTests: TestCase {
     self.useCase.inputs.tappedButton(forFilterType: .category)
     self.showFilters.assertDidEmitValue()
 
-    self.useCase.inputs.selectedCategory(.rootCategory(.art))
+    self.useCase.inputs.selectedFilter(.category(.rootCategory(.art)))
 
     guard let newCategory = self.selectedCategory.lastValue else {
       XCTFail("There should be a new selected category")
@@ -295,7 +295,7 @@ final class SearchFiltersUseCaseTests: TestCase {
     self.useCase.inputs.tappedButton(forFilterType: .sort)
     self.showFilters.assertDidEmitValue()
 
-    self.useCase.inputs.selectedSortOption(.endingSoon)
+    self.useCase.inputs.selectedFilter(.sort(.endingSoon))
 
     guard let newSelectedSort = self.selectedSort.lastValue else {
       XCTFail("There should be a new selected sort option")
@@ -310,7 +310,7 @@ final class SearchFiltersUseCaseTests: TestCase {
 
     self.assert_selectedProjectState_isDefault()
 
-    self.useCase.inputs.selectedProjectState(.late_pledge)
+    self.useCase.inputs.selectedFilter(.projectState(.late_pledge))
 
     guard let newSelectedState = self.selectedState.lastValue else {
       XCTFail("There should be a new selected state")
@@ -325,7 +325,7 @@ final class SearchFiltersUseCaseTests: TestCase {
 
     self.assert_selectedPercentRaisedBucket_isDefault()
 
-    self.useCase.inputs.selectedPercentRaisedBucket(.bucket_1)
+    self.useCase.inputs.selectedFilter(.percentRaised(.bucket_1))
 
     guard let newSelectedBucket = self.selectedPercentRaisedBucket.lastValue else {
       XCTFail("There should be a new selected bucket")
@@ -340,7 +340,7 @@ final class SearchFiltersUseCaseTests: TestCase {
 
     self.assert_selectedAmountRaisedBucket_isDefault()
 
-    self.useCase.inputs.selectedAmountRaisedBucket(.bucket_3)
+    self.useCase.inputs.selectedFilter(.amountRaised(.bucket_3))
 
     guard let newSelectedBucket = self.selectedAmountRaisedBucket.lastValue else {
       XCTFail("There should be a new selected bucket")
@@ -357,7 +357,7 @@ final class SearchFiltersUseCaseTests: TestCase {
 
     let location = threeLocations[1]
 
-    self.useCase.inputs.filteredLocation(location)
+    self.useCase.inputs.selectedFilter(.location(location))
 
     guard let newSelectedLocation = self.selectedLocation.lastValue else {
       XCTFail("There should be a new selected location")
@@ -386,7 +386,7 @@ final class SearchFiltersUseCaseTests: TestCase {
       XCTFail("Expected sort pill to be set")
     }
 
-    self.useCase.inputs.selectedSortOption(.endingSoon)
+    self.useCase.inputs.selectedFilter(.sort(.endingSoon))
 
     if let sortPill = self.useCase.uiOutputs.searchFilters.sortPill {
       XCTAssertEqual(
@@ -430,7 +430,10 @@ final class SearchFiltersUseCaseTests: TestCase {
       "Category pill should have placeholder text when no category is selected"
     )
 
-    self.useCase.inputs.selectedCategory(.subcategory(rootCategory: .art, subcategory: .illustration))
+    self.useCase.inputs.selectedFilter(.category(.subcategory(
+      rootCategory: .art,
+      subcategory: .illustration
+    )))
 
     guard let newCategoryPill = self.useCase.uiOutputs.searchFilters.categoryPill else {
       XCTFail("Category pill is missing.")
@@ -470,7 +473,7 @@ final class SearchFiltersUseCaseTests: TestCase {
       XCTFail("Expected percent raised pill to be set")
     }
 
-    self.useCase.inputs.selectedPercentRaisedBucket(.bucket_2)
+    self.useCase.inputs.selectedFilter(.percentRaised(.bucket_2))
 
     if let pill = self.useCase.uiOutputs.searchFilters.percentRaisedPill {
       XCTAssertEqual(
@@ -516,7 +519,7 @@ final class SearchFiltersUseCaseTests: TestCase {
         XCTFail("Expected percent raised pill to be set")
       }
 
-      self.useCase.inputs.selectedAmountRaisedBucket(.bucket_3)
+      self.useCase.inputs.selectedFilter(.amountRaised(.bucket_3))
 
       if let pill = self.useCase.uiOutputs.searchFilters.amountRaisedPill {
         XCTAssertEqual(
@@ -565,7 +568,7 @@ final class SearchFiltersUseCaseTests: TestCase {
 
       let location = threeLocations[0]
 
-      self.useCase.inputs.filteredLocation(location)
+      self.useCase.inputs.selectedFilter(.location(location))
 
       if let pill = self.useCase.uiOutputs.searchFilters.locationPill {
         XCTAssertEqual(
@@ -598,13 +601,13 @@ final class SearchFiltersUseCaseTests: TestCase {
       .documentarySpanish
     ])
 
-    self.useCase.inputs.selectedCategory(.rootCategory(.art))
+    self.useCase.inputs.selectedFilter(.category(.rootCategory(.art)))
     self.selectedCategory.assertLastValue(.art)
 
-    self.useCase.inputs.selectedProjectState(.late_pledge)
+    self.useCase.inputs.selectedFilter(.projectState(.late_pledge))
     self.selectedState.assertLastValue(.late_pledge)
 
-    self.useCase.inputs.selectedPercentRaisedBucket(.bucket_2)
+    self.useCase.inputs.selectedFilter(.percentRaised(.bucket_2))
     self.selectedPercentRaisedBucket.assertLastValue(.bucket_2)
 
     for type in SearchFilterModalType.allCases {
@@ -647,7 +650,7 @@ final class SearchFiltersUseCaseTests: TestCase {
     self.assert_selectedSort_isDefault()
     self.assertAllFilters_areSetToDefaults()
 
-    self.useCase.inputs.selectedSortOption(.endingSoon)
+    self.useCase.inputs.selectedFilter(.sort(.endingSoon))
     self.setAllFilters_toNonDefault_andAssert()
 
     self.useCase.inputs.clearedQueryText()

--- a/Library/ViewModels/SearchViewModel.swift
+++ b/Library/ViewModels/SearchViewModel.swift
@@ -50,26 +50,11 @@ public protocol SearchViewModelInputs {
   /// Call this when the user taps on a button to show one of the sort options.
   func tappedButton(forFilterType type: SearchFilterPill.FilterType)
 
-  /// Call this when the user selects a new sort option.
-  func selectedSortOption(_ sort: DiscoveryParams.Sort)
-
-  /// Call this when the user selects a new category.
-  func selectedCategory(_ category: SearchFiltersCategory)
-
-  /// Call this when the user selects a new project state filter.
-  func selectedProjectState(_ state: DiscoveryParams.State)
-
-  /// Call this when the user selects a new percent raised filter.
-  func selectedPercentRaisedBucket(_ bucket: DiscoveryParams.PercentRaisedBucket)
-
-  /// Call this when the user selects a filter location.
-  func filteredLocation(_: Location?)
+  /// Call this when the user updates a sort or filter option
+  func selectedFilter(_ event: SearchFilterEvent)
 
   /// Call this when the user types a location query string in the location filter
   func searchedForLocations(_ query: String)
-
-  /// Call this when the user selects a new amount raised filter.
-  func selectedAmountRaisedBucket(_ bucket: DiscoveryParams.AmountRaisedBucket)
 
   /// Call this when the user taps reset on a filter modal
   func resetFilters(for: SearchFilterModalType)
@@ -482,32 +467,12 @@ public final class SearchViewModel: SearchViewModelType, SearchViewModelInputs, 
     return self.searchFiltersUseCase.showFilters
   }
 
-  public func selectedCategory(_ category: SearchFiltersCategory) {
-    self.searchFiltersUseCase.selectedCategory(category)
-  }
-
-  public func selectedSortOption(_ sort: DiscoveryParams.Sort) {
-    self.searchFiltersUseCase.selectedSortOption(sort)
-  }
-
-  public func selectedProjectState(_ state: DiscoveryParams.State) {
-    self.searchFiltersUseCase.selectedProjectState(state)
-  }
-
-  public func selectedPercentRaisedBucket(_ bucket: DiscoveryParams.PercentRaisedBucket) {
-    self.searchFiltersUseCase.selectedPercentRaisedBucket(bucket)
-  }
-
-  public func filteredLocation(_ location: Location?) {
-    self.searchFiltersUseCase.filteredLocation(location)
+  public func selectedFilter(_ event: SearchFilterEvent) {
+    self.searchFiltersUseCase.selectedFilter(event)
   }
 
   public func searchedForLocations(_ query: String) {
     self.locationsUseCase.searchedForLocations(query)
-  }
-
-  public func selectedAmountRaisedBucket(_ bucket: DiscoveryParams.AmountRaisedBucket) {
-    self.searchFiltersUseCase.inputs.selectedAmountRaisedBucket(bucket)
   }
 
   public var searchFilters: SearchFilters {

--- a/Library/ViewModels/SearchViewModelTests.swift
+++ b/Library/ViewModels/SearchViewModelTests.swift
@@ -265,8 +265,8 @@ internal final class SearchViewModelTests: TestCase {
         XCTFail("Expected sort and category pills to be set")
       }
 
-      self.vm.inputs.selectedCategory(.rootCategory(.art))
-      self.vm.inputs.selectedSortOption(.endingSoon)
+      self.vm.inputs.selectedFilter(.category(.rootCategory(.art)))
+      self.vm.inputs.selectedFilter(.sort(.endingSoon))
 
       if let sortPill = self.vm.outputs.searchFilters.sortPill,
          let categoryPill = self.vm.outputs.searchFilters.categoryPill {
@@ -331,8 +331,8 @@ internal final class SearchViewModelTests: TestCase {
         XCTFail("Expected sort and category pills to be set")
       }
 
-      self.vm.inputs.selectedCategory(.rootCategory(.art))
-      self.vm.inputs.selectedSortOption(.endingSoon)
+      self.vm.inputs.selectedFilter(.category(.rootCategory(.art)))
+      self.vm.inputs.selectedFilter(.sort(.endingSoon))
 
       if let sortPill = self.vm.outputs.searchFilters.sortPill,
          let categoryPill = self.vm.outputs.searchFilters.categoryPill {
@@ -398,8 +398,8 @@ internal final class SearchViewModelTests: TestCase {
         XCTFail("Expected sort and filter pills to be set")
       }
 
-      self.vm.inputs.selectedCategory(.rootCategory(.art))
-      self.vm.inputs.selectedSortOption(.endingSoon)
+      self.vm.inputs.selectedFilter(.category(.rootCategory(.art)))
+      self.vm.inputs.selectedFilter(.sort(.endingSoon))
 
       if let sortPill = self.vm.outputs.searchFilters.sortPill,
          let categoryPill = self.vm.outputs.searchFilters.categoryPill {
@@ -467,8 +467,8 @@ internal final class SearchViewModelTests: TestCase {
         XCTFail("Expected sort and filter pills to be set")
       }
 
-      self.vm.inputs.selectedCategory(.rootCategory(.art))
-      self.vm.inputs.selectedSortOption(.endingSoon)
+      self.vm.inputs.selectedFilter(.category(.rootCategory(.art)))
+      self.vm.inputs.selectedFilter(.sort(.endingSoon))
 
       if let sortPill = self.vm.outputs.searchFilters.sortPill,
          let categoryPill = self.vm.outputs.searchFilters.categoryPill {
@@ -710,7 +710,7 @@ internal final class SearchViewModelTests: TestCase {
         "Sort sheet should have first option selected by default"
       )
 
-      self.vm.inputs.selectedSortOption(.newest)
+      self.vm.inputs.selectedFilter(.sort(.newest))
 
       self.hasProjects.assertLastValue(false, "Projects clear when new sort option is chosen")
       self.searchLoaderIndicatorIsAnimating.assertLastValue(
@@ -838,7 +838,7 @@ internal final class SearchViewModelTests: TestCase {
         "Category sheet should have empty option selected by default"
       )
 
-      self.vm.inputs.selectedCategory(.rootCategory(.filmAndVideo))
+      self.vm.inputs.selectedFilter(.category(.rootCategory(.filmAndVideo)))
 
       self.hasProjects.assertLastValue(false, "Projects clear when new category filter is chosen")
       self.searchLoaderIndicatorIsAnimating.assertLastValue(


### PR DESCRIPTION
# 📲 What

Refactor the interface to `SearchFiltersUseCase`, and clean up its `init` method.

# 🤔 Why

Now that we have _many_ filter types, all the plumbing required to set it up was getting very wordy. Since I'm about to add 4 more toggles (which means 4 more filters!), it was going to be too unwieldy.

# 🛠 How

* Instead of having individual methods `selectedFoo(value)`, have one method `selectedFilter` which takes a `SearchFilterEvent` called `foo`. So `selectedFoo` becomes `selectedFilter(.foo(value))`
* Add an extension to `MutableProperty` which simplifies the logic "give me this property's signal, but also its value when an initial signal is set".
* Create the `SearchFilters` output object in one line, because it took up too much screen space