### PR TITLE
[MBL-2716] AppTrackingTransparency Dialog Description Translations

### DIFF
--- a/Kickstarter-iOS/de.lproj/InfoPlist.strings
+++ b/Kickstarter-iOS/de.lproj/InfoPlist.strings
@@ -1,0 +1,6 @@
+/*
+ Description strings shown in the AppTrackingTransparency prompt.
+ If a user’s language isn’t localized, iOS falls back to the English default in Info.plist)
+ */
+
+"NSUserTrackingUsageDescription" = "Wir verwenden personenbezogene Daten, damit du Kickstarter besser nutzen kannst und wir dir Projekte zeigen können, die dir gefallen könnten.";

--- a/Kickstarter-iOS/en.lproj/InfoPlist.strings
+++ b/Kickstarter-iOS/en.lproj/InfoPlist.strings
@@ -1,0 +1,6 @@
+/*
+ Description strings shown in the AppTrackingTransparency prompt.
+ If a user’s language isn’t localized, iOS falls back to the English default in Info.plist)
+ */
+
+"NSUserTrackingUsageDescription" = "We use your data to show more relevant ads and to measure campaign performance.";

--- a/Kickstarter-iOS/es.lproj/InfoPlist.strings
+++ b/Kickstarter-iOS/es.lproj/InfoPlist.strings
@@ -1,0 +1,6 @@
+/*
+ Description strings shown in the AppTrackingTransparency prompt.
+ If a user’s language isn’t localized, iOS falls back to the English default in Info.plist)
+ */
+
+"NSUserTrackingUsageDescription" = "Usamos tus datos personales para ofrecerte una buena experiencia en Kickstarter y ayudarte a descubrir proyectos que te encantarán.";

--- a/Kickstarter-iOS/fr.lproj/InfoPlist.strings
+++ b/Kickstarter-iOS/fr.lproj/InfoPlist.strings
@@ -1,0 +1,6 @@
+/*
+ Description strings shown in the AppTrackingTransparency prompt.
+ If a user’s language isn’t localized, iOS falls back to the English default in Info.plist)
+ */
+
+"NSUserTrackingUsageDescription" = "Nous nous servons de données personnelles pour offrir une expérience Kickstarter agréable et pour vous aider à découvrir des projets qui vous plairont.";

--- a/Kickstarter-iOS/ja.lproj/InfoPlist.strings
+++ b/Kickstarter-iOS/ja.lproj/InfoPlist.strings
@@ -1,0 +1,6 @@
+/*
+ Description strings shown in the AppTrackingTransparency prompt.
+ If a user’s language isn’t localized, iOS falls back to the English default in Info.plist)
+ */
+
+"NSUserTrackingUsageDescription" = "Kickstarter では、ユーザーの皆様により良い体験を提供し、最適なプロジェクトをご紹介するために、個人データを利用しています。";

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -519,6 +519,7 @@
 		6008633429B8FBD700B87B39 /* GraphUserEmail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6008633329B8FBD700B87B39 /* GraphUserEmail.swift */; };
 		6008633729B9025F00B87B39 /* GraphUserEmailTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6008633529B9023300B87B39 /* GraphUserEmailTests.swift */; };
 		6008633F29BF750700B87B39 /* MockAppTrackingTransparency.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6008633E29BF750700B87B39 /* MockAppTrackingTransparency.swift */; };
+		600944E42E5CB3A7004A089F /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 600944E22E5CB3A7004A089F /* InfoPlist.strings */; };
 		600A0EEB2DD23BAA00954829 /* Lottie in Frameworks */ = {isa = PBXBuildFile; productRef = 600A0EEA2DD23BAA00954829 /* Lottie */; };
 		601342EC2C81414000B851FA /* PostCampaignCheckoutViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 601342EB2C81414000B851FA /* PostCampaignCheckoutViewController.swift */; };
 		601342EF2C81419C00B851FA /* PostCampaignCheckoutViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 601342ED2C81418700B851FA /* PostCampaignCheckoutViewControllerTests.swift */; };
@@ -2343,6 +2344,11 @@
 		6008633329B8FBD700B87B39 /* GraphUserEmail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphUserEmail.swift; sourceTree = "<group>"; };
 		6008633529B9023300B87B39 /* GraphUserEmailTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphUserEmailTests.swift; sourceTree = "<group>"; };
 		6008633E29BF750700B87B39 /* MockAppTrackingTransparency.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockAppTrackingTransparency.swift; sourceTree = "<group>"; };
+		600944E32E5CB3A7004A089F /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		600944E52E5CB3D5004A089F /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		600944E62E5CB3D6004A089F /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		600944E72E5CB3D7004A089F /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		600944E82E5CB3D8004A089F /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		601342EB2C81414000B851FA /* PostCampaignCheckoutViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostCampaignCheckoutViewController.swift; sourceTree = "<group>"; };
 		601342ED2C81418700B851FA /* PostCampaignCheckoutViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostCampaignCheckoutViewControllerTests.swift; sourceTree = "<group>"; };
 		601342F02C8141F000B851FA /* PostCampaignCheckoutViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostCampaignCheckoutViewModel.swift; sourceTree = "<group>"; };
@@ -6885,6 +6891,7 @@
 				80AB97B61D6281D60051C9D1 /* Debug.entitlements */,
 				A71FB0651E3FF347006C286E /* Release.entitlements */,
 				A7D1F9551C850B7C000D41D5 /* Info.plist */,
+				600944E22E5CB3A7004A089F /* InfoPlist.strings */,
 				60A80F522BD7F9A00052A829 /* PrivacyInfo.xcprivacy */,
 				A7D1F9471C850B7C000D41D5 /* AppDelegate.swift */,
 				A75CBDE61C8A26F800758C55 /* AppDelegateViewModel.swift */,
@@ -8506,6 +8513,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				9D50E9471D2EDBE50096DAEC /* Assets.xcassets in Resources */,
+				600944E42E5CB3A7004A089F /* InfoPlist.strings in Resources */,
 				8A65E79E2501AE89006F81CC /* GoogleService-Info.plist in Resources */,
 				01F219561DC12BF7005DD2E4 /* LaunchScreen.storyboard in Resources */,
 				A73924051D27247E004524C3 /* Main.storyboard in Resources */,
@@ -10302,6 +10310,18 @@
 /* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
+		600944E22E5CB3A7004A089F /* InfoPlist.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				600944E32E5CB3A7004A089F /* en */,
+				600944E52E5CB3D5004A089F /* fr */,
+				600944E62E5CB3D6004A089F /* de */,
+				600944E72E5CB3D7004A089F /* ja */,
+				600944E82E5CB3D8004A089F /* es */,
+			);
+			name = InfoPlist.strings;
+			sourceTree = "<group>";
+		};
 		A7A5F8231D11ECF60036139A /* Localizable.strings */ = {
 			isa = PBXVariantGroup;
 			children = (


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Localizes the AppTrackingTransparency purpose string by introducing InfoPlist.strings and per-language values for the `NSUserTrackingUsageDescription`.

# 🤔 Why

- We need the ATT dialog’s description to match the user’s preferred language.
- Currently we display in english regardless.

# 🛠 How

- Added InfoPlist.strings fille and localized it for all supported languages via the File Inspector.
- Added per-language values for: "NSUserTrackingUsageDescription"

# 👀 See

Trello, screenshots, external resources?

| English | German | Japanese | Spanish | French |
| --- | --- | --- | --- | --- |
| <img width="1206" height="2622" alt="english" src="https://github.com/user-attachments/assets/a7248e33-b754-4e0f-b29b-e326444898b9" /> | <img width="1206" height="2622" alt="german" src="https://github.com/user-attachments/assets/abaff30a-d337-4fb4-8ddc-2e59c7064b8f" /> | <img width="1206" height="2622" alt="japanese" src="https://github.com/user-attachments/assets/8c8ae7aa-570b-4c41-a9c9-86fdbf5fb400" /> | <img width="1206" height="2622" alt="spanish" src="https://github.com/user-attachments/assets/2c211932-6c5b-483d-99e5-c2bde534f758" /> | <img width="1206" height="2622" alt="french" src="https://github.com/user-attachments/assets/8a4ed75d-ed64-4fed-9b48-1f6206215d37" /> |


# ✅ Acceptance criteria

- [x] All ATT dialog's copy is in the user's preferred language for each of our support languages (en, de, es, ja, fr)
