### PR TITLE
Fix animated GIFs in RichTextView ImageBlock

### DIFF
--- a/GraphAPI/GraphAPITestMocks/RichTextPhoto+Mock.graphql.swift
+++ b/GraphAPI/GraphAPITestMocks/RichTextPhoto+Mock.graphql.swift
@@ -13,7 +13,6 @@ public class RichTextPhoto: MockObject {
     @Field<String>("altText") public var altText
     @Field<Photo>("asset") public var asset
     @Field<String>("caption") public var caption
-    @Field<String>("url") public var url
   }
 }
 
@@ -21,13 +20,11 @@ public extension Mock where O == RichTextPhoto {
   convenience init(
     altText: String? = nil,
     asset: Mock<Photo>? = nil,
-    caption: String? = nil,
-    url: String? = nil
+    caption: String? = nil
   ) {
     self.init()
     _setScalar(altText, for: \.altText)
     _setEntity(asset, for: \.asset)
     _setScalar(caption, for: \.caption)
-    _setScalar(url, for: \.url)
   }
 }

--- a/GraphAPI/Sources/Fragments/RichTextComponentFragment.graphql.swift
+++ b/GraphAPI/Sources/Fragments/RichTextComponentFragment.graphql.swift
@@ -412,7 +412,6 @@ public struct RichTextComponentFragment: GraphAPI.SelectionSet, Fragment {
           public var altText: String { __data["altText"] }
           public var asset: Asset? { __data["asset"] }
           public var caption: String { __data["caption"] }
-          public var url: String { __data["url"] }
 
           public struct Fragments: FragmentContainer {
             public let __data: DataDict
@@ -424,8 +423,7 @@ public struct RichTextComponentFragment: GraphAPI.SelectionSet, Fragment {
           public init(
             altText: String,
             asset: Asset? = nil,
-            caption: String,
-            url: String
+            caption: String
           ) {
             self.init(_dataDict: DataDict(
               data: [
@@ -433,7 +431,6 @@ public struct RichTextComponentFragment: GraphAPI.SelectionSet, Fragment {
                 "altText": altText,
                 "asset": asset._fieldData,
                 "caption": caption,
-                "url": url,
               ],
               fulfilledFragments: [
                 ObjectIdentifier(RichTextComponentFragment.Item.AsRichText.Child.self),
@@ -964,7 +961,6 @@ public struct RichTextComponentFragment: GraphAPI.SelectionSet, Fragment {
           public var altText: String { __data["altText"] }
           public var asset: Asset? { __data["asset"] }
           public var caption: String { __data["caption"] }
-          public var url: String { __data["url"] }
 
           public struct Fragments: FragmentContainer {
             public let __data: DataDict
@@ -976,8 +972,7 @@ public struct RichTextComponentFragment: GraphAPI.SelectionSet, Fragment {
           public init(
             altText: String,
             asset: Asset? = nil,
-            caption: String,
-            url: String
+            caption: String
           ) {
             self.init(_dataDict: DataDict(
               data: [
@@ -985,7 +980,6 @@ public struct RichTextComponentFragment: GraphAPI.SelectionSet, Fragment {
                 "altText": altText,
                 "asset": asset._fieldData,
                 "caption": caption,
-                "url": url,
               ],
               fulfilledFragments: [
                 ObjectIdentifier(RichTextComponentFragment.Item.AsRichTextHeader.Child.self),
@@ -1516,7 +1510,6 @@ public struct RichTextComponentFragment: GraphAPI.SelectionSet, Fragment {
           public var altText: String { __data["altText"] }
           public var asset: Asset? { __data["asset"] }
           public var caption: String { __data["caption"] }
-          public var url: String { __data["url"] }
 
           public struct Fragments: FragmentContainer {
             public let __data: DataDict
@@ -1528,8 +1521,7 @@ public struct RichTextComponentFragment: GraphAPI.SelectionSet, Fragment {
           public init(
             altText: String,
             asset: Asset? = nil,
-            caption: String,
-            url: String
+            caption: String
           ) {
             self.init(_dataDict: DataDict(
               data: [
@@ -1537,7 +1529,6 @@ public struct RichTextComponentFragment: GraphAPI.SelectionSet, Fragment {
                 "altText": altText,
                 "asset": asset._fieldData,
                 "caption": caption,
-                "url": url,
               ],
               fulfilledFragments: [
                 ObjectIdentifier(RichTextComponentFragment.Item.AsRichTextListItem.Child.self),
@@ -1836,7 +1827,6 @@ public struct RichTextComponentFragment: GraphAPI.SelectionSet, Fragment {
       public var altText: String { __data["altText"] }
       public var asset: Asset? { __data["asset"] }
       public var caption: String { __data["caption"] }
-      public var url: String { __data["url"] }
 
       public struct Fragments: FragmentContainer {
         public let __data: DataDict
@@ -1848,8 +1838,7 @@ public struct RichTextComponentFragment: GraphAPI.SelectionSet, Fragment {
       public init(
         altText: String,
         asset: Asset? = nil,
-        caption: String,
-        url: String
+        caption: String
       ) {
         self.init(_dataDict: DataDict(
           data: [
@@ -1857,7 +1846,6 @@ public struct RichTextComponentFragment: GraphAPI.SelectionSet, Fragment {
             "altText": altText,
             "asset": asset._fieldData,
             "caption": caption,
-            "url": url,
           ],
           fulfilledFragments: [
             ObjectIdentifier(RichTextComponentFragment.Item.self),

--- a/GraphAPI/Sources/Fragments/RichTextItemFragment.graphql.swift
+++ b/GraphAPI/Sources/Fragments/RichTextItemFragment.graphql.swift
@@ -5,7 +5,7 @@
 
 public struct RichTextItemFragment: GraphAPI.SelectionSet, Fragment {
   public static var fragmentDefinition: StaticString {
-    #"fragment RichTextItemFragment on RichTextItem { __typename ... on RichText { text link styles } ... on RichTextHeader { text link styles } ... on RichTextListItem { text link styles } ... on RichTextListOpen { _present } ... on RichTextListClose { _present } ... on RichTextPhoto { altText asset { __typename id } caption url } ... on RichTextAudio { altText asset { __typename id } caption url } ... on RichTextVideo { altText asset { __typename id poster formats { __typename encoding height width profile url } } caption url } ... on RichTextOembed { width height version title type iframeUrl originalUrl thumbnailHeight thumbnailUrl thumbnailWidth } }"#
+    #"fragment RichTextItemFragment on RichTextItem { __typename ... on RichText { text link styles } ... on RichTextHeader { text link styles } ... on RichTextListItem { text link styles } ... on RichTextListOpen { _present } ... on RichTextListClose { _present } ... on RichTextPhoto { altText asset { __typename id url(width: 99999) } caption } ... on RichTextAudio { altText asset { __typename id } caption url } ... on RichTextVideo { altText asset { __typename id poster formats { __typename encoding height width profile url } } caption url } ... on RichTextOembed { width height version title type iframeUrl originalUrl thumbnailHeight thumbnailUrl thumbnailWidth } }"#
   }
 
   public let __data: DataDict
@@ -242,19 +242,16 @@ public struct RichTextItemFragment: GraphAPI.SelectionSet, Fragment {
       .field("altText", String.self),
       .field("asset", Asset?.self),
       .field("caption", String.self),
-      .field("url", String.self),
     ] }
 
     public var altText: String { __data["altText"] }
     public var asset: Asset? { __data["asset"] }
     public var caption: String { __data["caption"] }
-    public var url: String { __data["url"] }
 
     public init(
       altText: String,
       asset: Asset? = nil,
-      caption: String,
-      url: String
+      caption: String
     ) {
       self.init(_dataDict: DataDict(
         data: [
@@ -262,7 +259,6 @@ public struct RichTextItemFragment: GraphAPI.SelectionSet, Fragment {
           "altText": altText,
           "asset": asset._fieldData,
           "caption": caption,
-          "url": url,
         ],
         fulfilledFragments: [
           ObjectIdentifier(RichTextItemFragment.self),
@@ -282,17 +278,22 @@ public struct RichTextItemFragment: GraphAPI.SelectionSet, Fragment {
       public static var __selections: [ApolloAPI.Selection] { [
         .field("__typename", String.self),
         .field("id", GraphAPI.ID.self),
+        .field("url", String.self, arguments: ["width": 99999]),
       ] }
 
       public var id: GraphAPI.ID { __data["id"] }
+      /// URL of the photo
+      public var url: String { __data["url"] }
 
       public init(
-        id: GraphAPI.ID
+        id: GraphAPI.ID,
+        url: String
       ) {
         self.init(_dataDict: DataDict(
           data: [
             "__typename": GraphAPI.Objects.Photo.typename,
             "id": id,
+            "url": url,
           ],
           fulfilledFragments: [
             ObjectIdentifier(RichTextItemFragment.AsRichTextPhoto.Asset.self)

--- a/ServerDrivenUI/Sources/ServerDrivenUI/RichTextGQLConversions.swift
+++ b/ServerDrivenUI/Sources/ServerDrivenUI/RichTextGQLConversions.swift
@@ -244,7 +244,7 @@ extension RichTextComponentFragment.Item.AsRichTextPhoto {
       altText: altText,
       assetID: asset?.id,
       caption: caption,
-      url: url
+      url: asset?.url
     ))
   }
 }
@@ -255,7 +255,7 @@ extension RichTextComponentFragment.Item.AsRichText.Child.AsRichTextPhoto {
       altText: altText,
       assetID: asset?.id,
       caption: caption,
-      url: url
+      url: asset?.url
     ))
   }
 }
@@ -266,7 +266,7 @@ extension RichTextComponentFragment.Item.AsRichTextHeader.Child.AsRichTextPhoto 
       altText: altText,
       assetID: asset?.id,
       caption: caption,
-      url: url
+      url: asset?.url
     ))
   }
 }
@@ -277,7 +277,7 @@ extension RichTextComponentFragment.Item.AsRichTextListItem.Child.AsRichTextPhot
       altText: altText,
       assetID: asset?.id,
       caption: caption,
-      url: url
+      url: asset?.url
     ))
   }
 }

--- a/ServerDrivenUI/Tests/ServerDrivenUITests/RichTextGQLConversionTests.swift
+++ b/ServerDrivenUI/Tests/ServerDrivenUITests/RichTextGQLConversionTests.swift
@@ -258,14 +258,13 @@ final class RichTextGQLConversionTests: XCTestCase {
   func testAsRichTextPhotoItem() throws {
     let gql = RichTextComponentFragment.Item.AsRichTextPhoto(
       altText: "photo",
-      asset: nil,
-      caption: "cap",
-      url: "https://img"
+      asset: .init(id: "", url: "https://img"),
+      caption: "cap"
     )
     let el = gql.asRichTextElement
     guard case let .photo(p) = el else { XCTFail("expected .photo"); return }
     XCTAssertEqual(p.altText, "photo")
-    XCTAssertNil(p.assetID)
+    XCTAssertNotNil(p.assetID)
     XCTAssertEqual(p.url, "https://img")
   }
 
@@ -273,9 +272,8 @@ final class RichTextGQLConversionTests: XCTestCase {
   func testAsRichTextPhotoChild() throws {
     let gql = RichTextComponentFragment.Item.AsRichText.Child.AsRichTextPhoto(
       altText: "p",
-      asset: nil,
+      asset: .init(id: "", url: "u"),
       caption: "c",
-      url: "u"
     )
     let el = gql.asRichTextElement
     guard case let .photo(p) = el else { XCTFail("expected .photo"); return }
@@ -508,9 +506,8 @@ final class RichTextGQLConversionTests: XCTestCase {
   func testAsRichTextHeaderChildAsRichTextPhoto() throws {
     let gql = RichTextComponentFragment.Item.AsRichTextHeader.Child.AsRichTextPhoto(
       altText: "hp",
-      asset: nil,
-      caption: "",
-      url: ""
+      asset: .init(id: "", url: ""),
+      caption: ""
     )
     let el = gql.asRichTextElement
     guard case let .photo(p) = el else { XCTFail("expected .photo"); return }
@@ -521,9 +518,8 @@ final class RichTextGQLConversionTests: XCTestCase {
   func testAsRichTextListItemChildAsRichTextPhoto() throws {
     let gql = RichTextComponentFragment.Item.AsRichTextListItem.Child.AsRichTextPhoto(
       altText: "lip",
-      asset: nil,
-      caption: "",
-      url: ""
+      asset: .init(id: "", url: ""),
+      caption: ""
     )
     let el = gql.asRichTextElement
     guard case let .photo(p) = el else { XCTFail("expected .photo"); return }

--- a/graphql/fragments/RichTextFragment.graphql
+++ b/graphql/fragments/RichTextFragment.graphql
@@ -24,9 +24,9 @@ fragment RichTextItemFragment on RichTextItem {
     altText
     asset {
       id
+      url(width:99999)
     }
     caption
-    url
   }
   ... on RichTextAudio {
     altText


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Animated GIFs were not playing in RichTextView. This corrects this issue.

# 🤔 Why

The GraphQL query has two separate fields; `url` and `asset.url()`. We were using the former, which shows a resized version that doesn't animate.

# 🛠 How

The code was updated to use the `asset.url()` field. This has a mandatory width parameter, so I set it to something very large (it doesn't upscale).

# 👀 See

Trello, screenshots, external resources?

| Before 🐛 | After 🦋 |
| --- | --- |
| <img width="320" alt="Screen Recording 2026-08-10 at 13 51 00" src="https://github.com/user-attachments/assets/b5cbdcf9-93bb-401b-a98d-0856fa5357f1" /> | <img width="320" alt="Screen Recording 2026-08-10 at 13 48 20" src="https://github.com/user-attachments/assets/a0784f1a-79be-437e-988a-7b6f8b79579c" /> |
