### PR TITLE
CHECK-46: Don't send anonymous ID to Statsig when tracking consent was denied

### DIFF
--- a/Kickstarter-iOS/AppDelegate.swift
+++ b/Kickstarter-iOS/AppDelegate.swift
@@ -230,7 +230,9 @@ internal final class AppDelegate: UIResponder, UIApplicationDelegate {
     self.disposables.append(
       self.viewModel.outputs.trackingAuthorizationStatus
         .observeForUI()
-        .startWithValues(self.updateFirebaseConsent(status:))
+        .startWithValues { status in
+          self.appTrackingAuthorizationChanged(status: status)
+        }
     )
 
     self.viewModel.outputs.synchronizeUbiquitousStore
@@ -431,6 +433,15 @@ internal final class AppDelegate: UIResponder, UIApplicationDelegate {
     let session = URLSession(configuration: .default, delegate: self, delegateQueue: nil)
     let task = session.dataTask(with: url)
     task.resume()
+  }
+
+  private func appTrackingAuthorizationChanged(status: AppTrackingAuthorization) {
+    self.updateFirebaseConsent(status: status)
+
+    // We only pass the Segment identifier to Statsig if tracking consent is enabled.
+    // Update Statsig if tracking authorization changes.
+    let statsigUser = AppEnvironment.current.statsigUser()
+    AppEnvironment.current.statsigClient?.reload(withUser: statsigUser)
   }
 
   private func updateFirebaseConsent(status: AppTrackingAuthorization) {

--- a/Library/Sources/Library/Library/Tracking/KSRAnalytics.swift
+++ b/Library/Sources/Library/Library/Tracking/KSRAnalytics.swift
@@ -16,7 +16,25 @@ public final class KSRAnalytics {
   private var segmentClient: (TrackingClientType & IdentifyingTrackingClient)?
 
   var anonymousId: String? {
+    // This anonymous ID is used by Statsig for bucketing experiments.
+    // If tracking has been disallowed via consent management, we won't return an anonymous ID.
+    // This makes the iOS behavior consistent with Android.
+    if self.disableTracking() {
+      return nil
+    }
+
     return self.segmentClient?.anonymousId
+  }
+
+  /// Returns `true` if the user has not consented to tracking, or if we can't determine their tracking state.
+  private func disableTracking() -> Bool {
+    guard let appTrackingTransparency = self.appTrackingTransparency else { return true }
+
+    self.appTrackingTransparency?.updateAdvertisingIdentifier()
+
+    guard let _ = appTrackingTransparency.advertisingIdentifier else { return true }
+
+    return false
   }
 
   /// Configures `KSRAnalytics` with a Segment tracking client. Call is idempotent and will only set once.

--- a/Library/Sources/Library/Library/Tracking/KSRAnalytics.swift
+++ b/Library/Sources/Library/Library/Tracking/KSRAnalytics.swift
@@ -27,7 +27,7 @@ public final class KSRAnalytics {
   }
 
   /// Returns `true` if the user has consented to tracking. Returns `false` if they have not, or if we can't determine their tracking state.
-  private func isTrackingEnabled() -> Bool {
+  internal func isTrackingEnabled() -> Bool {
     guard let appTrackingTransparency = self.appTrackingTransparency else { return false }
 
     self.appTrackingTransparency?.updateAdvertisingIdentifier()

--- a/Library/Sources/Library/Library/Tracking/KSRAnalytics.swift
+++ b/Library/Sources/Library/Library/Tracking/KSRAnalytics.swift
@@ -19,22 +19,22 @@ public final class KSRAnalytics {
     // This anonymous ID is used by Statsig for bucketing experiments.
     // If tracking has been disallowed via consent management, we won't return an anonymous ID.
     // This makes the iOS behavior consistent with Android.
-    if self.disableTracking() {
+    guard self.isTrackingEnabled() else {
       return nil
     }
 
     return self.segmentClient?.anonymousId
   }
 
-  /// Returns `true` if the user has not consented to tracking, or if we can't determine their tracking state.
-  private func disableTracking() -> Bool {
-    guard let appTrackingTransparency = self.appTrackingTransparency else { return true }
+  /// Returns `true` if the user has consented to tracking. Returns `false` if they have not, or if we can't determine their tracking state.
+  private func isTrackingEnabled() -> Bool {
+    guard let appTrackingTransparency = self.appTrackingTransparency else { return false }
 
     self.appTrackingTransparency?.updateAdvertisingIdentifier()
 
-    guard let _ = appTrackingTransparency.advertisingIdentifier else { return true }
+    guard let _ = appTrackingTransparency.advertisingIdentifier else { return false }
 
-    return false
+    return true
   }
 
   /// Configures `KSRAnalytics` with a Segment tracking client. Call is idempotent and will only set once.

--- a/LibraryTests/Library/Tracking/KSRAnalyticsTests.swift
+++ b/LibraryTests/Library/Tracking/KSRAnalyticsTests.swift
@@ -1,3 +1,4 @@
+import AppTrackingTransparency
 @testable import KsApi
 @testable import KsApiTestHelpers
 @testable import Library
@@ -2035,6 +2036,46 @@ final class KSRAnalyticsTests: TestCase {
     XCTAssertNil(props?["project_user_has_starred"])
     XCTAssertNil(props?["project_prelaunch_activated"] as? Bool)
     XCTAssertEqual(false, props?["project_has_add_ons"] as? Bool)
+  }
+
+  func testTrackingIsEnabled_andAnonymousIdIsSet_whenTrackingIsAllowed() {
+    let mockTransparency = MockAppTrackingTransparency()
+    mockTransparency.shouldRequestAuthStatus = true
+    let segmentClient = MockTrackingClient()
+
+    let ksrAnalytics = KSRAnalytics(
+      segmentClient: segmentClient,
+      appTrackingTransparency: mockTransparency
+    )
+
+    XCTAssertNotNil(ksrAnalytics.anonymousId)
+    XCTAssertTrue(ksrAnalytics.isTrackingEnabled())
+  }
+
+  func testTrackingIsNotEnabled_andAnonymousIdIsEmpty_whenTrackingIsDisallowed() {
+    let mockTransparency = MockAppTrackingTransparency()
+    mockTransparency.shouldRequestAuthStatus = false
+    let segmentClient = MockTrackingClient()
+
+    let ksrAnalytics = KSRAnalytics(
+      segmentClient: segmentClient,
+      appTrackingTransparency: mockTransparency
+    )
+
+    XCTAssertNil(ksrAnalytics.anonymousId)
+    XCTAssertFalse(ksrAnalytics.isTrackingEnabled())
+  }
+
+  func testTrackingIsNotEnabled_andAnonymousIdIsEmpty_whenTrackingIsMissing() {
+    let segmentClient = MockTrackingClient()
+
+    let ksrAnalytics = KSRAnalytics(
+      segmentClient: segmentClient,
+      appTrackingTransparency: nil
+    )
+
+    XCTAssertNil(ksrAnalytics.anonymousId)
+    XCTAssertFalse(ksrAnalytics.isTrackingEnabled())
   }
 
   /*


### PR DESCRIPTION
# 📲 What

Don't send Segment's anonymous ID to Statsig when tracking consent is denied.

# 🤔 Why

1. Even though Segment's ID is anonymous - and not subject to the restrictions of IDFA - this feels more honest.
2. The Statsig integration for anonymous users won't work when Segment isn't sending events, regardless.
3. This behavior is consistent with Android, and we want our Statsig clients to have a similar implementation.