### PR TITLE
[MBL-2743] Onboarding - Move App Tracking View & Update Analytics Events

### DIFF
--- a/Library/OnboardingUseCase.swift
+++ b/Library/OnboardingUseCase.swift
@@ -201,15 +201,15 @@ private func allOnboardingItems(
       in: bundle
     ),
     makeOnboardingItem(
-      title: Strings.onboarding_stay_in_the_know_title(),
-      subTitle: Strings.onboarding_stay_in_the_know_subtitle(),
-      type: .enableNotifications,
-      in: bundle
-    ),
-    makeOnboardingItem(
       title: Strings.onboarding_personalize_your_experience_title(),
       subTitle: Strings.onboarding_personalize_your_experience_subtitle(),
       type: .allowTracking,
+      in: bundle
+    ),
+    makeOnboardingItem(
+      title: Strings.onboarding_stay_in_the_know_title(),
+      subTitle: Strings.onboarding_stay_in_the_know_subtitle(),
+      type: .enableNotifications,
       in: bundle
     ),
     makeOnboardingItem(

--- a/Library/OnboardingUseCase.swift
+++ b/Library/OnboardingUseCase.swift
@@ -141,11 +141,6 @@ public final class OnboardingUseCase: OnboardingUseCaseType, OnboardingUseCaseUI
       .mapConst(())
 
     _ = self.goToNextItemTappedSignal.signal
-      .observeValues { itemType in
-        if itemType.isPermissionType {
-          // TODO: Emit analytic tracking events here so that we know that the user opted skipped push notifications and/or AppTrackingTransparency views
-        }
-      }
   }
 
   // MARK: - Inputs

--- a/Library/OnboardingViewModel.swift
+++ b/Library/OnboardingViewModel.swift
@@ -90,6 +90,7 @@ public final class OnboardingViewModel: OnboardingViewModelType, Equatable & Ide
 
   public func didCompletePushNotificationsDialog(with authStatus: UNAuthorizationStatus) {
     /// Send analytics event when the user has finished interacting with the PN system dialog. `authStatus` let's insights know whether they allowed or denied permissions.
+
     AppEnvironment.current.ksrAnalytics.trackPushNotificationPermissionsDialogInteraction(
       .onboardingNotificationsDialog,
       authStatus: authStatus
@@ -97,10 +98,11 @@ public final class OnboardingViewModel: OnboardingViewModelType, Equatable & Ide
   }
 
   public func didCompleteAppTrackingDialog(with authStatus: ATTrackingManager.AuthorizationStatus) {
-    /// Send analytics event when the user has finished interacting with the AppTracking  system dialog. `authStatus` let's insights know whether they allowed or denied permissions.
+    /// Send analytics event if the user has allowed AppTracking permission.
+    guard authStatus == .authorized else { return }
+
     AppEnvironment.current.ksrAnalytics.trackAppTrackingTransparencyPermissionsDialogInteraction(
-      .onboardingAppTrackingDialog,
-      authStatus: authStatus
+      .onboardingAppTrackingDialog
     )
   }
 

--- a/Library/OnboardingViewModelTests.swift
+++ b/Library/OnboardingViewModelTests.swift
@@ -113,13 +113,15 @@ final class OnboardingViewModelTest: TestCase {
 
     self.viewModel.inputs.didCompleteAppTrackingDialog(with: .denied)
 
-    XCTAssertEqual(["CTA Clicked", "CTA Clicked"], self.segmentTrackingClient.events)
+    XCTAssertEqual(["CTA Clicked"], self.segmentTrackingClient.events)
     XCTAssertEqual("onboarding", self.segmentTrackingClient.properties.last?["context_page"] as? String)
     XCTAssertEqual(
       "activity_tracking_prompt",
       self.segmentTrackingClient.properties.last?["context_section"] as? String
     )
-    XCTAssertEqual("deny", self.segmentTrackingClient.properties.last?["context_cta"] as? String)
+    
+    /// last ctaContext should be `allow` still because we shouldn't track denied events.
+    XCTAssertEqual("allow", self.segmentTrackingClient.properties.last?["context_cta"] as? String)
   }
 
   func testGoToLoginSignupTapped_FiresAnalyticsEvents() {

--- a/Library/Tracking/KSRAnalytics.swift
+++ b/Library/Tracking/KSRAnalytics.swift
@@ -1354,20 +1354,21 @@ public final class KSRAnalytics {
       .onboardingSystemPermissionsDenied
 
     let props = contextProperties(ctaContext: ctaContext, page: .onboarding, sectionContext: sectionContext)
+
     self.track(event: SegmentEvent.ctaClicked.rawValue, properties: props)
   }
 
   /**
-   Call when the user has finished interacting with the AppTrackingTransparency permissions dialog that was presented in the onboarding flow.
+   Call when the user has allowed the AppTrackingTransparency permissions dialog that was presented in the onboarding flow.
    */
   public func trackAppTrackingTransparencyPermissionsDialogInteraction(
-    _ sectionContext: SectionContext,
-    authStatus: ATTrackingManager.AuthorizationStatus
+    _ sectionContext: SectionContext
   ) {
-    let ctaContext: CTAContext = authStatus == .authorized ? .onboardingSystemPermissionsAllowed :
-      .onboardingSystemPermissionsDenied
-
-    let props = contextProperties(ctaContext: ctaContext, page: .onboarding, sectionContext: sectionContext)
+    let props = contextProperties(
+      ctaContext: .onboardingSystemPermissionsAllowed,
+      page: .onboarding,
+      sectionContext: sectionContext
+    )
     self.track(event: SegmentEvent.ctaClicked.rawValue, properties: props)
   }
 


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Moves the App Tracking View to be before the Push Notifications View.

# 🤔 Why

We want to be able to track as much data as we can if users have consented to AppTracking.
Today, if users consent after the notifications view we won't know what they actually did on that screen.

I also updated our app tracking analytic event so that we don't send anything if user "denied" consent permissions. That would defeat the purpose of denying!

# 👀 See

Trello, screenshots, external resources?

| | After 🦋 |
| --- | --- |
|  | ![Simulator Screen Recording - iPhone 16 Pro - 2025-09-03 at 08 36 00](https://github.com/user-attachments/assets/87fb2453-8477-4b57-aad9-a5c44be06940) |


# ✅ Acceptance criteria

- [x] AppTracking View is shown just before the Notifications View
- [x] Events are only sent if user has consented to app tracking
