### PR TITLE
CHECK-83: Add experiment to make the Project page full screen

### DIFF
--- a/Experimentation/Sources/Experimentation/Experiments/FullScreenCheckoutExperiment.swift
+++ b/Experimentation/Sources/Experimentation/Experiments/FullScreenCheckoutExperiment.swift
@@ -1,0 +1,14 @@
+/// An experiment with how we present screens in checkout.
+public struct FullScreenCheckoutExperiment: StatsigExperimentProtocol {
+  typealias ExperimentParameters = FullScreenCheckoutExperiment.Parameters
+
+  public enum Parameters: String, CaseIterable {
+    case fullscreen_project_page
+  }
+
+  public var name: StatsigExperimentName {
+    return .fullscreen_checkout_experience_experiment
+  }
+
+  public init() {}
+}

--- a/Experimentation/Sources/Experimentation/Experiments/StatsigExperiment.swift
+++ b/Experimentation/Sources/Experimentation/Experiments/StatsigExperiment.swift
@@ -33,4 +33,5 @@ public protocol StatsigExperimentProtocol<Parameters> {
 /// Maps directly to the experiment name in the Statsig console.
 public enum StatsigExperimentName: String, CaseIterable {
   case ios_test_experiment
+  case fullscreen_checkout_experience_experiment
 }

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework-iOSTests/Kickstarter-iOS/Features/ProjectPage/Controller/ProjectPageViewControllerTests.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework-iOSTests/Kickstarter-iOS/Features/ProjectPage/Controller/ProjectPageViewControllerTests.swift
@@ -1,3 +1,4 @@
+import Experimentation
 @testable import Kickstarter_Framework
 @testable import KsApi
 @testable import KsApiTestHelpers
@@ -1321,6 +1322,59 @@ internal final class ProjectPageViewControllerTests: TestCase {
           named: "lang_\(language)_device_\(device)"
         )
       }
+    }
+  }
+
+  func testModalPresentationStyle_isAlwaysFullScreen_forIpad() {
+    let mockStatsig = MockStatsigWrapper()
+    let mockExperimentOff = MockExperiment<FullScreenCheckoutExperiment>([
+      .fullscreen_project_page: false
+    ])
+
+    mockStatsig.overrideExperiment(FullScreenCheckoutExperiment(), withMock: mockExperimentOff)
+
+    let mockDevice = MockDevice.init(userInterfaceIdiom: .pad)
+
+    withEnvironment(device: mockDevice, statsigClient: mockStatsig) {
+      XCTAssertEqual(ProjectPageViewController.projectPageModalPresentationStyle, .fullScreen)
+    }
+
+    let mockExperimentOn = MockExperiment<FullScreenCheckoutExperiment>([
+      .fullscreen_project_page: true
+    ])
+    mockStatsig.overrideExperiment(FullScreenCheckoutExperiment(), withMock: mockExperimentOn)
+
+    withEnvironment(device: mockDevice, statsigClient: mockStatsig) {
+      XCTAssertEqual(ProjectPageViewController.projectPageModalPresentationStyle, .fullScreen)
+    }
+  }
+
+  func testModalPresentationStyle_isFullScreen_onIPhone_whenExperimentIsOn() {
+    let mockStatsig = MockStatsigWrapper()
+    let mockExperimentOn = MockExperiment<FullScreenCheckoutExperiment>([
+      .fullscreen_project_page: true
+    ])
+    mockStatsig.overrideExperiment(FullScreenCheckoutExperiment(), withMock: mockExperimentOn)
+
+    let mockDevice = MockDevice.init(userInterfaceIdiom: .phone)
+
+    withEnvironment(device: mockDevice, statsigClient: mockStatsig) {
+      XCTAssertEqual(ProjectPageViewController.projectPageModalPresentationStyle, .fullScreen)
+    }
+  }
+
+  func testModalPresentationStyle_isFormSheet_onIPhone_whenExperimentIsOff() {
+    let mockStatsig = MockStatsigWrapper()
+    let mockExperimentOff = MockExperiment<FullScreenCheckoutExperiment>([
+      .fullscreen_project_page: false
+    ])
+
+    mockStatsig.overrideExperiment(FullScreenCheckoutExperiment(), withMock: mockExperimentOff)
+
+    let mockDevice = MockDevice.init(userInterfaceIdiom: .phone)
+
+    withEnvironment(device: mockDevice, statsigClient: mockStatsig) {
+      XCTAssertEqual(ProjectPageViewController.projectPageModalPresentationStyle, .formSheet)
     }
   }
 }

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/ProjectPage/Controller/ProjectPageViewController.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/ProjectPage/Controller/ProjectPageViewController.swift
@@ -1,5 +1,6 @@
 import AVFoundation
 import Combine
+import Experimentation
 import KDS
 import KsApi
 import Library
@@ -52,13 +53,27 @@ public final class ProjectPageViewController: UIViewController, MessageBannerVie
   private var pinchToZoomData: PinchToZoomData?
   internal var overlayView: OverlayView? = OverlayView(frame: .zero)
 
+  private static var projectPageModalPresentationStyle: UIModalPresentationStyle {
+    // iPad always presents with .fullScreen.
+    if AppEnvironment.current.device.userInterfaceIdiom == .pad {
+      return .fullScreen
+    }
+
+    let experiment = FullScreenCheckoutExperiment()
+    guard let isFullScreen = experiment.boolValue(forKey: .fullscreen_project_page) else {
+      // Default to .formSheet if the experiment can't be found
+      return .formSheet
+    }
+
+    return isFullScreen ? .fullScreen : .formSheet
+  }
+
   static func navigationController(withViewControllers viewControllers: [UIViewController])
     -> UINavigationController {
     let nav = NavigationController()
     nav.viewControllers = viewControllers
 
-    nav.modalPresentationStyle =
-      AppEnvironment.current.device.userInterfaceIdiom == .pad ? .fullScreen : .formSheet
+    nav.modalPresentationStyle = ProjectPageViewController.projectPageModalPresentationStyle
 
     return nav
   }

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/ProjectPage/Controller/ProjectPageViewController.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/ProjectPage/Controller/ProjectPageViewController.swift
@@ -53,7 +53,7 @@ public final class ProjectPageViewController: UIViewController, MessageBannerVie
   private var pinchToZoomData: PinchToZoomData?
   internal var overlayView: OverlayView? = OverlayView(frame: .zero)
 
-  private static var projectPageModalPresentationStyle: UIModalPresentationStyle {
+  static var projectPageModalPresentationStyle: UIModalPresentationStyle {
     // iPad always presents with .fullScreen.
     if AppEnvironment.current.device.userInterfaceIdiom == .pad {
       return .fullScreen

--- a/Library/Sources/Library/Library/Statsig/StatsigExperiment+Helpers.swift
+++ b/Library/Sources/Library/Library/Statsig/StatsigExperiment+Helpers.swift
@@ -15,6 +15,8 @@ public extension StatsigExperimentName {
     switch self {
     case .ios_test_experiment:
       return iOSTestExperiment()
+    case .fullscreen_checkout_experience_experiment:
+      return FullScreenCheckoutExperiment()
     }
   }
 }


### PR DESCRIPTION
# 📲 What

1. Add `FullScreenCheckoutExperiment` to the `Experimentation` module
2. Add a check for `fullscreen_project_page` to the Project page, and use it to return the correct `UIModalPresentationStyle`

# 🤔 Why

This hooks up the guts for our first real A/B experiment to make the Project page full screen. There will be a few follow-up PRs to this (adding more parameters and more complex behavior), but this is the guts of it.

I also set up the experiment on the Statsig console.

# 👀 See
Experiment off:
<img height="500" alt="Screenshot 2026-05-06 at 11 59 14 AM" src="https://github.com/user-attachments/assets/26fc44d8-1fbf-495a-81a2-d9bf74c07fec" />

Experiment on:
<img height="500" alt="Screenshot 2026-05-06 at 2 18 12 PM" src="https://github.com/user-attachments/assets/9d95a419-3df3-4295-abc2-cfde7eb5ad2e" />

