### PR TITLE
CHECK-252: Add layer support to StatsigClientWrapper

### DIFF
--- a/Experimentation/Sources/Experimentation/Experiments/FullScreenCheckoutExperiment.swift
+++ b/Experimentation/Sources/Experimentation/Experiments/FullScreenCheckoutExperiment.swift
@@ -12,5 +12,9 @@ public struct FullScreenCheckoutExperiment: StatsigExperimentProtocol {
     return .fullscreen_checkout_experience_experiment
   }
 
+  public var layer: StatsigExperimentLayer? {
+    return nil
+  }
+
   public init() {}
 }

--- a/Experimentation/Sources/Experimentation/Experiments/NullExperiment.swift
+++ b/Experimentation/Sources/Experimentation/Experiments/NullExperiment.swift
@@ -12,6 +12,10 @@ public struct NullExperimentWithUserID: StatsigExperimentProtocol {
   public var name: StatsigExperimentName {
     return .logged_in_aa_experiment
   }
+
+  public var layer: StatsigExperimentLayer? {
+    return nil
+  }
 }
 
 /// This is an A/A experiment to test that our A/B testing infrastructure works correctly.
@@ -23,5 +27,9 @@ public struct NullExperimentWithAnonymousID: StatsigExperimentProtocol {
 
   public var name: StatsigExperimentName {
     return .logged_out_aa_experiment
+  }
+
+  public var layer: StatsigExperimentLayer? {
+    return nil
   }
 }

--- a/Experimentation/Sources/Experimentation/Experiments/StatsigExperiment.swift
+++ b/Experimentation/Sources/Experimentation/Experiments/StatsigExperiment.swift
@@ -27,13 +27,22 @@ public protocol StatsigExperimentProtocol<Parameters> {
 
   /// The name of the experiment (in Statsig)
   var name: StatsigExperimentName { get }
+
+  /// The layer of the experiment (in Statsig).
+  /// May be `nil` if the experiment is not part of a layer.
+  var layer: StatsigExperimentLayer? { get }
 }
 
 /// The names of our Statsig experiments.
 /// Maps directly to the experiment name in the Statsig console.
 public enum StatsigExperimentName: String, CaseIterable {
   case ios_test_experiment
+  case ios_test_experiment_in_layer
   case fullscreen_checkout_experience_experiment
   case logged_in_aa_experiment
   case logged_out_aa_experiment
+}
+
+public enum StatsigExperimentLayer: String, CaseIterable {
+  case ios_test_layer
 }

--- a/Experimentation/Sources/Experimentation/Experiments/iOSTestExperiment.swift
+++ b/Experimentation/Sources/Experimentation/Experiments/iOSTestExperiment.swift
@@ -11,5 +11,9 @@ public struct iOSTestExperiment: StatsigExperimentProtocol {
     return .ios_test_experiment
   }
 
+  public var layer: StatsigExperimentLayer? {
+    return nil
+  }
+
   public init() {}
 }

--- a/Experimentation/Sources/Experimentation/Experiments/iOSTestExperimentInLayer.swift
+++ b/Experimentation/Sources/Experimentation/Experiments/iOSTestExperimentInLayer.swift
@@ -1,0 +1,18 @@
+/// A test experiment for Statsig, in a layer, defined as `ios_test_experiment_in_layer` in the console.
+public struct iOSTestExperimentInLayer: StatsigExperimentProtocol {
+  typealias ExperimentParameters = iOSTestExperimentInLayer.Parameters
+
+  public enum Parameters: String, CaseIterable {
+    case test_parameter
+  }
+
+  public var name: StatsigExperimentName {
+    return .ios_test_experiment_in_layer
+  }
+
+  public var layer: StatsigExperimentLayer? {
+    return .ios_test_layer
+  }
+
+  public init() {}
+}

--- a/Experimentation/Sources/Experimentation/StatsigClient.swift
+++ b/Experimentation/Sources/Experimentation/StatsigClient.swift
@@ -83,6 +83,12 @@ public final class StatsigWrapper: StatsigClientType {
       return nil
     }
 
+    if let layer = experiment.layer {
+      return self.client
+        .getLayer(layer.rawValue)
+        .getValue(forKey: key.rawValue)
+    }
+
     return self.client
       .getExperiment(experiment.name.rawValue)
       .getValue(forKey: key.rawValue)

--- a/Experimentation/Tests/ExperimentationTests/StatsigClientTests.swift
+++ b/Experimentation/Tests/ExperimentationTests/StatsigClientTests.swift
@@ -88,4 +88,36 @@ final class StatsigWrapperTests: XCTestCase {
 
     XCTAssertEqual(client.checkGate(for: .videoFeed), false)
   }
+
+  func testClient_returnsBoolValue_forExperimentInLayer() {
+    let experiment = iOSTestExperimentInLayer()
+    let expectation = XCTestExpectation(description: "Waiting for Statsig")
+
+    let statsig = StatsigClient(sdkKey: "fake", options: StatsigOptions(initializeOffline: true)) { _ in
+      expectation.fulfill()
+    }
+
+    let client = StatsigWrapper(client: statsig)
+
+    XCTAssertNil(
+      client.boolValue(forKey: .test_parameter, inExperiment: experiment),
+      "Value should be nil because Statsig isn't initialized yet."
+    )
+
+    self.wait(for: [expectation])
+
+    XCTAssertNil(
+      client.boolValue(forKey: .test_parameter, inExperiment: experiment),
+      "Value should be nil because experiment has no value."
+    )
+
+    statsig.overrideLayer(
+      "ios_test_layer",
+      value: [
+        "test_parameter": true
+      ]
+    )
+
+    XCTAssertEqual(client.boolValue(forKey: .test_parameter, inExperiment: experiment), true)
+  }
 }

--- a/Library/Sources/Library/Library/Statsig/StatsigExperiment+Helpers.swift
+++ b/Library/Sources/Library/Library/Statsig/StatsigExperiment+Helpers.swift
@@ -15,6 +15,8 @@ public extension StatsigExperimentName {
     switch self {
     case .ios_test_experiment:
       return iOSTestExperiment()
+    case .ios_test_experiment_in_layer:
+      return iOSTestExperimentInLayer()
     case .fullscreen_checkout_experience_experiment:
       return FullScreenCheckoutExperiment()
     case .logged_in_aa_experiment:


### PR DESCRIPTION
# 📲 What

Add support for [Statsig Layers](https://docs.statsig.com/experiments/layers-overview) to `StatsigClientWrapper`.

# 🤔 Why

When we start to add multiple checkout experiments, we want to make sure that users are only bucketed in _one experiment at a time_. This prevents one experiment from contaminating another.

Statsig does this using a feature called "layers". This allows us to define an (optional) layer for our experiments.

