### PR TITLE
SDUI: Rich Text Example direct link field

### DIFF
--- a/GraphAPI/Sources/Operations/Queries/RichTextExampleProjectBySlugQuery.graphql.swift
+++ b/GraphAPI/Sources/Operations/Queries/RichTextExampleProjectBySlugQuery.graphql.swift
@@ -1,0 +1,128 @@
+// @generated
+// This file was automatically generated and should not be edited.
+
+@_exported import ApolloAPI
+
+public class RichTextExampleProjectBySlugQuery: GraphQLQuery {
+  public static let operationName: String = "RichTextExampleProjectBySlugQuery"
+  public static let operationDocument: ApolloAPI.OperationDocument = .init(
+    definition: .init(
+      #"query RichTextExampleProjectBySlugQuery($slug: String!) { project(slug: $slug) { __typename id name storyRichText { __typename ...RichTextComponentFragment } } }"#,
+      fragments: [RichTextComponentFragment.self, RichTextItemFragment.self]
+    ))
+
+  public var slug: String
+
+  public init(slug: String) {
+    self.slug = slug
+  }
+
+  public var __variables: Variables? { ["slug": slug] }
+
+  public struct Data: GraphAPI.SelectionSet {
+    public let __data: DataDict
+    public init(_dataDict: DataDict) { __data = _dataDict }
+
+    public static var __parentType: ApolloAPI.ParentType { GraphAPI.Objects.Query }
+    public static var __selections: [ApolloAPI.Selection] { [
+      .field("project", Project?.self, arguments: ["slug": .variable("slug")]),
+    ] }
+
+    /// Fetches a project given its slug or pid.
+    public var project: Project? { __data["project"] }
+
+    public init(
+      project: Project? = nil
+    ) {
+      self.init(_dataDict: DataDict(
+        data: [
+          "__typename": GraphAPI.Objects.Query.typename,
+          "project": project._fieldData,
+        ],
+        fulfilledFragments: [
+          ObjectIdentifier(RichTextExampleProjectBySlugQuery.Data.self)
+        ]
+      ))
+    }
+
+    /// Project
+    ///
+    /// Parent Type: `Project`
+    public struct Project: GraphAPI.SelectionSet {
+      public let __data: DataDict
+      public init(_dataDict: DataDict) { __data = _dataDict }
+
+      public static var __parentType: ApolloAPI.ParentType { GraphAPI.Objects.Project }
+      public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
+        .field("id", GraphAPI.ID.self),
+        .field("name", String.self),
+        .field("storyRichText", StoryRichText.self),
+      ] }
+
+      public var id: GraphAPI.ID { __data["id"] }
+      /// The project's name.
+      public var name: String { __data["name"] }
+      /// Return an itemized version of the story. This feature is in BETA: types can change anytime!
+      public var storyRichText: StoryRichText { __data["storyRichText"] }
+
+      public init(
+        id: GraphAPI.ID,
+        name: String,
+        storyRichText: StoryRichText
+      ) {
+        self.init(_dataDict: DataDict(
+          data: [
+            "__typename": GraphAPI.Objects.Project.typename,
+            "id": id,
+            "name": name,
+            "storyRichText": storyRichText._fieldData,
+          ],
+          fulfilledFragments: [
+            ObjectIdentifier(RichTextExampleProjectBySlugQuery.Data.Project.self)
+          ]
+        ))
+      }
+
+      /// Project.StoryRichText
+      ///
+      /// Parent Type: `RichTextComponent`
+      public struct StoryRichText: GraphAPI.SelectionSet {
+        public let __data: DataDict
+        public init(_dataDict: DataDict) { __data = _dataDict }
+
+        public static var __parentType: ApolloAPI.ParentType { GraphAPI.Objects.RichTextComponent }
+        public static var __selections: [ApolloAPI.Selection] { [
+          .field("__typename", String.self),
+          .fragment(RichTextComponentFragment.self),
+        ] }
+
+        public var items: [Item] { __data["items"] }
+
+        public struct Fragments: FragmentContainer {
+          public let __data: DataDict
+          public init(_dataDict: DataDict) { __data = _dataDict }
+
+          public var richTextComponentFragment: RichTextComponentFragment { _toFragment() }
+        }
+
+        public init(
+          items: [Item]
+        ) {
+          self.init(_dataDict: DataDict(
+            data: [
+              "__typename": GraphAPI.Objects.RichTextComponent.typename,
+              "items": items._fieldData,
+            ],
+            fulfilledFragments: [
+              ObjectIdentifier(RichTextExampleProjectBySlugQuery.Data.Project.StoryRichText.self),
+              ObjectIdentifier(RichTextComponentFragment.self)
+            ]
+          ))
+        }
+
+        public typealias Item = RichTextComponentFragment.Item
+      }
+    }
+  }
+}

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/RichTextExample/RichTextExampleProjectsView.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/RichTextExample/RichTextExampleProjectsView.swift
@@ -1,26 +1,57 @@
+import KDS
 import SwiftUI
 
 internal struct RichTextExampleProjectsView: View {
   private var viewModel = RichTextExampleProjectsViewModel()
   private var onSelectProject: (RichTextExampleProjectsViewModel.ProjectItem) -> Void
+  @State private var slug: String = ""
+  @State private var slugError: Bool = false
 
   init(onSelectProject: @escaping (RichTextExampleProjectsViewModel.ProjectItem) -> Void) {
     self.onSelectProject = onSelectProject
   }
 
+  @ViewBuilder var directLinkField: some View {
+    SwiftUI.Section {
+      TextField("Project slug or URL (optional)", text: self.$slug)
+        .autocorrectionDisabled()
+        .autocapitalization(.none)
+        .keyboardType(.URL)
+        .onChange(of: self.slug) { _, _ in
+          self.slugError = false
+        }
+        .onSubmit {
+          Task {
+            if let project = await self.viewModel.loadProject(slug: slug) {
+              self.onSelectProject(project)
+            } else {
+              self.slugError = true
+            }
+          }
+        }
+      if self.slugError {
+        Text("No project found")
+          .foregroundStyle(Colors.Text.Accent.red.swiftUIColor())
+      }
+    }
+  }
+
   var body: some View {
-    Group {
-      if self.viewModel.isLoading {
-        ProgressView()
-          .frame(maxWidth: .infinity, maxHeight: .infinity)
-      } else if let error = viewModel.errorMessage {
-        Text(error)
-          .foregroundColor(.red)
-          .frame(maxWidth: .infinity, maxHeight: .infinity)
-      } else {
-        List(self.viewModel.projects) { project in
-          Button(project.name) {
-            self.onSelectProject(project)
+    List {
+      self.directLinkField
+      SwiftUI.Section {
+        if self.viewModel.isLoading {
+          ProgressView()
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if let error = viewModel.errorMessage {
+          Text(error)
+            .foregroundColor(.red)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else {
+          ForEach(self.viewModel.projects) { project in
+            Button(project.name) {
+              self.onSelectProject(project)
+            }
           }
         }
       }

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/RichTextExample/RichTextExampleProjectsViewModel.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/RichTextExample/RichTextExampleProjectsViewModel.swift
@@ -18,6 +18,51 @@ internal final class RichTextExampleProjectsViewModel {
   private(set) var isLoading = true
   private(set) var errorMessage: String?
 
+  private static func extractSlug(from input: String) -> String? {
+    // Test for url slug: foo/bar
+    if input.contains("/"), !input.hasPrefix("http"), !input.hasPrefix("https") {
+      let parts = input.split(separator: "/").map(String.init)
+      if parts.count == 2, !parts[0].isEmpty, !parts[1].isEmpty {
+        return parts.joined(separator: "/")
+      }
+    }
+
+    // Test for url: (whatever kickstarter domain)/projects/foo/bar
+    if
+      let url = URL(string: input),
+      let components = URLComponents(url: url, resolvingAgainstBaseURL: false) {
+      let pathComponents = components.path.split(separator: "/").map(String.init)
+      if pathComponents.count >= 3, pathComponents[0].lowercased() == "projects" {
+        let owner = pathComponents[1]
+        let name = pathComponents[2]
+        if !owner.isEmpty, !name.isEmpty {
+          return "\(owner)/\(name)"
+        }
+      }
+    }
+
+    // No correct result found
+    return nil
+  }
+
+  func loadProject(slug slugOrURL: String) async -> ProjectItem? {
+    // Normalize input: accept either a raw slug "foo/bar" or a Kickstarter project URL
+    guard let slug = Self.extractSlug(from: slugOrURL) else {
+      return nil
+    }
+
+    let result = try? await AppEnvironment.current.apiService.fetch(
+      query: RichTextExampleProjectBySlugQuery(slug: slug)
+    )
+    guard let project = result?.project else { return nil }
+    let item = ProjectItem(
+      id: project.id,
+      name: project.name,
+      richText: project.storyRichText.fragments.richTextComponentFragment
+    )
+    return item
+  }
+
   func loadProjects() async {
     guard self.projects.isEmpty else { return }
 

--- a/graphql/queries/RichTextExampleProjectsQuery.graphql
+++ b/graphql/queries/RichTextExampleProjectsQuery.graphql
@@ -9,3 +9,14 @@ query RichTextExampleProjectsQuery{
     }
   }
 }
+
+query RichTextExampleProjectBySlugQuery($slug: String!){
+  project(slug: $slug) {
+    id
+    name
+    storyRichText {
+      ...RichTextComponentFragment
+    }
+  }
+}
+


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Adds a little text field to the top of the Rich Text Example view in the bug menu to jump to the project story for a specific project.

# 🤔 Why

Only certain projects have video/audio/oembed fields, so this helps with testing.

# 🛠 How

Added a little text field to the top of the example view, and when someone types a slug or a project URL in there, it loads a new GraphQL query to just fetch that specific project's story, and renders it.

# 👀 See

<img width="640" height="1266" alt="Screen Recording 2026-05-06 at 13 10 24" src="https://github.com/user-attachments/assets/e135f0c0-91a2-47f2-a26a-7f576d9bbc7c" />


