### PR TITLE
Video Feed: Fix Audio Playback and Save State

### DIFF
--- a/Kickstarter-Framework/Sources/Kickstarter-Framework-iOSTests/Kickstarter-iOS/Features/VideoFeed/VideoFeedPlaybackStateTests.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework-iOSTests/Kickstarter-iOS/Features/VideoFeed/VideoFeedPlaybackStateTests.swift
@@ -1,0 +1,70 @@
+@testable import Kickstarter_Framework
+@testable import LibraryTestHelpers
+import XCTest
+
+final class VideoFeedPlaybackStateTests: TestCase {
+  private let state = VideoFeedPlaybackState()
+
+  func testPause_SetsIsPlaying() {
+    self.state.pause()
+
+    XCTAssertFalse(self.state.isPlaying)
+
+    self.state.resume()
+
+    XCTAssertTrue(self.state.isPlaying)
+  }
+
+  func testReset_RestoresDefaultState() {
+    self.state.pause()
+    self.state.videoDidBecomeReady()
+    self.state.videoDidFail()
+    self.state.hasSaveFailed = true
+
+    self.state.reset()
+
+    XCTAssertTrue(self.state.isPlaying)
+    XCTAssertFalse(self.state.isVideoReady)
+    XCTAssertFalse(self.state.hasFailed)
+    XCTAssertFalse(self.state.hasSaveFailed)
+  }
+
+  func testVideoDidBecomeReady_SetsIsVideoReadyTrue() {
+    self.state.videoDidBecomeReady()
+
+    XCTAssertTrue(self.state.isVideoReady)
+  }
+
+  func testVideoDidFail_SetsHasFailedTrue() {
+    XCTAssertFalse(self.state.hasFailed)
+
+    self.state.videoDidFail()
+
+    XCTAssertTrue(self.state.hasFailed)
+  }
+
+  func testIsPlayButtonVisible_TrueWhenReadyAndPaused_FalseWhenPlaying() {
+    self.state.videoDidBecomeReady()
+    self.state.pause()
+
+    XCTAssertTrue(self.state.isPlayButtonVisible)
+
+    self.state.resume()
+
+    XCTAssertFalse(self.state.isPlayButtonVisible)
+  }
+
+  func testIsPlayButtonVisible_FalseWhenNotReady() {
+    self.state.pause()
+
+    XCTAssertFalse(self.state.isPlayButtonVisible)
+  }
+
+  func testIsPlayButtonVisible_FalseWhenFailed() {
+    self.state.videoDidBecomeReady()
+    self.state.pause()
+    self.state.videoDidFail()
+
+    XCTAssertFalse(self.state.isPlayButtonVisible)
+  }
+}

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/Discovery/Controller/DiscoveryPageViewController.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/Discovery/Controller/DiscoveryPageViewController.swift
@@ -28,8 +28,7 @@ internal final class DiscoveryPageViewController: UITableViewController,
 
   internal var messageBannerViewController: MessageBannerViewController?
 
-  /// Holds a ref to the VideoFeedViewController while its data loads.
-  var pendingVideoFeedVC: VideoFeedViewController?
+  var videoFeedVC: VideoFeedViewController?
 
   internal static func configuredWith(sort: DiscoveryParams.Sort) -> DiscoveryPageViewController {
     let vc = Storyboard.DiscoveryPage.instantiate(DiscoveryPageViewController.self)

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/Search/Controller/SearchViewController.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/Search/Controller/SearchViewController.swift
@@ -30,8 +30,7 @@ internal final class SearchViewController: UITableViewController,
 
   internal var messageBannerViewController: MessageBannerViewController?
 
-  /// Holds a ref to the VideoFeedViewController while its data loads.
-  var pendingVideoFeedVC: VideoFeedViewController?
+  var videoFeedVC: VideoFeedViewController?
 
   private var searchBarWidth: CGFloat {
     return self.view.bounds.width * Constants.searchBarWidthFactor

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Cell/VideoFeedCell.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Cell/VideoFeedCell.swift
@@ -126,7 +126,7 @@ final class VideoFeedCell: UICollectionViewCell, ValueCell {
   }
 
   func startPlayback() {
-    self.videoPlayer.play()
+    self.playbackState.resume()
   }
 
   func resetVideo() {
@@ -136,7 +136,7 @@ final class VideoFeedCell: UICollectionViewCell, ValueCell {
   }
 
   func pausePlayback() {
-    self.videoPlayer.pause()
+    self.playbackState.pause()
   }
 
   func resumePlayback() {

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Cell/VideoFeedCell.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Cell/VideoFeedCell.swift
@@ -139,11 +139,6 @@ final class VideoFeedCell: UICollectionViewCell, ValueCell {
     self.playbackState.pause()
   }
 
-  func resumePlayback() {
-    guard self.playbackState.isPlaying else { return }
-    self.videoPlayer.play()
-  }
-
   // MARK: - Toast View
 
   private func resetToasts() {
@@ -229,7 +224,7 @@ final class VideoFeedCell: UICollectionViewCell, ValueCell {
     self.addGestureRecognizer(tap)
   }
 
-  /// Tapping anywhere on the cell toggles playback:
+  /// Tapping anywhere on the cell toggles playback.
   @objc private func cellTapped() {
     if self.playbackState.isPlaying {
       self.playbackState.pause()

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Controller/VideoFeedBannerPresenting.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Controller/VideoFeedBannerPresenting.swift
@@ -2,25 +2,31 @@ import Library
 import UIKit
 
 protocol VideoFeedBannerPresenting: UIViewController, MessageBannerViewControllerPresenting {
-  var pendingVideoFeedVC: VideoFeedViewController? { get set }
+  /// Retained across opens so VM state persists. Also prevents double-tapping while loading.
+  var videoFeedVC: VideoFeedViewController? { get set }
 }
 
 extension VideoFeedBannerPresenting {
   func presentVideoFeed(from cell: VideoFeedBannerCell) {
-    guard self.pendingVideoFeedVC == nil else { return }
+    guard self.videoFeedVC == nil else {
+      /// Reuse an existing feed VC so VM state (optimistic saves, etc.) persists across opens.
+      if let existing = self.videoFeedVC, existing.isBeingPresented == false {
+        existing.modalPresentationStyle = .fullScreen
+        self.present(existing, animated: true)
+      }
+      return
+    }
 
     cell.setLoading(true)
 
     let feedVC = VideoFeedViewController()
 
-    self.pendingVideoFeedVC = feedVC
+    self.videoFeedVC = feedVC
 
     feedVC.loadViewIfNeeded()
 
     feedVC.onReadyToPresent = { [weak self, weak cell, weak feedVC] in
       guard let self, let feedVC else { return }
-
-      self.pendingVideoFeedVC = nil
 
       cell?.setLoading(false)
 
@@ -32,7 +38,7 @@ extension VideoFeedBannerPresenting {
     feedVC.onFetchFailed = { [weak self, weak cell] in
       guard let self else { return }
 
-      self.pendingVideoFeedVC = nil
+      self.videoFeedVC = nil
 
       cell?.setLoading(false)
 

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Controller/VideoFeedViewController.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Controller/VideoFeedViewController.swift
@@ -77,9 +77,10 @@ final class VideoFeedViewController: UIViewController {
     self.navigationController?.setNavigationBarHidden(true, animated: animated)
     self.viewModel.viewWillAppear()
 
-    DispatchQueue.main.async {
-      self.reconfigureVisibleCell()
-      self.activateCurrentPageCell()
+    /// Dispatching so item state updates on the project page (to handle project saves for example) before we reconfigure the cell.
+    DispatchQueue.main.async { [weak self] in
+      self?.reconfigureVisibleCell()
+      self?.activateCurrentPageCell()
     }
   }
 

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Controller/VideoFeedViewController.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Controller/VideoFeedViewController.swift
@@ -259,9 +259,7 @@ final class VideoFeedViewController: UIViewController {
   }
 
   private func resumeVisibleCell() {
-    self.collectionView.visibleCells
-      .compactMap { $0 as? VideoFeedCell }
-      .forEach { $0.resumePlayback() }
+    self.activateCurrentPageCell()
   }
 
   // MARK: - Navigation
@@ -335,8 +333,7 @@ extension VideoFeedViewController: UICollectionViewDelegateFlowLayout {
     cell.onCTATapped = { [weak self] in self?.goToProjectPage(for: item) }
 
     cell.onVideoReady = { [weak self, weak cell] in
-      guard let self, let cell else { return }
-      /// Only start playback once scroll has fully settled.
+      guard let self, let cell, !self.isScrolling else { return }
 
       cell.startPlayback()
     }

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Controller/VideoFeedViewController.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Controller/VideoFeedViewController.swift
@@ -176,6 +176,16 @@ final class VideoFeedViewController: UIViewController {
         self.bindViewModel()
       }
     }
+
+    /// Reconfigures the visible cell whenever items mutate (e.g. save state changes made on the project page).
+    withObservationTracking {
+      _ = self.viewModel.items
+    } onChange: { [weak self] in
+      DispatchQueue.main.async { [weak self] in
+        self?.reconfigureVisibleCell()
+        self?.bindViewModel()
+      }
+    }
   }
 
   /// Reloads the collection view with a fresh set of fetched items.

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Controller/VideoFeedViewController.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Controller/VideoFeedViewController.swift
@@ -76,12 +76,18 @@ final class VideoFeedViewController: UIViewController {
 
     self.navigationController?.setNavigationBarHidden(true, animated: animated)
     self.viewModel.viewWillAppear()
+
+    DispatchQueue.main.async {
+      self.reconfigureVisibleCell()
+      self.activateCurrentPageCell()
+    }
   }
 
   override func viewWillDisappear(_ animated: Bool) {
     super.viewWillDisappear(animated)
 
     self.navigationController?.setNavigationBarHidden(false, animated: animated)
+    self.pauseVisibleCell()
   }
 
   // MARK: - CollectionView
@@ -198,7 +204,7 @@ final class VideoFeedViewController: UIViewController {
         get: { self.viewModel.items.first(where: { $0.id == item.id }) ?? item },
         set: { _ in }
       ),
-      isSaved: self.viewModel.isSaved(id: item.id)
+      isSaved: self.viewModel.isSaved(projectId: item.id)
     )
   }
 
@@ -230,7 +236,7 @@ final class VideoFeedViewController: UIViewController {
 
   // MARK: - App lifecycle
 
-  /// Pause video on background and resumes on foreground.
+  /// Pause video on background, resume on foreground, and re-render the active cell after login.
   private func observeAppLifecycle() {
     let center = NotificationCenter.default
 
@@ -248,6 +254,18 @@ final class VideoFeedViewController: UIViewController {
         queue: .main
       ) { [weak self] _ in
         self?.resumeVisibleCell()
+      },
+      center.addObserver(
+        forName: .ksr_sessionStarted,
+        object: nil,
+        queue: .main
+      ) { [weak self] _ in
+        /// Re-render the active cell after login so  saves and state changes are reflected immediately.
+        self?.viewModel.viewWillAppear()
+
+        DispatchQueue.main.async {
+          self?.reconfigureVisibleCell()
+        }
       }
     ]
   }
@@ -332,18 +350,12 @@ extension VideoFeedViewController: UICollectionViewDelegateFlowLayout {
     cell.onMoreTapped = { [weak self] in self?.simpleAlert(title: "More") }
     cell.onCTATapped = { [weak self] in self?.goToProjectPage(for: item) }
 
-    cell.onVideoReady = { [weak self, weak cell] in
-      guard let self, let cell, !self.isScrolling else { return }
-
-      cell.startPlayback()
-    }
-
     cell.configureWith(
       item: Binding(
         get: { self.viewModel.items.first(where: { $0.id == item.id }) ?? item },
         set: { _ in }
       ),
-      isSaved: self.viewModel.isSaved(id: item.id)
+      isSaved: self.viewModel.isSaved(projectId: item.id)
     )
 
     if let url = item.videoURL {

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Controller/VideoFeedViewController.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Controller/VideoFeedViewController.swift
@@ -261,10 +261,10 @@ final class VideoFeedViewController: UIViewController {
         object: nil,
         queue: .main
       ) { [weak self] _ in
-        /// Re-render the active cell after login so  saves and state changes are reflected immediately.
-        self?.viewModel.viewWillAppear()
+        /// Fire any save that was deferred (pending login) then re-render the active cell.
+        self?.viewModel.userSessionStarted()
 
-        DispatchQueue.main.async {
+        DispatchQueue.main.async { [weak self] in
           self?.reconfigureVisibleCell()
         }
       }

--- a/Library/Sources/Library/Library/ViewModels/VideoFeedViewModel.swift
+++ b/Library/Sources/Library/Library/ViewModels/VideoFeedViewModel.swift
@@ -5,16 +5,28 @@ import ReactiveSwift
 import SwiftUI
 
 public protocol VideoFeedViewModelType: AnyObject {
+  /// Current active set of video items shown in the feed.
   var items: [VideoFeedItem] { get }
+  /// Updated only on a completed fetch. Used to trigger collection view reloads.
   var fetchedItems: [VideoFeedItem] { get }
+  /// Set when a logged-out user taps save. Triggers the login flow.
   var loginIntent: LoginIntent? { get }
+  /// True once the first fetch completes successfully.
   var isInitialLoadComplete: Bool { get }
+  /// Project ID of the most recent failed save. Triggers the error toast on the selected cell.
   var saveFailedItemId: String? { get }
+
+  /// Kicks off the initial feed fetch.
   func viewDidLoad()
+  /// Syncs save state and fires any save the user tapped before logging in.
   func viewWillAppear()
+  /// Optimistically toggles the saved state for a project.
   func toggleSaved(for item: VideoFeedItem)
-  func isSaved(id: String) -> Binding<Bool>
+  /// Returns a binding to the saved state for the given project ID.
+  func isSaved(projectId: String) -> Binding<Bool>
+  /// Clears the pending login intent after the login flow is presented.
   func clearLoginIntent()
+  /// Clears the save error after the toast has been shown.
   func clearSaveFailedItemId()
 }
 
@@ -39,6 +51,9 @@ public final class VideoFeedViewModel: VideoFeedViewModelType {
   /// Observed by `VideoFeedViewController` to trigger the error toast on the correct cell.
   public private(set) var saveFailedItemId: String? = nil
 
+  /// Store the item id when a logged-out user taps save. Finishes executing on next `viewWillAppear` if login succeeded.
+  private var pendingSaveItemId: String? = nil
+
   /// Tracks in-flight watch/unwatch requests.
   private var pendingWatchRequests: [String: Disposable] = [:]
 
@@ -56,34 +71,46 @@ public final class VideoFeedViewModel: VideoFeedViewModelType {
 
   /// Called each time the feed reappears.
   /// Reconciles the save button's state for when users save projects from a presented project page (when tapping the CTA).
+  /// Also executes any save action that was deferred, pending login.
   public func viewWillAppear() {
-    guard let cache = AppEnvironment.current.cache[KSCache.ksr_projectSaved] as? [Int: Bool] else {
-      return
-    }
+    if let cache = AppEnvironment.current.cache[KSCache.ksr_projectSaved] as? [Int: Bool] {
+      for index in self.items.indices {
+        if let id = decompose(id: self.items[index].projectId), let cached = cache[id] {
+          let wasSaved = self.items[index].isSaved
+          self.items[index].isSaved = cached
 
-    for index in self.items.indices {
-      if let id = decompose(id: self.items[index].projectId), let cached = cache[id] {
-        let wasSaved = self.items[index].isSaved
-        self.items[index].isSaved = cached
-
-        /// Update the count if the save state changed on the project page.
-        if cached != wasSaved {
-          self.items[index].watchesCount += cached ? 1 : -1
+          /// Update the count if the save state changed on the project page.
+          if cached != wasSaved {
+            self.items[index].watchesCount += cached ? 1 : -1
+          }
         }
       }
     }
+
+    /// If the user logged in after tapping save, execute the deferred toggle now.
+    guard let pendingId = self.pendingSaveItemId,
+          AppEnvironment.current.currentUser != nil,
+          let item = self.items.first(where: { $0.id == pendingId }) else {
+      self.pendingSaveItemId = nil
+      return
+    }
+
+    self.pendingSaveItemId = nil
+    self.toggleSaved(for: item)
   }
 
   /// Returns a binding to `isSaved` for the item with the given ID.
-  /// If the user is logged out, show login instead of toggling saved.
-  public func isSaved(id: String) -> Binding<Bool> {
+  /// If the user is logged out, save the intended id to save and show login instead.
+  public func isSaved(projectId: String) -> Binding<Bool> {
     Binding(
-      get: { self.items.first(where: { $0.id == id })?.isSaved ?? false },
+      get: { self.items.first(where: { $0.id == projectId })?.isSaved ?? false },
       set: { [weak self] _ in
-        guard let self, let item = self.items.first(where: { $0.id == id }) else { return }
+        guard let self, let item = self.items.first(where: { $0.id == projectId }) else { return }
 
         guard AppEnvironment.current.currentUser != nil else {
+          self.pendingSaveItemId = item.id
           self.showLogin()
+
           return
         }
 

--- a/Library/Sources/Library/Library/ViewModels/VideoFeedViewModel.swift
+++ b/Library/Sources/Library/Library/ViewModels/VideoFeedViewModel.swift
@@ -18,8 +18,10 @@ public protocol VideoFeedViewModelType: AnyObject {
 
   /// Kicks off the initial feed fetch.
   func viewDidLoad()
-  /// Syncs save state and fires any save the user tapped before logging in.
+  /// Syncs save state from the project page cache on return to the feed.
   func viewWillAppear()
+  /// Fires any save the user tapped before logging in.
+  func userSessionStarted()
   /// Optimistically toggles the saved state for a project.
   func toggleSaved(for item: VideoFeedItem)
   /// Returns a binding to the saved state for the given project ID.
@@ -51,7 +53,7 @@ public final class VideoFeedViewModel: VideoFeedViewModelType {
   /// Observed by `VideoFeedViewController` to trigger the error toast on the correct cell.
   public private(set) var saveFailedItemId: String? = nil
 
-  /// Store the item id when a logged-out user taps save. Finishes executing on next `viewWillAppear` if login succeeded.
+  /// Store the item id when a logged-out user taps save. Finishes executing on `userSessionStarted` if login succeeded.
   private var pendingSaveItemId: String? = nil
 
   /// Tracks in-flight watch/unwatch requests.
@@ -71,25 +73,26 @@ public final class VideoFeedViewModel: VideoFeedViewModelType {
 
   /// Called each time the feed reappears.
   /// Reconciles the save button's state for when users save projects from a presented project page (when tapping the CTA).
-  /// Also executes any save action that was deferred, pending login.
   public func viewWillAppear() {
-    if let cache = AppEnvironment.current.cache[KSCache.ksr_projectSaved] as? [Int: Bool] {
-      for index in self.items.indices {
-        if let id = decompose(id: self.items[index].projectId), let cached = cache[id] {
-          let wasSaved = self.items[index].isSaved
-          self.items[index].isSaved = cached
+    guard let cache = AppEnvironment.current.cache[KSCache.ksr_projectSaved] as? [Int: Bool] else { return }
 
-          /// Update the count if the save state changed on the project page.
-          if cached != wasSaved {
-            self.items[index].watchesCount += cached ? 1 : -1
-          }
+    for index in self.items.indices {
+      if let id = decompose(id: self.items[index].projectId), let cached = cache[id] {
+        let wasSaved = self.items[index].isSaved
+
+        self.items[index].isSaved = cached
+
+        /// Update the count if the save state changed on the project page.
+        if cached != wasSaved {
+          self.items[index].watchesCount += cached ? 1 : -1
         }
       }
     }
+  }
 
-    /// If the user logged in after tapping save, execute the deferred toggle now.
-    guard let pendingId = self.pendingSaveItemId,
-          AppEnvironment.current.currentUser != nil,
+  /// Called after login completes. Fires any save that was deferred due to a pending login.
+  public func userSessionStarted() {
+    guard let pendingId = self.pendingSaveItemId, AppEnvironment.current.currentUser != nil,
           let item = self.items.first(where: { $0.id == pendingId }) else {
       self.pendingSaveItemId = nil
       return

--- a/LibraryTests/Library/ViewModels/VideoFeedViewModelTests.swift
+++ b/LibraryTests/Library/ViewModels/VideoFeedViewModelTests.swift
@@ -4,6 +4,7 @@ import GraphAPI
 @testable import KsApiTestHelpers
 @testable import Library
 @testable import LibraryTestHelpers
+import SwiftUI
 import XCTest
 
 final class VideoFeedViewModelTests: TestCase {
@@ -83,7 +84,8 @@ final class VideoFeedViewModelTests: TestCase {
 
     self.vm.toggleSaved(for: item)
 
-    XCTAssert(self.vm.items.first?.isSaved == true)
+    XCTAssertTrue(self.vm.items.first?.isSaved == true)
+    XCTAssertEqual(self.vm.items.first?.watchesCount, 4)
   }
 
   func testToggleSaved_Unwatch_UpdatesIsSaved() async {
@@ -99,7 +101,36 @@ final class VideoFeedViewModelTests: TestCase {
 
     self.vm.toggleSaved(for: item)
 
-    XCTAssert(self.vm.items.first?.isSaved == false)
+    XCTAssertTrue(self.vm.items.first?.isSaved == false)
+    XCTAssertEqual(self.vm.items.first?.watchesCount, 2)
+  }
+
+  func testToggleSaved_WatchesCountIncrementsOptimistically() async {
+    let mockData = Self.mockVideoFeedQueryData(itemCount: 1, isWatched: false)
+
+    await withEnvironment(apiService: MockService(fetchGraphQLResponses: [(VideoFeedQuery.self, mockData)])) {
+      await self.vm.fetchVideoFeed()
+    }
+
+    let item = try! XCTUnwrap(self.vm.items.first)
+    let originalCount = item.watchesCount
+
+    self.vm.toggleSaved(for: item)
+    XCTAssertEqual(self.vm.items.first?.watchesCount, originalCount + 1, "Count should increment on save.")
+  }
+
+  func testToggleSaved_WatchesCountDecrementsOptimistically() async {
+    let mockData = Self.mockVideoFeedQueryData(itemCount: 1, isWatched: true)
+
+    await withEnvironment(apiService: MockService(fetchGraphQLResponses: [(VideoFeedQuery.self, mockData)])) {
+      await self.vm.fetchVideoFeed()
+    }
+
+    let item = try! XCTUnwrap(self.vm.items.first)
+    let originalCount = item.watchesCount
+
+    self.vm.toggleSaved(for: item)
+    XCTAssertEqual(self.vm.items.first?.watchesCount, originalCount - 1, "Count should decrement on unsave.")
   }
 
   func testToggleSaved_OnlyAffectsSelectItems() async {
@@ -126,6 +157,49 @@ final class VideoFeedViewModelTests: TestCase {
     }
 
     XCTAssertTrue(self.vm.items.allSatisfy { $0.isSaved })
+  }
+
+  func testViewWillAppear_UpdateSave_WhenLoggedIn() async {
+    let mockData = Self.mockVideoFeedQueryData(itemCount: 1, isWatched: false)
+
+    await withEnvironment(apiService: MockService(fetchGraphQLResponses: [(VideoFeedQuery.self, mockData)])) {
+      await self.vm.fetchVideoFeed()
+    }
+
+    let item = try! XCTUnwrap(self.vm.items.first)
+
+    /// Simulate logged-out save tap
+    withEnvironment(currentUser: nil) {
+      let binding = self.vm.isSaved(projectId: item.id)
+      binding.wrappedValue = true
+    }
+
+    XCTAssertEqual(self.vm.items.first?.isSaved, false, "Should not have saved yet. user was logged out.")
+
+    /// Simulate login and return to feed.
+    withEnvironment(currentUser: .template) {
+      self.vm.viewWillAppear()
+    }
+
+    XCTAssertTrue(self.vm.items.first?.isSaved == true, "Should have saved after logging in.")
+    XCTAssertEqual(self.vm.items.first?.watchesCount, 4, "Count should increment after deferred save fires.")
+
+    /// Same flow but staying logged out.
+    let vm2 = VideoFeedViewModel()
+
+    await withEnvironment(apiService: MockService(fetchGraphQLResponses: [(VideoFeedQuery.self, mockData)])) {
+      await vm2.fetchVideoFeed()
+    }
+
+    let item2 = try! XCTUnwrap(vm2.items.first)
+
+    withEnvironment(currentUser: nil) {
+      let binding = vm2.isSaved(projectId: item2.id)
+      binding.wrappedValue = true
+      vm2.viewWillAppear()
+    }
+
+    XCTAssertEqual(vm2.items.first?.isSaved, false, "Should not save if user is still logged out.")
   }
 
   // MARK: - Helpers

--- a/LibraryTests/Library/ViewModels/VideoFeedViewModelTests.swift
+++ b/LibraryTests/Library/ViewModels/VideoFeedViewModelTests.swift
@@ -178,7 +178,7 @@ final class VideoFeedViewModelTests: TestCase {
 
     /// Simulate login and return to feed.
     withEnvironment(currentUser: .template) {
-      self.vm.viewWillAppear()
+      self.vm.userSessionStarted()
     }
 
     XCTAssertTrue(self.vm.items.first?.isSaved == true, "Should have saved after logging in.")
@@ -196,7 +196,8 @@ final class VideoFeedViewModelTests: TestCase {
     withEnvironment(currentUser: nil) {
       let binding = vm2.isSaved(projectId: item2.id)
       binding.wrappedValue = true
-      vm2.viewWillAppear()
+
+      vm2.userSessionStarted()
     }
 
     XCTAssertEqual(vm2.items.first?.isSaved, false, "Should not save if user is still logged out.")


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

A batch of fixes to the video feed covering playback lifecycle and save state updates post login.

# 🤔 Why

Covering the last few issues found from QA in one PR:
- Backgrounding the app didn't pause audio, and foregrounding didn't resume it
- Dismissing the feed left the video paused with no way to auto resume playback on reopen
- Tapping save while logged out, logging in, then returning to the feed didn't
  reflect the save action or update the count

# 🛠 How

**Background/foreground**
 `pausePlayback` and `startPlayback` now go through `playbackState` so state stays current. Foreground resume calls
`activateCurrentPageCell` instead of `resumePlayback` to avoid the `isPlaying` guard blocking it.

**Reopen autoplay**
the feed VC is now retained across opens so nothing resets. `viewWillAppear` kicks off `activateCurrentPageCell` so that the current cell resumes on reopen.

**Deferred save after login**
the VM saves the intended save action when a logged-out user taps save, then fires it in `viewWillAppear` once they're logged in. The VC listens for `ksr_sessionStarted` to immediately re-render the active cell so the icon and count update right away.

# 👀 See

Trello, screenshots, external resources?

| Before 🐛 | After 🦋 |
| --- | --- |
|  |  |

# ✅ Acceptance criteria

- [x] Slow drag between two videos: only one plays audio at a time
- [x] Rapid scrolling: incoming cell audio doesn't bleed before it settles
- [x] Background app mid-video: audio stops. Foreground: resumes.
- [x] Dismiss feed, reopen: video autoplays
- [x] Tap save logged out, login, return to feed: icon and count reflect the save
- [x] Tap save logged out, dismiss login without logging in: no change to icon or count
- [x] First video in feed autoplays on cold open every time
- [x] Tap CTA, project page, dismiss: video resumes, play button not shown
