### PR TITLE
CHECK-213: Update Statsig SDK keys

### DIFF
--- a/Configs/Secrets.swift.example
+++ b/Configs/Secrets.swift.example
@@ -43,5 +43,7 @@ public enum Secrets {
   public enum Statsig {
     public static let production = "client-production"
     public static let staging = "client-staging"
+    public static let development = "client-development"
+    public static let sandbox = "client-sandbox"
   }
 }

--- a/Experimentation/Sources/Experimentation/StatsigClient.swift
+++ b/Experimentation/Sources/Experimentation/StatsigClient.swift
@@ -8,10 +8,14 @@ public let StatsigLoadedNotification = NSNotification.Name("StatsigClientDataRel
 ///
 /// See Statsig's documentation: https://docs.statsig.com/guides/using-environments
 public enum StatsigClientSDKKey {
-  /// An SDK key which will be sent to the Staging tier of Statsig.
-  case staging(String)
   /// An SDK key which will be sent to the Production tier of Statsig
-  case production(String)
+  case productionTier(String)
+
+  /// An SDK key which will be sent to the Staging tier of Statsig.
+  case stagingTier(String)
+
+  /// An SDK key which will be sent to the Development tier of Statsig.
+  case developmentTier(String)
 }
 
 /// A thin wrapper around the Statsig class `StatsigClient`.
@@ -23,12 +27,15 @@ public final class StatsigWrapper: StatsigClientType {
     let tier: StatsigEnvironment.EnvironmentTier
 
     switch sdkKey {
-    case let .production(prodKey):
+    case let .productionTier(prodKey):
       key = prodKey
       tier = .Production
-    case let .staging(stagingKey):
+    case let .stagingTier(stagingKey):
       key = stagingKey
       tier = .Staging
+    case let .developmentTier(devKey):
+      key = devKey
+      tier = .Development
     }
 
     let client = StatsigClient(

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/AppDelegateViewModel.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/AppDelegateViewModel.swift
@@ -559,11 +559,7 @@ public final class AppDelegateViewModel: AppDelegateViewModelType, AppDelegateVi
 
     self.configureStatsig = self.applicationLaunchOptionsProperty.signal.ignoreValues()
       .map { _ in
-        if AppEnvironment.current.mainBundle.isRelease {
-          return .production(Secrets.Statsig.production)
-        } else {
-          return .staging(Secrets.Statsig.staging)
-        }
+        statsigSDKKey()
       }
 
     self.setApplicationShortcutItems = currentUserEvent
@@ -1345,4 +1341,18 @@ private struct ProjectDeepLink {
       // This one is already in its own nav controller, `RewardPledgeNavigationController`
       .merge(with: fixErroredPledgeLink.map { $0 as UINavigationController })
   }
+}
+
+private func statsigSDKKey() -> StatsigClientSDKKey {
+  let mainBundle = AppEnvironment.current.mainBundle
+
+  if mainBundle.isRelease {
+    return .productionTier(Secrets.Statsig.production)
+  } else if mainBundle.isBeta {
+    return .stagingTier(Secrets.Statsig.staging)
+  } else if mainBundle.isDebug {
+    return .developmentTier(Secrets.Statsig.development)
+  }
+
+  return .stagingTier(Secrets.Statsig.sandbox)
 }


### PR DESCRIPTION
# 📲 What

Updates Statsig SDK keys to take advantage of environment tiers.

This PR adds keys that point to Statsig's "development" and "staging" environment tiers. This tags data on the _production_ Statsig project as _pre-production_ data. 

I also renamed the `StatsigSDKClientKey` enum types for clarity (e.g. from `staging` to `stagingTier`). 

# 🤔 Why

By using [Statsig's environment tiers](https://docs.statsig.com/guides/using-environments) feature, we can test the _production_ copy of our Statsig experiments, instead of the copy on the "staging" project. This reduces developer effort, and makes our beta testing more reliable.
