### PR TITLE
[PF-482] Migrate CircleCI regex to filter syntax

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -301,10 +301,10 @@ workflows:
       #         only: /beta-dist-.*/
       - deploy_alpha:
           context: aws
-          filters:
-            branches:
-              # matches all branches that contain 'feature' but do not contain 'alpha-dist'
-              only: /^((?!alpha\-dist).*feature.*)*$/
+          # matches all branches that contain 'feature' but do not contain 'alpha-dist'
+          filters: >-
+            pipeline.git.branch matches /.*feature.*/ and
+            not (pipeline.git.branch starts-with "alpha-dist")
           requires: *all_jobs
       - deploy_beta:
           context: aws


### PR DESCRIPTION
# 📲 What

Replace the negative-lookahead branch regex on the `deploy_alpha` job filter with an compatible expression-based filter.

# 🤔 Why

CircleCI no longer supports branch filter regexes with negative lookaheads. The old pattern (`/^((?!alpha\-dist).*feature.*)*$/`) relied on a lookahead to exclude `alpha-dist` branches, so config validation started failing.

# 🛠 How

`filters: branches: only` can't express "contains X AND not Y" (list entries are OR'd), so this switches to CircleCI's expression-based job filter:

```yaml
filters: >-
  pipeline.git.branch matches /.*feature.*/ and
  not (pipeline.git.branch matches /.*alpha-dist.*/)
```

Same behavior as before (job runs on branches containing `feature` but not `alpha-dist`) just without the unsupported regex construct. No other filters in the file needed changes.

# 👀 See
[CircleCI: Branch and tag filtering](https://circleci.com/docs/guides/orchestrate/using-branch-filters/)

| Before 🐛 | After 🦋 |
| --- | --- |
| <img width="300" alt="image" src="https://github.com/user-attachments/assets/10a7937c-bb93-4851-b726-aee2688100dc" /> | <img width="300" alt="image" src="https://github.com/user-attachments/assets/545a5cd6-8160-4382-9ea4-e1a11e4367e5" /> |


