### PR TITLE
Add project story rich text feature flag

### DIFF
--- a/Experimentation/Sources/Experimentation/Features/StatsigFeature.swift
+++ b/Experimentation/Sources/Experimentation/Features/StatsigFeature.swift
@@ -1,12 +1,14 @@
 import Foundation
 
 public enum StatsigFeature: String, CaseIterable {
+  case projectStoryRichText = "project_story_rich_text"
   case videoFeed = "video_feed"
 }
 
 extension StatsigFeature: CustomStringConvertible {
   public var description: String {
     switch self {
+    case .projectStoryRichText: "Project Story Rich Text"
     case .videoFeed: "Video Feed"
     }
   }

--- a/Library/Sources/Library/Library/Statsig/StatsigFeature+Helpers.swift
+++ b/Library/Sources/Library/Library/Statsig/StatsigFeature+Helpers.swift
@@ -19,6 +19,11 @@ public func statsigFeatureEnabled(feature: StatsigFeature) -> Bool {
   return false
 }
 
+/// Returns whether the project story rich text feature is enabled for the current user.
+public func featureProjectStoryRichTextEnabled() -> Bool {
+  statsigFeatureEnabled(feature: .projectStoryRichText)
+}
+
 /// Returns whether the video feed feature is enabled for the current user.
 public func featureVideoFeedEnabled() -> Bool {
   statsigFeatureEnabled(feature: .videoFeed)


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Adds a feature flag to enable the rich text-based project story.

Usage of it will come in a future PR.

# 🤔 Why

We are replacing the project story view with SDUI and this lets us switch it on and off.

# 🛠 How

Similar to other Statsig features, this adds a new constant for us to grab from Statsig features, and a convenience function to use it.