### PR TITLE
[DISC-459] Video Feed Share Sheet: X

### DIFF
--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Controller/VideoFeedViewController.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Controller/VideoFeedViewController.swift
@@ -27,6 +27,7 @@ final class VideoFeedViewController: UIViewController {
   private var previewImagePrefetcher: ImagePrefetcher?
   private var isScrolling = false
   private var currentPageIndex: Int = 0
+  private var isShareSheetPresented = false
 
   /// Called once the first batch of items has loaded and the feed is ready to present.
   var onReadyToPresent: (() -> Void)?
@@ -322,8 +323,8 @@ final class VideoFeedViewController: UIViewController {
 
   private func resumeVisibleCell() {
     /// `willEnterForegroundNotification` fires app-wide, and this VC is retained after dismissal.
-    ///  Skip resume if the feed is no longer visible.
-    guard self.view.window != nil else { return }
+    ///  Skip resume if the feed is no longer visible or the share sheet is still presented.
+    guard self.view.window != nil, !self.isShareSheetPresented else { return }
 
     self.activateCurrentPageCell()
   }
@@ -503,7 +504,9 @@ extension VideoFeedViewController: UICollectionViewDelegateFlowLayout {
     case .shareTapped:
       self.viewModel.trackCTAClicked(ctaContext: .videoFeedShare, item: item)
       self.pauseVisibleCell()
+      self.isShareSheetPresented = true
     case .sheetDismissedFromLinkCopied:
+      self.isShareSheetPresented = false
       self.resumeVisibleCell()
     case .moreTapped:
       self.simpleAlert(title: "More")

--- a/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Social Sharing/VideoFeedShareSheetView.swift
+++ b/Kickstarter-Framework/Sources/Kickstarter-Framework/Kickstarter-iOS/Features/VideoFeed/Social Sharing/VideoFeedShareSheetView.swift
@@ -281,7 +281,15 @@ struct VideoFeedShareSheetView: View {
 
   // MARK: - X
 
-  private func shareToX() {}
+  private func shareToX() {
+    guard let url = VideoFeedShareDestination.projectURL(for: self.item),
+          let encoded = url.absoluteString.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
+          let xURL = URL(string: "https://x.com/intent/tweet?text=\(encoded)") else {
+      return
+    }
+
+    UIApplication.shared.open(xURL)
+  }
 }
 
 // MARK: - ShareDestinationButton

--- a/Kickstarter-iOS/Info.plist
+++ b/Kickstarter-iOS/Info.plist
@@ -75,6 +75,7 @@
 		<string>facebook-stories</string>
 		<string>whatsapp</string>
 		<string>x-twitter</string>
+		<string>twitter</string>
 	</array>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What
Implements share video feed project as X (Twitter) post

# 🛠 How
- Share sheet opens `https://x.com/intent/tweet?text=<url>` via `UIApplication.shared.open`
- Also makes sure that the video doesn't resume playback when users navigate back to the share sheet from X
- Updated `Info.plist`:  `LSApplicationQueriesSchemes` actually needs both `x-twitter` _and_ **`twitter`** for the app to show up as an available app.

# 👀 See

Trello, screenshots, external resources?

| Before 🐛 | After 🦋 |
| --- | --- |
|  | <video width="295" height="640" alt="" src="https://github.com/user-attachments/assets/a42655a6-a096-489f-abdc-dab320630ec3" controls></video> |


# ✅ Acceptance criteria
- [x] X appears in the share sheet when the app is installed
- [x] X does not appear in the share sheet when the app is not installed
- [x] Tapping X opens the app with the project URL pre populated
- [x] Share sheet remains open after returning from X
- [x] Video does not resume playback while the share sheet is still visible
- [x] Video resumes normally after fully dismissing the share sheet
