### PR TITLE
[MBL-2533] Disabled autoscroll for unavailable secret rewards

### DIFF
--- a/Library/ViewModels/RewardsCollectionViewModel.swift
+++ b/Library/ViewModels/RewardsCollectionViewModel.swift
@@ -501,7 +501,7 @@ private func rewardToScrollIndexPath(
 }
 
 private func firstSecretRewardIndexPath(rewards: [Reward]) -> IndexPath? {
-  return rewards.firstIndex(where: { $0.isSecretReward })
+  return rewards.firstIndex(where: { $0.isSecretReward && $0.isAvailable == true })
     .flatMap { IndexPath(row: $0, section: 0) }
 }
 


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

This PR disables the auto-scroll behavior to secret rewards when those rewards are not available.

# 🛠 How

- Updated `firstSecretRewardIndexPath` logic in `RewardsCollectionViewModel` to return only the first available secret reward (via `isAvailable == true`)
- This avoids triggering auto-scroll when secret rewards are present in the data, but not currently accessible to the backer.

# 👀 See

- [MBL-2533](https://kickstarter.atlassian.net/browse/MBL-2533)

| Available Secret Reward | Unavailable Secret Reward |
| --- | --- |
| ![Simulator Screen Recording - iPhone 16 Pro - 2025-07-31 at 16 35 21](https://github.com/user-attachments/assets/a688c5d2-141c-47dc-b067-3c665182502b) | ![Simulator Screen Recording - iPhone 16 Pro - 2025-07-31 at 16 33 58](https://github.com/user-attachments/assets/59967c73-0e1a-4780-b38b-00288338755f) |

# ✅ Acceptance criteria

- [ ] Tested on Available and Unavailable secret rewards


[MBL-2533]: https://kickstarter.atlassian.net/browse/MBL-2533?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ