### PR TITLE
Update apollo-schema-download script to use apollo-ios-cli 

### DIFF
--- a/apollo-codegen-config.json
+++ b/apollo-codegen-config.json
@@ -1,5 +1,25 @@
 {
   "schemaNamespace": "GraphAPI",
+  "schemaDownload": {
+    "downloadMethod": {
+      "introspection": {
+        "endpointURL": "https://staging.kickstarter.com/graph",
+        "httpMethod": {
+          "POST": {}
+        },
+        "includeDeprecatedInputValues": false,
+        "outputFormat": "JSON"
+      }
+    },
+    "downloadTimeout": 60,
+    "headers": [
+      {
+        "key": "User-Agent",
+        "value": "Kickstarter-iOS"
+      }
+    ],
+    "outputPath": "graphql/graphql-schema.json"
+  },
   "input": {
     "operationSearchPaths": [
       "graphql/**/*.graphql"

--- a/bin/apollo-schema-download.sh
+++ b/bin/apollo-schema-download.sh
@@ -1,3 +1,2 @@
 #!/bin/sh
-npm install -D apollo@2.11.1
-npx apollo schema:download --header="Content-Type: application/json" --header="User-Agent: Kickstarter iOS" --endpoint="https://staging.kickstarter.com/graph" KsApi/graphql-schema.json
+./bin/apollo-ios-cli fetch-schema --verbose


### PR DESCRIPTION
# 📲 What

Update `apollo-schema-download` script to use `apollo-ios-cli`

# 🤔 Why

1. The original schema download script was downloading to the incorrect location (since I moved the schema from `KsApi/` to `graphql/`
2. The original schema script uses `npx`, which generates a `node_modules` folder I keep having to delete. Now that the Apollo CLI supports downloading the schema, we can skip that annoyance
