### PR TITLE
CHECK-210: Whitelist URL for new order edits

### DIFF
--- a/Library/Sources/Library/Library/Navigation.swift
+++ b/Library/Sources/Library/Library/Navigation.swift
@@ -161,7 +161,8 @@ private let allRoutes: [String: (RouteParamsDecoded) -> Navigation?] = [
   "/projects/:creator_param/:project_param/surveys/:survey_param/edit_address": pledgeManagerWebview,
   "/settings/:notification_param/:enabled_param": settingsNotifications,
   "/users/:user_param/surveys/:survey_response_id": userSurvey,
-  "/projects/:creator_param/:project_param/order_edits/:order_edit_id/checkout": pledgeManagerWebview
+  "/projects/:creator_param/:project_param/order_edits/:order_edit_id/checkout": pledgeManagerWebview,
+  "/projects/:creator_param/:project_param/order_edits/new": pledgeManagerWebview
 ]
 
 private let deepLinkRoutes: [String: (RouteParamsDecoded) -> Navigation?] = allRoutes.restrict(

--- a/Library/Sources/Library/Library/ViewModels/PledgeManagerWebViewModel.swift
+++ b/Library/Sources/Library/Library/ViewModels/PledgeManagerWebViewModel.swift
@@ -248,7 +248,8 @@ private func isUnpreparedSupportedRequest(request: URLRequest) -> Bool {
 }
 
 private func isSupportedRequest(request: URLRequest) -> Bool {
-  guard case (.project(_, .pledgeManagerWebview, _, _))? = Navigation.match(request) else { return false }
+  let navigation = Navigation.match(request)
+  guard case (.project(_, .pledgeManagerWebview, _, _))? = navigation else { return false }
   return true
 }
 


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Whitelist the URL for creating a new Order Edit.

# 🤔 Why

By whitelisting this URL, you can go through the Order Edits flow in the embedded Pledge Manager web view.