### PR TITLE
[DISC-229] Present Login Flow On Save/Creator Tap + Handle Save Updates On Project Page

### DIFF
--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/Discovery/Controller/DiscoveryPageViewController.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/Discovery/Controller/DiscoveryPageViewController.swift
@@ -424,7 +424,8 @@ extension DiscoveryPageViewController: VideoFeedBannerCellDelegate {
     let nav = UINavigationController(rootViewController: VideoFeedViewController())
     nav.modalPresentationStyle = .fullScreen
 
-    self.present(nav, animated: true)
+    let presenter = self.view.window?.rootViewController ?? self
+    presenter.present(nav, animated: true)
   }
 }
 

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/Search/Controller/SearchViewController.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/Search/Controller/SearchViewController.swift
@@ -308,6 +308,7 @@ extension SearchViewController: VideoFeedBannerCellDelegate {
     let nav = UINavigationController(rootViewController: VideoFeedViewController())
     nav.modalPresentationStyle = .fullScreen
 
-    self.present(nav, animated: true)
+    let presenter = self.view.window?.rootViewController ?? self
+    presenter.present(nav, animated: true)
   }
 }

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Controller/VideoFeedViewController.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Controller/VideoFeedViewController.swift
@@ -109,6 +109,18 @@ final class VideoFeedViewController: UIViewController {
         self.bindViewModel()
       }
     }
+
+    withObservationTracking {
+      _ = self.viewModel.loginIntent
+    } onChange: { [weak self] in
+      DispatchQueue.main.async { [weak self] in
+        guard let self, let intent = self.viewModel.loginIntent else { return }
+
+        self.goToLoginTout(intent: intent)
+        self.viewModel.clearLoginIntent()
+        self.bindViewModel()
+      }
+    }
   }
 
   /// Reloads the collection view with a fresh set of fetched items.
@@ -181,6 +193,21 @@ final class VideoFeedViewController: UIViewController {
 
   // MARK: - Navigation
 
+  private func goToLoginTout(intent: LoginIntent) {
+    let loginTout = LoginToutViewController.configuredWith(loginIntent: intent)
+    let isIpad = AppEnvironment.current.device.userInterfaceIdiom == .pad
+    let nav = UINavigationController(rootViewController: loginTout)
+    nav.modalPresentationStyle = isIpad ? .formSheet : .fullScreen
+
+    /// Presenting fullscreen over a dark video background can cause a black flash since UIKit briefly shows the default window background.
+    /// Setting the nav controller's background to match the login screen prevents that.
+    if !isIpad {
+      nav.view.backgroundColor = Colors.Background.Surface.primary.uiColor()
+    }
+
+    self.present(nav, animated: true)
+  }
+
   private func goToCreatorProfile(for item: VideoFeedItem) {
     let vc = ProjectCreatorViewController.configuredWith(project: item)
 
@@ -202,6 +229,14 @@ final class VideoFeedViewController: UIViewController {
 
     self.present(vc, animated: true)
   }
+
+  private func onCreatorTapped(for item: VideoFeedItem) {
+    if AppEnvironment.current.currentUser != nil {
+      self.goToCreatorProfile(for: item)
+    } else {
+      self.viewModel.showLogin()
+    }
+  }
 }
 
 extension VideoFeedViewController: UICollectionViewDelegateFlowLayout {
@@ -221,11 +256,13 @@ extension VideoFeedViewController: UICollectionViewDelegateFlowLayout {
     guard let cell = cell as? VideoFeedCell else { return }
 
     let items = self.viewModel.items
+
     guard indexPath.item < items.count else { return }
+
     let item = items[indexPath.item]
 
     cell.onCloseTapped = { [weak self] in self?.dismiss(animated: true) }
-    cell.onCreatorTapped = { [weak self] in self?.goToCreatorProfile(for: item) }
+    cell.onCreatorTapped = { [weak self] in self?.onCreatorTapped(for: item) }
     cell.onShareTapped = { [weak self] in self?.simpleAlert(title: "Share") }
     cell.onMoreTapped = { [weak self] in self?.simpleAlert(title: "More") }
     cell.onCTATapped = { [weak self] in self?.goToProjectPage(for: item) }

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Controller/VideoFeedViewController.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Controller/VideoFeedViewController.swift
@@ -194,6 +194,8 @@ final class VideoFeedViewController: UIViewController {
 
   // MARK: - Navigation
 
+  /// TODO: This pattern is duplicated across several VCs.
+  /// Its worth pulling into a `UIViewController` extension, with the background color fix keyed off the videoFeed intent.
   private func goToLoginTout(intent: LoginIntent) {
     let loginTout = LoginToutViewController.configuredWith(loginIntent: intent)
     let isIpad = AppEnvironment.current.device.userInterfaceIdiom == .pad

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Controller/VideoFeedViewController.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Controller/VideoFeedViewController.swift
@@ -230,14 +230,6 @@ final class VideoFeedViewController: UIViewController {
 
     self.present(vc, animated: true)
   }
-
-  private func onCreatorTapped(for item: VideoFeedItem) {
-    if AppEnvironment.current.currentUser != nil {
-      self.goToCreatorProfile(for: item)
-    } else {
-      self.viewModel.showLogin()
-    }
-  }
 }
 
 extension VideoFeedViewController: UICollectionViewDelegateFlowLayout {
@@ -263,7 +255,7 @@ extension VideoFeedViewController: UICollectionViewDelegateFlowLayout {
     let item = items[indexPath.item]
 
     cell.onCloseTapped = { [weak self] in self?.dismiss(animated: true) }
-    cell.onCreatorTapped = { [weak self] in self?.onCreatorTapped(for: item) }
+    cell.onCreatorTapped = { [weak self] in self?.goToCreatorProfile(for: item) }
     cell.onShareTapped = { [weak self] in self?.simpleAlert(title: "Share") }
     cell.onMoreTapped = { [weak self] in self?.simpleAlert(title: "More") }
     cell.onCTATapped = { [weak self] in self?.goToProjectPage(for: item) }

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Controller/VideoFeedViewController.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Controller/VideoFeedViewController.swift
@@ -63,6 +63,7 @@ final class VideoFeedViewController: UIViewController {
     super.viewWillAppear(animated)
 
     self.navigationController?.setNavigationBarHidden(true, animated: animated)
+    self.viewModel.viewWillAppear()
   }
 
   override func viewWillDisappear(_ animated: Bool) {

--- a/Library/Sources/Library/Library/LoginIntent.swift
+++ b/Library/Sources/Library/Library/LoginIntent.swift
@@ -8,6 +8,7 @@ public enum LoginIntent: String {
   case messageCreator
   case onboarding
   case starProject
+  case videoFeed
 
   var trackingString: String {
     switch self {
@@ -29,6 +30,8 @@ public enum LoginIntent: String {
       return "onboarding"
     case .starProject:
       return "star"
+    case .videoFeed:
+      return "video_feed"
     }
   }
 }

--- a/Library/Sources/Library/Library/ViewModels/LoginToutViewModel.swift
+++ b/Library/Sources/Library/Library/ViewModels/LoginToutViewModel.swift
@@ -353,7 +353,7 @@ public final class LoginToutViewModel: LoginToutViewModelType, LoginToutViewMode
 
 private func statusString(_ forStatus: LoginIntent) -> String {
   switch forStatus {
-  case .starProject:
+  case .starProject, .videoFeed:
     return Strings.Log_in_or_sign_up_to_save_this_project_and_we_ll_remind_you()
   case .backProject:
     return Strings.Please_log_in_or_sign_up_to_back_this_project()

--- a/Library/Sources/Library/Library/ViewModels/VideoFeedViewModel.swift
+++ b/Library/Sources/Library/Library/ViewModels/VideoFeedViewModel.swift
@@ -7,9 +7,12 @@ import SwiftUI
 public protocol VideoFeedViewModelType: AnyObject {
   var items: [VideoFeedItem] { get }
   var fetchedItems: [VideoFeedItem] { get }
+  var loginIntent: LoginIntent? { get }
   func viewDidLoad()
   func toggleSaved(for item: VideoFeedItem)
   func isSaved(id: String) -> Binding<Bool>
+  func showLogin()
+  func clearLoginIntent()
 }
 
 @Observable
@@ -26,13 +29,16 @@ public final class VideoFeedViewModel: VideoFeedViewModelType {
 
   public private(set) var isLoading = false
   public private(set) var errorMessage: String?
+  public private(set) var loginIntent: LoginIntent? = nil
 
   /// Tracks in-flight watch/unwatch requests.
   private var pendingWatchRequests: [String: Disposable] = [:]
 
-  // MARK: - Inputs
+  // MARK: - Init
 
   public init() {}
+
+  // MARK: - Inputs
 
   public func viewDidLoad() {
     Task {
@@ -41,11 +47,17 @@ public final class VideoFeedViewModel: VideoFeedViewModelType {
   }
 
   /// Returns a binding to `isSaved` for the item with the given ID.
+  /// If the user is logged out, show login instead of toggling saved.
   public func isSaved(id: String) -> Binding<Bool> {
     Binding(
       get: { self.items.first(where: { $0.id == id })?.isSaved ?? false },
       set: { [weak self] _ in
         guard let self, let item = self.items.first(where: { $0.id == id }) else { return }
+
+        guard AppEnvironment.current.currentUser != nil else {
+          self.showLogin()
+          return
+        }
 
         self.toggleSaved(for: item)
       }
@@ -83,6 +95,15 @@ public final class VideoFeedViewModel: VideoFeedViewModelType {
       }
 
     self.pendingWatchRequests[projectId] = disposable
+  }
+
+  /// Presents login. Called by the VC when a logged-out user taps the creator avatar or save button.
+  public func showLogin() {
+    self.loginIntent = .loginTab
+  }
+
+  public func clearLoginIntent() {
+    self.loginIntent = nil
   }
 
   // MARK: - Private

--- a/Library/Sources/Library/Library/ViewModels/VideoFeedViewModel.swift
+++ b/Library/Sources/Library/Library/ViewModels/VideoFeedViewModel.swift
@@ -12,7 +12,6 @@ public protocol VideoFeedViewModelType: AnyObject {
   func viewWillAppear()
   func toggleSaved(for item: VideoFeedItem)
   func isSaved(id: String) -> Binding<Bool>
-  func showLogin()
   func clearLoginIntent()
 }
 
@@ -122,16 +121,16 @@ public final class VideoFeedViewModel: VideoFeedViewModelType {
     self.pendingWatchRequests[projectId] = disposable
   }
 
-  /// Presents login. Called by the VC when a logged-out user taps the creator avatar or save button.
-  public func showLogin() {
-    self.loginIntent = .loginTab
-  }
-
   public func clearLoginIntent() {
     self.loginIntent = nil
   }
 
   // MARK: - Private
+
+  /// Triggers the login flow. Called  when a logged-out user tries to save a project.
+  private func showLogin() {
+    self.loginIntent = .loginTab
+  }
 
   func fetchVideoFeed() async {
     guard !self.isLoading else { return }

--- a/Library/Sources/Library/Library/ViewModels/VideoFeedViewModel.swift
+++ b/Library/Sources/Library/Library/ViewModels/VideoFeedViewModel.swift
@@ -54,20 +54,10 @@ public final class VideoFeedViewModel: VideoFeedViewModelType {
     }
 
     for index in self.items.indices {
-      if let id = self.projectIntID(from: self.items[index].projectId), let cached = cache[id] {
+      if let id = decompose(id: self.items[index].projectId), let cached = cache[id] {
         self.items[index].isSaved = cached
       }
     }
-  }
-
-  /// Decodes a base64 GraphQL ID into a normal integer for easier lookup..
-  private func projectIntID(from graphID: String) -> Int? {
-    guard
-      let data = Data(base64Encoded: graphID),
-      let decoded = String(data: data, encoding: .utf8)
-    else { return nil }
-
-    return Int(decoded.replacingOccurrences(of: "Project-", with: ""))
   }
 
   /// Returns a binding to `isSaved` for the item with the given ID.

--- a/Library/Sources/Library/Library/ViewModels/VideoFeedViewModel.swift
+++ b/Library/Sources/Library/Library/ViewModels/VideoFeedViewModel.swift
@@ -9,6 +9,7 @@ public protocol VideoFeedViewModelType: AnyObject {
   var fetchedItems: [VideoFeedItem] { get }
   var loginIntent: LoginIntent? { get }
   func viewDidLoad()
+  func viewWillAppear()
   func toggleSaved(for item: VideoFeedItem)
   func isSaved(id: String) -> Binding<Bool>
   func showLogin()
@@ -44,6 +45,30 @@ public final class VideoFeedViewModel: VideoFeedViewModelType {
     Task {
       await self.fetchVideoFeed()
     }
+  }
+
+  /// Called each time the feed reappears.
+  /// Reconciles the save button's state for when users save projects from a presented project page (when tapping the CTA).
+  public func viewWillAppear() {
+    guard let cache = AppEnvironment.current.cache[KSCache.ksr_projectSaved] as? [Int: Bool] else {
+      return
+    }
+
+    for index in self.items.indices {
+      if let id = self.projectIntID(from: self.items[index].projectId), let cached = cache[id] {
+        self.items[index].isSaved = cached
+      }
+    }
+  }
+
+  /// Decodes a base64 GraphQL ID into a normal integer for easier lookup..
+  private func projectIntID(from graphID: String) -> Int? {
+    guard
+      let data = Data(base64Encoded: graphID),
+      let decoded = String(data: data, encoding: .utf8)
+    else { return nil }
+
+    return Int(decoded.replacingOccurrences(of: "Project-", with: ""))
   }
 
   /// Returns a binding to `isSaved` for the item with the given ID.

--- a/Library/Sources/Library/Library/ViewModels/VideoFeedViewModel.swift
+++ b/Library/Sources/Library/Library/ViewModels/VideoFeedViewModel.swift
@@ -119,7 +119,7 @@ public final class VideoFeedViewModel: VideoFeedViewModelType {
 
   /// Triggers the login flow. Called  when a logged-out user tries to save a project.
   private func showLogin() {
-    self.loginIntent = .loginTab
+    self.loginIntent = .videoFeed
   }
 
   func fetchVideoFeed() async {


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Present the login flow when a logged-out user taps the save button in the Video Feed. 
Also ensures the save icon stays in sync after a user saves a project from the project page and then returns to the feed.

# 🤔 Why

- Only logged in users are allowed to save projects
- Saving projects from elsewhere in the app should be reflected in the video feed 

# 🛠 How

**Login presentation**
- Added a loginIntent output to view model that gets set when a logged-out user taps save or the creator avatar. 
   - The VC observes this output and presents LoginToutViewController. 
- Also set a white background on the login nav controller on iPad to avoid a black flash over the dark video background.

**Save state sync**
- `viewWillAppear` now syncs the feed's save icons against the project's save cache that the project page writes to. runs every time the feed reappears.

# 👀 See

Trello, screenshots, external resources?

| Login Presentation | Save State Sync (iPad) |
| --- | --- |
| <img width="295" height="640" alt="Simulator Screen Recording - iPhone 17 Pro - 2026-06-02 at 09 51 21" src="https://github.com/user-attachments/assets/70d2554e-44c9-40ad-b356-45674df557e6" /> | <img width="295" height="456" alt="Simulator Screen Recording - iPad mini (A17 Pro) - 2026-06-02 at 10 50 24" src="https://github.com/user-attachments/assets/673e415c-44c4-48f3-91c5-d4ef5a16e498" /> |

# ✅ Acceptance criteria

- [x] Login flow is presented when logged out and tapping save
- [x] Login flow is able to be presented again if manually closed
- [x] Save icon remains in sync with the presented project page (via CTA) when Logged-in users taps save project from project page or video feed
- [x] Test on iPhone
- [x] Test on iPad
