### PR TITLE
MBL-2681: Move GraphQL schema download from CircleCI step into GraphQL build target

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,9 +117,6 @@ jobs:
             BUNDLE_JOBS: 4
             BUNDLE_RETRY: 3
       - run:
-          name: Download GraphQL Schema
-          command: bin/apollo-schema-download.sh
-      - run:
           name: Danger
           command: bin/danger.sh
       - persist_to_workspace:

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -8611,7 +8611,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\n$SRCROOT/bin/apollo-ios-cli generate\n";
+			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\n$SRCROOT/bin/apollo-schema-download.sh\n$SRCROOT/bin/apollo-ios-cli generate\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
# 📲 What

* Delete the update schema step from our CircleCI build configuration
* Add the update schema step to the Generate GraphQL Library target

# 🤔 Why

Updating the schema in CircleCI effectively worked as a smoke test - if someone changed the GraphQL schema in a way that broke the apps, our build on CircleCI would get the new schema, try to build KsApi, and then break. This happened maybe once or twice a year as a rare failure mode.

However, we no longer automatically generate GraphQL objects when KsApi is built. That means we’re spending an extra ~30 seconds in the CircleCI build for no benefit.

Instead, it makes more sense to re-download the schema when we actually re-generate the objects.

I filed a separate ticket to rebuild this smoke test, if we decide it's useful in the future.