### PR TITLE
[DISC-242] Video Feed: Fix Audio Overlap Issue

### DIFF
--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Cell/VideoFeedCell.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Cell/VideoFeedCell.swift
@@ -114,14 +114,19 @@ final class VideoFeedCell: UICollectionViewCell, ValueCell {
   }
 
   func ctaTapped() {
-    self.pausePlayback()
+    self.playbackState.pause()
     self.onCTATapped?()
   }
 
   // MARK: - Video Playback
 
+  /// Buffers the video but does not start playback. Call `startPlayback()` once the cell is settled.
   func loadVideo(url: URL) {
     self.videoPlayer.load(url: url)
+  }
+
+  func startPlayback() {
+    self.videoPlayer.play()
   }
 
   func resetVideo() {

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Controller/VideoFeedViewController.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Controller/VideoFeedViewController.swift
@@ -9,7 +9,9 @@ import UIKit
 /// Full-screen swipeable video feed.
 ///   - Full-screen paging
 ///   - Plain data source driven by `VideoFeedViewModel`
-///   - Cells start loading video on `willDisplay` and reset on `didEndDisplaying`
+///   - Cells buffer video on `willDisplay` and reset on `didEndDisplaying`
+///   - Playback only starts once a cell is fully settled (scroll has ended)
+///   - Current cell audio plays until the next cell takes over
 ///   - Pauses video on background, resumes on foreground
 final class VideoFeedViewController: UIViewController {
   private enum Constants {
@@ -21,6 +23,7 @@ final class VideoFeedViewController: UIViewController {
 
   private var lifecycleObservers: [any NSObjectProtocol] = []
   private var previewImagePrefetcher: ImagePrefetcher?
+  private var isScrolling = false
 
   /// Called once the first batch of items has loaded and the feed is ready to present.
   var onReadyToPresent: (() -> Void)?
@@ -171,6 +174,10 @@ final class VideoFeedViewController: UIViewController {
   private func updateFeedWithFetchedItems(_ newItems: [VideoFeedItem]) {
     self.dataSource.load(newItems)
     self.collectionView.reloadData()
+
+    DispatchQueue.main.async {
+      self.activateCurrentPageCell()
+    }
   }
 
   private func snapToCurrentPage() {
@@ -283,7 +290,7 @@ extension VideoFeedViewController: UICollectionViewDelegateFlowLayout {
     layout _: UICollectionViewLayout,
     sizeForItemAt _: IndexPath
   ) -> CGSize {
-    collectionView.bounds.size
+    CGSize(width: floor(collectionView.bounds.width), height: floor(collectionView.bounds.height))
   }
 
   func collectionView(
@@ -304,6 +311,13 @@ extension VideoFeedViewController: UICollectionViewDelegateFlowLayout {
     cell.onShareTapped = { [weak self] in self?.simpleAlert(title: "Share") }
     cell.onMoreTapped = { [weak self] in self?.simpleAlert(title: "More") }
     cell.onCTATapped = { [weak self] in self?.goToProjectPage(for: item) }
+
+    cell.onVideoReady = { [weak self, weak cell] in
+      guard let self, let cell else { return }
+      /// Only start playback once scroll has fully settled.
+
+      cell.startPlayback()
+    }
 
     cell.configureWith(
       value: item,
@@ -340,6 +354,36 @@ extension VideoFeedViewController: UICollectionViewDelegateFlowLayout {
     self.previewImagePrefetcher?.stop()
     self.previewImagePrefetcher = nil
     (cell as? VideoFeedCell)?.resetVideo()
+  }
+
+  // MARK: - Scroll based playback
+
+  func scrollViewWillBeginDragging(_: UIScrollView) {
+    self.isScrolling = true
+  }
+
+  func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
+    guard !scrollView.isDragging else { return }
+
+    self.isScrolling = false
+    self.activateCurrentPageCell()
+  }
+
+  private func activateCurrentPageCell() {
+    let pageHeight = self.collectionView.bounds.height
+
+    guard pageHeight > 0 else { return }
+
+    let currentPage = Int(round(self.collectionView.contentOffset.y / pageHeight))
+    let activeIndexPath = IndexPath(item: currentPage, section: 0)
+
+    for cell in self.collectionView.visibleCells.compactMap({ $0 as? VideoFeedCell }) {
+      if self.collectionView.indexPath(for: cell) == activeIndexPath {
+        cell.startPlayback()
+      } else {
+        cell.pausePlayback()
+      }
+    }
   }
 
   // MARK: - Helpers

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/State/VideoFeedPlaybackState.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/State/VideoFeedPlaybackState.swift
@@ -40,7 +40,6 @@ final class VideoFeedPlaybackState {
   /// Called by the video player once it is ready to play.
   func videoDidBecomeReady() {
     self.isVideoReady = true
-    self.videoPlayer?.play()
   }
 
   /// Called by the video player when the current video feed item fails to load or play.

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/VideoPlayer/VideoFeedVideoPlayer.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/VideoPlayer/VideoFeedVideoPlayer.swift
@@ -90,8 +90,6 @@ class VideoFeedVideoPlayer {
       }
     }
 
-    self.player.play()
-
     /// Fallback handler:
     /// if the item hasn't started playing after 3s, check if it failed and notify the UI.
     /// The `=== item` check guards against the cell being recycled before this fires.


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Fixes audio overlap in the video feed when half-scrolling between cells.

# 🤔 Why

Both cells could play audio simultaneously during a drag. `willDisplay` was being triggered
on the incoming cell during scroll and started playback immediately

# 🛠 How

- Essentially decoupled buffering from playback. `load(url:)` on the player now only buffers and a new `startPlayback()` on the cell is what actually ends up calling `.play()`
- The VC tracks an `isScrolling` flag (gets set on scroll start, cleared on
`didEndDecelerating`) and gates all playback on it. Both in `onVideoReady` and
in the new `activateCurrentPageCell()`, which pauses all visible cells except
the settled one.

# ✅ Acceptance criteria

- [x] Slow scroll between two playing videos, only one plays audio at a time
- [x] Fast scroll to check that the next cell's audio doesn't bleed in before it settles
- [x] Tap to pause, swipe away and back, playback resumes correctly

