### PR TITLE
DISC-369: Simplify PledgeCTAContainerViewData type

### DIFF
--- a/Library/Sources/Library/Library/ViewModels/PledgeCTAContainerViewViewModel.swift
+++ b/Library/Sources/Library/Library/ViewModels/PledgeCTAContainerViewViewModel.swift
@@ -9,10 +9,10 @@ public typealias PledgeCTAPrelaunchState = (
   watchesCount: Int
 )
 
-public typealias PledgeCTAContainerViewData = (
-  projectOrError: Either<(Project, RefTag?), ErrorEnvelope>,
-  isLoading: Bool
-)
+public struct PledgeCTAContainerViewData {
+  let projectOrError: Either<Project, ErrorEnvelope>
+  let isLoading: Bool
+}
 
 public protocol PledgeCTAContainerViewViewModelInputs {
   func configureWith(value: PledgeCTAContainerViewData)
@@ -46,17 +46,16 @@ public final class PledgeCTAContainerViewViewModel: PledgeCTAContainerViewViewMo
   public init() {
     let projectOrError = self.configData.signal
       .skipNil()
-      .filter(second >>> isFalse)
-      .map(first)
+      .filter { $0.isLoading == false }
+      .map { $0.projectOrError }
 
     let isLoading = self.configData.signal
       .skipNil()
-      .map(second)
+      .map { $0.isLoading }
 
     let project = projectOrError
       .map(Either.left)
       .skipNil()
-      .map(first)
 
     let projectError = projectOrError
       .map(Either.right)

--- a/Library/Sources/Library/Library/ViewModels/ProjectPageViewModel.swift
+++ b/Library/Sources/Library/Library/ViewModels/ProjectPageViewModel.swift
@@ -369,7 +369,7 @@ public final class ProjectPageViewModel: ProjectPageViewModelType, ProjectPageVi
 
     let freshProjectOrError: Signal<Either<Project, ErrorEnvelope>, Never> =
       Signal.merge(
-        project.map(Either.left),
+        freshProject.map(Either.left),
         freshProjectAndRefTagEvent.errors().map(Either.right)
       )
 

--- a/Library/Sources/Library/Library/ViewModels/ProjectPageViewModel.swift
+++ b/Library/Sources/Library/Library/ViewModels/ProjectPageViewModel.swift
@@ -367,13 +367,14 @@ public final class ProjectPageViewModel: ProjectPageViewModelType, ProjectPageVi
       }
       .skipNil()
 
-    let projectError: Signal<ErrorEnvelope, Never> = freshProjectAndRefTagEvent.errors()
-
     self.configurePledgeCTAView = Signal.combineLatest(
-      Signal.merge(freshProjectAndRefTag.map(Either.left), projectError.map(Either.right)),
+      freshProjectAndRefTagEvent,
       isLoading.signal
     )
-    .map { ($0, $1) }
+    .map { event, isLoading -> PledgeCTAContainerViewData? in
+      PledgeCTAContainerViewData.from(event, isLoading: isLoading)
+    }
+    .skipNil()
 
     self.configureChildViewControllersWithProject = freshProjectAndRefTag
       .map { project, refTag in (project, refTag) }
@@ -955,6 +956,29 @@ private extension Either where A == Project, B == ProjectPageParam {
       return Param.id(project.id)
     case let .right(projectParam):
       return projectParam.param
+    }
+  }
+}
+
+private extension PledgeCTAContainerViewData {
+  /// Creates a `PledgeCTAContainerViewData` from the data type used for `freshProjectAndRefTag`
+  static func from(
+    _ event: Signal<(Project, RefTag?), ErrorEnvelope>.Event,
+    isLoading: Bool
+  ) -> PledgeCTAContainerViewData? {
+    if let value = event.value {
+      let project = value.0
+      return PledgeCTAContainerViewData(
+        projectOrError: .left(project),
+        isLoading: isLoading
+      )
+    } else if let error = event.error {
+      return PledgeCTAContainerViewData(
+        projectOrError: .right(error),
+        isLoading: isLoading
+      )
+    } else {
+      return nil
     }
   }
 }

--- a/Library/Sources/Library/Library/ViewModels/ProjectPageViewModel.swift
+++ b/Library/Sources/Library/Library/ViewModels/ProjectPageViewModel.swift
@@ -965,26 +965,3 @@ private extension Either where A == Project, B == ProjectPageParam {
     }
   }
 }
-
-private extension PledgeCTAContainerViewData {
-  /// Creates a `PledgeCTAContainerViewData` from the data type used for `freshProjectAndRefTag`
-  static func from(
-    _ event: Signal<(Project, RefTag?), ErrorEnvelope>.Event,
-    isLoading: Bool
-  ) -> PledgeCTAContainerViewData? {
-    if let value = event.value {
-      let project = value.0
-      return PledgeCTAContainerViewData(
-        projectOrError: .left(project),
-        isLoading: isLoading
-      )
-    } else if let error = event.error {
-      return PledgeCTAContainerViewData(
-        projectOrError: .right(error),
-        isLoading: isLoading
-      )
-    } else {
-      return nil
-    }
-  }
-}

--- a/Library/Sources/Library/Library/ViewModels/ProjectPageViewModel.swift
+++ b/Library/Sources/Library/Library/ViewModels/ProjectPageViewModel.swift
@@ -367,12 +367,18 @@ public final class ProjectPageViewModel: ProjectPageViewModelType, ProjectPageVi
       }
       .skipNil()
 
+    let freshProjectOrError: Signal<Either<Project, ErrorEnvelope>, Never> =
+      Signal.merge(
+        project.map(Either.left),
+        freshProjectAndRefTagEvent.errors().map(Either.right)
+      )
+
     self.configurePledgeCTAView = Signal.combineLatest(
-      freshProjectAndRefTagEvent,
+      freshProjectOrError,
       isLoading.signal
     )
-    .map { event, isLoading -> PledgeCTAContainerViewData? in
-      PledgeCTAContainerViewData.from(event, isLoading: isLoading)
+    .map { projectOrError, isLoading -> PledgeCTAContainerViewData? in
+      PledgeCTAContainerViewData(projectOrError: projectOrError, isLoading: isLoading)
     }
     .skipNil()
 

--- a/LibraryTests/Library/ViewModels/PledgeCTAContainerViewViewModelTests.swift
+++ b/LibraryTests/Library/ViewModels/PledgeCTAContainerViewViewModelTests.swift
@@ -55,7 +55,8 @@ internal final class PledgeCTAContainerViewViewModelTests: TestCase {
       |> Project.lens.country .~ .us
       |> Project.lens.stats.projectCurrency .~ Project.Country.us.currencyCode
 
-    self.vm.inputs.configureWith(value: (.left((project, nil)), false))
+    let value = PledgeCTAContainerViewData(projectOrError: .left(project), isLoading: false)
+    self.vm.inputs.configureWith(value: value)
     self.buttonStyleType.assertValues([ButtonStyleType.blue])
     self.buttonTitleText.assertValues([Strings.Manage()])
     self.titleText.assertValues([Strings.Youre_a_backer()])
@@ -76,7 +77,8 @@ internal final class PledgeCTAContainerViewViewModelTests: TestCase {
       |> Project.lens.country .~ .us
       |> Project.lens.stats.projectCurrency .~ Project.Country.mx.currencyCode
 
-    self.vm.inputs.configureWith(value: (.left((project, nil)), false))
+    let value = PledgeCTAContainerViewData(projectOrError: .left(project), isLoading: false)
+    self.vm.inputs.configureWith(value: value)
     self.buttonStyleType.assertValues([ButtonStyleType.blue])
     self.buttonTitleText.assertValues([Strings.Manage()])
     self.titleText.assertValues([Strings.Youre_a_backer()])
@@ -98,7 +100,8 @@ internal final class PledgeCTAContainerViewViewModelTests: TestCase {
       |> Project.lens.country .~ .us
       |> Project.lens.stats.projectCurrency .~ Project.Country.us.currencyCode
 
-    self.vm.inputs.configureWith(value: (.left((project, nil)), false))
+    let value = PledgeCTAContainerViewData(projectOrError: .left(project), isLoading: false)
+    self.vm.inputs.configureWith(value: value)
     self.buttonStyleType.assertValues([ButtonStyleType.blue])
     self.buttonTitleText.assertValues([Strings.Manage()])
     self.titleText.assertValues([Strings.Youre_a_backer()])
@@ -113,7 +116,8 @@ internal final class PledgeCTAContainerViewViewModelTests: TestCase {
       |> Project.lens.personalization.backing .~ Backing.template
       |> Project.lens.state .~ .successful
 
-    self.vm.inputs.configureWith(value: (.left((project, nil)), false))
+    let value = PledgeCTAContainerViewData(projectOrError: .left(project), isLoading: false)
+    self.vm.inputs.configureWith(value: value)
     self.buttonStyleType.assertValues([ButtonStyleType.black])
     self.buttonTitleText.assertValues([Strings.View_your_pledge()])
     self.spacerIsHidden.assertValues([true])
@@ -123,7 +127,8 @@ internal final class PledgeCTAContainerViewViewModelTests: TestCase {
   func testPledgeCTA_NetNewBackerGoToPM() {
     let project = Project.netNewBacker
 
-    self.vm.inputs.configureWith(value: (.left((project, nil)), false))
+    let value = PledgeCTAContainerViewData(projectOrError: .left(project), isLoading: false)
+    self.vm.inputs.configureWith(value: value)
     self.buttonStyleType.assertValues([ButtonStyleType.black])
     self.buttonTitleText.assertValues([Strings.Go_to_pledge_manager()])
     self.spacerIsHidden.assertValues([true])
@@ -136,7 +141,8 @@ internal final class PledgeCTAContainerViewViewModelTests: TestCase {
       |> Project.lens.personalization.isBacking .~ true
       |> Project.lens.pledgeManager .~ nil
 
-    self.vm.inputs.configureWith(value: (.left((project, nil)), false))
+    let value = PledgeCTAContainerViewData(projectOrError: .left(project), isLoading: false)
+    self.vm.inputs.configureWith(value: value)
     self.buttonStyleType.assertValues([ButtonStyleType.black])
     self.buttonTitleText.assertValues([Strings.Go_to_pledge_manager()])
     self.spacerIsHidden.assertValues([true])
@@ -150,7 +156,8 @@ internal final class PledgeCTAContainerViewViewModelTests: TestCase {
       |> Project.lens.personalization.backing .~ backing
       |> Project.lens.personalization.isBacking .~ true
 
-    self.vm.inputs.configureWith(value: (.left((project, nil)), false))
+    let value = PledgeCTAContainerViewData(projectOrError: .left(project), isLoading: false)
+    self.vm.inputs.configureWith(value: value)
     self.buttonStyleType.assertValues([ButtonStyleType.black])
     self.buttonTitleText.assertValues([Strings.Go_to_pledge_manager()])
     self.spacerIsHidden.assertValues([true])
@@ -162,7 +169,8 @@ internal final class PledgeCTAContainerViewViewModelTests: TestCase {
       |> Project.lens.personalization.isBacking .~ nil
       |> Project.lens.state .~ .live
 
-    self.vm.inputs.configureWith(value: (.left((project, nil)), false))
+    let value = PledgeCTAContainerViewData(projectOrError: .left(project), isLoading: false)
+    self.vm.inputs.configureWith(value: value)
     self.buttonStyleType.assertValues([ButtonStyleType.green])
     self.buttonTitleText.assertValues([Strings.Back_this_project()])
     self.spacerIsHidden.assertValues([true])
@@ -174,7 +182,8 @@ internal final class PledgeCTAContainerViewViewModelTests: TestCase {
       |> Project.lens.personalization.isBacking .~ nil
       |> Project.lens.state .~ .successful
 
-    self.vm.inputs.configureWith(value: (.left((project, nil)), false))
+    let value = PledgeCTAContainerViewData(projectOrError: .left(project), isLoading: false)
+    self.vm.inputs.configureWith(value: value)
     self.buttonStyleType.assertValues([ButtonStyleType.black])
     self.buttonTitleText.assertValues([Strings.View_rewards()])
     self.spacerIsHidden.assertValues([true])
@@ -192,7 +201,8 @@ internal final class PledgeCTAContainerViewViewModelTests: TestCase {
       |> Project.lens.country .~ .us
       |> Project.lens.stats.projectCurrency .~ Project.Country.us.currencyCode
 
-    self.vm.inputs.configureWith(value: (.left((project, nil)), false))
+    let value = PledgeCTAContainerViewData(projectOrError: .left(project), isLoading: false)
+    self.vm.inputs.configureWith(value: value)
     self.buttonStyleType.assertValues([ButtonStyleType.blue])
     self.buttonTitleText.assertValues([Strings.Manage()])
     self.titleText.assertValues([Strings.Youre_a_backer()])
@@ -209,7 +219,8 @@ internal final class PledgeCTAContainerViewViewModelTests: TestCase {
       |> Project.lens.state .~ .successful
       |> Project.lens.personalization.backing .~ backing
 
-    self.vm.inputs.configureWith(value: (.left((project, nil)), false))
+    let value = PledgeCTAContainerViewData(projectOrError: .left(project), isLoading: false)
+    self.vm.inputs.configureWith(value: value)
     self.buttonStyleType.assertValues([ButtonStyleType.red])
     self.buttonTitleText.assertValues([Strings.Manage()])
     self.titleText.assertValues(["Payment failure"])
@@ -223,7 +234,8 @@ internal final class PledgeCTAContainerViewViewModelTests: TestCase {
       |> Project.lens.personalization.backing .~ nil
       |> Project.lens.personalization.isBacking .~ false
 
-    self.vm.inputs.configureWith(value: (.left((project, nil)), false))
+    let value = PledgeCTAContainerViewData(projectOrError: .left(project), isLoading: false)
+    self.vm.inputs.configureWith(value: value)
     self.buttonStyleType.assertValues([ButtonStyleType.green])
     self.buttonTitleText.assertValues([Strings.Back_this_project()])
     self.spacerIsHidden.assertValues([true])
@@ -235,7 +247,8 @@ internal final class PledgeCTAContainerViewViewModelTests: TestCase {
       |> Project.lens.state .~ .successful
       |> Project.lens.personalization.isBacking .~ false
 
-    self.vm.inputs.configureWith(value: (.left((project, nil)), false))
+    let value = PledgeCTAContainerViewData(projectOrError: .left(project), isLoading: false)
+    self.vm.inputs.configureWith(value: value)
     self.buttonStyleType.assertValues([ButtonStyleType.black])
     self.buttonTitleText.assertValues([Strings.View_rewards()])
     self.spacerIsHidden.assertValues([true])
@@ -249,7 +262,8 @@ internal final class PledgeCTAContainerViewViewModelTests: TestCase {
       |> Project.lens.state .~ .live
 
     withEnvironment(currentUser: user) {
-      self.vm.inputs.configureWith(value: (.left((project, nil)), false))
+      let value = PledgeCTAContainerViewData(projectOrError: .left(project), isLoading: false)
+      self.vm.inputs.configureWith(value: value)
       self.buttonStyleType.assertValues([ButtonStyleType.black])
       self.buttonTitleText.assertValues(["View your rewards"])
       self.spacerIsHidden.assertValues([true])
@@ -264,7 +278,8 @@ internal final class PledgeCTAContainerViewViewModelTests: TestCase {
       |> Project.lens.state .~ .successful
 
     withEnvironment(currentUser: user) {
-      self.vm.inputs.configureWith(value: (.left((project, nil)), false))
+      let value = PledgeCTAContainerViewData(projectOrError: .left(project), isLoading: false)
+      self.vm.inputs.configureWith(value: value)
       self.buttonStyleType.assertValues([ButtonStyleType.black])
       self.buttonTitleText.assertValues(["View your rewards"])
       self.spacerIsHidden.assertValues([true])
@@ -276,7 +291,8 @@ internal final class PledgeCTAContainerViewViewModelTests: TestCase {
     let project = Project.template
       |> Project.lens.state .~ .live
 
-    self.vm.inputs.configureWith(value: (.left((project, nil)), true))
+    let value = PledgeCTAContainerViewData(projectOrError: .left(project), isLoading: true)
+    self.vm.inputs.configureWith(value: value)
     self.activityIndicatorIsHidden.assertValues([false])
     self.pledgeCTAButtonIsHidden.assertValues([true])
     self.pledgeRetryButtonIsHidden.assertValues([true])
@@ -286,7 +302,8 @@ internal final class PledgeCTAContainerViewViewModelTests: TestCase {
     self.spacerIsHidden.assertDidNotEmitValue()
     self.stackViewIsHidden.assertDidNotEmitValue()
 
-    self.vm.inputs.configureWith(value: (.left((project, nil)), false))
+    let value2 = PledgeCTAContainerViewData(projectOrError: .left(project), isLoading: false)
+    self.vm.inputs.configureWith(value: value2)
     self.activityIndicatorIsHidden.assertValues([false, true])
     self.pledgeCTAButtonIsHidden.assertValues([true, false])
     self.pledgeRetryButtonIsHidden.assertValues([true])
@@ -303,10 +320,12 @@ internal final class PledgeCTAContainerViewViewModelTests: TestCase {
 
     self.pledgeRetryButtonIsHidden.assertDidNotEmitValue()
 
-    self.vm.inputs.configureWith(value: (.left((project, nil)), false))
+    let value = PledgeCTAContainerViewData(projectOrError: .left(project), isLoading: false)
+    self.vm.inputs.configureWith(value: value)
     self.pledgeRetryButtonIsHidden.assertValues([true])
 
-    self.vm.inputs.configureWith(value: (.right(.couldNotParseJSON), false))
+    let value2 = PledgeCTAContainerViewData(projectOrError: .right(.couldNotParseJSON), isLoading: false)
+    self.vm.inputs.configureWith(value: value2)
     self.pledgeRetryButtonIsHidden.assertValues([true, false])
   }
 
@@ -317,7 +336,8 @@ internal final class PledgeCTAContainerViewViewModelTests: TestCase {
 
     self.notifyDelegateCTATapped.assertDidNotEmitValue()
 
-    self.vm.inputs.configureWith(value: (.left((project, nil)), false))
+    let value = PledgeCTAContainerViewData(projectOrError: .left(project), isLoading: false)
+    self.vm.inputs.configureWith(value: value)
     self.buttonStyleType.assertValues([ButtonStyleType.green])
     self.buttonTitleText.assertValues([Strings.Back_this_project()])
 
@@ -332,7 +352,8 @@ internal final class PledgeCTAContainerViewViewModelTests: TestCase {
 
     self.notifyDelegateCTATapped.assertDidNotEmitValue()
 
-    self.vm.inputs.configureWith(value: (.left((project, nil)), false))
+    let value = PledgeCTAContainerViewData(projectOrError: .left(project), isLoading: false)
+    self.vm.inputs.configureWith(value: value)
     self.buttonStyleType.assertValues([ButtonStyleType.black])
     self.buttonTitleText.assertValues([Strings.View_rewards()])
 
@@ -341,7 +362,8 @@ internal final class PledgeCTAContainerViewViewModelTests: TestCase {
   }
 
   func testTrackingEvents_Pledge() {
-    self.vm.inputs.configureWith(value: (.left((Project.template, nil)), false))
+    let value = PledgeCTAContainerViewData(projectOrError: .left(Project.template), isLoading: false)
+    self.vm.inputs.configureWith(value: value)
 
     self.notifyDelegateCTATapped.assertDidNotEmitValue()
 
@@ -365,7 +387,8 @@ internal final class PledgeCTAContainerViewViewModelTests: TestCase {
     let prelaunchCTAUnsaved = PledgeCTAPrelaunchState(prelaunch: true, saved: false, watchesCount: 99)
     let prelaunchCTASaved = PledgeCTAPrelaunchState(prelaunch: true, saved: true, watchesCount: 100)
 
-    self.vm.inputs.configureWith(value: (.left((unsavedProject, nil)), false))
+    let value = PledgeCTAContainerViewData(projectOrError: .left(unsavedProject), isLoading: false)
+    self.vm.inputs.configureWith(value: value)
 
     self.buttonStyleType.assertValues([.black])
     self.buttonTitleText.assertValues(["Notify me on launch"])
@@ -401,7 +424,8 @@ internal final class PledgeCTAContainerViewViewModelTests: TestCase {
       |> \.watchesCount .~ 102
       |> \.personalization.isStarred .~ true
 
-    self.vm.inputs.configureWith(value: (.left((savedProject, nil)), false))
+    let value = PledgeCTAContainerViewData(projectOrError: .left(savedProject), isLoading: false)
+    self.vm.inputs.configureWith(value: value)
 
     self.notifyDelegateCTATapped.assertDidNotEmitValue()
 

--- a/LibraryTests/Library/ViewModels/ProjectPageViewModelTests.swift
+++ b/LibraryTests/Library/ViewModels/ProjectPageViewModelTests.swift
@@ -238,16 +238,10 @@ final class ProjectPageViewModelTests: TestCase {
     let backing = Backing.template
       |> Backing.lens.id .~ 543
 
-    let projectPamphletData = Project
-      .ProjectPamphletData(project: USCurrencyProject, backingId: backing.id)
-
-    let projectFullAndEnvelope = ProjectAndBackingEnvelope(project: USCurrencyProject, backing: backing)
-
-    withEnvironment(apiService: MockService(
-      fetchProjectAndBackingResult: .success(projectFullAndEnvelope),
-      fetchProjectPamphletResult: .success(projectPamphletData),
-      fetchProjectRewardsResult: .success([.template])
-    )) {
+    ProjectPageViewModelTests.mockNetworkRequests(
+      project: USCurrencyProject,
+      backing: backing
+    ) {
       self.vm.inputs.configureWith(projectOrParam: .left(USCurrencyProject), refInfo: RefInfo(.category))
 
       self.configureDataSourceProject.assertDidNotEmitValue()
@@ -328,16 +322,11 @@ final class ProjectPageViewModelTests: TestCase {
     let backing = Backing.template
       |> Backing.lens.id .~ 543
 
-    let projectPamphletData = Project
-      .ProjectPamphletData(project: USCurrencyProject, backingId: backing.id)
-
-    let projectFullAndEnvelope = ProjectAndBackingEnvelope(project: USCurrencyProject, backing: backing)
-
-    withEnvironment(apiService: MockService(
-      fetchProjectAndBackingResult: .success(projectFullAndEnvelope),
-      fetchProjectPamphletResult: .success(projectPamphletData),
-      fetchProjectRewardsResult: .success([.template])
-    )) {
+    ProjectPageViewModelTests.mockNetworkRequests(
+      project: USCurrencyProject,
+      rewards: [Reward.template],
+      backing: backing
+    ) {
       self.vm.inputs.configureWith(projectOrParam: .left(USCurrencyProject), refInfo: RefInfo(.category))
 
       self.configureDataSourceProject.assertDidNotEmitValue()
@@ -364,13 +353,7 @@ final class ProjectPageViewModelTests: TestCase {
   }
 
   func testConfigureProjectNavigationSelectorView_ExtendedPropertiesEmpty_CreatesNavigationSelector_Success() {
-    let projectPamphletData = Project
-      .ProjectPamphletData(project: self.projectWithEmptyProperties, backingId: nil)
-
-    withEnvironment(apiService: MockService(
-      fetchProjectPamphletResult: .success(projectPamphletData),
-      fetchProjectRewardsResult: .success([.template])
-    )) {
+    ProjectPageViewModelTests.mockNetworkRequests(project: Project.template) {
       self.vm.inputs
         .configureWith(projectOrParam: .left(self.projectWithEmptyProperties), refInfo: RefInfo(.category))
 
@@ -386,13 +369,11 @@ final class ProjectPageViewModelTests: TestCase {
 
   func testConfigureProjectNavigationSelectorView_ExtendedProjectPropertiesNil_CreatesNavigationSelector_Success(
   ) {
-    let projectPamphletData = Project.ProjectPamphletData(project: .template, backingId: nil)
-
-    withEnvironment(apiService: MockService(
-      fetchProjectPamphletResult: .success(projectPamphletData),
-      fetchProjectRewardsResult: .success([.template])
-    )) {
-      self.vm.inputs.configureWith(projectOrParam: .left(.template), refInfo: RefInfo(.category))
+    ProjectPageViewModelTests.mockNetworkRequests(project: .template) {
+      self.vm.inputs.configureWith(
+        projectOrParam: .left(self.projectWithEmptyProperties),
+        refInfo: RefInfo(.category)
+      )
 
       self.configureProjectNavigationSelectorView.assertDidNotEmitValue()
 
@@ -406,15 +387,13 @@ final class ProjectPageViewModelTests: TestCase {
 
   func testConfiguredProject_WithNoBacking_Succcessfully() {
     let project = Project.template
-    let projectPamphletData = Project.ProjectPamphletData(project: project, backingId: nil)
     let refTag = RefTag.category
 
-    withEnvironment(apiService: MockService(
-      fetchProjectAndBackingResult: .success(.template),
-      fetchProjectPamphletResult: .success(projectPamphletData),
-      fetchProjectRewardsResult: .success([.template])
-    )) {
-      self.vm.inputs.configureWith(projectOrParam: .left(project), refInfo: RefInfo(refTag))
+    ProjectPageViewModelTests.mockNetworkRequests(project: project, backing: nil) {
+      self.vm.inputs.configureWith(
+        projectOrParam: .left(self.projectWithEmptyProperties),
+        refInfo: RefInfo(refTag)
+      )
       self.vm.inputs.viewDidLoad()
       self.vm.inputs.viewDidAppear(animated: false)
 
@@ -431,15 +410,15 @@ final class ProjectPageViewModelTests: TestCase {
   func testConfiguredProject_WithNoBacking_Unsuccessfully() {
     let project = Project.template
     let refTag = RefTag.category
-    let projectPamphletData = Project.ProjectPamphletData(project: project, backingId: nil)
 
-    withEnvironment(apiService: MockService(
-      // If there's no backingID, we won't fetch a backing.
-      // fetchProjectAndBackingResult: .success(.template),
-      fetchProjectPamphletResult: .success(projectPamphletData),
-      fetchProjectRewardsResult: .success([.template])
-    )) {
-      self.vm.inputs.configureWith(projectOrParam: .left(project), refInfo: RefInfo(refTag))
+    ProjectPageViewModelTests.mockNetworkRequests(
+      project: project,
+      backing: nil
+    ) {
+      self.vm.inputs.configureWith(
+        projectOrParam: .left(self.projectWithEmptyProperties),
+        refInfo: RefInfo(refTag)
+      )
       self.vm.inputs.viewDidLoad()
       self.vm.inputs.viewDidAppear(animated: false)
 
@@ -455,14 +434,16 @@ final class ProjectPageViewModelTests: TestCase {
   func testConfiguredProject_WithBacking_Succcessfully() {
     let project = Project.template
     let refTag = RefTag.category
-    let projectPamphletData = Project.ProjectPamphletData(project: project, backingId: 1)
 
-    withEnvironment(apiService: MockService(
-      fetchProjectAndBackingResult: .success(ProjectAndBackingEnvelope.template),
-      fetchProjectPamphletResult: .success(projectPamphletData),
-      fetchProjectRewardsResult: .success([Reward.template])
-    )) {
-      self.vm.inputs.configureWith(projectOrParam: .left(project), refInfo: RefInfo(refTag))
+    ProjectPageViewModelTests.mockNetworkRequests(
+      project: project,
+      rewards: [Reward.template],
+      backing: Backing.template
+    ) {
+      self.vm.inputs.configureWith(
+        projectOrParam: .left(self.projectWithEmptyProperties),
+        refInfo: RefInfo(refTag)
+      )
       self.vm.inputs.viewDidLoad()
       self.vm.inputs.viewDidAppear(animated: false)
 
@@ -605,37 +586,35 @@ final class ProjectPageViewModelTests: TestCase {
   func test_loadingFromParameter_loadsAllData() {
     let project = Project.template
 
+    // Rewards are fetched by rewards fetch, not the project fetch
     let projectFull = Project.template
       |> Project.lens.rewardData.rewards .~ []
-
-    let projectAndBacking = ProjectAndBackingEnvelope(project: projectFull, backing: Backing.template)
-    let initialProject = Project.ProjectPamphletData(project: projectFull, backingId: 1)
-
-    let mockService = MockService(
-      fetchProjectAndBackingResult: .success(projectAndBacking),
-      fetchProjectPamphletResult: .success(initialProject),
-      fetchProjectRewardsResult: .success([Reward.noReward, Reward.template]),
-    )
 
     let param = ProjectPageParamBox(param: .id(project.id), initialProject: nil)
     let initialData = Either<Project, any ProjectPageParam>.right(param)
 
-    withEnvironment(apiService: mockService, currentUser: .template) {
-      self.vm.configureAndLoad(initialData)
+    ProjectPageViewModelTests.mockNetworkRequests(
+      project: projectFull,
+      rewards: [Reward.noReward, Reward.template],
+      backing: Backing.template
+    ) {
+      withEnvironment(currentUser: .template) {
+        self.vm.configureAndLoad(initialData)
 
-      self.configureChildViewControllersWithProject.assertDidNotEmitValue()
+        self.configureChildViewControllersWithProject.assertDidNotEmitValue()
 
-      self.scheduler.advance()
+        self.scheduler.advance()
 
-      self.configureChildViewControllersWithProject.assertDidEmitValue()
-      guard let loadedProject = self.configureChildViewControllersWithProject.lastValue else {
-        XCTFail("Expected project to have loaded")
-        return
+        self.configureChildViewControllersWithProject.assertDidEmitValue()
+        guard let loadedProject = self.configureChildViewControllersWithProject.lastValue else {
+          XCTFail("Expected project to have loaded")
+          return
+        }
+
+        XCTAssertEqual(loadedProject.rewards.count, 2)
+        XCTAssertEqual(loadedProject.rewards.first, Reward.noReward)
+        XCTAssertEqual(loadedProject.personalization.backing, Backing.template)
       }
-
-      XCTAssertEqual(loadedProject.rewards.count, 2)
-      XCTAssertEqual(loadedProject.rewards.first, Reward.noReward)
-      XCTAssertEqual(loadedProject.personalization.backing, Backing.template)
     }
   }
 
@@ -645,35 +624,31 @@ final class ProjectPageViewModelTests: TestCase {
     let projectFull = Project.template
       |> Project.lens.rewardData.rewards .~ []
 
-    let projectAndBacking = ProjectAndBackingEnvelope(project: projectFull, backing: Backing.template)
-    let initialProject = Project.ProjectPamphletData(project: projectFull, backingId: 1)
-
-    let mockService = MockService(
-      addUserToSecretRewardGroup: .success(EmptyResponseEnvelope.init()),
-      fetchProjectAndBackingResult: .success(projectAndBacking),
-      fetchProjectPamphletResult: .success(initialProject),
-      fetchProjectRewardsResult: .success([Reward.secretRewardTemplate, Reward.noReward, Reward.template]),
-    )
-
     let param = ProjectPageParamBox(param: .id(project.id), initialProject: nil)
     let initialData = Either<Project, any ProjectPageParam>.right(param)
 
-    withEnvironment(apiService: mockService, currentUser: .template) {
-      self.vm.configureAndLoad(initialData, secretRewardToken: "foobar")
+    withEnvironment(currentUser: .template) {
+      ProjectPageViewModelTests.mockNetworkRequests(
+        project: projectFull,
+        rewards: [Reward.noReward, Reward.secretRewardTemplate, Reward.template],
+        backing: Backing.template
+      ) {
+        self.vm.configureAndLoad(initialData, secretRewardToken: "foobar")
 
-      self.configureChildViewControllersWithProject.assertDidNotEmitValue()
+        self.configureChildViewControllersWithProject.assertDidNotEmitValue()
 
-      self.scheduler.advance()
+        self.scheduler.advance()
 
-      self.configureChildViewControllersWithProject.assertDidEmitValue()
-      guard let loadedProject = self.configureChildViewControllersWithProject.lastValue else {
-        XCTFail("Expected project to have loaded")
-        return
+        self.configureChildViewControllersWithProject.assertDidEmitValue()
+        guard let loadedProject = self.configureChildViewControllersWithProject.lastValue else {
+          XCTFail("Expected project to have loaded")
+          return
+        }
+
+        XCTAssertEqual(loadedProject.rewards.count, 3)
+        XCTAssertEqual(loadedProject.rewards[1], Reward.secretRewardTemplate)
+        XCTAssertEqual(loadedProject.personalization.backing, Backing.template)
       }
-
-      XCTAssertEqual(loadedProject.rewards.count, 3)
-      XCTAssertEqual(loadedProject.rewards.first, Reward.secretRewardTemplate)
-      XCTAssertEqual(loadedProject.personalization.backing, Backing.template)
     }
   }
 
@@ -683,7 +658,6 @@ final class ProjectPageViewModelTests: TestCase {
     let projectFull = Project.template
       |> Project.lens.rewardData.rewards .~ []
 
-    let projectAndBacking = ProjectAndBackingEnvelope(project: projectFull, backing: Backing.template)
     let initialProject = Project.ProjectPamphletData(project: projectFull, backingId: 1)
 
     let mockService = MockService(
@@ -944,36 +918,31 @@ final class ProjectPageViewModelTests: TestCase {
     let project = Project.template
     let projectFull = Project.template
       |> \.id .~ 2
-      |> Project.lens.personalization.isBacking .~ true
 
-    let projectPamphletData = Project.ProjectPamphletData(project: projectFull, backingId: nil)
-
-    let mockService = MockService(
-      fetchProjectPamphletResult: .success(projectPamphletData),
-      fetchProjectRewardsResult: .success([Reward.noReward, Reward.template])
-    )
-
-    withEnvironment(
-      apiService: mockService,
-      apiDelayInterval: .seconds(1),
-      config: .template,
-      mainBundle: self.releaseBundle
+    ProjectPageViewModelTests.mockNetworkRequests(
+      project: projectFull
     ) {
-      self.configurePledgeCTAViewProject.assertDidNotEmitValue()
-      self.configurePledgeCTAViewIsLoading.assertDidNotEmitValue()
-      self.configurePledgeCTAViewRefTag.assertValues([])
+      withEnvironment(
+        apiDelayInterval: .seconds(1),
+        config: .template,
+        mainBundle: self.releaseBundle
+      ) {
+        self.configurePledgeCTAViewProject.assertDidNotEmitValue()
+        self.configurePledgeCTAViewIsLoading.assertDidNotEmitValue()
+        self.configurePledgeCTAViewRefTag.assertValues([])
 
-      self.vm.configureAndLoad(.left(project))
+        self.vm.configureAndLoad(.left(project))
 
-      self.configurePledgeCTAViewProject.assertValues([project])
-      self.configurePledgeCTAViewIsLoading.assertValues([true])
-      self.configurePledgeCTAViewRefTag.assertValues([.discovery])
+        self.configurePledgeCTAViewProject.assertValues([project])
+        self.configurePledgeCTAViewIsLoading.assertValues([true])
+        self.configurePledgeCTAViewRefTag.assertValues([.discovery])
 
-      self.scheduler.run()
+        self.scheduler.run()
 
-      self.configurePledgeCTAViewProject.assertValues([project, projectFull, projectFull])
-      self.configurePledgeCTAViewIsLoading.assertValues([true, true, false])
-      self.configurePledgeCTAViewRefTag.assertValues([.discovery, .discovery, .discovery])
+        self.configurePledgeCTAViewProject.assertValues([project, projectFull, projectFull])
+        self.configurePledgeCTAViewIsLoading.assertValues([true, true, false])
+        self.configurePledgeCTAViewRefTag.assertValues([.discovery, .discovery, .discovery])
+      }
     }
   }
 
@@ -1010,84 +979,66 @@ final class ProjectPageViewModelTests: TestCase {
   func testConfigurePledgeCTAView_ReloadsUponBackProject() {
     let config = Config.template
     let project = Project.template
-    let friends = [User.template]
     let projectFull = Project.template
       |> Project.lens.rewardData.rewards .~ []
 
-    let projectAndEnvelope = ProjectAndBackingEnvelope(project: projectFull, backing: Backing.template)
-    let projectPamphletData = Project.ProjectPamphletData(project: projectFull, backingId: 1)
-    let mockService = MockService(
-      fetchProjectAndBackingResult: .success(projectAndEnvelope),
-      fetchProjectPamphletResult: .success(projectPamphletData),
-      fetchProjectFriendsResult: .success(friends),
-      fetchProjectRewardsResult: .success([Reward.noReward, Reward.template])
-    )
+    withEnvironment(config: config, mainBundle: self.releaseBundle) {
+      ProjectPageViewModelTests.mockNetworkRequests(project: projectFull, backing: nil) {
+        self.configurePledgeCTAViewProject.assertDidNotEmitValue()
+        self.configurePledgeCTAViewIsLoading.assertDidNotEmitValue()
+        self.configurePledgeCTAViewRefTag.assertDidNotEmitValue()
 
-    withEnvironment(apiService: mockService, config: config, mainBundle: self.releaseBundle) {
-      self.configurePledgeCTAViewProject.assertDidNotEmitValue()
-      self.configurePledgeCTAViewIsLoading.assertDidNotEmitValue()
-      self.configurePledgeCTAViewRefTag.assertDidNotEmitValue()
+        self.vm.inputs.configureWith(projectOrParam: .left(project), refInfo: RefInfo(.discovery))
+        self.vm.inputs.viewDidLoad()
+        self.vm.inputs.viewDidAppear(animated: true)
 
-      self.vm.inputs.configureWith(projectOrParam: .left(project), refInfo: RefInfo(.discovery))
-      self.vm.inputs.viewDidLoad()
-      self.vm.inputs.viewDidAppear(animated: true)
+        self.configurePledgeCTAViewProject.assertValues([project])
+        self.configurePledgeCTAViewIsLoading.assertValues([true])
+        self.configurePledgeCTAViewRefTag.assertValues([.discovery])
 
-      self.configurePledgeCTAViewProject.assertValues([project])
-      self.configurePledgeCTAViewIsLoading.assertValues([true])
-      self.configurePledgeCTAViewRefTag.assertValues([.discovery])
+        self.scheduler.advance()
 
-      self.scheduler.advance()
+        self.configurePledgeCTAViewProject.assertValues([project, project, projectFull])
+        self.configurePledgeCTAViewIsLoading.assertValues([true, true, false])
+        self.configurePledgeCTAViewRefTag.assertValues([.discovery, .discovery, .discovery])
+      }
 
-      self.configurePledgeCTAViewProject.assertValues([project, project, projectFull])
-      self.configurePledgeCTAViewIsLoading.assertValues([true, true, false])
-      self.configurePledgeCTAViewRefTag.assertValues([.discovery, .discovery, .discovery])
-    }
+      ProjectPageViewModelTests.mockNetworkRequests(project: projectFull, backing: Backing.template) {
+        self.vm.inputs.didBackProject()
 
-    withEnvironment(
-      apiService: MockService(
-        fetchProjectAndBackingResult: .success(projectAndEnvelope),
-        fetchProjectPamphletResult: .success(projectPamphletData),
-        fetchProjectFriendsResult: .success(friends),
-        fetchProjectRewardsResult: .success([Reward.noReward, Reward.template])
-      ),
-      config: config,
-      mainBundle: self.releaseBundle
-    ) {
-      self.vm.inputs.didBackProject()
+        self.configurePledgeCTAViewProject.assertValues([project, project, projectFull, projectFull])
+        self.configurePledgeCTAViewIsLoading.assertValues([true, true, false, true])
+        self.configurePledgeCTAViewRefTag.assertValues([.discovery, .discovery, .discovery, .discovery])
 
-      self.configurePledgeCTAViewProject.assertValues([project, project, projectFull, projectFull])
-      self.configurePledgeCTAViewIsLoading.assertValues([true, true, false, true])
-      self.configurePledgeCTAViewRefTag.assertValues([.discovery, .discovery, .discovery, .discovery])
+        self.scheduler.advance()
 
-      self.scheduler.advance()
+        let projectWithBacking = project |> \.personalization.backing .~ .template
+          |> \.personalization.isBacking .~ true
 
-      let projectWithBacking = project |> \.personalization.backing .~ .template
-        |> \.personalization.isBacking .~ true
-
-      self.configurePledgeCTAViewProject.assertValues([
-        project,
-        project,
-        projectFull,
-        projectFull,
-        projectFull,
-        projectWithBacking
-      ])
-      self.configurePledgeCTAViewIsLoading.assertValues([true, true, false, true, true, false])
-      self.configurePledgeCTAViewRefTag.assertValues([
-        .discovery,
-        .discovery,
-        .discovery,
-        .discovery,
-        .discovery,
-        .discovery
-      ])
+        self.configurePledgeCTAViewProject.assertValues([
+          project,
+          project,
+          projectFull,
+          projectFull,
+          projectFull,
+          projectWithBacking
+        ])
+        self.configurePledgeCTAViewIsLoading.assertValues([true, true, false, true, true, false])
+        self.configurePledgeCTAViewRefTag.assertValues([
+          .discovery,
+          .discovery,
+          .discovery,
+          .discovery,
+          .discovery,
+          .discovery
+        ])
+      }
     }
   }
 
   func testConfigurePledgeCTAView_ReloadsUponUpdatePledge() {
     let config = Config.template
     let project = Project.template
-    let friends = [User.template]
     let backingFull = Backing.template |> Backing.lens.amount .~ 10.0
     let updatedBacking = Backing.template |> Backing.lens.amount .~ 15.0
     let projectFull = Project.template
@@ -1097,152 +1048,117 @@ final class ProjectPageViewModelTests: TestCase {
       |> Project.lens.personalization.backing .~ updatedBacking
       |> Project.lens.personalization.isBacking .~ true
 
-    let projectFullAndEnvelope = ProjectAndBackingEnvelope(project: projectFull, backing: backingFull)
-    let projectUpdatedAndEnvelope = ProjectAndBackingEnvelope(
-      project: updatedProject,
-      backing: updatedBacking
-    )
-    let projectFullPamphletData = Project.ProjectPamphletData(project: projectFull, backingId: 1)
-    let projectUpdatedPamphletData = Project.ProjectPamphletData(project: updatedProject, backingId: 1)
+    withEnvironment(config: config, mainBundle: self.releaseBundle) {
+      ProjectPageViewModelTests.mockNetworkRequests(
+        project: projectFull,
+        backing: backingFull
+      ) {
+        self.configurePledgeCTAViewProject.assertDidNotEmitValue()
+        self.configurePledgeCTAViewIsLoading.assertDidNotEmitValue()
+        self.configurePledgeCTAViewRefTag.assertDidNotEmitValue()
 
-    let mockService = MockService(
-      fetchProjectAndBackingResult: .success(projectFullAndEnvelope),
-      fetchProjectPamphletResult: .success(projectFullPamphletData),
-      fetchProjectFriendsResult: .success(friends),
-      fetchProjectRewardsResult: .success([Reward.noReward, Reward.template])
-    )
+        self.vm.inputs.configureWith(projectOrParam: .left(project), refInfo: RefInfo(.discovery))
+        self.vm.inputs.viewDidLoad()
 
-    withEnvironment(apiService: mockService, config: config, mainBundle: self.releaseBundle) {
-      self.configurePledgeCTAViewProject.assertDidNotEmitValue()
-      self.configurePledgeCTAViewIsLoading.assertDidNotEmitValue()
-      self.configurePledgeCTAViewRefTag.assertDidNotEmitValue()
+        self.configurePledgeCTAViewProject.assertValues([project])
+        self.configurePledgeCTAViewIsLoading.assertValues([true])
+        self.configurePledgeCTAViewRefTag.assertValues([.discovery])
 
-      self.vm.inputs.configureWith(projectOrParam: .left(project), refInfo: RefInfo(.discovery))
-      self.vm.inputs.viewDidLoad()
+        self.scheduler.advance()
 
-      self.configurePledgeCTAViewProject.assertValues([project])
-      self.configurePledgeCTAViewIsLoading.assertValues([true])
-      self.configurePledgeCTAViewRefTag.assertValues([.discovery])
+        self.configurePledgeCTAViewProject.assertValues([project, project, projectFull])
+        self.configurePledgeCTAViewIsLoading.assertValues([true, true, false])
+        self.configurePledgeCTAViewRefTag.assertValues([.discovery, .discovery, .discovery])
+      }
 
-      self.scheduler.advance()
+      ProjectPageViewModelTests.mockNetworkRequests(
+        project: updatedProject,
+        backing: updatedBacking
+      ) {
+        self.vm.inputs.managePledgeViewControllerFinished(with: nil)
 
-      self.configurePledgeCTAViewProject.assertValues([project, project, projectFull])
-      self.configurePledgeCTAViewIsLoading.assertValues([true, true, false])
-      self.configurePledgeCTAViewRefTag.assertValues([.discovery, .discovery, .discovery])
-    }
+        self.configurePledgeCTAViewProject.assertValues([project, project, projectFull, projectFull])
+        self.configurePledgeCTAViewIsLoading.assertValues([true, true, false, true])
+        self.configurePledgeCTAViewRefTag.assertValues([.discovery, .discovery, .discovery, .discovery])
 
-    withEnvironment(
-      apiService: MockService(
-        fetchProjectAndBackingResult: .success(projectUpdatedAndEnvelope),
-        fetchProjectPamphletResult: .success(projectUpdatedPamphletData),
-        fetchProjectFriendsResult: .success(friends),
-        fetchProjectRewardsResult: .success([Reward.noReward, Reward.template])
-      ),
-      config: config,
-      mainBundle: self.releaseBundle
-    ) {
-      self.vm.inputs.managePledgeViewControllerFinished(with: nil)
+        self.scheduler.advance()
 
-      self.configurePledgeCTAViewProject.assertValues([project, project, projectFull, projectFull])
-      self.configurePledgeCTAViewIsLoading.assertValues([true, true, false, true])
-      self.configurePledgeCTAViewRefTag.assertValues([.discovery, .discovery, .discovery, .discovery])
-
-      self.scheduler.advance()
-
-      self.configurePledgeCTAViewProject.assertValues([
-        project,
-        project,
-        projectFull,
-        projectFull,
-        projectFull,
-        updatedProject
-      ])
-      self.configurePledgeCTAViewIsLoading.assertValues([true, true, false, true, true, false])
-      self.configurePledgeCTAViewRefTag.assertValues([
-        .discovery,
-        .discovery,
-        .discovery,
-        .discovery,
-        .discovery,
-        .discovery
-      ])
+        self.configurePledgeCTAViewProject.assertValues([
+          project,
+          project,
+          projectFull,
+          projectFull,
+          projectFull,
+          updatedProject
+        ])
+        self.configurePledgeCTAViewIsLoading.assertValues([true, true, false, true, true, false])
+        self.configurePledgeCTAViewRefTag.assertValues([
+          .discovery,
+          .discovery,
+          .discovery,
+          .discovery,
+          .discovery,
+          .discovery
+        ])
+      }
     }
   }
 
   func testConfigurePledgeCTAView_ReloadsUponRetryButtonTappedEvent() {
     let config = Config.template
     let project = Project.template
-    let friends = [User.template]
     let projectFull = Project.template
       |> \.id .~ 2
       |> Project.lens.personalization.isBacking .~ true
     let projectFull2 = Project.template
       |> \.id .~ 3
 
-    let projectFullAndEnvelope = ProjectAndBackingEnvelope(project: projectFull, backing: .template)
-    let projectFull2AndEnvelope = ProjectAndBackingEnvelope(project: projectFull2, backing: .template)
-    let projectFullPamphletData = Project.ProjectPamphletData(project: projectFull, backingId: nil)
-    let projectFull2PamphletData = Project.ProjectPamphletData(project: projectFull2, backingId: nil)
+    withEnvironment(config: config) {
+      ProjectPageViewModelTests.mockNetworkRequests(project: projectFull) {
+        self.configurePledgeCTAViewProject.assertDidNotEmitValue()
+        self.configurePledgeCTAViewIsLoading.assertDidNotEmitValue()
+        self.configurePledgeCTAViewRefTag.assertDidNotEmitValue()
 
-    let mockService = MockService(
-      fetchProjectAndBackingResult: .success(projectFullAndEnvelope),
-      fetchProjectPamphletResult: .success(projectFullPamphletData),
-      fetchProjectFriendsResult: .success(friends),
-      fetchProjectRewardsResult: .success([Reward.noReward, Reward.template])
-    )
+        self.vm.inputs.configureWith(projectOrParam: .left(project), refInfo: RefInfo(.discovery))
+        self.vm.inputs.viewDidLoad()
 
-    withEnvironment(apiService: mockService, config: config) {
-      self.configurePledgeCTAViewProject.assertDidNotEmitValue()
-      self.configurePledgeCTAViewIsLoading.assertDidNotEmitValue()
-      self.configurePledgeCTAViewRefTag.assertDidNotEmitValue()
+        self.configurePledgeCTAViewProject.assertValues([project])
+        self.configurePledgeCTAViewIsLoading.assertValues([true])
+        self.configurePledgeCTAViewRefTag.assertValues([.discovery])
 
-      self.vm.inputs.configureWith(projectOrParam: .left(project), refInfo: RefInfo(.discovery))
-      self.vm.inputs.viewDidLoad()
+        self.scheduler.advance()
 
-      self.configurePledgeCTAViewProject.assertValues([project])
-      self.configurePledgeCTAViewIsLoading.assertValues([true])
-      self.configurePledgeCTAViewRefTag.assertValues([.discovery])
+        self.configurePledgeCTAViewProject.assertValues([project, projectFull, projectFull])
+        self.configurePledgeCTAViewIsLoading.assertValues([true, true, false])
+        self.configurePledgeCTAViewRefTag.assertValues([.discovery, .discovery, .discovery])
+      }
 
-      self.scheduler.advance()
+      ProjectPageViewModelTests.mockNetworkRequests(project: projectFull2) {
+        self.vm.inputs.pledgeRetryButtonTapped()
 
-      self.configurePledgeCTAViewProject.assertValues([project, projectFull, projectFull])
-      self.configurePledgeCTAViewIsLoading.assertValues([true, true, false])
-      self.configurePledgeCTAViewRefTag.assertValues([.discovery, .discovery, .discovery])
-    }
+        self.configurePledgeCTAViewProject.assertValues([project, projectFull, projectFull, projectFull])
+        self.configurePledgeCTAViewIsLoading.assertValues([true, true, false, true])
 
-    withEnvironment(
-      apiService: MockService(
-        fetchProjectAndBackingResult: .success(projectFull2AndEnvelope),
-        fetchProjectPamphletResult: .success(projectFull2PamphletData),
-        fetchProjectFriendsResult: .success(friends),
-        fetchProjectRewardsResult: .success([Reward.noReward, Reward.template])
-      ),
-      config: config
-    ) {
-      self.vm.inputs.pledgeRetryButtonTapped()
+        self.scheduler.advance()
 
-      self.configurePledgeCTAViewProject.assertValues([project, projectFull, projectFull, projectFull])
-      self.configurePledgeCTAViewIsLoading.assertValues([true, true, false, true])
-
-      self.scheduler.advance()
-
-      self.configurePledgeCTAViewProject.assertValues([
-        project,
-        projectFull,
-        projectFull,
-        projectFull,
-        projectFull2,
-        projectFull2
-      ])
-      self.configurePledgeCTAViewIsLoading.assertValues([true, true, false, true, true, false])
-      self.configurePledgeCTAViewRefTag.assertValues([
-        .discovery,
-        .discovery,
-        .discovery,
-        .discovery,
-        .discovery,
-        .discovery
-      ])
+        self.configurePledgeCTAViewProject.assertValues([
+          project,
+          projectFull,
+          projectFull,
+          projectFull,
+          projectFull2,
+          projectFull2
+        ])
+        self.configurePledgeCTAViewIsLoading.assertValues([true, true, false, true, true, false])
+        self.configurePledgeCTAViewRefTag.assertValues([
+          .discovery,
+          .discovery,
+          .discovery,
+          .discovery,
+          .discovery,
+          .discovery
+        ])
+      }
     }
   }
 
@@ -1504,28 +1420,24 @@ final class ProjectPageViewModelTests: TestCase {
         minimumPledgeAmount: 1,
         projectNotice: nil
       )
-    let projectFullAndEnvelope = ProjectAndBackingEnvelope(project: projectFull, backing: .template)
-    let projectFullPamphletData = Project.ProjectPamphletData(project: projectFull, backingId: nil)
 
-    let mockService = MockService(
-      fetchProjectAndBackingResult: .success(projectFullAndEnvelope),
-      fetchProjectPamphletResult: .success(projectFullPamphletData),
-      fetchProjectFriendsResult: .success(friends),
-      fetchProjectRewardsResult: .success([Reward.noReward, Reward.template])
-    )
+    ProjectPageViewModelTests.mockNetworkRequests(project: projectFull) {
+      withEnvironment(config: config) {
+        self.vm.inputs.configureWith(
+          projectOrParam: .left(self.projectWithEmptyProperties),
+          refInfo: RefInfo(.discovery)
+        )
+        self.vm.inputs.viewDidLoad()
 
-    withEnvironment(apiService: mockService, config: config) {
-      self.vm.inputs.configureWith(projectOrParam: .left(projectFull), refInfo: RefInfo(.discovery))
-      self.vm.inputs.viewDidLoad()
+        self.scheduler.advance()
 
-      self.scheduler.advance()
+        self.vm.inputs.projectNavigationSelectorViewDidSelect(index: campaignSection)
 
-      self.vm.inputs.projectNavigationSelectorViewDidSelect(index: campaignSection)
+        self.vm.inputs.prepareImageAt(expectedIndexPath)
 
-      self.vm.inputs.prepareImageAt(expectedIndexPath)
-
-      XCTAssertEqual(self.prefetchImageURLs.lastValue?.0, [expectedUrl])
-      XCTAssertEqual(self.prefetchImageURLs.lastValue?.1, expectedIndexPath)
+        XCTAssertEqual(self.prefetchImageURLs.lastValue?.0, [expectedUrl])
+        XCTAssertEqual(self.prefetchImageURLs.lastValue?.1, expectedIndexPath)
+      }
     }
   }
 
@@ -1555,39 +1467,35 @@ final class ProjectPageViewModelTests: TestCase {
         minimumPledgeAmount: 1,
         projectNotice: nil
       )
-    let projectFullAndEnvelope = ProjectAndBackingEnvelope(project: projectFull, backing: .template)
-    let projectFullPamphletData = Project.ProjectPamphletData(project: projectFull, backingId: nil)
 
-    let mockService = MockService(
-      fetchProjectAndBackingResult: .success(projectFullAndEnvelope),
-      fetchProjectPamphletResult: .success(projectFullPamphletData),
-      fetchProjectFriendsResult: .success(friends),
-      fetchProjectRewardsResult: .success([Reward.noReward, Reward.template])
-    )
+    ProjectPageViewModelTests.mockNetworkRequests(project: projectFull) {
+      withEnvironment(config: config) {
+        self.vm.inputs.configureWith(
+          projectOrParam: .left(self.projectWithEmptyProperties),
+          refInfo: RefInfo(.discovery)
+        )
+        self.vm.inputs.viewDidLoad()
 
-    withEnvironment(apiService: mockService, config: config) {
-      self.vm.inputs.configureWith(projectOrParam: .left(projectFull), refInfo: RefInfo(.discovery))
-      self.vm.inputs.viewDidLoad()
+        self.scheduler.advance()
 
-      self.scheduler.advance()
+        self.vm.inputs.projectNavigationSelectorViewDidSelect(index: campaignSection)
 
-      self.vm.inputs.projectNavigationSelectorViewDidSelect(index: campaignSection)
+        self.vm.inputs.prepareAudioVideoAt(
+          expectedIndexPath,
+          with: expectedAudioVideoElement
+        )
 
-      self.vm.inputs.prepareAudioVideoAt(
-        expectedIndexPath,
-        with: expectedAudioVideoElement
-      )
-
-      XCTAssertEqual(
-        self.precreateAudioVideoURLs.lastValue?.0.sourceURLString,
-        expectedAudioVideoElement.sourceURLString
-      )
-      XCTAssertEqual(
-        self.precreateAudioVideoURLs.lastValue?.0.thumbnailURLString,
-        expectedAudioVideoElement.thumbnailURLString
-      )
-      XCTAssertEqual(self.precreateAudioVideoURLs.lastValue?.0.seekPosition, expectedTime)
-      XCTAssertEqual(self.precreateAudioVideoURLs.lastValue?.1, expectedIndexPath)
+        XCTAssertEqual(
+          self.precreateAudioVideoURLs.lastValue?.0.sourceURLString,
+          expectedAudioVideoElement.sourceURLString
+        )
+        XCTAssertEqual(
+          self.precreateAudioVideoURLs.lastValue?.0.thumbnailURLString,
+          expectedAudioVideoElement.thumbnailURLString
+        )
+        XCTAssertEqual(self.precreateAudioVideoURLs.lastValue?.0.seekPosition, expectedTime)
+        XCTAssertEqual(self.precreateAudioVideoURLs.lastValue?.1, expectedIndexPath)
+      }
     }
   }
 
@@ -1618,33 +1526,29 @@ final class ProjectPageViewModelTests: TestCase {
         minimumPledgeAmount: 1,
         projectNotice: nil
       )
-    let projectFullAndEnvelope = ProjectAndBackingEnvelope(project: projectFull, backing: .template)
-    let projectFullPamphletData = Project.ProjectPamphletData(project: projectFull, backingId: nil)
 
-    let mockService = MockService(
-      fetchProjectAndBackingResult: .success(projectFullAndEnvelope),
-      fetchProjectPamphletResult: .success(projectFullPamphletData),
-      fetchProjectFriendsResult: .success(friends),
-      fetchProjectRewardsResult: .success([Reward.noReward, Reward.template])
-    )
+    ProjectPageViewModelTests.mockNetworkRequests(project: projectFull) {
+      withEnvironment(config: config) {
+        self.vm.inputs.configureWith(
+          projectOrParam: .left(self.projectWithEmptyProperties),
+          refInfo: RefInfo(.discovery)
+        )
+        self.vm.inputs.viewDidLoad()
 
-    withEnvironment(apiService: mockService, config: config) {
-      self.vm.inputs.configureWith(projectOrParam: .left(projectFull), refInfo: RefInfo(.discovery))
-      self.vm.inputs.viewDidLoad()
+        self.scheduler.advance()
 
-      self.scheduler.advance()
+        self.vm.inputs.projectNavigationSelectorViewDidSelect(index: campaignSection)
 
-      self.vm.inputs.projectNavigationSelectorViewDidSelect(index: campaignSection)
+        guard let audioVideoViewElement = self.precreateAudioVideoURLsFirstLoad.lastValue?.first else {
+          XCTFail()
 
-      guard let audioVideoViewElement = self.precreateAudioVideoURLsFirstLoad.lastValue?.first else {
-        XCTFail()
+          return
+        }
 
-        return
+        XCTAssertEqual(audioVideoViewElement.sourceURLString, expectedAudioVideoElement.sourceURLString)
+        XCTAssertEqual(audioVideoViewElement.thumbnailURLString, expectedAudioVideoElement.thumbnailURLString)
+        XCTAssertEqual(audioVideoViewElement.seekPosition, expectedTime)
       }
-
-      XCTAssertEqual(audioVideoViewElement.sourceURLString, expectedAudioVideoElement.sourceURLString)
-      XCTAssertEqual(audioVideoViewElement.thumbnailURLString, expectedAudioVideoElement.thumbnailURLString)
-      XCTAssertEqual(audioVideoViewElement.seekPosition, expectedTime)
     }
   }
 
@@ -1672,33 +1576,29 @@ final class ProjectPageViewModelTests: TestCase {
         minimumPledgeAmount: 1,
         projectNotice: nil
       )
-    let projectFullAndEnvelope = ProjectAndBackingEnvelope(project: projectFull, backing: .template)
-    let projectFullPamphletData = Project.ProjectPamphletData(project: projectFull, backingId: nil)
 
-    let mockService = MockService(
-      fetchProjectAndBackingResult: .success(projectFullAndEnvelope),
-      fetchProjectPamphletResult: .success(projectFullPamphletData),
-      fetchProjectFriendsResult: .success(friends),
-      fetchProjectRewardsResult: .success([Reward.noReward, Reward.template])
-    )
+    ProjectPageViewModelTests.mockNetworkRequests(project: projectFull) {
+      withEnvironment(config: config) {
+        self.vm.inputs.configureWith(
+          projectOrParam: .left(self.projectWithEmptyProperties),
+          refInfo: RefInfo(.discovery)
+        )
+        self.vm.inputs.viewDidLoad()
 
-    withEnvironment(apiService: mockService, config: config) {
-      self.vm.inputs.configureWith(projectOrParam: .left(projectFull), refInfo: RefInfo(.discovery))
-      self.vm.inputs.viewDidLoad()
+        self.scheduler.advance()
 
-      self.scheduler.advance()
+        self.vm.inputs.projectNavigationSelectorViewDidSelect(index: campaignSection)
 
-      self.vm.inputs.projectNavigationSelectorViewDidSelect(index: campaignSection)
+        guard let imageViewElement = self.prefetchImageURLsFirstLoad.lastValue?.first else {
+          XCTFail()
 
-      guard let imageViewElement = self.prefetchImageURLsFirstLoad.lastValue?.first else {
-        XCTFail()
+          return
+        }
 
-        return
+        XCTAssertEqual(imageViewElement.src, expectedImageViewElement.src)
+        XCTAssertEqual(imageViewElement.href, expectedImageViewElement.href)
+        XCTAssertEqual(imageViewElement.caption, expectedImageViewElement.caption)
       }
-
-      XCTAssertEqual(imageViewElement.src, expectedImageViewElement.src)
-      XCTAssertEqual(imageViewElement.href, expectedImageViewElement.href)
-      XCTAssertEqual(imageViewElement.caption, expectedImageViewElement.caption)
     }
   }
 
@@ -1947,15 +1847,10 @@ final class ProjectPageViewModelTests: TestCase {
         projectNotice: nil
       )
 
-    let projectPamphletData = Project.ProjectPamphletData(project: projectWithImageElement, backingId: nil)
-
     let prefetchImageElementsOnFirstLoad = TestObserver<[ImageViewElement], Never>()
     self.vm.outputs.prefetchImageURLsOnFirstLoad.observe(prefetchImageElementsOnFirstLoad.observer)
 
-    withEnvironment(apiService: MockService(
-      fetchProjectPamphletResult: .success(projectPamphletData),
-      fetchProjectRewardsResult: .success([.template])
-    )) {
+    ProjectPageViewModelTests.mockNetworkRequests(project: projectWithImageElement) {
       // When we configure with a project ID parameter and load the view
       self.vm.inputs.configureWith(projectOrParam: .right(Param.id(42)), refInfo: nil)
       self.vm.inputs.viewDidLoad()

--- a/LibraryTests/Library/ViewModels/ProjectPageViewModelTests.swift
+++ b/LibraryTests/Library/ViewModels/ProjectPageViewModelTests.swift
@@ -36,7 +36,6 @@ final class ProjectPageViewModelTests: TestCase {
   private let configurePledgeCTAViewErrorEnvelope = TestObserver<ErrorEnvelope, Never>()
   private let configurePledgeCTAViewProject = TestObserver<Project, Never>()
   private let configurePledgeCTAViewIsLoading = TestObserver<Bool, Never>()
-  private let configurePledgeCTAViewRefTag = TestObserver<RefTag?, Never>()
   private let configureProjectNavigationSelectorView = TestObserver<(Project, RefTag?), Never>()
   private let didBlockUser = TestObserver<(), Never>()
   private let didBlockUserError = TestObserver<(), Never>()
@@ -84,29 +83,22 @@ final class ProjectPageViewModelTests: TestCase {
       .observe(self.configureChildViewControllersWithRefTag.observer)
 
     self.vm.outputs.configurePledgeCTAView
-      .map(first)
-      .map(\.left)
+      .map { $0.projectOrError.left }
       .skipNil()
-      .map(first)
       .observe(self.configurePledgeCTAViewProject.observer)
-
-    self.vm.outputs.configurePledgeCTAView
-      .map(first)
-      .map(\.left)
-      .skipNil()
-      .map(second)
-      .observe(self.configurePledgeCTAViewRefTag.observer)
 
     self.vm.outputs.configureProjectNavigationSelectorView
       .observe(self.configureProjectNavigationSelectorView.observer)
 
     self.vm.outputs.configurePledgeCTAView
-      .map(first)
-      .map(\.right)
+      .map { $0.projectOrError.right }
       .skipNil()
       .observe(self.configurePledgeCTAViewErrorEnvelope.observer)
 
-    self.vm.outputs.configurePledgeCTAView.map(second).observe(self.configurePledgeCTAViewIsLoading.observer)
+    self.vm.outputs.configurePledgeCTAView
+      .map { $0.isLoading }
+      .observe(self.configurePledgeCTAViewIsLoading.observer)
+
     self.vm.outputs.didBlockUser.observe(self.didBlockUser.observer)
     self.vm.outputs.didBlockUserError.observe(self.didBlockUserError.observer)
     self.vm.outputs.dismissManagePledgeAndShowMessageBannerWithMessage
@@ -929,19 +921,16 @@ final class ProjectPageViewModelTests: TestCase {
       ) {
         self.configurePledgeCTAViewProject.assertDidNotEmitValue()
         self.configurePledgeCTAViewIsLoading.assertDidNotEmitValue()
-        self.configurePledgeCTAViewRefTag.assertValues([])
 
         self.vm.configureAndLoad(.left(project))
 
         self.configurePledgeCTAViewProject.assertValues([project])
         self.configurePledgeCTAViewIsLoading.assertValues([true])
-        self.configurePledgeCTAViewRefTag.assertValues([.discovery])
 
         self.scheduler.run()
 
         self.configurePledgeCTAViewProject.assertValues([project, projectFull, projectFull])
         self.configurePledgeCTAViewIsLoading.assertValues([true, true, false])
-        self.configurePledgeCTAViewRefTag.assertValues([.discovery, .discovery, .discovery])
       }
     }
   }
@@ -959,20 +948,17 @@ final class ProjectPageViewModelTests: TestCase {
     ) {
       self.configurePledgeCTAViewProject.assertDidNotEmitValue()
       self.configurePledgeCTAViewIsLoading.assertDidNotEmitValue()
-      self.configurePledgeCTAViewRefTag.assertDidNotEmitValue()
 
       self.vm.configureAndLoad(.left(project))
 
       self.configurePledgeCTAViewProject.assertValues([project])
       self.configurePledgeCTAViewIsLoading.assertValues([true])
-      self.configurePledgeCTAViewRefTag.assertValues([.discovery])
 
       self.scheduler.run()
 
       self.configurePledgeCTAViewProject.assertValues([project, project])
       self.configurePledgeCTAViewErrorEnvelope.assertValueCount(1)
       self.configurePledgeCTAViewIsLoading.assertValues([true, false, false])
-      self.configurePledgeCTAViewRefTag.assertValues([.discovery, .discovery])
     }
   }
 
@@ -986,7 +972,6 @@ final class ProjectPageViewModelTests: TestCase {
       ProjectPageViewModelTests.mockNetworkRequests(project: projectFull, backing: nil) {
         self.configurePledgeCTAViewProject.assertDidNotEmitValue()
         self.configurePledgeCTAViewIsLoading.assertDidNotEmitValue()
-        self.configurePledgeCTAViewRefTag.assertDidNotEmitValue()
 
         self.vm.inputs.configureWith(projectOrParam: .left(project), refInfo: RefInfo(.discovery))
         self.vm.inputs.viewDidLoad()
@@ -994,13 +979,11 @@ final class ProjectPageViewModelTests: TestCase {
 
         self.configurePledgeCTAViewProject.assertValues([project])
         self.configurePledgeCTAViewIsLoading.assertValues([true])
-        self.configurePledgeCTAViewRefTag.assertValues([.discovery])
 
         self.scheduler.advance()
 
         self.configurePledgeCTAViewProject.assertValues([project, project, projectFull])
         self.configurePledgeCTAViewIsLoading.assertValues([true, true, false])
-        self.configurePledgeCTAViewRefTag.assertValues([.discovery, .discovery, .discovery])
       }
 
       ProjectPageViewModelTests.mockNetworkRequests(project: projectFull, backing: Backing.template) {
@@ -1008,7 +991,6 @@ final class ProjectPageViewModelTests: TestCase {
 
         self.configurePledgeCTAViewProject.assertValues([project, project, projectFull, projectFull])
         self.configurePledgeCTAViewIsLoading.assertValues([true, true, false, true])
-        self.configurePledgeCTAViewRefTag.assertValues([.discovery, .discovery, .discovery, .discovery])
 
         self.scheduler.advance()
 
@@ -1024,14 +1006,6 @@ final class ProjectPageViewModelTests: TestCase {
           projectWithBacking
         ])
         self.configurePledgeCTAViewIsLoading.assertValues([true, true, false, true, true, false])
-        self.configurePledgeCTAViewRefTag.assertValues([
-          .discovery,
-          .discovery,
-          .discovery,
-          .discovery,
-          .discovery,
-          .discovery
-        ])
       }
     }
   }
@@ -1055,20 +1029,17 @@ final class ProjectPageViewModelTests: TestCase {
       ) {
         self.configurePledgeCTAViewProject.assertDidNotEmitValue()
         self.configurePledgeCTAViewIsLoading.assertDidNotEmitValue()
-        self.configurePledgeCTAViewRefTag.assertDidNotEmitValue()
 
         self.vm.inputs.configureWith(projectOrParam: .left(project), refInfo: RefInfo(.discovery))
         self.vm.inputs.viewDidLoad()
 
         self.configurePledgeCTAViewProject.assertValues([project])
         self.configurePledgeCTAViewIsLoading.assertValues([true])
-        self.configurePledgeCTAViewRefTag.assertValues([.discovery])
 
         self.scheduler.advance()
 
         self.configurePledgeCTAViewProject.assertValues([project, project, projectFull])
         self.configurePledgeCTAViewIsLoading.assertValues([true, true, false])
-        self.configurePledgeCTAViewRefTag.assertValues([.discovery, .discovery, .discovery])
       }
 
       ProjectPageViewModelTests.mockNetworkRequests(
@@ -1079,7 +1050,6 @@ final class ProjectPageViewModelTests: TestCase {
 
         self.configurePledgeCTAViewProject.assertValues([project, project, projectFull, projectFull])
         self.configurePledgeCTAViewIsLoading.assertValues([true, true, false, true])
-        self.configurePledgeCTAViewRefTag.assertValues([.discovery, .discovery, .discovery, .discovery])
 
         self.scheduler.advance()
 
@@ -1092,14 +1062,6 @@ final class ProjectPageViewModelTests: TestCase {
           updatedProject
         ])
         self.configurePledgeCTAViewIsLoading.assertValues([true, true, false, true, true, false])
-        self.configurePledgeCTAViewRefTag.assertValues([
-          .discovery,
-          .discovery,
-          .discovery,
-          .discovery,
-          .discovery,
-          .discovery
-        ])
       }
     }
   }
@@ -1117,20 +1079,17 @@ final class ProjectPageViewModelTests: TestCase {
       ProjectPageViewModelTests.mockNetworkRequests(project: projectFull) {
         self.configurePledgeCTAViewProject.assertDidNotEmitValue()
         self.configurePledgeCTAViewIsLoading.assertDidNotEmitValue()
-        self.configurePledgeCTAViewRefTag.assertDidNotEmitValue()
 
         self.vm.inputs.configureWith(projectOrParam: .left(project), refInfo: RefInfo(.discovery))
         self.vm.inputs.viewDidLoad()
 
         self.configurePledgeCTAViewProject.assertValues([project])
         self.configurePledgeCTAViewIsLoading.assertValues([true])
-        self.configurePledgeCTAViewRefTag.assertValues([.discovery])
 
         self.scheduler.advance()
 
         self.configurePledgeCTAViewProject.assertValues([project, projectFull, projectFull])
         self.configurePledgeCTAViewIsLoading.assertValues([true, true, false])
-        self.configurePledgeCTAViewRefTag.assertValues([.discovery, .discovery, .discovery])
       }
 
       ProjectPageViewModelTests.mockNetworkRequests(project: projectFull2) {
@@ -1150,14 +1109,6 @@ final class ProjectPageViewModelTests: TestCase {
           projectFull2
         ])
         self.configurePledgeCTAViewIsLoading.assertValues([true, true, false, true, true, false])
-        self.configurePledgeCTAViewRefTag.assertValues([
-          .discovery,
-          .discovery,
-          .discovery,
-          .discovery,
-          .discovery,
-          .discovery
-        ])
       }
     }
   }

--- a/LibraryTests/Library/ViewModels/ProjectPageViewModel_TrackingTests.swift
+++ b/LibraryTests/Library/ViewModels/ProjectPageViewModel_TrackingTests.swift
@@ -23,15 +23,8 @@ final class ProjectPageViewModel_TrackingTests: TestCase {
   // Tests that ref tags and referral credit cookies are tracked and saved like we expect.
   func testTracksRefTag() {
     let project = Project.template
-    let projectPamphletData = Project.ProjectPamphletData(project: .template, backingId: nil)
 
-    withEnvironment(apiService: MockService(
-      fetchProjectPamphletResult: .success(projectPamphletData),
-      fetchProjectRewardsResult: .success([
-        Reward.noReward,
-        Reward.template
-      ])
-    )) {
+    ProjectPageViewModelTests.mockNetworkRequests(project: project) {
       self.vm.inputs.configureWith(projectOrParam: .left(project), refInfo: RefInfo(.category))
       self.vm.inputs.viewDidLoad()
       self.vm.inputs.viewDidAppear(animated: false)
@@ -95,15 +88,8 @@ final class ProjectPageViewModel_TrackingTests: TestCase {
   // Tests that ref tags for similar projects and referral credit cookies are tracked and saved like we expect.
   func testTracksRefTag_SimilarProjects() {
     let project = Project.template
-    let projectPamphletData = Project.ProjectPamphletData(project: .template, backingId: nil)
 
-    withEnvironment(apiService: MockService(
-      fetchProjectPamphletResult: .success(projectPamphletData),
-      fetchProjectRewardsResult: .success([
-        Reward.noReward,
-        Reward.template
-      ])
-    )) {
+    ProjectPageViewModelTests.mockNetworkRequests(project: project) {
       self.vm.inputs.configureWith(projectOrParam: .left(project), refInfo: RefInfo(.similarProjects))
       self.vm.inputs.viewDidLoad()
       self.vm.inputs.viewDidAppear(animated: false)
@@ -176,12 +162,7 @@ final class ProjectPageViewModel_TrackingTests: TestCase {
   }
 
   func testProjectPageViewed_OnViewDidAppear() {
-    let projectPamphletData = Project.ProjectPamphletData(project: .template, backingId: nil)
-
-    withEnvironment(apiService: MockService(
-      fetchProjectPamphletResult: .success(projectPamphletData),
-      fetchProjectRewardsResult: .success([Reward.noReward, Reward.template])
-    )) {
+    ProjectPageViewModelTests.mockNetworkRequests {
       XCTAssertEqual([], self.segmentTrackingClient.events)
 
       self.vm.configureAndLoad(.init(left: .template))
@@ -200,49 +181,11 @@ final class ProjectPageViewModel_TrackingTests: TestCase {
     let project = Project.template
     let scheduler1 = TestScheduler(startDate: MockDate().date)
     let scheduler2 = TestScheduler(startDate: scheduler1.currentDate.addingTimeInterval(1))
-    let projectPamphletData = Project.ProjectPamphletData(project: .template, backingId: nil)
 
-    withEnvironment(
-      apiService: MockService(
-        fetchProjectPamphletResult: .success(projectPamphletData),
-        fetchProjectRewardsResult: .success([.template])
-      ),
-      scheduler: scheduler1
-    ) {
-      let newVm: ProjectPageViewModelType = ProjectPageViewModel()
-      newVm.inputs.configureWith(projectOrParam: .left(project), refInfo: RefInfo(.category))
-      newVm.inputs.viewDidLoad()
-      newVm.inputs.viewDidAppear(animated: true)
-
-      scheduler1.advance()
-
-      XCTAssertEqual(1, self.cookieStorage.cookies?.count, "A single cookie has been set.")
-    }
-
-    withEnvironment(
-      apiService: MockService(
-        fetchProjectPamphletResult: .success(projectPamphletData),
-        fetchProjectRewardsResult: .success([.template])
-      ),
-      scheduler: scheduler2
-    ) {
-      let newVm: ProjectPageViewModelType = ProjectPageViewModel()
-      newVm.inputs.configureWith(projectOrParam: .left(project), refInfo: RefInfo(.recommended))
-      newVm.inputs.viewDidLoad()
-      newVm.inputs.viewDidAppear(animated: true)
-
-      scheduler2.advance()
-
-      XCTAssertEqual(2, self.cookieStorage.cookies?.count, "Two cookies are set on separate schedulers.")
-    }
-  }
-
-  func testMockCookieStorageSet_SameScheduler() {
-    let project = Project.template
-    let scheduler1 = TestScheduler(startDate: MockDate().date)
-
-    withEnvironment(scheduler: scheduler1) {
-      ProjectPageViewModelTests.mockNetworkRequests {
+    ProjectPageViewModelTests.mockNetworkRequests(project: project) {
+      withEnvironment(
+        scheduler: scheduler1
+      ) {
         let newVm: ProjectPageViewModelType = ProjectPageViewModel()
         newVm.inputs.configureWith(projectOrParam: .left(project), refInfo: RefInfo(.category))
         newVm.inputs.viewDidLoad()
@@ -252,11 +195,40 @@ final class ProjectPageViewModel_TrackingTests: TestCase {
 
         XCTAssertEqual(1, self.cookieStorage.cookies?.count, "A single cookie has been set.")
       }
-    }
 
-    withEnvironment(scheduler: scheduler1) {
-      let newVm: ProjectPageViewModelType = ProjectPageViewModel()
-      ProjectPageViewModelTests.mockNetworkRequests {
+      withEnvironment(
+        scheduler: scheduler2
+      ) {
+        let newVm: ProjectPageViewModelType = ProjectPageViewModel()
+        newVm.inputs.configureWith(projectOrParam: .left(project), refInfo: RefInfo(.recommended))
+        newVm.inputs.viewDidLoad()
+        newVm.inputs.viewDidAppear(animated: true)
+
+        scheduler2.advance()
+
+        XCTAssertEqual(2, self.cookieStorage.cookies?.count, "Two cookies are set on separate schedulers.")
+      }
+    }
+  }
+
+  func testMockCookieStorageSet_SameScheduler() {
+    let project = Project.template
+    let scheduler1 = TestScheduler(startDate: MockDate().date)
+
+    ProjectPageViewModelTests.mockNetworkRequests {
+      withEnvironment(scheduler: scheduler1) {
+        let newVm: ProjectPageViewModelType = ProjectPageViewModel()
+        newVm.inputs.configureWith(projectOrParam: .left(project), refInfo: RefInfo(.category))
+        newVm.inputs.viewDidLoad()
+        newVm.inputs.viewDidAppear(animated: true)
+
+        scheduler1.advance()
+
+        XCTAssertEqual(1, self.cookieStorage.cookies?.count, "A single cookie has been set.")
+      }
+
+      withEnvironment(scheduler: scheduler1) {
+        let newVm: ProjectPageViewModelType = ProjectPageViewModel()
         newVm.inputs.configureWith(projectOrParam: .left(project), refInfo: RefInfo(.recommended))
         newVm.inputs.viewDidLoad()
         newVm.inputs.viewDidAppear(animated: true)
@@ -366,23 +338,19 @@ final class ProjectPageViewModel_TrackingTests: TestCase {
       appTrackingTransparency: appTrackingTransparency
     )
 
-    let projectPamphletData = Project.ProjectPamphletData(project: .template, backingId: nil)
+    ProjectPageViewModelTests.mockNetworkRequests {
+      withEnvironment(
+        currentUser: User.template,
+        ksrAnalytics: ksrAnalytics
+      ) {
+        self.vm.inputs.configureWith(projectOrParam: .left(.template), refInfo: RefInfo(.discovery))
+        self.vm.inputs.viewDidLoad()
+        self.vm.inputs.viewDidAppear(animated: false)
 
-    withEnvironment(
-      apiService: MockService(
-        fetchProjectPamphletResult: .success(projectPamphletData),
-        fetchProjectRewardsResult: .success([Reward.noReward, Reward.template])
-      ),
-      currentUser: User.template,
-      ksrAnalytics: ksrAnalytics
-    ) {
-      self.vm.inputs.configureWith(projectOrParam: .left(.template), refInfo: RefInfo(.discovery))
-      self.vm.inputs.viewDidLoad()
-      self.vm.inputs.viewDidAppear(animated: false)
+        self.scheduler.advance()
 
-      self.scheduler.advance()
-
-      XCTAssertEqual(segmentClient.events, [])
+        XCTAssertEqual(segmentClient.events, [])
+      }
     }
   }
 
@@ -395,31 +363,27 @@ final class ProjectPageViewModel_TrackingTests: TestCase {
       appTrackingTransparency: MockAppTrackingTransparency()
     )
 
-    let projectPamphletData = Project.ProjectPamphletData(project: .template, backingId: nil)
+    ProjectPageViewModelTests.mockNetworkRequests {
+      withEnvironment(
+        currentUser: User.template,
+        ksrAnalytics: ksrAnalytics
+      ) {
+        self.vm.inputs.configureWith(projectOrParam: .left(.template), refInfo: RefInfo(.discovery))
+        self.vm.inputs.viewDidLoad()
+        self.vm.inputs.viewDidAppear(animated: false)
 
-    withEnvironment(
-      apiService: MockService(
-        fetchProjectPamphletResult: .success(projectPamphletData),
-        fetchProjectRewardsResult: .success([Reward.noReward, Reward.template])
-      ),
-      currentUser: User.template,
-      ksrAnalytics: ksrAnalytics
-    ) {
-      self.vm.inputs.configureWith(projectOrParam: .left(.template), refInfo: RefInfo(.discovery))
-      self.vm.inputs.viewDidLoad()
-      self.vm.inputs.viewDidAppear(animated: false)
+        self.scheduler.advance()
 
-      self.scheduler.advance()
+        XCTAssertEqual(segmentClient.events, ["Page Viewed"])
 
-      XCTAssertEqual(segmentClient.events, ["Page Viewed"])
-
-      XCTAssertEqual(segmentClient.properties(forKey: "session_user_is_logged_in", as: Bool.self), [true])
-      XCTAssertEqual(segmentClient.properties(forKey: "user_uid", as: String.self), ["1"])
-      XCTAssertEqual(segmentClient.properties(forKey: "session_ref_tag"), ["discovery"])
-      XCTAssertEqual(segmentClient.properties(forKey: "project_subcategory"), ["Ceramics"])
-      XCTAssertEqual(segmentClient.properties(forKey: "project_category"), ["Art"])
-      XCTAssertEqual(segmentClient.properties(forKey: "project_country"), ["US"])
-      XCTAssertEqual(segmentClient.properties(forKey: "project_user_has_watched", as: Bool.self), [nil])
+        XCTAssertEqual(segmentClient.properties(forKey: "session_user_is_logged_in", as: Bool.self), [true])
+        XCTAssertEqual(segmentClient.properties(forKey: "user_uid", as: String.self), ["1"])
+        XCTAssertEqual(segmentClient.properties(forKey: "session_ref_tag"), ["discovery"])
+        XCTAssertEqual(segmentClient.properties(forKey: "project_subcategory"), ["Ceramics"])
+        XCTAssertEqual(segmentClient.properties(forKey: "project_category"), ["Art"])
+        XCTAssertEqual(segmentClient.properties(forKey: "project_country"), ["US"])
+        XCTAssertEqual(segmentClient.properties(forKey: "project_user_has_watched", as: Bool.self), [nil])
+      }
     }
   }
 
@@ -435,32 +399,28 @@ final class ProjectPageViewModel_TrackingTests: TestCase {
       appTrackingTransparency: MockAppTrackingTransparency()
     )
 
-    let projectPamphletData = Project.ProjectPamphletData(project: .template, backingId: nil)
+    ProjectPageViewModelTests.mockNetworkRequests {
+      withEnvironment(
+        currentUser: nil,
+        ksrAnalytics: ksrAnalytics
+      ) {
+        self.vm.inputs.configureWith(projectOrParam: .left(.template), refInfo: RefInfo(.discovery))
+        self.vm.inputs.viewDidLoad()
+        self.vm.inputs.viewDidAppear(animated: false)
 
-    withEnvironment(
-      apiService: MockService(
-        fetchProjectPamphletResult: .success(projectPamphletData),
-        fetchProjectRewardsResult: .success([Reward.noReward, Reward.template])
-      ),
-      currentUser: nil,
-      ksrAnalytics: ksrAnalytics
-    ) {
-      self.vm.inputs.configureWith(projectOrParam: .left(.template), refInfo: RefInfo(.discovery))
-      self.vm.inputs.viewDidLoad()
-      self.vm.inputs.viewDidAppear(animated: false)
+        self.scheduler.advance()
 
-      self.scheduler.advance()
+        XCTAssertEqual(segmentClient.events, ["Page Viewed"])
 
-      XCTAssertEqual(segmentClient.events, ["Page Viewed"])
+        XCTAssertEqual(segmentClient.properties(forKey: "session_ref_tag"), ["discovery"])
 
-      XCTAssertEqual(segmentClient.properties(forKey: "session_ref_tag"), ["discovery"])
-
-      XCTAssertEqual(segmentClient.properties(forKey: "session_user_is_logged_in", as: Bool.self), [false])
-      XCTAssertEqual(segmentClient.properties(forKey: "user_uid", as: Int.self), [nil])
-      XCTAssertEqual(segmentClient.properties(forKey: "project_subcategory"), ["Ceramics"])
-      XCTAssertEqual(segmentClient.properties(forKey: "project_category"), ["Art"])
-      XCTAssertEqual(segmentClient.properties(forKey: "project_country"), ["US"])
-      XCTAssertEqual(segmentClient.properties(forKey: "project_user_has_watched", as: Bool.self), [nil])
+        XCTAssertEqual(segmentClient.properties(forKey: "session_user_is_logged_in", as: Bool.self), [false])
+        XCTAssertEqual(segmentClient.properties(forKey: "user_uid", as: Int.self), [nil])
+        XCTAssertEqual(segmentClient.properties(forKey: "project_subcategory"), ["Ceramics"])
+        XCTAssertEqual(segmentClient.properties(forKey: "project_category"), ["Art"])
+        XCTAssertEqual(segmentClient.properties(forKey: "project_country"), ["US"])
+        XCTAssertEqual(segmentClient.properties(forKey: "project_user_has_watched", as: Bool.self), [nil])
+      }
     }
   }
 


### PR DESCRIPTION

<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

1. Turn `PledgeCTAContainerViewData` into a struct, instead of a tuple
2. Remove unused `refTag` from `PledgeCTAContainerViewData`

# 🤔 Why

I'm working on `PledgeCTAContainerViewModel` and how it loads from `ProjectPageViewModel`. The type for this class was hard to reason about:

```swift
//A tuple...
public typealias PledgeCTAContainerViewData = (
  // Containing an either...
  projectOrError: Either<(Project, RefTag?), ErrorEnvelope>,
  // With another tuple inside
```

By making this a `struct` and removing the unused `RefTag`, my life is a little easier.