### PR TITLE
[DISC-440] Display Pledged Amount in User's Preferred Currency

### DIFF
--- a/GraphAPI/Sources/Fragments/ProjectVideoFeedFragment.graphql.swift
+++ b/GraphAPI/Sources/Fragments/ProjectVideoFeedFragment.graphql.swift
@@ -5,7 +5,7 @@
 
 public struct ProjectVideoFeedFragment: GraphAPI.SelectionSet, Fragment {
   public static var fragmentDefinition: StaticString {
-    #"fragment ProjectVideoFeedFragment on Project { __typename id pid name slug url percentFunded deadlineAt launchedAt backersCount isWatched pledged { __typename amount } creator { __typename name imageUrl(blur: false, width: 200) } category { __typename name } verticalVideo { __typename id previewImageUrl videoSources { __typename hls { __typename src } } } sharesCount watchesCount }"#
+    #"fragment ProjectVideoFeedFragment on Project { __typename id pid name slug url percentFunded deadlineAt launchedAt backersCount isWatched fxRate fxRateCurrency pledged { __typename amount currency } creator { __typename name imageUrl(blur: false, width: 200) } category { __typename name } verticalVideo { __typename id previewImageUrl videoSources { __typename hls { __typename src } } } sharesCount watchesCount }"#
   }
 
   public let __data: DataDict
@@ -24,6 +24,8 @@ public struct ProjectVideoFeedFragment: GraphAPI.SelectionSet, Fragment {
     .field("launchedAt", GraphAPI.DateTime?.self),
     .field("backersCount", Int.self),
     .field("isWatched", Bool.self),
+    .field("fxRate", Double.self),
+    .field("fxRateCurrency", GraphQLEnum<GraphAPI.CurrencyCode>.self),
     .field("pledged", Pledged.self),
     .field("creator", Creator?.self),
     .field("category", Category?.self),
@@ -51,6 +53,10 @@ public struct ProjectVideoFeedFragment: GraphAPI.SelectionSet, Fragment {
   public var backersCount: Int { __data["backersCount"] }
   /// Is the current user watching this project?
   public var isWatched: Bool { __data["isWatched"] }
+  /// Exchange rate for the current user's currency
+  public var fxRate: Double { __data["fxRate"] }
+  /// Currency code for the current user's currency
+  public var fxRateCurrency: GraphQLEnum<GraphAPI.CurrencyCode> { __data["fxRateCurrency"] }
   /// How much money is pledged to the project.
   public var pledged: Pledged { __data["pledged"] }
   /// The project's creator.
@@ -75,6 +81,8 @@ public struct ProjectVideoFeedFragment: GraphAPI.SelectionSet, Fragment {
     launchedAt: GraphAPI.DateTime? = nil,
     backersCount: Int,
     isWatched: Bool,
+    fxRate: Double,
+    fxRateCurrency: GraphQLEnum<GraphAPI.CurrencyCode>,
     pledged: Pledged,
     creator: Creator? = nil,
     category: Category? = nil,
@@ -95,6 +103,8 @@ public struct ProjectVideoFeedFragment: GraphAPI.SelectionSet, Fragment {
         "launchedAt": launchedAt,
         "backersCount": backersCount,
         "isWatched": isWatched,
+        "fxRate": fxRate,
+        "fxRateCurrency": fxRateCurrency,
         "pledged": pledged._fieldData,
         "creator": creator._fieldData,
         "category": category._fieldData,
@@ -119,18 +129,23 @@ public struct ProjectVideoFeedFragment: GraphAPI.SelectionSet, Fragment {
     public static var __selections: [ApolloAPI.Selection] { [
       .field("__typename", String.self),
       .field("amount", String?.self),
+      .field("currency", GraphQLEnum<GraphAPI.CurrencyCode>?.self),
     ] }
 
     /// Floating-point numeric value of monetary amount represented as a string
     public var amount: String? { __data["amount"] }
+    /// Currency of the monetary amount
+    public var currency: GraphQLEnum<GraphAPI.CurrencyCode>? { __data["currency"] }
 
     public init(
-      amount: String? = nil
+      amount: String? = nil,
+      currency: GraphQLEnum<GraphAPI.CurrencyCode>? = nil
     ) {
       self.init(_dataDict: DataDict(
         data: [
           "__typename": GraphAPI.Objects.Money.typename,
           "amount": amount,
+          "currency": currency,
         ],
         fulfilledFragments: [
           ObjectIdentifier(ProjectVideoFeedFragment.Pledged.self)

--- a/GraphAPI/Sources/Operations/Queries/VideoFeedQuery.graphql.swift
+++ b/GraphAPI/Sources/Operations/Queries/VideoFeedQuery.graphql.swift
@@ -250,6 +250,10 @@ public class VideoFeedQuery: GraphQLQuery {
           public var backersCount: Int { __data["backersCount"] }
           /// Is the current user watching this project?
           public var isWatched: Bool { __data["isWatched"] }
+          /// Exchange rate for the current user's currency
+          public var fxRate: Double { __data["fxRate"] }
+          /// Currency code for the current user's currency
+          public var fxRateCurrency: GraphQLEnum<GraphAPI.CurrencyCode> { __data["fxRateCurrency"] }
           /// How much money is pledged to the project.
           public var pledged: Pledged { __data["pledged"] }
           /// The project's creator.
@@ -281,6 +285,8 @@ public class VideoFeedQuery: GraphQLQuery {
             launchedAt: GraphAPI.DateTime? = nil,
             backersCount: Int,
             isWatched: Bool,
+            fxRate: Double,
+            fxRateCurrency: GraphQLEnum<GraphAPI.CurrencyCode>,
             pledged: Pledged,
             creator: Creator? = nil,
             category: Category? = nil,
@@ -301,6 +307,8 @@ public class VideoFeedQuery: GraphQLQuery {
                 "launchedAt": launchedAt,
                 "backersCount": backersCount,
                 "isWatched": isWatched,
+                "fxRate": fxRate,
+                "fxRateCurrency": fxRateCurrency,
                 "pledged": pledged._fieldData,
                 "creator": creator._fieldData,
                 "category": category._fieldData,

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework-iOSTests/Kickstarter-iOS/Features/VideoFeed/Controller/VideoFeedViewControllerTests.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework-iOSTests/Kickstarter-iOS/Features/VideoFeed/Controller/VideoFeedViewControllerTests.swift
@@ -50,6 +50,7 @@ final class VideoFeedViewControllerTests: TestCase {
             creatorImageURL: nil,
             statsText: VideoFeedItem.statsTextInUserPreferredCurrency(
               pledgedAmount: 50_134,
+              currencyCode: "USD",
               backersCount: 431
             ),
             badges: [
@@ -110,6 +111,7 @@ final class VideoFeedViewControllerTests: TestCase {
             creatorImageURL: nil,
             statsText: VideoFeedItem.statsTextInUserPreferredCurrency(
               pledgedAmount: 50_134,
+              currencyCode: "USD",
               backersCount: 431
             ),
             badges: [
@@ -172,6 +174,7 @@ final class VideoFeedViewControllerTests: TestCase {
             creatorImageURL: nil,
             statsText: VideoFeedItem.statsTextInUserPreferredCurrency(
               pledgedAmount: 50_134,
+              currencyCode: "USD",
               backersCount: 431
             ),
             badges: [
@@ -233,6 +236,7 @@ final class VideoFeedViewControllerTests: TestCase {
             creatorImageURL: nil,
             statsText: VideoFeedItem.statsTextInUserPreferredCurrency(
               pledgedAmount: 50_134,
+              currencyCode: "USD",
               backersCount: 431
             ),
             badges: [
@@ -297,6 +301,7 @@ final class VideoFeedViewControllerTests: TestCase {
             creatorImageURL: nil,
             statsText: VideoFeedItem.statsTextInUserPreferredCurrency(
               pledgedAmount: 50_134,
+              currencyCode: "USD",
               backersCount: 431
             ),
             badges: [

--- a/Library/Sources/Library/Library/VideoFeedItem+Constructor.swift
+++ b/Library/Sources/Library/Library/VideoFeedItem+Constructor.swift
@@ -27,10 +27,12 @@ extension VideoFeedItem {
     )
   }
 
-  /// Formats a string using a pledge amount in the user's preferred currency and a given backers count.
-  static func statsTextInUserPreferredCurrency(pledgedAmount: Double, backersCount: Int) -> String {
-    let currencyCode = AppEnvironment.current.locale.currency?.identifier ?? Project.Country.us.currencyCode
-
+  /// Formats using a converted pledge amount in the user's preferred currency and a given backers count.
+  static func statsTextInUserPreferredCurrency(
+    pledgedAmount: Double,
+    currencyCode: String,
+    backersCount: Int
+  ) -> String {
     let pledgedFormatted = Format.currency(
       pledgedAmount,
       currencyCode: currencyCode,
@@ -46,10 +48,16 @@ extension VideoFeedItem {
   }
 
   private static func statsText(for project: VideoFeedQuery.Data.VideoFeed.Node.Project) -> String {
-    let amount = project.pledged.amount
-      .flatMap { Double($0) } ?? 0
+    let rawAmount = project.pledged.amount.flatMap { Double($0) } ?? 0
+    let fxRate = Double(project.fxRate)
+    let convertedAmount = rawAmount * fxRate
+    let currencyCode = project.fxRateCurrency.rawValue
 
-    return Self.statsTextInUserPreferredCurrency(pledgedAmount: amount, backersCount: project.backersCount)
+    return Self.statsTextInUserPreferredCurrency(
+      pledgedAmount: convertedAmount,
+      currencyCode: currencyCode,
+      backersCount: project.backersCount
+    )
   }
 }
 

--- a/LibraryTests/Library/ViewModels/VideoFeedViewModelTests.swift
+++ b/LibraryTests/Library/ViewModels/VideoFeedViewModelTests.swift
@@ -367,6 +367,8 @@ final class VideoFeedViewModelTests: TestCase {
         percentFunded: 75,
         backersCount: 100,
         isWatched: isWatched,
+        fxRate: 1.0,
+        fxRateCurrency: .case(.usd),
         pledged: pledged,
         creator: creator,
         category: category,

--- a/graphql/fragments/ProjectVideoFeedFragment.graphql
+++ b/graphql/fragments/ProjectVideoFeedFragment.graphql
@@ -10,8 +10,11 @@ fragment ProjectVideoFeedFragment on Project {
   launchedAt
   backersCount
   isWatched
+  fxRate
+  fxRateCurrency
   pledged {
     amount
+    currency
   }
   creator {
     name


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What
Display the pledged amount converted to the user's preferred currency instead of the raw project currency amount in video feed cells.

[Thread to the original issue that Sean called out](https://kickstarter.slack.com/archives/C0A9PNF26S3/p1785477672164439?thread_ts=1785477638.816529&cid=C0A9PNF26S3)

# 🤔 Why
A JPY project was showing 11,204,818 pledged amount instead of the user's converted amount ($69,762), making it inconsistent with the project page.

# 🛠 How
- Added `fxRate` and `fxRateCurrency` to `ProjectVideoFeedFragment` and updated the GraphQL Schema. 
- In `VideoFeedItem+Constructor`, the raw pledged amount is now multiplied by `fxRate` and displayed using `fxRateCurrency`, matching the pattern used in the Project Page.

# 👀 See

Because of personalization I'm not able to pull up the exact project in question on Prod. But I cross referenced about 10 project with web to make sure they all match on video feed and the project pages.

# ✅ Acceptance criteria
- [x] Open a project with a non-USD currency (e.g. JPY) in the video feed
- [x] Pledged amount matches the converted amount shown on the project page
