### PR TITLE
[MBL-2606] Add basic dummy pledge support

### DIFF
--- a/KsApi/models/Backing.swift
+++ b/KsApi/models/Backing.swift
@@ -45,6 +45,7 @@ public struct Backing {
     case canceled
     case collected
     case dropped
+    case dummy
     case errored
     case pledged
     case preauth

--- a/KsApi/models/Backing.swift
+++ b/KsApi/models/Backing.swift
@@ -45,6 +45,8 @@ public struct Backing {
     case canceled
     case collected
     case dropped
+    // A dummy pledge is a $0.0 pledge that was created behind the scenes
+    // to allow a net new backer to create a pledge management cart.
     case dummy
     case errored
     case pledged

--- a/Library/ViewModels/PledgeCTAContainerViewViewModel.swift
+++ b/Library/ViewModels/PledgeCTAContainerViewViewModel.swift
@@ -211,7 +211,8 @@ private func pledgeCTA(project: Project, backing: Backing?) -> PledgeStateCTATyp
     return .prelaunch(saved: projectIsSaved, watchCount: project.watchesCount ?? 0)
   }
 
-  if featureNetNewBackersGoToPMEnabled() && project.pledgeManagementAvailable {
+  if backing?.status == .dummy ||
+    (featureNetNewBackersGoToPMEnabled() && project.pledgeManagementAvailable) {
     return PledgeStateCTAType.pledgeManager
   }
 

--- a/Library/ViewModels/PledgeCTAContainerViewViewModelTests.swift
+++ b/Library/ViewModels/PledgeCTAContainerViewViewModelTests.swift
@@ -157,6 +157,20 @@ internal final class PledgeCTAContainerViewViewModelTests: TestCase {
     }
   }
 
+  func testPledgeCTA_dummyPledgeGoToPM() {
+    let backing = Backing.template
+      |> Backing.lens.status .~ .dummy
+    let project = Project.template
+      |> Project.lens.personalization.backing .~ backing
+      |> Project.lens.personalization.isBacking .~ true
+
+    self.vm.inputs.configureWith(value: (.left((project, nil)), false))
+    self.buttonStyleType.assertValues([ButtonStyleType.black])
+    self.buttonTitleText.assertValues([Strings.Go_to_pledge_manager()])
+    self.spacerIsHidden.assertValues([true])
+    self.stackViewIsHidden.assertValues([true])
+  }
+
   func testPledgeCTA_NonBacker_LiveProject_loggedOut() {
     let project = Project.template
       |> Project.lens.personalization.isBacking .~ nil

--- a/Library/ViewModels/PledgeStatusLabelViewModel.swift
+++ b/Library/ViewModels/PledgeStatusLabelViewModel.swift
@@ -102,6 +102,8 @@ private func statusLabelText(with data: PledgeStatusLabelViewData) -> NSAttribut
     string = Strings.You_canceled_your_pledge_for_this_project()
   case (.collected, false, _):
     string = Strings.We_collected_your_pledge_for_this_project()
+  case (.dummy, _, _):
+    string = Strings.We_collected_your_pledge_for_this_project()
   case (.dropped, false, _):
     string = Strings.Your_pledge_was_dropped_because_of_payment_errors()
   case (.errored, false, false):

--- a/Library/ViewModels/PledgeStatusLabelViewModelTests.swift
+++ b/Library/ViewModels/PledgeStatusLabelViewModelTests.swift
@@ -97,6 +97,26 @@ final class PledgeStatusLabelViewModelTests: TestCase {
     ])
   }
 
+  func testBackingStatus_Dummy_Backer() {
+    let data = PledgeStatusLabelViewData(
+      currentUserIsCreatorOfProject: false,
+      needsConversion: false,
+      pledgeAmount: 0,
+      currencyCode: Project.Country.hk.currencyCode,
+      projectDeadline: 1_476_657_315,
+      projectState: Project.State.successful,
+      backingState: Backing.Status.dummy,
+      paymentIncrements: nil,
+      project: nil
+    )
+
+    self.vm.inputs.configure(with: data)
+
+    self.labelTextString.assertValues([
+      "We collected your pledge for this project."
+    ])
+  }
+
   func testBackingStatus_Dropped_Backer() {
     let data = PledgeStatusLabelViewData(
       currentUserIsCreatorOfProject: false,
@@ -221,7 +241,7 @@ final class PledgeStatusLabelViewModelTests: TestCase {
   func testBackingStatus_AllOtherStatuses_Backer() {
     let statuses = Backing.Status.allCases
       .filter {
-        ![.canceled, .collected, .dropped, .errored, .authenticationRequired, .pledged, .preauth]
+        ![.canceled, .collected, .dropped, .dummy, .errored, .authenticationRequired, .pledged, .preauth]
           .contains($0)
       }
 
@@ -429,7 +449,7 @@ final class PledgeStatusLabelViewModelTests: TestCase {
   func testBackingStatus_AllOtherStatuses_Creator() {
     let statuses = Backing.Status.allCases
       .filter {
-        ![.canceled, .collected, .dropped, .errored, .authenticationRequired, .pledged, .preauth]
+        ![.canceled, .collected, .dropped, .dummy, .errored, .authenticationRequired, .pledged, .preauth]
           .contains($0)
       }
 


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Add `.dummy` as a backings status type and include minimal support. Use the `.dummy` status to decide if project page CTA should open pledge manager.

Note: I've also updated the native manage pledge page, mostly because it had an exhaustive switch statement, so I'm including a screenshot here. I don't think users can navigate to this page, so I didn't worry too much about what it looks like.

# 👀 See

[Jira](https://kickstarter.atlassian.net/browse/MBL-2606)

| Before 🐛 | After 🦋 | Native manage pledge view after |
| --- | --- | --- |
| <img width="415" height="855" alt="image" src="https://github.com/user-attachments/assets/183b1e67-8033-46c0-a34b-4850922fbbe4" /> | ![Simulator Screen Recording - iPhone 16 - 2025-07-10 at 13 06 06](https://github.com/user-attachments/assets/14c7cd1c-176e-4c2a-a8e8-ce327aaefcd0) | <img width="559" height="1062" alt="Screenshot 2025-07-10 at 12 14 44 PM" src="https://github.com/user-attachments/assets/a875c616-7e81-440e-a5d5-fb3b90095420" /> |

# ✅ Acceptance criteria

- [x] Project page for project backed as net new backer loads nicely
- [x] Project page CTA opens pledge manager
