### PR TITLE
Update `GraphAPI` and `GraphAPITestMocks` from sync group to standard folder

### DIFF
--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 70;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXAggregateTarget section */
@@ -291,6 +291,360 @@
 		33AA06592E38145C002DBD60 /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA06522E38145C002DBD60 /* OnboardingView.swift */; };
 		33AA065A2E38145C002DBD60 /* ResizableLottieView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA06532E38145C002DBD60 /* ResizableLottieView.swift */; };
 		33AA065B2E38145C002DBD60 /* OnboardingStyles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA06552E38145C002DBD60 /* OnboardingStyles.swift */; };
+		33AA16B82E38A76F002DBD60 /* GraphAPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 33AA16B62E38A76F002DBD60 /* GraphAPI.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		33AA16B92E38A76F002DBD60 /* BackerDashboardProjectCellFragment.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA15B52E38A76F002DBD60 /* BackerDashboardProjectCellFragment.graphql.swift */; };
+		33AA16BA2E38A76F002DBD60 /* BackingFragment.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA15B62E38A76F002DBD60 /* BackingFragment.graphql.swift */; };
+		33AA16BB2E38A76F002DBD60 /* CategoryFragment.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA15B72E38A76F002DBD60 /* CategoryFragment.graphql.swift */; };
+		33AA16BC2E38A76F002DBD60 /* CheckoutFragment.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA15B82E38A76F002DBD60 /* CheckoutFragment.graphql.swift */; };
+		33AA16BD2E38A76F002DBD60 /* CommentBaseFragment.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA15B92E38A76F002DBD60 /* CommentBaseFragment.graphql.swift */; };
+		33AA16BE2E38A76F002DBD60 /* CommentFragment.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA15BA2E38A76F002DBD60 /* CommentFragment.graphql.swift */; };
+		33AA16BF2E38A76F002DBD60 /* CommentWithRepliesFragment.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA15BB2E38A76F002DBD60 /* CommentWithRepliesFragment.graphql.swift */; };
+		33AA16C02E38A76F002DBD60 /* CountryFragment.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA15BC2E38A76F002DBD60 /* CountryFragment.graphql.swift */; };
+		33AA16C12E38A76F002DBD60 /* LastWaveFragment.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA15BD2E38A76F002DBD60 /* LastWaveFragment.graphql.swift */; };
+		33AA16C22E38A76F002DBD60 /* LocationFragment.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA15BE2E38A76F002DBD60 /* LocationFragment.graphql.swift */; };
+		33AA16C32E38A76F002DBD60 /* MoneyFragment.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA15BF2E38A76F002DBD60 /* MoneyFragment.graphql.swift */; };
+		33AA16C42E38A76F002DBD60 /* OrderFragment.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA15C02E38A76F002DBD60 /* OrderFragment.graphql.swift */; };
+		33AA16C52E38A76F002DBD60 /* PaymentIncrementFragment.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA15C12E38A76F002DBD60 /* PaymentIncrementFragment.graphql.swift */; };
+		33AA16C62E38A76F002DBD60 /* PaymentSourceFragment.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA15C22E38A76F002DBD60 /* PaymentSourceFragment.graphql.swift */; };
+		33AA16C72E38A76F002DBD60 /* PledgeManagerFragment.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA15C32E38A76F002DBD60 /* PledgeManagerFragment.graphql.swift */; };
+		33AA16C82E38A76F002DBD60 /* PledgeOverTimeFragment.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA15C42E38A76F002DBD60 /* PledgeOverTimeFragment.graphql.swift */; };
+		33AA16C92E38A76F002DBD60 /* PPOBackingFragment.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA15C52E38A76F002DBD60 /* PPOBackingFragment.graphql.swift */; };
+		33AA16CA2E38A76F002DBD60 /* PPOCardFragment.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA15C62E38A76F002DBD60 /* PPOCardFragment.graphql.swift */; };
+		33AA16CB2E38A76F002DBD60 /* PPOProjectFragment.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA15C72E38A76F002DBD60 /* PPOProjectFragment.graphql.swift */; };
+		33AA16CC2E38A76F002DBD60 /* PPOUserSetupFragment.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA15C82E38A76F002DBD60 /* PPOUserSetupFragment.graphql.swift */; };
+		33AA16CD2E38A76F002DBD60 /* ProjectAnalyticsFragment.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA15C92E38A76F002DBD60 /* ProjectAnalyticsFragment.graphql.swift */; };
+		33AA16CE2E38A76F002DBD60 /* ProjectCardFragment.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA15CA2E38A76F002DBD60 /* ProjectCardFragment.graphql.swift */; };
+		33AA16CF2E38A76F002DBD60 /* ProjectFragment.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA15CB2E38A76F002DBD60 /* ProjectFragment.graphql.swift */; };
+		33AA16D02E38A76F002DBD60 /* ProjectPamphletMainCellPropertiesFragment.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA15CC2E38A76F002DBD60 /* ProjectPamphletMainCellPropertiesFragment.graphql.swift */; };
+		33AA16D12E38A76F002DBD60 /* RewardFragment.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA15CD2E38A76F002DBD60 /* RewardFragment.graphql.swift */; };
+		33AA16D22E38A76F002DBD60 /* ShippingRuleFragment.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA15CE2E38A76F002DBD60 /* ShippingRuleFragment.graphql.swift */; };
+		33AA16D32E38A76F002DBD60 /* UserEmailFragment.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA15CF2E38A76F002DBD60 /* UserEmailFragment.graphql.swift */; };
+		33AA16D42E38A76F002DBD60 /* UserFeaturesFragment.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA15D02E38A76F002DBD60 /* UserFeaturesFragment.graphql.swift */; };
+		33AA16D52E38A76F002DBD60 /* UserFragment.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA15D12E38A76F002DBD60 /* UserFragment.graphql.swift */; };
+		33AA16D62E38A76F002DBD60 /* UserSettingsFragment.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA15D22E38A76F002DBD60 /* UserSettingsFragment.graphql.swift */; };
+		33AA16D72E38A76F002DBD60 /* UserStoredCardsFragment.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA15D32E38A76F002DBD60 /* UserStoredCardsFragment.graphql.swift */; };
+		33AA16D82E38A76F002DBD60 /* AddUserToSecretRewardGroupMutation.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA15D52E38A76F002DBD60 /* AddUserToSecretRewardGroupMutation.graphql.swift */; };
+		33AA16D92E38A76F002DBD60 /* BlockUserMutation.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA15D62E38A76F002DBD60 /* BlockUserMutation.graphql.swift */; };
+		33AA16DA2E38A76F002DBD60 /* CancelBackingMutation.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA15D72E38A76F002DBD60 /* CancelBackingMutation.graphql.swift */; };
+		33AA16DB2E38A76F002DBD60 /* ClearUserUnseenActivityMutation.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA15D82E38A76F002DBD60 /* ClearUserUnseenActivityMutation.graphql.swift */; };
+		33AA16DC2E38A76F002DBD60 /* CompleteOnSessionCheckoutMutation.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA15D92E38A76F002DBD60 /* CompleteOnSessionCheckoutMutation.graphql.swift */; };
+		33AA16DD2E38A76F002DBD60 /* CreateAttributionEventMutation.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA15DA2E38A76F002DBD60 /* CreateAttributionEventMutation.graphql.swift */; };
+		33AA16DE2E38A76F002DBD60 /* CreateBackingMutation.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA15DB2E38A76F002DBD60 /* CreateBackingMutation.graphql.swift */; };
+		33AA16DF2E38A76F002DBD60 /* CreateCheckoutMutation.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA15DC2E38A76F002DBD60 /* CreateCheckoutMutation.graphql.swift */; };
+		33AA16E02E38A76F002DBD60 /* CreateFlaggingMutation.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA15DD2E38A76F002DBD60 /* CreateFlaggingMutation.graphql.swift */; };
+		33AA16E12E38A76F002DBD60 /* CreateOrUpdateBackingAddressMutation.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA15DE2E38A76F002DBD60 /* CreateOrUpdateBackingAddressMutation.graphql.swift */; };
+		33AA16E22E38A76F002DBD60 /* CreatePaymentIntentMutation.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA15DF2E38A76F002DBD60 /* CreatePaymentIntentMutation.graphql.swift */; };
+		33AA16E32E38A76F002DBD60 /* CreatePaymentSourceMutation.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA15E02E38A76F002DBD60 /* CreatePaymentSourceMutation.graphql.swift */; };
+		33AA16E42E38A76F002DBD60 /* CreateSetupIntentMutation.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA15E12E38A76F002DBD60 /* CreateSetupIntentMutation.graphql.swift */; };
+		33AA16E52E38A76F002DBD60 /* DeletePaymentSourceMutation.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA15E22E38A76F002DBD60 /* DeletePaymentSourceMutation.graphql.swift */; };
+		33AA16E62E38A76F002DBD60 /* PostCommentMutation.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA15E32E38A76F002DBD60 /* PostCommentMutation.graphql.swift */; };
+		33AA16E72E38A76F002DBD60 /* SignInWithAppleMutation.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA15E42E38A76F002DBD60 /* SignInWithAppleMutation.graphql.swift */; };
+		33AA16E82E38A76F002DBD60 /* TriggerThirdPartyEventMutation.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA15E52E38A76F002DBD60 /* TriggerThirdPartyEventMutation.graphql.swift */; };
+		33AA16E92E38A76F002DBD60 /* UnwatchProjectMutation.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA15E62E38A76F002DBD60 /* UnwatchProjectMutation.graphql.swift */; };
+		33AA16EA2E38A76F002DBD60 /* UpdateBackingMutation.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA15E72E38A76F002DBD60 /* UpdateBackingMutation.graphql.swift */; };
+		33AA16EB2E38A76F002DBD60 /* UpdateUserAccountMutation.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA15E82E38A76F002DBD60 /* UpdateUserAccountMutation.graphql.swift */; };
+		33AA16EC2E38A76F002DBD60 /* UpdateUserProfileMutation.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA15E92E38A76F002DBD60 /* UpdateUserProfileMutation.graphql.swift */; };
+		33AA16ED2E38A76F002DBD60 /* UserSendEmailVerificationMutation.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA15EA2E38A76F002DBD60 /* UserSendEmailVerificationMutation.graphql.swift */; };
+		33AA16EE2E38A76F002DBD60 /* WatchProjectMutation.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA15EB2E38A76F002DBD60 /* WatchProjectMutation.graphql.swift */; };
+		33AA16EF2E38A76F002DBD60 /* BuildPaymentPlanQuery.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA15ED2E38A76F002DBD60 /* BuildPaymentPlanQuery.graphql.swift */; };
+		33AA16F02E38A76F002DBD60 /* DefaultLocationsQuery.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA15EE2E38A76F002DBD60 /* DefaultLocationsQuery.graphql.swift */; };
+		33AA16F12E38A76F002DBD60 /* FetchAddOnsQuery.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA15EF2E38A76F002DBD60 /* FetchAddOnsQuery.graphql.swift */; };
+		33AA16F22E38A76F002DBD60 /* FetchBackingQuery.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA15F02E38A76F002DBD60 /* FetchBackingQuery.graphql.swift */; };
+		33AA16F32E38A76F002DBD60 /* FetchCategoryQuery.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA15F12E38A76F002DBD60 /* FetchCategoryQuery.graphql.swift */; };
+		33AA16F42E38A76F002DBD60 /* FetchCommentRepliesQuery.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA15F22E38A76F002DBD60 /* FetchCommentRepliesQuery.graphql.swift */; };
+		33AA16F52E38A76F002DBD60 /* FetchMyBackedProjectsQuery.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA15F32E38A76F002DBD60 /* FetchMyBackedProjectsQuery.graphql.swift */; };
+		33AA16F62E38A76F002DBD60 /* FetchMySavedProjectsQuery.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA15F42E38A76F002DBD60 /* FetchMySavedProjectsQuery.graphql.swift */; };
+		33AA16F72E38A76F002DBD60 /* FetchPledgedProjectsQuery.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA15F52E38A76F002DBD60 /* FetchPledgedProjectsQuery.graphql.swift */; };
+		33AA16F82E38A76F002DBD60 /* FetchProjectByIdQuery.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA15F62E38A76F002DBD60 /* FetchProjectByIdQuery.graphql.swift */; };
+		33AA16F92E38A76F002DBD60 /* FetchProjectBySlugQuery.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA15F72E38A76F002DBD60 /* FetchProjectBySlugQuery.graphql.swift */; };
+		33AA16FA2E38A76F002DBD60 /* FetchProjectCommentsQuery.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA15F82E38A76F002DBD60 /* FetchProjectCommentsQuery.graphql.swift */; };
+		33AA16FB2E38A76F002DBD60 /* FetchProjectFriendsByIdQuery.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA15F92E38A76F002DBD60 /* FetchProjectFriendsByIdQuery.graphql.swift */; };
+		33AA16FC2E38A76F002DBD60 /* FetchProjectFriendsBySlugQuery.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA15FA2E38A76F002DBD60 /* FetchProjectFriendsBySlugQuery.graphql.swift */; };
+		33AA16FD2E38A76F002DBD60 /* FetchProjectRewardsByIdQuery.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA15FB2E38A76F002DBD60 /* FetchProjectRewardsByIdQuery.graphql.swift */; };
+		33AA16FE2E38A76F002DBD60 /* FetchRootCategoriesQuery.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA15FC2E38A76F002DBD60 /* FetchRootCategoriesQuery.graphql.swift */; };
+		33AA16FF2E38A76F002DBD60 /* FetchSimilarProjectsQuery.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA15FD2E38A76F002DBD60 /* FetchSimilarProjectsQuery.graphql.swift */; };
+		33AA17002E38A76F002DBD60 /* FetchUpdateCommentsQuery.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA15FE2E38A76F002DBD60 /* FetchUpdateCommentsQuery.graphql.swift */; };
+		33AA17012E38A76F002DBD60 /* FetchUserBackingsQuery.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA15FF2E38A76F002DBD60 /* FetchUserBackingsQuery.graphql.swift */; };
+		33AA17022E38A76F002DBD60 /* FetchUserEmailQuery.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16002E38A76F002DBD60 /* FetchUserEmailQuery.graphql.swift */; };
+		33AA17032E38A76F002DBD60 /* FetchUserQuery.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16012E38A76F002DBD60 /* FetchUserQuery.graphql.swift */; };
+		33AA17042E38A76F002DBD60 /* FetchUserSetupQuery.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16022E38A76F002DBD60 /* FetchUserSetupQuery.graphql.swift */; };
+		33AA17052E38A76F002DBD60 /* FetchUserStoredCardsQuery.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16032E38A76F002DBD60 /* FetchUserStoredCardsQuery.graphql.swift */; };
+		33AA17062E38A76F002DBD60 /* LocationsByTermQuery.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16042E38A76F002DBD60 /* LocationsByTermQuery.graphql.swift */; };
+		33AA17072E38A76F002DBD60 /* SearchQuery.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16052E38A76F002DBD60 /* SearchQuery.graphql.swift */; };
+		33AA17082E38A76F002DBD60 /* ValidateCheckoutQuery.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16062E38A76F002DBD60 /* ValidateCheckoutQuery.graphql.swift */; };
+		33AA17092E38A76F002DBD60 /* Date.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16092E38A76F002DBD60 /* Date.swift */; };
+		33AA170A2E38A76F002DBD60 /* DateTime.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA160A2E38A76F002DBD60 /* DateTime.swift */; };
+		33AA170B2E38A76F002DBD60 /* Email.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA160B2E38A76F002DBD60 /* Email.swift */; };
+		33AA170C2E38A76F002DBD60 /* HTML.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA160C2E38A76F002DBD60 /* HTML.swift */; };
+		33AA170D2E38A76F002DBD60 /* ISO8601DateTime.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA160D2E38A76F002DBD60 /* ISO8601DateTime.swift */; };
+		33AA170E2E38A76F002DBD60 /* JSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA160E2E38A76F002DBD60 /* JSON.swift */; };
+		33AA170F2E38A76F002DBD60 /* BackingState.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16102E38A76F002DBD60 /* BackingState.graphql.swift */; };
+		33AA17102E38A76F002DBD60 /* CheckoutState.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16112E38A76F002DBD60 /* CheckoutState.graphql.swift */; };
+		33AA17112E38A76F002DBD60 /* CheckoutStateEnum.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16122E38A76F002DBD60 /* CheckoutStateEnum.graphql.swift */; };
+		33AA17122E38A76F002DBD60 /* CommentBadge.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16132E38A76F002DBD60 /* CommentBadge.graphql.swift */; };
+		33AA17132E38A76F002DBD60 /* CountryCode.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16142E38A76F002DBD60 /* CountryCode.graphql.swift */; };
+		33AA17142E38A76F002DBD60 /* CreditCardPaymentType.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16152E38A76F002DBD60 /* CreditCardPaymentType.graphql.swift */; };
+		33AA17152E38A76F002DBD60 /* CreditCardTypes.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16162E38A76F002DBD60 /* CreditCardTypes.graphql.swift */; };
+		33AA17162E38A76F002DBD60 /* CurrencyCode.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16172E38A76F002DBD60 /* CurrencyCode.graphql.swift */; };
+		33AA17172E38A76F002DBD60 /* EnvironmentalCommitmentCategory.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16182E38A76F002DBD60 /* EnvironmentalCommitmentCategory.graphql.swift */; };
+		33AA17182E38A76F002DBD60 /* Feature.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16192E38A76F002DBD60 /* Feature.graphql.swift */; };
+		33AA17192E38A76F002DBD60 /* FlaggingKind.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA161A2E38A76F002DBD60 /* FlaggingKind.graphql.swift */; };
+		33AA171A2E38A76F002DBD60 /* GoalBuckets.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA161B2E38A76F002DBD60 /* GoalBuckets.graphql.swift */; };
+		33AA171B2E38A76F002DBD60 /* NonDeprecatedFlaggingKind.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA161C2E38A76F002DBD60 /* NonDeprecatedFlaggingKind.graphql.swift */; };
+		33AA171C2E38A76F002DBD60 /* PaymentIncrementState.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA161D2E38A76F002DBD60 /* PaymentIncrementState.graphql.swift */; };
+		33AA171D2E38A76F002DBD60 /* PaymentIncrementStateReason.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA161E2E38A76F002DBD60 /* PaymentIncrementStateReason.graphql.swift */; };
+		33AA171E2E38A76F002DBD60 /* PaymentTypes.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA161F2E38A76F002DBD60 /* PaymentTypes.graphql.swift */; };
+		33AA171F2E38A76F002DBD60 /* PledgedBuckets.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16202E38A76F002DBD60 /* PledgedBuckets.graphql.swift */; };
+		33AA17202E38A76F002DBD60 /* ProjectSort.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16212E38A76F002DBD60 /* ProjectSort.graphql.swift */; };
+		33AA17212E38A76F002DBD60 /* ProjectState.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16222E38A76F002DBD60 /* ProjectState.graphql.swift */; };
+		33AA17222E38A76F002DBD60 /* PublicProjectState.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16232E38A76F002DBD60 /* PublicProjectState.graphql.swift */; };
+		33AA17232E38A76F002DBD60 /* RaisedBuckets.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16242E38A76F002DBD60 /* RaisedBuckets.graphql.swift */; };
+		33AA17242E38A76F002DBD60 /* ShippingPreference.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16252E38A76F002DBD60 /* ShippingPreference.graphql.swift */; };
+		33AA17252E38A76F002DBD60 /* StripeIntentContextTypes.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16262E38A76F002DBD60 /* StripeIntentContextTypes.graphql.swift */; };
+		33AA17262E38A76F002DBD60 /* UserNotificationTopic.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16272E38A76F002DBD60 /* UserNotificationTopic.graphql.swift */; };
+		33AA17272E38A76F002DBD60 /* AddUserToSecretRewardGroupInput.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16292E38A76F002DBD60 /* AddUserToSecretRewardGroupInput.graphql.swift */; };
+		33AA17282E38A76F002DBD60 /* AppDataInput.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA162A2E38A76F002DBD60 /* AppDataInput.graphql.swift */; };
+		33AA17292E38A76F002DBD60 /* ApplePayInput.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA162B2E38A76F002DBD60 /* ApplePayInput.graphql.swift */; };
+		33AA172A2E38A76F002DBD60 /* BlockUserInput.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA162C2E38A76F002DBD60 /* BlockUserInput.graphql.swift */; };
+		33AA172B2E38A76F002DBD60 /* CancelBackingInput.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA162D2E38A76F002DBD60 /* CancelBackingInput.graphql.swift */; };
+		33AA172C2E38A76F002DBD60 /* ClearUserUnseenActivityInput.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA162E2E38A76F002DBD60 /* ClearUserUnseenActivityInput.graphql.swift */; };
+		33AA172D2E38A76F002DBD60 /* CompleteOnSessionCheckoutInput.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA162F2E38A76F002DBD60 /* CompleteOnSessionCheckoutInput.graphql.swift */; };
+		33AA172E2E38A76F002DBD60 /* CreateAttributionEventInput.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16302E38A76F002DBD60 /* CreateAttributionEventInput.graphql.swift */; };
+		33AA172F2E38A76F002DBD60 /* CreateBackingInput.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16312E38A76F002DBD60 /* CreateBackingInput.graphql.swift */; };
+		33AA17302E38A76F002DBD60 /* CreateCheckoutInput.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16322E38A76F002DBD60 /* CreateCheckoutInput.graphql.swift */; };
+		33AA17312E38A76F002DBD60 /* CreateFlaggingInput.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16332E38A76F002DBD60 /* CreateFlaggingInput.graphql.swift */; };
+		33AA17322E38A76F002DBD60 /* CreateOrUpdateBackingAddressInput.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16342E38A76F002DBD60 /* CreateOrUpdateBackingAddressInput.graphql.swift */; };
+		33AA17332E38A76F002DBD60 /* CreatePaymentIntentInput.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16352E38A76F002DBD60 /* CreatePaymentIntentInput.graphql.swift */; };
+		33AA17342E38A76F002DBD60 /* CreatePaymentSourceInput.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16362E38A76F002DBD60 /* CreatePaymentSourceInput.graphql.swift */; };
+		33AA17352E38A76F002DBD60 /* CreateSetupIntentInput.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16372E38A76F002DBD60 /* CreateSetupIntentInput.graphql.swift */; };
+		33AA17362E38A76F002DBD60 /* PaymentSourceDeleteInput.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16382E38A76F002DBD60 /* PaymentSourceDeleteInput.graphql.swift */; };
+		33AA17372E38A76F002DBD60 /* PostCommentInput.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16392E38A76F002DBD60 /* PostCommentInput.graphql.swift */; };
+		33AA17382E38A76F002DBD60 /* SignInWithAppleInput.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA163A2E38A76F002DBD60 /* SignInWithAppleInput.graphql.swift */; };
+		33AA17392E38A76F002DBD60 /* ThirdPartyEventItemInput.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA163B2E38A76F002DBD60 /* ThirdPartyEventItemInput.graphql.swift */; };
+		33AA173A2E38A76F002DBD60 /* TriggerThirdPartyEventInput.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA163C2E38A76F002DBD60 /* TriggerThirdPartyEventInput.graphql.swift */; };
+		33AA173B2E38A76F002DBD60 /* UnwatchProjectInput.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA163D2E38A76F002DBD60 /* UnwatchProjectInput.graphql.swift */; };
+		33AA173C2E38A76F002DBD60 /* UpdateBackingInput.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA163E2E38A76F002DBD60 /* UpdateBackingInput.graphql.swift */; };
+		33AA173D2E38A76F002DBD60 /* UpdateUserAccountInput.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA163F2E38A76F002DBD60 /* UpdateUserAccountInput.graphql.swift */; };
+		33AA173E2E38A76F002DBD60 /* UpdateUserProfileInput.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16402E38A76F002DBD60 /* UpdateUserProfileInput.graphql.swift */; };
+		33AA173F2E38A76F002DBD60 /* UserSendEmailVerificationInput.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16412E38A76F002DBD60 /* UserSendEmailVerificationInput.graphql.swift */; };
+		33AA17402E38A76F002DBD60 /* WatchProjectInput.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16422E38A76F002DBD60 /* WatchProjectInput.graphql.swift */; };
+		33AA17412E38A76F002DBD60 /* Commentable.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16442E38A76F002DBD60 /* Commentable.graphql.swift */; };
+		33AA17422E38A76F002DBD60 /* Node.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16452E38A76F002DBD60 /* Node.graphql.swift */; };
+		33AA17432E38A76F002DBD60 /* Postable.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16462E38A76F002DBD60 /* Postable.graphql.swift */; };
+		33AA17442E38A76F002DBD60 /* Address.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16482E38A76F002DBD60 /* Address.graphql.swift */; };
+		33AA17452E38A76F002DBD60 /* AddUserToSecretRewardGroupPayload.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16492E38A76F002DBD60 /* AddUserToSecretRewardGroupPayload.graphql.swift */; };
+		33AA17462E38A76F002DBD60 /* AdjustmentSummary.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA164A2E38A76F002DBD60 /* AdjustmentSummary.graphql.swift */; };
+		33AA17472E38A76F002DBD60 /* AiDisclosure.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA164B2E38A76F002DBD60 /* AiDisclosure.graphql.swift */; };
+		33AA17482E38A76F002DBD60 /* AttachedAudio.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA164C2E38A76F002DBD60 /* AttachedAudio.graphql.swift */; };
+		33AA17492E38A76F002DBD60 /* AttachedVideo.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA164D2E38A76F002DBD60 /* AttachedVideo.graphql.swift */; };
+		33AA174A2E38A76F002DBD60 /* Backing.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA164E2E38A76F002DBD60 /* Backing.graphql.swift */; };
+		33AA174B2E38A76F002DBD60 /* BankAccount.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA164F2E38A76F002DBD60 /* BankAccount.graphql.swift */; };
+		33AA174C2E38A76F002DBD60 /* BlockUserPayload.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16502E38A76F002DBD60 /* BlockUserPayload.graphql.swift */; };
+		33AA174D2E38A76F002DBD60 /* CancelBackingPayload.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16512E38A76F002DBD60 /* CancelBackingPayload.graphql.swift */; };
+		33AA174E2E38A76F002DBD60 /* Category.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16522E38A76F002DBD60 /* Category.graphql.swift */; };
+		33AA174F2E38A76F002DBD60 /* CategorySubcategoriesConnection.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16532E38A76F002DBD60 /* CategorySubcategoriesConnection.graphql.swift */; };
+		33AA17502E38A76F002DBD60 /* Checkout.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16542E38A76F002DBD60 /* Checkout.graphql.swift */; };
+		33AA17512E38A76F002DBD60 /* CheckoutWave.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16552E38A76F002DBD60 /* CheckoutWave.graphql.swift */; };
+		33AA17522E38A76F002DBD60 /* ClearUserUnseenActivityPayload.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16562E38A76F002DBD60 /* ClearUserUnseenActivityPayload.graphql.swift */; };
+		33AA17532E38A76F002DBD60 /* Comment.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16572E38A76F002DBD60 /* Comment.graphql.swift */; };
+		33AA17542E38A76F002DBD60 /* CommentConnection.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16582E38A76F002DBD60 /* CommentConnection.graphql.swift */; };
+		33AA17552E38A76F002DBD60 /* CommentEdge.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16592E38A76F002DBD60 /* CommentEdge.graphql.swift */; };
+		33AA17562E38A76F002DBD60 /* CompleteOnSessionCheckoutPayload.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA165A2E38A76F002DBD60 /* CompleteOnSessionCheckoutPayload.graphql.swift */; };
+		33AA17572E38A76F002DBD60 /* Conversation.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA165B2E38A76F002DBD60 /* Conversation.graphql.swift */; };
+		33AA17582E38A76F002DBD60 /* Country.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA165C2E38A76F002DBD60 /* Country.graphql.swift */; };
+		33AA17592E38A76F002DBD60 /* CreateAttributionEventPayload.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA165D2E38A76F002DBD60 /* CreateAttributionEventPayload.graphql.swift */; };
+		33AA175A2E38A76F002DBD60 /* CreateBackingPayload.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA165E2E38A76F002DBD60 /* CreateBackingPayload.graphql.swift */; };
+		33AA175B2E38A76F002DBD60 /* CreateCheckoutPayload.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA165F2E38A76F002DBD60 /* CreateCheckoutPayload.graphql.swift */; };
+		33AA175C2E38A76F002DBD60 /* CreateFlaggingPayload.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16602E38A76F002DBD60 /* CreateFlaggingPayload.graphql.swift */; };
+		33AA175D2E38A76F002DBD60 /* CreateOrUpdateBackingAddressPayload.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16612E38A76F002DBD60 /* CreateOrUpdateBackingAddressPayload.graphql.swift */; };
+		33AA175E2E38A76F002DBD60 /* CreatePaymentIntentPayload.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16622E38A76F002DBD60 /* CreatePaymentIntentPayload.graphql.swift */; };
+		33AA175F2E38A76F002DBD60 /* CreatePaymentSourcePayload.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16632E38A76F002DBD60 /* CreatePaymentSourcePayload.graphql.swift */; };
+		33AA17602E38A76F002DBD60 /* CreateSetupIntentPayload.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16642E38A76F002DBD60 /* CreateSetupIntentPayload.graphql.swift */; };
+		33AA17612E38A76F002DBD60 /* CreatorInterview.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16652E38A76F002DBD60 /* CreatorInterview.graphql.swift */; };
+		33AA17622E38A76F002DBD60 /* CreatorPrompt.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16662E38A76F002DBD60 /* CreatorPrompt.graphql.swift */; };
+		33AA17632E38A76F002DBD60 /* CreditCard.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16672E38A76F002DBD60 /* CreditCard.graphql.swift */; };
+		33AA17642E38A76F002DBD60 /* CuratedPage.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16682E38A76F002DBD60 /* CuratedPage.graphql.swift */; };
+		33AA17652E38A76F002DBD60 /* EnvironmentalCommitment.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16692E38A76F002DBD60 /* EnvironmentalCommitment.graphql.swift */; };
+		33AA17662E38A76F002DBD60 /* Flagging.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA166A2E38A76F002DBD60 /* Flagging.graphql.swift */; };
+		33AA17672E38A76F002DBD60 /* FreeformPost.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA166B2E38A76F002DBD60 /* FreeformPost.graphql.swift */; };
+		33AA17682E38A76F002DBD60 /* InterviewAnswer.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA166C2E38A76F002DBD60 /* InterviewAnswer.graphql.swift */; };
+		33AA17692E38A76F002DBD60 /* InterviewQuestion.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA166D2E38A76F002DBD60 /* InterviewQuestion.graphql.swift */; };
+		33AA176A2E38A76F002DBD60 /* Location.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA166E2E38A76F002DBD60 /* Location.graphql.swift */; };
+		33AA176B2E38A76F002DBD60 /* LocationsConnection.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA166F2E38A76F002DBD60 /* LocationsConnection.graphql.swift */; };
+		33AA176C2E38A76F002DBD60 /* Message.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16702E38A76F002DBD60 /* Message.graphql.swift */; };
+		33AA176D2E38A76F002DBD60 /* Money.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16712E38A76F002DBD60 /* Money.graphql.swift */; };
+		33AA176E2E38A76F002DBD60 /* Mutation.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16722E38A76F002DBD60 /* Mutation.graphql.swift */; };
+		33AA176F2E38A76F002DBD60 /* NewsletterSubscriptions.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16732E38A76F002DBD60 /* NewsletterSubscriptions.graphql.swift */; };
+		33AA17702E38A76F002DBD60 /* Notification.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16742E38A76F002DBD60 /* Notification.graphql.swift */; };
+		33AA17712E38A76F002DBD60 /* Order.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16752E38A76F002DBD60 /* Order.graphql.swift */; };
+		33AA17722E38A76F002DBD60 /* Organization.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16762E38A76F002DBD60 /* Organization.graphql.swift */; };
+		33AA17732E38A76F002DBD60 /* PageInfo.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16772E38A76F002DBD60 /* PageInfo.graphql.swift */; };
+		33AA17742E38A76F002DBD60 /* PaymentIncrement.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16782E38A76F002DBD60 /* PaymentIncrement.graphql.swift */; };
+		33AA17752E38A76F002DBD60 /* PaymentIncrementAmount.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16792E38A76F002DBD60 /* PaymentIncrementAmount.graphql.swift */; };
+		33AA17762E38A76F002DBD60 /* PaymentPlan.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA167A2E38A76F002DBD60 /* PaymentPlan.graphql.swift */; };
+		33AA17772E38A76F002DBD60 /* PaymentSourceDeletePayload.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA167B2E38A76F002DBD60 /* PaymentSourceDeletePayload.graphql.swift */; };
+		33AA17782E38A76F002DBD60 /* Photo.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA167C2E38A76F002DBD60 /* Photo.graphql.swift */; };
+		33AA17792E38A76F002DBD60 /* PledgedProjectsOverviewPledgeFlags.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA167D2E38A76F002DBD60 /* PledgedProjectsOverviewPledgeFlags.graphql.swift */; };
+		33AA177A2E38A76F002DBD60 /* PledgedProjectsOverviewPledgesConnection.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA167E2E38A76F002DBD60 /* PledgedProjectsOverviewPledgesConnection.graphql.swift */; };
+		33AA177B2E38A76F002DBD60 /* PledgeManager.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA167F2E38A76F002DBD60 /* PledgeManager.graphql.swift */; };
+		33AA177C2E38A76F002DBD60 /* PledgeProjectOverviewItem.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16802E38A76F002DBD60 /* PledgeProjectOverviewItem.graphql.swift */; };
+		33AA177D2E38A76F002DBD60 /* PledgeProjectOverviewItemEdge.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16812E38A76F002DBD60 /* PledgeProjectOverviewItemEdge.graphql.swift */; };
+		33AA177E2E38A76F002DBD60 /* PledgeProjectsOverview.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16822E38A76F002DBD60 /* PledgeProjectsOverview.graphql.swift */; };
+		33AA177F2E38A76F002DBD60 /* PostCommentPayload.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16832E38A76F002DBD60 /* PostCommentPayload.graphql.swift */; };
+		33AA17802E38A76F002DBD60 /* PostConnection.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16842E38A76F002DBD60 /* PostConnection.graphql.swift */; };
+		33AA17812E38A76F002DBD60 /* Project.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16852E38A76F002DBD60 /* Project.graphql.swift */; };
+		33AA17822E38A76F002DBD60 /* ProjectBackerFriendsConnection.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16862E38A76F002DBD60 /* ProjectBackerFriendsConnection.graphql.swift */; };
+		33AA17832E38A76F002DBD60 /* ProjectFaq.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16872E38A76F002DBD60 /* ProjectFaq.graphql.swift */; };
+		33AA17842E38A76F002DBD60 /* ProjectFaqConnection.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16882E38A76F002DBD60 /* ProjectFaqConnection.graphql.swift */; };
+		33AA17852E38A76F002DBD60 /* ProjectProfile.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16892E38A76F002DBD60 /* ProjectProfile.graphql.swift */; };
+		33AA17862E38A76F002DBD60 /* ProjectRewardConnection.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA168A2E38A76F002DBD60 /* ProjectRewardConnection.graphql.swift */; };
+		33AA17872E38A76F002DBD60 /* ProjectsConnectionWithTotalCount.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA168B2E38A76F002DBD60 /* ProjectsConnectionWithTotalCount.graphql.swift */; };
+		33AA17882E38A76F002DBD60 /* Query.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA168C2E38A76F002DBD60 /* Query.graphql.swift */; };
+		33AA17892E38A76F002DBD60 /* Refund.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA168D2E38A76F002DBD60 /* Refund.graphql.swift */; };
+		33AA178A2E38A76F002DBD60 /* ResourceAudience.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA168E2E38A76F002DBD60 /* ResourceAudience.graphql.swift */; };
+		33AA178B2E38A76F002DBD60 /* Reward.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA168F2E38A76F002DBD60 /* Reward.graphql.swift */; };
+		33AA178C2E38A76F002DBD60 /* RewardConnection.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16902E38A76F002DBD60 /* RewardConnection.graphql.swift */; };
+		33AA178D2E38A76F002DBD60 /* RewardItem.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16912E38A76F002DBD60 /* RewardItem.graphql.swift */; };
+		33AA178E2E38A76F002DBD60 /* RewardItemEdge.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16922E38A76F002DBD60 /* RewardItemEdge.graphql.swift */; };
+		33AA178F2E38A76F002DBD60 /* RewardItemsConnection.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16932E38A76F002DBD60 /* RewardItemsConnection.graphql.swift */; };
+		33AA17902E38A76F002DBD60 /* RewardShippingRulesConnection.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16942E38A76F002DBD60 /* RewardShippingRulesConnection.graphql.swift */; };
+		33AA17912E38A76F002DBD60 /* RewardTotalCountConnection.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16952E38A76F002DBD60 /* RewardTotalCountConnection.graphql.swift */; };
+		33AA17922E38A76F002DBD60 /* SavedSearchSegment.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16962E38A76F002DBD60 /* SavedSearchSegment.graphql.swift */; };
+		33AA17932E38A76F002DBD60 /* ShippingRule.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16972E38A76F002DBD60 /* ShippingRule.graphql.swift */; };
+		33AA17942E38A76F002DBD60 /* SignInWithApplePayload.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16982E38A76F002DBD60 /* SignInWithApplePayload.graphql.swift */; };
+		33AA17952E38A76F002DBD60 /* SimpleShippingRule.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16992E38A76F002DBD60 /* SimpleShippingRule.graphql.swift */; };
+		33AA17962E38A76F002DBD60 /* Survey.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA169A2E38A76F002DBD60 /* Survey.graphql.swift */; };
+		33AA17972E38A76F002DBD60 /* SurveyResponsesConnection.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA169B2E38A76F002DBD60 /* SurveyResponsesConnection.graphql.swift */; };
+		33AA17982E38A76F002DBD60 /* Tag.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA169C2E38A76F002DBD60 /* Tag.graphql.swift */; };
+		33AA17992E38A76F002DBD60 /* TriggerThirdPartyEventPayload.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA169D2E38A76F002DBD60 /* TriggerThirdPartyEventPayload.graphql.swift */; };
+		33AA179A2E38A76F002DBD60 /* UnwatchProjectPayload.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA169E2E38A76F002DBD60 /* UnwatchProjectPayload.graphql.swift */; };
+		33AA179B2E38A76F002DBD60 /* UpdateBackingPayload.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA169F2E38A76F002DBD60 /* UpdateBackingPayload.graphql.swift */; };
+		33AA179C2E38A76F002DBD60 /* UpdateUserAccountPayload.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16A02E38A76F002DBD60 /* UpdateUserAccountPayload.graphql.swift */; };
+		33AA179D2E38A76F002DBD60 /* UpdateUserProfilePayload.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16A12E38A76F002DBD60 /* UpdateUserProfilePayload.graphql.swift */; };
+		33AA179E2E38A76F002DBD60 /* User.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16A22E38A76F002DBD60 /* User.graphql.swift */; };
+		33AA179F2E38A76F002DBD60 /* UserBackingsConnection.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16A32E38A76F002DBD60 /* UserBackingsConnection.graphql.swift */; };
+		33AA17A02E38A76F002DBD60 /* UserCreatedProjectsConnection.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16A42E38A76F002DBD60 /* UserCreatedProjectsConnection.graphql.swift */; };
+		33AA17A12E38A76F002DBD60 /* UserCreditCardTypeConnection.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16A52E38A76F002DBD60 /* UserCreditCardTypeConnection.graphql.swift */; };
+		33AA17A22E38A76F002DBD60 /* UserSavedProjectsConnection.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16A62E38A76F002DBD60 /* UserSavedProjectsConnection.graphql.swift */; };
+		33AA17A32E38A76F002DBD60 /* UserSendEmailVerificationPayload.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16A72E38A76F002DBD60 /* UserSendEmailVerificationPayload.graphql.swift */; };
+		33AA17A42E38A76F002DBD60 /* UserUrl.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16A82E38A76F002DBD60 /* UserUrl.graphql.swift */; };
+		33AA17A52E38A76F002DBD60 /* Validation.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16A92E38A76F002DBD60 /* Validation.graphql.swift */; };
+		33AA17A62E38A76F002DBD60 /* Video.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16AA2E38A76F002DBD60 /* Video.graphql.swift */; };
+		33AA17A72E38A76F002DBD60 /* VideoSourceInfo.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16AB2E38A76F002DBD60 /* VideoSourceInfo.graphql.swift */; };
+		33AA17A82E38A76F002DBD60 /* VideoSources.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16AC2E38A76F002DBD60 /* VideoSources.graphql.swift */; };
+		33AA17A92E38A76F002DBD60 /* VideoTrack.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16AD2E38A76F002DBD60 /* VideoTrack.graphql.swift */; };
+		33AA17AA2E38A76F002DBD60 /* VideoTrackCue.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16AE2E38A76F002DBD60 /* VideoTrackCue.graphql.swift */; };
+		33AA17AB2E38A76F002DBD60 /* WatchProjectPayload.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16AF2E38A76F002DBD60 /* WatchProjectPayload.graphql.swift */; };
+		33AA17AC2E38A76F002DBD60 /* PaymentSource.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16B12E38A76F002DBD60 /* PaymentSource.graphql.swift */; };
+		33AA17AD2E38A76F002DBD60 /* SchemaConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16B32E38A76F002DBD60 /* SchemaConfiguration.swift */; };
+		33AA17AE2E38A76F002DBD60 /* SchemaMetadata.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA16B42E38A76F002DBD60 /* SchemaMetadata.graphql.swift */; };
+		33AA181B2E38A7B1002DBD60 /* GraphAPITestMocks.h in Headers */ = {isa = PBXBuildFile; fileRef = 33AA17D32E38A7B1002DBD60 /* GraphAPITestMocks.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		33AA181C2E38A7B1002DBD60 /* Address+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA17AF2E38A7B1002DBD60 /* Address+Mock.graphql.swift */; };
+		33AA181D2E38A7B1002DBD60 /* AddUserToSecretRewardGroupPayload+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA17B02E38A7B1002DBD60 /* AddUserToSecretRewardGroupPayload+Mock.graphql.swift */; };
+		33AA181E2E38A7B1002DBD60 /* AdjustmentSummary+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA17B12E38A7B1002DBD60 /* AdjustmentSummary+Mock.graphql.swift */; };
+		33AA181F2E38A7B1002DBD60 /* AiDisclosure+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA17B22E38A7B1002DBD60 /* AiDisclosure+Mock.graphql.swift */; };
+		33AA18202E38A7B1002DBD60 /* AttachedAudio+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA17B32E38A7B1002DBD60 /* AttachedAudio+Mock.graphql.swift */; };
+		33AA18212E38A7B1002DBD60 /* AttachedVideo+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA17B42E38A7B1002DBD60 /* AttachedVideo+Mock.graphql.swift */; };
+		33AA18222E38A7B1002DBD60 /* Backing+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA17B52E38A7B1002DBD60 /* Backing+Mock.graphql.swift */; };
+		33AA18232E38A7B1002DBD60 /* BankAccount+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA17B62E38A7B1002DBD60 /* BankAccount+Mock.graphql.swift */; };
+		33AA18242E38A7B1002DBD60 /* BlockUserPayload+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA17B72E38A7B1002DBD60 /* BlockUserPayload+Mock.graphql.swift */; };
+		33AA18252E38A7B1002DBD60 /* CancelBackingPayload+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA17B82E38A7B1002DBD60 /* CancelBackingPayload+Mock.graphql.swift */; };
+		33AA18262E38A7B1002DBD60 /* Category+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA17B92E38A7B1002DBD60 /* Category+Mock.graphql.swift */; };
+		33AA18272E38A7B1002DBD60 /* CategorySubcategoriesConnection+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA17BA2E38A7B1002DBD60 /* CategorySubcategoriesConnection+Mock.graphql.swift */; };
+		33AA18282E38A7B1002DBD60 /* Checkout+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA17BB2E38A7B1002DBD60 /* Checkout+Mock.graphql.swift */; };
+		33AA18292E38A7B1002DBD60 /* CheckoutWave+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA17BC2E38A7B1002DBD60 /* CheckoutWave+Mock.graphql.swift */; };
+		33AA182A2E38A7B1002DBD60 /* ClearUserUnseenActivityPayload+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA17BD2E38A7B1002DBD60 /* ClearUserUnseenActivityPayload+Mock.graphql.swift */; };
+		33AA182B2E38A7B1002DBD60 /* Comment+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA17BE2E38A7B1002DBD60 /* Comment+Mock.graphql.swift */; };
+		33AA182C2E38A7B1002DBD60 /* CommentConnection+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA17BF2E38A7B1002DBD60 /* CommentConnection+Mock.graphql.swift */; };
+		33AA182D2E38A7B1002DBD60 /* CommentEdge+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA17C02E38A7B1002DBD60 /* CommentEdge+Mock.graphql.swift */; };
+		33AA182E2E38A7B1002DBD60 /* CompleteOnSessionCheckoutPayload+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA17C12E38A7B1002DBD60 /* CompleteOnSessionCheckoutPayload+Mock.graphql.swift */; };
+		33AA182F2E38A7B1002DBD60 /* Conversation+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA17C22E38A7B1002DBD60 /* Conversation+Mock.graphql.swift */; };
+		33AA18302E38A7B1002DBD60 /* Country+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA17C32E38A7B1002DBD60 /* Country+Mock.graphql.swift */; };
+		33AA18312E38A7B1002DBD60 /* CreateAttributionEventPayload+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA17C42E38A7B1002DBD60 /* CreateAttributionEventPayload+Mock.graphql.swift */; };
+		33AA18322E38A7B1002DBD60 /* CreateBackingPayload+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA17C52E38A7B1002DBD60 /* CreateBackingPayload+Mock.graphql.swift */; };
+		33AA18332E38A7B1002DBD60 /* CreateCheckoutPayload+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA17C62E38A7B1002DBD60 /* CreateCheckoutPayload+Mock.graphql.swift */; };
+		33AA18342E38A7B1002DBD60 /* CreateFlaggingPayload+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA17C72E38A7B1002DBD60 /* CreateFlaggingPayload+Mock.graphql.swift */; };
+		33AA18352E38A7B1002DBD60 /* CreateOrUpdateBackingAddressPayload+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA17C82E38A7B1002DBD60 /* CreateOrUpdateBackingAddressPayload+Mock.graphql.swift */; };
+		33AA18362E38A7B1002DBD60 /* CreatePaymentIntentPayload+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA17C92E38A7B1002DBD60 /* CreatePaymentIntentPayload+Mock.graphql.swift */; };
+		33AA18372E38A7B1002DBD60 /* CreatePaymentSourcePayload+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA17CA2E38A7B1002DBD60 /* CreatePaymentSourcePayload+Mock.graphql.swift */; };
+		33AA18382E38A7B1002DBD60 /* CreateSetupIntentPayload+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA17CB2E38A7B1002DBD60 /* CreateSetupIntentPayload+Mock.graphql.swift */; };
+		33AA18392E38A7B1002DBD60 /* CreatorInterview+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA17CC2E38A7B1002DBD60 /* CreatorInterview+Mock.graphql.swift */; };
+		33AA183A2E38A7B1002DBD60 /* CreatorPrompt+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA17CD2E38A7B1002DBD60 /* CreatorPrompt+Mock.graphql.swift */; };
+		33AA183B2E38A7B1002DBD60 /* CreditCard+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA17CE2E38A7B1002DBD60 /* CreditCard+Mock.graphql.swift */; };
+		33AA183C2E38A7B1002DBD60 /* CuratedPage+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA17CF2E38A7B1002DBD60 /* CuratedPage+Mock.graphql.swift */; };
+		33AA183D2E38A7B1002DBD60 /* EnvironmentalCommitment+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA17D02E38A7B1002DBD60 /* EnvironmentalCommitment+Mock.graphql.swift */; };
+		33AA183E2E38A7B1002DBD60 /* Flagging+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA17D12E38A7B1002DBD60 /* Flagging+Mock.graphql.swift */; };
+		33AA183F2E38A7B1002DBD60 /* FreeformPost+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA17D22E38A7B1002DBD60 /* FreeformPost+Mock.graphql.swift */; };
+		33AA18402E38A7B1002DBD60 /* InterviewAnswer+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA17D42E38A7B1002DBD60 /* InterviewAnswer+Mock.graphql.swift */; };
+		33AA18412E38A7B1002DBD60 /* InterviewQuestion+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA17D52E38A7B1002DBD60 /* InterviewQuestion+Mock.graphql.swift */; };
+		33AA18422E38A7B1002DBD60 /* Location+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA17D62E38A7B1002DBD60 /* Location+Mock.graphql.swift */; };
+		33AA18432E38A7B1002DBD60 /* LocationsConnection+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA17D72E38A7B1002DBD60 /* LocationsConnection+Mock.graphql.swift */; };
+		33AA18442E38A7B1002DBD60 /* Message+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA17D82E38A7B1002DBD60 /* Message+Mock.graphql.swift */; };
+		33AA18452E38A7B1002DBD60 /* MockObject+Interfaces.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA17D92E38A7B1002DBD60 /* MockObject+Interfaces.graphql.swift */; };
+		33AA18462E38A7B1002DBD60 /* MockObject+Unions.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA17DA2E38A7B1002DBD60 /* MockObject+Unions.graphql.swift */; };
+		33AA18472E38A7B1002DBD60 /* Money+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA17DB2E38A7B1002DBD60 /* Money+Mock.graphql.swift */; };
+		33AA18482E38A7B1002DBD60 /* Mutation+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA17DC2E38A7B1002DBD60 /* Mutation+Mock.graphql.swift */; };
+		33AA18492E38A7B1002DBD60 /* NewsletterSubscriptions+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA17DD2E38A7B1002DBD60 /* NewsletterSubscriptions+Mock.graphql.swift */; };
+		33AA184A2E38A7B1002DBD60 /* Notification+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA17DE2E38A7B1002DBD60 /* Notification+Mock.graphql.swift */; };
+		33AA184B2E38A7B1002DBD60 /* Order+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA17DF2E38A7B1002DBD60 /* Order+Mock.graphql.swift */; };
+		33AA184C2E38A7B1002DBD60 /* Organization+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA17E02E38A7B1002DBD60 /* Organization+Mock.graphql.swift */; };
+		33AA184D2E38A7B1002DBD60 /* PageInfo+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA17E12E38A7B1002DBD60 /* PageInfo+Mock.graphql.swift */; };
+		33AA184E2E38A7B1002DBD60 /* PaymentIncrement+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA17E22E38A7B1002DBD60 /* PaymentIncrement+Mock.graphql.swift */; };
+		33AA184F2E38A7B1002DBD60 /* PaymentIncrementAmount+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA17E32E38A7B1002DBD60 /* PaymentIncrementAmount+Mock.graphql.swift */; };
+		33AA18502E38A7B1002DBD60 /* PaymentPlan+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA17E42E38A7B1002DBD60 /* PaymentPlan+Mock.graphql.swift */; };
+		33AA18512E38A7B1002DBD60 /* PaymentSourceDeletePayload+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA17E52E38A7B1002DBD60 /* PaymentSourceDeletePayload+Mock.graphql.swift */; };
+		33AA18522E38A7B1002DBD60 /* Photo+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA17E62E38A7B1002DBD60 /* Photo+Mock.graphql.swift */; };
+		33AA18532E38A7B1002DBD60 /* PledgedProjectsOverviewPledgeFlags+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA17E72E38A7B1002DBD60 /* PledgedProjectsOverviewPledgeFlags+Mock.graphql.swift */; };
+		33AA18542E38A7B1002DBD60 /* PledgedProjectsOverviewPledgesConnection+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA17E82E38A7B1002DBD60 /* PledgedProjectsOverviewPledgesConnection+Mock.graphql.swift */; };
+		33AA18552E38A7B1002DBD60 /* PledgeManager+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA17E92E38A7B1002DBD60 /* PledgeManager+Mock.graphql.swift */; };
+		33AA18562E38A7B1002DBD60 /* PledgeProjectOverviewItem+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA17EA2E38A7B1002DBD60 /* PledgeProjectOverviewItem+Mock.graphql.swift */; };
+		33AA18572E38A7B1002DBD60 /* PledgeProjectOverviewItemEdge+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA17EB2E38A7B1002DBD60 /* PledgeProjectOverviewItemEdge+Mock.graphql.swift */; };
+		33AA18582E38A7B1002DBD60 /* PledgeProjectsOverview+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA17EC2E38A7B1002DBD60 /* PledgeProjectsOverview+Mock.graphql.swift */; };
+		33AA18592E38A7B1002DBD60 /* PostCommentPayload+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA17ED2E38A7B1002DBD60 /* PostCommentPayload+Mock.graphql.swift */; };
+		33AA185A2E38A7B1002DBD60 /* PostConnection+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA17EE2E38A7B1002DBD60 /* PostConnection+Mock.graphql.swift */; };
+		33AA185B2E38A7B1002DBD60 /* Project+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA17EF2E38A7B1002DBD60 /* Project+Mock.graphql.swift */; };
+		33AA185C2E38A7B1002DBD60 /* ProjectBackerFriendsConnection+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA17F02E38A7B1002DBD60 /* ProjectBackerFriendsConnection+Mock.graphql.swift */; };
+		33AA185D2E38A7B1002DBD60 /* ProjectFaq+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA17F12E38A7B1002DBD60 /* ProjectFaq+Mock.graphql.swift */; };
+		33AA185E2E38A7B1002DBD60 /* ProjectFaqConnection+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA17F22E38A7B1002DBD60 /* ProjectFaqConnection+Mock.graphql.swift */; };
+		33AA185F2E38A7B1002DBD60 /* ProjectProfile+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA17F32E38A7B1002DBD60 /* ProjectProfile+Mock.graphql.swift */; };
+		33AA18602E38A7B1002DBD60 /* ProjectRewardConnection+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA17F42E38A7B1002DBD60 /* ProjectRewardConnection+Mock.graphql.swift */; };
+		33AA18612E38A7B1002DBD60 /* ProjectsConnectionWithTotalCount+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA17F52E38A7B1002DBD60 /* ProjectsConnectionWithTotalCount+Mock.graphql.swift */; };
+		33AA18622E38A7B1002DBD60 /* Query+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA17F62E38A7B1002DBD60 /* Query+Mock.graphql.swift */; };
+		33AA18632E38A7B1002DBD60 /* Refund+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA17F72E38A7B1002DBD60 /* Refund+Mock.graphql.swift */; };
+		33AA18642E38A7B1002DBD60 /* ResourceAudience+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA17F82E38A7B1002DBD60 /* ResourceAudience+Mock.graphql.swift */; };
+		33AA18652E38A7B1002DBD60 /* Reward+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA17F92E38A7B1002DBD60 /* Reward+Mock.graphql.swift */; };
+		33AA18662E38A7B1002DBD60 /* RewardConnection+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA17FA2E38A7B1002DBD60 /* RewardConnection+Mock.graphql.swift */; };
+		33AA18672E38A7B1002DBD60 /* RewardItem+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA17FB2E38A7B1002DBD60 /* RewardItem+Mock.graphql.swift */; };
+		33AA18682E38A7B1002DBD60 /* RewardItemEdge+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA17FC2E38A7B1002DBD60 /* RewardItemEdge+Mock.graphql.swift */; };
+		33AA18692E38A7B1002DBD60 /* RewardItemsConnection+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA17FD2E38A7B1002DBD60 /* RewardItemsConnection+Mock.graphql.swift */; };
+		33AA186A2E38A7B1002DBD60 /* RewardShippingRulesConnection+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA17FE2E38A7B1002DBD60 /* RewardShippingRulesConnection+Mock.graphql.swift */; };
+		33AA186B2E38A7B1002DBD60 /* RewardTotalCountConnection+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA17FF2E38A7B1002DBD60 /* RewardTotalCountConnection+Mock.graphql.swift */; };
+		33AA186C2E38A7B1002DBD60 /* SavedSearchSegment+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA18002E38A7B1002DBD60 /* SavedSearchSegment+Mock.graphql.swift */; };
+		33AA186D2E38A7B1002DBD60 /* ShippingRule+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA18012E38A7B1002DBD60 /* ShippingRule+Mock.graphql.swift */; };
+		33AA186E2E38A7B1002DBD60 /* SignInWithApplePayload+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA18022E38A7B1002DBD60 /* SignInWithApplePayload+Mock.graphql.swift */; };
+		33AA186F2E38A7B1002DBD60 /* SimpleShippingRule+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA18032E38A7B1002DBD60 /* SimpleShippingRule+Mock.graphql.swift */; };
+		33AA18702E38A7B1002DBD60 /* Survey+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA18042E38A7B1002DBD60 /* Survey+Mock.graphql.swift */; };
+		33AA18712E38A7B1002DBD60 /* SurveyResponsesConnection+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA18052E38A7B1002DBD60 /* SurveyResponsesConnection+Mock.graphql.swift */; };
+		33AA18722E38A7B1002DBD60 /* Tag+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA18062E38A7B1002DBD60 /* Tag+Mock.graphql.swift */; };
+		33AA18732E38A7B1002DBD60 /* TriggerThirdPartyEventPayload+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA18072E38A7B1002DBD60 /* TriggerThirdPartyEventPayload+Mock.graphql.swift */; };
+		33AA18742E38A7B1002DBD60 /* UnwatchProjectPayload+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA18082E38A7B1002DBD60 /* UnwatchProjectPayload+Mock.graphql.swift */; };
+		33AA18752E38A7B1002DBD60 /* UpdateBackingPayload+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA18092E38A7B1002DBD60 /* UpdateBackingPayload+Mock.graphql.swift */; };
+		33AA18762E38A7B1002DBD60 /* UpdateUserAccountPayload+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA180A2E38A7B1002DBD60 /* UpdateUserAccountPayload+Mock.graphql.swift */; };
+		33AA18772E38A7B1002DBD60 /* UpdateUserProfilePayload+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA180B2E38A7B1002DBD60 /* UpdateUserProfilePayload+Mock.graphql.swift */; };
+		33AA18782E38A7B1002DBD60 /* User+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA180C2E38A7B1002DBD60 /* User+Mock.graphql.swift */; };
+		33AA18792E38A7B1002DBD60 /* UserBackingsConnection+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA180D2E38A7B1002DBD60 /* UserBackingsConnection+Mock.graphql.swift */; };
+		33AA187A2E38A7B1002DBD60 /* UserCreatedProjectsConnection+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA180E2E38A7B1002DBD60 /* UserCreatedProjectsConnection+Mock.graphql.swift */; };
+		33AA187B2E38A7B1002DBD60 /* UserCreditCardTypeConnection+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA180F2E38A7B1002DBD60 /* UserCreditCardTypeConnection+Mock.graphql.swift */; };
+		33AA187C2E38A7B1002DBD60 /* UserSavedProjectsConnection+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA18102E38A7B1002DBD60 /* UserSavedProjectsConnection+Mock.graphql.swift */; };
+		33AA187D2E38A7B1002DBD60 /* UserSendEmailVerificationPayload+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA18112E38A7B1002DBD60 /* UserSendEmailVerificationPayload+Mock.graphql.swift */; };
+		33AA187E2E38A7B1002DBD60 /* UserUrl+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA18122E38A7B1002DBD60 /* UserUrl+Mock.graphql.swift */; };
+		33AA187F2E38A7B1002DBD60 /* Validation+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA18132E38A7B1002DBD60 /* Validation+Mock.graphql.swift */; };
+		33AA18802E38A7B1002DBD60 /* Video+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA18142E38A7B1002DBD60 /* Video+Mock.graphql.swift */; };
+		33AA18812E38A7B1002DBD60 /* VideoSourceInfo+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA18152E38A7B1002DBD60 /* VideoSourceInfo+Mock.graphql.swift */; };
+		33AA18822E38A7B1002DBD60 /* VideoSources+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA18162E38A7B1002DBD60 /* VideoSources+Mock.graphql.swift */; };
+		33AA18832E38A7B1002DBD60 /* VideoTrack+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA18172E38A7B1002DBD60 /* VideoTrack+Mock.graphql.swift */; };
+		33AA18842E38A7B1002DBD60 /* VideoTrackCue+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA18182E38A7B1002DBD60 /* VideoTrackCue+Mock.graphql.swift */; };
+		33AA18852E38A7B1002DBD60 /* WatchProjectPayload+Mock.graphql.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AA18192E38A7B1002DBD60 /* WatchProjectPayload+Mock.graphql.swift */; };
 		33AB202B2D268EE500B8C047 /* PledgeRewardsSummaryTotalViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AB20292D268E7700B8C047 /* PledgeRewardsSummaryTotalViewControllerTests.swift */; };
 		33AB202E2D269A8D00B8C047 /* MockPledgeOverTimePlanIntervals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AB202D2D269A6C00B8C047 /* MockPledgeOverTimePlanIntervals.swift */; };
 		33AB202F2D269A8D00B8C047 /* MockPledgeOverTimePlanIntervals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33AB202D2D269A6C00B8C047 /* MockPledgeOverTimePlanIntervals.swift */; };
@@ -2154,6 +2508,360 @@
 		33AA06522E38145C002DBD60 /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
 		33AA06532E38145C002DBD60 /* ResizableLottieView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResizableLottieView.swift; sourceTree = "<group>"; };
 		33AA06552E38145C002DBD60 /* OnboardingStyles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingStyles.swift; sourceTree = "<group>"; };
+		33AA15B52E38A76F002DBD60 /* BackerDashboardProjectCellFragment.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackerDashboardProjectCellFragment.graphql.swift; sourceTree = "<group>"; };
+		33AA15B62E38A76F002DBD60 /* BackingFragment.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackingFragment.graphql.swift; sourceTree = "<group>"; };
+		33AA15B72E38A76F002DBD60 /* CategoryFragment.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryFragment.graphql.swift; sourceTree = "<group>"; };
+		33AA15B82E38A76F002DBD60 /* CheckoutFragment.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckoutFragment.graphql.swift; sourceTree = "<group>"; };
+		33AA15B92E38A76F002DBD60 /* CommentBaseFragment.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentBaseFragment.graphql.swift; sourceTree = "<group>"; };
+		33AA15BA2E38A76F002DBD60 /* CommentFragment.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentFragment.graphql.swift; sourceTree = "<group>"; };
+		33AA15BB2E38A76F002DBD60 /* CommentWithRepliesFragment.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentWithRepliesFragment.graphql.swift; sourceTree = "<group>"; };
+		33AA15BC2E38A76F002DBD60 /* CountryFragment.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountryFragment.graphql.swift; sourceTree = "<group>"; };
+		33AA15BD2E38A76F002DBD60 /* LastWaveFragment.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LastWaveFragment.graphql.swift; sourceTree = "<group>"; };
+		33AA15BE2E38A76F002DBD60 /* LocationFragment.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationFragment.graphql.swift; sourceTree = "<group>"; };
+		33AA15BF2E38A76F002DBD60 /* MoneyFragment.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoneyFragment.graphql.swift; sourceTree = "<group>"; };
+		33AA15C02E38A76F002DBD60 /* OrderFragment.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderFragment.graphql.swift; sourceTree = "<group>"; };
+		33AA15C12E38A76F002DBD60 /* PaymentIncrementFragment.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentIncrementFragment.graphql.swift; sourceTree = "<group>"; };
+		33AA15C22E38A76F002DBD60 /* PaymentSourceFragment.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentSourceFragment.graphql.swift; sourceTree = "<group>"; };
+		33AA15C32E38A76F002DBD60 /* PledgeManagerFragment.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PledgeManagerFragment.graphql.swift; sourceTree = "<group>"; };
+		33AA15C42E38A76F002DBD60 /* PledgeOverTimeFragment.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PledgeOverTimeFragment.graphql.swift; sourceTree = "<group>"; };
+		33AA15C52E38A76F002DBD60 /* PPOBackingFragment.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PPOBackingFragment.graphql.swift; sourceTree = "<group>"; };
+		33AA15C62E38A76F002DBD60 /* PPOCardFragment.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PPOCardFragment.graphql.swift; sourceTree = "<group>"; };
+		33AA15C72E38A76F002DBD60 /* PPOProjectFragment.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PPOProjectFragment.graphql.swift; sourceTree = "<group>"; };
+		33AA15C82E38A76F002DBD60 /* PPOUserSetupFragment.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PPOUserSetupFragment.graphql.swift; sourceTree = "<group>"; };
+		33AA15C92E38A76F002DBD60 /* ProjectAnalyticsFragment.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectAnalyticsFragment.graphql.swift; sourceTree = "<group>"; };
+		33AA15CA2E38A76F002DBD60 /* ProjectCardFragment.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectCardFragment.graphql.swift; sourceTree = "<group>"; };
+		33AA15CB2E38A76F002DBD60 /* ProjectFragment.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectFragment.graphql.swift; sourceTree = "<group>"; };
+		33AA15CC2E38A76F002DBD60 /* ProjectPamphletMainCellPropertiesFragment.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectPamphletMainCellPropertiesFragment.graphql.swift; sourceTree = "<group>"; };
+		33AA15CD2E38A76F002DBD60 /* RewardFragment.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RewardFragment.graphql.swift; sourceTree = "<group>"; };
+		33AA15CE2E38A76F002DBD60 /* ShippingRuleFragment.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingRuleFragment.graphql.swift; sourceTree = "<group>"; };
+		33AA15CF2E38A76F002DBD60 /* UserEmailFragment.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserEmailFragment.graphql.swift; sourceTree = "<group>"; };
+		33AA15D02E38A76F002DBD60 /* UserFeaturesFragment.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserFeaturesFragment.graphql.swift; sourceTree = "<group>"; };
+		33AA15D12E38A76F002DBD60 /* UserFragment.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserFragment.graphql.swift; sourceTree = "<group>"; };
+		33AA15D22E38A76F002DBD60 /* UserSettingsFragment.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSettingsFragment.graphql.swift; sourceTree = "<group>"; };
+		33AA15D32E38A76F002DBD60 /* UserStoredCardsFragment.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserStoredCardsFragment.graphql.swift; sourceTree = "<group>"; };
+		33AA15D52E38A76F002DBD60 /* AddUserToSecretRewardGroupMutation.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddUserToSecretRewardGroupMutation.graphql.swift; sourceTree = "<group>"; };
+		33AA15D62E38A76F002DBD60 /* BlockUserMutation.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockUserMutation.graphql.swift; sourceTree = "<group>"; };
+		33AA15D72E38A76F002DBD60 /* CancelBackingMutation.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CancelBackingMutation.graphql.swift; sourceTree = "<group>"; };
+		33AA15D82E38A76F002DBD60 /* ClearUserUnseenActivityMutation.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClearUserUnseenActivityMutation.graphql.swift; sourceTree = "<group>"; };
+		33AA15D92E38A76F002DBD60 /* CompleteOnSessionCheckoutMutation.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompleteOnSessionCheckoutMutation.graphql.swift; sourceTree = "<group>"; };
+		33AA15DA2E38A76F002DBD60 /* CreateAttributionEventMutation.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateAttributionEventMutation.graphql.swift; sourceTree = "<group>"; };
+		33AA15DB2E38A76F002DBD60 /* CreateBackingMutation.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateBackingMutation.graphql.swift; sourceTree = "<group>"; };
+		33AA15DC2E38A76F002DBD60 /* CreateCheckoutMutation.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateCheckoutMutation.graphql.swift; sourceTree = "<group>"; };
+		33AA15DD2E38A76F002DBD60 /* CreateFlaggingMutation.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateFlaggingMutation.graphql.swift; sourceTree = "<group>"; };
+		33AA15DE2E38A76F002DBD60 /* CreateOrUpdateBackingAddressMutation.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateOrUpdateBackingAddressMutation.graphql.swift; sourceTree = "<group>"; };
+		33AA15DF2E38A76F002DBD60 /* CreatePaymentIntentMutation.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreatePaymentIntentMutation.graphql.swift; sourceTree = "<group>"; };
+		33AA15E02E38A76F002DBD60 /* CreatePaymentSourceMutation.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreatePaymentSourceMutation.graphql.swift; sourceTree = "<group>"; };
+		33AA15E12E38A76F002DBD60 /* CreateSetupIntentMutation.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateSetupIntentMutation.graphql.swift; sourceTree = "<group>"; };
+		33AA15E22E38A76F002DBD60 /* DeletePaymentSourceMutation.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeletePaymentSourceMutation.graphql.swift; sourceTree = "<group>"; };
+		33AA15E32E38A76F002DBD60 /* PostCommentMutation.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostCommentMutation.graphql.swift; sourceTree = "<group>"; };
+		33AA15E42E38A76F002DBD60 /* SignInWithAppleMutation.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInWithAppleMutation.graphql.swift; sourceTree = "<group>"; };
+		33AA15E52E38A76F002DBD60 /* TriggerThirdPartyEventMutation.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TriggerThirdPartyEventMutation.graphql.swift; sourceTree = "<group>"; };
+		33AA15E62E38A76F002DBD60 /* UnwatchProjectMutation.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnwatchProjectMutation.graphql.swift; sourceTree = "<group>"; };
+		33AA15E72E38A76F002DBD60 /* UpdateBackingMutation.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateBackingMutation.graphql.swift; sourceTree = "<group>"; };
+		33AA15E82E38A76F002DBD60 /* UpdateUserAccountMutation.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateUserAccountMutation.graphql.swift; sourceTree = "<group>"; };
+		33AA15E92E38A76F002DBD60 /* UpdateUserProfileMutation.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateUserProfileMutation.graphql.swift; sourceTree = "<group>"; };
+		33AA15EA2E38A76F002DBD60 /* UserSendEmailVerificationMutation.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSendEmailVerificationMutation.graphql.swift; sourceTree = "<group>"; };
+		33AA15EB2E38A76F002DBD60 /* WatchProjectMutation.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchProjectMutation.graphql.swift; sourceTree = "<group>"; };
+		33AA15ED2E38A76F002DBD60 /* BuildPaymentPlanQuery.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildPaymentPlanQuery.graphql.swift; sourceTree = "<group>"; };
+		33AA15EE2E38A76F002DBD60 /* DefaultLocationsQuery.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultLocationsQuery.graphql.swift; sourceTree = "<group>"; };
+		33AA15EF2E38A76F002DBD60 /* FetchAddOnsQuery.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchAddOnsQuery.graphql.swift; sourceTree = "<group>"; };
+		33AA15F02E38A76F002DBD60 /* FetchBackingQuery.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchBackingQuery.graphql.swift; sourceTree = "<group>"; };
+		33AA15F12E38A76F002DBD60 /* FetchCategoryQuery.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchCategoryQuery.graphql.swift; sourceTree = "<group>"; };
+		33AA15F22E38A76F002DBD60 /* FetchCommentRepliesQuery.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchCommentRepliesQuery.graphql.swift; sourceTree = "<group>"; };
+		33AA15F32E38A76F002DBD60 /* FetchMyBackedProjectsQuery.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchMyBackedProjectsQuery.graphql.swift; sourceTree = "<group>"; };
+		33AA15F42E38A76F002DBD60 /* FetchMySavedProjectsQuery.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchMySavedProjectsQuery.graphql.swift; sourceTree = "<group>"; };
+		33AA15F52E38A76F002DBD60 /* FetchPledgedProjectsQuery.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchPledgedProjectsQuery.graphql.swift; sourceTree = "<group>"; };
+		33AA15F62E38A76F002DBD60 /* FetchProjectByIdQuery.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchProjectByIdQuery.graphql.swift; sourceTree = "<group>"; };
+		33AA15F72E38A76F002DBD60 /* FetchProjectBySlugQuery.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchProjectBySlugQuery.graphql.swift; sourceTree = "<group>"; };
+		33AA15F82E38A76F002DBD60 /* FetchProjectCommentsQuery.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchProjectCommentsQuery.graphql.swift; sourceTree = "<group>"; };
+		33AA15F92E38A76F002DBD60 /* FetchProjectFriendsByIdQuery.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchProjectFriendsByIdQuery.graphql.swift; sourceTree = "<group>"; };
+		33AA15FA2E38A76F002DBD60 /* FetchProjectFriendsBySlugQuery.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchProjectFriendsBySlugQuery.graphql.swift; sourceTree = "<group>"; };
+		33AA15FB2E38A76F002DBD60 /* FetchProjectRewardsByIdQuery.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchProjectRewardsByIdQuery.graphql.swift; sourceTree = "<group>"; };
+		33AA15FC2E38A76F002DBD60 /* FetchRootCategoriesQuery.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchRootCategoriesQuery.graphql.swift; sourceTree = "<group>"; };
+		33AA15FD2E38A76F002DBD60 /* FetchSimilarProjectsQuery.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchSimilarProjectsQuery.graphql.swift; sourceTree = "<group>"; };
+		33AA15FE2E38A76F002DBD60 /* FetchUpdateCommentsQuery.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchUpdateCommentsQuery.graphql.swift; sourceTree = "<group>"; };
+		33AA15FF2E38A76F002DBD60 /* FetchUserBackingsQuery.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchUserBackingsQuery.graphql.swift; sourceTree = "<group>"; };
+		33AA16002E38A76F002DBD60 /* FetchUserEmailQuery.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchUserEmailQuery.graphql.swift; sourceTree = "<group>"; };
+		33AA16012E38A76F002DBD60 /* FetchUserQuery.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchUserQuery.graphql.swift; sourceTree = "<group>"; };
+		33AA16022E38A76F002DBD60 /* FetchUserSetupQuery.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchUserSetupQuery.graphql.swift; sourceTree = "<group>"; };
+		33AA16032E38A76F002DBD60 /* FetchUserStoredCardsQuery.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchUserStoredCardsQuery.graphql.swift; sourceTree = "<group>"; };
+		33AA16042E38A76F002DBD60 /* LocationsByTermQuery.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationsByTermQuery.graphql.swift; sourceTree = "<group>"; };
+		33AA16052E38A76F002DBD60 /* SearchQuery.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchQuery.graphql.swift; sourceTree = "<group>"; };
+		33AA16062E38A76F002DBD60 /* ValidateCheckoutQuery.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValidateCheckoutQuery.graphql.swift; sourceTree = "<group>"; };
+		33AA16092E38A76F002DBD60 /* Date.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Date.swift; sourceTree = "<group>"; };
+		33AA160A2E38A76F002DBD60 /* DateTime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateTime.swift; sourceTree = "<group>"; };
+		33AA160B2E38A76F002DBD60 /* Email.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Email.swift; sourceTree = "<group>"; };
+		33AA160C2E38A76F002DBD60 /* HTML.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTML.swift; sourceTree = "<group>"; };
+		33AA160D2E38A76F002DBD60 /* ISO8601DateTime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ISO8601DateTime.swift; sourceTree = "<group>"; };
+		33AA160E2E38A76F002DBD60 /* JSON.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSON.swift; sourceTree = "<group>"; };
+		33AA16102E38A76F002DBD60 /* BackingState.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackingState.graphql.swift; sourceTree = "<group>"; };
+		33AA16112E38A76F002DBD60 /* CheckoutState.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckoutState.graphql.swift; sourceTree = "<group>"; };
+		33AA16122E38A76F002DBD60 /* CheckoutStateEnum.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckoutStateEnum.graphql.swift; sourceTree = "<group>"; };
+		33AA16132E38A76F002DBD60 /* CommentBadge.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentBadge.graphql.swift; sourceTree = "<group>"; };
+		33AA16142E38A76F002DBD60 /* CountryCode.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountryCode.graphql.swift; sourceTree = "<group>"; };
+		33AA16152E38A76F002DBD60 /* CreditCardPaymentType.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreditCardPaymentType.graphql.swift; sourceTree = "<group>"; };
+		33AA16162E38A76F002DBD60 /* CreditCardTypes.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreditCardTypes.graphql.swift; sourceTree = "<group>"; };
+		33AA16172E38A76F002DBD60 /* CurrencyCode.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrencyCode.graphql.swift; sourceTree = "<group>"; };
+		33AA16182E38A76F002DBD60 /* EnvironmentalCommitmentCategory.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnvironmentalCommitmentCategory.graphql.swift; sourceTree = "<group>"; };
+		33AA16192E38A76F002DBD60 /* Feature.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Feature.graphql.swift; sourceTree = "<group>"; };
+		33AA161A2E38A76F002DBD60 /* FlaggingKind.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlaggingKind.graphql.swift; sourceTree = "<group>"; };
+		33AA161B2E38A76F002DBD60 /* GoalBuckets.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoalBuckets.graphql.swift; sourceTree = "<group>"; };
+		33AA161C2E38A76F002DBD60 /* NonDeprecatedFlaggingKind.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NonDeprecatedFlaggingKind.graphql.swift; sourceTree = "<group>"; };
+		33AA161D2E38A76F002DBD60 /* PaymentIncrementState.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentIncrementState.graphql.swift; sourceTree = "<group>"; };
+		33AA161E2E38A76F002DBD60 /* PaymentIncrementStateReason.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentIncrementStateReason.graphql.swift; sourceTree = "<group>"; };
+		33AA161F2E38A76F002DBD60 /* PaymentTypes.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentTypes.graphql.swift; sourceTree = "<group>"; };
+		33AA16202E38A76F002DBD60 /* PledgedBuckets.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PledgedBuckets.graphql.swift; sourceTree = "<group>"; };
+		33AA16212E38A76F002DBD60 /* ProjectSort.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectSort.graphql.swift; sourceTree = "<group>"; };
+		33AA16222E38A76F002DBD60 /* ProjectState.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectState.graphql.swift; sourceTree = "<group>"; };
+		33AA16232E38A76F002DBD60 /* PublicProjectState.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublicProjectState.graphql.swift; sourceTree = "<group>"; };
+		33AA16242E38A76F002DBD60 /* RaisedBuckets.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RaisedBuckets.graphql.swift; sourceTree = "<group>"; };
+		33AA16252E38A76F002DBD60 /* ShippingPreference.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingPreference.graphql.swift; sourceTree = "<group>"; };
+		33AA16262E38A76F002DBD60 /* StripeIntentContextTypes.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StripeIntentContextTypes.graphql.swift; sourceTree = "<group>"; };
+		33AA16272E38A76F002DBD60 /* UserNotificationTopic.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserNotificationTopic.graphql.swift; sourceTree = "<group>"; };
+		33AA16292E38A76F002DBD60 /* AddUserToSecretRewardGroupInput.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddUserToSecretRewardGroupInput.graphql.swift; sourceTree = "<group>"; };
+		33AA162A2E38A76F002DBD60 /* AppDataInput.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDataInput.graphql.swift; sourceTree = "<group>"; };
+		33AA162B2E38A76F002DBD60 /* ApplePayInput.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplePayInput.graphql.swift; sourceTree = "<group>"; };
+		33AA162C2E38A76F002DBD60 /* BlockUserInput.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockUserInput.graphql.swift; sourceTree = "<group>"; };
+		33AA162D2E38A76F002DBD60 /* CancelBackingInput.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CancelBackingInput.graphql.swift; sourceTree = "<group>"; };
+		33AA162E2E38A76F002DBD60 /* ClearUserUnseenActivityInput.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClearUserUnseenActivityInput.graphql.swift; sourceTree = "<group>"; };
+		33AA162F2E38A76F002DBD60 /* CompleteOnSessionCheckoutInput.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompleteOnSessionCheckoutInput.graphql.swift; sourceTree = "<group>"; };
+		33AA16302E38A76F002DBD60 /* CreateAttributionEventInput.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateAttributionEventInput.graphql.swift; sourceTree = "<group>"; };
+		33AA16312E38A76F002DBD60 /* CreateBackingInput.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateBackingInput.graphql.swift; sourceTree = "<group>"; };
+		33AA16322E38A76F002DBD60 /* CreateCheckoutInput.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateCheckoutInput.graphql.swift; sourceTree = "<group>"; };
+		33AA16332E38A76F002DBD60 /* CreateFlaggingInput.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateFlaggingInput.graphql.swift; sourceTree = "<group>"; };
+		33AA16342E38A76F002DBD60 /* CreateOrUpdateBackingAddressInput.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateOrUpdateBackingAddressInput.graphql.swift; sourceTree = "<group>"; };
+		33AA16352E38A76F002DBD60 /* CreatePaymentIntentInput.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreatePaymentIntentInput.graphql.swift; sourceTree = "<group>"; };
+		33AA16362E38A76F002DBD60 /* CreatePaymentSourceInput.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreatePaymentSourceInput.graphql.swift; sourceTree = "<group>"; };
+		33AA16372E38A76F002DBD60 /* CreateSetupIntentInput.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateSetupIntentInput.graphql.swift; sourceTree = "<group>"; };
+		33AA16382E38A76F002DBD60 /* PaymentSourceDeleteInput.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentSourceDeleteInput.graphql.swift; sourceTree = "<group>"; };
+		33AA16392E38A76F002DBD60 /* PostCommentInput.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostCommentInput.graphql.swift; sourceTree = "<group>"; };
+		33AA163A2E38A76F002DBD60 /* SignInWithAppleInput.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInWithAppleInput.graphql.swift; sourceTree = "<group>"; };
+		33AA163B2E38A76F002DBD60 /* ThirdPartyEventItemInput.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThirdPartyEventItemInput.graphql.swift; sourceTree = "<group>"; };
+		33AA163C2E38A76F002DBD60 /* TriggerThirdPartyEventInput.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TriggerThirdPartyEventInput.graphql.swift; sourceTree = "<group>"; };
+		33AA163D2E38A76F002DBD60 /* UnwatchProjectInput.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnwatchProjectInput.graphql.swift; sourceTree = "<group>"; };
+		33AA163E2E38A76F002DBD60 /* UpdateBackingInput.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateBackingInput.graphql.swift; sourceTree = "<group>"; };
+		33AA163F2E38A76F002DBD60 /* UpdateUserAccountInput.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateUserAccountInput.graphql.swift; sourceTree = "<group>"; };
+		33AA16402E38A76F002DBD60 /* UpdateUserProfileInput.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateUserProfileInput.graphql.swift; sourceTree = "<group>"; };
+		33AA16412E38A76F002DBD60 /* UserSendEmailVerificationInput.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSendEmailVerificationInput.graphql.swift; sourceTree = "<group>"; };
+		33AA16422E38A76F002DBD60 /* WatchProjectInput.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchProjectInput.graphql.swift; sourceTree = "<group>"; };
+		33AA16442E38A76F002DBD60 /* Commentable.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Commentable.graphql.swift; sourceTree = "<group>"; };
+		33AA16452E38A76F002DBD60 /* Node.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Node.graphql.swift; sourceTree = "<group>"; };
+		33AA16462E38A76F002DBD60 /* Postable.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Postable.graphql.swift; sourceTree = "<group>"; };
+		33AA16482E38A76F002DBD60 /* Address.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Address.graphql.swift; sourceTree = "<group>"; };
+		33AA16492E38A76F002DBD60 /* AddUserToSecretRewardGroupPayload.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddUserToSecretRewardGroupPayload.graphql.swift; sourceTree = "<group>"; };
+		33AA164A2E38A76F002DBD60 /* AdjustmentSummary.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdjustmentSummary.graphql.swift; sourceTree = "<group>"; };
+		33AA164B2E38A76F002DBD60 /* AiDisclosure.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AiDisclosure.graphql.swift; sourceTree = "<group>"; };
+		33AA164C2E38A76F002DBD60 /* AttachedAudio.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachedAudio.graphql.swift; sourceTree = "<group>"; };
+		33AA164D2E38A76F002DBD60 /* AttachedVideo.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachedVideo.graphql.swift; sourceTree = "<group>"; };
+		33AA164E2E38A76F002DBD60 /* Backing.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Backing.graphql.swift; sourceTree = "<group>"; };
+		33AA164F2E38A76F002DBD60 /* BankAccount.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BankAccount.graphql.swift; sourceTree = "<group>"; };
+		33AA16502E38A76F002DBD60 /* BlockUserPayload.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockUserPayload.graphql.swift; sourceTree = "<group>"; };
+		33AA16512E38A76F002DBD60 /* CancelBackingPayload.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CancelBackingPayload.graphql.swift; sourceTree = "<group>"; };
+		33AA16522E38A76F002DBD60 /* Category.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Category.graphql.swift; sourceTree = "<group>"; };
+		33AA16532E38A76F002DBD60 /* CategorySubcategoriesConnection.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategorySubcategoriesConnection.graphql.swift; sourceTree = "<group>"; };
+		33AA16542E38A76F002DBD60 /* Checkout.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Checkout.graphql.swift; sourceTree = "<group>"; };
+		33AA16552E38A76F002DBD60 /* CheckoutWave.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckoutWave.graphql.swift; sourceTree = "<group>"; };
+		33AA16562E38A76F002DBD60 /* ClearUserUnseenActivityPayload.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClearUserUnseenActivityPayload.graphql.swift; sourceTree = "<group>"; };
+		33AA16572E38A76F002DBD60 /* Comment.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Comment.graphql.swift; sourceTree = "<group>"; };
+		33AA16582E38A76F002DBD60 /* CommentConnection.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentConnection.graphql.swift; sourceTree = "<group>"; };
+		33AA16592E38A76F002DBD60 /* CommentEdge.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentEdge.graphql.swift; sourceTree = "<group>"; };
+		33AA165A2E38A76F002DBD60 /* CompleteOnSessionCheckoutPayload.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompleteOnSessionCheckoutPayload.graphql.swift; sourceTree = "<group>"; };
+		33AA165B2E38A76F002DBD60 /* Conversation.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Conversation.graphql.swift; sourceTree = "<group>"; };
+		33AA165C2E38A76F002DBD60 /* Country.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Country.graphql.swift; sourceTree = "<group>"; };
+		33AA165D2E38A76F002DBD60 /* CreateAttributionEventPayload.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateAttributionEventPayload.graphql.swift; sourceTree = "<group>"; };
+		33AA165E2E38A76F002DBD60 /* CreateBackingPayload.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateBackingPayload.graphql.swift; sourceTree = "<group>"; };
+		33AA165F2E38A76F002DBD60 /* CreateCheckoutPayload.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateCheckoutPayload.graphql.swift; sourceTree = "<group>"; };
+		33AA16602E38A76F002DBD60 /* CreateFlaggingPayload.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateFlaggingPayload.graphql.swift; sourceTree = "<group>"; };
+		33AA16612E38A76F002DBD60 /* CreateOrUpdateBackingAddressPayload.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateOrUpdateBackingAddressPayload.graphql.swift; sourceTree = "<group>"; };
+		33AA16622E38A76F002DBD60 /* CreatePaymentIntentPayload.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreatePaymentIntentPayload.graphql.swift; sourceTree = "<group>"; };
+		33AA16632E38A76F002DBD60 /* CreatePaymentSourcePayload.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreatePaymentSourcePayload.graphql.swift; sourceTree = "<group>"; };
+		33AA16642E38A76F002DBD60 /* CreateSetupIntentPayload.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateSetupIntentPayload.graphql.swift; sourceTree = "<group>"; };
+		33AA16652E38A76F002DBD60 /* CreatorInterview.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreatorInterview.graphql.swift; sourceTree = "<group>"; };
+		33AA16662E38A76F002DBD60 /* CreatorPrompt.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreatorPrompt.graphql.swift; sourceTree = "<group>"; };
+		33AA16672E38A76F002DBD60 /* CreditCard.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreditCard.graphql.swift; sourceTree = "<group>"; };
+		33AA16682E38A76F002DBD60 /* CuratedPage.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CuratedPage.graphql.swift; sourceTree = "<group>"; };
+		33AA16692E38A76F002DBD60 /* EnvironmentalCommitment.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnvironmentalCommitment.graphql.swift; sourceTree = "<group>"; };
+		33AA166A2E38A76F002DBD60 /* Flagging.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Flagging.graphql.swift; sourceTree = "<group>"; };
+		33AA166B2E38A76F002DBD60 /* FreeformPost.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FreeformPost.graphql.swift; sourceTree = "<group>"; };
+		33AA166C2E38A76F002DBD60 /* InterviewAnswer.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterviewAnswer.graphql.swift; sourceTree = "<group>"; };
+		33AA166D2E38A76F002DBD60 /* InterviewQuestion.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterviewQuestion.graphql.swift; sourceTree = "<group>"; };
+		33AA166E2E38A76F002DBD60 /* Location.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Location.graphql.swift; sourceTree = "<group>"; };
+		33AA166F2E38A76F002DBD60 /* LocationsConnection.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationsConnection.graphql.swift; sourceTree = "<group>"; };
+		33AA16702E38A76F002DBD60 /* Message.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Message.graphql.swift; sourceTree = "<group>"; };
+		33AA16712E38A76F002DBD60 /* Money.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Money.graphql.swift; sourceTree = "<group>"; };
+		33AA16722E38A76F002DBD60 /* Mutation.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Mutation.graphql.swift; sourceTree = "<group>"; };
+		33AA16732E38A76F002DBD60 /* NewsletterSubscriptions.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewsletterSubscriptions.graphql.swift; sourceTree = "<group>"; };
+		33AA16742E38A76F002DBD60 /* Notification.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Notification.graphql.swift; sourceTree = "<group>"; };
+		33AA16752E38A76F002DBD60 /* Order.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Order.graphql.swift; sourceTree = "<group>"; };
+		33AA16762E38A76F002DBD60 /* Organization.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Organization.graphql.swift; sourceTree = "<group>"; };
+		33AA16772E38A76F002DBD60 /* PageInfo.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageInfo.graphql.swift; sourceTree = "<group>"; };
+		33AA16782E38A76F002DBD60 /* PaymentIncrement.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentIncrement.graphql.swift; sourceTree = "<group>"; };
+		33AA16792E38A76F002DBD60 /* PaymentIncrementAmount.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentIncrementAmount.graphql.swift; sourceTree = "<group>"; };
+		33AA167A2E38A76F002DBD60 /* PaymentPlan.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentPlan.graphql.swift; sourceTree = "<group>"; };
+		33AA167B2E38A76F002DBD60 /* PaymentSourceDeletePayload.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentSourceDeletePayload.graphql.swift; sourceTree = "<group>"; };
+		33AA167C2E38A76F002DBD60 /* Photo.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Photo.graphql.swift; sourceTree = "<group>"; };
+		33AA167D2E38A76F002DBD60 /* PledgedProjectsOverviewPledgeFlags.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PledgedProjectsOverviewPledgeFlags.graphql.swift; sourceTree = "<group>"; };
+		33AA167E2E38A76F002DBD60 /* PledgedProjectsOverviewPledgesConnection.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PledgedProjectsOverviewPledgesConnection.graphql.swift; sourceTree = "<group>"; };
+		33AA167F2E38A76F002DBD60 /* PledgeManager.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PledgeManager.graphql.swift; sourceTree = "<group>"; };
+		33AA16802E38A76F002DBD60 /* PledgeProjectOverviewItem.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PledgeProjectOverviewItem.graphql.swift; sourceTree = "<group>"; };
+		33AA16812E38A76F002DBD60 /* PledgeProjectOverviewItemEdge.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PledgeProjectOverviewItemEdge.graphql.swift; sourceTree = "<group>"; };
+		33AA16822E38A76F002DBD60 /* PledgeProjectsOverview.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PledgeProjectsOverview.graphql.swift; sourceTree = "<group>"; };
+		33AA16832E38A76F002DBD60 /* PostCommentPayload.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostCommentPayload.graphql.swift; sourceTree = "<group>"; };
+		33AA16842E38A76F002DBD60 /* PostConnection.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostConnection.graphql.swift; sourceTree = "<group>"; };
+		33AA16852E38A76F002DBD60 /* Project.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Project.graphql.swift; sourceTree = "<group>"; };
+		33AA16862E38A76F002DBD60 /* ProjectBackerFriendsConnection.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectBackerFriendsConnection.graphql.swift; sourceTree = "<group>"; };
+		33AA16872E38A76F002DBD60 /* ProjectFaq.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectFaq.graphql.swift; sourceTree = "<group>"; };
+		33AA16882E38A76F002DBD60 /* ProjectFaqConnection.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectFaqConnection.graphql.swift; sourceTree = "<group>"; };
+		33AA16892E38A76F002DBD60 /* ProjectProfile.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectProfile.graphql.swift; sourceTree = "<group>"; };
+		33AA168A2E38A76F002DBD60 /* ProjectRewardConnection.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectRewardConnection.graphql.swift; sourceTree = "<group>"; };
+		33AA168B2E38A76F002DBD60 /* ProjectsConnectionWithTotalCount.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectsConnectionWithTotalCount.graphql.swift; sourceTree = "<group>"; };
+		33AA168C2E38A76F002DBD60 /* Query.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Query.graphql.swift; sourceTree = "<group>"; };
+		33AA168D2E38A76F002DBD60 /* Refund.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Refund.graphql.swift; sourceTree = "<group>"; };
+		33AA168E2E38A76F002DBD60 /* ResourceAudience.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResourceAudience.graphql.swift; sourceTree = "<group>"; };
+		33AA168F2E38A76F002DBD60 /* Reward.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Reward.graphql.swift; sourceTree = "<group>"; };
+		33AA16902E38A76F002DBD60 /* RewardConnection.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RewardConnection.graphql.swift; sourceTree = "<group>"; };
+		33AA16912E38A76F002DBD60 /* RewardItem.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RewardItem.graphql.swift; sourceTree = "<group>"; };
+		33AA16922E38A76F002DBD60 /* RewardItemEdge.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RewardItemEdge.graphql.swift; sourceTree = "<group>"; };
+		33AA16932E38A76F002DBD60 /* RewardItemsConnection.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RewardItemsConnection.graphql.swift; sourceTree = "<group>"; };
+		33AA16942E38A76F002DBD60 /* RewardShippingRulesConnection.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RewardShippingRulesConnection.graphql.swift; sourceTree = "<group>"; };
+		33AA16952E38A76F002DBD60 /* RewardTotalCountConnection.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RewardTotalCountConnection.graphql.swift; sourceTree = "<group>"; };
+		33AA16962E38A76F002DBD60 /* SavedSearchSegment.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SavedSearchSegment.graphql.swift; sourceTree = "<group>"; };
+		33AA16972E38A76F002DBD60 /* ShippingRule.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingRule.graphql.swift; sourceTree = "<group>"; };
+		33AA16982E38A76F002DBD60 /* SignInWithApplePayload.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInWithApplePayload.graphql.swift; sourceTree = "<group>"; };
+		33AA16992E38A76F002DBD60 /* SimpleShippingRule.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimpleShippingRule.graphql.swift; sourceTree = "<group>"; };
+		33AA169A2E38A76F002DBD60 /* Survey.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Survey.graphql.swift; sourceTree = "<group>"; };
+		33AA169B2E38A76F002DBD60 /* SurveyResponsesConnection.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveyResponsesConnection.graphql.swift; sourceTree = "<group>"; };
+		33AA169C2E38A76F002DBD60 /* Tag.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tag.graphql.swift; sourceTree = "<group>"; };
+		33AA169D2E38A76F002DBD60 /* TriggerThirdPartyEventPayload.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TriggerThirdPartyEventPayload.graphql.swift; sourceTree = "<group>"; };
+		33AA169E2E38A76F002DBD60 /* UnwatchProjectPayload.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnwatchProjectPayload.graphql.swift; sourceTree = "<group>"; };
+		33AA169F2E38A76F002DBD60 /* UpdateBackingPayload.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateBackingPayload.graphql.swift; sourceTree = "<group>"; };
+		33AA16A02E38A76F002DBD60 /* UpdateUserAccountPayload.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateUserAccountPayload.graphql.swift; sourceTree = "<group>"; };
+		33AA16A12E38A76F002DBD60 /* UpdateUserProfilePayload.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateUserProfilePayload.graphql.swift; sourceTree = "<group>"; };
+		33AA16A22E38A76F002DBD60 /* User.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = User.graphql.swift; sourceTree = "<group>"; };
+		33AA16A32E38A76F002DBD60 /* UserBackingsConnection.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserBackingsConnection.graphql.swift; sourceTree = "<group>"; };
+		33AA16A42E38A76F002DBD60 /* UserCreatedProjectsConnection.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserCreatedProjectsConnection.graphql.swift; sourceTree = "<group>"; };
+		33AA16A52E38A76F002DBD60 /* UserCreditCardTypeConnection.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserCreditCardTypeConnection.graphql.swift; sourceTree = "<group>"; };
+		33AA16A62E38A76F002DBD60 /* UserSavedProjectsConnection.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSavedProjectsConnection.graphql.swift; sourceTree = "<group>"; };
+		33AA16A72E38A76F002DBD60 /* UserSendEmailVerificationPayload.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSendEmailVerificationPayload.graphql.swift; sourceTree = "<group>"; };
+		33AA16A82E38A76F002DBD60 /* UserUrl.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserUrl.graphql.swift; sourceTree = "<group>"; };
+		33AA16A92E38A76F002DBD60 /* Validation.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Validation.graphql.swift; sourceTree = "<group>"; };
+		33AA16AA2E38A76F002DBD60 /* Video.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Video.graphql.swift; sourceTree = "<group>"; };
+		33AA16AB2E38A76F002DBD60 /* VideoSourceInfo.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoSourceInfo.graphql.swift; sourceTree = "<group>"; };
+		33AA16AC2E38A76F002DBD60 /* VideoSources.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoSources.graphql.swift; sourceTree = "<group>"; };
+		33AA16AD2E38A76F002DBD60 /* VideoTrack.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoTrack.graphql.swift; sourceTree = "<group>"; };
+		33AA16AE2E38A76F002DBD60 /* VideoTrackCue.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoTrackCue.graphql.swift; sourceTree = "<group>"; };
+		33AA16AF2E38A76F002DBD60 /* WatchProjectPayload.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchProjectPayload.graphql.swift; sourceTree = "<group>"; };
+		33AA16B12E38A76F002DBD60 /* PaymentSource.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentSource.graphql.swift; sourceTree = "<group>"; };
+		33AA16B32E38A76F002DBD60 /* SchemaConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchemaConfiguration.swift; sourceTree = "<group>"; };
+		33AA16B42E38A76F002DBD60 /* SchemaMetadata.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchemaMetadata.graphql.swift; sourceTree = "<group>"; };
+		33AA16B62E38A76F002DBD60 /* GraphAPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GraphAPI.h; sourceTree = "<group>"; };
+		33AA17AF2E38A7B1002DBD60 /* Address+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Address+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA17B02E38A7B1002DBD60 /* AddUserToSecretRewardGroupPayload+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AddUserToSecretRewardGroupPayload+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA17B12E38A7B1002DBD60 /* AdjustmentSummary+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AdjustmentSummary+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA17B22E38A7B1002DBD60 /* AiDisclosure+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AiDisclosure+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA17B32E38A7B1002DBD60 /* AttachedAudio+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AttachedAudio+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA17B42E38A7B1002DBD60 /* AttachedVideo+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AttachedVideo+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA17B52E38A7B1002DBD60 /* Backing+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Backing+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA17B62E38A7B1002DBD60 /* BankAccount+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BankAccount+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA17B72E38A7B1002DBD60 /* BlockUserPayload+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BlockUserPayload+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA17B82E38A7B1002DBD60 /* CancelBackingPayload+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CancelBackingPayload+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA17B92E38A7B1002DBD60 /* Category+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Category+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA17BA2E38A7B1002DBD60 /* CategorySubcategoriesConnection+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CategorySubcategoriesConnection+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA17BB2E38A7B1002DBD60 /* Checkout+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Checkout+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA17BC2E38A7B1002DBD60 /* CheckoutWave+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CheckoutWave+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA17BD2E38A7B1002DBD60 /* ClearUserUnseenActivityPayload+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ClearUserUnseenActivityPayload+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA17BE2E38A7B1002DBD60 /* Comment+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Comment+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA17BF2E38A7B1002DBD60 /* CommentConnection+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CommentConnection+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA17C02E38A7B1002DBD60 /* CommentEdge+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CommentEdge+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA17C12E38A7B1002DBD60 /* CompleteOnSessionCheckoutPayload+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CompleteOnSessionCheckoutPayload+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA17C22E38A7B1002DBD60 /* Conversation+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Conversation+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA17C32E38A7B1002DBD60 /* Country+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Country+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA17C42E38A7B1002DBD60 /* CreateAttributionEventPayload+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CreateAttributionEventPayload+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA17C52E38A7B1002DBD60 /* CreateBackingPayload+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CreateBackingPayload+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA17C62E38A7B1002DBD60 /* CreateCheckoutPayload+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CreateCheckoutPayload+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA17C72E38A7B1002DBD60 /* CreateFlaggingPayload+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CreateFlaggingPayload+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA17C82E38A7B1002DBD60 /* CreateOrUpdateBackingAddressPayload+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CreateOrUpdateBackingAddressPayload+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA17C92E38A7B1002DBD60 /* CreatePaymentIntentPayload+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CreatePaymentIntentPayload+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA17CA2E38A7B1002DBD60 /* CreatePaymentSourcePayload+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CreatePaymentSourcePayload+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA17CB2E38A7B1002DBD60 /* CreateSetupIntentPayload+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CreateSetupIntentPayload+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA17CC2E38A7B1002DBD60 /* CreatorInterview+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CreatorInterview+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA17CD2E38A7B1002DBD60 /* CreatorPrompt+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CreatorPrompt+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA17CE2E38A7B1002DBD60 /* CreditCard+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CreditCard+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA17CF2E38A7B1002DBD60 /* CuratedPage+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CuratedPage+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA17D02E38A7B1002DBD60 /* EnvironmentalCommitment+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EnvironmentalCommitment+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA17D12E38A7B1002DBD60 /* Flagging+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Flagging+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA17D22E38A7B1002DBD60 /* FreeformPost+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FreeformPost+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA17D32E38A7B1002DBD60 /* GraphAPITestMocks.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GraphAPITestMocks.h; sourceTree = "<group>"; };
+		33AA17D42E38A7B1002DBD60 /* InterviewAnswer+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "InterviewAnswer+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA17D52E38A7B1002DBD60 /* InterviewQuestion+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "InterviewQuestion+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA17D62E38A7B1002DBD60 /* Location+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Location+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA17D72E38A7B1002DBD60 /* LocationsConnection+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LocationsConnection+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA17D82E38A7B1002DBD60 /* Message+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Message+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA17D92E38A7B1002DBD60 /* MockObject+Interfaces.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MockObject+Interfaces.graphql.swift"; sourceTree = "<group>"; };
+		33AA17DA2E38A7B1002DBD60 /* MockObject+Unions.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MockObject+Unions.graphql.swift"; sourceTree = "<group>"; };
+		33AA17DB2E38A7B1002DBD60 /* Money+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Money+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA17DC2E38A7B1002DBD60 /* Mutation+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Mutation+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA17DD2E38A7B1002DBD60 /* NewsletterSubscriptions+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NewsletterSubscriptions+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA17DE2E38A7B1002DBD60 /* Notification+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Notification+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA17DF2E38A7B1002DBD60 /* Order+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Order+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA17E02E38A7B1002DBD60 /* Organization+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Organization+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA17E12E38A7B1002DBD60 /* PageInfo+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PageInfo+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA17E22E38A7B1002DBD60 /* PaymentIncrement+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PaymentIncrement+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA17E32E38A7B1002DBD60 /* PaymentIncrementAmount+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PaymentIncrementAmount+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA17E42E38A7B1002DBD60 /* PaymentPlan+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PaymentPlan+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA17E52E38A7B1002DBD60 /* PaymentSourceDeletePayload+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PaymentSourceDeletePayload+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA17E62E38A7B1002DBD60 /* Photo+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Photo+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA17E72E38A7B1002DBD60 /* PledgedProjectsOverviewPledgeFlags+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PledgedProjectsOverviewPledgeFlags+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA17E82E38A7B1002DBD60 /* PledgedProjectsOverviewPledgesConnection+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PledgedProjectsOverviewPledgesConnection+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA17E92E38A7B1002DBD60 /* PledgeManager+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PledgeManager+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA17EA2E38A7B1002DBD60 /* PledgeProjectOverviewItem+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PledgeProjectOverviewItem+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA17EB2E38A7B1002DBD60 /* PledgeProjectOverviewItemEdge+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PledgeProjectOverviewItemEdge+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA17EC2E38A7B1002DBD60 /* PledgeProjectsOverview+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PledgeProjectsOverview+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA17ED2E38A7B1002DBD60 /* PostCommentPayload+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PostCommentPayload+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA17EE2E38A7B1002DBD60 /* PostConnection+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PostConnection+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA17EF2E38A7B1002DBD60 /* Project+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Project+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA17F02E38A7B1002DBD60 /* ProjectBackerFriendsConnection+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProjectBackerFriendsConnection+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA17F12E38A7B1002DBD60 /* ProjectFaq+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProjectFaq+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA17F22E38A7B1002DBD60 /* ProjectFaqConnection+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProjectFaqConnection+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA17F32E38A7B1002DBD60 /* ProjectProfile+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProjectProfile+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA17F42E38A7B1002DBD60 /* ProjectRewardConnection+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProjectRewardConnection+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA17F52E38A7B1002DBD60 /* ProjectsConnectionWithTotalCount+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProjectsConnectionWithTotalCount+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA17F62E38A7B1002DBD60 /* Query+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Query+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA17F72E38A7B1002DBD60 /* Refund+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Refund+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA17F82E38A7B1002DBD60 /* ResourceAudience+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ResourceAudience+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA17F92E38A7B1002DBD60 /* Reward+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Reward+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA17FA2E38A7B1002DBD60 /* RewardConnection+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RewardConnection+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA17FB2E38A7B1002DBD60 /* RewardItem+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RewardItem+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA17FC2E38A7B1002DBD60 /* RewardItemEdge+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RewardItemEdge+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA17FD2E38A7B1002DBD60 /* RewardItemsConnection+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RewardItemsConnection+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA17FE2E38A7B1002DBD60 /* RewardShippingRulesConnection+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RewardShippingRulesConnection+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA17FF2E38A7B1002DBD60 /* RewardTotalCountConnection+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RewardTotalCountConnection+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA18002E38A7B1002DBD60 /* SavedSearchSegment+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SavedSearchSegment+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA18012E38A7B1002DBD60 /* ShippingRule+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ShippingRule+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA18022E38A7B1002DBD60 /* SignInWithApplePayload+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SignInWithApplePayload+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA18032E38A7B1002DBD60 /* SimpleShippingRule+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SimpleShippingRule+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA18042E38A7B1002DBD60 /* Survey+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Survey+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA18052E38A7B1002DBD60 /* SurveyResponsesConnection+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SurveyResponsesConnection+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA18062E38A7B1002DBD60 /* Tag+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Tag+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA18072E38A7B1002DBD60 /* TriggerThirdPartyEventPayload+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TriggerThirdPartyEventPayload+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA18082E38A7B1002DBD60 /* UnwatchProjectPayload+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UnwatchProjectPayload+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA18092E38A7B1002DBD60 /* UpdateBackingPayload+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UpdateBackingPayload+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA180A2E38A7B1002DBD60 /* UpdateUserAccountPayload+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UpdateUserAccountPayload+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA180B2E38A7B1002DBD60 /* UpdateUserProfilePayload+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UpdateUserProfilePayload+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA180C2E38A7B1002DBD60 /* User+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "User+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA180D2E38A7B1002DBD60 /* UserBackingsConnection+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserBackingsConnection+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA180E2E38A7B1002DBD60 /* UserCreatedProjectsConnection+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserCreatedProjectsConnection+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA180F2E38A7B1002DBD60 /* UserCreditCardTypeConnection+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserCreditCardTypeConnection+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA18102E38A7B1002DBD60 /* UserSavedProjectsConnection+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserSavedProjectsConnection+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA18112E38A7B1002DBD60 /* UserSendEmailVerificationPayload+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserSendEmailVerificationPayload+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA18122E38A7B1002DBD60 /* UserUrl+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserUrl+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA18132E38A7B1002DBD60 /* Validation+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Validation+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA18142E38A7B1002DBD60 /* Video+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Video+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA18152E38A7B1002DBD60 /* VideoSourceInfo+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "VideoSourceInfo+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA18162E38A7B1002DBD60 /* VideoSources+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "VideoSources+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA18172E38A7B1002DBD60 /* VideoTrack+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "VideoTrack+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA18182E38A7B1002DBD60 /* VideoTrackCue+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "VideoTrackCue+Mock.graphql.swift"; sourceTree = "<group>"; };
+		33AA18192E38A7B1002DBD60 /* WatchProjectPayload+Mock.graphql.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WatchProjectPayload+Mock.graphql.swift"; sourceTree = "<group>"; };
 		33AB20292D268E7700B8C047 /* PledgeRewardsSummaryTotalViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PledgeRewardsSummaryTotalViewControllerTests.swift; sourceTree = "<group>"; };
 		33AB202D2D269A6C00B8C047 /* MockPledgeOverTimePlanIntervals.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPledgeOverTimePlanIntervals.swift; sourceTree = "<group>"; };
 		33AF01B52D2BBCC90085A153 /* PledgeOverTimePaymentScheduleViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PledgeOverTimePaymentScheduleViewController.swift; sourceTree = "<group>"; };
@@ -3659,28 +4367,6 @@
 		E1EEED2A2B686829009976D9 /* PKCETest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PKCETest.swift; sourceTree = "<group>"; };
 		E1FDB1E72AEAAC6100285F93 /* CombineTestObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CombineTestObserver.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
-
-/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
-		E18A64692E28224A00BA0376 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
-			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
-			publicHeaders = (
-				GraphAPI.h,
-			);
-			target = E18A645C2E28224A00BA0376 /* GraphAPI */;
-		};
-		E18A666B2E28225E00BA0376 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
-			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
-			publicHeaders = (
-				GraphAPITestMocks.h,
-			);
-			target = E18A66662E28225E00BA0376 /* GraphAPITestMocks */;
-		};
-/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
-
-/* Begin PBXFileSystemSynchronizedRootGroup section */
-		E18A645E2E28224A00BA0376 /* GraphAPI */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (E18A64692E28224A00BA0376 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = GraphAPI; sourceTree = "<group>"; };
-		E18A66682E28225E00BA0376 /* GraphAPITestMocks */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (E18A666B2E28225E00BA0376 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = GraphAPITestMocks; sourceTree = "<group>"; };
-/* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
 		A75511381C8642B3005355CF /* Frameworks */ = {
@@ -6220,6 +6906,462 @@
 			path = Onboarding;
 			sourceTree = "<group>";
 		};
+		33AA15D42E38A76F002DBD60 /* Fragments */ = {
+			isa = PBXGroup;
+			children = (
+				33AA15B52E38A76F002DBD60 /* BackerDashboardProjectCellFragment.graphql.swift */,
+				33AA15B62E38A76F002DBD60 /* BackingFragment.graphql.swift */,
+				33AA15B72E38A76F002DBD60 /* CategoryFragment.graphql.swift */,
+				33AA15B82E38A76F002DBD60 /* CheckoutFragment.graphql.swift */,
+				33AA15B92E38A76F002DBD60 /* CommentBaseFragment.graphql.swift */,
+				33AA15BA2E38A76F002DBD60 /* CommentFragment.graphql.swift */,
+				33AA15BB2E38A76F002DBD60 /* CommentWithRepliesFragment.graphql.swift */,
+				33AA15BC2E38A76F002DBD60 /* CountryFragment.graphql.swift */,
+				33AA15BD2E38A76F002DBD60 /* LastWaveFragment.graphql.swift */,
+				33AA15BE2E38A76F002DBD60 /* LocationFragment.graphql.swift */,
+				33AA15BF2E38A76F002DBD60 /* MoneyFragment.graphql.swift */,
+				33AA15C02E38A76F002DBD60 /* OrderFragment.graphql.swift */,
+				33AA15C12E38A76F002DBD60 /* PaymentIncrementFragment.graphql.swift */,
+				33AA15C22E38A76F002DBD60 /* PaymentSourceFragment.graphql.swift */,
+				33AA15C32E38A76F002DBD60 /* PledgeManagerFragment.graphql.swift */,
+				33AA15C42E38A76F002DBD60 /* PledgeOverTimeFragment.graphql.swift */,
+				33AA15C52E38A76F002DBD60 /* PPOBackingFragment.graphql.swift */,
+				33AA15C62E38A76F002DBD60 /* PPOCardFragment.graphql.swift */,
+				33AA15C72E38A76F002DBD60 /* PPOProjectFragment.graphql.swift */,
+				33AA15C82E38A76F002DBD60 /* PPOUserSetupFragment.graphql.swift */,
+				33AA15C92E38A76F002DBD60 /* ProjectAnalyticsFragment.graphql.swift */,
+				33AA15CA2E38A76F002DBD60 /* ProjectCardFragment.graphql.swift */,
+				33AA15CB2E38A76F002DBD60 /* ProjectFragment.graphql.swift */,
+				33AA15CC2E38A76F002DBD60 /* ProjectPamphletMainCellPropertiesFragment.graphql.swift */,
+				33AA15CD2E38A76F002DBD60 /* RewardFragment.graphql.swift */,
+				33AA15CE2E38A76F002DBD60 /* ShippingRuleFragment.graphql.swift */,
+				33AA15CF2E38A76F002DBD60 /* UserEmailFragment.graphql.swift */,
+				33AA15D02E38A76F002DBD60 /* UserFeaturesFragment.graphql.swift */,
+				33AA15D12E38A76F002DBD60 /* UserFragment.graphql.swift */,
+				33AA15D22E38A76F002DBD60 /* UserSettingsFragment.graphql.swift */,
+				33AA15D32E38A76F002DBD60 /* UserStoredCardsFragment.graphql.swift */,
+			);
+			path = Fragments;
+			sourceTree = "<group>";
+		};
+		33AA15EC2E38A76F002DBD60 /* Mutations */ = {
+			isa = PBXGroup;
+			children = (
+				33AA15D52E38A76F002DBD60 /* AddUserToSecretRewardGroupMutation.graphql.swift */,
+				33AA15D62E38A76F002DBD60 /* BlockUserMutation.graphql.swift */,
+				33AA15D72E38A76F002DBD60 /* CancelBackingMutation.graphql.swift */,
+				33AA15D82E38A76F002DBD60 /* ClearUserUnseenActivityMutation.graphql.swift */,
+				33AA15D92E38A76F002DBD60 /* CompleteOnSessionCheckoutMutation.graphql.swift */,
+				33AA15DA2E38A76F002DBD60 /* CreateAttributionEventMutation.graphql.swift */,
+				33AA15DB2E38A76F002DBD60 /* CreateBackingMutation.graphql.swift */,
+				33AA15DC2E38A76F002DBD60 /* CreateCheckoutMutation.graphql.swift */,
+				33AA15DD2E38A76F002DBD60 /* CreateFlaggingMutation.graphql.swift */,
+				33AA15DE2E38A76F002DBD60 /* CreateOrUpdateBackingAddressMutation.graphql.swift */,
+				33AA15DF2E38A76F002DBD60 /* CreatePaymentIntentMutation.graphql.swift */,
+				33AA15E02E38A76F002DBD60 /* CreatePaymentSourceMutation.graphql.swift */,
+				33AA15E12E38A76F002DBD60 /* CreateSetupIntentMutation.graphql.swift */,
+				33AA15E22E38A76F002DBD60 /* DeletePaymentSourceMutation.graphql.swift */,
+				33AA15E32E38A76F002DBD60 /* PostCommentMutation.graphql.swift */,
+				33AA15E42E38A76F002DBD60 /* SignInWithAppleMutation.graphql.swift */,
+				33AA15E52E38A76F002DBD60 /* TriggerThirdPartyEventMutation.graphql.swift */,
+				33AA15E62E38A76F002DBD60 /* UnwatchProjectMutation.graphql.swift */,
+				33AA15E72E38A76F002DBD60 /* UpdateBackingMutation.graphql.swift */,
+				33AA15E82E38A76F002DBD60 /* UpdateUserAccountMutation.graphql.swift */,
+				33AA15E92E38A76F002DBD60 /* UpdateUserProfileMutation.graphql.swift */,
+				33AA15EA2E38A76F002DBD60 /* UserSendEmailVerificationMutation.graphql.swift */,
+				33AA15EB2E38A76F002DBD60 /* WatchProjectMutation.graphql.swift */,
+			);
+			path = Mutations;
+			sourceTree = "<group>";
+		};
+		33AA16072E38A76F002DBD60 /* Queries */ = {
+			isa = PBXGroup;
+			children = (
+				33AA15ED2E38A76F002DBD60 /* BuildPaymentPlanQuery.graphql.swift */,
+				33AA15EE2E38A76F002DBD60 /* DefaultLocationsQuery.graphql.swift */,
+				33AA15EF2E38A76F002DBD60 /* FetchAddOnsQuery.graphql.swift */,
+				33AA15F02E38A76F002DBD60 /* FetchBackingQuery.graphql.swift */,
+				33AA15F12E38A76F002DBD60 /* FetchCategoryQuery.graphql.swift */,
+				33AA15F22E38A76F002DBD60 /* FetchCommentRepliesQuery.graphql.swift */,
+				33AA15F32E38A76F002DBD60 /* FetchMyBackedProjectsQuery.graphql.swift */,
+				33AA15F42E38A76F002DBD60 /* FetchMySavedProjectsQuery.graphql.swift */,
+				33AA15F52E38A76F002DBD60 /* FetchPledgedProjectsQuery.graphql.swift */,
+				33AA15F62E38A76F002DBD60 /* FetchProjectByIdQuery.graphql.swift */,
+				33AA15F72E38A76F002DBD60 /* FetchProjectBySlugQuery.graphql.swift */,
+				33AA15F82E38A76F002DBD60 /* FetchProjectCommentsQuery.graphql.swift */,
+				33AA15F92E38A76F002DBD60 /* FetchProjectFriendsByIdQuery.graphql.swift */,
+				33AA15FA2E38A76F002DBD60 /* FetchProjectFriendsBySlugQuery.graphql.swift */,
+				33AA15FB2E38A76F002DBD60 /* FetchProjectRewardsByIdQuery.graphql.swift */,
+				33AA15FC2E38A76F002DBD60 /* FetchRootCategoriesQuery.graphql.swift */,
+				33AA15FD2E38A76F002DBD60 /* FetchSimilarProjectsQuery.graphql.swift */,
+				33AA15FE2E38A76F002DBD60 /* FetchUpdateCommentsQuery.graphql.swift */,
+				33AA15FF2E38A76F002DBD60 /* FetchUserBackingsQuery.graphql.swift */,
+				33AA16002E38A76F002DBD60 /* FetchUserEmailQuery.graphql.swift */,
+				33AA16012E38A76F002DBD60 /* FetchUserQuery.graphql.swift */,
+				33AA16022E38A76F002DBD60 /* FetchUserSetupQuery.graphql.swift */,
+				33AA16032E38A76F002DBD60 /* FetchUserStoredCardsQuery.graphql.swift */,
+				33AA16042E38A76F002DBD60 /* LocationsByTermQuery.graphql.swift */,
+				33AA16052E38A76F002DBD60 /* SearchQuery.graphql.swift */,
+				33AA16062E38A76F002DBD60 /* ValidateCheckoutQuery.graphql.swift */,
+			);
+			path = Queries;
+			sourceTree = "<group>";
+		};
+		33AA16082E38A76F002DBD60 /* Operations */ = {
+			isa = PBXGroup;
+			children = (
+				33AA15EC2E38A76F002DBD60 /* Mutations */,
+				33AA16072E38A76F002DBD60 /* Queries */,
+			);
+			path = Operations;
+			sourceTree = "<group>";
+		};
+		33AA160F2E38A76F002DBD60 /* CustomScalars */ = {
+			isa = PBXGroup;
+			children = (
+				33AA16092E38A76F002DBD60 /* Date.swift */,
+				33AA160A2E38A76F002DBD60 /* DateTime.swift */,
+				33AA160B2E38A76F002DBD60 /* Email.swift */,
+				33AA160C2E38A76F002DBD60 /* HTML.swift */,
+				33AA160D2E38A76F002DBD60 /* ISO8601DateTime.swift */,
+				33AA160E2E38A76F002DBD60 /* JSON.swift */,
+			);
+			path = CustomScalars;
+			sourceTree = "<group>";
+		};
+		33AA16282E38A76F002DBD60 /* Enums */ = {
+			isa = PBXGroup;
+			children = (
+				33AA16102E38A76F002DBD60 /* BackingState.graphql.swift */,
+				33AA16112E38A76F002DBD60 /* CheckoutState.graphql.swift */,
+				33AA16122E38A76F002DBD60 /* CheckoutStateEnum.graphql.swift */,
+				33AA16132E38A76F002DBD60 /* CommentBadge.graphql.swift */,
+				33AA16142E38A76F002DBD60 /* CountryCode.graphql.swift */,
+				33AA16152E38A76F002DBD60 /* CreditCardPaymentType.graphql.swift */,
+				33AA16162E38A76F002DBD60 /* CreditCardTypes.graphql.swift */,
+				33AA16172E38A76F002DBD60 /* CurrencyCode.graphql.swift */,
+				33AA16182E38A76F002DBD60 /* EnvironmentalCommitmentCategory.graphql.swift */,
+				33AA16192E38A76F002DBD60 /* Feature.graphql.swift */,
+				33AA161A2E38A76F002DBD60 /* FlaggingKind.graphql.swift */,
+				33AA161B2E38A76F002DBD60 /* GoalBuckets.graphql.swift */,
+				33AA161C2E38A76F002DBD60 /* NonDeprecatedFlaggingKind.graphql.swift */,
+				33AA161D2E38A76F002DBD60 /* PaymentIncrementState.graphql.swift */,
+				33AA161E2E38A76F002DBD60 /* PaymentIncrementStateReason.graphql.swift */,
+				33AA161F2E38A76F002DBD60 /* PaymentTypes.graphql.swift */,
+				33AA16202E38A76F002DBD60 /* PledgedBuckets.graphql.swift */,
+				33AA16212E38A76F002DBD60 /* ProjectSort.graphql.swift */,
+				33AA16222E38A76F002DBD60 /* ProjectState.graphql.swift */,
+				33AA16232E38A76F002DBD60 /* PublicProjectState.graphql.swift */,
+				33AA16242E38A76F002DBD60 /* RaisedBuckets.graphql.swift */,
+				33AA16252E38A76F002DBD60 /* ShippingPreference.graphql.swift */,
+				33AA16262E38A76F002DBD60 /* StripeIntentContextTypes.graphql.swift */,
+				33AA16272E38A76F002DBD60 /* UserNotificationTopic.graphql.swift */,
+			);
+			path = Enums;
+			sourceTree = "<group>";
+		};
+		33AA16432E38A76F002DBD60 /* InputObjects */ = {
+			isa = PBXGroup;
+			children = (
+				33AA16292E38A76F002DBD60 /* AddUserToSecretRewardGroupInput.graphql.swift */,
+				33AA162A2E38A76F002DBD60 /* AppDataInput.graphql.swift */,
+				33AA162B2E38A76F002DBD60 /* ApplePayInput.graphql.swift */,
+				33AA162C2E38A76F002DBD60 /* BlockUserInput.graphql.swift */,
+				33AA162D2E38A76F002DBD60 /* CancelBackingInput.graphql.swift */,
+				33AA162E2E38A76F002DBD60 /* ClearUserUnseenActivityInput.graphql.swift */,
+				33AA162F2E38A76F002DBD60 /* CompleteOnSessionCheckoutInput.graphql.swift */,
+				33AA16302E38A76F002DBD60 /* CreateAttributionEventInput.graphql.swift */,
+				33AA16312E38A76F002DBD60 /* CreateBackingInput.graphql.swift */,
+				33AA16322E38A76F002DBD60 /* CreateCheckoutInput.graphql.swift */,
+				33AA16332E38A76F002DBD60 /* CreateFlaggingInput.graphql.swift */,
+				33AA16342E38A76F002DBD60 /* CreateOrUpdateBackingAddressInput.graphql.swift */,
+				33AA16352E38A76F002DBD60 /* CreatePaymentIntentInput.graphql.swift */,
+				33AA16362E38A76F002DBD60 /* CreatePaymentSourceInput.graphql.swift */,
+				33AA16372E38A76F002DBD60 /* CreateSetupIntentInput.graphql.swift */,
+				33AA16382E38A76F002DBD60 /* PaymentSourceDeleteInput.graphql.swift */,
+				33AA16392E38A76F002DBD60 /* PostCommentInput.graphql.swift */,
+				33AA163A2E38A76F002DBD60 /* SignInWithAppleInput.graphql.swift */,
+				33AA163B2E38A76F002DBD60 /* ThirdPartyEventItemInput.graphql.swift */,
+				33AA163C2E38A76F002DBD60 /* TriggerThirdPartyEventInput.graphql.swift */,
+				33AA163D2E38A76F002DBD60 /* UnwatchProjectInput.graphql.swift */,
+				33AA163E2E38A76F002DBD60 /* UpdateBackingInput.graphql.swift */,
+				33AA163F2E38A76F002DBD60 /* UpdateUserAccountInput.graphql.swift */,
+				33AA16402E38A76F002DBD60 /* UpdateUserProfileInput.graphql.swift */,
+				33AA16412E38A76F002DBD60 /* UserSendEmailVerificationInput.graphql.swift */,
+				33AA16422E38A76F002DBD60 /* WatchProjectInput.graphql.swift */,
+			);
+			path = InputObjects;
+			sourceTree = "<group>";
+		};
+		33AA16472E38A76F002DBD60 /* Interfaces */ = {
+			isa = PBXGroup;
+			children = (
+				33AA16442E38A76F002DBD60 /* Commentable.graphql.swift */,
+				33AA16452E38A76F002DBD60 /* Node.graphql.swift */,
+				33AA16462E38A76F002DBD60 /* Postable.graphql.swift */,
+			);
+			path = Interfaces;
+			sourceTree = "<group>";
+		};
+		33AA16B02E38A76F002DBD60 /* Objects */ = {
+			isa = PBXGroup;
+			children = (
+				33AA16482E38A76F002DBD60 /* Address.graphql.swift */,
+				33AA16492E38A76F002DBD60 /* AddUserToSecretRewardGroupPayload.graphql.swift */,
+				33AA164A2E38A76F002DBD60 /* AdjustmentSummary.graphql.swift */,
+				33AA164B2E38A76F002DBD60 /* AiDisclosure.graphql.swift */,
+				33AA164C2E38A76F002DBD60 /* AttachedAudio.graphql.swift */,
+				33AA164D2E38A76F002DBD60 /* AttachedVideo.graphql.swift */,
+				33AA164E2E38A76F002DBD60 /* Backing.graphql.swift */,
+				33AA164F2E38A76F002DBD60 /* BankAccount.graphql.swift */,
+				33AA16502E38A76F002DBD60 /* BlockUserPayload.graphql.swift */,
+				33AA16512E38A76F002DBD60 /* CancelBackingPayload.graphql.swift */,
+				33AA16522E38A76F002DBD60 /* Category.graphql.swift */,
+				33AA16532E38A76F002DBD60 /* CategorySubcategoriesConnection.graphql.swift */,
+				33AA16542E38A76F002DBD60 /* Checkout.graphql.swift */,
+				33AA16552E38A76F002DBD60 /* CheckoutWave.graphql.swift */,
+				33AA16562E38A76F002DBD60 /* ClearUserUnseenActivityPayload.graphql.swift */,
+				33AA16572E38A76F002DBD60 /* Comment.graphql.swift */,
+				33AA16582E38A76F002DBD60 /* CommentConnection.graphql.swift */,
+				33AA16592E38A76F002DBD60 /* CommentEdge.graphql.swift */,
+				33AA165A2E38A76F002DBD60 /* CompleteOnSessionCheckoutPayload.graphql.swift */,
+				33AA165B2E38A76F002DBD60 /* Conversation.graphql.swift */,
+				33AA165C2E38A76F002DBD60 /* Country.graphql.swift */,
+				33AA165D2E38A76F002DBD60 /* CreateAttributionEventPayload.graphql.swift */,
+				33AA165E2E38A76F002DBD60 /* CreateBackingPayload.graphql.swift */,
+				33AA165F2E38A76F002DBD60 /* CreateCheckoutPayload.graphql.swift */,
+				33AA16602E38A76F002DBD60 /* CreateFlaggingPayload.graphql.swift */,
+				33AA16612E38A76F002DBD60 /* CreateOrUpdateBackingAddressPayload.graphql.swift */,
+				33AA16622E38A76F002DBD60 /* CreatePaymentIntentPayload.graphql.swift */,
+				33AA16632E38A76F002DBD60 /* CreatePaymentSourcePayload.graphql.swift */,
+				33AA16642E38A76F002DBD60 /* CreateSetupIntentPayload.graphql.swift */,
+				33AA16652E38A76F002DBD60 /* CreatorInterview.graphql.swift */,
+				33AA16662E38A76F002DBD60 /* CreatorPrompt.graphql.swift */,
+				33AA16672E38A76F002DBD60 /* CreditCard.graphql.swift */,
+				33AA16682E38A76F002DBD60 /* CuratedPage.graphql.swift */,
+				33AA16692E38A76F002DBD60 /* EnvironmentalCommitment.graphql.swift */,
+				33AA166A2E38A76F002DBD60 /* Flagging.graphql.swift */,
+				33AA166B2E38A76F002DBD60 /* FreeformPost.graphql.swift */,
+				33AA166C2E38A76F002DBD60 /* InterviewAnswer.graphql.swift */,
+				33AA166D2E38A76F002DBD60 /* InterviewQuestion.graphql.swift */,
+				33AA166E2E38A76F002DBD60 /* Location.graphql.swift */,
+				33AA166F2E38A76F002DBD60 /* LocationsConnection.graphql.swift */,
+				33AA16702E38A76F002DBD60 /* Message.graphql.swift */,
+				33AA16712E38A76F002DBD60 /* Money.graphql.swift */,
+				33AA16722E38A76F002DBD60 /* Mutation.graphql.swift */,
+				33AA16732E38A76F002DBD60 /* NewsletterSubscriptions.graphql.swift */,
+				33AA16742E38A76F002DBD60 /* Notification.graphql.swift */,
+				33AA16752E38A76F002DBD60 /* Order.graphql.swift */,
+				33AA16762E38A76F002DBD60 /* Organization.graphql.swift */,
+				33AA16772E38A76F002DBD60 /* PageInfo.graphql.swift */,
+				33AA16782E38A76F002DBD60 /* PaymentIncrement.graphql.swift */,
+				33AA16792E38A76F002DBD60 /* PaymentIncrementAmount.graphql.swift */,
+				33AA167A2E38A76F002DBD60 /* PaymentPlan.graphql.swift */,
+				33AA167B2E38A76F002DBD60 /* PaymentSourceDeletePayload.graphql.swift */,
+				33AA167C2E38A76F002DBD60 /* Photo.graphql.swift */,
+				33AA167D2E38A76F002DBD60 /* PledgedProjectsOverviewPledgeFlags.graphql.swift */,
+				33AA167E2E38A76F002DBD60 /* PledgedProjectsOverviewPledgesConnection.graphql.swift */,
+				33AA167F2E38A76F002DBD60 /* PledgeManager.graphql.swift */,
+				33AA16802E38A76F002DBD60 /* PledgeProjectOverviewItem.graphql.swift */,
+				33AA16812E38A76F002DBD60 /* PledgeProjectOverviewItemEdge.graphql.swift */,
+				33AA16822E38A76F002DBD60 /* PledgeProjectsOverview.graphql.swift */,
+				33AA16832E38A76F002DBD60 /* PostCommentPayload.graphql.swift */,
+				33AA16842E38A76F002DBD60 /* PostConnection.graphql.swift */,
+				33AA16852E38A76F002DBD60 /* Project.graphql.swift */,
+				33AA16862E38A76F002DBD60 /* ProjectBackerFriendsConnection.graphql.swift */,
+				33AA16872E38A76F002DBD60 /* ProjectFaq.graphql.swift */,
+				33AA16882E38A76F002DBD60 /* ProjectFaqConnection.graphql.swift */,
+				33AA16892E38A76F002DBD60 /* ProjectProfile.graphql.swift */,
+				33AA168A2E38A76F002DBD60 /* ProjectRewardConnection.graphql.swift */,
+				33AA168B2E38A76F002DBD60 /* ProjectsConnectionWithTotalCount.graphql.swift */,
+				33AA168C2E38A76F002DBD60 /* Query.graphql.swift */,
+				33AA168D2E38A76F002DBD60 /* Refund.graphql.swift */,
+				33AA168E2E38A76F002DBD60 /* ResourceAudience.graphql.swift */,
+				33AA168F2E38A76F002DBD60 /* Reward.graphql.swift */,
+				33AA16902E38A76F002DBD60 /* RewardConnection.graphql.swift */,
+				33AA16912E38A76F002DBD60 /* RewardItem.graphql.swift */,
+				33AA16922E38A76F002DBD60 /* RewardItemEdge.graphql.swift */,
+				33AA16932E38A76F002DBD60 /* RewardItemsConnection.graphql.swift */,
+				33AA16942E38A76F002DBD60 /* RewardShippingRulesConnection.graphql.swift */,
+				33AA16952E38A76F002DBD60 /* RewardTotalCountConnection.graphql.swift */,
+				33AA16962E38A76F002DBD60 /* SavedSearchSegment.graphql.swift */,
+				33AA16972E38A76F002DBD60 /* ShippingRule.graphql.swift */,
+				33AA16982E38A76F002DBD60 /* SignInWithApplePayload.graphql.swift */,
+				33AA16992E38A76F002DBD60 /* SimpleShippingRule.graphql.swift */,
+				33AA169A2E38A76F002DBD60 /* Survey.graphql.swift */,
+				33AA169B2E38A76F002DBD60 /* SurveyResponsesConnection.graphql.swift */,
+				33AA169C2E38A76F002DBD60 /* Tag.graphql.swift */,
+				33AA169D2E38A76F002DBD60 /* TriggerThirdPartyEventPayload.graphql.swift */,
+				33AA169E2E38A76F002DBD60 /* UnwatchProjectPayload.graphql.swift */,
+				33AA169F2E38A76F002DBD60 /* UpdateBackingPayload.graphql.swift */,
+				33AA16A02E38A76F002DBD60 /* UpdateUserAccountPayload.graphql.swift */,
+				33AA16A12E38A76F002DBD60 /* UpdateUserProfilePayload.graphql.swift */,
+				33AA16A22E38A76F002DBD60 /* User.graphql.swift */,
+				33AA16A32E38A76F002DBD60 /* UserBackingsConnection.graphql.swift */,
+				33AA16A42E38A76F002DBD60 /* UserCreatedProjectsConnection.graphql.swift */,
+				33AA16A52E38A76F002DBD60 /* UserCreditCardTypeConnection.graphql.swift */,
+				33AA16A62E38A76F002DBD60 /* UserSavedProjectsConnection.graphql.swift */,
+				33AA16A72E38A76F002DBD60 /* UserSendEmailVerificationPayload.graphql.swift */,
+				33AA16A82E38A76F002DBD60 /* UserUrl.graphql.swift */,
+				33AA16A92E38A76F002DBD60 /* Validation.graphql.swift */,
+				33AA16AA2E38A76F002DBD60 /* Video.graphql.swift */,
+				33AA16AB2E38A76F002DBD60 /* VideoSourceInfo.graphql.swift */,
+				33AA16AC2E38A76F002DBD60 /* VideoSources.graphql.swift */,
+				33AA16AD2E38A76F002DBD60 /* VideoTrack.graphql.swift */,
+				33AA16AE2E38A76F002DBD60 /* VideoTrackCue.graphql.swift */,
+				33AA16AF2E38A76F002DBD60 /* WatchProjectPayload.graphql.swift */,
+			);
+			path = Objects;
+			sourceTree = "<group>";
+		};
+		33AA16B22E38A76F002DBD60 /* Unions */ = {
+			isa = PBXGroup;
+			children = (
+				33AA16B12E38A76F002DBD60 /* PaymentSource.graphql.swift */,
+			);
+			path = Unions;
+			sourceTree = "<group>";
+		};
+		33AA16B52E38A76F002DBD60 /* Schema */ = {
+			isa = PBXGroup;
+			children = (
+				33AA160F2E38A76F002DBD60 /* CustomScalars */,
+				33AA16282E38A76F002DBD60 /* Enums */,
+				33AA16432E38A76F002DBD60 /* InputObjects */,
+				33AA16472E38A76F002DBD60 /* Interfaces */,
+				33AA16B02E38A76F002DBD60 /* Objects */,
+				33AA16B22E38A76F002DBD60 /* Unions */,
+				33AA16B32E38A76F002DBD60 /* SchemaConfiguration.swift */,
+				33AA16B42E38A76F002DBD60 /* SchemaMetadata.graphql.swift */,
+			);
+			path = Schema;
+			sourceTree = "<group>";
+		};
+		33AA16B72E38A76F002DBD60 /* GraphAPI */ = {
+			isa = PBXGroup;
+			children = (
+				33AA15D42E38A76F002DBD60 /* Fragments */,
+				33AA16082E38A76F002DBD60 /* Operations */,
+				33AA16B52E38A76F002DBD60 /* Schema */,
+				33AA16B62E38A76F002DBD60 /* GraphAPI.h */,
+			);
+			path = GraphAPI;
+			sourceTree = "<group>";
+		};
+		33AA181A2E38A7B1002DBD60 /* GraphAPITestMocks */ = {
+			isa = PBXGroup;
+			children = (
+				33AA17AF2E38A7B1002DBD60 /* Address+Mock.graphql.swift */,
+				33AA17B02E38A7B1002DBD60 /* AddUserToSecretRewardGroupPayload+Mock.graphql.swift */,
+				33AA17B12E38A7B1002DBD60 /* AdjustmentSummary+Mock.graphql.swift */,
+				33AA17B22E38A7B1002DBD60 /* AiDisclosure+Mock.graphql.swift */,
+				33AA17B32E38A7B1002DBD60 /* AttachedAudio+Mock.graphql.swift */,
+				33AA17B42E38A7B1002DBD60 /* AttachedVideo+Mock.graphql.swift */,
+				33AA17B52E38A7B1002DBD60 /* Backing+Mock.graphql.swift */,
+				33AA17B62E38A7B1002DBD60 /* BankAccount+Mock.graphql.swift */,
+				33AA17B72E38A7B1002DBD60 /* BlockUserPayload+Mock.graphql.swift */,
+				33AA17B82E38A7B1002DBD60 /* CancelBackingPayload+Mock.graphql.swift */,
+				33AA17B92E38A7B1002DBD60 /* Category+Mock.graphql.swift */,
+				33AA17BA2E38A7B1002DBD60 /* CategorySubcategoriesConnection+Mock.graphql.swift */,
+				33AA17BB2E38A7B1002DBD60 /* Checkout+Mock.graphql.swift */,
+				33AA17BC2E38A7B1002DBD60 /* CheckoutWave+Mock.graphql.swift */,
+				33AA17BD2E38A7B1002DBD60 /* ClearUserUnseenActivityPayload+Mock.graphql.swift */,
+				33AA17BE2E38A7B1002DBD60 /* Comment+Mock.graphql.swift */,
+				33AA17BF2E38A7B1002DBD60 /* CommentConnection+Mock.graphql.swift */,
+				33AA17C02E38A7B1002DBD60 /* CommentEdge+Mock.graphql.swift */,
+				33AA17C12E38A7B1002DBD60 /* CompleteOnSessionCheckoutPayload+Mock.graphql.swift */,
+				33AA17C22E38A7B1002DBD60 /* Conversation+Mock.graphql.swift */,
+				33AA17C32E38A7B1002DBD60 /* Country+Mock.graphql.swift */,
+				33AA17C42E38A7B1002DBD60 /* CreateAttributionEventPayload+Mock.graphql.swift */,
+				33AA17C52E38A7B1002DBD60 /* CreateBackingPayload+Mock.graphql.swift */,
+				33AA17C62E38A7B1002DBD60 /* CreateCheckoutPayload+Mock.graphql.swift */,
+				33AA17C72E38A7B1002DBD60 /* CreateFlaggingPayload+Mock.graphql.swift */,
+				33AA17C82E38A7B1002DBD60 /* CreateOrUpdateBackingAddressPayload+Mock.graphql.swift */,
+				33AA17C92E38A7B1002DBD60 /* CreatePaymentIntentPayload+Mock.graphql.swift */,
+				33AA17CA2E38A7B1002DBD60 /* CreatePaymentSourcePayload+Mock.graphql.swift */,
+				33AA17CB2E38A7B1002DBD60 /* CreateSetupIntentPayload+Mock.graphql.swift */,
+				33AA17CC2E38A7B1002DBD60 /* CreatorInterview+Mock.graphql.swift */,
+				33AA17CD2E38A7B1002DBD60 /* CreatorPrompt+Mock.graphql.swift */,
+				33AA17CE2E38A7B1002DBD60 /* CreditCard+Mock.graphql.swift */,
+				33AA17CF2E38A7B1002DBD60 /* CuratedPage+Mock.graphql.swift */,
+				33AA17D02E38A7B1002DBD60 /* EnvironmentalCommitment+Mock.graphql.swift */,
+				33AA17D12E38A7B1002DBD60 /* Flagging+Mock.graphql.swift */,
+				33AA17D22E38A7B1002DBD60 /* FreeformPost+Mock.graphql.swift */,
+				33AA17D32E38A7B1002DBD60 /* GraphAPITestMocks.h */,
+				33AA17D42E38A7B1002DBD60 /* InterviewAnswer+Mock.graphql.swift */,
+				33AA17D52E38A7B1002DBD60 /* InterviewQuestion+Mock.graphql.swift */,
+				33AA17D62E38A7B1002DBD60 /* Location+Mock.graphql.swift */,
+				33AA17D72E38A7B1002DBD60 /* LocationsConnection+Mock.graphql.swift */,
+				33AA17D82E38A7B1002DBD60 /* Message+Mock.graphql.swift */,
+				33AA17D92E38A7B1002DBD60 /* MockObject+Interfaces.graphql.swift */,
+				33AA17DA2E38A7B1002DBD60 /* MockObject+Unions.graphql.swift */,
+				33AA17DB2E38A7B1002DBD60 /* Money+Mock.graphql.swift */,
+				33AA17DC2E38A7B1002DBD60 /* Mutation+Mock.graphql.swift */,
+				33AA17DD2E38A7B1002DBD60 /* NewsletterSubscriptions+Mock.graphql.swift */,
+				33AA17DE2E38A7B1002DBD60 /* Notification+Mock.graphql.swift */,
+				33AA17DF2E38A7B1002DBD60 /* Order+Mock.graphql.swift */,
+				33AA17E02E38A7B1002DBD60 /* Organization+Mock.graphql.swift */,
+				33AA17E12E38A7B1002DBD60 /* PageInfo+Mock.graphql.swift */,
+				33AA17E22E38A7B1002DBD60 /* PaymentIncrement+Mock.graphql.swift */,
+				33AA17E32E38A7B1002DBD60 /* PaymentIncrementAmount+Mock.graphql.swift */,
+				33AA17E42E38A7B1002DBD60 /* PaymentPlan+Mock.graphql.swift */,
+				33AA17E52E38A7B1002DBD60 /* PaymentSourceDeletePayload+Mock.graphql.swift */,
+				33AA17E62E38A7B1002DBD60 /* Photo+Mock.graphql.swift */,
+				33AA17E72E38A7B1002DBD60 /* PledgedProjectsOverviewPledgeFlags+Mock.graphql.swift */,
+				33AA17E82E38A7B1002DBD60 /* PledgedProjectsOverviewPledgesConnection+Mock.graphql.swift */,
+				33AA17E92E38A7B1002DBD60 /* PledgeManager+Mock.graphql.swift */,
+				33AA17EA2E38A7B1002DBD60 /* PledgeProjectOverviewItem+Mock.graphql.swift */,
+				33AA17EB2E38A7B1002DBD60 /* PledgeProjectOverviewItemEdge+Mock.graphql.swift */,
+				33AA17EC2E38A7B1002DBD60 /* PledgeProjectsOverview+Mock.graphql.swift */,
+				33AA17ED2E38A7B1002DBD60 /* PostCommentPayload+Mock.graphql.swift */,
+				33AA17EE2E38A7B1002DBD60 /* PostConnection+Mock.graphql.swift */,
+				33AA17EF2E38A7B1002DBD60 /* Project+Mock.graphql.swift */,
+				33AA17F02E38A7B1002DBD60 /* ProjectBackerFriendsConnection+Mock.graphql.swift */,
+				33AA17F12E38A7B1002DBD60 /* ProjectFaq+Mock.graphql.swift */,
+				33AA17F22E38A7B1002DBD60 /* ProjectFaqConnection+Mock.graphql.swift */,
+				33AA17F32E38A7B1002DBD60 /* ProjectProfile+Mock.graphql.swift */,
+				33AA17F42E38A7B1002DBD60 /* ProjectRewardConnection+Mock.graphql.swift */,
+				33AA17F52E38A7B1002DBD60 /* ProjectsConnectionWithTotalCount+Mock.graphql.swift */,
+				33AA17F62E38A7B1002DBD60 /* Query+Mock.graphql.swift */,
+				33AA17F72E38A7B1002DBD60 /* Refund+Mock.graphql.swift */,
+				33AA17F82E38A7B1002DBD60 /* ResourceAudience+Mock.graphql.swift */,
+				33AA17F92E38A7B1002DBD60 /* Reward+Mock.graphql.swift */,
+				33AA17FA2E38A7B1002DBD60 /* RewardConnection+Mock.graphql.swift */,
+				33AA17FB2E38A7B1002DBD60 /* RewardItem+Mock.graphql.swift */,
+				33AA17FC2E38A7B1002DBD60 /* RewardItemEdge+Mock.graphql.swift */,
+				33AA17FD2E38A7B1002DBD60 /* RewardItemsConnection+Mock.graphql.swift */,
+				33AA17FE2E38A7B1002DBD60 /* RewardShippingRulesConnection+Mock.graphql.swift */,
+				33AA17FF2E38A7B1002DBD60 /* RewardTotalCountConnection+Mock.graphql.swift */,
+				33AA18002E38A7B1002DBD60 /* SavedSearchSegment+Mock.graphql.swift */,
+				33AA18012E38A7B1002DBD60 /* ShippingRule+Mock.graphql.swift */,
+				33AA18022E38A7B1002DBD60 /* SignInWithApplePayload+Mock.graphql.swift */,
+				33AA18032E38A7B1002DBD60 /* SimpleShippingRule+Mock.graphql.swift */,
+				33AA18042E38A7B1002DBD60 /* Survey+Mock.graphql.swift */,
+				33AA18052E38A7B1002DBD60 /* SurveyResponsesConnection+Mock.graphql.swift */,
+				33AA18062E38A7B1002DBD60 /* Tag+Mock.graphql.swift */,
+				33AA18072E38A7B1002DBD60 /* TriggerThirdPartyEventPayload+Mock.graphql.swift */,
+				33AA18082E38A7B1002DBD60 /* UnwatchProjectPayload+Mock.graphql.swift */,
+				33AA18092E38A7B1002DBD60 /* UpdateBackingPayload+Mock.graphql.swift */,
+				33AA180A2E38A7B1002DBD60 /* UpdateUserAccountPayload+Mock.graphql.swift */,
+				33AA180B2E38A7B1002DBD60 /* UpdateUserProfilePayload+Mock.graphql.swift */,
+				33AA180C2E38A7B1002DBD60 /* User+Mock.graphql.swift */,
+				33AA180D2E38A7B1002DBD60 /* UserBackingsConnection+Mock.graphql.swift */,
+				33AA180E2E38A7B1002DBD60 /* UserCreatedProjectsConnection+Mock.graphql.swift */,
+				33AA180F2E38A7B1002DBD60 /* UserCreditCardTypeConnection+Mock.graphql.swift */,
+				33AA18102E38A7B1002DBD60 /* UserSavedProjectsConnection+Mock.graphql.swift */,
+				33AA18112E38A7B1002DBD60 /* UserSendEmailVerificationPayload+Mock.graphql.swift */,
+				33AA18122E38A7B1002DBD60 /* UserUrl+Mock.graphql.swift */,
+				33AA18132E38A7B1002DBD60 /* Validation+Mock.graphql.swift */,
+				33AA18142E38A7B1002DBD60 /* Video+Mock.graphql.swift */,
+				33AA18152E38A7B1002DBD60 /* VideoSourceInfo+Mock.graphql.swift */,
+				33AA18162E38A7B1002DBD60 /* VideoSources+Mock.graphql.swift */,
+				33AA18172E38A7B1002DBD60 /* VideoTrack+Mock.graphql.swift */,
+				33AA18182E38A7B1002DBD60 /* VideoTrackCue+Mock.graphql.swift */,
+				33AA18192E38A7B1002DBD60 /* WatchProjectPayload+Mock.graphql.swift */,
+			);
+			path = GraphAPITestMocks;
+			sourceTree = "<group>";
+		};
 		33F55B472D4C70D40007E50E /* Resources */ = {
 			isa = PBXGroup;
 			children = (
@@ -6990,8 +8132,8 @@
 				A7D1F9461C850B7C000D41D5 /* Kickstarter-iOS */,
 				D01587511EEB2DE4006E7684 /* KsApi */,
 				A7C725771C85D36D005A016B /* Library */,
-				E18A645E2E28224A00BA0376 /* GraphAPI */,
-				E18A66682E28225E00BA0376 /* GraphAPITestMocks */,
+				33AA16B72E38A76F002DBD60 /* GraphAPI */,
+				33AA181A2E38A7B1002DBD60 /* GraphAPITestMocks */,
 				E190EB6F2E29944E006A6DB6 /* graphql */,
 				A7E06C7A1C5A6EB300EBDCC2 /* Products */,
 			);
@@ -8115,6 +9257,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				33AA16B82E38A76F002DBD60 /* GraphAPI.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -8122,6 +9265,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				33AA181B2E38A7B1002DBD60 /* GraphAPITestMocks.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -8367,9 +9511,6 @@
 			);
 			dependencies = (
 			);
-			fileSystemSynchronizedGroups = (
-				E18A645E2E28224A00BA0376 /* GraphAPI */,
-			);
 			name = GraphAPI;
 			packageProductDependencies = (
 				E18A67452E2822EA00BA0376 /* ApolloAPI */,
@@ -8390,9 +9531,6 @@
 			buildRules = (
 			);
 			dependencies = (
-			);
-			fileSystemSynchronizedGroups = (
-				E18A66682E28225E00BA0376 /* GraphAPITestMocks */,
 			);
 			name = GraphAPITestMocks;
 			packageProductDependencies = (
@@ -10400,6 +11538,252 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				33AA16B92E38A76F002DBD60 /* BackerDashboardProjectCellFragment.graphql.swift in Sources */,
+				33AA16BA2E38A76F002DBD60 /* BackingFragment.graphql.swift in Sources */,
+				33AA16BB2E38A76F002DBD60 /* CategoryFragment.graphql.swift in Sources */,
+				33AA16BC2E38A76F002DBD60 /* CheckoutFragment.graphql.swift in Sources */,
+				33AA16BD2E38A76F002DBD60 /* CommentBaseFragment.graphql.swift in Sources */,
+				33AA16BE2E38A76F002DBD60 /* CommentFragment.graphql.swift in Sources */,
+				33AA16BF2E38A76F002DBD60 /* CommentWithRepliesFragment.graphql.swift in Sources */,
+				33AA16C02E38A76F002DBD60 /* CountryFragment.graphql.swift in Sources */,
+				33AA16C12E38A76F002DBD60 /* LastWaveFragment.graphql.swift in Sources */,
+				33AA16C22E38A76F002DBD60 /* LocationFragment.graphql.swift in Sources */,
+				33AA16C32E38A76F002DBD60 /* MoneyFragment.graphql.swift in Sources */,
+				33AA16C42E38A76F002DBD60 /* OrderFragment.graphql.swift in Sources */,
+				33AA16C52E38A76F002DBD60 /* PaymentIncrementFragment.graphql.swift in Sources */,
+				33AA16C62E38A76F002DBD60 /* PaymentSourceFragment.graphql.swift in Sources */,
+				33AA16C72E38A76F002DBD60 /* PledgeManagerFragment.graphql.swift in Sources */,
+				33AA16C82E38A76F002DBD60 /* PledgeOverTimeFragment.graphql.swift in Sources */,
+				33AA16C92E38A76F002DBD60 /* PPOBackingFragment.graphql.swift in Sources */,
+				33AA16CA2E38A76F002DBD60 /* PPOCardFragment.graphql.swift in Sources */,
+				33AA16CB2E38A76F002DBD60 /* PPOProjectFragment.graphql.swift in Sources */,
+				33AA16CC2E38A76F002DBD60 /* PPOUserSetupFragment.graphql.swift in Sources */,
+				33AA16CD2E38A76F002DBD60 /* ProjectAnalyticsFragment.graphql.swift in Sources */,
+				33AA16CE2E38A76F002DBD60 /* ProjectCardFragment.graphql.swift in Sources */,
+				33AA16CF2E38A76F002DBD60 /* ProjectFragment.graphql.swift in Sources */,
+				33AA16D02E38A76F002DBD60 /* ProjectPamphletMainCellPropertiesFragment.graphql.swift in Sources */,
+				33AA16D12E38A76F002DBD60 /* RewardFragment.graphql.swift in Sources */,
+				33AA16D22E38A76F002DBD60 /* ShippingRuleFragment.graphql.swift in Sources */,
+				33AA16D32E38A76F002DBD60 /* UserEmailFragment.graphql.swift in Sources */,
+				33AA16D42E38A76F002DBD60 /* UserFeaturesFragment.graphql.swift in Sources */,
+				33AA16D52E38A76F002DBD60 /* UserFragment.graphql.swift in Sources */,
+				33AA16D62E38A76F002DBD60 /* UserSettingsFragment.graphql.swift in Sources */,
+				33AA16D72E38A76F002DBD60 /* UserStoredCardsFragment.graphql.swift in Sources */,
+				33AA16D82E38A76F002DBD60 /* AddUserToSecretRewardGroupMutation.graphql.swift in Sources */,
+				33AA16D92E38A76F002DBD60 /* BlockUserMutation.graphql.swift in Sources */,
+				33AA16DA2E38A76F002DBD60 /* CancelBackingMutation.graphql.swift in Sources */,
+				33AA16DB2E38A76F002DBD60 /* ClearUserUnseenActivityMutation.graphql.swift in Sources */,
+				33AA16DC2E38A76F002DBD60 /* CompleteOnSessionCheckoutMutation.graphql.swift in Sources */,
+				33AA16DD2E38A76F002DBD60 /* CreateAttributionEventMutation.graphql.swift in Sources */,
+				33AA16DE2E38A76F002DBD60 /* CreateBackingMutation.graphql.swift in Sources */,
+				33AA16DF2E38A76F002DBD60 /* CreateCheckoutMutation.graphql.swift in Sources */,
+				33AA16E02E38A76F002DBD60 /* CreateFlaggingMutation.graphql.swift in Sources */,
+				33AA16E12E38A76F002DBD60 /* CreateOrUpdateBackingAddressMutation.graphql.swift in Sources */,
+				33AA16E22E38A76F002DBD60 /* CreatePaymentIntentMutation.graphql.swift in Sources */,
+				33AA16E32E38A76F002DBD60 /* CreatePaymentSourceMutation.graphql.swift in Sources */,
+				33AA16E42E38A76F002DBD60 /* CreateSetupIntentMutation.graphql.swift in Sources */,
+				33AA16E52E38A76F002DBD60 /* DeletePaymentSourceMutation.graphql.swift in Sources */,
+				33AA16E62E38A76F002DBD60 /* PostCommentMutation.graphql.swift in Sources */,
+				33AA16E72E38A76F002DBD60 /* SignInWithAppleMutation.graphql.swift in Sources */,
+				33AA16E82E38A76F002DBD60 /* TriggerThirdPartyEventMutation.graphql.swift in Sources */,
+				33AA16E92E38A76F002DBD60 /* UnwatchProjectMutation.graphql.swift in Sources */,
+				33AA16EA2E38A76F002DBD60 /* UpdateBackingMutation.graphql.swift in Sources */,
+				33AA16EB2E38A76F002DBD60 /* UpdateUserAccountMutation.graphql.swift in Sources */,
+				33AA16EC2E38A76F002DBD60 /* UpdateUserProfileMutation.graphql.swift in Sources */,
+				33AA16ED2E38A76F002DBD60 /* UserSendEmailVerificationMutation.graphql.swift in Sources */,
+				33AA16EE2E38A76F002DBD60 /* WatchProjectMutation.graphql.swift in Sources */,
+				33AA16EF2E38A76F002DBD60 /* BuildPaymentPlanQuery.graphql.swift in Sources */,
+				33AA16F02E38A76F002DBD60 /* DefaultLocationsQuery.graphql.swift in Sources */,
+				33AA16F12E38A76F002DBD60 /* FetchAddOnsQuery.graphql.swift in Sources */,
+				33AA16F22E38A76F002DBD60 /* FetchBackingQuery.graphql.swift in Sources */,
+				33AA16F32E38A76F002DBD60 /* FetchCategoryQuery.graphql.swift in Sources */,
+				33AA16F42E38A76F002DBD60 /* FetchCommentRepliesQuery.graphql.swift in Sources */,
+				33AA16F52E38A76F002DBD60 /* FetchMyBackedProjectsQuery.graphql.swift in Sources */,
+				33AA16F62E38A76F002DBD60 /* FetchMySavedProjectsQuery.graphql.swift in Sources */,
+				33AA16F72E38A76F002DBD60 /* FetchPledgedProjectsQuery.graphql.swift in Sources */,
+				33AA16F82E38A76F002DBD60 /* FetchProjectByIdQuery.graphql.swift in Sources */,
+				33AA16F92E38A76F002DBD60 /* FetchProjectBySlugQuery.graphql.swift in Sources */,
+				33AA16FA2E38A76F002DBD60 /* FetchProjectCommentsQuery.graphql.swift in Sources */,
+				33AA16FB2E38A76F002DBD60 /* FetchProjectFriendsByIdQuery.graphql.swift in Sources */,
+				33AA16FC2E38A76F002DBD60 /* FetchProjectFriendsBySlugQuery.graphql.swift in Sources */,
+				33AA16FD2E38A76F002DBD60 /* FetchProjectRewardsByIdQuery.graphql.swift in Sources */,
+				33AA16FE2E38A76F002DBD60 /* FetchRootCategoriesQuery.graphql.swift in Sources */,
+				33AA16FF2E38A76F002DBD60 /* FetchSimilarProjectsQuery.graphql.swift in Sources */,
+				33AA17002E38A76F002DBD60 /* FetchUpdateCommentsQuery.graphql.swift in Sources */,
+				33AA17012E38A76F002DBD60 /* FetchUserBackingsQuery.graphql.swift in Sources */,
+				33AA17022E38A76F002DBD60 /* FetchUserEmailQuery.graphql.swift in Sources */,
+				33AA17032E38A76F002DBD60 /* FetchUserQuery.graphql.swift in Sources */,
+				33AA17042E38A76F002DBD60 /* FetchUserSetupQuery.graphql.swift in Sources */,
+				33AA17052E38A76F002DBD60 /* FetchUserStoredCardsQuery.graphql.swift in Sources */,
+				33AA17062E38A76F002DBD60 /* LocationsByTermQuery.graphql.swift in Sources */,
+				33AA17072E38A76F002DBD60 /* SearchQuery.graphql.swift in Sources */,
+				33AA17082E38A76F002DBD60 /* ValidateCheckoutQuery.graphql.swift in Sources */,
+				33AA17092E38A76F002DBD60 /* Date.swift in Sources */,
+				33AA170A2E38A76F002DBD60 /* DateTime.swift in Sources */,
+				33AA170B2E38A76F002DBD60 /* Email.swift in Sources */,
+				33AA170C2E38A76F002DBD60 /* HTML.swift in Sources */,
+				33AA170D2E38A76F002DBD60 /* ISO8601DateTime.swift in Sources */,
+				33AA170E2E38A76F002DBD60 /* JSON.swift in Sources */,
+				33AA170F2E38A76F002DBD60 /* BackingState.graphql.swift in Sources */,
+				33AA17102E38A76F002DBD60 /* CheckoutState.graphql.swift in Sources */,
+				33AA17112E38A76F002DBD60 /* CheckoutStateEnum.graphql.swift in Sources */,
+				33AA17122E38A76F002DBD60 /* CommentBadge.graphql.swift in Sources */,
+				33AA17132E38A76F002DBD60 /* CountryCode.graphql.swift in Sources */,
+				33AA17142E38A76F002DBD60 /* CreditCardPaymentType.graphql.swift in Sources */,
+				33AA17152E38A76F002DBD60 /* CreditCardTypes.graphql.swift in Sources */,
+				33AA17162E38A76F002DBD60 /* CurrencyCode.graphql.swift in Sources */,
+				33AA17172E38A76F002DBD60 /* EnvironmentalCommitmentCategory.graphql.swift in Sources */,
+				33AA17182E38A76F002DBD60 /* Feature.graphql.swift in Sources */,
+				33AA17192E38A76F002DBD60 /* FlaggingKind.graphql.swift in Sources */,
+				33AA171A2E38A76F002DBD60 /* GoalBuckets.graphql.swift in Sources */,
+				33AA171B2E38A76F002DBD60 /* NonDeprecatedFlaggingKind.graphql.swift in Sources */,
+				33AA171C2E38A76F002DBD60 /* PaymentIncrementState.graphql.swift in Sources */,
+				33AA171D2E38A76F002DBD60 /* PaymentIncrementStateReason.graphql.swift in Sources */,
+				33AA171E2E38A76F002DBD60 /* PaymentTypes.graphql.swift in Sources */,
+				33AA171F2E38A76F002DBD60 /* PledgedBuckets.graphql.swift in Sources */,
+				33AA17202E38A76F002DBD60 /* ProjectSort.graphql.swift in Sources */,
+				33AA17212E38A76F002DBD60 /* ProjectState.graphql.swift in Sources */,
+				33AA17222E38A76F002DBD60 /* PublicProjectState.graphql.swift in Sources */,
+				33AA17232E38A76F002DBD60 /* RaisedBuckets.graphql.swift in Sources */,
+				33AA17242E38A76F002DBD60 /* ShippingPreference.graphql.swift in Sources */,
+				33AA17252E38A76F002DBD60 /* StripeIntentContextTypes.graphql.swift in Sources */,
+				33AA17262E38A76F002DBD60 /* UserNotificationTopic.graphql.swift in Sources */,
+				33AA17272E38A76F002DBD60 /* AddUserToSecretRewardGroupInput.graphql.swift in Sources */,
+				33AA17282E38A76F002DBD60 /* AppDataInput.graphql.swift in Sources */,
+				33AA17292E38A76F002DBD60 /* ApplePayInput.graphql.swift in Sources */,
+				33AA172A2E38A76F002DBD60 /* BlockUserInput.graphql.swift in Sources */,
+				33AA172B2E38A76F002DBD60 /* CancelBackingInput.graphql.swift in Sources */,
+				33AA172C2E38A76F002DBD60 /* ClearUserUnseenActivityInput.graphql.swift in Sources */,
+				33AA172D2E38A76F002DBD60 /* CompleteOnSessionCheckoutInput.graphql.swift in Sources */,
+				33AA172E2E38A76F002DBD60 /* CreateAttributionEventInput.graphql.swift in Sources */,
+				33AA172F2E38A76F002DBD60 /* CreateBackingInput.graphql.swift in Sources */,
+				33AA17302E38A76F002DBD60 /* CreateCheckoutInput.graphql.swift in Sources */,
+				33AA17312E38A76F002DBD60 /* CreateFlaggingInput.graphql.swift in Sources */,
+				33AA17322E38A76F002DBD60 /* CreateOrUpdateBackingAddressInput.graphql.swift in Sources */,
+				33AA17332E38A76F002DBD60 /* CreatePaymentIntentInput.graphql.swift in Sources */,
+				33AA17342E38A76F002DBD60 /* CreatePaymentSourceInput.graphql.swift in Sources */,
+				33AA17352E38A76F002DBD60 /* CreateSetupIntentInput.graphql.swift in Sources */,
+				33AA17362E38A76F002DBD60 /* PaymentSourceDeleteInput.graphql.swift in Sources */,
+				33AA17372E38A76F002DBD60 /* PostCommentInput.graphql.swift in Sources */,
+				33AA17382E38A76F002DBD60 /* SignInWithAppleInput.graphql.swift in Sources */,
+				33AA17392E38A76F002DBD60 /* ThirdPartyEventItemInput.graphql.swift in Sources */,
+				33AA173A2E38A76F002DBD60 /* TriggerThirdPartyEventInput.graphql.swift in Sources */,
+				33AA173B2E38A76F002DBD60 /* UnwatchProjectInput.graphql.swift in Sources */,
+				33AA173C2E38A76F002DBD60 /* UpdateBackingInput.graphql.swift in Sources */,
+				33AA173D2E38A76F002DBD60 /* UpdateUserAccountInput.graphql.swift in Sources */,
+				33AA173E2E38A76F002DBD60 /* UpdateUserProfileInput.graphql.swift in Sources */,
+				33AA173F2E38A76F002DBD60 /* UserSendEmailVerificationInput.graphql.swift in Sources */,
+				33AA17402E38A76F002DBD60 /* WatchProjectInput.graphql.swift in Sources */,
+				33AA17412E38A76F002DBD60 /* Commentable.graphql.swift in Sources */,
+				33AA17422E38A76F002DBD60 /* Node.graphql.swift in Sources */,
+				33AA17432E38A76F002DBD60 /* Postable.graphql.swift in Sources */,
+				33AA17442E38A76F002DBD60 /* Address.graphql.swift in Sources */,
+				33AA17452E38A76F002DBD60 /* AddUserToSecretRewardGroupPayload.graphql.swift in Sources */,
+				33AA17462E38A76F002DBD60 /* AdjustmentSummary.graphql.swift in Sources */,
+				33AA17472E38A76F002DBD60 /* AiDisclosure.graphql.swift in Sources */,
+				33AA17482E38A76F002DBD60 /* AttachedAudio.graphql.swift in Sources */,
+				33AA17492E38A76F002DBD60 /* AttachedVideo.graphql.swift in Sources */,
+				33AA174A2E38A76F002DBD60 /* Backing.graphql.swift in Sources */,
+				33AA174B2E38A76F002DBD60 /* BankAccount.graphql.swift in Sources */,
+				33AA174C2E38A76F002DBD60 /* BlockUserPayload.graphql.swift in Sources */,
+				33AA174D2E38A76F002DBD60 /* CancelBackingPayload.graphql.swift in Sources */,
+				33AA174E2E38A76F002DBD60 /* Category.graphql.swift in Sources */,
+				33AA174F2E38A76F002DBD60 /* CategorySubcategoriesConnection.graphql.swift in Sources */,
+				33AA17502E38A76F002DBD60 /* Checkout.graphql.swift in Sources */,
+				33AA17512E38A76F002DBD60 /* CheckoutWave.graphql.swift in Sources */,
+				33AA17522E38A76F002DBD60 /* ClearUserUnseenActivityPayload.graphql.swift in Sources */,
+				33AA17532E38A76F002DBD60 /* Comment.graphql.swift in Sources */,
+				33AA17542E38A76F002DBD60 /* CommentConnection.graphql.swift in Sources */,
+				33AA17552E38A76F002DBD60 /* CommentEdge.graphql.swift in Sources */,
+				33AA17562E38A76F002DBD60 /* CompleteOnSessionCheckoutPayload.graphql.swift in Sources */,
+				33AA17572E38A76F002DBD60 /* Conversation.graphql.swift in Sources */,
+				33AA17582E38A76F002DBD60 /* Country.graphql.swift in Sources */,
+				33AA17592E38A76F002DBD60 /* CreateAttributionEventPayload.graphql.swift in Sources */,
+				33AA175A2E38A76F002DBD60 /* CreateBackingPayload.graphql.swift in Sources */,
+				33AA175B2E38A76F002DBD60 /* CreateCheckoutPayload.graphql.swift in Sources */,
+				33AA175C2E38A76F002DBD60 /* CreateFlaggingPayload.graphql.swift in Sources */,
+				33AA175D2E38A76F002DBD60 /* CreateOrUpdateBackingAddressPayload.graphql.swift in Sources */,
+				33AA175E2E38A76F002DBD60 /* CreatePaymentIntentPayload.graphql.swift in Sources */,
+				33AA175F2E38A76F002DBD60 /* CreatePaymentSourcePayload.graphql.swift in Sources */,
+				33AA17602E38A76F002DBD60 /* CreateSetupIntentPayload.graphql.swift in Sources */,
+				33AA17612E38A76F002DBD60 /* CreatorInterview.graphql.swift in Sources */,
+				33AA17622E38A76F002DBD60 /* CreatorPrompt.graphql.swift in Sources */,
+				33AA17632E38A76F002DBD60 /* CreditCard.graphql.swift in Sources */,
+				33AA17642E38A76F002DBD60 /* CuratedPage.graphql.swift in Sources */,
+				33AA17652E38A76F002DBD60 /* EnvironmentalCommitment.graphql.swift in Sources */,
+				33AA17662E38A76F002DBD60 /* Flagging.graphql.swift in Sources */,
+				33AA17672E38A76F002DBD60 /* FreeformPost.graphql.swift in Sources */,
+				33AA17682E38A76F002DBD60 /* InterviewAnswer.graphql.swift in Sources */,
+				33AA17692E38A76F002DBD60 /* InterviewQuestion.graphql.swift in Sources */,
+				33AA176A2E38A76F002DBD60 /* Location.graphql.swift in Sources */,
+				33AA176B2E38A76F002DBD60 /* LocationsConnection.graphql.swift in Sources */,
+				33AA176C2E38A76F002DBD60 /* Message.graphql.swift in Sources */,
+				33AA176D2E38A76F002DBD60 /* Money.graphql.swift in Sources */,
+				33AA176E2E38A76F002DBD60 /* Mutation.graphql.swift in Sources */,
+				33AA176F2E38A76F002DBD60 /* NewsletterSubscriptions.graphql.swift in Sources */,
+				33AA17702E38A76F002DBD60 /* Notification.graphql.swift in Sources */,
+				33AA17712E38A76F002DBD60 /* Order.graphql.swift in Sources */,
+				33AA17722E38A76F002DBD60 /* Organization.graphql.swift in Sources */,
+				33AA17732E38A76F002DBD60 /* PageInfo.graphql.swift in Sources */,
+				33AA17742E38A76F002DBD60 /* PaymentIncrement.graphql.swift in Sources */,
+				33AA17752E38A76F002DBD60 /* PaymentIncrementAmount.graphql.swift in Sources */,
+				33AA17762E38A76F002DBD60 /* PaymentPlan.graphql.swift in Sources */,
+				33AA17772E38A76F002DBD60 /* PaymentSourceDeletePayload.graphql.swift in Sources */,
+				33AA17782E38A76F002DBD60 /* Photo.graphql.swift in Sources */,
+				33AA17792E38A76F002DBD60 /* PledgedProjectsOverviewPledgeFlags.graphql.swift in Sources */,
+				33AA177A2E38A76F002DBD60 /* PledgedProjectsOverviewPledgesConnection.graphql.swift in Sources */,
+				33AA177B2E38A76F002DBD60 /* PledgeManager.graphql.swift in Sources */,
+				33AA177C2E38A76F002DBD60 /* PledgeProjectOverviewItem.graphql.swift in Sources */,
+				33AA177D2E38A76F002DBD60 /* PledgeProjectOverviewItemEdge.graphql.swift in Sources */,
+				33AA177E2E38A76F002DBD60 /* PledgeProjectsOverview.graphql.swift in Sources */,
+				33AA177F2E38A76F002DBD60 /* PostCommentPayload.graphql.swift in Sources */,
+				33AA17802E38A76F002DBD60 /* PostConnection.graphql.swift in Sources */,
+				33AA17812E38A76F002DBD60 /* Project.graphql.swift in Sources */,
+				33AA17822E38A76F002DBD60 /* ProjectBackerFriendsConnection.graphql.swift in Sources */,
+				33AA17832E38A76F002DBD60 /* ProjectFaq.graphql.swift in Sources */,
+				33AA17842E38A76F002DBD60 /* ProjectFaqConnection.graphql.swift in Sources */,
+				33AA17852E38A76F002DBD60 /* ProjectProfile.graphql.swift in Sources */,
+				33AA17862E38A76F002DBD60 /* ProjectRewardConnection.graphql.swift in Sources */,
+				33AA17872E38A76F002DBD60 /* ProjectsConnectionWithTotalCount.graphql.swift in Sources */,
+				33AA17882E38A76F002DBD60 /* Query.graphql.swift in Sources */,
+				33AA17892E38A76F002DBD60 /* Refund.graphql.swift in Sources */,
+				33AA178A2E38A76F002DBD60 /* ResourceAudience.graphql.swift in Sources */,
+				33AA178B2E38A76F002DBD60 /* Reward.graphql.swift in Sources */,
+				33AA178C2E38A76F002DBD60 /* RewardConnection.graphql.swift in Sources */,
+				33AA178D2E38A76F002DBD60 /* RewardItem.graphql.swift in Sources */,
+				33AA178E2E38A76F002DBD60 /* RewardItemEdge.graphql.swift in Sources */,
+				33AA178F2E38A76F002DBD60 /* RewardItemsConnection.graphql.swift in Sources */,
+				33AA17902E38A76F002DBD60 /* RewardShippingRulesConnection.graphql.swift in Sources */,
+				33AA17912E38A76F002DBD60 /* RewardTotalCountConnection.graphql.swift in Sources */,
+				33AA17922E38A76F002DBD60 /* SavedSearchSegment.graphql.swift in Sources */,
+				33AA17932E38A76F002DBD60 /* ShippingRule.graphql.swift in Sources */,
+				33AA17942E38A76F002DBD60 /* SignInWithApplePayload.graphql.swift in Sources */,
+				33AA17952E38A76F002DBD60 /* SimpleShippingRule.graphql.swift in Sources */,
+				33AA17962E38A76F002DBD60 /* Survey.graphql.swift in Sources */,
+				33AA17972E38A76F002DBD60 /* SurveyResponsesConnection.graphql.swift in Sources */,
+				33AA17982E38A76F002DBD60 /* Tag.graphql.swift in Sources */,
+				33AA17992E38A76F002DBD60 /* TriggerThirdPartyEventPayload.graphql.swift in Sources */,
+				33AA179A2E38A76F002DBD60 /* UnwatchProjectPayload.graphql.swift in Sources */,
+				33AA179B2E38A76F002DBD60 /* UpdateBackingPayload.graphql.swift in Sources */,
+				33AA179C2E38A76F002DBD60 /* UpdateUserAccountPayload.graphql.swift in Sources */,
+				33AA179D2E38A76F002DBD60 /* UpdateUserProfilePayload.graphql.swift in Sources */,
+				33AA179E2E38A76F002DBD60 /* User.graphql.swift in Sources */,
+				33AA179F2E38A76F002DBD60 /* UserBackingsConnection.graphql.swift in Sources */,
+				33AA17A02E38A76F002DBD60 /* UserCreatedProjectsConnection.graphql.swift in Sources */,
+				33AA17A12E38A76F002DBD60 /* UserCreditCardTypeConnection.graphql.swift in Sources */,
+				33AA17A22E38A76F002DBD60 /* UserSavedProjectsConnection.graphql.swift in Sources */,
+				33AA17A32E38A76F002DBD60 /* UserSendEmailVerificationPayload.graphql.swift in Sources */,
+				33AA17A42E38A76F002DBD60 /* UserUrl.graphql.swift in Sources */,
+				33AA17A52E38A76F002DBD60 /* Validation.graphql.swift in Sources */,
+				33AA17A62E38A76F002DBD60 /* Video.graphql.swift in Sources */,
+				33AA17A72E38A76F002DBD60 /* VideoSourceInfo.graphql.swift in Sources */,
+				33AA17A82E38A76F002DBD60 /* VideoSources.graphql.swift in Sources */,
+				33AA17A92E38A76F002DBD60 /* VideoTrack.graphql.swift in Sources */,
+				33AA17AA2E38A76F002DBD60 /* VideoTrackCue.graphql.swift in Sources */,
+				33AA17AB2E38A76F002DBD60 /* WatchProjectPayload.graphql.swift in Sources */,
+				33AA17AC2E38A76F002DBD60 /* PaymentSource.graphql.swift in Sources */,
+				33AA17AD2E38A76F002DBD60 /* SchemaConfiguration.swift in Sources */,
+				33AA17AE2E38A76F002DBD60 /* SchemaMetadata.graphql.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -10407,6 +11791,112 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				33AA181C2E38A7B1002DBD60 /* Address+Mock.graphql.swift in Sources */,
+				33AA181D2E38A7B1002DBD60 /* AddUserToSecretRewardGroupPayload+Mock.graphql.swift in Sources */,
+				33AA181E2E38A7B1002DBD60 /* AdjustmentSummary+Mock.graphql.swift in Sources */,
+				33AA181F2E38A7B1002DBD60 /* AiDisclosure+Mock.graphql.swift in Sources */,
+				33AA18202E38A7B1002DBD60 /* AttachedAudio+Mock.graphql.swift in Sources */,
+				33AA18212E38A7B1002DBD60 /* AttachedVideo+Mock.graphql.swift in Sources */,
+				33AA18222E38A7B1002DBD60 /* Backing+Mock.graphql.swift in Sources */,
+				33AA18232E38A7B1002DBD60 /* BankAccount+Mock.graphql.swift in Sources */,
+				33AA18242E38A7B1002DBD60 /* BlockUserPayload+Mock.graphql.swift in Sources */,
+				33AA18252E38A7B1002DBD60 /* CancelBackingPayload+Mock.graphql.swift in Sources */,
+				33AA18262E38A7B1002DBD60 /* Category+Mock.graphql.swift in Sources */,
+				33AA18272E38A7B1002DBD60 /* CategorySubcategoriesConnection+Mock.graphql.swift in Sources */,
+				33AA18282E38A7B1002DBD60 /* Checkout+Mock.graphql.swift in Sources */,
+				33AA18292E38A7B1002DBD60 /* CheckoutWave+Mock.graphql.swift in Sources */,
+				33AA182A2E38A7B1002DBD60 /* ClearUserUnseenActivityPayload+Mock.graphql.swift in Sources */,
+				33AA182B2E38A7B1002DBD60 /* Comment+Mock.graphql.swift in Sources */,
+				33AA182C2E38A7B1002DBD60 /* CommentConnection+Mock.graphql.swift in Sources */,
+				33AA182D2E38A7B1002DBD60 /* CommentEdge+Mock.graphql.swift in Sources */,
+				33AA182E2E38A7B1002DBD60 /* CompleteOnSessionCheckoutPayload+Mock.graphql.swift in Sources */,
+				33AA182F2E38A7B1002DBD60 /* Conversation+Mock.graphql.swift in Sources */,
+				33AA18302E38A7B1002DBD60 /* Country+Mock.graphql.swift in Sources */,
+				33AA18312E38A7B1002DBD60 /* CreateAttributionEventPayload+Mock.graphql.swift in Sources */,
+				33AA18322E38A7B1002DBD60 /* CreateBackingPayload+Mock.graphql.swift in Sources */,
+				33AA18332E38A7B1002DBD60 /* CreateCheckoutPayload+Mock.graphql.swift in Sources */,
+				33AA18342E38A7B1002DBD60 /* CreateFlaggingPayload+Mock.graphql.swift in Sources */,
+				33AA18352E38A7B1002DBD60 /* CreateOrUpdateBackingAddressPayload+Mock.graphql.swift in Sources */,
+				33AA18362E38A7B1002DBD60 /* CreatePaymentIntentPayload+Mock.graphql.swift in Sources */,
+				33AA18372E38A7B1002DBD60 /* CreatePaymentSourcePayload+Mock.graphql.swift in Sources */,
+				33AA18382E38A7B1002DBD60 /* CreateSetupIntentPayload+Mock.graphql.swift in Sources */,
+				33AA18392E38A7B1002DBD60 /* CreatorInterview+Mock.graphql.swift in Sources */,
+				33AA183A2E38A7B1002DBD60 /* CreatorPrompt+Mock.graphql.swift in Sources */,
+				33AA183B2E38A7B1002DBD60 /* CreditCard+Mock.graphql.swift in Sources */,
+				33AA183C2E38A7B1002DBD60 /* CuratedPage+Mock.graphql.swift in Sources */,
+				33AA183D2E38A7B1002DBD60 /* EnvironmentalCommitment+Mock.graphql.swift in Sources */,
+				33AA183E2E38A7B1002DBD60 /* Flagging+Mock.graphql.swift in Sources */,
+				33AA183F2E38A7B1002DBD60 /* FreeformPost+Mock.graphql.swift in Sources */,
+				33AA18402E38A7B1002DBD60 /* InterviewAnswer+Mock.graphql.swift in Sources */,
+				33AA18412E38A7B1002DBD60 /* InterviewQuestion+Mock.graphql.swift in Sources */,
+				33AA18422E38A7B1002DBD60 /* Location+Mock.graphql.swift in Sources */,
+				33AA18432E38A7B1002DBD60 /* LocationsConnection+Mock.graphql.swift in Sources */,
+				33AA18442E38A7B1002DBD60 /* Message+Mock.graphql.swift in Sources */,
+				33AA18452E38A7B1002DBD60 /* MockObject+Interfaces.graphql.swift in Sources */,
+				33AA18462E38A7B1002DBD60 /* MockObject+Unions.graphql.swift in Sources */,
+				33AA18472E38A7B1002DBD60 /* Money+Mock.graphql.swift in Sources */,
+				33AA18482E38A7B1002DBD60 /* Mutation+Mock.graphql.swift in Sources */,
+				33AA18492E38A7B1002DBD60 /* NewsletterSubscriptions+Mock.graphql.swift in Sources */,
+				33AA184A2E38A7B1002DBD60 /* Notification+Mock.graphql.swift in Sources */,
+				33AA184B2E38A7B1002DBD60 /* Order+Mock.graphql.swift in Sources */,
+				33AA184C2E38A7B1002DBD60 /* Organization+Mock.graphql.swift in Sources */,
+				33AA184D2E38A7B1002DBD60 /* PageInfo+Mock.graphql.swift in Sources */,
+				33AA184E2E38A7B1002DBD60 /* PaymentIncrement+Mock.graphql.swift in Sources */,
+				33AA184F2E38A7B1002DBD60 /* PaymentIncrementAmount+Mock.graphql.swift in Sources */,
+				33AA18502E38A7B1002DBD60 /* PaymentPlan+Mock.graphql.swift in Sources */,
+				33AA18512E38A7B1002DBD60 /* PaymentSourceDeletePayload+Mock.graphql.swift in Sources */,
+				33AA18522E38A7B1002DBD60 /* Photo+Mock.graphql.swift in Sources */,
+				33AA18532E38A7B1002DBD60 /* PledgedProjectsOverviewPledgeFlags+Mock.graphql.swift in Sources */,
+				33AA18542E38A7B1002DBD60 /* PledgedProjectsOverviewPledgesConnection+Mock.graphql.swift in Sources */,
+				33AA18552E38A7B1002DBD60 /* PledgeManager+Mock.graphql.swift in Sources */,
+				33AA18562E38A7B1002DBD60 /* PledgeProjectOverviewItem+Mock.graphql.swift in Sources */,
+				33AA18572E38A7B1002DBD60 /* PledgeProjectOverviewItemEdge+Mock.graphql.swift in Sources */,
+				33AA18582E38A7B1002DBD60 /* PledgeProjectsOverview+Mock.graphql.swift in Sources */,
+				33AA18592E38A7B1002DBD60 /* PostCommentPayload+Mock.graphql.swift in Sources */,
+				33AA185A2E38A7B1002DBD60 /* PostConnection+Mock.graphql.swift in Sources */,
+				33AA185B2E38A7B1002DBD60 /* Project+Mock.graphql.swift in Sources */,
+				33AA185C2E38A7B1002DBD60 /* ProjectBackerFriendsConnection+Mock.graphql.swift in Sources */,
+				33AA185D2E38A7B1002DBD60 /* ProjectFaq+Mock.graphql.swift in Sources */,
+				33AA185E2E38A7B1002DBD60 /* ProjectFaqConnection+Mock.graphql.swift in Sources */,
+				33AA185F2E38A7B1002DBD60 /* ProjectProfile+Mock.graphql.swift in Sources */,
+				33AA18602E38A7B1002DBD60 /* ProjectRewardConnection+Mock.graphql.swift in Sources */,
+				33AA18612E38A7B1002DBD60 /* ProjectsConnectionWithTotalCount+Mock.graphql.swift in Sources */,
+				33AA18622E38A7B1002DBD60 /* Query+Mock.graphql.swift in Sources */,
+				33AA18632E38A7B1002DBD60 /* Refund+Mock.graphql.swift in Sources */,
+				33AA18642E38A7B1002DBD60 /* ResourceAudience+Mock.graphql.swift in Sources */,
+				33AA18652E38A7B1002DBD60 /* Reward+Mock.graphql.swift in Sources */,
+				33AA18662E38A7B1002DBD60 /* RewardConnection+Mock.graphql.swift in Sources */,
+				33AA18672E38A7B1002DBD60 /* RewardItem+Mock.graphql.swift in Sources */,
+				33AA18682E38A7B1002DBD60 /* RewardItemEdge+Mock.graphql.swift in Sources */,
+				33AA18692E38A7B1002DBD60 /* RewardItemsConnection+Mock.graphql.swift in Sources */,
+				33AA186A2E38A7B1002DBD60 /* RewardShippingRulesConnection+Mock.graphql.swift in Sources */,
+				33AA186B2E38A7B1002DBD60 /* RewardTotalCountConnection+Mock.graphql.swift in Sources */,
+				33AA186C2E38A7B1002DBD60 /* SavedSearchSegment+Mock.graphql.swift in Sources */,
+				33AA186D2E38A7B1002DBD60 /* ShippingRule+Mock.graphql.swift in Sources */,
+				33AA186E2E38A7B1002DBD60 /* SignInWithApplePayload+Mock.graphql.swift in Sources */,
+				33AA186F2E38A7B1002DBD60 /* SimpleShippingRule+Mock.graphql.swift in Sources */,
+				33AA18702E38A7B1002DBD60 /* Survey+Mock.graphql.swift in Sources */,
+				33AA18712E38A7B1002DBD60 /* SurveyResponsesConnection+Mock.graphql.swift in Sources */,
+				33AA18722E38A7B1002DBD60 /* Tag+Mock.graphql.swift in Sources */,
+				33AA18732E38A7B1002DBD60 /* TriggerThirdPartyEventPayload+Mock.graphql.swift in Sources */,
+				33AA18742E38A7B1002DBD60 /* UnwatchProjectPayload+Mock.graphql.swift in Sources */,
+				33AA18752E38A7B1002DBD60 /* UpdateBackingPayload+Mock.graphql.swift in Sources */,
+				33AA18762E38A7B1002DBD60 /* UpdateUserAccountPayload+Mock.graphql.swift in Sources */,
+				33AA18772E38A7B1002DBD60 /* UpdateUserProfilePayload+Mock.graphql.swift in Sources */,
+				33AA18782E38A7B1002DBD60 /* User+Mock.graphql.swift in Sources */,
+				33AA18792E38A7B1002DBD60 /* UserBackingsConnection+Mock.graphql.swift in Sources */,
+				33AA187A2E38A7B1002DBD60 /* UserCreatedProjectsConnection+Mock.graphql.swift in Sources */,
+				33AA187B2E38A7B1002DBD60 /* UserCreditCardTypeConnection+Mock.graphql.swift in Sources */,
+				33AA187C2E38A7B1002DBD60 /* UserSavedProjectsConnection+Mock.graphql.swift in Sources */,
+				33AA187D2E38A7B1002DBD60 /* UserSendEmailVerificationPayload+Mock.graphql.swift in Sources */,
+				33AA187E2E38A7B1002DBD60 /* UserUrl+Mock.graphql.swift in Sources */,
+				33AA187F2E38A7B1002DBD60 /* Validation+Mock.graphql.swift in Sources */,
+				33AA18802E38A7B1002DBD60 /* Video+Mock.graphql.swift in Sources */,
+				33AA18812E38A7B1002DBD60 /* VideoSourceInfo+Mock.graphql.swift in Sources */,
+				33AA18822E38A7B1002DBD60 /* VideoSources+Mock.graphql.swift in Sources */,
+				33AA18832E38A7B1002DBD60 /* VideoTrack+Mock.graphql.swift in Sources */,
+				33AA18842E38A7B1002DBD60 /* VideoTrackCue+Mock.graphql.swift in Sources */,
+				33AA18852E38A7B1002DBD60 /* WatchProjectPayload+Mock.graphql.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -10574,7 +12064,6 @@
 		A745D1D51CAAD0A400C12802 /* Internal Beta */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = "app-icon-beta";
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = "Kickstarter-iOS/Beta.entitlements";
@@ -10909,7 +12398,6 @@
 		A7D1F9621C850B7C000D41D5 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = "app-icon-debug";
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = "Kickstarter-iOS/Debug.entitlements";
@@ -10944,7 +12432,6 @@
 		A7D1F9631C850B7C000D41D5 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = "app-icon";
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = "Kickstarter-iOS/Release.entitlements";
@@ -11422,7 +12909,6 @@
 		D083B1041F27EF0400BEC742 /* Internal Alpha */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = "app-icon-alpha";
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = "Kickstarter-iOS/Alpha.entitlements";


### PR DESCRIPTION
… folder reference

<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Fix beta build by converting the `GraphAPI` and `GraphAPITestMocks` from a sync group (`PBXFileSystemSynchronizedRootGroup`) to a standard folder reference in Xcode.

# 👀 See

[CircleCI](https://app.circleci.com/pipelines/github/kickstarter/ios-private/1690/workflows/5e5eadd3-d859-41c9-bc8c-9f7f794de063/jobs/20610)
