### PR TITLE
[PF-267] Prelaunch story in Server-Driven UI

### DIFF
--- a/GraphAPI/GraphAPITestMocks/Project+Mock.graphql.swift
+++ b/GraphAPI/GraphAPITestMocks/Project+Mock.graphql.swift
@@ -58,6 +58,7 @@ public class Project: MockObject {
     @Field<Bool>("postCampaignPledgingEnabled") public var postCampaignPledgingEnabled
     @Field<PostConnection>("posts") public var posts
     @Field<Bool>("prelaunchActivated") public var prelaunchActivated
+    @Field<RichTextComponent>("prelaunchStoryRichText") public var prelaunchStoryRichText
     @Field<String>("projectDescription") public var projectDescription
     @Field<GraphAPI.ID>("projectId") public var projectId
     @Field<GraphAPI.DateTime>("projectLaunchedAt") public var projectLaunchedAt
@@ -136,6 +137,7 @@ public extension Mock where O == Project {
     postCampaignPledgingEnabled: Bool? = nil,
     posts: Mock<PostConnection>? = nil,
     prelaunchActivated: Bool? = nil,
+    prelaunchStoryRichText: Mock<RichTextComponent>? = nil,
     projectDescription: String? = nil,
     projectId: GraphAPI.ID? = nil,
     projectLaunchedAt: GraphAPI.DateTime? = nil,
@@ -211,6 +213,7 @@ public extension Mock where O == Project {
     _setScalar(postCampaignPledgingEnabled, for: \.postCampaignPledgingEnabled)
     _setEntity(posts, for: \.posts)
     _setScalar(prelaunchActivated, for: \.prelaunchActivated)
+    _setEntity(prelaunchStoryRichText, for: \.prelaunchStoryRichText)
     _setScalar(projectDescription, for: \.projectDescription)
     _setScalar(projectId, for: \.projectId)
     _setScalar(projectLaunchedAt, for: \.projectLaunchedAt)

--- a/GraphAPI/Sources/Fragments/ExtendedProjectPropertiesFragment.graphql.swift
+++ b/GraphAPI/Sources/Fragments/ExtendedProjectPropertiesFragment.graphql.swift
@@ -5,7 +5,7 @@
 
 public struct ExtendedProjectPropertiesFragment: GraphAPI.SelectionSet, Fragment {
   public static var fragmentDefinition: StaticString {
-    #"fragment ExtendedProjectPropertiesFragment on Project { __typename aiDisclosure { __typename id fundingForAiAttribution fundingForAiConsent fundingForAiOption generatedByAiConsent generatedByAiDetails involvesAi involvesFunding involvesGeneration involvesOther otherAiDetails } environmentalCommitments { __typename commitmentCategory description id } faqs { __typename nodes { __typename question answer id createdAt } } minPledge projectNotice risks story storyRichText { __typename ...RichTextComponentFragment } }"#
+    #"fragment ExtendedProjectPropertiesFragment on Project { __typename aiDisclosure { __typename id fundingForAiAttribution fundingForAiConsent fundingForAiOption generatedByAiConsent generatedByAiDetails involvesAi involvesFunding involvesGeneration involvesOther otherAiDetails } environmentalCommitments { __typename commitmentCategory description id } faqs { __typename nodes { __typename question answer id createdAt } } minPledge projectNotice risks story prelaunchStoryRichText { __typename ...RichTextComponentFragment } storyRichText { __typename ...RichTextComponentFragment } }"#
   }
 
   public let __data: DataDict
@@ -21,6 +21,7 @@ public struct ExtendedProjectPropertiesFragment: GraphAPI.SelectionSet, Fragment
     .field("projectNotice", String?.self),
     .field("risks", String.self),
     .field("story", GraphAPI.HTML.self),
+    .field("prelaunchStoryRichText", PrelaunchStoryRichText.self),
     .field("storyRichText", StoryRichText.self),
   ] }
 
@@ -37,6 +38,8 @@ public struct ExtendedProjectPropertiesFragment: GraphAPI.SelectionSet, Fragment
   public var risks: String { __data["risks"] }
   /// The story behind the project, parsed for presentation.
   public var story: GraphAPI.HTML { __data["story"] }
+  /// Return an itemized version of the prelaunch story. This feature is in BETA: types can change anytime!
+  public var prelaunchStoryRichText: PrelaunchStoryRichText { __data["prelaunchStoryRichText"] }
   /// Return an itemized version of the story. This feature is in BETA: types can change anytime!
   public var storyRichText: StoryRichText { __data["storyRichText"] }
 
@@ -48,6 +51,7 @@ public struct ExtendedProjectPropertiesFragment: GraphAPI.SelectionSet, Fragment
     projectNotice: String? = nil,
     risks: String,
     story: GraphAPI.HTML,
+    prelaunchStoryRichText: PrelaunchStoryRichText,
     storyRichText: StoryRichText
   ) {
     self.init(_dataDict: DataDict(
@@ -60,6 +64,7 @@ public struct ExtendedProjectPropertiesFragment: GraphAPI.SelectionSet, Fragment
         "projectNotice": projectNotice,
         "risks": risks,
         "story": story,
+        "prelaunchStoryRichText": prelaunchStoryRichText._fieldData,
         "storyRichText": storyRichText._fieldData,
       ],
       fulfilledFragments: [
@@ -252,6 +257,46 @@ public struct ExtendedProjectPropertiesFragment: GraphAPI.SelectionSet, Fragment
         ))
       }
     }
+  }
+
+  /// PrelaunchStoryRichText
+  ///
+  /// Parent Type: `RichTextComponent`
+  public struct PrelaunchStoryRichText: GraphAPI.SelectionSet {
+    public let __data: DataDict
+    public init(_dataDict: DataDict) { __data = _dataDict }
+
+    public static var __parentType: ApolloAPI.ParentType { GraphAPI.Objects.RichTextComponent }
+    public static var __selections: [ApolloAPI.Selection] { [
+      .field("__typename", String.self),
+      .fragment(RichTextComponentFragment.self),
+    ] }
+
+    public var items: [Item] { __data["items"] }
+
+    public struct Fragments: FragmentContainer {
+      public let __data: DataDict
+      public init(_dataDict: DataDict) { __data = _dataDict }
+
+      public var richTextComponentFragment: RichTextComponentFragment { _toFragment() }
+    }
+
+    public init(
+      items: [Item]
+    ) {
+      self.init(_dataDict: DataDict(
+        data: [
+          "__typename": GraphAPI.Objects.RichTextComponent.typename,
+          "items": items._fieldData,
+        ],
+        fulfilledFragments: [
+          ObjectIdentifier(ExtendedProjectPropertiesFragment.PrelaunchStoryRichText.self),
+          ObjectIdentifier(RichTextComponentFragment.self)
+        ]
+      ))
+    }
+
+    public typealias Item = RichTextComponentFragment.Item
   }
 
   /// StoryRichText

--- a/GraphAPI/Sources/Fragments/ExtendedProjectPropertiesFragment.graphql.swift
+++ b/GraphAPI/Sources/Fragments/ExtendedProjectPropertiesFragment.graphql.swift
@@ -5,7 +5,7 @@
 
 public struct ExtendedProjectPropertiesFragment: GraphAPI.SelectionSet, Fragment {
   public static var fragmentDefinition: StaticString {
-    #"fragment ExtendedProjectPropertiesFragment on Project { __typename aiDisclosure { __typename id fundingForAiAttribution fundingForAiConsent fundingForAiOption generatedByAiConsent generatedByAiDetails involvesAi involvesFunding involvesGeneration involvesOther otherAiDetails } environmentalCommitments { __typename commitmentCategory description id } faqs { __typename nodes { __typename question answer id createdAt } } minPledge projectNotice risks story prelaunchStoryRichText { __typename ...RichTextComponentFragment } storyRichText { __typename ...RichTextComponentFragment } }"#
+    #"fragment ExtendedProjectPropertiesFragment on Project { __typename aiDisclosure { __typename id fundingForAiAttribution fundingForAiConsent fundingForAiOption generatedByAiConsent generatedByAiDetails involvesAi involvesFunding involvesGeneration involvesOther otherAiDetails } environmentalCommitments { __typename commitmentCategory description id } faqs { __typename nodes { __typename question answer id createdAt } } minPledge projectNotice risks story isLaunched prelaunchStoryRichText { __typename ...RichTextComponentFragment } storyRichText { __typename ...RichTextComponentFragment } }"#
   }
 
   public let __data: DataDict
@@ -21,6 +21,7 @@ public struct ExtendedProjectPropertiesFragment: GraphAPI.SelectionSet, Fragment
     .field("projectNotice", String?.self),
     .field("risks", String.self),
     .field("story", GraphAPI.HTML.self),
+    .field("isLaunched", Bool.self),
     .field("prelaunchStoryRichText", PrelaunchStoryRichText.self),
     .field("storyRichText", StoryRichText.self),
   ] }
@@ -38,6 +39,8 @@ public struct ExtendedProjectPropertiesFragment: GraphAPI.SelectionSet, Fragment
   public var risks: String { __data["risks"] }
   /// The story behind the project, parsed for presentation.
   public var story: GraphAPI.HTML { __data["story"] }
+  /// The project has launched
+  public var isLaunched: Bool { __data["isLaunched"] }
   /// Return an itemized version of the prelaunch story. This feature is in BETA: types can change anytime!
   public var prelaunchStoryRichText: PrelaunchStoryRichText { __data["prelaunchStoryRichText"] }
   /// Return an itemized version of the story. This feature is in BETA: types can change anytime!
@@ -51,6 +54,7 @@ public struct ExtendedProjectPropertiesFragment: GraphAPI.SelectionSet, Fragment
     projectNotice: String? = nil,
     risks: String,
     story: GraphAPI.HTML,
+    isLaunched: Bool,
     prelaunchStoryRichText: PrelaunchStoryRichText,
     storyRichText: StoryRichText
   ) {
@@ -64,6 +68,7 @@ public struct ExtendedProjectPropertiesFragment: GraphAPI.SelectionSet, Fragment
         "projectNotice": projectNotice,
         "risks": risks,
         "story": story,
+        "isLaunched": isLaunched,
         "prelaunchStoryRichText": prelaunchStoryRichText._fieldData,
         "storyRichText": storyRichText._fieldData,
       ],

--- a/GraphAPI/Sources/Operations/Queries/FastFetchProjectPageExtendedPropertiesQuery.graphql.swift
+++ b/GraphAPI/Sources/Operations/Queries/FastFetchProjectPageExtendedPropertiesQuery.graphql.swift
@@ -88,6 +88,8 @@ public class FastFetchProjectPageExtendedPropertiesQuery: GraphQLQuery {
       public var risks: String { __data["risks"] }
       /// The story behind the project, parsed for presentation.
       public var story: GraphAPI.HTML { __data["story"] }
+      /// Return an itemized version of the prelaunch story. This feature is in BETA: types can change anytime!
+      public var prelaunchStoryRichText: PrelaunchStoryRichText { __data["prelaunchStoryRichText"] }
       /// Return an itemized version of the story. This feature is in BETA: types can change anytime!
       public var storyRichText: StoryRichText { __data["storyRichText"] }
 
@@ -108,6 +110,7 @@ public class FastFetchProjectPageExtendedPropertiesQuery: GraphQLQuery {
         projectNotice: String? = nil,
         risks: String,
         story: GraphAPI.HTML,
+        prelaunchStoryRichText: PrelaunchStoryRichText,
         storyRichText: StoryRichText
       ) {
         self.init(_dataDict: DataDict(
@@ -122,6 +125,7 @@ public class FastFetchProjectPageExtendedPropertiesQuery: GraphQLQuery {
             "projectNotice": projectNotice,
             "risks": risks,
             "story": story,
+            "prelaunchStoryRichText": prelaunchStoryRichText._fieldData,
             "storyRichText": storyRichText._fieldData,
           ],
           fulfilledFragments: [
@@ -211,6 +215,43 @@ public class FastFetchProjectPageExtendedPropertiesQuery: GraphQLQuery {
       public typealias EnvironmentalCommitment = ExtendedProjectPropertiesFragment.EnvironmentalCommitment
 
       public typealias Faqs = ExtendedProjectPropertiesFragment.Faqs
+
+      /// Project.PrelaunchStoryRichText
+      ///
+      /// Parent Type: `RichTextComponent`
+      public struct PrelaunchStoryRichText: GraphAPI.SelectionSet {
+        public let __data: DataDict
+        public init(_dataDict: DataDict) { __data = _dataDict }
+
+        public static var __parentType: ApolloAPI.ParentType { GraphAPI.Objects.RichTextComponent }
+
+        public var items: [Item] { __data["items"] }
+
+        public struct Fragments: FragmentContainer {
+          public let __data: DataDict
+          public init(_dataDict: DataDict) { __data = _dataDict }
+
+          public var richTextComponentFragment: RichTextComponentFragment { _toFragment() }
+        }
+
+        public init(
+          items: [Item]
+        ) {
+          self.init(_dataDict: DataDict(
+            data: [
+              "__typename": GraphAPI.Objects.RichTextComponent.typename,
+              "items": items._fieldData,
+            ],
+            fulfilledFragments: [
+              ObjectIdentifier(FastFetchProjectPageExtendedPropertiesQuery.Data.Project.PrelaunchStoryRichText.self),
+              ObjectIdentifier(ExtendedProjectPropertiesFragment.PrelaunchStoryRichText.self),
+              ObjectIdentifier(RichTextComponentFragment.self)
+            ]
+          ))
+        }
+
+        public typealias Item = RichTextComponentFragment.Item
+      }
 
       /// Project.StoryRichText
       ///

--- a/GraphAPI/Sources/Operations/Queries/FastFetchProjectPageExtendedPropertiesQuery.graphql.swift
+++ b/GraphAPI/Sources/Operations/Queries/FastFetchProjectPageExtendedPropertiesQuery.graphql.swift
@@ -88,6 +88,8 @@ public class FastFetchProjectPageExtendedPropertiesQuery: GraphQLQuery {
       public var risks: String { __data["risks"] }
       /// The story behind the project, parsed for presentation.
       public var story: GraphAPI.HTML { __data["story"] }
+      /// The project has launched
+      public var isLaunched: Bool { __data["isLaunched"] }
       /// Return an itemized version of the prelaunch story. This feature is in BETA: types can change anytime!
       public var prelaunchStoryRichText: PrelaunchStoryRichText { __data["prelaunchStoryRichText"] }
       /// Return an itemized version of the story. This feature is in BETA: types can change anytime!
@@ -110,6 +112,7 @@ public class FastFetchProjectPageExtendedPropertiesQuery: GraphQLQuery {
         projectNotice: String? = nil,
         risks: String,
         story: GraphAPI.HTML,
+        isLaunched: Bool,
         prelaunchStoryRichText: PrelaunchStoryRichText,
         storyRichText: StoryRichText
       ) {
@@ -125,6 +128,7 @@ public class FastFetchProjectPageExtendedPropertiesQuery: GraphQLQuery {
             "projectNotice": projectNotice,
             "risks": risks,
             "story": story,
+            "isLaunched": isLaunched,
             "prelaunchStoryRichText": prelaunchStoryRichText._fieldData,
             "storyRichText": storyRichText._fieldData,
           ],

--- a/GraphAPI/Sources/Operations/Queries/FetchProjectByParamQuery.graphql.swift
+++ b/GraphAPI/Sources/Operations/Queries/FetchProjectByParamQuery.graphql.swift
@@ -182,6 +182,8 @@ public class FetchProjectByParamQuery: GraphQLQuery {
       public var risks: String { __data["risks"] }
       /// The story behind the project, parsed for presentation.
       public var story: GraphAPI.HTML { __data["story"] }
+      /// Return an itemized version of the prelaunch story. This feature is in BETA: types can change anytime!
+      public var prelaunchStoryRichText: PrelaunchStoryRichText { __data["prelaunchStoryRichText"] }
       /// Return an itemized version of the story. This feature is in BETA: types can change anytime!
       public var storyRichText: StoryRichText { __data["storyRichText"] }
 
@@ -253,6 +255,7 @@ public class FetchProjectByParamQuery: GraphQLQuery {
         projectNotice: String? = nil,
         risks: String,
         story: GraphAPI.HTML,
+        prelaunchStoryRichText: PrelaunchStoryRichText,
         storyRichText: StoryRichText
       ) {
         self.init(_dataDict: DataDict(
@@ -313,6 +316,7 @@ public class FetchProjectByParamQuery: GraphQLQuery {
             "projectNotice": projectNotice,
             "risks": risks,
             "story": story,
+            "prelaunchStoryRichText": prelaunchStoryRichText._fieldData,
             "storyRichText": storyRichText._fieldData,
           ],
           fulfilledFragments: [
@@ -877,6 +881,43 @@ public class FetchProjectByParamQuery: GraphQLQuery {
       public typealias EnvironmentalCommitment = ExtendedProjectPropertiesFragment.EnvironmentalCommitment
 
       public typealias Faqs = ExtendedProjectPropertiesFragment.Faqs
+
+      /// Project.PrelaunchStoryRichText
+      ///
+      /// Parent Type: `RichTextComponent`
+      public struct PrelaunchStoryRichText: GraphAPI.SelectionSet {
+        public let __data: DataDict
+        public init(_dataDict: DataDict) { __data = _dataDict }
+
+        public static var __parentType: ApolloAPI.ParentType { GraphAPI.Objects.RichTextComponent }
+
+        public var items: [Item] { __data["items"] }
+
+        public struct Fragments: FragmentContainer {
+          public let __data: DataDict
+          public init(_dataDict: DataDict) { __data = _dataDict }
+
+          public var richTextComponentFragment: RichTextComponentFragment { _toFragment() }
+        }
+
+        public init(
+          items: [Item]
+        ) {
+          self.init(_dataDict: DataDict(
+            data: [
+              "__typename": GraphAPI.Objects.RichTextComponent.typename,
+              "items": items._fieldData,
+            ],
+            fulfilledFragments: [
+              ObjectIdentifier(FetchProjectByParamQuery.Data.Project.PrelaunchStoryRichText.self),
+              ObjectIdentifier(ExtendedProjectPropertiesFragment.PrelaunchStoryRichText.self),
+              ObjectIdentifier(RichTextComponentFragment.self)
+            ]
+          ))
+        }
+
+        public typealias Item = RichTextComponentFragment.Item
+      }
 
       /// Project.StoryRichText
       ///

--- a/KsApi/Sources/KsApi/models/graphql/adapters/Project+ProjectFragment.swift
+++ b/KsApi/Sources/KsApi/models/graphql/adapters/Project+ProjectFragment.swift
@@ -275,7 +275,14 @@ internal extension ExtendedProjectProperties {
     let faqs = extendedProjectFAQs(from: fragment)
     let minimumSingleTierPledgeAmount = fragment.minPledge
     let aiDisclosure = extendedProjectAIDisclosure(from: fragment)
-    let storyRichTextFragment = fragment.storyRichText.fragments.richTextComponentFragment
+    let prelaunchStoryRichTextFragment = fragment.prelaunchStoryRichText.fragments.richTextComponentFragment
+    let liveStoryRichTextFragment = fragment.storyRichText.fragments.richTextComponentFragment
+
+    let storyRichTextFragment = if prelaunchStoryRichTextFragment.items.isEmpty {
+      liveStoryRichTextFragment
+    } else {
+      prelaunchStoryRichTextFragment
+    }
 
     let extendedProjectProperties = ExtendedProjectProperties(
       environmentalCommitments: environmentalCommitments,

--- a/KsApi/Sources/KsApi/models/graphql/adapters/Project+ProjectFragment.swift
+++ b/KsApi/Sources/KsApi/models/graphql/adapters/Project+ProjectFragment.swift
@@ -277,8 +277,9 @@ internal extension ExtendedProjectProperties {
     let aiDisclosure = extendedProjectAIDisclosure(from: fragment)
     let prelaunchStoryRichTextFragment = fragment.prelaunchStoryRichText.fragments.richTextComponentFragment
     let liveStoryRichTextFragment = fragment.storyRichText.fragments.richTextComponentFragment
+    let launched = fragment.isLaunched
 
-    let storyRichTextFragment = if prelaunchStoryRichTextFragment.items.isEmpty {
+    let storyRichTextFragment = if launched || prelaunchStoryRichTextFragment.items.isEmpty {
       liveStoryRichTextFragment
     } else {
       prelaunchStoryRichTextFragment

--- a/KsApi/Sources/KsApiTests/ProjectPageFetcherTests.swift
+++ b/KsApi/Sources/KsApiTests/ProjectPageFetcherTests.swift
@@ -288,6 +288,10 @@ private extension GraphAPI.FastFetchProjectPageExtendedPropertiesQuery.Data {
     mockExtraProperties.storyRichText?.items = [
       header
     ]
+    mockExtraProperties.prelaunchStoryRichText = Mock<GraphAPITestMocks.RichTextComponent>()
+    mockExtraProperties.prelaunchStoryRichText?.items = [
+      header
+    ]
 
     return GraphAPI.FastFetchProjectPageExtendedPropertiesQuery.Data(
       project: FastFetchProjectPageExtendedPropertiesQuery.Data.Project.from(mockExtraProperties)

--- a/KsApi/Sources/KsApiTests/ProjectPageFetcherTests.swift
+++ b/KsApi/Sources/KsApiTests/ProjectPageFetcherTests.swift
@@ -288,6 +288,7 @@ private extension GraphAPI.FastFetchProjectPageExtendedPropertiesQuery.Data {
     mockExtraProperties.storyRichText?.items = [
       header
     ]
+    mockExtraProperties.isLaunched = true
     mockExtraProperties.prelaunchStoryRichText = Mock<GraphAPITestMocks.RichTextComponent>()
     mockExtraProperties.prelaunchStoryRichText?.items = [
       header

--- a/KsApi/Sources/KsApiTests/models/graphql/adapters/Project+ProjectFragmentTests.swift
+++ b/KsApi/Sources/KsApiTests/models/graphql/adapters/Project+ProjectFragmentTests.swift
@@ -529,6 +529,10 @@ final class Project_ProjectFragmentTests: XCTestCase {
        },
       "watchesCount": 18,
       "isPledgeOverTimeAllowed": false,
+      "prelaunchStoryRichText": {
+        "__typename": "RichTextComponent",
+        "items": []
+      },
       "storyRichText": {
         "__typename": "RichTextComponent",
         "items": []

--- a/KsApi/Sources/KsApiTests/models/graphql/adapters/Project+ProjectFragmentTests.swift
+++ b/KsApi/Sources/KsApiTests/models/graphql/adapters/Project+ProjectFragmentTests.swift
@@ -529,6 +529,7 @@ final class Project_ProjectFragmentTests: XCTestCase {
        },
       "watchesCount": 18,
       "isPledgeOverTimeAllowed": false,
+      "isLaunched": true,
       "prelaunchStoryRichText": {
         "__typename": "RichTextComponent",
         "items": []

--- a/KsApi/Sources/KsApiTests/mutations/templates/query/FetchProjectQueryTemplate.swift
+++ b/KsApi/Sources/KsApiTests/mutations/templates/query/FetchProjectQueryTemplate.swift
@@ -288,6 +288,10 @@ public enum FetchProjectQueryTemplate {
     projectResultMap["faqs"] = updatedFaqs
     projectResultMap["environmentalCommitments"] = updatedEnvironmentalCommitments
     projectResultMap["creator"] = updatedCreatorResultMap
+    projectResultMap["prelaunchStoryRichText"] = [
+      "__typename": "RichTextComponent",
+      "items": [] as [[String: Any]]
+    ]
     projectResultMap["storyRichText"] = [
       "__typename": "RichTextComponent",
       "items": [] as [[String: Any]]

--- a/KsApi/Sources/KsApiTests/mutations/templates/query/FetchProjectQueryTemplate.swift
+++ b/KsApi/Sources/KsApiTests/mutations/templates/query/FetchProjectQueryTemplate.swift
@@ -288,6 +288,7 @@ public enum FetchProjectQueryTemplate {
     projectResultMap["faqs"] = updatedFaqs
     projectResultMap["environmentalCommitments"] = updatedEnvironmentalCommitments
     projectResultMap["creator"] = updatedCreatorResultMap
+    projectResultMap["isLaunched"] = true
     projectResultMap["prelaunchStoryRichText"] = [
       "__typename": "RichTextComponent",
       "items": [] as [[String: Any]]

--- a/KsApi/Sources/KsApiTests/queries/templates/ProjectPageFetcher/FetchProjectByParamQuery_Backing.json
+++ b/KsApi/Sources/KsApiTests/queries/templates/ProjectPageFetcher/FetchProjectByParamQuery_Backing.json
@@ -164,6 +164,10 @@
         }
       },
       "watchesCount": 0,
+      "prelaunchStoryRichText": {
+        "__typename": "RichTextComponent",
+        "items": []
+      },
       "storyRichText": {
         "__typename": "RichTextComponent",
         "items": []

--- a/KsApi/Sources/KsApiTests/queries/templates/ProjectPageFetcher/FetchProjectByParamQuery_Backing.json
+++ b/KsApi/Sources/KsApiTests/queries/templates/ProjectPageFetcher/FetchProjectByParamQuery_Backing.json
@@ -164,6 +164,7 @@
         }
       },
       "watchesCount": 0,
+      "isLaunched": true,
       "prelaunchStoryRichText": {
         "__typename": "RichTextComponent",
         "items": []

--- a/KsApi/Sources/KsApiTests/queries/templates/ProjectPageFetcher/FetchProjectByParamQuery_NoBacking.json
+++ b/KsApi/Sources/KsApiTests/queries/templates/ProjectPageFetcher/FetchProjectByParamQuery_NoBacking.json
@@ -160,6 +160,7 @@
         }
       },
       "watchesCount": 0,
+      "isLaunched": true,
       "prelaunchStoryRichText": {
         "__typename": "RichTextComponent",
         "items": []

--- a/KsApi/Sources/KsApiTests/queries/templates/ProjectPageFetcher/FetchProjectByParamQuery_NoBacking.json
+++ b/KsApi/Sources/KsApiTests/queries/templates/ProjectPageFetcher/FetchProjectByParamQuery_NoBacking.json
@@ -160,6 +160,10 @@
         }
       },
       "watchesCount": 0,
+      "prelaunchStoryRichText": {
+        "__typename": "RichTextComponent",
+        "items": []
+      },
       "storyRichText": {
         "__typename": "RichTextComponent",
         "items": []

--- a/Library/Sources/Library/Library/ViewModels/ProjectNavigationSelectorViewModel.swift
+++ b/Library/Sources/Library/Library/ViewModels/ProjectNavigationSelectorViewModel.swift
@@ -63,7 +63,11 @@ public final class ProjectNavigationSelectorViewModel: ProjectNavigationSelector
       guard let extendedProjectProperties = project.extendedProjectProperties,
             let displayPrelaunch = project.displayPrelaunch,
             !displayPrelaunch else {
-        return baseTabs
+        if featureProjectStoryRichTextEnabled() {
+          return baseTabs + [.campaign]
+        } else {
+          return baseTabs
+        }
       }
 
       let moreTabs: [NavigationSection] = [.campaign, .faq, .risks]

--- a/graphql/fragments/ExtendedProjectPropertiesFragment.graphql
+++ b/graphql/fragments/ExtendedProjectPropertiesFragment.graphql
@@ -29,6 +29,9 @@ fragment ExtendedProjectPropertiesFragment on Project {
   projectNotice
   risks
   story
+  prelaunchStoryRichText {
+    ...RichTextComponentFragment
+  }
   storyRichText {
     ...RichTextComponentFragment
   }

--- a/graphql/fragments/ExtendedProjectPropertiesFragment.graphql
+++ b/graphql/fragments/ExtendedProjectPropertiesFragment.graphql
@@ -29,6 +29,7 @@ fragment ExtendedProjectPropertiesFragment on Project {
   projectNotice
   risks
   story
+  isLaunched
   prelaunchStoryRichText {
     ...RichTextComponentFragment
   }


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Using the SDUI rich text code, we're adding prelaunch story to the project page.

# 🤔 Why

So people can see more about a project before it launches, and have more reason to be notified that it is available.

# 🛠 How

The GraphQL query was extended to request `prelaunchStoryRichText`, and we switch between the two based on which is showing.

# 👀 See

<img width="640" alt="image" src="https://github.com/user-attachments/assets/929b8256-de59-446f-a9b2-6bd9d21312ef" />
