### PR TITLE
CHECK-134: Add plumbing to change position of no-reward in rewards list

### DIFF
--- a/KsApi/Sources/KsApi/MockService.swift
+++ b/KsApi/Sources/KsApi/MockService.swift
@@ -1439,9 +1439,10 @@
         )
     }
 
-    func fetchProjectRewardsWithNoReward(
+    func fetchProjectRewards(
       projectId: Int,
-      sortedForShippingCountryCode _: String?
+      sortedForShippingCountryCode _: String?,
+      withNoReward _: NoRewardSortType
     ) -> SignalProducer<[Reward], ErrorEnvelope> {
       guard let client = self.apolloClient else {
         return .empty

--- a/KsApi/Sources/KsApi/Service.swift
+++ b/KsApi/Sources/KsApi/Service.swift
@@ -633,9 +633,10 @@ public struct Service: ServiceType {
       .flatMap(Project.projectRewardsProducer(from:))
   }
 
-  public func fetchProjectRewardsWithNoReward(
+  public func fetchProjectRewards(
     projectId: Int,
-    sortedForShippingCountryCode code: String?
+    sortedForShippingCountryCode code: String?,
+    withNoReward noRewardSortType: NoRewardSortType
   ) -> SignalProducer<[Reward], ErrorEnvelope> {
     let graphCountryCode: GraphAPI.CountryCode?
     if let code {
@@ -653,7 +654,9 @@ public struct Service: ServiceType {
 
     return GraphQL.shared.client
       .fetch(query: query)
-      .map(Project.projectRewards(from:))
+      .map { results in
+        Project.projectRewards(from: results, withNoReward: noRewardSortType)
+      }
   }
 
   public func fetchProjectRewardsAndPledgeOverTimeData(projectId: Int)

--- a/KsApi/Sources/KsApi/ServiceType.swift
+++ b/KsApi/Sources/KsApi/ServiceType.swift
@@ -262,7 +262,11 @@ public protocol ServiceType {
   func fetchProjectRewards(projectId: Int) -> SignalProducer<[Reward], ErrorEnvelope>
 
   /// Fetch the project's rewards, including 'No Reward'. Includes all shipping rules.
-  func fetchProjectRewardsWithNoReward(projectId: Int, sortedForShippingCountryCode: String?)
+  func fetchProjectRewards(
+    projectId: Int,
+    sortedForShippingCountryCode: String?,
+    withNoReward: NoRewardSortType
+  )
     -> SignalProducer<[Reward], ErrorEnvelope>
 
   /// Fetch a single project with the specified discovery params.

--- a/KsApi/Sources/KsApi/models/graphql/adapters/Project+FetchProjectRewardsByIdQueryData.swift
+++ b/KsApi/Sources/KsApi/models/graphql/adapters/Project+FetchProjectRewardsByIdQueryData.swift
@@ -3,6 +3,11 @@ import GraphAPI
 import Prelude
 import ReactiveSwift
 
+public enum NoRewardSortType {
+  case first
+  case last
+}
+
 extension Project {
   static func projectRewardsProducer(
     from data: GraphAPI.FetchProjectRewardsByIdQuery.Data
@@ -12,7 +17,10 @@ extension Project {
     return SignalProducer(value: projectRewards)
   }
 
-  static func projectRewards(from data: GraphAPI.FetchSortedProjectRewardsByIdQuery.Data) -> [Reward] {
+  static func projectRewards(
+    from data: GraphAPI.FetchSortedProjectRewardsByIdQuery.Data,
+    withNoReward noRewardSortType: NoRewardSortType
+  ) -> [Reward] {
     guard let project = data.project else {
       return []
     }
@@ -31,7 +39,13 @@ extension Project {
       } ?? []
 
     let noReward = Reward.noRewardReward(from: project.fragments.noRewardRewardFragment)
-    return [noReward] + projectRewards
+
+    switch noRewardSortType {
+    case .first:
+      return [noReward] + projectRewards
+    case .last:
+      return projectRewards + [noReward]
+    }
   }
 
   static func projectRewards(from data: GraphAPI.FetchProjectRewardsByIdQuery.Data) -> [Reward] {

--- a/KsApi/Sources/KsApiTests/models/graphql/adapters/Project+FetchSortedProjectRewardsByIdQueryDataTests.swift
+++ b/KsApi/Sources/KsApiTests/models/graphql/adapters/Project+FetchSortedProjectRewardsByIdQueryDataTests.swift
@@ -17,7 +17,7 @@ final class Project_FetchSortedProjectRewardsByIdQueryDataTests: XCTestCase {
       ])
     XCTAssertNotNil(data)
 
-    let rewards = Project.projectRewards(from: data)
+    let rewards = Project.projectRewards(from: data, withNoReward: .first)
 
     XCTAssertEqual(rewards.count, 2)
 
@@ -27,7 +27,7 @@ final class Project_FetchSortedProjectRewardsByIdQueryDataTests: XCTestCase {
     }
 
     // Unlike the other rewards fetch, this one automatically adds no-reward.
-    XCTAssertTrue(firstReward.isNoReward, "Query should have inserted no-reward reward")
+    XCTAssertTrue(firstReward.isNoReward, "Query should have inserted no-reward reward first")
     XCTAssertEqual(firstReward.convertedMinimum, 0.780313)
 
     // The rewards and shipping rules code goes through the same pathway as
@@ -39,5 +39,29 @@ final class Project_FetchSortedProjectRewardsByIdQueryDataTests: XCTestCase {
       1,
       "Should have parsed the expanded shipping rules"
     )
+  }
+
+  func testFetch_noRewardSort_lastPutsNoRewardLast() {
+    let dataUrl = Bundle.module.url(forResource: "FetchSortedProjectRewardsById", withExtension: "json")!
+    let data: GraphAPI.FetchSortedProjectRewardsByIdQuery.Data =
+      try! testGraphObject(fromResource: dataUrl, variables: [
+        "projectId": 1_480_998_200,
+        "location": "DE",
+        "includeShippingRules": true,
+        "includeLocalPickup": true
+      ])
+    XCTAssertNotNil(data)
+
+    let rewards = Project.projectRewards(from: data, withNoReward: .last)
+
+    XCTAssertEqual(rewards.count, 2)
+
+    guard let lastReward = rewards.last else {
+      XCTFail("Expected there to be two rewards")
+      return
+    }
+
+    // Unlike the other rewards fetch, this one automatically adds no-reward.
+    XCTAssertTrue(lastReward.isNoReward, "Query should have inserted no-reward reward last")
   }
 }

--- a/Library/Sources/Library/Library/ViewModels/RewardsCollectionViewModel.swift
+++ b/Library/Sources/Library/Library/ViewModels/RewardsCollectionViewModel.swift
@@ -89,9 +89,10 @@ public final class RewardsCollectionViewModel: RewardsCollectionViewModelType,
       })
       .flatMap { project, location in
         AppEnvironment.current.apiService
-          .fetchProjectRewardsWithNoReward(
+          .fetchProjectRewards(
             projectId: project.id,
-            sortedForShippingCountryCode: location
+            sortedForShippingCountryCode: location,
+            withNoReward: .first
           )
           .ksr_delay(AppEnvironment.current.apiDelayInterval, on: AppEnvironment.current.scheduler)
           .materialize()


### PR DESCRIPTION
# 📲 What

Add code that lets you change the location of 'No Reward' in the rewards list.

# 🤔 Why

We're currently running an experiment on Android which moves the 'No Reward' card from first to last. We're going to run the same experiment on iOS.

This is part 1 of 2 to implement that experiment - adding the plumbing to move the reward's position. This plumbing keeps our experiment framework out of `KsApi` by adding a new sort parameter to the rewards fetch.