### PR TITLE
CHECK-84: Add helper method to create Project page with correct presentation style

### DIFF
--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/AppDelegateViewModel.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/AppDelegateViewModel.swift
@@ -1339,6 +1339,7 @@ private struct ProjectDeepLink {
         updateCommentThreadLink
       )
       .map { ProjectPageViewController.navigationController(withViewControllers: $0) }
+      // This one is already in its own nav controller, `RewardPledgeNavigationController`
       .merge(with: fixErroredPledgeLink.map { $0 as UINavigationController })
   }
 }

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/AppDelegateViewModel.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/AppDelegateViewModel.swift
@@ -1338,13 +1338,7 @@ private struct ProjectDeepLink {
         updateCommentsLink,
         updateCommentThreadLink
       )
-      .map { viewControllers in
-        let navigation = UINavigationController()
-        navigation.modalPresentationStyle = .pageSheet
-        navigation.viewControllers = viewControllers
-        return navigation
-      }
-      // This one is already in its own nav controller, `RewardPledgeNavigationController`
+      .map { ProjectPageViewController.navigationController(withViewControllers: $0) }
       .merge(with: fixErroredPledgeLink.map { $0 as UINavigationController })
   }
 }

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/Activities/Controller/ActivitiesViewController.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/Activities/Controller/ActivitiesViewController.swift
@@ -230,13 +230,10 @@ internal final class ActivitiesViewController: UITableViewController {
 
   fileprivate func present(project: Project, refTag: RefTag) {
     let projectParam = Either<Project, any ProjectPageParam>(left: project)
-    let vc = ProjectPageViewController.configuredWith(
-      projectOrParam: projectParam,
+    let nav = ProjectPageViewController.navigationController(
+      withProjectOrParam: projectParam,
       refInfo: RefInfo(refTag)
     )
-
-    let nav = NavigationController(rootViewController: vc)
-    nav.modalPresentationStyle = self.traitCollection.userInterfaceIdiom == .pad ? .fullScreen : .formSheet
 
     self.present(nav, animated: true, completion: nil)
   }

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/BackerDashboardProjects/Controller/BackerDashboardProjectsViewController.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/BackerDashboardProjects/Controller/BackerDashboardProjectsViewController.swift
@@ -143,13 +143,10 @@ internal final class BackerDashboardProjectsViewController: UITableViewControlle
 
   private func goTo(project: ProjectCardProperties, refTag: RefTag) {
     let projectParam = Either<Project, any ProjectPageParam>(right: project.projectPageParam)
-    let vc = ProjectPageViewController.configuredWith(
-      projectOrParam: projectParam,
+    let nav = ProjectPageViewController.navigationController(
+      withProjectOrParam: projectParam,
       refInfo: RefInfo(refTag)
     )
-
-    let nav = NavigationController(rootViewController: vc)
-    nav.modalPresentationStyle = self.traitCollection.userInterfaceIdiom == .pad ? .fullScreen : .formSheet
 
     self.present(nav, animated: true, completion: nil)
   }

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/CuratedProjects/Controller/CuratedProjectsViewController.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/CuratedProjects/Controller/CuratedProjectsViewController.swift
@@ -160,13 +160,10 @@ final class CuratedProjectsViewController: UIViewController {
 
   fileprivate func goToProject(_ project: Project, projects _: [Project], refTag: RefTag) {
     let projectParam = Either<Project, any ProjectPageParam>(left: project)
-    let vc = ProjectPageViewController.configuredWith(
-      projectOrParam: projectParam,
+    let nav = ProjectPageViewController.navigationController(
+      withProjectOrParam: projectParam,
       refInfo: RefInfo(refTag)
     )
-
-    let nav = NavigationController(rootViewController: vc)
-    nav.modalPresentationStyle = self.traitCollection.userInterfaceIdiom == .pad ? .fullScreen : .formSheet
 
     self.present(nav, animated: true, completion: nil)
   }

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/Discovery/Controller/DiscoveryPageViewController.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/Discovery/Controller/DiscoveryPageViewController.swift
@@ -363,26 +363,20 @@ internal final class DiscoveryPageViewController: UITableViewController {
 
   fileprivate func goTo(project: Project, refTag: RefTag) {
     let projectParam = Either<Project, any ProjectPageParam>(left: project)
-    let vc = ProjectPageViewController.configuredWith(
-      projectOrParam: projectParam,
+    let nav = ProjectPageViewController.navigationController(
+      withProjectOrParam: projectParam,
       refInfo: RefInfo(refTag)
     )
-
-    let nav = NavigationController(rootViewController: vc)
-    nav.modalPresentationStyle = self.traitCollection.userInterfaceIdiom == .pad ? .fullScreen : .formSheet
 
     self.present(nav, animated: true, completion: nil)
   }
 
   fileprivate func goTo(project: Project, initialPlaylist _: [Project], refTag: RefTag) {
     let projectParam = Either<Project, any ProjectPageParam>(left: project)
-    let vc = ProjectPageViewController.configuredWith(
-      projectOrParam: projectParam,
+    let nav = ProjectPageViewController.navigationController(
+      withProjectOrParam: projectParam,
       refInfo: RefInfo(refTag)
     )
-
-    let nav = NavigationController(rootViewController: vc)
-    nav.modalPresentationStyle = self.traitCollection.userInterfaceIdiom == .pad ? .fullScreen : .formSheet
 
     self.present(nav, animated: true, completion: nil)
   }

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/Messages/Controller/MessagesViewController.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/Messages/Controller/MessagesViewController.swift
@@ -178,13 +178,10 @@ internal final class MessagesViewController: UITableViewController, MessageBanne
 
   fileprivate func goTo(project: Project, refTag: RefTag) {
     let projectParam = Either<Project, any ProjectPageParam>(left: project)
-    let vc = ProjectPageViewController.configuredWith(
-      projectOrParam: projectParam,
+    let nav = ProjectPageViewController.navigationController(
+      withProjectOrParam: projectParam,
       refInfo: RefInfo(refTag)
     )
-
-    let nav = NavigationController(rootViewController: vc)
-    nav.modalPresentationStyle = self.traitCollection.userInterfaceIdiom == .pad ? .fullScreen : .formSheet
 
     self.present(nav, animated: true, completion: nil)
   }

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOContainerViewController.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/PledgedProjectsOverview/PPOContainerViewController.swift
@@ -187,15 +187,12 @@ public class PPOContainerViewController: PagedContainerViewController<PPOContain
 
   private func openProjectPage(_ param: ProjectPageParam) {
     let projectParam = Either<Project, any ProjectPageParam>(right: param)
-    let vc = ProjectPageViewController.configuredWith(
-      projectOrParam: projectParam,
+    let nav = ProjectPageViewController.navigationController(
+      withProjectOrParam: projectParam,
       refInfo: nil
     )
 
-    let nav = UINavigationController(rootViewController: vc)
-    nav.modalPresentationStyle = .pageSheet
     nav.presentationController?.delegate = self
-
     self.present(nav, animated: true, completion: nil)
   }
 

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/ProjectPage/Controller/ProjectPageViewController.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/ProjectPage/Controller/ProjectPageViewController.swift
@@ -52,6 +52,31 @@ public final class ProjectPageViewController: UIViewController, MessageBannerVie
   private var pinchToZoomData: PinchToZoomData?
   internal var overlayView: OverlayView? = OverlayView(frame: .zero)
 
+  static func navigationController(withViewControllers viewControllers: [UIViewController])
+    -> UINavigationController {
+    let nav = NavigationController()
+    nav.viewControllers = viewControllers
+
+    nav.modalPresentationStyle =
+      AppEnvironment.current.device.userInterfaceIdiom == .pad ? .fullScreen : .formSheet
+
+    return nav
+  }
+
+  public static func navigationController(
+    withProjectOrParam projectOrParam: Either<Project, any ProjectPageParam>,
+    refInfo: RefInfo?,
+    secretRewardToken: String? = nil
+  ) -> UINavigationController {
+    let vc = ProjectPageViewController.configuredWith(
+      projectOrParam: projectOrParam,
+      refInfo: refInfo,
+      secretRewardToken: secretRewardToken
+    )
+
+    return ProjectPageViewController.navigationController(withViewControllers: [vc])
+  }
+
   public static func configuredWith(
     projectOrParam: Either<Project, any ProjectPageParam>,
     refInfo: RefInfo?,
@@ -575,10 +600,11 @@ public final class ProjectPageViewController: UIViewController, MessageBannerVie
       .observeForUI()
       .observeValues { [weak self] project in
         guard let self else { return }
-        let vc = ProjectPageViewController.configuredWith(
-          projectOrParam: Either<Project, any ProjectPageParam>.right(project.projectPageParam),
+        let vc = ProjectPageViewController.navigationController(
+          withProjectOrParam: .right(project.projectPageParam),
           refInfo: RefInfo(.similarProjects)
         )
+
         if let nav = self.navigationController {
           nav.pushViewController(vc, animated: true)
         } else {

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/Search/Controller/SearchViewController.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/Search/Controller/SearchViewController.swift
@@ -232,13 +232,10 @@ internal final class SearchViewController: UITableViewController {
   }
 
   fileprivate func goTo(project projectParam: ProjectPageParam, refTag: RefTag) {
-    let vc = ProjectPageViewController.configuredWith(
-      projectOrParam: Either.right(projectParam),
+    let nav = ProjectPageViewController.navigationController(
+      withProjectOrParam: Either.right(projectParam),
       refInfo: RefInfo(refTag)
     )
-
-    let nav = NavigationController(rootViewController: vc)
-    nav.modalPresentationStyle = self.traitCollection.userInterfaceIdiom == .pad ? .fullScreen : .formSheet
 
     self.present(nav, animated: true, completion: nil)
   }

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/SurveyResponse/Controller/PledgeManagerWebViewController.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/SurveyResponse/Controller/PledgeManagerWebViewController.swift
@@ -118,11 +118,13 @@ internal final class PledgeManagerWebViewController: WebViewController {
   // MARK: - Deeplinks
 
   fileprivate func goToProject(param: Param, refTag: RefTag?) {
-    let vc = ProjectPageViewController.configuredWith(
-      projectOrParam: .right(param),
+    /// Instead of using the helper `self.presentViewController`, use the project page's preferred navigation wrapper.
+    let nav = ProjectPageViewController.navigationController(
+      withProjectOrParam: .right(param),
       refInfo: RefInfo(refTag)
     )
-    self.presentViewController(vc)
+
+    self.present(nav, animated: true, completion: nil)
   }
 
   fileprivate func goToUpdate(project: Project, update: Update) {

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/ThanksProjects/Controller/ThanksViewController.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/ThanksProjects/Controller/ThanksViewController.swift
@@ -214,13 +214,10 @@ internal final class ThanksViewController: UIViewController, UITableViewDelegate
 
   fileprivate func goToProject(_ project: Project, projects _: [Project], refTag: RefTag) {
     let projectParam = Either<Project, any ProjectPageParam>(left: project)
-    let vc = ProjectPageViewController.configuredWith(
-      projectOrParam: projectParam,
+    let nav = ProjectPageViewController.navigationController(
+      withProjectOrParam: projectParam,
       refInfo: RefInfo(refTag)
     )
-
-    let nav = NavigationController(rootViewController: vc)
-    nav.modalPresentationStyle = self.traitCollection.userInterfaceIdiom == .pad ? .fullScreen : .formSheet
 
     self.present(nav, animated: true, completion: nil)
   }


### PR DESCRIPTION
# 📲 What

1. Add a helper method, `ProjectPageViewController.navigationController(withProjectOrParam:refInfo:secretRewardToken)`. The method creates a project page, in a navigation controller, with the correct presentation mode. 
2. Update everywhere that created a project page to use the new helper methods

# 🤔 Why

We're going to run an experiment to use `.fullScreen` instead of `.formSheet` on the project page. This will be much easier once we only have one call site to update the presentation mode.

# 👀 Note
This PR is a follow-on to the refactoring in #2839. I split them out because it seemed clearer!