### PR TITLE
[DISC-220] Fix Statsig Gate Race Condition With StableID

### DIFF
--- a/Experimentation/Sources/Experimentation/StatsigClient.swift
+++ b/Experimentation/Sources/Experimentation/StatsigClient.swift
@@ -55,9 +55,15 @@ public final class StatsigWrapper: StatsigClientType {
     self.client.openDebugView()
   }
 
+  /// Returns the Statsig SDK generated stableID as soon as the SDK is initialized.
+  public func stableID() -> String? {
+    return self.client.getStableID()
+  }
+
   public func reload(withUser user: StatsigClientUser) {
-    let user = StatsigUser.from(user)
-    self.client.updateUserWithResult(user) { error in
+    let statsigUser = StatsigUser.from(user, stableID: self.client.getStableID())
+
+    self.client.updateUserWithResult(statsigUser) { error in
       if let error {
         debugPrint("Statsig reload error: \(error.localizedDescription)")
       } else {
@@ -96,14 +102,25 @@ public final class StatsigWrapper: StatsigClientType {
 }
 
 private extension StatsigUser {
-  /// Create a `StatsigUser` (Statsig's model object) from a `StatsigClientUser` (our model object)
-  static func from(_ clientUser: StatsigClientUser) -> StatsigUser {
+  /// Create a `StatsigUser` (Statsig's model object) from a `StatsigClientUser` (our model object).
+  ///
+  /// - Parameter stableID: The device ID  from `StatsigClient.getStableID()`.
+  ///   Passed in so the gate always has something to evaluate against, even before
+  ///   the user is logged in or Segment has loaded. Gates using this should be set
+  ///   to Stable ID in the Statsig console.
+  static func from(_ clientUser: StatsigClientUser, stableID: String? = nil) -> StatsigUser {
     let ksrStringId = clientUser.ksrUserId != nil ? String(clientUser.ksrUserId!) : nil
 
-    if let segmentId = clientUser.segmentAnonymousId {
-      return StatsigUser(userID: ksrStringId, customIDs: ["segmentAnonymousID": segmentId])
-    } else {
-      return StatsigUser(userID: ksrStringId)
+    var customIDs: [String: String] = [:]
+
+    if let stableID = stableID ?? clientUser.stableId {
+      customIDs["stableID"] = stableID
     }
+
+    if let segmentId = clientUser.segmentAnonymousId {
+      customIDs["segmentAnonymousID"] = segmentId
+    }
+
+    return StatsigUser(userID: ksrStringId, customIDs: customIDs.isEmpty ? nil : customIDs)
   }
 }

--- a/Experimentation/Sources/Experimentation/StatsigClientType.swift
+++ b/Experimentation/Sources/Experimentation/StatsigClientType.swift
@@ -4,10 +4,12 @@ import Foundation
 public struct StatsigClientUser {
   let ksrUserId: Int?
   let segmentAnonymousId: String?
+  let stableId: String?
 
-  public init(ksrUserId: Int?, segmentAnonymousId: String?) {
+  public init(ksrUserId: Int?, segmentAnonymousId: String?, stableId: String? = nil) {
     self.ksrUserId = ksrUserId
     self.segmentAnonymousId = segmentAnonymousId
+    self.stableId = stableId
   }
 }
 
@@ -27,6 +29,9 @@ public protocol StatsigClientType: AnyObject {
   /// Returns a boolean value from an experiment.
   /// May return `nil` if the experiment or key are invalid.
   func boolValue<T: StatsigExperimentProtocol>(forKey key: T.Parameters, inExperiment experiment: T) -> Bool?
+
+  /// Returns the Statsig SDK generated stable device ID.
+  func stableID() -> String?
 
   // Statsig supports Bool, Int, String and even Object parameters for experiments.
   // When and if we need them, we can expand this implementation to support more types.

--- a/Experimentation/Sources/ExperimentationTestHelpers/MockStatsigClient.swift
+++ b/Experimentation/Sources/ExperimentationTestHelpers/MockStatsigClient.swift
@@ -17,6 +17,10 @@ public final class MockStatsigWrapper: StatsigClientType {
 
   public func showDebugger() {}
 
+  public func stableID() -> String? {
+    return nil
+  }
+
   public func checkGate(for feature: StatsigFeature) -> Bool? {
     self.features[feature]
   }

--- a/Experimentation/Tests/ExperimentationTests/StatsigClientTests.swift
+++ b/Experimentation/Tests/ExperimentationTests/StatsigClientTests.swift
@@ -120,4 +120,22 @@ final class StatsigWrapperTests: XCTestCase {
 
     XCTAssertEqual(client.boolValue(forKey: .test_parameter, inExperiment: experiment), true)
   }
+
+  func testClient_includesStableID_inUserCustomIDs() {
+    let expectation = XCTestExpectation(description: "Waiting for Statsig")
+    let statsig = StatsigClient(sdkKey: "fake", options: StatsigOptions(initializeOffline: true)) { _ in
+      expectation.fulfill()
+    }
+
+    self.wait(for: [expectation])
+
+    let client = StatsigWrapper(client: statsig)
+    XCTAssertNotNil(client.stableID(), "stableID should not be nil after initialization")
+
+    /// Reload with a user that has no login or segment ID yet
+    let user = StatsigClientUser(ksrUserId: nil, segmentAnonymousId: nil, stableId: client.stableID())
+    client.reload(withUser: user)
+
+    XCTAssertNotNil(client.stableID(), "stableID should persist after reload")
+  }
 }

--- a/Library/Sources/Library/Library/Environment+Identity.swift
+++ b/Library/Sources/Library/Library/Environment+Identity.swift
@@ -8,7 +8,8 @@ public extension Environment {
 
     let statsigUser = StatsigClientUser(
       ksrUserId: user?.id,
-      segmentAnonymousId: self.ksrAnalytics.anonymousId
+      segmentAnonymousId: self.ksrAnalytics.anonymousId,
+      stableId: self.statsigClient?.stableID()
     )
 
     self.statsigClient?.reload(withUser: statsigUser)
@@ -17,7 +18,8 @@ public extension Environment {
   func statsigUser() -> StatsigClientUser {
     StatsigClientUser(
       ksrUserId: self.currentUser?.id,
-      segmentAnonymousId: self.ksrAnalytics.anonymousId
+      segmentAnonymousId: self.ksrAnalytics.anonymousId,
+      stableId: self.statsigClient?.stableID()
     )
   }
 }


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What
Passes Statsig's `stableID` through to the user object so the `video_feed` gate always has a valid ID to evaluate against.

# 🤔 Why
The Discover page can load before the user is logged in and before Segment has initialized. 
When that happens, the user object we send to Statsig doesn't have an ID, so the gate defaults to `false` and logs cache warnings in the Statsig [exposure stream](https://console.statsig.com/63RYuAXh4n2yKAubACXeg1/gates/video_feed/diagnostics). 
Statsig generates a `stableID` the moment the SDK boots up, so we can use that as a consistent device-level ID from the jump

# 🛠 How
- Added `stableID` to `StatsigClientUser` (optional, defaults to `nil` so existing calls don't need changes)
- Added `stableID() -> String?` to `StatsigClientType` and implemented it in `StatsigWrapper` via `client.getStableID()`
- `reload(withUser:)` now injects `stableID` into `customIDs` on the `StatsigUser` alongside `segmentAnonymousID`  so there's always a valid device ID no matter when the reload fires
- Added a test for when `stableID` isn't nil after init to check that it survives a reload with an empty user

I've also updated the `video_feed` gate in the [Statsig console](https://console.statsig.com/63RYuAXh4n2yKAubACXeg1/gates/video_feed) so that its ID type is Stable ID instead of  User ID.

# ✅ Acceptance criteria

- [x] On a fresh install, when logged out, the video feed banner should show/hide correctly with no `Cache:Recognized` warnings in the Statsig exposure stream
- [x] every row for `video_feed` in the console exposure stream should have a non-nil `stableID`
- [x] Existing experiment and gate behavior unchanged
