### PR TITLE
Enable Swift 6 for KDS

### DIFF
--- a/KDS/Package.swift
+++ b/KDS/Package.swift
@@ -34,8 +34,5 @@ let package = Package(
         .product(name: "SnapshotTesting", package: "swift-snapshot-testing")
       ]
     )
-  ],
-  swiftLanguageModes: [
-    .v5
   ]
 )

--- a/KDS/Sources/KDS/Colors/SemanticColor.swift
+++ b/KDS/Sources/KDS/Colors/SemanticColor.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 import UIKit
 
-public protocol AdaptiveColor {
+public protocol AdaptiveColor: Sendable {
   /// Returns a dynamically-provided `UIColor`, which responds to light/dark mode.
   var dynamicColor: UIColor { get }
 }
@@ -30,7 +30,7 @@ public extension AdaptiveColor {
 
 /// A semantic color from the Kickstarter design system, like "surface/primary".
 /// Includes a light and dark mode color pair, as well as an identifying title.
-public struct SemanticColor: AdaptiveColor {
+public struct SemanticColor: AdaptiveColor, Sendable {
   public let dynamicColor: UIColor
 
   public let name: String
@@ -62,7 +62,7 @@ public struct SemanticColor: AdaptiveColor {
 }
 
 /// Used for old design system colors which can't be mapped directly to the Kickstarter color palette.
-public struct LegacyColor: AdaptiveColor {
+public struct LegacyColor: AdaptiveColor, Sendable {
   public let name: String
   public let dynamicColor: UIColor
 

--- a/KDS/Sources/KDS/Controllers/ColorsView.swift
+++ b/KDS/Sources/KDS/Controllers/ColorsView.swift
@@ -176,13 +176,13 @@ public struct ColorsView: View {
   }
 }
 
-extension SemanticColor: @retroactive Identifiable {
+extension SemanticColor: Identifiable {
   public var id: String {
     return self.name
   }
 }
 
-extension LegacyColor: @retroactive Identifiable {
+extension LegacyColor: Identifiable {
   public var id: String {
     return self.name
   }

--- a/KDS/Sources/KDS/Fonts/InterFont.swift
+++ b/KDS/Sources/KDS/Fonts/InterFont.swift
@@ -77,17 +77,13 @@ public enum InterFont: CustomFont, CaseIterable {
 }
 
 extension InterFont: CustomFontAccessible {
-  private static let registeredInterfont = Mutex<Bool>(false)
+  private static let registeredInterfont = Atomic(false)
   public static var isRegistered: Bool {
     get {
-      registeredInterfont.withLock { isRegistered in
-        isRegistered
-      }
+      registeredInterfont.load(ordering: .acquiring)
     }
     set {
-      registeredInterfont.withLock { isRegistered in
-        isRegistered = newValue
-      }
+      _ = registeredInterfont.exchange(newValue, ordering: .acquiringAndReleasing)
     }
   }
 

--- a/KDS/Sources/KDS/Fonts/InterFont.swift
+++ b/KDS/Sources/KDS/Fonts/InterFont.swift
@@ -1,3 +1,4 @@
+import Synchronization
 import UIKit
 
 public enum InterFont: CustomFont, CaseIterable {
@@ -75,15 +76,18 @@ public enum InterFont: CustomFont, CaseIterable {
   }
 }
 
-var registeredInterfont = false
-
 extension InterFont: CustomFontAccessible {
+  private static let registeredInterfont = Mutex<Bool>(false)
   public static var isRegistered: Bool {
     get {
-      registeredInterfont
+      registeredInterfont.withLock { isRegistered in
+        isRegistered
+      }
     }
     set {
-      registeredInterfont = newValue
+      registeredInterfont.withLock { isRegistered in
+        isRegistered = newValue
+      }
     }
   }
 


### PR DESCRIPTION
# 📲 What

This PR enables Swift 6 support for the KDS module.

# 🤔 Why

Swift 6 makes stronger guarantees about memory safety and concurrency, and can be accessed by Swift 5 modules.

# 🛠 How

- Disabled the Swift 5 compatibility mode in KDS
- Added an `Atomic<Bool>` for the font registration static value, which gives Swift 6 the synchronization guarantee to make it `Sendable`
- Added `Sendable` conformance to the different Color types
- Deleted the `@retroactive Identifiable` which is now a compile time error in Swift 6 mode

# ✅ Acceptance criteria

App should build and run. Tests should work. 