### PR TITLE
Stop truncating KSRButton text

### DIFF
--- a/Library/Styles/Buttons/KSRButtonStyleConfiguration.swift
+++ b/Library/Styles/Buttons/KSRButtonStyleConfiguration.swift
@@ -45,7 +45,7 @@ extension UIButton {
     buttonConfiguration.imagePadding = Styles.grid(1)
     buttonConfiguration.imagePlacement = .leading
 
-    buttonConfiguration.titleLineBreakMode = .byTruncatingMiddle
+    buttonConfiguration.titleLineBreakMode = .byWordWrapping
     buttonConfiguration.titleAlignment = .center
 
     self.tintColor = styleConfig.titleColor


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

The UIKit version of the `KSRButton` was (probably accidentally) set up so it truncated text if the button text didn't fit on one line. I'm updating the button to wrap text (by word) instead.

I did a quick code search and it looks like the only usage of this button is in the `RewardTrackingDetailsView`. I'm not sure how to make that view show up, so I didn't properly test these changes, but I looked at the snapshot tests and it definitely looks like that's a button that'll benefit from this change, too.

# 👀 See

[Jira for the empty state search ticket](https://kickstarter.atlassian.net/browse/MBL-2618) (I was testing dynamic type for the new UI when I found this issue)

# ✅ Acceptance criteria

- [ ] Tests pass
