### PR TITLE
CHECK-228: Add fallback if Rewards page tries to scroll out-of-bounds

### DIFF
--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/RewardsCollection/Controller/RewardsCollectionViewController.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/RewardsCollection/Controller/RewardsCollectionViewController.swift
@@ -184,7 +184,7 @@ final class RewardsCollectionViewController: UICollectionViewController {
     self.viewModel.outputs.scrollToRewardIndexPath
       .observeForUI()
       .observeValues { [weak self] indexPath in
-        self?.collectionView.scrollToItem(at: indexPath, at: .centeredHorizontally, animated: false)
+        self?.scrollToReward(atIndexPath: indexPath)
       }
 
     self.viewModel.outputs.goToAddOnSelection
@@ -246,6 +246,17 @@ final class RewardsCollectionViewController: UICollectionViewController {
   }
 
   // MARK: - Functions
+
+  private func scrollToReward(atIndexPath indexPath: IndexPath) {
+    let rewardCount = self.collectionView.numberOfItems(inSection: indexPath.section)
+
+    guard indexPath.row < rewardCount else {
+      assert(false, "scrollToReward(atIndexPath:) tried to scroll out-of-bounds.")
+      return
+    }
+
+    self.collectionView.scrollToItem(at: indexPath, at: .centeredHorizontally, animated: false)
+  }
 
   private func setupConstraints() {
     _ = self.collectionView


### PR DESCRIPTION
# 📲 What

Catch `RewardsCollectionViewController` before it tries to scroll to a Reward that is out-of-bounds.

# 🤔 Why

This addresses a low-frequency crash we've been seeing since 5.33.0.

I did some digging into how exactly this is happening. The crash occurs due to a race condition between the outputs `scrollToRewardAtIndexPath` and `reloadDataWithValues`.  It's possible for`scrollToRewardAtIndexPath` to be called before `reloadDataWithValues`. In very rare cases, this causes the app to try to scroll to a card before it has actually been displayed, triggering a crash.

I found this crash very difficult to duplicate. The only way I could trigger it was to change the code to load _too few_ placeholder cards. I believe this crash will only occur if, for some reason, the app loads _n_ placeholder cards but then fetches at least _n+1_ rewards.

I spent a few hours digging into the race condition itself and trying to find a better solution - but I didn't land on anything robust enough to feel worth the refactoring for such a rare crash. Instead, I decided to add a `guard` to the scrolling code, and silently cancel if it tries to scroll to an invalid reward. I also added an `assert` so that, if this ever occurs more frequently during development, we'll notice quickly.
