### PR TITLE
CHECK-88: Present Project page through SPC instead of pushing it

### DIFF
--- a/Experimentation/Sources/Experimentation/Experiments/FullScreenCheckoutExperiment.swift
+++ b/Experimentation/Sources/Experimentation/Experiments/FullScreenCheckoutExperiment.swift
@@ -4,6 +4,7 @@ public struct FullScreenCheckoutExperiment: StatsigExperimentProtocol {
 
   public enum Parameters: String, CaseIterable {
     case fullscreen_project_page
+    case push_spc
   }
 
   public var name: StatsigExperimentName {

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/ProjectPage/Controller/ProjectPageViewController.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/ProjectPage/Controller/ProjectPageViewController.swift
@@ -634,23 +634,32 @@ public final class ProjectPageViewController: UIViewController, MessageBannerVie
       }
   }
 
+  private func shouldPushSPC() -> Bool {
+    let experiment = FullScreenCheckoutExperiment()
+    guard let shouldPush = experiment.boolValue(forKey: .push_spc) else {
+      // The old (default) behavior is that SPC is pushed, not presented.
+      return true
+    }
+
+    return shouldPush
+  }
+
   private func goToSimilarProject(_ param: any ProjectPageParam) {
-    guard let nav = self.navigationController else {
-      assertionFailure("We expect a navigation controller to be here")
-      let nav = ProjectPageViewController.navigationController(
-        withProjectOrParam: .right(param),
+    if self.shouldPushSPC() {
+      let vc = ProjectPageViewController.configuredWith(
+        projectOrParam: .right(param),
         refInfo: RefInfo(.similarProjects)
       )
-      self.present(nav, animated: true)
+
+      self.navigationController?.pushViewController(vc, animated: true)
       return
     }
 
-    let vc = ProjectPageViewController.configuredWith(
-      projectOrParam: .right(param),
+    let nav = ProjectPageViewController.navigationController(
+      withProjectOrParam: .right(param),
       refInfo: RefInfo(.similarProjects)
     )
-
-    nav.pushViewController(vc, animated: true)
+    self.present(nav, animated: true)
   }
 
   private func prepareToPlayAudioVideoURL(

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/ProjectPage/Controller/ProjectPageViewController.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/ProjectPage/Controller/ProjectPageViewController.swift
@@ -630,19 +630,27 @@ public final class ProjectPageViewController: UIViewController, MessageBannerVie
       .observeForUI()
       .observeValues { [weak self] project in
         guard let self else { return }
-        let vc = ProjectPageViewController.navigationController(
-          withProjectOrParam: .right(project.projectPageParam),
-          refInfo: RefInfo(.similarProjects)
-        )
-
-        if let nav = self.navigationController {
-          nav.pushViewController(vc, animated: true)
-        } else {
-          assertionFailure("We expect a navigation controller to be here")
-          let nav = UINavigationController(rootViewController: vc)
-          self.present(nav, animated: true)
-        }
+        self.goToSimilarProject(project.projectPageParam)
       }
+  }
+
+  private func goToSimilarProject(_ param: any ProjectPageParam) {
+    guard let nav = self.navigationController else {
+      assertionFailure("We expect a navigation controller to be here")
+      let nav = ProjectPageViewController.navigationController(
+        withProjectOrParam: .right(param),
+        refInfo: RefInfo(.similarProjects)
+      )
+      self.present(nav, animated: true)
+      return
+    }
+
+    let vc = ProjectPageViewController.configuredWith(
+      projectOrParam: .right(param),
+      refInfo: RefInfo(.similarProjects)
+    )
+
+    nav.pushViewController(vc, animated: true)
   }
 
   private func prepareToPlayAudioVideoURL(

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/ProjectPage/Controller/ProjectPageViewController.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/ProjectPage/Controller/ProjectPageViewController.swift
@@ -651,6 +651,11 @@ public final class ProjectPageViewController: UIViewController, MessageBannerVie
         refInfo: RefInfo(.similarProjects)
       )
 
+      assert(
+        self.navigationController.isSome,
+        "The project page requires a navigation controller to push SPC."
+      )
+
       self.navigationController?.pushViewController(vc, animated: true)
       return
     }


### PR DESCRIPTION
# 📲 What

When you tap a Similar Project carousel item:
* If the full screen checkout experiment is on, present the project page modally.
* If the experiment is off, push the project page onto the stack.

# 👀 See

| Off | On |
| --- | --- |
| <img height="500" alt="spc-push-style" src="https://github.com/user-attachments/assets/90afa786-ccc0-4509-9580-6d90bfae2099" /> | <img height="500" alt="spc-with-present" src="https://github.com/user-attachments/assets/6c7aced1-5af6-465e-992c-ef4e73c4b3d1" /> |