### PR TITLE
Move ProjectPageViewModel to Kickstarter-Framework

### DIFF
--- a/Kickstarter-Framework/Sources/Kickstarter-Framework-iOSTests/Kickstarter-iOS/Features/ProjectPage/ViewModel/ProjectPageViewModelTests.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework-iOSTests/Kickstarter-iOS/Features/ProjectPage/ViewModel/ProjectPageViewModelTests.swift
@@ -1,4 +1,7 @@
 import AVFoundation
+import Experimentation
+import GraphAPI
+@testable import Kickstarter_Framework
 @testable import KsApi
 @testable import KsApiTestHelpers
 @testable import Library

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework-iOSTests/Kickstarter-iOS/Features/ProjectPage/ViewModel/ProjectPageViewModel_TrackingTests.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework-iOSTests/Kickstarter-iOS/Features/ProjectPage/ViewModel/ProjectPageViewModel_TrackingTests.swift
@@ -3,6 +3,7 @@ import AVFoundation
 @testable import KsApiTestHelpers
 @testable import Library
 @testable import LibraryTestHelpers
+@testable import Kickstarter_Framework
 import Prelude
 import ReactiveExtensions_TestHelpers
 import ReactiveSwift

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/ProjectPage/ViewModel/ProjectPageViewModel.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/ProjectPage/ViewModel/ProjectPageViewModel.swift
@@ -1,28 +1,9 @@
 import Foundation
 import GraphAPI
 import KsApi
+import Library
 import Prelude
 import ReactiveSwift
-
-public protocol ProjectPageParam {
-  var param: Param { get }
-  var initialProject: (any ProjectPamphletMainCellConfiguration)? { get }
-}
-
-public struct ProjectPageParamBox: ProjectPageParam {
-  public let param: Param
-  public let initialProject: (any ProjectPamphletMainCellConfiguration)?
-
-  public init(param: Param, initialProject: (any ProjectPamphletMainCellConfiguration)?) {
-    self.param = param
-    self.initialProject = initialProject
-  }
-}
-
-extension Param: ProjectPageParam {
-  public var param: Param { self }
-  public var initialProject: (any ProjectPamphletMainCellConfiguration)? { nil }
-}
 
 public protocol ProjectPageViewModelInputs {
   /// Call when didSelectRowAt is called on a `ProjectFAQAskAQuestionCell`

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -178,7 +178,6 @@
 		AAF5494D2F2445C0001DB5AC /* ProjectNavigationSelectorViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAF5486B2F2445C0001DB5AC /* ProjectNavigationSelectorViewModelTests.swift */; };
 		AAF5494E2F2445C0001DB5AC /* ProjectNotificationCellViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAF5486C2F2445C0001DB5AC /* ProjectNotificationCellViewModelTests.swift */; };
 		AAF5494F2F2445C0001DB5AC /* ProjectNotificationsViewModelTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAF5486D2F2445C0001DB5AC /* ProjectNotificationsViewModelTest.swift */; };
-		AAF549502F2445C0001DB5AC /* ProjectPageViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAF5486E2F2445C0001DB5AC /* ProjectPageViewModelTests.swift */; };
 		AAF549512F2445C0001DB5AC /* ProjectPamphletContentViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAF5486F2F2445C0001DB5AC /* ProjectPamphletContentViewModelTests.swift */; };
 		AAF549522F2445C0001DB5AC /* ProjectPamphletCreatorHeaderCellViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAF548702F2445C0001DB5AC /* ProjectPamphletCreatorHeaderCellViewModelTests.swift */; };
 		AAF549532F2445C0001DB5AC /* ProjectPamphletMainCellViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAF548712F2445C0001DB5AC /* ProjectPamphletMainCellViewModelTests.swift */; };
@@ -313,7 +312,6 @@
 		E108416C2DC27F24000E4F17 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		E10BE8D02B02975C00F73DC9 /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10BE8CF2B02975C00F73DC9 /* NotificationService.swift */; };
 		E10BE8D42B02975C00F73DC9 /* RichPushNotifications.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = E10BE8CD2B02975C00F73DC9 /* RichPushNotifications.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
-		E10FED153005D38600EAF400 /* ProjectPageViewModel_TrackingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10FED143005D38600EAF400 /* ProjectPageViewModel_TrackingTests.swift */; };
 		E113BD842B7D255000D3A809 /* Library_Keychain_iOSTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E113BD832B7D255000D3A809 /* Library_Keychain_iOSTests.swift */; };
 		E113BD8D2B7D255A00D3A809 /* KeychainTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E113BD772B7D1B7700D3A809 /* KeychainTests.swift */; };
 		E182E5BA2B8CDFDE0008DD69 /* AppEnvironmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7ED1F121E830FDC00BFFA01 /* AppEnvironmentTests.swift */; };
@@ -544,7 +542,6 @@
 		AAF5486B2F2445C0001DB5AC /* ProjectNavigationSelectorViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectNavigationSelectorViewModelTests.swift; sourceTree = "<group>"; };
 		AAF5486C2F2445C0001DB5AC /* ProjectNotificationCellViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectNotificationCellViewModelTests.swift; sourceTree = "<group>"; };
 		AAF5486D2F2445C0001DB5AC /* ProjectNotificationsViewModelTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectNotificationsViewModelTest.swift; sourceTree = "<group>"; };
-		AAF5486E2F2445C0001DB5AC /* ProjectPageViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectPageViewModelTests.swift; sourceTree = "<group>"; };
 		AAF5486F2F2445C0001DB5AC /* ProjectPamphletContentViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectPamphletContentViewModelTests.swift; sourceTree = "<group>"; };
 		AAF548702F2445C0001DB5AC /* ProjectPamphletCreatorHeaderCellViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectPamphletCreatorHeaderCellViewModelTests.swift; sourceTree = "<group>"; };
 		AAF548712F2445C0001DB5AC /* ProjectPamphletMainCellViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectPamphletMainCellViewModelTests.swift; sourceTree = "<group>"; };
@@ -650,7 +647,6 @@
 		E10BE8CD2B02975C00F73DC9 /* RichPushNotifications.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = RichPushNotifications.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		E10BE8CF2B02975C00F73DC9 /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
 		E10BE8D12B02975C00F73DC9 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		E10FED143005D38600EAF400 /* ProjectPageViewModel_TrackingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectPageViewModel_TrackingTests.swift; sourceTree = "<group>"; };
 		E113BD772B7D1B7700D3A809 /* KeychainTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeychainTests.swift; sourceTree = "<group>"; };
 		E113BD812B7D255000D3A809 /* Library-Keychain-iOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Library-Keychain-iOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		E113BD832B7D255000D3A809 /* Library_Keychain_iOSTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Library_Keychain_iOSTests.swift; sourceTree = "<group>"; };
@@ -1106,8 +1102,6 @@
 				AAF5486B2F2445C0001DB5AC /* ProjectNavigationSelectorViewModelTests.swift */,
 				AAF5486C2F2445C0001DB5AC /* ProjectNotificationCellViewModelTests.swift */,
 				AAF5486D2F2445C0001DB5AC /* ProjectNotificationsViewModelTest.swift */,
-				AAF5486E2F2445C0001DB5AC /* ProjectPageViewModelTests.swift */,
-				E10FED143005D38600EAF400 /* ProjectPageViewModel_TrackingTests.swift */,
 				AAF5486F2F2445C0001DB5AC /* ProjectPamphletContentViewModelTests.swift */,
 				AAF548702F2445C0001DB5AC /* ProjectPamphletCreatorHeaderCellViewModelTests.swift */,
 				AAF548712F2445C0001DB5AC /* ProjectPamphletMainCellViewModelTests.swift */,
@@ -1761,7 +1755,6 @@
 				AAF5491B2F2445C0001DB5AC /* HelpViewModelTests.swift in Sources */,
 				AAF5491C2F2445C0001DB5AC /* KSRSearchBarViewModelTests.swift in Sources */,
 				AAF5491D2F2445C0001DB5AC /* LoadingBarButtonItemViewModelTests.swift in Sources */,
-				E10FED153005D38600EAF400 /* ProjectPageViewModel_TrackingTests.swift in Sources */,
 				AAF5491E2F2445C0001DB5AC /* LoadingButtonViewModelTests.swift in Sources */,
 				AAF5491F2F2445C0001DB5AC /* LoginSignupUseCaseTests.swift in Sources */,
 				AAF549202F2445C0001DB5AC /* LoginToutViewModelTests.swift in Sources */,
@@ -1814,7 +1807,6 @@
 				AAF5494D2F2445C0001DB5AC /* ProjectNavigationSelectorViewModelTests.swift in Sources */,
 				AAF5494E2F2445C0001DB5AC /* ProjectNotificationCellViewModelTests.swift in Sources */,
 				AAF5494F2F2445C0001DB5AC /* ProjectNotificationsViewModelTest.swift in Sources */,
-				AAF549502F2445C0001DB5AC /* ProjectPageViewModelTests.swift in Sources */,
 				AAF549512F2445C0001DB5AC /* ProjectPamphletContentViewModelTests.swift in Sources */,
 				AAF549522F2445C0001DB5AC /* ProjectPamphletCreatorHeaderCellViewModelTests.swift in Sources */,
 				AAF549532F2445C0001DB5AC /* ProjectPamphletMainCellViewModelTests.swift in Sources */,

--- a/KsApi/Sources/KsApiTests/queries/templates/ProjectPageFetcher/FetchProjectByParamQuery.json
+++ b/KsApi/Sources/KsApiTests/queries/templates/ProjectPageFetcher/FetchProjectByParamQuery.json
@@ -145,7 +145,11 @@
       "url": "https://staging.kickstarter.com/projects/amy-at-kickstarter/crossfit-think-tank-cooler",
       "usdExchangeRate": 1,
       "video": null,
-      "watchesCount": 0
+      "watchesCount": 0,
+      "storyRichText": {
+        "__typename": "RichTextComponent",
+        "items": []
+      }
     }
   }
 }

--- a/Library/Package.resolved
+++ b/Library/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "186a9681f4b880ab31689bb4eefc5971656e90bed22eb7f90817ff7b3c5cf6f6",
+  "originHash" : "d133cc19ed539b131d195a4788eaf816afbfeb93b6120715a2dd6ee928980aed",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -287,6 +287,15 @@
       "state" : {
         "revision" : "392dd6058624d9f6c5b4c769d165ddd8c7293394",
         "version" : "0.15.4"
+      }
+    },
+    {
+      "identity" : "statsig-kit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/statsig-io/statsig-kit.git",
+      "state" : {
+        "revision" : "ca19474601d61dfcc9fc38b82dcb6408ea0b8631",
+        "version" : "1.62.6"
       }
     },
     {

--- a/Library/Package.swift
+++ b/Library/Package.swift
@@ -80,6 +80,7 @@ let package = Package(
       dependencies: [
         .byName(name: "Library"),
         .byName(name: "LibraryTestHelpers"),
+        .product(name: "Experimentation", package: "Experimentation"),
         .product(name: "KsApiTestHelpers", package: "KsApi"),
         .product(name: "SnapshotTesting", package: "swift-snapshot-testing"),
         .product(name: "ReactiveExtensions-TestHelpers", package: "Kickstarter-ReactiveExtensions")

--- a/Library/Sources/Library/Library/Tracking/AttributionTracking.swift
+++ b/Library/Sources/Library/Library/Tracking/AttributionTracking.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-struct AttributionTracking {
+public struct AttributionTracking {
   public enum AttributionEvent: String {
     case projectPageViewed = "Project Page Viewed"
   }
 
-  static func eventParametersString(refInfo: RefInfo?) -> String? {
+  public static func eventParametersString(refInfo: RefInfo?) -> String? {
     let sessionRefTag = refInfo?.refTag?.stringTag
     let contextPageUrl = refInfo?.deeplinkUrl
     var props = [String: String]()

--- a/Library/Sources/Library/Library/UseCases/SimilarProjects/SimilarProjectsUseCase.swift
+++ b/Library/Sources/Library/Library/UseCases/SimilarProjects/SimilarProjectsUseCase.swift
@@ -36,7 +36,7 @@ public final class SimilarProjectsUseCase: SimilarProjectsUseCaseType, SimilarPr
   SimilarProjectsUseCaseOutputs {
   // MARK: - Initialization
 
-  init() {
+  public init() {
     self.navigateToProject = self.projectTappedSignal
 
     self.projectIDLoadedSignal

--- a/Library/Sources/Library/Library/ViewModels/ProjectPageParam.swift
+++ b/Library/Sources/Library/Library/ViewModels/ProjectPageParam.swift
@@ -1,0 +1,22 @@
+import Foundation
+import KsApi
+
+public protocol ProjectPageParam {
+  var param: Param { get }
+  var initialProject: (any ProjectPamphletMainCellConfiguration)? { get }
+}
+
+public struct ProjectPageParamBox: ProjectPageParam {
+  public let param: Param
+  public let initialProject: (any ProjectPamphletMainCellConfiguration)?
+
+  public init(param: Param, initialProject: (any ProjectPamphletMainCellConfiguration)?) {
+    self.param = param
+    self.initialProject = initialProject
+  }
+}
+
+extension Param: ProjectPageParam {
+  public var param: Param { self }
+  public var initialProject: (any ProjectPamphletMainCellConfiguration)? { nil }
+}

--- a/Library/Sources/Library/Library/ViewModels/RewardsUseCase.swift
+++ b/Library/Sources/Library/Library/ViewModels/RewardsUseCase.swift
@@ -67,7 +67,7 @@ public final class RewardsUseCase: RewardsUseCaseType, RewardsUseCaseOutputs {
   /// Attempts to add the user to the secret reward group if logged in and a valid token is present.
   /// - Returns: `true` if the GraphQL mutation `addUserToSecretRewardGroup` was triggered successfully.
   ///            `false` if the user is not logged in or the token is missing/empty, thus skipping the mutation.
-  static func addUserToSecretRewardGroupIfNeeded(
+  public static func addUserToSecretRewardGroupIfNeeded(
     project param: Param,
     secretRewardToken: String?
   ) -> SignalProducer<Bool, ErrorEnvelope> {


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

This PR moves the ProjectPageViewModel and associated tests from Library to Kickstarter-Framework.

We need this for a future PR which will connect SDUI to project page.

# 🤔 Why

Because of legacy reasons, the Library-Keychain-iOSTests target runs as an Xcode test target. When adding SDUI to project page, we need to include some types from it in the view model. This chain of linking causes it to end up in Library-Keychain-iOSTests. This fails because the linker can't figure out it needs to include ServerDrivenUI. If you include it manually, it tries to link ServerDrivenUI twice. Either way breaks the compile.

ProjectPageViewController lives in Kickstarter-Framework, and ProjectPageViewModel lives in Library. So this just puts them next to each other.

# 🛠 How

Just moved a few files from one folder to another, fixed some internal-to-public types, and added some imports.