### PR TITLE
[MBL-2774] Auto Scale Onboarding Views For Smaller Devices

### DIFF
--- a/Kickstarter-iOS/Features/Onboarding/Views/OnboardingItemView.swift
+++ b/Kickstarter-iOS/Features/Onboarding/Views/OnboardingItemView.swift
@@ -8,7 +8,7 @@ private enum Constants {
   static let rootStackViewBottomPadding = Spacing.unit_20
   static let horizontalPadding = Spacing.unit_05
   static let lottieViewTopPadding = Spacing.unit_04
-  static let rootStackViewTopPadding = Spacing.unit_05
+  static let rootStackViewTopPadding = Spacing.unit_01
   static let titleSubtitleSpacing = Spacing.unit_03
   static let verticalSpacing = Spacing.unit_06
 }
@@ -20,7 +20,7 @@ struct OnboardingItemView: View {
   let onSecondaryTap: () -> Void
 
   var body: some View {
-    VStack {
+    ScrollView(showsIndicators: false) {
       VStack(spacing: Constants.titleSubtitleSpacing) {
         Text(self.item.title)
           .font(Font(OnboardingStyles.title))
@@ -41,9 +41,10 @@ struct OnboardingItemView: View {
       ResizableLottieView(onboardingItem: self.item, isVisible: true)
         .frame(maxWidth: .infinity)
         .padding(.top, Constants.lottieViewTopPadding)
-
-      Spacer()
-
+    }
+    .padding(.top, Constants.rootStackViewTopPadding)
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+    .safeAreaInset(edge: .bottom, spacing: 0) {
       CallToActionView(
         item: self.item,
         animationDuration: Constants.animationDuration,
@@ -51,10 +52,8 @@ struct OnboardingItemView: View {
         onSecondaryTap: self.onSecondaryTap
       )
       .padding(.horizontal, Constants.horizontalPadding)
+      .ignoresSafeArea(.all)
     }
-    .padding(.top, Constants.rootStackViewTopPadding)
-    .padding(.bottom, Constants.rootStackViewBottomPadding)
-    .frame(maxWidth: .infinity, maxHeight: .infinity)
     .accessibilityElement(children: .contain)
   }
 

--- a/Kickstarter-iOS/Features/Onboarding/Views/OnboardingView.swift
+++ b/Kickstarter-iOS/Features/Onboarding/Views/OnboardingView.swift
@@ -29,13 +29,6 @@ public struct OnboardingView: View {
     return Double(self.currentIndex + 1) / onboardingItemsCount
   }
 
-  @SwiftUI.Environment(\.sizeCategory) private var sizeCategory
-
-  /// SE / older small devices are ~667pt tall
-  private var isSmallDevice: Bool {
-    UIScreen.main.bounds.height < 700
-  }
-
   public init(viewModel: OnboardingViewModel) {
     self.viewModel = viewModel
   }
@@ -52,6 +45,7 @@ public struct OnboardingView: View {
       VStack {
         self.ProgressBarView()
           .accessibilityElement(children: .combine)
+        // TODO: Add accessibility translations [mbl-2418]
 
         ZStack {
           ForEach(Array(self.onboardingItems.enumerated()), id: \.element.id) { index, item in
@@ -68,9 +62,10 @@ public struct OnboardingView: View {
               ))
             }
           }
+          .animation(.easeInOut(duration: Constants.animationDuration), value: self.currentIndex)
         }
+        .animation(.easeInOut(duration: Constants.animationDuration), value: self.currentIndex)
       }
-      .scaleEffect(self.isSmallDevice ? 0.85 : 1.0, anchor: .center)
       .padding(.top)
     }
     .onAppear {
@@ -165,9 +160,7 @@ public struct OnboardingView: View {
   private func goToNextItem() {
     guard self.currentIndex < self.onboardingItems.count - 1 else { return }
 
-    withAnimation(.easeInOut(duration: Constants.animationDuration)) {
-      self.currentIndex += 1
-    }
+    self.currentIndex += 1
 
     self.viewModel.inputs.goToNextItemTapped(item: self.onboardingItems[self.currentIndex])
   }

--- a/Kickstarter-iOS/Features/Onboarding/Views/OnboardingView.swift
+++ b/Kickstarter-iOS/Features/Onboarding/Views/OnboardingView.swift
@@ -22,6 +22,7 @@ public struct OnboardingView: View {
   @ObservedObject var viewModel: OnboardingViewModel
   @Namespace private var animation
   @State private var currentIndex: Int = 0
+  @State private var contentHeight: CGFloat = 1
   @State private var onboardingItems: [OnboardingItem] = []
 
   private var progress: Double {
@@ -45,28 +46,56 @@ public struct OnboardingView: View {
       VStack {
         self.ProgressBarView()
           .accessibilityElement(children: .combine)
-        // TODO: Add accessibility translations [mbl-2418]
 
-        ZStack {
-          ForEach(Array(self.onboardingItems.enumerated()), id: \.element.id) { index, item in
-            if index == self.currentIndex {
-              OnboardingItemView(
-                item: item,
-                progress: self.progress,
-                onPrimaryTap: { self.handlePrimaryTap(for: item) },
-                onSecondaryTap: { self.handleSecondaryTap(for: item) }
-              )
-              .transition(.asymmetric(
-                insertion: .move(edge: .trailing).combined(with: .opacity),
-                removal: .move(edge: .leading).combined(with: .opacity)
-              ))
+        /// Scale down view only if its height exceeds available height
+        GeometryReader { proxy in
+          let availableHeight = proxy.size.height
+          /// Compute how much to scale down the view to fit the available height.
+          /// - min(1, …) - don't scale up beyond 100% (full view height)
+          /// - max(0.86, …) - don’t let it shrink past 86% (keep tap targets accessible)
+          /// - availableHeight / max(contentHeight, 1) - fit ratio
+          let scale = min(1, max(0.86, availableHeight / max(self.contentHeight, 1)))
+
+          ZStack {
+            ForEach(Array(self.onboardingItems.enumerated()), id: \.element.id) { index, item in
+              if index == self.currentIndex {
+                OnboardingItemView(
+                  item: item,
+                  progress: self.progress,
+                  onPrimaryTap: { self.handlePrimaryTap(for: item) },
+                  onSecondaryTap: { self.handleSecondaryTap(for: item) }
+                )
+                .transition(.asymmetric(
+                  insertion: .move(edge: .trailing).combined(with: .opacity),
+                  removal: .move(edge: .leading).combined(with: .opacity)
+                ))
+              }
             }
           }
-          .animation(.easeInOut(duration: Constants.animationDuration), value: self.currentIndex)
+          /// Get the view content's height.
+          .background(
+            GeometryReader { geo in
+              Color.clear
+                .onAppear {
+                  self.contentHeight = geo.size.height
+                }
+                .onChange(of: geo.size.height) { height in
+                  withAnimation {
+                    self.contentHeight = height
+                  }
+                }
+            }
+          )
+          /// scale down  just enough to fit on screen and achor to  top
+          .scaleEffect(
+            scale,
+            anchor: .top
+          )
+          .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
         }
         .animation(.easeInOut(duration: Constants.animationDuration), value: self.currentIndex)
       }
-      .padding(.top)
+      .padding(.vertical)
     }
     .onAppear {
       self.viewModel.inputs.onAppear()
@@ -121,7 +150,6 @@ public struct OnboardingView: View {
           .accessibilityAddTraits(.isButton)
       }
     }
-    .padding(.top, Constants.verticalPadding)
     .padding(.horizontal, Constants.horizontalPadding)
   }
 

--- a/Kickstarter-iOS/Features/Onboarding/Views/OnboardingView.swift
+++ b/Kickstarter-iOS/Features/Onboarding/Views/OnboardingView.swift
@@ -29,6 +29,13 @@ public struct OnboardingView: View {
     return Double(self.currentIndex + 1) / onboardingItemsCount
   }
 
+  @SwiftUI.Environment(\.sizeCategory) private var sizeCategory
+
+  /// SE / older small devices are ~667pt tall
+  private var isSmallDevice: Bool {
+    UIScreen.main.bounds.height < 700
+  }
+
   public init(viewModel: OnboardingViewModel) {
     self.viewModel = viewModel
   }
@@ -45,7 +52,6 @@ public struct OnboardingView: View {
       VStack {
         self.ProgressBarView()
           .accessibilityElement(children: .combine)
-        // TODO: Add accessibility translations [mbl-2418]
 
         ZStack {
           ForEach(Array(self.onboardingItems.enumerated()), id: \.element.id) { index, item in
@@ -62,10 +68,9 @@ public struct OnboardingView: View {
               ))
             }
           }
-          .animation(.easeInOut(duration: Constants.animationDuration), value: self.currentIndex)
         }
-        .animation(.easeInOut(duration: Constants.animationDuration), value: self.currentIndex)
       }
+      .scaleEffect(self.isSmallDevice ? 0.85 : 1.0, anchor: .center)
       .padding(.top)
     }
     .onAppear {
@@ -160,7 +165,9 @@ public struct OnboardingView: View {
   private func goToNextItem() {
     guard self.currentIndex < self.onboardingItems.count - 1 else { return }
 
-    self.currentIndex += 1
+    withAnimation(.easeInOut(duration: Constants.animationDuration)) {
+      self.currentIndex += 1
+    }
 
     self.viewModel.inputs.goToNextItemTapped(item: self.onboardingItems[self.currentIndex])
   }


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Update onboarding views to account for smaller screen sizes.

# 🤔 Why

The new Onboarding view is cut off on small phones - the progress bar is missing, and the secondary button is pushed towards the bottom.

For example, here’s how it looks on the iPhone SE:
<img width="249" height="743" alt="image" src="https://github.com/user-attachments/assets/d66d776c-8b9b-47dc-8601-1171ec63b7ba" />

# 🛠 How

From what I've found, SwiftUI doesn’t have a way to auto-scale an entire view tree to fit a device's height if the content height exceeds it. `minimumScaleFactor` only works on `Text`, and `ViewThatFits` swaps layouts, but it doesn’t scale them.

`scaleEffect` was also causing blurry text depending on the font size which was no good either.

I ended up putting the text and lottie view in a scrollview and pinning the CTA to the bottom safe area inset.

I ran this by Alison and she gave the ok as well. It's not my favorite that you can see the main text behind the CTAs on larger font sizes, but we decided that adding a background to that area wasn't a better alternative.

# 👀 See

Trello, screenshots, external resources?

| SE | SE Large Text | 15 Pro |
| --- | --- | --- |
| ![SE normal font](https://github.com/user-attachments/assets/64e2a7f3-7338-4a4c-9fb2-e9627698cca4) | ![SE Large Font](https://github.com/user-attachments/assets/558d7842-9a09-48d9-9889-fa76a6344fac) | <img width="479" height="956" alt="15 pro" src="https://github.com/user-attachments/assets/040b01cf-9851-4f97-ad26-362542b84c70" /> |

# ✅ Acceptance criteria

- [x] Onboarding flow view content is always visible regardless of device size.
