### PR TITLE
Fix download location for apollo-schema-download.sh script

### DIFF
--- a/bin/apollo-schema-download.sh
+++ b/bin/apollo-schema-download.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 npm install -D apollo@2.11.1
-npx apollo schema:download --header="Content-Type: application/json" --header="User-Agent: Kickstarter iOS" --endpoint="https://staging.kickstarter.com/graph" KsApi/graphql-schema.json
+npx apollo schema:download --header="Content-Type: application/json" --header="User-Agent: Kickstarter iOS" --endpoint="https://staging.kickstarter.com/graph" graphql/graphql-schema.json


### PR DESCRIPTION
# 📲 What

Change download location of `apollo-schema-download.sh` from `KsApi/` to `graphql/`.

# 🤔 Why

I moved the schema file when I upgraded Apollo, but I forgot to change this script!