### PR TITLE
CHECK-87: Clean up navigation bar in pledge flow for consistent behavior with Liquid Glass

### DIFF
--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/ManagePledge/Controllers/ManagePledgeViewController.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/ManagePledge/Controllers/ManagePledgeViewController.swift
@@ -172,9 +172,7 @@ final class ManagePledgeViewController: UIViewController, MessageBannerViewContr
     _ = self.tableView
       |> checkoutBackgroundStyle
 
-    _ = self.closeButton
-      |> \.accessibilityLabel %~ { _ in Strings.Dismiss() }
-      |> \.width .~ Styles.minTouchSize.width
+    self.closeButton.accessibilityLabel = Strings.Dismiss()
 
     _ = self.menuButton
       |> \.accessibilityLabel %~ { _ in Strings.Menu() }
@@ -614,9 +612,7 @@ extension ManagePledgeViewController {
       action: #selector(ManagePledgeViewController.closeButtonTapped)
     )
 
-    _ = closeButton
-      |> \.width .~ Styles.minTouchSize.width
-      |> \.accessibilityLabel %~ { _ in Strings.Dismiss() }
+    closeButton.accessibilityLabel = Strings.Dismiss()
 
     managePledgeViewController.navigationItem.setLeftBarButton(closeButton, animated: false)
 

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/PledgeView/Controllers/PledgeViewController.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/PledgeView/Controllers/PledgeViewController.swift
@@ -134,8 +134,9 @@ final class PledgeViewController: UIViewController,
   override func viewDidLoad() {
     super.viewDidLoad()
 
-    _ = self
-      |> \.extendedLayoutIncludesOpaqueBars .~ true
+    self.configureNavigationBarForPledgeFlow()
+
+    self.extendedLayoutIncludesOpaqueBars = true
 
     self.titleLabel.text = Strings.Checkout()
 
@@ -208,7 +209,7 @@ final class PledgeViewController: UIViewController,
 
   private func setupConstraints() {
     NSLayoutConstraint.activate([
-      self.rootScrollView.topAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.topAnchor),
+      self.rootScrollView.topAnchor.constraint(equalTo: self.view.topAnchor),
       self.rootScrollView.leftAnchor.constraint(equalTo: self.view.leftAnchor),
       self.rootScrollView.rightAnchor.constraint(equalTo: self.view.rightAnchor),
       self.rootScrollView.bottomAnchor.constraint(equalTo: self.pledgeCTAContainerView.topAnchor),
@@ -364,6 +365,7 @@ final class PledgeViewController: UIViewController,
         self.delegate?.pledgeViewControllerDidUpdatePledge(self, message: message)
       }
 
+    // This is currently called when a pledge is being *edited*.
     self.viewModel.outputs.popToRootViewController
       .observeForControllerAction()
       .observeValues { [weak self] in

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/PledgeView/Controllers/PostCampaignCheckoutViewController.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/PledgeView/Controllers/PostCampaignCheckoutViewController.swift
@@ -93,6 +93,8 @@ final class PostCampaignCheckoutViewController: UIViewController,
   override func viewDidLoad() {
     super.viewDidLoad()
 
+    self.configureNavigationBarForPledgeFlow()
+
     self.navigationItem
       .backBarButtonItem = UIBarButtonItem(title: " ", style: .plain, target: nil, action: nil)
 
@@ -155,7 +157,7 @@ final class PostCampaignCheckoutViewController: UIViewController,
 
   private func setupConstraints() {
     NSLayoutConstraint.activate([
-      self.rootScrollView.topAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.topAnchor),
+      self.rootScrollView.topAnchor.constraint(equalTo: self.view.topAnchor),
       self.rootScrollView.leftAnchor.constraint(equalTo: self.view.leftAnchor),
       self.rootScrollView.rightAnchor.constraint(equalTo: self.view.rightAnchor),
       self.rootScrollView.bottomAnchor.constraint(equalTo: self.pledgeCTAContainerView.topAnchor),

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/ProjectPage/Controller/ProjectPageViewController.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/ProjectPage/Controller/ProjectPageViewController.swift
@@ -111,6 +111,10 @@ public final class ProjectPageViewController: UIViewController, MessageBannerVie
   public override func viewDidLoad() {
     super.viewDidLoad()
 
+    // Extend the white of the screen behind the (possibly transparent) navigation bar.
+    self.extendedLayoutIncludesOpaqueBars = true
+    self.view.backgroundColor = Colors.Background.Surface.primary.uiColor()
+
     self.configureNavigation()
     self.configurePledgeCTAContainerView()
     self.configureTableView()

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/ProjectPage/Views/ProjectPageNavigation.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/ProjectPage/Views/ProjectPageNavigation.swift
@@ -232,10 +232,18 @@ private enum Layout {
 extension UINavigationBarAppearance {
   static var projectPageNavigationBarAppearance: UINavigationBarAppearance {
     let appearance = UINavigationBarAppearance()
-    // On iOS 18, if we don't set the color explicitly, it's slight off from the white we want.
-    appearance.backgroundColor = Colors.Background.Surface.primary.uiColor()
+
+    // On iOS 26, we leave the background transparent.
+    // That way, if we transition between the Project page and a page with a transparent Liquid Glass header,
+    // we get nicest possible animated transitions.
+
+    // On iOS 18, we set it to white to get it to match the project page header.
+    if #unavailable(iOS 26) {
+      appearance.backgroundColor = Colors.Background.Surface.primary.uiColor()
+    }
+
     // Hide the nav bar shadow, so it blends in with the project page tabs below.
-    appearance.shadowColor = Colors.Background.Surface.primary.uiColor()
+    appearance.shadowColor = nil
     return appearance
   }
 }

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/RewardAddOnSelection/Controller/RewardAddOnSelectionViewController.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/RewardAddOnSelection/Controller/RewardAddOnSelectionViewController.swift
@@ -47,6 +47,8 @@ final class RewardAddOnSelectionViewController: UIViewController {
   override func viewDidLoad() {
     super.viewDidLoad()
 
+    self.configureNavigationBarForPledgeFlow()
+
     self.configureViews()
     self.configureHeaderView()
     self.setupConstraints()

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/RewardPledgeNavigation/RewardPledgeNavigationController.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/RewardPledgeNavigation/RewardPledgeNavigationController.swift
@@ -1,7 +1,30 @@
 import KDS
 import Library
-import Prelude
 import UIKit
+
+public extension UINavigationBarAppearance {
+  /// Configures the appearance with an opaque white bar for iOS 18, and a liquid glass transparent bar for iOS 26+.
+  func configureForPledgeFlow() {
+    if #available(iOS 26, *) {
+      self.configureWithDefaultBackground()
+    } else {
+      self.configureWithOpaqueBackground()
+      self.shadowImage = UIImage()
+      self.backgroundColor = Colors.Background.Surface.primary.uiColor()
+    }
+  }
+}
+
+public extension UIViewController {
+  /// Configures the `navigationItem` with an opaque white bar for iOS 18, and a liquid glass transparent bar for iOS 26+.
+  func configureNavigationBarForPledgeFlow() {
+    let appearance = UINavigationBarAppearance()
+    appearance.configureForPledgeFlow()
+
+    self.navigationItem.standardAppearance = appearance
+    self.navigationItem.scrollEdgeAppearance = appearance
+  }
+}
 
 final class RewardPledgeNavigationController: UINavigationController {
   // MARK: - Lifecycle
@@ -9,18 +32,13 @@ final class RewardPledgeNavigationController: UINavigationController {
   override func viewDidLoad() {
     super.viewDidLoad()
 
-    _ = self.navigationBar
-      ?|> \.standardAppearance .~ self.navigationBarAppearance
-      ?|> \.scrollEdgeAppearance .~ self.navigationBarAppearance
-      ?|> \.isTranslucent .~ false
-      ?|> \.shadowImage .~ UIImage()
+    self.navigationBar.standardAppearance = self.navigationBarAppearance
+    self.navigationBar.scrollEdgeAppearance = self.navigationBarAppearance
   }
 
   private var navigationBarAppearance: UINavigationBarAppearance {
     let navBarAppearance = UINavigationBarAppearance()
-    navBarAppearance.configureWithOpaqueBackground()
-    navBarAppearance.backgroundColor = LegacyColors.ksr_white.uiColor()
-
+    navBarAppearance.configureForPledgeFlow()
     return navBarAppearance
   }
 }

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/RewardsCollection/Controller/RewardsCollectionViewController.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/RewardsCollection/Controller/RewardsCollectionViewController.swift
@@ -80,6 +80,8 @@ final class RewardsCollectionViewController: UICollectionViewController {
   override func viewDidLoad() {
     super.viewDidLoad()
 
+    self.configureNavigationBarForPledgeFlow()
+
     _ = self
       |> \.extendedLayoutIncludesOpaqueBars .~ true
 

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/RewardsCollection/Controller/RewardsCollectionViewController.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/RewardsCollection/Controller/RewardsCollectionViewController.swift
@@ -432,7 +432,6 @@ extension RewardsCollectionViewController {
       action: #selector(RewardsCollectionViewController.closeButtonTapped)
     )
 
-    closeButton.width = Styles.minTouchSize.width
     closeButton.accessibilityLabel = Strings.Dismiss()
 
     rewardsCollectionViewController.navigationItem.setLeftBarButton(closeButton, animated: false)

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/ThanksProjects/Controller/ThanksViewController.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/ThanksProjects/Controller/ThanksViewController.swift
@@ -30,6 +30,8 @@ internal final class ThanksViewController: UIViewController, UITableViewDelegate
   override func viewDidLoad() {
     super.viewDidLoad()
 
+    self.view.backgroundColor = Colors.Background.Surface.primary.uiColor()
+
     self.projectsTableView.register(nib: .DiscoveryPostcardCell)
     self.projectsTableView.register(nib: .ThanksCategoryCell)
     self.projectsTableView.registerCellClass(DiscoveryProjectCardCell.self)
@@ -55,13 +57,14 @@ internal final class ThanksViewController: UIViewController, UITableViewDelegate
 
     self.navigationItem.leftBarButtonItem = closeButton
 
-    let appearance = UINavigationBarAppearance()
-    // This makes the navigation bar appear hidden
-    appearance.shadowColor = nil
-    appearance.backgroundColor = Colors.Background.Surface.primary.uiColor()
+    self.configureNavigationBarForPledgeFlow()
 
-    self.navigationItem.standardAppearance = appearance
-    self.navigationItem.scrollEdgeAppearance = appearance
+    // Make the nav bar look seamless until you scroll.
+    // The seamless look matches how this page used to be designed when it didn't use a navigation bar.
+    let scrollEdgeHiddenAppearance = UINavigationBarAppearance()
+    scrollEdgeHiddenAppearance.configureForPledgeFlow()
+    scrollEdgeHiddenAppearance.shadowColor = nil
+    self.navigationItem.scrollEdgeAppearance = scrollEdgeHiddenAppearance
 
     // We don't show a title on this page.
     let emptyTitleView = UIView()

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Resources/Thanks.storyboard
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Resources/Thanks.storyboard
@@ -23,7 +23,7 @@
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Uj7-Jz-Wug" userLabel="Woohoo Banner">
-                                            <rect key="frame" x="12" y="0.0" width="351" height="70"/>
+                                            <rect key="frame" x="12" y="8" width="351" height="70"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" " textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FWZ-5u-RHC">
                                                     <rect key="frame" x="8" y="25" width="355" height="20.5"/>
@@ -41,7 +41,7 @@
                                             </constraints>
                                         </view>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" " lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0W0-Br-5Lh">
-                                            <rect key="frame" x="12" y="78" width="351" height="20.5"/>
+                                            <rect key="frame" x="12" y="86" width="351" height="20.5"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <nil key="highlightedColor"/>
@@ -90,7 +90,7 @@
                                         </stackView>
                                     </subviews>
                                     <constraints>
-                                        <constraint firstItem="Uj7-Jz-Wug" firstAttribute="top" secondItem="LC4-lC-v0V" secondAttribute="top" id="9NB-8Q-71D"/>
+                                        <constraint firstItem="Uj7-Jz-Wug" firstAttribute="top" secondItem="LC4-lC-v0V" secondAttribute="top" constant="8" id="9NB-8Q-71D"/>
                                         <constraint firstItem="0W0-Br-5Lh" firstAttribute="leading" secondItem="LC4-lC-v0V" secondAttribute="leading" constant="12" id="AYB-w7-KoT"/>
                                         <constraint firstAttribute="trailing" secondItem="kb6-LU-AvY" secondAttribute="trailing" constant="12" id="CiI-u5-9m5"/>
                                         <constraint firstAttribute="trailing" secondItem="DBG-8g-JC1" secondAttribute="trailing" id="FNf-8p-A9J"/>

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Resources/Thanks.storyboard
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Resources/Thanks.storyboard
@@ -16,10 +16,10 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="40" sectionHeaderHeight="1" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="K36-s7-mGm">
-                                <rect key="frame" x="0.0" y="28" width="375" height="627"/>
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="655"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <view key="tableHeaderView" contentMode="scaleToFill" id="LC4-lC-v0V">
-                                    <rect key="frame" x="0.0" y="0.0" width="375" height="347"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="375" height="375"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Uj7-Jz-Wug" userLabel="Woohoo Banner">
@@ -47,13 +47,13 @@
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="kb6-LU-AvY">
-                                            <rect key="frame" x="12" y="200" width="351" height="44"/>
+                                            <rect key="frame" x="12" y="228" width="351" height="44"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="44" id="Afh-a9-DP3"/>
                                             </constraints>
                                         </button>
                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="DBG-8g-JC1">
-                                            <rect key="frame" x="0.0" y="244" width="375" height="103"/>
+                                            <rect key="frame" x="0.0" y="272" width="375" height="103"/>
                                             <subviews>
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="oH7-8O-oQk">
                                                     <rect key="frame" x="0.0" y="0.0" width="375" height="37"/>
@@ -110,7 +110,7 @@
                         <viewLayoutGuide key="safeArea" id="WMM-y8-QSH"/>
                         <constraints>
                             <constraint firstItem="WMM-y8-QSH" firstAttribute="bottom" secondItem="K36-s7-mGm" secondAttribute="bottom" constant="12" id="0N8-cc-Ig3"/>
-                            <constraint firstItem="K36-s7-mGm" firstAttribute="top" secondItem="WMM-y8-QSH" secondAttribute="top" constant="8" id="T7f-bX-4fo"/>
+                            <constraint firstItem="K36-s7-mGm" firstAttribute="top" secondItem="Ket-JX-mNi" secondAttribute="top" id="T7f-bX-4fo"/>
                             <constraint firstItem="K36-s7-mGm" firstAttribute="leading" secondItem="WMM-y8-QSH" secondAttribute="leading" id="VLd-o4-JOx"/>
                             <constraint firstItem="WMM-y8-QSH" firstAttribute="trailing" secondItem="K36-s7-mGm" secondAttribute="trailing" id="xFn-zh-ST0"/>
                         </constraints>

--- a/Library/Sources/Library/Library/ViewModels/RewardsCollectionViewModel.swift
+++ b/Library/Sources/Library/Library/ViewModels/RewardsCollectionViewModel.swift
@@ -467,6 +467,10 @@ private func titleForContext(_ context: RewardsCollectionViewContext, project: P
   }
 
   guard project.state == .live else {
+    if project.isInPostCampaignPledgingPhase {
+      return Strings.Back_this_project()
+    }
+
     return Strings.View_rewards()
   }
 


### PR DESCRIPTION
# 📲 What

Add a consistent `UINavigationBarAppearance` to the `navigationItem` of screens in the Pledge flow.

# 🤔 Why

Once I started pushing the pledge flow instead of presenting it, I noticed a lot of inconsistencies in the navigation bar. 

In the modal pledge flow, we use an opaque navigation bar (see [RewardPledgeNavigationController](https://github.com/kickstarter/ios-oss/blob/main/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/RewardPledgeNavigation/RewardPledgeNavigationController.swift)). 

In the pushed pledge flow, we wanted to use system default navigation bars to get us nice Liquid Glassy behavior. But many of the screens were either incompatible with liquid glass, or caused subtle animation bugs (by moving from opaque to transparent navigation bars).

By using a consistent `UINavigationBarAppearance`, I'm able to get smooth animations and native Liquid Glass behavior, which makes the pledge flow a bit snazzier.

# 🛠 How

1. Make sure all pledge pages have content that scrolls under the navigation bar
2. Make sure all pledge pages use translucent bars on iOS 26
3. Lots of clean-up and double-checking everything for consistency

# 👀 See

## iOS 26, with full screen checkout experiment on
<img height="500" alt="nice-nav-bars-ios-26-on" src="https://github.com/user-attachments/assets/184dc74a-895c-47aa-a75f-b180e9d13395" />

## iOS 26, with full screen checkout experiment off
<img height="500" alt="nice-nav-bars-ios-26-off" src="https://github.com/user-attachments/assets/e8f69a57-285f-4ac9-83c5-0623b88dcfbc" />

## iOS 18, with full screen checkout experiment on
<img height="500" alt="nice-nav-bars-ios-18-on" src="https://github.com/user-attachments/assets/de8a4486-9ba8-41cf-9f04-a977fc460d69" />

## iOS 18, with full screen checkout experiment off
<img height="500" alt="nice-nav-bars-ios-18-off" src="https://github.com/user-attachments/assets/ee507783-4890-4acf-9a1b-6dbdd048ae3f" />


# ✅ Acceptance criteria

I wanted to make sure I tested this across multiple platforms, with `FullScreenCheckoutExperiment` both on and off. Before I merge this, I'll run simulator tests for the following:

* Push comments from Project page
* Push updates from Project page
* Push/present SPC from Project page
* Complete a pledge
* Manage a pledge

- [x] iPhone 26
  - [x] Full screen experiment on
  - [x] Full screen experiment off
- [x] iPad 26
  - [x] Full screen experiment on
  - [x] Full screen experiment off
- [x] iPhone 18
  - [x] Full screen experiment on
  - [x] Full screen experiment off
- [x] iPad 18
  - [x] Full screen experiment on
  - [x] Full screen experiment off