### PR TITLE
[MBL-2421] Present Push and AppTracking Permission Dialogs

### DIFF
--- a/Kickstarter-iOS/AppDelegate.swift
+++ b/Kickstarter-iOS/AppDelegate.swift
@@ -15,6 +15,7 @@ import ReactiveExtensions
 import ReactiveSwift
 import SafariServices
 import Segment
+import SwiftUI
 import UIKit
 import UserNotifications
 
@@ -139,6 +140,18 @@ internal final class AppDelegate: UIResponder, UIApplicationDelegate {
       .observeForUI()
       .observeValues { token in
         Analytics.shared().registeredForRemoteNotifications(withDeviceToken: token)
+      }
+
+    self.viewModel.outputs.triggerOnboardingFlow
+      .observeForUI()
+      .observeValues { [weak self] in
+        guard let rootTabBarController = self?.rootTabBarController else { return }
+
+        let onboardingVC = UIHostingController(rootView: OnboardingView(viewModel: OnboardingViewModel()))
+        onboardingVC.modalPresentationStyle = .fullScreen
+
+        rootTabBarController.navigationController?.isNavigationBarHidden = true
+        rootTabBarController.present(onboardingVC, animated: true, completion: nil)
       }
 
     self.viewModel.outputs.showAlert

--- a/Kickstarter-iOS/AppDelegateViewModel.swift
+++ b/Kickstarter-iOS/AppDelegateViewModel.swift
@@ -291,7 +291,9 @@ public final class AppDelegateViewModel: AppDelegateViewModelType, AppDelegateVi
 
     let pushTokenRegistrationStartedEvents = Signal.merge(
       self.didAcceptReceivingRemoteNotificationsProperty.signal,
-      pushNotificationsPreviouslyAuthorized.filter(isTrue).ignoreValues()
+      pushNotificationsPreviouslyAuthorized
+        .filter { isTrue($0) && featureOnboardingFlowEnabled() == false }
+        .ignoreValues()
     )
     .flatMap {
       AppEnvironment.current.pushRegistrationType.register(for: [.alert, .sound, .badge])
@@ -752,7 +754,7 @@ public final class AppDelegateViewModel: AppDelegateViewModelType, AppDelegateVi
       .map(second)
       .skipRepeats()
       .ksr_delay(.seconds(1), on: AppEnvironment.current.scheduler)
-      .filter(isTrue)
+      .filter { isTrue($0) && featureOnboardingFlowEnabled() == false }
       .map { _ in AppEnvironment.current.appTrackingTransparency }
       .map { appTrackingTransparency in
         if

--- a/Kickstarter-iOS/AppDelegateViewModel.swift
+++ b/Kickstarter-iOS/AppDelegateViewModel.swift
@@ -148,7 +148,7 @@ public protocol AppDelegateViewModelOutputs {
   /// Emits when we should register the device push token in Segment Analytics.
   var registerPushTokenInSegment: Signal<Data, Never> { get }
 
-  /// Emits when  application didFinishLaunchingWithOptions.
+  /// Emits when application didFinishLaunchingWithOptions.
   var requestATTrackingAuthorizationStatus: Signal<Void, Never> { get }
 
   /// Emits when our config updates with the enabled state for Semgent Analytics.
@@ -165,6 +165,9 @@ public protocol AppDelegateViewModelOutputs {
 
   /// Emits immediately and when the user's authorization status changes
   var trackingAuthorizationStatus: SignalProducer<AppTrackingAuthorization, Never> { get }
+
+  /// Emits when application didFinishLaunchingWithOptions and the Onboarding Flow feature flag is enabled.
+  var triggerOnboardingFlow: Signal<(), Never> { get }
 
   /// Emits when we should unregister the user from notifications.
   var unregisterForRemoteNotifications: Signal<(), Never> { get }
@@ -326,6 +329,18 @@ public final class AppDelegateViewModel: AppDelegateViewModelType, AppDelegateVi
       }
 
     self.registerPushTokenInSegment = self.deviceTokenDataProperty.signal
+
+    // MARK: - Onboarding Flow
+
+    /// Trigger if featureOnboardingFlowEnabled and the user hasn't authorized or denied Push Notification or AppTrackingTransparency permissions yet.
+    self.triggerOnboardingFlow = Signal.combineLatest(
+      self.applicationLaunchOptionsProperty.signal.ignoreValues(),
+      pushNotificationsPreviouslyAuthorized.filter { isFalse($0) && featureOnboardingFlowEnabled() }
+    )
+    .filter { _ in
+      AppEnvironment.current.appTrackingTransparency.shouldRequestAuthorizationStatus() == false
+    }
+    .mapConst(())
 
     // Deep links. For more information, see
     // https://app.getguru.com/card/cyRdjqgi/How-iOS-Universal-Links-work
@@ -947,6 +962,7 @@ public final class AppDelegateViewModel: AppDelegateViewModelType, AppDelegateVi
   public let showAlert: Signal<Notification, Never>
   public let synchronizeUbiquitousStore: Signal<(), Never>
   public let trackingAuthorizationStatus: SignalProducer<AppTrackingAuthorization, Never>
+  public let triggerOnboardingFlow: Signal<(), Never>
   public let unregisterForRemoteNotifications: Signal<(), Never>
   public let updateCurrentUserInEnvironment: Signal<User, Never>
   public let updateConfigInEnvironment: Signal<Config, Never>

--- a/Kickstarter-iOS/AppDelegateViewModel.swift
+++ b/Kickstarter-iOS/AppDelegateViewModel.swift
@@ -338,7 +338,7 @@ public final class AppDelegateViewModel: AppDelegateViewModelType, AppDelegateVi
       pushNotificationsPreviouslyAuthorized.filter { isFalse($0) && featureOnboardingFlowEnabled() }
     )
     .filter { _ in
-      AppEnvironment.current.appTrackingTransparency.shouldRequestAuthorizationStatus() == false
+      AppEnvironment.current.appTrackingTransparency.shouldRequestAuthorizationStatus() == true
     }
     .mapConst(())
 
@@ -775,7 +775,7 @@ public final class AppDelegateViewModel: AppDelegateViewModelType, AppDelegateVi
         if
           appTrackingTransparency.advertisingIdentifier == nil &&
           appTrackingTransparency.shouldRequestAuthorizationStatus() {
-          appTrackingTransparency.requestAndSetAuthorizationStatus()
+          appTrackingTransparency.requestAndSetAuthorizationStatus {}
         }
         return ()
       }

--- a/Kickstarter-iOS/AppDelegateViewModelTests.swift
+++ b/Kickstarter-iOS/AppDelegateViewModelTests.swift
@@ -2278,8 +2278,8 @@ final class AppDelegateViewModelTests: TestCase {
     MockPushRegistration.registerProducer = .init(value: true)
 
     let appTrackingTransparency = MockAppTrackingTransparency()
-    appTrackingTransparency.requestAndSetAuthorizationStatusFlag = false
-    appTrackingTransparency.shouldRequestAuthStatus = false
+    appTrackingTransparency.requestAndSetAuthorizationStatusFlag = true
+    appTrackingTransparency.shouldRequestAuthStatus = true
 
     withEnvironment(
       appTrackingTransparency: appTrackingTransparency,
@@ -2319,7 +2319,7 @@ final class AppDelegateViewModelTests: TestCase {
 
     let appTrackingTransparency = MockAppTrackingTransparency()
     appTrackingTransparency.requestAndSetAuthorizationStatusFlag = true
-    appTrackingTransparency.shouldRequestAuthStatus = true
+    appTrackingTransparency.shouldRequestAuthStatus = false
 
     withEnvironment(
       appTrackingTransparency: appTrackingTransparency,

--- a/Kickstarter-iOS/Features/Onboarding/Views/OnboardingView.swift
+++ b/Kickstarter-iOS/Features/Onboarding/Views/OnboardingView.swift
@@ -71,6 +71,9 @@ public struct OnboardingView: View {
         }
         .padding(.top)
       }
+      .onReceive(self.viewModel.triggerAppTrackingTransparencyPopup) {
+        self.presentAppTrackingPopup()
+      }
     }
   }
 
@@ -125,5 +128,11 @@ public struct OnboardingView: View {
     guard self.currentIndex < self.viewModel.onboardingItems.count - 1 else { return }
 
     self.currentIndex += 1
+  }
+
+  private func presentAppTrackingPopup() {
+    AppEnvironment.current.appTrackingTransparency.requestAndSetAuthorizationStatus {
+      self.goToNextItem()
+    }
   }
 }

--- a/Kickstarter-iOS/Features/Onboarding/Views/OnboardingView.swift
+++ b/Kickstarter-iOS/Features/Onboarding/Views/OnboardingView.swift
@@ -74,6 +74,9 @@ public struct OnboardingView: View {
       .onReceive(self.viewModel.triggerAppTrackingTransparencyPopup) {
         self.presentAppTrackingPopup()
       }
+      .onReceive(self.viewModel.triggerPushNotificationPermissionDialog) {
+        self.goToNextItem()
+      }
     }
   }
 

--- a/Kickstarter-iOS/Features/Onboarding/Views/OnboardingView.swift
+++ b/Kickstarter-iOS/Features/Onboarding/Views/OnboardingView.swift
@@ -16,7 +16,7 @@ private enum Constants {
   static let verticalSpacing: CGFloat = 24
 }
 
-struct OnboardingView: View {
+public struct OnboardingView: View {
   @ObservedObject var viewModel: OnboardingViewModel
   @State private var currentIndex: Int = 0
   @Namespace private var animation
@@ -25,7 +25,11 @@ struct OnboardingView: View {
     Double(self.currentIndex + 1) / Double(self.viewModel.onboardingItems.count)
   }
 
-  var body: some View {
+  public init(viewModel: OnboardingViewModel) {
+    self.viewModel = viewModel
+  }
+
+  public var body: some View {
     GeometryReader { geo in
       let width = geo.size.width
 

--- a/Library/OnboardingUseCaseTests.swift
+++ b/Library/OnboardingUseCaseTests.swift
@@ -1,15 +1,17 @@
+@testable import KsApi
 @testable import Library
 import Prelude
 import ReactiveExtensions_TestHelpers
 import ReactiveSwift
 import XCTest
 
-final class OnboardingUseCaseTests: XCTestCase {
+final class OnboardingUseCaseTests: TestCase {
   var useCase: OnboardingUseCase!
 
   let onboardingItems = TestObserver<[OnboardingItem], Never>()
   let goToLoginSignup = TestObserver<LoginIntent, Never>()
-  let completedAllowTrackingRequest = TestObserver<Void, Never>()
+  let triggerAppTrackingTransparencyDialog = TestObserver<Void, Never>()
+  let triggerPushNotificationDialog = TestObserver<Void, Never>()
 
   override func setUp() {
     super.setUp()
@@ -18,14 +20,46 @@ final class OnboardingUseCaseTests: XCTestCase {
 
     self.useCase.uiOutputs.onboardingItems.start(self.onboardingItems.observer)
     self.useCase.uiOutputs.goToLoginSignup.observe(self.goToLoginSignup.observer)
-    self.useCase.outputs.triggerAppTrackingTransparencyPopup
-      .observe(self.completedAllowTrackingRequest.observer)
+    self.useCase.outputs.triggerAppTrackingTransparencyDialog
+      .observe(self.triggerAppTrackingTransparencyDialog.observer)
+    self.useCase.outputs.triggerPushNotificationSystemDialog
+      .observe(self.triggerPushNotificationDialog.observer)
+  }
+
+  override func tearDown() {
+    super.tearDown()
   }
 
   func testUseCase_onboardingItems_EmitsAListOfAll5OboardingItemTypes_Once() {
     self.onboardingItems.assertValueCount(1)
 
     XCTAssertEqual(self.onboardingItems.lastValue?.count, 5)
+  }
+
+  func testUseCase_triggerPushNotificationSystemDialog_Emits_WhenNotAuthorized() {
+    MockPushRegistration.hasAuthorizedNotificationsProducer = .init(value: false)
+    MockPushRegistration.registerProducer = .init(value: true)
+
+    withEnvironment(pushRegistrationType: MockPushRegistration.self) {
+      self.triggerPushNotificationDialog.assertDidNotEmitValue()
+
+      self.useCase.uiInputs.getNotifiedTapped()
+
+      self.triggerPushNotificationDialog.assertValueCount(1)
+    }
+  }
+
+  func testUseCase_triggerPushNotificationSystemDialog_DoesNotEmit_WhenAlreadyAuthorized() {
+    MockPushRegistration.hasAuthorizedNotificationsProducer = .init(value: true)
+    MockPushRegistration.registerProducer = .init(value: true)
+
+    withEnvironment(pushRegistrationType: MockPushRegistration.self) {
+      self.triggerPushNotificationDialog.assertDidNotEmitValue()
+
+      self.useCase.uiInputs.getNotifiedTapped()
+
+      self.triggerPushNotificationDialog.assertDidNotEmitValue()
+    }
   }
 
   func testUseCase_completedAllowTrackingRequest_SetsAdvertisingID_WhenShouldRequestAuthStatus_isTrue() {
@@ -36,13 +70,13 @@ final class OnboardingUseCaseTests: XCTestCase {
     withEnvironment(
       appTrackingTransparency: appTrackingTransparency
     ) {
-      self.completedAllowTrackingRequest.assertValueCount(0)
+      self.triggerAppTrackingTransparencyDialog.assertValueCount(0)
 
       XCTAssertNil(appTrackingTransparency.advertisingIdentifier)
 
       self.useCase.uiInputs.allowTrackingTapped()
 
-      self.completedAllowTrackingRequest.assertValueCount(1)
+      self.triggerAppTrackingTransparencyDialog.assertValueCount(1)
     }
   }
 

--- a/Library/OnboardingViewModel.swift
+++ b/Library/OnboardingViewModel.swift
@@ -11,7 +11,7 @@ public protocol OnboardingViewModelInputs {
 
 public protocol OnboardingViewModelOutputs {
   var onboardingItems: [OnboardingItem] { get }
-  var triggerPushNotificationPermissionPopup: AnyPublisher<Void, Never> { get }
+  var triggerPushNotificationPermissionDialog: AnyPublisher<Void, Never> { get }
   var triggerAppTrackingTransparencyPopup: AnyPublisher<Void, Never> { get }
   var goToLoginSignup: AnyPublisher<LoginIntent, Never> { get }
 }
@@ -42,10 +42,16 @@ public final class OnboardingViewModel: OnboardingViewModelType {
         self?.onboardingItems = items
       }
 
-    self.useCase.outputs.triggerAppTrackingTransparencyPopup
+    self.useCase.outputs.triggerAppTrackingTransparencyDialog
       .observe(on: UIScheduler())
       .observeValues { [weak self] in
-        self?.triggerAppTrackingTransparencyPopupSubject.send()
+        self?.triggerAppTrackingTransparencyDialogSubject.send()
+      }
+
+    self.useCase.outputs.triggerPushNotificationSystemDialog
+      .observe(on: UIScheduler())
+      .observeValues { [weak self] in
+        self?.triggerPushNotificationPermissionDialogSubject.send()
       }
 
     self.useCase.uiOutputs.goToLoginSignup
@@ -59,18 +65,18 @@ public final class OnboardingViewModel: OnboardingViewModelType {
     lhs.id == rhs.id
   }
 
-  private let triggerPushNotificationPermissionPopupSubject = PassthroughSubject<Void, Never>()
-  private let triggerAppTrackingTransparencyPopupSubject = PassthroughSubject<Void, Never>()
+  private let triggerPushNotificationPermissionDialogSubject = PassthroughSubject<Void, Never>()
+  private let triggerAppTrackingTransparencyDialogSubject = PassthroughSubject<Void, Never>()
   private let goToLoginSignupSubject = PassthroughSubject<LoginIntent, Never>()
 
   // MARK: - Outputs
 
-  public var triggerPushNotificationPermissionPopup: AnyPublisher<Void, Never> {
-    self.triggerPushNotificationPermissionPopupSubject.eraseToAnyPublisher()
+  public var triggerPushNotificationPermissionDialog: AnyPublisher<Void, Never> {
+    self.triggerPushNotificationPermissionDialogSubject.eraseToAnyPublisher()
   }
 
   public var triggerAppTrackingTransparencyPopup: AnyPublisher<Void, Never> {
-    self.triggerAppTrackingTransparencyPopupSubject.eraseToAnyPublisher()
+    self.triggerAppTrackingTransparencyDialogSubject.eraseToAnyPublisher()
   }
 
   public var goToLoginSignup: AnyPublisher<LoginIntent, Never> {
@@ -80,7 +86,7 @@ public final class OnboardingViewModel: OnboardingViewModelType {
   // MARK: - Inputs
 
   public func getNotifiedTapped() {
-    self.triggerPushNotificationPermissionPopupSubject.send()
+    self.useCase.uiInputs.getNotifiedTapped()
   }
 
   public func allowTrackingTapped() {

--- a/Library/OnboardingViewModelTests.swift
+++ b/Library/OnboardingViewModelTests.swift
@@ -26,21 +26,26 @@ final class OnboardingViewModelTest: XCTestCase {
   }
 
   func testTriggerPushNotificationPopup_IsCalled_OnGetNotifiedTapped() throws {
-    var cancellables: [AnyCancellable] = []
+    MockPushRegistration.hasAuthorizedNotificationsProducer = .init(value: false)
+    MockPushRegistration.registerProducer = .init(value: true)
 
-    let expectation = expectation(description: "Waiting for action to be performed")
-    var triggeredPushNotificationPopup = false
-    self.viewModel.triggerPushNotificationPermissionPopup
-      .sink { () in
-        triggeredPushNotificationPopup = true
-        expectation.fulfill()
-      }
-      .store(in: &cancellables)
+    withEnvironment(pushRegistrationType: MockPushRegistration.self) {
+      var cancellables: [AnyCancellable] = []
 
-    self.viewModel.getNotifiedTapped()
-    waitForExpectations(timeout: 0.1)
+      let expectation = expectation(description: "Waiting for action to be performed")
+      var triggeredPushNotificationPopup = false
+      self.viewModel.triggerPushNotificationPermissionDialog
+        .sink { () in
+          triggeredPushNotificationPopup = true
+          expectation.fulfill()
+        }
+        .store(in: &cancellables)
 
-    XCTAssertTrue(triggeredPushNotificationPopup)
+      self.viewModel.getNotifiedTapped()
+      waitForExpectations(timeout: 0.1)
+
+      XCTAssertTrue(triggeredPushNotificationPopup)
+    }
   }
 
   func testAppTrackingTransparencyPopup_IsCalled_OnAllowTrackingTapped() throws {

--- a/Library/RemoteConfig/RemoteConfigFeature+Helpers.swift
+++ b/Library/RemoteConfig/RemoteConfigFeature+Helpers.swift
@@ -31,7 +31,7 @@ public func featureUseKeychainForOAuthTokenEnabled() -> Bool {
   featureEnabled(feature: .useKeychainForOAuthToken)
 }
 
-public func onboardingFlowEnabled() -> Bool {
+public func featureOnboardingFlowEnabled() -> Bool {
   featureEnabled(feature: .onboardingFlow)
 }
 

--- a/Library/TestHelpers/MockAppTrackingTransparency.swift
+++ b/Library/TestHelpers/MockAppTrackingTransparency.swift
@@ -27,9 +27,10 @@ class MockAppTrackingTransparency: AppTrackingTransparencyType {
     self.advertisingIdentifier = self.shouldRequestAuthStatus ? "advertisingIdentifer" : nil
   }
 
-  func requestAndSetAuthorizationStatus() {
+  func requestAndSetAuthorizationStatus(_ completion: (() -> Void)? = nil) {
     self.authorizationStatusProperty.value = .authorized
     self.advertisingIdentifier = self.requestAndSetAuthorizationStatusFlag ? "advertisingIdentifier" : nil
+    completion?()
   }
 
   func shouldRequestAuthorizationStatus() -> Bool {

--- a/Library/Tracking/AppTrackingTransparency.swift
+++ b/Library/Tracking/AppTrackingTransparency.swift
@@ -9,7 +9,7 @@ public protocol AppTrackingTransparencyType {
   var advertisingIdentifier: String? { get }
   var authorizationStatus: SignalProducer<AppTrackingAuthorization, Never> { get }
   func updateAdvertisingIdentifier()
-  func requestAndSetAuthorizationStatus()
+  func requestAndSetAuthorizationStatus(_ completion: (() -> Void)?)
   func shouldRequestAuthorizationStatus() -> Bool
 }
 
@@ -20,7 +20,7 @@ public class AppTrackingTransparency: AppTrackingTransparencyType {
     self.updateAdvertisingIdentifier()
   }
 
-  public func requestAndSetAuthorizationStatus() {
+  public func requestAndSetAuthorizationStatus(_ completion: (() -> Void)? = nil) {
     ATTrackingManager.requestTrackingAuthorization { [weak self] authStatus in
       self?.authorizationStatusProperty.value = authStatus
 
@@ -30,6 +30,8 @@ public class AppTrackingTransparency: AppTrackingTransparencyType {
       default:
         self?.advertisingIdentifier = nil
       }
+
+      completion?()
     }
   }
 


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Launches the full onboarding flow _and_ PN and ATT permission dialogs in the onboarding flow.
The full flow should be launched when:
- The onboarding ff is on
- The current user hasn't previously authorized or denied these permissions. (This is also how we'll avoid showing the onboarding flow to existing users.)

Gates the existing permission triggers from firing if the onboarding flow is launched.

# 🤔 Why

- Onboarding flow should be launched at the right time for new users.
- Users can trigger both permissions dialogs from the correct onboarding views.

# 🛠 How

- Trigger the onboarding flow in AppDelagate, after the app root tab bar has finished loading and selecting the explore view, if the app meets the conditions mentioned above.
- Add outputs and observers so that each permission dialog can be triggered and interacted with from the correct `OnboardingView` item.

# 👀 See

Trello, screenshots, external resources?

| User does trigger permissions | User opts to skip permission requests |
| --- | --- |
| ![Simulator Screen Recording - iPhone 15 Pro 17 5 - 2025-07-21 at 12 48 54](https://github.com/user-attachments/assets/740e2f87-0d13-41cb-91c3-21da002e6e56) | ![Simulator Screen Recording - iPhone 15 Pro 17 5 - 2025-07-21 at 12 49 38](https://github.com/user-attachments/assets/3bde2f07-bf4d-4365-9872-b185c623326d) |

# ✅ Acceptance criteria

- [x] Onboarding flow launches for new users that haven't interacted with the permission dialogs, once the app and explore as loaded
- [x] Permission dialogs can be triggered from their respective onboarding views
- [x] all tests pass
