### PR TITLE
Video Feed: Cancel In-Flight Save Requests To Avoid State Confusion 

### DIFF
--- a/Library/Sources/Library/Library/ViewModels/VideoFeedViewModel.swift
+++ b/Library/Sources/Library/Library/ViewModels/VideoFeedViewModel.swift
@@ -22,7 +22,7 @@ public protocol VideoFeedViewModelType: AnyObject {
   func viewWillAppear()
   /// Fires any save the user tapped before logging in.
   func userSessionStarted()
-  /// Optimistically toggles the saved state for a project.
+  /// Optimistically toggles the saved state for a project, cancelling any in-flight request first.
   func toggleSaved(for item: VideoFeedItem)
   /// Returns a binding to the saved state for the given project ID.
   func isSaved(projectId: String) -> Binding<Bool>
@@ -63,6 +63,8 @@ public final class VideoFeedViewModel: VideoFeedViewModelType {
 
   /// Tracks in-flight watch/unwatch requests.
   private var pendingWatchRequests: [String: Disposable] = [:]
+
+  private var saveRequestTokens: [String: UUID] = [:]
 
   private var lastPageIndex: Int = 0
 
@@ -129,20 +131,28 @@ public final class VideoFeedViewModel: VideoFeedViewModelType {
     )
   }
 
-  /// Toggles the watched state for a given project.
-  /// Ignores taps while a request is already in flight.
-  /// Optimistically updates `isSaved` and `watchesCount` (Reverts both on failure).
+  /// Optimistically toggles the watched state for a given project.
+  /// Cancels any in-flight request for this item before firing a new one, so rapid taps
+  /// (e.g. save then quick-unsave) don't get into a wonky state. The optimistic state always reflects the
+  /// latest tap, and the final request always matches it.
   public func toggleSaved(for item: VideoFeedItem) {
     guard let index = self.items.firstIndex(where: { $0.id == item.id }) else { return }
-    guard self.pendingWatchRequests[item.projectId] == nil else { return }
 
     let projectId = item.projectId
+
+    /// Cancel the in-flight request if there is one before firing the new one.
+    self.pendingWatchRequests[projectId]?.dispose()
+    self.pendingWatchRequests.removeValue(forKey: projectId)
+
+    let token = UUID()
+    self.saveRequestTokens[projectId] = token
+
     let wasSaved = self.items[index].isSaved
 
     /// Optimistic update.
     if wasSaved {
       self.items[index].isSaved = false
-      self.items[index].watchesCount -= 1
+      self.items[index].watchesCount = max(0, self.items[index].watchesCount - 1)
     } else {
       self.items[index].isSaved = true
       self.items[index].watchesCount += 1
@@ -159,17 +169,21 @@ public final class VideoFeedViewModel: VideoFeedViewModelType {
       : AppEnvironment.current.apiService.watchProject(input: .init(id: projectId))
 
     let disposable = producer
-      .observe(on: QueueScheduler.main)
       .startWithResult { [weak self] result in
         guard let self, let index = self.items.firstIndex(where: { $0.id == projectId }) else { return }
+
+        /// Ignore this response if a newer tap has already replaced this request.
+        guard self.saveRequestTokens[projectId] == token else { return }
 
         if case .failure = result {
           /// Revert optimistic update on failure and surface the error toast.
           self.items[index].isSaved = wasSaved
-          self.saveFailedItemId = projectId
+          self.items[index].watchesCount = max(0, self.items[index].watchesCount + (wasSaved ? 1 : -1))
+          self.saveFailedItemId = self.items[index].id
         }
 
         self.pendingWatchRequests.removeValue(forKey: projectId)
+        self.saveRequestTokens.removeValue(forKey: projectId)
       }
 
     self.pendingWatchRequests[projectId] = disposable

--- a/LibraryTests/Library/ViewModels/VideoFeedViewModelTests.swift
+++ b/LibraryTests/Library/ViewModels/VideoFeedViewModelTests.swift
@@ -133,6 +133,20 @@ final class VideoFeedViewModelTests: TestCase {
     XCTAssertEqual(self.vm.items.first?.watchesCount, originalCount - 1, "Count should decrement on unsave.")
   }
 
+  func testToggleSaved_WatchesCount_NeverDropsBelowOne_OnUnsave() async {
+    let mockData = Self.mockVideoFeedQueryData(itemCount: 1, isWatched: true, watchesCount: 1)
+
+    await withEnvironment(apiService: MockService(fetchGraphQLResponses: [(VideoFeedQuery.self, mockData)])) {
+      await self.vm.fetchVideoFeed()
+    }
+
+    let item = try! XCTUnwrap(self.vm.items.first)
+
+    self.vm.toggleSaved(for: item)
+
+    XCTAssertEqual(self.vm.items.first?.watchesCount, 0, "Count should not drop below 1 on unsave.")
+  }
+
   func testToggleSaved_OnlyAffectsSelectItems() async {
     let mockData = Self.mockVideoFeedQueryData(itemCount: 3, isWatched: false)
 
@@ -147,6 +161,48 @@ final class VideoFeedViewModelTests: TestCase {
     XCTAssertFalse(self.vm.items[0].isSaved, "First item should be unaffected.")
     XCTAssertTrue(self.vm.items[1].isSaved, "Second item should be toggled.")
     XCTAssertFalse(self.vm.items[2].isSaved, "Third item should be unaffected.")
+  }
+
+  func testToggleSaved_RapidTaps_OnlyLastRequestWins() async {
+    let mockData = Self.mockVideoFeedQueryData(itemCount: 1, isWatched: false)
+
+    await withEnvironment(apiService: MockService(fetchGraphQLResponses: [(VideoFeedQuery.self, mockData)])) {
+      await self.vm.fetchVideoFeed()
+    }
+
+    let item = try! XCTUnwrap(self.vm.items.first)
+
+    /// Tap 3 times rapidly: save, unsave, save.
+    self.vm.toggleSaved(for: item)
+    self.vm.toggleSaved(for: self.vm.items.first!)
+    self.vm.toggleSaved(for: self.vm.items.first!)
+
+    /// Final optimistic state should reflect the last tap (saved).
+    XCTAssertTrue(self.vm.items.first?.isSaved == true, "Final state should reflect last tap.")
+    XCTAssertNil(self.vm.saveFailedItemId, "No error toast should show for cancelled intermediate requests.")
+  }
+
+  func testToggleSaved_RapidTaps_CountIsConsistent() async {
+    let mockData = Self.mockVideoFeedQueryData(itemCount: 1, isWatched: false)
+
+    await withEnvironment(apiService: MockService(fetchGraphQLResponses: [(VideoFeedQuery.self, mockData)])) {
+      await self.vm.fetchVideoFeed()
+    }
+
+    let originalCount = self.vm.items.first!.watchesCount
+    let item = try! XCTUnwrap(self.vm.items.first)
+
+    /// Tap twice: save then unsave.
+    self.vm.toggleSaved(for: item)
+    self.vm.toggleSaved(for: self.vm.items.first!)
+
+    /// Final optimistic state should be back to unsaved with original count.
+    XCTAssertFalse(self.vm.items.first?.isSaved == true)
+    XCTAssertEqual(
+      self.vm.items.first?.watchesCount,
+      originalCount,
+      "Count should return to original after save then unsave."
+    )
   }
 
   func testFetchVideoFeed_SetsIsWatched() async {
@@ -278,7 +334,8 @@ final class VideoFeedViewModelTests: TestCase {
     itemCount: Int,
     hlsSrc: String? = nil,
     previewImageUrl: String? = nil,
-    isWatched: Bool = false
+    isWatched: Bool = false,
+    watchesCount: Int = 3
   ) -> VideoFeedQuery.Data {
     let nodes: [VideoFeedQuery.Data.VideoFeed.Node] = (0..<itemCount).map { i in
       let pledged = VideoFeedQuery.Data.VideoFeed.Node.Project.Pledged(amount: "1000")
@@ -315,7 +372,7 @@ final class VideoFeedViewModelTests: TestCase {
         category: category,
         verticalVideo: verticalVideo,
         sharesCount: 2,
-        watchesCount: 3
+        watchesCount: watchesCount
       )
 
       return VideoFeedQuery.Data.VideoFeed.Node(badges: [], project: project)


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Fixes a few of issues found in QA around saving/unsaving with poor internet:
- Rapid taps no longer stack up conflicting in-flight requests
- The save count no longer goes negative from optimistic unsaves
- The save count revert on failure was missing 

# 🤔 Why

On slow internet connections, users would tap save, see nothing happen, and tap again, causing multiple in-flight requests that could race and leave the UI in a state inconsistent with what the server actually did. 
Also stale callbacks from cancelled requests could fire after a newer tap had already updated state, triggering incorrect reverts

# 🛠 How

Each `toggleSaved` call  now disposes any in-flight request before firing a new one. 
Basically, a `UUID` token is captured per tap and if it no longer matches when the response arrives, the result is dropped. Both `isSaved` and `watchesCount` revert together on failure, and `watchesCount` is floored at `0` for optimistic unsaves.

# 👀 See

Trello, screenshots, external resources?

| Before 🐛 | After 🦋 |
| --- | --- |
|  |  |


# ✅ Acceptance criteria

- [x] Tap save on a video, icon and count update immediately
- [x] Tap save then quickly tap again, only the final state is applied, no error toast fires
- [x] Spam tap for several seconds on a good connection, feed recovers to the correct saved/unsaved state
- [x] Turn on airplane mode, tap save, error toast appears and icon/count revert
- [x] Unsave a project with a count of 1, count stays at 1, does not drop to 0 or below
