### PR TITLE
CHECK-134: Refactor no-reward insertion to make it more flexible

### DIFF
--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -323,6 +323,7 @@
 		E19D49C72DB7F07A004A74D5 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		E1A310242D270CB00062646C /* (null) in Sources */ = {isa = PBXBuildFile; };
 		E1BAA03E2C1A1CE4004F8B06 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		E1BBB0482FDB0F3C0045D296 /* NoRewardInserterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1BBB0472FDB0F320045D296 /* NoRewardInserterTests.swift */; };
 		E1BBB65E2E00724100291D48 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		E1DBB2372DAEBCE10050733F /* (null) in Sources */ = {isa = PBXBuildFile; };
 /* End PBXBuildFile section */
@@ -739,6 +740,7 @@
 		E190EB6E2E29944E006A6DB6 /* graphql-schema.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "graphql-schema.json"; sourceTree = "<group>"; };
 		E19C55F02F4CB84D00C768F6 /* NoRewardRewardFragment.graphql */ = {isa = PBXFileReference; lastKnownFileType = text; path = NoRewardRewardFragment.graphql; sourceTree = "<group>"; };
 		E1B33F502E538157008903BA /* GraphAPI */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = GraphAPI; sourceTree = "<group>"; };
+		E1BBB0472FDB0F320045D296 /* NoRewardInserterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoRewardInserterTests.swift; sourceTree = "<group>"; };
 		E1D529FC2ED4D21A00923AA9 /* ShippableLocationsForProjectQuery.graphql */ = {isa = PBXFileReference; lastKnownFileType = text; path = ShippableLocationsForProjectQuery.graphql; sourceTree = "<group>"; };
 		E1FD854E2F9A7FF50095DBDB /* Experimentation */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = Experimentation; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -1122,6 +1124,7 @@
 				AAF548802F2445C0001DB5AC /* RewardCardViewModelTests.swift */,
 				AAF548812F2445C0001DB5AC /* RewardCellViewModelTests.swift */,
 				AAF548822F2445C0001DB5AC /* RewardsCollectionViewModelTests.swift */,
+				E1BBB0472FDB0F320045D296 /* NoRewardInserterTests.swift */,
 				AAF548832F2445C0001DB5AC /* RewardsUseCaseTests.swift */,
 				AAF548842F2445C0001DB5AC /* RewardTrackingActivitiesCellViewModelTest.swift */,
 				AAF548852F2445C0001DB5AC /* RewardTrackingDetailsViewModelTest.swift */,
@@ -1842,6 +1845,7 @@
 				AAF549732F2445C0001DB5AC /* SettingsRecommendationsCellViewModelTests.swift in Sources */,
 				AAF549742F2445C0001DB5AC /* ShareViewModelTests.swift in Sources */,
 				AAF549752F2445C0001DB5AC /* ShippingRulesViewModelTests.swift in Sources */,
+				E1BBB0482FDB0F3C0045D296 /* NoRewardInserterTests.swift in Sources */,
 				AAF549762F2445C0001DB5AC /* SortPagerViewModelTests.swift in Sources */,
 				AAF549772F2445C0001DB5AC /* ThanksCategoryCellViewModelTests.swift in Sources */,
 				AAF549782F2445C0001DB5AC /* ThanksViewModelTests.swift in Sources */,

--- a/KsApi/Sources/KsApi/MockService.swift
+++ b/KsApi/Sources/KsApi/MockService.swift
@@ -1442,7 +1442,7 @@
     func fetchProjectRewards(
       projectId: Int,
       sortedForShippingCountryCode _: String?,
-      withNoReward _: NoRewardSortType
+      withNoReward _: NoRewardInserter
     ) -> SignalProducer<[Reward], ErrorEnvelope> {
       guard let client = self.apolloClient else {
         return .empty

--- a/KsApi/Sources/KsApi/Service.swift
+++ b/KsApi/Sources/KsApi/Service.swift
@@ -636,7 +636,7 @@ public struct Service: ServiceType {
   public func fetchProjectRewards(
     projectId: Int,
     sortedForShippingCountryCode code: String?,
-    withNoReward noRewardSortType: NoRewardSortType
+    withNoReward inserter: NoRewardInserter
   ) -> SignalProducer<[Reward], ErrorEnvelope> {
     let graphCountryCode: GraphAPI.CountryCode?
     if let code {
@@ -655,7 +655,7 @@ public struct Service: ServiceType {
     return GraphQL.shared.client
       .fetch(query: query)
       .map { results in
-        Project.projectRewards(from: results, withNoReward: noRewardSortType)
+        Project.projectRewards(from: results, withNoReward: inserter)
       }
   }
 

--- a/KsApi/Sources/KsApi/ServiceType.swift
+++ b/KsApi/Sources/KsApi/ServiceType.swift
@@ -262,10 +262,11 @@ public protocol ServiceType {
   func fetchProjectRewards(projectId: Int) -> SignalProducer<[Reward], ErrorEnvelope>
 
   /// Fetch the project's rewards, including 'No Reward'. Includes all shipping rules.
+  /// Uses the included `NoRewardInserter` to decide where 'No Reward' should live in the list.
   func fetchProjectRewards(
     projectId: Int,
     sortedForShippingCountryCode: String?,
-    withNoReward: NoRewardSortType
+    withNoReward: NoRewardInserter
   )
     -> SignalProducer<[Reward], ErrorEnvelope>
 

--- a/KsApi/Sources/KsApi/models/graphql/adapters/Project+FetchProjectRewardsByIdQueryData.swift
+++ b/KsApi/Sources/KsApi/models/graphql/adapters/Project+FetchProjectRewardsByIdQueryData.swift
@@ -3,9 +3,15 @@ import GraphAPI
 import Prelude
 import ReactiveSwift
 
-public enum NoRewardSortType {
-  case first
-  case last
+/// A protocol that defines how we want to insert the `No Reward` into the overall rewards list.
+///
+/// The project rewards fetched by `FetchSortedProjectRewardsByIdQuery` are sorted on the backend -
+/// but 'No Reward' is inserted by the frontend.
+///
+/// This is pulled out into its own protocol so that we can implement more complex sort behavior, including context that
+/// KsApi doesn't necessarily have.
+public protocol NoRewardInserter {
+  func insert(noReward: Reward, intoRewards: [Reward]) -> [Reward]
 }
 
 extension Project {
@@ -19,7 +25,7 @@ extension Project {
 
   static func projectRewards(
     from data: GraphAPI.FetchSortedProjectRewardsByIdQuery.Data,
-    withNoReward noRewardSortType: NoRewardSortType
+    withNoReward inserter: NoRewardInserter
   ) -> [Reward] {
     guard let project = data.project else {
       return []
@@ -39,13 +45,7 @@ extension Project {
       } ?? []
 
     let noReward = Reward.noRewardReward(from: project.fragments.noRewardRewardFragment)
-
-    switch noRewardSortType {
-    case .first:
-      return [noReward] + projectRewards
-    case .last:
-      return projectRewards + [noReward]
-    }
+    return inserter.insert(noReward: noReward, intoRewards: projectRewards)
   }
 
   static func projectRewards(from data: GraphAPI.FetchProjectRewardsByIdQuery.Data) -> [Reward] {

--- a/KsApi/Sources/KsApiTests/models/graphql/adapters/Project+FetchSortedProjectRewardsByIdQueryDataTests.swift
+++ b/KsApi/Sources/KsApiTests/models/graphql/adapters/Project+FetchSortedProjectRewardsByIdQueryDataTests.swift
@@ -5,6 +5,24 @@ import GraphAPI
 import ReactiveSwift
 import XCTest
 
+private enum NoRewardSortType {
+  case first
+  case last
+}
+
+private struct TestNoRewardInserter: NoRewardInserter {
+  let sortType: NoRewardSortType
+
+  func insert(noReward: KsApi.Reward, intoRewards rewards: [KsApi.Reward]) -> [KsApi.Reward] {
+    switch self.sortType {
+    case .first:
+      return [noReward] + rewards
+    case .last:
+      return rewards + [noReward]
+    }
+  }
+}
+
 final class Project_FetchSortedProjectRewardsByIdQueryDataTests: XCTestCase {
   func testFetch_parsesRewards_andAddsNoRewardReward() {
     let dataUrl = Bundle.module.url(forResource: "FetchSortedProjectRewardsById", withExtension: "json")!
@@ -17,7 +35,7 @@ final class Project_FetchSortedProjectRewardsByIdQueryDataTests: XCTestCase {
       ])
     XCTAssertNotNil(data)
 
-    let rewards = Project.projectRewards(from: data, withNoReward: .first)
+    let rewards = Project.projectRewards(from: data, withNoReward: TestNoRewardInserter(sortType: .first))
 
     XCTAssertEqual(rewards.count, 2)
 
@@ -52,7 +70,7 @@ final class Project_FetchSortedProjectRewardsByIdQueryDataTests: XCTestCase {
       ])
     XCTAssertNotNil(data)
 
-    let rewards = Project.projectRewards(from: data, withNoReward: .last)
+    let rewards = Project.projectRewards(from: data, withNoReward: TestNoRewardInserter(sortType: .last))
 
     XCTAssertEqual(rewards.count, 2)
 

--- a/Library/Sources/Library/Library/ViewModels/RewardsCollectionViewModel+NoRewardInsertion.swift
+++ b/Library/Sources/Library/Library/ViewModels/RewardsCollectionViewModel+NoRewardInsertion.swift
@@ -1,0 +1,39 @@
+import KsApi
+
+/// Inserts 'No Reward' before all the project rewards
+struct NoRewardFirst: NoRewardInserter {
+  func insert(noReward: Reward, intoRewards rewards: [Reward]) -> [Reward] {
+    return [noReward] + rewards
+  }
+}
+
+/// Inserts 'No Reward' after the last reward that is available, using `rewardsCarouselCanNavigateToReward` to check availability.
+struct NoRewardAfterLastAvailableReward: NoRewardInserter {
+  let shippingLocation: Location?
+  let project: Project
+
+  public init(shippingLocation: Location?, project: Project) {
+    self.shippingLocation = shippingLocation
+    self.project = project
+  }
+
+  private func indexOfFirstUnavailableReward(_ rewards: [Reward]) -> Int? {
+    return rewards.firstIndex(where: { reward in
+      !rewardsCarouselCanNavigateToReward(
+        reward,
+        in: self.project,
+        selectedShippingLocation: self.shippingLocation
+      )
+    })
+  }
+
+  func insert(noReward: Reward, intoRewards rewards: [Reward]) -> [Reward] {
+    var newRewards = rewards
+    if let firstUnavailable = self.indexOfFirstUnavailableReward(rewards) {
+      newRewards.insert(noReward, at: firstUnavailable)
+    } else {
+      newRewards.append(noReward)
+    }
+    return newRewards
+  }
+}

--- a/Library/Sources/Library/Library/ViewModels/RewardsCollectionViewModel.swift
+++ b/Library/Sources/Library/Library/ViewModels/RewardsCollectionViewModel.swift
@@ -92,7 +92,7 @@ public final class RewardsCollectionViewModel: RewardsCollectionViewModelType,
           .fetchProjectRewards(
             projectId: project.id,
             sortedForShippingCountryCode: location,
-            withNoReward: .first
+            withNoReward: NoRewardFirst()
           )
           .ksr_delay(AppEnvironment.current.apiDelayInterval, on: AppEnvironment.current.scheduler)
           .materialize()

--- a/LibraryTests/Library/ViewModels/NoRewardInserterTests.swift
+++ b/LibraryTests/Library/ViewModels/NoRewardInserterTests.swift
@@ -1,0 +1,178 @@
+@testable import KsApi
+@testable import Library
+@testable import LibraryTestHelpers
+import Prelude
+import XCTest
+
+final class NoRewardInserterTests: TestCase {
+  func testNoRewardFirstInserter_insertsRewardFirst() {
+    let inserter = NoRewardFirst()
+
+    let availableReward = Reward.template
+      |> Reward.lens.isAvailable .~ true
+
+    let notAvailableReward = Reward.template
+      |> Reward.lens.isAvailable .~ false
+
+    let projectRewards = [
+      availableReward,
+      notAvailableReward
+    ]
+
+    let rewards = inserter.insert(noReward: Reward.noReward, intoRewards: projectRewards)
+    XCTAssertEqual(rewards.count, 3)
+    XCTAssertEqual(
+      rewards,
+      [
+        Reward.noReward,
+        availableReward,
+        notAvailableReward
+      ]
+    )
+  }
+
+  func testNoRewardFirstInserter_succeedsWithEmptyProjectRewards() {
+    let inserter = NoRewardFirst()
+
+    let rewards = inserter.insert(noReward: Reward.noReward, intoRewards: [])
+    XCTAssertEqual(rewards.count, 1)
+    XCTAssertEqual(rewards, [Reward.noReward])
+  }
+
+  func testNoRewardAfterLastAvailableReward_insertsNoRewardBeforeUnavilableRewards_inUnbackedProject() {
+    let availableReward = Reward.template
+      |> Reward.lens.isAvailable .~ true
+
+    let notAvailableReward = Reward.template
+      |> Reward.lens.isAvailable .~ false
+
+    let notStartedYetReward = Reward.template
+      |> Reward.lens.startsAt .~ NSDate.distantFuture.timeIntervalSince1970
+
+    let onlyShipsToUSAReward = Reward.shipsToUSAReward
+    let onlyShipsToAustraliaReward = Reward.shipsToAustraliaReward
+    let digitalReward = Reward.digitalReward
+    let localShippingReward = Reward.localShippingReward
+
+    let projectRewards = [
+      // Available rewards
+      availableReward,
+      onlyShipsToUSAReward,
+      digitalReward,
+      localShippingReward,
+
+      // Unavailable rewards
+      notAvailableReward,
+      notStartedYetReward,
+      onlyShipsToAustraliaReward
+    ]
+
+    let inserter = NoRewardAfterLastAvailableReward(
+      shippingLocation: Location.usa,
+      project: Project.template
+    )
+
+    XCTAssertEqual(projectRewards.count, 7)
+
+    let rewards = inserter.insert(noReward: Reward.noReward, intoRewards: projectRewards)
+
+    XCTAssertEqual(rewards.count, 8)
+    XCTAssertEqual(rewards, [
+      // Available rewards
+      availableReward,
+      onlyShipsToUSAReward,
+      digitalReward,
+      localShippingReward,
+      Reward.noReward,
+
+      // Unavailable rewards
+      notAvailableReward,
+      notStartedYetReward,
+      onlyShipsToAustraliaReward
+    ])
+  }
+
+  func testNoRewardAfterLastAvailableReward_insertsNoRewardBeforeUnavilableRewards_withAllUnavailableRewards(
+  ) {
+    let notAvailableReward = Reward.template
+      |> Reward.lens.isAvailable .~ false
+
+    let notStartedYetReward = Reward.template
+      |> Reward.lens.startsAt .~ NSDate.distantFuture.timeIntervalSince1970
+
+    let onlyShipsToAustraliaReward = Reward.shipsToAustraliaReward
+
+    let projectRewards = [
+      // Unavailable rewards
+      notAvailableReward,
+      notStartedYetReward,
+      onlyShipsToAustraliaReward
+    ]
+
+    let inserter = NoRewardAfterLastAvailableReward(
+      shippingLocation: Location.usa,
+      project: Project.template
+    )
+
+    XCTAssertEqual(projectRewards.count, 3)
+
+    let rewards = inserter.insert(noReward: Reward.noReward, intoRewards: projectRewards)
+
+    XCTAssertEqual(rewards.count, 4)
+    XCTAssertEqual(rewards, [
+      // Available rewards
+      Reward.noReward,
+
+      // Unavailable rewards
+      notAvailableReward,
+      notStartedYetReward,
+      onlyShipsToAustraliaReward
+    ])
+  }
+
+  func testNoRewardAfterLastAvailableReward_allRewardsAvailable_insertsNoRewardAtEndOfList() {
+    let availableReward = Reward.template
+      |> Reward.lens.isAvailable .~ true
+
+    let onlyShipsToUSAReward = Reward.shipsToUSAReward
+    let digitalReward = Reward.digitalReward
+    let localShippingReward = Reward.localShippingReward
+
+    let projectRewards = [
+      // Available rewards
+      availableReward,
+      onlyShipsToUSAReward,
+      digitalReward,
+      localShippingReward
+    ]
+
+    let inserter = NoRewardAfterLastAvailableReward(
+      shippingLocation: Location.usa,
+      project: Project.template
+    )
+
+    XCTAssertEqual(projectRewards.count, 4)
+
+    let rewards = inserter.insert(noReward: Reward.noReward, intoRewards: projectRewards)
+
+    XCTAssertEqual(rewards.count, 5)
+    XCTAssertEqual(rewards, [
+      // Available rewards
+      availableReward,
+      onlyShipsToUSAReward,
+      digitalReward,
+      localShippingReward,
+      Reward.noReward
+    ])
+  }
+
+  func testNoRewardAfterLastAvailableReward_succeedsWithEmptyProjectRewards() {
+    let inserter = NoRewardAfterLastAvailableReward(
+      shippingLocation: nil,
+      project: Project.template
+    )
+
+    let rewards = inserter.insert(noReward: Reward.noReward, intoRewards: [])
+    XCTAssertEqual(rewards, [Reward.noReward])
+  }
+}


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Refactor the way we insert the "no-reward reward" into the rewards list.

Instead of passing a `NoRewardSortType` into the API layer, pass an object that conforms to the protocol `NoRewardInserter`. The `NoRewardInserter` figures out where to put "no reward" in the list.

# 🤔 Why

I wanted to insert "No Reward" after the last available reward, instead of at the end of the list.

For example, if we had 2 available and 1 unavailable rewards, it should return a list like:

> Available Reward
> Available Reward
> Pledge without a reward
> Unavailable Reward


This presented a problem. The rewards are sorted on the backend (great!), but the "No Reward" is inserted by frontend. Down in the `KsApi` layer, we don't have enough context to figure out which rewards are available to pledge and which are not. That code lives a level up, in `Library`, especially in the function `rewardsCarouselCanNavigateToReward`.

My solution was to create the `NoRewardInserter` protocol. At the view model level, in `Library`, I create a `NoRewardInserter` that knows more about the backing and shipping location. Then that inserter gets passed down to `KsApi`, which doesn't need to care about _how_ the no reward is being inserted.

# 🛠 How

1. This implementation was loosely inspired by the `Comparator` protocol.
2. I explored some other solutions - most notably, I experimented with a refactor to move reward sorting out of `KsApi` and into `RewardsCollectionViewModel`. Eventually I decided that refactor was too invasive; too many pieces of the code relied on KsApi returning a list of rewards _including the no reward_.
