### PR TITLE
[MBL-2766] Remove IBDesignable

### DIFF
--- a/Kickstarter-iOS/Features/Discovery/Views/DiscoveryProjectCategoryView.swift
+++ b/Kickstarter-iOS/Features/Discovery/Views/DiscoveryProjectCategoryView.swift
@@ -4,7 +4,7 @@ import Library
 import Prelude
 import UIKit
 
-@IBDesignable internal final class DiscoveryProjectCategoryView: UIView, NibLoading {
+internal final class DiscoveryProjectCategoryView: UIView, NibLoading {
   private let viewModel: DiscoveryProjectCategoryViewModelType = DiscoveryProjectCategoryViewModel()
 
   @IBOutlet private var blurView: UIImageView!


### PR DESCRIPTION
Removes a use of IBDesignable, which is deprecated in iOS 18.