### PR TITLE
CHECK-46: Fix warnings from Statsig diagnostics

### DIFF
--- a/Experimentation/Sources/Experimentation/StatsigClient.swift
+++ b/Experimentation/Sources/Experimentation/StatsigClient.swift
@@ -14,19 +14,49 @@ public enum StatsigClientSDKKey {
   case production(String)
 }
 
-public final class StatsigClient: StatsigClientType {
-  private let sdkKey: StatsigClientSDKKey
+/// A thin wrapper around the Statsig class `StatsigClient`.
+public final class StatsigWrapper: StatsigClientType {
+  private let client: StatsigClient
 
-  public init(sdkKey: StatsigClientSDKKey) {
-    self.sdkKey = sdkKey
+  public convenience init(sdkKey: StatsigClientSDKKey, userID: String?) {
+    let key: String
+    let tier: StatsigEnvironment.EnvironmentTier
+
+    switch sdkKey {
+    case let .production(prodKey):
+      key = prodKey
+      tier = .Production
+    case let .staging(stagingKey):
+      key = stagingKey
+      tier = .Staging
+    }
+
+    let client = StatsigClient(
+      sdkKey: key,
+      user: StatsigUser(userID: userID),
+      options: StatsigOptions(environment: StatsigEnvironment(tier: tier))
+    ) { error in
+      if let error {
+        debugPrint("Statsig reload error: \(error.localizedDescription)")
+      } else {
+        NotificationCenter.default.post(name: StatsigLoadedNotification, object: nil)
+        debugPrint("Successfully reloaded Statsig")
+      }
+    }
+
+    self.init(client: client)
+  }
+
+  init(client: StatsigClient) {
+    self.client = client
   }
 
   public func showDebugger() {
-    Statsig.openDebugView()
+    self.client.openDebugView()
   }
 
   public func reload(withUserID userID: String?) {
-    Statsig.updateUserWithResult(StatsigUser(userID: userID)) { error in
+    self.client.updateUserWithResult(StatsigUser(userID: userID)) { error in
       if let error {
         debugPrint("Statsig reload error: \(error.localizedDescription)")
       } else {
@@ -36,52 +66,23 @@ public final class StatsigClient: StatsigClientType {
     }
   }
 
-  /// Initializes the SDK with the given user. Call once on app launch.
-  public func initialize(userID: String?) {
-    let key: String
-    let tier: StatsigEnvironment.EnvironmentTier
-
-    switch self.sdkKey {
-    case let .production(prodKey):
-      key = prodKey
-      tier = .Production
-    case let .staging(stagingKey):
-      key = stagingKey
-      tier = .Staging
-    }
-
-    Statsig.initialize(
-      sdkKey: key,
-      user: StatsigUser(userID: userID),
-      options: StatsigOptions(environment: StatsigEnvironment(tier: tier))
-    ) { error in
-      if let error {
-        debugPrint("Statsig initializer error: \(error.localizedDescription)")
-      } else {
-        NotificationCenter.default.post(name: StatsigLoadedNotification, object: nil)
-        debugPrint("Successfully initialized Statsig")
-      }
-    }
-  }
-
-  /// Returns `true` if the named gate is enabled for the current user.
   public func checkGate(for feature: StatsigFeature) -> Bool? {
-    guard Statsig.isInitialized() else {
+    guard self.client.isInitialized() else {
       return nil
     }
 
-    return Statsig.checkGate(feature.rawValue)
+    return self.client.checkGate(feature.rawValue)
   }
 
   public func boolValue<T: StatsigExperimentProtocol>(
     forKey key: T.Parameters,
     inExperiment experiment: T
   ) -> Bool? {
-    guard Statsig.isInitialized() else {
+    guard self.client.isInitialized() else {
       return nil
     }
 
-    return Statsig
+    return self.client
       .getExperiment(experiment.name.rawValue)
       .getValue(forKey: key.rawValue)
   }

--- a/Experimentation/Sources/Experimentation/StatsigClient.swift
+++ b/Experimentation/Sources/Experimentation/StatsigClient.swift
@@ -1,9 +1,23 @@
 internal import Statsig
+import Foundation
+
+public let StatsigLoadedNotification = NSNotification.Name("StatsigClientDataReloaded")
+
+/// SDK keys in Statsig can be associated with "environment tiers" - development, staging or production.
+/// The Statsig client needs to be initialized with the same tier that the SDK key supports.
+///
+/// See Statsig's documentation: https://docs.statsig.com/guides/using-environments
+public enum StatsigClientSDKKey {
+  /// An SDK key which will be sent to the Staging tier of Statsig.
+  case staging(String)
+  /// An SDK key which will be sent to the Production tier of Statsig
+  case production(String)
+}
 
 public final class StatsigClient: StatsigClientType {
-  private let sdkKey: String
+  private let sdkKey: StatsigClientSDKKey
 
-  public init(sdkKey: String) {
+  public init(sdkKey: StatsigClientSDKKey) {
     self.sdkKey = sdkKey
   }
 
@@ -16,6 +30,7 @@ public final class StatsigClient: StatsigClientType {
       if let error {
         debugPrint("Statsig reload error: \(error.localizedDescription)")
       } else {
+        NotificationCenter.default.post(name: StatsigLoadedNotification, object: nil)
         debugPrint("Successfully reloaded Statsig")
       }
     }
@@ -23,24 +38,49 @@ public final class StatsigClient: StatsigClientType {
 
   /// Initializes the SDK with the given user. Call once on app launch.
   public func initialize(userID: String?) {
-    Statsig.initialize(sdkKey: self.sdkKey, user: StatsigUser(userID: userID)) { error in
+    let key: String
+    let tier: StatsigEnvironment.EnvironmentTier
+
+    switch self.sdkKey {
+    case let .production(prodKey):
+      key = prodKey
+      tier = .Production
+    case let .staging(stagingKey):
+      key = stagingKey
+      tier = .Staging
+    }
+
+    Statsig.initialize(
+      sdkKey: key,
+      user: StatsigUser(userID: userID),
+      options: StatsigOptions(environment: StatsigEnvironment(tier: tier))
+    ) { error in
       if let error {
         debugPrint("Statsig initializer error: \(error.localizedDescription)")
       } else {
+        NotificationCenter.default.post(name: StatsigLoadedNotification, object: nil)
         debugPrint("Successfully initialized Statsig")
       }
     }
   }
 
   /// Returns `true` if the named gate is enabled for the current user.
-  public func checkGate(for feature: StatsigFeature) -> Bool {
-    Statsig.checkGate(feature.rawValue)
+  public func checkGate(for feature: StatsigFeature) -> Bool? {
+    guard Statsig.isInitialized() else {
+      return nil
+    }
+
+    return Statsig.checkGate(feature.rawValue)
   }
 
   public func boolValue<T: StatsigExperimentProtocol>(
     forKey key: T.Parameters,
     inExperiment experiment: T
   ) -> Bool? {
+    guard Statsig.isInitialized() else {
+      return nil
+    }
+
     return Statsig
       .getExperiment(experiment.name.rawValue)
       .getValue(forKey: key.rawValue)

--- a/Experimentation/Sources/Experimentation/StatsigClientType.swift
+++ b/Experimentation/Sources/Experimentation/StatsigClientType.swift
@@ -13,7 +13,8 @@ public protocol StatsigClientType: AnyObject {
   func showDebugger()
 
   /// Returns whether a feature gate is enabled for the current user.
-  func checkGate(for feature: StatsigFeature) -> Bool
+  /// May return `nil` if `Statsig` has not completed initialization.
+  func checkGate(for feature: StatsigFeature) -> Bool?
 
   /// Returns a boolean value from an experiment.
   /// May return `nil` if the experiment or key are invalid.

--- a/Experimentation/Sources/Experimentation/StatsigClientType.swift
+++ b/Experimentation/Sources/Experimentation/StatsigClientType.swift
@@ -2,9 +2,6 @@ import Foundation
 
 /// Abstracts the Statsig SDK so the rest of the app never imports Statsig directly.
 public protocol StatsigClientType: AnyObject {
-  /// Initializes Statsig and fetches gates/configs for the given user.
-  func initialize(userID: String?)
-
   /// Reloads Statsig with values the for the given user.
   /// Switches the user and pulls in their current values.
   func reload(withUserID userID: String?)

--- a/Experimentation/Sources/ExperimentationTestHelpers/MockStatsigClient.swift
+++ b/Experimentation/Sources/ExperimentationTestHelpers/MockStatsigClient.swift
@@ -18,7 +18,7 @@ public final class MockStatsigWrapper: StatsigClientType {
   public func showDebugger() {}
 
   public func checkGate(for feature: StatsigFeature) -> Bool? {
-    self.features[feature] ?? false
+    self.features[feature]
   }
 
   /// Set mock values for an experiment using MockStatsigExperiment.

--- a/Experimentation/Sources/ExperimentationTestHelpers/MockStatsigClient.swift
+++ b/Experimentation/Sources/ExperimentationTestHelpers/MockStatsigClient.swift
@@ -1,7 +1,7 @@
 import Experimentation
 import Foundation
 
-public final class MockStatsigClient: StatsigClientType {
+public final class MockStatsigWrapper: StatsigClientType {
   public var features: [StatsigFeature: Bool] = [:]
 
   // Set experiments by calling overrideExperiment(_,withMock:)

--- a/Experimentation/Sources/ExperimentationTestHelpers/MockStatsigClient.swift
+++ b/Experimentation/Sources/ExperimentationTestHelpers/MockStatsigClient.swift
@@ -17,7 +17,7 @@ public final class MockStatsigClient: StatsigClientType {
 
   public func showDebugger() {}
 
-  public func checkGate(for feature: StatsigFeature) -> Bool {
+  public func checkGate(for feature: StatsigFeature) -> Bool? {
     self.features[feature] ?? false
   }
 

--- a/Experimentation/Tests/ExperimentationTests/StatsigClientTests.swift
+++ b/Experimentation/Tests/ExperimentationTests/StatsigClientTests.swift
@@ -12,14 +12,16 @@ final class StatsigClientTests: XCTestCase {
     }
 
     self.wait(for: [expectation])
+  }
 
+  override func tearDown() {
     Statsig.removeAllOverrides()
   }
 
   func testClient_returnsBoolValue_forExperiment() {
     let experiment = iOSTestExperiment()
 
-    let client = StatsigClient(sdkKey: "")
+    let client = StatsigClient(sdkKey: .production(""))
 
     XCTAssertNil(client.boolValue(forKey: .experiment_parameter_one, inExperiment: experiment))
 
@@ -29,12 +31,14 @@ final class StatsigClientTests: XCTestCase {
   }
 
   func testClient_returnsBoolValue_forFeatureGate() {
-    let client = StatsigClient(sdkKey: "")
-
-    XCTAssertFalse(client.checkGate(for: .videoFeed))
+    let client = StatsigClient(sdkKey: .production(""))
 
     Statsig.overrideGate("video_feed", value: true)
 
-    XCTAssertTrue(client.checkGate(for: .videoFeed))
+    XCTAssertEqual(client.checkGate(for: .videoFeed), true)
+
+    Statsig.overrideGate("video_feed", value: false)
+
+    XCTAssertEqual(client.checkGate(for: .videoFeed), false)
   }
 }

--- a/Experimentation/Tests/ExperimentationTests/StatsigClientTests.swift
+++ b/Experimentation/Tests/ExperimentationTests/StatsigClientTests.swift
@@ -2,42 +2,89 @@
 import Statsig
 import XCTest
 
-final class StatsigClientTests: XCTestCase {
-  override func setUp() {
+final class StatsigWrapperTests: XCTestCase {
+  override func tearDown() {
     let expectation = XCTestExpectation(description: "Waiting for Statsig")
 
-    // Statsig uses a singleton, so fake-initializing it first.
-    Statsig.initialize(sdkKey: "fake", options: StatsigOptions(initializeOffline: true)) { _ in
+    let statsig = StatsigClient(sdkKey: "fake", options: StatsigOptions(initializeOffline: true)) { _ in
       expectation.fulfill()
     }
 
     self.wait(for: [expectation])
-  }
 
-  override func tearDown() {
-    Statsig.removeAllOverrides()
+    // The overrides use an internal store (not linked to an individual `StatsigClient`) and are stateful.
+    // Clean them up to prevent flaky tests.
+    statsig.removeAllOverrides()
   }
 
   func testClient_returnsBoolValue_forExperiment() {
     let experiment = iOSTestExperiment()
+    let expectation = XCTestExpectation(description: "Waiting for Statsig")
 
-    let client = StatsigClient(sdkKey: .production(""))
+    let statsig = StatsigClient(sdkKey: "fake", options: StatsigOptions(initializeOffline: true)) { _ in
+      expectation.fulfill()
+    }
 
-    XCTAssertNil(client.boolValue(forKey: .experiment_parameter_one, inExperiment: experiment))
+    let client = StatsigWrapper(client: statsig)
 
-    Statsig.overrideConfig("ios_test_experiment", value: ["experiment_parameter_one": true])
+    XCTAssertNil(
+      client.boolValue(forKey: .experiment_parameter_one, inExperiment: experiment),
+      "Value should be nil because Statsig isn't initialized yet."
+    )
+    XCTAssertNil(
+      client.boolValue(forKey: .experiment_parameter_two, inExperiment: experiment),
+      "Value should be nil because Statsig isn't initialized yet."
+    )
+
+    self.wait(for: [expectation])
+
+    XCTAssertNil(
+      client.boolValue(forKey: .experiment_parameter_one, inExperiment: experiment),
+      "Value should be nil because experiment has no value."
+    )
+    XCTAssertNil(
+      client.boolValue(forKey: .experiment_parameter_two, inExperiment: experiment),
+      "Value should be nil because Statsig isn't initialized yet."
+    )
+
+    statsig.overrideConfig(
+      "ios_test_experiment",
+      value: [
+        "experiment_parameter_one": true,
+        "experiment_parameter_two": false
+      ]
+    )
 
     XCTAssertEqual(client.boolValue(forKey: .experiment_parameter_one, inExperiment: experiment), true)
+    XCTAssertEqual(client.boolValue(forKey: .experiment_parameter_two, inExperiment: experiment), false)
   }
 
   func testClient_returnsBoolValue_forFeatureGate() {
-    let client = StatsigClient(sdkKey: .production(""))
+    let expectation = XCTestExpectation(description: "Waiting for Statsig")
+    let statsig = StatsigClient(sdkKey: "fake", options: StatsigOptions(initializeOffline: true)) { _ in
+      expectation.fulfill()
+    }
 
-    Statsig.overrideGate("video_feed", value: true)
+    let client = StatsigWrapper(client: statsig)
+
+    XCTAssertNil(
+      client.checkGate(for: .videoFeed),
+      "Gate should be nil because Statsig isn't initialized yet."
+    )
+
+    self.wait(for: [expectation])
+
+    XCTAssertEqual(
+      client.checkGate(for: .videoFeed),
+      false,
+      "Gate should be false because gate has no value."
+    )
+
+    statsig.overrideGate("video_feed", value: true)
 
     XCTAssertEqual(client.checkGate(for: .videoFeed), true)
 
-    Statsig.overrideGate("video_feed", value: false)
+    statsig.overrideGate("video_feed", value: false)
 
     XCTAssertEqual(client.checkGate(for: .videoFeed), false)
   }

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework-iOSTests/Kickstarter-iOS/Features/Discovery/Controller/DiscoveryPageViewControllerTests.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework-iOSTests/Kickstarter-iOS/Features/Discovery/Controller/DiscoveryPageViewControllerTests.swift
@@ -258,7 +258,7 @@ internal final class DiscoveryPageViewControllerTests: TestCase {
   }
 
   func testView_VideoFeedBanner() {
-    let mockStatsigClient = MockStatsigClient()
+    let mockStatsigClient = MockStatsigWrapper()
     mockStatsigClient.features = [.videoFeed: true]
 
     // TODO: Update to all languages once translations are in [mbl-3158](https://kickstarter.atlassian.net/browse/MBL-3158)

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework-iOSTests/Kickstarter-iOS/Features/Search/Controller/SearchViewControllerTests.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework-iOSTests/Kickstarter-iOS/Features/Search/Controller/SearchViewControllerTests.swift
@@ -246,7 +246,7 @@ internal final class SearchViewContollerTests: TestCase {
       GraphAPI.SearchQuery.Data.activeResults
     )]
 
-    let mockStatsigClient = MockStatsigClient()
+    let mockStatsigClient = MockStatsigWrapper()
     mockStatsigClient.features = [.videoFeed: true]
 
     // TODO: Update to all languages once translations are in [mbl-3158](https://kickstarter.atlassian.net/browse/MBL-3158)

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/AppDelegateViewModel.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/AppDelegateViewModel.swift
@@ -1,3 +1,4 @@
+import Experimentation
 import FirebaseCrashlytics
 import KsApi
 import Library
@@ -100,8 +101,8 @@ public protocol AppDelegateViewModelOutputs {
   /// Emits when the application should configure Segment with an instance of Braze.
   var configureSegmentWithBraze: Signal<String, Never> { get }
 
-  /// Emits when the application should configure Statsig and returns the correct API Key.
-  var configureStatsig: Signal<String, Never> { get }
+  /// Emits when the application should configure Statsig
+  var configureStatsig: Signal<StatsigClientSDKKey, Never> { get }
 
   /// Return this value in the delegate method.
   var continueUserActivityReturnValue: MutableProperty<Bool> { get }
@@ -558,9 +559,11 @@ public final class AppDelegateViewModel: AppDelegateViewModelType, AppDelegateVi
 
     self.configureStatsig = self.applicationLaunchOptionsProperty.signal.ignoreValues()
       .map { _ in
-        AppEnvironment.current.mainBundle.isRelease
-          ? Secrets.Statsig.production
-          : Secrets.Statsig.staging
+        if AppEnvironment.current.mainBundle.isRelease {
+          return .production(Secrets.Statsig.production)
+        } else {
+          return .staging(Secrets.Statsig.staging)
+        }
       }
 
     self.setApplicationShortcutItems = currentUserEvent
@@ -768,7 +771,7 @@ public final class AppDelegateViewModel: AppDelegateViewModelType, AppDelegateVi
   public let applicationIconBadgeNumber: Signal<Int, Never>
   public let configureFirebase: Signal<(), Never>
   public let configureSegmentWithBraze: Signal<String, Never>
-  public let configureStatsig: Signal<String, Never>
+  public let configureStatsig: Signal<StatsigClientSDKKey, Never>
   public let continueUserActivityReturnValue = MutableProperty(false)
   public let emailVerificationCompleted: Signal<(String, Bool), Never>
   public let findRedirectUrl: Signal<URL, Never>

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/Discovery/Controller/DiscoveryPageViewController.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/Discovery/Controller/DiscoveryPageViewController.swift
@@ -1,3 +1,4 @@
+import Experimentation
 import KDS
 import KsApi
 import Library
@@ -17,16 +18,11 @@ internal final class DiscoveryPageViewController: UITableViewController {
 
   // MARK: - Properties
 
-  private var configUpdatedObserver: Any?
-  private var currentEnvironmentChangedObserver: Any?
-  private var blockedUserObserver: Any?
+  private var observers: [Any] = []
   fileprivate let dataSource = DiscoveryProjectsDataSource()
   public weak var delegate: DiscoveryPageViewControllerDelegate?
   fileprivate var emptyStatesController: EmptyStatesViewController?
   private lazy var headerLabel = { UILabel(frame: .zero) }()
-  private var onboardingCompletedObserver: Any?
-  private var sessionEndedObserver: Any?
-  private var sessionStartedObserver: Any?
 
   internal static func configuredWith(sort: DiscoveryParams.Sort) -> DiscoveryPageViewController {
     let vc = Storyboard.DiscoveryPage.instantiate(DiscoveryPageViewController.self)
@@ -52,38 +48,32 @@ internal final class DiscoveryPageViewController: UITableViewController {
     )
     self.refreshControl = refreshControl
 
-    self.onboardingCompletedObserver = NotificationCenter.default
-      .addObserver(forName: .ksr_onboardingCompleted, object: nil, queue: nil) { [weak self] _ in
-        self?.viewModel.inputs.onboardingCompleted()
-      }
+    self.subscribe(toNotification: .ksr_onboardingCompleted) { [weak self] _ in
+      self?.viewModel.inputs.onboardingCompleted()
+    }
 
-    self.sessionStartedObserver = NotificationCenter.default
-      .addObserver(forName: .ksr_sessionStarted, object: nil, queue: nil) { [weak self] _ in
-        self?.viewModel.inputs.userSessionStarted()
-      }
+    self.subscribe(toNotification: .ksr_sessionStarted) { [weak self] _ in
+      self?.viewModel.inputs.userSessionStarted()
+    }
 
-    self.sessionEndedObserver = NotificationCenter.default
-      .addObserver(forName: .ksr_sessionEnded, object: nil, queue: nil) { [weak self] _ in
-        self?.viewModel.inputs.userSessionEnded()
-      }
+    self.subscribe(toNotification: .ksr_sessionEnded) { [weak self] _ in
+      self?.viewModel.inputs.userSessionEnded()
+    }
 
-    self.currentEnvironmentChangedObserver = NotificationCenter.default
-      .addObserver(forName: .ksr_environmentChanged, object: nil, queue: nil, using: { [weak self] _ in
-        self?.viewModel.inputs.currentEnvironmentChanged(
-          environment:
-          AppEnvironment.current.apiService.serverConfig.environment
-        )
-      })
+    self.subscribe(toNotification: .ksr_environmentChanged) { [weak self] _ in
+      self?.viewModel.inputs.currentEnvironmentChanged(
+        environment:
+        AppEnvironment.current.apiService.serverConfig.environment
+      )
+    }
 
-    self.configUpdatedObserver = NotificationCenter.default
-      .addObserver(forName: .ksr_configUpdated, object: nil, queue: nil, using: { [weak self] _ in
-        self?.viewModel.inputs.configUpdated(config: AppEnvironment.current.config)
-      })
+    self.subscribe(toNotification: StatsigLoadedNotification) { [weak self] _ in
+      self?.viewModel.inputs.configUpdated()
+    }
 
-    self.blockedUserObserver = NotificationCenter.default
-      .addObserver(forName: .ksr_blockedUser, object: nil, queue: nil, using: { [weak self] _ in
-        self?.viewModel.inputs.blockedUser()
-      })
+    self.subscribe(toNotification: .ksr_blockedUser) { [weak self] _ in
+      self?.viewModel.inputs.blockedUser()
+    }
 
     let emptyVC = EmptyStatesViewController.configuredWith(emptyState: nil)
     self.emptyStatesController = emptyVC
@@ -100,13 +90,9 @@ internal final class DiscoveryPageViewController: UITableViewController {
   }
 
   deinit {
-    [
-      self.sessionEndedObserver,
-      self.sessionStartedObserver,
-      self.currentEnvironmentChangedObserver,
-      self.configUpdatedObserver,
-      self.onboardingCompletedObserver
-    ].forEach { $0.doIfSome(NotificationCenter.default.removeObserver) }
+    self.observers.forEach {
+      NotificationCenter.default.removeObserver($0)
+    }
   }
 
   internal override func viewWillAppear(_ animated: Bool) {
@@ -131,6 +117,19 @@ internal final class DiscoveryPageViewController: UITableViewController {
     super.viewDidLayoutSubviews()
 
     self.tableView.ksr_sizeHeaderFooterViewsToFit()
+  }
+
+  private func subscribe(
+    toNotification notification: Notification.Name,
+    using action: @escaping @Sendable (Notification) -> Void
+  ) {
+    let observer = NotificationCenter.default.addObserver(
+      forName: notification,
+      object: nil,
+      queue: nil,
+      using: action
+    )
+    self.observers.append(observer)
   }
 
   internal override func bindStyles() {

--- a/Kickstarter-iOS/AppDelegate.swift
+++ b/Kickstarter-iOS/AppDelegate.swift
@@ -464,7 +464,7 @@ internal final class AppDelegate: UIResponder, UIApplicationDelegate {
       }
   }
 
-  private func configureStatsig(with key: String) {
+  private func configureStatsig(with key: StatsigClientSDKKey) {
     let client = StatsigClient(sdkKey: key)
     AppEnvironment.updateStatsigClient(client)
 

--- a/Kickstarter-iOS/AppDelegate.swift
+++ b/Kickstarter-iOS/AppDelegate.swift
@@ -81,8 +81,10 @@ internal final class AppDelegate: UIResponder, UIApplicationDelegate {
         AppEnvironment.updateCurrentUser(user)
         // Update user in Braze.
         self?.braze?.changeUser(userId: String(user.id))
+
         // Update user in Segment.
         AppEnvironment.current.ksrAnalytics.identify(newUser: user)
+
         self?.viewModel.inputs.currentUserUpdatedInEnvironment()
       }
 
@@ -465,10 +467,8 @@ internal final class AppDelegate: UIResponder, UIApplicationDelegate {
   }
 
   private func configureStatsig(with key: StatsigClientSDKKey) {
-    let client = StatsigClient(sdkKey: key)
+    let client = StatsigWrapper(sdkKey: key, userID: AppEnvironment.current.currentUser?.id.toString())
     AppEnvironment.updateStatsigClient(client)
-
-    client.initialize(userID: AppEnvironment.current.currentUser?.id.toString())
   }
 
   private func fetchAndActivateRemoteConfig() {

--- a/Library/Sources/Library/Library/ViewModels/DiscoveryPageViewModel.swift
+++ b/Library/Sources/Library/Library/ViewModels/DiscoveryPageViewModel.swift
@@ -6,7 +6,7 @@ import UIKit
 
 public protocol DiscoveryPageViewModelInputs {
   /// Call when the Config has been updated in the AppEnvironment
-  func configUpdated(config: Config?)
+  func configUpdated()
 
   /// Call with the sort provided to the view.
   func configureWith(sort: DiscoveryParams.Sort)
@@ -337,9 +337,13 @@ public final class DiscoveryPageViewModel: DiscoveryPageViewModelType, Discovery
     .ignoreValues()
     .map(shouldShowPersonalization)
 
-    self.showVideoFeedBanner = self.viewWillAppearProperty.signal
-      .map { featureVideoFeedEnabled() }
-      .skipRepeats()
+    self.showVideoFeedBanner = Signal.merge(
+      self.viewWillAppearProperty.signal,
+      // Because the Discover page is the first page we see, it might appear before config values load.
+      self.configUpdatedSignal
+    )
+    .map { featureVideoFeedEnabled() }
+    .skipRepeats()
 
     self.goToCuratedProjects = self.personalizationCellTappedProperty.signal
       .map(cachedCategories)
@@ -379,9 +383,9 @@ public final class DiscoveryPageViewModel: DiscoveryPageViewModelType, Discovery
       }
   }
 
-  fileprivate let configUpdatedProperty = MutableProperty<Config?>(nil)
-  public func configUpdated(config: Config?) {
-    self.configUpdatedProperty.value = config
+  fileprivate let (configUpdatedSignal, configUpdatedObserver) = Signal<Void, Never>.pipe()
+  public func configUpdated() {
+    self.configUpdatedObserver.send(value: ())
   }
 
   fileprivate let currentEnvironmentChangedProperty = MutableProperty<EnvironmentType?>(nil)

--- a/LibraryTests/Library/Statsig/StatsigExperiment+HelperTests.swift
+++ b/LibraryTests/Library/Statsig/StatsigExperiment+HelperTests.swift
@@ -6,7 +6,7 @@ import XCTest
 final class StatsigExperimentHelperTests: TestCase {
   func testExperimentValue_IsOverriddenByMockExperimentValues() {
     let experiment = iOSTestExperiment()
-    let mockStatsigClient = MockStatsigClient()
+    let mockStatsigClient = MockStatsigWrapper()
 
     withEnvironment(statsigClient: mockStatsigClient) {
       XCTAssertEqual(experiment.boolValue(forKey: .experiment_parameter_one), nil)

--- a/LibraryTests/Library/Statsig/StatsigFeature+HelperTests.swift
+++ b/LibraryTests/Library/Statsig/StatsigFeature+HelperTests.swift
@@ -5,7 +5,7 @@ import XCTest
 
 final class StatsigFeatureHelpersTests: TestCase {
   func testFeatureIsFalse_whenStatsigFeatureOff() {
-    let mockStatsigClient = MockStatsigClient()
+    let mockStatsigClient = MockStatsigWrapper()
     mockStatsigClient.features[.videoFeed] = false
 
     withEnvironment(statsigClient: mockStatsigClient) {
@@ -14,7 +14,7 @@ final class StatsigFeatureHelpersTests: TestCase {
   }
 
   func testFeatureIsTrue_whenStatsigFeatureOn() {
-    let mockStatsigClient = MockStatsigClient()
+    let mockStatsigClient = MockStatsigWrapper()
     mockStatsigClient.features[.videoFeed] = true
 
     withEnvironment(statsigClient: mockStatsigClient) {


### PR DESCRIPTION
# 📲 What

This PR addresses some issues we discovered in our integration when we launched the Video Feed feature gate.

1. More gracefully (and explicitly) handle features and experiments that haven't loaded yet. This fixes warnings on the Statsig diagnostics console about the SDK not being initialized.
2. Explicitly declare the environment tier of the SDK. This fixes warnings on the Statsig diagnostics console about the environment tier of our client events not matching the expected environment tier.
3. Add `StatsigLoadedNotification` and use it on the Discover page, to reload `featureVideoFeedEnabled()` once Statsig is fully initialized. This fixes a race condition between Statsig's initialization and the Discover page appearing.
4. Use Statsig's `StatsigClient` directly, instead of through the singleton interface. This lets us write more granular tests. I also renamed _our_ client `StatsigWrapper` to fix a naming conflict.

# 🤔  Why?

We're trying to get our Statsig integration in tip-top shape.

# 👀   See

Before:
<img width="1054" height="125" alt="Screenshot 2026-05-04 at 5 15 27 PM" src="https://github.com/user-attachments/assets/07c72a44-58e4-4ded-bace-690f5ec0dc57" />

After:
<img width="1053" height="204" alt="Screenshot 2026-05-04 at 5 15 22 PM" src="https://github.com/user-attachments/assets/a366ae94-9623-410e-9e61-723fb8c51d40" />


