### PR TITLE
[MBL-3164] Update the ppo card id to only be based on the project id

### DIFF
--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/PledgedProjectsOverview/CardView/PPOProjectCardModel.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/PledgedProjectsOverview/CardView/PPOProjectCardModel.swift
@@ -42,10 +42,9 @@ public struct PPOProjectCardModel: Identifiable, Equatable, Hashable {
 
   // MARK: - Identifiable
 
-  // Create the card's id from the project id, tier type, and actions.
-  // If any other fields change, the card should be considered the same card, just modified.
+  // Create the card's id from the project id. There will be at most one PPO card per project.
   public var id: String {
-    "\(self.projectId)-\(self.tierType)-\(self.action?.id ?? "")"
+    "\(self.projectId)"
   }
 
   // MARK: - Equatable


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Update the PPO card identifier to be equal to the project id, instead of also being based on the tier type and actions.

# 🤔 Why

I did some testing and this doesn't make a difference in most cases. But I think it'll make PPO actions a little better in the edge case where a card tier type changes, but the cards position in the list doesn't change. I wasn't able to find this edge case in any of my test accounts, but it could theoretically make the auto refresh better for some users.

Also, now that we've decided we'll have at most one card per project id, this change makes the identifier more intuitive for any future work in this space.

# 👀 See

[Jira](https://kickstarter.atlassian.net/browse/MBL-3164)

# ✅ Acceptance criteria

- [x] PPO behavior isn't worse (in almost all cases, the list will still behave the same)

# ⏰ TODO

- [ ] Wait for https://kickstarter.atlassian.net/browse/MBL-3139 to be fixed and merged before merging this pr. (Currently, there could be separate PPO cards for a canceled and successful pledge to the same project, and I want those cards to have separate ids while they can coexist)
