### PR TITLE
fix video feed audio resume on foreground bug

### DIFF
--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Controller/VideoFeedViewController.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Controller/VideoFeedViewController.swift
@@ -294,6 +294,10 @@ final class VideoFeedViewController: UIViewController {
   }
 
   private func resumeVisibleCell() {
+    /// `willEnterForegroundNotification` fires app-wide, and this VC is retained after dismissal.
+    ///  Skip resume if the feed is no longer visible.
+    guard self.view.window != nil else { return }
+
     self.activateCurrentPageCell()
   }
 

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Controller/VideoFeedViewController.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Controller/VideoFeedViewController.swift
@@ -370,28 +370,7 @@ extension VideoFeedViewController: UICollectionViewDelegateFlowLayout {
 
     cell.onEvent = { [weak self] event in
       guard let self else { return }
-
-      switch event {
-      case .closeTapped:
-        self.dismiss(animated: true)
-      case .creatorTapped:
-        self.goToCreatorProfile(for: item)
-      case .shareTapped:
-        self.simpleAlert(title: "Share")
-        self.viewModel.trackCTAClicked(ctaContext: .videoFeedShare, item: item)
-      case .moreTapped:
-        self.simpleAlert(title: "More")
-      case .ctaTapped:
-        self.goToProjectPage(for: item)
-      case .pauseTapped:
-        self.viewModel.trackCTAClicked(ctaContext: .videoFeedPause, item: item)
-      case .resumeTapped:
-        self.viewModel.trackCTAClicked(ctaContext: .videoFeedPlay, item: item)
-      case let .progressBarTapped(percentageWatched):
-        self.trackProgressBarTapped(item: item, percentageWatched: percentageWatched)
-      case .videoReady, .videoFailed:
-        break
-      }
+      self.handleOnEvent(event, item: item)
     }
 
     cell.configureWith(
@@ -483,6 +462,30 @@ extension VideoFeedViewController: UICollectionViewDelegateFlowLayout {
   }
 
   // MARK: - Helpers
+
+  private func handleOnEvent(_ event: VideoFeedCell.Event, item: VideoFeedItem) {
+    switch event {
+    case .closeTapped:
+      self.dismiss(animated: true)
+    case .creatorTapped:
+      self.goToCreatorProfile(for: item)
+    case .shareTapped:
+      self.simpleAlert(title: "Share")
+      self.viewModel.trackCTAClicked(ctaContext: .videoFeedShare, item: item)
+    case .moreTapped:
+      self.simpleAlert(title: "More")
+    case .ctaTapped:
+      self.goToProjectPage(for: item)
+    case .pauseTapped:
+      self.viewModel.trackCTAClicked(ctaContext: .videoFeedPause, item: item)
+    case .resumeTapped:
+      self.viewModel.trackCTAClicked(ctaContext: .videoFeedPlay, item: item)
+    case let .progressBarTapped(percentageWatched):
+      self.trackProgressBarTapped(item: item, percentageWatched: percentageWatched)
+    case .videoReady, .videoFailed:
+      break
+    }
+  }
 
   private func trackProgressBarTapped(item: VideoFeedItem, percentageWatched: Float) {
     let pageHeight = self.collectionView.bounds.height


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Guard against video feed resuming audio/playback after the feed has been dismissed and the app has re-foregrounded.

# 🤔 Why

There was a bug found following these steps
- Open Video Feed
- Close Video Feed
- Background the app
- Bring app to the foreground
- Music resumes playing from the video feed despite not being in the feed.

The `willEnterForegroundNotification` that we're using to pause/resume video and audio is registered in `viewDidLoad` and lives until `deinit`. 
When the feed is dismissed but not yet deallocated, foregrounding the app fires the observer but then unconditionally resumes playback even though the feed is no longer on presented.

# 🛠 How

Added a `view.window != nil` guard in `resumeVisibleCell()`. 
This is pretty standard for checking whether a VC's view is in the visible hierarchy when the feed is dismissed

# 👀 See

Trello, screenshots, external resources?

| Before 🐛 | After 🦋 |
| --- | --- |
|  | <video width="375" height="570" src="https://github.com/user-attachments/assets/e57910e0-4ddd-4e3e-bd45-49916e928693" /> |

# ✅ Acceptance criteria

- [x] Running the reproduce bug steps result in no bug
- [x] All other audio/video play/pause behavior functions as expected
