### PR TITLE
CHECK-395: Hook new project page fetch into ProjectPageViewModel

### DIFF
--- a/KsApi/Sources/KsApi/MockService.swift
+++ b/KsApi/Sources/KsApi/MockService.swift
@@ -1338,7 +1338,7 @@
       }
 
       // Otherwise, fall back to the GraphQL mocking code.
-        let query = GraphAPI.FastFetchProjectPageBaseQuery(
+      let query = GraphAPI.FastFetchProjectPageBaseQuery(
         projectId: .someOrNil(projectParam.id),
         slug: .someOrNil(projectParam.slug)
       )
@@ -1360,7 +1360,7 @@
         }
       }
 
-        let query = GraphAPI.FastFetchProjectPageExtendedPropertiesQuery(
+      let query = GraphAPI.FastFetchProjectPageExtendedPropertiesQuery(
         projectId: .someOrNil(projectParam.id),
         slug: .someOrNil(projectParam.slug)
       )

--- a/KsApi/Sources/KsApi/MockService.swift
+++ b/KsApi/Sources/KsApi/MockService.swift
@@ -129,6 +129,10 @@
      FIXME: Eventually combine `fetchProjectEnvelopeResult` and `fetchProjectPamphletEnvelopeResult` once all calls returning `Project` are using GQL. https://kickstarter.atlassian.net/browse/NTV-219
      */
     fileprivate let fetchProjectEnvelopeResult: Result<Project, ErrorEnvelope>?
+    fileprivate let fastFetchProjectPageResult: (
+      Result<Project, ErrorEnvelope>,
+      Result<ProjectPageExtraProperties, ErrorEnvelope>
+    )?
     fileprivate let fetchProjectPamphletEnvelopeResult: Result<Project.ProjectPamphletData, ErrorEnvelope>?
     fileprivate let fetchProjectFriendsEnvelopeResult: Result<[User], ErrorEnvelope>?
     fileprivate let fetchProjectRewardsAndPledgeOverTimeDataResult: Result<
@@ -315,6 +319,10 @@
       fetchMessageThreadsResponse: [MessageThread]? = nil,
       fetchPledgedProjectsResult: Result<GraphAPI.FetchPledgedProjectsQuery.Data, ErrorEnvelope>? = nil,
       fetchProjectResult: Result<Project, ErrorEnvelope>? = nil,
+      fastFetchProjectPage: (
+        Result<Project, ErrorEnvelope>,
+        Result<ProjectPageExtraProperties, ErrorEnvelope>
+      )? = nil,
       fetchProjectPamphletResult: Result<Project.ProjectPamphletData, ErrorEnvelope>? = nil,
       fetchProjectFriendsResult: Result<[User], ErrorEnvelope>? = nil,
       fetchProjectRewardsAndPledgeOverTimeDataResult: Result<
@@ -515,6 +523,7 @@
       self.fetchProjectsError = fetchProjectsError
 
       self.fetchProjectEnvelopeResult = fetchProjectResult
+      self.fastFetchProjectPageResult = fastFetchProjectPage
       self.fetchProjectPamphletEnvelopeResult = fetchProjectPamphletResult
       self.fetchProjectFriendsEnvelopeResult = fetchProjectFriendsResult
       self.fetchProjectRewardsAndPledgeOverTimeDataResult = fetchProjectRewardsAndPledgeOverTimeDataResult
@@ -1318,12 +1327,22 @@
 
     internal func fastFetchProjectPageBase(projectParam: Param)
       -> SignalProducer<Project, ErrorEnvelope> {
-      let query = GraphAPI.FastFetchProjectPageBaseQuery(
+      // If a result was set, use the result for mocking.
+      if let result = self.fastFetchProjectPageResult {
+        switch result.0 {
+        case let .success(project):
+          return SignalProducer(value: project)
+        case let .failure(error):
+          return SignalProducer(error: error)
+        }
+      }
+
+      // Otherwise, fall back to the GraphQL mocking code.
+        let query = GraphAPI.FastFetchProjectPageBaseQuery(
         projectId: .someOrNil(projectParam.id),
         slug: .someOrNil(projectParam.slug)
       )
 
-      // Use the GraphQL mocking infrastructure
       return self
         .fetch(query: query)
         .flatMap { Project.projectProducer(from: $0) }
@@ -1331,12 +1350,22 @@
 
     internal func fastFetchProjectPageExtendedProperties(projectParam: Param)
       -> SignalProducer<ProjectPageExtraProperties, ErrorEnvelope> {
-      let query = GraphAPI.FastFetchProjectPageExtendedPropertiesQuery(
+      // If a result was set, use the result for mocking.
+      if let result = self.fastFetchProjectPageResult {
+        switch result.1 {
+        case let .success(project):
+          return SignalProducer(value: project)
+        case let .failure(error):
+          return SignalProducer(error: error)
+        }
+      }
+
+        let query = GraphAPI.FastFetchProjectPageExtendedPropertiesQuery(
         projectId: .someOrNil(projectParam.id),
         slug: .someOrNil(projectParam.slug)
       )
 
-      // Use the GraphQL mocking infrastructure
+      // Otherwise, fall back to the GraphQL mocking code.
       return self
         .fetch(query: query)
         .flatMap { ProjectPageExtraProperties.extraPropertiesProducer(from: $0) }

--- a/KsApi/Sources/KsApi/MockService.swift
+++ b/KsApi/Sources/KsApi/MockService.swift
@@ -1329,7 +1329,8 @@
       -> SignalProducer<Project, ErrorEnvelope> {
       // If a result was set, use the result for mocking.
       if let result = self.fastFetchProjectPageResult {
-        switch result.0 {
+        let baseProjectResult = result.0
+        switch baseProjectResult {
         case let .success(project):
           return SignalProducer(value: project)
         case let .failure(error):
@@ -1352,7 +1353,8 @@
       -> SignalProducer<ProjectPageExtraProperties, ErrorEnvelope> {
       // If a result was set, use the result for mocking.
       if let result = self.fastFetchProjectPageResult {
-        switch result.1 {
+        let extraPropertiesResult = result.1
+        switch extraPropertiesResult {
         case let .success(project):
           return SignalProducer(value: project)
         case let .failure(error):

--- a/Library/Sources/Library/Library/ViewModels/ProjectPageViewModel.swift
+++ b/Library/Sources/Library/Library/ViewModels/ProjectPageViewModel.swift
@@ -1,3 +1,4 @@
+import Experimentation
 import Foundation
 import GraphAPI
 import KsApi
@@ -943,12 +944,17 @@ private func fetchProject(
   -> SignalProducer<Project, ErrorEnvelope> {
   let param = projectOrParam.param
   let fetcher = ProjectPageFetcher(withService: AppEnvironment.current.apiService)
-  let producer = fetcher.fetchProjectPage(
+
+  let experiment = InstantPledgeButtonExperiment()
+  if experiment.boolValue(forKey: .instant_pledge_enabled) == true {
+    return fetcher.fastFetchProjectPage(projectParam: param.param)
+      .ksr_delay(AppEnvironment.current.apiDelayInterval, on: AppEnvironment.current.scheduler)
+  }
+
+  return fetcher.fetchProjectPage(
     projectParam: param.param
   )
   .ksr_delay(AppEnvironment.current.apiDelayInterval, on: AppEnvironment.current.scheduler)
-
-  return producer
 }
 
 private func shouldGoToManagePledge(with ctaType: PledgeStateCTAType) -> Bool {

--- a/LibraryTests/Library/ViewModels/ProjectPageViewModelTests.swift
+++ b/LibraryTests/Library/ViewModels/ProjectPageViewModelTests.swift
@@ -1,6 +1,7 @@
 import AVFoundation
 import Experimentation
 import GraphAPI
+import ExperimentationTestHelpers
 @testable import KsApi
 @testable import KsApiTestHelpers
 @testable import Library
@@ -1828,7 +1829,7 @@ final class ProjectPageViewModelTests: TestCase {
   func testSelectedContentView_featureFlagOff_campaignSection_returnsTableView() {
     let mockStatsig = MockStatsigWrapper()
     mockStatsig.features = [.projectStoryRichText: false]
-
+    
     Self.mockNetworkRequests(project: self.projectWithRichText) {
       withEnvironment(statsigClient: mockStatsig) {
         self.vm.inputs.configureWith(
@@ -1840,11 +1841,40 @@ final class ProjectPageViewModelTests: TestCase {
           index: NavigationSection.campaign.rawValue
         )
         self.scheduler.advance()
-
+        
         self.showProjectPageTabWithDataContentView.assertLastValue(
           .tableView,
           "Feature flag off → table view even with rich text."
         )
+      }
+    }
+  }
+  
+  func testLoadingPage_whenInstantPledgeExperimentIsOn_UsesFastFetch() {
+    let mockStatsigClient = MockStatsigWrapper()
+
+    let mockExperiment = MockExperiment<InstantPledgeButtonExperiment>(
+      [
+        .instant_pledge_enabled: true
+      ]
+    )
+
+    let experiment = InstantPledgeButtonExperiment()
+    mockStatsigClient.overrideExperiment(experiment, withMock: mockExperiment)
+
+    withEnvironment(statsigClient: mockStatsigClient) {
+      ProjectPageViewModelTests.mockNetworkRequests_newQuery {
+        self.vm.configureAndLoad(.right(Param.id(1)))
+
+        self.configureChildViewControllersWithProject.assertDidNotEmitValue()
+        self.configureDataSourceProject.assertDidNotEmitValue()
+        self.configurePledgeCTAView.assertValues([.loading])
+
+        self.scheduler.advance()
+
+        self.configureChildViewControllersWithProject.assertValueCount(1)
+        self.configureDataSourceProject.assertValueCount(1)
+        self.configurePledgeCTAView.assertValues([.loading, .project(Project.template)])
       }
     }
   }
@@ -1993,12 +2023,33 @@ final class ProjectPageViewModelTests: TestCase {
   }
 
   static func mockNetworkRequests_newQuery(
-    project _: Project = Project.template,
-    rewards _: [Reward] = [Reward.noReward, Reward.template],
-    backing _: Backing? = nil,
+    project: Project = Project.template,
+    rewards: [Reward] = [Reward.noReward, Reward.template],
+    backing: Backing? = nil,
     action: () -> Void
   ) {
-    AppEnvironment.pushEnvironment(apiService: MockService())
+    var baseResult = project
+    baseResult.rewardData.rewards = rewards
+    baseResult.personalization.backing = backing
+    if backing.isSome {
+      baseResult.personalization.isBacking = true
+    }
+
+    let extraResult = ProjectPageExtraProperties(
+      extendedProjectProperties: project.extendedProjectProperties ?? ExtendedProjectProperties.template,
+      video: project.video,
+      flagging: project.flagging ?? false,
+    )
+
+    let mockService = MockService(
+      fastFetchProjectPage: (
+        .success(baseResult),
+        .success(extraResult)
+      )
+    )
+
+    AppEnvironment.pushEnvironment(apiService: mockService)
+
     action()
     AppEnvironment.popEnvironment()
   }
@@ -2018,5 +2069,19 @@ extension ProjectPageViewModelType {
     )
     self.inputs.viewDidLoad()
     self.inputs.viewDidAppear(animated: false)
+  }
+}
+
+private extension ExtendedProjectProperties {
+  static var template: ExtendedProjectProperties {
+    return ExtendedProjectProperties(
+      environmentalCommitments: [],
+      faqs: [],
+      aiDisclosure: nil,
+      risks: "",
+      story: ProjectStoryElements(htmlViewElements: []),
+      minimumPledgeAmount: 1,
+      projectNotice: nil
+    )
   }
 }

--- a/LibraryTests/Library/ViewModels/ProjectPageViewModelTests.swift
+++ b/LibraryTests/Library/ViewModels/ProjectPageViewModelTests.swift
@@ -1,7 +1,7 @@
 import AVFoundation
 import Experimentation
-import GraphAPI
 import ExperimentationTestHelpers
+import GraphAPI
 @testable import KsApi
 @testable import KsApiTestHelpers
 @testable import Library
@@ -1829,7 +1829,7 @@ final class ProjectPageViewModelTests: TestCase {
   func testSelectedContentView_featureFlagOff_campaignSection_returnsTableView() {
     let mockStatsig = MockStatsigWrapper()
     mockStatsig.features = [.projectStoryRichText: false]
-    
+
     Self.mockNetworkRequests(project: self.projectWithRichText) {
       withEnvironment(statsigClient: mockStatsig) {
         self.vm.inputs.configureWith(
@@ -1841,7 +1841,7 @@ final class ProjectPageViewModelTests: TestCase {
           index: NavigationSection.campaign.rawValue
         )
         self.scheduler.advance()
-        
+
         self.showProjectPageTabWithDataContentView.assertLastValue(
           .tableView,
           "Feature flag off → table view even with rich text."
@@ -1849,7 +1849,7 @@ final class ProjectPageViewModelTests: TestCase {
       }
     }
   }
-  
+
   func testLoadingPage_whenInstantPledgeExperimentIsOn_UsesFastFetch() {
     let mockStatsigClient = MockStatsigWrapper()
 

--- a/LibraryTests/Library/ViewModels/ProjectPageViewModelTests.swift
+++ b/LibraryTests/Library/ViewModels/ProjectPageViewModelTests.swift
@@ -1991,6 +1991,17 @@ final class ProjectPageViewModelTests: TestCase {
 
     AppEnvironment.popEnvironment()
   }
+
+  static func mockNetworkRequests_newQuery(
+    project _: Project = Project.template,
+    rewards _: [Reward] = [Reward.noReward, Reward.template],
+    backing _: Backing? = nil,
+    action: () -> Void
+  ) {
+    AppEnvironment.pushEnvironment(apiService: MockService())
+    action()
+    AppEnvironment.popEnvironment()
+  }
 }
 
 extension ProjectPageViewModelType {


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Use `ProjectPageFetcher.fastFastProjectPage` in `ProjectPageViewModel` when the `InstantPledgeButtonExperiment` is on.

# 🤔 Why

This actually integrates the faster fetch with `ProjectPageViewModel`.

# 👀 See

Not all pages have this dramatic of a speedup, but here's one that makes a particular satisfying before-and-after gif.

| Before 🐛 | After 🦋 |
| --- | --- |
| <img height="500" alt="page-load-before-example" src="https://github.com/user-attachments/assets/99368ecc-3f59-4d5e-8a94-f16d5e5f04cc" /> | <img height="500" alt="page-load-after-example" src="https://github.com/user-attachments/assets/997239e3-9dad-4a0e-9f31-6d558b9a5a11" /> |
