### PR TITLE
VideoFeed Crash When Opened From Multiple Tabs With Slow Network

### DIFF
--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Controller/VideoFeedBannerPresenting.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Controller/VideoFeedBannerPresenting.swift
@@ -10,7 +10,8 @@ extension VideoFeedBannerPresenting {
   func presentVideoFeed(from cell: VideoFeedBannerCell) {
     guard self.videoFeedVC == nil else {
       /// Reuse an existing feed VC so VM state (optimistic saves, etc.) persists across opens.
-      if let existing = self.videoFeedVC, existing.isBeingPresented == false {
+      if let existing = self.videoFeedVC, existing.presentingViewController == nil,
+         !existing.isBeingPresented {
         existing.modalPresentationStyle = .fullScreen
         self.present(existing, animated: true)
       }
@@ -27,6 +28,12 @@ extension VideoFeedBannerPresenting {
 
     feedVC.onReadyToPresent = { [weak self, weak cell, weak feedVC] in
       guard let self, let feedVC else { return }
+
+      /// Prevent double-tap and cross tab race condition from presenting the same VC more than once.
+      guard feedVC.presentingViewController == nil, !feedVC.isBeingPresented else {
+        cell?.setLoading(false)
+        return
+      }
 
       cell?.setLoading(false)
 

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Controller/VideoFeedBannerPresenting.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Controller/VideoFeedBannerPresenting.swift
@@ -27,18 +27,15 @@ extension VideoFeedBannerPresenting {
     feedVC.loadViewIfNeeded()
 
     feedVC.onReadyToPresent = { [weak self, weak cell, weak feedVC] in
-      guard let self, let feedVC else { return }
+      cell?.setLoading(false)
 
-      /// Prevent double-tap and cross tab race condition from presenting the same VC more than once.
-      guard feedVC.presentingViewController == nil, !feedVC.isBeingPresented else {
-        cell?.setLoading(false)
+      guard let self, let feedVC,
+            feedVC.presentingViewController == nil,
+            !feedVC.isBeingPresented else {
         return
       }
 
-      cell?.setLoading(false)
-
       feedVC.modalPresentationStyle = .fullScreen
-
       self.present(feedVC, animated: true)
     }
 


### PR DESCRIPTION
# 📲 What
Guard against a crash in `VideoFeedBannerPresenting` when `VideoFeedViewController` is presented twice in quick succession.

**[Crash Logs](https://console.firebase.google.com/u/0/project/kickstarter-ios/crashlytics/app/ios:com.kickstarter.kickstarter/issues/e48b3e6f16dd37b4b0c6d23af1d6c2dc?time=7d&versions=5.36.0%20(1784658)&types=crash&sessionEventKey=d3be22e318bb4d5fb0884c2f01b0e2bb_2251255844980847832)**: Affecting a very minor amount of users, but might as well get ahead of it.

# 🤔 Why
On slow connections, a user could tap "Try it Now" on the Discovery tab, switch to Search while it's still loading, and tap "Try it Now" there too. 
Both `onReadyToPresent` callbacks eventually fire and both attempt to present a `VideoFeedViewController` through `RootTabBarViewController`, which can throw an `NSInvalidArgumentException` and crashes.

# 🛠 How
In `onReadyToPresent`, added a guard that checks `feedVC.presentingViewController == nil` and `!feedVC.isBeingPresented` before calling `present`. 
Also tightened the existing reuse path guard to use `presentingViewController` instead of only `isBeingPresented`, since `isBeingPresented` returns `false` once the presentation animation completes.

# 👀 See

No crash now 🪄 

# ✅ Acceptance criteria

- [x] Tap "Try it Now" on Discovery on a slow connection (Network Link Conditioner helps)
- [x] While the banner is loading, switch to Search and tap "Try it Now"
- [x] App should not crash — second tap is silently ignored
- [x] Tapping "Try it Now" under normal conditions still opens the feed as expected
