### PR TITLE
DISC-369: Make PledgeCTAContainerViewData an enum

### DIFF
--- a/Library/Sources/Library/Library/ViewModels/PledgeCTAContainerViewViewModel.swift
+++ b/Library/Sources/Library/Library/ViewModels/PledgeCTAContainerViewViewModel.swift
@@ -9,9 +9,14 @@ public typealias PledgeCTAPrelaunchState = (
   watchesCount: Int
 )
 
-public struct PledgeCTAContainerViewData {
-  let projectOrError: Either<Project, ErrorEnvelope>
-  let isLoading: Bool
+/// The Pledge CTA can be in three states:
+/// - It can be loading
+/// - It can have a loaded project
+/// - It can have a loading error
+public enum PledgeCTAContainerViewData {
+  case loading
+  case project(Project)
+  case error(ErrorEnvelope)
 }
 
 public protocol PledgeCTAContainerViewViewModelInputs {
@@ -46,8 +51,8 @@ public final class PledgeCTAContainerViewViewModel: PledgeCTAContainerViewViewMo
   public init() {
     let projectOrError = self.configData.signal
       .skipNil()
-      .filter { $0.isLoading == false }
       .map { $0.projectOrError }
+      .skipNil()
 
     let isLoading = self.configData.signal
       .skipNil()
@@ -270,4 +275,65 @@ private func formattedPledge(amount: Double, project: Project) -> String {
     currencyCode: project.statsCurrency,
     omitCurrencyCode: project.stats.omitUSCurrencyCode
   )
+}
+
+/// PledgeCTAContainerViewData was originally a tuple like
+/// `(projectOrError: Either<Project, ErrorEnvelope>, isLoading: Bool)`
+///
+/// These are some convenience methods that bridge the original interface
+/// with the new `enum` interface for this type.
+extension PledgeCTAContainerViewData {
+  init?(projectOrError: Either<Project, ErrorEnvelope>?, isLoading: Bool) {
+    if isLoading {
+      self = .loading
+      return
+    }
+
+    if case let .left(project) = projectOrError {
+      self = .project(project)
+      return
+    }
+
+    if case let .right(error) = projectOrError {
+      self = .error(error)
+      return
+    }
+
+    return nil
+  }
+
+  var projectOrError: Either<Project, ErrorEnvelope>? {
+    switch self {
+    case .loading:
+      return nil
+    case let .project(project):
+      return Either.left(project)
+    case let .error(error):
+      return Either.right(error)
+    }
+  }
+
+  var isLoading: Bool {
+    switch self {
+    case .loading:
+      return true
+    default:
+      return false
+    }
+  }
+}
+
+extension PledgeCTAContainerViewData: Equatable {
+  public static func == (lhs: PledgeCTAContainerViewData, rhs: PledgeCTAContainerViewData) -> Bool {
+    switch (lhs, rhs) {
+    case (.loading, .loading):
+      return true
+    case let (.project(lProject), .project(rProject)):
+      return lProject == rProject
+    case let (.error(lError), .error(rError)):
+      return lError.errorMessages == rError.errorMessages
+    default:
+      return false
+    }
+  }
 }

--- a/Library/Sources/Library/Library/ViewModels/ProjectPageViewModel.swift
+++ b/Library/Sources/Library/Library/ViewModels/ProjectPageViewModel.swift
@@ -381,6 +381,7 @@ public final class ProjectPageViewModel: ProjectPageViewModelType, ProjectPageVi
       PledgeCTAContainerViewData(projectOrError: projectOrError, isLoading: isLoading)
     }
     .skipNil()
+    .skipRepeats()
 
     self.configureChildViewControllersWithProject = freshProjectAndRefTag
       .map { project, refTag in (project, refTag) }

--- a/LibraryTests/Library/ViewModels/PledgeCTAContainerViewViewModelTests.swift
+++ b/LibraryTests/Library/ViewModels/PledgeCTAContainerViewViewModelTests.swift
@@ -55,7 +55,7 @@ internal final class PledgeCTAContainerViewViewModelTests: TestCase {
       |> Project.lens.country .~ .us
       |> Project.lens.stats.projectCurrency .~ Project.Country.us.currencyCode
 
-    let value = PledgeCTAContainerViewData(projectOrError: .left(project), isLoading: false)
+    let value = PledgeCTAContainerViewData.project(project)
     self.vm.inputs.configureWith(value: value)
     self.buttonStyleType.assertValues([ButtonStyleType.blue])
     self.buttonTitleText.assertValues([Strings.Manage()])
@@ -77,7 +77,7 @@ internal final class PledgeCTAContainerViewViewModelTests: TestCase {
       |> Project.lens.country .~ .us
       |> Project.lens.stats.projectCurrency .~ Project.Country.mx.currencyCode
 
-    let value = PledgeCTAContainerViewData(projectOrError: .left(project), isLoading: false)
+    let value = PledgeCTAContainerViewData.project(project)
     self.vm.inputs.configureWith(value: value)
     self.buttonStyleType.assertValues([ButtonStyleType.blue])
     self.buttonTitleText.assertValues([Strings.Manage()])
@@ -100,7 +100,7 @@ internal final class PledgeCTAContainerViewViewModelTests: TestCase {
       |> Project.lens.country .~ .us
       |> Project.lens.stats.projectCurrency .~ Project.Country.us.currencyCode
 
-    let value = PledgeCTAContainerViewData(projectOrError: .left(project), isLoading: false)
+    let value = PledgeCTAContainerViewData.project(project)
     self.vm.inputs.configureWith(value: value)
     self.buttonStyleType.assertValues([ButtonStyleType.blue])
     self.buttonTitleText.assertValues([Strings.Manage()])
@@ -116,7 +116,7 @@ internal final class PledgeCTAContainerViewViewModelTests: TestCase {
       |> Project.lens.personalization.backing .~ Backing.template
       |> Project.lens.state .~ .successful
 
-    let value = PledgeCTAContainerViewData(projectOrError: .left(project), isLoading: false)
+    let value = PledgeCTAContainerViewData.project(project)
     self.vm.inputs.configureWith(value: value)
     self.buttonStyleType.assertValues([ButtonStyleType.black])
     self.buttonTitleText.assertValues([Strings.View_your_pledge()])
@@ -127,7 +127,7 @@ internal final class PledgeCTAContainerViewViewModelTests: TestCase {
   func testPledgeCTA_NetNewBackerGoToPM() {
     let project = Project.netNewBacker
 
-    let value = PledgeCTAContainerViewData(projectOrError: .left(project), isLoading: false)
+    let value = PledgeCTAContainerViewData.project(project)
     self.vm.inputs.configureWith(value: value)
     self.buttonStyleType.assertValues([ButtonStyleType.black])
     self.buttonTitleText.assertValues([Strings.Go_to_pledge_manager()])
@@ -141,7 +141,7 @@ internal final class PledgeCTAContainerViewViewModelTests: TestCase {
       |> Project.lens.personalization.isBacking .~ true
       |> Project.lens.pledgeManager .~ nil
 
-    let value = PledgeCTAContainerViewData(projectOrError: .left(project), isLoading: false)
+    let value = PledgeCTAContainerViewData.project(project)
     self.vm.inputs.configureWith(value: value)
     self.buttonStyleType.assertValues([ButtonStyleType.black])
     self.buttonTitleText.assertValues([Strings.Go_to_pledge_manager()])
@@ -156,7 +156,7 @@ internal final class PledgeCTAContainerViewViewModelTests: TestCase {
       |> Project.lens.personalization.backing .~ backing
       |> Project.lens.personalization.isBacking .~ true
 
-    let value = PledgeCTAContainerViewData(projectOrError: .left(project), isLoading: false)
+    let value = PledgeCTAContainerViewData.project(project)
     self.vm.inputs.configureWith(value: value)
     self.buttonStyleType.assertValues([ButtonStyleType.black])
     self.buttonTitleText.assertValues([Strings.Go_to_pledge_manager()])
@@ -169,7 +169,7 @@ internal final class PledgeCTAContainerViewViewModelTests: TestCase {
       |> Project.lens.personalization.isBacking .~ nil
       |> Project.lens.state .~ .live
 
-    let value = PledgeCTAContainerViewData(projectOrError: .left(project), isLoading: false)
+    let value = PledgeCTAContainerViewData.project(project)
     self.vm.inputs.configureWith(value: value)
     self.buttonStyleType.assertValues([ButtonStyleType.green])
     self.buttonTitleText.assertValues([Strings.Back_this_project()])
@@ -182,7 +182,7 @@ internal final class PledgeCTAContainerViewViewModelTests: TestCase {
       |> Project.lens.personalization.isBacking .~ nil
       |> Project.lens.state .~ .successful
 
-    let value = PledgeCTAContainerViewData(projectOrError: .left(project), isLoading: false)
+    let value = PledgeCTAContainerViewData.project(project)
     self.vm.inputs.configureWith(value: value)
     self.buttonStyleType.assertValues([ButtonStyleType.black])
     self.buttonTitleText.assertValues([Strings.View_rewards()])
@@ -201,7 +201,7 @@ internal final class PledgeCTAContainerViewViewModelTests: TestCase {
       |> Project.lens.country .~ .us
       |> Project.lens.stats.projectCurrency .~ Project.Country.us.currencyCode
 
-    let value = PledgeCTAContainerViewData(projectOrError: .left(project), isLoading: false)
+    let value = PledgeCTAContainerViewData.project(project)
     self.vm.inputs.configureWith(value: value)
     self.buttonStyleType.assertValues([ButtonStyleType.blue])
     self.buttonTitleText.assertValues([Strings.Manage()])
@@ -219,7 +219,7 @@ internal final class PledgeCTAContainerViewViewModelTests: TestCase {
       |> Project.lens.state .~ .successful
       |> Project.lens.personalization.backing .~ backing
 
-    let value = PledgeCTAContainerViewData(projectOrError: .left(project), isLoading: false)
+    let value = PledgeCTAContainerViewData.project(project)
     self.vm.inputs.configureWith(value: value)
     self.buttonStyleType.assertValues([ButtonStyleType.red])
     self.buttonTitleText.assertValues([Strings.Manage()])
@@ -234,7 +234,7 @@ internal final class PledgeCTAContainerViewViewModelTests: TestCase {
       |> Project.lens.personalization.backing .~ nil
       |> Project.lens.personalization.isBacking .~ false
 
-    let value = PledgeCTAContainerViewData(projectOrError: .left(project), isLoading: false)
+    let value = PledgeCTAContainerViewData.project(project)
     self.vm.inputs.configureWith(value: value)
     self.buttonStyleType.assertValues([ButtonStyleType.green])
     self.buttonTitleText.assertValues([Strings.Back_this_project()])
@@ -247,7 +247,7 @@ internal final class PledgeCTAContainerViewViewModelTests: TestCase {
       |> Project.lens.state .~ .successful
       |> Project.lens.personalization.isBacking .~ false
 
-    let value = PledgeCTAContainerViewData(projectOrError: .left(project), isLoading: false)
+    let value = PledgeCTAContainerViewData.project(project)
     self.vm.inputs.configureWith(value: value)
     self.buttonStyleType.assertValues([ButtonStyleType.black])
     self.buttonTitleText.assertValues([Strings.View_rewards()])
@@ -262,7 +262,7 @@ internal final class PledgeCTAContainerViewViewModelTests: TestCase {
       |> Project.lens.state .~ .live
 
     withEnvironment(currentUser: user) {
-      let value = PledgeCTAContainerViewData(projectOrError: .left(project), isLoading: false)
+      let value = PledgeCTAContainerViewData.project(project)
       self.vm.inputs.configureWith(value: value)
       self.buttonStyleType.assertValues([ButtonStyleType.black])
       self.buttonTitleText.assertValues(["View your rewards"])
@@ -278,7 +278,7 @@ internal final class PledgeCTAContainerViewViewModelTests: TestCase {
       |> Project.lens.state .~ .successful
 
     withEnvironment(currentUser: user) {
-      let value = PledgeCTAContainerViewData(projectOrError: .left(project), isLoading: false)
+      let value = PledgeCTAContainerViewData.project(project)
       self.vm.inputs.configureWith(value: value)
       self.buttonStyleType.assertValues([ButtonStyleType.black])
       self.buttonTitleText.assertValues(["View your rewards"])
@@ -291,7 +291,7 @@ internal final class PledgeCTAContainerViewViewModelTests: TestCase {
     let project = Project.template
       |> Project.lens.state .~ .live
 
-    let value = PledgeCTAContainerViewData(projectOrError: .left(project), isLoading: true)
+    let value = PledgeCTAContainerViewData.loading
     self.vm.inputs.configureWith(value: value)
     self.activityIndicatorIsHidden.assertValues([false])
     self.pledgeCTAButtonIsHidden.assertValues([true])
@@ -302,7 +302,7 @@ internal final class PledgeCTAContainerViewViewModelTests: TestCase {
     self.spacerIsHidden.assertDidNotEmitValue()
     self.stackViewIsHidden.assertDidNotEmitValue()
 
-    let value2 = PledgeCTAContainerViewData(projectOrError: .left(project), isLoading: false)
+    let value2 = PledgeCTAContainerViewData.project(project)
     self.vm.inputs.configureWith(value: value2)
     self.activityIndicatorIsHidden.assertValues([false, true])
     self.pledgeCTAButtonIsHidden.assertValues([true, false])
@@ -320,11 +320,11 @@ internal final class PledgeCTAContainerViewViewModelTests: TestCase {
 
     self.pledgeRetryButtonIsHidden.assertDidNotEmitValue()
 
-    let value = PledgeCTAContainerViewData(projectOrError: .left(project), isLoading: false)
+    let value = PledgeCTAContainerViewData.project(project)
     self.vm.inputs.configureWith(value: value)
     self.pledgeRetryButtonIsHidden.assertValues([true])
 
-    let value2 = PledgeCTAContainerViewData(projectOrError: .right(.couldNotParseJSON), isLoading: false)
+    let value2 = PledgeCTAContainerViewData.error(.couldNotParseJSON)
     self.vm.inputs.configureWith(value: value2)
     self.pledgeRetryButtonIsHidden.assertValues([true, false])
   }
@@ -336,7 +336,7 @@ internal final class PledgeCTAContainerViewViewModelTests: TestCase {
 
     self.notifyDelegateCTATapped.assertDidNotEmitValue()
 
-    let value = PledgeCTAContainerViewData(projectOrError: .left(project), isLoading: false)
+    let value = PledgeCTAContainerViewData.project(project)
     self.vm.inputs.configureWith(value: value)
     self.buttonStyleType.assertValues([ButtonStyleType.green])
     self.buttonTitleText.assertValues([Strings.Back_this_project()])
@@ -352,7 +352,7 @@ internal final class PledgeCTAContainerViewViewModelTests: TestCase {
 
     self.notifyDelegateCTATapped.assertDidNotEmitValue()
 
-    let value = PledgeCTAContainerViewData(projectOrError: .left(project), isLoading: false)
+    let value = PledgeCTAContainerViewData.project(project)
     self.vm.inputs.configureWith(value: value)
     self.buttonStyleType.assertValues([ButtonStyleType.black])
     self.buttonTitleText.assertValues([Strings.View_rewards()])
@@ -362,7 +362,7 @@ internal final class PledgeCTAContainerViewViewModelTests: TestCase {
   }
 
   func testTrackingEvents_Pledge() {
-    let value = PledgeCTAContainerViewData(projectOrError: .left(Project.template), isLoading: false)
+    let value = PledgeCTAContainerViewData.project(Project.template)
     self.vm.inputs.configureWith(value: value)
 
     self.notifyDelegateCTATapped.assertDidNotEmitValue()
@@ -387,7 +387,7 @@ internal final class PledgeCTAContainerViewViewModelTests: TestCase {
     let prelaunchCTAUnsaved = PledgeCTAPrelaunchState(prelaunch: true, saved: false, watchesCount: 99)
     let prelaunchCTASaved = PledgeCTAPrelaunchState(prelaunch: true, saved: true, watchesCount: 100)
 
-    let value = PledgeCTAContainerViewData(projectOrError: .left(unsavedProject), isLoading: false)
+    let value = PledgeCTAContainerViewData.project(unsavedProject)
     self.vm.inputs.configureWith(value: value)
 
     self.buttonStyleType.assertValues([.black])
@@ -424,7 +424,7 @@ internal final class PledgeCTAContainerViewViewModelTests: TestCase {
       |> \.watchesCount .~ 102
       |> \.personalization.isStarred .~ true
 
-    let value = PledgeCTAContainerViewData(projectOrError: .left(savedProject), isLoading: false)
+    let value = PledgeCTAContainerViewData.project(savedProject)
     self.vm.inputs.configureWith(value: value)
 
     self.notifyDelegateCTATapped.assertDidNotEmitValue()

--- a/LibraryTests/Library/ViewModels/ProjectPageViewModelTests.swift
+++ b/LibraryTests/Library/ViewModels/ProjectPageViewModelTests.swift
@@ -33,9 +33,7 @@ final class ProjectPageViewModelTests: TestCase {
   private let configureDataSourceProject = TestObserver<Either<Project, any ProjectPageParam>, Never>()
   private let configureChildViewControllersWithProject = TestObserver<Project, Never>()
   private let configureChildViewControllersWithRefTag = TestObserver<RefTag?, Never>()
-  private let configurePledgeCTAViewErrorEnvelope = TestObserver<ErrorEnvelope, Never>()
-  private let configurePledgeCTAViewProject = TestObserver<Project, Never>()
-  private let configurePledgeCTAViewIsLoading = TestObserver<Bool, Never>()
+  private let configurePledgeCTAView = TestObserver<PledgeCTAContainerViewData, Never>()
   private let configureProjectNavigationSelectorView = TestObserver<(Project, RefTag?), Never>()
   private let didBlockUser = TestObserver<(), Never>()
   private let didBlockUserError = TestObserver<(), Never>()
@@ -83,21 +81,10 @@ final class ProjectPageViewModelTests: TestCase {
       .observe(self.configureChildViewControllersWithRefTag.observer)
 
     self.vm.outputs.configurePledgeCTAView
-      .map { $0.projectOrError.left }
-      .skipNil()
-      .observe(self.configurePledgeCTAViewProject.observer)
+      .observe(self.configurePledgeCTAView.observer)
 
     self.vm.outputs.configureProjectNavigationSelectorView
       .observe(self.configureProjectNavigationSelectorView.observer)
-
-    self.vm.outputs.configurePledgeCTAView
-      .map { $0.projectOrError.right }
-      .skipNil()
-      .observe(self.configurePledgeCTAViewErrorEnvelope.observer)
-
-    self.vm.outputs.configurePledgeCTAView
-      .map { $0.isLoading }
-      .observe(self.configurePledgeCTAViewIsLoading.observer)
 
     self.vm.outputs.didBlockUser.observe(self.didBlockUser.observer)
     self.vm.outputs.didBlockUserError.observe(self.didBlockUserError.observer)
@@ -919,18 +906,15 @@ final class ProjectPageViewModelTests: TestCase {
         config: .template,
         mainBundle: self.releaseBundle
       ) {
-        self.configurePledgeCTAViewProject.assertDidNotEmitValue()
-        self.configurePledgeCTAViewIsLoading.assertDidNotEmitValue()
+        self.configurePledgeCTAView.assertDidNotEmitValue()
 
         self.vm.configureAndLoad(.left(project))
 
-        self.configurePledgeCTAViewProject.assertValues([project])
-        self.configurePledgeCTAViewIsLoading.assertValues([true])
+        self.configurePledgeCTAView.assertValues([.loading])
 
         self.scheduler.run()
 
-        self.configurePledgeCTAViewProject.assertValues([project, projectFull, projectFull])
-        self.configurePledgeCTAViewIsLoading.assertValues([true, true, false])
+        self.configurePledgeCTAView.assertValues([.loading, .project(projectFull)])
       }
     }
   }
@@ -946,19 +930,15 @@ final class ProjectPageViewModelTests: TestCase {
       config: config,
       mainBundle: self.releaseBundle
     ) {
-      self.configurePledgeCTAViewProject.assertDidNotEmitValue()
-      self.configurePledgeCTAViewIsLoading.assertDidNotEmitValue()
+      self.configurePledgeCTAView.assertDidNotEmitValue()
 
       self.vm.configureAndLoad(.left(project))
 
-      self.configurePledgeCTAViewProject.assertValues([project])
-      self.configurePledgeCTAViewIsLoading.assertValues([true])
+      self.configurePledgeCTAView.assertValues([.loading])
 
       self.scheduler.run()
 
-      self.configurePledgeCTAViewProject.assertValues([project, project])
-      self.configurePledgeCTAViewErrorEnvelope.assertValueCount(1)
-      self.configurePledgeCTAViewIsLoading.assertValues([true, false, false])
+      self.configurePledgeCTAView.assertValues([.loading, .project(project), .error(.couldNotParseJSON)])
     }
   }
 
@@ -970,42 +950,39 @@ final class ProjectPageViewModelTests: TestCase {
 
     withEnvironment(config: config, mainBundle: self.releaseBundle) {
       ProjectPageViewModelTests.mockNetworkRequests(project: projectFull, backing: nil) {
-        self.configurePledgeCTAViewProject.assertDidNotEmitValue()
-        self.configurePledgeCTAViewIsLoading.assertDidNotEmitValue()
+        self.configurePledgeCTAView.assertDidNotEmitValue()
 
         self.vm.inputs.configureWith(projectOrParam: .left(project), refInfo: RefInfo(.discovery))
         self.vm.inputs.viewDidLoad()
         self.vm.inputs.viewDidAppear(animated: true)
 
-        self.configurePledgeCTAViewProject.assertValues([project])
-        self.configurePledgeCTAViewIsLoading.assertValues([true])
+        self.configurePledgeCTAView.assertValues([.loading])
 
         self.scheduler.advance()
 
-        self.configurePledgeCTAViewProject.assertValues([project, project, projectFull])
-        self.configurePledgeCTAViewIsLoading.assertValues([true, true, false])
+        self.configurePledgeCTAView.assertValues([.loading, .project(projectFull)])
       }
 
       ProjectPageViewModelTests.mockNetworkRequests(project: projectFull, backing: Backing.template) {
         self.vm.inputs.didBackProject()
 
-        self.configurePledgeCTAViewProject.assertValues([project, project, projectFull, projectFull])
-        self.configurePledgeCTAViewIsLoading.assertValues([true, true, false, true])
+        self.configurePledgeCTAView.assertValues([
+          .loading,
+          .project(projectFull),
+          .loading
+        ])
 
         self.scheduler.advance()
 
         let projectWithBacking = project |> \.personalization.backing .~ .template
           |> \.personalization.isBacking .~ true
 
-        self.configurePledgeCTAViewProject.assertValues([
-          project,
-          project,
-          projectFull,
-          projectFull,
-          projectFull,
-          projectWithBacking
+        self.configurePledgeCTAView.assertValues([
+          .loading,
+          .project(projectFull),
+          .loading,
+          .project(projectWithBacking)
         ])
-        self.configurePledgeCTAViewIsLoading.assertValues([true, true, false, true, true, false])
       }
     }
   }
@@ -1027,19 +1004,16 @@ final class ProjectPageViewModelTests: TestCase {
         project: projectFull,
         backing: backingFull
       ) {
-        self.configurePledgeCTAViewProject.assertDidNotEmitValue()
-        self.configurePledgeCTAViewIsLoading.assertDidNotEmitValue()
+        self.configurePledgeCTAView.assertDidNotEmitValue()
 
         self.vm.inputs.configureWith(projectOrParam: .left(project), refInfo: RefInfo(.discovery))
         self.vm.inputs.viewDidLoad()
 
-        self.configurePledgeCTAViewProject.assertValues([project])
-        self.configurePledgeCTAViewIsLoading.assertValues([true])
+        self.configurePledgeCTAView.assertValues([.loading])
 
         self.scheduler.advance()
 
-        self.configurePledgeCTAViewProject.assertValues([project, project, projectFull])
-        self.configurePledgeCTAViewIsLoading.assertValues([true, true, false])
+        self.configurePledgeCTAView.assertValues([.loading, .project(projectFull)])
       }
 
       ProjectPageViewModelTests.mockNetworkRequests(
@@ -1048,20 +1022,20 @@ final class ProjectPageViewModelTests: TestCase {
       ) {
         self.vm.inputs.managePledgeViewControllerFinished(with: nil)
 
-        self.configurePledgeCTAViewProject.assertValues([project, project, projectFull, projectFull])
-        self.configurePledgeCTAViewIsLoading.assertValues([true, true, false, true])
+        self.configurePledgeCTAView.assertValues([
+          .loading,
+          .project(projectFull),
+          .loading
+        ])
 
         self.scheduler.advance()
 
-        self.configurePledgeCTAViewProject.assertValues([
-          project,
-          project,
-          projectFull,
-          projectFull,
-          projectFull,
-          updatedProject
+        self.configurePledgeCTAView.assertValues([
+          .loading,
+          .project(projectFull),
+          .loading,
+          .project(updatedProject)
         ])
-        self.configurePledgeCTAViewIsLoading.assertValues([true, true, false, true, true, false])
       }
     }
   }
@@ -1077,38 +1051,35 @@ final class ProjectPageViewModelTests: TestCase {
 
     withEnvironment(config: config) {
       ProjectPageViewModelTests.mockNetworkRequests(project: projectFull) {
-        self.configurePledgeCTAViewProject.assertDidNotEmitValue()
-        self.configurePledgeCTAViewIsLoading.assertDidNotEmitValue()
+        self.configurePledgeCTAView.assertDidNotEmitValue()
 
         self.vm.inputs.configureWith(projectOrParam: .left(project), refInfo: RefInfo(.discovery))
         self.vm.inputs.viewDidLoad()
 
-        self.configurePledgeCTAViewProject.assertValues([project])
-        self.configurePledgeCTAViewIsLoading.assertValues([true])
+        self.configurePledgeCTAView.assertValues([.loading])
 
         self.scheduler.advance()
 
-        self.configurePledgeCTAViewProject.assertValues([project, projectFull, projectFull])
-        self.configurePledgeCTAViewIsLoading.assertValues([true, true, false])
+        self.configurePledgeCTAView.assertValues([.loading, .project(projectFull)])
       }
 
       ProjectPageViewModelTests.mockNetworkRequests(project: projectFull2) {
         self.vm.inputs.pledgeRetryButtonTapped()
 
-        self.configurePledgeCTAViewProject.assertValues([project, projectFull, projectFull, projectFull])
-        self.configurePledgeCTAViewIsLoading.assertValues([true, true, false, true])
+        self.configurePledgeCTAView.assertValues([
+          .loading,
+          .project(projectFull),
+          .loading
+        ])
 
         self.scheduler.advance()
 
-        self.configurePledgeCTAViewProject.assertValues([
-          project,
-          projectFull,
-          projectFull,
-          projectFull,
-          projectFull2,
-          projectFull2
+        self.configurePledgeCTAView.assertValues([
+          .loading,
+          .project(projectFull),
+          .loading,
+          .project(projectFull2)
         ])
-        self.configurePledgeCTAViewIsLoading.assertValues([true, true, false, true, true, false])
       }
     }
   }


### PR DESCRIPTION
# 📲 What

Make `PledgeCTAContainerViewData` an enum with three states - `.loading`, `.project` and `.error`.

# 🤔 Why

In #2933, I said,
> I played around with simplifying this type even further - like making it an enum with three cases, loading, project and error - but that would have required more view model changes.

When I continued working on `ProjectPageViewModel`, I changed my mind.

The problem was: `PledgeCTAContainerViewData` required a project or an error. When the Project Page is first loading, it may not have either of them. For example, the Project Page can be created from a deep link URL, in which case it just has a project id. This gave me a catch-22 in my refactoring: I couldn't set the CTA to be loading before I had loaded the project.

By making this `PledgeCTAContainerViewData` into an `enum` with three _mutually exclusive_ states, the way the CTA loads is significantly more clear. You can see this in the unit tests, which are also much simpler.