### PR TITLE
Rename SurveyResponse classes to PledgeManagerWebView

### DIFF
--- a/Kickstarter-iOS/AppDelegateViewModel.swift
+++ b/Kickstarter-iOS/AppDelegateViewModel.swift
@@ -614,17 +614,17 @@ public final class AppDelegateViewModel: AppDelegateViewModelType, AppDelegateVi
 
     let surveyUrlFromProjectLink = deepLink
       .map { link -> String? in
-        if case let .project(_, .surveyWebview(surveyUrl), _, _) = link {
+        if case let .project(_, .pledgeManagerWebview(surveyUrl), _, _) = link {
           return surveyUrl
         }
         return nil
       }
       .skipNil()
 
-    let surveyResponseLink = Signal.merge(surveyUrlFromProjectLink, surveyUrlFromUserLink)
+    let pledgeManagerLink = Signal.merge(surveyUrlFromProjectLink, surveyUrlFromUserLink)
       .observeForUI()
       .map { url -> [UIViewController] in
-        [SurveyResponseViewController.configuredWith(surveyUrl: url)]
+        [PledgeManagerWebViewController.configuredWith(url: url)]
       }
 
     let updatesLink = projectLink
@@ -703,7 +703,7 @@ public final class AppDelegateViewModel: AppDelegateViewModelType, AppDelegateVi
         projectRootLink,
         projectCommentsLink,
         projectCommentThreadLink,
-        surveyResponseLink,
+        pledgeManagerLink,
         updatesLink,
         updateRootLink,
         updateCommentsLink,
@@ -1071,7 +1071,7 @@ private func navigation(fromPushEnvelope envelope: PushEnvelope) -> Navigation? 
   if let pledgeRedemption = envelope.pledgeRedemption {
     let path = pledgeRedemption.pledgeManagerPath
     let url = AppEnvironment.current.apiService.serverConfig.webBaseUrl.absoluteString + path
-    return .project(.id(pledgeRedemption.projectId), .surveyWebview(url), refInfo: RefInfo(.push))
+    return .project(.id(pledgeRedemption.projectId), .pledgeManagerWebview(url), refInfo: RefInfo(.push))
   }
 
   if let project = envelope.project {
@@ -1085,7 +1085,7 @@ private func navigation(fromPushEnvelope envelope: PushEnvelope) -> Navigation? 
   if let survey = envelope.survey {
     let path = survey.urls.web.survey
     let url = AppEnvironment.current.apiService.serverConfig.webBaseUrl.absoluteString + path
-    return .project(.id(survey.projectId), .surveyWebview(url), refInfo: RefInfo(.push))
+    return .project(.id(survey.projectId), .pledgeManagerWebview(url), refInfo: RefInfo(.push))
   }
 
   if let update = envelope.update {

--- a/Kickstarter-iOS/Features/Activities/Controller/ActivitiesViewController.swift
+++ b/Kickstarter-iOS/Features/Activities/Controller/ActivitiesViewController.swift
@@ -227,7 +227,7 @@ internal final class ActivitiesViewController: UITableViewController {
 
   fileprivate func goToSurveyResponse(surveyResponse: SurveyResponse) {
     let url = surveyResponse.urls.web.survey
-    let vc = SurveyResponseViewController.configuredWith(surveyUrl: url)
+    let vc = PledgeManagerWebViewController.configuredWith(url: url)
     vc.delegate = self
 
     let nav = UINavigationController(rootViewController: vc)
@@ -277,8 +277,8 @@ extension ActivitiesViewController: EmptyStatesViewControllerDelegate {
   func emptyStatesViewControllerGoToFriends() {}
 }
 
-extension ActivitiesViewController: SurveyResponseViewControllerDelegate {
-  func surveyResponseViewControllerDismissed() {
+extension ActivitiesViewController: PledgeManagerWebViewControllerDelegate {
+  func pledgeManagerWebViewControllerDismissed() {
     self.viewModel.inputs.surveyResponseViewControllerDismissed()
   }
 }

--- a/Kickstarter-iOS/Features/Messages/Controller/MessagesViewController.swift
+++ b/Kickstarter-iOS/Features/Messages/Controller/MessagesViewController.swift
@@ -195,7 +195,7 @@ internal final class MessagesViewController: UITableViewController, MessageBanne
   }
 
   fileprivate func goToPMPledeView(with url: String) {
-    let vc = SurveyResponseViewController.configuredWith(surveyUrl: url)
+    let vc = PledgeManagerWebViewController.configuredWith(url: url)
     self.present(vc, animated: true)
   }
 

--- a/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOContainerViewController.swift
+++ b/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOContainerViewController.swift
@@ -164,7 +164,7 @@ public class PPOContainerViewController: PagedContainerViewController<PPOContain
   }
 
   private func openSurvey(_ url: String) {
-    let vc = SurveyResponseViewController.configuredWith(surveyUrl: url)
+    let vc = PledgeManagerWebViewController.configuredWith(url: url)
     vc.delegate = self
     let nav = UINavigationController(rootViewController: vc)
     nav.modalPresentationStyle = .formSheet
@@ -296,8 +296,8 @@ extension PPOContainerViewController: STPAuthenticationContext {
   }
 }
 
-extension PPOContainerViewController: SurveyResponseViewControllerDelegate {
-  public func surveyResponseViewControllerDismissed() {
+extension PPOContainerViewController: PledgeManagerWebViewControllerDelegate {
+  public func pledgeManagerWebViewControllerDismissed() {
     self.viewModel.actionFinishedPerforming()
   }
 }

--- a/Kickstarter-iOS/Features/ProjectPage/Controller/ProjectPageViewController.swift
+++ b/Kickstarter-iOS/Features/ProjectPage/Controller/ProjectPageViewController.swift
@@ -720,7 +720,7 @@ public final class ProjectPageViewController: UIViewController, MessageBannerVie
   }
 
   private func goToPledgeManagementWebViewController(with backingDetailsURL: String) {
-    let vc = SurveyResponseViewController.configuredWith(surveyUrl: backingDetailsURL)
+    let vc = PledgeManagerWebViewController.configuredWith(url: backingDetailsURL)
 
     let nc = RewardPledgeNavigationController(rootViewController: vc)
 

--- a/Kickstarter-iOS/Features/SurveyResponse/Controller/PledgeManagerWebViewController.swift
+++ b/Kickstarter-iOS/Features/SurveyResponse/Controller/PledgeManagerWebViewController.swift
@@ -4,20 +4,20 @@ import Prelude
 import UIKit
 import WebKit
 
-internal protocol SurveyResponseViewControllerDelegate: AnyObject {
+internal protocol PledgeManagerWebViewControllerDelegate: AnyObject {
   /// Called when the delegate should notify the parent that self was dismissed.
-  func surveyResponseViewControllerDismissed()
+  func pledgeManagerWebViewControllerDismissed()
 }
 
-internal final class SurveyResponseViewController: WebViewController {
-  internal weak var delegate: SurveyResponseViewControllerDelegate?
+internal final class PledgeManagerWebViewController: WebViewController {
+  internal weak var delegate: PledgeManagerWebViewControllerDelegate?
   private var sessionStartedObserver: Any?
-  fileprivate let viewModel: SurveyResponseViewModelType = SurveyResponseViewModel()
+  fileprivate let viewModel: PledgeManagerWebViewModelType = PledgeManagerWebViewModel()
 
-  internal static func configuredWith(surveyUrl: String)
-    -> SurveyResponseViewController {
-    let vc = SurveyResponseViewController()
-    vc.viewModel.inputs.configureWith(surveyUrl: surveyUrl)
+  internal static func configuredWith(url: String)
+    -> PledgeManagerWebViewController {
+    let vc = PledgeManagerWebViewController()
+    vc.viewModel.inputs.configureWith(url: url)
     return vc
   }
 
@@ -52,7 +52,7 @@ internal final class SurveyResponseViewController: WebViewController {
       .observeForControllerAction()
       .observeValues { [weak self] in
         self?.navigationController?.dismiss(animated: true, completion: nil)
-        self?.delegate?.surveyResponseViewControllerDismissed()
+        self?.delegate?.pledgeManagerWebViewControllerDismissed()
       }
 
     self.viewModel.outputs.goToLoginSignup

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -962,8 +962,8 @@
 		94C92E8A2659F09A00A96818 /* PaddingLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94C92E7B2659EDBF00A96818 /* PaddingLabel.swift */; };
 		9D10B91B1D35407C008B8045 /* String+Truncate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D10B91A1D35407C008B8045 /* String+Truncate.swift */; };
 		9D50E9471D2EDBE50096DAEC /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A7D1F9501C850B7C000D41D5 /* Assets.xcassets */; };
-		9D7536CD1D78D78600A7623B /* SurveyResponseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D7536CC1D78D78600A7623B /* SurveyResponseViewController.swift */; };
-		9D7536CF1D78D88D00A7623B /* SurveyResponseViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D7536CE1D78D88D00A7623B /* SurveyResponseViewModel.swift */; };
+		9D7536CD1D78D78600A7623B /* PledgeManagerWebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D7536CC1D78D78600A7623B /* PledgeManagerWebViewController.swift */; };
+		9D7536CF1D78D88D00A7623B /* PledgeManagerWebViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D7536CE1D78D88D00A7623B /* PledgeManagerWebViewModel.swift */; };
 		9DC572E51D36CA9800AE209C /* ProjectActivityStyles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DC572E41D36CA9800AE209C /* ProjectActivityStyles.swift */; };
 		A707BAD81CFFAB9400653B2F /* LoginIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = A707BAD41CFFAB9400653B2F /* LoginIntent.swift */; };
 		A707BADA1CFFAB9400653B2F /* Notifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = A707BAD51CFFAB9400653B2F /* Notifications.swift */; };
@@ -1130,7 +1130,7 @@
 		A7ED1FBC1E831C5C00BFFA01 /* FindFriendsFriendFollowCellViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7ED1F601E831C5C00BFFA01 /* FindFriendsFriendFollowCellViewModelTests.swift */; };
 		A7ED1FBE1E831C5C00BFFA01 /* ProjectNotificationCellViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7ED1F621E831C5C00BFFA01 /* ProjectNotificationCellViewModelTests.swift */; };
 		A7ED1FBF1E831C5C00BFFA01 /* SortPagerViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7ED1F631E831C5C00BFFA01 /* SortPagerViewModelTests.swift */; };
-		A7ED1FC61E831C5C00BFFA01 /* SurveyResponseViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7ED1F6A1E831C5C00BFFA01 /* SurveyResponseViewModelTests.swift */; };
+		A7ED1FC61E831C5C00BFFA01 /* PledgeManagerWebViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7ED1F6A1E831C5C00BFFA01 /* PledgeManagerWebViewModelTests.swift */; };
 		A7ED1FC81E831C5C00BFFA01 /* MessageThreadsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7ED1F6C1E831C5C00BFFA01 /* MessageThreadsViewModelTests.swift */; };
 		A7ED1FC91E831C5C00BFFA01 /* ActivitiesViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7ED1F6D1E831C5C00BFFA01 /* ActivitiesViewModelTests.swift */; };
 		A7ED1FCB1E831C5C00BFFA01 /* ActivityFriendBackingViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7ED1F6F1E831C5C00BFFA01 /* ActivityFriendBackingViewModelTests.swift */; };
@@ -2708,8 +2708,8 @@
 		94C92E7B2659EDBF00A96818 /* PaddingLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaddingLabel.swift; sourceTree = "<group>"; };
 		94F4A96126125EA0000C21F9 /* TimeInterval+ISO8601DateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TimeInterval+ISO8601DateTests.swift"; sourceTree = "<group>"; };
 		9D10B91A1D35407C008B8045 /* String+Truncate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+Truncate.swift"; sourceTree = "<group>"; };
-		9D7536CC1D78D78600A7623B /* SurveyResponseViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SurveyResponseViewController.swift; sourceTree = "<group>"; };
-		9D7536CE1D78D88D00A7623B /* SurveyResponseViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SurveyResponseViewModel.swift; sourceTree = "<group>"; };
+		9D7536CC1D78D78600A7623B /* PledgeManagerWebViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PledgeManagerWebViewController.swift; sourceTree = "<group>"; };
+		9D7536CE1D78D88D00A7623B /* PledgeManagerWebViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PledgeManagerWebViewModel.swift; sourceTree = "<group>"; };
 		9DC572E41D36CA9800AE209C /* ProjectActivityStyles.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProjectActivityStyles.swift; sourceTree = "<group>"; };
 		A707BAD31CFFAB9400653B2F /* HelpType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HelpType.swift; sourceTree = "<group>"; };
 		A707BAD41CFFAB9400653B2F /* LoginIntent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoginIntent.swift; sourceTree = "<group>"; };
@@ -2886,7 +2886,7 @@
 		A7ED1F601E831C5C00BFFA01 /* FindFriendsFriendFollowCellViewModelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FindFriendsFriendFollowCellViewModelTests.swift; sourceTree = "<group>"; };
 		A7ED1F621E831C5C00BFFA01 /* ProjectNotificationCellViewModelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProjectNotificationCellViewModelTests.swift; sourceTree = "<group>"; };
 		A7ED1F631E831C5C00BFFA01 /* SortPagerViewModelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SortPagerViewModelTests.swift; sourceTree = "<group>"; };
-		A7ED1F6A1E831C5C00BFFA01 /* SurveyResponseViewModelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SurveyResponseViewModelTests.swift; sourceTree = "<group>"; };
+		A7ED1F6A1E831C5C00BFFA01 /* PledgeManagerWebViewModelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PledgeManagerWebViewModelTests.swift; sourceTree = "<group>"; };
 		A7ED1F6C1E831C5C00BFFA01 /* MessageThreadsViewModelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MessageThreadsViewModelTests.swift; sourceTree = "<group>"; };
 		A7ED1F6D1E831C5C00BFFA01 /* ActivitiesViewModelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActivitiesViewModelTests.swift; sourceTree = "<group>"; };
 		A7ED1F6F1E831C5C00BFFA01 /* ActivityFriendBackingViewModelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActivityFriendBackingViewModelTests.swift; sourceTree = "<group>"; };
@@ -4269,7 +4269,7 @@
 		1937A71628C93DA800DD732D /* Controller */ = {
 			isa = PBXGroup;
 			children = (
-				9D7536CC1D78D78600A7623B /* SurveyResponseViewController.swift */,
+				9D7536CC1D78D78600A7623B /* PledgeManagerWebViewController.swift */,
 			);
 			path = Controller;
 			sourceTree = "<group>";
@@ -7139,8 +7139,8 @@
 				3767EDB222CFFF380088E8E4 /* ShippingRulesViewModelTests.swift */,
 				A72C3A921D00F6C70075227E /* SortPagerViewModel.swift */,
 				A7ED1F631E831C5C00BFFA01 /* SortPagerViewModelTests.swift */,
-				9D7536CE1D78D88D00A7623B /* SurveyResponseViewModel.swift */,
-				A7ED1F6A1E831C5C00BFFA01 /* SurveyResponseViewModelTests.swift */,
+				9D7536CE1D78D88D00A7623B /* PledgeManagerWebViewModel.swift */,
+				A7ED1F6A1E831C5C00BFFA01 /* PledgeManagerWebViewModelTests.swift */,
 				D79970B223EB6FF800584911 /* ThanksCategoryCellViewModel.swift */,
 				D79970B523EC88BB00584911 /* ThanksCategoryCellViewModelTests.swift */,
 				A7F441AB1D005A9400FE6FC5 /* ThanksViewModel.swift */,
@@ -8717,7 +8717,7 @@
 				A755116B1C8642C3005355CF /* UILabel+SimpleHTML.swift in Sources */,
 				D66850A1236CA44C00EE9AC2 /* ProjectPamphletCreatorHeaderCellViewModel.swift in Sources */,
 				A75C81201D210C4700B5AD03 /* UpdateActivityItemProvider.swift in Sources */,
-				9D7536CF1D78D88D00A7623B /* SurveyResponseViewModel.swift in Sources */,
+				9D7536CF1D78D88D00A7623B /* PledgeManagerWebViewModel.swift in Sources */,
 				6018626829A91B8C00EA2842 /* ThirdPartyEventInputName.swift in Sources */,
 				A710573B1DC2B2DF00A69552 /* SharedFunctions.swift in Sources */,
 				D6089E8F209106CD0032CC99 /* PushNotificationDialog.swift in Sources */,
@@ -8888,7 +8888,7 @@
 				37CBA64D221E10E100E6CAB6 /* HelpTypeTests.swift in Sources */,
 				A7ED1FA91E831C5C00BFFA01 /* ActivityProjectStatusViewModelTests.swift in Sources */,
 				D04AACAE218BB72100CF713E /* SettingsPrivacySwitchCellViewModelTests.swift in Sources */,
-				A7ED1FC61E831C5C00BFFA01 /* SurveyResponseViewModelTests.swift in Sources */,
+				A7ED1FC61E831C5C00BFFA01 /* PledgeManagerWebViewModelTests.swift in Sources */,
 				061645AE26697D55007D8D96 /* CommentRepliesViewModelTests.swift in Sources */,
 				A7ED1F281E830FDC00BFFA01 /* CircleAvatarImageViewTests.swift in Sources */,
 				606C45F829FACD9F001BA067 /* RemoteConfigFeature+HelpersTests.swift in Sources */,
@@ -9195,7 +9195,7 @@
 				A71003E01CDD06E600B4F4D7 /* MessageThreadCell.swift in Sources */,
 				D0A787B52204D40E006AE4F4 /* SelectCurrencyViewController.swift in Sources */,
 				33C2FB6C2E203B640083B5FB /* KSRSearchBar.swift in Sources */,
-				9D7536CD1D78D78600A7623B /* SurveyResponseViewController.swift in Sources */,
+				9D7536CD1D78D78600A7623B /* PledgeManagerWebViewController.swift in Sources */,
 				59392BEC1D7094B0001C99A4 /* ProjectUpdatesViewController.swift in Sources */,
 				8A1A93D024C601CA0012FB43 /* PledgeShippingSummaryView.swift in Sources */,
 				8AE09C3A244537BE00036043 /* PledgeDisclaimerView.swift in Sources */,

--- a/Library/Navigation.swift
+++ b/Library/Navigation.swift
@@ -447,8 +447,8 @@ private func pledgeManagerWebview(_ params: RouteParamsDecoded) -> Navigation? {
 
     let url = AppEnvironment.current.apiService.serverConfig.webBaseUrl.absoluteString + path
     let refInfo = refInfoFromParams(params)
-    let survey = Navigation.Project.pledgeManagerWebview(url)
-    return Navigation.project(projectParam, survey, refInfo: refInfo)
+    let pmWebview = Navigation.Project.pledgeManagerWebview(url)
+    return Navigation.project(projectParam, pmWebview, refInfo: refInfo)
   }
 
   return nil

--- a/Library/Navigation.swift
+++ b/Library/Navigation.swift
@@ -52,7 +52,9 @@ public enum Navigation: Equatable {
     case pledge(Navigation.Project.Pledge)
     case updates
     case update(Int, Navigation.Project.Update)
-    case surveyWebview(String)
+    /// Redirects to an authenticated web view which can support pledge manager workflows.
+    /// Argument is a fully-qualified URL for the web view.
+    case pledgeManagerWebview(String)
 
     public enum Checkout: Equatable {
       case thanks(racing: Bool?)
@@ -136,7 +138,7 @@ private let allRoutes: [String: (RouteParamsDecoded) -> Navigation?] = [
   "/search": search,
   "/signup": signup,
   "/projects/:creator_param/:project_param": project,
-  "/projects/:creator_param/:project_param/backing/:backing_tab": projectSurvey,
+  "/projects/:creator_param/:project_param/backing/:backing_tab": pledgeManagerWebview,
   "/projects/:creator_param/:project_param/checkouts/:checkout_param/thanks": thanks,
   "/projects/:creator_param/:project_param/comments": projectComments,
   "/projects/:creator_param/:project_param/creator_bio": creatorBio,
@@ -154,9 +156,9 @@ private let allRoutes: [String: (RouteParamsDecoded) -> Navigation?] = [
   "/projects/:creator_param/:project_param/posts/:update_param": update,
   "/projects/:creator_param/:project_param/updates": updates,
   "/projects/:creator_param/:project_param/posts/:update_param/comments": updateComments,
-  "/projects/:creator_param/:project_param/surveys/:survey_param": projectSurvey,
-  "/projects/:creator_param/:project_param/surveys/:survey_param/edit": projectSurvey,
-  "/projects/:creator_param/:project_param/surveys/:survey_param/edit_address": projectSurvey,
+  "/projects/:creator_param/:project_param/surveys/:survey_param": pledgeManagerWebview,
+  "/projects/:creator_param/:project_param/surveys/:survey_param/edit": pledgeManagerWebview,
+  "/projects/:creator_param/:project_param/surveys/:survey_param/edit_address": pledgeManagerWebview,
   "/settings/:notification_param/:enabled_param": settingsNotifications,
   "/users/:user_param/surveys/:survey_response_id": userSurvey
 ]
@@ -430,7 +432,7 @@ private func posts(_ params: RouteParamsDecoded) -> Navigation? {
   return nil
 }
 
-private func projectSurvey(_ params: RouteParamsDecoded) -> Navigation? {
+private func pledgeManagerWebview(_ params: RouteParamsDecoded) -> Navigation? {
   if let projectParam = params.projectParam(),
      var path = params.path() {
     // Fallback logic for deeplinks: replace `backing/details` with `backing/survey_responses`
@@ -445,7 +447,7 @@ private func projectSurvey(_ params: RouteParamsDecoded) -> Navigation? {
 
     let url = AppEnvironment.current.apiService.serverConfig.webBaseUrl.absoluteString + path
     let refInfo = refInfoFromParams(params)
-    let survey = Navigation.Project.surveyWebview(url)
+    let survey = Navigation.Project.pledgeManagerWebview(url)
     return Navigation.project(projectParam, survey, refInfo: refInfo)
   }
 

--- a/Library/NavigationTests.swift
+++ b/Library/NavigationTests.swift
@@ -129,14 +129,14 @@ public final class NavigationTests: XCTestCase {
     withEnvironment(apiService: MockService(serverConfig: ServerConfig.production)) {
       self.assertProjectMatch(
         path: "/projects/creator/project/surveys/3",
-        navigation: .surveyWebview("https://www.kickstarter.com/projects/creator/project/surveys/3")
+        navigation: .pledgeManagerWebview("https://www.kickstarter.com/projects/creator/project/surveys/3")
       )
     }
 
     withEnvironment(apiService: MockService(serverConfig: ServerConfig.production)) {
       self.assertProjectMatch(
         path: "/projects/1234567890/project/backing/survey_responses",
-        navigation: .surveyWebview(
+        navigation: .pledgeManagerWebview(
           "https://www.kickstarter.com/projects/1234567890/project/backing/survey_responses"
         )
       )
@@ -145,7 +145,7 @@ public final class NavigationTests: XCTestCase {
       // This mimics the runtime fallback applied to avoid re-auth issues in the WebView.
       self.assertProjectMatch(
         path: "/projects/1234567890/project/backing/details",
-        navigation: .surveyWebview(
+        navigation: .pledgeManagerWebview(
           "https://www.kickstarter.com/projects/1234567890/project/backing/survey_responses"
         )
       )

--- a/Library/ViewModels/PledgeManagerWebViewModelTests.swift
+++ b/Library/ViewModels/PledgeManagerWebViewModelTests.swift
@@ -5,8 +5,8 @@ import ReactiveExtensions_TestHelpers
 import WebKit
 import XCTest
 
-final class SurveyResponseViewModelTests: TestCase {
-  fileprivate let vm: SurveyResponseViewModelType = SurveyResponseViewModel()
+final class PledgeManagerWebViewModelTests: TestCase {
+  fileprivate let vm: PledgeManagerWebViewModelType = PledgeManagerWebViewModel()
 
   fileprivate let dismissViewController = TestObserver<Void, Never>()
   fileprivate let goToPledge = TestObserver<Param, Never>()
@@ -35,7 +35,7 @@ final class SurveyResponseViewModelTests: TestCase {
   }
 
   func testDismissViewControllerOnCloseButtonTapped() {
-    self.vm.inputs.configureWith(surveyUrl: SurveyResponse.template.urls.web.survey)
+    self.vm.inputs.configureWith(url: SurveyResponse.template.urls.web.survey)
     self.vm.inputs.viewDidLoad()
     self.dismissViewController.assertDidNotEmitValue()
 
@@ -49,7 +49,7 @@ final class SurveyResponseViewModelTests: TestCase {
       |> SurveyResponse.lens.id .~ 123
       |> SurveyResponse.lens.project .~ project
 
-    self.vm.inputs.configureWith(surveyUrl: surveyResponse.urls.web.survey)
+    self.vm.inputs.configureWith(url: surveyResponse.urls.web.survey)
     self.vm.inputs.viewDidLoad()
 
     // 1. Load survey.
@@ -150,7 +150,7 @@ final class SurveyResponseViewModelTests: TestCase {
     let surveyResponse = .template
       |> SurveyResponse.lens.project .~ project
 
-    self.vm.inputs.configureWith(surveyUrl: surveyResponse.urls.web.survey)
+    self.vm.inputs.configureWith(url: surveyResponse.urls.web.survey)
     self.vm.inputs.viewDidLoad()
 
     self.goToPledge.assertDidNotEmitValue()
@@ -175,7 +175,7 @@ final class SurveyResponseViewModelTests: TestCase {
     let surveyResponse = .template
       |> SurveyResponse.lens.project .~ project
 
-    self.vm.inputs.configureWith(surveyUrl: surveyResponse.urls.web.survey)
+    self.vm.inputs.configureWith(url: surveyResponse.urls.web.survey)
     self.vm.inputs.viewDidLoad()
 
     self.goToProjectParam.assertDidNotEmitValue()
@@ -203,7 +203,7 @@ final class SurveyResponseViewModelTests: TestCase {
 
     let update = Update.template
 
-    self.vm.inputs.configureWith(surveyUrl: surveyResponse.urls.web.survey)
+    self.vm.inputs.configureWith(url: surveyResponse.urls.web.survey)
     self.vm.inputs.viewDidLoad()
 
     withEnvironment(apiService: MockService(
@@ -237,7 +237,7 @@ final class SurveyResponseViewModelTests: TestCase {
     withEnvironment(currentUser: nil) {
       let surveyResponse = SurveyResponse.template
 
-      self.vm.inputs.configureWith(surveyUrl: surveyResponse.urls.web.survey)
+      self.vm.inputs.configureWith(url: surveyResponse.urls.web.survey)
       self.vm.inputs.viewDidLoad()
 
       self.goToLoginSignup.assertValue(.generic)
@@ -248,7 +248,7 @@ final class SurveyResponseViewModelTests: TestCase {
     withEnvironment(currentUser: nil) {
       let surveyResponse = SurveyResponse.template
 
-      self.vm.inputs.configureWith(surveyUrl: surveyResponse.urls.web.survey)
+      self.vm.inputs.configureWith(url: surveyResponse.urls.web.survey)
       self.vm.inputs.viewDidLoad()
 
       // Request should not send when user is logged out.


### PR DESCRIPTION
# 📲 What

1. Rename all the classes that contain `SurveyResponse` to `PledgeMangerWebView`.
2. Rename the navigation type `surveyWebview` to `pledgeManagerWebView`
3. Rename some other survey-specific variables

# 🤔 Why

I'm working on implementing deep links and push notifications for order edits, which is a new feature in Pledge Manager. I found that the best way to do that would be to extend the functionality of `SurveyResponseViewController` and the `surveyWebview` navigation type. We want essentially the same behavior - links that go to an embedded webview, with login support - so it makes sense.

For clarity, I renamed all of these types to be a little more generically applicable to Pledge Manager. 