### PR TITLE
[DISC-221] Video Feed: Creator Icon Tap

### DIFF
--- a/Kickstarter-Framework/Sources/Kickstarter-Framework-iOSTests/Kickstarter-iOS/Features/VideoFeed/Controller/VideoFeedViewControllerTests.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework-iOSTests/Kickstarter-iOS/Features/VideoFeed/Controller/VideoFeedViewControllerTests.swift
@@ -43,6 +43,7 @@ final class VideoFeedViewControllerTests: TestCase {
         cell.configureWith(
           value: VideoFeedItem(
             id: "0",
+            pid: 3,
             slug: "video_feed",
             projectURL: "https://test.com",
             title: "Ringo Move - The Ultimate Workout Bottle",
@@ -96,6 +97,7 @@ final class VideoFeedViewControllerTests: TestCase {
         cell.configureWith(
           value: VideoFeedItem(
             id: "0",
+            pid: 3,
             slug: "video_feed",
             projectURL: "https://test.com",
             title: "Ringo Move - The Ultimate Workout Bottle for People Who Like Long Product Names That Wrap Across Several Lines For People Who Like Long Product Names That Wrap Across Several Lines",
@@ -151,6 +153,7 @@ final class VideoFeedViewControllerTests: TestCase {
         cell.configureWith(
           value: VideoFeedItem(
             id: "0",
+            pid: 3,
             slug: "video_feed",
             projectURL: "https://test.com",
             title: "Ringo Move - The Ultimate Workout Bottle",

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Controller/VideoFeedViewController.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Controller/VideoFeedViewController.swift
@@ -34,7 +34,6 @@ final class VideoFeedViewController: UIViewController {
     super.viewDidLoad()
 
     self.view.backgroundColor = Constants.backgroundColor
-    self.navigationController?.navigationBar.isHidden = true
 
     self.configureAudioSession()
     self.observeAppLifecycle()
@@ -47,6 +46,18 @@ final class VideoFeedViewController: UIViewController {
 
   deinit {
     self.lifecycleObservers.forEach(NotificationCenter.default.removeObserver)
+  }
+
+  override func viewWillAppear(_ animated: Bool) {
+    super.viewWillAppear(animated)
+
+    self.navigationController?.setNavigationBarHidden(true, animated: animated)
+  }
+
+  override func viewWillDisappear(_ animated: Bool) {
+    super.viewWillDisappear(animated)
+
+    self.navigationController?.setNavigationBarHidden(false, animated: animated)
   }
 
   // MARK: - CollectionView
@@ -159,6 +170,18 @@ final class VideoFeedViewController: UIViewController {
 
   // MARK: - Navigation
 
+  private func goToCreatorProfile(for item: VideoFeedItem) {
+    let vc = ProjectCreatorViewController.configuredWith(project: item)
+
+    if self.traitCollection.userInterfaceIdiom == .pad {
+      let nav = UINavigationController(rootViewController: vc)
+      nav.modalPresentationStyle = .formSheet
+      self.present(nav, animated: true)
+    } else {
+      self.navigationController?.pushViewController(vc, animated: true)
+    }
+  }
+
   private func goToProjectPage(for item: VideoFeedItem) {
     let vc = ProjectPageViewController.navigationController(
       withProjectOrParam: .right(Param.slug(item.slug)),
@@ -191,7 +214,7 @@ extension VideoFeedViewController: UICollectionViewDelegateFlowLayout {
     let item = items[indexPath.item]
 
     cell.onCloseTapped = { [weak self] in self?.dismiss(animated: true) }
-    cell.onCreatorTapped = { [weak self] in self?.simpleAlert(title: "Creator") }
+    cell.onCreatorTapped = { [weak self] in self?.goToCreatorProfile(for: item) }
     cell.onShareTapped = { [weak self] in self?.simpleAlert(title: "Share") }
     cell.onMoreTapped = { [weak self] in self?.simpleAlert(title: "More") }
     cell.onVideoReady = { [weak self] in self?.unlockScrollingIfNeeded() }

--- a/Library/Sources/Library/Library/VideoFeedItem+Constructor.swift
+++ b/Library/Sources/Library/Library/VideoFeedItem+Constructor.swift
@@ -9,6 +9,7 @@ extension VideoFeedItem {
 
     self.init(
       id: node.project.id,
+      pid: node.project.pid,
       slug: node.project.slug,
       projectURL: node.project.url,
       title: node.project.name,

--- a/Library/Sources/Library/Library/VideoFeedItem+ProjectCreatorConfiguration.swift
+++ b/Library/Sources/Library/Library/VideoFeedItem+ProjectCreatorConfiguration.swift
@@ -1,0 +1,15 @@
+import KsApi
+
+extension VideoFeedItem: HasProjectCreatorProperties {
+  public var projectCreatorProperties: ProjectCreatorProperties {
+    ProjectCreatorProperties(
+      id: self.pid,
+      name: self.title,
+      projectWebURL: self.projectURL
+    )
+  }
+}
+
+extension VideoFeedItem: HasProjectWebURL {
+  public var projectWebURL: String { self.projectURL }
+}

--- a/Library/Sources/Library/Library/VideoFeedItem.swift
+++ b/Library/Sources/Library/Library/VideoFeedItem.swift
@@ -2,6 +2,9 @@ import Foundation
 
 public struct VideoFeedItem: Hashable {
   public let id: String
+
+  public let pid: Int
+
   public let slug: String
 
   /// The project's web URL, used for the creator profile webview.


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Tapping the creator avatar in the video feed now navigates to the creator's profile page

# 🛠 How

- Added pid to VideoFeedItem (already in the fragment)
- Conformed VideoFeedItem to ProjectCreatorConfiguration via HasProjectCreatorProperties + HasProjectWebURL so it can be passed directly to ProjectCreatorViewController
- Push ProjectCreatorViewController on creator icon tap
- Updated nav bar visibility to viewWillAppear/viewWillDisappear so the back button shows correctly on push and hides again on pop

# 👀 See

Trello, screenshots, external resources?

| Before 🐛 | After 🦋 |
| --- | --- |
|  | <img width="295" height="640" alt="Simulator Screen Recording - iPhone 17 Pro - 2026-05-26 at 12 48 01" src="https://github.com/user-attachments/assets/c43639f6-221b-4f64-94f5-582da5978a50" /> |

# ✅ Acceptance criteria

- [x] Tapping the creator avatar pushes the creator profile on iPhone
- [x] Tapping the creator avatar presents as a form sheet on iPad
- [x] Nav bar is unhidden on creator profile push and re-hidden when popping back to the video feed
