### PR TITLE
DISC-369: Add helpful utilities to ProjectPageViewModelTests

### DIFF
--- a/LibraryTests/Library/ViewModels/ProjectPageViewModelTests.swift
+++ b/LibraryTests/Library/ViewModels/ProjectPageViewModelTests.swift
@@ -565,7 +565,7 @@ final class ProjectPageViewModelTests: TestCase {
     withEnvironment(config: .template, currentUser: .template, mainBundle: self.releaseBundle) {
       let project = Project.template
 
-      self.configureInitialState(.left(project))
+      self.vm.configureAndLoad(.left(project))
 
       self.goToRewardsProject.assertDidNotEmitValue()
       self.goToRewardsRefTag.assertDidNotEmitValue()
@@ -603,7 +603,7 @@ final class ProjectPageViewModelTests: TestCase {
     withEnvironment(config: .template, currentUser: nil, mainBundle: self.releaseBundle) {
       let project = Project.template
 
-      self.configureInitialState(.left(project))
+      self.vm.configureAndLoad(.left(project))
 
       self.goToRewardsProject.assertDidNotEmitValue()
       self.goToRewardsRefTag.assertDidNotEmitValue()
@@ -656,7 +656,7 @@ final class ProjectPageViewModelTests: TestCase {
     let initialData = Either<Project, any ProjectPageParam>.right(param)
 
     withEnvironment(apiService: mockService, currentUser: .template) {
-      self.configureInitialState(initialData)
+      self.vm.configureAndLoad(initialData)
 
       self.configureChildViewControllersWithProject.assertDidNotEmitValue()
 
@@ -694,7 +694,7 @@ final class ProjectPageViewModelTests: TestCase {
     let initialData = Either<Project, any ProjectPageParam>.right(param)
 
     withEnvironment(apiService: mockService, currentUser: .template) {
-      self.configureInitialState(initialData, secretRewardToken: "foobar")
+      self.vm.configureAndLoad(initialData, secretRewardToken: "foobar")
 
       self.configureChildViewControllersWithProject.assertDidNotEmitValue()
 
@@ -731,7 +731,7 @@ final class ProjectPageViewModelTests: TestCase {
     let initialData = Either<Project, any ProjectPageParam>.right(param)
 
     withEnvironment(apiService: mockService, currentUser: .template) {
-      self.configureInitialState(initialData)
+      self.vm.configureAndLoad(initialData)
 
       self.configureChildViewControllersWithProject.assertDidNotEmitValue()
 
@@ -749,7 +749,7 @@ final class ProjectPageViewModelTests: TestCase {
       currentUser: .template,
       mainBundle: self.releaseBundle
     ) {
-      self.configureInitialState(.left(project), secretRewardToken: "secret-reward-token")
+      self.vm.configureAndLoad(.left(project), secretRewardToken: "secret-reward-token")
 
       self.goToRewardsProject.assertDidNotEmitValue()
       self.goToRewardsRefTag.assertDidNotEmitValue()
@@ -773,7 +773,7 @@ final class ProjectPageViewModelTests: TestCase {
     ) {
       let project = Project.template
 
-      self.configureInitialState(.left(project), secretRewardToken: "secret-reward-token")
+      self.vm.configureAndLoad(.left(project), secretRewardToken: "secret-reward-token")
 
       self.goToRewardsProject.assertDidNotEmitValue()
       self.goToRewardsRefTag.assertDidNotEmitValue()
@@ -797,7 +797,7 @@ final class ProjectPageViewModelTests: TestCase {
         |> \.watchesCount .~ 10
         |> \.personalization.isStarred .~ true
 
-      self.configureInitialState(.left(project))
+      self.vm.configureAndLoad(.left(project))
 
       self.updateWatchProjectWithPrelaunchProjectState.assertDidNotEmitValue()
 
@@ -821,7 +821,7 @@ final class ProjectPageViewModelTests: TestCase {
         |> Project.lens.personalization.backing .~ backing
         |> Project.lens.personalization.isBacking .~ true
 
-      self.configureInitialState(.left(project))
+      self.vm.configureAndLoad(.left(project))
 
       self.goToManagePledgeProjectParam.assertDidNotEmitValue()
       self.goToManagePledgeBackingParam.assertDidNotEmitValue()
@@ -847,7 +847,7 @@ final class ProjectPageViewModelTests: TestCase {
         |> Project.lens.personalization.backing .~ backing
         |> Project.lens.personalization.isBacking .~ true
 
-      self.configureInitialState(.left(project))
+      self.vm.configureAndLoad(.left(project))
 
       self.goToManagePledgeProjectParam.assertDidNotEmitValue()
       self.goToManagePledgeBackingParam.assertDidNotEmitValue()
@@ -874,7 +874,7 @@ final class ProjectPageViewModelTests: TestCase {
 
       let backingDetailsPageURL = backing.backingDetailsPageRoute
 
-      self.configureInitialState(.left(project))
+      self.vm.configureAndLoad(.left(project))
 
       self.goToManagePledgeProjectParam.assertDidNotEmitValue()
       self.goToManagePledgeBackingParam.assertDidNotEmitValue()
@@ -902,7 +902,7 @@ final class ProjectPageViewModelTests: TestCase {
 
       let backingDetailsPageURL = backing.backingDetailsPageRoute
 
-      self.configureInitialState(.left(project))
+      self.vm.configureAndLoad(.left(project))
 
       self.goToManagePledgeProjectParam.assertDidNotEmitValue()
       self.goToManagePledgeBackingParam.assertDidNotEmitValue()
@@ -923,7 +923,7 @@ final class ProjectPageViewModelTests: TestCase {
       AppEnvironment.current.apiService.serverConfig.webBaseUrl.absoluteString +
       project.redemptionPageUrl
 
-    self.configureInitialState(.left(project))
+    self.vm.configureAndLoad(.left(project))
 
     self.goToPledgeManager.assertDidNotEmitValue()
 
@@ -967,7 +967,7 @@ final class ProjectPageViewModelTests: TestCase {
       self.configurePledgeCTAViewIsLoading.assertDidNotEmitValue()
       self.configurePledgeCTAViewRefTag.assertValues([])
 
-      self.configureInitialState(.left(project))
+      self.vm.configureAndLoad(.left(project))
 
       self.configurePledgeCTAViewProject.assertValues([project])
       self.configurePledgeCTAViewIsLoading.assertValues([true])
@@ -996,7 +996,7 @@ final class ProjectPageViewModelTests: TestCase {
       self.configurePledgeCTAViewIsLoading.assertDidNotEmitValue()
       self.configurePledgeCTAViewRefTag.assertDidNotEmitValue()
 
-      self.configureInitialState(.left(project))
+      self.vm.configureAndLoad(.left(project))
 
       self.configurePledgeCTAViewProject.assertValues([project])
       self.configurePledgeCTAViewIsLoading.assertValues([true])
@@ -1919,18 +1919,56 @@ final class ProjectPageViewModelTests: TestCase {
     }
   }
 
-  // MARK: - Functions
-
-  private func configureInitialState(
-    _ projectOrParam: Either<Project, any ProjectPageParam>,
-    secretRewardToken: String? = nil
+  static func mockNetworkRequests(
+    project: Project = Project.template,
+    rewards: [Reward] = [Reward.noReward, Reward.template],
+    backing: Backing? = nil,
+    action: () -> Void
   ) {
-    self.vm.inputs.configureWith(
-      projectOrParam: projectOrParam,
-      refInfo: RefInfo(.discovery),
+    if let backing {
+      let projectPamphletData = Project.ProjectPamphletData(project: project, backingId: backing.id)
+      let projectAndBacking = ProjectAndBackingEnvelope(project: project, backing: backing)
+
+      AppEnvironment.pushEnvironment(
+        apiService: MockService(
+          addUserToSecretRewardGroup: .success(EmptyResponseEnvelope()),
+          fetchProjectAndBackingResult: .success(projectAndBacking),
+          fetchProjectPamphletResult: .success(projectPamphletData),
+          fetchProjectRewardsResult: .success(rewards),
+        )
+      )
+
+    } else {
+      let projectPamphletData = Project.ProjectPamphletData(project: project, backingId: nil)
+
+      AppEnvironment.pushEnvironment(
+        apiService: MockService(
+          addUserToSecretRewardGroup: .success(EmptyResponseEnvelope()),
+          fetchProjectPamphletResult: .success(projectPamphletData),
+          fetchProjectRewardsResult: .success(rewards)
+        )
+      )
+    }
+
+    action()
+
+    AppEnvironment.popEnvironment()
+  }
+}
+
+extension ProjectPageViewModelType {
+  /// Convenience method which calls `configureWith`, `viewDidLoad` and `viewDidAppear`.
+  func configureAndLoad(
+    _ either: Either<Project, any ProjectPageParam>,
+    secretRewardToken: String? = nil,
+    refTag: RefTag? = .discovery
+  ) {
+    self.inputs.configureWith(
+      projectOrParam: either,
+      refInfo: RefInfo(refTag),
       secretRewardToken: secretRewardToken
     )
-    self.vm.inputs.viewDidLoad()
-    self.vm.inputs.viewDidAppear(animated: false)
+    self.inputs.viewDidLoad()
+    self.inputs.viewDidAppear(animated: false)
   }
 }

--- a/LibraryTests/Library/ViewModels/ProjectPageViewModel_TrackingTests.swift
+++ b/LibraryTests/Library/ViewModels/ProjectPageViewModel_TrackingTests.swift
@@ -163,7 +163,7 @@ final class ProjectPageViewModel_TrackingTests: TestCase {
     let service = MockService(fetchProjectPamphletResult: .failure(.couldNotParseJSON))
 
     withEnvironment(apiService: service) {
-      self.configureInitialState(.init(left: .template))
+      self.vm.configureAndLoad(.init(left: .template))
 
       self.scheduler.advance()
 
@@ -184,7 +184,7 @@ final class ProjectPageViewModel_TrackingTests: TestCase {
     )) {
       XCTAssertEqual([], self.segmentTrackingClient.events)
 
-      self.configureInitialState(.init(left: .template))
+      self.vm.configureAndLoad(.init(left: .template))
 
       self.scheduler.advance()
 
@@ -503,20 +503,5 @@ final class ProjectPageViewModel_TrackingTests: TestCase {
       XCTAssertEqual(segmentClient.properties(forKey: "context_type"), ["initiate", "confirm"])
       XCTAssertEqual(segmentClient.properties(forKey: "interaction_target_uid"), ["111", "111"])
     }
-  }
-
-  // MARK: - Functions
-
-  private func configureInitialState(
-    _ projectOrParam: Either<Project, any ProjectPageParam>,
-    secretRewardToken: String? = nil
-  ) {
-    self.vm.inputs.configureWith(
-      projectOrParam: projectOrParam,
-      refInfo: RefInfo(.discovery),
-      secretRewardToken: secretRewardToken
-    )
-    self.vm.inputs.viewDidLoad()
-    self.vm.inputs.viewDidAppear(animated: false)
   }
 }


### PR DESCRIPTION
# 📲 What

Update `ProjectPageViewModelTests`: by adding two utilities:
1. Rename and move `configureInitialState` to `ProjectPageViewModelType.configureAndLoad`
2. Add helper function, `mockNetworkRequests`, which makes it easier to stub the 2-4 fetches required for this page


# 🤔 Why

I'm working on some changes to the Project page loading for an A/B test. I realized pretty quickly that I need to tackle some of the refactoring for DISC-369 that I put off. 

The refactoring was easy - but what actually turns out to be hard is fixing the tests once you _do_ that refactor. This PR adds some utilities to make `ProjectPageViewModelTests` more managable.

I'll spin out separate PRs for test updates in manageable chunks.