### PR TITLE
[PF-560] Add missing image block caption

### DIFF
--- a/ServerDrivenUI/Sources/ServerDrivenUI/Blocks/ImageBlock.swift
+++ b/ServerDrivenUI/Sources/ServerDrivenUI/Blocks/ImageBlock.swift
@@ -14,8 +14,23 @@ struct ImageBlock: View {
     return URL(string: urlString)
   }
 
+  private var caption: AttributedString? {
+    guard let caption = self.photo.caption else {
+      return nil
+    }
+
+    var attributes = AttributeContainer()
+    attributes.font = self.style.mediaCaptionFont
+    attributes.foregroundColor = self.style.mediaCaptionColor.swiftUIColor()
+    if let link = self.photo.link {
+      attributes.link = link
+      attributes.underlineStyle = self.style.linkUnderlined ? .single : .none
+    }
+    return AttributedString(caption, attributes: attributes)
+  }
+
   @ViewBuilder private var image: some View {
-    Group {
+    VStack {
       if let imageURL {
         KFAnimatedImage(imageURL)
           .placeholder { _ in
@@ -31,6 +46,10 @@ struct ImageBlock: View {
         Color.clear
           .frame(maxWidth: .infinity)
           .accessibilityLabel(self.photo.altText ?? "")
+      }
+      if let caption = self.caption {
+        Text(caption)
+          .multilineTextAlignment(self.style.mediaCaptionAlignment)
       }
     }
   }

--- a/ServerDrivenUI/Sources/ServerDrivenUI/Styling/AutomaticRichTextStyle.swift
+++ b/ServerDrivenUI/Sources/ServerDrivenUI/Styling/AutomaticRichTextStyle.swift
@@ -60,6 +60,19 @@ public struct AutomaticRichTextStyle: RichTextStyle, Sendable {
     Spacing.unit_04
   }
 
+  public var mediaCaptionFont: Font {
+    InterFont.caption1.swiftUIFont(size: nil)
+      .italic()
+  }
+
+  public var mediaCaptionColor: AdaptiveColor {
+    Colors.Text.secondary
+  }
+
+  public var mediaCaptionAlignment: TextAlignment {
+    .center
+  }
+
   public var mediaCornerRadius: CGFloat {
     Dimension.CornerRadius.medium
   }

--- a/ServerDrivenUI/Sources/ServerDrivenUI/Styling/RichTextStyle.swift
+++ b/ServerDrivenUI/Sources/ServerDrivenUI/Styling/RichTextStyle.swift
@@ -40,6 +40,11 @@ public protocol RichTextStyle: Sendable {
 
   // MARK: - Media blocks
 
+  /// Attributes for captions in image blocks
+  var mediaCaptionFont: Font { get }
+  var mediaCaptionColor: AdaptiveColor { get }
+  var mediaCaptionAlignment: TextAlignment { get }
+
   /// Corner radius for image, audio/video, and oEmbed blocks
   var mediaCornerRadius: CGFloat { get }
 

--- a/ServerDrivenUI/Sources/ServerDrivenUITestHelpers/DarkRichTextStyle.swift
+++ b/ServerDrivenUI/Sources/ServerDrivenUITestHelpers/DarkRichTextStyle.swift
@@ -24,5 +24,8 @@ public struct DarkRichTextStyle: RichTextStyle, Sendable {
   public var listIndentation: CGFloat { self.parent.listIndentation }
   public var contentHorizontalPadding: CGFloat { self.parent.contentHorizontalPadding }
   public var mediaCornerRadius: CGFloat { self.parent.mediaCornerRadius }
+  public var mediaCaptionFont: Font { self.parent.mediaCaptionFont }
+  public var mediaCaptionColor: AdaptiveColor { self.parent.mediaCaptionColor.resolvedForDarkMode() }
+  public var mediaCaptionAlignment: TextAlignment { self.parent.mediaCaptionAlignment }
   public var mediaPlaceholderColor: AdaptiveColor { self.parent.mediaPlaceholderColor.resolvedForDarkMode() }
 }

--- a/ServerDrivenUI/Sources/ServerDrivenUITestHelpers/LightRichTextStyle.swift
+++ b/ServerDrivenUI/Sources/ServerDrivenUITestHelpers/LightRichTextStyle.swift
@@ -24,5 +24,8 @@ public struct LightRichTextStyle: RichTextStyle, Sendable {
   public var listIndentation: CGFloat { self.parent.listIndentation }
   public var contentHorizontalPadding: CGFloat { self.parent.contentHorizontalPadding }
   public var mediaCornerRadius: CGFloat { self.parent.mediaCornerRadius }
+  public var mediaCaptionFont: Font { self.parent.mediaCaptionFont }
+  public var mediaCaptionColor: AdaptiveColor { self.parent.mediaCaptionColor.resolvedForLightMode() }
+  public var mediaCaptionAlignment: TextAlignment { self.parent.mediaCaptionAlignment }
   public var mediaPlaceholderColor: AdaptiveColor { self.parent.mediaPlaceholderColor.resolvedForLightMode() }
 }

--- a/ServerDrivenUI/Tests/ServerDrivenUITests/Blocks/ImageBlockTests.swift
+++ b/ServerDrivenUI/Tests/ServerDrivenUITests/Blocks/ImageBlockTests.swift
@@ -207,13 +207,54 @@ final class ImageBlockTests: XCTestCase {
       "Expected ImageBlock height to respect the container height \(containerHeight). Actual: \(String(describing: frame.height))"
     )
   }
+
+  func testImageBlockWithCaption_rendersCaptionText() throws {
+    // Given a photo with a non-empty caption
+    let photo = makePhoto(
+      altText: "Test image",
+      url: testImageURL().absoluteString,
+      caption: "A descriptive caption"
+    )
+
+    // When rendering the ImageBlock
+    let view = imageBlock(photo: photo, colorScheme: .light)
+
+    // Then the caption should be present as a Text view with the expected string
+    XCTAssertNoThrow(
+      try view.inspect().find(text: "A descriptive caption"),
+      "Expected ImageBlock to render the provided caption text."
+    )
+  }
+
+  func testImageBlockWithoutCaption_doesNotRenderCaptionText() throws {
+    // Given a photo whose caption is nil
+    var photo = makePhoto(
+      altText: "Test image",
+      url: testImageURL().absoluteString,
+      caption: nil
+    )
+
+    // When rendering the ImageBlock
+    let view = imageBlock(photo: photo, colorScheme: .light)
+
+    // Then no Text with an empty string or a placeholder should be found for caption
+    XCTAssertThrowsError(
+      try view.inspect().find(text: ""),
+      "Expected ImageBlock not to render an empty caption Text when caption is nil."
+    )
+  }
 }
 
-private func makePhoto(altText: String?, url: String?, link: URL? = nil) -> RichTextElement.Photo {
+private func makePhoto(
+  altText: String?,
+  url: String?,
+  link: URL? = nil,
+  caption: String? = "Test caption"
+) -> RichTextElement.Photo {
   RichTextElement.Photo(
     altText: altText,
     assetID: "123",
-    caption: "Test caption",
+    caption: caption,
     url: url,
     link: link
   )


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

# 📲 What

Image blocks were missing figcaptions, this adds them

# 🤔 Why

Creators add them and we need to show them

# 🛠 How

Add new styles for media captions, then add the caption label to the text. Parsing and fetching already existed.

# 👀 See

| Before 🐛 | After 🦋 |
| --- | --- |
| <img width="350" alt="image" src="https://github.com/user-attachments/assets/4ba117ee-df5a-4508-ab6d-b91c49219137" /> | <img width="350" alt="image" src="https://github.com/user-attachments/assets/ca109c13-d5de-4f04-8f4a-f4ad8ea660ca" /> |
