### PR TITLE
[DISC-227] Video Feed: Fix layout Issue and Remove Scroll Locking

### DIFF
--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Cell/VideoFeedCell.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Cell/VideoFeedCell.swift
@@ -12,9 +12,9 @@ import UIKit
 ///
 /// # Playback flow
 /// Loads video on `CollectionView.willDisplay`
-/// After the first frame renders, we call `onVideoReady` +`playbackState.videoDidBecomeReady()`
-/// Preview image fades out , video begins playback, and controller unlocks scrolling.
-/// On `didEndDisplaying`, `clearVideo()` fully tears down the item so recycled cells don't keep buffering.
+/// After the first frame renders, we call `onVideoReady` + `playbackState.videoDidBecomeReady()`
+/// Preview image fades out and video begins playback.
+/// On `didEndDisplaying`, `resetVideo()` fully tears down the item so recycled cells don't keep buffering.
 final class VideoFeedCell: UICollectionViewCell, ValueCell {
   static let reuseIdentifier = "VideoFeedCell"
 
@@ -33,7 +33,7 @@ final class VideoFeedCell: UICollectionViewCell, ValueCell {
   var onMoreTapped: (() -> Void)?
   var onCTATapped: (() -> Void)?
 
-  /// Called once the video is ready to play. Used to unlock feed scrolling.
+  /// Called once the video is ready to play.
   var onVideoReady: (() -> Void)?
   /// Called when the video fails to load or play.
   var onVideoFailed: (() -> Void)?

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Controller/VideoFeedViewController.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Controller/VideoFeedViewController.swift
@@ -8,8 +8,7 @@ import UIKit
 /// Full-screen swipeable video feed.
 ///   - Full-screen paging
 ///   - Plain data source driven by `VideoFeedViewModel`
-///   - Scrolling locked until the first video is ready to play
-///   - Cells starts to load video on `willDisplay` and loops on `didEndDisplaying`
+///   - Cells start loading video on `willDisplay` and reset on `didEndDisplaying`
 ///   - Pauses video on background, resumes on foreground
 final class VideoFeedViewController: UIViewController {
   private enum Constants {
@@ -78,7 +77,6 @@ final class VideoFeedViewController: UIViewController {
     self.collectionView.translatesAutoresizingMaskIntoConstraints = false
     self.collectionView.backgroundColor = Constants.backgroundColor
     self.collectionView.isPagingEnabled = true
-    self.collectionView.isScrollEnabled = false
     self.collectionView.showsVerticalScrollIndicator = false
     self.collectionView.contentInsetAdjustmentBehavior = .never
 
@@ -115,15 +113,6 @@ final class VideoFeedViewController: UIViewController {
   private func updateFeedWithFetchedItems(_ newItems: [VideoFeedItem]) {
     self.dataSource.load(newItems)
     self.collectionView.reloadData()
-  }
-
-  // MARK: - Scroll locking
-
-  /// Unlocks scrolling once the first video is ready to play.
-  private func unlockScrollingIfNeeded() {
-    guard !self.collectionView.isScrollEnabled else { return }
-
-    self.collectionView.isScrollEnabled = true
   }
 
   private func snapToCurrentPage() {
@@ -237,9 +226,6 @@ extension VideoFeedViewController: UICollectionViewDelegateFlowLayout {
     cell.onCreatorTapped = { [weak self] in self?.goToCreatorProfile(for: item) }
     cell.onShareTapped = { [weak self] in self?.simpleAlert(title: "Share") }
     cell.onMoreTapped = { [weak self] in self?.simpleAlert(title: "More") }
-    cell.onVideoReady = { [weak self] in self?.unlockScrollingIfNeeded() }
-    /// Failed videos still need scroll unlocked so the user can swipe past.
-    cell.onVideoFailed = { [weak self] in self?.unlockScrollingIfNeeded() }
     cell.onCTATapped = { [weak self] in self?.goToProjectPage(for: item) }
 
     cell.configureWith(

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Controller/VideoFeedViewController.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Controller/VideoFeedViewController.swift
@@ -48,6 +48,16 @@ final class VideoFeedViewController: UIViewController {
     self.lifecycleObservers.forEach(NotificationCenter.default.removeObserver)
   }
 
+  override func viewDidAppear(_ animated: Bool) {
+    super.viewDidAppear(animated)
+
+    /// Presenting a fullscreen modal nudges the contentOffset.
+    /// This is a side effect of UIKit re-measuring UIHostingConfiguration cells when presenting views.
+    /// This method snaps the collection view cell back into place once the layout has settled.
+
+    self.snapToCurrentPage()
+  }
+
   override func viewWillAppear(_ animated: Bool) {
     super.viewWillAppear(animated)
 
@@ -114,6 +124,16 @@ final class VideoFeedViewController: UIViewController {
     guard !self.collectionView.isScrollEnabled else { return }
 
     self.collectionView.isScrollEnabled = true
+  }
+
+  private func snapToCurrentPage() {
+    let pageHeight = self.collectionView.bounds.height
+
+    guard pageHeight > 0 else { return }
+
+    let currentPage = round(self.collectionView.contentOffset.y / pageHeight)
+
+    self.collectionView.contentOffset.y = currentPage * pageHeight
   }
 
   // MARK: - Audio session


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Fixes a layout bug where dismissing the project page left the video feed cells partially offset, showing some of the previous cell. 

Also removes the scroll lock that was preventing the feed from being scrollable before the first video was ready.

# 🤔 Why

Fixing little bugs is important and sometimes SwiftUI and UIKit to play as nicely as you expect them to

# 🛠 How

- Added a method snap the contentOffset back to the nearest cell boundary after a pushed view controller is dismissed.
- Removed collection view scroll locking logic

# 👀 See

Trello, screenshots, external resources?

| Before 🐛 | After 🦋 |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/61ad7ce4-9238-432e-bfee-e98976b0f284" controls width="295"></video> | <img width="295" height="640" alt="Simulator Screen Recording - iPhone 17 Pro - 2026-05-28 at 11 38 55" src="https://github.com/user-attachments/assets/a2808052-a629-42e8-98cc-cdd31f57dc69" /> |

# ✅ Acceptance criteria

- [x] Tapping the CTA on any video feed cell and dismissing the project page shows the feed to be perfectly snapped to the current cell
- [x] Feed is scrollable immediately on first load even if the first video isn't loaded up and ready
