### PR TITLE
CHECK-179: Don't show corners of background when pushing pages in the Pledge flow

### DIFF
--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/ProjectPage/Controller/ProjectPageViewController.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/ProjectPage/Controller/ProjectPageViewController.swift
@@ -71,9 +71,19 @@ public final class ProjectPageViewController: UIViewController, MessageBannerVie
   static func navigationController(withViewControllers viewControllers: [UIViewController])
     -> UINavigationController {
     let nav = NavigationController()
+
     nav.viewControllers = viewControllers
 
-    nav.modalPresentationStyle = ProjectPageViewController.projectPageModalPresentationStyle
+    let modalPresentationStyle = ProjectPageViewController.projectPageModalPresentationStyle
+
+    nav.modalPresentationStyle = modalPresentationStyle
+
+    // If you present a navigation controller .fullScreen, and subsequently push/pop screens onto its stack,
+    // you may briefly see the default (black) background behind the navigation controller.
+    // Setting this background to white prevents us from seeing some odd effects as pages animate.
+    if modalPresentationStyle == .fullScreen {
+      nav.view.backgroundColor = Colors.Background.Surface.primary.uiColor()
+    }
 
     return nav
   }


### PR DESCRIPTION
# 📲 What

@kaokiizu discovered a visual bug in the new full-screen checkout flow. When pushing and popping screens, you could see a black rounded corner behind each one.

https://github.com/user-attachments/assets/dea4709d-9b9f-4acc-9309-e9f6fca92b44

By setting an opaque background on the `UINavigationController` that contains the project page stack, we fix this bug.
 
# 🤔 Why

Setting a page to `.fullScreen` removes all screens below it. Instead, it's presented on top of a wrapper view, which iOS sets to black.

By setting our own opaque color on the stack, we cover up that black background with something that matches our apps a bit better.

# 👀 Tested on

- [x] iPhone 26 experiment on
- [x] iPhone 26 experiment off
- [x] iPhone 18 experiment on
- [x] iPhone 18 experiment off
- [x] iPad 26 (not eligible for experiment)
- [x] iPad 18 (not eligible for experiment)
- [x] KK's phone (light mode)
- [x] KK's phone (dark mode)