### PR TITLE
[MBL-2690] Async/Await Apollo Wrapper

### DIFF
--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -583,6 +583,8 @@
 		6059151C2E1590D90030BB90 /* onboarding-flow-welcome-es.json in Resources */ = {isa = PBXBuildFile; fileRef = 605914F22E1590D90030BB90 /* onboarding-flow-welcome-es.json */; };
 		6059151E2E15913A0030BB90 /* LocalizedLottieFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6059151D2E15913A0030BB90 /* LocalizedLottieFile.swift */; };
 		605915212E15914C0030BB90 /* LocalizedLottieFileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6059151F2E15914C0030BB90 /* LocalizedLottieFileTests.swift */; };
+		6061009A2E71F6EB008CA69B /* AsyncApolloClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 606100992E71F6EB008CA69B /* AsyncApolloClient.swift */; };
+		606100B72E7211B0008CA69B /* AsyncApolloClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 606100B52E7211B0008CA69B /* AsyncApolloClientTests.swift */; };
 		606754BD28CF91D60033CD5E /* FacebookCore in Frameworks */ = {isa = PBXBuildFile; productRef = 606754BC28CF91D60033CD5E /* FacebookCore */; };
 		606754BF28CF91DD0033CD5E /* FacebookLogin in Frameworks */ = {isa = PBXBuildFile; productRef = 606754BE28CF91DD0033CD5E /* FacebookLogin */; };
 		6067BCE9293E49AC0036ABB1 /* FacebookResetPasswordViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6067BCE7293E48140036ABB1 /* FacebookResetPasswordViewController.swift */; };
@@ -652,6 +654,7 @@
 		60F03AC12D8AFCE300DB6C01 /* SimilarProjectsCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60F03AC02D8AFCE300DB6C01 /* SimilarProjectsCollectionViewCell.swift */; };
 		60F03AC42D8AFD6100DB6C01 /* SimilarProjectsCollectionViewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60F03AC32D8AFD6100DB6C01 /* SimilarProjectsCollectionViewDataSource.swift */; };
 		60F03AC62D8B0C1600DB6C01 /* SimilarProjectsLoadingCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60F03AC52D8B0C1600DB6C01 /* SimilarProjectsLoadingCollectionViewCell.swift */; };
+		60F7FAB32E7323CB004B3177 /* MockApolloClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60F7FAB12E7323CB004B3177 /* MockApolloClient.swift */; };
 		701160D4291ECB9F0095BF24 /* LoadingBarButtonItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 701160D2291ECB250095BF24 /* LoadingBarButtonItem.swift */; };
 		70495690299D53ED00B273DF /* SnapshotTesting in Frameworks */ = {isa = PBXBuildFile; productRef = 7049568F299D53ED00B273DF /* SnapshotTesting */; };
 		7061848B29BE4CD8008F9941 /* MessageBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7061848829BE4C11008F9941 /* MessageBannerView.swift */; };
@@ -2360,6 +2363,8 @@
 		605914F42E1590D90030BB90 /* onboarding-flow-welcome-ja.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "onboarding-flow-welcome-ja.json"; sourceTree = "<group>"; };
 		6059151D2E15913A0030BB90 /* LocalizedLottieFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalizedLottieFile.swift; sourceTree = "<group>"; };
 		6059151F2E15914C0030BB90 /* LocalizedLottieFileTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalizedLottieFileTests.swift; sourceTree = "<group>"; };
+		606100992E71F6EB008CA69B /* AsyncApolloClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncApolloClient.swift; sourceTree = "<group>"; };
+		606100B52E7211B0008CA69B /* AsyncApolloClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncApolloClientTests.swift; sourceTree = "<group>"; };
 		6067BCE7293E48140036ABB1 /* FacebookResetPasswordViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FacebookResetPasswordViewController.swift; sourceTree = "<group>"; };
 		6067BCEA293E49CB0036ABB1 /* FacebookResetPasswordViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FacebookResetPasswordViewModel.swift; sourceTree = "<group>"; };
 		6067BCEF293FC10E0036ABB1 /* FacebookResetPasswordViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FacebookResetPasswordViewModelTests.swift; sourceTree = "<group>"; };
@@ -2402,6 +2407,7 @@
 		60F03AC02D8AFCE300DB6C01 /* SimilarProjectsCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimilarProjectsCollectionViewCell.swift; sourceTree = "<group>"; };
 		60F03AC32D8AFD6100DB6C01 /* SimilarProjectsCollectionViewDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimilarProjectsCollectionViewDataSource.swift; sourceTree = "<group>"; };
 		60F03AC52D8B0C1600DB6C01 /* SimilarProjectsLoadingCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimilarProjectsLoadingCollectionViewCell.swift; sourceTree = "<group>"; };
+		60F7FAB12E7323CB004B3177 /* MockApolloClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockApolloClient.swift; sourceTree = "<group>"; };
 		701160D2291ECB250095BF24 /* LoadingBarButtonItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingBarButtonItem.swift; sourceTree = "<group>"; };
 		7061848829BE4C11008F9941 /* MessageBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageBannerView.swift; sourceTree = "<group>"; };
 		7061848C29BE577B008F9941 /* MessageBannerViewViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageBannerViewViewModel.swift; sourceTree = "<group>"; };
@@ -7201,6 +7207,9 @@
 			isa = PBXGroup;
 			children = (
 				D01587531EEB2DE4006E7684 /* Info.plist */,
+				606100992E71F6EB008CA69B /* AsyncApolloClient.swift */,
+				606100B52E7211B0008CA69B /* AsyncApolloClientTests.swift */,
+				60F7FAB12E7323CB004B3177 /* MockApolloClient.swift */,
 				D08CD1BF21910C97009F89F0 /* GraphIDBridging.swift */,
 				775DFA9C215E758400620CED /* GraphMutation.swift */,
 				D67F29351F68333800E399A6 /* GraphSchema.swift */,
@@ -9614,6 +9623,7 @@
 				D0158A191EEB30A2006E7684 /* MessageThreadTemplates.swift in Sources */,
 				D01588AF1EEB2ED7006E7684 /* Project.VideoLenses.swift in Sources */,
 				D0158A091EEB30A2006E7684 /* ActivityTemplates.swift in Sources */,
+				6061009A2E71F6EB008CA69B /* AsyncApolloClient.swift in Sources */,
 				8A1557152693B28300017845 /* User+UserFragment.swift in Sources */,
 				8AC3E0AC2698EFAA00168BF8 /* Project+FetchAddOnsQueryData.swift in Sources */,
 				D01589811EEB2ED7006E7684 /* Update.swift in Sources */,
@@ -9906,6 +9916,7 @@
 				20A0938A2666578D00DEC258 /* CommentTests.swift in Sources */,
 				E10BE8E72B151D2700F73DC9 /* BlockUserInputTests.swift in Sources */,
 				77272D382370AB8E003B7A9C /* BackingPaymentSourceTests.swift in Sources */,
+				60F7FAB32E7323CB004B3177 /* MockApolloClient.swift in Sources */,
 				8A15574326951A4B00017845 /* Backing+BackingFragmentTests.swift in Sources */,
 				0665C74B26E930BC00A0EDA1 /* FetchProjectQueryTemplate.swift in Sources */,
 				06D23BBF26F2484500F76122 /* Project+FetchProjectFriendsQueryDataTests.swift in Sources */,
@@ -9962,6 +9973,7 @@
 				E1A149272ACE063400F49709 /* FetchBackerProjectsQueryDataTemplate.swift in Sources */,
 				194154D328D928C9004648C8 /* CreatePaymentSourceSetupIntentInputTests.swift in Sources */,
 				8AF34C762342D1D2000B211D /* UpdateBackingInputTests.swift in Sources */,
+				606100B72E7211B0008CA69B /* AsyncApolloClientTests.swift in Sources */,
 				33AA26DF2E3B146C002DBD60 /* UserMocks.swift in Sources */,
 				D0D10C191EEB4550005EBAD0 /* RewardTests.swift in Sources */,
 				D0D10C101EEB4550005EBAD0 /* MessageTests.swift in Sources */,

--- a/KsApi/AsyncApolloClient.swift
+++ b/KsApi/AsyncApolloClient.swift
@@ -1,0 +1,80 @@
+@preconcurrency import Apollo
+import Foundation
+import GraphAPI
+
+/**
+ An async/await wrapper around `ApolloClientProtocol`.
+
+ Purpose:
+    - bridge Apollo’s callback APIs with Swift Concurrency.
+
+ Callback queue:
+    - all Apollo completions run on `callbackQueue`(defaults to `.global(qos: .userInitiated)`.
+
+ Methods:
+    - `fetch(_:)`: forwards `cachePolicy`/`contextIdentifier`
+      - returns `GraphQLResult`or throws an Apollo error.
+    - `perform(_:)`: forwards `publishResultToStore`
+      - returns `GraphQLResult`or throws an Apollo error.
+
+ Concurrency: marked `@unchecked Sendable`. queue hopping is controlled by `callbackQueue`.
+
+ */
+public final class AsyncApolloClient: @unchecked Sendable {
+  private let client: ApolloClientProtocol
+  private let callbackQueue: DispatchQueue
+
+  /// `callbackQueue` defaults to a background queue..
+  public init(
+    client: ApolloClientProtocol,
+    /// using `.userInitiated` for scheduling the work the user is waiting on  more efficiently.. `.background` can sometimes get deprioritized.
+    callbackQueue: DispatchQueue = .global(qos: .userInitiated)
+  ) {
+    self.client = client
+    self.callbackQueue = callbackQueue
+  }
+
+  // MARK: - Queries
+
+  public func fetch<Query: GraphQLQuery>(
+    _ query: Query,
+    cachePolicy: CachePolicy = .fetchIgnoringCacheCompletely,
+    contextIdentifier: UUID? = nil
+  ) async throws -> GraphQLResult<Query.Data> {
+    try await withCheckedThrowingContinuation { cont in
+      _ = self.client.fetch(
+        query: query,
+        cachePolicy: cachePolicy,
+        contextIdentifier: contextIdentifier,
+        context: nil,
+        queue: self.callbackQueue
+      ) { result in
+        switch result {
+        case let .success(value): cont.resume(returning: value)
+        case let .failure(error): cont.resume(throwing: error)
+        }
+      }
+    }
+  }
+
+  // MARK: - Mutations
+
+  public func perform<Mutation: GraphQLMutation>(
+    _ mutation: Mutation,
+    publishResultToStore: Bool = true
+  ) async throws -> GraphQLResult<Mutation.Data> {
+    try await withCheckedThrowingContinuation { cont in
+      _ = self.client.perform(
+        mutation: mutation,
+        publishResultToStore: publishResultToStore,
+        context: nil,
+        queue: self.callbackQueue
+      ) { result in
+        switch result {
+        case let .success(value): cont.resume(returning: value)
+        case let .failure(error): cont.resume(throwing: error)
+        }
+      }
+    }
+  }
+}

--- a/KsApi/AsyncApolloClientTests.swift
+++ b/KsApi/AsyncApolloClientTests.swift
@@ -1,0 +1,108 @@
+@preconcurrency import Apollo
+import GraphAPI
+@testable import KsApi
+import XCTest
+
+final class AsyncApolloClientTests: XCTestCase {
+  func testFetch_Errors_And_UpdatesCallbackQueue() async {
+    let mock = MockApolloClient()
+    mock.fetchShouldSucceed = false
+
+    let queue = DispatchQueue(label: "fetchQueue")
+    let asyncClient = AsyncApolloClient(client: mock, callbackQueue: queue)
+
+    do {
+      _ = try await asyncClient.fetch(StubQuery())
+
+      XCTFail("Expected to throw an error but didn't")
+    } catch {
+      XCTAssertEqual(
+        String(describing: error),
+        String(describing: MockApolloClient.StubError.boom)
+      )
+    }
+
+    XCTAssertIdentical(mock.lastFetchQueue, queue)
+  }
+
+  func testPerform_Errors_And_UpdatesCallbackQueue() async {
+    let mock = MockApolloClient()
+    mock.performShouldSucceed = false
+
+    let queue = DispatchQueue(label: "performQueue")
+    let asyncClient = AsyncApolloClient(client: mock, callbackQueue: queue)
+
+    do {
+      _ = try await asyncClient.perform(StubMutation())
+
+      XCTFail("Expected to throw an error but didn't")
+    } catch {
+      XCTAssertEqual(
+        String(describing: error),
+        String(describing: MockApolloClient.StubError.boom)
+      )
+    }
+
+    XCTAssertIdentical(mock.lastPerformQueue, queue)
+  }
+
+  func testFetch_Succeeds_And_UpdatesCallbackQueue() async throws {
+    let mock = MockApolloClient()
+    mock.fetchShouldSucceed = true
+
+    let queue = DispatchQueue(label: "fetchQueue.success")
+    let asyncClient = AsyncApolloClient(client: mock, callbackQueue: queue)
+
+    let result: GraphQLResult<StubQuery.Data> = try await asyncClient.fetch(StubQuery())
+
+    XCTAssertNotNil(result.data)
+    XCTAssertIdentical(mock.lastFetchQueue, queue)
+  }
+
+  func testPerform_Succeeds_And_UpdatesCallbackQueue() async throws {
+    let mock = MockApolloClient()
+    mock.performShouldSucceed = true
+
+    let queue = DispatchQueue(label: "performQueue.success")
+    let asyncClient = AsyncApolloClient(client: mock, callbackQueue: queue)
+
+    let result: GraphQLResult<StubMutation.Data> = try await asyncClient.perform(StubMutation())
+
+    XCTAssertNotNil(result.data)
+    XCTAssertIdentical(mock.lastPerformQueue, queue)
+  }
+}
+
+// MARK: - Stub Query & Mutation
+
+private final class StubQuery: GraphQLQuery {
+  static var operationName: String { "StubQuery" }
+  static var operationDocument: ApolloAPI.OperationDocument {
+    .init(definition: .init("query StubQuery { __typename }"))
+  }
+
+  init() {}
+
+  final class Data: GraphAPI.SelectionSet {
+    static var __parentType: ApolloAPI.ParentType { GraphAPI.Objects.Query }
+    static var __selections: [GraphAPI.Selection] { [] }
+    var __data: GraphAPI.DataDict
+    required init(_dataDict: GraphAPI.DataDict) { self.__data = _dataDict }
+  }
+}
+
+private final class StubMutation: GraphQLMutation {
+  static var operationName: String { "StubMutation" }
+  static var operationDocument: ApolloAPI.OperationDocument {
+    .init(definition: .init("mutation StubMutation { __typename }"))
+  }
+
+  init() {}
+
+  final class Data: GraphAPI.SelectionSet {
+    static var __parentType: ApolloAPI.ParentType { GraphAPI.Objects.Mutation }
+    static var __selections: [GraphAPI.Selection] { [] }
+    var __data: GraphAPI.DataDict
+    required init(_dataDict: GraphAPI.DataDict) { self.__data = _dataDict }
+  }
+}

--- a/KsApi/AsyncApolloClientTests.swift
+++ b/KsApi/AsyncApolloClientTests.swift
@@ -14,7 +14,7 @@ final class AsyncApolloClientTests: XCTestCase {
     do {
       _ = try await asyncClient.fetch(StubQuery())
 
-      XCTFail("Expected to throw an error but didn't")
+      XCTFail("Expected to throw an error.")
     } catch {
       XCTAssertEqual(
         String(describing: error),
@@ -35,7 +35,7 @@ final class AsyncApolloClientTests: XCTestCase {
     do {
       _ = try await asyncClient.perform(StubMutation())
 
-      XCTFail("Expected to throw an error but didn't")
+      XCTFail("Expected to throw an error.")
     } catch {
       XCTAssertEqual(
         String(describing: error),

--- a/KsApi/MockApolloClient.swift
+++ b/KsApi/MockApolloClient.swift
@@ -1,0 +1,140 @@
+import Apollo
+import GraphAPI
+import XCTest
+
+/**
+ A simple Apollo Mock used in our `AsyncApolloClientTests`.
+
+ - Simulates Apollo for unit tests for `AsyncApolloClient`..
+ - Ultimately calls `resultHandler` on the provided `DispatchQueue`.
+
+ - Controlled by flags:
+   - `fetchShouldSucceed` for `fetch(...)`
+   - `performShouldSucceed` for `perform(...)`
+
+ - On success: returns a minimal `GraphQLResult` with only `__typename`.
+ - On failure: returns `StubError.boom`.
+
+ - Records last queue/flags so tests can assert queue changes.
+ */
+public final class MockApolloClient: ApolloClientProtocol {
+  enum StubError: Error, Equatable { case boom }
+
+  /// `ApolloStore` requires a cache and `InMemoryNormalizedCache()` is the simplest, zero-IO choice for testing.
+  public let store: ApolloStore = ApolloStore(cache: InMemoryNormalizedCache())
+
+  /// Controls success/failure per call
+  public var fetchShouldSucceed = false
+  public var performShouldSucceed = false
+
+  private(set) var lastFetchQueue: DispatchQueue?
+  private(set) var lastPerformQueue: DispatchQueue?
+
+  @discardableResult
+  public func fetch<Query: GraphQLQuery>(
+    query _: Query,
+    cachePolicy _: Apollo.CachePolicy,
+    contextIdentifier _: UUID?,
+    context _: (any Apollo.RequestContext)?,
+    queue: DispatchQueue,
+    resultHandler: Apollo.GraphQLResultHandler<Query.Data>?
+  ) -> Cancellable {
+    self.lastFetchQueue = queue
+
+    /// Mimic Apollo getting called on the provided queue
+    queue.async {
+      if self.fetchShouldSucceed {
+        /// Build a minimal data payload for a Query
+        let dataDict = GraphAPI.DataDict(data: ["__typename": "Query"], fulfilledFragments: [])
+        let data = Query.Data(_dataDict: dataDict)
+
+        let result = GraphQLResult<Query.Data>(
+          data: data,
+          extensions: nil,
+          errors: nil,
+          source: .server,
+          dependentKeys: nil
+        )
+
+        resultHandler?(.success(result))
+      } else {
+        resultHandler?(.failure(StubError.boom))
+      }
+    }
+
+    return EmptyCancellable() /// nothing to cancel in this mock.
+  }
+
+  @discardableResult
+  public func perform<Mutation: GraphQLMutation>(
+    mutation _: Mutation,
+    publishResultToStore _: Bool,
+    contextIdentifier _: UUID?,
+    context _: (any Apollo.RequestContext)?,
+    queue: DispatchQueue,
+    resultHandler: Apollo.GraphQLResultHandler<Mutation.Data>?
+  ) -> Cancellable {
+    self.lastPerformQueue = queue
+
+    /// Mimic Apollo getting called on the provided queue
+    queue.async {
+      if self.performShouldSucceed {
+        /// Build a minimal data payload for a Mutation
+        let dataDict = GraphAPI.DataDict(data: ["__typename": "Mutation"], fulfilledFragments: [])
+        let data = Mutation.Data(_dataDict: dataDict)
+
+        let result = GraphQLResult<Mutation.Data>(
+          data: data,
+          extensions: nil,
+          errors: nil,
+          source: .server,
+          dependentKeys: nil
+        )
+
+        resultHandler?(.success(result))
+      } else {
+        resultHandler?(.failure(StubError.boom))
+      }
+    }
+    return EmptyCancellable() /// nothing to cancel in this mock.
+  }
+
+  private class EmptyCancellable: Cancellable { func cancel() {} }
+
+  // MARK: - Intentionally unimplemented methods to satisfy protocol conformance
+
+  public func clearCache(callbackQueue _: DispatchQueue, completion _: ((Result<Void, Error>) -> Void)?) {}
+
+  public func watch<Query>(
+    query _: Query,
+    cachePolicy _: Apollo.CachePolicy,
+    context _: (any Apollo.RequestContext)?,
+    callbackQueue _: DispatchQueue,
+    resultHandler _: @escaping Apollo.GraphQLResultHandler<Query.Data>
+  ) -> Apollo.GraphQLQueryWatcher<Query> where Query: ApolloAPI.GraphQLQuery {
+    fatalError("watch(query): not implemented in MockApolloClient")
+  }
+
+  public func upload<Operation>(
+    operation _: Operation,
+    files _: [Apollo.GraphQLFile],
+    context _: (any Apollo.RequestContext)?,
+    queue _: DispatchQueue,
+    resultHandler _: Apollo.GraphQLResultHandler<Operation.Data>?
+  ) -> any Apollo.Cancellable
+    where Operation: ApolloAPI
+    .GraphQLOperation {
+    fatalError("upload(operation): not implemented in MockApolloClient")
+  }
+
+  public func subscribe<Subscription>(
+    subscription _: Subscription,
+    context _: (any Apollo.RequestContext)?,
+    queue _: DispatchQueue,
+    resultHandler _: @escaping Apollo.GraphQLResultHandler<Subscription.Data>
+  ) -> any Apollo.Cancellable
+    where Subscription: ApolloAPI
+    .GraphQLSubscription {
+    fatalError("subscribe(subscription): not implemented in MockApolloClient")
+  }
+}


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Adds a lightweight `AsyncApolloClient` to `KsApi` with some unit tests.

This wrapper converts Apollo’s callback-based fetch and perform methods into modern Swift async/await APIs.

# 🛠 How

- Adds`AsyncApolloClient`:  a minimal async/await bridge around `ApolloClientProtocol`.
   - Supports both fetch (queries) and perform (mutations).
- Adds `MockApolloClient` for testing.
   - simulates success/failure cases
   - records callbackQueue changes
- Adds `AsyncApolloClientTests`
   - Tests success and failure paths for both fetch and perform.

# ✅ Acceptance criteria

- [x] `AsyncApolloClient` builds and passes unit tests.
- [x] Existing Apollo code is unaffected.
- [x] Tests cover success/failure and queue forwarding.

# ⏰ TODO

- [ ] Consider adding Task cancellation support. If fetch or perform are cancelled, we should cancel the underlying Apollo request, too. Otherwise the network work keeps running pointlessly and may still call the completion later.
