### PR TITLE
CHECK-51: Add A/A Experiments to Project page

### DIFF
--- a/Experimentation/Sources/Experimentation/Experiments/NullExperiment.swift
+++ b/Experimentation/Sources/Experimentation/Experiments/NullExperiment.swift
@@ -1,0 +1,19 @@
+/// This is an A/A experiment to test that our A/B testing infrastructure works correctly.
+/// Nothing is actually changed by this experiment.
+public struct NullExperiment: StatsigExperimentProtocol {
+  typealias ExperimentParameters = NullExperiment.Parameters
+
+  let isLoggedIn: Bool
+
+  public init(isLoggedIn: Bool) {
+    self.isLoggedIn = isLoggedIn
+  }
+
+  public enum Parameters: String, CaseIterable {
+    case test_parameter
+  }
+
+  public var name: StatsigExperimentName {
+    return self.isLoggedIn ? .logged_in_aa_experiment : .logged_out_aa_experiment
+  }
+}

--- a/Experimentation/Sources/Experimentation/Experiments/NullExperiment.swift
+++ b/Experimentation/Sources/Experimentation/Experiments/NullExperiment.swift
@@ -1,19 +1,27 @@
+public enum NullExperimentParameters: String, CaseIterable {
+  case test_parameter
+}
+
 /// This is an A/A experiment to test that our A/B testing infrastructure works correctly.
 /// Nothing is actually changed by this experiment.
-public struct NullExperiment: StatsigExperimentProtocol {
-  typealias ExperimentParameters = NullExperiment.Parameters
+public struct NullExperimentWithUserID: StatsigExperimentProtocol {
+  public typealias Parameters = NullExperimentParameters
 
-  let isLoggedIn: Bool
-
-  public init(isLoggedIn: Bool) {
-    self.isLoggedIn = isLoggedIn
-  }
-
-  public enum Parameters: String, CaseIterable {
-    case test_parameter
-  }
+  public init() {}
 
   public var name: StatsigExperimentName {
-    return self.isLoggedIn ? .logged_in_aa_experiment : .logged_out_aa_experiment
+    return .logged_in_aa_experiment
+  }
+}
+
+/// This is an A/A experiment to test that our A/B testing infrastructure works correctly.
+/// Nothing is actually changed by this experiment.
+public struct NullExperimentWithAnonymousID: StatsigExperimentProtocol {
+  public typealias Parameters = NullExperimentParameters
+
+  public init() {}
+
+  public var name: StatsigExperimentName {
+    return .logged_out_aa_experiment
   }
 }

--- a/Experimentation/Sources/Experimentation/Experiments/StatsigExperiment.swift
+++ b/Experimentation/Sources/Experimentation/Experiments/StatsigExperiment.swift
@@ -34,4 +34,6 @@ public protocol StatsigExperimentProtocol<Parameters> {
 public enum StatsigExperimentName: String, CaseIterable {
   case ios_test_experiment
   case fullscreen_checkout_experience_experiment
+  case logged_in_aa_experiment
+  case logged_out_aa_experiment
 }

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/ProjectPage/Controller/ProjectPageViewController.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/ProjectPage/Controller/ProjectPageViewController.swift
@@ -143,17 +143,25 @@ public final class ProjectPageViewController: UIViewController, MessageBannerVie
     self.navigation.viewDidLoad()
   }
 
-  private var nullExperimentValue: Bool? = nil
-
   public override func viewDidAppear(_ animated: Bool) {
     super.viewDidAppear(animated)
 
     self.viewModel.inputs.viewDidAppear(animated: animated)
 
-    let experiment = NullExperiment(isLoggedIn: AppEnvironment.current.currentUser != nil)
-    // We don't actually switch anything on this experiment value, since it's just an A/A test.
-    // But I'm saving it to a variable just to be sure that the Swift compiler won't prune it as dead code.
-    self.nullExperimentValue = experiment.boolValue(forKey: .test_parameter)
+    self.logNullExperiments()
+  }
+
+  // We don't actually switch anything on these experiment values, since they're just A/A tests.
+  // But I'm saving them to a variable, just to be sure that the Swift compiler won't prune it as dead code.
+  private var nullExperimentValue1: Bool? = nil
+  private var nullExperimentValue2: Bool? = nil
+
+  private func logNullExperiments() {
+    let experiment1 = NullExperimentWithUserID()
+    self.nullExperimentValue1 = experiment1.boolValue(forKey: .test_parameter)
+
+    let experiment2 = NullExperimentWithAnonymousID()
+    self.nullExperimentValue2 = experiment2.boolValue(forKey: .test_parameter)
   }
 
   public override func viewDidDisappear(_ animated: Bool) {

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/ProjectPage/Controller/ProjectPageViewController.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/ProjectPage/Controller/ProjectPageViewController.swift
@@ -153,8 +153,8 @@ public final class ProjectPageViewController: UIViewController, MessageBannerVie
 
   // We don't actually switch anything on these experiment values, since they're just A/A tests.
   // But I'm saving them to a variable, just to be sure that the Swift compiler won't prune it as dead code.
-  private var nullExperimentValue1: Bool? = nil
-  private var nullExperimentValue2: Bool? = nil
+  private var nullExperimentValue1: Bool?
+  private var nullExperimentValue2: Bool?
 
   private func logNullExperiments() {
     let experiment1 = NullExperimentWithUserID()

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/ProjectPage/Controller/ProjectPageViewController.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/ProjectPage/Controller/ProjectPageViewController.swift
@@ -143,10 +143,17 @@ public final class ProjectPageViewController: UIViewController, MessageBannerVie
     self.navigation.viewDidLoad()
   }
 
+  private var nullExperimentValue: Bool? = nil
+
   public override func viewDidAppear(_ animated: Bool) {
     super.viewDidAppear(animated)
 
     self.viewModel.inputs.viewDidAppear(animated: animated)
+
+    let experiment = NullExperiment(isLoggedIn: AppEnvironment.current.currentUser != nil)
+    // We don't actually switch anything on this experiment value, since it's just an A/A test.
+    // But I'm saving it to a variable just to be sure that the Swift compiler won't prune it as dead code.
+    self.nullExperimentValue = experiment.boolValue(forKey: .test_parameter)
   }
 
   public override func viewDidDisappear(_ animated: Bool) {

--- a/Library/Sources/Library/Library/Statsig/StatsigExperiment+Helpers.swift
+++ b/Library/Sources/Library/Library/Statsig/StatsigExperiment+Helpers.swift
@@ -18,9 +18,9 @@ public extension StatsigExperimentName {
     case .fullscreen_checkout_experience_experiment:
       return FullScreenCheckoutExperiment()
     case .logged_in_aa_experiment:
-      return NullExperiment(isLoggedIn: true)
+      return NullExperimentWithUserID()
     case .logged_out_aa_experiment:
-      return NullExperiment(isLoggedIn: false)
+      return NullExperimentWithAnonymousID()
     }
   }
 }

--- a/Library/Sources/Library/Library/Statsig/StatsigExperiment+Helpers.swift
+++ b/Library/Sources/Library/Library/Statsig/StatsigExperiment+Helpers.swift
@@ -17,6 +17,10 @@ public extension StatsigExperimentName {
       return iOSTestExperiment()
     case .fullscreen_checkout_experience_experiment:
       return FullScreenCheckoutExperiment()
+    case .logged_in_aa_experiment:
+      return NullExperiment(isLoggedIn: true)
+    case .logged_out_aa_experiment:
+      return NullExperiment(isLoggedIn: false)
     }
   }
 }


### PR DESCRIPTION
# 📲 What

Add A/A experiments (aka the Null experiment) to the Project page.

# 🤔 Why

Checkout will be using these experiments to verify that our Statsig setup works as intended. Since the experiment tests nothing, we expect to see no statistically significant changes in our metrics.