### PR TITLE
[DISC-217] Repeating Saved/Backed Projects In Profile Bug

### DIFF
--- a/KsApi/Sources/KsApiTestHelpers/ProjectCardFragment+TestHelpers.swift
+++ b/KsApi/Sources/KsApiTestHelpers/ProjectCardFragment+TestHelpers.swift
@@ -18,6 +18,7 @@ extension GraphAPI.ProjectCardFragment {
 
     let pageInfo = Mock<PageInfo>()
     pageInfo.hasNextPage = true
+    pageInfo.endCursor = "mockEndCursor"
     pageInfo.hasPreviousPage = false
 
     let projectsConnectionMock = Mock<GraphAPITestMocks.ProjectsConnectionWithTotalCount>(

--- a/Library/Sources/Library/Library/Paginate.swift
+++ b/Library/Sources/Library/Library/Paginate.swift
@@ -25,6 +25,7 @@ import ReactiveSwift
  - parameter skipRepeats:          A boolean that determines if results can be repeated.
  - parameter valuesFromEnvelope:   A function to get an array of values from the results envelope.
  - parameter cursorFromEnvelope:   A function to get the cursor for the next page from a results envelope.
+                                   Return `nil` when there is no next page.
  - parameter requestFromParams:    A function to get a request for values from a params value.
  - parameter requestFromCursor:    A function to get a request for values from a cursor value.
  - parameter concater:             An optional function that concats a page of values to the current array of
@@ -43,7 +44,7 @@ public func paginate<Cursor, Value: Equatable, Envelope, ErrorEnvelope, RequestP
   clearOnNewRequest: Bool,
   skipRepeats: Bool = true,
   valuesFromEnvelope: @escaping ((Envelope) -> [Value]),
-  cursorFromEnvelope: @escaping ((Envelope) -> Cursor),
+  cursorFromEnvelope: @escaping ((Envelope) -> Cursor?),
   requestFromParams: @escaping ((RequestParams) -> SignalProducer<Envelope, ErrorEnvelope>),
   requestFromCursor: @escaping ((Cursor) -> SignalProducer<Envelope, ErrorEnvelope>),
   concater: @escaping (([Value], [Value]) -> [Value]) = (+)
@@ -59,8 +60,8 @@ public func paginate<Cursor, Value: Equatable, Envelope, ErrorEnvelope, RequestP
   let isLoading = MutableProperty<Bool>(false)
   let errors = MutableProperty<ErrorEnvelope?>(nil)
 
-  // Emits the last cursor when nextPage emits
-  let cursorOnNextPage = cursor.producer.skipNil().sample(on: requestNextPage)
+  // Emits the last cursor when nextPage emits, only when a next page actually exists.
+  let cursorOnNextPage = cursor.producer.sample(on: requestNextPage).skipNil()
 
   let paginatedValues = requestFirstPage
     .switchMap { requestParams in

--- a/LibraryTests/Library/PaginateTests.swift
+++ b/LibraryTests/Library/PaginateTests.swift
@@ -797,4 +797,70 @@ final class PaginateTests: TestCase {
 
     pageCountLoadedTest.assertValues([1, 2, 3, 1, 2, 3, 4, 1])
   }
+
+  func testPagination_StopsWhenCursorIsNil() {
+    var numberOfRequests = 0
+
+    let requestFromParams: (Int) -> SignalProducer<[Int], Never> = { p in
+      numberOfRequests += 1
+      return .init(value: [p])
+    }
+    let requestFromCursor: (Int) -> SignalProducer<[Int], Never> = { c in
+      numberOfRequests += 1
+      return .init(value: [c])
+    }
+
+    /// Returns a cursor for the first page, nil after that to simulate hasNextPage: false
+    let cursorFromEnvelope: ([Int]) -> Int? = { values in
+      guard let last = values.last else { return nil }
+
+      return last == 1 ? last + 1 : nil
+    }
+
+    let (values, loading, _, _) = paginate(
+      requestFirstPageWith: newRequest,
+      requestNextPageWhen: nextPage,
+      clearOnNewRequest: true,
+      valuesFromEnvelope: valuesFromEnvelope,
+      cursorFromEnvelope: cursorFromEnvelope,
+      requestFromParams: requestFromParams,
+      requestFromCursor: requestFromCursor
+    )
+
+    let valuesTest = TestObserver<[Int], Never>()
+    values.observe(valuesTest.observer)
+
+    let loadingTest = TestObserver<Bool, Never>()
+    loading.observe(loadingTest.observer)
+
+    /// Load first page (cursor will be 2)
+    self.newRequestObserver.send(value: 1)
+
+    self.scheduler.advance()
+
+    valuesTest.assertValues([[1]], "First page of values emitted.")
+    loadingTest.assertValues([true, false], "Loading started and stopped.")
+
+    XCTAssertEqual(1, numberOfRequests, "One request made.")
+
+    /// Load second page (cursor will be nil after this)
+    self.nextPageObserver.send(value: ())
+
+    self.scheduler.advance()
+
+    valuesTest.assertValues([[1], [1, 2]], "Second page of values emitted.")
+    loadingTest.assertValues([true, false, true, false], "Loading started and stopped.")
+
+    XCTAssertEqual(2, numberOfRequests, "Two requests made.")
+
+    /// Try to load a third page (cursor is nil so no request should fire)
+    self.nextPageObserver.send(value: ())
+
+    self.scheduler.advance()
+
+    valuesTest.assertValues([[1], [1, 2]], "No new values emitted.")
+    loadingTest.assertValues([true, false, true, false], "Loading did not start again.")
+
+    XCTAssertEqual(2, numberOfRequests, "No additional requests made.")
+  }
 }


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Fixes a bug where paginated lists (backed projects, saved projects) would show duplicate results by looping back to the first page after reaching the end of the list.

# 🤔 Why

When the server signals there are no more pages, it returns `hasNextPage: false` and a nil `endCursor`. 
The app was accidentally treating that nil cursor as a valid "start from the beginning" cursor, triggering a request with `after: null` which the server interprets as a first-page request.

# 🛠 How

The root cause is just the operator ordering in `Paginate.swift`

Confirmed with Zak that requesting with `after: null` returns the first page of results on the backend.

before: 
samples the last non-nil cursor, even if cursor is now nil
```swift
cursor.producer.skipNil().sample(on: requestNextPage)
```

after: 
samples current cursor value first, _then_ filters nil
```swift
cursor.producer.sample(on: requestNextPage).skipNil()
```

- Also updated `cursorFromEnvelope`'s return type from `Cursor` to `Cursor?` so callers can explicitly return `nil` to signal that there's no next page rather than relying on an empty result being the only stop condition.

I don't feel _super_ confident in my paginate skills so if you see any issues or edge cases that I'm not thinking about here please call them out.

# 👀 See

Trello, screenshots, external resources?

| Before 🐛 (Lists keep fetching at end of lists resulting in duplicates) | After 🦋 (Lists stop fetching at the end of the list avoiding duplicates) |
| --- | --- |
| <img width="295" height="640" alt="Simulator Screen Recording - iPhone 17 Pro - 2026-06-03 at 10 34 23" src="https://github.com/user-attachments/assets/5eca770c-3050-491a-9fd4-46b668c14e2d" /> |  <img width="295" height="640" alt="Simulator Screen Recording - iPhone 17 Pro - 2026-06-03 at 10 32 32" src="https://github.com/user-attachments/assets/8d2e9ed6-7ba7-4e59-b3ac-c3e10bbbca9a" /> |

# ✅ Acceptance criteria

- [x] Scrolling to the last page of results of backed and saved projects does not result in duplicate fetches or data displayed
- [x] Other parts of the app that use Paginate (Activity, Discovery, Messages, Comments) are unaffected by this change
- [x] All app tests pass 