### PR TITLE
Configure Statsig for all build targets

### DIFF
--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/AppDelegateViewModel.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/AppDelegateViewModel.swift
@@ -100,8 +100,8 @@ public protocol AppDelegateViewModelOutputs {
   /// Emits when the application should configure Segment with an instance of Braze.
   var configureSegmentWithBraze: Signal<String, Never> { get }
 
-  /// Emits when the application should configure Statsig.
-  var configureStatsig: Signal<(), Never> { get }
+  /// Emits when the application should configure Statsig and returns the correct API Key.
+  var configureStatsig: Signal<String, Never> { get }
 
   /// Return this value in the delegate method.
   var continueUserActivityReturnValue: MutableProperty<Bool> { get }
@@ -721,6 +721,11 @@ public final class AppDelegateViewModel: AppDelegateViewModelType, AppDelegateVi
     self.configureFirebase = self.applicationLaunchOptionsProperty.signal.ignoreValues()
 
     self.configureStatsig = self.applicationLaunchOptionsProperty.signal.ignoreValues()
+      .map { _ in
+        AppEnvironment.current.mainBundle.isRelease
+          ? Secrets.Statsig.production
+          : Secrets.Statsig.staging
+      }
 
     self.setApplicationShortcutItems = currentUserEvent
       .values()
@@ -927,7 +932,7 @@ public final class AppDelegateViewModel: AppDelegateViewModelType, AppDelegateVi
   public let applicationIconBadgeNumber: Signal<Int, Never>
   public let configureFirebase: Signal<(), Never>
   public let configureSegmentWithBraze: Signal<String, Never>
-  public let configureStatsig: Signal<(), Never>
+  public let configureStatsig: Signal<String, Never>
   public let continueUserActivityReturnValue = MutableProperty(false)
   public let emailVerificationCompleted: Signal<(String, Bool), Never>
   public let findRedirectUrl: Signal<URL, Never>

--- a/Kickstarter-iOS/AppDelegate.swift
+++ b/Kickstarter-iOS/AppDelegate.swift
@@ -218,13 +218,11 @@ internal final class AppDelegate: UIResponder, UIApplicationDelegate {
 
           strongSelf.configureRemoteConfig()
         }
-    #endif
 
-    #if INTERNAL_BUILD
       self.viewModel.outputs.configureStatsig
         .observeForUI()
-        .observeValues { [weak self] in
-          self?.configureStatsig()
+        .observeValues { [weak self] key in
+          self?.configureStatsig(with: key)
         }
     #endif
 
@@ -467,8 +465,8 @@ internal final class AppDelegate: UIResponder, UIApplicationDelegate {
       }
   }
 
-  private func configureStatsig() {
-    let client = StatsigClient(sdkKey: Secrets.Statsig.staging)
+  private func configureStatsig(with key: String) {
+    let client = StatsigClient(sdkKey: key)
     AppEnvironment.updateStatsigClient(client)
 
     client.initialize(userID: AppEnvironment.current.currentUser?.id.toString())


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Initializes Statsig for Release or Internal Builds with the correct API Key (Prod/Staging)

# 🛠 How

Pass the correct api key (from Secrets), based on whether the current build is Release or not, from `AppDelegateViewModel` to the Statsig initializer in `AppDelegate`

# ✅ Acceptance criteria

- [x] The app launches and runs w/o issue on Prod and Staging
- [x] The current Video Feed code is shown/hidden correctly based on it's Statsig Feature Gate
- [x] All tests pass
