### PR TITLE
[DISC-225] Project Page GIFs Not Loading 

### DIFF
--- a/KsApi/Sources/KsApi/lib/HTML Parser/Element+Helpers.swift
+++ b/KsApi/Sources/KsApi/lib/HTML Parser/Element+Helpers.swift
@@ -138,7 +138,8 @@ extension Element {
 
     // - if it's a gif collect attribute data-src instead
     if updatedSrc.contains(HTMLRawText.Image.gifExtension.rawValue),
-       let dataSource = try? child.attr(HTMLRawText.Image.dataSource.rawValue) {
+       let dataSource = try? child.attr(HTMLRawText.Image.dataSource.rawValue),
+       !dataSource.isEmpty {
       updatedSrc = dataSource
     }
 

--- a/KsApi/Sources/KsApi/lib/HTML Parser/Element+Helpers.swift
+++ b/KsApi/Sources/KsApi/lib/HTML Parser/Element+Helpers.swift
@@ -136,7 +136,8 @@ extension Element {
       updatedSrc = source
     }
 
-    // - if it's a gif collect attribute data-src instead
+    /// GIFs use `data-src` for the real URL since `src` just holds a lazy-load placeholder.
+    /// skip if `data-src` is an empty string so we don't replace the real URL with nothing
     if updatedSrc.contains(HTMLRawText.Image.gifExtension.rawValue),
        let dataSource = try? child.attr(HTMLRawText.Image.dataSource.rawValue),
        !dataSource.isEmpty {


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Adds a `!dataSource.isEmpty` check in our `HTML Parser.Element+Helpers.parseImageElementSrc()` method when attempting to parse a GIF.

# 🤔 Why

GIFs aren't loading in Project Campaign. This is the fix

# 🛠 How

When we parse html images on iOS the app first grabs the image URL from the `src` attribute. 
Then, if that URL is a gif, it goes ahead and swaps it out using the image's `data-src` attribute instead. _Unless `data-src` is  `nil`._

However, after a [recent backend change](https://github.com/kickstarter/kickstarter/pull/34502) it looks like `data-src` values are empty strings for gifs (not `nil`). So we're just setting the gif source to be nothing.

# 👀 See

Trello, screenshots, external resources?

| Before 🐛 | After 🦋 |
| --- | --- |
|  |<img width="295" height="640" alt="Simulator Screen Recording - iPhone 17 Pro - 2026-05-27 at 09 41 53" src="https://github.com/user-attachments/assets/76d5d341-2f53-45c8-83bb-c79b0fce1ef9" /> |


# ✅ Acceptance criteria

- [x] Project page GIFs load and play if `data-src` is empty or nil
