### PR TITLE
[DISC-441] Enable Audio on Volume Up Press When In Silent Mode

### DIFF
--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Controller/VideoFeedViewController.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Controller/VideoFeedViewController.swift
@@ -270,6 +270,7 @@ final class VideoFeedViewController: UIViewController {
     let volumeView = MPVolumeView(frame: .zero)
     volumeView.alpha = 0.001
     volumeView.isUserInteractionEnabled = false
+    volumeView.accessibilityElementsHidden = true
     self.view.addSubview(volumeView)
 
     self.volumeObservation = AVAudioSession.sharedInstance()

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Controller/VideoFeedViewController.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Controller/VideoFeedViewController.swift
@@ -4,6 +4,7 @@ import KDS
 import Kingfisher
 import KsApi
 import Library
+import MediaPlayer
 import SwiftUI
 import UIKit
 
@@ -27,6 +28,8 @@ final class VideoFeedViewController: UIViewController {
   private var isScrolling = false
   private var currentPageIndex: Int = 0
 
+  private var volumeObservation: NSKeyValueObservation?
+
   /// Called once the first batch of items has loaded and the feed is ready to present.
   var onReadyToPresent: (() -> Void)?
 
@@ -48,6 +51,7 @@ final class VideoFeedViewController: UIViewController {
     self.view.backgroundColor = Constants.backgroundColor
 
     self.configureAudioSession()
+    self.setupSilentModeOverride()
     self.observeAppLifecycle()
 
     self.setupCollectionView()
@@ -61,6 +65,7 @@ final class VideoFeedViewController: UIViewController {
 
   deinit {
     self.lifecycleObservers.forEach(NotificationCenter.default.removeObserver)
+    self.volumeObservation?.invalidate()
   }
 
   public override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
@@ -94,6 +99,13 @@ final class VideoFeedViewController: UIViewController {
 
     self.navigationController?.setNavigationBarHidden(false, animated: animated)
     self.pauseVisibleCell()
+
+    /// Only reset on dismiss not when a modal (project page, login, etc.) is presented.
+    if self.isBeingDismissed {
+      self.volumeObservation?.invalidate()
+      self.volumeObservation = nil
+      try? AVAudioSession.sharedInstance().setCategory(.soloAmbient, mode: .default)
+    }
   }
 
   // MARK: - CollectionView
@@ -237,7 +249,6 @@ final class VideoFeedViewController: UIViewController {
 
   // MARK: - Audio session
 
-  /// Auto play video audio
   private func configureAudioSession() {
     do {
       try AVAudioSession.sharedInstance().setCategory(.soloAmbient, mode: .default)
@@ -249,6 +260,33 @@ final class VideoFeedViewController: UIViewController {
 
       Crashlytics.crashlytics().record(error: error)
     }
+  }
+
+  /// Detects a volume up press to unmute the feed when the silent switch is on.
+  /// In silent mode, volume buttons control ringer (not media) volume, so `outputVolume` KVO never fires.
+  /// We can use a `MPVolumeView` to reroute buttons to media volume, fixing this.  it's the only way iOS exposes this AFAIK.
+  /// On the first volume-up, switches to `.playback` to bypass the silent switch, then tears itself down.
+  private func setupSilentModeOverride() {
+    let volumeView = MPVolumeView(frame: .zero)
+    volumeView.alpha = 0.001
+    volumeView.isUserInteractionEnabled = false
+    self.view.addSubview(volumeView)
+
+    self.volumeObservation = AVAudioSession.sharedInstance()
+      .observe(\.outputVolume, options: [.old, .new]) { [weak self] _, change in
+        guard let oldVolume = change.oldValue,
+              let newVolume = change.newValue,
+              newVolume > oldVolume else { return }
+
+        DispatchQueue.main.async { [weak self] in
+          guard let self else { return }
+
+          self.volumeObservation?.invalidate()
+          self.volumeObservation = nil
+
+          try? AVAudioSession.sharedInstance().setCategory(.playback, mode: .default)
+        }
+      }
   }
 
   // MARK: - App lifecycle


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What
Unmutes video feed videos when the user presses volume-up while in silent mode.

# 🤔 Why
The feed previously respected the silent switch on load but gave users no way to opt into audio without leaving silent mode. This matches the behavior of Instagram's explore tab and similar video feed experiences.

# 🛠 How
On load, the audio session is configured with `.soloAmbient` so the silent switch is respected by default.

To detect a volume-up press in silent mode, a hidden `MPVolumeView` is added to the view hierarchy. 
Without it, volume buttons in silent mode control ringer volume rather than media volume, so `AVAudioSession.outputVolume` KVO never fires. 
The `MPVolumeView` reroutes button events to media volume, making KVO fire. As far as I can tell, this is the standard iOS pattern for this use case and no public API exists to detect volume presses or silent mode state directly.

Note: once the user unlocks audio, flipping the silent switch back does not re-silence the feed. I couldn't find a public API to detect silent switch state changes in real time, so we're accepting that as a limitation of this UX

# ✅ Acceptance criteria

- [x] Open feed with silent switch on, confirm no audio plays
- [x] Press volume-up, confirm audio starts playing
- [x] Open feed with silent switch off, confirm audio plays normally
- [x] Test on physical device