### PR TITLE
CHECK-403: Use fxRateCurrency on Project for user selected currency code

### DIFF
--- a/GraphAPI/GraphAPITestMocks/Project+Mock.graphql.swift
+++ b/GraphAPI/GraphAPITestMocks/Project+Mock.graphql.swift
@@ -29,6 +29,7 @@ public class Project: MockObject {
     @Field<GraphAPI.ISO8601DateTime>("finalCollectionDate") public var finalCollectionDate
     @Field<Flagging>("flagging") public var flagging
     @Field<Double>("fxRate") public var fxRate
+    @Field<GraphQLEnum<GraphAPI.CurrencyCode>>("fxRateCurrency") public var fxRateCurrency
     @Field<Money>("goal") public var goal
     @Field<GraphAPI.ID>("id") public var id
     @Field<Photo>("image") public var image
@@ -106,6 +107,7 @@ public extension Mock where O == Project {
     finalCollectionDate: GraphAPI.ISO8601DateTime? = nil,
     flagging: Mock<Flagging>? = nil,
     fxRate: Double? = nil,
+    fxRateCurrency: GraphQLEnum<GraphAPI.CurrencyCode>? = nil,
     goal: Mock<Money>? = nil,
     id: GraphAPI.ID? = nil,
     image: Mock<Photo>? = nil,
@@ -180,6 +182,7 @@ public extension Mock where O == Project {
     _setScalar(finalCollectionDate, for: \.finalCollectionDate)
     _setEntity(flagging, for: \.flagging)
     _setScalar(fxRate, for: \.fxRate)
+    _setScalar(fxRateCurrency, for: \.fxRateCurrency)
     _setEntity(goal, for: \.goal)
     _setScalar(id, for: \.id)
     _setEntity(image, for: \.image)

--- a/GraphAPI/Sources/Fragments/ProjectFragment.graphql.swift
+++ b/GraphAPI/Sources/Fragments/ProjectFragment.graphql.swift
@@ -134,6 +134,8 @@ public struct ProjectFragment: GraphAPI.SelectionSet, Fragment {
   public var commentsCount: Int { __data["commentsCount"] }
   /// The project's currency code.
   public var currency: GraphQLEnum<GraphAPI.CurrencyCode> { __data["currency"] }
+  /// Currency code for the current user's currency
+  public var fxRateCurrency: GraphQLEnum<GraphAPI.CurrencyCode> { __data["fxRateCurrency"] }
   /// The minimum amount to raise for the project to be successful.
   public var goal: Goal? { __data["goal"] }
   /// How much money is pledged to the project.
@@ -208,6 +210,7 @@ public struct ProjectFragment: GraphAPI.SelectionSet, Fragment {
     backersCount: Int,
     commentsCount: Int,
     currency: GraphQLEnum<GraphAPI.CurrencyCode>,
+    fxRateCurrency: GraphQLEnum<GraphAPI.CurrencyCode>,
     goal: Goal? = nil,
     pledged: Pledged,
     posts: Posts,
@@ -264,6 +267,7 @@ public struct ProjectFragment: GraphAPI.SelectionSet, Fragment {
         "backersCount": backersCount,
         "commentsCount": commentsCount,
         "currency": currency,
+        "fxRateCurrency": fxRateCurrency,
         "goal": goal._fieldData,
         "pledged": pledged._fieldData,
         "posts": posts._fieldData,

--- a/GraphAPI/Sources/Fragments/ProjectStatsFragment.graphql.swift
+++ b/GraphAPI/Sources/Fragments/ProjectStatsFragment.graphql.swift
@@ -5,7 +5,7 @@
 
 public struct ProjectStatsFragment: GraphAPI.SelectionSet, Fragment {
   public static var fragmentDefinition: StaticString {
-    #"fragment ProjectStatsFragment on Project { __typename backersCount commentsCount(withReplies: true) currency fxRate goal { __typename ...MoneyFragment } pledged { __typename ...MoneyFragment } posts { __typename totalCount } usdExchangeRate }"#
+    #"fragment ProjectStatsFragment on Project { __typename backersCount commentsCount(withReplies: true) currency fxRate fxRateCurrency goal { __typename ...MoneyFragment } pledged { __typename ...MoneyFragment } posts { __typename totalCount } usdExchangeRate }"#
   }
 
   public let __data: DataDict
@@ -18,6 +18,7 @@ public struct ProjectStatsFragment: GraphAPI.SelectionSet, Fragment {
     .field("commentsCount", Int.self, arguments: ["withReplies": true]),
     .field("currency", GraphQLEnum<GraphAPI.CurrencyCode>.self),
     .field("fxRate", Double.self),
+    .field("fxRateCurrency", GraphQLEnum<GraphAPI.CurrencyCode>.self),
     .field("goal", Goal?.self),
     .field("pledged", Pledged.self),
     .field("posts", Posts.self),
@@ -32,6 +33,8 @@ public struct ProjectStatsFragment: GraphAPI.SelectionSet, Fragment {
   public var currency: GraphQLEnum<GraphAPI.CurrencyCode> { __data["currency"] }
   /// Exchange rate for the current user's currency
   public var fxRate: Double { __data["fxRate"] }
+  /// Currency code for the current user's currency
+  public var fxRateCurrency: GraphQLEnum<GraphAPI.CurrencyCode> { __data["fxRateCurrency"] }
   /// The minimum amount to raise for the project to be successful.
   public var goal: Goal? { __data["goal"] }
   /// How much money is pledged to the project.
@@ -46,6 +49,7 @@ public struct ProjectStatsFragment: GraphAPI.SelectionSet, Fragment {
     commentsCount: Int,
     currency: GraphQLEnum<GraphAPI.CurrencyCode>,
     fxRate: Double,
+    fxRateCurrency: GraphQLEnum<GraphAPI.CurrencyCode>,
     goal: Goal? = nil,
     pledged: Pledged,
     posts: Posts,
@@ -58,6 +62,7 @@ public struct ProjectStatsFragment: GraphAPI.SelectionSet, Fragment {
         "commentsCount": commentsCount,
         "currency": currency,
         "fxRate": fxRate,
+        "fxRateCurrency": fxRateCurrency,
         "goal": goal._fieldData,
         "pledged": pledged._fieldData,
         "posts": posts._fieldData,

--- a/GraphAPI/Sources/Operations/Queries/FetchAddOnsQuery.graphql.swift
+++ b/GraphAPI/Sources/Operations/Queries/FetchAddOnsQuery.graphql.swift
@@ -166,6 +166,8 @@ public class FetchAddOnsQuery: GraphQLQuery {
       public var commentsCount: Int { __data["commentsCount"] }
       /// The project's currency code.
       public var currency: GraphQLEnum<GraphAPI.CurrencyCode> { __data["currency"] }
+      /// Currency code for the current user's currency
+      public var fxRateCurrency: GraphQLEnum<GraphAPI.CurrencyCode> { __data["fxRateCurrency"] }
       /// The minimum amount to raise for the project to be successful.
       public var goal: Goal? { __data["goal"] }
       /// How much money is pledged to the project.
@@ -242,6 +244,7 @@ public class FetchAddOnsQuery: GraphQLQuery {
         backersCount: Int,
         commentsCount: Int,
         currency: GraphQLEnum<GraphAPI.CurrencyCode>,
+        fxRateCurrency: GraphQLEnum<GraphAPI.CurrencyCode>,
         goal: Goal? = nil,
         pledged: Pledged,
         posts: Posts,
@@ -299,6 +302,7 @@ public class FetchAddOnsQuery: GraphQLQuery {
             "backersCount": backersCount,
             "commentsCount": commentsCount,
             "currency": currency,
+            "fxRateCurrency": fxRateCurrency,
             "goal": goal._fieldData,
             "pledged": pledged._fieldData,
             "posts": posts._fieldData,

--- a/GraphAPI/Sources/Operations/Queries/FetchBackingQuery.graphql.swift
+++ b/GraphAPI/Sources/Operations/Queries/FetchBackingQuery.graphql.swift
@@ -838,6 +838,8 @@ public class FetchBackingQuery: GraphQLQuery {
         public var commentsCount: Int { __data["commentsCount"] }
         /// The project's currency code.
         public var currency: GraphQLEnum<GraphAPI.CurrencyCode> { __data["currency"] }
+        /// Currency code for the current user's currency
+        public var fxRateCurrency: GraphQLEnum<GraphAPI.CurrencyCode> { __data["fxRateCurrency"] }
         /// The minimum amount to raise for the project to be successful.
         public var goal: Goal? { __data["goal"] }
         /// How much money is pledged to the project.
@@ -913,6 +915,7 @@ public class FetchBackingQuery: GraphQLQuery {
           backersCount: Int,
           commentsCount: Int,
           currency: GraphQLEnum<GraphAPI.CurrencyCode>,
+          fxRateCurrency: GraphQLEnum<GraphAPI.CurrencyCode>,
           goal: Goal? = nil,
           pledged: Pledged,
           posts: Posts,
@@ -969,6 +972,7 @@ public class FetchBackingQuery: GraphQLQuery {
               "backersCount": backersCount,
               "commentsCount": commentsCount,
               "currency": currency,
+              "fxRateCurrency": fxRateCurrency,
               "goal": goal._fieldData,
               "pledged": pledged._fieldData,
               "posts": posts._fieldData,

--- a/GraphAPI/Sources/Operations/Queries/FetchProjectByParamQuery.graphql.swift
+++ b/GraphAPI/Sources/Operations/Queries/FetchProjectByParamQuery.graphql.swift
@@ -7,7 +7,7 @@ public class FetchProjectByParamQuery: GraphQLQuery {
   public static let operationName: String = "FetchProjectByParam"
   public static let operationDocument: ApolloAPI.OperationDocument = .init(
     definition: .init(
-      #"query FetchProjectByParam($projectId: Int, $slug: String) { me { __typename chosenCurrency } project(pid: $projectId, slug: $slug) { __typename ...ProjectFragment backing { __typename id } flagging { __typename id kind } } }"#,
+      #"query FetchProjectByParam($projectId: Int, $slug: String) { project(pid: $projectId, slug: $slug) { __typename ...ProjectFragment backing { __typename id } flagging { __typename id kind } } }"#,
       fragments: [CategoryFragment.self, CountryFragment.self, ExtendedProjectPropertiesFragment.self, LastWaveFragment.self, LocationFragment.self, MoneyFragment.self, NoRewardRewardFragment.self, PledgeManagerFragment.self, PledgeOverTimeFragment.self, ProjectDatesFragment.self, ProjectFragment.self, ProjectStatsFragment.self, ProjectVideoFragment.self, PublicUserFragment.self]
     ))
 
@@ -33,63 +33,27 @@ public class FetchProjectByParamQuery: GraphQLQuery {
 
     public static var __parentType: ApolloAPI.ParentType { GraphAPI.Objects.Query }
     public static var __selections: [ApolloAPI.Selection] { [
-      .field("me", Me?.self),
       .field("project", Project?.self, arguments: [
         "pid": .variable("projectId"),
         "slug": .variable("slug")
       ]),
     ] }
 
-    /// You.
-    public var me: Me? { __data["me"] }
     /// Fetches a project given its slug or pid.
     public var project: Project? { __data["project"] }
 
     public init(
-      me: Me? = nil,
       project: Project? = nil
     ) {
       self.init(_dataDict: DataDict(
         data: [
           "__typename": GraphAPI.Objects.Query.typename,
-          "me": me._fieldData,
           "project": project._fieldData,
         ],
         fulfilledFragments: [
           ObjectIdentifier(FetchProjectByParamQuery.Data.self)
         ]
       ))
-    }
-
-    /// Me
-    ///
-    /// Parent Type: `User`
-    public struct Me: GraphAPI.SelectionSet {
-      public let __data: DataDict
-      public init(_dataDict: DataDict) { __data = _dataDict }
-
-      public static var __parentType: ApolloAPI.ParentType { GraphAPI.Objects.User }
-      public static var __selections: [ApolloAPI.Selection] { [
-        .field("__typename", String.self),
-        .field("chosenCurrency", String?.self),
-      ] }
-
-      /// The user's chosen currency
-      public var chosenCurrency: String? { __data["chosenCurrency"] }
-
-      public init(
-        chosenCurrency: String? = nil
-      ) {
-        self.init(_dataDict: DataDict(
-          data: [
-            "__typename": GraphAPI.Objects.User.typename,
-            "chosenCurrency": chosenCurrency,
-          ],
-          fulfilledFragments: [
-            ObjectIdentifier(FetchProjectByParamQuery.Data.Me.self)
-          ]
-        ))
-      }
     }
 
     /// Project

--- a/GraphAPI/Sources/Operations/Queries/FetchProjectByParamQuery.graphql.swift
+++ b/GraphAPI/Sources/Operations/Queries/FetchProjectByParamQuery.graphql.swift
@@ -196,6 +196,8 @@ public class FetchProjectByParamQuery: GraphQLQuery {
       public var commentsCount: Int { __data["commentsCount"] }
       /// The project's currency code.
       public var currency: GraphQLEnum<GraphAPI.CurrencyCode> { __data["currency"] }
+      /// Currency code for the current user's currency
+      public var fxRateCurrency: GraphQLEnum<GraphAPI.CurrencyCode> { __data["fxRateCurrency"] }
       /// The minimum amount to raise for the project to be successful.
       public var goal: Goal? { __data["goal"] }
       /// How much money is pledged to the project.
@@ -273,6 +275,7 @@ public class FetchProjectByParamQuery: GraphQLQuery {
         backersCount: Int,
         commentsCount: Int,
         currency: GraphQLEnum<GraphAPI.CurrencyCode>,
+        fxRateCurrency: GraphQLEnum<GraphAPI.CurrencyCode>,
         goal: Goal? = nil,
         pledged: Pledged,
         posts: Posts,
@@ -331,6 +334,7 @@ public class FetchProjectByParamQuery: GraphQLQuery {
             "backersCount": backersCount,
             "commentsCount": commentsCount,
             "currency": currency,
+            "fxRateCurrency": fxRateCurrency,
             "goal": goal._fieldData,
             "pledged": pledged._fieldData,
             "posts": posts._fieldData,

--- a/GraphAPI/Sources/Operations/Queries/FetchUserBackingsQuery.graphql.swift
+++ b/GraphAPI/Sources/Operations/Queries/FetchUserBackingsQuery.graphql.swift
@@ -930,6 +930,8 @@ public class FetchUserBackingsQuery: GraphQLQuery {
             public var commentsCount: Int { __data["commentsCount"] }
             /// The project's currency code.
             public var currency: GraphQLEnum<GraphAPI.CurrencyCode> { __data["currency"] }
+            /// Currency code for the current user's currency
+            public var fxRateCurrency: GraphQLEnum<GraphAPI.CurrencyCode> { __data["fxRateCurrency"] }
             /// The minimum amount to raise for the project to be successful.
             public var goal: Goal? { __data["goal"] }
             /// How much money is pledged to the project.
@@ -1005,6 +1007,7 @@ public class FetchUserBackingsQuery: GraphQLQuery {
               backersCount: Int,
               commentsCount: Int,
               currency: GraphQLEnum<GraphAPI.CurrencyCode>,
+              fxRateCurrency: GraphQLEnum<GraphAPI.CurrencyCode>,
               goal: Goal? = nil,
               pledged: Pledged,
               posts: Posts,
@@ -1061,6 +1064,7 @@ public class FetchUserBackingsQuery: GraphQLQuery {
                   "backersCount": backersCount,
                   "commentsCount": commentsCount,
                   "currency": currency,
+                  "fxRateCurrency": fxRateCurrency,
                   "goal": goal._fieldData,
                   "pledged": pledged._fieldData,
                   "posts": posts._fieldData,

--- a/GraphAPI/Sources/Schema/SchemaMetadata.graphql.swift
+++ b/GraphAPI/Sources/Schema/SchemaMetadata.graphql.swift
@@ -96,7 +96,17 @@ public enum SchemaMetadata: ApolloAPI.SchemaMetadata {
     case "TriggerThirdPartyEventPayload": return GraphAPI.Objects.TriggerThirdPartyEventPayload
     case "UpdateBackerCompletedPayload": return GraphAPI.Objects.UpdateBackerCompletedPayload
     case "Query": return GraphAPI.Objects.Query
+    case "Country": return GraphAPI.Objects.Country
+    case "UserCreatedProjectsConnection": return GraphAPI.Objects.UserCreatedProjectsConnection
+    case "EnvironmentalCommitment": return GraphAPI.Objects.EnvironmentalCommitment
+    case "ProjectFaqConnection": return GraphAPI.Objects.ProjectFaqConnection
+    case "ProjectFaq": return GraphAPI.Objects.ProjectFaq
+    case "CheckoutWave": return GraphAPI.Objects.CheckoutWave
+    case "PledgeManager": return GraphAPI.Objects.PledgeManager
     case "Money": return GraphAPI.Objects.Money
+    case "PostConnection": return GraphAPI.Objects.PostConnection
+    case "VideoSources": return GraphAPI.Objects.VideoSources
+    case "VideoSourceInfo": return GraphAPI.Objects.VideoSourceInfo
     case "RewardConnection": return GraphAPI.Objects.RewardConnection
     case "PageInfo": return GraphAPI.Objects.PageInfo
     case "RewardItemsConnection": return GraphAPI.Objects.RewardItemsConnection
@@ -104,11 +114,6 @@ public enum SchemaMetadata: ApolloAPI.SchemaMetadata {
     case "ResourceAudience": return GraphAPI.Objects.ResourceAudience
     case "SimpleShippingRule": return GraphAPI.Objects.SimpleShippingRule
     case "ProjectsConnectionWithTotalCount": return GraphAPI.Objects.ProjectsConnectionWithTotalCount
-    case "Country": return GraphAPI.Objects.Country
-    case "UserCreatedProjectsConnection": return GraphAPI.Objects.UserCreatedProjectsConnection
-    case "PostConnection": return GraphAPI.Objects.PostConnection
-    case "VideoSources": return GraphAPI.Objects.VideoSources
-    case "VideoSourceInfo": return GraphAPI.Objects.VideoSourceInfo
     case "VideoFeedConnection": return GraphAPI.Objects.VideoFeedConnection
     case "VideoFeedItem": return GraphAPI.Objects.VideoFeedItem
     case "Badge": return GraphAPI.Objects.Badge
@@ -118,11 +123,6 @@ public enum SchemaMetadata: ApolloAPI.SchemaMetadata {
     case "UserSavedProjectsConnection": return GraphAPI.Objects.UserSavedProjectsConnection
     case "SurveyResponsesConnection": return GraphAPI.Objects.SurveyResponsesConnection
     case "RewardTotalCountConnection": return GraphAPI.Objects.RewardTotalCountConnection
-    case "EnvironmentalCommitment": return GraphAPI.Objects.EnvironmentalCommitment
-    case "ProjectFaqConnection": return GraphAPI.Objects.ProjectFaqConnection
-    case "ProjectFaq": return GraphAPI.Objects.ProjectFaq
-    case "CheckoutWave": return GraphAPI.Objects.CheckoutWave
-    case "PledgeManager": return GraphAPI.Objects.PledgeManager
     case "PaymentIncrement": return GraphAPI.Objects.PaymentIncrement
     case "PaymentIncrementAmount": return GraphAPI.Objects.PaymentIncrementAmount
     case "RichTextComponent": return GraphAPI.Objects.RichTextComponent

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework-iOSTests/Resources/SearchQuery_AnotherFiveResults.json
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework-iOSTests/Resources/SearchQuery_AnotherFiveResults.json
@@ -102,6 +102,7 @@
             }
           },
           "fxRate": 0.12867125,
+          "fxRateCurrency": "USD",
           "usdExchangeRate": 0.12867125,
           "posts": {
             "__typename": "PostConnection",
@@ -193,6 +194,7 @@
           "state": "LIVE",
           "video": null,
           "fxRate": 1.0884875,
+          "fxRateCurrency": "USD",
           "usdExchangeRate": 1.0884875,
           "posts": {
             "__typename": "PostConnection",
@@ -298,6 +300,7 @@
             }
           },
           "fxRate": 1,
+          "fxRateCurrency": "USD",
           "usdExchangeRate": 1,
           "posts": {
             "__typename": "PostConnection",
@@ -403,6 +406,7 @@
             }
           },
           "fxRate": 1,
+          "fxRateCurrency": "USD",
           "usdExchangeRate": 1,
           "posts": {
             "__typename": "PostConnection",
@@ -508,6 +512,7 @@
             }
           },
           "fxRate": 1,
+          "fxRateCurrency": "USD",
           "usdExchangeRate": 1,
           "posts": {
             "__typename": "PostConnection",

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework-iOSTests/Resources/SearchQuery_FiveResults.json
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework-iOSTests/Resources/SearchQuery_FiveResults.json
@@ -102,6 +102,7 @@
             }
           },
           "fxRate": 1,
+          "fxRateCurrency": "USD",
           "usdExchangeRate": 1,
           "posts": {
             "__typename": "PostConnection",
@@ -193,6 +194,7 @@
           "state": "LIVE",
           "video": null,
           "fxRate": 1,
+          "fxRateCurrency": "USD",
           "usdExchangeRate": 1,
           "posts": {
             "__typename": "PostConnection",
@@ -284,6 +286,7 @@
           "state": "LIVE",
           "video": null,
           "fxRate": 0.12867125,
+          "fxRateCurrency": "USD",
           "usdExchangeRate": 0.12867125,
           "posts": {
             "__typename": "PostConnection",
@@ -375,6 +378,7 @@
           "state": "LIVE",
           "video": null,
           "fxRate": 1,
+          "fxRateCurrency": "USD",
           "usdExchangeRate": 1,
           "posts": {
             "__typename": "PostConnection",
@@ -471,6 +475,7 @@
           "state": "LIVE",
           "video": null,
           "fxRate": 1,
+          "fxRateCurrency": "USD",
           "usdExchangeRate": 1,
           "posts": {
             "__typename": "PostConnection",

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework-iOSTests/Resources/SearchQuery_SearchViewControllerTests_Active.json
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework-iOSTests/Resources/SearchQuery_SearchViewControllerTests_Active.json
@@ -88,6 +88,7 @@
           "state": "LIVE",
           "video": null,
           "fxRate": 1,
+          "fxRateCurrency": "USD",
           "usdExchangeRate": 1,
           "posts": {
             "__typename": "PostConnection",
@@ -179,6 +180,7 @@
           "state": "LIVE",
           "video": null,
           "fxRate": 1,
+          "fxRateCurrency": "USD",
           "usdExchangeRate": 1,
           "posts": {
             "__typename": "PostConnection",
@@ -270,6 +272,7 @@
           "state": "LIVE",
           "video": null,
           "fxRate": 1,
+          "fxRateCurrency": "USD",
           "usdExchangeRate": 1,
           "posts": {
             "__typename": "PostConnection",
@@ -361,6 +364,7 @@
           "state": "LIVE",
           "video": null,
           "fxRate": 1,
+          "fxRateCurrency": "USD",
           "usdExchangeRate": 1,
           "posts": {
             "__typename": "PostConnection",
@@ -452,6 +456,7 @@
           "state": "LIVE",
           "video": null,
           "fxRate": 1,
+          "fxRateCurrency": "USD",
           "usdExchangeRate": 1,
           "posts": {
             "__typename": "PostConnection",
@@ -543,6 +548,7 @@
           "state": "LIVE",
           "video": null,
           "fxRate": 1,
+          "fxRateCurrency": "USD",
           "usdExchangeRate": 1,
           "posts": {
             "__typename": "PostConnection",
@@ -634,6 +640,7 @@
           "state": "LIVE",
           "video": null,
           "fxRate": 1,
+          "fxRateCurrency": "USD",
           "usdExchangeRate": 1,
           "posts": {
             "__typename": "PostConnection",
@@ -725,6 +732,7 @@
           "state": "LIVE",
           "video": null,
           "fxRate": 1,
+          "fxRateCurrency": "USD",
           "usdExchangeRate": 1,
           "posts": {
             "__typename": "PostConnection",
@@ -816,6 +824,7 @@
           "state": "LIVE",
           "video": null,
           "fxRate": 1,
+          "fxRateCurrency": "USD",
           "usdExchangeRate": 1,
           "posts": {
             "__typename": "PostConnection",
@@ -907,6 +916,7 @@
           "state": "LIVE",
           "video": null,
           "fxRate": 1,
+          "fxRateCurrency": "USD",
           "usdExchangeRate": 1,
           "posts": {
             "__typename": "PostConnection",

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework-iOSTests/Resources/SearchQuery_SearchViewControllerTests_Prelaunch.json
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework-iOSTests/Resources/SearchQuery_SearchViewControllerTests_Prelaunch.json
@@ -88,6 +88,7 @@
           "state": "LIVE",
           "video": null,
           "fxRate": 1,
+          "fxRateCurrency": "USD",
           "usdExchangeRate": 1,
           "posts": {
             "__typename": "PostConnection",
@@ -179,6 +180,7 @@
           "state": "LIVE",
           "video": null,
           "fxRate": 1,
+          "fxRateCurrency": "USD",
           "usdExchangeRate": 1,
           "posts": {
             "__typename": "PostConnection",
@@ -270,6 +272,7 @@
           "state": "LIVE",
           "video": null,
           "fxRate": 1,
+          "fxRateCurrency": "USD",
           "usdExchangeRate": 1,
           "posts": {
             "__typename": "PostConnection",
@@ -361,6 +364,7 @@
           "state": "LIVE",
           "video": null,
           "fxRate": 1,
+          "fxRateCurrency": "USD",
           "usdExchangeRate": 1,
           "posts": {
             "__typename": "PostConnection",
@@ -452,6 +456,7 @@
           "state": "LIVE",
           "video": null,
           "fxRate": 1,
+          "fxRateCurrency": "USD",
           "usdExchangeRate": 1,
           "posts": {
             "__typename": "PostConnection",
@@ -543,6 +548,7 @@
           "state": "LIVE",
           "video": null,
           "fxRate": 1,
+          "fxRateCurrency": "USD",
           "usdExchangeRate": 1,
           "posts": {
             "__typename": "PostConnection",
@@ -634,6 +640,7 @@
           "state": "LIVE",
           "video": null,
           "fxRate": 1,
+          "fxRateCurrency": "USD",
           "usdExchangeRate": 1,
           "posts": {
             "__typename": "PostConnection",
@@ -725,6 +732,7 @@
           "state": "LIVE",
           "video": null,
           "fxRate": 1,
+          "fxRateCurrency": "USD",
           "usdExchangeRate": 1,
           "posts": {
             "__typename": "PostConnection",
@@ -816,6 +824,7 @@
           "state": "LIVE",
           "video": null,
           "fxRate": 1,
+          "fxRateCurrency": "USD",
           "usdExchangeRate": 1,
           "posts": {
             "__typename": "PostConnection",
@@ -907,6 +916,7 @@
           "state": "LIVE",
           "video": null,
           "fxRate": 1,
+          "fxRateCurrency": "USD",
           "usdExchangeRate": 1,
           "posts": {
             "__typename": "PostConnection",

--- a/KsApi/Sources/KsApi/MockService.swift
+++ b/KsApi/Sources/KsApi/MockService.swift
@@ -1313,7 +1313,7 @@
       }
     }
 
-    internal func fetchProject(projectParam: Param, configCurrency _: String?)
+    internal func fetchProject(projectParam: Param)
       -> SignalProducer<Project.ProjectPamphletData, ErrorEnvelope> {
       guard let client = self.apolloClient else {
         return .empty

--- a/KsApi/Sources/KsApi/ProjectPageFetcher.swift
+++ b/KsApi/Sources/KsApi/ProjectPageFetcher.swift
@@ -9,12 +9,10 @@ public struct ProjectPageFetcher {
   }
 
   public func fetchProjectPage(
-    projectParam param: Param,
-    configCurrency: String?
+    projectParam param: Param
   ) -> SignalProducer<Project, ErrorEnvelope> {
     let projectAndBackingIdProducer = self.apiService.fetchProject(
-      projectParam: param,
-      configCurrency: configCurrency
+      projectParam: param
     )
 
     let projectAndBackingProducer = projectAndBackingIdProducer

--- a/KsApi/Sources/KsApi/Service.swift
+++ b/KsApi/Sources/KsApi/Service.swift
@@ -582,7 +582,7 @@ public struct Service: ServiceType {
 
    This is the only use case at the moment as it effects the `ProjectPageViewController` directly.
    */
-  public func fetchProject(projectParam: Param, configCurrency: String?)
+  public func fetchProject(projectParam: Param)
     -> SignalProducer<Project.ProjectPamphletData, ErrorEnvelope> {
     let query = GraphAPI.FetchProjectByParamQuery(
       projectId: .someOrNil(projectParam.id),
@@ -591,7 +591,7 @@ public struct Service: ServiceType {
 
     return GraphQL.shared.client
       .fetch(query: query)
-      .flatMap { Project.projectProducer(from: $0, configCurrency: configCurrency) }
+      .flatMap { Project.projectProducer(from: $0) }
   }
 
   /**

--- a/KsApi/Sources/KsApi/ServiceType.swift
+++ b/KsApi/Sources/KsApi/ServiceType.swift
@@ -251,7 +251,7 @@ public protocol ServiceType {
 
   /// Fetch the newest data for a particular project from its id or slug, including an optional backing id if current user is backing project
   /// (currently only used on `ProjectPamphetViewModel`and `ProjectPageViewModel`  because it's a GQL query)
-  func fetchProject(projectParam: Param, configCurrency: String?)
+  func fetchProject(projectParam: Param)
     -> SignalProducer<Project.ProjectPamphletData, ErrorEnvelope>
 
   /// Fetch the project's rewards and pledge over time data

--- a/KsApi/Sources/KsApi/models/ErroredBackingsEnvelope.swift
+++ b/KsApi/Sources/KsApi/models/ErroredBackingsEnvelope.swift
@@ -35,7 +35,7 @@ extension ErroredBackingsEnvelope {
       guard let backingFragment = node?.fragments.backingFragment,
             let projectFragment = node?.project?.fragments.projectFragment,
             let backing = Backing.backing(from: backingFragment, paymentIncrements: paymentIncrements),
-            let project = Project.project(from: projectFragment, currentUserChosenCurrency: nil)
+            let project = Project.project(from: projectFragment)
       else { return nil }
 
       return ProjectAndBackingEnvelope(project: project, backing: backing)

--- a/KsApi/Sources/KsApi/models/ProjectAndBackingEnvelope.swift
+++ b/KsApi/Sources/KsApi/models/ProjectAndBackingEnvelope.swift
@@ -35,7 +35,7 @@ extension ProjectAndBackingEnvelope {
         addOns: addOns,
         paymentIncrements: paymentIncrements
       ),
-      let project = Project.project(from: projectFragment, backing: backing, currentUserChosenCurrency: nil)
+      let project = Project.project(from: projectFragment, backing: backing)
     else {
       return SignalProducer(error: .couldNotParseJSON)
     }

--- a/KsApi/Sources/KsApi/models/graphql/adapters/Project+FetchAddOnsQueryData.swift
+++ b/KsApi/Sources/KsApi/models/graphql/adapters/Project+FetchAddOnsQueryData.swift
@@ -30,7 +30,7 @@ extension Project {
 
     guard
       let fragment = data.project?.fragments.projectFragment,
-      let project = Project.project(from: fragment, addOns: addOns, currentUserChosenCurrency: nil)
+      let project = Project.project(from: fragment, addOns: addOns)
     else { return nil }
 
     return project

--- a/KsApi/Sources/KsApi/models/graphql/adapters/Project+FetchProjectQueryData.swift
+++ b/KsApi/Sources/KsApi/models/graphql/adapters/Project+FetchProjectQueryData.swift
@@ -11,12 +11,10 @@ extension Project {
   }
 
   static func projectProducer(
-    from data: GraphAPI.FetchProjectByParamQuery.Data,
-    configCurrency: String?
+    from data: GraphAPI.FetchProjectByParamQuery.Data
   ) -> SignalProducer<ProjectPamphletData, ErrorEnvelope> {
     let projectAndBackingId = Project.project(
-      from: data,
-      configCurrency: configCurrency
+      from: data
     )
 
     guard let project = projectAndBackingId.0 else {
@@ -32,8 +30,7 @@ extension Project {
   }
 
   internal static func project(
-    from data: GraphAPI.FetchProjectByParamQuery.Data,
-    configCurrency: String?
+    from data: GraphAPI.FetchProjectByParamQuery.Data
   ) -> (Project?, Int?) {
     var projectBackingId: Int?
 
@@ -49,8 +46,7 @@ extension Project {
         flagging: data.project?.flagging != nil,
         rewards: [Reward.noRewardReward(from: noRewardFragment)],
         addOns: nil,
-        backing: nil,
-        currentUserChosenCurrency: data.me?.chosenCurrency ?? configCurrency
+        backing: nil
       )
     else { return (nil, nil) }
 

--- a/KsApi/Sources/KsApi/models/graphql/adapters/Project+ProjectFragment.swift
+++ b/KsApi/Sources/KsApi/models/graphql/adapters/Project+ProjectFragment.swift
@@ -14,8 +14,7 @@ extension Project {
     flagging: Bool? = nil,
     rewards: [Reward] = [],
     addOns: [Reward]? = nil,
-    backing: Backing? = nil,
-    currentUserChosenCurrency: String?
+    backing: Backing? = nil
   ) -> Project? {
     guard
       let country = Country.country(
@@ -87,7 +86,7 @@ extension Project {
     let plotFragment = projectFragment.fragments.pledgeOverTimeFragment
 
     let statsFragment = projectFragment.fragments.projectStatsFragment
-    let stats = projectStats(from: statsFragment, currentUserChosenCurrency: currentUserChosenCurrency)
+    let stats = projectStats(from: statsFragment)
 
     return
       Project(
@@ -218,8 +217,7 @@ private func projectState(from projectState: GraphAPI.ProjectState?) -> Project.
  Returns a minimal `Project.Stats` from a `ProjectStatsFragment`
  */
 private func projectStats(
-  from statsFragment: GraphAPI.ProjectStatsFragment,
-  currentUserChosenCurrency: String?
+  from statsFragment: GraphAPI.ProjectStatsFragment
 ) -> Project.Stats {
   let pledgedRawData = statsFragment.pledged.fragments.moneyFragment.amount.flatMap(Float.init)
   let pledgedRawValue = statsFragment.pledged.fragments.moneyFragment.amount.flatMap(Float.init) ?? 0
@@ -238,7 +236,7 @@ private func projectStats(
     commentsCount: statsFragment.commentsCount,
     convertedPledgedAmount: convertedPledgedAmountValue,
     projectCurrency: statsFragment.currency.rawValue,
-    userCurrency: currentUserChosenCurrency,
+    userCurrency: statsFragment.fxRateCurrency.rawValue,
     userCurrencyRate: fxRateValue,
     goal: statsFragment.goal?.fragments.moneyFragment.amount.flatMap(Float.init).flatMap(Int.init) ?? 0,
     pledged: pledgedValue,

--- a/KsApi/Sources/KsApiTests/ProjectPageFetcherTests.swift
+++ b/KsApi/Sources/KsApiTests/ProjectPageFetcherTests.swift
@@ -35,7 +35,7 @@ public final class ProjectPageFetcherTests: XCTestCase {
     // This mimicks what Service does internally to map the GraphAPI objects to V1 model objects.
     // MockService requires V1 objects, so this is a best effort
     // to duplicate the actual GraphQL mapping behavior.
-    let projectResult = Project.projectProducer(from: fetchProjectResponse, configCurrency: nil).first()
+    let projectResult = Project.projectProducer(from: fetchProjectResponse).first()
     let backingResult = ProjectAndBackingEnvelope.envelopeProducer(from: fetchBackingResponse).first()
     let rewardsResult = Project.projectRewardsProducer(from: fetchRewardsResponse).first()
 
@@ -47,7 +47,7 @@ public final class ProjectPageFetcherTests: XCTestCase {
 
     let fetcher = ProjectPageFetcher(withService: mockService)
 
-    let producer = fetcher.fetchProjectPage(projectParam: .id(0), configCurrency: nil)
+    let producer = fetcher.fetchProjectPage(projectParam: .id(0))
     let project = producer.allValues().first
 
     XCTAssertNotNil(project)

--- a/KsApi/Sources/KsApiTests/models/graphql/adapters/Backing+BackingFragmentTests.swift
+++ b/KsApi/Sources/KsApiTests/models/graphql/adapters/Backing+BackingFragmentTests.swift
@@ -904,6 +904,7 @@ private func backingDictionary() -> [String: Any] {
         "nodes": []
       },
       "fxRate": 1.23244501,
+      "fxRateCurrency": "USD",
       "goal": {
         "__typename": "Money",
         "amount": "3000.0",

--- a/KsApi/Sources/KsApiTests/models/graphql/adapters/Project+FetchProjectQueryDataTests.swift
+++ b/KsApi/Sources/KsApiTests/models/graphql/adapters/Project+FetchProjectQueryDataTests.swift
@@ -8,8 +8,7 @@ final class Project_FetchProjectQueryDataTests: XCTestCase {
   /// `FetchProjectQueryBySlug` returns identical data.
   func testFetchProjectQueryData_Success() {
     let producer = Project.projectProducer(
-      from: FetchProjectQueryTemplate.valid.data,
-      configCurrency: Project.Country.de.currencyCode
+      from: FetchProjectQueryTemplate.valid.data
     )
 
     let projectProducer = producer

--- a/KsApi/Sources/KsApiTests/models/graphql/adapters/Project+ProjectFragmentTests.swift
+++ b/KsApi/Sources/KsApiTests/models/graphql/adapters/Project+ProjectFragmentTests.swift
@@ -18,8 +18,7 @@ final class Project_ProjectFragmentTests: XCTestCase {
 
       let project = Project.project(
         from: fragment,
-        flagging: false,
-        currentUserChosenCurrency: nil
+        flagging: false
       )
 
       guard let project = project else {
@@ -389,6 +388,7 @@ final class Project_ProjectFragmentTests: XCTestCase {
        "description":"In this unforgiving Hell, people are forced to fight to the death in an elite gamble for their souls.",
        "finalCollectionDate":null,
        "fxRate":1.26411401,
+       "fxRateCurrency":"USD",
        "friends":{
           "__typename":"ProjectBackerFriendsConnection",
           "nodes":[

--- a/KsApi/Sources/KsApiTests/models/mocks/ProjectMocks.swift
+++ b/KsApi/Sources/KsApiTests/models/mocks/ProjectMocks.swift
@@ -16,6 +16,7 @@ extension GraphAPITestMocks.Project {
     project.minPledge = 678
     project.maxPledge = 999_999
     project.fxRate = 1.0
+    project.fxRateCurrency = GraphQLEnum(.usd)
     project.stateChangedAt = "232434"
     project.location = GraphAPITestMocks.Location.mock
     project.canComment = true

--- a/KsApi/Sources/KsApiTests/mutations/templates/query/FetchAddOnsQueryTemplate.swift
+++ b/KsApi/Sources/KsApiTests/mutations/templates/query/FetchAddOnsQueryTemplate.swift
@@ -258,6 +258,7 @@ public enum FetchAddsOnsQueryTemplate {
             "description": "Notebooks, paper tape and sticker sets from the Peppermint Fox Press, inspired by vintage books. For poets, planners, and storytellers.",
             "finalCollectionDate": null,
             "fxRate": 0.93110152,
+            "fxRateCurrency": "USD",
             "goal": {
               "__typename": "Money",
               "amount": "1500.0",

--- a/KsApi/Sources/KsApiTests/mutations/templates/query/FetchProjectQueryTemplate.swift
+++ b/KsApi/Sources/KsApiTests/mutations/templates/query/FetchProjectQueryTemplate.swift
@@ -20,10 +20,6 @@ public enum FetchProjectQueryTemplate {
   private var validResultMap: [String: Any] {
     let json = """
     {
-       "me":{
-          "__typename": "User",
-          "chosenCurrency":"CAD"
-       },
        "project":{
           "backing": {
             "__typename": "Backing",
@@ -116,7 +112,7 @@ public enum FetchProjectQueryTemplate {
           "description":"A photographic book about the daily life and work on board of a Russian research vessel during the MOSAiC expedition in the Arctic.",
           "finalCollectionDate":null,
           "fxRate":1.49547966,
-          "fxRateCurrency": "USD",
+          "fxRateCurrency": "CAD",
           "friends":{
              "__typename":"ProjectBackerFriendsConnection",
              "nodes":[]

--- a/KsApi/Sources/KsApiTests/mutations/templates/query/FetchProjectQueryTemplate.swift
+++ b/KsApi/Sources/KsApiTests/mutations/templates/query/FetchProjectQueryTemplate.swift
@@ -116,6 +116,7 @@ public enum FetchProjectQueryTemplate {
           "description":"A photographic book about the daily life and work on board of a Russian research vessel during the MOSAiC expedition in the Arctic.",
           "finalCollectionDate":null,
           "fxRate":1.49547966,
+          "fxRateCurrency": "USD",
           "friends":{
              "__typename":"ProjectBackerFriendsConnection",
              "nodes":[]

--- a/KsApi/Sources/KsApiTests/mutations/templates/query/FetchUserBackingsQueryTemplate.swift
+++ b/KsApi/Sources/KsApiTests/mutations/templates/query/FetchUserBackingsQueryTemplate.swift
@@ -111,6 +111,7 @@ public enum FetchUserBackingsQueryTemplate {
                 "description": "test blurb",
                 "finalCollectionDate": nil,
                 "fxRate": 1.0,
+                "fxRateCurrency": "USD",
                 "friends": [
                   "__typename": "ProjectBackerFriendsConnection",
                   "nodes": []

--- a/KsApi/Sources/KsApiTests/queries/templates/FetchMyBackedProjectsQuery.json
+++ b/KsApi/Sources/KsApiTests/queries/templates/FetchMyBackedProjectsQuery.json
@@ -110,6 +110,7 @@
           },
           "finalCollectionDate": null,
           "fxRate": 1,
+          "fxRateCurrency": "USD",
           "goal": {
             "__typename": "Money",
             "amount": "1000.0",
@@ -305,6 +306,7 @@
           },
           "finalCollectionDate": null,
           "fxRate": 1,
+          "fxRateCurrency": "USD",
           "goal": {
             "__typename": "Money",
             "amount": "2000.0",
@@ -535,6 +537,7 @@
           },
           "finalCollectionDate": null,
           "fxRate": 1,
+          "fxRateCurrency": "USD",
           "goal": {
             "__typename": "Money",
             "amount": "20000.0",

--- a/KsApi/Sources/KsApiTests/queries/templates/FetchMySavedProjectsQuery.json
+++ b/KsApi/Sources/KsApiTests/queries/templates/FetchMySavedProjectsQuery.json
@@ -300,6 +300,7 @@
           },
           "finalCollectionDate": null,
           "fxRate": 1,
+          "fxRateCurrency": "USD",
           "goal": {
             "__typename": "Money",
             "amount": "1000.0",
@@ -598,6 +599,7 @@
           },
           "finalCollectionDate": "2023-11-16T11:22:26-05:00",
           "fxRate": 1,
+          "fxRateCurrency": "USD",
           "goal": {
             "__typename": "Money",
             "amount": "126000.0",
@@ -1055,6 +1057,7 @@
           },
           "finalCollectionDate": "2023-10-17T10:15:39-04:00",
           "fxRate": 1,
+          "fxRateCurrency": "USD",
           "goal": {
             "__typename": "Money",
             "amount": "10000.0",
@@ -1331,6 +1334,7 @@
           },
           "finalCollectionDate": "2023-10-11T14:25:50-04:00",
           "fxRate": 1,
+          "fxRateCurrency": "USD",
           "goal": {
             "__typename": "Money",
             "amount": "5000.0",

--- a/KsApi/Sources/KsApiTests/queries/templates/FetchSortedProjectRewardsById.json
+++ b/KsApi/Sources/KsApiTests/queries/templates/FetchSortedProjectRewardsById.json
@@ -125,7 +125,8 @@
         ]
       },
       "minPledge": 1,
-      "fxRate": 0.780313
+      "fxRate": 0.780313,
+      "fxRateCurrency": "CHF",
     }
   }
 }

--- a/KsApi/Sources/KsApiTests/queries/templates/ProjectPageFetcher/FetchBackingQuery.json
+++ b/KsApi/Sources/KsApiTests/queries/templates/ProjectPageFetcher/FetchBackingQuery.json
@@ -10,6 +10,7 @@
         "__typename": "Project",
         "pid": 1452473812,
         "fxRate": 0.848212,
+        "fxRateCurrency": "EUR",
         "minPledge": 1,
         "country": {
           "__typename": "Country",

--- a/KsApi/Sources/KsApiTests/queries/templates/ProjectPageFetcher/FetchProjectByParamQuery.json
+++ b/KsApi/Sources/KsApiTests/queries/templates/ProjectPageFetcher/FetchProjectByParamQuery.json
@@ -88,6 +88,7 @@
       },
       "finalCollectionDate": null,
       "fxRate": 0.848212,
+      "fxRateCurrency": "EUR",
       "goal": {
         "__typename": "Money",
         "amount": "1000.0",

--- a/KsApi/Sources/KsApiTests/queries/templates/ProjectPageFetcher/FetchProjectByParamQuery.json
+++ b/KsApi/Sources/KsApiTests/queries/templates/ProjectPageFetcher/FetchProjectByParamQuery.json
@@ -1,9 +1,5 @@
 {
   "data": {
-    "me": {
-      "__typename": "User",
-      "chosenCurrency": "EUR"
-    },
     "project": {
       "__typename": "Project",
       "backing": {

--- a/Library/Sources/Library/Library/ViewModels/ProjectPageViewModel.swift
+++ b/Library/Sources/Library/Library/ViewModels/ProjectPageViewModel.swift
@@ -926,13 +926,9 @@ private func fetchProject(
 )
   -> SignalProducer<Project, ErrorEnvelope> {
   let param = projectOrParam.param
-  let configCurrency = AppEnvironment.current.launchedCountries.countries
-    .first(where: { $0.countryCode == AppEnvironment.current.countryCode })?.currencyCode
-
   let fetcher = ProjectPageFetcher(withService: AppEnvironment.current.apiService)
   let producer = fetcher.fetchProjectPage(
-    projectParam: param.param,
-    configCurrency: configCurrency
+    projectParam: param.param
   )
   .ksr_delay(AppEnvironment.current.apiDelayInterval, on: AppEnvironment.current.scheduler)
 

--- a/LibraryTests/Resources/SearchQuery_AnotherFiveResults.json
+++ b/LibraryTests/Resources/SearchQuery_AnotherFiveResults.json
@@ -102,6 +102,7 @@
             }
           },
           "fxRate": 0.12867125,
+          "fxRateCurrency": "USD",
           "usdExchangeRate": 0.12867125,
           "posts": {
             "__typename": "PostConnection",
@@ -193,6 +194,7 @@
           "state": "LIVE",
           "video": null,
           "fxRate": 1.0884875,
+          "fxRateCurrency": "USD",
           "usdExchangeRate": 1.0884875,
           "posts": {
             "__typename": "PostConnection",
@@ -298,6 +300,7 @@
             }
           },
           "fxRate": 1,
+          "fxRateCurrency": "USD",
           "usdExchangeRate": 1,
           "posts": {
             "__typename": "PostConnection",
@@ -403,6 +406,7 @@
             }
           },
           "fxRate": 1,
+          "fxRateCurrency": "USD",
           "usdExchangeRate": 1,
           "posts": {
             "__typename": "PostConnection",
@@ -508,6 +512,7 @@
             }
           },
           "fxRate": 1,
+          "fxRateCurrency": "USD",
           "usdExchangeRate": 1,
           "posts": {
             "__typename": "PostConnection",

--- a/LibraryTests/Resources/SearchQuery_FiveResults.json
+++ b/LibraryTests/Resources/SearchQuery_FiveResults.json
@@ -102,6 +102,7 @@
             }
           },
           "fxRate": 1,
+          "fxRateCurrency": "USD",
           "usdExchangeRate": 1,
           "posts": {
             "__typename": "PostConnection",
@@ -193,6 +194,7 @@
           "state": "LIVE",
           "video": null,
           "fxRate": 1,
+          "fxRateCurrency": "USD",
           "usdExchangeRate": 1,
           "posts": {
             "__typename": "PostConnection",
@@ -284,6 +286,7 @@
           "state": "LIVE",
           "video": null,
           "fxRate": 0.12867125,
+          "fxRateCurrency": "USD",
           "usdExchangeRate": 0.12867125,
           "posts": {
             "__typename": "PostConnection",
@@ -375,6 +378,7 @@
           "state": "LIVE",
           "video": null,
           "fxRate": 1,
+          "fxRateCurrency": "USD",
           "usdExchangeRate": 1,
           "posts": {
             "__typename": "PostConnection",
@@ -471,6 +475,7 @@
           "state": "LIVE",
           "video": null,
           "fxRate": 1,
+          "fxRateCurrency": "USD",
           "usdExchangeRate": 1,
           "posts": {
             "__typename": "PostConnection",

--- a/graphql/fragments/ProjectStatsFragment.graphql
+++ b/graphql/fragments/ProjectStatsFragment.graphql
@@ -3,6 +3,7 @@ fragment ProjectStatsFragment on Project {
   commentsCount(withReplies: true)
   currency
   fxRate
+  fxRateCurrency
   goal {
     ...MoneyFragment
   }

--- a/graphql/queries/FetchProjectByParamQuery.graphql
+++ b/graphql/queries/FetchProjectByParamQuery.graphql
@@ -1,7 +1,4 @@
 query FetchProjectByParam($projectId: Int, $slug: String) {
-  me {
-    chosenCurrency
-  }
   project(pid: $projectId, slug: $slug) {
     ...ProjectFragment
     backing {


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Use `fxRateCurrency` on Project for the user's selected currency code when creating a `Project`.

# 🤔 Why

The user's chosen currency lives on the `User` object in GraphQL, not on the `Project`. That meant we had a lot of extra plumbing to pass it down - either from `AppEnvironment.current.currentUser`, or from a top-level GraphQL query like  `me { currency }`.

To clean this up, I added the GraphQL field `fxRateCurrency` to `ProjectFragment`. This field matches the user's chosen currency (the same one used for the `fxRate`). 

This PR also depends on #2910 and #2908. I created a separate base branch with both those changes for clarity.