### PR TITLE
[DISC-243] Video Feed: Optimistically Update Projects' Save Count

### DIFF
--- a/Kickstarter-Framework/Sources/Kickstarter-Framework-iOSTests/Kickstarter-iOS/Features/VideoFeed/Controller/VideoFeedViewControllerTests.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework-iOSTests/Kickstarter-iOS/Features/VideoFeed/Controller/VideoFeedViewControllerTests.swift
@@ -40,7 +40,7 @@ final class VideoFeedViewControllerTests: TestCase {
         )
 
         cell.configureWith(
-          value: VideoFeedItem(
+          item: .constant(VideoFeedItem(
             id: "0",
             pid: 3,
             slug: "video_feed",
@@ -61,7 +61,7 @@ final class VideoFeedViewControllerTests: TestCase {
             sharesCount: 1,
             watchesCount: 50,
             percentFunded: 100
-          ),
+          )),
           isSaved: .constant(false)
         )
 
@@ -98,7 +98,7 @@ final class VideoFeedViewControllerTests: TestCase {
         )
 
         cell.configureWith(
-          value: VideoFeedItem(
+          item: .constant(VideoFeedItem(
             id: "0",
             pid: 3,
             slug: "video_feed",
@@ -119,7 +119,7 @@ final class VideoFeedViewControllerTests: TestCase {
             sharesCount: 1,
             watchesCount: 50,
             percentFunded: 42
-          ),
+          )),
           isSaved: .constant(true)
         )
 
@@ -158,7 +158,7 @@ final class VideoFeedViewControllerTests: TestCase {
         )
 
         cell.configureWith(
-          value: VideoFeedItem(
+          item: .constant(VideoFeedItem(
             id: "0",
             pid: 3,
             slug: "video_feed",
@@ -179,7 +179,7 @@ final class VideoFeedViewControllerTests: TestCase {
             sharesCount: 1,
             watchesCount: 50,
             percentFunded: 42
-          ),
+          )),
           isSaved: .constant(false)
         )
 
@@ -218,7 +218,7 @@ final class VideoFeedViewControllerTests: TestCase {
         )
 
         cell.configureWith(
-          value: VideoFeedItem(
+          item: .constant(VideoFeedItem(
             id: "0",
             pid: 3,
             slug: "video_feed",
@@ -239,7 +239,7 @@ final class VideoFeedViewControllerTests: TestCase {
             sharesCount: 1,
             watchesCount: 50,
             percentFunded: 42
-          ),
+          )),
           isSaved: .constant(false)
         )
 
@@ -280,7 +280,7 @@ final class VideoFeedViewControllerTests: TestCase {
         )
 
         cell.configureWith(
-          value: VideoFeedItem(
+          item: .constant(VideoFeedItem(
             id: "0",
             pid: 3,
             slug: "video_feed",
@@ -301,7 +301,7 @@ final class VideoFeedViewControllerTests: TestCase {
             sharesCount: 1,
             watchesCount: 50,
             percentFunded: 42
-          ),
+          )),
           isSaved: .constant(false)
         )
 

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Cell/VideoFeedCell.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Cell/VideoFeedCell.swift
@@ -92,15 +92,15 @@ final class VideoFeedCell: UICollectionViewCell, ValueCell {
   func configureWith(value _: VideoFeedItem) {}
 
   func configureWith(
-    value: VideoFeedItem,
+    item: Binding<VideoFeedItem>,
     isSaved: Binding<Bool>
   ) {
-    self.currentItemId = value.id
+    self.currentItemId = item.wrappedValue.id
 
     self.contentConfiguration = UIHostingConfiguration {
       VideoFeedOverlayView(
         isSaved: isSaved,
-        item: value,
+        item: item,
         playbackState: self.playbackState,
         videoPlayer: self.videoPlayer,
         onCloseTapped: { [weak self] in self?.onCloseTapped?() },

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Controller/VideoFeedViewController.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Controller/VideoFeedViewController.swift
@@ -4,6 +4,7 @@ import KDS
 import Kingfisher
 import KsApi
 import Library
+import SwiftUI
 import UIKit
 
 /// Full-screen swipeable video feed.
@@ -173,6 +174,27 @@ final class VideoFeedViewController: UIViewController {
     self.collectionView.reloadData()
   }
 
+  /// This re-runs `UIHostingConfiguration` on the currently active cell so the SwiftUI view can get any updated values that may have mutated when presenting a view on top of the feed.
+  /// (i.e. `watchesCount` and `isSaved` changes made in the Project Page).
+  private func reconfigureVisibleCell() {
+    guard let indexPath = self.collectionView.indexPathsForVisibleItems.first,
+          let cell = self.collectionView.cellForItem(at: indexPath) as? VideoFeedCell else { return }
+
+    let items = self.viewModel.items
+
+    guard indexPath.item < items.count else { return }
+
+    let item = items[indexPath.item]
+
+    cell.configureWith(
+      item: Binding(
+        get: { self.viewModel.items.first(where: { $0.id == item.id }) ?? item },
+        set: { _ in }
+      ),
+      isSaved: self.viewModel.isSaved(id: item.id)
+    )
+  }
+
   private func snapToCurrentPage() {
     let pageHeight = self.collectionView.bounds.height
 
@@ -306,7 +328,10 @@ extension VideoFeedViewController: UICollectionViewDelegateFlowLayout {
     cell.onCTATapped = { [weak self] in self?.goToProjectPage(for: item) }
 
     cell.configureWith(
-      value: item,
+      item: Binding(
+        get: { self.viewModel.items.first(where: { $0.id == item.id }) ?? item },
+        set: { _ in }
+      ),
       isSaved: self.viewModel.isSaved(id: item.id)
     )
 

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Overlay/VideoFeedOverlayView.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Overlay/VideoFeedOverlayView.swift
@@ -4,7 +4,7 @@ import Library
 import SwiftUI
 
 /// Full-screen SwiftUI Video Feed overlay.
-/// Takes a plain `VideoFeedItem`
+/// Takes a `Binding<VideoFeedItem>` so mutations to things like, watchesCount, re-render automatically.
 struct VideoFeedOverlayView: View {
   private enum Constants {
     static let topGradientOverlayOpacity: Double = 0.2
@@ -34,7 +34,8 @@ struct VideoFeedOverlayView: View {
   /// Owned by `VideoFeedViewModel`
   @Binding var isSaved: Bool
 
-  let item: VideoFeedItem
+  @Binding var item: VideoFeedItem
+
   let playbackState: VideoFeedPlaybackState
   let videoPlayer: VideoFeedVideoPlayer
 
@@ -64,7 +65,7 @@ struct VideoFeedOverlayView: View {
 
       VStack(alignment: .trailing, spacing: Constants.railBottomSpacing) {
         VideoFeedRightRailView(
-          item: self.item,
+          item: self.$item,
           isSaved: self.$isSaved,
           onCreatorTapped: self.onCreatorTapped,
           onShareTapped: self.onShareTapped,

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Overlay/VideoFeedRightRailView.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Overlay/VideoFeedRightRailView.swift
@@ -17,7 +17,7 @@ struct VideoFeedRightRailView: View {
     static let avatarPlaceholderIcon = "avatar--placeholder"
   }
 
-  let item: VideoFeedItem
+  @Binding var item: VideoFeedItem
   @Binding var isSaved: Bool
 
   var onCreatorTapped: (() -> Void)?

--- a/Library/Sources/Library/Library/ViewModels/VideoFeedViewModel.swift
+++ b/Library/Sources/Library/Library/ViewModels/VideoFeedViewModel.swift
@@ -63,7 +63,13 @@ public final class VideoFeedViewModel: VideoFeedViewModelType {
 
     for index in self.items.indices {
       if let id = decompose(id: self.items[index].projectId), let cached = cache[id] {
+        let wasSaved = self.items[index].isSaved
         self.items[index].isSaved = cached
+
+        /// Update the count if the save state changed on the project page.
+        if cached != wasSaved {
+          self.items[index].watchesCount += cached ? 1 : -1
+        }
       }
     }
   }
@@ -88,7 +94,7 @@ public final class VideoFeedViewModel: VideoFeedViewModelType {
 
   /// Toggles the watched state for a given project.
   /// Ignores taps while a request is already in flight.
-  /// Optimistically updates `isSaved`. Reverts on failure and triggers the save error toast.
+  /// Optimistically updates `isSaved` and `watchesCount` (Reverts both on failure).
   public func toggleSaved(for item: VideoFeedItem) {
     guard let index = self.items.firstIndex(where: { $0.id == item.id }) else { return }
     guard self.pendingWatchRequests[item.projectId] == nil else { return }
@@ -97,7 +103,13 @@ public final class VideoFeedViewModel: VideoFeedViewModelType {
     let wasSaved = self.items[index].isSaved
 
     /// Optimistic update.
-    self.items[index].isSaved = !wasSaved
+    if wasSaved {
+      self.items[index].isSaved = false
+      self.items[index].watchesCount -= 1
+    } else {
+      self.items[index].isSaved = true
+      self.items[index].watchesCount += 1
+    }
 
     let producer = wasSaved
       ? AppEnvironment.current.apiService.unwatchProject(input: .init(id: projectId))


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Save count on the video feed now increments/decrements immediately when saving/unsaving. Both from the feed and from the project page that is presented when tapping "Back this project".

# 🤔 Why

The save icon was toggling its filled/outline state correctly but the count label wasn't updating until the next feed fetch. 
Also, saving from the project page (via the CTA) would correctly update the icon but not the count.

# 🛠 How

-  `toggleSaved(for:)` now updates `watchesCount` alongside `isSaved`. Both revert together on API errors.
- `viewWillAppear` already updated `isSaved` from the cache when dismissing the project page so I extended it to also update `watchesCount`.
- `item` was being passed as a plain value into `UIHostingConfiguration`, so `formattedWatchesCount` would get stuck with stale data. Changed it to a `Binding<VideoFeedItem>`, and added an observation tracking block in the ViewController so the visible cell gets reconfigured when `items` changes.

# 👀 See

Trello, screenshots, external resources?

| Before 🐛 | After 🦋 (Save count updates from the feed and if saved/unsaved from Project Page) |
| --- | --- |
|  | <img width="295" height="640" alt="Simulator Screen Recording - iPhone 17 Pro - 2026-06-10 at 08 43 00" src="https://github.com/user-attachments/assets/ce934dce-3888-4c1b-a546-3273a0233943" />|


# ✅ Acceptance criteria
- [x] Tap save on an unsaved project in the feed, count increments immediately
- [x] Tap save on a saved project in the feed, count decrements immediately
- [x] Open project page via CTA, save/unsave, dismiss, count reflects the appropriately
