### PR TITLE
[PF-17] SDUI OEmbed Block

### DIFF
--- a/ServerDrivenUI/Sources/ServerDrivenUI/Blocks/OEmbedBlock.swift
+++ b/ServerDrivenUI/Sources/ServerDrivenUI/Blocks/OEmbedBlock.swift
@@ -3,7 +3,7 @@ import SwiftUI
 import WebKit
 
 struct OEmbedBlock: View {
-  var oembed: RichTextElement.Oembed
+  var oembed: RichTextElement.OEmbed
   @Environment(\.richTextStyle) var style: any RichTextStyle
   internal var onWebViewCreated: ((WKWebView) -> Void)?
 

--- a/ServerDrivenUI/Sources/ServerDrivenUI/Blocks/OEmbedBlock.swift
+++ b/ServerDrivenUI/Sources/ServerDrivenUI/Blocks/OEmbedBlock.swift
@@ -5,6 +5,8 @@ import WebKit
 struct OEmbedBlock: View {
   var oembed: RichTextElement.OEmbed
   @Environment(\.richTextStyle) var style: any RichTextStyle
+
+  // Just for testing, please do not use directly
   internal var onWebViewCreated: ((WKWebView) -> Void)?
 
   var iframeURL: URL? {

--- a/ServerDrivenUI/Sources/ServerDrivenUI/Blocks/OEmbedBlock.swift
+++ b/ServerDrivenUI/Sources/ServerDrivenUI/Blocks/OEmbedBlock.swift
@@ -54,7 +54,7 @@ private struct OEmbedWebView: UIViewRepresentable {
   var onWebViewCreated: ((WKWebView) -> Void)?
 
   /// Referrer sent with embed requests so providers can validate the source domain.
-  static let referrer = "https://www.kickstarter.com"
+  @Environment(\.referrer) var referrer: URL
 
   func makeCoordinator() -> Coordinator {
     Coordinator()
@@ -85,7 +85,7 @@ private struct OEmbedWebView: UIViewRepresentable {
     context.coordinator.loadedURL = self.url
 
     var request = URLRequest(url: self.url)
-    request.setValue(Self.referrer, forHTTPHeaderField: "Referer")
+    request.setValue(self.referrer.absoluteString, forHTTPHeaderField: "Referer")
     webView.load(request)
   }
 }
@@ -114,4 +114,8 @@ extension OEmbedWebView {
       return nil
     }
   }
+}
+
+extension EnvironmentValues {
+  @Entry var referrer: URL = URL(string: "https://www.kickstarter.com/")!
 }

--- a/ServerDrivenUI/Sources/ServerDrivenUI/Blocks/OEmbedBlock.swift
+++ b/ServerDrivenUI/Sources/ServerDrivenUI/Blocks/OEmbedBlock.swift
@@ -1,0 +1,131 @@
+import KDS
+import SwiftUI
+import WebKit
+
+struct OEmbedBlock: View {
+  var oembed: RichTextElement.Oembed
+  @Environment(\.richTextStyle) var style: any RichTextStyle
+  internal var onWebViewCreated: ((WKWebView) -> Void)?
+
+  var iframeURL: URL? {
+    guard let urlString = oembed.iframeUrl, !urlString.isEmpty else {
+      return nil
+    }
+
+    guard var components = URLComponents(string: urlString) else {
+      return nil
+    }
+
+    // Append playsinline=1 for inline video playback on iOS, matching legacy behavior.
+    var queryItems = components.queryItems ?? []
+    if !queryItems.contains(where: { $0.name == "playsinline" }) {
+      queryItems.append(URLQueryItem(name: "playsinline", value: "1"))
+    }
+    components.queryItems = queryItems
+
+    return components.url
+  }
+
+  private var aspectRatio: CGFloat? {
+    guard self.oembed.width > 0, self.oembed.height > 0 else {
+      return nil
+    }
+    return CGFloat(self.oembed.width) / CGFloat(self.oembed.height)
+  }
+
+  var body: some View {
+    Group {
+      if let iframeURL {
+        OEmbedWebView(url: iframeURL, onWebViewCreated: self.onWebViewCreated)
+          .aspectRatio(self.aspectRatio ?? 16.0 / 9.0, contentMode: .fit)
+          .clipShape(RoundedRectangle(cornerRadius: self.style.mediaCornerRadius))
+          .accessibilityElement()
+          .accessibilityLabel(self.oembed.title)
+          .accessibilityAddTraits(.isLink)
+      } else {
+        self.unavailablePlaceholder
+      }
+    }
+  }
+
+  private var unavailablePlaceholder: some View {
+    RoundedRectangle(cornerRadius: self.style.mediaCornerRadius)
+      .fill(self.style.mediaPlaceholderColor.swiftUIColor())
+      .aspectRatio(self.aspectRatio ?? 16.0 / 9.0, contentMode: .fit)
+      .overlay {
+        Image(systemName: "globe")
+          .font(.title)
+          .foregroundStyle(self.style.bodyColor.swiftUIColor())
+      }
+      .accessibilityLabel("Embedded content unavailable")
+  }
+}
+
+// MARK: - OEmbedWebView
+
+private struct OEmbedWebView: UIViewRepresentable {
+  let url: URL
+  var onWebViewCreated: ((WKWebView) -> Void)?
+
+  /// Referrer sent with embed requests so providers can validate the source domain.
+  static let referrer = "https://www.kickstarter.com"
+
+  func makeCoordinator() -> Coordinator {
+    Coordinator()
+  }
+
+  func makeUIView(context: Context) -> WKWebView {
+    let configuration = WKWebViewConfiguration()
+    configuration.allowsInlineMediaPlayback = true
+    configuration.suppressesIncrementalRendering = true
+    configuration.mediaTypesRequiringUserActionForPlayback = .all
+    configuration.applicationNameForUserAgent = "Kickstarter-iOS"
+
+    let webView = WKWebView(frame: .zero, configuration: configuration)
+    webView.isOpaque = false
+    webView.backgroundColor = .clear
+    webView.scrollView.isScrollEnabled = false
+    webView.uiDelegate = context.coordinator
+
+    self.onWebViewCreated?(webView)
+
+    return webView
+  }
+
+  func updateUIView(_ webView: WKWebView, context: Context) {
+    // Only reload when the URL actually changes, since SwiftUI can call
+    // updateUIView on every state change.
+    guard context.coordinator.loadedURL != self.url else { return }
+    context.coordinator.loadedURL = self.url
+
+    var request = URLRequest(url: self.url)
+    request.setValue(Self.referrer, forHTTPHeaderField: "Referer")
+    webView.load(request)
+  }
+}
+
+// MARK: - Coordinator
+
+extension OEmbedWebView {
+  /// Coordinator that acts as WKUIDelegate to handle links targeting new windows
+  /// by opening them in the system browser instead of silently dropping them.
+  final class Coordinator: NSObject, WKUIDelegate {
+    var loadedURL: URL?
+
+    func webView(
+      _: WKWebView,
+      createWebViewWith _: WKWebViewConfiguration,
+      for navigationAction: WKNavigationAction,
+      windowFeatures _: WKWindowFeatures
+    ) -> WKWebView? {
+      let targetsNewWindow = navigationAction.targetFrame == nil
+        || navigationAction.targetFrame?.isMainFrame == false
+
+      if targetsNewWindow, let url = navigationAction.request.url {
+        UIApplication.shared.open(url)
+      }
+
+      return nil
+    }
+  }
+}

--- a/ServerDrivenUI/Sources/ServerDrivenUI/Blocks/OEmbedBlock.swift
+++ b/ServerDrivenUI/Sources/ServerDrivenUI/Blocks/OEmbedBlock.swift
@@ -34,30 +34,14 @@ struct OEmbedBlock: View {
   }
 
   var body: some View {
-    Group {
-      if let iframeURL {
-        OEmbedWebView(url: iframeURL, onWebViewCreated: self.onWebViewCreated)
-          .aspectRatio(self.aspectRatio ?? 16.0 / 9.0, contentMode: .fit)
-          .clipShape(RoundedRectangle(cornerRadius: self.style.mediaCornerRadius))
-          .accessibilityElement()
-          .accessibilityLabel(self.oembed.title)
-          .accessibilityAddTraits(.isLink)
-      } else {
-        self.unavailablePlaceholder
-      }
+    if let iframeURL {
+      OEmbedWebView(url: iframeURL, onWebViewCreated: self.onWebViewCreated)
+        .aspectRatio(self.aspectRatio ?? 16.0 / 9.0, contentMode: .fit)
+        .clipShape(RoundedRectangle(cornerRadius: self.style.mediaCornerRadius))
+        .accessibilityElement()
+        .accessibilityLabel(self.oembed.title)
+        .accessibilityAddTraits(.isLink)
     }
-  }
-
-  private var unavailablePlaceholder: some View {
-    RoundedRectangle(cornerRadius: self.style.mediaCornerRadius)
-      .fill(self.style.mediaPlaceholderColor.swiftUIColor())
-      .aspectRatio(self.aspectRatio ?? 16.0 / 9.0, contentMode: .fit)
-      .overlay {
-        Image(systemName: "globe")
-          .font(.title)
-          .foregroundStyle(self.style.bodyColor.swiftUIColor())
-      }
-      .accessibilityLabel("Embedded content unavailable")
   }
 }
 

--- a/ServerDrivenUI/Sources/ServerDrivenUI/RichTextElement.swift
+++ b/ServerDrivenUI/Sources/ServerDrivenUI/RichTextElement.swift
@@ -11,7 +11,7 @@ public indirect enum RichTextElement: Sendable {
   case audio(Audio)
   case photo(Photo)
   case video(Video)
-  case oembed(Oembed)
+  case oembed(OEmbed)
   case unknown
 
   public struct Text: Sendable {
@@ -107,7 +107,7 @@ public indirect enum RichTextElement: Sendable {
     let formats: [VideoFormat]
   }
 
-  public struct Oembed: Sendable {
+  public struct OEmbed: Sendable {
     let width: Int
     let height: Int
     let version: String

--- a/ServerDrivenUI/Sources/ServerDrivenUI/RichTextGQLConversions.swift
+++ b/ServerDrivenUI/Sources/ServerDrivenUI/RichTextGQLConversions.swift
@@ -336,7 +336,7 @@ extension RichTextComponentFragment.Item.AsRichTextListItem.Child.AsRichTextVide
 
 extension RichTextComponentFragment.Item.AsRichTextOembed {
   var asRichTextElement: RichTextElement {
-    .oembed(RichTextElement.Oembed(
+    .oembed(RichTextElement.OEmbed(
       width: width,
       height: height,
       version: version,
@@ -353,7 +353,7 @@ extension RichTextComponentFragment.Item.AsRichTextOembed {
 
 extension RichTextComponentFragment.Item.AsRichText.Child.AsRichTextOembed {
   var asRichTextElement: RichTextElement {
-    .oembed(RichTextElement.Oembed(
+    .oembed(RichTextElement.OEmbed(
       width: width,
       height: height,
       version: version,
@@ -370,7 +370,7 @@ extension RichTextComponentFragment.Item.AsRichText.Child.AsRichTextOembed {
 
 extension RichTextComponentFragment.Item.AsRichTextHeader.Child.AsRichTextOembed {
   var asRichTextElement: RichTextElement {
-    .oembed(RichTextElement.Oembed(
+    .oembed(RichTextElement.OEmbed(
       width: width,
       height: height,
       version: version,
@@ -387,7 +387,7 @@ extension RichTextComponentFragment.Item.AsRichTextHeader.Child.AsRichTextOembed
 
 extension RichTextComponentFragment.Item.AsRichTextListItem.Child.AsRichTextOembed {
   var asRichTextElement: RichTextElement {
-    .oembed(RichTextElement.Oembed(
+    .oembed(RichTextElement.OEmbed(
       width: width,
       height: height,
       version: version,

--- a/ServerDrivenUI/Sources/ServerDrivenUI/RichTextView.swift
+++ b/ServerDrivenUI/Sources/ServerDrivenUI/RichTextView.swift
@@ -32,8 +32,8 @@ public struct RichTextView: View {
           ImageBlock(photo: photo)
         case let .video(video):
           AudioVideoBlock(content: .video(video))
-        case .oembed:
-          self.unimplemented("Oembed")
+        case let .oembed(oembed):
+          OEmbedBlock(oembed: oembed)
         case .listItemOpen, .listItemClose:
           Group {}
         case .unknown:

--- a/ServerDrivenUI/Tests/ServerDrivenUITests/Blocks/OEmbedBlockTests.swift
+++ b/ServerDrivenUI/Tests/ServerDrivenUITests/Blocks/OEmbedBlockTests.swift
@@ -47,29 +47,25 @@ final class OEmbedBlockTests: TestCase {
 
   // MARK: - Missing iframe URL
 
-  func testOEmbedBlockWithNilIframeURL_rendersUnavailablePlaceholder() throws {
+  func testOEmbedBlockWithNilIframeURL_rendersNothing() throws {
     let oembed = makeOembed(title: "Missing Embed", iframeUrl: nil)
 
-    let view = oembedBlock(oembed: oembed, colorScheme: .light)
+    let block = OEmbedBlock(oembed: oembed)
 
-    XCTAssertNoThrow(
-      try view.inspect().find(viewWithAccessibilityLabel: "Embedded content unavailable"),
-      "Expected unavailable placeholder when iframe URL is nil."
-    )
-    XCTAssertNoThrow(
-      try view.inspect().find(ViewType.Image.self),
-      "Expected globe system image in unavailable placeholder."
+    XCTAssertNil(
+      block.iframeURL,
+      "Expected iframeURL to be nil when iframe URL string is nil."
     )
   }
 
-  func testOEmbedBlockWithEmptyIframeURL_rendersUnavailablePlaceholder() throws {
+  func testOEmbedBlockWithEmptyIframeURL_rendersNothing() throws {
     let oembed = makeOembed(title: "Missing Embed", iframeUrl: "")
 
-    let view = oembedBlock(oembed: oembed, colorScheme: .light)
+    let block = OEmbedBlock(oembed: oembed)
 
-    XCTAssertNoThrow(
-      try view.inspect().find(viewWithAccessibilityLabel: "Embedded content unavailable"),
-      "Expected unavailable placeholder when iframe URL is empty."
+    XCTAssertNil(
+      block.iframeURL,
+      "Expected iframeURL to be nil when iframe URL string is empty."
     )
   }
 
@@ -317,49 +313,6 @@ final class OEmbedBlockTests: TestCase {
     )
   }
 
-  func testUnavailablePlaceholder_usesProvidedAspectRatio() throws {
-    let oembed = makeOembed(
-      width: 640,
-      height: 480,
-      title: "Missing",
-      iframeUrl: nil
-    )
-
-    let view = oembedBlock(oembed: oembed, colorScheme: .light)
-    let placeholder = try view.inspect().find(viewWithAccessibilityLabel: "Embedded content unavailable")
-    let aspectRatio = try placeholder.aspectRatio()
-
-    XCTAssertEqual(
-      aspectRatio.aspectRatio,
-      640.0 / 480.0 as CGFloat,
-      "Expected placeholder to use provided aspect ratio."
-    )
-    XCTAssertEqual(
-      aspectRatio.contentMode,
-      .fit,
-      "Expected placeholder content mode to be .fit."
-    )
-  }
-
-  func testUnavailablePlaceholder_withZeroDimensions_fallsBackToSixteenByNine() throws {
-    let oembed = makeOembed(
-      width: 0,
-      height: 0,
-      title: "Missing",
-      iframeUrl: nil
-    )
-
-    let view = oembedBlock(oembed: oembed, colorScheme: .light)
-    let placeholder = try view.inspect().find(viewWithAccessibilityLabel: "Embedded content unavailable")
-    let aspectRatio = try placeholder.aspectRatio()
-
-    XCTAssertEqual(
-      aspectRatio.aspectRatio,
-      16.0 / 9.0 as CGFloat,
-      "Expected placeholder to fall back to 16:9 when dimensions are zero."
-    )
-  }
-
   // MARK: - Empty title
 
   func testOEmbedBlockWithEmptyTitle_hasEmptyAccessibilityLabel() throws {
@@ -396,19 +349,6 @@ final class OEmbedBlockTests: TestCase {
       XCTAssertNoThrow(
         try view.inspect().find(viewWithAccessibilityLabel: "Styled Embed"),
         "Expected accessibility label for color scheme \(colorScheme)."
-      )
-    }
-  }
-
-  func testOEmbedBlockWithNilIframeURL_lightAndDarkStyles() throws {
-    let oembed = makeOembed(title: "Missing Embed", iframeUrl: nil)
-
-    for colorScheme in [ColorScheme.light, ColorScheme.dark] {
-      let view = oembedBlock(oembed: oembed, colorScheme: colorScheme)
-
-      XCTAssertNoThrow(
-        try view.inspect().find(viewWithAccessibilityLabel: "Embedded content unavailable"),
-        "Expected unavailable placeholder for color scheme \(colorScheme)."
       )
     }
   }

--- a/ServerDrivenUI/Tests/ServerDrivenUITests/Blocks/OEmbedBlockTests.swift
+++ b/ServerDrivenUI/Tests/ServerDrivenUITests/Blocks/OEmbedBlockTests.swift
@@ -393,8 +393,8 @@ private func makeOembed(
   type: String = "video",
   iframeUrl: String?,
   originalUrl: String? = "https://example.com/original"
-) -> RichTextElement.Oembed {
-  RichTextElement.Oembed(
+) -> RichTextElement.OEmbed {
+  RichTextElement.OEmbed(
     width: width,
     height: height,
     version: "1.0",
@@ -411,7 +411,7 @@ private func makeOembed(
 @MainActor
 @ViewBuilder
 private func oembedBlock(
-  oembed: RichTextElement.Oembed,
+  oembed: RichTextElement.OEmbed,
   colorScheme: ColorScheme,
   width: CGFloat? = 300,
   height: CGFloat? = 200

--- a/ServerDrivenUI/Tests/ServerDrivenUITests/Blocks/OEmbedBlockTests.swift
+++ b/ServerDrivenUI/Tests/ServerDrivenUITests/Blocks/OEmbedBlockTests.swift
@@ -418,6 +418,7 @@ private func oembedBlock(
 ) -> some View {
   let block = OEmbedBlock(oembed: oembed)
     .environment(\.richTextStyle, richTextStyle(colorScheme))
+    .environment(\.referrer, URL(string: "https://staging.kickstarter.com/")!)
 
   if let width, let height {
     block.frame(width: width, height: height)

--- a/ServerDrivenUI/Tests/ServerDrivenUITests/Blocks/OEmbedBlockTests.swift
+++ b/ServerDrivenUI/Tests/ServerDrivenUITests/Blocks/OEmbedBlockTests.swift
@@ -1,0 +1,499 @@
+@testable import LibraryTestHelpers
+@testable import ServerDrivenUI
+import ServerDrivenUITestHelpers
+import SwiftUI
+import ViewInspector
+import WebKit
+import XCTest
+
+@MainActor
+final class OEmbedBlockTests: TestCase {
+  // MARK: - Valid iframe URL
+
+  func testOEmbedBlockWithValidIframeURL_hasAccessibilityLabel() throws {
+    let oembed = makeOembed(
+      title: "YouTube Video",
+      iframeUrl: "https://www.youtube.com/embed/dQw4w9WgXcQ"
+    )
+
+    let view = oembedBlock(oembed: oembed, colorScheme: .light)
+
+    XCTAssertNoThrow(
+      try view.inspect().find(viewWithAccessibilityLabel: "YouTube Video"),
+      "Expected OEmbedBlock to expose accessibility label from title when iframe URL is valid."
+    )
+  }
+
+  func testOEmbedBlockWithValidIframeURL_exposesOembed() throws {
+    let oembed = makeOembed(
+      title: "YouTube Video",
+      iframeUrl: "https://www.youtube.com/embed/dQw4w9WgXcQ"
+    )
+
+    let view = oembedBlock(oembed: oembed, colorScheme: .light)
+    let block = try view.inspect().find(OEmbedBlock.self).actualView()
+
+    XCTAssertEqual(
+      block.oembed.title,
+      "YouTube Video",
+      "OEmbedBlock.oembed.title should equal the provided title."
+    )
+    XCTAssertEqual(
+      block.oembed.iframeUrl,
+      "https://www.youtube.com/embed/dQw4w9WgXcQ",
+      "OEmbedBlock.oembed.iframeUrl should equal the provided iframe URL."
+    )
+  }
+
+  // MARK: - Missing iframe URL
+
+  func testOEmbedBlockWithNilIframeURL_rendersUnavailablePlaceholder() throws {
+    let oembed = makeOembed(title: "Missing Embed", iframeUrl: nil)
+
+    let view = oembedBlock(oembed: oembed, colorScheme: .light)
+
+    XCTAssertNoThrow(
+      try view.inspect().find(viewWithAccessibilityLabel: "Embedded content unavailable"),
+      "Expected unavailable placeholder when iframe URL is nil."
+    )
+    XCTAssertNoThrow(
+      try view.inspect().find(ViewType.Image.self),
+      "Expected globe system image in unavailable placeholder."
+    )
+  }
+
+  func testOEmbedBlockWithEmptyIframeURL_rendersUnavailablePlaceholder() throws {
+    let oembed = makeOembed(title: "Missing Embed", iframeUrl: "")
+
+    let view = oembedBlock(oembed: oembed, colorScheme: .light)
+
+    XCTAssertNoThrow(
+      try view.inspect().find(viewWithAccessibilityLabel: "Embedded content unavailable"),
+      "Expected unavailable placeholder when iframe URL is empty."
+    )
+  }
+
+  // MARK: - Playsinline query parameter
+
+  func testOEmbedBlockIframeURL_appendsPlaysinlineParameter() throws {
+    let oembed = makeOembed(
+      title: "Video",
+      iframeUrl: "https://www.youtube.com/embed/abc123"
+    )
+
+    let block = OEmbedBlock(oembed: oembed)
+    let iframeURL = block.iframeURL
+
+    XCTAssertNotNil(iframeURL, "Expected a valid iframe URL.")
+    let components = URLComponents(url: iframeURL!, resolvingAgainstBaseURL: false)
+    let playsinline = components?.queryItems?.first(where: { $0.name == "playsinline" })
+
+    XCTAssertNotNil(playsinline, "Expected playsinline query parameter to be appended.")
+    XCTAssertEqual(
+      playsinline?.value,
+      "1",
+      "Expected playsinline value to be '1'."
+    )
+  }
+
+  func testOEmbedBlockIframeURL_preservesExistingQueryParameters() throws {
+    let oembed = makeOembed(
+      title: "Video",
+      iframeUrl: "https://www.youtube.com/embed/abc123?feature=oembed"
+    )
+
+    let block = OEmbedBlock(oembed: oembed)
+    let iframeURL = block.iframeURL
+
+    XCTAssertNotNil(iframeURL, "Expected a valid iframe URL.")
+    let components = URLComponents(url: iframeURL!, resolvingAgainstBaseURL: false)
+    let queryItems = components?.queryItems ?? []
+
+    let feature = queryItems.first(where: { $0.name == "feature" })
+    XCTAssertEqual(
+      feature?.value,
+      "oembed",
+      "Expected existing query parameter 'feature' to be preserved."
+    )
+
+    let playsinline = queryItems.first(where: { $0.name == "playsinline" })
+    XCTAssertEqual(
+      playsinline?.value,
+      "1",
+      "Expected playsinline to be appended alongside existing parameters."
+    )
+  }
+
+  func testOEmbedBlockIframeURL_doesNotDuplicatePlaysinline() throws {
+    let oembed = makeOembed(
+      title: "Video",
+      iframeUrl: "https://www.youtube.com/embed/abc123?playsinline=1"
+    )
+
+    let block = OEmbedBlock(oembed: oembed)
+    let iframeURL = block.iframeURL
+
+    XCTAssertNotNil(iframeURL, "Expected a valid iframe URL.")
+    let components = URLComponents(url: iframeURL!, resolvingAgainstBaseURL: false)
+    let playsinlineItems = components?.queryItems?.filter { $0.name == "playsinline" } ?? []
+
+    XCTAssertEqual(
+      playsinlineItems.count,
+      1,
+      "Expected exactly one playsinline parameter, not a duplicate."
+    )
+  }
+
+  // MARK: - WebView configuration
+
+  func testOEmbedWebView_configuresInlineMediaPlayback() throws {
+    let expectation = expectation(description: "WebView created")
+    var capturedWebView: WKWebView?
+
+    let oembed = makeOembed(
+      title: "Config Test",
+      iframeUrl: "https://example.com/embed"
+    )
+    var block = OEmbedBlock(oembed: oembed)
+    block.onWebViewCreated = { webView in
+      capturedWebView = webView
+      expectation.fulfill()
+    }
+
+    let view = block
+      .environment(\.richTextStyle, richTextStyle(.light))
+      .frame(width: 300, height: 200)
+
+    ViewHosting.host(view: view)
+    defer { ViewHosting.expel() }
+    wait(for: [expectation], timeout: 1.0)
+
+    let webView = try XCTUnwrap(capturedWebView, "Expected the onWebViewCreated callback to fire.")
+
+    XCTAssertTrue(
+      webView.configuration.allowsInlineMediaPlayback,
+      "Expected allowsInlineMediaPlayback to be true."
+    )
+    XCTAssertTrue(
+      webView.configuration.suppressesIncrementalRendering,
+      "Expected suppressesIncrementalRendering to be true to prevent partial content flicker."
+    )
+  }
+
+  func testOEmbedWebView_setsKickstarterApplicationName() throws {
+    let expectation = expectation(description: "WebView created")
+    var capturedWebView: WKWebView?
+
+    let oembed = makeOembed(
+      title: "UA Test",
+      iframeUrl: "https://example.com/embed"
+    )
+    var block = OEmbedBlock(oembed: oembed)
+    block.onWebViewCreated = { webView in
+      capturedWebView = webView
+      expectation.fulfill()
+    }
+
+    let view = block
+      .environment(\.richTextStyle, richTextStyle(.light))
+      .frame(width: 300, height: 200)
+
+    ViewHosting.host(view: view)
+    defer { ViewHosting.expel() }
+    wait(for: [expectation], timeout: 1.0)
+
+    let webView = try XCTUnwrap(capturedWebView, "Expected the onWebViewCreated callback to fire.")
+    let appName = webView.configuration.applicationNameForUserAgent
+
+    XCTAssertEqual(
+      appName,
+      "Kickstarter-iOS",
+      "Expected applicationNameForUserAgent to identify the app."
+    )
+  }
+
+  func testOEmbedWebView_disablesScrolling() throws {
+    let expectation = expectation(description: "WebView created")
+    var capturedWebView: WKWebView?
+
+    let oembed = makeOembed(
+      title: "Scroll Test",
+      iframeUrl: "https://example.com/embed"
+    )
+    var block = OEmbedBlock(oembed: oembed)
+    block.onWebViewCreated = { webView in
+      capturedWebView = webView
+      expectation.fulfill()
+    }
+
+    let view = block
+      .environment(\.richTextStyle, richTextStyle(.light))
+      .frame(width: 300, height: 200)
+
+    ViewHosting.host(view: view)
+    defer { ViewHosting.expel() }
+    wait(for: [expectation], timeout: 1.0)
+
+    let webView = try XCTUnwrap(capturedWebView, "Expected the onWebViewCreated callback to fire.")
+
+    XCTAssertFalse(
+      webView.scrollView.isScrollEnabled,
+      "Expected scroll to be disabled so the embed sizes to its container."
+    )
+  }
+
+  func testOEmbedWebView_hasUIDelegateForLinkHandling() throws {
+    let expectation = expectation(description: "WebView created")
+    var capturedWebView: WKWebView?
+
+    let oembed = makeOembed(
+      title: "Delegate Test",
+      iframeUrl: "https://example.com/embed"
+    )
+    var block = OEmbedBlock(oembed: oembed)
+    block.onWebViewCreated = { webView in
+      capturedWebView = webView
+      expectation.fulfill()
+    }
+
+    let view = block
+      .environment(\.richTextStyle, richTextStyle(.light))
+      .frame(width: 300, height: 200)
+
+    ViewHosting.host(view: view)
+    defer { ViewHosting.expel() }
+    wait(for: [expectation], timeout: 1.0)
+
+    let webView = try XCTUnwrap(capturedWebView, "Expected the onWebViewCreated callback to fire.")
+
+    XCTAssertNotNil(
+      webView.uiDelegate,
+      "Expected a WKUIDelegate to handle links that target new windows."
+    )
+  }
+
+  // MARK: - Aspect ratio
+
+  func testOEmbedBlockWithValidDimensions_usesProvidedAspectRatio() throws {
+    let oembed = makeOembed(
+      width: 640,
+      height: 480,
+      title: "4:3 Video",
+      iframeUrl: "https://example.com/embed"
+    )
+
+    let view = oembedBlock(oembed: oembed, colorScheme: .light)
+    let element = try view.inspect().find(viewWithAccessibilityLabel: "4:3 Video")
+    let aspectRatio = try element.aspectRatio()
+
+    XCTAssertEqual(
+      aspectRatio.aspectRatio,
+      640.0 / 480.0 as CGFloat,
+      "Expected aspect ratio to match width/height from oembed data."
+    )
+    XCTAssertEqual(
+      aspectRatio.contentMode,
+      .fit,
+      "Expected content mode to be .fit."
+    )
+  }
+
+  func testOEmbedBlockWithZeroDimensions_fallsBackToSixteenByNine() throws {
+    let oembed = makeOembed(
+      width: 0,
+      height: 0,
+      title: "Fallback Ratio",
+      iframeUrl: "https://example.com/embed"
+    )
+
+    let view = oembedBlock(oembed: oembed, colorScheme: .light)
+    let element = try view.inspect().find(viewWithAccessibilityLabel: "Fallback Ratio")
+    let aspectRatio = try element.aspectRatio()
+
+    XCTAssertEqual(
+      aspectRatio.aspectRatio,
+      16.0 / 9.0 as CGFloat,
+      "Expected 16:9 fallback aspect ratio when dimensions are zero."
+    )
+  }
+
+  func testUnavailablePlaceholder_usesProvidedAspectRatio() throws {
+    let oembed = makeOembed(
+      width: 640,
+      height: 480,
+      title: "Missing",
+      iframeUrl: nil
+    )
+
+    let view = oembedBlock(oembed: oembed, colorScheme: .light)
+    let placeholder = try view.inspect().find(viewWithAccessibilityLabel: "Embedded content unavailable")
+    let aspectRatio = try placeholder.aspectRatio()
+
+    XCTAssertEqual(
+      aspectRatio.aspectRatio,
+      640.0 / 480.0 as CGFloat,
+      "Expected placeholder to use provided aspect ratio."
+    )
+    XCTAssertEqual(
+      aspectRatio.contentMode,
+      .fit,
+      "Expected placeholder content mode to be .fit."
+    )
+  }
+
+  func testUnavailablePlaceholder_withZeroDimensions_fallsBackToSixteenByNine() throws {
+    let oembed = makeOembed(
+      width: 0,
+      height: 0,
+      title: "Missing",
+      iframeUrl: nil
+    )
+
+    let view = oembedBlock(oembed: oembed, colorScheme: .light)
+    let placeholder = try view.inspect().find(viewWithAccessibilityLabel: "Embedded content unavailable")
+    let aspectRatio = try placeholder.aspectRatio()
+
+    XCTAssertEqual(
+      aspectRatio.aspectRatio,
+      16.0 / 9.0 as CGFloat,
+      "Expected placeholder to fall back to 16:9 when dimensions are zero."
+    )
+  }
+
+  // MARK: - Empty title
+
+  func testOEmbedBlockWithEmptyTitle_hasEmptyAccessibilityLabel() throws {
+    let oembed = makeOembed(
+      title: "",
+      iframeUrl: "https://example.com/embed"
+    )
+
+    let view = oembedBlock(oembed: oembed, colorScheme: .light)
+
+    XCTAssertNoThrow(
+      try view.inspect().find(viewWithAccessibilityLabel: ""),
+      "Expected empty accessibility label when title is empty."
+    )
+  }
+
+  // MARK: - Color schemes
+
+  func testOEmbedBlockWithValidIframeURL_lightAndDarkStyles() throws {
+    let oembed = makeOembed(
+      title: "Styled Embed",
+      iframeUrl: "https://example.com/embed"
+    )
+
+    for colorScheme in [ColorScheme.light, ColorScheme.dark] {
+      let view = oembedBlock(oembed: oembed, colorScheme: colorScheme)
+      let block = try view.inspect().find(OEmbedBlock.self).actualView()
+
+      XCTAssertEqual(
+        block.oembed.title,
+        "Styled Embed",
+        "OEmbedBlock.oembed.title should be preserved for color scheme \(colorScheme)."
+      )
+      XCTAssertNoThrow(
+        try view.inspect().find(viewWithAccessibilityLabel: "Styled Embed"),
+        "Expected accessibility label for color scheme \(colorScheme)."
+      )
+    }
+  }
+
+  func testOEmbedBlockWithNilIframeURL_lightAndDarkStyles() throws {
+    let oembed = makeOembed(title: "Missing Embed", iframeUrl: nil)
+
+    for colorScheme in [ColorScheme.light, ColorScheme.dark] {
+      let view = oembedBlock(oembed: oembed, colorScheme: colorScheme)
+
+      XCTAssertNoThrow(
+        try view.inspect().find(viewWithAccessibilityLabel: "Embedded content unavailable"),
+        "Expected unavailable placeholder for color scheme \(colorScheme)."
+      )
+    }
+  }
+
+  // MARK: - Container sizing
+
+  func testOEmbedBlockWithValidIframeURL_respectsContainerFrame() throws {
+    let oembed = makeOembed(
+      title: "Framed Embed",
+      iframeUrl: "https://example.com/embed"
+    )
+    let containerWidth: CGFloat = 400
+    let containerHeight: CGFloat = 300
+
+    let view = oembedBlock(
+      oembed: oembed,
+      colorScheme: .light,
+      width: containerWidth,
+      height: containerHeight
+    )
+    let frame = try view.inspect().fixedFrame()
+
+    XCTAssertEqual(
+      frame.width,
+      containerWidth,
+      "Expected OEmbedBlock width to respect container width."
+    )
+    XCTAssertEqual(
+      frame.height,
+      containerHeight,
+      "Expected OEmbedBlock height to respect container height."
+    )
+  }
+}
+
+// MARK: - Helpers
+
+private func makeOembed(
+  width: Int = 640,
+  height: Int = 360,
+  title: String,
+  type: String = "video",
+  iframeUrl: String?,
+  originalUrl: String? = "https://example.com/original"
+) -> RichTextElement.Oembed {
+  RichTextElement.Oembed(
+    width: width,
+    height: height,
+    version: "1.0",
+    title: title,
+    type: type,
+    iframeUrl: iframeUrl,
+    originalUrl: originalUrl,
+    thumbnailUrl: nil,
+    thumbnailWidth: nil,
+    thumbnailHeight: nil
+  )
+}
+
+@MainActor
+@ViewBuilder
+private func oembedBlock(
+  oembed: RichTextElement.Oembed,
+  colorScheme: ColorScheme,
+  width: CGFloat? = 300,
+  height: CGFloat? = 200
+) -> some View {
+  let block = OEmbedBlock(oembed: oembed)
+    .environment(\.richTextStyle, richTextStyle(colorScheme))
+
+  if let width, let height {
+    block.frame(width: width, height: height)
+  } else {
+    block
+  }
+}
+
+private func richTextStyle(_ colorScheme: ColorScheme) -> any RichTextStyle {
+  switch colorScheme {
+  case .light:
+    return LightRichTextStyle()
+  case .dark:
+    return DarkRichTextStyle()
+  @unknown default:
+    assertionFailure()
+    return AutomaticRichTextStyle()
+  }
+}

--- a/ServerDrivenUI/Tests/ServerDrivenUITests/Blocks/OEmbedBlockTests.swift
+++ b/ServerDrivenUI/Tests/ServerDrivenUITests/Blocks/OEmbedBlockTests.swift
@@ -329,30 +329,6 @@ final class OEmbedBlockTests: TestCase {
     )
   }
 
-  // MARK: - Color schemes
-
-  func testOEmbedBlockWithValidIframeURL_lightAndDarkStyles() throws {
-    let oembed = makeOembed(
-      title: "Styled Embed",
-      iframeUrl: "https://example.com/embed"
-    )
-
-    for colorScheme in [ColorScheme.light, ColorScheme.dark] {
-      let view = oembedBlock(oembed: oembed, colorScheme: colorScheme)
-      let block = try view.inspect().find(OEmbedBlock.self).actualView()
-
-      XCTAssertEqual(
-        block.oembed.title,
-        "Styled Embed",
-        "OEmbedBlock.oembed.title should be preserved for color scheme \(colorScheme)."
-      )
-      XCTAssertNoThrow(
-        try view.inspect().find(viewWithAccessibilityLabel: "Styled Embed"),
-        "Expected accessibility label for color scheme \(colorScheme)."
-      )
-    }
-  }
-
   // MARK: - Container sizing
 
   func testOEmbedBlockWithValidIframeURL_respectsContainerFrame() throws {


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Adds the OEmbed block (aka the YouTube player block) to the RichTextView.

# 🤔 Why

This is what powers the YouTube player. I'm sure someone is using it for something else, too.

# 🛠 How

Added the OEmbed block view the same way we have other views, added a bunch of AI-generated tests for it, and integrated it into the RichTextView.

The ExternalSourceViewElementCell was cribbed from to figure out some edge cases (this is what we currently use for project story today).

# 👀 See

<img width="500" height="1014" alt="Screen Recording 2026-05-28 at 18 20 47" src="https://github.com/user-attachments/assets/9c45f84b-88d6-424e-b7dc-cdf486acae6c" />
