### PR TITLE
[DISC-159] Launch Project Page On CTA Tap

### DIFF
--- a/Kickstarter-Framework/Sources/Kickstarter-Framework-iOSTests/Kickstarter-iOS/Features/VideoFeed/Controller/VideoFeedViewControllerTests.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework-iOSTests/Kickstarter-iOS/Features/VideoFeed/Controller/VideoFeedViewControllerTests.swift
@@ -41,6 +41,7 @@ final class VideoFeedViewControllerTests: TestCase {
 
         cell.configureWith(value: VideoFeedItem(
           id: "0",
+          slug: "video_feed",
           title: "Ringo Move - The Ultimate Workout Bottle",
           creator: "Creator Name",
           creatorImageURL: nil,
@@ -85,6 +86,7 @@ final class VideoFeedViewControllerTests: TestCase {
 
         cell.configureWith(value: VideoFeedItem(
           id: "0",
+          slug: "video_feed",
           title: "Ringo Move - The Ultimate Workout Bottle for People Who Like Long Product Names That Wrap Across Several Lines For People Who Like Long Product Names That Wrap Across Several Lines",
           creator: "Creator Name",
           creatorImageURL: nil,

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Cell/VideoFeedCell.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Cell/VideoFeedCell.swift
@@ -23,6 +23,7 @@ final class VideoFeedCell: UICollectionViewCell, ValueCell {
   var onSaveTapped: (() -> Void)?
   var onShareTapped: (() -> Void)?
   var onMoreTapped: (() -> Void)?
+  var onCTATapped: (() -> Void)?
 
   /// Called once the video is ready to play. Used to unlock feed scrolling.
   var onVideoReady: (() -> Void)?
@@ -66,6 +67,7 @@ final class VideoFeedCell: UICollectionViewCell, ValueCell {
     self.onSaveTapped = nil
     self.onShareTapped = nil
     self.onMoreTapped = nil
+    self.onCTATapped = nil
     self.onVideoReady = nil
     self.onVideoFailed = nil
     self.playbackState.reset()
@@ -84,10 +86,16 @@ final class VideoFeedCell: UICollectionViewCell, ValueCell {
         onCreatorTapped: { [weak self] in self?.onCreatorTapped?() },
         onSaveTapped: { [weak self] in self?.onSaveTapped?() },
         onShareTapped: { [weak self] in self?.onShareTapped?() },
-        onMoreTapped: { [weak self] in self?.onMoreTapped?() }
+        onMoreTapped: { [weak self] in self?.onMoreTapped?() },
+        onCTATapped: { [weak self] in self?.ctaTapped() }
       )
     }
     .margins(.all, 0)
+  }
+
+  func ctaTapped() {
+    self.pausePlayback()
+    self.onCTATapped?()
   }
 
   // MARK: - Video Playback

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Controller/VideoFeedViewController.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Controller/VideoFeedViewController.swift
@@ -1,6 +1,7 @@
 import AVFoundation
 import FirebaseCrashlytics
 import KDS
+import KsApi
 import Library
 import UIKit
 
@@ -148,6 +149,18 @@ final class VideoFeedViewController: UIViewController {
       .compactMap { $0 as? VideoFeedCell }
       .forEach { $0.resumePlayback() }
   }
+
+  // MARK: - Navigation
+
+  private func goToProjectPage(for item: VideoFeedItem) {
+    let vc = ProjectPageViewController.navigationController(
+      withProjectOrParam: .right(Param.slug(item.slug)),
+      refInfo: RefInfo(.videoFeed)
+    )
+    vc.modalPresentationStyle = .fullScreen
+
+    self.present(vc, animated: true)
+  }
 }
 
 extension VideoFeedViewController: UICollectionViewDelegateFlowLayout {
@@ -178,6 +191,7 @@ extension VideoFeedViewController: UICollectionViewDelegateFlowLayout {
     cell.onVideoReady = { [weak self] in self?.unlockScrollingIfNeeded() }
     /// Failed videos still need scroll unlocked so the user can swipe past.
     cell.onVideoFailed = { [weak self] in self?.unlockScrollingIfNeeded() }
+    cell.onCTATapped = { [weak self] in self?.goToProjectPage(for: item) }
 
     /// Re-configure after wiring callbacks so SwiftUI picks up the closures.
     cell.configureWith(value: item)

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Overlay/VideoFeedBottomOverlayView.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Overlay/VideoFeedBottomOverlayView.swift
@@ -17,6 +17,7 @@ struct VideoFeedBottomOverlayView: View {
 
   let item: VideoFeedItem
   let videoPlayer: VideoFeedVideoPlayer
+  var onCTATapped: (() -> Void)?
 
   var body: some View {
     VStack(alignment: .leading, spacing: Constants.contentSpacing) {
@@ -69,7 +70,7 @@ struct VideoFeedBottomOverlayView: View {
   private var ctaButton: some View {
     let ctaTitle = Strings.Back_this_project()
 
-    return Button(ctaTitle, action: {})
+    return Button(ctaTitle, action: { self.onCTATapped?() })
       .buttonStyle(CTAButtonStyle())
       .padding(.top, Constants.ctaTopPadding)
       .accessibilityLabel(ctaTitle)

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Overlay/VideoFeedOverlayView.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Overlay/VideoFeedOverlayView.swift
@@ -37,6 +37,7 @@ struct VideoFeedOverlayView: View {
   var onSaveTapped: (() -> Void)?
   var onShareTapped: (() -> Void)?
   var onMoreTapped: (() -> Void)?
+  var onCTATapped: (() -> Void)?
 
   var body: some View {
     ZStack(alignment: .bottom) {
@@ -65,8 +66,12 @@ struct VideoFeedOverlayView: View {
           onMoreTapped: self.onMoreTapped
         )
 
-        VideoFeedBottomOverlayView(item: self.item, videoPlayer: self.videoPlayer)
-          .frame(maxWidth: .infinity, alignment: .leading)
+        VideoFeedBottomOverlayView(
+          item: self.item,
+          videoPlayer: self.videoPlayer,
+          onCTATapped: self.onCTATapped
+        )
+        .frame(maxWidth: .infinity, alignment: .leading)
       }
       .padding(.horizontal, Constants.horizontalPadding)
       .padding(.bottom, Constants.bottomPadding + Constants.bottomSafeAreaPadding)

--- a/Library/Sources/Library/Library/RefInfo.swift
+++ b/Library/Sources/Library/Library/RefInfo.swift
@@ -42,6 +42,7 @@ public enum RefTag {
   case thanks
   case unrecognized(String)
   case update
+  case videoFeed
 
   /**
    Create a RefTag value from a code string. If a ref tag cannot be matched, an `.unrecognized` tag is
@@ -101,6 +102,7 @@ public enum RefTag {
     case "starred_popular": self = .starredWithSort(.popular)
     case "thanks": self = .thanks
     case "update": self = .update
+    case "video_feed": self = .videoFeed
     default: self = .unrecognized(code)
     }
   }
@@ -170,6 +172,8 @@ public enum RefTag {
       return code
     case .update:
       return "update"
+    case .videoFeed:
+      return "video_feed"
     }
   }
 }

--- a/Library/Sources/Library/Library/VideoFeedItem+Constructor.swift
+++ b/Library/Sources/Library/Library/VideoFeedItem+Constructor.swift
@@ -9,6 +9,7 @@ extension VideoFeedItem {
 
     self.init(
       id: node.project.id,
+      slug: node.project.slug,
       title: node.project.name,
       creator: node.project.creator?.name ?? "",
       creatorImageURL: node.project.creator.flatMap { URL(string: $0.imageUrl) },

--- a/Library/Sources/Library/Library/VideoFeedItem.swift
+++ b/Library/Sources/Library/Library/VideoFeedItem.swift
@@ -3,6 +3,8 @@ import Foundation
 public struct VideoFeedItem: Hashable {
   public let id: String
 
+  public let slug: String
+
   /// Main title shown in the bottom overlay.
   public let title: String
 


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Wires up the "Back this project" CTA to launch the project page

# 🤔 Why

We want to provide users with a way to get to the full project and ultimately the pledge flow directly from the video feed

# 🛠 How

- Added an `onCTATapped` callback that triggers in `VideoFeedBottomOverlayView` and goes up to the `VideoFeedViewController`. 
- `VideoFeedViewController` handles navigates to the Project Page via `ProjectPageViewController.navigationController(withProjectOrParam:refInfo:)`
- Added a new .videoFeed Param slug 

# 👀 See

Trello, screenshots, external resources?

| Before 🐛 | After 🦋 |
| --- | --- |
|  | <img width="295" height="640" alt="Simulator Screen Recording - iPhone 17 Pro - 2026-05-12 at 10 59 14" src="https://github.com/user-attachments/assets/fac3672a-0157-4b95-9dca-3b88dfc6f3ff" /> |

# ✅ Acceptance criteria

- [x] Tap the "Back this project" button should present the project page should present fullscreen
- [x] Dismissing the project page should bring users back to the video feed
- [x] Presenting the project page should pause video playback on the current cell
