### PR TITLE
CHECK-157: Use correct label for segment anonymous identifier

### DIFF
--- a/Experimentation/Sources/Experimentation/StatsigClient.swift
+++ b/Experimentation/Sources/Experimentation/StatsigClient.swift
@@ -95,7 +95,7 @@ private extension StatsigUser {
     let ksrStringId = clientUser.ksrUserId != nil ? String(clientUser.ksrUserId!) : nil
 
     if let segmentId = clientUser.segmentAnonymousId {
-      return StatsigUser(userID: ksrStringId, customIDs: ["segmentAnonymousId": segmentId])
+      return StatsigUser(userID: ksrStringId, customIDs: ["segmentAnonymousID": segmentId])
     } else {
       return StatsigUser(userID: ksrStringId)
     }


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Use correct key name for the Segment anonymous ID.

# 🤔 Why

This was mis-matched between Staging and Production. Now both environments use the same key, `segmentAnonymousID`.