### PR TITLE
SDUI: Video formats for RichTextElement.Video

### DIFF
--- a/GraphAPI/GraphAPITestMocks/AttachedVideo+Mock.graphql.swift
+++ b/GraphAPI/GraphAPITestMocks/AttachedVideo+Mock.graphql.swift
@@ -10,15 +10,21 @@ public class AttachedVideo: MockObject {
   public typealias MockValueCollectionType = Array<Mock<AttachedVideo>>
 
   public struct MockFields {
+    @Field<[AttachedVideoFormat?]>("formats") public var formats
     @Field<GraphAPI.ID>("id") public var id
+    @Field<String>("poster") public var poster
   }
 }
 
 public extension Mock where O == AttachedVideo {
   convenience init(
-    id: GraphAPI.ID? = nil
+    formats: [Mock<AttachedVideoFormat>?]? = nil,
+    id: GraphAPI.ID? = nil,
+    poster: String? = nil
   ) {
     self.init()
+    _setList(formats, for: \.formats)
     _setScalar(id, for: \.id)
+    _setScalar(poster, for: \.poster)
   }
 }

--- a/GraphAPI/GraphAPITestMocks/AttachedVideoFormat+Mock.graphql.swift
+++ b/GraphAPI/GraphAPITestMocks/AttachedVideoFormat+Mock.graphql.swift
@@ -1,0 +1,36 @@
+// @generated
+// This file was automatically generated and should not be edited.
+
+import ApolloTestSupport
+import GraphAPI
+
+public class AttachedVideoFormat: MockObject {
+  public static let objectType: ApolloAPI.Object = GraphAPI.Objects.AttachedVideoFormat
+  public static let _mockFields = MockFields()
+  public typealias MockValueCollectionType = Array<Mock<AttachedVideoFormat>>
+
+  public struct MockFields {
+    @Field<String>("encoding") public var encoding
+    @Field<String>("height") public var height
+    @Field<String>("profile") public var profile
+    @Field<String>("url") public var url
+    @Field<String>("width") public var width
+  }
+}
+
+public extension Mock where O == AttachedVideoFormat {
+  convenience init(
+    encoding: String? = nil,
+    height: String? = nil,
+    profile: String? = nil,
+    url: String? = nil,
+    width: String? = nil
+  ) {
+    self.init()
+    _setScalar(encoding, for: \.encoding)
+    _setScalar(height, for: \.height)
+    _setScalar(profile, for: \.profile)
+    _setScalar(url, for: \.url)
+    _setScalar(width, for: \.width)
+  }
+}

--- a/GraphAPI/Sources/Fragments/RichTextItemFragment.graphql.swift
+++ b/GraphAPI/Sources/Fragments/RichTextItemFragment.graphql.swift
@@ -5,7 +5,7 @@
 
 public struct RichTextItemFragment: GraphAPI.SelectionSet, Fragment {
   public static var fragmentDefinition: StaticString {
-    #"fragment RichTextItemFragment on RichTextItem { __typename ... on RichText { text link styles } ... on RichTextHeader { text link styles } ... on RichTextListItem { text link styles } ... on RichTextListOpen { _present } ... on RichTextListClose { _present } ... on RichTextPhoto { altText asset { __typename id } caption url } ... on RichTextAudio { altText asset { __typename id } caption url } ... on RichTextVideo { altText asset { __typename id } caption url } ... on RichTextOembed { width height version title type iframeUrl originalUrl thumbnailHeight thumbnailUrl thumbnailWidth } }"#
+    #"fragment RichTextItemFragment on RichTextItem { __typename ... on RichText { text link styles } ... on RichTextHeader { text link styles } ... on RichTextListItem { text link styles } ... on RichTextListOpen { _present } ... on RichTextListClose { _present } ... on RichTextPhoto { altText asset { __typename id } caption url } ... on RichTextAudio { altText asset { __typename id } caption url } ... on RichTextVideo { altText asset { __typename id poster formats { __typename encoding height width profile url } } caption url } ... on RichTextOembed { width height version title type iframeUrl originalUrl thumbnailHeight thumbnailUrl thumbnailWidth } }"#
   }
 
   public let __data: DataDict
@@ -428,22 +428,77 @@ public struct RichTextItemFragment: GraphAPI.SelectionSet, Fragment {
       public static var __selections: [ApolloAPI.Selection] { [
         .field("__typename", String.self),
         .field("id", GraphAPI.ID.self),
+        .field("poster", String?.self),
+        .field("formats", [Format?]?.self),
       ] }
 
       public var id: GraphAPI.ID { __data["id"] }
+      /// Image preview url
+      public var poster: String? { __data["poster"] }
+      public var formats: [Format?]? { __data["formats"] }
 
       public init(
-        id: GraphAPI.ID
+        id: GraphAPI.ID,
+        poster: String? = nil,
+        formats: [Format?]? = nil
       ) {
         self.init(_dataDict: DataDict(
           data: [
             "__typename": GraphAPI.Objects.AttachedVideo.typename,
             "id": id,
+            "poster": poster,
+            "formats": formats._fieldData,
           ],
           fulfilledFragments: [
             ObjectIdentifier(RichTextItemFragment.AsRichTextVideo.Asset.self)
           ]
         ))
+      }
+
+      /// AsRichTextVideo.Asset.Format
+      ///
+      /// Parent Type: `AttachedVideoFormat`
+      public struct Format: GraphAPI.SelectionSet {
+        public let __data: DataDict
+        public init(_dataDict: DataDict) { __data = _dataDict }
+
+        public static var __parentType: ApolloAPI.ParentType { GraphAPI.Objects.AttachedVideoFormat }
+        public static var __selections: [ApolloAPI.Selection] { [
+          .field("__typename", String.self),
+          .field("encoding", String.self),
+          .field("height", String.self),
+          .field("width", String.self),
+          .field("profile", String.self),
+          .field("url", String.self),
+        ] }
+
+        public var encoding: String { __data["encoding"] }
+        public var height: String { __data["height"] }
+        public var width: String { __data["width"] }
+        public var profile: String { __data["profile"] }
+        public var url: String { __data["url"] }
+
+        public init(
+          encoding: String,
+          height: String,
+          width: String,
+          profile: String,
+          url: String
+        ) {
+          self.init(_dataDict: DataDict(
+            data: [
+              "__typename": GraphAPI.Objects.AttachedVideoFormat.typename,
+              "encoding": encoding,
+              "height": height,
+              "width": width,
+              "profile": profile,
+              "url": url,
+            ],
+            fulfilledFragments: [
+              ObjectIdentifier(RichTextItemFragment.AsRichTextVideo.Asset.Format.self)
+            ]
+          ))
+        }
       }
     }
   }

--- a/GraphAPI/Sources/Schema/Objects/AttachedVideoFormat.graphql.swift
+++ b/GraphAPI/Sources/Schema/Objects/AttachedVideoFormat.graphql.swift
@@ -1,0 +1,11 @@
+// @generated
+// This file was automatically generated and should not be edited.
+
+import ApolloAPI
+
+public extension Objects {
+  static let AttachedVideoFormat = ApolloAPI.Object(
+    typename: "AttachedVideoFormat",
+    implementedInterfaces: []
+  )
+}

--- a/GraphAPI/Sources/Schema/SchemaMetadata.graphql.swift
+++ b/GraphAPI/Sources/Schema/SchemaMetadata.graphql.swift
@@ -134,6 +134,7 @@ public enum SchemaMetadata: ApolloAPI.SchemaMetadata {
     case "RichTextAudio": return GraphAPI.Objects.RichTextAudio
     case "RichTextVideo": return GraphAPI.Objects.RichTextVideo
     case "RichTextOembed": return GraphAPI.Objects.RichTextOembed
+    case "AttachedVideoFormat": return GraphAPI.Objects.AttachedVideoFormat
     case "CategorySubcategoriesConnection": return GraphAPI.Objects.CategorySubcategoriesConnection
     case "PaymentPlan": return GraphAPI.Objects.PaymentPlan
     case "Validation": return GraphAPI.Objects.Validation

--- a/ServerDrivenUI/Sources/ServerDrivenUI/RichTextElement.swift
+++ b/ServerDrivenUI/Sources/ServerDrivenUI/RichTextElement.swift
@@ -90,11 +90,21 @@ public indirect enum RichTextElement: Sendable {
     let url: String?
   }
 
+  public struct VideoFormat: Sendable {
+    let encoding: String
+    let height: String
+    let width: String
+    let profile: String
+    let url: String
+  }
+
   public struct Video: Sendable {
     let altText: String?
     let assetID: String?
     let caption: String?
     let url: String?
+    let posterURL: String?
+    let formats: [VideoFormat]
   }
 
   public struct Oembed: Sendable {

--- a/ServerDrivenUI/Sources/ServerDrivenUI/RichTextGQLConversions.swift
+++ b/ServerDrivenUI/Sources/ServerDrivenUI/RichTextGQLConversions.swift
@@ -288,7 +288,9 @@ extension RichTextComponentFragment.Item.AsRichTextVideo {
       altText: altText,
       assetID: asset?.id,
       caption: caption,
-      url: url
+      url: url,
+      posterURL: asset?.poster,
+      formats: makeVideoFormats(asset?.formats)
     ))
   }
 }
@@ -299,7 +301,9 @@ extension RichTextComponentFragment.Item.AsRichText.Child.AsRichTextVideo {
       altText: altText,
       assetID: asset?.id,
       caption: caption,
-      url: url
+      url: url,
+      posterURL: asset?.poster,
+      formats: makeVideoFormats(asset?.formats)
     ))
   }
 }
@@ -310,7 +314,9 @@ extension RichTextComponentFragment.Item.AsRichTextHeader.Child.AsRichTextVideo 
       altText: altText,
       assetID: asset?.id,
       caption: caption,
-      url: url
+      url: url,
+      posterURL: asset?.poster,
+      formats: makeVideoFormats(asset?.formats)
     ))
   }
 }
@@ -321,7 +327,9 @@ extension RichTextComponentFragment.Item.AsRichTextListItem.Child.AsRichTextVide
       altText: altText,
       assetID: asset?.id,
       caption: caption,
-      url: url
+      url: url,
+      posterURL: asset?.poster,
+      formats: makeVideoFormats(asset?.formats)
     ))
   }
 }
@@ -391,6 +399,21 @@ extension RichTextComponentFragment.Item.AsRichTextListItem.Child.AsRichTextOemb
       thumbnailWidth: thumbnailWidth,
       thumbnailHeight: thumbnailHeight
     ))
+  }
+}
+
+private func makeVideoFormats(
+  _ formats: [RichTextItemFragment.AsRichTextVideo.Asset.Format?]?
+) -> [RichTextElement.VideoFormat] {
+  (formats ?? []).compactMap { format in
+    guard let format else { return nil }
+    return RichTextElement.VideoFormat(
+      encoding: format.encoding,
+      height: format.height,
+      width: format.width,
+      profile: format.profile,
+      url: format.url
+    )
   }
 }
 

--- a/ServerDrivenUI/Tests/ServerDrivenUITests/RichTextGQLConversionTests.swift
+++ b/ServerDrivenUI/Tests/ServerDrivenUITests/RichTextGQLConversionTests.swift
@@ -297,6 +297,95 @@ struct RichTextGQLConversionTests {
     guard case let .video(v) = el else { Issue.record("expected .video"); return }
     #expect(v.altText == "v")
     #expect(v.url == "https://vid")
+    #expect(v.posterURL == nil)
+    #expect(v.formats.isEmpty)
+  }
+
+  @Test("AsRichTextVideo item with asset -> .video element with assetID and posterURL")
+  func asRichTextVideoItemWithAsset() async throws {
+    let asset = RichTextItemFragment.AsRichTextVideo.Asset(
+      id: "vid-asset-1",
+      poster: "https://example.com/poster.jpg",
+      formats: nil
+    )
+    let gql = RichTextComponentFragment.Item.AsRichTextVideo(
+      altText: "v",
+      asset: asset,
+      caption: "cap",
+      url: "https://vid"
+    )
+    let el = gql.asRichTextElement
+    guard case let .video(v) = el else { Issue.record("expected .video"); return }
+    #expect(v.assetID == "vid-asset-1")
+    #expect(v.posterURL == "https://example.com/poster.jpg")
+    #expect(v.formats.isEmpty)
+  }
+
+  @Test("AsRichTextVideo item with formats -> .video element with all format fields")
+  func asRichTextVideoItemWithFormats() async throws {
+    let hi = RichTextItemFragment.AsRichTextVideo.Asset.Format(
+      encoding: #"video/mp4; codecs="avc1.64001E, mp4a.40.2""#,
+      height: "1080",
+      width: "1920",
+      profile: "high",
+      url: "https://vid/high.mp4"
+    )
+    let lo = RichTextItemFragment.AsRichTextVideo.Asset.Format(
+      encoding: #"video/mp4; codecs="avc1.42E01E, mp4a.40.2""#,
+      height: "720",
+      width: "1280",
+      profile: "baseline",
+      url: "https://vid/baseline.mp4"
+    )
+    let asset = RichTextItemFragment.AsRichTextVideo.Asset(
+      id: "vid-asset-2",
+      poster: nil,
+      formats: [hi, lo]
+    )
+    let gql = RichTextComponentFragment.Item.AsRichTextVideo(
+      altText: "",
+      asset: asset,
+      caption: "",
+      url: "https://vid"
+    )
+    let el = gql.asRichTextElement
+    guard case let .video(v) = el else { Issue.record("expected .video"); return }
+    #expect(v.posterURL == nil)
+    #expect(v.formats.count == 2)
+    let first = try #require(v.formats.first)
+    #expect(first.encoding == #"video/mp4; codecs="avc1.64001E, mp4a.40.2""#)
+    #expect(first.width == "1920")
+    #expect(first.height == "1080")
+    #expect(first.profile == "high")
+    #expect(first.url == "https://vid/high.mp4")
+    let second = try #require(v.formats.last)
+    #expect(second.profile == "baseline")
+    #expect(second.url == "https://vid/baseline.mp4")
+  }
+
+  @Test("AsRichTextVideo item with nil format entries -> nil entries skipped")
+  func asRichTextVideoItemNilFormatEntriesSkipped() async throws {
+    let format = RichTextItemFragment.AsRichTextVideo.Asset.Format(
+      encoding: "video/mp4",
+      height: "720",
+      width: "1280",
+      profile: "main",
+      url: "https://vid/main.mp4"
+    )
+    let asset = RichTextItemFragment.AsRichTextVideo.Asset(
+      id: "vid-asset-3",
+      poster: nil,
+      formats: [format, nil]
+    )
+    let gql = RichTextComponentFragment.Item.AsRichTextVideo(
+      altText: "",
+      asset: asset,
+      caption: "",
+      url: ""
+    )
+    let el = gql.asRichTextElement
+    guard case let .video(v) = el else { Issue.record("expected .video"); return }
+    #expect(v.formats.count == 1)
   }
 
   @Test("Child.AsRichTextVideo -> .video element")
@@ -310,6 +399,36 @@ struct RichTextGQLConversionTests {
     let el = gql.asRichTextElement
     guard case let .video(v) = el else { Issue.record("expected .video"); return }
     #expect(v.altText == "x")
+    #expect(v.posterURL == nil)
+    #expect(v.formats.isEmpty)
+  }
+
+  @Test("Child.AsRichTextVideo with asset -> .video element with posterURL and formats")
+  func asRichTextVideoChildWithAsset() async throws {
+    let format = RichTextItemFragment.AsRichTextVideo.Asset.Format(
+      encoding: "video/mp4",
+      height: "1080",
+      width: "1920",
+      profile: "high",
+      url: "https://vid/high.mp4"
+    )
+    let asset = RichTextItemFragment.AsRichTextVideo.Asset(
+      id: "child-asset",
+      poster: "https://example.com/child-poster.jpg",
+      formats: [format]
+    )
+    let gql = RichTextComponentFragment.Item.AsRichText.Child.AsRichTextVideo(
+      altText: "",
+      asset: asset,
+      caption: "",
+      url: ""
+    )
+    let el = gql.asRichTextElement
+    guard case let .video(v) = el else { Issue.record("expected .video"); return }
+    #expect(v.assetID == "child-asset")
+    #expect(v.posterURL == "https://example.com/child-poster.jpg")
+    #expect(v.formats.count == 1)
+    #expect(v.formats.first?.profile == "high")
   }
 
   @Test(
@@ -416,30 +535,46 @@ struct RichTextGQLConversionTests {
     #expect(p.altText == "lip")
   }
 
-  @Test("Header.Child.AsRichTextVideo -> .video element")
+  @Test("Header.Child.AsRichTextVideo -> .video element with posterURL and formats")
   func asRichTextHeaderChildAsRichTextVideo() async throws {
+    let asset = RichTextItemFragment.AsRichTextVideo.Asset(
+      id: "h-asset",
+      poster: "https://example.com/header-poster.jpg",
+      formats: nil
+    )
     let gql = RichTextComponentFragment.Item.AsRichTextHeader.Child.AsRichTextVideo(
       altText: "hv",
-      asset: nil,
+      asset: asset,
       caption: "",
       url: ""
     )
     let el = gql.asRichTextElement
     guard case let .video(v) = el else { Issue.record("expected .video"); return }
     #expect(v.altText == "hv")
+    #expect(v.assetID == "h-asset")
+    #expect(v.posterURL == "https://example.com/header-poster.jpg")
+    #expect(v.formats.isEmpty)
   }
 
-  @Test("ListItem.Child.AsRichTextVideo -> .video element")
+  @Test("ListItem.Child.AsRichTextVideo -> .video element with posterURL and formats")
   func asRichTextListItemChildAsRichTextVideo() async throws {
+    let asset = RichTextItemFragment.AsRichTextVideo.Asset(
+      id: "li-asset",
+      poster: "https://example.com/li-poster.jpg",
+      formats: nil
+    )
     let gql = RichTextComponentFragment.Item.AsRichTextListItem.Child.AsRichTextVideo(
       altText: "liv",
-      asset: nil,
+      asset: asset,
       caption: "",
       url: ""
     )
     let el = gql.asRichTextElement
     guard case let .video(v) = el else { Issue.record("expected .video"); return }
     #expect(v.altText == "liv")
+    #expect(v.assetID == "li-asset")
+    #expect(v.posterURL == "https://example.com/li-poster.jpg")
+    #expect(v.formats.isEmpty)
   }
 
   @Test("Header.Child.AsRichTextOembed -> .oembed element")

--- a/graphql/fragments/RichTextFragment.graphql
+++ b/graphql/fragments/RichTextFragment.graphql
@@ -40,6 +40,14 @@ fragment RichTextItemFragment on RichTextItem {
     altText
     asset {
       id
+      poster
+      formats {
+        encoding
+        height
+        width
+        profile
+        url
+      }
     }
     caption
     url


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

This PR adds some fields to the RichTextElement.Video type for video playback support.

# 🤔 Why

A future PR will be adding video playback and we need some fields to support it.

# 🛠 How

This PR adds new fields to the GraphQL RichTextComponentFragment. Those fields are then also added to the converted type `RichTextElement.Video`. The conversion methods have been updated. And unit tests were added.

# ⏰ TODO

Swift Testing was considered a bad practice so a future PR will convert that to XCTestCase.