### PR TITLE
CHECK-87: Update navigation bar titles in Pledge flow

### DIFF
--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/PledgeView/Controllers/PostCampaignCheckoutViewController.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/PledgeView/Controllers/PostCampaignCheckoutViewController.swift
@@ -99,8 +99,7 @@ final class PostCampaignCheckoutViewController: UIViewController,
     _ = self
       |> \.extendedLayoutIncludesOpaqueBars .~ true
 
-    self.title = Strings.Back_this_project()
-
+    self.title = Strings.Pledge_flow_navigation_bar_titles_Payment()
     self.messageBannerViewController = self.configureMessageBannerViewController(on: self)
 
     self.configureChildViewControllers()

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/ProjectPage/Controller/ProjectPageViewController.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/ProjectPage/Controller/ProjectPageViewController.swift
@@ -194,6 +194,10 @@ public final class ProjectPageViewController: UIViewController, MessageBannerVie
     if self == root {
       self.navigationItem.leftBarButtonItem = self.navigation.closeButton
     }
+
+    self.navigationItem.title = Strings.Pledge_flow_navigation_bar_titles_Project()
+    // Hide the title, but keep it set for the back button.
+    self.navigationItem.titleView = UIView()
   }
 
   private func configurePledgeCTAContainerView() {

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/RewardAddOnSelection/Controller/RewardAddOnSelectionViewController.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/RewardAddOnSelection/Controller/RewardAddOnSelectionViewController.swift
@@ -150,6 +150,12 @@ final class RewardAddOnSelectionViewController: UIViewController {
 
     self.headerLabel.rac.text = self.viewModel.outputs.headerTitle
 
+    self.viewModel.outputs.pageTitle
+      .observeForUI()
+      .observeValues { [weak self] title in
+        self?.navigationItem.title = title
+      }
+
     self.viewModel.outputs.configureContinueCTAViewWithData
       .observeForUI()
       .observeValues { [weak self] data in
@@ -215,7 +221,7 @@ final class RewardAddOnSelectionViewController: UIViewController {
   private func goToLatePledge(data: PledgeViewData) {
     let vc = PostCampaignCheckoutViewController.instantiate()
     vc.configure(with: data)
-    vc.title = self.title
+    vc.title = Strings.Pledge_flow_navigation_bar_titles_Payment()
 
     self.navigationController?.pushViewController(vc, animated: true)
   }

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/RewardsCollection/Controller/RewardsCollectionViewController.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/RewardsCollection/Controller/RewardsCollectionViewController.swift
@@ -301,7 +301,6 @@ final class RewardsCollectionViewController: UICollectionViewController {
     let vc = RewardAddOnSelectionViewController.instantiate()
     vc.pledgeViewDelegate = self.pledgeViewDelegate
     vc.configure(with: data)
-    vc.navigationItem.title = self.title
     self.navigationController?.pushViewController(vc, animated: true)
   }
 

--- a/Library/Sources/Library/Library/PledgeViewContext.swift
+++ b/Library/Sources/Library/Library/PledgeViewContext.swift
@@ -104,7 +104,7 @@ public enum PledgeViewContext {
   var title: String {
     switch self {
     case .fixPaymentMethod: return Strings.Fix_payment_method()
-    case .pledge, .latePledge: return Strings.Back_this_project()
+    case .pledge, .latePledge: return Strings.Pledge_flow_navigation_bar_titles_Payment()
     case .update, .updateReward, .editPledgeOverTime: return Strings.Update_pledge()
     case .changePaymentMethod: return Strings.Change_payment_method()
     }

--- a/Library/Sources/Library/Library/Strings.swift
+++ b/Library/Sources/Library/Library/Strings.swift
@@ -1736,6 +1736,40 @@ contributeurs"
     )
   }
   /**
+   "Bookmark"
+
+   - **en**: "Bookmark"
+   - **de**: "Bookmark"
+   - **es**: "Bookmark"
+   - **fr**: "Bookmark"
+   - **ja**: "ブックマーク"
+  */
+  public static func Bookmark() -> String {
+    return localizedString(
+      key: "Bookmark",
+      defaultValue: "Bookmark",
+      count: nil,
+      substitutions: [:]
+    )
+  }
+  /**
+   "Bookmark this project"
+
+   - **en**: "Bookmark this project"
+   - **de**: "Bookmark this project"
+   - **es**: "Bookmark this project"
+   - **fr**: "Bookmark this project"
+   - **ja**: "このプロジェクトをブックマーク"
+  */
+  public static func Bookmark_this_project() -> String {
+    return localizedString(
+      key: "Bookmark_this_project",
+      defaultValue: "Bookmark this project",
+      count: nil,
+      substitutions: [:]
+    )
+  }
+  /**
    "Bookmarks"
 
    - **en**: "Bookmarks"
@@ -1765,6 +1799,23 @@ contributeurs"
     return localizedString(
       key: "Bring_creative_projects_to_life",
       defaultValue: "Bring creative projects to life.",
+      count: nil,
+      substitutions: [:]
+    )
+  }
+  /**
+   "By a superbacker"
+
+   - **en**: "By a superbacker"
+   - **de**: "By a superbacker"
+   - **es**: "By a superbacker"
+   - **fr**: "Par un Superbacker"
+   - **ja**: "スーパーバッカー"
+  */
+  public static func By_a_superbacker() -> String {
+    return localizedString(
+      key: "By_a_superbacker",
+      defaultValue: "By a superbacker",
       count: nil,
       substitutions: [:]
     )
@@ -1901,6 +1952,23 @@ contributeurs"
     return localizedString(
       key: "Campaign",
       defaultValue: "Campaign",
+      count: nil,
+      substitutions: [:]
+    )
+  }
+  /**
+   "Campaign goal reached"
+
+   - **en**: "Campaign goal reached"
+   - **de**: "Campaign goal reached"
+   - **es**: "Meta de campaña alcanzada"
+   - **fr**: "Objectif de campagne atteint"
+   - **ja**: "Campaign goal reached"
+  */
+  public static func Campaign_goal_reached() -> String {
+    return localizedString(
+      key: "Campaign_goal_reached",
+      defaultValue: "Campaign goal reached",
       count: nil,
       substitutions: [:]
     )
@@ -4910,6 +4978,23 @@ Cliquez pour réessayer."
     )
   }
   /**
+   "First-time creator"
+
+   - **en**: "First-time creator"
+   - **de**: "First-time creator"
+   - **es**: "Creador novato"
+   - **fr**: "Nouveau créateur"
+   - **ja**: "First-time creator"
+  */
+  public static func First_time_creator() -> String {
+    return localizedString(
+      key: "First_time_creator",
+      defaultValue: "First-time creator",
+      count: nil,
+      substitutions: [:]
+    )
+  }
+  /**
    "Fix"
 
    - **en**: "Fix"
@@ -6015,6 +6100,23 @@ Cliquez pour réessayer."
     )
   }
   /**
+   "This project is hot!"
+
+   - **en**: "This project is hot!"
+   - **de**: "Absolutes Highlight"
+   - **es**: "Proyecto en tendencia"
+   - **fr**: "Ce projet décolle !"
+   - **ja**: "人気プロジェクト！"
+  */
+  public static func Hot_right_now() -> String {
+    return localizedString(
+      key: "Hot_right_now",
+      defaultValue: "This project is hot!",
+      count: nil,
+      substitutions: [:]
+    )
+  }
+  /**
    "How backers found your project"
 
    - **en**: "How backers found your project"
@@ -6625,6 +6727,23 @@ with friends."
     return localizedString(
       key: "Just_for_you",
       defaultValue: "Just for you.",
+      count: nil,
+      substitutions: [:]
+    )
+  }
+  /**
+   "Just launched"
+
+   - **en**: "Just launched"
+   - **de**: "Gerade veröffentlicht"
+   - **es**: "Proyectos recientes"
+   - **fr**: "En début de campagne"
+   - **ja**: "最新"
+  */
+  public static func Just_launched() -> String {
+    return localizedString(
+      key: "Just_launched",
+      defaultValue: "Just launched",
       count: nil,
       substitutions: [:]
     )
@@ -7684,6 +7803,23 @@ with friends."
     )
   }
   /**
+   "More options"
+
+   - **en**: "More options"
+   - **de**: "Weitere Optionen"
+   - **es**: "Más opciones"
+   - **fr**: "Plus d'options"
+   - **ja**: "その他のオプション"
+  */
+  public static func More_options() -> String {
+    return localizedString(
+      key: "More_options",
+      defaultValue: "More options",
+      count: nil,
+      substitutions: [:]
+    )
+  }
+  /**
    "More than %{number_of_items} items"
 
    - **en**: "More than %{number_of_items} items"
@@ -7781,6 +7917,23 @@ with friends."
     return localizedString(
       key: "Near_me",
       defaultValue: "Near me",
+      count: nil,
+      substitutions: [:]
+    )
+  }
+  /**
+   "Near you"
+
+   - **en**: "Near you"
+   - **de**: "Near you"
+   - **es**: "Near you"
+   - **fr**: "Près de chez moi"
+   - **ja**: "Near you"
+  */
+  public static func Near_you() -> String {
+    return localizedString(
+      key: "Near_you",
+      defaultValue: "Near you",
       count: nil,
       substitutions: [:]
     )
@@ -9081,6 +9234,23 @@ n'ont rien soutenu."
     )
   }
   /**
+   "Play"
+
+   - **en**: "Play"
+   - **de**: "Abspielen"
+   - **es**: "Reproducir"
+   - **fr**: "Lecture"
+   - **ja**: "動画を再生"
+  */
+  public static func Play() -> String {
+    return localizedString(
+      key: "Play",
+      defaultValue: "Play",
+      count: nil,
+      substitutions: [:]
+    )
+  }
+  /**
    "Please enter a pledge amount between %{min} and %{max}."
 
    - **en**: "Please enter a pledge amount between %{min} and %{max}."
@@ -9314,6 +9484,91 @@ n'ont rien soutenu."
     return localizedString(
       key: "Pledge_details",
       defaultValue: "Pledge details",
+      count: nil,
+      substitutions: [:]
+    )
+  }
+  /**
+   "Add-ons"
+
+   - **en**: "Add-ons"
+   - **de**: "Add-ons"
+   - **es**: "Complementos"
+   - **fr**: "Compléments"
+   - **ja**: "アドオン"
+  */
+  public static func Pledge_flow_navigation_bar_titles_Addons() -> String {
+    return localizedString(
+      key: "Pledge_flow_navigation_bar_titles.Addons",
+      defaultValue: "Add-ons",
+      count: nil,
+      substitutions: [:]
+    )
+  }
+  /**
+   "Bonus Support"
+
+   - **en**: "Bonus Support"
+   - **de**: "Bonus-Unterstützung"
+   - **es**: "Apoyo extra"
+   - **fr**: "Coup de pouce"
+   - **ja**: "ボーナスサポート"
+  */
+  public static func Pledge_flow_navigation_bar_titles_Bonus_support() -> String {
+    return localizedString(
+      key: "Pledge_flow_navigation_bar_titles.Bonus_support",
+      defaultValue: "Bonus Support",
+      count: nil,
+      substitutions: [:]
+    )
+  }
+  /**
+   "Payment"
+
+   - **en**: "Payment"
+   - **de**: "Zahlung"
+   - **es**: "Pago"
+   - **fr**: "Paiement"
+   - **ja**: "支払い"
+  */
+  public static func Pledge_flow_navigation_bar_titles_Payment() -> String {
+    return localizedString(
+      key: "Pledge_flow_navigation_bar_titles.Payment",
+      defaultValue: "Payment",
+      count: nil,
+      substitutions: [:]
+    )
+  }
+  /**
+   "Project"
+
+   - **en**: "Project"
+   - **de**: "Projekt"
+   - **es**: "Proyecto"
+   - **fr**: "Projet"
+   - **ja**: "プロジェクト"
+  */
+  public static func Pledge_flow_navigation_bar_titles_Project() -> String {
+    return localizedString(
+      key: "Pledge_flow_navigation_bar_titles.Project",
+      defaultValue: "Project",
+      count: nil,
+      substitutions: [:]
+    )
+  }
+  /**
+   "Rewards"
+
+   - **en**: "Rewards"
+   - **de**: "Belohnungen"
+   - **es**: "Recompensas"
+   - **fr**: "Vos récompenses"
+   - **ja**: "リワード"
+  */
+  public static func Pledge_flow_navigation_bar_titles_Rewards() -> String {
+    return localizedString(
+      key: "Pledge_flow_navigation_bar_titles.Rewards",
+      defaultValue: "Rewards",
       count: nil,
       substitutions: [:]
     )
@@ -9756,6 +10011,23 @@ n'ont rien soutenu."
     return localizedString(
       key: "Project_Suspended",
       defaultValue: "Project Suspended.",
+      count: nil,
+      substitutions: [:]
+    )
+  }
+  /**
+   "Project We Love"
+
+   - **en**: "Project We Love"
+   - **de**: "Team-Favoriten"
+   - **es**: "Nuestros Favoritos"
+   - **fr**: "Nos coups de cœur"
+   - **ja**: "素敵なプロジェクト"
+  */
+  public static func Project_We_Love() -> String {
+    return localizedString(
+      key: "Project_We_Love",
+      defaultValue: "Project We Love",
       count: nil,
       substitutions: [:]
     )
@@ -13945,6 +14217,23 @@ catch your eye?"
       defaultValue: "Tracking number: %{number}",
       count: nil,
       substitutions: ["number": number]
+    )
+  }
+  /**
+   "Trending"
+
+   - **en**: "Trending"
+   - **de**: "Im Trend"
+   - **es**: "Trending"
+   - **fr**: "Les tendances"
+   - **ja**: "急上昇"
+  */
+  public static func Trending() -> String {
+    return localizedString(
+      key: "Trending",
+      defaultValue: "Trending",
+      count: nil,
+      substitutions: [:]
     )
   }
   /**
@@ -23163,6 +23452,23 @@ Veuillez réessayer ultérieurement."
     )
   }
   /**
+   "Discovery mode preview"
+
+   - **en**: "Discovery mode preview"
+   - **de**: "Discovery mode preview"
+   - **es**: "Discovery mode preview"
+   - **fr**: "Aperçu du mode découverte"
+   - **ja**: "Discovery mode preview"
+  */
+  public static func discovery_banner_image_content_description() -> String {
+    return localizedString(
+      key: "discovery_banner_image_content_description",
+      defaultValue: "Discovery mode preview",
+      count: nil,
+      substitutions: [:]
+    )
+  }
+  /**
    "…more"
 
    - **en**: "…more"
@@ -30205,6 +30511,23 @@ projets enregistrés"
     )
   }
   /**
+   "Swipe through a video feed, tuning your recommendations along the way."
+
+   - **en**: "Swipe through a video feed, tuning your recommendations along the way."
+   - **de**: "Swipe through a video feed, tuning your recommendations along the way."
+   - **es**: "Swipe through a video feed, tuning your recommendations along the way."
+   - **fr**: "À découvrir : un flux de vidéos qui affinera vos recommandations au fur et à mesure."
+   - **ja**: "Swipe through a video feed, tuning your recommendations along the way."
+  */
+  public static func swipe_through_a_video_feed_tuning_your_recommendations_along_the_way() -> String {
+    return localizedString(
+      key: "swipe_through_a_video_feed_tuning_your_recommendations_along_the_way",
+      defaultValue: "Swipe through a video feed, tuning your recommendations along the way.",
+      count: nil,
+      substitutions: [:]
+    )
+  }
+  /**
    "Activity"
 
    - **en**: "Activity"
@@ -30353,6 +30676,40 @@ projets enregistrés"
     return localizedString(
       key: "tabbar.search_projects",
       defaultValue: "Search projects",
+      count: nil,
+      substitutions: [:]
+    )
+  }
+  /**
+   "Try it now"
+
+   - **en**: "Try it now"
+   - **de**: "Try it now"
+   - **es**: "Probarlo ahora"
+   - **fr**: "J'essaie"
+   - **ja**: "Try it now"
+  */
+  public static func try_it_now() -> String {
+    return localizedString(
+      key: "try_it_now",
+      defaultValue: "Try it now",
+      count: nil,
+      substitutions: [:]
+    )
+  }
+  /**
+   "Try our new discovery mode"
+
+   - **en**: "Try our new discovery mode"
+   - **de**: "Try our new discovery mode"
+   - **es**: "Prueba nuestro nuevo modo de descubrimiento"
+   - **fr**: "Essayez notre nouveau mode découverte"
+   - **ja**: "Try our new discovery mode"
+  */
+  public static func try_our_new_discovery_mode() -> String {
+    return localizedString(
+      key: "try_our_new_discovery_mode",
+      defaultValue: "Try our new discovery mode",
       count: nil,
       substitutions: [:]
     )
@@ -30746,6 +31103,23 @@ projets enregistrés"
       defaultValue: "via Kickstarter",
       count: nil,
       substitutions: [:]
+    )
+  }
+  /**
+   "%{pledged} pledged • Join %{backers} backers"
+
+   - **en**: "%{pledged} pledged • Join %{backers} backers"
+   - **de**: "%{pledged} pledged • Join %{backers} backers"
+   - **es**: "%{pledged} recaudado • Únete a %{backers} patrocinadores"
+   - **fr**: "%{pledged} engagés • Rejoignez les %{backers} contributeurs"
+   - **ja**: "プレッジ総額: %{pledged} • 現在のバッカー数: %{backers}"
+  */
+  public static func video_feed_campaign_subtitle(pledged: String, backers: String) -> String {
+    return localizedString(
+      key: "video_feed_campaign_subtitle",
+      defaultValue: "%{pledged} pledged • Join %{backers} backers",
+      count: nil,
+      substitutions: ["pledged": pledged, "backers": backers]
     )
   }
 }

--- a/Library/Sources/Library/Library/ViewModels/RewardAddOnSelectionViewModel.swift
+++ b/Library/Sources/Library/Library/ViewModels/RewardAddOnSelectionViewModel.swift
@@ -41,6 +41,7 @@ public protocol RewardAddOnSelectionViewModelOutputs {
   var endRefreshing: Signal<(), Never> { get }
   var goToPledge: Signal<PledgeViewData, Never> { get }
   var headerTitle: Signal<String, Never> { get }
+  var pageTitle: Signal<String, Never> { get }
   var loadAddOnRewardsIntoDataSource: Signal<[RewardAddOnSelectionDataSourceItem], Never> { get }
   var loadAddOnRewardsIntoDataSourceAndReloadTableView:
     Signal<[RewardAddOnSelectionDataSourceItem], Never> { get }
@@ -83,6 +84,12 @@ public final class RewardAddOnSelectionViewModel: RewardAddOnSelectionViewModelT
       hasAddons
         ? Strings.Customize_your_reward_with_optional_addons()
         : Strings.Customize_your_reward()
+    }
+
+    self.pageTitle = hasAddOns.map { (hasAddOns: Bool) -> String in
+      hasAddOns
+        ? Strings.Pledge_flow_navigation_bar_titles_Addons()
+        : Strings.Pledge_flow_navigation_bar_titles_Bonus_support()
     }
 
     // Only fetch add-ons if the base reward has add-ons.
@@ -422,6 +429,7 @@ public final class RewardAddOnSelectionViewModel: RewardAddOnSelectionViewModelT
   public let endRefreshing: Signal<(), Never>
   public let goToPledge: Signal<PledgeViewData, Never>
   public let headerTitle: Signal<String, Never>
+  public let pageTitle: Signal<String, Never>
   public let loadAddOnRewardsIntoDataSource: Signal<[RewardAddOnSelectionDataSourceItem], Never>
   public let loadAddOnRewardsIntoDataSourceAndReloadTableView:
     Signal<[RewardAddOnSelectionDataSourceItem], Never>

--- a/Library/Sources/Library/Library/ViewModels/RewardsCollectionViewModel.swift
+++ b/Library/Sources/Library/Library/ViewModels/RewardsCollectionViewModel.swift
@@ -470,7 +470,8 @@ private func titleForContext(_ context: RewardsCollectionViewContext, project: P
     return Strings.View_rewards()
   }
 
-  return context == .createPledge ? Strings.Back_this_project() : Strings.Edit_reward()
+  return context == .createPledge ? Strings.Pledge_flow_navigation_bar_titles_Rewards() : Strings
+    .Edit_reward()
 }
 
 private func shouldTriggerEditRewardPrompt(_ data: PledgeViewData) -> Bool {

--- a/Library/Sources/Library/Resources/Locales/Base.lproj/Localizable.strings
+++ b/Library/Sources/Library/Resources/Locales/Base.lproj/Localizable.strings
@@ -103,8 +103,11 @@
 "Blocked_user_confirmation" = "Blocking this user means that you won’t see their comments or content anymore. If you have saved or backed projects from this user, you must remove your pledge before blocking. To unblock a user in the future, please go through our Help Center.";
 "Bonus" = "Bonus";
 "Bonus_support" = "Bonus support";
+"Bookmark" = "Bookmark";
+"Bookmark_this_project" = "Bookmark this project";
 "Bookmarks" = "Bookmarks";
 "Bring_creative_projects_to_life" = "Bring creative projects to life.";
+"By_a_superbacker" = "By a superbacker";
 "By_creating_an_account_you_agree_to_Kickstarters_Terms_of_Use_and_Privacy_Policy" = "By creating an account, you agree to Kickstarter’s <a href=\"%{terms_of_use_link}\">Terms of Use</a> and <a href=\"%{privacy_policy_link}\">Privacy Policy</a>.";
 "By_pledging_you_acknowledge" = "By pledging, you acknowledge that rewards or reimbursements aren’t guaranteed by either Kickstarter or the creator.";
 "By_pledging_you_agree_to_Kickstarters_Terms_of_Use_Privacy_Policy_and_Cookie_Policy" = "By pledging you agree to Kickstarter's <a href=\"%{terms_of_use_link}\">Terms of Use</a>, <a href=\"%{privacy_policy_link}\">Privacy Policy</a> and <a href=\"%{cookie_policy_link}\">Cookie Policy</a>.";
@@ -113,6 +116,7 @@
 "By_submitting_your_pledge_you_agree_that_Stripe_may_charge_your_payment_method" = "By submitting your pledge, you agree that our payment processor, Stripe, may charge your payment method.";
 "CVC" = "CVC";
 "Campaign" = "Campaign";
+"Campaign_goal_reached" = "Campaign goal reached";
 "Cancel" = "Cancel";
 "Cancel_pledge" = "Cancel pledge";
 "Cancel_your_pledge" = "Cancel your pledge";
@@ -297,6 +301,7 @@
 "Find_projects_youll_love_and_help_bring" = "Find projects you’ll love and help bring creative ideas to life.";
 "Find_projects_youll_love_in_art_design_film" = "Find projects you’ll love in art, design, film, games, music, and more. Once you back a project, you’ll see all your activity here.";
 "First_created" = "First created";
+"First_time_creator" = "First-time creator";
 "Fix" = "Fix";
 "Fix_payment" = "Fix Payment";
 "Fix_payment_method" = "Fix payment method";
@@ -362,6 +367,7 @@
 "Help_local_businesses_keep_the_lights" = "Help local businesses keep the lights on during COVID-19 closures.";
 "Hide_password" = "Hide password";
 "Home" = "Home";
+"Hot_right_now" = "This project is hot!";
 "How_backers_found_your_project" = "How backers found your project";
 "I_am_incorporating_AI_in_my_project" = "I am incorporating AI in my project in another way.";
 "I_plan_to_use_AI_generated_content" = "I plan to use AI-generated content in my project.";
@@ -398,6 +404,7 @@
 "Join_our_secret_society" = "Join our secret society.";
 "Joining_the_live_stream" = "Joining the live stream";
 "Just_for_you" = "Just for you.";
+"Just_launched" = "Just launched";
 "Keep_in_touch_after_your_campaign" = "Keep in touch after your campaign and plan your next project.";
 "Keep_reading" = "Keep reading";
 "Keep_up_with_future_live_streams" = "Keep up with future live streams";
@@ -464,12 +471,14 @@
 "Message_user_name" = "Message %{user_name}…";
 "Messages" = "Messages";
 "Million_plus" = "%{total_amount} million+";
+"More_options" = "More options";
 "More_than_number_of_items_items" = "More than %{number_of_items} items";
 "Most_backed" = "Most backed";
 "Most_funded" = "Most funded";
 "My_project_seeks_funding_for_AI_technology" = "My project seeks funding for AI technology.";
 "Name" = "Name";
 "Near_me" = "Near me";
+"Near_you" = "Near you";
 "Never" = "Never";
 "New_email" = "New email";
 "New_password" = "New password";
@@ -546,6 +555,7 @@
 "Percentage_raised_pill_bucket_0" = "Under 75% raised";
 "Percentage_raised_pill_bucket_1" = "75% to 100% raised";
 "Percentage_raised_pill_bucket_2" = "More than 100% raised";
+"Play" = "Play";
 "Please_enter_a_pledge_amount_between_min_and_max" = "Please enter a pledge amount between %{min} and %{max}.";
 "Please_enter_an_amount_of_amount_or_less" = "Please enter an amount of %{amount} or less.";
 "Please_enter_an_amount_of_amount_or_more" = "Please enter an amount of %{amount} or more.";
@@ -560,6 +570,11 @@
 "Pledge_amount_pledged" = "%{pledge_amount} pledged";
 "Pledge_any_amount_to_help_bring_this_project_to_life" = "Pledge any amount to help bring this project to life.";
 "Pledge_details" = "Pledge details";
+"Pledge_flow_navigation_bar_titles.Addons" = "Add-ons";
+"Pledge_flow_navigation_bar_titles.Bonus_support" = "Bonus Support";
+"Pledge_flow_navigation_bar_titles.Payment" = "Payment";
+"Pledge_flow_navigation_bar_titles.Project" = "Project";
+"Pledge_flow_navigation_bar_titles.Rewards" = "Rewards";
 "Pledge_in_full" = "Pledge in full";
 "Pledge_label" = "Pledge";
 "Pledge_management" = "Pledge management";
@@ -586,6 +601,7 @@
 "Prohibited_items" = "Prohibited items";
 "Project_Cancelled" = "Project Cancelled.";
 "Project_Suspended" = "Project Suspended.";
+"Project_We_Love" = "Project We Love";
 "Project_activity" = "Project activity";
 "Project_alerts" = "Project Alerts";
 "Project_cancelled" = "Project cancelled";
@@ -852,6 +868,7 @@
 "Track_shipment" = "Track shipment";
 "Track_your_backings" = "Track your backings";
 "Tracking_number" = "Tracking number: %{number}";
+"Trending" = "Trending";
 "Try_adjusting_the_filters" = "Try adjusting the filters";
 "Try_rephrasing_your_search" = "Try rephrasing your search";
 "Try_rephrasing_your_search_or_adjusting_the_filters" = "Try rephrasing your search or adjusting the filters";
@@ -1526,6 +1543,7 @@
 "discovery.survey.button.respond_now" = "Respond now";
 "discovery.survey.creator_needs_some_info_to_deliver_reward_for_project" = "%{creator_name} needs some info to deliver your reward for %{project_name}.";
 "discovery.survey.reward_survey" = "Reward Survey!";
+"discovery_banner_image_content_description" = "Discovery mode preview";
 "ellipsis_more" = "…more";
 "facebook_confirmation.button" = "Create new account";
 "facebook_confirmation.could_not_log_in" = "Couldn't log in with Facebook.";
@@ -1999,6 +2017,7 @@
 "support_email.subject" = "Hello Kickstarter App Support";
 "support_email.to" = "app@kickstarter.com";
 "support_email.to_android" = "android@kickstarter.com";
+"swipe_through_a_video_feed_tuning_your_recommendations_along_the_way" = "Swipe through a video feed, tuning your recommendations along the way.";
 "tabbar.activity" = "Activity";
 "tabbar.backings" = "Backings";
 "tabbar.dashboard" = "Dashboard";
@@ -2008,6 +2027,8 @@
 "tabbar.profile" = "Profile";
 "tabbar.search" = "Search";
 "tabbar.search_projects" = "Search projects";
+"try_it_now" = "Try it now";
+"try_our_new_discovery_mode" = "Try our new discovery mode";
 "two_factor.buttons.resend" = "Resend";
 "two_factor.buttons.submit" = "Submit";
 "two_factor.code_placeholder" = "Enter code";
@@ -2035,3 +2056,4 @@
 "via_custom" = "via custom";
 "via_external" = "via external";
 "via_kickstarter" = "via Kickstarter";
+"video_feed_campaign_subtitle" = "%{pledged} pledged • Join %{backers} backers";

--- a/Library/Sources/Library/Resources/Locales/de.lproj/Localizable.strings
+++ b/Library/Sources/Library/Resources/Locales/de.lproj/Localizable.strings
@@ -103,8 +103,11 @@
 "Blocked_user_confirmation" = "Wenn du diesen Nutzer blockierst, siehst du keine Kommentare oder Inhalte mehr von ihm. Falls du Projekte von diesem Nutzer gespeichert oder unterstützt hast, musst du deinen Beitrag vor dem Blockieren entfernen. Weitere Informationen dazu, wie du die Blockierung eines Nutzers aufheben kannst, findest du im Hilfecenter.";
 "Bonus" = "Bonus";
 "Bonus_support" = "Bonus-Unterstützung";
+"Bookmark" = "Bookmark";
+"Bookmark_this_project" = "Bookmark this project";
 "Bookmarks" = "Bookmarks";
 "Bring_creative_projects_to_life" = "Kreative Projekte werden Wirklichkeit!";
+"By_a_superbacker" = "By a superbacker";
 "By_creating_an_account_you_agree_to_Kickstarters_Terms_of_Use_and_Privacy_Policy" = "Mit Erstellung eines Kontos erklärst du dich mit Kickstarters <a href=\"%{terms_of_use_link}\">Nutzungsbedingungen</a> und <a href=\"%{privacy_policy_link}\">Datenschutzrichtlinien</a> einverstanden.";
 "By_pledging_you_acknowledge" = "Durch deinen Finanzierungsbeitrag erkennst du an, dass weder der Projektgründer noch Kickstarter Belohnungen oder Rückerstattungen garantieren.";
 "By_pledging_you_agree_to_Kickstarters_Terms_of_Use_Privacy_Policy_and_Cookie_Policy" = "Bei Leistung eines Finanzierungsbeitrags erkennst du Kickstarters <a href=\"%{terms_of_use_link}\">Nutzungsbedingungen</a>, <a href=\"%{privacy_policy_link}\">Datenschutzrichtlinien</a> und <a href=\"%{cookie_policy_link}\">Cookie-Richtlinien</a> an.";
@@ -113,6 +116,7 @@
 "By_submitting_your_pledge_you_agree_that_Stripe_may_charge_your_payment_method" = "Durch das Einsenden deines Finanzierungsbeitrags erklärst du dich mit einer Abbuchung von deiner Zahlungsweise durch unseren Zahlungsdienstleister Stripe einverstanden.";
 "CVC" = "CVC";
 "Campaign" = "Kampagne";
+"Campaign_goal_reached" = "Campaign goal reached";
 "Cancel" = "Abbrechen";
 "Cancel_pledge" = "Beitrag zurückziehen";
 "Cancel_your_pledge" = "Deinen Beitrag zurückziehen";
@@ -297,6 +301,7 @@
 "Find_projects_youll_love_and_help_bring" = "Finde Projekte, die zu dir passen und hilf mit bei der Umsetzung neuer, kreativer Ideen.";
 "Find_projects_youll_love_in_art_design_film" = "Finde Projekte nach deinem Geschmack - in Kunst, Design, Film, Spiele, Musik und vielen anderen Kategorien. Wenn du ein Projekt unterstützt hast, wird deren Aktivität hier angezeigt.";
 "First_created" = "Erstes Projekt";
+"First_time_creator" = "First-time creator";
 "Fix" = "Korrigieren";
 "Fix_payment" = "Zahlung korrigieren";
 "Fix_payment_method" = "Zahlungsmethode ändern";
@@ -362,6 +367,7 @@
 "Help_local_businesses_keep_the_lights" = "Mit deiner Hilfe gehen bei lokalen Geschäften während COVID-19 nicht die Lichter aus.";
 "Hide_password" = "Passwort verbergen";
 "Home" = "Home";
+"Hot_right_now" = "Absolutes Highlight";
 "How_backers_found_your_project" = "Wie Unterstützer dein Projekt gefunden haben";
 "I_am_incorporating_AI_in_my_project" = "Ich werde KI auf andere Weise in mein Projekt integrieren.";
 "I_plan_to_use_AI_generated_content" = "Ich plane, bei meinem Projekt KI-generierte Inhalte zu nutzen.";
@@ -398,6 +404,7 @@
 "Join_our_secret_society" = "Sei dabei bei unserem Geheimbund.";
 "Joining_the_live_stream" = "Verbindung zum Live-Stream wird aufgebaut";
 "Just_for_you" = "Nur für dich.";
+"Just_launched" = "Gerade veröffentlicht";
 "Keep_in_touch_after_your_campaign" = "Bleibe auch nach deiner Kampagne in Verbindung und plane dein nächstes Projekt.";
 "Keep_reading" = "Mehr lesen";
 "Keep_up_with_future_live_streams" = "Zeitnahe Info zu zukünftigen Live-Streams";
@@ -464,12 +471,14 @@
 "Message_user_name" = "Nachricht senden an %{user_name}…";
 "Messages" = "Nachrichten";
 "Million_plus" = "Über %{total_amount} Millionen";
+"More_options" = "Weitere Optionen";
 "More_than_number_of_items_items" = "Mehr als %{number_of_items} Benachrichtigungen";
 "Most_backed" = "Meist unterstüzt";
 "Most_funded" = "Meist finanziert";
 "My_project_seeks_funding_for_AI_technology" = "Mit meinem Projekt soll KI-Technologie finanziert werden.";
 "Name" = "Name";
 "Near_me" = "In meiner Nähe";
+"Near_you" = "Near you";
 "Never" = "Niemals";
 "New_email" = "Neue E-Mail";
 "New_password" = "Neues Passwort";
@@ -546,6 +555,7 @@
 "Percentage_raised_pill_bucket_0" = "Unter 75 % gesammelt";
 "Percentage_raised_pill_bucket_1" = "75–100 % gesammelt";
 "Percentage_raised_pill_bucket_2" = "Über 100 % gesammelt";
+"Play" = "Abspielen";
 "Please_enter_a_pledge_amount_between_min_and_max" = "Bitte gebe einen Betrag zwischen %{min} und %{max} ein.";
 "Please_enter_an_amount_of_amount_or_less" = "Bitte gib einen Finanzierungsbeitrag von %{amount} oder weniger ein.";
 "Please_enter_an_amount_of_amount_or_more" = "Bitte gib einen Finanzierungsbeitrag von mindestens %{amount} ein.";
@@ -560,6 +570,11 @@
 "Pledge_amount_pledged" = "%{pledge_amount} beigetragen";
 "Pledge_any_amount_to_help_bring_this_project_to_life" = "Du kannst jeden beliebigen Betrag eingeben, um das Projekt zu unterstützen.";
 "Pledge_details" = "Dein Finanzierungsbeitrag";
+"Pledge_flow_navigation_bar_titles.Addons" = "Add-ons";
+"Pledge_flow_navigation_bar_titles.Bonus_support" = "Bonus-Unterstützung";
+"Pledge_flow_navigation_bar_titles.Payment" = "Zahlung";
+"Pledge_flow_navigation_bar_titles.Project" = "Projekt";
+"Pledge_flow_navigation_bar_titles.Rewards" = "Belohnungen";
 "Pledge_in_full" = "Sofortzahlung";
 "Pledge_label" = "Finanzierungsbeitrag";
 "Pledge_management" = "Beitragsverwaltung";
@@ -586,6 +601,7 @@
 "Prohibited_items" = "Unzulässige Artikel";
 "Project_Cancelled" = "Projekt abgebrochen.";
 "Project_Suspended" = "Projekt ausgesetzt.";
+"Project_We_Love" = "Team-Favoriten";
 "Project_activity" = "Projektaktivität";
 "Project_alerts" = "Wichtige Projekthinweise";
 "Project_cancelled" = "Projekt abgebrochen";
@@ -852,6 +868,7 @@
 "Track_shipment" = "Sendung verfolgen";
 "Track_your_backings" = "Folge deinen unterstützten Projekten";
 "Tracking_number" = "Sendungsnummer: %{number}";
+"Trending" = "Im Trend";
 "Try_adjusting_the_filters" = "Versuche, die Filter anzupassen";
 "Try_rephrasing_your_search" = "Versuche, deine Suche anders zu formulieren";
 "Try_rephrasing_your_search_or_adjusting_the_filters" = "Versuche, deine Suche anders zu formulieren oder die Filter anzupassen";
@@ -1526,6 +1543,7 @@
 "discovery.survey.button.respond_now" = "Jetzt antworten";
 "discovery.survey.creator_needs_some_info_to_deliver_reward_for_project" = "%{creator_name} benötigt einige Angaben, um dir deine Belohnung für %{project_name} zustellen zu können.";
 "discovery.survey.reward_survey" = "Befragung zur Belohnung!";
+"discovery_banner_image_content_description" = "Discovery mode preview";
 "ellipsis_more" = "... weiterlesen";
 "facebook_confirmation.button" = "Neues Konto einrichten";
 "facebook_confirmation.could_not_log_in" = "Anmeldung über Facebook fehlgeschlagen";
@@ -1999,6 +2017,7 @@
 "support_email.subject" = "Hallo Kickstarter App Support";
 "support_email.to" = "app@kickstarter.com";
 "support_email.to_android" = "android@kickstarter.com";
+"swipe_through_a_video_feed_tuning_your_recommendations_along_the_way" = "Swipe through a video feed, tuning your recommendations along the way.";
 "tabbar.activity" = "Aktivität";
 "tabbar.backings" = "Unterstützte Projekte";
 "tabbar.dashboard" = "Dashboard";
@@ -2008,6 +2027,8 @@
 "tabbar.profile" = "Profil";
 "tabbar.search" = "Suche";
 "tabbar.search_projects" = "Projekte suchen";
+"try_it_now" = "Try it now";
+"try_our_new_discovery_mode" = "Try our new discovery mode";
 "two_factor.buttons.resend" = "Erneut senden";
 "two_factor.buttons.submit" = "Absenden";
 "two_factor.code_placeholder" = "Code eingeben";
@@ -2035,3 +2056,4 @@
 "via_custom" = "Benutzerdefiniert";
 "via_external" = "Extern";
 "via_kickstarter" = "über Kickstarter";
+"video_feed_campaign_subtitle" = "%{pledged} pledged • Join %{backers} backers";

--- a/Library/Sources/Library/Resources/Locales/es.lproj/Localizable.strings
+++ b/Library/Sources/Library/Resources/Locales/es.lproj/Localizable.strings
@@ -103,8 +103,11 @@
 "Blocked_user_confirmation" = "Al bloquear a este usuario, ya no verás sus comentarios ni su contenido. Si guardaste o patrocinaste proyectos del usuario, debes eliminar tu contribución antes de bloquearlo. Puedes desbloquear usuarios desde nuestro Centro de ayuda.";
 "Bonus" = "Extra";
 "Bonus_support" = "Apoyo extra";
+"Bookmark" = "Bookmark";
+"Bookmark_this_project" = "Bookmark this project";
 "Bookmarks" = "Marcadores";
 "Bring_creative_projects_to_life" = "Dale vida a proyectos creativos.";
+"By_a_superbacker" = "By a superbacker";
 "By_creating_an_account_you_agree_to_Kickstarters_Terms_of_Use_and_Privacy_Policy" = "Si creas una cuenta, aceptas los <a href=\"%{terms_of_use_link}\">Términos de uso</a> y la <a href=\"%{privacy_policy_link}\">Política de privacidad</a> de Kickstarter.";
 "By_pledging_you_acknowledge" = "Al hacer la contribución, reconoces que las recompensas o los reembolsos no están garantizados por Kickstarter o el creador.";
 "By_pledging_you_agree_to_Kickstarters_Terms_of_Use_Privacy_Policy_and_Cookie_Policy" = "Al contribuir, aceptas las <a href=\"%{terms_of_use_link}\">Condiciones de uso</a>, <a href=\"%{privacy_policy_link}\">Política de privacidad</a> y <a href=\"%{cookie_policy_link}\">Política de cookies</a> de Kickstarter.";
@@ -113,6 +116,7 @@
 "By_submitting_your_pledge_you_agree_that_Stripe_may_charge_your_payment_method" = "Si envías tu contribución, aceptas que Stripe, nuestro proveedor de procesamiento de pagos, te cobre a tu método de pago.";
 "CVC" = "CVC";
 "Campaign" = "Campaña";
+"Campaign_goal_reached" = "Meta de campaña alcanzada";
 "Cancel" = "Cancelar";
 "Cancel_pledge" = "Cancelar contribución";
 "Cancel_your_pledge" = "Cancela tu contribución";
@@ -297,6 +301,7 @@
 "Find_projects_youll_love_and_help_bring" = "Aquí encuentras proyectos a tu gusto - ¡tu contribución ayudará a hacerlos realidad!";
 "Find_projects_youll_love_in_art_design_film" = "Proyectos a tu gusto - en arte, diseño, cine, juegos, música y otras categorías. Una vez que hayas patrocinado un proyecto, verás todas las actividades pertinentes aquí.";
 "First_created" = "Primer proyecto creado";
+"First_time_creator" = "Creador novato";
 "Fix" = "Corregir";
 "Fix_payment" = "Arreglar pago";
 "Fix_payment_method" = "Corregir el método de pago";
@@ -362,6 +367,7 @@
 "Help_local_businesses_keep_the_lights" = "Ayuda a que los negocios locales sigan activos durante los cierres producidos por el COVID-19.";
 "Hide_password" = "Ocultar contraseña";
 "Home" = "Inicio";
+"Hot_right_now" = "Proyecto en tendencia";
 "How_backers_found_your_project" = "Cómo encontraron tu proyecto los patrocinadores";
 "I_am_incorporating_AI_in_my_project" = "Voy a incorporar la IA en mi proyecto de otra manera.";
 "I_plan_to_use_AI_generated_content" = "Tengo pensado usar contenido generado por IA en mi proyecto.";
@@ -398,6 +404,7 @@
 "Join_our_secret_society" = "Únete a nuestra sociedad secreta.";
 "Joining_the_live_stream" = "Abriendo conexión a Live Stream";
 "Just_for_you" = "Sólo para ti.";
+"Just_launched" = "Proyectos recientes";
 "Keep_in_touch_after_your_campaign" = "Mantente en contacto después de tu campaña y planifica tu próximo proyecto.";
 "Keep_reading" = "Leer más";
 "Keep_up_with_future_live_streams" = "Recibe info sobre live streams futuros";
@@ -464,12 +471,14 @@
 "Message_user_name" = "Mensaje a %{user_name}…";
 "Messages" = "Mensajes";
 "Million_plus" = "Más de %{total_amount} millones";
+"More_options" = "Más opciones";
 "More_than_number_of_items_items" = "Más de %{number_of_items} notificaciones";
 "Most_backed" = "Más patrocinadores";
 "Most_funded" = "Más financiados";
 "My_project_seeks_funding_for_AI_technology" = "Mi proyecto busca financiamiento para la tecnología de IA.";
 "Name" = "Nombre";
 "Near_me" = "Cerca de mí";
+"Near_you" = "Near you";
 "Never" = "Nunca";
 "New_email" = "Nuevo correo electrónico";
 "New_password" = "Contraseña nueva";
@@ -546,6 +555,7 @@
 "Percentage_raised_pill_bucket_0" = "Menos del 75  % recaudado";
 "Percentage_raised_pill_bucket_1" = "Entre el 75  % y el 100  % recaudado";
 "Percentage_raised_pill_bucket_2" = "Más del 100  % recaudado";
+"Play" = "Reproducir";
 "Please_enter_a_pledge_amount_between_min_and_max" = "Por favor ingresa un monto de contribución entre %{min} y %{max}.";
 "Please_enter_an_amount_of_amount_or_less" = "Ingresa un monto de contribución de %{amount} o menor.";
 "Please_enter_an_amount_of_amount_or_more" = "Ingresa un monto de contribución de %{amount} o más.";
@@ -560,6 +570,11 @@
 "Pledge_amount_pledged" = "%{pledge_amount} contribuido";
 "Pledge_any_amount_to_help_bring_this_project_to_life" = "Puedes contribuir un monto de libre selección para apoyar este proyecto.";
 "Pledge_details" = "Detalles de la contribución";
+"Pledge_flow_navigation_bar_titles.Addons" = "Complementos";
+"Pledge_flow_navigation_bar_titles.Bonus_support" = "Apoyo extra";
+"Pledge_flow_navigation_bar_titles.Payment" = "Pago";
+"Pledge_flow_navigation_bar_titles.Project" = "Proyecto";
+"Pledge_flow_navigation_bar_titles.Rewards" = "Recompensas";
 "Pledge_in_full" = "Contribución total";
 "Pledge_label" = "Contribución";
 "Pledge_management" = "Gestión de contribución";
@@ -586,6 +601,7 @@
 "Prohibited_items" = "Artículos prohibidos";
 "Project_Cancelled" = "Proyecto cancelado.";
 "Project_Suspended" = "Proyecto suspendido.";
+"Project_We_Love" = "Nuestros Favoritos";
 "Project_activity" = "Actividad del proyecto";
 "Project_alerts" = "Alertas del proyecto";
 "Project_cancelled" = "Proyecto cancelado";
@@ -852,6 +868,7 @@
 "Track_shipment" = "Seguir envío";
 "Track_your_backings" = "Sigue los proyectos que has patrocinado";
 "Tracking_number" = "Número de seguimiento: %{number}";
+"Trending" = "Trending";
 "Try_adjusting_the_filters" = "Prueba modificar los filtros";
 "Try_rephrasing_your_search" = "Intenta reformular tu búsqueda";
 "Try_rephrasing_your_search_or_adjusting_the_filters" = "Intenta reformular tu búsqueda o ajustar los filtros";
@@ -1526,6 +1543,7 @@
 "discovery.survey.button.respond_now" = "Responder ahora";
 "discovery.survey.creator_needs_some_info_to_deliver_reward_for_project" = "%{creator_name} necesita un par de datos para entregarte tu recompensa de %{project_name}.";
 "discovery.survey.reward_survey" = "¡Encuesta sobre recompensas!";
+"discovery_banner_image_content_description" = "Discovery mode preview";
 "ellipsis_more" = "... leer más";
 "facebook_confirmation.button" = "Crear una nueva cuenta";
 "facebook_confirmation.could_not_log_in" = "No se pudo iniciar sesión con Facebook.";
@@ -1999,6 +2017,7 @@
 "support_email.subject" = "Saludos al equipo de atención al cliente de Kickstarter";
 "support_email.to" = "app@kickstarter.com";
 "support_email.to_android" = "android@kickstarter.com";
+"swipe_through_a_video_feed_tuning_your_recommendations_along_the_way" = "Swipe through a video feed, tuning your recommendations along the way.";
 "tabbar.activity" = "Actividad";
 "tabbar.backings" = "Contribuciones";
 "tabbar.dashboard" = "Panel de control";
@@ -2008,6 +2027,8 @@
 "tabbar.profile" = "Perfil";
 "tabbar.search" = "Búsqueda";
 "tabbar.search_projects" = "Buscar proyectos";
+"try_it_now" = "Probarlo ahora";
+"try_our_new_discovery_mode" = "Prueba nuestro nuevo modo de descubrimiento";
 "two_factor.buttons.resend" = "Volver a enviar";
 "two_factor.buttons.submit" = "Enviar";
 "two_factor.code_placeholder" = "Ingresar código";
@@ -2035,3 +2056,4 @@
 "via_custom" = "a través de personalizados";
 "via_external" = "a través de externos";
 "via_kickstarter" = "a través de Kickstarter";
+"video_feed_campaign_subtitle" = "%{pledged} recaudado • Únete a %{backers} patrocinadores";

--- a/Library/Sources/Library/Resources/Locales/fr.lproj/Localizable.strings
+++ b/Library/Sources/Library/Resources/Locales/fr.lproj/Localizable.strings
@@ -103,8 +103,11 @@
 "Blocked_user_confirmation" = "Si vous bloquez cet utilisateur, vous ne verrez plus ses commentaires ni son contenu. Si vous avez sauvegardé ou soutenu ses projets, veuillez supprimer votre engagement avant de le bloquer. Pour débloquer un utilisateur, veuillez consulter notre Centre d'assistance.";
 "Bonus" = "Bonus";
 "Bonus_support" = "Coup de pouce";
+"Bookmark" = "Bookmark";
+"Bookmark_this_project" = "Bookmark this project";
 "Bookmarks" = "Signets";
 "Bring_creative_projects_to_life" = "Réalisez vos projets créatifs.";
+"By_a_superbacker" = "Par un Superbacker";
 "By_creating_an_account_you_agree_to_Kickstarters_Terms_of_Use_and_Privacy_Policy" = "Lorsque vous créez un compte, vous acceptez les <a href=\"%{terms_of_use_link}\">Conditions d'utilisation</a> et la <a href=\"%{privacy_policy_link}\">Politique de confidentialité</a> de Kickstarter.";
 "By_pledging_you_acknowledge" = "En vous engageant, vous reconnaissez que ni Kickstarter ni le créateur ne garantit une récompense ou un remboursement.";
 "By_pledging_you_agree_to_Kickstarters_Terms_of_Use_Privacy_Policy_and_Cookie_Policy" = "Lorsque vous vous engagez, vous acceptez les <a href=\"%{terms_of_use_link}\">Conditions d'utilisation</a> de Kickstarter, notre <a href=\"%{privacy_policy_link}\">Politique de confidentialité</a> et notre <a href=\"%{cookie_policy_link}\">Politique en matière de cookies</a>.";
@@ -113,6 +116,7 @@
 "By_submitting_your_pledge_you_agree_that_Stripe_may_charge_your_payment_method" = "En vous engageant, vous acceptez que Stripe, notre prestataire de traitement des règlements, débite votre moyen de paiement.";
 "CVC" = "Cryptogramme";
 "Campaign" = "Campagne";
+"Campaign_goal_reached" = "Objectif de campagne atteint";
 "Cancel" = "Annuler";
 "Cancel_pledge" = "Annuler mon engagement";
 "Cancel_your_pledge" = "Annuler mon engagement";
@@ -297,6 +301,7 @@
 "Find_projects_youll_love_and_help_bring" = "Découvrez de beaux projets et participez à la concrétisation d'idées créatives.";
 "Find_projects_youll_love_in_art_design_film" = "Découvrez des projets que vous allez adorer : art, design, cinéma, jeux, musique et plus encore. L'activité des projets que vous soutenez s'affichera ici.";
 "First_created" = "Premier projet créé";
+"First_time_creator" = "Nouveau créateur";
 "Fix" = "Corriger";
 "Fix_payment" = "Corriger mon paiement";
 "Fix_payment_method" = "Correction du moyen de paiement";
@@ -362,6 +367,7 @@
 "Help_local_businesses_keep_the_lights" = "À l'ère du COVID-19, les entreprises de votre région ont besoin de vous pour survire.";
 "Hide_password" = "Masquer le mot de passe";
 "Home" = "Accueil";
+"Hot_right_now" = "Ce projet décolle !";
 "How_backers_found_your_project" = "Comment les contributeurs ont découvert votre projet";
 "I_am_incorporating_AI_in_my_project" = "Je prévois d'incorporer une IA dans mon projet d'une autre façon.";
 "I_plan_to_use_AI_generated_content" = "Je prévois d'utiliser du contenu généré par une IA dans mon projet.";
@@ -398,6 +404,7 @@
 "Join_our_secret_society" = "Notre société secrète n'attend que vous.";
 "Joining_the_live_stream" = "Connexion à la diffusion en direct en cours";
 "Just_for_you" = "Rien que pour vous.";
+"Just_launched" = "En début de campagne";
 "Keep_in_touch_after_your_campaign" = "Une façon de garder le contact après votre campagne et de prévoir votre prochain projet.";
 "Keep_reading" = "Plus";
 "Keep_up_with_future_live_streams" = "Soyez informé des prochaines diffusions en direct";
@@ -464,12 +471,14 @@
 "Message_user_name" = "Envoyer un message à %{user_name}";
 "Messages" = "Messages";
 "Million_plus" = "Plus de %{total_amount} millions";
+"More_options" = "Plus d'options";
 "More_than_number_of_items_items" = "Plus de %{number_of_items} éléments";
 "Most_backed" = "Nombre d'engagements";
 "Most_funded" = "Financement";
 "My_project_seeks_funding_for_AI_technology" = "Le but de mon projet est de financer une technologie d'IA.";
 "Name" = "Nom";
 "Near_me" = "Près de moi";
+"Near_you" = "Près de chez moi";
 "Never" = "Jamais";
 "New_email" = "Nouvelle adresse e-mail";
 "New_password" = "Nouveau mot de passe";
@@ -546,6 +555,7 @@
 "Percentage_raised_pill_bucket_0" = "Financé à moins de 75 %";
 "Percentage_raised_pill_bucket_1" = "Financé entre 75 % et 100 %";
 "Percentage_raised_pill_bucket_2" = "Financé à plus de 100 %";
+"Play" = "Lecture";
 "Please_enter_a_pledge_amount_between_min_and_max" = "Veuillez saisir un engagement entre %{min} et %{max}.";
 "Please_enter_an_amount_of_amount_or_less" = "Veuillez saisir un montant de %{amount} ou moins.";
 "Please_enter_an_amount_of_amount_or_more" = "Veuillez saisir un montant de %{amount} ou plus.";
@@ -560,6 +570,11 @@
 "Pledge_amount_pledged" = "%{pledge_amount} engagés";
 "Pledge_any_amount_to_help_bring_this_project_to_life" = "Choisissez le montant de votre engagement à soutenir ce projet.";
 "Pledge_details" = "Détails de mon engagement";
+"Pledge_flow_navigation_bar_titles.Addons" = "Compléments";
+"Pledge_flow_navigation_bar_titles.Bonus_support" = "Coup de pouce";
+"Pledge_flow_navigation_bar_titles.Payment" = "Paiement";
+"Pledge_flow_navigation_bar_titles.Project" = "Projet";
+"Pledge_flow_navigation_bar_titles.Rewards" = "Vos récompenses";
 "Pledge_in_full" = "Engagement intégral";
 "Pledge_label" = "Contribution";
 "Pledge_management" = "Gestion des engagements";
@@ -586,6 +601,7 @@
 "Prohibited_items" = "Articles interdits";
 "Project_Cancelled" = "Projet annulé.";
 "Project_Suspended" = "Projet suspendu.";
+"Project_We_Love" = "Nos coups de cœur";
 "Project_activity" = "Activité de mon projet";
 "Project_alerts" = "Alertes sur les projets";
 "Project_cancelled" = "Projet annulé";
@@ -852,6 +868,7 @@
 "Track_shipment" = "Suivre le colis";
 "Track_your_backings" = "Suivi de vos engagements";
 "Tracking_number" = "Numéro de suivi : %{number}";
+"Trending" = "Les tendances";
 "Try_adjusting_the_filters" = "Essayez de modifier les filtres";
 "Try_rephrasing_your_search" = "Essayez de reformuler votre recherche";
 "Try_rephrasing_your_search_or_adjusting_the_filters" = "Essayez de reformuler votre recherche ou de modifier les filtres";
@@ -1526,6 +1543,7 @@
 "discovery.survey.button.respond_now" = "Répondre";
 "discovery.survey.creator_needs_some_info_to_deliver_reward_for_project" = "%{creator_name} a besoin de quelques informations pour vous envoyer votre récompense pour le projet %{project_name}.";
 "discovery.survey.reward_survey" = "Le questionnaire des récompenses !";
+"discovery_banner_image_content_description" = "Aperçu du mode découverte";
 "ellipsis_more" = "... plus";
 "facebook_confirmation.button" = "Créer un nouveau compte";
 "facebook_confirmation.could_not_log_in" = "La connexion Facebook a échoué.";
@@ -1999,6 +2017,7 @@
 "support_email.subject" = "Bonjour, Assistance de l'application Kickstarter";
 "support_email.to" = "app@kickstarter.com";
 "support_email.to_android" = "android@kickstarter.com";
+"swipe_through_a_video_feed_tuning_your_recommendations_along_the_way" = "À découvrir : un flux de vidéos qui affinera vos recommandations au fur et à mesure.";
 "tabbar.activity" = "Activité";
 "tabbar.backings" = "Engagements";
 "tabbar.dashboard" = "Tableau de bord";
@@ -2008,6 +2027,8 @@
 "tabbar.profile" = "Profil";
 "tabbar.search" = "Recherche";
 "tabbar.search_projects" = "Rechercher des projets";
+"try_it_now" = "J'essaie";
+"try_our_new_discovery_mode" = "Essayez notre nouveau mode découverte";
 "two_factor.buttons.resend" = "Renvoyer";
 "two_factor.buttons.submit" = "Envoyer";
 "two_factor.code_placeholder" = "Saisir le code";
@@ -2035,3 +2056,4 @@
 "via_custom" = "sites référents personnalisés";
 "via_external" = "sites référents externes";
 "via_kickstarter" = "Kickstarter";
+"video_feed_campaign_subtitle" = "%{pledged} engagés • Rejoignez les %{backers} contributeurs";

--- a/Library/Sources/Library/Resources/Locales/ja.lproj/Localizable.strings
+++ b/Library/Sources/Library/Resources/Locales/ja.lproj/Localizable.strings
@@ -103,8 +103,11 @@
 "Blocked_user_confirmation" = "このユーザーをブロックすると、その後はこのユーザーのコメントやコンテンツを閲覧することができなくなります。このユーザーのプロジェクトを保存またはバックしたことがある場合は、ブロックする前にプレッジを取り消す必要があります。今後ユーザーのブロックを解除するには、ヘルプセンターをご参照ください。";
 "Bonus" = "ボーナス";
 "Bonus_support" = "ボーナスサポート";
+"Bookmark" = "ブックマーク";
+"Bookmark_this_project" = "このプロジェクトをブックマーク";
 "Bookmarks" = "ブックマーク";
 "Bring_creative_projects_to_life" = "クリエイティブなプロジェクトに生命を。";
+"By_a_superbacker" = "スーパーバッカー";
 "By_creating_an_account_you_agree_to_Kickstarters_Terms_of_Use_and_Privacy_Policy" = "アカウントを作成することで、Kickstarter の <a href=\"%{terms_of_use_link}\">利用規約</a> と<a href=\"%{privacy_policy_link}\">プライバシーポリシー</a>に同意したことになります。";
 "By_pledging_you_acknowledge" = "プレッジすると、リワードや払い戻しが Kickstarter またはクリエイターによって保証されていないことを理解したものとみなされます。";
 "By_pledging_you_agree_to_Kickstarters_Terms_of_Use_Privacy_Policy_and_Cookie_Policy" = "プレッジをすることにより、Kickstarter の <a href=\"%{terms_of_use_link}\">利用規約</a>、<a href=\"%{privacy_policy_link}\">プライバシーポリシー</a>、<a href=\"%{cookie_policy_link}\">Cookie ポリシー</a>に同意したとみなされます。";
@@ -113,6 +116,7 @@
 "By_submitting_your_pledge_you_agree_that_Stripe_may_charge_your_payment_method" = "プレッジを送信することで、Kickstarter の決済サービスプロバイダー、Stripe がご利用のお支払い方法へ請求を行うことに同意するものとみなされます。";
 "CVC" = "CVC";
 "Campaign" = "プロジェクト";
+"Campaign_goal_reached" = "Campaign goal reached";
 "Cancel" = "キャンセル";
 "Cancel_pledge" = "プレッジを取り消す";
 "Cancel_your_pledge" = "プレッジを取り消す";
@@ -297,6 +301,7 @@
 "Find_projects_youll_love_and_help_bring" = "お気に入りを見つけて、クリエイティブなプロジェクトに生命を吹き込もう。";
 "Find_projects_youll_love_in_art_design_film" = "お気に入りを見つけて、クリエイティブなプロジェクトに生命を吹き込もう。";
 "First_created" = "1つめのプロジェクト";
+"First_time_creator" = "First-time creator";
 "Fix" = "修正する";
 "Fix_payment" = "お支払い方法の修正";
 "Fix_payment_method" = "お支払い方法を修正";
@@ -362,6 +367,7 @@
 "Help_local_businesses_keep_the_lights" = "新型コロナウイルス感染症(COVID- 19)の影響により休業を強いられた地元のビジネスを支援しましょう。";
 "Hide_password" = "パスワードを非表示にする";
 "Home" = "ホーム";
+"Hot_right_now" = "人気プロジェクト！";
 "How_backers_found_your_project" = "バッカ―があなたのプロジェクトを見つけた経緯";
 "I_am_incorporating_AI_in_my_project" = "他の形で自分のプロジェクトに AI を取り入れる予定です。";
 "I_plan_to_use_AI_generated_content" = "自分のプロジェクトで AI で生成されたコンテンツを使用する予定です。";
@@ -398,6 +404,7 @@
 "Join_our_secret_society" = "この秘密の世界にあなたも浸ってみませんか。";
 "Joining_the_live_stream" = "ライブ配信に参加";
 "Just_for_you" = "あなたのために。";
+"Just_launched" = "最新";
 "Keep_in_touch_after_your_campaign" = "キャンペーン終了後もニュースレターで最新情報をチェックし、次のプロジェクトに備えましょう。";
 "Keep_reading" = "続きを読む";
 "Keep_up_with_future_live_streams" = "ライブ配信を通知";
@@ -464,12 +471,14 @@
 "Message_user_name" = "%{user_name} にメッセージ";
 "Messages" = "メッセージ";
 "Million_plus" = "%{total_amount},000,000 以上";
+"More_options" = "その他のオプション";
 "More_than_number_of_items_items" = "%{number_of_items} 件以上のアイテム";
 "Most_backed" = "バッカー数";
 "Most_funded" = "達成額";
 "My_project_seeks_funding_for_AI_technology" = "私のプロジェクトの目的は、AI テクノロジーのための資金調達です。";
 "Name" = "名前";
 "Near_me" = "近辺";
+"Near_you" = "Near you";
 "Never" = "通知を受けない";
 "New_email" = "新しいメールアドレス";
 "New_password" = "新しいパスワード";
@@ -546,6 +555,7 @@
 "Percentage_raised_pill_bucket_0" = "資金調達達成率：75% 未満";
 "Percentage_raised_pill_bucket_1" = "資金調達達成率：75% ～ 100%";
 "Percentage_raised_pill_bucket_2" = "資金調達達成率：100%";
+"Play" = "動画を再生";
 "Please_enter_a_pledge_amount_between_min_and_max" = "%{min} から %{max} までのプレッジ額を入力してください。";
 "Please_enter_an_amount_of_amount_or_less" = "%{amount} 以下の金額を入力してくだささい。";
 "Please_enter_an_amount_of_amount_or_more" = "%{amount} 以上の金額を入力してください。";
@@ -560,6 +570,11 @@
 "Pledge_amount_pledged" = "%{pledge_amount} のプレッジ";
 "Pledge_any_amount_to_help_bring_this_project_to_life" = "プレッジでプロジェクトに生命を。";
 "Pledge_details" = "プレッジ詳細";
+"Pledge_flow_navigation_bar_titles.Addons" = "アドオン";
+"Pledge_flow_navigation_bar_titles.Bonus_support" = "ボーナスサポート";
+"Pledge_flow_navigation_bar_titles.Payment" = "支払い";
+"Pledge_flow_navigation_bar_titles.Project" = "プロジェクト";
+"Pledge_flow_navigation_bar_titles.Rewards" = "リワード";
 "Pledge_in_full" = "一括払いのプレッジ";
 "Pledge_label" = "プレッジ";
 "Pledge_management" = "プレッジ管理";
@@ -586,6 +601,7 @@
 "Prohibited_items" = "禁止事項";
 "Project_Cancelled" = "プロジェクトが取り消されました。";
 "Project_Suspended" = "プロジェクトは停止されました。";
+"Project_We_Love" = "素敵なプロジェクト";
 "Project_activity" = "プロジェクトのアクティビティ";
 "Project_alerts" = "プロジェクトのアラート";
 "Project_cancelled" = "プロジェクトが取り消されました。";
@@ -852,6 +868,7 @@
 "Track_shipment" = "配送状況を追跡";
 "Track_your_backings" = "支援したプロジェクトを追跡";
 "Tracking_number" = "追跡番号：%{number}";
+"Trending" = "急上昇";
 "Try_adjusting_the_filters" = "フィルターを調整してみてください";
 "Try_rephrasing_your_search" = "検索キーワードを変更してみてください";
 "Try_rephrasing_your_search_or_adjusting_the_filters" = "検索キーワードを変更するか、フィルターを調整してみてください";
@@ -1526,6 +1543,7 @@
 "discovery.survey.button.respond_now" = "返信";
 "discovery.survey.creator_needs_some_info_to_deliver_reward_for_project" = "%{creator_name} は%{project_name} のリワードの情報が必要です。";
 "discovery.survey.reward_survey" = "リワードサーベイ";
+"discovery_banner_image_content_description" = "Discovery mode preview";
 "ellipsis_more" = "さらに表示";
 "facebook_confirmation.button" = "Newアカウント作成";
 "facebook_confirmation.could_not_log_in" = "Facebookでのログインに失敗";
@@ -1999,6 +2017,7 @@
 "support_email.subject" = "ようこそ、Kickstarter App Supportへ";
 "support_email.to" = "app@kickstarter.com";
 "support_email.to_android" = "android@kickstarter.com";
+"swipe_through_a_video_feed_tuning_your_recommendations_along_the_way" = "Swipe through a video feed, tuning your recommendations along the way.";
 "tabbar.activity" = "アクティビティ";
 "tabbar.backings" = "支援";
 "tabbar.dashboard" = "ダッシュボード";
@@ -2008,6 +2027,8 @@
 "tabbar.profile" = "プロフィール";
 "tabbar.search" = "さがす";
 "tabbar.search_projects" = "プロジェクトを探す";
+"try_it_now" = "Try it now";
+"try_our_new_discovery_mode" = "Try our new discovery mode";
 "two_factor.buttons.resend" = "再送する";
 "two_factor.buttons.submit" = "提出する";
 "two_factor.code_placeholder" = "認証コードを入力";
@@ -2035,3 +2056,4 @@
 "via_custom" = "リファラー経由";
 "via_external" = "外部を経由";
 "via_kickstarter" = "kickstarterを経由";
+"video_feed_campaign_subtitle" = "プレッジ総額: %{pledged} • 現在のバッカー数: %{backers}";

--- a/LibraryTests/Library/PledgeViewContextTests.swift
+++ b/LibraryTests/Library/PledgeViewContextTests.swift
@@ -35,7 +35,7 @@ final class PledgeViewContextTests: TestCase {
     XCTAssertFalse(context.sectionSeparatorsHidden)
     XCTAssertFalse(context.shippingLocationViewHidden)
     XCTAssertEqual(context.submitButtonTitle, "Pledge")
-    XCTAssertEqual(context.title, "Back this project")
+    XCTAssertEqual(context.title, "Payment")
   }
 
   func testUpdate() {

--- a/LibraryTests/Library/ViewModels/PledgeViewModelTests.swift
+++ b/LibraryTests/Library/ViewModels/PledgeViewModelTests.swift
@@ -197,7 +197,7 @@ final class PledgeViewModelTests: TestCase {
       self.vm.inputs.configure(with: data)
       self.vm.inputs.viewDidLoad()
 
-      self.title.assertValues(["Back this project"])
+      self.title.assertValues(["Payment"])
 
       self.configurePledgeRewardsSummaryViewRewards.assertValues([[reward]])
       self.configurePledgeRewardsSummaryViewProjectCurrency.assertValues([Project.Country.us.currencyCode])
@@ -242,7 +242,7 @@ final class PledgeViewModelTests: TestCase {
       self.vm.inputs.configure(with: data)
       self.vm.inputs.viewDidLoad()
 
-      self.title.assertValues(["Back this project"])
+      self.title.assertValues(["Payment"])
 
       self.configurePledgeRewardsSummaryViewRewards.assertValues([[reward]])
       self.configurePledgeRewardsSummaryViewProjectCurrency.assertValues([Project.Country.us.currencyCode])


### PR DESCRIPTION
# 📲 What

Update the navigation bar titles in the Pledge flow. Instead of each title saying "Back this Project", use context-dependent titles like "Payment" and "Bonus Support".

<img height="500" alt="nav-titles-fixed" src="https://github.com/user-attachments/assets/1b88e2c2-44e7-4bc6-9dae-97599248eeb1" />

# 🤔 Why

At some point Apple added a feature to the Back button that displays the titles of all the pages in the stack. Because all of our pages were named "Back this Project", the Back button felt broken.

<img height="500" alt="bad back button" src="https://github.com/user-attachments/assets/ccd71cbb-d89c-4e60-9ba6-9086946301c3" />

I'm fixing this as part of CHECK-87, which makes other improvements to the navigation bar in the Pledge flow.