### PR TITLE
[MBL-2744] Fix push notification registration

### DIFF
--- a/Kickstarter-iOS/AppDelegate.swift
+++ b/Kickstarter-iOS/AppDelegate.swift
@@ -161,10 +161,10 @@ internal final class AppDelegate: UIResponder, UIApplicationDelegate {
         print("📲 [Push Registration] Push token successfully registered (\(token)) ✨")
       }
 
-    self.viewModel.outputs.registerPushTokenInSegment
+    self.viewModel.outputs.registerPushTokenInBraze
       .observeForUI()
       .observeValues { token in
-        self.analytics?.registeredForRemoteNotifications(deviceToken: token)
+        self.braze?.notifications.register(deviceToken: token)
       }
 
     self.viewModel.outputs.triggerOnboardingFlow
@@ -520,6 +520,7 @@ internal final class AppDelegate: UIResponder, UIApplicationDelegate {
     let automation: BrazeKit.Braze.Configuration.Push.Automation = true
     automation.automaticSetup = false
     automation.requestAuthorizationAtLaunch = false
+    automation.registerDeviceToken = false
     return automation
   }
 }

--- a/Kickstarter-iOS/AppDelegate.swift
+++ b/Kickstarter-iOS/AppDelegate.swift
@@ -48,7 +48,7 @@ internal final class AppDelegate: UIResponder, UIApplicationDelegate {
     // Braze expects to be configured immediately, but segment destination plugins are initialized
     // async. This method bridges that gap.
     // https://www.braze.com/docs/developer_guide/sdk_integration#swift_step-2-set-up-delayed-initialization-optional
-    Braze.prepareForDelayedInitialization(pushAutomation: .init(automaticSetup: false))
+    Braze.prepareForDelayedInitialization(pushAutomation: self.configuredBrazePushAutmation())
 
     UIView.doBadSwizzleStuff()
     UIViewController.doBadSwizzleStuff()
@@ -478,9 +478,7 @@ internal final class AppDelegate: UIResponder, UIApplicationDelegate {
     return BrazeDestination(
       additionalConfiguration: { configuration in
         configuration.triggerMinimumTimeInterval = 5
-        configuration.push.automation = true
-        configuration.push.automation.requestAuthorizationAtLaunch = false
-        configuration.push.automation.automaticSetup = false
+        configuration.push.automation = self.configuredBrazePushAutmation()
         // TODO(MBL-2742): Change the logger level to `info` or `error` if it gets tedious.
         configuration.logger.level = .debug
       }
@@ -507,6 +505,16 @@ internal final class AppDelegate: UIResponder, UIApplicationDelegate {
           }
         }
     }
+  }
+
+  // This configuration object defines how much automation Braze does. It gets set both when
+  // we configure `BrazeDestination` and when we call `Braze.prepareForDelayedInitialization`.
+  // https://braze-inc.github.io/braze-swift-sdk/documentation/brazekit/braze/configuration-swift.class/push-swift.class/automation-swift.class/
+  private func configuredBrazePushAutmation() -> BrazeKit.Braze.Configuration.Push.Automation {
+    let automation: BrazeKit.Braze.Configuration.Push.Automation = true
+    automation.automaticSetup = false
+    automation.requestAuthorizationAtLaunch = false
+    return automation
   }
 }
 

--- a/Kickstarter-iOS/AppDelegate.swift
+++ b/Kickstarter-iOS/AppDelegate.swift
@@ -161,12 +161,6 @@ internal final class AppDelegate: UIResponder, UIApplicationDelegate {
         print("📲 [Push Registration] Push token successfully registered (\(token)) ✨")
       }
 
-    self.viewModel.outputs.registerPushTokenInSegment
-      .observeForUI()
-      .observeValues { token in
-        self.analytics?.registeredForRemoteNotifications(deviceToken: token)
-      }
-
     self.viewModel.outputs.triggerOnboardingFlow
       .observeForUI()
       .observeValues { [weak self] in

--- a/Kickstarter-iOS/AppDelegate.swift
+++ b/Kickstarter-iOS/AppDelegate.swift
@@ -161,6 +161,12 @@ internal final class AppDelegate: UIResponder, UIApplicationDelegate {
         print("📲 [Push Registration] Push token successfully registered (\(token)) ✨")
       }
 
+    self.viewModel.outputs.registerPushTokenInSegment
+      .observeForUI()
+      .observeValues { token in
+        self.analytics?.registeredForRemoteNotifications(deviceToken: token)
+      }
+
     self.viewModel.outputs.triggerOnboardingFlow
       .observeForUI()
       .observeValues { [weak self] in

--- a/Kickstarter-iOS/AppDelegate.swift
+++ b/Kickstarter-iOS/AppDelegate.swift
@@ -48,7 +48,7 @@ internal final class AppDelegate: UIResponder, UIApplicationDelegate {
     // Braze expects to be configured immediately, but segment destination plugins are initialized
     // async. This method bridges that gap.
     // https://www.braze.com/docs/developer_guide/sdk_integration#swift_step-2-set-up-delayed-initialization-optional
-    Braze.prepareForDelayedInitialization(pushAutomation: self.configuredBrazePushAutmation())
+    Braze.prepareForDelayedInitialization(pushAutomation: self.configuredBrazePushAutomation())
 
     UIView.doBadSwizzleStuff()
     UIViewController.doBadSwizzleStuff()
@@ -484,7 +484,7 @@ internal final class AppDelegate: UIResponder, UIApplicationDelegate {
     return BrazeDestination(
       additionalConfiguration: { configuration in
         configuration.triggerMinimumTimeInterval = 5
-        configuration.push.automation = self.configuredBrazePushAutmation()
+        configuration.push.automation = self.configuredBrazePushAutomation()
         // TODO(MBL-2742): Change the logger level to `info` or `error` if it gets tedious.
         configuration.logger.level = .debug
       }
@@ -516,7 +516,7 @@ internal final class AppDelegate: UIResponder, UIApplicationDelegate {
   // This configuration object defines how much automation Braze does. It gets set both when
   // we configure `BrazeDestination` and when we call `Braze.prepareForDelayedInitialization`.
   // https://braze-inc.github.io/braze-swift-sdk/documentation/brazekit/braze/configuration-swift.class/push-swift.class/automation-swift.class/
-  private func configuredBrazePushAutmation() -> BrazeKit.Braze.Configuration.Push.Automation {
+  private func configuredBrazePushAutomation() -> BrazeKit.Braze.Configuration.Push.Automation {
     let automation: BrazeKit.Braze.Configuration.Push.Automation = true
     automation.automaticSetup = false
     automation.requestAuthorizationAtLaunch = false

--- a/Kickstarter-iOS/AppDelegate.swift
+++ b/Kickstarter-iOS/AppDelegate.swift
@@ -31,6 +31,7 @@ internal final class AppDelegate: UIResponder, UIApplicationDelegate {
   fileprivate var brazeSubscription: BrazeKit.Braze.Cancellable?
 
   private var analytics: Segment.Analytics?
+  private weak var braze: Braze?
 
   internal var rootTabBarController: RootTabBarViewController? {
     return self.window?.rootViewController as? RootTabBarViewController
@@ -47,7 +48,7 @@ internal final class AppDelegate: UIResponder, UIApplicationDelegate {
     // Braze expects to be configured immediately, but segment destination plugins are initialized
     // async. This method bridges that gap.
     // https://www.braze.com/docs/developer_guide/sdk_integration#swift_step-2-set-up-delayed-initialization-optional
-    BrazeDestination.prepareForDelayedInitialization()
+    Braze.prepareForDelayedInitialization(pushAutomation: .init(automaticSetup: false))
 
     UIView.doBadSwizzleStuff()
     UIViewController.doBadSwizzleStuff()
@@ -74,6 +75,9 @@ internal final class AppDelegate: UIResponder, UIApplicationDelegate {
       .observeForUI()
       .observeValues { [weak self] user in
         AppEnvironment.updateCurrentUser(user)
+        // Update user in Braze.
+        self?.braze?.changeUser(userId: String(user.id))
+        // Update user in Segment.
         AppEnvironment.current.ksrAnalytics.identify(newUser: user)
         self?.viewModel.inputs.currentUserUpdatedInEnvironment()
       }
@@ -482,12 +486,14 @@ internal final class AppDelegate: UIResponder, UIApplicationDelegate {
         configuration.triggerMinimumTimeInterval = 5
         configuration.push.automation = true
         configuration.push.automation.requestAuthorizationAtLaunch = false
+        configuration.push.automation.automaticSetup = false
         // TODO(MBL-2742): Change the logger level to `info` or `error` if it gets tedious.
         configuration.logger.level = .debug
       }
     ) { [weak self] braze in
       guard let self else { return }
       braze.delegate = self
+      self.braze = braze
 
       braze.inAppMessagePresenter = BrazeUI.BrazeInAppMessageUI()
 

--- a/Kickstarter-iOS/AppDelegateViewModel.swift
+++ b/Kickstarter-iOS/AppDelegateViewModel.swift
@@ -145,8 +145,8 @@ public protocol AppDelegateViewModelOutputs {
   /// Emits the push token that has been successfully registered on the server.
   var pushTokenSuccessfullyRegistered: Signal<String, Never> { get }
 
-  /// Emits when we should register the device push token in Segment Analytics.
-  var registerPushTokenInSegment: Signal<Data, Never> { get }
+  /// Emits when we should register the device push token in Braze.
+  var registerPushTokenInBraze: Signal<Data, Never> { get }
 
   /// Emits when application didFinishLaunchingWithOptions.
   var requestATTrackingAuthorizationStatus: Signal<Void, Never> { get }
@@ -327,7 +327,7 @@ public final class AppDelegateViewModel: AppDelegateViewModelType, AppDelegateVi
           .map { _ in token }
       }
 
-    self.registerPushTokenInSegment = self.deviceTokenDataProperty.signal
+    self.registerPushTokenInBraze = self.deviceTokenDataProperty.signal
 
     // MARK: - Onboarding Flow
 
@@ -939,7 +939,7 @@ public final class AppDelegateViewModel: AppDelegateViewModelType, AppDelegateVi
   public let presentViewController: Signal<UIViewController, Never>
   public let pushTokenRegistrationStarted: Signal<(), Never>
   public let pushTokenSuccessfullyRegistered: Signal<String, Never>
-  public let registerPushTokenInSegment: Signal<Data, Never>
+  public let registerPushTokenInBraze: Signal<Data, Never>
   public let requestATTrackingAuthorizationStatus: Signal<Void, Never>
   public let segmentIsEnabled: Signal<Bool, Never>
   public let setApplicationShortcutItems: Signal<[ShortcutItem], Never>

--- a/Kickstarter-iOS/AppDelegateViewModel.swift
+++ b/Kickstarter-iOS/AppDelegateViewModel.swift
@@ -145,6 +145,9 @@ public protocol AppDelegateViewModelOutputs {
   /// Emits the push token that has been successfully registered on the server.
   var pushTokenSuccessfullyRegistered: Signal<String, Never> { get }
 
+  /// Emits when we should register the device push token in Segment Analytics.
+  var registerPushTokenInSegment: Signal<Data, Never> { get }
+
   /// Emits when application didFinishLaunchingWithOptions.
   var requestATTrackingAuthorizationStatus: Signal<Void, Never> { get }
 
@@ -323,6 +326,8 @@ public final class AppDelegateViewModel: AppDelegateViewModelType, AppDelegateVi
           .demoteErrors()
           .map { _ in token }
       }
+
+    self.registerPushTokenInSegment = self.deviceTokenDataProperty.signal
 
     // MARK: - Onboarding Flow
 
@@ -934,6 +939,7 @@ public final class AppDelegateViewModel: AppDelegateViewModelType, AppDelegateVi
   public let presentViewController: Signal<UIViewController, Never>
   public let pushTokenRegistrationStarted: Signal<(), Never>
   public let pushTokenSuccessfullyRegistered: Signal<String, Never>
+  public let registerPushTokenInSegment: Signal<Data, Never>
   public let requestATTrackingAuthorizationStatus: Signal<Void, Never>
   public let segmentIsEnabled: Signal<Bool, Never>
   public let setApplicationShortcutItems: Signal<[ShortcutItem], Never>

--- a/Kickstarter-iOS/AppDelegateViewModel.swift
+++ b/Kickstarter-iOS/AppDelegateViewModel.swift
@@ -145,9 +145,6 @@ public protocol AppDelegateViewModelOutputs {
   /// Emits the push token that has been successfully registered on the server.
   var pushTokenSuccessfullyRegistered: Signal<String, Never> { get }
 
-  /// Emits when we should register the device push token in Segment Analytics.
-  var registerPushTokenInSegment: Signal<Data, Never> { get }
-
   /// Emits when application didFinishLaunchingWithOptions.
   var requestATTrackingAuthorizationStatus: Signal<Void, Never> { get }
 
@@ -326,8 +323,6 @@ public final class AppDelegateViewModel: AppDelegateViewModelType, AppDelegateVi
           .demoteErrors()
           .map { _ in token }
       }
-
-    self.registerPushTokenInSegment = self.deviceTokenDataProperty.signal
 
     // MARK: - Onboarding Flow
 
@@ -939,7 +934,6 @@ public final class AppDelegateViewModel: AppDelegateViewModelType, AppDelegateVi
   public let presentViewController: Signal<UIViewController, Never>
   public let pushTokenRegistrationStarted: Signal<(), Never>
   public let pushTokenSuccessfullyRegistered: Signal<String, Never>
-  public let registerPushTokenInSegment: Signal<Data, Never>
   public let requestATTrackingAuthorizationStatus: Signal<Void, Never>
   public let segmentIsEnabled: Signal<Bool, Never>
   public let setApplicationShortcutItems: Signal<[ShortcutItem], Never>

--- a/Kickstarter-iOS/AppDelegateViewModelTests.swift
+++ b/Kickstarter-iOS/AppDelegateViewModelTests.swift
@@ -30,7 +30,7 @@ final class AppDelegateViewModelTests: TestCase {
   private let presentViewController = TestObserver<Int, Never>()
   private let pushRegistrationStarted = TestObserver<(), Never>()
   private let pushTokenSuccessfullyRegistered = TestObserver<String, Never>()
-  private let registerPushTokenInSegment = TestObserver<Data, Never>()
+  private let registerPushTokenInBraze = TestObserver<Data, Never>()
   private let requestATTrackingAuthorizationStatus = TestObserver<Void, Never>()
   private let setApplicationShortcutItems = TestObserver<[ShortcutItem], Never>()
   private let segmentIsEnabled = TestObserver<Bool, Never>()
@@ -77,7 +77,7 @@ final class AppDelegateViewModelTests: TestCase {
       .observe(self.presentViewController.observer)
     self.vm.outputs.pushTokenRegistrationStarted.observe(self.pushRegistrationStarted.observer)
     self.vm.outputs.pushTokenSuccessfullyRegistered.observe(self.pushTokenSuccessfullyRegistered.observer)
-    self.vm.outputs.registerPushTokenInSegment.observe(self.registerPushTokenInSegment.observer)
+    self.vm.outputs.registerPushTokenInBraze.observe(self.registerPushTokenInBraze.observer)
     self.vm.outputs.requestATTrackingAuthorizationStatus
       .observe(self.requestATTrackingAuthorizationStatus.observer)
     self.vm.outputs.setApplicationShortcutItems.observe(self.setApplicationShortcutItems.observer)
@@ -1035,10 +1035,10 @@ final class AppDelegateViewModelTests: TestCase {
     }
   }
 
-  func testRegisterPushTokenInSegment() {
+  func testRegisterPushTokenInBraze() {
     let data = Data("deadbeef".utf8)
 
-    self.registerPushTokenInSegment.assertDidNotEmitValue()
+    self.registerPushTokenInBraze.assertDidNotEmitValue()
 
     withEnvironment(currentUser: .template) {
       self.vm.inputs.applicationDidFinishLaunching(
@@ -1047,7 +1047,7 @@ final class AppDelegateViewModelTests: TestCase {
       )
       self.vm.inputs.didRegisterForRemoteNotifications(withDeviceTokenData: data)
 
-      self.registerPushTokenInSegment.assertValueCount(1)
+      self.registerPushTokenInBraze.assertValueCount(1)
     }
   }
 

--- a/Kickstarter-iOS/AppDelegateViewModelTests.swift
+++ b/Kickstarter-iOS/AppDelegateViewModelTests.swift
@@ -30,7 +30,6 @@ final class AppDelegateViewModelTests: TestCase {
   private let presentViewController = TestObserver<Int, Never>()
   private let pushRegistrationStarted = TestObserver<(), Never>()
   private let pushTokenSuccessfullyRegistered = TestObserver<String, Never>()
-  private let registerPushTokenInSegment = TestObserver<Data, Never>()
   private let requestATTrackingAuthorizationStatus = TestObserver<Void, Never>()
   private let setApplicationShortcutItems = TestObserver<[ShortcutItem], Never>()
   private let segmentIsEnabled = TestObserver<Bool, Never>()
@@ -77,7 +76,6 @@ final class AppDelegateViewModelTests: TestCase {
       .observe(self.presentViewController.observer)
     self.vm.outputs.pushTokenRegistrationStarted.observe(self.pushRegistrationStarted.observer)
     self.vm.outputs.pushTokenSuccessfullyRegistered.observe(self.pushTokenSuccessfullyRegistered.observer)
-    self.vm.outputs.registerPushTokenInSegment.observe(self.registerPushTokenInSegment.observer)
     self.vm.outputs.requestATTrackingAuthorizationStatus
       .observe(self.requestATTrackingAuthorizationStatus.observer)
     self.vm.outputs.setApplicationShortcutItems.observe(self.setApplicationShortcutItems.observer)
@@ -1032,22 +1030,6 @@ final class AppDelegateViewModelTests: TestCase {
       self.scheduler.advance(by: .seconds(5))
 
       self.pushTokenSuccessfullyRegistered.assertValueCount(1)
-    }
-  }
-
-  func testRegisterPushTokenInSegment() {
-    let data = Data("deadbeef".utf8)
-
-    self.registerPushTokenInSegment.assertDidNotEmitValue()
-
-    withEnvironment(currentUser: .template) {
-      self.vm.inputs.applicationDidFinishLaunching(
-        application: UIApplication.shared,
-        launchOptions: [:]
-      )
-      self.vm.inputs.didRegisterForRemoteNotifications(withDeviceTokenData: data)
-
-      self.registerPushTokenInSegment.assertValueCount(1)
     }
   }
 

--- a/Kickstarter-iOS/AppDelegateViewModelTests.swift
+++ b/Kickstarter-iOS/AppDelegateViewModelTests.swift
@@ -30,6 +30,7 @@ final class AppDelegateViewModelTests: TestCase {
   private let presentViewController = TestObserver<Int, Never>()
   private let pushRegistrationStarted = TestObserver<(), Never>()
   private let pushTokenSuccessfullyRegistered = TestObserver<String, Never>()
+  private let registerPushTokenInSegment = TestObserver<Data, Never>()
   private let requestATTrackingAuthorizationStatus = TestObserver<Void, Never>()
   private let setApplicationShortcutItems = TestObserver<[ShortcutItem], Never>()
   private let segmentIsEnabled = TestObserver<Bool, Never>()
@@ -76,6 +77,7 @@ final class AppDelegateViewModelTests: TestCase {
       .observe(self.presentViewController.observer)
     self.vm.outputs.pushTokenRegistrationStarted.observe(self.pushRegistrationStarted.observer)
     self.vm.outputs.pushTokenSuccessfullyRegistered.observe(self.pushTokenSuccessfullyRegistered.observer)
+    self.vm.outputs.registerPushTokenInSegment.observe(self.registerPushTokenInSegment.observer)
     self.vm.outputs.requestATTrackingAuthorizationStatus
       .observe(self.requestATTrackingAuthorizationStatus.observer)
     self.vm.outputs.setApplicationShortcutItems.observe(self.setApplicationShortcutItems.observer)
@@ -1030,6 +1032,22 @@ final class AppDelegateViewModelTests: TestCase {
       self.scheduler.advance(by: .seconds(5))
 
       self.pushTokenSuccessfullyRegistered.assertValueCount(1)
+    }
+  }
+
+  func testRegisterPushTokenInSegment() {
+    let data = Data("deadbeef".utf8)
+
+    self.registerPushTokenInSegment.assertDidNotEmitValue()
+
+    withEnvironment(currentUser: .template) {
+      self.vm.inputs.applicationDidFinishLaunching(
+        application: UIApplication.shared,
+        launchOptions: [:]
+      )
+      self.vm.inputs.didRegisterForRemoteNotifications(withDeviceTokenData: data)
+
+      self.registerPushTokenInSegment.assertValueCount(1)
     }
   }
 


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

The segment/braze upgrade broke our push notification registration for some edge cases. Fix push token setup by
1. Ensuring that we tell Braze when new users log in (this fixes the Braze issue where we had to quit and relaunch the app after deleting and reinstalling the app)
2. Telling Braze to never attempt to automatically set up push notifications or push registration. This doesn't fully fix aws notification registration (it still sometimes gets in a weird state when you uninstall and reinstall the app), but it seems to help

# See

[Jira](https://kickstarter.atlassian.net/browse/MBL-2744)

# ✅ Acceptance criteria

- [x] Braze notifications work on a fresh install (after user has logged in and we give the app a little time to actually finish push registration)
- [x] ~aws notifications work even after uninstalling app, reinstalling, and logging back in as same user~ aws notifications sometimes work after uninstalling app, reinstalling, and logging back in as same user. (In current app store version, we see the same issue sometimes, too. It might still be happening more frequently after braze upgrade than before, but these changes make behavior pretty similar.)
