### PR TITLE
MBL-1382: Log more detailed errors when keychain fails

### DIFF
--- a/Library/AppEnvironment.swift
+++ b/Library/AppEnvironment.swift
@@ -335,6 +335,14 @@ public struct AppEnvironment: AppEnvironmentType {
     )
   }
 
+  private static func logKeychainError(_ error: KeychainError) {
+    Crashlytics.crashlytics().record(error: error.nsError)
+  }
+
+  private static func logUnknownError(_ error: Error) {
+    Crashlytics.crashlytics().record(error: error)
+  }
+
   internal static let accountNameForKeychain = "kickstarter_currently_logged_in_user"
 
   private static func storeOAuthTokenToKeychain(_ oauthToken: String) -> Bool {
@@ -346,8 +354,10 @@ public struct AppEnvironment: AppEnvironmentType {
     do {
       try Keychain.storePassword(oauthToken, forAccount: self.accountNameForKeychain)
       return true
+    } catch let error as KeychainError {
+      logKeychainError(error)
     } catch {
-      Crashlytics.crashlytics().record(error: error)
+      self.logUnknownError(error)
     }
 
     return false
@@ -361,8 +371,10 @@ public struct AppEnvironment: AppEnvironmentType {
 
     do {
       return try Keychain.fetchPassword(forAccount: self.accountNameForKeychain)
+    } catch let error as KeychainError {
+      logKeychainError(error)
     } catch {
-      Crashlytics.crashlytics().record(error: error)
+      self.logUnknownError(error)
     }
 
     return nil
@@ -374,8 +386,10 @@ public struct AppEnvironment: AppEnvironmentType {
     do {
       try Keychain.deletePassword(forAccount: self.accountNameForKeychain)
       return true
+    } catch let error as KeychainError {
+      logKeychainError(error)
     } catch {
-      Crashlytics.crashlytics().record(error: error)
+      self.logUnknownError(error)
     }
 
     return false

--- a/Library/Keychain.swift
+++ b/Library/Keychain.swift
@@ -5,7 +5,7 @@ public enum KeychainError: Error {
   case unexpectedStatus(OSStatus)
   case unableToDecodePasswordData
 
-  public var errorMessage: String {
+  private var errorMessage: String {
     switch self {
     case let .unexpectedStatus(status):
       let errString = SecCopyErrorMessageString(status, nil) as String?
@@ -13,6 +13,25 @@ public enum KeychainError: Error {
     case .unableToDecodePasswordData:
       return "Unable to decode password data from keychain."
     }
+  }
+
+  private var errorCode: Int {
+    switch self {
+    case let .unexpectedStatus(status):
+      return Int(status)
+    case .unableToDecodePasswordData:
+      return -999
+    }
+  }
+
+  public var nsError: NSError {
+    return NSError(
+      domain: "Library.KeychainError",
+      code: self.errorCode,
+      userInfo: [
+        NSLocalizedDescriptionKey: self.errorMessage
+      ]
+    )
   }
 }
 


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Log a more detailed `NSError` when the keychain encounters a failure.

# 🤔 Why

These are showing up in Firebase with no context:
<img width="734" height="465" alt="Screenshot 2025-09-23 at 10 39 12 AM" src="https://github.com/user-attachments/assets/9b73bb77-07c0-4d40-9527-abd3987feea8" />

I ran some tests, and if you log them as properly configured `NSError`s instead of just an `Error` protocol, you get much more detailed information.

For example,
```swift
Crashlytics.crashlytics().record(error: NSError(domain: "TestDomain", code: 1_234, userInfo: [
   NSLocalizedDescriptionKey: "This is a localized error description",
   NSLocalizedFailureErrorKey: "This is a localized failure reason"
]))
```
results in:
<img width="759" height="417" alt="Screenshot 2025-09-23 at 10 42 18 AM" src="https://github.com/user-attachments/assets/d57d12e1-4901-4d28-a217-b3425c18a5c6" />

My hope is that by logging these, we can address any other underlying keychain issues and ramp this change up completely. 

# 🛠 How

I ran a quick smoke test of this by manually throwing an error from the Keychain code and confirming it propagates correctly.