### PR TITLE
[MBL-2714] Fix default search results sort order bug

### DIFF
--- a/Library/ViewModels/SearchViewModel+GraphQL.swift
+++ b/Library/ViewModels/SearchViewModel+GraphQL.swift
@@ -170,10 +170,12 @@ extension DiscoveryParams {
     params.location = location
     params.amountRaised = amountRaised
     params.goal = goal
-    params.recommended = toggles.recommended
-    params.starred = toggles.savedProjects
-    params.staffPicks = toggles.projectsWeLove
-    params.social = toggles.following
+    // `false` and `nil` are supposed to have the same effect (this filter is not applied).
+    // In practice, setting these to `false` sometimes affects the sort, so `nil` is safer.
+    params.recommended = toggles.recommended == true ? true : nil
+    params.starred = toggles.savedProjects == true ? true : nil
+    params.staffPicks = toggles.projectsWeLove == true ? true : nil
+    params.social = toggles.following == true ? true : nil
     return params
   }
 }


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Fix default search sort order by setting toggle-related params to `false` when the toggles are not selected.

Note: Specifically, the filter that caused this was the starred/saved projects toggle, but it feels safer to me to just set all of them to nil.

# 👀 See

[Jira](https://kickstarter.atlassian.net/browse/MBL-2714)

| Before 🐛 | After 🦋 |
| --- | --- |
| <img width="404" height="823" alt="image" src="https://github.com/user-attachments/assets/ba14c524-c260-4607-aebf-02bec246a2c8" /> | <img width="409" height="826" alt="image" src="https://github.com/user-attachments/assets/4e15effd-2ae1-47a2-8ecc-8a0828f83e89" /> |

# ✅ Acceptance criteria

- [x] Default search results look normal
- [x] I checked in the current production app (5.27.1) and in a simulator with these changes and verified that default search results are the same

