### PR TITLE
[MBL-2799] Delete `featurePostCampaignPledgeEnabled` flag

### DIFF
--- a/Library/RemoteConfig/RemoteConfigFeature+Helpers.swift
+++ b/Library/RemoteConfig/RemoteConfigFeature+Helpers.swift
@@ -19,10 +19,6 @@ public func featureEditPledgeOverTimeEnabled() -> Bool {
   return featureEnabled(feature: .editPledgeOverTimeEnabled)
 }
 
-public func featurePostCampaignPledgeEnabled() -> Bool {
-  featureEnabled(feature: .postCampaignPledgeEnabled)
-}
-
 public func featureUseKeychainForOAuthTokenEnabled() -> Bool {
   featureEnabled(feature: .useKeychainForOAuthToken)
 }

--- a/Library/RemoteConfig/RemoteConfigFeature+HelpersTests.swift
+++ b/Library/RemoteConfig/RemoteConfigFeature+HelpersTests.swift
@@ -27,22 +27,6 @@ final class RemoteConfigFeatureHelpersTests: TestCase {
     }
   }
 
-  func testPostCampaignPledge_RemoteConfig_FeatureFlag_True() {
-    self
-      .assert(
-        featureFlagIsTrue: featurePostCampaignPledgeEnabled,
-        whenRemoteConfigFeatureIsTrue: .postCampaignPledgeEnabled
-      )
-  }
-
-  func testPostCampaignPledge_RemoteConfig_FeatureFlag_False() {
-    self
-      .assert(
-        featureFlagIsFalse: featurePostCampaignPledgeEnabled,
-        whenRemoteConfigFeatureIsFalse: .postCampaignPledgeEnabled
-      )
-  }
-
   func testUseKeychainForOAuthTokenEnabled_RemoteConfig_FeatureFlag_False() {
     self
       .assert(

--- a/Library/RemoteConfig/RemoteConfigFeature.swift
+++ b/Library/RemoteConfig/RemoteConfigFeature.swift
@@ -2,7 +2,6 @@ import Foundation
 
 public enum RemoteConfigFeature: String, CaseIterable {
   case editPledgeOverTimeEnabled = "edit_pledge_over_time"
-  case postCampaignPledgeEnabled = "post_campaign_pledge"
   case useKeychainForOAuthToken = "use_keychain_for_oauth_token"
   case onboardingFlow = "onboarding_flow"
   case pledgedProjectsOverviewV2Enabled = "pledged_projects_overview_v2"
@@ -23,7 +22,6 @@ extension RemoteConfigFeature: CustomStringConvertible {
   public var description: String {
     switch self {
     case .editPledgeOverTimeEnabled: return "Edit Pledge Over Time"
-    case .postCampaignPledgeEnabled: return "Post Campaign Pledging"
     case .useKeychainForOAuthToken: return "Use Keychain for OAuth token"
     case .onboardingFlow: return "Onboarding Flow"
     case .pledgedProjectsOverviewV2Enabled: return "Pledged Projects Overview V2"

--- a/Library/RewardCellProjectBackingStateType.swift
+++ b/Library/RewardCellProjectBackingStateType.swift
@@ -14,7 +14,7 @@ public enum RewardCellProjectBackingStateType: Equatable {
 
   static func state(with project: Project) -> RewardCellProjectBackingStateType {
     guard let backing = project.personalization.backing else {
-      if featurePostCampaignPledgeEnabled(), project.isInPostCampaignPledgingPhase {
+      if project.isInPostCampaignPledgingPhase {
         return .nonBacked(live: .inPostCampaignPledgingPhase)
       }
 

--- a/Library/SharedFunctions.swift
+++ b/Library/SharedFunctions.swift
@@ -372,7 +372,7 @@ public func rewardsCarouselCanNavigateToReward(_ reward: Reward, in project: Pro
   /// Backers should always be able to edit the currently backed reward. It's the only path to update the pledge/bonus amount.
   let isAvailableForExistingBackerToEdit = isBacking
 
-  if featurePostCampaignPledgeEnabled(), project.isInPostCampaignPledgingPhase {
+  if project.isInPostCampaignPledgingPhase {
     return [
       project.state == .successful,
       isAvailableForNewBacker

--- a/Library/Tracking/KSRAnalytics.swift
+++ b/Library/Tracking/KSRAnalytics.swift
@@ -1579,15 +1579,10 @@ private func projectProperties(
   props["tags"] = project.tags?.joined(separator: ", ")
   props["updates_count"] = project.statsUpdatesCount
   props["is_repeat_creator"] = project.creatorIsRepeatCreator ?? false
-
-  if featurePostCampaignPledgeEnabled() {
-    props["late_pledge_enabled"] = project.postCampaignPledgingEnabled
-    props["state"] = project.isInPostCampaignPledgingPhase
-      ? "post_campaign"
-      : project.stateValue
-  } else {
-    props["state"] = project.stateValue
-  }
+  props["late_pledge_enabled"] = project.postCampaignPledgingEnabled
+  props["state"] = project.isInPostCampaignPledgingPhase
+    ? "post_campaign"
+    : project.stateValue
 
   let now = dateType.init().date
   props["hours_remaining"] = project.datesHoursRemaining(from: now, using: calendar)

--- a/Library/Tracking/KSRAnalyticsTests.swift
+++ b/Library/Tracking/KSRAnalyticsTests.swift
@@ -326,7 +326,7 @@ final class KSRAnalyticsTests: TestCase {
     XCTAssertEqual(1, segmentClientProperties?["project_rewards_count"] as? Int)
     XCTAssertEqual(project.tags?.joined(separator: ", "), segmentClientProperties?["project_tags"] as? String)
     XCTAssertEqual(1, segmentClientProperties?["project_updates_count"] as? Int)
-    XCTAssertEqual(27, segmentClientProperties?.keys.filter { $0.hasPrefix("project_") }.count)
+    XCTAssertEqual(28, segmentClientProperties?.keys.filter { $0.hasPrefix("project_") }.count)
 
     XCTAssertEqual(false, segmentClientProperties?["project_user_is_backer"] as? Bool)
     XCTAssertNil(segmentClientProperties?["project_user_is_project_creator"])
@@ -357,7 +357,7 @@ final class KSRAnalyticsTests: TestCase {
     XCTAssertEqual(false, segmentClientProperties?["project_user_has_watched"] as? Bool)
     XCTAssertEqual(project.tags?.joined(separator: ", "), segmentClientProperties?["project_tags"] as? String)
 
-    XCTAssertEqual(27, segmentClientProperties?.keys.filter { $0.hasPrefix("project_") }.count)
+    XCTAssertEqual(28, segmentClientProperties?.keys.filter { $0.hasPrefix("project_") }.count)
   }
 
   func testProjectProperties_LoggedInBacker() {
@@ -381,7 +381,7 @@ final class KSRAnalyticsTests: TestCase {
     XCTAssertEqual(false, segmentClientProperties?["project_user_has_watched"] as? Bool)
     XCTAssertEqual(project.tags?.joined(separator: ", "), segmentClientProperties?["project_tags"] as? String)
 
-    XCTAssertEqual(27, segmentClientProperties?.keys.filter { $0.hasPrefix("project_") }.count)
+    XCTAssertEqual(28, segmentClientProperties?.keys.filter { $0.hasPrefix("project_") }.count)
   }
 
   func testProjectProperties_LoggedInStarrer() {
@@ -405,7 +405,7 @@ final class KSRAnalyticsTests: TestCase {
     XCTAssertEqual(true, segmentClientProperties?["project_user_has_watched"] as? Bool)
     XCTAssertEqual(project.tags?.joined(separator: ", "), segmentClientProperties?["project_tags"] as? String)
 
-    XCTAssertEqual(27, segmentClientProperties?.keys.filter { $0.hasPrefix("project_") }.count)
+    XCTAssertEqual(28, segmentClientProperties?.keys.filter { $0.hasPrefix("project_") }.count)
   }
 
   func testProjectProperties_LoggedInCreator() {
@@ -429,7 +429,7 @@ final class KSRAnalyticsTests: TestCase {
     XCTAssertEqual(false, segmentClientProperties?["project_user_has_watched"] as? Bool)
     XCTAssertEqual(project.tags?.joined(separator: ", "), segmentClientProperties?["project_tags"] as? String)
 
-    XCTAssertEqual(27, segmentClientProperties?.keys.filter { $0.hasPrefix("project_") }.count)
+    XCTAssertEqual(28, segmentClientProperties?.keys.filter { $0.hasPrefix("project_") }.count)
   }
 
   func testProjectProperties_SpanishCategory() {
@@ -2005,6 +2005,7 @@ final class KSRAnalyticsTests: TestCase {
     XCTAssertEqual(30, props?["project_duration"] as? Int)
     XCTAssertEqual("2016-10-16T22:35:15Z", props?["project_deadline"] as? String)
     XCTAssertEqual("2016-09-16T22:35:15Z", props?["project_launched_at"] as? String)
+    XCTAssertEqual(false, props?["project_late_pledge_enabled"] as? Bool)
     XCTAssertEqual("live", props?["project_state"] as? String)
     XCTAssertEqual(1_000, props?["project_current_pledge_amount"] as? Int)
     XCTAssertEqual(1_213.75, props?["project_current_amount_pledged_usd"] as? Decimal)

--- a/Library/ViewModels/PledgeCTAContainerViewViewModel.swift
+++ b/Library/ViewModels/PledgeCTAContainerViewViewModel.swift
@@ -216,7 +216,7 @@ private func pledgeCTA(project: Project, backing: Backing?) -> PledgeStateCTATyp
     return PledgeStateCTAType.pledgeManager
   }
 
-  let isInPostCampaign = featurePostCampaignPledgeEnabled() && project.isInPostCampaignPledgingPhase
+  let isInPostCampaign = project.isInPostCampaignPledgingPhase
 
   guard let projectBacking = backing, project.personalization.isBacking == .some(true) else {
     if currentUserIsCreator(of: project) {

--- a/Library/ViewModels/PledgeSummaryViewModel.swift
+++ b/Library/ViewModels/PledgeSummaryViewModel.swift
@@ -108,7 +108,7 @@ public class PledgeSummaryViewModel: PledgeSummaryViewModelType,
 
     self.confirmationLabelHidden = Signal.combineLatest(initialData, project)
       .map { initialData, project in
-        guard featurePostCampaignPledgeEnabled(), project.isInPostCampaignPledgingPhase else {
+        guard project.isInPostCampaignPledgingPhase else {
           return initialData.confirmationLabelHidden
         }
 

--- a/Library/ViewModels/RewardsCollectionViewModel.swift
+++ b/Library/ViewModels/RewardsCollectionViewModel.swift
@@ -161,7 +161,7 @@ public final class RewardsCollectionViewModel: RewardsCollectionViewModelType,
     }
     .map { project, reward, refTag, selectedShippingRule -> (PledgeViewData, Bool) in
       let pledgeContext =
-        featurePostCampaignPledgeEnabled() && project.isInPostCampaignPledgingPhase
+        project.isInPostCampaignPledgingPhase
           ? PledgeViewContext.latePledge
           : PledgeViewContext.pledge
 

--- a/Library/ViewModels/ThanksViewModel.swift
+++ b/Library/ViewModels/ThanksViewModel.swift
@@ -90,14 +90,9 @@ public final class ThanksViewModel: ThanksViewModelType, ThanksViewModelInputs, 
 
         let string: String
 
-        /// Setting this to a an empty string for the late pledge beta release.
-        // TODO: [MBL-1351[(https://kickstarter.atlassian.net/browse/MBL-1350) Update as fast-follow when there is time to get translations in for a new more contextually accurate string.
-        let isInPostCampaignPledging = featurePostCampaignPledgeEnabled() && project
-          .isInPostCampaignPledgingPhase
-
         let totalString = Format.currency(pledgeTotal, currencyCode: project.statsCurrency)
 
-        string = isInPostCampaignPledging
+        string = project.isInPostCampaignPledgingPhase
           ? Strings
           .You_have_successfully_pledged_to_project_post_campaign_html_short(pledge_total: totalString)
           : Strings.You_have_successfully_backed_project_html(project_name: project.name)

--- a/Library/ViewModels/ThanksViewModelTests.swift
+++ b/Library/ViewModels/ThanksViewModelTests.swift
@@ -116,9 +116,6 @@ final class ThanksViewModelTests: TestCase {
 
   func testDisplayBackedProjectText_postCampaignBackings() {
     let mockConfigClient = MockRemoteConfigClient()
-    mockConfigClient.features = [
-      RemoteConfigFeature.postCampaignPledgeEnabled.rawValue: true
-    ]
 
     var project = Project.template
     project.name = "Test Project"
@@ -126,7 +123,7 @@ final class ThanksViewModelTests: TestCase {
     project.country = Project.Country.jp
     project.stats.projectCurrency = Project.Country.jp.currencyCode
 
-    withEnvironment(Environment(currentUserEmail: "test@user.com", remoteConfigClient: mockConfigClient)) {
+    withEnvironment(Environment(currentUserEmail: "test@user.com")) {
       self.vm.inputs.configure(with: self.thanksPageData(project: project, pledgeTotal: 127))
       self.vm.inputs.viewDidLoad()
 


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Clean up the post campaign pledge feature flag by deleting it and keeping the same behavior as if the flag were on. (This flag has been turned on in firebase since out 5.14 release.) The analytics test needed to be updated, since flag on means there's an additional property set, but otherwise I just deleted code.

# 👀 See

[Jira](https://kickstarter.atlassian.net/browse/MBL-2799)

# ✅ Acceptance criteria

- [x] Tests pass

# ⏰ TODO

- I'll update firebase to stop sending the flag to new releases once our next release is out and stable.
