### PR TITLE
[MBL-2829] Stop trying to open unrecognized ksr urls in safari

### DIFF
--- a/Kickstarter-iOS/AppDelegateViewModel.swift
+++ b/Kickstarter-iOS/AppDelegateViewModel.swift
@@ -1,3 +1,4 @@
+import FirebaseCrashlytics
 import KsApi
 import Library
 import Prelude
@@ -1036,6 +1037,10 @@ private func shouldOpenUrlInBrowser(_ url: URL) -> Bool {
         + "is included in the list of deeplinks and that you're not trying to "
         + "use a staging url in prod (or vice versa)."
     )
+    let error = NSError(domain: "Kickstarter.Deeplink", code: 0, userInfo: [
+      NSLocalizedDescriptionKey: "Unable to open unsupported ksr deeplink."
+    ])
+    Crashlytics.crashlytics().record(error: error)
     return false
   }
   // Otherwise, open url in browser.

--- a/Kickstarter-iOS/AppDelegateViewModel.swift
+++ b/Kickstarter-iOS/AppDelegateViewModel.swift
@@ -550,13 +550,11 @@ public final class AppDelegateViewModel: AppDelegateViewModelType, AppDelegateVi
       .filter { $0 == .tab(.me) }
       .ignoreValues()
 
-    let resolvedRedirectUrl = Signal.merge(
+    self.goToMobileSafari = Signal.merge(
       deepLinkUrl,
       urlFromBraze
     )
-    .filter { Navigation.deepLinkMatch($0) == nil }
-
-    self.goToMobileSafari = resolvedRedirectUrl
+    .filter(shouldOpenUrlInBrowser)
 
     let projectRootLink = Signal.merge(projectLink, projectPreviewLink)
       .filter { _, subpage, _, _ in subpage == .root }
@@ -1024,6 +1022,24 @@ private func deviceToken(fromData data: Data) -> String {
   return data
     .map { String(format: "%02.2hhx", $0 as CVarArg) }
     .joined()
+}
+
+private func shouldOpenUrlInBrowser(_ url: URL) -> Bool {
+  // If url has a deeplink match, never attempt to open the url in the browser.
+  if Navigation.deepLinkMatch(url) != nil {
+    return false
+  }
+  // Never attempt to open `ksr` urls in the browser; they'll redirect straight back to our app.
+  if let scheme = url.scheme, scheme == "ksr" {
+    print(
+      "Error: Unable to open 'ksr' deeplink. Please doublecheck that the url "
+        + "is included in the list of deeplinks and that you're not trying to "
+        + "use a staging url in prod (or vice versa)."
+    )
+    return false
+  }
+  // Otherwise, open url in browser.
+  return true
 }
 
 private func navigation(fromPushEnvelope envelope: PushEnvelope) -> Navigation? {

--- a/Kickstarter-iOS/AppDelegateViewModelTests.swift
+++ b/Kickstarter-iOS/AppDelegateViewModelTests.swift
@@ -2571,6 +2571,54 @@ final class AppDelegateViewModelTests: TestCase {
     self.presentViewController.assertValues([])
   }
 
+  func testGoToMobileSafari_unrecognizedDeeplink() {
+    self.vm.inputs.applicationDidFinishLaunching(
+      application: UIApplication.shared,
+      launchOptions: [:]
+    )
+
+    let url = URL(string: "https://fake-url.com")!
+    _ = self.vm.inputs.applicationOpenUrl(application: nil, url: url, options: [:])
+
+    self.goToMobileSafari.assertLastValue(url)
+  }
+
+  func testGoToMobileSafari_deeplinkFound() {
+    self.vm.inputs.applicationDidFinishLaunching(
+      application: UIApplication.shared,
+      launchOptions: [:]
+    )
+
+    let url = URL(string: "https://kickstarter.com/activity")!
+    _ = self.vm.inputs.applicationOpenUrl(application: nil, url: url, options: [:])
+
+    self.goToMobileSafari.assertDidNotEmitValue()
+  }
+
+  func testGoToMobileSafari_ksrUnrecognizedDeeplink() throws {
+    self.vm.inputs.applicationDidFinishLaunching(
+      application: UIApplication.shared,
+      launchOptions: [:]
+    )
+
+    let url = URL(string: "ksr://fake-url.com")!
+    _ = self.vm.inputs.applicationOpenUrl(application: nil, url: url, options: [:])
+
+    self.goToMobileSafari.assertDidNotEmitValue()
+  }
+
+  func testGoToMobileSafari_ksrDeeplinkFound() {
+    self.vm.inputs.applicationDidFinishLaunching(
+      application: UIApplication.shared,
+      launchOptions: [:]
+    )
+
+    let url = URL(string: "https://kickstarter.com/activity")!
+    _ = self.vm.inputs.applicationOpenUrl(application: nil, url: url, options: [:])
+
+    self.goToMobileSafari.assertDidNotEmitValue()
+  }
+
   func testRemoteConfigClientConfiguredNotification_Success() {
     let mockService = MockService(serverConfig: ServerConfig.staging)
 


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Filter out `ksr://` urls before we open unrecognized urls in safari.

Also, add non-fatal error tracking when the app is opened with an invalid `ksr://` url. I didn't add the specific url to the logging, since this could theoretically include sensitive info. If we're seeing a lot of these non-fatal errors and we want to investigate further in the future, we can talk to legal about if it makes sense to log them.

# 🤔 Why

In the app, we fall back to opening unrecognized urls in safari. This is generally a good thing. However, `ksr://` urls will always open the kickstarter app, so we used to get into the following loop for these urls:
 - Attempt to open weird `ksr://` url
 - Realize we couldn't, so we tell safari to open it instead
 - Safari helpfully recognizes it as a `ksr://` url and therefore opens it in our app
 - Repeat forever.

With these changes, we'll never open `ksr://` urls in safari.

Note:
It is still possible for universal links to end up in this infinite loop. This happens if our app site association says that we handle the url as a deeplink, but it's not actually in our list of supported deeplinks. I expect this to happen less frequently and be significantly harder to fix (as far as I know, there's no way for us to check if a link is part of the app site association supported links). If we want to make sure this never happens for universal links, we would need to do one of the following:
 - update our app site association jsons to explicitly list out all supported links (tedious and makes it tedious to add new links)
 - update our app to have a local copy of the app site association to do local "if not deeplink but in app site association list, don't open in browser" logic - also tedious and would easily get out of sync
 - simpler solution: never open kickstarter links in the browser, but this would limit functionality. Having a browser fallback for ex older versions of the app is actually really useful.

I think it's not worth fixing this for universal links; we'd either impact functionality or need to add a rather tedious solution. But we can definitely consider revisiting this if we run into similar issues with universal links getting into infinite loops in the future.

# 👀 See

[Jira](https://kickstarter.atlassian.net/browse/MBL-2829)

# ✅ Acceptance criteria

- [x] Unsupported ksr urls now error nicely instead of getting the app into a weird state
- [x] Verified (in internal builds) that opening the app through an unsupported `ksr://` deeplink causes a non-fatal error to get logged in crashlytics.

