### PR TITLE
Video Feed: Lost Connection Edge Cases

### DIFF
--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/VideoPlayer/VideoFeedVideoPlayer.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/VideoPlayer/VideoFeedVideoPlayer.swift
@@ -21,6 +21,7 @@ class VideoFeedVideoPlayer {
   private var timeObserverToken: Any?
   private var endObserver: (any NSObjectProtocol)?
   private var failedObserver: (any NSObjectProtocol)?
+  private var stalledObserver: (any NSObjectProtocol)?
   /// Once `onReady` has fired, flip this so we don't fire it repeatedly.
   private var hasFiredOnReady = false
   private var hasFiredOnFailed = false
@@ -59,6 +60,7 @@ class VideoFeedVideoPlayer {
         self?.player.play()
       }
     }
+
     /// Catches mid-playback failures (network drop, decoder errors, etc.).
     self.failedObserver = NotificationCenter.default.addObserver(
       forName: .AVPlayerItemFailedToPlayToEndTime,
@@ -66,6 +68,26 @@ class VideoFeedVideoPlayer {
       queue: .main
     ) { [weak self] _ in
       self?.notifyFailed()
+    }
+
+    /// Catches errors caused by losing network connection mid-playback.
+    /// AVPlayer triggers this when it can no longer load a video but doesn't transition to .failed it just freezes,
+    /// `AVPlayerItemFailedToPlayToEndTime` never fires in this specific case.
+    self.stalledObserver = NotificationCenter.default.addObserver(
+      forName: AVPlayerItem.playbackStalledNotification,
+      object: item,
+      queue: .main
+    ) { [weak self] _ in
+      guard let self, self.player.currentItem === item else { return }
+
+      /// Giving the player a 3s window to recover.
+      DispatchQueue.main.asyncAfter(deadline: .now() + 3) { [weak self] in
+        guard let self,
+              self.player.currentItem === item,
+              self.player.rate == 0 else { return }
+
+        self.notifyFailed()
+      }
     }
 
     self.player.play()
@@ -155,6 +177,7 @@ class VideoFeedVideoPlayer {
   /// Both the `AVPlayerItemFailedToPlayToEndTime` notification and the failed to load timeout can observe the same failure.
   private func notifyFailed() {
     guard !self.hasFiredOnFailed else { return }
+
     self.hasFiredOnFailed = true
     self.onVideoFailed?()
   }
@@ -163,11 +186,19 @@ class VideoFeedVideoPlayer {
     if let endObserver = self.endObserver {
       NotificationCenter.default.removeObserver(endObserver)
     }
+
     self.endObserver = nil
 
     if let failedObserver = self.failedObserver {
       NotificationCenter.default.removeObserver(failedObserver)
     }
+
     self.failedObserver = nil
+
+    if let stalledObserver = self.stalledObserver {
+      NotificationCenter.default.removeObserver(stalledObserver)
+    }
+
+    self.stalledObserver = nil
   }
 }

--- a/Library/Sources/Library/Library/ViewModels/DiscoveryPageViewModel.swift
+++ b/Library/Sources/Library/Library/ViewModels/DiscoveryPageViewModel.swift
@@ -337,10 +337,13 @@ public final class DiscoveryPageViewModel: DiscoveryPageViewModelType, Discovery
     .ignoreValues()
     .map(shouldShowPersonalization)
 
+    self.reachabilityProperty <~ Reachability.signalProducer
+
     self.showVideoFeedBanner = Signal.merge(
       self.viewWillAppearProperty.signal,
-      // Because the Discover page is the first page we see, it might appear before config values load.
-      self.configUpdatedSignal
+      /// Because the Discover page is the first page we see, it might appear before config values load.
+      self.configUpdatedSignal,
+      self.reachabilityProperty.signal.ignoreValues()
     )
     .map { featureVideoFeedEnabled() && Reachability.current != .none }
     .skipRepeats()
@@ -477,6 +480,8 @@ public final class DiscoveryPageViewModel: DiscoveryPageViewModelType, Discovery
   public func willDisplayRow(_ row: Int, outOf totalRows: Int) {
     self.willDisplayRowProperty.value = (row, totalRows)
   }
+
+  private let reachabilityProperty = MutableProperty(Reachability.current)
 
   public let activitiesForSample: Signal<[Activity], Never>
   public let asyncReloadData: Signal<Void, Never>

--- a/Library/Sources/Library/Library/ViewModels/SearchViewModel.swift
+++ b/Library/Sources/Library/Library/ViewModels/SearchViewModel.swift
@@ -241,9 +241,14 @@ public final class SearchViewModel: SearchViewModelType, SearchViewModelInputs, 
     self.showEmptyState = requestFirstPageWith
       .takePairWhen(shouldShowEmptyState)
 
-    self.showVideoFeedBanner = self.viewWillAppearAnimatedProperty.signal.ignoreValues()
-      .map { featureVideoFeedEnabled() && Reachability.current != .none }
-      .skipRepeats()
+    self.reachabilityProperty <~ Reachability.signalProducer
+
+    self.showVideoFeedBanner = Signal.merge(
+      self.viewWillAppearAnimatedProperty.signal.ignoreValues(),
+      self.reachabilityProperty.signal.ignoreValues()
+    )
+    .map { featureVideoFeedEnabled() && Reachability.current != .none }
+    .skipRepeats()
 
     self.goToProject = Signal.combineLatest(searchResults, queryText)
       .takePairWhen(self.tappedProjectIndexSignal)
@@ -399,6 +404,7 @@ public final class SearchViewModel: SearchViewModelType, SearchViewModelInputs, 
   private let categoriesUseCase: FetchCategoriesUseCase
   private let searchFiltersUseCase: SearchFiltersUseCase
   private let locationsUseCase: FetchLocationsUseCase
+  private let reachabilityProperty = MutableProperty(Reachability.current)
 
   public let goToProject: Signal<(ProjectPageParam, RefTag), Never>
   public let projects: Signal<[SearchResultCard], Never>

--- a/LibraryTests/Library/ViewModels/DiscoveryPageViewModelTests.swift
+++ b/LibraryTests/Library/ViewModels/DiscoveryPageViewModelTests.swift
@@ -1,3 +1,4 @@
+import Experimentation
 @testable import KsApi
 @testable import KsApiTestHelpers
 @testable import Library
@@ -35,6 +36,7 @@ internal final class DiscoveryPageViewModelTests: TestCase {
   fileprivate let showEmptyState = TestObserver<EmptyState, Never>()
   fileprivate let showOnboarding = TestObserver<Bool, Never>()
   fileprivate let showPersonalization = TestObserver<Bool, Never>()
+  fileprivate let showVideoFeedBanner = TestObserver<Bool, Never>()
 
   internal override func setUp() {
     super.setUp()
@@ -60,6 +62,7 @@ internal final class DiscoveryPageViewModelTests: TestCase {
     self.vm.outputs.showEmptyState.observe(self.showEmptyState.observer)
     self.vm.outputs.showOnboarding.observe(self.showOnboarding.observer)
     self.vm.outputs.showPersonalization.observe(self.showPersonalization.observer)
+    self.vm.outputs.showVideoFeedBanner.observe(self.showVideoFeedBanner.observer)
 
     self.vm.outputs.projectsLoaded
       .map { $0.0.count }
@@ -1205,6 +1208,59 @@ internal final class DiscoveryPageViewModelTests: TestCase {
       self.scheduler.advance()
 
       self.projectsAreLoading.assertValueCount(4)
+    }
+  }
+
+  func testShowVideoFeedBanner_featureEnabled_showsOnViewWillAppear() {
+    let mockStatsig = MockStatsigWrapper()
+    mockStatsig.features = [.videoFeed: true]
+
+    withEnvironment(statsigClient: mockStatsig) {
+      self.showVideoFeedBanner.assertDidNotEmitValue()
+
+      self.vm.inputs.viewWillAppear()
+
+      self.showVideoFeedBanner.assertLastValue(true, "Banner shows when feature flag is on.")
+    }
+  }
+
+  func testShowVideoFeedBanner_featureDisabled_hiddenOnViewWillAppear() {
+    let mockStatsig = MockStatsigWrapper()
+    mockStatsig.features = [.videoFeed: false]
+
+    withEnvironment(statsigClient: mockStatsig) {
+      self.vm.inputs.viewWillAppear()
+
+      self.showVideoFeedBanner.assertLastValue(false, "Banner hidden when feature flag is off.")
+    }
+  }
+
+  func testShowVideoFeedBanner_featureEnabled_showsOnConfigUpdated() {
+    let mockStatsig = MockStatsigWrapper()
+    mockStatsig.features = [.videoFeed: true]
+
+    withEnvironment(statsigClient: mockStatsig) {
+      self.showVideoFeedBanner.assertDidNotEmitValue()
+
+      self.vm.inputs.configUpdated()
+
+      self.showVideoFeedBanner.assertLastValue(
+        true,
+        "Banner shows when config updates with feature flag on."
+      )
+    }
+  }
+
+  func testShowVideoFeedBanner_skipRepeats() {
+    let mockStatsig = MockStatsigWrapper()
+    mockStatsig.features = [.videoFeed: true]
+
+    withEnvironment(statsigClient: mockStatsig) {
+      self.vm.inputs.viewWillAppear()
+      self.vm.inputs.viewWillAppear()
+      self.vm.inputs.viewWillAppear()
+
+      self.showVideoFeedBanner.assertValueCount(1, "Repeated identical values are skipped.")
     }
   }
 }

--- a/LibraryTests/Library/ViewModels/SearchViewModelTests.swift
+++ b/LibraryTests/Library/ViewModels/SearchViewModelTests.swift
@@ -1,3 +1,4 @@
+import Experimentation
 import Foundation
 import GraphAPI
 @testable import KsApi
@@ -24,6 +25,7 @@ internal final class SearchViewModelTests: TestCase {
   fileprivate let showEmptyState = TestObserver<Bool, Never>()
   fileprivate let showEmptyStateParams = TestObserver<DiscoveryParams, Never>()
   fileprivate let showFilters = TestObserver<SearchFilterModalType, Never>()
+  fileprivate let showVideoFeedBanner = TestObserver<Bool, Never>()
 
   override func setUp() {
     super.setUp()
@@ -38,6 +40,7 @@ internal final class SearchViewModelTests: TestCase {
     self.vm.outputs.searchLoaderIndicatorIsAnimating.observe(self.searchLoaderIndicatorIsAnimating.observer)
     self.vm.outputs.showEmptyState.map(second).observe(self.showEmptyState.observer)
     self.vm.outputs.showEmptyState.map(first).observe(self.showEmptyStateParams.observer)
+    self.vm.outputs.showVideoFeedBanner.observe(self.showVideoFeedBanner.observer)
 
     self.vm.outputs.searchResults
       .map { $0.projects.count }
@@ -1050,6 +1053,43 @@ internal final class SearchViewModelTests: TestCase {
 
       XCTAssertEqual("maverick", segmentClientProps?["discover_search_term"] as? String)
       XCTAssertEqual(200, segmentClientProps?["discover_search_results_count"] as? Int)
+    }
+  }
+
+  func testShowVideoFeedBanner_featureEnabled_showsOnViewWillAppear() {
+    let mockStatsig = MockStatsigWrapper()
+    mockStatsig.features = [.videoFeed: true]
+
+    withEnvironment(statsigClient: mockStatsig) {
+      self.showVideoFeedBanner.assertDidNotEmitValue()
+
+      self.vm.inputs.viewWillAppear(animated: true)
+
+      self.showVideoFeedBanner.assertLastValue(true, "Banner shows when feature flag is on.")
+    }
+  }
+
+  func testShowVideoFeedBanner_featureDisabled_hiddenOnViewWillAppear() {
+    let mockStatsig = MockStatsigWrapper()
+    mockStatsig.features = [.videoFeed: false]
+
+    withEnvironment(statsigClient: mockStatsig) {
+      self.vm.inputs.viewWillAppear(animated: true)
+
+      self.showVideoFeedBanner.assertLastValue(false, "Banner hidden when feature flag is off.")
+    }
+  }
+
+  func testShowVideoFeedBanner_skipRepeats() {
+    let mockStatsig = MockStatsigWrapper()
+    mockStatsig.features = [.videoFeed: true]
+
+    withEnvironment(statsigClient: mockStatsig) {
+      self.vm.inputs.viewWillAppear(animated: true)
+      self.vm.inputs.viewWillAppear(animated: true)
+      self.vm.inputs.viewWillAppear(animated: true)
+
+      self.showVideoFeedBanner.assertValueCount(1, "Repeated identical values are skipped.")
     }
   }
 }


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Fix error toast not showing when network is lost mid playback and immediately hide the video feed banner entry points on Discovery and Search when connectivity drops.

# 🤔 Why

- If a user entered the video feed with connection and then lost it, videos would freeze or show a black screen without the error toast ever appearing.
- If a user lost connectivity while on the Discovery or Search screens, the "Try it now" video feed banner would still be visible. Tapping it would open the feed and leave them on a black screen with no way to close it.

# 🛠 How

- AVPlayer doesn't actually "fail" when the network drops mid-playback, it just stalls silently. I added an observer for `AVPlayerItem.playbackStalledNotification` with a 3s recovery window that then triggers the error toast.
- For the banner views, both VMs already checked Reachability.current != .none but only on viewWillAppear. I wired up Reachability.signalProducer as an additional trigger so the banner also hides immediately when connectivity changes.

# 👀 See

Trello, screenshots, external resources?

|  | Turning off/on wifi on simulator outside of the feed and with it open |
| --- | --- |
|  | <img width="295" height="640" alt="Simulator Screen Recording - iPhone 17 Pro - 2026-06-04 at 10 42 57" src="https://github.com/user-attachments/assets/13da9d47-66ce-4985-9572-2b32b7b6f65a" /> |


# ✅ Acceptance criteria

- [x] Load the video feed with a working connection, then turn on airplane mode. The error toast should appear on the current video and any other videos while connection is off
- [x] On the Discovery or Search screen with the video feed banner visible, turn on airplane mode. The banner should disappear immediately
- [x] Turn airplane mode off while on Discovery or Search and the banner should reappear
