### PR TITLE
MBL-2653: Replace hardcoded spacing constants with Spacing_xx and Dimensions

### DIFF
--- a/Kickstarter-iOS/Features/ChangeEmail/Controller/ChangeEmailView.swift
+++ b/Kickstarter-iOS/Features/ChangeEmail/Controller/ChangeEmailView.swift
@@ -10,7 +10,7 @@ enum FocusField {
 struct ChangeEmailView: View {
   @SwiftUI.Environment(\.defaultMinListRowHeight) var minListRow
   @FocusState private var focusField: FocusField?
-  private let contentPadding = 12.0
+  private let contentPadding = Spacing_03
   @ObservedObject private var reactiveViewModel = ChangeEmailViewModelSwiftUIIntegrationTest()
   @State private var retrievedEmailText = ""
   @State private var newEmailText = ""

--- a/Kickstarter-iOS/Features/Comments/Views/CommentInputContainerView.swift
+++ b/Kickstarter-iOS/Features/Comments/Views/CommentInputContainerView.swift
@@ -4,7 +4,7 @@ import UIKit
 
 private enum Layout {
   enum Button {
-    static let height: CGFloat = 20.0
+    static let height: CGFloat = Spacing_05
   }
 
   enum Container {

--- a/Kickstarter-iOS/Features/CreatePassword/Views/ErroredBackingView.swift
+++ b/Kickstarter-iOS/Features/CreatePassword/Views/ErroredBackingView.swift
@@ -11,7 +11,7 @@ private enum Layout {
   }
 
   enum ImageView {
-    static let minWidth: CGFloat = 16.0
+    static let minWidth: CGFloat = Spacing_04
   }
 }
 

--- a/Kickstarter-iOS/Features/LoginTout/Controller/LoginToutViewController.swift
+++ b/Kickstarter-iOS/Features/LoginTout/Controller/LoginToutViewController.swift
@@ -533,7 +533,7 @@ private let separatorViewStyle: ViewStyle = { view in
 }
 
 private func applyAppleLoginButtonStyle(_ button: AdaptiveAppleIDButton) {
-  let cornerRadius: CGFloat = featureNewDesignSystemEnabled() ? Styles.cornerRadius : Styles.grid(2)
+  let cornerRadius: CGFloat = featureNewDesignSystemEnabled() ? Dimension.CornerRadius.small : Styles.grid(2)
 
   button.cornerRadius(cornerRadius)
 }
@@ -645,8 +645,8 @@ private class AdaptiveAppleIDButton: UIView {
 
   /// Sets the corner radius for both the light and dark mode Apple ID buttons.
   ///
-  /// - Parameter cornerRadius: The radius to apply to the corners of the buttons. Defaults to `Styles.cornerRadius`.
-  func cornerRadius(_ cornerRadius: CGFloat = Styles.cornerRadius) {
+  /// - Parameter cornerRadius: The radius to apply to the corners of the buttons. Defaults to `Dimension.CornerRadius.small`.
+  func cornerRadius(_ cornerRadius: CGFloat = Dimension.CornerRadius.small) {
     self.lightModeButton.cornerRadius = cornerRadius
     self.darkModeButton.cornerRadius = cornerRadius
   }

--- a/Kickstarter-iOS/Features/ManagePledge/Controllers/PledgeOverTimePaymentScheduleViewController.swift
+++ b/Kickstarter-iOS/Features/ManagePledge/Controllers/PledgeOverTimePaymentScheduleViewController.swift
@@ -4,7 +4,7 @@ import UIKit
 
 private enum Constants {
   static let animationDuration: TimeInterval = 0.3
-  static let collapseIndicatorSize: CGFloat = 20.0
+  static let collapseIndicatorSize: CGFloat = Spacing_05
   static let contentInsets = NSDirectionalEdgeInsets(top: 1.0, leading: 0, bottom: 1.0, trailing: 0)
   static let paymentsScheduleStackViewSpacing = Styles.grid(3)
   static let rootStackViewSpacing = Styles.grid(4)

--- a/Kickstarter-iOS/Features/ManagePledge/Views/BadgeView.swift
+++ b/Kickstarter-iOS/Features/ManagePledge/Views/BadgeView.swift
@@ -4,7 +4,7 @@ import UIKit
 private enum Constants {
   /// Spacing & Padding
   public static let badgeTopButtonPadding = 6.0
-  public static let badgeLeadingTrailingPadding = 8.0
+  public static let badgeLeadingTrailingPadding = Spacing_02
   public static let defaultStackViewSpacing = Styles.grid(1)
 
   /// Corner radius

--- a/Kickstarter-iOS/Features/MessageBanner/Views/MessageBannerView.swift
+++ b/Kickstarter-iOS/Features/MessageBanner/Views/MessageBannerView.swift
@@ -36,7 +36,7 @@ struct MessageBannerView: View {
         trailing: Constants.defaultSpacing
       ))
       .background {
-        RoundedRectangle(cornerRadius: Styles.cornerRadius)
+        RoundedRectangle(cornerRadius: Dimension.CornerRadius.small)
           .foregroundColor(vm.bannerBackgroundColor)
       }
       .accessibilityElement()

--- a/Kickstarter-iOS/Features/Onboarding/Views/OnboardingCTAView.swift
+++ b/Kickstarter-iOS/Features/Onboarding/Views/OnboardingCTAView.swift
@@ -2,9 +2,9 @@ import Library
 import SwiftUI
 
 private enum Constants {
-  static let rootStackViewSpacing: CGFloat = 12
-  static let rootStackViewHorizontalPadding: CGFloat = 20
-  static let ctaCornerRadius: CGFloat = 12
+  static let rootStackViewSpacing = Spacing_03
+  static let rootStackViewHorizontalPadding = Spacing_05
+  static let ctaCornerRadius = Spacing_03
 }
 
 struct CallToActionView: View {

--- a/Kickstarter-iOS/Features/Onboarding/Views/OnboardingItemView.swift
+++ b/Kickstarter-iOS/Features/Onboarding/Views/OnboardingItemView.swift
@@ -4,12 +4,12 @@ import SwiftUI
 
 private enum Constants {
   static let animationDuration: Double = 0.35
-  static let rootStackViewBottomPadding: CGFloat = 80
-  static let horizontalPadding: CGFloat = 20
-  static let lottieViewTopPadding: CGFloat = 16
-  static let rootStackViewTopPadding: CGFloat = 20
-  static let titleSubtitleSpacing: CGFloat = 12
-  static let verticalSpacing: CGFloat = 24
+  static let rootStackViewBottomPadding = Spacing_20
+  static let horizontalPadding = Spacing_05
+  static let lottieViewTopPadding = Spacing_04
+  static let rootStackViewTopPadding = Spacing_05
+  static let titleSubtitleSpacing = Spacing_03
+  static let verticalSpacing = Spacing_06
 }
 
 struct OnboardingItemView: View {

--- a/Kickstarter-iOS/Features/Onboarding/Views/OnboardingView.swift
+++ b/Kickstarter-iOS/Features/Onboarding/Views/OnboardingView.swift
@@ -4,16 +4,16 @@ import SwiftUI
 
 private enum Constants {
   static let animationDuration: Double = 0.35
-  static let closeIconPadding: CGFloat = 8
+  static let closeIconPadding = Spacing_02
   static let ctaBottomPadding: CGFloat = 60
-  static let horizontalPadding: CGFloat = 20
-  static let lottieViewTopPadding: CGFloat = 16
-  static let progressViewHeight: CGFloat = 8
-  static let rootStackViewCornerRadius: CGFloat = 20
-  static let rootStackViewTopPadding: CGFloat = 20
-  static let titleSubtitleSpacing: CGFloat = 12
-  static let verticalPadding: CGFloat = 20
-  static let verticalSpacing: CGFloat = 24
+  static let horizontalPadding = Spacing_05
+  static let lottieViewTopPadding = Spacing_04
+  static let progressViewHeight = Spacing_02
+  static let rootStackViewCornerRadius = Spacing_05
+  static let rootStackViewTopPadding = Spacing_05
+  static let titleSubtitleSpacing = Spacing_03
+  static let verticalPadding = Spacing_05
+  static let verticalSpacing = Spacing_06
 }
 
 public struct OnboardingView: View {

--- a/Kickstarter-iOS/Features/PledgePaymentMethods/Controller/PledgeRewardsSummaryViewController.swift
+++ b/Kickstarter-iOS/Features/PledgePaymentMethods/Controller/PledgeRewardsSummaryViewController.swift
@@ -4,7 +4,7 @@ import UIKit
 
 public enum PledgeRewardsSummaryStyles {
   public enum Layout {
-    public static let sectionHeaderLabelHeight: CGFloat = 20
+    public static let sectionHeaderLabelHeight: CGFloat = Spacing_05
     public static let rootStackViewSpacing: CGFloat = Styles.grid(1)
     public static let separatorViewLeftAnchorConstant: CGFloat = Styles.grid(4)
     public static let separatorViewRightAnchorConstant: CGFloat = -Styles.grid(4)

--- a/Kickstarter-iOS/Features/PledgeView/Controllers/PostCampaignCheckoutViewController.swift
+++ b/Kickstarter-iOS/Features/PledgeView/Controllers/PostCampaignCheckoutViewController.swift
@@ -535,7 +535,7 @@ private func rootInsetStackViewStyle(_ stackView: UIStackView) {
   )
 }
 
-public func roundedStyle(_ view: UIView, cornerRadius: CGFloat = Styles.cornerRadius) {
+public func roundedStyle(_ view: UIView, cornerRadius: CGFloat = Dimension.CornerRadius.small) {
   view.clipsToBounds = true
   view.layer.masksToBounds = true
   view.layer.cornerRadius = cornerRadius

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/CardView/PPOAlertFlag.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/CardView/PPOAlertFlag.swift
@@ -57,10 +57,15 @@ struct PPOAlertFlag: View {
 
   private enum Constants {
     static let imageSize: CGFloat = 18
-    static let spacerWidth: CGFloat = 4
+    static let spacerWidth = Spacing_01
     static let cornerRadius: CGFloat = 6
     static let font = UIFont.ksr_caption1().bolded
-    static let padding = EdgeInsets(top: 4, leading: 12, bottom: 4, trailing: 8)
+    static let padding = EdgeInsets(
+      top: Spacing_01,
+      leading: Spacing_03,
+      bottom: Spacing_01,
+      trailing: Spacing_02
+    )
   }
 }
 

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/CardView/PPOProjectCard.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/CardView/PPOProjectCard.swift
@@ -182,7 +182,7 @@ struct PPOProjectCard: View {
   }
 
   private enum Constants {
-    static let cornerRadius: CGFloat = Styles.cornerRadius * 2
+    static let cornerRadius: CGFloat = Dimension.CornerRadius.medium
     static let borderColor = LegacyColors.ksr_support_300.uiColor()
     static let borderWidth: CGFloat = 1
     static let badgeAlignment = Alignment(horizontal: .trailing, vertical: .top)

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/CardView/PPOProjectCreator.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/CardView/PPOProjectCreator.swift
@@ -33,7 +33,7 @@ struct PPOProjectCreator: View {
   }
 
   private enum Constants {
-    static let messageIconSize: CGFloat = 24
+    static let messageIconSize: CGFloat = Spacing_06
     static let spacerWidth = Styles.grid(1)
     static let textLineLimit = 1
     static let largeTextLineLimit = 3

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/CardView/PPOProjectDetails.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/CardView/PPOProjectDetails.swift
@@ -57,7 +57,7 @@ struct PPOProjectDetails: View {
   private enum Constants {
     static let spacing: CGFloat = Styles.grid(1)
 
-    static let imageShape = RoundedRectangle(cornerRadius: Styles.cornerRadius)
+    static let imageShape = RoundedRectangle(cornerRadius: Dimension.CornerRadius.small)
     static let imageAspectRatio: CGFloat = 16 / 9
     static let imageContentMode = ContentMode.fit
 

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOEmptyStateView.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOEmptyStateView.swift
@@ -5,8 +5,8 @@ struct PPOEmptyStateView: View {
   var onOpenBackedProjects: (() -> Void)? = nil
 
   private enum Constants {
-    public static let largePadding = 24.0
-    public static let horizontalPadding = 16.0
+    public static let largePadding = Spacing_06
+    public static let horizontalPadding = Spacing_04
   }
 
   var body: some View {

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOStyles.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOStyles.swift
@@ -49,7 +49,7 @@ enum PPOStyles {
   )
 
   static let flagFont = UIFont.ksr_caption1().bolded
-  static let flagSpacing: CGFloat = 8
+  static let flagSpacing: CGFloat = Spacing_02
 
   static let bannerPadding = 7
 

--- a/Kickstarter-iOS/Features/ProjectCard/ProjectCardView.swift
+++ b/Kickstarter-iOS/Features/ProjectCard/ProjectCardView.swift
@@ -4,12 +4,12 @@ import UIKit
 
 private enum Constants {
   static let imageAspectRatio = CGFloat(9.0 / 16.0)
-  static let cornerRadius = 12.0
+  static let cornerRadius = Spacing_03
   static let projectImageViewHeight = 198.0
-  static let projectStatusStackViewSpacing = 8.0
-  static let daysLeftImageViewHeight = 16.0
-  static let daysLeftImageViewWidth = 16.0
-  static let daysLeftLabelLeadingSpacing = 8.0
+  static let projectStatusStackViewSpacing = Spacing_02
+  static let daysLeftImageViewHeight = Spacing_04
+  static let daysLeftImageViewWidth = Spacing_04
+  static let daysLeftLabelLeadingSpacing = Spacing_02
   static let progressBarHeight = 9.0
   static let viewSpacing = Styles.grid(3)
 }

--- a/Kickstarter-iOS/Features/ProjectPage/SimilarProjects/Cells/SimilarProjectsTableViewCell.swift
+++ b/Kickstarter-iOS/Features/ProjectPage/SimilarProjects/Cells/SimilarProjectsTableViewCell.swift
@@ -8,7 +8,7 @@ protocol SimilarProjectsTableViewCellDelegate: AnyObject {
 
 enum SimilarProjectsCellConstants {
   static let spacing: CGFloat = Styles.grid(3)
-  static let collectionViewInteritemSpacing: CGFloat = 8.0
+  static let collectionViewInteritemSpacing: CGFloat = Spacing_02
   static let collectionViewItemSize = CGSize(width: 327, height: 279)
   static let collectionViewBottomSpacing: CGFloat = -Styles.grid(6)
   static let collectionViewHeight: CGFloat = 350.0

--- a/Kickstarter-iOS/Features/ReportProject/ReportProjectInfoView.swift
+++ b/Kickstarter-iOS/Features/ReportProject/ReportProjectInfoView.swift
@@ -118,7 +118,7 @@ struct RowView: View {
   @Binding var popToRoot: Bool
 
   private let contentSpacing = 10.0
-  private let contentPadding = 12.0
+  private let contentPadding = Spacing_03
 
   var body: some View {
     HStack {

--- a/Kickstarter-iOS/Features/RewardTracking/Views/RewardTrackingDetailsView.swift
+++ b/Kickstarter-iOS/Features/RewardTracking/Views/RewardTrackingDetailsView.swift
@@ -5,9 +5,9 @@ private enum Constants {
   static let rootStackViewSpacing = 14.0
   static let rootStackViewCustomSpacing = Styles.grid(1)
   static let rootStackViewLayoutMargins = UIEdgeInsets(all: 16.0)
-  static let titleStackViewSpacing: CGFloat = 8.0
-  static let activityStyleCornerRadius: CGFloat = 8.0
-  static let backingStyleCornerRadius: CGFloat = 8.0
+  static let titleStackViewSpacing = Spacing_02
+  static let activityStyleCornerRadius = Spacing_02
+  static let backingStyleCornerRadius = Spacing_02
 }
 
 public enum RewardTrackingDetailsViewStyle {

--- a/Kickstarter-iOS/Features/SortFilter/AmountRaisedView/AmountRaisedView.swift
+++ b/Kickstarter-iOS/Features/SortFilter/AmountRaisedView/AmountRaisedView.swift
@@ -26,9 +26,9 @@ public struct AmountRaisedView: View {
   }
 
   internal enum Constants {
-    static let padding: CGFloat = 24.0
-    static let spacing: CGFloat = 24.0
-    static let buttonLabelSpacing: CGFloat = 8.0
+    static let padding = Spacing_06
+    static let spacing = Spacing_06
+    static let buttonLabelSpacing = Spacing_02
   }
 }
 

--- a/Kickstarter-iOS/Features/SortFilter/Components/RadioButton.swift
+++ b/Kickstarter-iOS/Features/SortFilter/Components/RadioButton.swift
@@ -24,7 +24,7 @@ struct RadioButton: View {
   }
 
   internal enum Constants {
-    static let radioButtonSize: CGFloat = Styles.grid(4)
+    static let radioButtonSize = Spacing_06
     static let radioButtonOuterBorder: CGFloat = 1.0
     static let radioButtonInnerBorder: CGFloat = 8.0
   }

--- a/Kickstarter-iOS/Features/SortFilter/FilterCategory/FilterCategoryView.swift
+++ b/Kickstarter-iOS/Features/SortFilter/FilterCategory/FilterCategoryView.swift
@@ -115,14 +115,14 @@ struct FilterCategoryView: View {
 }
 
 private enum Constants {
-  static let headerPadding: CGFloat = 24.0
-  static let progressViewPadding: CGFloat = 24.0
-  static let radioButtonSize: CGFloat = 24.0
+  static let headerPadding = Spacing_06
+  static let progressViewPadding = Spacing_06
+  static let radioButtonSize = Spacing_06
   static let radioButtonOuterBorder: CGFloat = 1.0
-  static let radioButtonInnerBorder: CGFloat = 8.0
+  static let radioButtonInnerBorder = Spacing_02
   static let resetButtonMaxWidth: CGFloat = 130.0
-  static let rowPaddingHorizontal: CGFloat = 24.0
-  static let rowPaddingVertical: CGFloat = 20.0
+  static let rowPaddingHorizontal = Spacing_06
+  static let rowPaddingVertical = Spacing_05
   static let separatorHeight: CGFloat = 1.0
 }
 

--- a/Kickstarter-iOS/Features/SortFilter/FilterRootView/FilterRootView.swift
+++ b/Kickstarter-iOS/Features/SortFilter/FilterRootView/FilterRootView.swift
@@ -267,9 +267,14 @@ struct FilterRootView: View {
   }
 
   enum Constants {
-    static let sectionPadding: EdgeInsets = EdgeInsets(top: 24.0, leading: 24.0, bottom: 24.0, trailing: 24.0)
-    static let sectionSpacing: CGFloat = 12.0
-    static let flowLayoutSpacing: CGFloat = 8.0
+    static let sectionPadding: EdgeInsets = EdgeInsets(
+      top: Spacing_06,
+      leading: Spacing_06,
+      bottom: Spacing_06,
+      trailing: Spacing_06
+    )
+    static let sectionSpacing = Spacing_03
+    static let flowLayoutSpacing = Spacing_02
     static let resetButtonMaxWidth: CGFloat = 130.0
   }
 }

--- a/Kickstarter-iOS/Features/SortFilter/GoalView/GoalView.swift
+++ b/Kickstarter-iOS/Features/SortFilter/GoalView/GoalView.swift
@@ -26,9 +26,9 @@ public struct GoalView: View {
   }
 
   internal enum Constants {
-    static let padding: CGFloat = 24.0
-    static let spacing: CGFloat = 24.0
-    static let buttonLabelSpacing: CGFloat = 8.0
+    static let padding = Spacing_06
+    static let spacing = Spacing_06
+    static let buttonLabelSpacing = Spacing_02
   }
 }
 

--- a/Kickstarter-iOS/Features/SortFilter/HeaderView/PillButtons.swift
+++ b/Kickstarter-iOS/Features/SortFilter/HeaderView/PillButtons.swift
@@ -1,7 +1,6 @@
 import Library
 import SwiftUI
 
-private let spacing01 = 4.0
 private let buttonFont = InterFont.headingMD
 
 internal struct SearchFiltersPillStyle: SwiftUI.ButtonStyle {
@@ -10,8 +9,8 @@ internal struct SearchFiltersPillStyle: SwiftUI.ButtonStyle {
   /// and needs a little extra space in the end caps. If the pill is displaying square content (i.e. an icon),
   /// set `isSquare` to `true` to remove that extra spacing.
   var isSquare: Bool = false
-  private let padding: CGFloat = spacing01 * 2
-  private let extraPadding: CGFloat = spacing01
+  private let padding: CGFloat = Spacing_02
+  private let extraPadding: CGFloat = Spacing_01
 
   func makeBody(configuration: Configuration) -> some View {
     configuration.label
@@ -68,10 +67,10 @@ internal struct FilterBadgeView: View {
     Text("\(self.count)")
       .font(InterFont.headingXS.swiftUIFont())
       .padding(EdgeInsets(
-        top: spacing01,
-        leading: spacing01,
-        bottom: spacing01,
-        trailing: spacing01
+        top: Spacing_01,
+        leading: Spacing_01,
+        bottom: Spacing_01,
+        trailing: Spacing_01
       ))
       .foregroundStyle(Colors.Text.primary.swiftUIColor())
       .background(Colors.Background.Accent.Gray.subtle.swiftUIColor())
@@ -163,7 +162,7 @@ internal struct TogglePillButton: View {
 
   var body: some View {
     Button(action: self.action) {
-      HStack(spacing: spacing01) {
+      HStack(spacing: Spacing_01) {
         if let image = self.image {
           Image(uiImage: image)
             .aspectRatio(1.0, contentMode: .fill)

--- a/Kickstarter-iOS/Features/SortFilter/LocationView/LocationView.swift
+++ b/Kickstarter-iOS/Features/SortFilter/LocationView/LocationView.swift
@@ -117,9 +117,9 @@ public struct LocationView: View {
   }
 
   internal enum Constants {
-    static let padding: CGFloat = 24.0
-    static let spacing: CGFloat = 24.0
-    static let buttonLabelSpacing: CGFloat = 8.0
+    static let padding = Spacing_06
+    static let spacing = Spacing_06
+    static let buttonLabelSpacing = Spacing_02
   }
 }
 

--- a/Kickstarter-iOS/Features/SortFilter/PercentRaisedView/PercentRaisedView.swift
+++ b/Kickstarter-iOS/Features/SortFilter/PercentRaisedView/PercentRaisedView.swift
@@ -26,9 +26,9 @@ public struct PercentRaisedView: View {
   }
 
   internal enum Constants {
-    static let padding: CGFloat = 24.0
-    static let spacing: CGFloat = 24.0
-    static let buttonLabelSpacing: CGFloat = 8.0
+    static let padding = Spacing_06
+    static let spacing = Spacing_06
+    static let buttonLabelSpacing = Spacing_02
   }
 }
 

--- a/Kickstarter-iOS/SharedViews/AlertBanner.swift
+++ b/Kickstarter-iOS/SharedViews/AlertBanner.swift
@@ -25,7 +25,7 @@ final class AlertBanner: UIView {
 
   private func configureViews() {
     self.backgroundColor = Colors.Background.Danger.subtle.uiColor()
-    self.layer.cornerRadius = Styles.cornerRadius
+    self.layer.cornerRadius = Dimension.CornerRadius.small
     self.layer.masksToBounds = true
     self.translatesAutoresizingMaskIntoConstraints = false
 
@@ -51,7 +51,7 @@ final class AlertBanner: UIView {
     self.button.setBackgroundColor(LegacyColors.ksr_support_300.uiColor(), for: .highlighted)
     self.button.layer.borderColor = LegacyColors.ksr_support_300.uiColor().cgColor
     self.button.layer.borderWidth = 1
-    self.button.layer.cornerRadius = Styles.cornerRadius
+    self.button.layer.cornerRadius = Dimension.CornerRadius.small
     self.button.configurationUpdateHandler = { button in
       switch button.state {
       case .highlighted, .selected:
@@ -76,7 +76,7 @@ final class AlertBanner: UIView {
 
     let padding = Styles.grid(3)
     NSLayoutConstraint.activate([
-      leadingEdgeBar.widthAnchor.constraint(equalToConstant: Styles.cornerRadius),
+      leadingEdgeBar.widthAnchor.constraint(equalToConstant: Dimension.CornerRadius.small),
       leadingEdgeBar.leadingAnchor.constraint(equalTo: self.leadingAnchor),
       leadingEdgeBar.topAnchor.constraint(equalTo: self.topAnchor),
       leadingEdgeBar.bottomAnchor.constraint(equalTo: self.bottomAnchor),

--- a/Kickstarter-iOS/SharedViews/KSRSearchBar.swift
+++ b/Kickstarter-iOS/SharedViews/KSRSearchBar.swift
@@ -6,7 +6,7 @@ private enum Constants {
   static let alphaVisible = 1.0
   static let alphaHidden = 0.0
 
-  static let searchIconSize = 24.0
+  static let searchIconSize = Spacing_06
   static let borderWidth = 1.0
 
   static let focusedBorderColor = Colors.Border.active.uiColor().cgColor

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -2101,6 +2101,8 @@
 		E1A310242D270CB00062646C /* BuildPaymentPlanQueryTestData.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1A310212D270C610062646C /* BuildPaymentPlanQueryTestData.swift */; };
 		E1A310262D28406F0062646C /* PledgeOverTimeUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1A310252D2840680062646C /* PledgeOverTimeUseCase.swift */; };
 		E1A310292D2845E00062646C /* PledgeOverTimeUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1A310272D2845CB0062646C /* PledgeOverTimeUseCaseTests.swift */; };
+		E1A9678C2E40F9B2009D99CC /* CoreSpacing.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1A9678B2E40F9AE009D99CC /* CoreSpacing.swift */; };
+		E1A9678E2E40F9C0009D99CC /* Dimension.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1A9678D2E40F9BC009D99CC /* Dimension.swift */; };
 		E1AA8ABF2AEABBB100AC98BF /* Signal+Combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1EA34EE2AE1B28400942A04 /* Signal+Combine.swift */; };
 		E1AABC2B2DD259BA00BFFACF /* ColorsViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1AABC292DD2599600BFFACF /* ColorsViewTests.swift */; };
 		E1AACA872DDBB3AA005C38F1 /* LegacyColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1AACA862DDBB3AA005C38F1 /* LegacyColors.swift */; };
@@ -4351,6 +4353,8 @@
 		E1A310212D270C610062646C /* BuildPaymentPlanQueryTestData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildPaymentPlanQueryTestData.swift; sourceTree = "<group>"; };
 		E1A310252D2840680062646C /* PledgeOverTimeUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PledgeOverTimeUseCase.swift; sourceTree = "<group>"; };
 		E1A310272D2845CB0062646C /* PledgeOverTimeUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PledgeOverTimeUseCaseTests.swift; sourceTree = "<group>"; };
+		E1A9678B2E40F9AE009D99CC /* CoreSpacing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreSpacing.swift; sourceTree = "<group>"; };
+		E1A9678D2E40F9BC009D99CC /* Dimension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Dimension.swift; sourceTree = "<group>"; };
 		E1AABC292DD2599600BFFACF /* ColorsViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorsViewTests.swift; sourceTree = "<group>"; };
 		E1AACA862DDBB3AA005C38F1 /* LegacyColors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyColors.swift; sourceTree = "<group>"; };
 		E1AACA882DDBB48A005C38F1 /* ColorResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorResolver.swift; sourceTree = "<group>"; };
@@ -4375,29 +4379,6 @@
 		E1EEED2A2B686829009976D9 /* PKCETest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PKCETest.swift; sourceTree = "<group>"; };
 		E1FDB1E72AEAAC6100285F93 /* CombineTestObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CombineTestObserver.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
-
-/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
-		E18A64692E28224A00BA0376 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
-			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
-			publicHeaders = (
-				GraphAPI.h,
-			);
-			target = E18A645C2E28224A00BA0376 /* GraphAPI */;
-		};
-		E18A666B2E28225E00BA0376 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
-			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
-			publicHeaders = (
-				GraphAPITestMocks.h,
-			);
-			target = E18A66662E28225E00BA0376 /* GraphAPITestMocks */;
-		};
-/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
-
-/* Begin PBXFileSystemSynchronizedRootGroup section */
-		60CC7C9C2E269D270055BE8F /* Onboarding */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Onboarding; sourceTree = "<group>"; };
-		E18A645E2E28224A00BA0376 /* GraphAPI */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (E18A64692E28224A00BA0376 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = GraphAPI; sourceTree = "<group>"; };
-		E18A66682E28225E00BA0376 /* GraphAPITestMocks */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (E18A666B2E28225E00BA0376 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = GraphAPITestMocks; sourceTree = "<group>"; };
-/* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
 		A75511381C8642B3005355CF /* Frameworks */ = {
@@ -7832,6 +7813,7 @@
 		A73378F91D0AE33B00C91445 /* Styles */ = {
 			isa = PBXGroup;
 			children = (
+				E1A9678A2E40F9A7009D99CC /* Spacing */,
 				338E60282D70CACB008D42F9 /* Buttons */,
 				338E601D2D6FE303008D42F9 /* Colors */,
 				33F55B552D552BEF0007E50E /* Fonts */,
@@ -9195,6 +9177,15 @@
 			path = templates;
 			sourceTree = "<group>";
 		};
+		E1A9678A2E40F9A7009D99CC /* Spacing */ = {
+			isa = PBXGroup;
+			children = (
+				E1A9678B2E40F9AE009D99CC /* CoreSpacing.swift */,
+				E1A9678D2E40F9BC009D99CC /* Dimension.swift */,
+			);
+			path = Spacing;
+			sourceTree = "<group>";
+		};
 		E1AA8ABE2AEABB1900AC98BF /* combine */ = {
 			isa = PBXGroup;
 			children = (
@@ -10055,6 +10046,7 @@
 				067E7EC927BF0F2B00F02B33 /* AudioVideoViewElementCellViewModel.swift in Sources */,
 				8AE09C3C2446330100036043 /* PledgeDisclaimerViewModel.swift in Sources */,
 				77BC00F623301BD400808E75 /* RewardCellViewModel.swift in Sources */,
+				E1A9678C2E40F9B2009D99CC /* CoreSpacing.swift in Sources */,
 				D710ADFB243FB94A00DC7199 /* PledgeViewCTAContainerViewModel.swift in Sources */,
 				3767EDB122CFFF2B0088E8E4 /* ShippingRulesViewModel.swift in Sources */,
 				33D11D422D68C57300CC88A3 /* KSRButtonStyle.swift in Sources */,
@@ -10123,6 +10115,7 @@
 				D04AAC29218BB70D00CF713E /* BetaToolsViewModel.swift in Sources */,
 				D093B49C21A86FD800910962 /* PushRegistration.swift in Sources */,
 				A7F441B31D005A9400FE6FC5 /* ActivityProjectStatusViewModel.swift in Sources */,
+				E1A9678E2E40F9C0009D99CC /* Dimension.swift in Sources */,
 				E1A310262D28406F0062646C /* PledgeOverTimeUseCase.swift in Sources */,
 				AAE7C9A42C7527E000800E03 /* PagedTabBar.swift in Sources */,
 				370BE71622541C8100B44DB2 /* UIViewController+URL.swift in Sources */,

--- a/Library/Extensions/UIView+Helper.swift
+++ b/Library/Extensions/UIView+Helper.swift
@@ -2,8 +2,8 @@ import UIKit
 
 extension UIView {
   /// Rounds the corners of the view with a specified corner radius.
-  /// - Parameter cornerRadius: The radius to apply to the view's corners. Defaults to `Styles.cornerRadius`.
-  public func rounded(with cornerRadius: CGFloat = Styles.cornerRadius) {
+  /// - Parameter cornerRadius: The radius to apply to the view's corners. Defaults to `Dimension.CornerRadius.small`.
+  public func rounded(with cornerRadius: CGFloat = Dimension.CornerRadius.small) {
     self.clipsToBounds = true
     self.layer.masksToBounds = true
     self.layer.cornerRadius = cornerRadius

--- a/Library/Styles/BaseStyles.swift
+++ b/Library/Styles/BaseStyles.swift
@@ -3,7 +3,6 @@ import Prelude_UIKit
 import UIKit
 
 public enum Styles {
-  public static let cornerRadius: CGFloat = 4.0
   public static let minTouchSize: CGSize = CGSize(width: 44, height: 44)
   public static let projectPageLeftRightInset: CGFloat = Styles.grid(3)
   public static let projectPageTopBottomInset: CGFloat = Styles.grid(4)
@@ -61,7 +60,7 @@ public func cardStyle<V: UIViewProtocol>(cornerRadius radius: CGFloat = 0) -> ((
 }
 
 public func darkCardStyle<V: UIViewProtocol>
-(cornerRadius radius: CGFloat = Styles.cornerRadius) -> ((V) -> V) {
+(cornerRadius radius: CGFloat = Dimension.CornerRadius.small) -> ((V) -> V) {
   return cardStyle(cornerRadius: radius)
     <> V.lens.layer.borderColor .~ LegacyColors.ksr_support_400.uiColor().cgColor
 }
@@ -155,7 +154,10 @@ public let separatorStyleDark: ViewStyle = { view in
 
  - returns: A view transformer that rounds corners.
  */
-public func roundedStyle<V: UIViewProtocol>(cornerRadius r: CGFloat = Styles.cornerRadius) -> ((V) -> V) {
+public func roundedStyle<V: UIViewProtocol>(
+  cornerRadius r: CGFloat = Dimension.CornerRadius
+    .small
+) -> ((V) -> V) {
   return V.lens.clipsToBounds .~ true
     <> V.lens.layer.masksToBounds .~ true
     <> V.lens.layer.cornerRadius .~ r

--- a/Library/Styles/ButtonStyles.swift
+++ b/Library/Styles/ButtonStyles.swift
@@ -8,7 +8,7 @@ import UIKit
 // MARK: - Apple Pay
 
 public let applePayButtonStyle: ButtonStyle = { button in
-  let cornerRadius: CGFloat = featureNewDesignSystemEnabled() ? Styles.cornerRadius : Styles.grid(2)
+  let cornerRadius: CGFloat = featureNewDesignSystemEnabled() ? Dimension.CornerRadius.small : Styles.grid(2)
 
   return button
     |> roundedStyle(cornerRadius: cornerRadius)
@@ -22,7 +22,7 @@ public let applePayButtonStyle: ButtonStyle = { button in
 /// These styles are temporary for buttons that do not yet have a direct equivalent in the new system
 /// and are expected to be replaced in the future.
 public let baseButtonStyle: ButtonStyle = { button in
-  let cornerRadius: CGFloat = featureNewDesignSystemEnabled() ? Styles.cornerRadius : Styles.grid(2)
+  let cornerRadius: CGFloat = featureNewDesignSystemEnabled() ? Dimension.CornerRadius.small : Styles.grid(2)
   let font: UIFont = featureNewDesignSystemEnabled() ? .ksr_ButtonLabel() : .ksr_headline(size: 16)
 
   return button

--- a/Library/Styles/Buttons/KSRButtonLegacyStyle.swift
+++ b/Library/Styles/Buttons/KSRButtonLegacyStyle.swift
@@ -70,7 +70,7 @@ public enum KSRButtonLegacyStyle: KSRButtonStyleConfiguration, CaseIterable {
   }
 
   public var cornerRadius: CGFloat {
-    Styles.cornerRadius
+    Dimension.CornerRadius.small
   }
 
   public var buttonConfiguration: UIButton.Configuration {

--- a/Library/Styles/Buttons/KSRButtonStyle.swift
+++ b/Library/Styles/Buttons/KSRButtonStyle.swift
@@ -105,7 +105,7 @@ public enum KSRButtonStyle: KSRButtonStyleConfiguration, CaseIterable {
   }
 
   public var cornerRadius: CGFloat {
-    Styles.cornerRadius
+    Dimension.CornerRadius.small
   }
 
   public var buttonConfiguration: UIButton.Configuration {

--- a/Library/Styles/Spacing/CoreSpacing.swift
+++ b/Library/Styles/Spacing/CoreSpacing.swift
@@ -1,0 +1,46 @@
+import CoreFoundation
+
+/// A unit of spacing in our design system. Equal to Spacing/01.
+public let Spacing_01: CGFloat = 4.0
+
+/// A unit of spacing in our design system. Equal to Spacing/02.
+public let Spacing_02: CGFloat = 8.0
+
+/// A unit of spacing in our design system. Equal to Spacing/03.
+public let Spacing_03: CGFloat = 12.0
+
+/// A unit of spacing in our design system. Equal to Spacing/04.
+public let Spacing_04: CGFloat = 16.0
+
+/// A unit of spacing in our design system. Equal to Spacing/05.
+public let Spacing_05: CGFloat = 20.0
+
+/// A unit of spacing in our design system. Equal to Spacing/06.
+public let Spacing_06: CGFloat = 24.0
+
+/// A unit of spacing in our design system. Equal to Spacing/07.
+public let Spacing_07: CGFloat = 28.0
+
+/// A unit of spacing in our design system. Equal to Spacing/08.
+public let Spacing_08: CGFloat = 32.0
+
+/// A unit of spacing in our design system. Equal to Spacing/09.
+public let Spacing_09: CGFloat = 36.0
+
+/// A unit of spacing in our design system. Equal to Spacing/10.
+public let Spacing_10: CGFloat = 40.0
+
+/// A unit of spacing in our design system. Equal to Spacing/11.
+public let Spacing_11: CGFloat = 44.0
+
+/// A unit of spacing in our design system. Equal to Spacing/12.
+public let Spacing_12: CGFloat = 48.0
+
+/// A unit of spacing in our design system. Equal to Spacing/14.
+public let Spacing_14: CGFloat = 56.0
+
+/// A unit of spacing in our design system. Equal to Spacing/16.
+public let Spacing_16: CGFloat = 64.0
+
+/// A unit of spacing in our design system. Equal to Spacing/20.
+public let Spacing_20: CGFloat = 80.0

--- a/Library/Styles/Spacing/Dimension.swift
+++ b/Library/Styles/Spacing/Dimension.swift
@@ -1,0 +1,10 @@
+import CoreFoundation
+
+/// Represents semantic spacing constants in our design system.
+public struct Dimension {
+  public struct CornerRadius {
+    public static let small = Spacing_01
+    public static let medium = Spacing_02
+    public static let large = Spacing_04
+  }
+}


### PR DESCRIPTION
# 📲 What

Replace hardcoded spacing constants with their equivalent `Spacing_xx` or `Dimensions`.

# 🤔 Why

This will help us keep newer areas of the codebase in line with our design system, and it improves code clarity.

# 🛠 How

I focused on places where we defined `Constants`, and where we used values which were equivalent to `Spacing_01` through `Spacing_06`. I ignored files that still relied heavily on `Styles.grid`, since those are basically still in the old design system. 