### PR TITLE
Fix beta build error by moving GraphAPI extensions inside DEBUG macro

### DIFF
--- a/KsApi/MockService.swift
+++ b/KsApi/MockService.swift
@@ -2037,32 +2037,33 @@
     case let .failure(error): return .init(error: error)
     }
   }
+
+  private extension Result {
+    var value: Success? {
+      switch self {
+      case let .success(value): return value
+      case .failure: return nil
+      }
+    }
+
+    var error: Failure? {
+      switch self {
+      case .success: return nil
+      case let .failure(error): return error
+      }
+    }
+  }
+
+  extension GraphAPI.CompleteOnSessionCheckoutMutation.Data: Decodable {
+    public init(from _: Decoder) throws {
+      fatalError("The test code should not actually be decoding this object.")
+    }
+  }
+
+  extension GraphAPI.BuildPaymentPlanQuery.Data: Decodable {
+    public init(from _: Decoder) throws {
+      fatalError("The test code should not actually be decoding this object.")
+    }
+  }
+
 #endif
-
-private extension Result {
-  var value: Success? {
-    switch self {
-    case let .success(value): return value
-    case .failure: return nil
-    }
-  }
-
-  var error: Failure? {
-    switch self {
-    case .success: return nil
-    case let .failure(error): return error
-    }
-  }
-}
-
-extension GraphAPI.CompleteOnSessionCheckoutMutation.Data: Decodable {
-  public init(from _: Decoder) throws {
-    fatalError("The test code should not actually be decoding this object.")
-  }
-}
-
-extension GraphAPI.BuildPaymentPlanQuery.Data: Decodable {
-  public init(from _: Decoder) throws {
-    fatalError("The test code should not actually be decoding this object.")
-  }
-}


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Moves some `GraphAPI` extensions and `Result` helpers inside the `#if DEBUG` macro to prevent beta build errors caused by missing GraphAPI types in non-debug contexts.

# 🤔 Why

After the Apollo upgrade, `GraphAPI` was converted into a framework, which broke previous assumptions about type visibility. Some `GraphAPI` extensions (like `GraphAPI.CompleteOnSessionCheckoutMutation.Data`) were being declared outside the `#if DEBUG` macro and caused build errors in beta pipelines where the framework is not available outside test/debug contexts.

# 🛠 How

- Moved the following extensions inside the `#if DEBUG` macro:
  - `extension GraphAPI.CompleteOnSessionCheckoutMutation.Data`
  - `extension GraphAPI.BuildPaymentPlanQuery.Data`
  - `extension Result` (value/error)
- This ensures the code is only compiled in the correct context where `GraphAPI` is available.

# 👀 See

- [CircleCI pipeline](https://app.circleci.com/pipelines/github/kickstarter/ios-private/1692/workflows/f32f95f2-bac0-404a-9b5f-2c2d8c825bac/jobs/20621/parallel-runs/0/steps/0-108)

# ✅ Acceptance criteria

- [ ] Beta builds complete successfully
- [ ] Local debug builds still run and test features as expected

# ⏰ TODO

- [ ] Monitor future Apollo upgrades for similar scope/visibility changes