### PR TITLE
MBL-2658: Use palette colors instead of hex colors in OnboardingStyles and PPOStyles

### DIFF
--- a/Kickstarter-iOS/Features/Onboarding/OnboardingStyles.swift
+++ b/Kickstarter-iOS/Features/Onboarding/OnboardingStyles.swift
@@ -8,8 +8,8 @@ enum OnboardingStyles {
 
   static let ctaFont = UIFont.ksr_bodyLG().bolded
 
-  static let backgroundColor = Color(.hex(0x06E584))
-  static let progressBarTintColor = Color(.hex(0x00743D))
+  static let backgroundColor = Color(UIColor(coreColor: .green_04))
+  static let progressBarTintColor = Color(UIColor(coreColor: .green_06))
 
   static let closeImage = ImageResource.closeIconNoBackground
   static let backgroundImage = ImageResource.onboardingSquiggleBackground

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOStyles.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOStyles.swift
@@ -59,5 +59,5 @@ enum PPOStyles {
   static let alertImage = ImageResource.iconNotice
   static let sendMessageImage = ImageResource.iconSendMessage
 
-  static let badgeColor = UIColor.hex(0xFF3B30)
+  static let badgeColor = LegacyColors.Badge.Notification.background.uiColor()
 }

--- a/Library/Styles/Colors/CoreColor.swift
+++ b/Library/Styles/Colors/CoreColor.swift
@@ -87,7 +87,7 @@ public enum CoreColor: Int {
   case blue_10 = 0x050543
 }
 
-extension UIColor {
+public extension UIColor {
   convenience init(coreColor: CoreColor) {
     let rgbValue = coreColor.rawValue
     self.init(

--- a/Library/Styles/Colors/LegacyColors.swift
+++ b/Library/Styles/Colors/LegacyColors.swift
@@ -92,6 +92,16 @@ public struct LegacyColors {
     )
   }
 
+  public struct Badge {
+    public struct Notification {
+      public static let background = LegacyColor(
+        "legacy/badge/notification/background",
+        lightMode: UIColor.hex(0xFF3B30),
+        darkMode: UIColor.hex(0xFF3B30)
+      )
+    }
+  }
+
   public struct Facebook {
     public static let primary = LegacyColor(
       "legacy/facebook/primary",


### PR DESCRIPTION
# 📲 What

* Replace hardcoded hex values for three colors in the app

# 🤔 Why

I'm making `UIColor.hex` private to the `KDS` package. These colors need to use either a core color, or a semantic color.

# 🛠 How

I spoke with design to get their nearest equivalents!