### PR TITLE
[SDUI] Remove Swift Testing in RichTextGQLConversionTests

### DIFF
--- a/ServerDrivenUI/Tests/ServerDrivenUITests/RichTextGQLConversionTests.swift
+++ b/ServerDrivenUI/Tests/ServerDrivenUITests/RichTextGQLConversionTests.swift
@@ -5,6 +5,7 @@ import GraphAPI
 import XCTest
 
 final class RichTextGQLConversionTests: TestCase {
+  /* AsRichText item -> .text element with styles, link, no children */
   func testAsRichTextItemAsRichText() throws {
     let gql = RichTextComponentFragment.Item.AsRichText(
       children: nil,
@@ -21,6 +22,7 @@ final class RichTextGQLConversionTests: TestCase {
     XCTAssertNil(level)
   }
 
+  /* Child.AsRichText -> .text element, no children */
   func testAsRichTextChildAsRichText() throws {
     let gql = RichTextComponentFragment.Item.AsRichText.Child.AsRichText(text: "bar", link: nil, styles: [])
     let el = gql.asRichTextElement
@@ -29,6 +31,7 @@ final class RichTextGQLConversionTests: TestCase {
     XCTAssertTrue(t.children.isEmpty)
   }
 
+  /* Header.Child.AsRichText -> .text element with emphasis style */
   func testAsRichTextHeaderChildAsRichText() throws {
     let gql = RichTextComponentFragment.Item.AsRichTextHeader.Child.AsRichText(
       text: "h",
@@ -41,6 +44,7 @@ final class RichTextGQLConversionTests: TestCase {
     XCTAssertEqual(t.styles, [.emphasis])
   }
 
+  /* ListItem.Child.AsRichText -> .text element */
   func testAsRichTextListItemChildAsRichText() throws {
     let gql = RichTextComponentFragment.Item.AsRichTextListItem.Child.AsRichText(
       text: "li",
@@ -52,6 +56,7 @@ final class RichTextGQLConversionTests: TestCase {
     XCTAssertEqual(t.text, "li")
   }
 
+  /* AsRichTextHeader item -> .text element */
   func testAsRichTextHeader() throws {
     let gql = RichTextComponentFragment.Item.AsRichTextHeader(
       children: nil,
@@ -64,6 +69,7 @@ final class RichTextGQLConversionTests: TestCase {
     XCTAssertEqual(t.text, "header")
   }
 
+  /* Header.Child.AsRichTextHeader -> .text element */
   func testAsRichTextHeaderChildAsRichTextHeader() throws {
     let gql = RichTextComponentFragment.Item.AsRichTextHeader.Child.AsRichTextHeader(
       text: "h2",
@@ -75,6 +81,7 @@ final class RichTextGQLConversionTests: TestCase {
     XCTAssertEqual(t.text, "h2")
   }
 
+  /* Child.AsRichTextHeader -> .text element */
   func testAsRichTextChildAsRichTextHeader() throws {
     let gql = RichTextComponentFragment.Item.AsRichText.Child.AsRichTextHeader(
       text: "x",
@@ -86,6 +93,7 @@ final class RichTextGQLConversionTests: TestCase {
     XCTAssertEqual(t.text, "x")
   }
 
+  /* ListItem.Child.AsRichTextHeader -> .text element */
   func testAsRichTextListItemChildAsRichTextHeader() throws {
     let gql = RichTextComponentFragment.Item.AsRichTextListItem.Child.AsRichTextHeader(
       text: "y",
@@ -97,6 +105,7 @@ final class RichTextGQLConversionTests: TestCase {
     XCTAssertEqual(t.text, "y")
   }
 
+  /* AsRichTextListItem item -> .listItem element with no children */
   func testAsRichTextListItem() throws {
     let gql = RichTextComponentFragment.Item.AsRichTextListItem(
       children: nil,
@@ -110,6 +119,7 @@ final class RichTextGQLConversionTests: TestCase {
     XCTAssertTrue(t.children.isEmpty)
   }
 
+  /* ListItem.Child.AsRichTextListItem -> .listItem element */
   func testAsRichTextListItemChildAsRichTextListItem() throws {
     let gql = RichTextComponentFragment.Item.AsRichTextListItem.Child.AsRichTextListItem(
       text: "nested",
@@ -121,6 +131,7 @@ final class RichTextGQLConversionTests: TestCase {
     XCTAssertEqual(t.text, "nested")
   }
 
+  /* Child.AsRichTextListItem -> .listItem element */
   func testAsRichTextChildAsRichTextListItem() throws {
     let gql = RichTextComponentFragment.Item.AsRichText.Child.AsRichTextListItem(
       text: "a",
@@ -132,6 +143,7 @@ final class RichTextGQLConversionTests: TestCase {
     XCTAssertEqual(t.text, "a")
   }
 
+  /* Header.Child.AsRichTextListItem -> .listItem element */
   func testAsRichTextHeaderChildAsRichTextListItem() throws {
     let gql = RichTextComponentFragment.Item.AsRichTextHeader.Child.AsRichTextListItem(
       text: "b",
@@ -143,54 +155,63 @@ final class RichTextGQLConversionTests: TestCase {
     XCTAssertEqual(t.text, "b")
   }
 
+  /* AsRichTextListOpen item -> .listItemOpen element */
   func testAsRichTextListOpenItem() throws {
     let gql = RichTextComponentFragment.Item.AsRichTextListOpen(_present: true)
     let el = gql.asRichTextElement
     guard case .listItemOpen = el else { XCTFail("expected .listItemOpen"); return }
   }
 
+  /* Child.AsRichTextListOpen -> .listItemOpen element */
   func testAsRichTextListOpenChild() throws {
     let gql = RichTextComponentFragment.Item.AsRichText.Child.AsRichTextListOpen(_present: true)
     let el = gql.asRichTextElement
     guard case .listItemOpen = el else { XCTFail("expected .listItemOpen"); return }
   }
 
+  /* Header.Child.AsRichTextListOpen -> .listItemOpen element */
   func testAsRichTextListOpenHeaderChild() throws {
     let gql = RichTextComponentFragment.Item.AsRichTextHeader.Child.AsRichTextListOpen(_present: true)
     let el = gql.asRichTextElement
     guard case .listItemOpen = el else { XCTFail("expected .listItemOpen"); return }
   }
 
+  /* ListItem.Child.AsRichTextListOpen -> .listItemOpen element */
   func testAsRichTextListOpenListItemChild() throws {
     let gql = RichTextComponentFragment.Item.AsRichTextListItem.Child.AsRichTextListOpen(_present: true)
     let el = gql.asRichTextElement
     guard case .listItemOpen = el else { XCTFail("expected .listItemOpen"); return }
   }
 
+  /* AsRichTextListClose item -> .listItemClose element */
   func testAsRichTextListCloseItem() throws {
     let gql = RichTextComponentFragment.Item.AsRichTextListClose(_present: true)
     let el = gql.asRichTextElement
     guard case .listItemClose = el else { XCTFail("expected .listItemClose"); return }
   }
 
+  /* Child.AsRichTextListClose -> .listItemClose element */
   func testAsRichTextListCloseChild() throws {
     let gql = RichTextComponentFragment.Item.AsRichText.Child.AsRichTextListClose(_present: true)
     let el = gql.asRichTextElement
     guard case .listItemClose = el else { XCTFail("expected .listItemClose"); return }
   }
 
+  /* Header.Child.AsRichTextListClose -> .listItemClose element */
   func testAsRichTextListCloseHeaderChild() throws {
     let gql = RichTextComponentFragment.Item.AsRichTextHeader.Child.AsRichTextListClose(_present: true)
     let el = gql.asRichTextElement
     guard case .listItemClose = el else { XCTFail("expected .listItemClose"); return }
   }
 
+  /* ListItem.Child.AsRichTextListClose -> .listItemClose element */
   func testAsRichTextListCloseListItemChild() throws {
     let gql = RichTextComponentFragment.Item.AsRichTextListItem.Child.AsRichTextListClose(_present: true)
     let el = gql.asRichTextElement
     guard case .listItemClose = el else { XCTFail("expected .listItemClose"); return }
   }
 
+  /* AsRichTextAudio item -> .audio element with alt, caption, url */
   func testAsRichTextAudioItem() throws {
     let gql = RichTextComponentFragment.Item.AsRichTextAudio(
       altText: "alt",
@@ -206,6 +227,7 @@ final class RichTextGQLConversionTests: TestCase {
     XCTAssertEqual(a.url, "https://audio")
   }
 
+  /* Child.AsRichTextAudio -> .audio element */
   func testAsRichTextAudioChild() throws {
     let gql = RichTextComponentFragment.Item.AsRichText.Child.AsRichTextAudio(
       altText: "a",
@@ -219,6 +241,7 @@ final class RichTextGQLConversionTests: TestCase {
     XCTAssertEqual(a.url, "u")
   }
 
+  /* AsRichTextAudio with Asset -> .audio element with assetID */
   func testAsRichTextAudioWithAsset() throws {
     let asset = RichTextItemFragment.AsRichTextAudio.Asset(id: "asset-1")
     let gql = RichTextComponentFragment.Item.AsRichText.Child.AsRichTextAudio(
@@ -232,6 +255,7 @@ final class RichTextGQLConversionTests: TestCase {
     XCTAssertEqual(a.assetID, "asset-1")
   }
 
+  /* AsRichTextPhoto item -> .photo element with alt, caption, url */
   func testAsRichTextPhotoItem() throws {
     let gql = RichTextComponentFragment.Item.AsRichTextPhoto(
       altText: "photo",
@@ -246,6 +270,7 @@ final class RichTextGQLConversionTests: TestCase {
     XCTAssertEqual(p.url, "https://img")
   }
 
+  /* Child.AsRichTextPhoto -> .photo element */
   func testAsRichTextPhotoChild() throws {
     let gql = RichTextComponentFragment.Item.AsRichText.Child.AsRichTextPhoto(
       altText: "p",
@@ -258,6 +283,7 @@ final class RichTextGQLConversionTests: TestCase {
     XCTAssertEqual(p.altText, "p")
   }
 
+  /* AsRichTextVideo item -> .video element with alt, caption, url */
   func testAsRichTextVideoItem() throws {
     let gql = RichTextComponentFragment.Item.AsRichTextVideo(
       altText: "v",
@@ -273,6 +299,7 @@ final class RichTextGQLConversionTests: TestCase {
     XCTAssertTrue(v.formats.isEmpty)
   }
 
+  /* AsRichTextVideo item with asset -> .video element with assetID and posterURL */
   func testAsRichTextVideoItemWithAsset() throws {
     let asset = RichTextItemFragment.AsRichTextVideo.Asset(
       id: "vid-asset-1",
@@ -292,6 +319,7 @@ final class RichTextGQLConversionTests: TestCase {
     XCTAssertTrue(v.formats.isEmpty)
   }
 
+  /* AsRichTextVideo item with formats -> .video element with all format fields */
   func testAsRichTextVideoItemWithFormats() throws {
     let hi = RichTextItemFragment.AsRichTextVideo.Asset.Format(
       encoding: #"video/mp4; codecs="avc1.64001E, mp4a.40.2""#,
@@ -333,6 +361,7 @@ final class RichTextGQLConversionTests: TestCase {
     XCTAssertEqual(second.url, "https://vid/baseline.mp4")
   }
 
+  /* AsRichTextVideo item with nil format entries -> nil entries skipped */
   func testAsRichTextVideoItemNilFormatEntriesSkipped() throws {
     let format = RichTextItemFragment.AsRichTextVideo.Asset.Format(
       encoding: "video/mp4",
@@ -357,6 +386,7 @@ final class RichTextGQLConversionTests: TestCase {
     XCTAssertEqual(v.formats.count, 1)
   }
 
+  /* Child.AsRichTextVideo -> .video element */
   func testAsRichTextVideoChild() throws {
     let gql = RichTextComponentFragment.Item.AsRichText.Child.AsRichTextVideo(
       altText: "x",
@@ -371,6 +401,7 @@ final class RichTextGQLConversionTests: TestCase {
     XCTAssertTrue(v.formats.isEmpty)
   }
 
+  /* Child.AsRichTextVideo with asset -> .video element with posterURL and formats */
   func testAsRichTextVideoChildWithAsset() throws {
     let format = RichTextItemFragment.AsRichTextVideo.Asset.Format(
       encoding: "video/mp4",
@@ -398,6 +429,7 @@ final class RichTextGQLConversionTests: TestCase {
     XCTAssertEqual(v.formats.first?.profile, "high")
   }
 
+  /* AsRichTextOembed item -> .oembed element with dimensions, urls, and thumbnail */
   func testAsRichTextOembedItem() throws {
     let gql = RichTextComponentFragment.Item.AsRichTextOembed(
       width: 200,
@@ -425,6 +457,7 @@ final class RichTextGQLConversionTests: TestCase {
     XCTAssertEqual(o.thumbnailHeight, 50)
   }
 
+  /* Child.AsRichTextOembed -> .oembed element */
   func testAsRichTextOembedChild() throws {
     let gql = RichTextComponentFragment.Item.AsRichText.Child.AsRichTextOembed(
       width: 4,
@@ -446,6 +479,7 @@ final class RichTextGQLConversionTests: TestCase {
     XCTAssertEqual(o.type, "rich")
   }
 
+  /* Header.Child.AsRichTextAudio -> .audio element */
   func testAsRichTextHeaderChildAsRichTextAudio() throws {
     let gql = RichTextComponentFragment.Item.AsRichTextHeader.Child.AsRichTextAudio(
       altText: "h",
@@ -458,6 +492,7 @@ final class RichTextGQLConversionTests: TestCase {
     XCTAssertEqual(a.altText, "h")
   }
 
+  /* ListItem.Child.AsRichTextAudio -> .audio element */
   func testAsRichTextListItemChildAsRichTextAudio() throws {
     let gql = RichTextComponentFragment.Item.AsRichTextListItem.Child.AsRichTextAudio(
       altText: "li",
@@ -470,6 +505,7 @@ final class RichTextGQLConversionTests: TestCase {
     XCTAssertEqual(a.altText, "li")
   }
 
+  /* Header.Child.AsRichTextPhoto -> .photo element */
   func testAsRichTextHeaderChildAsRichTextPhoto() throws {
     let gql = RichTextComponentFragment.Item.AsRichTextHeader.Child.AsRichTextPhoto(
       altText: "hp",
@@ -482,6 +518,7 @@ final class RichTextGQLConversionTests: TestCase {
     XCTAssertEqual(p.altText, "hp")
   }
 
+  /* ListItem.Child.AsRichTextPhoto -> .photo element */
   func testAsRichTextListItemChildAsRichTextPhoto() throws {
     let gql = RichTextComponentFragment.Item.AsRichTextListItem.Child.AsRichTextPhoto(
       altText: "lip",
@@ -494,6 +531,7 @@ final class RichTextGQLConversionTests: TestCase {
     XCTAssertEqual(p.altText, "lip")
   }
 
+  /* Header.Child.AsRichTextVideo -> .video element with posterURL and formats */
   func testAsRichTextHeaderChildAsRichTextVideo() throws {
     let asset = RichTextItemFragment.AsRichTextVideo.Asset(
       id: "h-asset",
@@ -514,6 +552,7 @@ final class RichTextGQLConversionTests: TestCase {
     XCTAssertTrue(v.formats.isEmpty)
   }
 
+  /* ListItem.Child.AsRichTextVideo -> .video element with posterURL and formats */
   func testAsRichTextListItemChildAsRichTextVideo() throws {
     let asset = RichTextItemFragment.AsRichTextVideo.Asset(
       id: "li-asset",
@@ -534,6 +573,7 @@ final class RichTextGQLConversionTests: TestCase {
     XCTAssertTrue(v.formats.isEmpty)
   }
 
+  /* Header.Child.AsRichTextOembed -> .oembed element */
   func testAsRichTextHeaderChildAsRichTextOembed() throws {
     let gql = RichTextComponentFragment.Item.AsRichTextHeader.Child.AsRichTextOembed(
       width: 10,
@@ -552,6 +592,7 @@ final class RichTextGQLConversionTests: TestCase {
     XCTAssertEqual(o.title, "H")
   }
 
+  /* ListItem.Child.AsRichTextOembed -> .oembed element */
   func testAsRichTextListItemChildAsRichTextOembed() throws {
     let gql = RichTextComponentFragment.Item.AsRichTextListItem.Child.AsRichTextOembed(
       width: 5,

--- a/ServerDrivenUI/Tests/ServerDrivenUITests/RichTextGQLConversionTests.swift
+++ b/ServerDrivenUI/Tests/ServerDrivenUITests/RichTextGQLConversionTests.swift
@@ -1,12 +1,11 @@
 import Foundation
 import GraphAPI
+@testable import LibraryTestHelpers
 @testable import ServerDrivenUI
-import Testing
+import XCTest
 
-@Suite("RichText GraphQL parsing")
-struct RichTextGQLConversionTests {
-  @Test("AsRichText item -> .text element with styles, link, no children")
-  func asRichTextItemAsRichText() async throws {
+final class RichTextGQLConversionTests: TestCase {
+  func testAsRichTextItemAsRichText() throws {
     let gql = RichTextComponentFragment.Item.AsRichText(
       children: nil,
       text: "foo",
@@ -14,50 +13,46 @@ struct RichTextGQLConversionTests {
       styles: ["STRONG"]
     )
     let el = gql.asRichTextElement
-    guard case let .text(t, level) = el else { Issue.record("expected .text"); return }
-    #expect(t.text == "foo")
-    #expect(t.link == URL(string: "https://kickstarter.com/"))
-    #expect(t.styles == [.strong])
-    #expect(t.children.isEmpty)
-    #expect(level == nil)
+    guard case let .text(t, level) = el else { XCTFail("expected .text"); return }
+    XCTAssertEqual(t.text, "foo")
+    XCTAssertEqual(t.link, URL(string: "https://kickstarter.com/"))
+    XCTAssertEqual(t.styles, [.strong])
+    XCTAssertTrue(t.children.isEmpty)
+    XCTAssertNil(level)
   }
 
-  @Test("Child.AsRichText -> .text element, no children")
-  func asRichTextChildAsRichText() async throws {
+  func testAsRichTextChildAsRichText() throws {
     let gql = RichTextComponentFragment.Item.AsRichText.Child.AsRichText(text: "bar", link: nil, styles: [])
     let el = gql.asRichTextElement
-    guard case .text(let t, nil) = el else { Issue.record("expected .text"); return }
-    #expect(t.text == "bar")
-    #expect(t.children.isEmpty)
+    guard case .text(let t, nil) = el else { XCTFail("expected .text"); return }
+    XCTAssertEqual(t.text, "bar")
+    XCTAssertTrue(t.children.isEmpty)
   }
 
-  @Test("Header.Child.AsRichText -> .text element with emphasis style")
-  func asRichTextHeaderChildAsRichText() async throws {
+  func testAsRichTextHeaderChildAsRichText() throws {
     let gql = RichTextComponentFragment.Item.AsRichTextHeader.Child.AsRichText(
       text: "h",
       link: nil,
       styles: ["EMPHASIS"]
     )
     let el = gql.asRichTextElement
-    guard case .text(let t, nil) = el else { Issue.record("expected .text"); return }
-    #expect(t.text == "h")
-    #expect(t.styles == [.emphasis])
+    guard case .text(let t, nil) = el else { XCTFail("expected .text"); return }
+    XCTAssertEqual(t.text, "h")
+    XCTAssertEqual(t.styles, [.emphasis])
   }
 
-  @Test("ListItem.Child.AsRichText -> .text element")
-  func asRichTextListItemChildAsRichText() async throws {
+  func testAsRichTextListItemChildAsRichText() throws {
     let gql = RichTextComponentFragment.Item.AsRichTextListItem.Child.AsRichText(
       text: "li",
       link: nil,
       styles: nil
     )
     let el = gql.asRichTextElement
-    guard case .text(let t, nil) = el else { Issue.record("expected .text"); return }
-    #expect(t.text == "li")
+    guard case .text(let t, nil) = el else { XCTFail("expected .text"); return }
+    XCTAssertEqual(t.text, "li")
   }
 
-  @Test("AsRichTextHeader item -> .text element")
-  func asRichTextHeader() async throws {
+  func testAsRichTextHeader() throws {
     let gql = RichTextComponentFragment.Item.AsRichTextHeader(
       children: nil,
       text: "header",
@@ -65,48 +60,44 @@ struct RichTextGQLConversionTests {
       styles: []
     )
     let el = gql.asRichTextElement
-    guard case .text(let t, nil) = el else { Issue.record("expected .text"); return }
-    #expect(t.text == "header")
+    guard case .text(let t, nil) = el else { XCTFail("expected .text"); return }
+    XCTAssertEqual(t.text, "header")
   }
 
-  @Test("Header.Child.AsRichTextHeader -> .text element")
-  func asRichTextHeaderChildAsRichTextHeader() async throws {
+  func testAsRichTextHeaderChildAsRichTextHeader() throws {
     let gql = RichTextComponentFragment.Item.AsRichTextHeader.Child.AsRichTextHeader(
       text: "h2",
       link: nil,
       styles: []
     )
     let el = gql.asRichTextElement
-    guard case .text(let t, nil) = el else { Issue.record("expected .text"); return }
-    #expect(t.text == "h2")
+    guard case .text(let t, nil) = el else { XCTFail("expected .text"); return }
+    XCTAssertEqual(t.text, "h2")
   }
 
-  @Test("Child.AsRichTextHeader -> .text element")
-  func asRichTextChildAsRichTextHeader() async throws {
+  func testAsRichTextChildAsRichTextHeader() throws {
     let gql = RichTextComponentFragment.Item.AsRichText.Child.AsRichTextHeader(
       text: "x",
       link: nil,
       styles: nil
     )
     let el = gql.asRichTextElement
-    guard case .text(let t, nil) = el else { Issue.record("expected .text"); return }
-    #expect(t.text == "x")
+    guard case .text(let t, nil) = el else { XCTFail("expected .text"); return }
+    XCTAssertEqual(t.text, "x")
   }
 
-  @Test("ListItem.Child.AsRichTextHeader -> .text element")
-  func asRichTextListItemChildAsRichTextHeader() async throws {
+  func testAsRichTextListItemChildAsRichTextHeader() throws {
     let gql = RichTextComponentFragment.Item.AsRichTextListItem.Child.AsRichTextHeader(
       text: "y",
       link: nil,
       styles: nil
     )
     let el = gql.asRichTextElement
-    guard case .text(let t, nil) = el else { Issue.record("expected .text"); return }
-    #expect(t.text == "y")
+    guard case .text(let t, nil) = el else { XCTFail("expected .text"); return }
+    XCTAssertEqual(t.text, "y")
   }
 
-  @Test("AsRichTextListItem item -> .listItem element with no children")
-  func asRichTextListItem() async throws {
+  func testAsRichTextListItem() throws {
     let gql = RichTextComponentFragment.Item.AsRichTextListItem(
       children: nil,
       text: "bullet",
@@ -114,107 +105,93 @@ struct RichTextGQLConversionTests {
       styles: []
     )
     let el = gql.asRichTextElement
-    guard case let .listItem(t) = el else { Issue.record("expected .listItem"); return }
-    #expect(t.text == "bullet")
-    #expect(t.children.isEmpty)
+    guard case let .listItem(t) = el else { XCTFail("expected .listItem"); return }
+    XCTAssertEqual(t.text, "bullet")
+    XCTAssertTrue(t.children.isEmpty)
   }
 
-  @Test(
-    "ListItem.Child.AsRichTextListItem -> .listItem element"
-  )
-  func asRichTextListItemChildAsRichTextListItem() async throws {
+  func testAsRichTextListItemChildAsRichTextListItem() throws {
     let gql = RichTextComponentFragment.Item.AsRichTextListItem.Child.AsRichTextListItem(
       text: "nested",
       link: nil,
       styles: []
     )
     let el = gql.asRichTextElement
-    guard case let .listItem(t) = el else { Issue.record("expected .listItem"); return }
-    #expect(t.text == "nested")
+    guard case let .listItem(t) = el else { XCTFail("expected .listItem"); return }
+    XCTAssertEqual(t.text, "nested")
   }
 
-  @Test("Child.AsRichTextListItem -> .listItem element")
-  func asRichTextChildAsRichTextListItem() async throws {
+  func testAsRichTextChildAsRichTextListItem() throws {
     let gql = RichTextComponentFragment.Item.AsRichText.Child.AsRichTextListItem(
       text: "a",
       link: nil,
       styles: nil
     )
     let el = gql.asRichTextElement
-    guard case let .listItem(t) = el else { Issue.record("expected .listItem"); return }
-    #expect(t.text == "a")
+    guard case let .listItem(t) = el else { XCTFail("expected .listItem"); return }
+    XCTAssertEqual(t.text, "a")
   }
 
-  @Test("Header.Child.AsRichTextListItem -> .listItem element")
-  func asRichTextHeaderChildAsRichTextListItem() async throws {
+  func testAsRichTextHeaderChildAsRichTextListItem() throws {
     let gql = RichTextComponentFragment.Item.AsRichTextHeader.Child.AsRichTextListItem(
       text: "b",
       link: nil,
       styles: nil
     )
     let el = gql.asRichTextElement
-    guard case let .listItem(t) = el else { Issue.record("expected .listItem"); return }
-    #expect(t.text == "b")
+    guard case let .listItem(t) = el else { XCTFail("expected .listItem"); return }
+    XCTAssertEqual(t.text, "b")
   }
 
-  @Test("AsRichTextListOpen item -> .listItemOpen element")
-  func asRichTextListOpenItem() async throws {
+  func testAsRichTextListOpenItem() throws {
     let gql = RichTextComponentFragment.Item.AsRichTextListOpen(_present: true)
     let el = gql.asRichTextElement
-    guard case .listItemOpen = el else { Issue.record("expected .listItemOpen"); return }
+    guard case .listItemOpen = el else { XCTFail("expected .listItemOpen"); return }
   }
 
-  @Test("Child.AsRichTextListOpen -> .listItemOpen element")
-  func asRichTextListOpenChild() async throws {
+  func testAsRichTextListOpenChild() throws {
     let gql = RichTextComponentFragment.Item.AsRichText.Child.AsRichTextListOpen(_present: true)
     let el = gql.asRichTextElement
-    guard case .listItemOpen = el else { Issue.record("expected .listItemOpen"); return }
+    guard case .listItemOpen = el else { XCTFail("expected .listItemOpen"); return }
   }
 
-  @Test("Header.Child.AsRichTextListOpen -> .listItemOpen element")
-  func asRichTextListOpenHeaderChild() async throws {
+  func testAsRichTextListOpenHeaderChild() throws {
     let gql = RichTextComponentFragment.Item.AsRichTextHeader.Child.AsRichTextListOpen(_present: true)
     let el = gql.asRichTextElement
-    guard case .listItemOpen = el else { Issue.record("expected .listItemOpen"); return }
+    guard case .listItemOpen = el else { XCTFail("expected .listItemOpen"); return }
   }
 
-  @Test("ListItem.Child.AsRichTextListOpen -> .listItemOpen element")
-  func asRichTextListOpenListItemChild() async throws {
+  func testAsRichTextListOpenListItemChild() throws {
     let gql = RichTextComponentFragment.Item.AsRichTextListItem.Child.AsRichTextListOpen(_present: true)
     let el = gql.asRichTextElement
-    guard case .listItemOpen = el else { Issue.record("expected .listItemOpen"); return }
+    guard case .listItemOpen = el else { XCTFail("expected .listItemOpen"); return }
   }
 
-  @Test("AsRichTextListClose item -> .listItemClose element")
-  func asRichTextListCloseItem() async throws {
+  func testAsRichTextListCloseItem() throws {
     let gql = RichTextComponentFragment.Item.AsRichTextListClose(_present: true)
     let el = gql.asRichTextElement
-    guard case .listItemClose = el else { Issue.record("expected .listItemClose"); return }
+    guard case .listItemClose = el else { XCTFail("expected .listItemClose"); return }
   }
 
-  @Test("Child.AsRichTextListClose -> .listItemClose element")
-  func asRichTextListCloseChild() async throws {
+  func testAsRichTextListCloseChild() throws {
     let gql = RichTextComponentFragment.Item.AsRichText.Child.AsRichTextListClose(_present: true)
     let el = gql.asRichTextElement
-    guard case .listItemClose = el else { Issue.record("expected .listItemClose"); return }
+    guard case .listItemClose = el else { XCTFail("expected .listItemClose"); return }
   }
 
-  @Test("Header.Child.AsRichTextListClose -> .listItemClose element")
-  func asRichTextListCloseHeaderChild() async throws {
+  func testAsRichTextListCloseHeaderChild() throws {
     let gql = RichTextComponentFragment.Item.AsRichTextHeader.Child.AsRichTextListClose(_present: true)
     let el = gql.asRichTextElement
-    guard case .listItemClose = el else { Issue.record("expected .listItemClose"); return }
+    guard case .listItemClose = el else { XCTFail("expected .listItemClose"); return }
   }
 
-  @Test("ListItem.Child.AsRichTextListClose -> .listItemClose element")
-  func asRichTextListCloseListItemChild() async throws {
+  func testAsRichTextListCloseListItemChild() throws {
     let gql = RichTextComponentFragment.Item.AsRichTextListItem.Child.AsRichTextListClose(_present: true)
     let el = gql.asRichTextElement
-    guard case .listItemClose = el else { Issue.record("expected .listItemClose"); return }
+    guard case .listItemClose = el else { XCTFail("expected .listItemClose"); return }
   }
 
-  @Test("AsRichTextAudio item -> .audio element with alt, caption, url")
-  func asRichTextAudioItem() async throws {
+  func testAsRichTextAudioItem() throws {
     let gql = RichTextComponentFragment.Item.AsRichTextAudio(
       altText: "alt",
       asset: nil,
@@ -222,15 +199,14 @@ struct RichTextGQLConversionTests {
       url: "https://audio"
     )
     let el = gql.asRichTextElement
-    guard case let .audio(a) = el else { Issue.record("expected .audio"); return }
-    #expect(a.altText == "alt")
-    #expect(a.assetID == nil)
-    #expect(a.caption == "cap")
-    #expect(a.url == "https://audio")
+    guard case let .audio(a) = el else { XCTFail("expected .audio"); return }
+    XCTAssertEqual(a.altText, "alt")
+    XCTAssertNil(a.assetID)
+    XCTAssertEqual(a.caption, "cap")
+    XCTAssertEqual(a.url, "https://audio")
   }
 
-  @Test("Child.AsRichTextAudio -> .audio element")
-  func asRichTextAudioChild() async throws {
+  func testAsRichTextAudioChild() throws {
     let gql = RichTextComponentFragment.Item.AsRichText.Child.AsRichTextAudio(
       altText: "a",
       asset: nil,
@@ -238,13 +214,12 @@ struct RichTextGQLConversionTests {
       url: "u"
     )
     let el = gql.asRichTextElement
-    guard case let .audio(a) = el else { Issue.record("expected .audio"); return }
-    #expect(a.altText == "a")
-    #expect(a.url == "u")
+    guard case let .audio(a) = el else { XCTFail("expected .audio"); return }
+    XCTAssertEqual(a.altText, "a")
+    XCTAssertEqual(a.url, "u")
   }
 
-  @Test("AsRichTextAudio with Asset -> .audio element with assetID")
-  func asRichTextAudioWithAsset() async throws {
+  func testAsRichTextAudioWithAsset() throws {
     let asset = RichTextItemFragment.AsRichTextAudio.Asset(id: "asset-1")
     let gql = RichTextComponentFragment.Item.AsRichText.Child.AsRichTextAudio(
       altText: "",
@@ -253,12 +228,11 @@ struct RichTextGQLConversionTests {
       url: ""
     )
     let el = gql.asRichTextElement
-    guard case let .audio(a) = el else { Issue.record("expected .audio"); return }
-    #expect(a.assetID == "asset-1")
+    guard case let .audio(a) = el else { XCTFail("expected .audio"); return }
+    XCTAssertEqual(a.assetID, "asset-1")
   }
 
-  @Test("AsRichTextPhoto item -> .photo element with alt, caption, url")
-  func asRichTextPhotoItem() async throws {
+  func testAsRichTextPhotoItem() throws {
     let gql = RichTextComponentFragment.Item.AsRichTextPhoto(
       altText: "photo",
       asset: nil,
@@ -266,14 +240,13 @@ struct RichTextGQLConversionTests {
       url: "https://img"
     )
     let el = gql.asRichTextElement
-    guard case let .photo(p) = el else { Issue.record("expected .photo"); return }
-    #expect(p.altText == "photo")
-    #expect(p.assetID == nil)
-    #expect(p.url == "https://img")
+    guard case let .photo(p) = el else { XCTFail("expected .photo"); return }
+    XCTAssertEqual(p.altText, "photo")
+    XCTAssertNil(p.assetID)
+    XCTAssertEqual(p.url, "https://img")
   }
 
-  @Test("Child.AsRichTextPhoto -> .photo element")
-  func asRichTextPhotoChild() async throws {
+  func testAsRichTextPhotoChild() throws {
     let gql = RichTextComponentFragment.Item.AsRichText.Child.AsRichTextPhoto(
       altText: "p",
       asset: nil,
@@ -281,12 +254,11 @@ struct RichTextGQLConversionTests {
       url: "u"
     )
     let el = gql.asRichTextElement
-    guard case let .photo(p) = el else { Issue.record("expected .photo"); return }
-    #expect(p.altText == "p")
+    guard case let .photo(p) = el else { XCTFail("expected .photo"); return }
+    XCTAssertEqual(p.altText, "p")
   }
 
-  @Test("AsRichTextVideo item -> .video element with alt, caption, url")
-  func asRichTextVideoItem() async throws {
+  func testAsRichTextVideoItem() throws {
     let gql = RichTextComponentFragment.Item.AsRichTextVideo(
       altText: "v",
       asset: nil,
@@ -294,15 +266,14 @@ struct RichTextGQLConversionTests {
       url: "https://vid"
     )
     let el = gql.asRichTextElement
-    guard case let .video(v) = el else { Issue.record("expected .video"); return }
-    #expect(v.altText == "v")
-    #expect(v.url == "https://vid")
-    #expect(v.posterURL == nil)
-    #expect(v.formats.isEmpty)
+    guard case let .video(v) = el else { XCTFail("expected .video"); return }
+    XCTAssertEqual(v.altText, "v")
+    XCTAssertEqual(v.url, "https://vid")
+    XCTAssertNil(v.posterURL)
+    XCTAssertTrue(v.formats.isEmpty)
   }
 
-  @Test("AsRichTextVideo item with asset -> .video element with assetID and posterURL")
-  func asRichTextVideoItemWithAsset() async throws {
+  func testAsRichTextVideoItemWithAsset() throws {
     let asset = RichTextItemFragment.AsRichTextVideo.Asset(
       id: "vid-asset-1",
       poster: "https://example.com/poster.jpg",
@@ -315,14 +286,13 @@ struct RichTextGQLConversionTests {
       url: "https://vid"
     )
     let el = gql.asRichTextElement
-    guard case let .video(v) = el else { Issue.record("expected .video"); return }
-    #expect(v.assetID == "vid-asset-1")
-    #expect(v.posterURL == "https://example.com/poster.jpg")
-    #expect(v.formats.isEmpty)
+    guard case let .video(v) = el else { XCTFail("expected .video"); return }
+    XCTAssertEqual(v.assetID, "vid-asset-1")
+    XCTAssertEqual(v.posterURL, "https://example.com/poster.jpg")
+    XCTAssertTrue(v.formats.isEmpty)
   }
 
-  @Test("AsRichTextVideo item with formats -> .video element with all format fields")
-  func asRichTextVideoItemWithFormats() async throws {
+  func testAsRichTextVideoItemWithFormats() throws {
     let hi = RichTextItemFragment.AsRichTextVideo.Asset.Format(
       encoding: #"video/mp4; codecs="avc1.64001E, mp4a.40.2""#,
       height: "1080",
@@ -349,22 +319,21 @@ struct RichTextGQLConversionTests {
       url: "https://vid"
     )
     let el = gql.asRichTextElement
-    guard case let .video(v) = el else { Issue.record("expected .video"); return }
-    #expect(v.posterURL == nil)
-    #expect(v.formats.count == 2)
-    let first = try #require(v.formats.first)
-    #expect(first.encoding == #"video/mp4; codecs="avc1.64001E, mp4a.40.2""#)
-    #expect(first.width == "1920")
-    #expect(first.height == "1080")
-    #expect(first.profile == "high")
-    #expect(first.url == "https://vid/high.mp4")
-    let second = try #require(v.formats.last)
-    #expect(second.profile == "baseline")
-    #expect(second.url == "https://vid/baseline.mp4")
+    guard case let .video(v) = el else { XCTFail("expected .video"); return }
+    XCTAssertNil(v.posterURL)
+    XCTAssertEqual(v.formats.count, 2)
+    guard let first = v.formats.first else { return XCTFail("missing first format") }
+    XCTAssertEqual(first.encoding, #"video/mp4; codecs="avc1.64001E, mp4a.40.2""#)
+    XCTAssertEqual(first.width, "1920")
+    XCTAssertEqual(first.height, "1080")
+    XCTAssertEqual(first.profile, "high")
+    XCTAssertEqual(first.url, "https://vid/high.mp4")
+    guard let second = v.formats.last else { return XCTFail("missing second format") }
+    XCTAssertEqual(second.profile, "baseline")
+    XCTAssertEqual(second.url, "https://vid/baseline.mp4")
   }
 
-  @Test("AsRichTextVideo item with nil format entries -> nil entries skipped")
-  func asRichTextVideoItemNilFormatEntriesSkipped() async throws {
+  func testAsRichTextVideoItemNilFormatEntriesSkipped() throws {
     let format = RichTextItemFragment.AsRichTextVideo.Asset.Format(
       encoding: "video/mp4",
       height: "720",
@@ -384,12 +353,11 @@ struct RichTextGQLConversionTests {
       url: ""
     )
     let el = gql.asRichTextElement
-    guard case let .video(v) = el else { Issue.record("expected .video"); return }
-    #expect(v.formats.count == 1)
+    guard case let .video(v) = el else { XCTFail("expected .video"); return }
+    XCTAssertEqual(v.formats.count, 1)
   }
 
-  @Test("Child.AsRichTextVideo -> .video element")
-  func asRichTextVideoChild() async throws {
+  func testAsRichTextVideoChild() throws {
     let gql = RichTextComponentFragment.Item.AsRichText.Child.AsRichTextVideo(
       altText: "x",
       asset: nil,
@@ -397,14 +365,13 @@ struct RichTextGQLConversionTests {
       url: ""
     )
     let el = gql.asRichTextElement
-    guard case let .video(v) = el else { Issue.record("expected .video"); return }
-    #expect(v.altText == "x")
-    #expect(v.posterURL == nil)
-    #expect(v.formats.isEmpty)
+    guard case let .video(v) = el else { XCTFail("expected .video"); return }
+    XCTAssertEqual(v.altText, "x")
+    XCTAssertNil(v.posterURL)
+    XCTAssertTrue(v.formats.isEmpty)
   }
 
-  @Test("Child.AsRichTextVideo with asset -> .video element with posterURL and formats")
-  func asRichTextVideoChildWithAsset() async throws {
+  func testAsRichTextVideoChildWithAsset() throws {
     let format = RichTextItemFragment.AsRichTextVideo.Asset.Format(
       encoding: "video/mp4",
       height: "1080",
@@ -424,17 +391,14 @@ struct RichTextGQLConversionTests {
       url: ""
     )
     let el = gql.asRichTextElement
-    guard case let .video(v) = el else { Issue.record("expected .video"); return }
-    #expect(v.assetID == "child-asset")
-    #expect(v.posterURL == "https://example.com/child-poster.jpg")
-    #expect(v.formats.count == 1)
-    #expect(v.formats.first?.profile == "high")
+    guard case let .video(v) = el else { XCTFail("expected .video"); return }
+    XCTAssertEqual(v.assetID, "child-asset")
+    XCTAssertEqual(v.posterURL, "https://example.com/child-poster.jpg")
+    XCTAssertEqual(v.formats.count, 1)
+    XCTAssertEqual(v.formats.first?.profile, "high")
   }
 
-  @Test(
-    "AsRichTextOembed item -> .oembed element with dimensions, urls, and thumbnail"
-  )
-  func asRichTextOembedItem() async throws {
+  func testAsRichTextOembedItem() throws {
     let gql = RichTextComponentFragment.Item.AsRichTextOembed(
       width: 200,
       height: 100,
@@ -448,21 +412,20 @@ struct RichTextGQLConversionTests {
       thumbnailWidth: 60
     )
     let el = gql.asRichTextElement
-    guard case let .oembed(o) = el else { Issue.record("expected .oembed"); return }
-    #expect(o.width == 200)
-    #expect(o.height == 100)
-    #expect(o.title == "Title")
-    #expect(o.type == "video")
-    #expect(o.version == "1.0")
-    #expect(o.iframeUrl == "https://iframe")
-    #expect(o.originalUrl == "https://orig")
-    #expect(o.thumbnailUrl == "https://thumb")
-    #expect(o.thumbnailWidth == 60)
-    #expect(o.thumbnailHeight == 50)
+    guard case let .oembed(o) = el else { XCTFail("expected .oembed"); return }
+    XCTAssertEqual(o.width, 200)
+    XCTAssertEqual(o.height, 100)
+    XCTAssertEqual(o.title, "Title")
+    XCTAssertEqual(o.type, "video")
+    XCTAssertEqual(o.version, "1.0")
+    XCTAssertEqual(o.iframeUrl, "https://iframe")
+    XCTAssertEqual(o.originalUrl, "https://orig")
+    XCTAssertEqual(o.thumbnailUrl, "https://thumb")
+    XCTAssertEqual(o.thumbnailWidth, 60)
+    XCTAssertEqual(o.thumbnailHeight, 50)
   }
 
-  @Test("Child.AsRichTextOembed -> .oembed element")
-  func asRichTextOembedChild() async throws {
+  func testAsRichTextOembedChild() throws {
     let gql = RichTextComponentFragment.Item.AsRichText.Child.AsRichTextOembed(
       width: 4,
       height: 1,
@@ -476,15 +439,14 @@ struct RichTextGQLConversionTests {
       thumbnailWidth: 3
     )
     let el = gql.asRichTextElement
-    guard case let .oembed(o) = el else { Issue.record("expected .oembed"); return }
-    #expect(o.width == 4)
-    #expect(o.height == 1)
-    #expect(o.title == "T")
-    #expect(o.type == "rich")
+    guard case let .oembed(o) = el else { XCTFail("expected .oembed"); return }
+    XCTAssertEqual(o.width, 4)
+    XCTAssertEqual(o.height, 1)
+    XCTAssertEqual(o.title, "T")
+    XCTAssertEqual(o.type, "rich")
   }
 
-  @Test("Header.Child.AsRichTextAudio -> .audio element")
-  func asRichTextHeaderChildAsRichTextAudio() async throws {
+  func testAsRichTextHeaderChildAsRichTextAudio() throws {
     let gql = RichTextComponentFragment.Item.AsRichTextHeader.Child.AsRichTextAudio(
       altText: "h",
       asset: nil,
@@ -492,12 +454,11 @@ struct RichTextGQLConversionTests {
       url: ""
     )
     let el = gql.asRichTextElement
-    guard case let .audio(a) = el else { Issue.record("expected .audio"); return }
-    #expect(a.altText == "h")
+    guard case let .audio(a) = el else { XCTFail("expected .audio"); return }
+    XCTAssertEqual(a.altText, "h")
   }
 
-  @Test("ListItem.Child.AsRichTextAudio -> .audio element")
-  func asRichTextListItemChildAsRichTextAudio() async throws {
+  func testAsRichTextListItemChildAsRichTextAudio() throws {
     let gql = RichTextComponentFragment.Item.AsRichTextListItem.Child.AsRichTextAudio(
       altText: "li",
       asset: nil,
@@ -505,12 +466,11 @@ struct RichTextGQLConversionTests {
       url: ""
     )
     let el = gql.asRichTextElement
-    guard case let .audio(a) = el else { Issue.record("expected .audio"); return }
-    #expect(a.altText == "li")
+    guard case let .audio(a) = el else { XCTFail("expected .audio"); return }
+    XCTAssertEqual(a.altText, "li")
   }
 
-  @Test("Header.Child.AsRichTextPhoto -> .photo element")
-  func asRichTextHeaderChildAsRichTextPhoto() async throws {
+  func testAsRichTextHeaderChildAsRichTextPhoto() throws {
     let gql = RichTextComponentFragment.Item.AsRichTextHeader.Child.AsRichTextPhoto(
       altText: "hp",
       asset: nil,
@@ -518,12 +478,11 @@ struct RichTextGQLConversionTests {
       url: ""
     )
     let el = gql.asRichTextElement
-    guard case let .photo(p) = el else { Issue.record("expected .photo"); return }
-    #expect(p.altText == "hp")
+    guard case let .photo(p) = el else { XCTFail("expected .photo"); return }
+    XCTAssertEqual(p.altText, "hp")
   }
 
-  @Test("ListItem.Child.AsRichTextPhoto -> .photo element")
-  func asRichTextListItemChildAsRichTextPhoto() async throws {
+  func testAsRichTextListItemChildAsRichTextPhoto() throws {
     let gql = RichTextComponentFragment.Item.AsRichTextListItem.Child.AsRichTextPhoto(
       altText: "lip",
       asset: nil,
@@ -531,12 +490,11 @@ struct RichTextGQLConversionTests {
       url: ""
     )
     let el = gql.asRichTextElement
-    guard case let .photo(p) = el else { Issue.record("expected .photo"); return }
-    #expect(p.altText == "lip")
+    guard case let .photo(p) = el else { XCTFail("expected .photo"); return }
+    XCTAssertEqual(p.altText, "lip")
   }
 
-  @Test("Header.Child.AsRichTextVideo -> .video element with posterURL and formats")
-  func asRichTextHeaderChildAsRichTextVideo() async throws {
+  func testAsRichTextHeaderChildAsRichTextVideo() throws {
     let asset = RichTextItemFragment.AsRichTextVideo.Asset(
       id: "h-asset",
       poster: "https://example.com/header-poster.jpg",
@@ -549,15 +507,14 @@ struct RichTextGQLConversionTests {
       url: ""
     )
     let el = gql.asRichTextElement
-    guard case let .video(v) = el else { Issue.record("expected .video"); return }
-    #expect(v.altText == "hv")
-    #expect(v.assetID == "h-asset")
-    #expect(v.posterURL == "https://example.com/header-poster.jpg")
-    #expect(v.formats.isEmpty)
+    guard case let .video(v) = el else { XCTFail("expected .video"); return }
+    XCTAssertEqual(v.altText, "hv")
+    XCTAssertEqual(v.assetID, "h-asset")
+    XCTAssertEqual(v.posterURL, "https://example.com/header-poster.jpg")
+    XCTAssertTrue(v.formats.isEmpty)
   }
 
-  @Test("ListItem.Child.AsRichTextVideo -> .video element with posterURL and formats")
-  func asRichTextListItemChildAsRichTextVideo() async throws {
+  func testAsRichTextListItemChildAsRichTextVideo() throws {
     let asset = RichTextItemFragment.AsRichTextVideo.Asset(
       id: "li-asset",
       poster: "https://example.com/li-poster.jpg",
@@ -570,15 +527,14 @@ struct RichTextGQLConversionTests {
       url: ""
     )
     let el = gql.asRichTextElement
-    guard case let .video(v) = el else { Issue.record("expected .video"); return }
-    #expect(v.altText == "liv")
-    #expect(v.assetID == "li-asset")
-    #expect(v.posterURL == "https://example.com/li-poster.jpg")
-    #expect(v.formats.isEmpty)
+    guard case let .video(v) = el else { XCTFail("expected .video"); return }
+    XCTAssertEqual(v.altText, "liv")
+    XCTAssertEqual(v.assetID, "li-asset")
+    XCTAssertEqual(v.posterURL, "https://example.com/li-poster.jpg")
+    XCTAssertTrue(v.formats.isEmpty)
   }
 
-  @Test("Header.Child.AsRichTextOembed -> .oembed element")
-  func asRichTextHeaderChildAsRichTextOembed() async throws {
+  func testAsRichTextHeaderChildAsRichTextOembed() throws {
     let gql = RichTextComponentFragment.Item.AsRichTextHeader.Child.AsRichTextOembed(
       width: 10,
       height: 10,
@@ -592,12 +548,11 @@ struct RichTextGQLConversionTests {
       thumbnailWidth: 10
     )
     let el = gql.asRichTextElement
-    guard case let .oembed(o) = el else { Issue.record("expected .oembed"); return }
-    #expect(o.title == "H")
+    guard case let .oembed(o) = el else { XCTFail("expected .oembed"); return }
+    XCTAssertEqual(o.title, "H")
   }
 
-  @Test("ListItem.Child.AsRichTextOembed -> .oembed element")
-  func asRichTextListItemChildAsRichTextOembed() async throws {
+  func testAsRichTextListItemChildAsRichTextOembed() throws {
     let gql = RichTextComponentFragment.Item.AsRichTextListItem.Child.AsRichTextOembed(
       width: 5,
       height: 5,
@@ -611,8 +566,8 @@ struct RichTextGQLConversionTests {
       thumbnailWidth: 5
     )
     let el = gql.asRichTextElement
-    guard case let .oembed(o) = el else { Issue.record("expected .oembed"); return }
-    #expect(o.title == "L")
-    #expect(o.width == 5)
+    guard case let .oembed(o) = el else { XCTFail("expected .oembed"); return }
+    XCTAssertEqual(o.title, "L")
+    XCTAssertEqual(o.width, 5)
   }
 }


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Swift Testing was still being used in RichTextGQLConversionTests. This PR migrates that back to Xcode-based XCTestCase and our TestCase abstraction.

# 🤔 Why

Our CI reporting doesn't work great with Swift Testing.

# 🛠 How

These changes were AI-generated by asking Claude Code to understand our XCTestCase abstraction and then rewrite the tests in this file to use XCTestCase and our TestCase abstraction.

