### PR TITLE
Video Feed: Replace Private API Usage and Extract Audio Session Logic Into Its Own File

### DIFF
--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Controller/VideoFeedAudioController.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Controller/VideoFeedAudioController.swift
@@ -1,4 +1,6 @@
 import AVFoundation
+import MediaPlayer
+import UIKit
 
 protocol AudioSessionManaging: AnyObject {
   func setCategory(_ category: AVAudioSession.Category, mode: AVAudioSession.Mode) throws
@@ -33,11 +35,24 @@ final class LiveAudioSession: AudioSessionManaging {
 /// On iOS versions below 26, the session stays in `.playback` so that mute state is managed via the overlay button.
 final class VideoFeedAudioController {
   private let session: AudioSessionManaging
+
   private(set) var isPlaybackSessionActive = false
-  private(set) var isResettingAudioSession = false
+  private var isResettingAudioSession = false
+
+  private var volumeObservation: NSKeyValueObservation?
+  private var muteStateObserver: (any NSObjectProtocol)?
+
+  var onVolumeUpDetected: (() -> Void)?
 
   init(session: AudioSessionManaging = LiveAudioSession.shared) {
     self.session = session
+  }
+
+  deinit {
+    self.volumeObservation?.invalidate()
+    if let observer = self.muteStateObserver {
+      NotificationCenter.default.removeObserver(observer)
+    }
   }
 
   func configure() {
@@ -50,6 +65,40 @@ final class VideoFeedAudioController {
       try self.session.setActive(true)
     } catch {
       assertionFailure("VideoFeedAudioController: Failed to configure audio session: \(error)")
+    }
+  }
+
+  /// Sets up volume up detection and silent switch observation on iOS 26+.
+  /// `MPVolumeView` reroutes hardware volume buttons to media volume so `outputVolume` KVO fires in silent mode.
+  @available(iOS 26, *)
+  func setupObservers(in view: UIView) {
+    let volumeView = MPVolumeView(frame: .zero)
+    volumeView.alpha = 0.001
+    volumeView.isUserInteractionEnabled = false
+    volumeView.accessibilityElementsHidden = true
+    view.addSubview(volumeView)
+
+    self.volumeObservation = AVAudioSession.sharedInstance()
+      .observe(\.outputVolume, options: [.old, .new]) { [weak self] _, change in
+        guard let oldVolume = change.oldValue,
+              let newVolume = change.newValue,
+              newVolume > oldVolume else { return }
+
+        DispatchQueue.main.async { [weak self] in
+          guard let self else { return }
+          self.handleVolumeUp()
+          if self.isPlaybackSessionActive {
+            self.onVolumeUpDetected?()
+          }
+        }
+      }
+
+    self.muteStateObserver = NotificationCenter.default.addObserver(
+      forName: AVAudioSession.outputMuteStateChangeNotification,
+      object: nil,
+      queue: .main
+    ) { [weak self] _ in
+      self?.handleSilentSwitchChange()
     }
   }
 

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Controller/VideoFeedAudioController.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Controller/VideoFeedAudioController.swift
@@ -42,8 +42,7 @@ final class VideoFeedAudioController {
   private var volumeObservation: NSKeyValueObservation?
   private var muteStateObserver: (any NSObjectProtocol)?
 
-@available(iOS 26, *)
-var onVolumeUpDetected: (() -> Void)?
+  var onVolumeUpDetected: (() -> Void)?
 
   init(session: AudioSessionManaging = LiveAudioSession.shared) {
     self.session = session
@@ -119,6 +118,7 @@ var onVolumeUpDetected: (() -> Void)?
 
   /// Called when the overlay mute button is tapped and the result is unmuted.
   /// Switches to `.playback` so the overlay can override the silent switch.
+  @available(iOS 26, *)
   func handleOverlayUnmute() {
     self.activatePlayback()
   }

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Controller/VideoFeedAudioController.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Controller/VideoFeedAudioController.swift
@@ -1,0 +1,112 @@
+import AVFoundation
+
+protocol AudioSessionManaging: AnyObject {
+  func setCategory(_ category: AVAudioSession.Category, mode: AVAudioSession.Mode) throws
+  func setActive(_ active: Bool) throws
+  func setActive(_ active: Bool, options: AVAudioSession.SetActiveOptions) throws
+}
+
+final class LiveAudioSession: AudioSessionManaging {
+  static let shared = LiveAudioSession()
+
+  func setCategory(_ category: AVAudioSession.Category, mode: AVAudioSession.Mode) throws {
+    try AVAudioSession.sharedInstance().setCategory(category, mode: mode, options: [])
+  }
+
+  func setActive(_ active: Bool) throws {
+    try AVAudioSession.sharedInstance().setActive(active)
+  }
+
+  func setActive(_ active: Bool, options: AVAudioSession.SetActiveOptions) throws {
+    try AVAudioSession.sharedInstance().setActive(active, options: options)
+  }
+}
+
+// MARK: - Controller
+
+/// Manages the AVAudioSession state machine for the video feed.
+///
+/// On iOS 26+, the session starts in `.soloAmbient` so the physical silent switch is respected.
+/// When the user signals intent to hear audio (volume-up or the unmute overlay button), the session switches
+/// to `.playback` to bypass the physical switch.
+///
+/// On iOS versions below 26, the session stays in `.playback` so that mute state is managed via the overlay button.
+final class VideoFeedAudioController {
+  private let session: AudioSessionManaging
+  private(set) var isPlaybackSessionActive = false
+  private(set) var isResettingAudioSession = false
+
+  init(session: AudioSessionManaging = LiveAudioSession.shared) {
+    self.session = session
+  }
+
+  func configure() {
+    do {
+      if #available(iOS 26, *) {
+        try self.session.setCategory(.soloAmbient, mode: .default)
+      } else {
+        try self.session.setCategory(.playback, mode: .default)
+      }
+      try self.session.setActive(true)
+    } catch {
+      assertionFailure("VideoFeedAudioController: Failed to configure audio session: \(error)")
+    }
+  }
+
+  /// Called when a volume-up press is detected.
+  /// Switches to `.playback` to bypass the silent switch and marks the override as active.
+  func handleVolumeUp() {
+    guard !self.isResettingAudioSession else { return }
+
+    self.activatePlayback()
+  }
+
+  /// Called when `outputMuteStateChangeNotification` fires (physical silent switch toggled).
+  /// Resets the session to `.soloAmbient` so the switch takes effect.
+  func handleSilentSwitchChange() {
+    self.resetSession()
+  }
+
+  /// Called when the overlay mute button is tapped and the result is unmuted.
+  /// Switches to `.playback` so the overlay can override the silent switch.
+  func handleOverlayUnmute() {
+    self.activatePlayback()
+  }
+
+  /// Called when a new video is activated.
+  func handleNewVideoActivated() {
+    if self.isPlaybackSessionActive {
+      try? self.session.setCategory(.playback, mode: .default)
+      try? self.session.setActive(true)
+    } else {
+      self.resetSession()
+    }
+  }
+
+  /// Called on dismiss. Resets to `.soloAmbient` so the feed doesn't hold `.playback` after leaving.
+  func handleDismiss() {
+    try? self.session.setCategory(.soloAmbient, mode: .default)
+  }
+
+  // MARK: - Private
+
+  private func activatePlayback() {
+    try? self.session.setCategory(.playback, mode: .default)
+    try? self.session.setActive(true)
+
+    self.isPlaybackSessionActive = true
+  }
+
+  private func resetSession() {
+    self.isResettingAudioSession = true
+    self.isPlaybackSessionActive = false
+
+    try? self.session.setActive(false, options: .notifyOthersOnDeactivation)
+    try? self.session.setCategory(.soloAmbient, mode: .default)
+    try? self.session.setActive(true)
+
+    DispatchQueue.main.async {
+      self.isResettingAudioSession = false
+    }
+  }
+}

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Controller/VideoFeedAudioController.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Controller/VideoFeedAudioController.swift
@@ -42,7 +42,8 @@ final class VideoFeedAudioController {
   private var volumeObservation: NSKeyValueObservation?
   private var muteStateObserver: (any NSObjectProtocol)?
 
-  var onVolumeUpDetected: (() -> Void)?
+@available(iOS 26, *)
+var onVolumeUpDetected: (() -> Void)?
 
   init(session: AudioSessionManaging = LiveAudioSession.shared) {
     self.session = session

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Controller/VideoFeedViewController.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Controller/VideoFeedViewController.swift
@@ -15,6 +15,7 @@ import UIKit
 ///   - Playback only starts once a cell is fully settled (scroll has ended)
 ///   - Current cell audio plays until the next cell takes over
 ///   - Pauses video on background, resumes on foreground
+///   - On iOS 26+ we start audio in `.soloAmbient` so the silent switch is respected. But we still allow volume-up in silent mode to switch to `.playback` (unmute).
 final class VideoFeedViewController: UIViewController {
   private enum Constants {
     static let backgroundColor = KDS.Colors.Icon.dark.uiColor()
@@ -27,9 +28,9 @@ final class VideoFeedViewController: UIViewController {
   private var previewImagePrefetcher: ImagePrefetcher?
   private var isScrolling = false
   private var currentPageIndex: Int = 0
-
-  private var volumeObservation: NSKeyValueObservation?
   private var isResettingAudioSession = false
+  private var volumeObservation: NSKeyValueObservation?
+  private var isPlaybackSessionActive = false
 
   /// Called once the first batch of items has loaded and the feed is ready to present.
   var onReadyToPresent: (() -> Void)?
@@ -52,8 +53,11 @@ final class VideoFeedViewController: UIViewController {
     self.view.backgroundColor = Constants.backgroundColor
 
     self.configureAudioSession()
-    self.setupSilentModeOverride()
     self.observeAppLifecycle()
+
+    if #available(iOS 26, *) {
+      self.setupSilentModeOverride()
+    }
 
     self.setupCollectionView()
     self.bindViewModel()
@@ -101,10 +105,8 @@ final class VideoFeedViewController: UIViewController {
     self.navigationController?.setNavigationBarHidden(false, animated: animated)
     self.pauseVisibleCell()
 
-    /// Only reset on dismiss not when a modal (project page, login, etc.) is presented.
-    if self.isBeingDismissed {
-      self.volumeObservation?.invalidate()
-      self.volumeObservation = nil
+    /// Reset to .soloAmbient on dismiss so we don't hold .playback after leaving the feed.
+    if self.isBeingDismissed, #available(iOS 26, *) {
       try? AVAudioSession.sharedInstance().setCategory(.soloAmbient, mode: .default)
     }
   }
@@ -260,10 +262,15 @@ final class VideoFeedViewController: UIViewController {
 
   // MARK: - Audio session
 
-  /// Starts silent. Respects the physical silent switch via .soloAmbient.
+  /// On iOS 26+: starts in `.soloAmbient` so the silent switch is respected by default.
+  /// Otherwise we use `.playback` throughout.
   private func configureAudioSession() {
     do {
-      try AVAudioSession.sharedInstance().setCategory(.soloAmbient, mode: .default)
+      if #available(iOS 26, *) {
+        try AVAudioSession.sharedInstance().setCategory(.soloAmbient, mode: .default)
+      } else {
+        try AVAudioSession.sharedInstance().setCategory(.playback, mode: .default)
+      }
       try AVAudioSession.sharedInstance().setActive(true)
     } catch {
       #if DEBUG
@@ -274,17 +281,20 @@ final class VideoFeedViewController: UIViewController {
     }
   }
 
-  /// Detects a volume up press to unmute the feed when the silent switch is on.
-  /// In silent mode, volume buttons control ringer (not media) volume, so `outputVolume` KVO never fires.
-  /// We can use a `MPVolumeView` to reroute buttons to media volume, fixing this.  it's the only way iOS exposes this AFAIK.
-  /// On the first volume-up, switches to `.playback` to bypass the silent switch,.
+  /// Sets up silent switch support on iOS 26+ using public AVAudioSession APIs.
+  /// `MPVolumeView` reroutes volume buttons to media volume so `outputVolume` KVO fires in silent mode.
+  /// On volume-up switch to `.playback` to bypass the silent switch.
+  /// `outputMuteStateChangeNotification` used for detecting when the physical switch is toggled.
+  @available(iOS 26, *)
   private func setupSilentModeOverride() {
+    /// Reroutes hardware volume buttons from ringer to media volume so `outputVolume` KVO fires in silent mode.
     let volumeView = MPVolumeView(frame: .zero)
     volumeView.alpha = 0.001
     volumeView.isUserInteractionEnabled = false
     volumeView.accessibilityElementsHidden = true
     self.view.addSubview(volumeView)
 
+    /// Fires when the user presses volume-up to bypass the physical device's silent switch
     self.volumeObservation = AVAudioSession.sharedInstance()
       .observe(\.outputVolume, options: [.old, .new]) { [weak self] _, change in
         guard let oldVolume = change.oldValue,
@@ -297,19 +307,22 @@ final class VideoFeedViewController: UIViewController {
           try? AVAudioSession.sharedInstance().setCategory(.playback, mode: .default)
           try? AVAudioSession.sharedInstance().setActive(true)
 
+          self.isPlaybackSessionActive = true
           self.muteVisibleCells()
         }
       }
 
-    let silentSwitch = NotificationCenter.default.addObserver(
-      forName: Notification.Name("com.apple.springboard.ringerstate"),
+    /// Fires when the silent switch is toggled in either direction.
+    /// Reset to .soloAmbient so the switch state takes effect and clears the .playback override.
+    let muteStateObserver = NotificationCenter.default.addObserver(
+      forName: AVAudioSession.outputMuteStateChangeNotification,
       object: nil,
       queue: .main
     ) { [weak self] _ in
       self?.resetAudioSession()
     }
 
-    self.lifecycleObservers.append(silentSwitch)
+    self.lifecycleObservers.append(muteStateObserver)
   }
 
   // MARK: - App lifecycle
@@ -353,10 +366,12 @@ final class VideoFeedViewController: UIViewController {
     self.muteVisibleCells()
     self.reconfigureVisibleCell()
 
-    /// Switching to .playback when unmuting ensures audio isn't blocked by the silent switch.
-    if !self.viewModel.isMuted {
+    /// On iOS 26+: switching to .playback when unmuting ensures audio isn't blocked by the silent switch.
+    if #available(iOS 26, *), !self.viewModel.isMuted {
       try? AVAudioSession.sharedInstance().setCategory(.playback, mode: .default)
       try? AVAudioSession.sharedInstance().setActive(true)
+
+      self.isPlaybackSessionActive = true
     }
   }
 
@@ -537,9 +552,20 @@ extension VideoFeedViewController: UICollectionViewDelegateFlowLayout {
 
     for cell in self.collectionView.visibleCells.compactMap({ $0 as? VideoFeedCell }) {
       if self.collectionView.indexPath(for: cell) == activeIndexPath {
-        /// Reset the session before starting the new video so any prior volume-up override doesn't carry over.
-        self.resetAudioSession()
+        if #available(iOS 26, *) {
+          if self.isPlaybackSessionActive {
+            /// User explicitly activated .playback (via overlay or volume-up)
+            try? AVAudioSession.sharedInstance().setCategory(.playback, mode: .default)
+            try? AVAudioSession.sharedInstance().setActive(true)
+          } else {
+            /// No explicit override
+            /// reset to .soloAmbient so the silent switch is respected.
+            self.resetAudioSession()
+          }
+        }
+
         cell.startPlayback()
+        cell.mutePlayback(self.viewModel.isMuted)
       } else {
         cell.pausePlayback()
       }
@@ -547,9 +573,13 @@ extension VideoFeedViewController: UICollectionViewDelegateFlowLayout {
   }
 
   /// Resets the audio session to `.soloAmbient` so the silent switch is respected.
+  /// Deactivating first interrupts any in-flight audio that was playing under `.playback`.
+  /// The `isResettingAudioSession` flag blocks any  notification fires during the transition.
+  @available(iOS 26, *)
   private func resetAudioSession() {
     self.isResettingAudioSession = true
-    /// Deactivate first to interrupt any in-flight audio, then reactivate under .soloAmbient.
+    self.isPlaybackSessionActive = false
+
     try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
     try? AVAudioSession.sharedInstance().setCategory(.soloAmbient, mode: .default)
     try? AVAudioSession.sharedInstance().setActive(true)

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Controller/VideoFeedViewController.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Controller/VideoFeedViewController.swift
@@ -23,14 +23,14 @@ final class VideoFeedViewController: UIViewController {
 
   private let viewModel = VideoFeedViewModel()
   private let dataSource = VideoFeedDataSource()
+  private let audioController = VideoFeedAudioController()
 
   private var lifecycleObservers: [any NSObjectProtocol] = []
   private var previewImagePrefetcher: ImagePrefetcher?
   private var isScrolling = false
   private var currentPageIndex: Int = 0
-  private var isResettingAudioSession = false
+
   private var volumeObservation: NSKeyValueObservation?
-  private var isPlaybackSessionActive = false
 
   /// Called once the first batch of items has loaded and the feed is ready to present.
   var onReadyToPresent: (() -> Void)?
@@ -52,7 +52,7 @@ final class VideoFeedViewController: UIViewController {
 
     self.view.backgroundColor = Constants.backgroundColor
 
-    self.configureAudioSession()
+    self.audioController.configure()
     self.observeAppLifecycle()
 
     if #available(iOS 26, *) {
@@ -105,9 +105,8 @@ final class VideoFeedViewController: UIViewController {
     self.navigationController?.setNavigationBarHidden(false, animated: animated)
     self.pauseVisibleCell()
 
-    /// Reset to .soloAmbient on dismiss so we don't hold .playback after leaving the feed.
     if self.isBeingDismissed, #available(iOS 26, *) {
-      try? AVAudioSession.sharedInstance().setCategory(.soloAmbient, mode: .default)
+      self.audioController.handleDismiss()
     }
   }
 
@@ -262,29 +261,11 @@ final class VideoFeedViewController: UIViewController {
 
   // MARK: - Audio session
 
-  /// On iOS 26+: starts in `.soloAmbient` so the silent switch is respected by default.
-  /// Otherwise we use `.playback` throughout.
-  private func configureAudioSession() {
-    do {
-      if #available(iOS 26, *) {
-        try AVAudioSession.sharedInstance().setCategory(.soloAmbient, mode: .default)
-      } else {
-        try AVAudioSession.sharedInstance().setCategory(.playback, mode: .default)
-      }
-      try AVAudioSession.sharedInstance().setActive(true)
-    } catch {
-      #if DEBUG
-        print("`VideoFeedViewController`: Failed to configure audio session:", error.localizedDescription)
-      #endif
-
-      Crashlytics.crashlytics().record(error: error)
-    }
-  }
-
   /// Sets up silent switch support on iOS 26+ using public AVAudioSession APIs.
   /// `MPVolumeView` reroutes volume buttons to media volume so `outputVolume` KVO fires in silent mode.
-  /// On volume-up switch to `.playback` to bypass the silent switch.
-  /// `outputMuteStateChangeNotification` used for detecting when the physical switch is toggled.
+  /// On volume-up, switches to `.playback` to bypass the silent switch.
+  /// `outputMuteStateChangeNotification` replaces the rejected `com.apple.springboard.ringerstate` Darwin
+  /// notification for detecting when the physical switch is toggled.
   @available(iOS 26, *)
   private func setupSilentModeOverride() {
     /// Reroutes hardware volume buttons from ringer to media volume so `outputVolume` KVO fires in silent mode.
@@ -294,7 +275,8 @@ final class VideoFeedViewController: UIViewController {
     volumeView.accessibilityElementsHidden = true
     self.view.addSubview(volumeView)
 
-    /// Fires when the user presses volume-up to bypass the physical device's silent switch
+    /// Fires when the user presses volume-up. Switch to .playback to bypass the silent switch,
+    /// then re-apply the user's current mute preference.
     self.volumeObservation = AVAudioSession.sharedInstance()
       .observe(\.outputVolume, options: [.old, .new]) { [weak self] _, change in
         guard let oldVolume = change.oldValue,
@@ -302,24 +284,21 @@ final class VideoFeedViewController: UIViewController {
               newVolume > oldVolume else { return }
 
         DispatchQueue.main.async { [weak self] in
-          guard let self, !self.isResettingAudioSession else { return }
-
-          try? AVAudioSession.sharedInstance().setCategory(.playback, mode: .default)
-          try? AVAudioSession.sharedInstance().setActive(true)
-
-          self.isPlaybackSessionActive = true
+          guard let self else { return }
+          self.audioController.handleVolumeUp()
+          guard self.audioController.isPlaybackSessionActive else { return }
           self.muteVisibleCells()
         }
       }
 
     /// Fires when the silent switch is toggled in either direction.
-    /// Reset to .soloAmbient so the switch state takes effect and clears the .playback override.
+    /// Reset to .soloAmbient so the switch state takes effect and clear the .playback override.
     let muteStateObserver = NotificationCenter.default.addObserver(
       forName: AVAudioSession.outputMuteStateChangeNotification,
       object: nil,
       queue: .main
     ) { [weak self] _ in
-      self?.resetAudioSession()
+      self?.audioController.handleSilentSwitchChange()
     }
 
     self.lifecycleObservers.append(muteStateObserver)
@@ -367,11 +346,9 @@ final class VideoFeedViewController: UIViewController {
     self.reconfigureVisibleCell()
 
     /// On iOS 26+: switching to .playback when unmuting ensures audio isn't blocked by the silent switch.
+    /// On iOS < 26: already in .playback, nothing to switch.
     if #available(iOS 26, *), !self.viewModel.isMuted {
-      try? AVAudioSession.sharedInstance().setCategory(.playback, mode: .default)
-      try? AVAudioSession.sharedInstance().setActive(true)
-
-      self.isPlaybackSessionActive = true
+      self.audioController.handleOverlayUnmute()
     }
   }
 
@@ -553,39 +530,13 @@ extension VideoFeedViewController: UICollectionViewDelegateFlowLayout {
     for cell in self.collectionView.visibleCells.compactMap({ $0 as? VideoFeedCell }) {
       if self.collectionView.indexPath(for: cell) == activeIndexPath {
         if #available(iOS 26, *) {
-          if self.isPlaybackSessionActive {
-            /// User explicitly activated .playback (via overlay or volume-up)
-            try? AVAudioSession.sharedInstance().setCategory(.playback, mode: .default)
-            try? AVAudioSession.sharedInstance().setActive(true)
-          } else {
-            /// No explicit override
-            /// reset to .soloAmbient so the silent switch is respected.
-            self.resetAudioSession()
-          }
+          self.audioController.handleNewVideoActivated()
         }
-
         cell.startPlayback()
         cell.mutePlayback(self.viewModel.isMuted)
       } else {
         cell.pausePlayback()
       }
-    }
-  }
-
-  /// Resets the audio session to `.soloAmbient` so the silent switch is respected.
-  /// Deactivating first interrupts any in-flight audio that was playing under `.playback`.
-  /// The `isResettingAudioSession` flag blocks any  notification fires during the transition.
-  @available(iOS 26, *)
-  private func resetAudioSession() {
-    self.isResettingAudioSession = true
-    self.isPlaybackSessionActive = false
-
-    try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
-    try? AVAudioSession.sharedInstance().setCategory(.soloAmbient, mode: .default)
-    try? AVAudioSession.sharedInstance().setActive(true)
-
-    DispatchQueue.main.async {
-      self.isResettingAudioSession = false
     }
   }
 

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Controller/VideoFeedViewController.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Controller/VideoFeedViewController.swift
@@ -1,10 +1,8 @@
-import AVFoundation
 import FirebaseCrashlytics
 import KDS
 import Kingfisher
 import KsApi
 import Library
-import MediaPlayer
 import SwiftUI
 import UIKit
 
@@ -15,7 +13,7 @@ import UIKit
 ///   - Playback only starts once a cell is fully settled (scroll has ended)
 ///   - Current cell audio plays until the next cell takes over
 ///   - Pauses video on background, resumes on foreground
-///   - On iOS 26+ we start audio in `.soloAmbient` so the silent switch is respected. But we still allow volume-up in silent mode to switch to `.playback` (unmute).
+///   - Audio session managed by `VideoFeedAudioController`.
 final class VideoFeedViewController: UIViewController {
   private enum Constants {
     static let backgroundColor = KDS.Colors.Icon.dark.uiColor()
@@ -29,8 +27,6 @@ final class VideoFeedViewController: UIViewController {
   private var previewImagePrefetcher: ImagePrefetcher?
   private var isScrolling = false
   private var currentPageIndex: Int = 0
-
-  private var volumeObservation: NSKeyValueObservation?
 
   /// Called once the first batch of items has loaded and the feed is ready to present.
   var onReadyToPresent: (() -> Void)?
@@ -56,7 +52,10 @@ final class VideoFeedViewController: UIViewController {
     self.observeAppLifecycle()
 
     if #available(iOS 26, *) {
-      self.setupSilentModeOverride()
+      self.audioController.onVolumeUpDetected = { [weak self] in
+        self?.muteVisibleCells()
+      }
+      self.audioController.setupObservers(in: self.view)
     }
 
     self.setupCollectionView()
@@ -70,7 +69,6 @@ final class VideoFeedViewController: UIViewController {
 
   deinit {
     self.lifecycleObservers.forEach(NotificationCenter.default.removeObserver)
-    self.volumeObservation?.invalidate()
   }
 
   public override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
@@ -257,51 +255,6 @@ final class VideoFeedViewController: UIViewController {
     let currentPage = round(self.collectionView.contentOffset.y / pageHeight)
 
     self.collectionView.contentOffset.y = currentPage * pageHeight
-  }
-
-  // MARK: - Audio session
-
-  /// Sets up silent switch support on iOS 26+ using public AVAudioSession APIs.
-  /// `MPVolumeView` reroutes volume buttons to media volume so `outputVolume` KVO fires in silent mode.
-  /// On volume-up, switches to `.playback` to bypass the silent switch.
-  /// `outputMuteStateChangeNotification` replaces the rejected `com.apple.springboard.ringerstate` Darwin
-  /// notification for detecting when the physical switch is toggled.
-  @available(iOS 26, *)
-  private func setupSilentModeOverride() {
-    /// Reroutes hardware volume buttons from ringer to media volume so `outputVolume` KVO fires in silent mode.
-    let volumeView = MPVolumeView(frame: .zero)
-    volumeView.alpha = 0.001
-    volumeView.isUserInteractionEnabled = false
-    volumeView.accessibilityElementsHidden = true
-    self.view.addSubview(volumeView)
-
-    /// Fires when the user presses volume-up. Switch to .playback to bypass the silent switch,
-    /// then re-apply the user's current mute preference.
-    self.volumeObservation = AVAudioSession.sharedInstance()
-      .observe(\.outputVolume, options: [.old, .new]) { [weak self] _, change in
-        guard let oldVolume = change.oldValue,
-              let newVolume = change.newValue,
-              newVolume > oldVolume else { return }
-
-        DispatchQueue.main.async { [weak self] in
-          guard let self else { return }
-          self.audioController.handleVolumeUp()
-          guard self.audioController.isPlaybackSessionActive else { return }
-          self.muteVisibleCells()
-        }
-      }
-
-    /// Fires when the silent switch is toggled in either direction.
-    /// Reset to .soloAmbient so the switch state takes effect and clear the .playback override.
-    let muteStateObserver = NotificationCenter.default.addObserver(
-      forName: AVAudioSession.outputMuteStateChangeNotification,
-      object: nil,
-      queue: .main
-    ) { [weak self] _ in
-      self?.audioController.handleSilentSwitchChange()
-    }
-
-    self.lifecycleObservers.append(muteStateObserver)
   }
 
   // MARK: - App lifecycle

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		39AE63502F6C581D00481A76 /* GraphAPITestMocks in Frameworks */ = {isa = PBXBuildFile; productRef = 39AE634F2F6C581D00481A76 /* GraphAPITestMocks */; };
 		600944E42E5CB3A7004A089F /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 600944E22E5CB3A7004A089F /* InfoPlist.strings */; };
 		60253C0F2FA0F677008E30A6 /* VideoFeedViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60253C0E2FA0F677008E30A6 /* VideoFeedViewModelTests.swift */; };
+		6049E67D303C9B48004A9B79 /* VideoFeedAudioControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6049E67C303C9B48004A9B79 /* VideoFeedAudioControllerTests.swift */; };
 		6069CC542F5F66160029A67F /* Statsig in Frameworks */ = {isa = PBXBuildFile; productRef = 6069CC532F5F66160029A67F /* Statsig */; };
 		60A776A83020EFD80063D0A3 /* ReportProjectInfoViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60A776A73020EFD80063D0A3 /* ReportProjectInfoViewModelTests.swift */; };
 		60A80F532BD7F9A00052A829 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 60A80F522BD7F9A00052A829 /* PrivacyInfo.xcprivacy */; };
@@ -390,6 +391,7 @@
 		600944E82E5CB3D8004A089F /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		60253C0D2FA0EF59008E30A6 /* VideoFeedQuery.graphql */ = {isa = PBXFileReference; lastKnownFileType = text; path = VideoFeedQuery.graphql; sourceTree = "<group>"; };
 		60253C0E2FA0F677008E30A6 /* VideoFeedViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoFeedViewModelTests.swift; sourceTree = "<group>"; };
+		6049E67C303C9B48004A9B79 /* VideoFeedAudioControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoFeedAudioControllerTests.swift; sourceTree = "<group>"; };
 		60A776A6301938EE0063D0A3 /* FlaggingOptionsQuery.graphql */ = {isa = PBXFileReference; lastKnownFileType = text; path = FlaggingOptionsQuery.graphql; sourceTree = "<group>"; };
 		60A776A73020EFD80063D0A3 /* ReportProjectInfoViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportProjectInfoViewModelTests.swift; sourceTree = "<group>"; };
 		60A80F522BD7F9A00052A829 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
@@ -1227,6 +1229,7 @@
 				AAF548CE2F2445C0001DB5AC /* UIViewController+URLTests.swift */,
 				AAF548CF2F2445C0001DB5AC /* UpdateActivityItemProviderTests.swift */,
 				AAF548D02F2445C0001DB5AC /* UpdateBackingInput+ConstructorTests.swift */,
+				6049E67C303C9B48004A9B79 /* VideoFeedAudioControllerTests.swift */,
 				60A776A73020EFD80063D0A3 /* ReportProjectInfoViewModelTests.swift */,
 			);
 			path = Library;
@@ -1863,6 +1866,7 @@
 				AAF549732F2445C0001DB5AC /* SettingsRecommendationsCellViewModelTests.swift in Sources */,
 				AAF549742F2445C0001DB5AC /* ShareViewModelTests.swift in Sources */,
 				E1BBB0482FDB0F3C0045D296 /* NoRewardInserterTests.swift in Sources */,
+				6049E67D303C9B48004A9B79 /* VideoFeedAudioControllerTests.swift in Sources */,
 				AAF549762F2445C0001DB5AC /* SortPagerViewModelTests.swift in Sources */,
 				AAF549772F2445C0001DB5AC /* ThanksCategoryCellViewModelTests.swift in Sources */,
 				AAF549782F2445C0001DB5AC /* ThanksViewModelTests.swift in Sources */,

--- a/Library/Sources/Library/Library/VideoFeedAudioController.swift
+++ b/Library/Sources/Library/Library/VideoFeedAudioController.swift
@@ -1,0 +1,112 @@
+import AVFoundation
+
+protocol AudioSessionManaging: AnyObject {
+  func setCategory(_ category: AVAudioSession.Category, mode: AVAudioSession.Mode) throws
+  func setActive(_ active: Bool) throws
+  func setActive(_ active: Bool, options: AVAudioSession.SetActiveOptions) throws
+}
+
+final class LiveAudioSession: AudioSessionManaging {
+  static let shared = LiveAudioSession()
+
+  func setCategory(_ category: AVAudioSession.Category, mode: AVAudioSession.Mode) throws {
+    try AVAudioSession.sharedInstance().setCategory(category, mode: mode, options: [])
+  }
+
+  func setActive(_ active: Bool) throws {
+    try AVAudioSession.sharedInstance().setActive(active)
+  }
+
+  func setActive(_ active: Bool, options: AVAudioSession.SetActiveOptions) throws {
+    try AVAudioSession.sharedInstance().setActive(active, options: options)
+  }
+}
+
+// MARK: - Controller
+
+/// Manages the AVAudioSession state machine for the video feed.
+///
+/// On iOS 26+, the session starts in `.soloAmbient` so the physical silent switch is respected.
+/// When the user signals intent to hear audio (volume-up or the unmute overlay button), the session switches
+/// to `.playback` to bypass the physical switch.
+///
+/// On iOS versions below 26, the session stays in `.playback` so that mute state is managed via the overlay button.
+final class VideoFeedAudioController {
+  private let session: AudioSessionManaging
+  private(set) var isPlaybackSessionActive = false
+  private(set) var isResettingAudioSession = false
+
+  init(session: AudioSessionManaging = LiveAudioSession.shared) {
+    self.session = session
+  }
+
+  func configure() {
+    do {
+      if #available(iOS 26, *) {
+        try self.session.setCategory(.soloAmbient, mode: .default)
+      } else {
+        try self.session.setCategory(.playback, mode: .default)
+      }
+      try self.session.setActive(true)
+    } catch {
+      assertionFailure("VideoFeedAudioController: Failed to configure audio session: \(error)")
+    }
+  }
+
+  /// Called when a volume-up press is detected.
+  /// Switches to `.playback` to bypass the silent switch and marks the override as active.
+  func handleVolumeUp() {
+    guard !self.isResettingAudioSession else { return }
+
+    self.activatePlayback()
+  }
+
+  /// Called when `outputMuteStateChangeNotification` fires (physical silent switch toggled).
+  /// Resets the session to `.soloAmbient` so the switch takes effect.
+  func handleSilentSwitchChange() {
+    self.resetSession()
+  }
+
+  /// Called when the overlay mute button is tapped and the result is unmuted.
+  /// Switches to `.playback` so the overlay can override the silent switch.
+  func handleOverlayUnmute() {
+    self.activatePlayback()
+  }
+
+  /// Called when a new video is activated.
+  func handleNewVideoActivated() {
+    if self.isPlaybackSessionActive {
+      try? self.session.setCategory(.playback, mode: .default)
+      try? self.session.setActive(true)
+    } else {
+      self.resetSession()
+    }
+  }
+
+  /// Called on dismiss. Resets to `.soloAmbient` so the feed doesn't hold `.playback` after leaving.
+  func handleDismiss() {
+    try? self.session.setCategory(.soloAmbient, mode: .default)
+  }
+
+  // MARK: - Private
+
+  private func activatePlayback() {
+    try? self.session.setCategory(.playback, mode: .default)
+    try? self.session.setActive(true)
+
+    self.isPlaybackSessionActive = true
+  }
+
+  private func resetSession() {
+    self.isResettingAudioSession = true
+    self.isPlaybackSessionActive = false
+
+    try? self.session.setActive(false, options: .notifyOthersOnDeactivation)
+    try? self.session.setCategory(.soloAmbient, mode: .default)
+    try? self.session.setActive(true)
+
+    DispatchQueue.main.async {
+      self.isResettingAudioSession = false
+    }
+  }
+}

--- a/LibraryTests/Library/VideoFeedAudioControllerTests.swift
+++ b/LibraryTests/Library/VideoFeedAudioControllerTests.swift
@@ -1,8 +1,7 @@
+import AVFoundation
 @testable import Library
 @testable import LibraryTestHelpers
-import AVFoundation
 import XCTest
-
 
 final class MockAudioSession: AudioSessionManaging {
   private(set) var categories: [AVAudioSession.Category] = []
@@ -10,7 +9,7 @@ final class MockAudioSession: AudioSessionManaging {
 
   var lastCategory: AVAudioSession.Category? { self.categories.last }
 
-  func setCategory(_ category: AVAudioSession.Category, mode: AVAudioSession.Mode) throws {
+  func setCategory(_ category: AVAudioSession.Category, mode _: AVAudioSession.Mode) throws {
     self.categories.append(category)
   }
 
@@ -24,22 +23,20 @@ final class MockAudioSession: AudioSessionManaging {
 }
 
 final class VideoFeedAudioControllerTests: TestCase {
-
   func testConfigure() {
-      let mock = MockAudioSession()
-      let controller = VideoFeedAudioController(session: mock)
-   
-      controller.configure()
-   
-      if #available(iOS 26, *) {
-        XCTAssertEqual(mock.lastCategory, .soloAmbient)
-      } else {
-        XCTAssertEqual(mock.lastCategory, .playback)
-      }
-    
-      XCTAssertEqual(mock.activeStates.last, true)
+    let mock = MockAudioSession()
+    let controller = VideoFeedAudioController(session: mock)
+
+    controller.configure()
+
+    if #available(iOS 26, *) {
+      XCTAssertEqual(mock.lastCategory, .soloAmbient)
+    } else {
+      XCTAssertEqual(mock.lastCategory, .playback)
     }
 
+    XCTAssertEqual(mock.activeStates.last, true)
+  }
 
   func testVolumeUp_SwitchesToPlaybackAndSetsFlag() {
     let mock = MockAudioSession()
@@ -56,7 +53,7 @@ final class VideoFeedAudioControllerTests: TestCase {
     let controller = VideoFeedAudioController(session: mock)
 
     controller.handleSilentSwitchChange()
-    
+
     let categoryAfterReset = mock.lastCategory
 
     controller.handleVolumeUp()

--- a/LibraryTests/Library/VideoFeedAudioControllerTests.swift
+++ b/LibraryTests/Library/VideoFeedAudioControllerTests.swift
@@ -1,0 +1,109 @@
+@testable import Library
+@testable import LibraryTestHelpers
+import AVFoundation
+import XCTest
+
+
+final class MockAudioSession: AudioSessionManaging {
+  private(set) var categories: [AVAudioSession.Category] = []
+  private(set) var activeStates: [Bool] = []
+
+  var lastCategory: AVAudioSession.Category? { self.categories.last }
+
+  func setCategory(_ category: AVAudioSession.Category, mode: AVAudioSession.Mode) throws {
+    self.categories.append(category)
+  }
+
+  func setActive(_ active: Bool) throws {
+    self.activeStates.append(active)
+  }
+
+  func setActive(_ active: Bool, options _: AVAudioSession.SetActiveOptions) throws {
+    self.activeStates.append(active)
+  }
+}
+
+final class VideoFeedAudioControllerTests: TestCase {
+
+  func testConfigure() {
+      let mock = MockAudioSession()
+      let controller = VideoFeedAudioController(session: mock)
+   
+      controller.configure()
+   
+      if #available(iOS 26, *) {
+        XCTAssertEqual(mock.lastCategory, .soloAmbient)
+      } else {
+        XCTAssertEqual(mock.lastCategory, .playback)
+      }
+    
+      XCTAssertEqual(mock.activeStates.last, true)
+    }
+
+
+  func testVolumeUp_SwitchesToPlaybackAndSetsFlag() {
+    let mock = MockAudioSession()
+    let controller = VideoFeedAudioController(session: mock)
+
+    controller.handleVolumeUp()
+
+    XCTAssertEqual(mock.lastCategory, .playback)
+    XCTAssertTrue(controller.isPlaybackSessionActive)
+  }
+
+  func testVolumeUp_IsBlockedDuringSessionReset() {
+    let mock = MockAudioSession()
+    let controller = VideoFeedAudioController(session: mock)
+
+    controller.handleSilentSwitchChange()
+    
+    let categoryAfterReset = mock.lastCategory
+
+    controller.handleVolumeUp()
+
+    XCTAssertEqual(mock.lastCategory, categoryAfterReset)
+    XCTAssertFalse(controller.isPlaybackSessionActive)
+  }
+
+  func testSilentSwitch_ResetsTSoloAmbient() {
+    let mock = MockAudioSession()
+    let controller = VideoFeedAudioController(session: mock)
+
+    controller.handleVolumeUp() /// puts us in .playback
+    controller.handleSilentSwitchChange()
+
+    XCTAssertEqual(mock.lastCategory, .soloAmbient)
+  }
+
+  func testSilentSwitch_ClearsPlaybackFlag() {
+    let mock = MockAudioSession()
+    let controller = VideoFeedAudioController(session: mock)
+
+    controller.handleVolumeUp()
+    XCTAssertTrue(controller.isPlaybackSessionActive)
+
+    controller.handleSilentSwitchChange()
+
+    XCTAssertFalse(controller.isPlaybackSessionActive)
+  }
+
+  func testOverlayUnmute_SwitchesToPlayback() {
+    let mock = MockAudioSession()
+    let controller = VideoFeedAudioController(session: mock)
+
+    controller.handleOverlayUnmute()
+
+    XCTAssertEqual(mock.lastCategory, .playback)
+    XCTAssertTrue(controller.isPlaybackSessionActive)
+  }
+
+  func testDismiss_ResetsTSoloAmbient() {
+    let mock = MockAudioSession()
+    let controller = VideoFeedAudioController(session: mock)
+
+    controller.handleVolumeUp()
+    controller.handleDismiss()
+
+    XCTAssertEqual(mock.lastCategory, .soloAmbient)
+  }
+}


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What
Replaces the rejected `com.apple.springboard.ringerstate` Darwin notification with a first party
[`AVAudioSession` API](https://developer.apple.com/documentation/avfaudio/avaudiosession/userintenttounmuteoutputnotification)
and cleans things up to extract audio session logic into a new `VideoFeedAudioController` with tests

# 🤔 Why
Apple rejected the previous release because `com.apple.springboard.ringerstate` is a non-public API.

# 🛠 How

**Replacing the private API**

On iOS 26+, we can  replace the `ringerstate` implementation for detecting physical silent switch toggle with the `outputMuteStateChangeNotification`.  Since this is only available in 26+ it's gated behind #available

**Extracting audio logic**

- a new `VideoFeedAudioController` owns the full audio session state. 
- `AudioSessionManaging` is a protocol that abstracts `AVAudioSession` so its easier to mock and test

`VideoFeedViewController` now delegates all session work to the controller via these handler methods
(`handleVolumeUp`, `handleSilentSwitchChange`, `handleOverlayUnmute`, `handleNewVideoActivated`,
`handleDismiss`).

# ✅ Acceptance criteria

- [x] Feed opens in silent mode: no audio
- [x] Volume up while silent: audio plays
- [x] Scroll to a new video in silent mode: audio stays silent
- [x] Volume up on the new video: audio plays
- [x] Overlay mute button mutes and unmutes still
- [x] After a volume up or overlay unmute, scrolling to the next video carries that audio state forward
