### PR TITLE
CHECK-400: Add fast fetch for reward add-ons

### DIFF
--- a/GraphAPI/GraphAPITestMocks/Query+Mock.graphql.swift
+++ b/GraphAPI/GraphAPITestMocks/Query+Mock.graphql.swift
@@ -21,6 +21,7 @@ public class Query: MockObject {
     @Field<Postable>("post") public var post
     @Field<Project>("project") public var project
     @Field<ProjectsConnectionWithTotalCount>("projects") public var projects
+    @Field<Reward>("reward") public var reward
     @Field<[Category]>("rootCategories") public var rootCategories
     @Field<VideoFeedConnection>("videoFeed") public var videoFeed
   }
@@ -39,6 +40,7 @@ public extension Mock where O == Query {
     post: AnyMock? = nil,
     project: Mock<Project>? = nil,
     projects: Mock<ProjectsConnectionWithTotalCount>? = nil,
+    reward: Mock<Reward>? = nil,
     rootCategories: [Mock<Category>]? = nil,
     videoFeed: Mock<VideoFeedConnection>? = nil
   ) {
@@ -54,6 +56,7 @@ public extension Mock where O == Query {
     _setEntity(post, for: \.post)
     _setEntity(project, for: \.project)
     _setEntity(projects, for: \.projects)
+    _setEntity(reward, for: \.reward)
     _setList(rootCategories, for: \.rootCategories)
     _setEntity(videoFeed, for: \.videoFeed)
   }

--- a/GraphAPI/GraphAPITestMocks/Reward+Mock.graphql.swift
+++ b/GraphAPI/GraphAPITestMocks/Reward+Mock.graphql.swift
@@ -18,6 +18,7 @@ public class Reward: MockObject {
     @Field<Money>("convertedAmount") public var convertedAmount
     @Field<String>("description") public var description
     @Field<String>("displayName") public var displayName
+    @Field<RewardConnection>("displayableAddons") public var displayableAddons
     @Field<GraphAPI.DateTime>("endsAt") public var endsAt
     @Field<GraphAPI.Date>("estimatedDeliveryOn") public var estimatedDeliveryOn
     @Field<Bool>("featured") public var featured
@@ -34,6 +35,7 @@ public class Reward: MockObject {
     @Field<Bool>("postCampaignPledgingEnabled") public var postCampaignPledgingEnabled
     @Field<Project>("project") public var project
     @Field<Int>("remainingQuantity") public var remainingQuantity
+    @Field<ShippingForLocation>("shippingForLocation") public var shippingForLocation
     @Field<GraphQLEnum<GraphAPI.ShippingPreference>>("shippingPreference") public var shippingPreference
     @Field<RewardShippingRulesConnection>("shippingRulesExpanded") public var shippingRulesExpanded
     @Field<String>("shippingSummary") public var shippingSummary
@@ -52,6 +54,7 @@ public extension Mock where O == Reward {
     convertedAmount: Mock<Money>? = nil,
     description: String? = nil,
     displayName: String? = nil,
+    displayableAddons: Mock<RewardConnection>? = nil,
     endsAt: GraphAPI.DateTime? = nil,
     estimatedDeliveryOn: GraphAPI.Date? = nil,
     featured: Bool? = nil,
@@ -68,6 +71,7 @@ public extension Mock where O == Reward {
     postCampaignPledgingEnabled: Bool? = nil,
     project: Mock<Project>? = nil,
     remainingQuantity: Int? = nil,
+    shippingForLocation: Mock<ShippingForLocation>? = nil,
     shippingPreference: GraphQLEnum<GraphAPI.ShippingPreference>? = nil,
     shippingRulesExpanded: Mock<RewardShippingRulesConnection>? = nil,
     shippingSummary: String? = nil,
@@ -83,6 +87,7 @@ public extension Mock where O == Reward {
     _setEntity(convertedAmount, for: \.convertedAmount)
     _setScalar(description, for: \.description)
     _setScalar(displayName, for: \.displayName)
+    _setEntity(displayableAddons, for: \.displayableAddons)
     _setScalar(endsAt, for: \.endsAt)
     _setScalar(estimatedDeliveryOn, for: \.estimatedDeliveryOn)
     _setScalar(featured, for: \.featured)
@@ -99,6 +104,7 @@ public extension Mock where O == Reward {
     _setScalar(postCampaignPledgingEnabled, for: \.postCampaignPledgingEnabled)
     _setEntity(project, for: \.project)
     _setScalar(remainingQuantity, for: \.remainingQuantity)
+    _setEntity(shippingForLocation, for: \.shippingForLocation)
     _setScalar(shippingPreference, for: \.shippingPreference)
     _setEntity(shippingRulesExpanded, for: \.shippingRulesExpanded)
     _setScalar(shippingSummary, for: \.shippingSummary)

--- a/GraphAPI/GraphAPITestMocks/RewardConnection+Mock.graphql.swift
+++ b/GraphAPI/GraphAPITestMocks/RewardConnection+Mock.graphql.swift
@@ -10,15 +10,18 @@ public class RewardConnection: MockObject {
   public typealias MockValueCollectionType = Array<Mock<RewardConnection>>
 
   public struct MockFields {
+    @Field<[Reward?]>("nodes") public var nodes
     @Field<PageInfo>("pageInfo") public var pageInfo
   }
 }
 
 public extension Mock where O == RewardConnection {
   convenience init(
+    nodes: [Mock<Reward>?]? = nil,
     pageInfo: Mock<PageInfo>? = nil
   ) {
     self.init()
+    _setList(nodes, for: \.nodes)
     _setEntity(pageInfo, for: \.pageInfo)
   }
 }

--- a/GraphAPI/GraphAPITestMocks/ShippingForLocation+Mock.graphql.swift
+++ b/GraphAPI/GraphAPITestMocks/ShippingForLocation+Mock.graphql.swift
@@ -1,0 +1,24 @@
+// @generated
+// This file was automatically generated and should not be edited.
+
+import ApolloTestSupport
+import GraphAPI
+
+public class ShippingForLocation: MockObject {
+  public static let objectType: ApolloAPI.Object = GraphAPI.Objects.ShippingForLocation
+  public static let _mockFields = MockFields()
+  public typealias MockValueCollectionType = Array<Mock<ShippingForLocation>>
+
+  public struct MockFields {
+    @Field<SimpleShippingRule>("shippingRule") public var shippingRule
+  }
+}
+
+public extension Mock where O == ShippingForLocation {
+  convenience init(
+    shippingRule: Mock<SimpleShippingRule>? = nil
+  ) {
+    self.init()
+    _setEntity(shippingRule, for: \.shippingRule)
+  }
+}

--- a/GraphAPI/Sources/Operations/Queries/FastFetchAddOnsQuery.graphql.swift
+++ b/GraphAPI/Sources/Operations/Queries/FastFetchAddOnsQuery.graphql.swift
@@ -1,0 +1,598 @@
+// @generated
+// This file was automatically generated and should not be edited.
+
+@_exported import ApolloAPI
+
+public class FastFetchAddOnsQuery: GraphQLQuery {
+  public static let operationName: String = "FastFetchAddOns"
+  public static let operationDocument: ApolloAPI.OperationDocument = .init(
+    definition: .init(
+      #"query FastFetchAddOns($baseRewardId: ID!, $country: CountryCode!) { reward(id: $baseRewardId) { __typename displayableAddons { __typename nodes { __typename ...RewardFragment ...RewardImageFragment ...RewardItemsFragment shippingForLocation(countryCode: $country) { __typename shippingRule { __typename ...SimpleShippingRuleFragment } } } } } }"#,
+      fragments: [LocationFragment.self, MoneyFragment.self, RewardFragment.self, RewardImageFragment.self, RewardItemsFragment.self, SimpleShippingRuleFragment.self]
+    ))
+
+  public var baseRewardId: ID
+  public var country: GraphQLEnum<CountryCode>
+
+  public init(
+    baseRewardId: ID,
+    country: GraphQLEnum<CountryCode>
+  ) {
+    self.baseRewardId = baseRewardId
+    self.country = country
+  }
+
+  public var __variables: Variables? { [
+    "baseRewardId": baseRewardId,
+    "country": country
+  ] }
+
+  public struct Data: GraphAPI.SelectionSet {
+    public let __data: DataDict
+    public init(_dataDict: DataDict) { __data = _dataDict }
+
+    public static var __parentType: ApolloAPI.ParentType { GraphAPI.Objects.Query }
+    public static var __selections: [ApolloAPI.Selection] { [
+      .field("reward", Reward?.self, arguments: ["id": .variable("baseRewardId")]),
+    ] }
+
+    public var reward: Reward? { __data["reward"] }
+
+    public init(
+      reward: Reward? = nil
+    ) {
+      self.init(_dataDict: DataDict(
+        data: [
+          "__typename": GraphAPI.Objects.Query.typename,
+          "reward": reward._fieldData,
+        ],
+        fulfilledFragments: [
+          ObjectIdentifier(FastFetchAddOnsQuery.Data.self)
+        ]
+      ))
+    }
+
+    /// Reward
+    ///
+    /// Parent Type: `Reward`
+    public struct Reward: GraphAPI.SelectionSet {
+      public let __data: DataDict
+      public init(_dataDict: DataDict) { __data = _dataDict }
+
+      public static var __parentType: ApolloAPI.ParentType { GraphAPI.Objects.Reward }
+      public static var __selections: [ApolloAPI.Selection] { [
+        .field("__typename", String.self),
+        .field("displayableAddons", DisplayableAddons.self),
+      ] }
+
+      /// The same as allowed_addons but with an additional scope that filters out addons with a start date that falls in the future
+      ///
+      public var displayableAddons: DisplayableAddons { __data["displayableAddons"] }
+
+      public init(
+        displayableAddons: DisplayableAddons
+      ) {
+        self.init(_dataDict: DataDict(
+          data: [
+            "__typename": GraphAPI.Objects.Reward.typename,
+            "displayableAddons": displayableAddons._fieldData,
+          ],
+          fulfilledFragments: [
+            ObjectIdentifier(FastFetchAddOnsQuery.Data.Reward.self)
+          ]
+        ))
+      }
+
+      /// Reward.DisplayableAddons
+      ///
+      /// Parent Type: `RewardConnection`
+      public struct DisplayableAddons: GraphAPI.SelectionSet {
+        public let __data: DataDict
+        public init(_dataDict: DataDict) { __data = _dataDict }
+
+        public static var __parentType: ApolloAPI.ParentType { GraphAPI.Objects.RewardConnection }
+        public static var __selections: [ApolloAPI.Selection] { [
+          .field("__typename", String.self),
+          .field("nodes", [Node?]?.self),
+        ] }
+
+        /// A list of nodes.
+        public var nodes: [Node?]? { __data["nodes"] }
+
+        public init(
+          nodes: [Node?]? = nil
+        ) {
+          self.init(_dataDict: DataDict(
+            data: [
+              "__typename": GraphAPI.Objects.RewardConnection.typename,
+              "nodes": nodes._fieldData,
+            ],
+            fulfilledFragments: [
+              ObjectIdentifier(FastFetchAddOnsQuery.Data.Reward.DisplayableAddons.self)
+            ]
+          ))
+        }
+
+        /// Reward.DisplayableAddons.Node
+        ///
+        /// Parent Type: `Reward`
+        public struct Node: GraphAPI.SelectionSet {
+          public let __data: DataDict
+          public init(_dataDict: DataDict) { __data = _dataDict }
+
+          public static var __parentType: ApolloAPI.ParentType { GraphAPI.Objects.Reward }
+          public static var __selections: [ApolloAPI.Selection] { [
+            .field("__typename", String.self),
+            .field("shippingForLocation", ShippingForLocation.self, arguments: ["countryCode": .variable("country")]),
+            .fragment(RewardFragment.self),
+            .fragment(RewardImageFragment.self),
+            .fragment(RewardItemsFragment.self),
+          ] }
+
+          /// Shipping availability and matching rule for a reward at a given country.
+          public var shippingForLocation: ShippingForLocation { __data["shippingForLocation"] }
+          /// Amount for claiming this reward.
+          public var amount: Amount { __data["amount"] }
+          /// count of backers for this reward
+          public var backersCount: Int? { __data["backersCount"] }
+          /// Amount for claiming this reward, in the current user's chosen currency
+          public var convertedAmount: ConvertedAmount { __data["convertedAmount"] }
+          /// Add-ons which can be combined with this reward.
+          /// Uses creator preferences and shipping rules to determine allow-ability.
+          /// Inclusion in this list does not necessarily indicate that the add-on is available for backing.
+          ///
+          public var allowedAddons: AllowedAddons { __data["allowedAddons"] }
+          /// A reward description.
+          public var description: String? { __data["description"] }
+          /// A reward's title plus the amount, or a default title (the reward amount) if it doesn't have a title.
+          public var displayName: String { __data["displayName"] }
+          /// When the reward is scheduled to end in seconds
+          public var endsAt: GraphAPI.DateTime? { __data["endsAt"] }
+          /// Estimated delivery day.
+          public var estimatedDeliveryOn: GraphAPI.Date? { __data["estimatedDeliveryOn"] }
+          public var id: GraphAPI.ID { __data["id"] }
+          /// Does reward amount meet or exceed maximum pledge for the project
+          public var isMaxPledge: Bool { __data["isMaxPledge"] }
+          /// Whether or not the reward is available for new pledges
+          public var available: Bool { __data["available"] }
+          /// Whether or not the reward is featured
+          public var featured: Bool { __data["featured"] }
+          /// A reward limit.
+          public var limit: Int? { __data["limit"] }
+          /// Per backer reward limit.
+          public var limitPerBacker: Int? { __data["limitPerBacker"] }
+          /// Where the reward can be locally received if local receipt is selected as the shipping preference
+          public var localReceiptLocation: LocalReceiptLocation? { __data["localReceiptLocation"] }
+          /// A reward title.
+          public var name: String? { __data["name"] }
+          /// Amount for claiming this reward during the campaign.
+          public var pledgeAmount: PledgeAmount { __data["pledgeAmount"] }
+          /// Amount for claiming this reward after the campaign.
+          public var latePledgeAmount: LatePledgeAmount { __data["latePledgeAmount"] }
+          /// Is this reward available for post-campaign pledges?
+          public var postCampaignPledgingEnabled: Bool { __data["postCampaignPledgingEnabled"] }
+          /// Remaining reward quantity.
+          public var remainingQuantity: Int? { __data["remainingQuantity"] }
+          /// Shipping preference for this reward
+          public var shippingPreference: GraphQLEnum<GraphAPI.ShippingPreference>? { __data["shippingPreference"] }
+          /// A shipping summary
+          public var shippingSummary: String? { __data["shippingSummary"] }
+          /// When the reward is scheduled to start
+          public var startsAt: GraphAPI.DateTime? { __data["startsAt"] }
+          /// Data related to who can view/access this reward
+          public var audienceData: AudienceData { __data["audienceData"] }
+          /// The reward image.
+          public var image: Image? { __data["image"] }
+          /// The project
+          public var project: Project? { __data["project"] }
+          /// Items in the reward.
+          public var items: Items? { __data["items"] }
+
+          public struct Fragments: FragmentContainer {
+            public let __data: DataDict
+            public init(_dataDict: DataDict) { __data = _dataDict }
+
+            public var rewardFragment: RewardFragment { _toFragment() }
+            public var rewardImageFragment: RewardImageFragment { _toFragment() }
+            public var rewardItemsFragment: RewardItemsFragment { _toFragment() }
+          }
+
+          public init(
+            shippingForLocation: ShippingForLocation,
+            amount: Amount,
+            backersCount: Int? = nil,
+            convertedAmount: ConvertedAmount,
+            allowedAddons: AllowedAddons,
+            description: String? = nil,
+            displayName: String,
+            endsAt: GraphAPI.DateTime? = nil,
+            estimatedDeliveryOn: GraphAPI.Date? = nil,
+            id: GraphAPI.ID,
+            isMaxPledge: Bool,
+            available: Bool,
+            featured: Bool,
+            limit: Int? = nil,
+            limitPerBacker: Int? = nil,
+            localReceiptLocation: LocalReceiptLocation? = nil,
+            name: String? = nil,
+            pledgeAmount: PledgeAmount,
+            latePledgeAmount: LatePledgeAmount,
+            postCampaignPledgingEnabled: Bool,
+            remainingQuantity: Int? = nil,
+            shippingPreference: GraphQLEnum<GraphAPI.ShippingPreference>? = nil,
+            shippingSummary: String? = nil,
+            startsAt: GraphAPI.DateTime? = nil,
+            audienceData: AudienceData,
+            image: Image? = nil,
+            project: Project? = nil,
+            items: Items? = nil
+          ) {
+            self.init(_dataDict: DataDict(
+              data: [
+                "__typename": GraphAPI.Objects.Reward.typename,
+                "shippingForLocation": shippingForLocation._fieldData,
+                "amount": amount._fieldData,
+                "backersCount": backersCount,
+                "convertedAmount": convertedAmount._fieldData,
+                "allowedAddons": allowedAddons._fieldData,
+                "description": description,
+                "displayName": displayName,
+                "endsAt": endsAt,
+                "estimatedDeliveryOn": estimatedDeliveryOn,
+                "id": id,
+                "isMaxPledge": isMaxPledge,
+                "available": available,
+                "featured": featured,
+                "limit": limit,
+                "limitPerBacker": limitPerBacker,
+                "localReceiptLocation": localReceiptLocation._fieldData,
+                "name": name,
+                "pledgeAmount": pledgeAmount._fieldData,
+                "latePledgeAmount": latePledgeAmount._fieldData,
+                "postCampaignPledgingEnabled": postCampaignPledgingEnabled,
+                "remainingQuantity": remainingQuantity,
+                "shippingPreference": shippingPreference,
+                "shippingSummary": shippingSummary,
+                "startsAt": startsAt,
+                "audienceData": audienceData._fieldData,
+                "image": image._fieldData,
+                "project": project._fieldData,
+                "items": items._fieldData,
+              ],
+              fulfilledFragments: [
+                ObjectIdentifier(FastFetchAddOnsQuery.Data.Reward.DisplayableAddons.Node.self),
+                ObjectIdentifier(RewardFragment.self),
+                ObjectIdentifier(RewardImageFragment.self),
+                ObjectIdentifier(RewardItemsFragment.self)
+              ]
+            ))
+          }
+
+          /// Reward.DisplayableAddons.Node.ShippingForLocation
+          ///
+          /// Parent Type: `ShippingForLocation`
+          public struct ShippingForLocation: GraphAPI.SelectionSet {
+            public let __data: DataDict
+            public init(_dataDict: DataDict) { __data = _dataDict }
+
+            public static var __parentType: ApolloAPI.ParentType { GraphAPI.Objects.ShippingForLocation }
+            public static var __selections: [ApolloAPI.Selection] { [
+              .field("__typename", String.self),
+              .field("shippingRule", ShippingRule?.self),
+            ] }
+
+            /// The shipping rule matching the given country, if one exists.
+            public var shippingRule: ShippingRule? { __data["shippingRule"] }
+
+            public init(
+              shippingRule: ShippingRule? = nil
+            ) {
+              self.init(_dataDict: DataDict(
+                data: [
+                  "__typename": GraphAPI.Objects.ShippingForLocation.typename,
+                  "shippingRule": shippingRule._fieldData,
+                ],
+                fulfilledFragments: [
+                  ObjectIdentifier(FastFetchAddOnsQuery.Data.Reward.DisplayableAddons.Node.ShippingForLocation.self)
+                ]
+              ))
+            }
+
+            /// Reward.DisplayableAddons.Node.ShippingForLocation.ShippingRule
+            ///
+            /// Parent Type: `SimpleShippingRule`
+            public struct ShippingRule: GraphAPI.SelectionSet {
+              public let __data: DataDict
+              public init(_dataDict: DataDict) { __data = _dataDict }
+
+              public static var __parentType: ApolloAPI.ParentType { GraphAPI.Objects.SimpleShippingRule }
+              public static var __selections: [ApolloAPI.Selection] { [
+                .field("__typename", String.self),
+                .fragment(SimpleShippingRuleFragment.self),
+              ] }
+
+              public var cost: String? { __data["cost"] }
+              public var estimatedMin: String? { __data["estimatedMin"] }
+              public var estimatedMax: String? { __data["estimatedMax"] }
+              public var currency: String? { __data["currency"] }
+              public var locationId: GraphAPI.ID? { __data["locationId"] }
+              public var locationName: String? { __data["locationName"] }
+              public var country: String { __data["country"] }
+
+              public struct Fragments: FragmentContainer {
+                public let __data: DataDict
+                public init(_dataDict: DataDict) { __data = _dataDict }
+
+                public var simpleShippingRuleFragment: SimpleShippingRuleFragment { _toFragment() }
+              }
+
+              public init(
+                cost: String? = nil,
+                estimatedMin: String? = nil,
+                estimatedMax: String? = nil,
+                currency: String? = nil,
+                locationId: GraphAPI.ID? = nil,
+                locationName: String? = nil,
+                country: String
+              ) {
+                self.init(_dataDict: DataDict(
+                  data: [
+                    "__typename": GraphAPI.Objects.SimpleShippingRule.typename,
+                    "cost": cost,
+                    "estimatedMin": estimatedMin,
+                    "estimatedMax": estimatedMax,
+                    "currency": currency,
+                    "locationId": locationId,
+                    "locationName": locationName,
+                    "country": country,
+                  ],
+                  fulfilledFragments: [
+                    ObjectIdentifier(FastFetchAddOnsQuery.Data.Reward.DisplayableAddons.Node.ShippingForLocation.ShippingRule.self),
+                    ObjectIdentifier(SimpleShippingRuleFragment.self)
+                  ]
+                ))
+              }
+            }
+          }
+
+          /// Reward.DisplayableAddons.Node.Amount
+          ///
+          /// Parent Type: `Money`
+          public struct Amount: GraphAPI.SelectionSet {
+            public let __data: DataDict
+            public init(_dataDict: DataDict) { __data = _dataDict }
+
+            public static var __parentType: ApolloAPI.ParentType { GraphAPI.Objects.Money }
+
+            /// Floating-point numeric value of monetary amount represented as a string
+            public var amount: String? { __data["amount"] }
+            /// Currency of the monetary amount
+            public var currency: GraphQLEnum<GraphAPI.CurrencyCode>? { __data["currency"] }
+            /// Symbol of the currency in which the monetary amount appears
+            public var symbol: String? { __data["symbol"] }
+
+            public struct Fragments: FragmentContainer {
+              public let __data: DataDict
+              public init(_dataDict: DataDict) { __data = _dataDict }
+
+              public var moneyFragment: MoneyFragment { _toFragment() }
+            }
+
+            public init(
+              amount: String? = nil,
+              currency: GraphQLEnum<GraphAPI.CurrencyCode>? = nil,
+              symbol: String? = nil
+            ) {
+              self.init(_dataDict: DataDict(
+                data: [
+                  "__typename": GraphAPI.Objects.Money.typename,
+                  "amount": amount,
+                  "currency": currency,
+                  "symbol": symbol,
+                ],
+                fulfilledFragments: [
+                  ObjectIdentifier(FastFetchAddOnsQuery.Data.Reward.DisplayableAddons.Node.Amount.self),
+                  ObjectIdentifier(RewardFragment.Amount.self),
+                  ObjectIdentifier(MoneyFragment.self)
+                ]
+              ))
+            }
+          }
+
+          /// Reward.DisplayableAddons.Node.ConvertedAmount
+          ///
+          /// Parent Type: `Money`
+          public struct ConvertedAmount: GraphAPI.SelectionSet {
+            public let __data: DataDict
+            public init(_dataDict: DataDict) { __data = _dataDict }
+
+            public static var __parentType: ApolloAPI.ParentType { GraphAPI.Objects.Money }
+
+            /// Floating-point numeric value of monetary amount represented as a string
+            public var amount: String? { __data["amount"] }
+            /// Currency of the monetary amount
+            public var currency: GraphQLEnum<GraphAPI.CurrencyCode>? { __data["currency"] }
+            /// Symbol of the currency in which the monetary amount appears
+            public var symbol: String? { __data["symbol"] }
+
+            public struct Fragments: FragmentContainer {
+              public let __data: DataDict
+              public init(_dataDict: DataDict) { __data = _dataDict }
+
+              public var moneyFragment: MoneyFragment { _toFragment() }
+            }
+
+            public init(
+              amount: String? = nil,
+              currency: GraphQLEnum<GraphAPI.CurrencyCode>? = nil,
+              symbol: String? = nil
+            ) {
+              self.init(_dataDict: DataDict(
+                data: [
+                  "__typename": GraphAPI.Objects.Money.typename,
+                  "amount": amount,
+                  "currency": currency,
+                  "symbol": symbol,
+                ],
+                fulfilledFragments: [
+                  ObjectIdentifier(FastFetchAddOnsQuery.Data.Reward.DisplayableAddons.Node.ConvertedAmount.self),
+                  ObjectIdentifier(RewardFragment.ConvertedAmount.self),
+                  ObjectIdentifier(MoneyFragment.self)
+                ]
+              ))
+            }
+          }
+
+          public typealias AllowedAddons = RewardFragment.AllowedAddons
+
+          /// Reward.DisplayableAddons.Node.LocalReceiptLocation
+          ///
+          /// Parent Type: `Location`
+          public struct LocalReceiptLocation: GraphAPI.SelectionSet {
+            public let __data: DataDict
+            public init(_dataDict: DataDict) { __data = _dataDict }
+
+            public static var __parentType: ApolloAPI.ParentType { GraphAPI.Objects.Location }
+
+            /// The country code.
+            public var country: String { __data["country"] }
+            /// The localized country name.
+            public var countryName: String? { __data["countryName"] }
+            /// The displayable name. It includes the state code for US cities. ex: 'Seattle, WA'
+            public var displayableName: String { __data["displayableName"] }
+            public var id: GraphAPI.ID { __data["id"] }
+            /// The localized name
+            public var name: String { __data["name"] }
+
+            public struct Fragments: FragmentContainer {
+              public let __data: DataDict
+              public init(_dataDict: DataDict) { __data = _dataDict }
+
+              public var locationFragment: LocationFragment { _toFragment() }
+            }
+
+            public init(
+              country: String,
+              countryName: String? = nil,
+              displayableName: String,
+              id: GraphAPI.ID,
+              name: String
+            ) {
+              self.init(_dataDict: DataDict(
+                data: [
+                  "__typename": GraphAPI.Objects.Location.typename,
+                  "country": country,
+                  "countryName": countryName,
+                  "displayableName": displayableName,
+                  "id": id,
+                  "name": name,
+                ],
+                fulfilledFragments: [
+                  ObjectIdentifier(FastFetchAddOnsQuery.Data.Reward.DisplayableAddons.Node.LocalReceiptLocation.self),
+                  ObjectIdentifier(RewardFragment.LocalReceiptLocation.self),
+                  ObjectIdentifier(LocationFragment.self)
+                ]
+              ))
+            }
+          }
+
+          /// Reward.DisplayableAddons.Node.PledgeAmount
+          ///
+          /// Parent Type: `Money`
+          public struct PledgeAmount: GraphAPI.SelectionSet {
+            public let __data: DataDict
+            public init(_dataDict: DataDict) { __data = _dataDict }
+
+            public static var __parentType: ApolloAPI.ParentType { GraphAPI.Objects.Money }
+
+            /// Floating-point numeric value of monetary amount represented as a string
+            public var amount: String? { __data["amount"] }
+            /// Currency of the monetary amount
+            public var currency: GraphQLEnum<GraphAPI.CurrencyCode>? { __data["currency"] }
+            /// Symbol of the currency in which the monetary amount appears
+            public var symbol: String? { __data["symbol"] }
+
+            public struct Fragments: FragmentContainer {
+              public let __data: DataDict
+              public init(_dataDict: DataDict) { __data = _dataDict }
+
+              public var moneyFragment: MoneyFragment { _toFragment() }
+            }
+
+            public init(
+              amount: String? = nil,
+              currency: GraphQLEnum<GraphAPI.CurrencyCode>? = nil,
+              symbol: String? = nil
+            ) {
+              self.init(_dataDict: DataDict(
+                data: [
+                  "__typename": GraphAPI.Objects.Money.typename,
+                  "amount": amount,
+                  "currency": currency,
+                  "symbol": symbol,
+                ],
+                fulfilledFragments: [
+                  ObjectIdentifier(FastFetchAddOnsQuery.Data.Reward.DisplayableAddons.Node.PledgeAmount.self),
+                  ObjectIdentifier(RewardFragment.PledgeAmount.self),
+                  ObjectIdentifier(MoneyFragment.self)
+                ]
+              ))
+            }
+          }
+
+          /// Reward.DisplayableAddons.Node.LatePledgeAmount
+          ///
+          /// Parent Type: `Money`
+          public struct LatePledgeAmount: GraphAPI.SelectionSet {
+            public let __data: DataDict
+            public init(_dataDict: DataDict) { __data = _dataDict }
+
+            public static var __parentType: ApolloAPI.ParentType { GraphAPI.Objects.Money }
+
+            /// Floating-point numeric value of monetary amount represented as a string
+            public var amount: String? { __data["amount"] }
+            /// Currency of the monetary amount
+            public var currency: GraphQLEnum<GraphAPI.CurrencyCode>? { __data["currency"] }
+            /// Symbol of the currency in which the monetary amount appears
+            public var symbol: String? { __data["symbol"] }
+
+            public struct Fragments: FragmentContainer {
+              public let __data: DataDict
+              public init(_dataDict: DataDict) { __data = _dataDict }
+
+              public var moneyFragment: MoneyFragment { _toFragment() }
+            }
+
+            public init(
+              amount: String? = nil,
+              currency: GraphQLEnum<GraphAPI.CurrencyCode>? = nil,
+              symbol: String? = nil
+            ) {
+              self.init(_dataDict: DataDict(
+                data: [
+                  "__typename": GraphAPI.Objects.Money.typename,
+                  "amount": amount,
+                  "currency": currency,
+                  "symbol": symbol,
+                ],
+                fulfilledFragments: [
+                  ObjectIdentifier(FastFetchAddOnsQuery.Data.Reward.DisplayableAddons.Node.LatePledgeAmount.self),
+                  ObjectIdentifier(RewardFragment.LatePledgeAmount.self),
+                  ObjectIdentifier(MoneyFragment.self)
+                ]
+              ))
+            }
+          }
+
+          public typealias AudienceData = RewardFragment.AudienceData
+
+          public typealias Image = RewardImageFragment.Image
+
+          public typealias Project = RewardItemsFragment.Project
+
+          public typealias Items = RewardItemsFragment.Items
+        }
+      }
+    }
+  }
+}

--- a/GraphAPI/Sources/Schema/Objects/ShippingForLocation.graphql.swift
+++ b/GraphAPI/Sources/Schema/Objects/ShippingForLocation.graphql.swift
@@ -1,0 +1,12 @@
+// @generated
+// This file was automatically generated and should not be edited.
+
+import ApolloAPI
+
+public extension Objects {
+  /// Shipping availability for a reward at a given location.
+  static let ShippingForLocation = ApolloAPI.Object(
+    typename: "ShippingForLocation",
+    implementedInterfaces: []
+  )
+}

--- a/GraphAPI/Sources/Schema/SchemaMetadata.graphql.swift
+++ b/GraphAPI/Sources/Schema/SchemaMetadata.graphql.swift
@@ -139,6 +139,7 @@ public enum SchemaMetadata: ApolloAPI.SchemaMetadata {
     case "CommentEdge": return GraphAPI.Objects.CommentEdge
     case "PaymentIncrementBadge": return GraphAPI.Objects.PaymentIncrementBadge
     case "LocationsConnection": return GraphAPI.Objects.LocationsConnection
+    case "ShippingForLocation": return GraphAPI.Objects.ShippingForLocation
     case "EnvironmentalCommitment": return GraphAPI.Objects.EnvironmentalCommitment
     case "ProjectFaqConnection": return GraphAPI.Objects.ProjectFaqConnection
     case "ProjectFaq": return GraphAPI.Objects.ProjectFaq

--- a/Kickstarter.xcodeproj/project.pbxproj
+++ b/Kickstarter.xcodeproj/project.pbxproj
@@ -665,6 +665,7 @@
 		E15E22CD2E54B91B00EE6BB0 /* KDS */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = KDS; sourceTree = "<group>"; };
 		E182E5BB2B8D36FE0008DD69 /* AppEnvironmentTests+OAuthInKeychain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppEnvironmentTests+OAuthInKeychain.swift"; sourceTree = "<group>"; };
 		E18B2547303F42170087CCA9 /* RewardSimpleShippingRulesExpandedFragment.graphql */ = {isa = PBXFileReference; lastKnownFileType = text; path = RewardSimpleShippingRulesExpandedFragment.graphql; sourceTree = "<group>"; };
+		E18B2546303E24430087CCA9 /* FastFetchAddOnsQuery.graphql */ = {isa = PBXFileReference; lastKnownFileType = text; path = FastFetchAddOnsQuery.graphql; sourceTree = "<group>"; };
 		E18CA2882F9A864E005C22AE /* StatsigExperiment+HelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StatsigExperiment+HelperTests.swift"; sourceTree = "<group>"; };
 		E18CA2892F9A864E005C22AE /* StatsigFeature+HelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StatsigFeature+HelperTests.swift"; sourceTree = "<group>"; };
 		E190EB1B2E29944E006A6DB6 /* BackerDashboardProjectCellFragment.graphql */ = {isa = PBXFileReference; lastKnownFileType = text; path = BackerDashboardProjectCellFragment.graphql; sourceTree = "<group>"; };
@@ -1374,6 +1375,7 @@
 				E1D04A92302B61D6005719DF /* FastFetchProjectPageBaseQuery.graphql */,
 				E1D04A93302B61D6005719DF /* FastFetchProjectPageExtendedPropertiesQuery.graphql */,
 				E190EB552E29944E006A6DB6 /* FetchAddOnsQuery.graphql */,
+				E18B2546303E24430087CCA9 /* FastFetchAddOnsQuery.graphql */,
 				E190EB562E29944E006A6DB6 /* FetchBackingQuery.graphql */,
 				33AA26C72E39E9BD002DBD60 /* FetchBackingWithIncrementsRefundedQuery.graphql */,
 				E190EB572E29944E006A6DB6 /* FetchCategory.graphql */,

--- a/KsApi/Sources/KsApi/MockService.swift
+++ b/KsApi/Sources/KsApi/MockService.swift
@@ -1213,6 +1213,13 @@
         )
     }
 
+    func fastFetchRewardAddOnsSelection(
+      baseRewardId _: Int,
+      countryCode _: String
+    ) -> SignalProducer<[Reward], ErrorEnvelope> {
+      return SignalProducer(error: ErrorEnvelope.graphError("Unimplemented mock"))
+    }
+
     internal func fetchMessageThread(messageThreadId _: Int)
       -> SignalProducer<MessageThreadEnvelope, ErrorEnvelope> {
       if let error = self.fetchMessageThreadResult?.error {

--- a/KsApi/Sources/KsApi/Service.swift
+++ b/KsApi/Sources/KsApi/Service.swift
@@ -724,6 +724,25 @@ public struct Service: ServiceType {
       .flatMap(Project.projectProducer(from:))
   }
 
+  public func fastFetchRewardAddOnsSelection(
+    baseRewardId: Int,
+    countryCode: String
+  ) -> SignalProducer<[Reward], ErrorEnvelope> {
+    guard let graphCountryCode = GraphAPI.CountryCode(rawValue: countryCode) else {
+      assertionFailure("Unable to map selected code to country")
+      return SignalProducer(error: .graphError("Invalid country code"))
+    }
+
+    let query = GraphAPI.FastFetchAddOnsQuery(
+      baseRewardId: "\(baseRewardId)",
+      country: .case(graphCountryCode)
+    )
+
+    return GraphQL.shared.client
+      .fetch(query: query)
+      .flatMap(Reward.addOnsProducer(from:))
+  }
+
   public func fetchBackedProjects(
     cursor: String? = nil,
     limit: Int? = nil

--- a/KsApi/Sources/KsApi/ServiceType.swift
+++ b/KsApi/Sources/KsApi/ServiceType.swift
@@ -310,6 +310,11 @@ public protocol ServiceType {
   func fetchRewardAddOnsSelectionViewRewards(slug: String, shippingEnabled: Bool, locationId: String?)
     -> SignalProducer<Project, ErrorEnvelope>
 
+  func fastFetchRewardAddOnsSelection(
+    baseRewardId: Int,
+    countryCode: String
+  ) -> SignalProducer<[Reward], ErrorEnvelope>
+
   /// Fetches a reward's shipping rules for a project and reward id.
   func fetchRewardShippingRules(projectId: Int, rewardId: Int)
     -> SignalProducer<ShippingRulesEnvelope, ErrorEnvelope>

--- a/KsApi/Sources/KsApi/models/graphql/adapters/Reward+FastFetchAddOns.swift
+++ b/KsApi/Sources/KsApi/models/graphql/adapters/Reward+FastFetchAddOns.swift
@@ -1,0 +1,43 @@
+import GraphAPI
+import ReactiveSwift
+
+extension Reward {
+  static func addOnsProducer(
+    from data: GraphAPI.FastFetchAddOnsQuery.Data
+  ) -> SignalProducer<[Reward], ErrorEnvelope> {
+    guard let addOns = Reward.addOns(from: data) else {
+      return SignalProducer(error: ErrorEnvelope.couldNotParseJSON)
+    }
+
+    return SignalProducer(value: addOns)
+  }
+
+  static func addOns(from data: GraphAPI.FastFetchAddOnsQuery.Data) -> [Reward]? {
+    guard let baseReward = data.reward else { return nil }
+    let addOns = baseReward.displayableAddons.nodes?
+      .compactMap { node -> Reward? in
+        guard let node else { return nil }
+
+        let rewardFragment = node.fragments.rewardFragment
+        let imageFragment = node.fragments.rewardImageFragment
+        let itemFragment = node.fragments.rewardItemsFragment
+
+        var shippingRules: [ShippingRule] = []
+        if let shippingRuleData = node.shippingForLocation.shippingRule {
+          let fragment = shippingRuleData.fragments.simpleShippingRuleFragment
+          if let shippingRule = ShippingRule.shippingRule(from: fragment) {
+            shippingRules.append(shippingRule)
+          }
+        }
+
+        return Reward.reward(
+          from: rewardFragment,
+          expandedShippingRules: shippingRules,
+          rewardItems: RewardsItem.rewardItemsData(from: itemFragment),
+          rewardImage: Reward.Image.rewardPhoto(from: imageFragment)
+        )
+      }
+
+    return addOns
+  }
+}

--- a/Library/Sources/Library/Library/ViewModels/RewardAddOnSelectionViewModel.swift
+++ b/Library/Sources/Library/Library/ViewModels/RewardAddOnSelectionViewModel.swift
@@ -91,19 +91,12 @@ public final class RewardAddOnSelectionViewModel: RewardAddOnSelectionViewModelT
         : Strings.Pledge_flow_navigation_bar_titles_Bonus_support()
     }
 
-    // Only fetch add-ons if the base reward has add-ons.
-    let fetchAddOns = Signal.combineLatest(
-      refreshAddons,
-      hasAddOns.filter(isTrue)
-    )
-    .map(first)
-
     let shippingRule = Signal.merge(
       selectedShippingRule,
       baseReward.filter { reward in !reward.shipping.enabled }.mapConst(nil)
     )
 
-    let addOnsEvent = fetchAddOns.switchMap { data in
+    let addOnsEvent = refreshAddons.switchMap { data in
       let slug = data.project.slug
       let baseReward = data.rewards.first
       let shippingRule = data.selectedShippingRule
@@ -118,13 +111,7 @@ public final class RewardAddOnSelectionViewModel: RewardAddOnSelectionViewModelT
     }
 
     self.startRefreshing = self.beginRefreshSignal
-    self.endRefreshing = Signal.merge(
-      addOnsEvent.filter { $0.isTerminating }.ignoreValues(),
-      // If there aren't add-ons to fetch, end refresh immediately.
-      hasAddOns.takeWhen(self.beginRefreshSignal).filter(isFalse)
-        .ksr_delay(.milliseconds(100), on: AppEnvironment.current.scheduler)
-        .ignoreValues()
-    )
+    self.endRefreshing = addOnsEvent.filter { $0.isTerminating }.ignoreValues()
 
     let addOns = addOnsEvent.values().skipNil()
     let requestErrored = addOnsEvent.map(\.error).map(isNotNil)
@@ -447,12 +434,18 @@ private func addOnsProducer(
   baseReward: Reward?,
   shippingRule: ShippingRule?
 ) -> SignalProducer<[Reward]?, ErrorEnvelope> {
+  // You can't add add-ons to No Reward.
+  guard let baseReward, baseReward.isNoReward == false else {
+    return SignalProducer(value: nil)
+  }
+
+  // Only fetch add-ons if the base reward has add-ons.
+  guard baseReward.hasAddOns else {
+    return SignalProducer(value: nil)
+  }
+
   let experiment = SpeedyCheckoutExperiment()
   if experiment.boolValue(forKey: .speedy_checkout_enabled) == true {
-    guard let baseReward, baseReward.isNoReward == false else {
-      return SignalProducer(value: nil)
-    }
-
     // Shipping rule may be nil if the backer selected no reward or a digital reward.
     let shippingCountryCode = shippingRule?.location.country ?? AppEnvironment.current.countryCode
 

--- a/Library/Sources/Library/Library/ViewModels/RewardAddOnSelectionViewModel.swift
+++ b/Library/Sources/Library/Library/ViewModels/RewardAddOnSelectionViewModel.swift
@@ -74,8 +74,6 @@ public final class RewardAddOnSelectionViewModel: RewardAddOnSelectionViewModelT
 
     let hasAddOns = baseReward.map(\.hasAddOns)
 
-    let slug = project.map(\.slug)
-
     let refreshAddons = Signal.merge(
       configData,
       configData.takeWhen(self.beginRefreshSignal)

--- a/Library/Sources/Library/Library/ViewModels/RewardAddOnSelectionViewModel.swift
+++ b/Library/Sources/Library/Library/ViewModels/RewardAddOnSelectionViewModel.swift
@@ -1,3 +1,4 @@
+import Experimentation
 import Foundation
 import KsApi
 import Prelude
@@ -76,8 +77,8 @@ public final class RewardAddOnSelectionViewModel: RewardAddOnSelectionViewModelT
     let slug = project.map(\.slug)
 
     let refreshAddons = Signal.merge(
-      slug,
-      slug.takeWhen(self.beginRefreshSignal)
+      configData,
+      configData.takeWhen(self.beginRefreshSignal)
     )
 
     self.headerTitle = hasAddOns.map { (hasAddons: Bool) -> String in
@@ -93,7 +94,7 @@ public final class RewardAddOnSelectionViewModel: RewardAddOnSelectionViewModelT
     }
 
     // Only fetch add-ons if the base reward has add-ons.
-    let fetchAddOnsWithSlug = Signal.combineLatest(
+    let fetchAddOns = Signal.combineLatest(
       refreshAddons,
       hasAddOns.filter(isTrue)
     )
@@ -104,12 +105,18 @@ public final class RewardAddOnSelectionViewModel: RewardAddOnSelectionViewModelT
       baseReward.filter { reward in !reward.shipping.enabled }.mapConst(nil)
     )
 
-    let slugAndShippingRule = Signal.combineLatest(fetchAddOnsWithSlug, shippingRule)
+    let addOnsEvent = fetchAddOns.switchMap { data in
+      let slug = data.project.slug
+      let baseReward = data.rewards.first
+      let shippingRule = data.selectedShippingRule
 
-    let addOnsEvent = slugAndShippingRule.switchMap { slug, shippingRule in
-      addOnsProducer(slug: slug, shippingRule: shippingRule)
-        .ksr_delay(AppEnvironment.current.apiDelayInterval, on: AppEnvironment.current.scheduler)
-        .materialize()
+      return addOnsProducer(
+        slug: slug,
+        baseReward: baseReward,
+        shippingRule: shippingRule
+      )
+      .ksr_delay(AppEnvironment.current.apiDelayInterval, on: AppEnvironment.current.scheduler)
+      .materialize()
     }
 
     self.startRefreshing = self.beginRefreshSignal
@@ -439,8 +446,24 @@ public final class RewardAddOnSelectionViewModel: RewardAddOnSelectionViewModelT
 
 private func addOnsProducer(
   slug: String,
+  baseReward: Reward?,
   shippingRule: ShippingRule?
 ) -> SignalProducer<[Reward]?, ErrorEnvelope> {
+  let experiment = SpeedyCheckoutExperiment()
+  if experiment.boolValue(forKey: .speedy_checkout_enabled) == true {
+    guard let baseReward, baseReward.isNoReward == false else {
+      return SignalProducer(value: nil)
+    }
+
+    // Shipping rule may be nil if the backer selected no reward or a digital reward.
+    let shippingCountryCode = shippingRule?.location.country ?? AppEnvironment.current.countryCode
+
+    return AppEnvironment.current.apiService.fastFetchRewardAddOnsSelection(
+      baseRewardId: baseReward.id,
+      countryCode: shippingCountryCode
+    ).map { .some($0) }
+  }
+
   return AppEnvironment.current.apiService.fetchRewardAddOnsSelectionViewRewards(
     slug: slug,
     shippingEnabled: shippingRule?.location.graphID != nil,

--- a/LibraryTests/Library/ViewModels/RewardAddOnSelectionViewModelTests.swift
+++ b/LibraryTests/Library/ViewModels/RewardAddOnSelectionViewModelTests.swift
@@ -90,10 +90,10 @@ final class RewardAddOnSelectionViewModelTests: TestCase {
       self.scheduler.advance()
 
       self.startRefreshing.assertValueCount(0)
-      self.endRefreshing.assertValueCount(2)
+      self.endRefreshing.assertValueCount(1)
 
+      self.loadAddOnRewardsIntoDataSourceAndReloadTableView.assertValueCount(1)
       self.loadAddOnRewardsIntoDataSourceAndReloadTableView.assertValues([
-        [.rewardAddOn(expected)],
         [.rewardAddOn(expected)]
       ])
     }
@@ -209,7 +209,7 @@ final class RewardAddOnSelectionViewModelTests: TestCase {
       self.scheduler.advance()
 
       self.startRefreshing.assertValueCount(0)
-      self.endRefreshing.assertValueCount(2)
+      self.endRefreshing.assertValueCount(1)
 
       self.loadAddOnRewardsIntoDataSourceAndReloadTableView.assertValues([[.emptyState(.errorPullToRefresh)]])
     }
@@ -228,12 +228,12 @@ final class RewardAddOnSelectionViewModelTests: TestCase {
       self.vm.inputs.beginRefresh()
 
       self.startRefreshing.assertValueCount(1)
-      self.endRefreshing.assertValueCount(2)
+      self.endRefreshing.assertValueCount(1)
 
       self.scheduler.advance()
 
       self.startRefreshing.assertValueCount(1)
-      self.endRefreshing.assertValueCount(3)
+      self.endRefreshing.assertValueCount(2)
 
       self.loadAddOnRewardsIntoDataSourceAndReloadTableView.assertValues([
         [.emptyState(.errorPullToRefresh)],
@@ -302,7 +302,6 @@ final class RewardAddOnSelectionViewModelTests: TestCase {
       self.scheduler.advance()
 
       self.loadAddOnRewardsIntoDataSourceAndReloadTableView.assertValues([
-        [.rewardAddOn(expected)],
         [.rewardAddOn(expected)]
       ])
       XCTAssertEqual(
@@ -441,7 +440,7 @@ final class RewardAddOnSelectionViewModelTests: TestCase {
 
       self.scheduler.advance()
 
-      self.loadAddOnRewardsIntoDataSourceAndReloadTableView.assertValues([expected, expected])
+      self.loadAddOnRewardsIntoDataSourceAndReloadTableView.assertValues([expected])
     }
   }
 

--- a/graphql/queries/FastFetchAddOnsQuery.graphql
+++ b/graphql/queries/FastFetchAddOnsQuery.graphql
@@ -1,0 +1,16 @@
+query FastFetchAddOns($baseRewardId: ID!, $country: CountryCode!) {
+  reward(id: $baseRewardId) {
+    displayableAddons {
+      nodes {
+        ...RewardFragment
+        ...RewardImageFragment
+        ...RewardItemsFragment
+        shippingForLocation(countryCode: $country) {
+          shippingRule {
+            ...SimpleShippingRuleFragment
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
# 📲 What

Add fast(er) fetch for reward add-ons.

# 🤔 Why

The add-ons fetch is slow, hitting several seconds in the worst case scenario.

This adds a new, faster fetch:
1. It doesn't fetch the Project
2. It fetches add-ons directly off of the base reward, instead of off the Project
3. It uses the new, faster `shippingForLocation` connection instead of `shippingRulesExpanded(forLocation:)`