### PR TITLE
[DISC-224] Resume Playback By Tapping Anywhere On Video + Respect iPhone Silent Mode

### DIFF
--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Cell/VideoFeedCell.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Cell/VideoFeedCell.swift
@@ -223,9 +223,12 @@ final class VideoFeedCell: UICollectionViewCell, ValueCell {
     self.addGestureRecognizer(tap)
   }
 
-  /// Tapping anywhere on the cell pauses playback and shows the play button.
-  /// Tapping the play button resumes playback and hides it.
+  /// Tapping anywhere on the cell toggles playback:
   @objc private func cellTapped() {
-    self.playbackState.pause()
+    if self.playbackState.isPlaying {
+      self.playbackState.pause()
+    } else {
+      self.playbackState.resume()
+    }
   }
 }

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Controller/VideoFeedViewController.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Controller/VideoFeedViewController.swift
@@ -145,7 +145,7 @@ final class VideoFeedViewController: UIViewController {
   /// Auto play video audio
   private func configureAudioSession() {
     do {
-      try AVAudioSession.sharedInstance().setCategory(.playback, mode: .moviePlayback)
+      try AVAudioSession.sharedInstance().setCategory(.soloAmbient, mode: .default)
       try AVAudioSession.sharedInstance().setActive(true)
     } catch {
       #if DEBUG

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Overlay/VideoFeedOverlayView.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Overlay/VideoFeedOverlayView.swift
@@ -135,8 +135,6 @@ struct VideoFeedOverlayView: View {
         .frame(width: Constants.playButtonSize, height: Constants.playButtonSize)
         .background(FrostedGlassBackgroundView())
         .clipShape(Circle())
-        /// Tapping the play button resumes playback and hides the button.
-        .onTapGesture { self.playbackState.resume() }
         .opacity(self.playbackState.isPlayButtonVisible ? 1 : 0)
         .animation(.easeInOut(duration: 0.15), value: self.playbackState.isPlayButtonVisible)
         .accessibilityLabel(Strings.Play())


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

- Tapping anywhere on the video now toggles pause/resume (before tapping would only pause)
- Video audio now respects the hardware silent switch

# 🤔 Why

- The play button was the only way to resume. Tapping the video a second time did nothing, which felt broken and unlike other feed apps like Reels.
- `AVAudioSession` was configured with `.playback`, which bypasses the silent switch entirely. We need to use `.soloAmbient` which respects silent and also interrupts any other currently playing audio

# 🛠 How

- `VideoFeedCell.cellTapped()` now checks `playbackState.isPlaying` and toggles accordingly. 
- `AVAudioSession` category is now `.soloAmbient`. This respects silent mode and interrupts other audio (music, podcasts) when the feed opens.

# ✅ Acceptance criteria

- [x] Tap video while playing. Video pauses, play icon appears
- [x] Tap video while paused. Video resumes, play icon hides
- [x] Open video feed with silent switch on. No audio plays
- [x] Open video feed while music is playing. Music pauses
- [x] Turn silent switch on while video audio is playing. Video audio is slenced.