### PR TITLE
MBL-1891, CHECK-356: Remove reference to Reward.shippingRules from estimated shipping

### DIFF
--- a/GraphAPI/Sources/Operations/Queries/FetchBackingWithIncrementsRefundedQuery.graphql.swift
+++ b/GraphAPI/Sources/Operations/Queries/FetchBackingWithIncrementsRefundedQuery.graphql.swift
@@ -7,8 +7,8 @@ public class FetchBackingWithIncrementsRefundedQuery: GraphQLQuery {
   public static let operationName: String = "FetchBackingWithIncrementsRefunded"
   public static let operationDocument: ApolloAPI.OperationDocument = .init(
     definition: .init(
-      #"query FetchBackingWithIncrementsRefunded($id: ID!, $includeShippingRules: Boolean!, $includeLocalPickup: Boolean!) { backing(id: $id) { __typename addOns { __typename nodes { __typename ...RewardFragment } } ...BackingFragment paymentIncrements { __typename ...PaymentIncrementBackingFragment } } }"#,
-      fragments: [BackingFragment.self, CountryFragment.self, LocationFragment.self, MoneyFragment.self, NoRewardRewardFragment.self, OrderFragment.self, PaymentIncrementBackingFragment.self, PaymentSourceFragment.self, PublicUserFragment.self, RewardFragment.self, ShippingRuleFragment.self]
+      #"query FetchBackingWithIncrementsRefunded($id: ID!, $includeShippingRules: Boolean!, $includeLocalPickup: Boolean!) { backing(id: $id) { __typename addOns { __typename nodes { __typename ...RewardFragment } } ...BackingFragment reward { __typename ...SimpleShippingRulesExpandedFragment } paymentIncrements { __typename ...PaymentIncrementBackingFragment } } }"#,
+      fragments: [BackingFragment.self, CountryFragment.self, LocationFragment.self, MoneyFragment.self, NoRewardRewardFragment.self, OrderFragment.self, PaymentIncrementBackingFragment.self, PaymentSourceFragment.self, PublicUserFragment.self, RewardFragment.self, ShippingRuleFragment.self, SimpleShippingRulesExpandedFragment.self]
     ))
 
   public var id: ID
@@ -68,12 +68,15 @@ public class FetchBackingWithIncrementsRefundedQuery: GraphQLQuery {
       public static var __selections: [ApolloAPI.Selection] { [
         .field("__typename", String.self),
         .field("addOns", AddOns?.self),
+        .field("reward", Reward?.self),
         .field("paymentIncrements", [PaymentIncrement]?.self),
         .fragment(BackingFragment.self),
       ] }
 
       /// The add-ons that the backer selected
       public var addOns: AddOns? { __data["addOns"] }
+      /// The reward the backer is expecting
+      public var reward: Reward? { __data["reward"] }
       /// Scheduled incremental payments
       public var paymentIncrements: [PaymentIncrement]? { __data["paymentIncrements"] }
       /// Total amount pledged by the backer to the project, including shipping.
@@ -99,8 +102,6 @@ public class FetchBackingWithIncrementsRefundedQuery: GraphQLQuery {
       public var pledgedOn: GraphAPI.DateTime? { __data["pledgedOn"] }
       /// The project
       public var project: Project? { __data["project"] }
-      /// The reward the backer is expecting
-      public var reward: Reward? { __data["reward"] }
       /// Amount pledged for all rewards, the sum off all minimums, excluding shipping
       public var rewardsAmount: RewardsAmount { __data["rewardsAmount"] }
       /// Sequence of the backing
@@ -121,6 +122,7 @@ public class FetchBackingWithIncrementsRefundedQuery: GraphQLQuery {
 
       public init(
         addOns: AddOns? = nil,
+        reward: Reward? = nil,
         paymentIncrements: [PaymentIncrement]? = nil,
         amount: Amount,
         backer: Backer? = nil,
@@ -134,7 +136,6 @@ public class FetchBackingWithIncrementsRefundedQuery: GraphQLQuery {
         order: Order? = nil,
         pledgedOn: GraphAPI.DateTime? = nil,
         project: Project? = nil,
-        reward: Reward? = nil,
         rewardsAmount: RewardsAmount,
         sequence: Int? = nil,
         shippingAmount: ShippingAmount? = nil,
@@ -145,6 +146,7 @@ public class FetchBackingWithIncrementsRefundedQuery: GraphQLQuery {
           data: [
             "__typename": GraphAPI.Objects.Backing.typename,
             "addOns": addOns._fieldData,
+            "reward": reward._fieldData,
             "paymentIncrements": paymentIncrements._fieldData,
             "amount": amount._fieldData,
             "backer": backer._fieldData,
@@ -158,7 +160,6 @@ public class FetchBackingWithIncrementsRefundedQuery: GraphQLQuery {
             "order": order._fieldData,
             "pledgedOn": pledgedOn,
             "project": project._fieldData,
-            "reward": reward._fieldData,
             "rewardsAmount": rewardsAmount._fieldData,
             "sequence": sequence,
             "shippingAmount": shippingAmount._fieldData,
@@ -739,6 +740,551 @@ public class FetchBackingWithIncrementsRefundedQuery: GraphQLQuery {
         }
       }
 
+      /// Backing.Reward
+      ///
+      /// Parent Type: `Reward`
+      public struct Reward: GraphAPI.SelectionSet {
+        public let __data: DataDict
+        public init(_dataDict: DataDict) { __data = _dataDict }
+
+        public static var __parentType: ApolloAPI.ParentType { GraphAPI.Objects.Reward }
+        public static var __selections: [ApolloAPI.Selection] { [
+          .field("__typename", String.self),
+          .fragment(SimpleShippingRulesExpandedFragment.self),
+        ] }
+
+        /// Simple shipping rules expanded as a faster alternative to shippingRulesExpanded since connection type is slow
+        public var simpleShippingRulesExpanded: [SimpleShippingRulesExpanded?] { __data["simpleShippingRulesExpanded"] }
+        /// Amount for claiming this reward.
+        public var amount: Amount { __data["amount"] }
+        /// count of backers for this reward
+        public var backersCount: Int? { __data["backersCount"] }
+        /// Amount for claiming this reward, in the current user's chosen currency
+        public var convertedAmount: ConvertedAmount { __data["convertedAmount"] }
+        /// Add-ons which can be combined with this reward.
+        /// Uses creator preferences and shipping rules to determine allow-ability.
+        /// Inclusion in this list does not necessarily indicate that the add-on is available for backing.
+        ///
+        public var allowedAddons: AllowedAddons { __data["allowedAddons"] }
+        /// A reward description.
+        public var description: String? { __data["description"] }
+        /// A reward's title plus the amount, or a default title (the reward amount) if it doesn't have a title.
+        public var displayName: String { __data["displayName"] }
+        /// When the reward is scheduled to end in seconds
+        public var endsAt: GraphAPI.DateTime? { __data["endsAt"] }
+        /// Estimated delivery day.
+        public var estimatedDeliveryOn: GraphAPI.Date? { __data["estimatedDeliveryOn"] }
+        public var id: GraphAPI.ID { __data["id"] }
+        /// Does reward amount meet or exceed maximum pledge for the project
+        public var isMaxPledge: Bool { __data["isMaxPledge"] }
+        /// Whether or not the reward is available for new pledges
+        public var available: Bool { __data["available"] }
+        /// Whether or not the reward is featured
+        public var featured: Bool { __data["featured"] }
+        /// Items in the reward.
+        public var items: Items? { __data["items"] }
+        /// A reward limit.
+        public var limit: Int? { __data["limit"] }
+        /// Per backer reward limit.
+        public var limitPerBacker: Int? { __data["limitPerBacker"] }
+        /// Where the reward can be locally received if local receipt is selected as the shipping preference
+        public var localReceiptLocation: LocalReceiptLocation? { __data["localReceiptLocation"] }
+        /// A reward title.
+        public var name: String? { __data["name"] }
+        /// Amount for claiming this reward during the campaign.
+        public var pledgeAmount: PledgeAmount { __data["pledgeAmount"] }
+        /// Amount for claiming this reward after the campaign.
+        public var latePledgeAmount: LatePledgeAmount { __data["latePledgeAmount"] }
+        /// Is this reward available for post-campaign pledges?
+        public var postCampaignPledgingEnabled: Bool { __data["postCampaignPledgingEnabled"] }
+        /// The project
+        public var project: Project? { __data["project"] }
+        /// Remaining reward quantity.
+        public var remainingQuantity: Int? { __data["remainingQuantity"] }
+        /// Shipping preference for this reward
+        public var shippingPreference: GraphQLEnum<GraphAPI.ShippingPreference>? { __data["shippingPreference"] }
+        /// A shipping summary
+        public var shippingSummary: String? { __data["shippingSummary"] }
+        /// Shipping rules defined by the creator for this reward
+        public var shippingRules: [ShippingRule?]? { __data["shippingRules"] }
+        /// When the reward is scheduled to start
+        public var startsAt: GraphAPI.DateTime? { __data["startsAt"] }
+        /// The reward image.
+        public var image: Image? { __data["image"] }
+        /// Data related to who can view/access this reward
+        public var audienceData: AudienceData { __data["audienceData"] }
+
+        public struct Fragments: FragmentContainer {
+          public let __data: DataDict
+          public init(_dataDict: DataDict) { __data = _dataDict }
+
+          public var simpleShippingRulesExpandedFragment: SimpleShippingRulesExpandedFragment { _toFragment() }
+          public var rewardFragment: RewardFragment { _toFragment() }
+        }
+
+        public init(
+          simpleShippingRulesExpanded: [SimpleShippingRulesExpanded?],
+          amount: Amount,
+          backersCount: Int? = nil,
+          convertedAmount: ConvertedAmount,
+          allowedAddons: AllowedAddons,
+          description: String? = nil,
+          displayName: String,
+          endsAt: GraphAPI.DateTime? = nil,
+          estimatedDeliveryOn: GraphAPI.Date? = nil,
+          id: GraphAPI.ID,
+          isMaxPledge: Bool,
+          available: Bool,
+          featured: Bool,
+          items: Items? = nil,
+          limit: Int? = nil,
+          limitPerBacker: Int? = nil,
+          localReceiptLocation: LocalReceiptLocation? = nil,
+          name: String? = nil,
+          pledgeAmount: PledgeAmount,
+          latePledgeAmount: LatePledgeAmount,
+          postCampaignPledgingEnabled: Bool,
+          project: Project? = nil,
+          remainingQuantity: Int? = nil,
+          shippingPreference: GraphQLEnum<GraphAPI.ShippingPreference>? = nil,
+          shippingSummary: String? = nil,
+          shippingRules: [ShippingRule?]? = nil,
+          startsAt: GraphAPI.DateTime? = nil,
+          image: Image? = nil,
+          audienceData: AudienceData
+        ) {
+          self.init(_dataDict: DataDict(
+            data: [
+              "__typename": GraphAPI.Objects.Reward.typename,
+              "simpleShippingRulesExpanded": simpleShippingRulesExpanded._fieldData,
+              "amount": amount._fieldData,
+              "backersCount": backersCount,
+              "convertedAmount": convertedAmount._fieldData,
+              "allowedAddons": allowedAddons._fieldData,
+              "description": description,
+              "displayName": displayName,
+              "endsAt": endsAt,
+              "estimatedDeliveryOn": estimatedDeliveryOn,
+              "id": id,
+              "isMaxPledge": isMaxPledge,
+              "available": available,
+              "featured": featured,
+              "items": items._fieldData,
+              "limit": limit,
+              "limitPerBacker": limitPerBacker,
+              "localReceiptLocation": localReceiptLocation._fieldData,
+              "name": name,
+              "pledgeAmount": pledgeAmount._fieldData,
+              "latePledgeAmount": latePledgeAmount._fieldData,
+              "postCampaignPledgingEnabled": postCampaignPledgingEnabled,
+              "project": project._fieldData,
+              "remainingQuantity": remainingQuantity,
+              "shippingPreference": shippingPreference,
+              "shippingSummary": shippingSummary,
+              "shippingRules": shippingRules._fieldData,
+              "startsAt": startsAt,
+              "image": image._fieldData,
+              "audienceData": audienceData._fieldData,
+            ],
+            fulfilledFragments: [
+              ObjectIdentifier(FetchBackingWithIncrementsRefundedQuery.Data.Backing.Reward.self),
+              ObjectIdentifier(SimpleShippingRulesExpandedFragment.self),
+              ObjectIdentifier(BackingFragment.Reward.self),
+              ObjectIdentifier(RewardFragment.self)
+            ]
+          ))
+        }
+
+        public typealias SimpleShippingRulesExpanded = SimpleShippingRulesExpandedFragment.SimpleShippingRulesExpanded
+
+        /// Backing.Reward.Amount
+        ///
+        /// Parent Type: `Money`
+        public struct Amount: GraphAPI.SelectionSet {
+          public let __data: DataDict
+          public init(_dataDict: DataDict) { __data = _dataDict }
+
+          public static var __parentType: ApolloAPI.ParentType { GraphAPI.Objects.Money }
+
+          /// Floating-point numeric value of monetary amount represented as a string
+          public var amount: String? { __data["amount"] }
+          /// Currency of the monetary amount
+          public var currency: GraphQLEnum<GraphAPI.CurrencyCode>? { __data["currency"] }
+          /// Symbol of the currency in which the monetary amount appears
+          public var symbol: String? { __data["symbol"] }
+
+          public struct Fragments: FragmentContainer {
+            public let __data: DataDict
+            public init(_dataDict: DataDict) { __data = _dataDict }
+
+            public var moneyFragment: MoneyFragment { _toFragment() }
+          }
+
+          public init(
+            amount: String? = nil,
+            currency: GraphQLEnum<GraphAPI.CurrencyCode>? = nil,
+            symbol: String? = nil
+          ) {
+            self.init(_dataDict: DataDict(
+              data: [
+                "__typename": GraphAPI.Objects.Money.typename,
+                "amount": amount,
+                "currency": currency,
+                "symbol": symbol,
+              ],
+              fulfilledFragments: [
+                ObjectIdentifier(FetchBackingWithIncrementsRefundedQuery.Data.Backing.Reward.Amount.self),
+                ObjectIdentifier(RewardFragment.Amount.self),
+                ObjectIdentifier(MoneyFragment.self)
+              ]
+            ))
+          }
+        }
+
+        /// Backing.Reward.ConvertedAmount
+        ///
+        /// Parent Type: `Money`
+        public struct ConvertedAmount: GraphAPI.SelectionSet {
+          public let __data: DataDict
+          public init(_dataDict: DataDict) { __data = _dataDict }
+
+          public static var __parentType: ApolloAPI.ParentType { GraphAPI.Objects.Money }
+
+          /// Floating-point numeric value of monetary amount represented as a string
+          public var amount: String? { __data["amount"] }
+          /// Currency of the monetary amount
+          public var currency: GraphQLEnum<GraphAPI.CurrencyCode>? { __data["currency"] }
+          /// Symbol of the currency in which the monetary amount appears
+          public var symbol: String? { __data["symbol"] }
+
+          public struct Fragments: FragmentContainer {
+            public let __data: DataDict
+            public init(_dataDict: DataDict) { __data = _dataDict }
+
+            public var moneyFragment: MoneyFragment { _toFragment() }
+          }
+
+          public init(
+            amount: String? = nil,
+            currency: GraphQLEnum<GraphAPI.CurrencyCode>? = nil,
+            symbol: String? = nil
+          ) {
+            self.init(_dataDict: DataDict(
+              data: [
+                "__typename": GraphAPI.Objects.Money.typename,
+                "amount": amount,
+                "currency": currency,
+                "symbol": symbol,
+              ],
+              fulfilledFragments: [
+                ObjectIdentifier(FetchBackingWithIncrementsRefundedQuery.Data.Backing.Reward.ConvertedAmount.self),
+                ObjectIdentifier(RewardFragment.ConvertedAmount.self),
+                ObjectIdentifier(MoneyFragment.self)
+              ]
+            ))
+          }
+        }
+
+        public typealias AllowedAddons = RewardFragment.AllowedAddons
+
+        public typealias Items = RewardFragment.Items
+
+        /// Backing.Reward.LocalReceiptLocation
+        ///
+        /// Parent Type: `Location`
+        public struct LocalReceiptLocation: GraphAPI.SelectionSet {
+          public let __data: DataDict
+          public init(_dataDict: DataDict) { __data = _dataDict }
+
+          public static var __parentType: ApolloAPI.ParentType { GraphAPI.Objects.Location }
+
+          /// The country code.
+          public var country: String { __data["country"] }
+          /// The localized country name.
+          public var countryName: String? { __data["countryName"] }
+          /// The displayable name. It includes the state code for US cities. ex: 'Seattle, WA'
+          public var displayableName: String { __data["displayableName"] }
+          public var id: GraphAPI.ID { __data["id"] }
+          /// The localized name
+          public var name: String { __data["name"] }
+
+          public struct Fragments: FragmentContainer {
+            public let __data: DataDict
+            public init(_dataDict: DataDict) { __data = _dataDict }
+
+            public var locationFragment: LocationFragment { _toFragment() }
+          }
+
+          public init(
+            country: String,
+            countryName: String? = nil,
+            displayableName: String,
+            id: GraphAPI.ID,
+            name: String
+          ) {
+            self.init(_dataDict: DataDict(
+              data: [
+                "__typename": GraphAPI.Objects.Location.typename,
+                "country": country,
+                "countryName": countryName,
+                "displayableName": displayableName,
+                "id": id,
+                "name": name,
+              ],
+              fulfilledFragments: [
+                ObjectIdentifier(FetchBackingWithIncrementsRefundedQuery.Data.Backing.Reward.LocalReceiptLocation.self),
+                ObjectIdentifier(RewardFragment.LocalReceiptLocation.self),
+                ObjectIdentifier(LocationFragment.self)
+              ]
+            ))
+          }
+        }
+
+        /// Backing.Reward.PledgeAmount
+        ///
+        /// Parent Type: `Money`
+        public struct PledgeAmount: GraphAPI.SelectionSet {
+          public let __data: DataDict
+          public init(_dataDict: DataDict) { __data = _dataDict }
+
+          public static var __parentType: ApolloAPI.ParentType { GraphAPI.Objects.Money }
+
+          /// Floating-point numeric value of monetary amount represented as a string
+          public var amount: String? { __data["amount"] }
+          /// Currency of the monetary amount
+          public var currency: GraphQLEnum<GraphAPI.CurrencyCode>? { __data["currency"] }
+          /// Symbol of the currency in which the monetary amount appears
+          public var symbol: String? { __data["symbol"] }
+
+          public struct Fragments: FragmentContainer {
+            public let __data: DataDict
+            public init(_dataDict: DataDict) { __data = _dataDict }
+
+            public var moneyFragment: MoneyFragment { _toFragment() }
+          }
+
+          public init(
+            amount: String? = nil,
+            currency: GraphQLEnum<GraphAPI.CurrencyCode>? = nil,
+            symbol: String? = nil
+          ) {
+            self.init(_dataDict: DataDict(
+              data: [
+                "__typename": GraphAPI.Objects.Money.typename,
+                "amount": amount,
+                "currency": currency,
+                "symbol": symbol,
+              ],
+              fulfilledFragments: [
+                ObjectIdentifier(FetchBackingWithIncrementsRefundedQuery.Data.Backing.Reward.PledgeAmount.self),
+                ObjectIdentifier(RewardFragment.PledgeAmount.self),
+                ObjectIdentifier(MoneyFragment.self)
+              ]
+            ))
+          }
+        }
+
+        /// Backing.Reward.LatePledgeAmount
+        ///
+        /// Parent Type: `Money`
+        public struct LatePledgeAmount: GraphAPI.SelectionSet {
+          public let __data: DataDict
+          public init(_dataDict: DataDict) { __data = _dataDict }
+
+          public static var __parentType: ApolloAPI.ParentType { GraphAPI.Objects.Money }
+
+          /// Floating-point numeric value of monetary amount represented as a string
+          public var amount: String? { __data["amount"] }
+          /// Currency of the monetary amount
+          public var currency: GraphQLEnum<GraphAPI.CurrencyCode>? { __data["currency"] }
+          /// Symbol of the currency in which the monetary amount appears
+          public var symbol: String? { __data["symbol"] }
+
+          public struct Fragments: FragmentContainer {
+            public let __data: DataDict
+            public init(_dataDict: DataDict) { __data = _dataDict }
+
+            public var moneyFragment: MoneyFragment { _toFragment() }
+          }
+
+          public init(
+            amount: String? = nil,
+            currency: GraphQLEnum<GraphAPI.CurrencyCode>? = nil,
+            symbol: String? = nil
+          ) {
+            self.init(_dataDict: DataDict(
+              data: [
+                "__typename": GraphAPI.Objects.Money.typename,
+                "amount": amount,
+                "currency": currency,
+                "symbol": symbol,
+              ],
+              fulfilledFragments: [
+                ObjectIdentifier(FetchBackingWithIncrementsRefundedQuery.Data.Backing.Reward.LatePledgeAmount.self),
+                ObjectIdentifier(RewardFragment.LatePledgeAmount.self),
+                ObjectIdentifier(MoneyFragment.self)
+              ]
+            ))
+          }
+        }
+
+        public typealias Project = RewardFragment.Project
+
+        /// Backing.Reward.ShippingRule
+        ///
+        /// Parent Type: `ShippingRule`
+        public struct ShippingRule: GraphAPI.SelectionSet {
+          public let __data: DataDict
+          public init(_dataDict: DataDict) { __data = _dataDict }
+
+          public static var __parentType: ApolloAPI.ParentType { GraphAPI.Objects.ShippingRule }
+
+          /// The shipping cost for this location.
+          public var cost: Cost? { __data["cost"] }
+          public var id: GraphAPI.ID { __data["id"] }
+          /// The shipping location to which the rule pertains.
+          public var location: Location? { __data["location"] }
+          /// The estimated minimum shipping cost
+          public var estimatedMin: EstimatedMin? { __data["estimatedMin"] }
+          /// The estimated maximum shipping cost
+          public var estimatedMax: EstimatedMax? { __data["estimatedMax"] }
+
+          public struct Fragments: FragmentContainer {
+            public let __data: DataDict
+            public init(_dataDict: DataDict) { __data = _dataDict }
+
+            public var shippingRuleFragment: ShippingRuleFragment { _toFragment() }
+          }
+
+          public init(
+            cost: Cost? = nil,
+            id: GraphAPI.ID,
+            location: Location? = nil,
+            estimatedMin: EstimatedMin? = nil,
+            estimatedMax: EstimatedMax? = nil
+          ) {
+            self.init(_dataDict: DataDict(
+              data: [
+                "__typename": GraphAPI.Objects.ShippingRule.typename,
+                "cost": cost._fieldData,
+                "id": id,
+                "location": location._fieldData,
+                "estimatedMin": estimatedMin._fieldData,
+                "estimatedMax": estimatedMax._fieldData,
+              ],
+              fulfilledFragments: [
+                ObjectIdentifier(FetchBackingWithIncrementsRefundedQuery.Data.Backing.Reward.ShippingRule.self),
+                ObjectIdentifier(RewardFragment.ShippingRule.self),
+                ObjectIdentifier(ShippingRuleFragment.self)
+              ]
+            ))
+          }
+
+          /// Backing.Reward.ShippingRule.Cost
+          ///
+          /// Parent Type: `Money`
+          public struct Cost: GraphAPI.SelectionSet {
+            public let __data: DataDict
+            public init(_dataDict: DataDict) { __data = _dataDict }
+
+            public static var __parentType: ApolloAPI.ParentType { GraphAPI.Objects.Money }
+
+            /// Floating-point numeric value of monetary amount represented as a string
+            public var amount: String? { __data["amount"] }
+            /// Currency of the monetary amount
+            public var currency: GraphQLEnum<GraphAPI.CurrencyCode>? { __data["currency"] }
+            /// Symbol of the currency in which the monetary amount appears
+            public var symbol: String? { __data["symbol"] }
+
+            public struct Fragments: FragmentContainer {
+              public let __data: DataDict
+              public init(_dataDict: DataDict) { __data = _dataDict }
+
+              public var moneyFragment: MoneyFragment { _toFragment() }
+            }
+
+            public init(
+              amount: String? = nil,
+              currency: GraphQLEnum<GraphAPI.CurrencyCode>? = nil,
+              symbol: String? = nil
+            ) {
+              self.init(_dataDict: DataDict(
+                data: [
+                  "__typename": GraphAPI.Objects.Money.typename,
+                  "amount": amount,
+                  "currency": currency,
+                  "symbol": symbol,
+                ],
+                fulfilledFragments: [
+                  ObjectIdentifier(FetchBackingWithIncrementsRefundedQuery.Data.Backing.Reward.ShippingRule.Cost.self),
+                  ObjectIdentifier(ShippingRuleFragment.Cost.self),
+                  ObjectIdentifier(MoneyFragment.self)
+                ]
+              ))
+            }
+          }
+
+          /// Backing.Reward.ShippingRule.Location
+          ///
+          /// Parent Type: `Location`
+          public struct Location: GraphAPI.SelectionSet {
+            public let __data: DataDict
+            public init(_dataDict: DataDict) { __data = _dataDict }
+
+            public static var __parentType: ApolloAPI.ParentType { GraphAPI.Objects.Location }
+
+            /// The country code.
+            public var country: String { __data["country"] }
+            /// The localized country name.
+            public var countryName: String? { __data["countryName"] }
+            /// The displayable name. It includes the state code for US cities. ex: 'Seattle, WA'
+            public var displayableName: String { __data["displayableName"] }
+            public var id: GraphAPI.ID { __data["id"] }
+            /// The localized name
+            public var name: String { __data["name"] }
+
+            public struct Fragments: FragmentContainer {
+              public let __data: DataDict
+              public init(_dataDict: DataDict) { __data = _dataDict }
+
+              public var locationFragment: LocationFragment { _toFragment() }
+            }
+
+            public init(
+              country: String,
+              countryName: String? = nil,
+              displayableName: String,
+              id: GraphAPI.ID,
+              name: String
+            ) {
+              self.init(_dataDict: DataDict(
+                data: [
+                  "__typename": GraphAPI.Objects.Location.typename,
+                  "country": country,
+                  "countryName": countryName,
+                  "displayableName": displayableName,
+                  "id": id,
+                  "name": name,
+                ],
+                fulfilledFragments: [
+                  ObjectIdentifier(FetchBackingWithIncrementsRefundedQuery.Data.Backing.Reward.ShippingRule.Location.self),
+                  ObjectIdentifier(ShippingRuleFragment.Location.self),
+                  ObjectIdentifier(LocationFragment.self)
+                ]
+              ))
+            }
+          }
+
+          public typealias EstimatedMin = ShippingRuleFragment.EstimatedMin
+
+          public typealias EstimatedMax = ShippingRuleFragment.EstimatedMax
+        }
+
+        public typealias Image = RewardFragment.Image
+
+        public typealias AudienceData = RewardFragment.AudienceData
+      }
+
       /// Backing.PaymentIncrement
       ///
       /// Parent Type: `PaymentIncrement`
@@ -1201,539 +1747,6 @@ public class FetchBackingWithIncrementsRefundedQuery: GraphQLQuery {
             ))
           }
         }
-      }
-
-      /// Backing.Reward
-      ///
-      /// Parent Type: `Reward`
-      public struct Reward: GraphAPI.SelectionSet {
-        public let __data: DataDict
-        public init(_dataDict: DataDict) { __data = _dataDict }
-
-        public static var __parentType: ApolloAPI.ParentType { GraphAPI.Objects.Reward }
-
-        /// Amount for claiming this reward.
-        public var amount: Amount { __data["amount"] }
-        /// count of backers for this reward
-        public var backersCount: Int? { __data["backersCount"] }
-        /// Amount for claiming this reward, in the current user's chosen currency
-        public var convertedAmount: ConvertedAmount { __data["convertedAmount"] }
-        /// Add-ons which can be combined with this reward.
-        /// Uses creator preferences and shipping rules to determine allow-ability.
-        /// Inclusion in this list does not necessarily indicate that the add-on is available for backing.
-        ///
-        public var allowedAddons: AllowedAddons { __data["allowedAddons"] }
-        /// A reward description.
-        public var description: String? { __data["description"] }
-        /// A reward's title plus the amount, or a default title (the reward amount) if it doesn't have a title.
-        public var displayName: String { __data["displayName"] }
-        /// When the reward is scheduled to end in seconds
-        public var endsAt: GraphAPI.DateTime? { __data["endsAt"] }
-        /// Estimated delivery day.
-        public var estimatedDeliveryOn: GraphAPI.Date? { __data["estimatedDeliveryOn"] }
-        public var id: GraphAPI.ID { __data["id"] }
-        /// Does reward amount meet or exceed maximum pledge for the project
-        public var isMaxPledge: Bool { __data["isMaxPledge"] }
-        /// Whether or not the reward is available for new pledges
-        public var available: Bool { __data["available"] }
-        /// Whether or not the reward is featured
-        public var featured: Bool { __data["featured"] }
-        /// Items in the reward.
-        public var items: Items? { __data["items"] }
-        /// A reward limit.
-        public var limit: Int? { __data["limit"] }
-        /// Per backer reward limit.
-        public var limitPerBacker: Int? { __data["limitPerBacker"] }
-        /// Where the reward can be locally received if local receipt is selected as the shipping preference
-        public var localReceiptLocation: LocalReceiptLocation? { __data["localReceiptLocation"] }
-        /// A reward title.
-        public var name: String? { __data["name"] }
-        /// Amount for claiming this reward during the campaign.
-        public var pledgeAmount: PledgeAmount { __data["pledgeAmount"] }
-        /// Amount for claiming this reward after the campaign.
-        public var latePledgeAmount: LatePledgeAmount { __data["latePledgeAmount"] }
-        /// Is this reward available for post-campaign pledges?
-        public var postCampaignPledgingEnabled: Bool { __data["postCampaignPledgingEnabled"] }
-        /// The project
-        public var project: Project? { __data["project"] }
-        /// Remaining reward quantity.
-        public var remainingQuantity: Int? { __data["remainingQuantity"] }
-        /// Shipping preference for this reward
-        public var shippingPreference: GraphQLEnum<GraphAPI.ShippingPreference>? { __data["shippingPreference"] }
-        /// A shipping summary
-        public var shippingSummary: String? { __data["shippingSummary"] }
-        /// Shipping rules defined by the creator for this reward
-        public var shippingRules: [ShippingRule?]? { __data["shippingRules"] }
-        /// When the reward is scheduled to start
-        public var startsAt: GraphAPI.DateTime? { __data["startsAt"] }
-        /// The reward image.
-        public var image: Image? { __data["image"] }
-        /// Data related to who can view/access this reward
-        public var audienceData: AudienceData { __data["audienceData"] }
-
-        public struct Fragments: FragmentContainer {
-          public let __data: DataDict
-          public init(_dataDict: DataDict) { __data = _dataDict }
-
-          public var rewardFragment: RewardFragment { _toFragment() }
-        }
-
-        public init(
-          amount: Amount,
-          backersCount: Int? = nil,
-          convertedAmount: ConvertedAmount,
-          allowedAddons: AllowedAddons,
-          description: String? = nil,
-          displayName: String,
-          endsAt: GraphAPI.DateTime? = nil,
-          estimatedDeliveryOn: GraphAPI.Date? = nil,
-          id: GraphAPI.ID,
-          isMaxPledge: Bool,
-          available: Bool,
-          featured: Bool,
-          items: Items? = nil,
-          limit: Int? = nil,
-          limitPerBacker: Int? = nil,
-          localReceiptLocation: LocalReceiptLocation? = nil,
-          name: String? = nil,
-          pledgeAmount: PledgeAmount,
-          latePledgeAmount: LatePledgeAmount,
-          postCampaignPledgingEnabled: Bool,
-          project: Project? = nil,
-          remainingQuantity: Int? = nil,
-          shippingPreference: GraphQLEnum<GraphAPI.ShippingPreference>? = nil,
-          shippingSummary: String? = nil,
-          shippingRules: [ShippingRule?]? = nil,
-          startsAt: GraphAPI.DateTime? = nil,
-          image: Image? = nil,
-          audienceData: AudienceData
-        ) {
-          self.init(_dataDict: DataDict(
-            data: [
-              "__typename": GraphAPI.Objects.Reward.typename,
-              "amount": amount._fieldData,
-              "backersCount": backersCount,
-              "convertedAmount": convertedAmount._fieldData,
-              "allowedAddons": allowedAddons._fieldData,
-              "description": description,
-              "displayName": displayName,
-              "endsAt": endsAt,
-              "estimatedDeliveryOn": estimatedDeliveryOn,
-              "id": id,
-              "isMaxPledge": isMaxPledge,
-              "available": available,
-              "featured": featured,
-              "items": items._fieldData,
-              "limit": limit,
-              "limitPerBacker": limitPerBacker,
-              "localReceiptLocation": localReceiptLocation._fieldData,
-              "name": name,
-              "pledgeAmount": pledgeAmount._fieldData,
-              "latePledgeAmount": latePledgeAmount._fieldData,
-              "postCampaignPledgingEnabled": postCampaignPledgingEnabled,
-              "project": project._fieldData,
-              "remainingQuantity": remainingQuantity,
-              "shippingPreference": shippingPreference,
-              "shippingSummary": shippingSummary,
-              "shippingRules": shippingRules._fieldData,
-              "startsAt": startsAt,
-              "image": image._fieldData,
-              "audienceData": audienceData._fieldData,
-            ],
-            fulfilledFragments: [
-              ObjectIdentifier(FetchBackingWithIncrementsRefundedQuery.Data.Backing.Reward.self),
-              ObjectIdentifier(BackingFragment.Reward.self),
-              ObjectIdentifier(RewardFragment.self)
-            ]
-          ))
-        }
-
-        /// Backing.Reward.Amount
-        ///
-        /// Parent Type: `Money`
-        public struct Amount: GraphAPI.SelectionSet {
-          public let __data: DataDict
-          public init(_dataDict: DataDict) { __data = _dataDict }
-
-          public static var __parentType: ApolloAPI.ParentType { GraphAPI.Objects.Money }
-
-          /// Floating-point numeric value of monetary amount represented as a string
-          public var amount: String? { __data["amount"] }
-          /// Currency of the monetary amount
-          public var currency: GraphQLEnum<GraphAPI.CurrencyCode>? { __data["currency"] }
-          /// Symbol of the currency in which the monetary amount appears
-          public var symbol: String? { __data["symbol"] }
-
-          public struct Fragments: FragmentContainer {
-            public let __data: DataDict
-            public init(_dataDict: DataDict) { __data = _dataDict }
-
-            public var moneyFragment: MoneyFragment { _toFragment() }
-          }
-
-          public init(
-            amount: String? = nil,
-            currency: GraphQLEnum<GraphAPI.CurrencyCode>? = nil,
-            symbol: String? = nil
-          ) {
-            self.init(_dataDict: DataDict(
-              data: [
-                "__typename": GraphAPI.Objects.Money.typename,
-                "amount": amount,
-                "currency": currency,
-                "symbol": symbol,
-              ],
-              fulfilledFragments: [
-                ObjectIdentifier(FetchBackingWithIncrementsRefundedQuery.Data.Backing.Reward.Amount.self),
-                ObjectIdentifier(RewardFragment.Amount.self),
-                ObjectIdentifier(MoneyFragment.self)
-              ]
-            ))
-          }
-        }
-
-        /// Backing.Reward.ConvertedAmount
-        ///
-        /// Parent Type: `Money`
-        public struct ConvertedAmount: GraphAPI.SelectionSet {
-          public let __data: DataDict
-          public init(_dataDict: DataDict) { __data = _dataDict }
-
-          public static var __parentType: ApolloAPI.ParentType { GraphAPI.Objects.Money }
-
-          /// Floating-point numeric value of monetary amount represented as a string
-          public var amount: String? { __data["amount"] }
-          /// Currency of the monetary amount
-          public var currency: GraphQLEnum<GraphAPI.CurrencyCode>? { __data["currency"] }
-          /// Symbol of the currency in which the monetary amount appears
-          public var symbol: String? { __data["symbol"] }
-
-          public struct Fragments: FragmentContainer {
-            public let __data: DataDict
-            public init(_dataDict: DataDict) { __data = _dataDict }
-
-            public var moneyFragment: MoneyFragment { _toFragment() }
-          }
-
-          public init(
-            amount: String? = nil,
-            currency: GraphQLEnum<GraphAPI.CurrencyCode>? = nil,
-            symbol: String? = nil
-          ) {
-            self.init(_dataDict: DataDict(
-              data: [
-                "__typename": GraphAPI.Objects.Money.typename,
-                "amount": amount,
-                "currency": currency,
-                "symbol": symbol,
-              ],
-              fulfilledFragments: [
-                ObjectIdentifier(FetchBackingWithIncrementsRefundedQuery.Data.Backing.Reward.ConvertedAmount.self),
-                ObjectIdentifier(RewardFragment.ConvertedAmount.self),
-                ObjectIdentifier(MoneyFragment.self)
-              ]
-            ))
-          }
-        }
-
-        public typealias AllowedAddons = RewardFragment.AllowedAddons
-
-        public typealias Items = RewardFragment.Items
-
-        /// Backing.Reward.LocalReceiptLocation
-        ///
-        /// Parent Type: `Location`
-        public struct LocalReceiptLocation: GraphAPI.SelectionSet {
-          public let __data: DataDict
-          public init(_dataDict: DataDict) { __data = _dataDict }
-
-          public static var __parentType: ApolloAPI.ParentType { GraphAPI.Objects.Location }
-
-          /// The country code.
-          public var country: String { __data["country"] }
-          /// The localized country name.
-          public var countryName: String? { __data["countryName"] }
-          /// The displayable name. It includes the state code for US cities. ex: 'Seattle, WA'
-          public var displayableName: String { __data["displayableName"] }
-          public var id: GraphAPI.ID { __data["id"] }
-          /// The localized name
-          public var name: String { __data["name"] }
-
-          public struct Fragments: FragmentContainer {
-            public let __data: DataDict
-            public init(_dataDict: DataDict) { __data = _dataDict }
-
-            public var locationFragment: LocationFragment { _toFragment() }
-          }
-
-          public init(
-            country: String,
-            countryName: String? = nil,
-            displayableName: String,
-            id: GraphAPI.ID,
-            name: String
-          ) {
-            self.init(_dataDict: DataDict(
-              data: [
-                "__typename": GraphAPI.Objects.Location.typename,
-                "country": country,
-                "countryName": countryName,
-                "displayableName": displayableName,
-                "id": id,
-                "name": name,
-              ],
-              fulfilledFragments: [
-                ObjectIdentifier(FetchBackingWithIncrementsRefundedQuery.Data.Backing.Reward.LocalReceiptLocation.self),
-                ObjectIdentifier(RewardFragment.LocalReceiptLocation.self),
-                ObjectIdentifier(LocationFragment.self)
-              ]
-            ))
-          }
-        }
-
-        /// Backing.Reward.PledgeAmount
-        ///
-        /// Parent Type: `Money`
-        public struct PledgeAmount: GraphAPI.SelectionSet {
-          public let __data: DataDict
-          public init(_dataDict: DataDict) { __data = _dataDict }
-
-          public static var __parentType: ApolloAPI.ParentType { GraphAPI.Objects.Money }
-
-          /// Floating-point numeric value of monetary amount represented as a string
-          public var amount: String? { __data["amount"] }
-          /// Currency of the monetary amount
-          public var currency: GraphQLEnum<GraphAPI.CurrencyCode>? { __data["currency"] }
-          /// Symbol of the currency in which the monetary amount appears
-          public var symbol: String? { __data["symbol"] }
-
-          public struct Fragments: FragmentContainer {
-            public let __data: DataDict
-            public init(_dataDict: DataDict) { __data = _dataDict }
-
-            public var moneyFragment: MoneyFragment { _toFragment() }
-          }
-
-          public init(
-            amount: String? = nil,
-            currency: GraphQLEnum<GraphAPI.CurrencyCode>? = nil,
-            symbol: String? = nil
-          ) {
-            self.init(_dataDict: DataDict(
-              data: [
-                "__typename": GraphAPI.Objects.Money.typename,
-                "amount": amount,
-                "currency": currency,
-                "symbol": symbol,
-              ],
-              fulfilledFragments: [
-                ObjectIdentifier(FetchBackingWithIncrementsRefundedQuery.Data.Backing.Reward.PledgeAmount.self),
-                ObjectIdentifier(RewardFragment.PledgeAmount.self),
-                ObjectIdentifier(MoneyFragment.self)
-              ]
-            ))
-          }
-        }
-
-        /// Backing.Reward.LatePledgeAmount
-        ///
-        /// Parent Type: `Money`
-        public struct LatePledgeAmount: GraphAPI.SelectionSet {
-          public let __data: DataDict
-          public init(_dataDict: DataDict) { __data = _dataDict }
-
-          public static var __parentType: ApolloAPI.ParentType { GraphAPI.Objects.Money }
-
-          /// Floating-point numeric value of monetary amount represented as a string
-          public var amount: String? { __data["amount"] }
-          /// Currency of the monetary amount
-          public var currency: GraphQLEnum<GraphAPI.CurrencyCode>? { __data["currency"] }
-          /// Symbol of the currency in which the monetary amount appears
-          public var symbol: String? { __data["symbol"] }
-
-          public struct Fragments: FragmentContainer {
-            public let __data: DataDict
-            public init(_dataDict: DataDict) { __data = _dataDict }
-
-            public var moneyFragment: MoneyFragment { _toFragment() }
-          }
-
-          public init(
-            amount: String? = nil,
-            currency: GraphQLEnum<GraphAPI.CurrencyCode>? = nil,
-            symbol: String? = nil
-          ) {
-            self.init(_dataDict: DataDict(
-              data: [
-                "__typename": GraphAPI.Objects.Money.typename,
-                "amount": amount,
-                "currency": currency,
-                "symbol": symbol,
-              ],
-              fulfilledFragments: [
-                ObjectIdentifier(FetchBackingWithIncrementsRefundedQuery.Data.Backing.Reward.LatePledgeAmount.self),
-                ObjectIdentifier(RewardFragment.LatePledgeAmount.self),
-                ObjectIdentifier(MoneyFragment.self)
-              ]
-            ))
-          }
-        }
-
-        public typealias Project = RewardFragment.Project
-
-        /// Backing.Reward.ShippingRule
-        ///
-        /// Parent Type: `ShippingRule`
-        public struct ShippingRule: GraphAPI.SelectionSet {
-          public let __data: DataDict
-          public init(_dataDict: DataDict) { __data = _dataDict }
-
-          public static var __parentType: ApolloAPI.ParentType { GraphAPI.Objects.ShippingRule }
-
-          /// The shipping cost for this location.
-          public var cost: Cost? { __data["cost"] }
-          public var id: GraphAPI.ID { __data["id"] }
-          /// The shipping location to which the rule pertains.
-          public var location: Location? { __data["location"] }
-          /// The estimated minimum shipping cost
-          public var estimatedMin: EstimatedMin? { __data["estimatedMin"] }
-          /// The estimated maximum shipping cost
-          public var estimatedMax: EstimatedMax? { __data["estimatedMax"] }
-
-          public struct Fragments: FragmentContainer {
-            public let __data: DataDict
-            public init(_dataDict: DataDict) { __data = _dataDict }
-
-            public var shippingRuleFragment: ShippingRuleFragment { _toFragment() }
-          }
-
-          public init(
-            cost: Cost? = nil,
-            id: GraphAPI.ID,
-            location: Location? = nil,
-            estimatedMin: EstimatedMin? = nil,
-            estimatedMax: EstimatedMax? = nil
-          ) {
-            self.init(_dataDict: DataDict(
-              data: [
-                "__typename": GraphAPI.Objects.ShippingRule.typename,
-                "cost": cost._fieldData,
-                "id": id,
-                "location": location._fieldData,
-                "estimatedMin": estimatedMin._fieldData,
-                "estimatedMax": estimatedMax._fieldData,
-              ],
-              fulfilledFragments: [
-                ObjectIdentifier(FetchBackingWithIncrementsRefundedQuery.Data.Backing.Reward.ShippingRule.self),
-                ObjectIdentifier(RewardFragment.ShippingRule.self),
-                ObjectIdentifier(ShippingRuleFragment.self)
-              ]
-            ))
-          }
-
-          /// Backing.Reward.ShippingRule.Cost
-          ///
-          /// Parent Type: `Money`
-          public struct Cost: GraphAPI.SelectionSet {
-            public let __data: DataDict
-            public init(_dataDict: DataDict) { __data = _dataDict }
-
-            public static var __parentType: ApolloAPI.ParentType { GraphAPI.Objects.Money }
-
-            /// Floating-point numeric value of monetary amount represented as a string
-            public var amount: String? { __data["amount"] }
-            /// Currency of the monetary amount
-            public var currency: GraphQLEnum<GraphAPI.CurrencyCode>? { __data["currency"] }
-            /// Symbol of the currency in which the monetary amount appears
-            public var symbol: String? { __data["symbol"] }
-
-            public struct Fragments: FragmentContainer {
-              public let __data: DataDict
-              public init(_dataDict: DataDict) { __data = _dataDict }
-
-              public var moneyFragment: MoneyFragment { _toFragment() }
-            }
-
-            public init(
-              amount: String? = nil,
-              currency: GraphQLEnum<GraphAPI.CurrencyCode>? = nil,
-              symbol: String? = nil
-            ) {
-              self.init(_dataDict: DataDict(
-                data: [
-                  "__typename": GraphAPI.Objects.Money.typename,
-                  "amount": amount,
-                  "currency": currency,
-                  "symbol": symbol,
-                ],
-                fulfilledFragments: [
-                  ObjectIdentifier(FetchBackingWithIncrementsRefundedQuery.Data.Backing.Reward.ShippingRule.Cost.self),
-                  ObjectIdentifier(ShippingRuleFragment.Cost.self),
-                  ObjectIdentifier(MoneyFragment.self)
-                ]
-              ))
-            }
-          }
-
-          /// Backing.Reward.ShippingRule.Location
-          ///
-          /// Parent Type: `Location`
-          public struct Location: GraphAPI.SelectionSet {
-            public let __data: DataDict
-            public init(_dataDict: DataDict) { __data = _dataDict }
-
-            public static var __parentType: ApolloAPI.ParentType { GraphAPI.Objects.Location }
-
-            /// The country code.
-            public var country: String { __data["country"] }
-            /// The localized country name.
-            public var countryName: String? { __data["countryName"] }
-            /// The displayable name. It includes the state code for US cities. ex: 'Seattle, WA'
-            public var displayableName: String { __data["displayableName"] }
-            public var id: GraphAPI.ID { __data["id"] }
-            /// The localized name
-            public var name: String { __data["name"] }
-
-            public struct Fragments: FragmentContainer {
-              public let __data: DataDict
-              public init(_dataDict: DataDict) { __data = _dataDict }
-
-              public var locationFragment: LocationFragment { _toFragment() }
-            }
-
-            public init(
-              country: String,
-              countryName: String? = nil,
-              displayableName: String,
-              id: GraphAPI.ID,
-              name: String
-            ) {
-              self.init(_dataDict: DataDict(
-                data: [
-                  "__typename": GraphAPI.Objects.Location.typename,
-                  "country": country,
-                  "countryName": countryName,
-                  "displayableName": displayableName,
-                  "id": id,
-                  "name": name,
-                ],
-                fulfilledFragments: [
-                  ObjectIdentifier(FetchBackingWithIncrementsRefundedQuery.Data.Backing.Reward.ShippingRule.Location.self),
-                  ObjectIdentifier(ShippingRuleFragment.Location.self),
-                  ObjectIdentifier(LocationFragment.self)
-                ]
-              ))
-            }
-          }
-
-          public typealias EstimatedMin = ShippingRuleFragment.EstimatedMin
-
-          public typealias EstimatedMax = ShippingRuleFragment.EstimatedMax
-        }
-
-        public typealias Image = RewardFragment.Image
-
-        public typealias AudienceData = RewardFragment.AudienceData
       }
 
       /// Backing.RewardsAmount

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework-iOSTests/Kickstarter-iOS/Features/PledgeView/Controllers/PledgeViewControllerTests.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework-iOSTests/Kickstarter-iOS/Features/PledgeView/Controllers/PledgeViewControllerTests.swift
@@ -202,7 +202,7 @@ final class PledgeViewControllerTests: TestCase {
       |> ShippingRule.lens.estimatedMax .~ Money(amount: 10.0)
     let reward = Reward.template
       |> Reward.lens.shipping.enabled .~ true
-      |> Reward.lens.shippingRules .~ [shippingRule]
+      |> Reward.lens.shippingRulesExpanded .~ [shippingRule]
       |> Reward.lens.id .~ 99
     let addOnReward1 = Reward.template
       |> Reward.lens.shipping.enabled .~ true

--- a/KsApi/Sources/KsApi/models/graphql/adapters/Backing+BackingFragment.swift
+++ b/KsApi/Sources/KsApi/models/graphql/adapters/Backing+BackingFragment.swift
@@ -9,7 +9,8 @@ extension Backing {
   static func backing(
     from backingFragment: GraphAPI.BackingFragment,
     addOns: [Reward]? = nil,
-    paymentIncrements: [PledgePaymentIncrement] = []
+    paymentIncrements: [PledgePaymentIncrement] = [],
+    rewardExpandedShippingRules: [ShippingRule]? = nil,
   ) -> Backing? {
     guard
       let id = decompose(id: backingFragment.id),
@@ -21,7 +22,10 @@ extension Backing {
       let user = backingFragment.backer?.fragments.publicUserFragment
     else { return nil }
 
-    let reward = backingReward(from: backingFragment)
+    let reward = backingReward(
+      from: backingFragment,
+      expandedShippingRules: rewardExpandedShippingRules
+    )
     /// Usually we only fetch your _own_ backings, but if you're a creator, it's possible to fetch the backings
     /// for one of your projects' backers.
     /// If you're fetching your own backing, and you need private fields, you should be getting them from `me` or
@@ -83,12 +87,18 @@ extension Backing {
         }
     }
 
+    var rewardShippingRules: [ShippingRule]? = nil
+    if let rewardShippingRulesFragment = data.backing?.reward?.fragments.simpleShippingRulesExpandedFragment {
+      rewardShippingRules = ShippingRule.simpleShippingRulesExpanded(from: rewardShippingRulesFragment)
+    }
+
     guard
       let backingFragment = data.backing?.fragments.backingFragment,
       let backing = Backing.backing(
         from: backingFragment,
         addOns: addOns,
-        paymentIncrements: paymentIncrements
+        paymentIncrements: paymentIncrements,
+        rewardExpandedShippingRules: rewardShippingRules
       )
     else {
       return SignalProducer(error: .couldNotParseJSON)
@@ -102,7 +112,10 @@ private func backingStatus(from backingFragment: GraphAPI.BackingFragment) -> Ba
   return Backing.Status(rawValue: backingFragment.status.rawValue)
 }
 
-private func backingReward(from backingFragment: GraphAPI.BackingFragment) -> Reward? {
+private func backingReward(
+  from backingFragment: GraphAPI.BackingFragment,
+  expandedShippingRules: [ShippingRule]? = nil
+) -> Reward? {
   guard let reward = backingFragment.reward?.fragments.rewardFragment else {
     guard let project = backingFragment.project else {
       return Reward.noReward
@@ -112,7 +125,7 @@ private func backingReward(from backingFragment: GraphAPI.BackingFragment) -> Re
     return Reward.noRewardReward(from: noRewardFragment)
   }
 
-  return Reward.reward(from: reward)
+  return Reward.reward(from: reward, expandedShippingRules: expandedShippingRules)
 }
 
 private func backingPaymentSource(from backingFragment: GraphAPI.BackingFragment) -> Backing.PaymentSource? {

--- a/Library/Sources/Library/Library/SharedFunctions.swift
+++ b/Library/Sources/Library/Library/SharedFunctions.swift
@@ -847,13 +847,9 @@ private func estimatedMinMax(
 
   rewards.forEach { reward in
     guard reward.shipping.enabled,
-          let shippingRules = reward.shippingRulesExpanded ?? reward.shippingRules else { return }
+          let shippingRules = reward.shippingRulesExpanded else { return }
 
     var shipping: ShippingRule? = shippingRules.first(where: { $0.location.id == locationId })
-
-    if shipping == nil && reward.shipping.preference == .unrestricted {
-      shipping = shippingRules.first
-    }
 
     /// Verify there are estimated amounts greater than 0
     guard let estimatedMin = shipping?.estimatedMin?.amount,

--- a/graphql/queries/FetchBackingWithIncrementsRefundedQuery.graphql
+++ b/graphql/queries/FetchBackingWithIncrementsRefundedQuery.graphql
@@ -1,3 +1,4 @@
+# Query used to fetch the backing for the Manage Pledge page.
 query FetchBackingWithIncrementsRefunded($id: ID!, $includeShippingRules: Boolean!, $includeLocalPickup: Boolean!) {
   backing(id: $id) {
     addOns {
@@ -6,6 +7,9 @@ query FetchBackingWithIncrementsRefunded($id: ID!, $includeShippingRules: Boolea
       }
     }
     ...BackingFragment
+    reward {
+      ...SimpleShippingRulesExpandedFragment
+    }
     paymentIncrements {
       ...PaymentIncrementBackingFragment
     }


### PR DESCRIPTION
# 📲 What

Fetch shipping rules for a backing's reward on the Manage Pledge page.

This uses `SimpleShippingRulesExpanded` for the `Reward` attached to a `Backing`, and updates some plumbing to pass that fragment into the right place.

# 🤔 Why

This removes the only place in the app where we reference `Reward.shippingRules` directly. These are the shipping rules as set _by the creator_, instead of the shipping rules denormalized by country as displayed _to the backer_.

By removing this one reference, I can go ahead and remove `Reward.shippingRules` completely in the follow-up PR #2920. This will substantially simplify our shipping code.

# ✅ Acceptance criteria

- [x] Pledge page correctly shows estimated shipping
- [x] Late pledge page correctly shows estimated shipping
- [x] Manage pledge page correctly shows estimated shipping
- [x] Reward cards correctly show estimated shipping
- [x] Validate test case in #2200
