### PR TITLE
Video Feed: Creator Icon Fix

### DIFF
--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Overlay/FundedPercentageCircleView.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Overlay/FundedPercentageCircleView.swift
@@ -6,7 +6,7 @@ import SwiftUI
 /// The circle animates from 0% up to the target `fundedPercent` when the view appears.
 struct FundedPercentageCircleView: View {
   private enum Constants {
-    static let size: CGFloat = 40
+    static let baseSize: CGFloat = 40
     static let lineWidth: CGFloat = 6
     static let animationDuration: Double = 1.25
     static let innerCircleOpacity: Double = 0.3
@@ -19,6 +19,7 @@ struct FundedPercentageCircleView: View {
   var animationDisabled: Bool = false
 
   @State private var animatedProgress: Double
+  @ScaledMetric private var size: CGFloat = Constants.baseSize
 
   /// SwiftUI's `@State` initializes before `onAppear` fires, so we need a custom init so that
   /// the snapshot tests can capture a filled in circle.
@@ -37,7 +38,7 @@ struct FundedPercentageCircleView: View {
       self.FilledCircle
       self.PercentFundedAmount
     }
-    .frame(width: Constants.size, height: Constants.size)
+    .frame(width: self.size, height: self.size)
     .onAppear {
       guard UIView.areAnimationsEnabled else { return }
 
@@ -91,10 +92,13 @@ struct FundedPercentageCircleView: View {
       }
     } else {
       Text("\(self.fundedPercent)")
-        .font(Font(UIFont.ksr_caption1()).bold())
+        .font(Font(UIFont.ksr_caption1()))
+        .bold()
         .foregroundColor(Color(Colors.Text.light.uiColor()))
         .monospacedDigit()
         .lineLimit(1)
+        .minimumScaleFactor(0.5)
+        .padding(Constants.lineWidth)
     }
   }
 }

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Overlay/VideoFeedRightRailView.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Overlay/VideoFeedRightRailView.swift
@@ -1,4 +1,5 @@
 import KDS
+import Kingfisher
 import Library
 import SwiftUI
 
@@ -36,7 +37,7 @@ struct VideoFeedRightRailView: View {
 
   private var creatorAvatar: some View {
     Button(action: { self.onCreatorTapped?() }) {
-      self.avatarPlaceholder
+      self.avatarImage
         .frame(width: Constants.avatarSize, height: Constants.avatarSize)
         .clipShape(Circle())
     }
@@ -44,14 +45,19 @@ struct VideoFeedRightRailView: View {
   }
 
   @ViewBuilder
-  private var avatarPlaceholder: some View {
-    if let image = Library.image(named: Constants.avatarPlaceholderIcon) {
-      Image(uiImage: image)
-        .resizable()
-        .scaledToFill()
-    } else {
-      Color(Colors.Text.placeholder.uiColor())
-    }
+  private var avatarImage: some View {
+    KFImage(self.item.creatorImageURL)
+      .placeholder {
+        if let image = Library.image(named: Constants.avatarPlaceholderIcon) {
+          Image(uiImage: image)
+            .resizable()
+            .scaledToFill()
+        } else {
+          Color(Colors.Text.placeholder.uiColor())
+        }
+      }
+      .resizable()
+      .scaledToFill()
   }
 
   private var saveButton: some View {


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Makes sure the creator avatar image url is being used, but reverts to a placeholder if it isn't available

# 🛠 How

The code was already setup for this, I just forgot to update the current placeholder implementation

# ✅ Acceptance criteria

- [x] The correct creator avatar image is used
- [x] The placeholder image is used if the actual image is unavailable
