### PR TITLE
[DISC-241] Video Feed: Pre-fetch Feed Items Before Launch

### DIFF
--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/Discovery/Controller/DiscoveryPageViewController.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/Discovery/Controller/DiscoveryPageViewController.swift
@@ -12,7 +12,8 @@ protocol DiscoveryPageViewControllerDelegate: AnyObject {
   )
 }
 
-internal final class DiscoveryPageViewController: UITableViewController {
+internal final class DiscoveryPageViewController: UITableViewController,
+  MessageBannerViewControllerPresenting {
   fileprivate let viewModel: DiscoveryPageViewModelType = DiscoveryPageViewModel()
   fileprivate let shareViewModel: ShareViewModelType = ShareViewModel()
 
@@ -24,6 +25,11 @@ internal final class DiscoveryPageViewController: UITableViewController {
   fileprivate var emptyStatesController: EmptyStatesViewController?
   private lazy var headerLabel = { UILabel(frame: .zero) }()
 
+  internal var messageBannerViewController: MessageBannerViewController?
+
+  /// Holds a ref to the VideoFeedViewController while its data loads.
+  private var pendingVideoFeedVC: VideoFeedViewController?
+
   internal static func configuredWith(sort: DiscoveryParams.Sort) -> DiscoveryPageViewController {
     let vc = Storyboard.DiscoveryPage.instantiate(DiscoveryPageViewController.self)
     vc.viewModel.inputs.configureWith(sort: sort)
@@ -32,6 +38,8 @@ internal final class DiscoveryPageViewController: UITableViewController {
 
   internal override func viewDidLoad() {
     super.viewDidLoad()
+
+    self.messageBannerViewController = self.configureMessageBannerViewController(on: self)
 
     self.tableView.register(nib: Nib.DiscoveryPostcardCell)
     self.tableView.registerCellClass(PersonalizationCell.self)
@@ -419,13 +427,44 @@ internal final class DiscoveryPageViewController: UITableViewController {
   }
 }
 
-extension DiscoveryPageViewController: VideoFeedBannerCellDelegate {
-  func videoFeedBannerCellDidTapTryItNow(_: VideoFeedBannerCell) {
-    let nav = UINavigationController(rootViewController: VideoFeedViewController())
-    nav.modalPresentationStyle = .fullScreen
+// MARK: - VideoFeedBannerCellDelegate
 
-    let presenter = self.view.window?.rootViewController ?? self
-    presenter.present(nav, animated: true)
+extension DiscoveryPageViewController: VideoFeedBannerCellDelegate {
+  func videoFeedBannerCellDidTapTryItNow(_ cell: VideoFeedBannerCell) {
+    guard self.pendingVideoFeedVC == nil else { return }
+
+    cell.setLoading(true)
+
+    let feedVC = VideoFeedViewController()
+
+    self.pendingVideoFeedVC = feedVC
+
+    feedVC.loadViewIfNeeded()
+
+    feedVC.onReadyToPresent = { [weak self, weak cell, weak feedVC] in
+      guard let self, let feedVC else { return }
+
+      self.pendingVideoFeedVC = nil
+      cell?.setLoading(false)
+
+      let nav = UINavigationController(rootViewController: feedVC)
+      nav.modalPresentationStyle = .fullScreen
+
+      let presenter = self.view.window?.rootViewController ?? self
+      presenter.present(nav, animated: true)
+    }
+
+    feedVC.onFetchFailed = { [weak self, weak cell] in
+      guard let self else { return }
+
+      self.pendingVideoFeedVC = nil
+      cell?.setLoading(false)
+
+      self.messageBannerViewController?.showBanner(
+        with: .error,
+        message: Strings.Something_went_wrong_please_try_again()
+      )
+    }
   }
 }
 

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/Discovery/Controller/DiscoveryPageViewController.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/Discovery/Controller/DiscoveryPageViewController.swift
@@ -13,7 +13,8 @@ protocol DiscoveryPageViewControllerDelegate: AnyObject {
 }
 
 internal final class DiscoveryPageViewController: UITableViewController,
-  MessageBannerViewControllerPresenting {
+  MessageBannerViewControllerPresenting,
+  VideoFeedBannerPresenting {
   fileprivate let viewModel: DiscoveryPageViewModelType = DiscoveryPageViewModel()
   fileprivate let shareViewModel: ShareViewModelType = ShareViewModel()
 
@@ -28,7 +29,7 @@ internal final class DiscoveryPageViewController: UITableViewController,
   internal var messageBannerViewController: MessageBannerViewController?
 
   /// Holds a ref to the VideoFeedViewController while its data loads.
-  private var pendingVideoFeedVC: VideoFeedViewController?
+  var pendingVideoFeedVC: VideoFeedViewController?
 
   internal static func configuredWith(sort: DiscoveryParams.Sort) -> DiscoveryPageViewController {
     let vc = Storyboard.DiscoveryPage.instantiate(DiscoveryPageViewController.self)
@@ -431,40 +432,7 @@ internal final class DiscoveryPageViewController: UITableViewController,
 
 extension DiscoveryPageViewController: VideoFeedBannerCellDelegate {
   func videoFeedBannerCellDidTapTryItNow(_ cell: VideoFeedBannerCell) {
-    guard self.pendingVideoFeedVC == nil else { return }
-
-    cell.setLoading(true)
-
-    let feedVC = VideoFeedViewController()
-
-    self.pendingVideoFeedVC = feedVC
-
-    feedVC.loadViewIfNeeded()
-
-    feedVC.onReadyToPresent = { [weak self, weak cell, weak feedVC] in
-      guard let self, let feedVC else { return }
-
-      self.pendingVideoFeedVC = nil
-      cell?.setLoading(false)
-
-      let nav = UINavigationController(rootViewController: feedVC)
-      nav.modalPresentationStyle = .fullScreen
-
-      let presenter = self.view.window?.rootViewController ?? self
-      presenter.present(nav, animated: true)
-    }
-
-    feedVC.onFetchFailed = { [weak self, weak cell] in
-      guard let self else { return }
-
-      self.pendingVideoFeedVC = nil
-      cell?.setLoading(false)
-
-      self.messageBannerViewController?.showBanner(
-        with: .error,
-        message: Strings.Something_went_wrong_please_try_again()
-      )
-    }
+    self.presentVideoFeed(from: cell)
   }
 }
 

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/Discovery/Views/Cells/VideoFeedBannerCell.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/Discovery/Views/Cells/VideoFeedBannerCell.swift
@@ -7,6 +7,13 @@ internal protocol VideoFeedBannerCellDelegate: AnyObject {
   func videoFeedBannerCellDidTapTryItNow(_ cell: VideoFeedBannerCell)
 }
 
+@Observable
+final class VideoFeedBannerViewState {
+  var isLoading: Bool = false
+}
+
+// MARK: - Cell
+
 internal final class VideoFeedBannerCell: UITableViewCell, ValueCell {
   internal weak var delegate: VideoFeedBannerCellDelegate?
 
@@ -16,6 +23,7 @@ internal final class VideoFeedBannerCell: UITableViewCell, ValueCell {
   }
 
   private var hostingController: UIHostingController<VideoFeedBannerView>?
+  private let bannerState = VideoFeedBannerViewState()
 
   override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
     super.init(style: style, reuseIdentifier: reuseIdentifier)
@@ -29,16 +37,25 @@ internal final class VideoFeedBannerCell: UITableViewCell, ValueCell {
 
   internal func configureWith(value _: Void) {}
 
+  // MARK: - Loading
+
+  func setLoading(_ loading: Bool) {
+    withAnimation(.easeInOut(duration: 0.2)) {
+      self.bannerState.isLoading = loading
+    }
+  }
+
+  // MARK: - Setup
+
   private func setUp() {
     self.selectionStyle = .none
     self.backgroundColor = .clear
     self.contentView.backgroundColor = .clear
 
-    var bannerView = VideoFeedBannerView()
+    var bannerView = VideoFeedBannerView(state: self.bannerState)
 
     bannerView.onTryItNowTapped = { [weak self] in
       guard let self else { return }
-
       self.delegate?.videoFeedBannerCellDidTapTryItNow(self)
     }
 
@@ -74,7 +91,6 @@ internal final class VideoFeedBannerCell: UITableViewCell, ValueCell {
     guard let host = self.hostingController, host.parent == nil else { return }
 
     parent.addChild(host)
-
     host.didMove(toParent: parent)
   }
 }

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/Discovery/Views/VideoFeedBannerView.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/Discovery/Views/VideoFeedBannerView.swift
@@ -24,6 +24,8 @@ internal struct VideoFeedBannerView: View {
 
   internal var onTryItNowTapped: (() -> Void)?
 
+  @Bindable var state: VideoFeedBannerViewState
+
   var body: some View {
     HStack(alignment: .center, spacing: Constants.rootStackSpacing) {
       VStack(alignment: .leading, spacing: Constants.textStackSpacing) {
@@ -38,13 +40,30 @@ internal struct VideoFeedBannerView: View {
         Button {
           self.onTryItNowTapped?()
         } label: {
+          /// ProgressView has no intrinsic size, so we use the label as the layout anchor
+          /// and swap the visible content on top via overlay.
+          /// Without this the ProgressView's lack of intrinsic size causes the animation to stutter.
           Text(Strings.try_it_now())
             .font(Font(UIFont.ksr_bodyMD()))
-            .foregroundColor(Color(Colors.Text.constantPrimary.uiColor()))
+            .hidden()
             .padding(Constants.ctaContentInsets)
             .background(Color.white)
             .cornerRadius(Constants.ctaCornerRadius)
+            .overlay {
+              if self.state.isLoading {
+                ProgressView()
+                  .progressViewStyle(.circular)
+                  .tint(Color(Colors.Icon.dark.uiColor()))
+                  .transition(.opacity.combined(with: .scale(scale: 0.8)))
+              } else {
+                Text(Strings.try_it_now())
+                  .font(Font(UIFont.ksr_bodyMD()))
+                  .foregroundColor(Color(Colors.Text.constantPrimary.uiColor()))
+                  .transition(.opacity.combined(with: .scale(scale: 0.8)))
+              }
+            }
         }
+        .disabled(self.state.isLoading)
         .accessibilityLabel(Strings.try_it_now())
       }
 

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/Search/Controller/SearchViewController.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/Search/Controller/SearchViewController.swift
@@ -13,7 +13,9 @@ private enum Constants {
   static let searchBarHeight = Styles.grid(8)
 }
 
-internal final class SearchViewController: UITableViewController, MessageBannerViewControllerPresenting {
+internal final class SearchViewController: UITableViewController,
+  MessageBannerViewControllerPresenting,
+  VideoFeedBannerPresenting {
   internal let viewModel: SearchViewModelType = SearchViewModel()
   internal let dataSource = SearchDataSource()
 
@@ -29,7 +31,7 @@ internal final class SearchViewController: UITableViewController, MessageBannerV
   internal var messageBannerViewController: MessageBannerViewController?
 
   /// Holds a ref to the VideoFeedViewController while its data loads.
-  private var pendingVideoFeedVC: VideoFeedViewController?
+  var pendingVideoFeedVC: VideoFeedViewController?
 
   private var searchBarWidth: CGFloat {
     return self.view.bounds.width * Constants.searchBarWidthFactor
@@ -60,7 +62,6 @@ internal final class SearchViewController: UITableViewController, MessageBannerV
     _ = self
       |> baseTableControllerStyle(estimatedRowHeight: Constants.estimatedRowHeight)
 
-    // Hides the bottom border (shadow) of the navigation bar to visually give the search bar more space
     self.navigationController?.navigationBar.standardAppearance.shadowColor = .clear
     self.navigationController?.navigationBar.scrollEdgeAppearance?.shadowColor = .clear
 
@@ -128,12 +129,10 @@ internal final class SearchViewController: UITableViewController, MessageBannerV
       .observeForControllerAction()
       .observeValues { [weak self] type in
         if type == .sort {
-          // Sort is a special case modal, not part of the root filter view.
           self?.showSort()
           return
         }
 
-        // All other filters go to the same modal.
         self?.showFilters(filterType: type)
       }
   }
@@ -184,7 +183,6 @@ internal final class SearchViewController: UITableViewController, MessageBannerV
       self.searchBar.bottomAnchor.constraint(equalTo: self.searchBarContainerView.bottomAnchor)
     ])
 
-    // Set initial width based on current view bounds; updated later in `bindStyles` if needed
     self.searchBarWidthConstraint = self.searchBar.widthAnchor
       .constraint(equalToConstant: self.searchBarWidth)
 
@@ -312,39 +310,6 @@ extension SearchViewController: SearchEmptyStateCellDelegate {
 
 extension SearchViewController: VideoFeedBannerCellDelegate {
   func videoFeedBannerCellDidTapTryItNow(_ cell: VideoFeedBannerCell) {
-    guard self.pendingVideoFeedVC == nil else { return }
-
-    cell.setLoading(true)
-
-    let feedVC = VideoFeedViewController()
-
-    self.pendingVideoFeedVC = feedVC
-
-    feedVC.loadViewIfNeeded()
-
-    feedVC.onReadyToPresent = { [weak self, weak cell, weak feedVC] in
-      guard let self, let feedVC else { return }
-
-      self.pendingVideoFeedVC = nil
-      cell?.setLoading(false)
-
-      let nav = UINavigationController(rootViewController: feedVC)
-      nav.modalPresentationStyle = .fullScreen
-
-      let presenter = self.view.window?.rootViewController ?? self
-      presenter.present(nav, animated: true)
-    }
-
-    feedVC.onFetchFailed = { [weak self, weak cell] in
-      guard let self else { return }
-
-      self.pendingVideoFeedVC = nil
-      cell?.setLoading(false)
-
-      self.messageBannerViewController?.showBanner(
-        with: .error,
-        message: Strings.Something_went_wrong_please_try_again()
-      )
-    }
+    self.presentVideoFeed(from: cell)
   }
 }

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/Search/Controller/SearchViewController.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/Search/Controller/SearchViewController.swift
@@ -13,7 +13,7 @@ private enum Constants {
   static let searchBarHeight = Styles.grid(8)
 }
 
-internal final class SearchViewController: UITableViewController {
+internal final class SearchViewController: UITableViewController, MessageBannerViewControllerPresenting {
   internal let viewModel: SearchViewModelType = SearchViewModel()
   internal let dataSource = SearchDataSource()
 
@@ -26,6 +26,11 @@ internal final class SearchViewController: UITableViewController {
   private let searchLoaderIndicator = UIActivityIndicatorView()
   private var sortAndFilterHeader: UIViewController?
 
+  internal var messageBannerViewController: MessageBannerViewController?
+
+  /// Holds a ref to the VideoFeedViewController while its data loads.
+  private var pendingVideoFeedVC: VideoFeedViewController?
+
   private var searchBarWidth: CGFloat {
     return self.view.bounds.width * Constants.searchBarWidthFactor
   }
@@ -36,6 +41,8 @@ internal final class SearchViewController: UITableViewController {
 
   internal override func viewDidLoad() {
     super.viewDidLoad()
+
+    self.messageBannerViewController = self.configureMessageBannerViewController(on: self)
 
     self.configureSubviews()
     self.setupConstraints()
@@ -304,11 +311,40 @@ extension SearchViewController: SearchEmptyStateCellDelegate {
 // MARK: - VideoFeedBannerCellDelegate
 
 extension SearchViewController: VideoFeedBannerCellDelegate {
-  func videoFeedBannerCellDidTapTryItNow(_: VideoFeedBannerCell) {
-    let nav = UINavigationController(rootViewController: VideoFeedViewController())
-    nav.modalPresentationStyle = .fullScreen
+  func videoFeedBannerCellDidTapTryItNow(_ cell: VideoFeedBannerCell) {
+    guard self.pendingVideoFeedVC == nil else { return }
 
-    let presenter = self.view.window?.rootViewController ?? self
-    presenter.present(nav, animated: true)
+    cell.setLoading(true)
+
+    let feedVC = VideoFeedViewController()
+
+    self.pendingVideoFeedVC = feedVC
+
+    feedVC.loadViewIfNeeded()
+
+    feedVC.onReadyToPresent = { [weak self, weak cell, weak feedVC] in
+      guard let self, let feedVC else { return }
+
+      self.pendingVideoFeedVC = nil
+      cell?.setLoading(false)
+
+      let nav = UINavigationController(rootViewController: feedVC)
+      nav.modalPresentationStyle = .fullScreen
+
+      let presenter = self.view.window?.rootViewController ?? self
+      presenter.present(nav, animated: true)
+    }
+
+    feedVC.onFetchFailed = { [weak self, weak cell] in
+      guard let self else { return }
+
+      self.pendingVideoFeedVC = nil
+      cell?.setLoading(false)
+
+      self.messageBannerViewController?.showBanner(
+        with: .error,
+        message: Strings.Something_went_wrong_please_try_again()
+      )
+    }
   }
 }

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Controller/VideoFeedBannerPresenting.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Controller/VideoFeedBannerPresenting.swift
@@ -1,0 +1,47 @@
+import Library
+import UIKit
+
+protocol VideoFeedBannerPresenting: UIViewController, MessageBannerViewControllerPresenting {
+  var pendingVideoFeedVC: VideoFeedViewController? { get set }
+}
+
+extension VideoFeedBannerPresenting {
+  func presentVideoFeed(from cell: VideoFeedBannerCell) {
+    guard self.pendingVideoFeedVC == nil else { return }
+
+    cell.setLoading(true)
+
+    let feedVC = VideoFeedViewController()
+
+    self.pendingVideoFeedVC = feedVC
+
+    feedVC.loadViewIfNeeded()
+
+    feedVC.onReadyToPresent = { [weak self, weak cell, weak feedVC] in
+      guard let self, let feedVC else { return }
+
+      self.pendingVideoFeedVC = nil
+
+      cell?.setLoading(false)
+
+      feedVC.modalPresentationStyle = .fullScreen
+
+      self.present(feedVC, animated: true)
+    }
+
+    feedVC.onFetchFailed = { [weak self, weak cell] in
+      guard let self else { return }
+
+      self.pendingVideoFeedVC = nil
+
+      cell?.setLoading(false)
+
+      self.messageBannerViewController?.showBanner(
+        with: .error,
+        message: Strings.Something_went_wrong_please_try_again()
+      )
+    }
+
+    feedVC.startFetch()
+  }
+}

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Controller/VideoFeedViewController.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Controller/VideoFeedViewController.swift
@@ -47,8 +47,11 @@ final class VideoFeedViewController: UIViewController {
 
     self.setupCollectionView()
     self.bindViewModel()
+  }
 
+  func startFetch() {
     self.viewModel.viewDidLoad()
+    self.bindViewModel()
   }
 
   deinit {
@@ -112,17 +115,15 @@ final class VideoFeedViewController: UIViewController {
       DispatchQueue.main.async { [weak self] in
         guard let self else { return }
 
-        let items = self.viewModel.items
+        self.updateFeedWithFetchedItems(self.viewModel.items)
 
-        self.updateFeedWithFetchedItems(items)
-        self.bindViewModel()
-
-        if !items.isEmpty, let readyToPresent = self.onReadyToPresent {
-          self.onReadyToPresent = nil
-          self.onFetchFailed = nil
-
-          readyToPresent()
+        /// isInitialLoadComplete is set before fetchedItems in the VM, so it's
+        /// guaranteed to be true here on the first successful fetch.
+        if self.viewModel.isInitialLoadComplete {
+          self.onReadyToPresent?()
         }
+
+        self.bindViewModel()
       }
     }
 
@@ -132,14 +133,7 @@ final class VideoFeedViewController: UIViewController {
       DispatchQueue.main.async { [weak self] in
         guard let self, self.viewModel.errorMessage != nil else { return }
 
-        self.onReadyToPresent = nil
-
-        if let fetchFailed = self.onFetchFailed {
-          self.onFetchFailed = nil
-
-          fetchFailed()
-        }
-
+        self.onFetchFailed?()
         self.bindViewModel()
       }
     }

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Controller/VideoFeedViewController.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Controller/VideoFeedViewController.swift
@@ -22,6 +22,12 @@ final class VideoFeedViewController: UIViewController {
   private var lifecycleObservers: [any NSObjectProtocol] = []
   private var previewImagePrefetcher: ImagePrefetcher?
 
+  /// Called once the first batch of items has loaded and the feed is ready to present.
+  var onReadyToPresent: (() -> Void)?
+
+  /// Called if the initial fetch fails.
+  var onFetchFailed: (() -> Void)?
+
   private lazy var collectionView: UICollectionView = {
     let layout = UICollectionViewFlowLayout()
     layout.scrollDirection = .vertical
@@ -55,7 +61,6 @@ final class VideoFeedViewController: UIViewController {
     /// Presenting a fullscreen modal nudges the contentOffset.
     /// This is a side effect of UIKit re-measuring UIHostingConfiguration cells when presenting views.
     /// This method snaps the collection view cell back into place once the layout has settled.
-
     self.snapToCurrentPage()
   }
 
@@ -106,7 +111,35 @@ final class VideoFeedViewController: UIViewController {
     } onChange: { [weak self] in
       DispatchQueue.main.async { [weak self] in
         guard let self else { return }
-        self.updateFeedWithFetchedItems(self.viewModel.items)
+
+        let items = self.viewModel.items
+
+        self.updateFeedWithFetchedItems(items)
+        self.bindViewModel()
+
+        if !items.isEmpty, let readyToPresent = self.onReadyToPresent {
+          self.onReadyToPresent = nil
+          self.onFetchFailed = nil
+
+          readyToPresent()
+        }
+      }
+    }
+
+    withObservationTracking {
+      _ = self.viewModel.errorMessage
+    } onChange: { [weak self] in
+      DispatchQueue.main.async { [weak self] in
+        guard let self, self.viewModel.errorMessage != nil else { return }
+
+        self.onReadyToPresent = nil
+
+        if let fetchFailed = self.onFetchFailed {
+          self.onFetchFailed = nil
+
+          fetchFailed()
+        }
+
         self.bindViewModel()
       }
     }

--- a/Library/Sources/Library/Library/ViewModels/VideoFeedViewModel.swift
+++ b/Library/Sources/Library/Library/ViewModels/VideoFeedViewModel.swift
@@ -8,6 +8,7 @@ public protocol VideoFeedViewModelType: AnyObject {
   var items: [VideoFeedItem] { get }
   var fetchedItems: [VideoFeedItem] { get }
   var loginIntent: LoginIntent? { get }
+  var isInitialLoadComplete: Bool { get }
   func viewDidLoad()
   func viewWillAppear()
   func toggleSaved(for item: VideoFeedItem)
@@ -30,6 +31,7 @@ public final class VideoFeedViewModel: VideoFeedViewModelType {
   public private(set) var isLoading = false
   public private(set) var errorMessage: String?
   public private(set) var loginIntent: LoginIntent? = nil
+  public private(set) var isInitialLoadComplete: Bool = false
 
   /// Tracks in-flight watch/unwatch requests.
   private var pendingWatchRequests: [String: Disposable] = [:]
@@ -41,7 +43,7 @@ public final class VideoFeedViewModel: VideoFeedViewModelType {
   // MARK: - Inputs
 
   public func viewDidLoad() {
-    Task {
+    Task { @MainActor in
       await self.fetchVideoFeed()
     }
   }
@@ -122,6 +124,7 @@ public final class VideoFeedViewModel: VideoFeedViewModelType {
     self.loginIntent = .videoFeed
   }
 
+  @MainActor
   func fetchVideoFeed() async {
     guard !self.isLoading else { return }
 
@@ -135,6 +138,15 @@ public final class VideoFeedViewModel: VideoFeedViewModelType {
 
       let nodes = result?.videoFeed?.nodes?.compactMap { $0 } ?? []
 
+      guard !nodes.isEmpty else {
+        self.isLoading = false
+        self.errorMessage = Strings.Something_went_wrong_please_try_again()
+        return
+      }
+
+      /// Set isInitialLoadComplete before fetchedItems so the fetchedItems observer
+      /// sees the correct value when it fires.
+      self.isInitialLoadComplete = true
       self.fetchedItems = nodes.map(VideoFeedItem.init)
       self.items = self.fetchedItems
       self.isLoading = false

--- a/LibraryTests/Library/ViewModels/VideoFeedViewModelTests.swift
+++ b/LibraryTests/Library/ViewModels/VideoFeedViewModelTests.swift
@@ -57,7 +57,7 @@ final class VideoFeedViewModelTests: TestCase {
 
     XCTAssertTrue(self.vm.items.isEmpty)
     XCTAssertFalse(self.vm.isLoading)
-    XCTAssertNil(self.vm.errorMessage)
+    XCTAssertEqual(self.vm.errorMessage, Strings.Something_went_wrong_please_try_again())
   }
 
   func testViewDidLoad_Failure_SetsErrorMessage() async {


### PR DESCRIPTION
* includes showing the message banner if loading fails

<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Load the video feed data before it's presented from Discovery or Search. 
And show a loading indicator on the banner while it loads.

# 🤔 Why

A couple of folks were seeing a black screen when launching the feed from Discovery and Search before the actual content. 
While I couldn't reproduce consistently, I did see it once or twice. I think this prefetch UX is much cleaner and should keep that issue from happening.

# 🛠 How

- `VideoFeedViewController` now exposes `onReadyToPresent` and `onFetchFailed` callbacks. This let's the parent VCs know when the feed data is loaded and ready to present.
- `VideoFeedBannerCell` now has a `setLoading(_:)` which animates the button label to a spinner and back while the feed loads.

# 👀 See

Trello, screenshots, external resources?

| Before 🐛 | After 🦋 |
| --- | --- |
|  | <img width="295" height="640" alt="Simulator Screen Recording - iPhone 17 Pro - 2026-06-10 at 14 04 21" src="https://github.com/user-attachments/assets/625ebc52-18d2-4e78-8360-7a792881e2c1" /> |


# ✅ Acceptance criteria

- [x] Tap "Try it now" on Discovery or Search, loading spinner appears in the button smoothly
- [x] Feed presents without a black screen once loaded
- [x] Tap "Try it now" rapidly, only one request fires
- [x] Trigger an error manually when tapping "try it now", error message banner should appear instead of the feed.
- [x] Re-tapping after a failure works normally
