### PR TITLE
CHECK-134: Add A/B test to move the 'No Reward' card

### DIFF
--- a/Experimentation/Sources/Experimentation/Experiments/MoveNoRewardOptionExperiment.swift
+++ b/Experimentation/Sources/Experimentation/Experiments/MoveNoRewardOptionExperiment.swift
@@ -1,0 +1,18 @@
+/// An experiment to move the 'Pledge without a reward' (aka No Reward) card in the Rewards carousel.
+public struct MoveNoRewardOptionExperiment: StatsigExperimentProtocol {
+  typealias ExperimentParameters = MoveNoRewardOptionExperiment.Parameters
+
+  public enum Parameters: String, CaseIterable {
+    case show_no_reward_after_available_rewards
+  }
+
+  public var name: StatsigExperimentName {
+    return .move_no_reward_option_ios
+  }
+
+  public var layer: StatsigExperimentLayer? {
+    return .ios_checkout
+  }
+
+  public init() {}
+}

--- a/Experimentation/Sources/Experimentation/Experiments/StatsigExperiment.swift
+++ b/Experimentation/Sources/Experimentation/Experiments/StatsigExperiment.swift
@@ -41,8 +41,10 @@ public enum StatsigExperimentName: String, CaseIterable {
   case fullscreen_checkout_experience_experiment
   case logged_in_aa_experiment
   case logged_out_aa_experiment
+  case move_no_reward_option_ios = "move_no-reward_option_ios"
 }
 
 public enum StatsigExperimentLayer: String, CaseIterable {
   case ios_test_layer
+  case ios_checkout
 }

--- a/Library/Sources/Library/Library/Statsig/StatsigExperiment+Helpers.swift
+++ b/Library/Sources/Library/Library/Statsig/StatsigExperiment+Helpers.swift
@@ -23,6 +23,8 @@ public extension StatsigExperimentName {
       return NullExperimentWithUserID()
     case .logged_out_aa_experiment:
       return NullExperimentWithAnonymousID()
+    case .move_no_reward_option_ios:
+      return MoveNoRewardOptionExperiment()
     }
   }
 }

--- a/Library/Sources/Library/Library/ViewModels/RewardsCollectionViewModel.swift
+++ b/Library/Sources/Library/Library/ViewModels/RewardsCollectionViewModel.swift
@@ -1,3 +1,4 @@
+import Experimentation
 import KsApi
 import Prelude
 import ReactiveSwift
@@ -68,38 +69,32 @@ public final class RewardsCollectionViewModel: RewardsCollectionViewModelType,
       .takeWhen(self.viewDidLoadProperty.signal)
       .map(titleForContext)
 
-    // The actual selected shipping location.
+    // The selected shipping location.
     // Can be nil if the project has no shippable rewards.
-    let selectedShippingLocation: Signal<Location?, Never> = self.shippingLocationSelectedSignal
-
-    // The country to which we should filter the rewards.
     // TODO: If we passed in ShippableCountries to the location selector, we could call this faster.
-    let filterCountry: Signal<String?, Never> = self.shippingLocationSelectedSignal
+    let selectedShippingLocation: Signal<Location?, Never> = self.shippingLocationSelectedSignal
       .signal
-      .map { $0?.country }
       .skipRepeats()
 
     let isLoadingProperty = MutableProperty(true)
 
     // Fetch the sorted rewards when a shipping country code is selected
     let fetchedRewards = project
-      .combineLatest(with: filterCountry)
+      .combineLatest(with: selectedShippingLocation)
       .on(value: { _ in
         isLoadingProperty.value = true
       })
       .flatMap { project, location in
-        AppEnvironment.current.apiService
-          .fetchProjectRewards(
-            projectId: project.id,
-            sortedForShippingCountryCode: location,
-            withNoReward: NoRewardFirst()
-          )
-          .ksr_delay(AppEnvironment.current.apiDelayInterval, on: AppEnvironment.current.scheduler)
-          .materialize()
-          .values()
-          .on(completed: {
-            isLoadingProperty.value = false
-          })
+        fetchRewards(
+          forProject: project,
+          sortedForShippingLocation: location
+        )
+        .ksr_delay(AppEnvironment.current.apiDelayInterval, on: AppEnvironment.current.scheduler)
+        .materialize()
+        .values()
+        .on(completed: {
+          isLoadingProperty.value = false
+        })
       }
       .map(filteredRewards)
 
@@ -590,4 +585,36 @@ private extension Signal where Error == Never {
       .filter { _, test in test == true }
       .map { value, _ in value }
   }
+}
+
+private func shouldMoveNoRewardCard() -> Bool {
+  let experiment = MoveNoRewardOptionExperiment()
+  guard let shouldMove = experiment.boolValue(forKey: .show_no_reward_after_available_rewards) else {
+    return false
+  }
+
+  return shouldMove
+}
+
+private func fetchRewards(
+  forProject project: Project,
+  sortedForShippingLocation location: Location?
+) -> SignalProducer<[Reward], ErrorEnvelope> {
+  let inserter: NoRewardInserter
+
+  if shouldMoveNoRewardCard() {
+    inserter = NoRewardAfterLastAvailableReward(
+      shippingLocation: location,
+      project: project
+    )
+  } else {
+    inserter = NoRewardFirst()
+  }
+
+  return AppEnvironment.current.apiService
+    .fetchProjectRewards(
+      projectId: project.id,
+      sortedForShippingCountryCode: location?.country,
+      withNoReward: inserter
+    )
 }

--- a/Library/Sources/Library/Library/ViewModels/RewardsCollectionViewModel.swift
+++ b/Library/Sources/Library/Library/ViewModels/RewardsCollectionViewModel.swift
@@ -587,7 +587,9 @@ private extension Signal where Error == Never {
   }
 }
 
-private func shouldMoveNoRewardCard() -> Bool {
+// MARK: Experiments
+
+private func shouldMoveNoReward_afterLastAvailableReward() -> Bool {
   let experiment = MoveNoRewardOptionExperiment()
   guard let shouldMove = experiment.boolValue(forKey: .show_no_reward_after_available_rewards) else {
     return false
@@ -602,7 +604,7 @@ private func fetchRewards(
 ) -> SignalProducer<[Reward], ErrorEnvelope> {
   let inserter: NoRewardInserter
 
-  if shouldMoveNoRewardCard() {
+  if shouldMoveNoReward_afterLastAvailableReward() {
     inserter = NoRewardAfterLastAvailableReward(
       shippingLocation: location,
       project: project


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Add an A/B test to move the "Pledge with no reward" card after all the available project rewards.

This A/B test is our first test to use Statsig's "Layer's" feature!

# 🤔 Why

Checkout is experimenting with moving this card around to see if it improves conversion.