### PR TITLE
[DISC-164] Video Feed Analytics

### DIFF
--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Cell/VideoFeedCell.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Cell/VideoFeedCell.swift
@@ -239,6 +239,8 @@ final class VideoFeedCell: UICollectionViewCell, ValueCell {
 
   /// Tapping anywhere on the cell toggles playback.
   @objc private func cellTapped() {
+    guard self.playbackState.isVideoReady else { return }
+
     if self.playbackState.isPlaying {
       self.playbackState.pause()
       self.onEvent?(.pauseTapped)

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Cell/VideoFeedCell.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Cell/VideoFeedCell.swift
@@ -23,16 +23,20 @@ final class VideoFeedCell: UICollectionViewCell, ValueCell {
     static let toastTopGap: CGFloat = 8
   }
 
-  var onCloseTapped: (() -> Void)?
-  var onCreatorTapped: (() -> Void)?
-  var onShareTapped: (() -> Void)?
-  var onMoreTapped: (() -> Void)?
-  var onCTATapped: (() -> Void)?
-  var onVideoReady: (() -> Void)?
-  var onVideoFailed: (() -> Void)?
-  var onPauseTapped: (() -> Void)?
-  var onResumeTapped: (() -> Void)?
-  var onProgressBarTapped: ((Float) -> Void)?
+  enum Event {
+    case closeTapped
+    case creatorTapped
+    case shareTapped
+    case moreTapped
+    case ctaTapped
+    case videoReady
+    case videoFailed
+    case pauseTapped
+    case resumeTapped
+    case progressBarTapped(Float)
+  }
+
+  var onEvent: ((Event) -> Void)?
 
   private(set) var currentItemId: String?
 
@@ -75,16 +79,7 @@ final class VideoFeedCell: UICollectionViewCell, ValueCell {
 
   override func prepareForReuse() {
     super.prepareForReuse()
-    self.onCloseTapped = nil
-    self.onCreatorTapped = nil
-    self.onShareTapped = nil
-    self.onMoreTapped = nil
-    self.onCTATapped = nil
-    self.onVideoReady = nil
-    self.onVideoFailed = nil
-    self.onPauseTapped = nil
-    self.onResumeTapped = nil
-    self.onProgressBarTapped = nil
+    self.onEvent = nil
     self.currentItemId = nil
     self.resetToasts()
     self.playbackState.reset()
@@ -107,12 +102,12 @@ final class VideoFeedCell: UICollectionViewCell, ValueCell {
         item: item,
         playbackState: self.playbackState,
         videoPlayer: self.videoPlayer,
-        onCloseTapped: { [weak self] in self?.onCloseTapped?() },
-        onCreatorTapped: { [weak self] in self?.onCreatorTapped?() },
-        onShareTapped: { [weak self] in self?.onShareTapped?() },
-        onMoreTapped: { [weak self] in self?.onMoreTapped?() },
+        onCloseTapped: { [weak self] in self?.onEvent?(.closeTapped) },
+        onCreatorTapped: { [weak self] in self?.onEvent?(.creatorTapped) },
+        onShareTapped: { [weak self] in self?.onEvent?(.shareTapped) },
+        onMoreTapped: { [weak self] in self?.onEvent?(.moreTapped) },
         onCTATapped: { [weak self] in self?.ctaTapped() },
-        onProgressBarTapped: { [weak self] progress in self?.onProgressBarTapped?(progress) }
+        onProgressBarTapped: { [weak self] progress in self?.onEvent?(.progressBarTapped(progress)) }
       )
     }
     .margins(.all, 0)
@@ -120,7 +115,7 @@ final class VideoFeedCell: UICollectionViewCell, ValueCell {
 
   func ctaTapped() {
     self.playbackState.pause()
-    self.onCTATapped?()
+    self.onEvent?(.ctaTapped)
   }
 
   // MARK: - Video Playback
@@ -223,14 +218,14 @@ final class VideoFeedCell: UICollectionViewCell, ValueCell {
     self.videoPlayer.onVideoReady = { [weak self] in
       guard let self else { return }
       self.playbackState.videoDidBecomeReady()
-      self.onVideoReady?()
+      self.onEvent?(.videoReady)
     }
 
     self.videoPlayer.onVideoFailed = { [weak self] in
       guard let self else { return }
       self.playbackState.videoDidFail()
       self.showVideoErrorToast()
-      self.onVideoFailed?()
+      self.onEvent?(.videoFailed)
     }
   }
 
@@ -246,10 +241,10 @@ final class VideoFeedCell: UICollectionViewCell, ValueCell {
   @objc private func cellTapped() {
     if self.playbackState.isPlaying {
       self.playbackState.pause()
-      self.onPauseTapped?()
+      self.onEvent?(.pauseTapped)
     } else {
       self.playbackState.resume()
-      self.onResumeTapped?()
+      self.onEvent?(.resumeTapped)
     }
   }
 }

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Cell/VideoFeedCell.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Cell/VideoFeedCell.swift
@@ -28,10 +28,10 @@ final class VideoFeedCell: UICollectionViewCell, ValueCell {
   var onShareTapped: (() -> Void)?
   var onMoreTapped: (() -> Void)?
   var onCTATapped: (() -> Void)?
-  /// Called once the video is ready to play.
   var onVideoReady: (() -> Void)?
-  /// Called when the video fails to load or play.
   var onVideoFailed: (() -> Void)?
+  var onPauseTapped: (() -> Void)?
+  var onResumeTapped: (() -> Void)?
 
   private(set) var currentItemId: String?
 
@@ -81,6 +81,8 @@ final class VideoFeedCell: UICollectionViewCell, ValueCell {
     self.onCTATapped = nil
     self.onVideoReady = nil
     self.onVideoFailed = nil
+    self.onPauseTapped = nil
+    self.onResumeTapped = nil
     self.currentItemId = nil
     self.resetToasts()
     self.playbackState.reset()
@@ -228,8 +230,10 @@ final class VideoFeedCell: UICollectionViewCell, ValueCell {
   @objc private func cellTapped() {
     if self.playbackState.isPlaying {
       self.playbackState.pause()
+      self.onPauseTapped?()
     } else {
       self.playbackState.resume()
+      self.onResumeTapped?()
     }
   }
 }

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Cell/VideoFeedCell.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Cell/VideoFeedCell.swift
@@ -146,11 +146,15 @@ final class VideoFeedCell: UICollectionViewCell, ValueCell {
 
   /// Duration of the current video in milliseconds
   var currentVideoDurationMs: Int? {
-    guard let duration = self.videoPlayer.player.currentItem?.duration, duration.isNumeric,
+    guard let duration = self.videoPlayer.player.currentItem?.duration,
+          duration.isNumeric,
           duration.seconds > 0
     else { return nil }
-
     return Int(duration.seconds * 1_000)
+  }
+
+  var watchTimeMs: Int {
+    self.videoPlayer.watchTimeMs
   }
 
   // MARK: - Toast View

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Cell/VideoFeedCell.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Cell/VideoFeedCell.swift
@@ -144,6 +144,15 @@ final class VideoFeedCell: UICollectionViewCell, ValueCell {
     self.playbackState.pause()
   }
 
+  /// Duration of the current video in milliseconds
+  var currentVideoDurationMs: Int? {
+    guard let duration = self.videoPlayer.player.currentItem?.duration, duration.isNumeric,
+          duration.seconds > 0
+    else { return nil }
+
+    return Int(duration.seconds * 1_000)
+  }
+
   // MARK: - Toast View
 
   private func resetToasts() {

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Cell/VideoFeedCell.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Cell/VideoFeedCell.swift
@@ -32,6 +32,7 @@ final class VideoFeedCell: UICollectionViewCell, ValueCell {
   var onVideoFailed: (() -> Void)?
   var onPauseTapped: (() -> Void)?
   var onResumeTapped: (() -> Void)?
+  var onProgressBarTapped: ((Float) -> Void)?
 
   private(set) var currentItemId: String?
 
@@ -83,6 +84,7 @@ final class VideoFeedCell: UICollectionViewCell, ValueCell {
     self.onVideoFailed = nil
     self.onPauseTapped = nil
     self.onResumeTapped = nil
+    self.onProgressBarTapped = nil
     self.currentItemId = nil
     self.resetToasts()
     self.playbackState.reset()
@@ -109,7 +111,8 @@ final class VideoFeedCell: UICollectionViewCell, ValueCell {
         onCreatorTapped: { [weak self] in self?.onCreatorTapped?() },
         onShareTapped: { [weak self] in self?.onShareTapped?() },
         onMoreTapped: { [weak self] in self?.onMoreTapped?() },
-        onCTATapped: { [weak self] in self?.ctaTapped() }
+        onCTATapped: { [weak self] in self?.ctaTapped() },
+        onProgressBarTapped: { [weak self] progress in self?.onProgressBarTapped?(progress) }
       )
     }
     .margins(.all, 0)

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Controller/VideoFeedViewController.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Controller/VideoFeedViewController.swift
@@ -429,7 +429,21 @@ extension VideoFeedViewController: UICollectionViewDelegateFlowLayout {
 
     let currentPage = Int(round(self.collectionView.contentOffset.y / pageHeight))
 
-    self.viewModel.trackPageViewed(atIndex: currentPage)
+    /// The departing cell is the one still partially on-screen that the user swiped away from.
+    /// It hasn't been recycled yet so we can still read its watch time and duration.
+    let departingCell = self.collectionView.visibleCells
+      .compactMap { $0 as? VideoFeedCell }
+      .first { cell in
+        guard let indexPath = self.collectionView.indexPath(for: cell) else { return false }
+
+        return indexPath.item != currentPage
+      }
+
+    self.viewModel.trackPageViewed(
+      atIndex: currentPage,
+      totalWatchTimeMs: departingCell?.watchTimeMs ?? 0,
+      totalVideoDurationMs: departingCell?.currentVideoDurationMs ?? 0
+    )
     self.activateCurrentPageCell()
   }
 
@@ -457,7 +471,6 @@ extension VideoFeedViewController: UICollectionViewDelegateFlowLayout {
     let positionInSession = pageHeight > 0
       ? Int(round(self.collectionView.contentOffset.y / pageHeight))
       : 0
-
     self.viewModel.trackProgressBarTapped(
       item: item,
       positionInSession: positionInSession,

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Controller/VideoFeedViewController.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Controller/VideoFeedViewController.swift
@@ -357,9 +357,21 @@ extension VideoFeedViewController: UICollectionViewDelegateFlowLayout {
 
     cell.onCloseTapped = { [weak self] in self?.dismiss(animated: true) }
     cell.onCreatorTapped = { [weak self] in self?.goToCreatorProfile(for: item) }
-    cell.onShareTapped = { [weak self] in self?.simpleAlert(title: "Share") }
+    cell.onShareTapped = { [weak self] in
+      self?.simpleAlert(title: "Share")
+      self?.viewModel.trackCTAClicked(ctaContext: .videoFeedShare, item: item)
+    }
     cell.onMoreTapped = { [weak self] in self?.simpleAlert(title: "More") }
     cell.onCTATapped = { [weak self] in self?.goToProjectPage(for: item) }
+    cell.onPauseTapped = { [weak self] in
+      self?.viewModel.trackCTAClicked(ctaContext: .videoFeedPause, item: item)
+    }
+    cell.onResumeTapped = { [weak self] in
+      self?.viewModel.trackCTAClicked(ctaContext: .videoFeedPlay, item: item)
+    }
+    cell.onProgressBarTapped = { [weak self] percentageWatched in
+      self?.trackProgressBarTapped(item: item, percentageWatched: percentageWatched)
+    }
 
     cell.configureWith(
       item: Binding(
@@ -439,6 +451,19 @@ extension VideoFeedViewController: UICollectionViewDelegateFlowLayout {
   }
 
   // MARK: - Helpers
+
+  private func trackProgressBarTapped(item: VideoFeedItem, percentageWatched: Float) {
+    let pageHeight = self.collectionView.bounds.height
+    let positionInSession = pageHeight > 0
+      ? Int(round(self.collectionView.contentOffset.y / pageHeight))
+      : 0
+
+    self.viewModel.trackProgressBarTapped(
+      item: item,
+      positionInSession: positionInSession,
+      percentageWatched: percentageWatched
+    )
+  }
 
   private func simpleAlert(title: String) {
     let alert = UIAlertController(title: title, message: "", preferredStyle: .alert)

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Controller/VideoFeedViewController.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Controller/VideoFeedViewController.swift
@@ -411,6 +411,13 @@ extension VideoFeedViewController: UICollectionViewDelegateFlowLayout {
     guard !scrollView.isDragging else { return }
 
     self.isScrolling = false
+
+    let pageHeight = self.collectionView.bounds.height
+    guard pageHeight > 0 else { return }
+
+    let currentPage = Int(round(self.collectionView.contentOffset.y / pageHeight))
+
+    self.viewModel.trackPageViewed(atIndex: currentPage)
     self.activateCurrentPageCell()
   }
 

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Controller/VideoFeedViewController.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Controller/VideoFeedViewController.swift
@@ -357,22 +357,30 @@ extension VideoFeedViewController: UICollectionViewDelegateFlowLayout {
 
     let item = items[indexPath.item]
 
-    cell.onCloseTapped = { [weak self] in self?.dismiss(animated: true) }
-    cell.onCreatorTapped = { [weak self] in self?.goToCreatorProfile(for: item) }
-    cell.onShareTapped = { [weak self] in
-      self?.simpleAlert(title: "Share")
-      self?.viewModel.trackCTAClicked(ctaContext: .videoFeedShare, item: item)
-    }
-    cell.onMoreTapped = { [weak self] in self?.simpleAlert(title: "More") }
-    cell.onCTATapped = { [weak self] in self?.goToProjectPage(for: item) }
-    cell.onPauseTapped = { [weak self] in
-      self?.viewModel.trackCTAClicked(ctaContext: .videoFeedPause, item: item)
-    }
-    cell.onResumeTapped = { [weak self] in
-      self?.viewModel.trackCTAClicked(ctaContext: .videoFeedPlay, item: item)
-    }
-    cell.onProgressBarTapped = { [weak self] percentageWatched in
-      self?.trackProgressBarTapped(item: item, percentageWatched: percentageWatched)
+    cell.onEvent = { [weak self] event in
+      guard let self else { return }
+
+      switch event {
+      case .closeTapped:
+        self.dismiss(animated: true)
+      case .creatorTapped:
+        self.goToCreatorProfile(for: item)
+      case .shareTapped:
+        self.simpleAlert(title: "Share")
+        self.viewModel.trackCTAClicked(ctaContext: .videoFeedShare, item: item)
+      case .moreTapped:
+        self.simpleAlert(title: "More")
+      case .ctaTapped:
+        self.goToProjectPage(for: item)
+      case .pauseTapped:
+        self.viewModel.trackCTAClicked(ctaContext: .videoFeedPause, item: item)
+      case .resumeTapped:
+        self.viewModel.trackCTAClicked(ctaContext: .videoFeedPlay, item: item)
+      case let .progressBarTapped(percentageWatched):
+        self.trackProgressBarTapped(item: item, percentageWatched: percentageWatched)
+      case .videoReady, .videoFailed:
+        break
+      }
     }
 
     cell.configureWith(
@@ -387,8 +395,6 @@ extension VideoFeedViewController: UICollectionViewDelegateFlowLayout {
       cell.loadVideo(url: url)
     }
 
-    /// Prefetch the next cell's preview image so it's ready before the user swipes.
-    /// Cancel any in-flight prefetching first so rapid scrolling doesn't queue up old requests.
     let nextIndex = indexPath.item + 1
 
     self.previewImagePrefetcher?.stop()

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Controller/VideoFeedViewController.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Controller/VideoFeedViewController.swift
@@ -25,6 +25,7 @@ final class VideoFeedViewController: UIViewController {
   private var lifecycleObservers: [any NSObjectProtocol] = []
   private var previewImagePrefetcher: ImagePrefetcher?
   private var isScrolling = false
+  private var currentPageIndex: Int = 0
 
   /// Called once the first batch of items has loaded and the feed is ready to present.
   var onReadyToPresent: (() -> Void)?
@@ -190,6 +191,7 @@ final class VideoFeedViewController: UIViewController {
 
   /// Reloads the collection view with a fresh set of fetched items.
   private func updateFeedWithFetchedItems(_ newItems: [VideoFeedItem]) {
+    self.currentPageIndex = 0
     self.dataSource.load(newItems)
     self.collectionView.reloadData()
 
@@ -427,23 +429,22 @@ extension VideoFeedViewController: UICollectionViewDelegateFlowLayout {
     let pageHeight = self.collectionView.bounds.height
     guard pageHeight > 0 else { return }
 
-    let currentPage = Int(round(self.collectionView.contentOffset.y / pageHeight))
+    let newPageIndex = Int(round(self.collectionView.contentOffset.y / pageHeight))
 
-    /// The departing cell is the one still partially on-screen that the user swiped away from.
-    /// It hasn't been recycled yet so we can still read its watch time and duration.
+    /// Look up the departing cell directly by the last known page index.
     let departingCell = self.collectionView.visibleCells
       .compactMap { $0 as? VideoFeedCell }
-      .first { cell in
-        guard let indexPath = self.collectionView.indexPath(for: cell) else { return false }
-
-        return indexPath.item != currentPage
+      .first {
+        self.collectionView.indexPath(for: $0)?.item == self.currentPageIndex
       }
 
     self.viewModel.trackPageViewed(
-      atIndex: currentPage,
+      atIndex: newPageIndex,
       totalWatchTimeMs: departingCell?.watchTimeMs ?? 0,
       totalVideoDurationMs: departingCell?.currentVideoDurationMs ?? 0
     )
+
+    self.currentPageIndex = newPageIndex
     self.activateCurrentPageCell()
   }
 

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Overlay/VideoFeedBottomOverlayView.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Overlay/VideoFeedBottomOverlayView.swift
@@ -18,6 +18,7 @@ struct VideoFeedBottomOverlayView: View {
   let item: VideoFeedItem
   let videoPlayer: VideoFeedVideoPlayer
   var onCTATapped: (() -> Void)?
+  var onProgressBarTapped: ((Float) -> Void)?
 
   var body: some View {
     VStack(alignment: .leading, spacing: Constants.contentSpacing) {
@@ -87,7 +88,7 @@ struct VideoFeedBottomOverlayView: View {
   }
 
   private var progressBar: some View {
-    VideoFeedProgressBarView(player: self.videoPlayer)
+    VideoFeedProgressBarView(player: self.videoPlayer, onProgressBarTapped: self.onProgressBarTapped)
       .padding(.top, Constants.progressTopPadding)
   }
 }

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Overlay/VideoFeedOverlayView.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Overlay/VideoFeedOverlayView.swift
@@ -44,6 +44,7 @@ struct VideoFeedOverlayView: View {
   var onShareTapped: (() -> Void)?
   var onMoreTapped: (() -> Void)?
   var onCTATapped: (() -> Void)?
+  var onProgressBarTapped: ((Float) -> Void)?
 
   var body: some View {
     ZStack(alignment: .bottom) {
@@ -75,7 +76,8 @@ struct VideoFeedOverlayView: View {
         VideoFeedBottomOverlayView(
           item: self.item,
           videoPlayer: self.videoPlayer,
-          onCTATapped: self.onCTATapped
+          onCTATapped: self.onCTATapped,
+          onProgressBarTapped: self.onProgressBarTapped
         )
         .frame(maxWidth: .infinity, alignment: .leading)
       }

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Overlay/VideoFeedProgressBarView.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Overlay/VideoFeedProgressBarView.swift
@@ -11,6 +11,7 @@ struct VideoFeedProgressBarView: View {
   }
 
   let player: VideoFeedVideoPlayer
+  var onProgressBarTapped: ((Float) -> Void)?
 
   @State private var isScrubbing = false
   @State private var scrubProgress: Double = 0
@@ -55,6 +56,8 @@ struct VideoFeedProgressBarView: View {
           }
           .onEnded { value in
             self.scrubProgress = min(max(value.location.x / geo.size.width, 0), 1)
+
+            self.onProgressBarTapped?(Float(self.scrubProgress))
 
             self.player.seek(to: self.scrubProgress) { success in
               /// If Seek failed. Revert video back to where it was.

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/VideoPlayer/VideoFeedVideoPlayer.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/VideoPlayer/VideoFeedVideoPlayer.swift
@@ -9,6 +9,9 @@ class VideoFeedVideoPlayer {
   // MARK: - Outputs
 
   private(set) var progress: Double = 0
+  /// Total watch time in milliseconds. Excludes paused intervals.
+  /// Resets when the player stops. Does not reset on scrub.
+  private(set) var watchTimeMs: Int = 0
 
   var isPlaying: Bool { self.player.rate > 0 }
   let player = AVPlayer()
@@ -123,6 +126,7 @@ class VideoFeedVideoPlayer {
     self.player.replaceCurrentItem(with: nil)
 
     self.progress = 0
+    self.watchTimeMs = 0
 
     self.hasFiredOnReady = false
     self.hasFiredOnFailed = false
@@ -165,6 +169,11 @@ class VideoFeedVideoPlayer {
       if !self.hasFiredOnReady, time.seconds > 0 {
         self.hasFiredOnReady = true
         self.onVideoReady?()
+      }
+
+      /// Watch time only while playing (rate > 0 means not paused).
+      if self.player.rate > 0 {
+        self.watchTimeMs = Int(time.seconds * 1_000)
       }
 
       self.progress = time.seconds / duration.seconds

--- a/Library/Sources/Library/Library/Tracking/KSRAnalytics.swift
+++ b/Library/Sources/Library/Library/Tracking/KSRAnalytics.swift
@@ -76,6 +76,7 @@ public final class KSRAnalytics {
     case thanks // ThanksViewController
     case twoFactorAuth = "two_factor_auth" // TwoFactorViewController
     case updatePledge = "update_pledge" // PledgeViewController
+    case videoFeed = "video_feed" // VideoFeedViewController
   }
 
   /// Determines the authentication type for login or signup events.
@@ -189,6 +190,11 @@ public final class KSRAnalytics {
     case signUpSubmit
     case surveyResponseInitiate
     case toggleRewardReceived
+    case videoFeedPlay
+    case videoFeedPause
+    case videoFeedSave
+    case videoFeedShare
+    case videoFeedProgressBar
     case watchProject
     /// Onboarding CTA Context
     case onboardingClose
@@ -239,6 +245,11 @@ public final class KSRAnalytics {
       case .signUpSubmit: return "sign_up_submit"
       case .surveyResponseInitiate: return "survey_response_initiate"
       case .toggleRewardReceived: return "toggle_reward_received"
+      case .videoFeedPlay: return "video_feed_play"
+      case .videoFeedPause: return "video_feed_pause"
+      case .videoFeedSave: return "video_feed_save"
+      case .videoFeedShare: return "video_feed_share"
+      case .videoFeedProgressBar: return "video_feed_progress_bar"
       case .watchProject: return "watch_project"
       }
     }
@@ -516,6 +527,7 @@ public final class KSRAnalytics {
     case globalNav
     case recommendations
     case searchResults
+    case videoFeed
 
     var trackingString: String {
       switch self {
@@ -527,6 +539,7 @@ public final class KSRAnalytics {
       case .globalNav: return "global_nav"
       case .recommendations: return "recommendations"
       case .searchResults: return "search_results"
+      case .videoFeed: return "video_feed"
       }
     }
   }

--- a/Library/Sources/Library/Library/Tracking/KSRAnalytics.swift
+++ b/Library/Sources/Library/Library/Tracking/KSRAnalytics.swift
@@ -1435,6 +1435,44 @@ public final class KSRAnalytics {
     return props.withAllValuesFrom(["login_intent": intent.trackingString])
   }
 
+  // MARK: - VideoFeed Events
+
+  /// Call when a video becomes the actively visible item, including on first load.
+  public func trackVideoFeedImpression(
+    videoId: String,
+    projectId: String,
+    positionInSession: Int
+  ) {
+    var props = contextProperties(page: .videoFeed, locationContext: .videoFeed)
+
+    props["video_feed_video_id"] = videoId
+    props["video_feed_project_id"] = projectId
+    props["video_feed_position_in_session"] = positionInSession
+
+    self.track(event: SegmentEvent.pageViewed.rawValue, properties: props)
+  }
+
+  /// Call when the user swipes to a new video.
+  public func trackVideoFeedSwipe(
+    videoId: String,
+    projectId: String,
+    positionInSession: Int,
+    fromVideoId: String,
+    totalWatchTimeMs: Int,
+    totalVideoDurationMs: Int
+  ) {
+    var props = contextProperties(page: .videoFeed, locationContext: .videoFeed)
+
+    props["video_feed_video_id"] = videoId
+    props["video_feed_project_id"] = projectId
+    props["video_feed_position_in_session"] = positionInSession
+    props["video_feed_from_video_id"] = fromVideoId
+    props["video_feed_total_watch_time"] = totalWatchTimeMs
+    props["video_feed_total_video_duration"] = totalVideoDurationMs
+
+    self.track(event: SegmentEvent.pageViewed.rawValue, properties: props)
+  }
+
   // MARK: - Onboarding Events
 
   /**

--- a/Library/Sources/Library/Library/Tracking/KSRAnalytics.swift
+++ b/Library/Sources/Library/Library/Tracking/KSRAnalytics.swift
@@ -1473,6 +1473,37 @@ public final class KSRAnalytics {
     self.track(event: SegmentEvent.pageViewed.rawValue, properties: props)
   }
 
+  /// Call when the user taps play, pause, save, or share in the video feed.
+  public func trackVideoFeedCTAClicked(
+    ctaContext: CTAContext,
+    videoId: String,
+    projectId: String
+  ) {
+    var props = contextProperties(ctaContext: ctaContext, page: .videoFeed)
+
+    props["video_feed_video_id"] = videoId
+    props["video_feed_project_id"] = projectId
+
+    self.track(event: SegmentEvent.ctaClicked.rawValue, properties: props)
+  }
+
+  /// Call when the user lifts their finger from the video progress bar scrubber.
+  public func trackVideoFeedProgressBarTapped(
+    videoId: String,
+    projectId: String,
+    positionInSession: Int,
+    percentageWatched: Float
+  ) {
+    var props = contextProperties(ctaContext: .videoFeedProgressBar, page: .videoFeed)
+
+    props["video_feed_video_id"] = videoId
+    props["video_feed_project_id"] = projectId
+    props["video_feed_position_in_session"] = positionInSession
+    props["video_feed_percentage_watched"] = percentageWatched
+
+    self.track(event: SegmentEvent.ctaClicked.rawValue, properties: props)
+  }
+
   // MARK: - Onboarding Events
 
   /**

--- a/Library/Sources/Library/Library/ViewModels/VideoFeedViewModel.swift
+++ b/Library/Sources/Library/Library/ViewModels/VideoFeedViewModel.swift
@@ -32,6 +32,10 @@ public protocol VideoFeedViewModelType: AnyObject {
   func clearSaveFailedItemId()
   /// Tracks a swipe to a new video, then fires an impression for the incoming video.
   func trackPageViewed(atIndex index: Int)
+  /// Tracks a CTA tap in the video feed (play, pause, save, share).
+  func trackCTAClicked(ctaContext: KSRAnalytics.CTAContext, item: VideoFeedItem)
+  /// Tracks progress bar scrubs in the video feed.
+  func trackProgressBarTapped(item: VideoFeedItem, positionInSession: Int, percentageWatched: Float)
 }
 
 @Observable
@@ -202,6 +206,23 @@ public final class VideoFeedViewModel: VideoFeedViewModelType {
     )
 
     self.lastPageIndex = index
+  }
+
+  public func trackCTAClicked(ctaContext: KSRAnalytics.CTAContext, item: VideoFeedItem) {
+    AppEnvironment.current.ksrAnalytics.trackVideoFeedCTAClicked(
+      ctaContext: ctaContext,
+      videoId: item.id,
+      projectId: item.projectId
+    )
+  }
+
+  public func trackProgressBarTapped(item: VideoFeedItem, positionInSession: Int, percentageWatched: Float) {
+    AppEnvironment.current.ksrAnalytics.trackVideoFeedProgressBarTapped(
+      videoId: item.id,
+      projectId: item.projectId,
+      positionInSession: positionInSession,
+      percentageWatched: percentageWatched
+    )
   }
 
   // MARK: - Private

--- a/Library/Sources/Library/Library/ViewModels/VideoFeedViewModel.swift
+++ b/Library/Sources/Library/Library/ViewModels/VideoFeedViewModel.swift
@@ -30,6 +30,8 @@ public protocol VideoFeedViewModelType: AnyObject {
   func clearLoginIntent()
   /// Clears the save error after the toast has been shown.
   func clearSaveFailedItemId()
+  /// Tracks a swipe to a new video, then fires an impression for the incoming video.
+  func trackPageViewed(atIndex index: Int)
 }
 
 @Observable
@@ -58,6 +60,8 @@ public final class VideoFeedViewModel: VideoFeedViewModelType {
 
   /// Tracks in-flight watch/unwatch requests.
   private var pendingWatchRequests: [String: Disposable] = [:]
+
+  private var lastPageIndex: Int = 0
 
   // MARK: - Init
 
@@ -141,6 +145,12 @@ public final class VideoFeedViewModel: VideoFeedViewModelType {
       self.items[index].watchesCount += 1
     }
 
+    AppEnvironment.current.ksrAnalytics.trackVideoFeedCTAClicked(
+      ctaContext: .videoFeedSave,
+      videoId: item.id,
+      projectId: item.projectId
+    )
+
     let producer = wasSaved
       ? AppEnvironment.current.apiService.unwatchProject(input: .init(id: projectId))
       : AppEnvironment.current.apiService.watchProject(input: .init(id: projectId))
@@ -168,6 +178,30 @@ public final class VideoFeedViewModel: VideoFeedViewModelType {
 
   public func clearSaveFailedItemId() {
     self.saveFailedItemId = nil
+  }
+
+  public func trackPageViewed(atIndex index: Int) {
+    guard index < self.items.count else { return }
+
+    let incoming = self.items[index]
+    let outgoing = self.items[self.lastPageIndex]
+
+    AppEnvironment.current.ksrAnalytics.trackVideoFeedSwipe(
+      videoId: incoming.id,
+      projectId: incoming.projectId,
+      positionInSession: index,
+      fromVideoId: outgoing.id,
+      totalWatchTimeMs: 0,
+      totalVideoDurationMs: 0
+    )
+
+    AppEnvironment.current.ksrAnalytics.trackVideoFeedImpression(
+      videoId: incoming.id,
+      projectId: incoming.projectId,
+      positionInSession: index
+    )
+
+    self.lastPageIndex = index
   }
 
   // MARK: - Private
@@ -203,6 +237,12 @@ public final class VideoFeedViewModel: VideoFeedViewModelType {
       self.fetchedItems = nodes.map(VideoFeedItem.init)
       self.items = self.fetchedItems
       self.isLoading = false
+
+      AppEnvironment.current.ksrAnalytics.trackVideoFeedImpression(
+        videoId: self.items[0].id,
+        projectId: self.items[0].projectId,
+        positionInSession: 0
+      )
     } catch {
       self.isLoading = false
       self.errorMessage = error.localizedDescription

--- a/Library/Sources/Library/Library/ViewModels/VideoFeedViewModel.swift
+++ b/Library/Sources/Library/Library/ViewModels/VideoFeedViewModel.swift
@@ -31,10 +31,9 @@ public protocol VideoFeedViewModelType: AnyObject {
   /// Clears the save error after the toast has been shown.
   func clearSaveFailedItemId()
   /// Tracks a swipe to a new video, then fires an impression for the incoming video.
-  func trackPageViewed(atIndex index: Int)
+  func trackPageViewed(atIndex index: Int, totalWatchTimeMs: Int, totalVideoDurationMs: Int)
   /// Tracks a CTA tap in the video feed (play, pause, save, share).
   func trackCTAClicked(ctaContext: KSRAnalytics.CTAContext, item: VideoFeedItem)
-  /// Tracks progress bar scrubs in the video feed.
   func trackProgressBarTapped(item: VideoFeedItem, positionInSession: Int, percentageWatched: Float)
 }
 
@@ -184,7 +183,7 @@ public final class VideoFeedViewModel: VideoFeedViewModelType {
     self.saveFailedItemId = nil
   }
 
-  public func trackPageViewed(atIndex index: Int) {
+  public func trackPageViewed(atIndex index: Int, totalWatchTimeMs: Int, totalVideoDurationMs: Int) {
     guard index < self.items.count else { return }
 
     let incoming = self.items[index]
@@ -195,8 +194,8 @@ public final class VideoFeedViewModel: VideoFeedViewModelType {
       projectId: incoming.projectId,
       positionInSession: index,
       fromVideoId: outgoing.id,
-      totalWatchTimeMs: 0,
-      totalVideoDurationMs: 0
+      totalWatchTimeMs: totalWatchTimeMs,
+      totalVideoDurationMs: totalVideoDurationMs
     )
 
     AppEnvironment.current.ksrAnalytics.trackVideoFeedImpression(

--- a/LibraryTests/Library/Tracking/KSRAnalyticsTests.swift
+++ b/LibraryTests/Library/Tracking/KSRAnalyticsTests.swift
@@ -1916,6 +1916,11 @@ final class KSRAnalyticsTests: TestCase {
     XCTAssertEqual(KSRAnalytics.CTAContext.signUpInitiate.trackingString, "sign_up_initiate")
     XCTAssertEqual(KSRAnalytics.CTAContext.signUpSubmit.trackingString, "sign_up_submit")
     XCTAssertEqual(KSRAnalytics.CTAContext.forgotPassword.trackingString, "forgot_password")
+    XCTAssertEqual(KSRAnalytics.CTAContext.videoFeedPlay.trackingString, "video_feed_play")
+    XCTAssertEqual(KSRAnalytics.CTAContext.videoFeedPause.trackingString, "video_feed_pause")
+    XCTAssertEqual(KSRAnalytics.CTAContext.videoFeedSave.trackingString, "video_feed_save")
+    XCTAssertEqual(KSRAnalytics.CTAContext.videoFeedShare.trackingString, "video_feed_share")
+    XCTAssertEqual(KSRAnalytics.CTAContext.videoFeedProgressBar.trackingString, "video_feed_progress_bar")
   }
 
   func testSectionContextTrackingStrings() {
@@ -1968,6 +1973,7 @@ final class KSRAnalyticsTests: TestCase {
     XCTAssertEqual(KSRAnalytics.LocationContext.globalNav.trackingString, "global_nav")
     XCTAssertEqual(KSRAnalytics.LocationContext.recommendations.trackingString, "recommendations")
     XCTAssertEqual(KSRAnalytics.LocationContext.searchResults.trackingString, "search_results")
+    XCTAssertEqual(KSRAnalytics.LocationContext.videoFeed.trackingString, "video_feed")
   }
 
   func testPaymentTypeTrackingStrings() {
@@ -2076,6 +2082,54 @@ final class KSRAnalyticsTests: TestCase {
 
     XCTAssertNil(ksrAnalytics.anonymousId)
     XCTAssertFalse(ksrAnalytics.isTrackingEnabled())
+  }
+
+  func testTrackVideoFeedImpression() {
+    let segmentClient = MockTrackingClient()
+    let ksrAnalytics = KSRAnalytics(
+      segmentClient: segmentClient,
+      appTrackingTransparency: self.appTrackingTransparency
+    )
+
+    ksrAnalytics.trackVideoFeedImpression(
+      videoId: "video_123",
+      projectId: "project_456",
+      positionInSession: 2
+    )
+
+    XCTAssertEqual(["Page Viewed"], segmentClient.events)
+    XCTAssertEqual("video_feed", segmentClient.properties.last?["context_page"] as? String)
+    XCTAssertEqual("video_feed", segmentClient.properties.last?["context_location"] as? String)
+    XCTAssertEqual("video_123", segmentClient.properties.last?["video_feed_video_id"] as? String)
+    XCTAssertEqual("project_456", segmentClient.properties.last?["video_feed_project_id"] as? String)
+    XCTAssertEqual(2, segmentClient.properties.last?["video_feed_position_in_session"] as? Int)
+  }
+
+  func testTrackVideoFeedSwipe() {
+    let segmentClient = MockTrackingClient()
+    let ksrAnalytics = KSRAnalytics(
+      segmentClient: segmentClient,
+      appTrackingTransparency: self.appTrackingTransparency
+    )
+
+    ksrAnalytics.trackVideoFeedSwipe(
+      videoId: "video_456",
+      projectId: "project_789",
+      positionInSession: 3,
+      fromVideoId: "video_123",
+      totalWatchTimeMs: 4_200,
+      totalVideoDurationMs: 30_000
+    )
+
+    XCTAssertEqual(["Page Viewed"], segmentClient.events)
+    XCTAssertEqual("video_feed", segmentClient.properties.last?["context_page"] as? String)
+    XCTAssertEqual("video_feed", segmentClient.properties.last?["context_location"] as? String)
+    XCTAssertEqual("video_456", segmentClient.properties.last?["video_feed_video_id"] as? String)
+    XCTAssertEqual("project_789", segmentClient.properties.last?["video_feed_project_id"] as? String)
+    XCTAssertEqual(3, segmentClient.properties.last?["video_feed_position_in_session"] as? Int)
+    XCTAssertEqual("video_123", segmentClient.properties.last?["video_feed_from_video_id"] as? String)
+    XCTAssertEqual(4_200, segmentClient.properties.last?["video_feed_total_watch_time"] as? Int)
+    XCTAssertEqual(30_000, segmentClient.properties.last?["video_feed_total_video_duration"] as? Int)
   }
 
   /*

--- a/LibraryTests/Library/Tracking/KSRAnalyticsTests.swift
+++ b/LibraryTests/Library/Tracking/KSRAnalyticsTests.swift
@@ -2132,6 +2132,109 @@ final class KSRAnalyticsTests: TestCase {
     XCTAssertEqual(30_000, segmentClient.properties.last?["video_feed_total_video_duration"] as? Int)
   }
 
+  func testTrackVideoFeedCTAClicked_Play() {
+    let segmentClient = MockTrackingClient()
+    let ksrAnalytics = KSRAnalytics(
+      segmentClient: segmentClient,
+      appTrackingTransparency: self.appTrackingTransparency
+    )
+
+    ksrAnalytics.trackVideoFeedCTAClicked(
+      ctaContext: .videoFeedPlay,
+      videoId: "video_123",
+      projectId: "project_456"
+    )
+
+    XCTAssertEqual(["CTA Clicked"], segmentClient.events)
+    XCTAssertEqual("video_feed", segmentClient.properties.last?["context_page"] as? String)
+    XCTAssertEqual("video_feed_play", segmentClient.properties.last?["context_cta"] as? String)
+    XCTAssertEqual("video_123", segmentClient.properties.last?["video_feed_video_id"] as? String)
+    XCTAssertEqual("project_456", segmentClient.properties.last?["video_feed_project_id"] as? String)
+  }
+
+  func testTrackVideoFeedCTAClicked_Pause() {
+    let segmentClient = MockTrackingClient()
+    let ksrAnalytics = KSRAnalytics(
+      segmentClient: segmentClient,
+      appTrackingTransparency: self.appTrackingTransparency
+    )
+
+    ksrAnalytics.trackVideoFeedCTAClicked(
+      ctaContext: .videoFeedPause,
+      videoId: "video_123",
+      projectId: "project_456"
+    )
+
+    XCTAssertEqual(["CTA Clicked"], segmentClient.events)
+    XCTAssertEqual("video_feed", segmentClient.properties.last?["context_page"] as? String)
+    XCTAssertEqual("video_feed_pause", segmentClient.properties.last?["context_cta"] as? String)
+    XCTAssertEqual("video_123", segmentClient.properties.last?["video_feed_video_id"] as? String)
+    XCTAssertEqual("project_456", segmentClient.properties.last?["video_feed_project_id"] as? String)
+  }
+
+  func testTrackVideoFeedCTAClicked_Save() {
+    let segmentClient = MockTrackingClient()
+    let ksrAnalytics = KSRAnalytics(
+      segmentClient: segmentClient,
+      appTrackingTransparency: self.appTrackingTransparency
+    )
+
+    ksrAnalytics.trackVideoFeedCTAClicked(
+      ctaContext: .videoFeedSave,
+      videoId: "video_123",
+      projectId: "project_456"
+    )
+
+    XCTAssertEqual(["CTA Clicked"], segmentClient.events)
+    XCTAssertEqual("video_feed", segmentClient.properties.last?["context_page"] as? String)
+    XCTAssertEqual("video_feed_save", segmentClient.properties.last?["context_cta"] as? String)
+    XCTAssertEqual("video_123", segmentClient.properties.last?["video_feed_video_id"] as? String)
+    XCTAssertEqual("project_456", segmentClient.properties.last?["video_feed_project_id"] as? String)
+  }
+
+  func testTrackVideoFeedCTAClicked_Share() {
+    let segmentClient = MockTrackingClient()
+    let ksrAnalytics = KSRAnalytics(
+      segmentClient: segmentClient,
+      appTrackingTransparency: self.appTrackingTransparency
+    )
+
+    ksrAnalytics.trackVideoFeedCTAClicked(
+      ctaContext: .videoFeedShare,
+      videoId: "video_123",
+      projectId: "project_456"
+    )
+
+    XCTAssertEqual(["CTA Clicked"], segmentClient.events)
+    XCTAssertEqual("video_feed", segmentClient.properties.last?["context_page"] as? String)
+    XCTAssertEqual("video_feed_share", segmentClient.properties.last?["context_cta"] as? String)
+    XCTAssertEqual("video_123", segmentClient.properties.last?["video_feed_video_id"] as? String)
+    XCTAssertEqual("project_456", segmentClient.properties.last?["video_feed_project_id"] as? String)
+  }
+
+  func testTrackVideoFeedProgressBarTapped() {
+    let segmentClient = MockTrackingClient()
+    let ksrAnalytics = KSRAnalytics(
+      segmentClient: segmentClient,
+      appTrackingTransparency: self.appTrackingTransparency
+    )
+
+    ksrAnalytics.trackVideoFeedProgressBarTapped(
+      videoId: "video_123",
+      projectId: "project_456",
+      positionInSession: 1,
+      percentageWatched: 0.45
+    )
+
+    XCTAssertEqual(["CTA Clicked"], segmentClient.events)
+    XCTAssertEqual("video_feed", segmentClient.properties.last?["context_page"] as? String)
+    XCTAssertEqual("video_feed_progress_bar", segmentClient.properties.last?["context_cta"] as? String)
+    XCTAssertEqual("video_123", segmentClient.properties.last?["video_feed_video_id"] as? String)
+    XCTAssertEqual("project_456", segmentClient.properties.last?["video_feed_project_id"] as? String)
+    XCTAssertEqual(1, segmentClient.properties.last?["video_feed_position_in_session"] as? Int)
+    XCTAssertEqual(0.45, segmentClient.properties.last?["video_feed_percentage_watched"] as? Float)
+  }
+
   /*
    Helper for testing pledgeProperties from a template Reward
    */

--- a/LibraryTests/Library/ViewModels/VideoFeedViewModelTests.swift
+++ b/LibraryTests/Library/ViewModels/VideoFeedViewModelTests.swift
@@ -203,6 +203,75 @@ final class VideoFeedViewModelTests: TestCase {
     XCTAssertEqual(vm2.items.first?.isSaved, false, "Should not save if user is still logged out.")
   }
 
+  // MARK: - Analytics
+
+  func testTrackPageViewed_FiresOnSwipeForDepartingVideo() async {
+    let mockData = Self.mockVideoFeedQueryData(itemCount: 3)
+    var propertiesList: [[String: Any]] = []
+
+    await withEnvironment(
+      apiService: MockService(fetchGraphQLResponses: [(VideoFeedQuery.self, mockData)]),
+      appTrackingTransparency: self.appTrackingTransparency
+    ) {
+      await self.vm.fetchVideoFeed()
+
+      AppEnvironment.current.ksrAnalytics.logEventCallback = { _, props in
+        propertiesList.append(props)
+      }
+
+      self.vm.trackPageViewed(atIndex: 1, totalWatchTimeMs: 3_000, totalVideoDurationMs: 8_000)
+    }
+
+    let swipeProps = propertiesList.first
+    XCTAssertEqual("project-0", swipeProps?["video_feed_from_video_id"] as? String)
+    XCTAssertEqual("project-1", swipeProps?["video_feed_video_id"] as? String)
+    XCTAssertEqual(3_000, swipeProps?["video_feed_total_watch_time"] as? Int)
+    XCTAssertEqual(8_000, swipeProps?["video_feed_total_video_duration"] as? Int)
+  }
+
+  func testTrackPageViewed_FiresImpressionOfIncomingVideo() async {
+    let mockData = Self.mockVideoFeedQueryData(itemCount: 3)
+    var propertiesList: [[String: Any]] = []
+
+    await withEnvironment(
+      apiService: MockService(fetchGraphQLResponses: [(VideoFeedQuery.self, mockData)]),
+      appTrackingTransparency: self.appTrackingTransparency
+    ) {
+      await self.vm.fetchVideoFeed()
+
+      AppEnvironment.current.ksrAnalytics.logEventCallback = { _, props in
+        propertiesList.append(props)
+      }
+
+      self.vm.trackPageViewed(atIndex: 1, totalWatchTimeMs: 5_000, totalVideoDurationMs: 10_000)
+    }
+
+    let impressionProps = propertiesList.last
+    XCTAssertEqual("project-1", impressionProps?["video_feed_video_id"] as? String)
+    XCTAssertEqual(1, impressionProps?["video_feed_position_in_session"] as? Int)
+    XCTAssertEqual("video_feed", impressionProps?["context_page"] as? String)
+  }
+
+  func testFetchVideoFeed_FiresImpressionForFirstItem() async {
+    let mockData = Self.mockVideoFeedQueryData(itemCount: 3)
+    var propertiesList: [[String: Any]] = []
+
+    await withEnvironment(
+      apiService: MockService(fetchGraphQLResponses: [(VideoFeedQuery.self, mockData)]),
+      appTrackingTransparency: self.appTrackingTransparency
+    ) {
+      AppEnvironment.current.ksrAnalytics.logEventCallback = { _, props in
+        propertiesList.append(props)
+      }
+
+      await self.vm.fetchVideoFeed()
+    }
+
+    let impressionProps = propertiesList.last
+    XCTAssertEqual("project-0", impressionProps?["video_feed_video_id"] as? String)
+    XCTAssertEqual(0, impressionProps?["video_feed_position_in_session"] as? Int)
+  }
+
   // MARK: - Helpers
 
   private static func mockVideoFeedQueryData(


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Adds  `page_viewed` and `cta_clicked` events for impression, swipe, save, share, play, pause, and progress bar interactions.

ticket with more context around these events here: https://kickstarter.atlassian.net/browse/DISC-260

# 🤔 Why
Always Be Data Collecting

# 🛠 How

**Update KSRAnalytics** 
- added `PageContext.videoFeed`, `LocationContext.videoFeed`, and five `CTAContext` video feed cases    
   - `trackVideoFeedImpression`
   - `trackVideoFeedSwipe`
   - `trackVideoFeedCTAClicked`
   - `trackVideoFeedProgressBarTapped` 
- with tests.

**page_viewed events**
-  `VideoFeedViewModel` fires the first video loaded event at the end of `fetchVideoFeed`. 
- `trackPageViewed(atIndex:totalWatchTimeMs:totalVideoDurationMs:)` handles swipe + impression on each scroll. called from `scrollViewDidEndDecelerating`. 
- Watch time accumulates in `VideoFeedVideoPlayer` and only increments while `rate > 0` so paused intervals are excluded.

**cta_clicked events**
- all CTA events route through `VideoFeedViewModel`
- Save fires inside `toggleSaved`. Play/pause/share/progress bar fire via callback in the feed cells (`onPauseTapped`, `onResumeTapped`, `onProgressBarTapped`).

# ✅ Acceptance criteria
- [x] Events fire and show up in Segment as expected according to our analytics spec: https://kickstarter.atlassian.net/browse/DISC-260
