### PR TITLE
CHECK-87: Push pledge flow when full screen checkout experiment is on

### DIFF
--- a/Experimentation/Sources/Experimentation/Experiments/FullScreenCheckoutExperiment.swift
+++ b/Experimentation/Sources/Experimentation/Experiments/FullScreenCheckoutExperiment.swift
@@ -5,6 +5,7 @@ public struct FullScreenCheckoutExperiment: StatsigExperimentProtocol {
   public enum Parameters: String, CaseIterable {
     case fullscreen_project_page
     case push_spc
+    case push_pledge_flow
   }
 
   public var name: StatsigExperimentName {

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/ProjectPage/Controller/ProjectPageViewController.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/ProjectPage/Controller/ProjectPageViewController.swift
@@ -780,6 +780,12 @@ public final class ProjectPageViewController: UIViewController, MessageBannerVie
         refTag: refTag,
         secretRewardToken: secretRewardToken
       )
+
+      assert(
+        self.navigationController.isSome,
+        "The project page requires a navigation controller to push the rewards flow."
+      )
+
       self.navigationController?.pushViewController(vc, animated: true)
       return
     }

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/ProjectPage/Controller/ProjectPageViewController.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/ProjectPage/Controller/ProjectPageViewController.swift
@@ -573,10 +573,11 @@ public final class ProjectPageViewController: UIViewController, MessageBannerVie
         self?.tableView.reloadData()
       }
 
-    self.viewModel.outputs.popToRootViewController
+    self.viewModel.outputs.navigateBackToProjectPage
       .observeForControllerAction()
       .observeValues { [weak self] in
-        self?.navigationController?.popToRootViewController(animated: false)
+        guard let self = self else { return }
+        self.navigateBackToProjectPage()
       }
 
     self.viewModel.outputs.pauseMedia
@@ -722,6 +723,21 @@ public final class ProjectPageViewController: UIViewController, MessageBannerVie
     }
   }
 
+  private func navigateBackToProjectPage() {
+    // If the FullScreenCheckoutExperiment is off, the pledge flow is presented.
+    // To go back to the project page, we need to dismiss the pledge flow as well as pop backwards.
+    if let presented = self.presentedViewController,
+       presented is RewardPledgeNavigationController {
+      self.dismiss(animated: true)
+      self.navigationController?.popToRootViewController(animated: false)
+      return
+    }
+
+    // Otherwise, if the experiment is on, the pledge flow was pushed.
+    // Pop all the way to the bottom of the stack to show the Project page again.
+    self.navigationController?.popToRootViewController(animated: true)
+  }
+
   private func showProjectStarredPrompt() {
     let alert = UIAlertController(
       title: Strings.Project_saved(),
@@ -748,25 +764,44 @@ public final class ProjectPageViewController: UIViewController, MessageBannerVie
     self.present(nav, animated: true, completion: nil)
   }
 
+  private func shouldPushPledgeFlow() -> Bool {
+    let experiment = FullScreenCheckoutExperiment()
+    guard let shouldPush = experiment.boolValue(forKey: .push_pledge_flow) else {
+      return false
+    }
+
+    return shouldPush
+  }
+
   private func goToRewards(project: Project, refTag: RefTag?, secretRewardToken: String?) {
-    let vc = RewardsCollectionViewController.controller(
+    if self.shouldPushPledgeFlow() {
+      let vc = RewardsCollectionViewController.rewardsController(
+        with: project,
+        refTag: refTag,
+        secretRewardToken: secretRewardToken
+      )
+      self.navigationController?.pushViewController(vc, animated: true)
+      return
+    }
+
+    let vc = RewardsCollectionViewController.navigationController(
       with: project,
       refTag: refTag,
       secretRewardToken: secretRewardToken
     )
+
     self.present(vc, animated: true)
   }
 
   private func goToManagePledge(params: ManagePledgeViewParamConfigData) {
     let vc = ManagePledgeViewController.instantiate()
-      |> \.delegate .~ self
+    vc.delegate = self
     vc.configureWith(params: params)
 
     let nc = RewardPledgeNavigationController(rootViewController: vc)
 
     if AppEnvironment.current.device.userInterfaceIdiom == .pad {
-      _ = nc
-        |> \.modalPresentationStyle .~ .pageSheet
+      nc.modalPresentationStyle = .pageSheet
     }
 
     self.present(nc, animated: true)

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/RewardsCollection/Controller/RewardsCollectionViewController.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/RewardsCollection/Controller/RewardsCollectionViewController.swift
@@ -396,7 +396,21 @@ private var collectionViewStyle: CollectionViewStyle = { collectionView -> UICol
 }
 
 extension RewardsCollectionViewController {
-  public static func controller(
+  public static func rewardsController(
+    with project: Project,
+    refTag: RefTag?,
+    secretRewardToken: String?
+  ) -> UIViewController {
+    return RewardsCollectionViewController
+      .instantiate(
+        with: project,
+        refTag: refTag,
+        context: .createPledge,
+        secretRewardToken: secretRewardToken
+      )
+  }
+
+  public static func navigationController(
     with project: Project,
     refTag: RefTag?,
     secretRewardToken: String?
@@ -416,9 +430,8 @@ extension RewardsCollectionViewController {
       action: #selector(RewardsCollectionViewController.closeButtonTapped)
     )
 
-    _ = closeButton
-      |> \.width .~ Styles.minTouchSize.width
-      |> \.accessibilityLabel %~ { _ in Strings.Dismiss() }
+    closeButton.width = Styles.minTouchSize.width
+    closeButton.accessibilityLabel = Strings.Dismiss()
 
     rewardsCollectionViewController.navigationItem.setLeftBarButton(closeButton, animated: false)
 
@@ -427,8 +440,7 @@ extension RewardsCollectionViewController {
     )
 
     if AppEnvironment.current.device.userInterfaceIdiom == .pad {
-      _ = navigationController
-        |> \.modalPresentationStyle .~ .pageSheet
+      navigationController.modalPresentationStyle = .pageSheet
     }
 
     return navigationController

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/ThanksProjects/Controller/ThanksViewController.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/ThanksProjects/Controller/ThanksViewController.swift
@@ -117,11 +117,10 @@ internal final class ThanksViewController: UIViewController, UITableViewDelegate
 
     self.backedLabel.rac.attributedText = self.viewModel.outputs.backedProjectText
 
-    self.viewModel.outputs.dismissToRootViewControllerAndPostNotification
+    self.viewModel.outputs.postProjectBackedNotification
       .observeForControllerAction()
-      .observeValues { [weak self] in
+      .observeValues {
         NotificationCenter.default.post($0)
-        self?.dismiss(animated: true)
       }
 
     self.viewModel.outputs.goToDiscovery

--- a/Library/Sources/Library/Library/ViewModels/ProjectPageViewModel.swift
+++ b/Library/Sources/Library/Library/ViewModels/ProjectPageViewModel.swift
@@ -162,8 +162,8 @@ public protocol ProjectPageViewModelOutputs {
   /// Emits a signal when the app is no longer being actively used to pause any playing media.
   var pauseMedia: Signal<Void, Never> { get }
 
-  /// Emits when the navigation stack should be popped to the root view controller.
-  var popToRootViewController: Signal<(), Never> { get }
+  /// Emits when the Project page should be shown again (popping back in the stack and dismissing any modals).
+  var navigateBackToProjectPage: Signal<(), Never> { get }
 
   /// Emits `Project` when the MessageDialogViewController should be presented
   var presentMessageDialog: Signal<Project, Never> { get }
@@ -225,7 +225,7 @@ public final class ProjectPageViewModel: ProjectPageViewModelType, ProjectPageVi
   public init() {
     let isLoading = MutableProperty(false)
 
-    self.popToRootViewController = self.didBackProjectProperty.signal.ignoreValues()
+    self.navigateBackToProjectPage = self.didBackProjectProperty.signal.ignoreValues()
 
     let freshProjectAndRefTagEvent = self.configDataProperty.signal
       .skipNil()
@@ -858,7 +858,7 @@ public final class ProjectPageViewModel: ProjectPageViewModelType, ProjectPageVi
   public let goToReportProject: Signal<(Bool, String, String), Never>
   public let goToURL: Signal<URL, Never>
   public let pauseMedia: Signal<Void, Never>
-  public let popToRootViewController: Signal<(), Never>
+  public let navigateBackToProjectPage: Signal<(), Never>
   public let presentMessageDialog: Signal<Project, Never>
   public let precreateAudioVideoURLs: Signal<(AudioVideoViewElement, IndexPath), Never>
   public let precreateAudioVideoURLsOnFirstLoad: Signal<[AudioVideoViewElement], Never>

--- a/Library/Sources/Library/Library/ViewModels/ThanksViewModel.swift
+++ b/Library/Sources/Library/Library/ViewModels/ThanksViewModel.swift
@@ -39,7 +39,7 @@ public protocol ThanksViewModelOutputs {
   var backedProjectText: Signal<NSAttributedString, Never> { get }
 
   /// Emits when view controller should dismiss
-  var dismissToRootViewControllerAndPostNotification: Signal<Notification, Never> { get }
+  var postProjectBackedNotification: Signal<Notification, Never> { get }
 
   /// Emits DiscoveryParams when should go to Discovery
   var goToDiscovery: Signal<DiscoveryParams, Never> { get }
@@ -129,7 +129,7 @@ public final class ThanksViewModel: ThanksViewModelType, ThanksViewModelInputs, 
       .ignoreValues()
       .on(value: { AppEnvironment.current.userDefaults.hasSeenAppRating = true })
 
-    self.dismissToRootViewControllerAndPostNotification = self.closeButtonTappedProperty.signal
+    self.postProjectBackedNotification = self.closeButtonTappedProperty.signal
       .mapConst(Notification(name: .ksr_projectBacked))
 
     self.goToDiscovery = self.categoryCellTappedProperty.signal.skipNil()
@@ -308,7 +308,7 @@ public final class ThanksViewModel: ThanksViewModelType, ThanksViewModelInputs, 
 
   // MARK: - ThanksViewModelOutputs
 
-  public let dismissToRootViewControllerAndPostNotification: Signal<Notification, Never>
+  public let postProjectBackedNotification: Signal<Notification, Never>
   public let goToDiscovery: Signal<DiscoveryParams, Never>
   public let backedProjectText: Signal<NSAttributedString, Never>
   public let goToProject: Signal<(Project, [Project], RefTag), Never>

--- a/LibraryTests/Library/ViewModels/ProjectPageViewModelTests.swift
+++ b/LibraryTests/Library/ViewModels/ProjectPageViewModelTests.swift
@@ -50,7 +50,7 @@ final class ProjectPageViewModelTests: TestCase {
   private let goToUpdates = TestObserver<Project, Never>()
   private let goToURL = TestObserver<URL, Never>()
   private let pauseMedia = TestObserver<(), Never>()
-  private let popToRootViewController = TestObserver<(), Never>()
+  private let navigateBackToProjectPage = TestObserver<(), Never>()
   private let presentMessageDialog = TestObserver<Project, Never>()
   private let prefetchImageURLs = TestObserver<([URL], IndexPath), Never>()
   private let prefetchImageURLsFirstLoad = TestObserver<[ImageViewElement], Never>()
@@ -120,7 +120,7 @@ final class ProjectPageViewModelTests: TestCase {
     self.vm.outputs.goToUpdates.observe(self.goToUpdates.observer)
     self.vm.outputs.goToURL.observe(self.goToURL.observer)
     self.vm.outputs.pauseMedia.observe(self.pauseMedia.observer)
-    self.vm.outputs.popToRootViewController.observe(self.popToRootViewController.observer)
+    self.vm.outputs.navigateBackToProjectPage.observe(self.navigateBackToProjectPage.observer)
     self.vm.outputs.presentMessageDialog.observe(self.presentMessageDialog.observer)
     self.vm.outputs.precreateAudioVideoURLs.observe(self.precreateAudioVideoURLs.observer)
     self.vm.outputs.precreateAudioVideoURLsOnFirstLoad.observe(self.precreateAudioVideoURLsFirstLoad.observer)
@@ -1698,15 +1698,15 @@ final class ProjectPageViewModelTests: TestCase {
     }
   }
 
-  func testPopToRootViewController() {
+  func testnavigateBackToProjectPage() {
     self.vm.inputs.configureWith(projectOrParam: .left(.template), refInfo: nil)
     self.vm.inputs.viewDidLoad()
 
-    self.popToRootViewController.assertDidNotEmitValue()
+    self.navigateBackToProjectPage.assertDidNotEmitValue()
 
     self.vm.inputs.didBackProject()
 
-    self.popToRootViewController.assertValueCount(1)
+    self.navigateBackToProjectPage.assertValueCount(1)
   }
 
   func testOutput_PresentMessageDialog() {

--- a/LibraryTests/Library/ViewModels/ThanksViewModelTests.swift
+++ b/LibraryTests/Library/ViewModels/ThanksViewModelTests.swift
@@ -16,7 +16,7 @@ final class ThanksViewModelTests: TestCase {
   private let categoryEnvelope = CategoryEnvelope(node: .template)
 
   private let backedProjectText = TestObserver<String, Never>()
-  private let dismissToRootViewControllerAndPostNotification = TestObserver<Notification.Name, Never>()
+  private let postBackedNotification = TestObserver<Notification.Name, Never>()
   private let goToDiscovery = TestObserver<KsApi.Category, Never>()
   private let goToProject = TestObserver<Project, Never>()
   private let goToProjects = TestObserver<[Project], Never>()
@@ -34,8 +34,8 @@ final class ThanksViewModelTests: TestCase {
   override func setUp() {
     super.setUp()
     self.vm.outputs.backedProjectText.map { $0.string }.observe(self.backedProjectText.observer)
-    self.vm.outputs.dismissToRootViewControllerAndPostNotification.map { $0.name }
-      .observe(self.dismissToRootViewControllerAndPostNotification.observer)
+    self.vm.outputs.postProjectBackedNotification.map { $0.name }
+      .observe(self.postBackedNotification.observer)
     self.vm.outputs.goToDiscovery.map { params in params.category ?? Category.filmAndVideo }
       .observe(self.goToDiscovery.observer)
     self.vm.outputs.goToProject.map { $0.0 }.observe(self.goToProject.observer)
@@ -61,14 +61,15 @@ final class ThanksViewModelTests: TestCase {
     return (project, reward, checkoutData, pledgeTotal)
   }
 
-  // FIXME: MBL-2857
-  func testDismissToRootViewController() {
+  func testPostBackedNotification() {
     self.vm.inputs.configure(with: self.thanksPageData())
     self.vm.inputs.viewDidLoad()
 
+    self.postBackedNotification.assertDidNotEmitValue()
+
     self.vm.inputs.closeButtonTapped()
 
-    self.dismissToRootViewControllerAndPostNotification.assertValue(Notification.Name.ksr_projectBacked)
+    self.postBackedNotification.assertValue(Notification.Name.ksr_projectBacked)
   }
 
   // FIXME: MBL-2857


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

When the full screen checkout experiment is on, push the pledge flow (instead of presenting it modally).

This PR includes some minor flow changes and renaming, just to make the code more clear. See inline comments for details.

# 🤔 Why

Our theory is that making this flow _less_ modal will improve conversion. It's harder to accidentally dismiss the flow when it is pushed instead of presented as a `.formSheet`, and it feels more "important" than it does as a modal.

# 👀 See

| Off  | On |
| --- | --- |
| <img height="500" alt="push-pledge-flow-before-26" src="https://github.com/user-attachments/assets/ceef13d2-8b57-4d18-8918-502441014dcb" /> | <img height="500" alt="push-pledge-flow-after-26" src="https://github.com/user-attachments/assets/fe4b5d25-80a5-4bd3-b791-5cf386ee0c8b" /> |