### PR TITLE
[MBL-2715] Remove Subtitle Line Limit

### DIFF
--- a/Kickstarter-iOS/Features/Onboarding/Views/OnboardingItemView.swift
+++ b/Kickstarter-iOS/Features/Onboarding/Views/OnboardingItemView.swift
@@ -30,7 +30,6 @@ struct OnboardingItemView: View {
 
         Text(self.item.subtitle)
           .font(Font(OnboardingStyles.subtitle))
-          .lineLimit(4)
           .multilineTextAlignment(.center)
           .frame(maxWidth: .infinity)
           .accessibilityLabel(Text(self.accessibilityLabel(for: self.item)))


### PR DESCRIPTION
# 🤔 Why

German translations have some longer text that we don't want truncated.

I think the `.lineLimit` property was left over from trying to maintain the view height and button placement a few PRs ago.

# 👀 See

Trello, screenshots, external resources?

| Before 🐛 | After 🦋 |
| --- | --- |
| <img width="300" height="700" alt="179d251d-347e-4669-8311-028396645c6e" src="https://github.com/user-attachments/assets/46b5952d-8f5c-4872-a8d2-f711bdc34f08" /> | ![Simulator Screen Recording - iPhone 15 Pro 17 5 - 2025-08-11 at 14 04 42](https://github.com/user-attachments/assets/e562a431-4733-46b6-a439-484e00263fba) |
