### PR TITLE
CHECK-398: Add speedy checkout experiment

### DIFF
--- a/Experimentation/Sources/Experimentation/Experiments/SpeedyCheckoutExperiment.swift
+++ b/Experimentation/Sources/Experimentation/Experiments/SpeedyCheckoutExperiment.swift
@@ -1,0 +1,18 @@
+/// An experiment to make pages in the pledge flow load much faster.
+public struct SpeedyCheckoutExperiment: StatsigExperimentProtocol {
+  typealias ExperimentParameters = SpeedyCheckoutExperiment.Parameters
+
+  public enum Parameters: String, CaseIterable {
+    case speedy_checkout_enabled
+  }
+
+  public var name: StatsigExperimentName {
+    return .speedy_checkout_experiment
+  }
+
+  public var layer: StatsigExperimentLayer? {
+    return nil
+  }
+
+  public init() {}
+}

--- a/Experimentation/Sources/Experimentation/Experiments/StatsigExperiment.swift
+++ b/Experimentation/Sources/Experimentation/Experiments/StatsigExperiment.swift
@@ -42,6 +42,7 @@ public enum StatsigExperimentName: String, CaseIterable {
   case logged_out_aa_experiment
   case move_no_reward_option_ios = "move_no-reward_option_ios"
   case instant_pledge_button_experiment
+  case speedy_checkout_experiment = "speedy_checkout_experiment_-_ios"
 }
 
 public enum StatsigExperimentLayer: String, CaseIterable {

--- a/Library/Sources/Library/Library/Statsig/StatsigExperiment+Helpers.swift
+++ b/Library/Sources/Library/Library/Statsig/StatsigExperiment+Helpers.swift
@@ -25,6 +25,8 @@ public extension StatsigExperimentName {
       return MoveNoRewardOptionExperiment()
     case .instant_pledge_button_experiment:
       return InstantPledgeButtonExperiment()
+    case .speedy_checkout_experiment:
+      return SpeedyCheckoutExperiment()
     }
   }
 }


### PR DESCRIPTION
# 📲 What

Add an experiment for Speedy Checkout, our next A/B test.

# 🤔 Why

This test will be for general performance improvements in the Checkout flow. We'd like to measure the impact that performance improvements have on conversion, which is why this is an A/B test. These improvements will be rolled out to 100% after the experiment is complete.